### PR TITLE
Fixed build failure from side_panel.h

### DIFF
--- a/browser/ai_chat/ai_chat_ui_browsertest.cc
+++ b/browser/ai_chat/ai_chat_ui_browsertest.cc
@@ -31,6 +31,7 @@
 #include "chrome/browser/ui/side_panel/side_panel_ui.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/side_panel/side_panel.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h"
 #include "chrome/common/chrome_paths.h"
 #include "chrome/common/pref_names.h"

--- a/browser/ui/brave_browser_command_controller_browsertest.cc
+++ b/browser/ui/brave_browser_command_controller_browsertest.cc
@@ -73,6 +73,7 @@
 #include "chrome/browser/ui/side_panel/side_panel_enums.h"
 #include "chrome/browser/ui/side_panel/side_panel_ui.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/side_panel/side_panel.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_coordinator.h"
 #endif
 

--- a/browser/ui/views/frame/BUILD.gn
+++ b/browser/ui/views/frame/BUILD.gn
@@ -49,6 +49,7 @@ source_set("frame_impl") {
     "//chrome/browser/profiles:profile",
     "//chrome/browser/ui/browser_window",
     "//chrome/browser/ui/tabs:tab_strip",
+    "//chrome/browser/ui/views/side_panel",
     "//chrome/common:constants",
     "//components/prefs",
     "//components/split_tabs",

--- a/browser/ui/views/frame/brave_contents_view_util.cc
+++ b/browser/ui/views/frame/brave_contents_view_util.cc
@@ -14,6 +14,7 @@
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/browser/ui/views/side_panel/side_panel.h"
 #include "chrome/common/pref_names.h"
 #include "components/prefs/pref_service.h"
 #include "components/split_tabs/split_tab_id.h"

--- a/browser/ui/views/side_panel/sources.gni
+++ b/browser/ui/views/side_panel/sources.gni
@@ -5,7 +5,8 @@
 
 import("//brave/browser/ui/sidebar/buildflags/buildflags.gni")
 
-brave_browser_ui_views_side_panel_deps =
+brave_browser_ui_views_side_panel_deps = []
+brave_browser_ui_views_side_panel_public_deps =
     [ "//brave/browser/ui/sidebar/buildflags" ]
 
 if (enable_sidebar_v2) {

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view.h
@@ -11,7 +11,6 @@
 #include "build/build_config.h"
 #include "chrome/browser/ui/exclusive_access/exclusive_access_context.h"
 #include "chrome/browser/ui/views/frame/shadow_overlay_view.h"
-#include "chrome/browser/ui/views/side_panel/side_panel.h"
 
 #define BrowserViewLayoutDelegateImplOld                        \
   BrowserViewLayoutDelegateImplOld;                             \

--- a/patches/chrome-browser-ui-views-side_panel-BUILD.gn.patch
+++ b/patches/chrome-browser-ui-views-side_panel-BUILD.gn.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/browser/ui/views/side_panel/BUILD.gn b/chrome/browser/ui/views/side_panel/BUILD.gn
-index a17f1908734fac900b56de764f7b1d801564359d..f1ce1cd10229ed625c82ab5c9db1902aa4142208 100644
+index a17f1908734fac900b56de764f7b1d801564359d..acc1d6b12129fa69389412be3895fd83d1fdad20 100644
 --- a/chrome/browser/ui/views/side_panel/BUILD.gn
 +++ b/chrome/browser/ui/views/side_panel/BUILD.gn
 @@ -173,6 +173,7 @@ source_set("side_panel") {
      "//ui/webui",
    ]
  
-+  import("//brave/browser/ui/views/side_panel/sources.gni") deps += brave_browser_ui_views_side_panel_deps
++  import("//brave/browser/ui/views/side_panel/sources.gni") deps += brave_browser_ui_views_side_panel_deps public_deps += brave_browser_ui_views_side_panel_public_deps
    if (enable_extensions) {
      public_deps += [
        "//extensions/browser",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves - no issue. simple build fix

`/brave/browser/ui/sidebar/buildflags` should be in public_deps.

```
05:31:05  In file included from ../../chrome/browser/lens/region_search/lens_region_search_controller.cc:17:
05:31:05  In file included from ../../brave/chromium_src/chrome/browser/ui/views/frame/browser_view.h:14:
05:31:05  ../../brave/chromium_src/chrome/browser/ui/views/side_panel/side_panel.h:11:10: fatal error: 'brave/browser/ui/sidebar/buildflags/buildflags.h' file not found
05:31:05     11 | #include "brave/browser/ui/sidebar/buildflags/buildflags.h"
05:31:05        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
05:31:05  1 error generated.
```

Also removed unnecessary `side_panel.h` including from `browser_view.h`.
and added missing `side_panel.h` includings. It was hidden due to unnecessary including from browser_view.h

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
