### PR TITLE
[asan] Dispose vertical tab strip's context menu

### DIFF
--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -33,6 +33,7 @@
 #include "brave/components/vector_icons/vector_icons.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/themes/theme_properties.h"
+#include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
 #include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
@@ -378,6 +379,11 @@ BraveVerticalTabStripRegionView::BraveVerticalTabStripRegionView(
   }
 
   widget_observation_.Observe(browser_view->GetWidget());
+
+  // Subscribe browser closing event, so we can dispose of the context menu.
+  browser_did_close_subscription_ = browser_->RegisterBrowserDidClose(
+      base::BindRepeating(&BraveVerticalTabStripRegionView::OnBrowserClosing,
+                          base::Unretained(this)));
 
   // Note: This should happen after all the PrefMembers have been initialized.
   OnFloatingModePrefChanged();
@@ -1255,6 +1261,14 @@ void BraveVerticalTabStripRegionView::ShowContextMenuForViewImpl(
 }
 
 void BraveVerticalTabStripRegionView::OnMenuClosed() {
+  menu_runner_.reset();
+}
+
+void BraveVerticalTabStripRegionView::OnBrowserClosing(
+    BrowserWindowInterface* browser) {
+  // Resetting the context menu at this stage, as `SystemMenuModelBuilder` is
+  // destroyed during `browser_widget_.reset()`, so we want to tear down our
+  // menu runner before that happens.
   menu_runner_.reset();
 }
 

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 
+#include "base/callback_list.h"
 #include "base/functional/callback_helpers.h"
 #include "base/gtest_prod_util.h"
 #include "base/memory/weak_ptr.h"
@@ -32,6 +33,7 @@ class MenuRunner;
 
 class BraveNewTabButton;
 class BrowserView;
+class BrowserWindowInterface;
 class FullscreenController;
 class TabStyle;
 
@@ -184,6 +186,10 @@ class BraveVerticalTabStripRegionView : public views::View,
 
   void OnMenuClosed();
 
+  // Subscription to `RegisterBrowserDidClose`. We use this event to handle the
+  // lifetime of `menu_runner_`.
+  void OnBrowserClosing(BrowserWindowInterface* browser);
+
   // Callback that is called when collapse animation ends. We update visibility
   // of this view if it's needed
   void OnCollapseAnimationEnded();
@@ -245,6 +251,10 @@ class BraveVerticalTabStripRegionView : public views::View,
   BooleanPrefMember vertical_tab_on_right_;
 
   std::unique_ptr<views::MenuRunner> menu_runner_;
+
+  // A subscription to `Browser::RegisterBrowserDidClose`, to manage the
+  // lifetime of `menu_runner_`.
+  base::CallbackListSubscription browser_did_close_subscription_;
 
   base::WeakPtrFactory<BraveVerticalTabStripRegionView> weak_factory_{this};
 };

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_root_view_browsertest.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_root_view_browsertest.cc
@@ -10,6 +10,7 @@
 #include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h"
 #include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_widget_delegate_view.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
+#include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/views/frame/browser_frame_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/tabs/tab_strip.h"
@@ -167,9 +168,9 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripRootViewBrowserTest,
                   .EqualsIgnoringRef(url));
 }
 
-// Flaky on Mac.
-// System menu is used on Windows.
-#if BUILDFLAG(IS_MAC) || BUILDFLAG(IS_WIN)
+// System menu is used on Windows, so the menu_runner_ path under test does not
+// apply there.
+#if BUILDFLAG(IS_WIN)
 #define MAYBE_ContextMenuInUnobscuredRegion \
   DISABLED_ContextMenuInUnobscuredRegion
 #else
@@ -190,4 +191,34 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripRootViewBrowserTest,
       vtab_strip_root_view, gfx::Point(), ui::mojom::MenuSourceType::kMouse);
 
   EXPECT_TRUE(vtab_strip_root_view->IsMenuShowing());
+}
+
+// Teesting menu tear down for `menu_runner_`, which is only used on
+// non-Windows platforms.
+#if BUILDFLAG(IS_WIN)
+#define MAYBE_CloseBrowserWithContextMenuOpen \
+  DISABLED_CloseBrowserWithContextMenuOpen
+#else
+#define MAYBE_CloseBrowserWithContextMenuOpen CloseBrowserWithContextMenuOpen
+#endif
+IN_PROC_BROWSER_TEST_F(VerticalTabStripRootViewBrowserTest,
+                       MAYBE_CloseBrowserWithContextMenuOpen) {
+  ToggleVerticalTabStrip();
+
+  ASSERT_TRUE(tabs::utils::ShouldShowBraveVerticalTabs(browser()));
+
+  auto* region_view =
+      vtab_tab_strip_widget_delegate_view()->vertical_tab_strip_region_view();
+  ASSERT_FALSE(region_view->IsMenuShowing());
+
+  region_view->ShowContextMenuForView(region_view, gfx::Point(),
+                                      ui::mojom::MenuSourceType::kMouse);
+  ASSERT_TRUE(region_view->IsMenuShowing());
+
+  // Keep the browser process alive after the target browser is closed.
+  ASSERT_TRUE(CreateBrowser(browser()->profile()));
+
+  // Closing the browser must not use the system menu model after it has been
+  // freed.
+  CloseBrowserSynchronously(browser());
 }


### PR DESCRIPTION
This PR makes the lifetime of the context menu for
`BraveVerticalTabStripRegionView` a bit more explicit, but making sure
we dispose of it during `OnBrowserClosing`. This avoid potential issues
during browser shutdown.

If the browser is closed while this menu is open, BrowserView::
DeleteBrowserWindow() resets browser_widget_, freeing the SimpleMenuModel
during ~BrowserWidget member cleanup. The base ~Widget then runs
HandleWidgetDestroying(), which drives the still-open menu's
MenuController -> MenuModelAdapter::WillHideMenu(), dereferencing the
freed model.

We now cancel the menu at a early stage, via
Browser::RegisterBrowserDidClose, which fires from
Browser::OnWindowClosing(), before browser deletion is scheduled.

This change also re-enables one other test that had been disabled due to
flakiness, as this seems to be associated.

Fixed: https://github.com/brave/internal/issues/1770
