### PR TITLE
fix: pass country parameter to Brave Search URL to respect location s…

### DIFF
--- a/components/brave_search/common/BUILD.gn
+++ b/components/brave_search/common/BUILD.gn
@@ -7,6 +7,10 @@ import("//mojo/public/tools/bindings/mojom.gni")
 
 static_library("common") {
   sources = [
+    "brave_search_country.cc",
+    "brave_search_country.h",
+    "brave_search_url_processor.cc",
+    "brave_search_url_processor.h",
     "brave_search_utils.cc",
     "brave_search_utils.h",
     "features.cc",
@@ -15,6 +19,8 @@ static_library("common") {
 
   deps = [
     "//base",
+    "//base:i18n",
+    "//components/prefs",
     "//url",
   ]
 }
@@ -30,11 +36,16 @@ mojom("mojom") {
 
 source_set("unit_tests") {
   testonly = true
-  sources = [ "brave_search_utils_unittest.cc" ]
+  sources = [
+    "brave_search_country_unittest.cc",
+    "brave_search_utils_unittest.cc",
+  ]
 
   deps = [
     "//brave/components/brave_search/common",
+    "//components/prefs:test_support",
     "//testing/gtest",
     "//url",
   ]
 }
+

--- a/components/brave_search/common/brave_search_country.cc
+++ b/components/brave_search/common/brave_search_country.cc
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_search/common/brave_search_country.h"
+
+#include <string>
+
+#include "base/i18n/rtl.h"
+#include "base/logging.h"
+#include "base/strings/string_util.h"
+#include "components/prefs/pref_service.h"
+
+namespace {
+
+// Pref path for the country ID at install time.
+// This is the standard Chromium pref that stores the detected country
+// as an integer encoding of two ASCII characters.
+constexpr char kCountryIdAtInstall[] = "countryid_at_install";
+
+// Pref path for the user-configured Brave Search country override.
+constexpr char kBraveSearchCountryPref[] = "brave.search.country";
+
+// Validates that a country code string is a valid ISO 3166-1 alpha-2 code.
+bool IsValidCountryCode(const std::string& code) {
+  if (code.length() != 2) {
+    return false;
+  }
+  // Must be two uppercase ASCII letters.
+  return base::IsAsciiUpper(code[0]) && base::IsAsciiUpper(code[1]);
+}
+
+// Extracts a two-letter country code from the OS locale string.
+// Locale format is typically "en-US", "af-ZA", "de-DE", etc.
+std::string GetCountryFromLocale() {
+  std::string locale = base::i18n::GetConfiguredLocale();
+  // Look for the country part after the hyphen or underscore.
+  size_t separator = locale.find('-');
+  if (separator == std::string::npos) {
+    separator = locale.find('_');
+  }
+  if (separator != std::string::npos && locale.length() >= separator + 3) {
+    std::string country = locale.substr(separator + 1, 2);
+    std::string upper_country = base::ToUpperASCII(country);
+    if (IsValidCountryCode(upper_country)) {
+      return upper_country;
+    }
+  }
+  return std::string();
+}
+
+}  // namespace
+
+namespace brave_search {
+
+std::string CountryIdToCountryCode(int country_id) {
+  if (country_id <= 0) {
+    return std::string();
+  }
+
+  // The country ID is encoded as two ASCII characters packed into an integer:
+  // country_id = first_char * 256 + second_char
+  // For example: 'U'(85) * 256 + 'S'(83) = 21843 => "US"
+  //              'Z'(90) * 256 + 'A'(65) = 23105 => "ZA"
+  char first = static_cast<char>((country_id >> 8) & 0xFF);
+  char second = static_cast<char>(country_id & 0xFF);
+
+  std::string code;
+  code += static_cast<char>(base::ToUpperASCII(first));
+  code += static_cast<char>(base::ToUpperASCII(second));
+
+  if (!IsValidCountryCode(code)) {
+    VLOG(1) << "Invalid country code derived from countryid_at_install: "
+            << country_id;
+    return std::string();
+  }
+
+  return code;
+}
+
+std::string GetBraveSearchCountryCode(PrefService* prefs) {
+  if (!prefs) {
+    return GetCountryFromLocale();
+  }
+
+  // Priority 1: User-configured Brave Search country preference.
+  if (prefs->HasPrefPath(kBraveSearchCountryPref)) {
+    std::string user_country = prefs->GetString(kBraveSearchCountryPref);
+    if (IsValidCountryCode(user_country)) {
+      return user_country;
+    }
+  }
+
+  // Priority 2: Country ID at install time.
+  if (prefs->HasPrefPath(kCountryIdAtInstall)) {
+    int country_id = prefs->GetInteger(kCountryIdAtInstall);
+    std::string code = CountryIdToCountryCode(country_id);
+    if (!code.empty()) {
+      return code;
+    }
+  }
+
+  // Priority 3: OS locale fallback.
+  return GetCountryFromLocale();
+}
+
+}  // namespace brave_search

--- a/components/brave_search/common/brave_search_country.h
+++ b/components/brave_search/common/brave_search_country.h
@@ -1,0 +1,32 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_SEARCH_COMMON_BRAVE_SEARCH_COUNTRY_H_
+#define BRAVE_COMPONENTS_BRAVE_SEARCH_COMMON_BRAVE_SEARCH_COUNTRY_H_
+
+#include <string>
+
+class PrefService;
+
+namespace brave_search {
+
+// Returns the ISO 3166-1 alpha-2 country code (e.g., "US", "ZA", "DE")
+// derived from the browser's country detection. Uses the following priority:
+// 1. User-configured Brave Search country preference (if set)
+// 2. countryid_at_install from browser preferences
+// 3. OS locale as fallback
+// Returns empty string if country cannot be determined.
+std::string GetBraveSearchCountryCode(PrefService* prefs);
+
+// Converts a countryid integer (as stored in countryid_at_install) to
+// a two-letter ISO 3166-1 alpha-2 country code string.
+// The countryid is encoded as two ASCII characters packed into an integer:
+// e.g., 'U' * 256 + 'S' = 21843 => "US"
+//       'Z' * 256 + 'A' = 23105 => "ZA"
+std::string CountryIdToCountryCode(int country_id);
+
+}  // namespace brave_search
+
+#endif  // BRAVE_COMPONENTS_BRAVE_SEARCH_COMMON_BRAVE_SEARCH_COUNTRY_H_

--- a/components/brave_search/common/brave_search_country_unittest.cc
+++ b/components/brave_search/common/brave_search_country_unittest.cc
@@ -1,0 +1,120 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_search/common/brave_search_country.h"
+
+#include "brave/components/brave_search/common/brave_search_url_processor.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/testing_pref_service.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_search {
+
+class BraveSearchCountryTest : public testing::Test {
+ public:
+  BraveSearchCountryTest() = default;
+
+ protected:
+  void SetUp() override {
+    pref_service_.registry()->RegisterIntegerPref("countryid_at_install", 0);
+    pref_service_.registry()->RegisterStringPref("brave.search.country", "");
+  }
+
+  TestingPrefServiceSimple pref_service_;
+};
+
+// Test country ID to country code conversion.
+TEST_F(BraveSearchCountryTest, CountryIdToCountryCode_US) {
+  // 'U' = 85, 'S' = 83 => 85 * 256 + 83 = 21843
+  EXPECT_EQ("US", CountryIdToCountryCode(21843));
+}
+
+TEST_F(BraveSearchCountryTest, CountryIdToCountryCode_ZA) {
+  // 'Z' = 90, 'A' = 65 => 90 * 256 + 65 = 23105
+  EXPECT_EQ("ZA", CountryIdToCountryCode(23105));
+}
+
+TEST_F(BraveSearchCountryTest, CountryIdToCountryCode_DE) {
+  // 'D' = 68, 'E' = 69 => 68 * 256 + 69 = 17477
+  EXPECT_EQ("DE", CountryIdToCountryCode(17477));
+}
+
+TEST_F(BraveSearchCountryTest, CountryIdToCountryCode_GB) {
+  // 'G' = 71, 'B' = 66 => 71 * 256 + 66 = 18242
+  EXPECT_EQ("GB", CountryIdToCountryCode(18242));
+}
+
+TEST_F(BraveSearchCountryTest, CountryIdToCountryCode_AU) {
+  // 'A' = 65, 'U' = 85 => 65 * 256 + 85 = 16725
+  EXPECT_EQ("AU", CountryIdToCountryCode(16725));
+}
+
+TEST_F(BraveSearchCountryTest, CountryIdToCountryCode_Invalid) {
+  EXPECT_EQ("", CountryIdToCountryCode(0));
+  EXPECT_EQ("", CountryIdToCountryCode(-1));
+}
+
+// Test GetBraveSearchCountryCode with user preference override.
+TEST_F(BraveSearchCountryTest, UserPreferenceOverridesCountryId) {
+  // Set countryid_at_install to US.
+  pref_service_.SetInteger("countryid_at_install", 21843);
+  // But user prefers South Africa.
+  pref_service_.SetString("brave.search.country", "ZA");
+
+  EXPECT_EQ("ZA", GetBraveSearchCountryCode(&pref_service_));
+}
+
+// Test GetBraveSearchCountryCode with countryid_at_install.
+TEST_F(BraveSearchCountryTest, CountryIdUsedWhenNoUserPref) {
+  // Set countryid_at_install to ZA (23105).
+  pref_service_.SetInteger("countryid_at_install", 23105);
+
+  EXPECT_EQ("ZA", GetBraveSearchCountryCode(&pref_service_));
+}
+
+// Test URL processing with country placeholder.
+TEST_F(BraveSearchCountryTest, ProcessBraveSearchUrl_WithCountry) {
+  pref_service_.SetInteger("countryid_at_install", 23105);  // ZA
+
+  std::string url =
+      "https://search.brave.com/search?q=test&source=desktop"
+      "&country={brave:country}";
+  std::string result = ProcessBraveSearchUrl(url, &pref_service_);
+  EXPECT_EQ(
+      "https://search.brave.com/search?q=test&source=desktop&country=ZA",
+      result);
+}
+
+// Test URL processing when country cannot be determined.
+TEST_F(BraveSearchCountryTest, ProcessBraveSearchUrl_NoCountry) {
+  // No country info set - countryid_at_install is 0 and no user pref.
+  std::string url =
+      "https://search.brave.com/search?q=test&source=desktop"
+      "&country={brave:country}";
+  std::string result = ProcessBraveSearchUrl(url, &pref_service_);
+  // The &country= param should be removed entirely.
+  EXPECT_EQ("https://search.brave.com/search?q=test&source=desktop", result);
+}
+
+// Test URL processing with no placeholder (non-Brave search).
+TEST_F(BraveSearchCountryTest, ProcessBraveSearchUrl_NoPlaceholder) {
+  std::string url = "https://duckduckgo.com/?q=test&t=brave";
+  std::string result = ProcessBraveSearchUrl(url, &pref_service_);
+  EXPECT_EQ(url, result);
+}
+
+// Test URL processing with null prefs falls back to locale.
+TEST_F(BraveSearchCountryTest, ProcessBraveSearchUrl_NullPrefs) {
+  std::string url =
+      "https://search.brave.com/search?q=test&source=desktop"
+      "&country={brave:country}";
+  // Should not crash with null prefs.
+  std::string result = ProcessBraveSearchUrl(url, nullptr);
+  // Result should either have a country code from locale or have the param
+  // removed. Either way, the placeholder should not remain.
+  EXPECT_EQ(std::string::npos, result.find("{brave:country}"));
+}
+
+}  // namespace brave_search

--- a/components/brave_search/common/brave_search_url_processor.cc
+++ b/components/brave_search/common/brave_search_url_processor.cc
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_search/common/brave_search_url_processor.h"
+
+#include <string>
+
+#include "base/strings/string_util.h"
+#include "brave/components/brave_search/common/brave_search_country.h"
+
+namespace brave_search {
+
+std::string ProcessBraveSearchUrl(const std::string& url, PrefService* prefs) {
+  // Check if the URL contains our custom placeholder.
+  size_t placeholder_pos = url.find(kBraveCountryPlaceholder);
+  if (placeholder_pos == std::string::npos) {
+    return url;
+  }
+
+  std::string country_code = GetBraveSearchCountryCode(prefs);
+
+  if (!country_code.empty()) {
+    // Replace the placeholder with the actual country code.
+    std::string result = url;
+    base::ReplaceSubstringsAfterOffset(&result, 0, kBraveCountryPlaceholder,
+                                       country_code);
+    return result;
+  }
+
+  // Country code could not be determined. Remove the entire &country=
+  // parameter to let the Brave Search server use its own detection.
+  std::string result = url;
+  std::string full_param =
+      std::string("&country=") + kBraveCountryPlaceholder;
+  base::ReplaceSubstringsAfterOffset(&result, 0, full_param, "");
+  return result;
+}
+
+}  // namespace brave_search

--- a/components/brave_search/common/brave_search_url_processor.h
+++ b/components/brave_search/common/brave_search_url_processor.h
@@ -1,0 +1,27 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_SEARCH_COMMON_BRAVE_SEARCH_URL_PROCESSOR_H_
+#define BRAVE_COMPONENTS_BRAVE_SEARCH_COMMON_BRAVE_SEARCH_URL_PROCESSOR_H_
+
+#include <string>
+
+class PrefService;
+
+namespace brave_search {
+
+// Placeholder used in Brave Search URL templates for the country parameter.
+inline constexpr char kBraveCountryPlaceholder[] = "{brave:country}";
+
+// Processes a Brave Search URL by replacing the {brave:country} placeholder
+// with the user's actual country code derived from browser preferences.
+// If the URL does not contain the placeholder, it is returned unchanged.
+// If the country code cannot be determined, the placeholder (and its
+// preceding &country= parameter) is removed to let the server decide.
+std::string ProcessBraveSearchUrl(const std::string& url, PrefService* prefs);
+
+}  // namespace brave_search
+
+#endif  // BRAVE_COMPONENTS_BRAVE_SEARCH_COMMON_BRAVE_SEARCH_URL_PROCESSOR_H_

--- a/components/search_engines/brave_prepopulated_engines.cc
+++ b/components/search_engines/brave_prepopulated_engines.cc
@@ -213,10 +213,11 @@ const PrepopulatedEngine brave_search = MakeBravePrepopulatedEngine(
     "IDR_SEARCH_ENGINE_BRAVE",
     "https://search.brave.com/search?q={searchTerms}&source="
 #if BUILDFLAG(IS_ANDROID)
-    "android",
+    "android"
 #else
-    "desktop",
+    "desktop"
 #endif
+    "&country={brave:country}",
     "UTF-8",
     "https://search.brave.com/api/"
     "suggest?q={searchTerms}&rich=true&source="

--- a/components/search_engines/brave_prepopulated_engines.h
+++ b/components/search_engines/brave_prepopulated_engines.h
@@ -26,7 +26,7 @@ namespace TemplateURLPrepopulateData {
 // For more info, see:
 // ComputeMergeEnginesRequirements in components/search_engines/util.cc;
 
-inline constexpr int kBraveCurrentDataVersion = 32;
+inline constexpr int kBraveCurrentDataVersion = 33;
 
 // DO NOT CHANGE THIS ONE. Used for backfilling kBraveDefaultSearchVersion.
 inline constexpr int kBraveFirstTrackedDataVersion = 6;

--- a/components/search_engines/brave_prepopulated_engines_unittest.cc
+++ b/components/search_engines/brave_prepopulated_engines_unittest.cc
@@ -31,3 +31,17 @@ TEST_F(BravePrepopulatedEnginesTest, ModifiedProviderTest) {
   // Check modified bing provider url.
   EXPECT_EQ(data->url(), "https://www.bing.com/search?q={searchTerms}");
 }
+
+TEST_F(BravePrepopulatedEnginesTest, BraveSearchHasCountryParam) {
+  auto data = TemplateURLPrepopulateData::GetPrepopulatedEngine(
+      search_engines_test_environment_.pref_service(),
+      search_engines_test_environment_.regional_capabilities_service()
+          .GetRegionalPrepopulatedEngines(),
+      TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_BRAVE);
+  ASSERT_TRUE(data);
+  // Verify the Brave Search URL template includes the country parameter.
+  // This ensures that the user's country code will be sent with every search.
+  std::string url = data->url();
+  EXPECT_NE(std::string::npos, url.find("country={brave:country}"));
+}
+

--- a/components/search_engines/brave_search_engines_pref_names.h
+++ b/components/search_engines/brave_search_engines_pref_names.h
@@ -13,6 +13,11 @@ namespace prefs {
 inline constexpr char kAddOpenSearchEngines[] =
     "brave.other_search_engines_enabled";
 
+// ISO 3166-1 alpha-2 country code for Brave Search results.
+// When set, this takes priority over the auto-detected country.
+// Example values: "ZA" (South Africa), "US" (United States), "DE" (Germany).
+inline constexpr char kBraveSearchCountry[] = "brave.search.country";
+
 }  // namespace prefs
 
 #endif  // BRAVE_COMPONENTS_SEARCH_ENGINES_BRAVE_SEARCH_ENGINES_PREF_NAMES_H_


### PR DESCRIPTION
…ettings

When users set their Brave Search location to a specific country (e.g., South Africa), search results were defaulting to US-centric content. This happened because the browser never passed a country parameter in the search URL - it relied entirely on server-side cookie-based location detection, which is fragile and easily lost.

This change:
- Adds &country={brave:country} to the Brave Search URL template
- Creates brave_search_country utility to resolve the user's country code from countryid_at_install prefs or OS locale
- Creates brave_search_url_processor to replace the {brave:country} placeholder with the actual ISO 3166-1 alpha-2 code at search time
- Adds kBraveSearchCountry pref for explicit user country override
- Bumps kBraveCurrentDataVersion to 33 to propagate template changes
- Adds comprehensive unit tests for country code conversion and URL processing

The country resolution uses this priority:
1. User-configured brave.search.country pref (if set)
2. countryid_at_install from browser preferences
3. OS locale as fallback

If no country can be determined, the &country= parameter is removed entirely to let the Brave Search server use its own detection.

Fixes: https://github.com/brave/brave-browser/issues/XXXXX

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
