### PR TITLE
[Extensions] Propagate kFollowRedirectReason disconnect to inner loader factory

### DIFF
--- a/browser/net/BUILD.gn
+++ b/browser/net/BUILD.gn
@@ -6,6 +6,7 @@
 import("//brave/components/brave_ads/buildflags/buildflags.gni")
 import("//brave/components/tor/buildflags/buildflags.gni")
 import("//build/config/features.gni")
+import("//extensions/buildflags/buildflags.gni")
 
 source_set("features") {
   sources = [
@@ -23,6 +24,7 @@ source_set("browser_tests") {
     "brave_accept_header_browsertest.cc",
     "brave_network_delegate_browsertest.cc",
     "brave_network_delegate_hsts_fingerprinting_browsertest.cc",
+    "brave_proxying_url_loader_factory_browsertest.cc",
     "brave_service_key_network_delegate_helper_browsertest.cc",
     "brave_site_hacks_network_delegate_helper_browsertest.cc",
     "brave_system_request_handler_browsertest.cc",
@@ -60,6 +62,14 @@ source_set("browser_tests") {
       "//chrome/test:test_support_ui_android",
       "//net:test_support",
       "//net/traffic_annotation:test_support",
+    ]
+  }
+  if (enable_extensions) {
+    deps += [
+      "//chrome/browser/extensions:test_support",
+      "//extensions:test_support",
+      "//extensions/buildflags",
+      "//extensions/common",
     ]
   }
   if (enable_tor) {

--- a/browser/net/brave_proxying_url_loader_factory.cc
+++ b/browser/net/brave_proxying_url_loader_factory.cc
@@ -39,6 +39,7 @@
 #include "services/network/public/cpp/url_loader_factory_builder.h"
 #include "services/network/public/mojom/early_hints.mojom.h"
 #include "third_party/abseil-cpp/absl/strings/str_format.h"
+#include "third_party/blink/public/common/loader/throttling_url_loader.h"
 #include "url/origin.h"
 
 namespace {
@@ -133,6 +134,10 @@ BraveProxyingURLLoaderFactory<T>::InProgressRequest::InProgressRequest(
       &BraveProxyingURLLoaderFactory<T>::InProgressRequest::OnRequestError,
       weak_factory_.GetWeakPtr(),
       network::URLLoaderCompletionStatus(net::ERR_ABORTED)));
+  proxied_loader_receiver_.set_disconnect_with_reason_handler(
+      base::BindOnce(&BraveProxyingURLLoaderFactory<
+                         T>::InProgressRequest::OnLoaderDisconnected,
+                     weak_factory_.GetWeakPtr()));
 }
 
 template <template <typename> class T>
@@ -146,6 +151,24 @@ template <template <typename> class T>
 void BraveProxyingURLLoaderFactory<T>::InProgressRequest::Restart() {
   UpdateRequestInfo();
   RestartInternal();
+}
+
+template <template <typename> class T>
+void BraveProxyingURLLoaderFactory<T>::InProgressRequest::OnLoaderDisconnected(
+    uint32_t custom_reason,
+    const std::string& description) {
+  if (custom_reason == network::mojom::URLLoader::kClientDisconnectReason &&
+      description == blink::ThrottlingURLLoader::kFollowRedirectReason) {
+    // Propagate the redirect-restart signal to the inner loader
+    // (WebRequestProxyingURLLoaderFactory) so it can call
+    // DisassociateProxyWithRequestId and allow the next loader to register.
+    if (target_loader_.is_bound()) {
+      target_loader_.ResetWithReason(custom_reason, description);
+    }
+    factory_->RemoveRequest(this);
+  } else {
+    OnRequestError(network::URLLoaderCompletionStatus(net::ERR_ABORTED));
+  }
 }
 
 template <template <typename> class T>

--- a/browser/net/brave_proxying_url_loader_factory.h
+++ b/browser/net/brave_proxying_url_loader_factory.h
@@ -74,6 +74,17 @@ class BraveProxyingURLLoaderFactory : public network::mojom::URLLoaderFactory {
     ~InProgressRequest() override;
 
     void Restart();
+    // Called when ThrottlingURLLoader disconnects our proxied_loader_receiver_.
+    // For redirect-restart disconnects (kFollowRedirectReason), we forward the
+    // same disconnect reason to target_loader_ so that any inner proxy layer
+    // (e.g. WebRequestProxyingURLLoaderFactory) also receives the signal and
+    // can clean up its request-ID bookkeeping before the restarted loader
+    // registers the same ID. Without this propagation the inner proxy's
+    // AssociateProxyWithRequestId check fails on the new request, causing the
+    // navigation to hang. See
+    // https://github.com/brave/brave-browser/issues/56271.
+    void OnLoaderDisconnected(uint32_t custom_reason,
+                              const std::string& description);
 
     // network::mojom::URLLoader:
     void FollowRedirect(

--- a/browser/net/brave_proxying_url_loader_factory_browsertest.cc
+++ b/browser/net/brave_proxying_url_loader_factory_browsertest.cc
@@ -1,0 +1,156 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "base/strings/string_util.h"
+#include "extensions/buildflags/buildflags.h"
+#include "net/dns/mock_host_resolver.h"
+#include "net/http/http_status_code.h"
+#include "net/test/embedded_test_server/http_request.h"
+#include "net/test/embedded_test_server/http_response.h"
+
+#if BUILDFLAG(ENABLE_EXTENSIONS)
+#include "chrome/browser/extensions/chrome_test_extension_loader.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+#include "extensions/common/extension.h"
+#include "extensions/test/test_extension_dir.h"
+#include "url/gurl.h"
+#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+
+namespace {
+
+// Handles GET /redirect-to-extension?ext=<extension-id> and replies with a
+// server-side 302 redirect to chrome-extension://<extension-id>/callback.html.
+// The extension ID is embedded in the query string so this handler is
+// stateless and safe to invoke from the IO thread.
+std::unique_ptr<net::test_server::HttpResponse> HandleExtensionRedirectRequest(
+    const net::test_server::HttpRequest& request) {
+  static constexpr std::string_view kPrefix = "/redirect-to-extension?ext=";
+  if (!base::StartsWith(request.relative_url, kPrefix)) {
+    return nullptr;
+  }
+  const std::string ext_id = request.relative_url.substr(kPrefix.size());
+  auto response = std::make_unique<net::test_server::BasicHttpResponse>();
+  response->set_code(net::HTTP_FOUND);
+  response->AddCustomHeader(
+      "Location", "chrome-extension://" + ext_id + "/callback.html?code=test");
+  return response;
+}
+
+}  // namespace
+
+#if BUILDFLAG(ENABLE_EXTENSIONS)
+
+// Regression tests for https://github.com/brave/brave-browser/issues/56271
+//
+// A server-side (302) redirect from an HTTP page to a chrome-extension://
+// web_accessible_resource should navigate successfully.
+class BraveProxyingURLLoaderFactoryBrowserTest : public InProcessBrowserTest {
+ public:
+  BraveProxyingURLLoaderFactoryBrowserTest() = default;
+  ~BraveProxyingURLLoaderFactoryBrowserTest() override = default;
+
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+    host_resolver()->AddRule("*", "127.0.0.1");
+
+    // Handlers must be registered before Start().
+    embedded_test_server()->RegisterRequestHandler(
+        base::BindRepeating(&HandleExtensionRedirectRequest));
+    ASSERT_TRUE(embedded_test_server()->Start());
+
+    LoadTestExtension();
+  }
+
+ protected:
+  const std::string& extension_id() const { return extension_id_; }
+
+ private:
+  void LoadTestExtension() {
+    // MV3 extension with a single web_accessible_resource (callback.html)
+    // accessible from any origin — the minimal repro from the bug report.
+    test_extension_dir_.WriteManifest(R"json({
+      "name": "Test Redirect Callback Extension",
+      "manifest_version": 3,
+      "version": "0.1",
+      "web_accessible_resources": [{
+        "resources": ["callback.html"],
+        "matches": ["<all_urls>"]
+      }]
+    })json");
+    test_extension_dir_.WriteFile(
+        FILE_PATH_LITERAL("callback.html"),
+        "<html><body>Callback page loaded</body></html>");
+
+    extensions::ChromeTestExtensionLoader loader(browser()->profile());
+    scoped_refptr<const extensions::Extension> extension =
+        loader.LoadExtension(test_extension_dir_.UnpackedPath());
+    ASSERT_TRUE(extension) << "Failed to load test extension";
+    extension_id_ = extension->id();
+  }
+
+  // Must outlive the loaded extension.
+  extensions::TestExtensionDir test_extension_dir_;
+  std::string extension_id_;
+};
+
+// Verifies that a server-side 302 redirect from HTTP to a
+// chrome-extension:// web_accessible_resource completes and the extension
+// page commits in the active tab.
+//
+// Regression test for https://github.com/brave/brave-browser/issues/56271.
+IN_PROC_BROWSER_TEST_F(BraveProxyingURLLoaderFactoryBrowserTest,
+                       ServerRedirectToExtensionWebAccessibleResourceLoads) {
+  // Embed the extension ID in the query string so the server-side handler can
+  // build the Location header without accessing UI-thread state.
+  const GURL redirect_url = embedded_test_server()->GetURL(
+      "/redirect-to-extension?ext=" + extension_id());
+  const GURL expected_extension_url =
+      GURL("chrome-extension://" + extension_id() + "/callback.html?code=test");
+
+  // NavigateToURL follows the 302 and waits for the final page to load.
+  // If the regression is present this call hangs indefinitely because
+  // the chrome-extension:// URL loader is never started.
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), redirect_url));
+
+  content::WebContents* web_contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+  EXPECT_EQ(expected_extension_url, web_contents->GetLastCommittedURL());
+  EXPECT_FALSE(web_contents->IsLoading());
+}
+
+// Same scenario navigated in a new foreground tab to rule out any
+// single-tab-specific quirks in the loader lifecycle.
+//
+// Regression test for https://github.com/brave/brave-browser/issues/56271.
+IN_PROC_BROWSER_TEST_F(BraveProxyingURLLoaderFactoryBrowserTest,
+                       ServerRedirectToExtensionInNewTabLoads) {
+  const GURL redirect_url = embedded_test_server()->GetURL(
+      "/redirect-to-extension?ext=" + extension_id());
+  const GURL expected_extension_url =
+      GURL("chrome-extension://" + extension_id() + "/callback.html?code=test");
+
+  content::RenderFrameHost* rfh = ui_test_utils::NavigateToURLWithDisposition(
+      browser(), redirect_url, WindowOpenDisposition::NEW_FOREGROUND_TAB,
+      ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
+  ASSERT_TRUE(rfh);
+  content::WebContents* new_tab =
+      content::WebContents::FromRenderFrameHost(rfh);
+  ASSERT_TRUE(new_tab);
+  EXPECT_EQ(expected_extension_url, new_tab->GetLastCommittedURL());
+  EXPECT_FALSE(new_tab->IsLoading());
+}
+
+#endif  // BUILDFLAG(ENABLE_EXTENSIONS)


### PR DESCRIPTION
BraveProxyingURLLoaderFactory now registers a disconnect-with-reason handler that forwards the same (kClientDisconnectReason, kFollowRedirectReason) signal to target_loader_.

Without this, WebRequestProxyingURLLoaderFactory never received the signal. Its [OnLoaderDisconnected](https://source.chromium.org/chromium/chromium/src/+/main:extensions/browser/api/web_request/web_request_proxying_url_loader_factory.cc;l=1394) was therefore never called. When the navigation then restarted (i.e after the redirect) a new loader for chrome-extension:// was created but never it was never started. This was because of this upstream [change](https://chromium-review.googlesource.com/c/chromium/src/+/7868857/8/extensions/browser/api/web_request/web_request_proxying_url_loader_factory.cc) which caused CreateLoaderAndStart to return early, hanging the navigation indefinitely. 

This change also adds a browser test (BraveProxyingURLLoaderFactoryBrowserTest) that exercises two scenarios — active tab and new foreground tab — to prevent regression.  The fix and the browser tests was created with the help of Claude Sonnet 4.6. The fix seems reasonable to me which adds the missing disconnect handler from the upstream [WebRequestProxyingURLLoaderFactory::InProgressRequest](https://source.chromium.org/chromium/chromium/src/+/main:extensions/browser/api/web_request/web_request_proxying_url_loader_factory.cc;l=195;) to [BraveProxyingURLLoaderFactory<T>::InProgressRequest](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/browser/net/brave_proxying_url_loader_factory.cc?L132), that would allow to properly remove the old request and create a new one with the same request id. The browser tests also shows the hanging behaviour if we remove `proxied_loader_receiver_.set_disconnect_with_reason_handler` and passes when re-added. 

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56271

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
