### PR TITLE
[AI Chat] Fix content agent form controls not being targetable

### DIFF
--- a/browser/ai_chat/BUILD.gn
+++ b/browser/ai_chat/BUILD.gn
@@ -474,6 +474,7 @@ source_set("browser_tests") {
       "//brave/test/data/ai_chat/youtubei/v1/player_dir/default.json",
       "//brave/test/data/ai_chat/youtubei/v1/player_dir/video_id_001.json",
       "//brave/test/data/ai_chat/youtubei/v1/player_dir/video_id_002.json",
+      "//brave/test/data/leo/content_agent_form.html",
     ]
 
     if (enable_brave_ai_chat_agent_profile) {

--- a/browser/ai_chat/content_agent_tool_provider_browsertest.cc
+++ b/browser/ai_chat/content_agent_tool_provider_browsertest.cc
@@ -6,16 +6,26 @@
 #include "brave/browser/ai_chat/content_agent_tool_provider.h"
 
 #include <memory>
+#include <string>
 #include <vector>
 
+#include "base/files/file_path.h"
+#include "base/json/json_writer.h"
+#include "base/path_service.h"
+#include "base/strings/strcat.h"
+#include "base/strings/string_split.h"
+#include "base/strings/string_util.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/test_future.h"
+#include "base/values.h"
 #include "brave/browser/ai_chat/ai_chat_agent_profile_helper.h"
 #include "brave/components/ai_chat/core/browser/tools/tool.h"
 #include "brave/components/ai_chat/core/browser/utils.h"
 #include "brave/components/ai_chat/core/common/features.h"
+#include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
 #include "brave/components/ai_chat/core/common/test_utils.h"
+#include "brave/components/constants/brave_paths.h"
 #include "chrome/browser/actor/actor_keyed_service_factory.h"
 #include "chrome/browser/actor/actor_proto_conversion.h"
 #include "chrome/browser/glic/actor/glic_actor_policy_checker.h"
@@ -38,6 +48,71 @@
 
 namespace ai_chat {
 
+namespace {
+
+// Concatenate the text of all text content blocks in a tool result.
+std::string GetContentBlocksText(const Tool::ToolResult& blocks) {
+  std::string text;
+  for (const auto& block : blocks) {
+    if (block && block->is_text_content_block()) {
+      base::StrAppend(&text, {block->get_text_content_block()->text, "\n"});
+    }
+  }
+  return text;
+}
+
+// Returns the single line within `text` that contains `needle`, or an empty
+// string if not found. The page structure serializes each element's opening
+// tag (with all of its attributes) on its own line, so this lets us assert on
+// the attributes of a specific element.
+std::string GetLineContaining(const std::string& text,
+                              const std::string& needle) {
+  size_t pos = text.find(needle);
+  if (pos == std::string::npos) {
+    return std::string();
+  }
+  size_t line_start = text.rfind('\n', pos);
+  line_start = (line_start == std::string::npos) ? 0 : line_start + 1;
+  size_t line_end = text.find('\n', pos);
+  if (line_end == std::string::npos) {
+    line_end = text.size();
+  }
+  return text.substr(line_start, line_end - line_start);
+}
+
+// Returns the opening tag line of the element whose visible text is `text`.
+// Visible text is serialized as a nested <text> node, so the element that owns
+// the text (e.g. a button) is the nearest preceding open tag that is neither a
+// closing tag nor a <text> wrapper. This lets a test target an element the way
+// a user would refer to it - by its visible label - rather than by an
+// incidental attribute.
+std::string GetElementLineForText(const std::string& structure,
+                                  std::string_view text) {
+  const std::vector<std::string_view> lines = base::SplitStringPiece(
+      structure, "\n", base::KEEP_WHITESPACE, base::SPLIT_WANT_ALL);
+  size_t text_line = lines.size();
+  for (size_t i = 0; i < lines.size(); ++i) {
+    if (lines[i].find(text) != std::string_view::npos) {
+      text_line = i;
+      break;
+    }
+  }
+  if (text_line == lines.size()) {
+    return std::string();
+  }
+  for (size_t i = text_line + 1; i-- > 0;) {
+    std::string_view line =
+        base::TrimWhitespaceASCII(lines[i], base::TRIM_LEADING);
+    if (base::StartsWith(line, "<") && !base::StartsWith(line, "</") &&
+        !base::StartsWith(line, "<text")) {
+      return std::string(line);
+    }
+  }
+  return std::string();
+}
+
+}  // namespace
+
 class ContentAgentToolProviderBrowserTest : public InProcessBrowserTest {
  public:
   ContentAgentToolProviderBrowserTest() {
@@ -52,7 +127,15 @@ class ContentAgentToolProviderBrowserTest : public InProcessBrowserTest {
     InProcessBrowserTest::SetUpOnMainThread();
 
     host_resolver()->AddRule("*", "127.0.0.1");
+    // Also serve Brave's test data (in addition to the default chrome/test/data
+    // handlers) so tests can load fixtures from //brave/test/data/leo. The
+    // navigation tool only navigates to https:// URLs, so serve over https too.
+    const base::FilePath leo_dir =
+        base::PathService::CheckedGet(brave::DIR_TEST_DATA).AppendASCII("leo");
+    embedded_test_server()->ServeFilesFromDirectory(leo_dir);
+    embedded_https_test_server().ServeFilesFromDirectory(leo_dir);
     ASSERT_TRUE(embedded_test_server()->Start());
+    ASSERT_TRUE(embedded_https_test_server().Start());
 
     // Create the agent profile
     auto* profile = browser()->profile();
@@ -106,6 +189,54 @@ class ContentAgentToolProviderBrowserTest : public InProcessBrowserTest {
     ASSERT_TRUE(tab_handle.Get());
     content::WebContents* web_contents = tab_handle.Get()->GetContents();
     ASSERT_TRUE(content::NavigateToURL(web_contents, url));
+  }
+
+  // Helper to find a tool by name
+  base::WeakPtr<Tool> FindToolByName(std::string_view name) {
+    for (auto& tool : tool_provider_->GetTools()) {
+      if (tool && tool->Name() == name) {
+        return tool;
+      }
+    }
+    return nullptr;
+  }
+
+  // Navigates the agent's tab to `url` using the navigation tool and returns
+  // the serialized page structure (the XML representation) from the tool
+  // result. The surrounding page metadata and interaction instructions are
+  // excluded so that assertions only match the page structure and not, for
+  // example, the page title or the description of the
+  // "dom_id"/"clickable"/"editable" attributes.
+  std::string NavigateAndGetPageStructure(const GURL& url) {
+    // TODO(https://github.com/brave/brave-browser/issues/49928): Creating a tab
+    // handle first avoids a race condition with the browser window
+    // initializing.
+    EXPECT_TRUE(GetToolProviderTabHandle().Get());
+
+    base::WeakPtr<Tool> navigation_tool =
+        FindToolByName(mojom::kNavigateToolName);
+    EXPECT_TRUE(navigation_tool);
+    if (!navigation_tool) {
+      return std::string();
+    }
+
+    base::DictValue input;
+    input.Set("website_url", url.spec());
+    base::test::TestFuture<Tool::ToolResult, Tool::ToolArtifacts> result_future;
+    navigation_tool->UseTool(*base::WriteJson(input),
+                             result_future.GetCallback());
+    auto [result, artifacts] = result_future.Take();
+    EXPECT_TRUE(artifacts.empty());
+
+    const std::string page_content = GetContentBlocksText(result);
+    static constexpr char kStructureHeader[] =
+        "=== PAGE STRUCTURE (XML representation) ===";
+    const size_t start = page_content.find(kStructureHeader);
+    if (start == std::string::npos) {
+      return std::string();
+    }
+    const size_t end = page_content.find("=== INTERACTION INSTRUCTIONS", start);
+    return page_content.substr(start, end - start);
   }
 
   // Helper to create a valid Actions proto for testing
@@ -247,6 +378,56 @@ IN_PROC_BROWSER_TEST_F(ContentAgentToolProviderBrowserTest,
   EXPECT_TRUE(artifacts.empty());
 
   EXPECT_THAT(result, ContentBlockText(testing::HasSubstr("No root node")));
+}
+
+// The navigation tool's page content reports text input form controls (the
+// title and description fields) with a dom_id and as clickable, and exposes
+// their editable region as a separate node with a dom_id and the editable
+// attribute. The fields are nested inside several single-child containers.
+IN_PROC_BROWSER_TEST_F(ContentAgentToolProviderBrowserTest,
+                       PageContentReportsTargetableFormControls) {
+  const std::string structure = NavigateAndGetPageStructure(
+      embedded_https_test_server().GetURL("/content_agent_form.html"));
+  SCOPED_TRACE(structure);
+
+  // The title text input is targetable (has a dom_id) and clickable.
+  const std::string title_line =
+      GetLineContaining(structure, "placeholder=\"Title\"");
+  ASSERT_FALSE(title_line.empty());
+  EXPECT_THAT(title_line, testing::HasSubstr("<input"));
+  EXPECT_THAT(title_line, testing::HasSubstr("dom_id="));
+  EXPECT_THAT(title_line, testing::HasSubstr("clickable"));
+
+  // The description textarea is likewise targetable and clickable.
+  const std::string description_line =
+      GetLineContaining(structure, "placeholder=\"Describe the issue\"");
+  ASSERT_FALSE(description_line.empty());
+  EXPECT_THAT(description_line, testing::HasSubstr("<input"));
+  EXPECT_THAT(description_line, testing::HasSubstr("dom_id="));
+  EXPECT_THAT(description_line, testing::HasSubstr("clickable"));
+
+  // The editable region of a form control is targetable for text input: it has
+  // a dom_id and the editable attribute.
+  const std::string editable_line = GetLineContaining(structure, " editable");
+  ASSERT_FALSE(editable_line.empty());
+  EXPECT_THAT(editable_line, testing::HasSubstr("dom_id="));
+}
+
+// The navigation tool's page content reports the submit button with a dom_id
+// and as clickable, so it can be targeted.
+IN_PROC_BROWSER_TEST_F(ContentAgentToolProviderBrowserTest,
+                       PageContentReportsTargetableButton) {
+  const std::string structure = NavigateAndGetPageStructure(
+      embedded_https_test_server().GetURL("/content_agent_form.html"));
+  SCOPED_TRACE(structure);
+
+  // The submit button (identified by its visible "Create" text) is targetable
+  // (has a dom_id) and clickable.
+  const std::string button_line = GetElementLineForText(structure, "Create");
+  ASSERT_FALSE(button_line.empty());
+  EXPECT_THAT(button_line, testing::HasSubstr("<input"));
+  EXPECT_THAT(button_line, testing::HasSubstr("dom_id="));
+  EXPECT_THAT(button_line, testing::HasSubstr("clickable"));
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/content/browser/annotated_page_content_test_util.cc
+++ b/components/ai_chat/content/browser/annotated_page_content_test_util.cc
@@ -350,14 +350,20 @@ ContentNodeBuilder& ContentNodeBuilder::AsCanvas() {
 ContentNodeBuilder& ContentNodeBuilder::MakeClickable(int dom_id) {
   auto* attrs = node_.mutable_content_attributes();
   attrs->set_common_ancestor_dom_node_id(dom_id);
-  attrs->mutable_interaction_info()->set_is_clickable(true);
+  // The deprecated `is_clickable` boolean is no longer populated by Chromium;
+  // actionability is expressed via `clickability_reasons`.
+  attrs->mutable_interaction_info()->add_clickability_reasons(
+      optimization_guide::proto::CLICKABILITY_REASON_CLICK_HANDLER);
   return *this;
 }
 
 ContentNodeBuilder& ContentNodeBuilder::MakeEditable(int dom_id) {
   auto* attrs = node_.mutable_content_attributes();
   attrs->set_common_ancestor_dom_node_id(dom_id);
-  attrs->mutable_interaction_info()->set_is_editable(true);
+  // The deprecated `is_editable` boolean is no longer populated by Chromium;
+  // editability is expressed via the EDITABLE clickability reason.
+  attrs->mutable_interaction_info()->add_clickability_reasons(
+      optimization_guide::proto::CLICKABILITY_REASON_EDITABLE);
   return *this;
 }
 

--- a/components/ai_chat/content/browser/page_content_blocks.cc
+++ b/components/ai_chat/content/browser/page_content_blocks.cc
@@ -26,8 +26,29 @@ using optimization_guide::proto::AnnotatedPageContent;
 using optimization_guide::proto::ContentAttributes;
 using optimization_guide::proto::ContentAttributeType;
 using optimization_guide::proto::ContentNode;
+using optimization_guide::proto::InteractionInfo;
 
 constexpr size_t kMaxTreeStringLength = 100000;
+
+// Actionability is expressed through the `clickability_reasons` list, so the
+// signals must be derived from it
+bool IsNodeEditable(const InteractionInfo& interaction) {
+  for (int reason : interaction.clickability_reasons()) {
+    if (reason == optimization_guide::proto::CLICKABILITY_REASON_EDITABLE) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool IsNodeClickable(const InteractionInfo& interaction) {
+  for (int reason : interaction.clickability_reasons()) {
+    if (reason != optimization_guide::proto::CLICKABILITY_REASON_EDITABLE) {
+      return true;
+    }
+  }
+  return false;
+}
 
 bool ShouldFlattenContainer(const ContentNode& node) {
   // Only consider flattening if there's exactly one child
@@ -39,7 +60,7 @@ bool ShouldFlattenContainer(const ContentNode& node) {
   const auto& interaction = attrs.interaction_info();
   // Flatten non-interactive containers with only 1 child
   // but don't consider focusable, selectable and draggable for now
-  if (interaction.is_clickable() || interaction.is_editable()) {
+  if (IsNodeClickable(interaction) || IsNodeEditable(interaction)) {
     return false;
   }
 
@@ -112,7 +133,7 @@ std::string BuildAttributes(const ContentAttributes& attrs,
       }
     }
     if (!is_interactive &&
-        (interaction.is_clickable() || interaction.is_editable())) {
+        (IsNodeClickable(interaction) || IsNodeEditable(interaction))) {
       // ignore selectable, focusable and draggable for now
       is_interactive = true;
     }
@@ -128,10 +149,10 @@ std::string BuildAttributes(const ContentAttributes& attrs,
   // Add interaction capabilities
   if (attrs.has_interaction_info()) {
     const auto& interaction = attrs.interaction_info();
-    if (interaction.is_clickable()) {
+    if (IsNodeClickable(interaction)) {
       attr_result.append(" clickable");
     }
-    if (interaction.is_editable()) {
+    if (IsNodeEditable(interaction)) {
       attr_result.append(" editable");
     }
     if (interaction.has_scroller_info()) {

--- a/test/data/leo/content_agent_form.html
+++ b/test/data/leo/content_agent_form.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Create new issue</title>
+  </head>
+  <body>
+    <!-- Form controls are deliberately nested inside several single-child
+         containers, mirroring real sites (e.g. GitHub's "new issue" page) where
+         the title and description fields were not being assigned a dom_id and so
+         could not be targeted by the content agent. -->
+    <div class="page">
+      <div class="form-wrapper">
+        <form aria-label="issueform">
+          <div class="field">
+            <div class="control">
+              <label>
+                Add a title
+                <span class="input-wrapper">
+                  <input
+                    id="title"
+                    name="title"
+                    type="text"
+                    placeholder="Title"
+                    aria-label="Add a title"
+                  >
+                </span>
+              </label>
+            </div>
+          </div>
+          <div class="field">
+            <div class="control">
+              <label>
+                Add a description
+                <textarea
+                  id="description"
+                  name="description"
+                  rows="6"
+                  placeholder="Describe the issue"
+                  aria-label="Add a description"
+                ></textarea>
+              </label>
+            </div>
+          </div>
+          <button id="create" type="submit">Create</button>
+        </form>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
The content agent serialized page content using the deprecated InteractionInfo.is_clickable / is_editable proto fields, which Chromium no longer populates (actionability moved to the clickability_reasons list). As a result no element was considered interactive, so dom_id and clickable/editable were only ever emitted for the root node and form fields (e.g. GitHub's issue title) could not be targeted.

Derive the clickable/editable signals from clickability_reasons instead: editable when the EDITABLE reason is present, clickable when any other reason is present (so an inner editable region reads as "editable" rather than redundantly "clickable editable").

Update the annotated page content test util to populate clickability_reasons like real Chromium for unit tests.

Add browser tests that loads a sample page and asserts the inputs and their editable regions are assigned a dom_id.
Also add a browser test for buttons since we didn't have such a test previously.

- Fixes https://github.com/brave/brave-browser/issues/56358
- Fixes https://github.com/brave/brave-browser/issues/56360



https://github.com/user-attachments/assets/b7882275-4e8a-46fe-8ede-d4ef3977ff03




<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
