### PR TITLE
Implement restoration of tree tab structure

### DIFF
--- a/browser/sessions/brave_session_restore_browsertest.cc
+++ b/browser/sessions/brave_session_restore_browsertest.cc
@@ -19,6 +19,7 @@
 #include "brave/browser/ui/tabs/tree_tab_model.h"
 #include "brave/components/tabs/public/tree_tab_node.h"
 #include "brave/components/tabs/public/tree_tab_node_tab_collection.h"
+#include "chrome/browser/prefs/session_startup_pref.h"
 #include "chrome/browser/sessions/session_service.h"
 #include "chrome/browser/sessions/session_service_factory.h"
 #include "chrome/browser/sessions/tab_restore_service_factory.h"
@@ -35,7 +36,6 @@
 #include "components/sessions/core/session_types.h"
 #include "components/sessions/core/tab_restore_service.h"
 #include "components/sessions/core/tab_restore_types.h"
-#include "components/tabs/public/tab_collection.h"
 #include "components/tabs/public/tab_interface.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/test/browser_test.h"
@@ -215,36 +215,19 @@ class BraveTreeTabSessionRestoreBrowserTest : public InProcessBrowserTest {
   }
 
   // Returns the tree node id string for the tab at |index|, or an empty string
-  // if the tab is not inside a tree node. Mirrors the GetTreeTabNodeCollection
-  // helper used by TreeTabSessionManager.
+  // if the tab is not inside a tree node.
   std::string GetTreeNodeIdForTab(int index) {
-    const tabs::TabInterface* tab =
-        brave_tab_strip_model()->GetTabAtIndex(index);
-    const tabs::TabCollection* parent = tab->GetParentCollection();
-    if (parent && parent->type() == tabs::TabCollection::Type::TREE_NODE) {
-      return static_cast<const tabs::TreeTabNodeTabCollection*>(parent)
-          ->node()
-          .id()
-          .ToString();
-    }
-    return std::string();
+    const tabs::TreeTabNodeTabCollection* tree_collection =
+        GetTreeCollectionForTab(index);
+    return tree_collection ? tree_collection->node().id().ToString()
+                           : std::string();
   }
 
   // Returns the TreeTabNodeTabCollection for the tab at |index|, or nullptr.
-  const tabs::TreeTabNodeTabCollection* GetTreeCollectionForTab(
-      BraveTabStripModel* model,
-      int index) {
-    const tabs::TabInterface* tab = model->GetTabAtIndex(index);
-    const tabs::TabCollection* parent = tab->GetParentCollection();
-    if (parent && parent->type() == tabs::TabCollection::Type::TREE_NODE) {
-      return static_cast<const tabs::TreeTabNodeTabCollection*>(parent);
-    }
-    return nullptr;
-  }
-
   // Convenience overload for the default browser().
   const tabs::TreeTabNodeTabCollection* GetTreeCollectionForTab(int index) {
-    return GetTreeCollectionForTab(brave_tab_strip_model(), index);
+    return tabs::TreeTabNodeTabCollection::GetTreeTabNodeCollection(
+        brave_tab_strip_model()->GetTabAtIndex(index));
   }
 
   SessionService* session_service() {
@@ -667,11 +650,26 @@ IN_PROC_BROWSER_TEST_F(BraveTreeTabSessionRestoreBrowserTest,
       << "Restored B must be nested under A's tree node";
 }
 
-// Verifies that closing a browser window containing a parent-child tree tab
-// pair and then restoring the window (AddRestoredTab path, same as session
-// restore on browser restart) reconstructs the tree hierarchy.
-IN_PROC_BROWSER_TEST_F(BraveTreeTabSessionRestoreBrowserTest,
-                       RestoreClosedWindowPreservesTreeTabHierarchy) {
+// Fixture for tree-tab tests that exercise real session restore across a
+// browser relaunch via PRE_ tests. Setting the startup preference to LAST makes
+// the next launch restore the previous session's tabs.
+class BraveTreeTabSessionRestoreOnRelaunchBrowserTest
+    : public BraveTreeTabSessionRestoreBrowserTest {
+ protected:
+  void SetUpOnMainThread() override {
+    BraveTreeTabSessionRestoreBrowserTest::SetUpOnMainThread();
+    SessionStartupPref::SetStartupPref(
+        browser()->profile(), SessionStartupPref(SessionStartupPref::LAST));
+  }
+};
+
+// Builds a parent-child tree tab hierarchy that the following (non-PRE_) test
+// verifies after a real browser relaunch. Forcing a full session rebuild
+// captures the tree extra-data on disk so the next launch can reconstruct the
+// hierarchy via the AddRestoredTab path (the same path as session restore on
+// browser restart).
+IN_PROC_BROWSER_TEST_F(BraveTreeTabSessionRestoreOnRelaunchBrowserTest,
+                       PRE_RestoreClosedWindowPreservesTreeTabHierarchy) {
   ASSERT_TRUE(brave_tab_strip_model()->tree_model());
 
   // Navigate tab A so the session records a committed entry for it.
@@ -695,44 +693,39 @@ IN_PROC_BROWSER_TEST_F(BraveTreeTabSessionRestoreBrowserTest,
   ASSERT_TRUE(wc_b);
   ASSERT_TRUE(content::NavigateToURL(wc_b, GURL("about:blank")));
 
-  // Verify initial hierarchy.
+  // Verify initial hierarchy before relaunch.
   const auto* coll_a = GetTreeCollectionForTab(0);
   const auto* coll_b = GetTreeCollectionForTab(1);
   ASSERT_TRUE(coll_a && coll_b);
   ASSERT_EQ(coll_b->GetParentCollection(), coll_a);
-  const std::string node_a_id = coll_a->node().id().ToString();
 
-  // Open a second browser so the app stays alive when browser() is closed.
-  Browser* second_browser = CreateBrowser(browser()->profile());
-  ASSERT_TRUE(second_browser);
+  // Force a full session rebuild so the tree extra-data is captured on disk
+  // (BuildCommandsForBrowser scans the live tree) regardless of any pending
+  // deferred kNodeCreated notifications. The session is restored on the next
+  // launch via the SessionStartupPref::LAST set in SetUpOnMainThread().
+  session_service()->ResetFromCurrentBrowsers();
+}
 
-  // Set up the observer before closing browser() so we don't miss the open
-  // event when the window is restored.
-  ui_test_utils::BrowserCreatedObserver browser_observer;
+// On relaunch the previous session is restored. AddRestoredTab is called for
+// each tab, exercising the same MaybeRestoreTabTreeHierarchy path as session
+// restore on browser restart; the tree hierarchy (B nested under A) must be
+// reconstructed.
+IN_PROC_BROWSER_TEST_F(BraveTreeTabSessionRestoreOnRelaunchBrowserTest,
+                       RestoreClosedWindowPreservesTreeTabHierarchy) {
+  ASSERT_TRUE(brave_tab_strip_model()->tree_model());
 
-  // Close browser() — this creates a WINDOW entry in TabRestoreService.
-  CloseBrowserSynchronously(browser());
+  auto* restored_model = brave_tab_strip_model();
 
-  // Restore the closed window. AddRestoredTab is called for each tab, which
-  // exercises the same MaybeRestoreTabTreeHierarchy path as session restore.
-  chrome::RestoreTab(second_browser);
-  Browser* restored_browser = browser_observer.Wait();
-  ASSERT_TRUE(restored_browser);
+  EXPECT_EQ(restored_model->count(), 3)
+      << "Restored window should have two more tabs";
 
-  // Wait until both tabs are present in the restored browser.
-  ASSERT_TRUE(base::test::RunUntil(
-      [&]() { return restored_browser->tab_strip_model()->count() == 2; }));
-
-  auto* restored_model =
-      static_cast<BraveTabStripModel*>(restored_browser->tab_strip_model());
-  const auto* restored_coll_a = GetTreeCollectionForTab(restored_model, 0);
-  const auto* restored_coll_b = GetTreeCollectionForTab(restored_model, 1);
+  const auto* restored_coll_a = GetTreeCollectionForTab(0);
+  const auto* restored_coll_b = GetTreeCollectionForTab(1);
   ASSERT_TRUE(restored_coll_a)
       << "Tab A must be inside a tree node in the restored window";
   ASSERT_TRUE(restored_coll_b)
       << "Tab B must be inside a tree node in the restored window";
-  EXPECT_EQ(restored_coll_a->node().id().ToString(), node_a_id)
-      << "A's node ID must match the original after window restore";
-  EXPECT_EQ(restored_coll_b->GetParentCollection(), restored_coll_a)
-      << "Restored B must be nested under A's tree node";
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return restored_coll_b->GetParentCollection() == restored_coll_a;
+  })) << "Restored B must be nested under A's tree node";
 }

--- a/browser/sessions/brave_session_restore_browsertest.cc
+++ b/browser/sessions/brave_session_restore_browsertest.cc
@@ -10,6 +10,7 @@
 #include "base/containers/map_util.h"
 #include "base/run_loop.h"
 #include "base/test/bind.h"
+#include "base/test/run_until.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/brave_browser_features.h"
 #include "brave/browser/sessions/brave_session_keys.h"
@@ -22,6 +23,7 @@
 #include "chrome/browser/sessions/session_service_factory.h"
 #include "chrome/browser/sessions/tab_restore_service_factory.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_commands.h"
 #include "chrome/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/tabs/tab_enums.h"
 #include "chrome/browser/ui/tabs/tab_model.h"
@@ -226,6 +228,23 @@ class BraveTreeTabSessionRestoreBrowserTest : public InProcessBrowserTest {
           .ToString();
     }
     return std::string();
+  }
+
+  // Returns the TreeTabNodeTabCollection for the tab at |index|, or nullptr.
+  const tabs::TreeTabNodeTabCollection* GetTreeCollectionForTab(
+      BraveTabStripModel* model,
+      int index) {
+    const tabs::TabInterface* tab = model->GetTabAtIndex(index);
+    const tabs::TabCollection* parent = tab->GetParentCollection();
+    if (parent && parent->type() == tabs::TabCollection::Type::TREE_NODE) {
+      return static_cast<const tabs::TreeTabNodeTabCollection*>(parent);
+    }
+    return nullptr;
+  }
+
+  // Convenience overload for the default browser().
+  const tabs::TreeTabNodeTabCollection* GetTreeCollectionForTab(int index) {
+    return GetTreeCollectionForTab(brave_tab_strip_model(), index);
   }
 
   SessionService* session_service() {
@@ -594,4 +613,126 @@ IN_PROC_BROWSER_TEST_F(BraveTreeTabSessionRestoreBrowserTest,
       base::FindOrNull(restored_tab->extra_data, kBraveTreeParentNodeIdKey));
   EXPECT_FALSE(
       base::FindOrNull(restored_tab->extra_data, kBraveTreeNodeCollapsedKey));
+}
+
+// Verifies that closing a child tree tab and restoring it via Ctrl+Shift+T
+// (ReplaceRestoredTab path) puts the tab back under its original parent node.
+IN_PROC_BROWSER_TEST_F(BraveTreeTabSessionRestoreBrowserTest,
+                       RestoreClosedTreeChildTabRestoresHierarchy) {
+  ASSERT_TRUE(brave_tab_strip_model()->tree_model());
+
+  // Build A (root at 0) -> B (child of A at 1).
+  auto* tab_a_iface = browser()->tab_strip_model()->GetTabAtIndex(0);
+  {
+    auto tab_b = std::make_unique<tabs::TabModel>(
+        content::WebContents::Create(
+            content::WebContents::CreateParams(browser()->profile())),
+        browser()->tab_strip_model());
+    tab_b->set_opener(tab_a_iface);
+    brave_tab_strip_model()->AddTab(
+        std::move(tab_b), -1, ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  }
+  // Navigate B so TabRestoreService records it (tabs with no committed entry
+  // are skipped during capture).
+  content::WebContents* wc_b =
+      browser()->tab_strip_model()->GetWebContentsAt(1);
+  ASSERT_TRUE(wc_b);
+  ASSERT_TRUE(content::NavigateToURL(wc_b, GURL("about:blank")));
+
+  // Verify the initial hierarchy before closing.
+  const auto* coll_a = GetTreeCollectionForTab(0);
+  const auto* coll_b = GetTreeCollectionForTab(1);
+  ASSERT_TRUE(coll_a && coll_b);
+  ASSERT_EQ(coll_b->GetParentCollection(), coll_a)
+      << "B should be nested under A before close";
+
+  // Record A's node ID — it must survive the close+restore cycle unchanged.
+  const std::string node_a_id = coll_a->node().id().ToString();
+
+  // Close B (CLOSE_CREATE_HISTORICAL_TAB populates TabRestoreService).
+  browser()->tab_strip_model()->CloseWebContentsAt(
+      1, TabCloseTypes::CLOSE_CREATE_HISTORICAL_TAB);
+  ASSERT_EQ(1, browser()->tab_strip_model()->count());
+
+  // Restore B via chrome::RestoreTab (Ctrl+Shift+T equivalent).
+  ui_test_utils::TabAddedWaiter tab_added_waiter(browser());
+  chrome::RestoreTab(browser());
+  tab_added_waiter.Wait();
+  ASSERT_EQ(2, browser()->tab_strip_model()->count());
+
+  // After restoration, B's tree node must still be nested under A's tree node.
+  const auto* restored_coll_b = GetTreeCollectionForTab(1);
+  ASSERT_TRUE(restored_coll_b) << "Restored tab B must be inside a tree node";
+  EXPECT_EQ(restored_coll_b->GetParentCollection(), coll_a)
+      << "Restored B must be nested under A's tree node";
+}
+
+// Verifies that closing a browser window containing a parent-child tree tab
+// pair and then restoring the window (AddRestoredTab path, same as session
+// restore on browser restart) reconstructs the tree hierarchy.
+IN_PROC_BROWSER_TEST_F(BraveTreeTabSessionRestoreBrowserTest,
+                       RestoreClosedWindowPreservesTreeTabHierarchy) {
+  ASSERT_TRUE(brave_tab_strip_model()->tree_model());
+
+  // Navigate tab A so the session records a committed entry for it.
+  content::WebContents* wc_a =
+      browser()->tab_strip_model()->GetWebContentsAt(0);
+  ASSERT_TRUE(content::NavigateToURL(wc_a, GURL("about:blank")));
+
+  // Build A (root at 0) -> B (child of A at 1).
+  auto* tab_a_iface = browser()->tab_strip_model()->GetTabAtIndex(0);
+  {
+    auto tab_b = std::make_unique<tabs::TabModel>(
+        content::WebContents::Create(
+            content::WebContents::CreateParams(browser()->profile())),
+        browser()->tab_strip_model());
+    tab_b->set_opener(tab_a_iface);
+    brave_tab_strip_model()->AddTab(
+        std::move(tab_b), -1, ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  }
+  content::WebContents* wc_b =
+      browser()->tab_strip_model()->GetWebContentsAt(1);
+  ASSERT_TRUE(wc_b);
+  ASSERT_TRUE(content::NavigateToURL(wc_b, GURL("about:blank")));
+
+  // Verify initial hierarchy.
+  const auto* coll_a = GetTreeCollectionForTab(0);
+  const auto* coll_b = GetTreeCollectionForTab(1);
+  ASSERT_TRUE(coll_a && coll_b);
+  ASSERT_EQ(coll_b->GetParentCollection(), coll_a);
+  const std::string node_a_id = coll_a->node().id().ToString();
+
+  // Open a second browser so the app stays alive when browser() is closed.
+  Browser* second_browser = CreateBrowser(browser()->profile());
+  ASSERT_TRUE(second_browser);
+
+  // Set up the observer before closing browser() so we don't miss the open
+  // event when the window is restored.
+  ui_test_utils::BrowserCreatedObserver browser_observer;
+
+  // Close browser() — this creates a WINDOW entry in TabRestoreService.
+  CloseBrowserSynchronously(browser());
+
+  // Restore the closed window. AddRestoredTab is called for each tab, which
+  // exercises the same MaybeRestoreTabTreeHierarchy path as session restore.
+  chrome::RestoreTab(second_browser);
+  Browser* restored_browser = browser_observer.Wait();
+  ASSERT_TRUE(restored_browser);
+
+  // Wait until both tabs are present in the restored browser.
+  ASSERT_TRUE(base::test::RunUntil(
+      [&]() { return restored_browser->tab_strip_model()->count() == 2; }));
+
+  auto* restored_model =
+      static_cast<BraveTabStripModel*>(restored_browser->tab_strip_model());
+  const auto* restored_coll_a = GetTreeCollectionForTab(restored_model, 0);
+  const auto* restored_coll_b = GetTreeCollectionForTab(restored_model, 1);
+  ASSERT_TRUE(restored_coll_a)
+      << "Tab A must be inside a tree node in the restored window";
+  ASSERT_TRUE(restored_coll_b)
+      << "Tab B must be inside a tree node in the restored window";
+  EXPECT_EQ(restored_coll_a->node().id().ToString(), node_a_id)
+      << "A's node ID must match the original after window restore";
+  EXPECT_EQ(restored_coll_b->GetParentCollection(), restored_coll_a)
+      << "Restored B must be nested under A's tree node";
 }

--- a/browser/ui/tabs/brave_tree_tab_strip_collection_delegate.cc
+++ b/browser/ui/tabs/brave_tree_tab_strip_collection_delegate.cc
@@ -138,6 +138,7 @@ void BraveTreeTabStripCollectionDelegate::WrapCollectionInTreeNodeAndInsert(
     std::optional<tab_groups::TabGroupId> parent_group) {
   auto wrapper = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(), std::move(collection),
+      base::BindRepeating(&TreeTabModel::AddTreeTabNode, tree_tab_model_),
       base::BindRepeating(&TreeTabModel::RemoveTreeTabNode, tree_tab_model_),
       base::BindRepeating(&TreeTabModel::OnTreeTabNodeMoved, tree_tab_model_));
   InsertTreeNodeWrapperAt(std::move(wrapper), index, pinned, parent_group);
@@ -150,6 +151,7 @@ void BraveTreeTabStripCollectionDelegate::WrapCollectionInTreeNodeAndInsert(
     std::optional<tab_groups::TabGroupId> parent_group) {
   auto wrapper = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(), std::move(collection),
+      base::BindRepeating(&TreeTabModel::AddTreeTabNode, tree_tab_model_),
       base::BindRepeating(&TreeTabModel::RemoveTreeTabNode, tree_tab_model_),
       base::BindRepeating(&TreeTabModel::OnTreeTabNodeMoved, tree_tab_model_));
   InsertTreeNodeWrapperAt(std::move(wrapper), index, pinned, parent_group);
@@ -424,6 +426,7 @@ void BraveTreeTabStripCollectionDelegate::AddTabAsTreeNodeToCollection(
 #endif
   auto tree_tab_node = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(), std::move(tab),
+      base::BindRepeating(&TreeTabModel::AddTreeTabNode, tree_tab_model_),
       base::BindRepeating(&TreeTabModel::RemoveTreeTabNode, tree_tab_model_),
       base::BindRepeating(&TreeTabModel::OnTreeTabNodeMoved, tree_tab_model_));
   auto* tree_tab_node_ptr = tree_tab_node.get();
@@ -466,6 +469,7 @@ void BraveTreeTabStripCollectionDelegate::AddTabToUnpinnedCollectionAsTreeNode(
   CHECK(detached_tab);
   auto tree_tab_node = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(), std::move(detached_tab),
+      base::BindRepeating(&TreeTabModel::AddTreeTabNode, tree_tab_model_),
       base::BindRepeating(&TreeTabModel::RemoveTreeTabNode, tree_tab_model_),
       base::BindRepeating(&TreeTabModel::OnTreeTabNodeMoved, tree_tab_model_));
   auto* tree_tab_node_ptr = tree_tab_node.get();
@@ -755,6 +759,7 @@ void BraveTreeTabStripCollectionDelegate::AttachDetachedGroupCollection(
   CHECK(group);
   auto wrapper = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(), std::move(group),
+      base::BindRepeating(&TreeTabModel::AddTreeTabNode, tree_tab_model_),
       base::BindRepeating(&TreeTabModel::RemoveTreeTabNode, tree_tab_model_),
       base::BindRepeating(&TreeTabModel::OnTreeTabNodeMoved, tree_tab_model_));
   tabs::TreeTabNode& node = wrapper->node();
@@ -1021,6 +1026,8 @@ void BraveTreeTabStripCollectionDelegate::MoveTabsOutOfGroup(
                 tree_node = std::make_unique<tabs::TreeTabNodeTabCollection>(
                     tree_tab::TreeTabNodeId::GenerateNew(),
                     std::move(detached_tab),
+                    base::BindRepeating(&TreeTabModel::AddTreeTabNode,
+                                        tree_tab_model_),
                     base::BindRepeating(&TreeTabModel::RemoveTreeTabNode,
                                         tree_tab_model_),
                     base::BindRepeating(&TreeTabModel::OnTreeTabNodeMoved,
@@ -1217,6 +1224,7 @@ void BraveTreeTabStripCollectionDelegate::UnpinSplit(
 
   auto tree_node_collection = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(), std::move(owned_split_collection),
+      base::BindRepeating(&TreeTabModel::AddTreeTabNode, tree_tab_model_),
       base::BindRepeating(&TreeTabModel::RemoveTreeTabNode, tree_tab_model_),
       base::BindRepeating(&TreeTabModel::OnTreeTabNodeMoved, tree_tab_model_));
   auto* tree_node_ptr = tree_node_collection.get();
@@ -1264,6 +1272,7 @@ void BraveTreeTabStripCollectionDelegate::UnpinTabs(
     // Wraps with tree node.
     auto tree_tab_node = std::make_unique<tabs::TreeTabNodeTabCollection>(
         tree_tab::TreeTabNodeId::GenerateNew(), std::move(detached_tab),
+        base::BindRepeating(&TreeTabModel::AddTreeTabNode, tree_tab_model_),
         base::BindRepeating(&TreeTabModel::RemoveTreeTabNode, tree_tab_model_),
         base::BindRepeating(&TreeTabModel::OnTreeTabNodeMoved,
                             tree_tab_model_));
@@ -1459,6 +1468,7 @@ bool BraveTreeTabStripCollectionDelegate::CreateSplit(
   // Wrap split in a single tree node and insert at the original position.
   auto wrapper = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(), std::move(split),
+      base::BindRepeating(&TreeTabModel::AddTreeTabNode, tree_tab_model_),
       base::BindRepeating(&TreeTabModel::RemoveTreeTabNode, tree_tab_model_),
       base::BindRepeating(&TreeTabModel::OnTreeTabNodeMoved, tree_tab_model_));
   auto& node = wrapper->node();

--- a/browser/ui/tabs/test/tree_tab_node_tab_collection_unittest.cc
+++ b/browser/ui/tabs/test/tree_tab_node_tab_collection_unittest.cc
@@ -48,7 +48,7 @@ TEST_F(TreeTabNodeTabCollectionUnitTest, Constructor) {
   EXPECT_DEATH(tabs::TreeTabNodeTabCollection(
                    tree_tab::TreeTabNodeId::CreateEmpty(),
                    std::make_unique<MockTabInterfaceWithWeakPtr>(),
-                   base::DoNothing(), base::DoNothing()),
+                   base::DoNothing(), base::DoNothing(), base::DoNothing()),
                "");
 
   // Valid construction with a tab should succeed.
@@ -57,7 +57,7 @@ TEST_F(TreeTabNodeTabCollectionUnitTest, Constructor) {
   auto mock_tab_interface_ptr = mock_tab_interface.get();
   tabs::TreeTabNodeTabCollection tree_tab_node_tab_collection(
       tree_tab_node_id, std::move(mock_tab_interface), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
 
   // Check that the tabs::TreeTabNodeTabCollection is constructed correctly.
   EXPECT_EQ(tree_tab_node_id, tree_tab_node_tab_collection.node().id());
@@ -75,7 +75,7 @@ TEST_F(TreeTabNodeTabCollectionUnitTest, CanNotBeAddedToPinnedCollection) {
   auto tree_tab_node = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
   tabs::PinnedTabCollection pinned_collection;
 
   // Verify that adding a tabs::TreeTabNodeTabCollection to a
@@ -90,7 +90,7 @@ TEST_F(TreeTabNodeTabCollectionUnitTest, CanBeAddedToUnpinnedCollection) {
   auto tree_tab_node = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
   auto tree_tab_node_ptr = tree_tab_node.get();
   tabs::UnpinnedTabCollection unpinned_collection;
   unpinned_collection.AddCollection(std::move(tree_tab_node), 0);
@@ -106,11 +106,11 @@ TEST_F(TreeTabNodeTabCollectionUnitTest, CanAddAnotherTreeTabNodeRecursively) {
   auto parent_tree_tab_node = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
   auto child_tree_tab_node = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
   auto child_tree_tab_node_ptr = child_tree_tab_node.get();
 
   parent_tree_tab_node->AddCollection(std::move(child_tree_tab_node), 0);
@@ -124,7 +124,7 @@ TEST_F(TreeTabNodeTabCollectionUnitTest, CanAddGroupCollection) {
   tabs::TreeTabNodeTabCollection tree_tab_node(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
 
   // Create a TabGroupTabCollection and add it to the
   // tabs::TreeTabNodeTabCollection.
@@ -144,7 +144,7 @@ TEST_F(TreeTabNodeTabCollectionUnitTest, CanAddSplitTabCollection) {
   tabs::TreeTabNodeTabCollection tree_tab_node(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
 
   // Create a SplitTabCollection and add it to the
   // tabs::TreeTabNodeTabCollection.
@@ -164,7 +164,7 @@ TEST_F(TreeTabNodeTabCollectionUnitTest, LevelAndHeight_SingleRootNode) {
   auto tree_tab_node = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
   auto* node_ptr = tree_tab_node.get();
   tabs::UnpinnedTabCollection unpinned_collection;
   unpinned_collection.AddCollection(std::move(tree_tab_node), 0);
@@ -178,11 +178,11 @@ TEST_F(TreeTabNodeTabCollectionUnitTest, LevelAndHeight_RootWithOneTreeChild) {
   auto parent = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
   auto child = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
   tabs::TreeTabNodeTabCollection* child_ptr = child.get();
 
   parent->AddCollection(std::move(child), 0);
@@ -199,15 +199,15 @@ TEST_F(TreeTabNodeTabCollectionUnitTest, LevelAndHeight_ChainOfThree) {
   auto root = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
   auto child1 = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
   auto child2 = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
   tabs::TreeTabNodeTabCollection* child1_ptr = child1.get();
   tabs::TreeTabNodeTabCollection* child2_ptr = child2.get();
 
@@ -231,15 +231,15 @@ TEST_F(TreeTabNodeTabCollectionUnitTest, LevelAndHeight_Reparenting) {
   auto parent1 = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
   auto parent2 = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
   auto node = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
 
   tabs::TreeTabNodeTabCollection* parent1_ptr = parent1.get();
   tabs::TreeTabNodeTabCollection* parent2_ptr = parent2.get();
@@ -286,19 +286,19 @@ TEST_F(TreeTabNodeTabCollectionUnitTest, LevelAndHeight_ReparentingSubtree) {
   auto parent1 = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
   auto parent2 = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
   auto middle = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
   auto leaf = std::make_unique<tabs::TreeTabNodeTabCollection>(
       tree_tab::TreeTabNodeId::GenerateNew(),
       std::make_unique<MockTabInterfaceWithWeakPtr>(), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
 
   tabs::TreeTabNodeTabCollection* parent1_ptr = parent1.get();
   tabs::TreeTabNodeTabCollection* parent2_ptr = parent2.get();

--- a/browser/ui/tabs/tree_tab_session_manager.cc
+++ b/browser/ui/tabs/tree_tab_session_manager.cc
@@ -9,10 +9,12 @@
 #include <string>
 
 #include "base/check.h"
+#include "base/containers/map_util.h"
 #include "base/feature_list.h"
 #include "brave/browser/sessions/brave_session_keys.h"
 #include "brave/browser/ui/tabs/brave_tab_strip_model.h"
 #include "brave/components/tabs/public/tree_tab_node.h"
+#include "brave/components/tabs/public/tree_tab_node_id.h"
 #include "brave/components/tabs/public/tree_tab_node_tab_collection.h"
 #include "chrome/browser/sessions/session_service.h"
 #include "chrome/browser/sessions/session_service_factory.h"
@@ -21,21 +23,6 @@
 #include "components/sessions/content/session_tab_helper.h"
 #include "components/tabs/public/tab_interface.h"
 #include "content/public/browser/web_contents.h"
-
-namespace {
-
-// Finds the nearest TreeTabNodeTabCollection ancestor of |tab| and returns it,
-// or nullptr if the tab is not inside a tree node.
-const tabs::TreeTabNodeTabCollection* GetTreeTabNodeCollection(
-    const tabs::TabInterface* tab) {
-  const tabs::TabCollection* parent = tab->GetParentCollection();
-  if (parent && parent->type() == tabs::TabCollection::Type::TREE_NODE) {
-    return static_cast<const tabs::TreeTabNodeTabCollection*>(parent);
-  }
-  return nullptr;
-}
-
-}  // namespace
 
 TreeTabSessionManager::TreeTabSessionManager(Profile* profile,
                                              TabStripModel* tab_strip_model,
@@ -64,7 +51,8 @@ void TreeTabSessionManager::MaybePopulateTreeTabExtraData(
   auto* tab_interface = brave_tab_strip_model->GetTabAtIndex(index);
   CHECK(tab_interface);
 
-  const auto* tree_collection = GetTreeTabNodeCollection(tab_interface);
+  const auto* tree_collection =
+      tabs::TreeTabNodeTabCollection::GetTreeTabNodeCollection(tab_interface);
   if (!tree_collection) {
     // In case the tab is under group or split, tree_collection can be null.
     // TODO(https://github.com/brave/brave-browser/issues/49792): Add support
@@ -78,6 +66,87 @@ void TreeTabSessionManager::MaybePopulateTreeTabExtraData(
       parent_id ? parent_id->ToString() : "";
   (*extra_data)[kBraveTreeNodeCollapsedKey] =
       tree_collection->node().collapsed() ? "1" : "0";
+}
+
+void TreeTabSessionManager::MaybeRestoreTabTreeHierarchy(
+    content::WebContents* restored_web_contents,
+    const std::map<std::string, std::string>& extra_data) {
+  if (!base::FeatureList::IsEnabled(tabs::kBraveTreeTab)) {
+    return;
+  }
+
+  auto* brave_tab_strip_model =
+      static_cast<BraveTabStripModel*>(tab_strip_model_);
+  if (!brave_tab_strip_model->tree_model()) {
+    return;
+  }
+
+  auto* node_id = base::FindOrNull(extra_data, kBraveTreeNodeIdKey);
+  if (!node_id || node_id->empty()) {
+    // Can be pinned tab.
+    return;
+  }
+
+  // Locate the restored tab in the strip.
+  auto* restored_tab =
+      brave_tab_strip_model->GetTabForWebContents(restored_web_contents);
+  CHECK(restored_tab);
+
+  tabs::TreeTabNodeTabCollection* child_collection =
+      tabs::TreeTabNodeTabCollection::GetTreeTabNodeCollection(restored_tab);
+  if (!child_collection) {
+    // Not a child of tree node tab.
+    // TODO(https://github.com/brave/brave-browser/issues/49792) Consider
+    // group and split.
+    return;
+  }
+
+  auto token = base::Token::FromString(*node_id);
+  if (!token) {
+    return;
+  }
+  child_collection->SetNodeId(
+      tree_tab::TreeTabNodeId::FromRawToken(token.value()));
+
+  // Only reparent if the saved data describes a child node (non-empty parent).
+  auto* parent_id = base::FindOrNull(extra_data, kBraveTreeParentNodeIdKey);
+  if (!parent_id || parent_id->empty()) {
+    return;
+  }
+  const std::string& target_parent_node_id = *parent_id;
+
+  // Scan the strip to find the live TreeTabNodeTabCollection whose node ID
+  // matches the saved parent node ID. Because the parent tab was not closed
+  // (only the child was), its node ID is stable within this session.
+  tabs::TreeTabNodeTabCollection* parent_collection = nullptr;
+  for (int i = 0; i < brave_tab_strip_model->count(); ++i) {
+    auto* candidate = brave_tab_strip_model->GetTabAtIndex(i);
+    if (!candidate || candidate == restored_tab) {
+      continue;
+    }
+    auto* tree_collection =
+        tabs::TreeTabNodeTabCollection::GetTreeTabNodeCollection(candidate);
+    if (!tree_collection) {
+      continue;
+    }
+    if (tree_collection->node().id().ToString() == target_parent_node_id) {
+      parent_collection = tree_collection;
+      break;
+    }
+  }
+
+  if (!parent_collection) {
+    return;  // Parent tab was also closed; nothing to reparent under.
+  }
+
+  if (child_collection->GetParentCollection() == parent_collection) {
+    return;  // Already correctly nested (shouldn't happen, but guard anyway).
+  }
+
+  auto* current_parent = child_collection->GetParentCollection();
+  auto owned = current_parent->MaybeRemoveCollection(child_collection);
+  parent_collection->AddCollection(std::move(owned),
+                                   parent_collection->ChildCount());
 }
 
 void TreeTabSessionManager::OnTreeTabChanged(const TreeTabChange& change) {
@@ -124,7 +193,8 @@ void TreeTabSessionManager::UpdateTreeTabSessionDataForNode(
     CHECK(session_helper);
 
     const SessionID tab_id = session_helper->session_id();
-    const auto* tree_coll = GetTreeTabNodeCollection(tab_iface);
+    const auto* tree_coll =
+        tabs::TreeTabNodeTabCollection::GetTreeTabNodeCollection(tab_iface);
     if (!tree_coll) {
       // TODO(https://github.com/brave/brave-browser/issues/49792): Add support
       // Tabs are in the groups or splits. In this case, we don't do anything
@@ -154,7 +224,8 @@ void TreeTabSessionManager::UpdateTreeTabCollapsedState(
 
   // Only the primary (kTab) tab of a node carries the collapsed state key.
   for (const tabs::TabInterface* tab_iface : node.GetTabs()) {
-    const auto* tree_coll = GetTreeTabNodeCollection(tab_iface);
+    const auto* tree_coll =
+        tabs::TreeTabNodeTabCollection::GetTreeTabNodeCollection(tab_iface);
     if (!tree_coll) {
       // TODO(https://github.com/brave/brave-browser/issues/49792): Add support
       // Tabs are in the groups or splits. In this case, we don't do anything

--- a/browser/ui/tabs/tree_tab_session_manager.h
+++ b/browser/ui/tabs/tree_tab_session_manager.h
@@ -44,6 +44,14 @@ class TreeTabSessionManager : public TabStripModelObserver {
       int index,
       std::map<std::string, std::string>* extra_data);
 
+  // Called from BrowserLiveTabContext::AddRestoredTab after the tab has been
+  // re-inserted into the browser. Reads kBraveTreeParentNodeIdKey from
+  // |extra_data| and, if the parent tree node is still present in the strip,
+  // reparents the restored tab's TreeTabNodeTabCollection under it.
+  void MaybeRestoreTabTreeHierarchy(
+      content::WebContents* restored_web_contents,
+      const std::map<std::string, std::string>& extra_data);
+
  private:
   // TabStripModelObserver:
   void OnTreeTabChanged(const TreeTabChange& change) override;

--- a/browser/ui/views/tabs/brave_tab_unittest.cc
+++ b/browser/ui/views/tabs/brave_tab_unittest.cc
@@ -458,7 +458,7 @@ TEST_F(BraveTabTestWithTreeTab, TreeToggleButtonVisibleInsteadOfCloseButton) {
 
   tabs::TreeTabNodeTabCollection collection(
       node_id, std::move(split_collection), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
 
   ASSERT_EQ(collection.node().height(), 0);
 
@@ -506,7 +506,7 @@ TEST_F(BraveTabTestWithTreeTab,
 
   tabs::TreeTabNodeTabCollection collection(
       node_id, std::move(split_collection), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
   ASSERT_EQ(collection.node().height(), 0);
 
   // When tree tab has descendants, the tree toggle button should be visible.
@@ -558,7 +558,7 @@ TEST_F(BraveTabTestWithTreeTab,
 
   tabs::TreeTabNodeTabCollection collection(
       node_id, std::move(split_collection), base::DoNothing(),
-      base::DoNothing());
+      base::DoNothing(), base::DoNothing());
   collection.node().set_height_for_test(100);
   collection.node().set_collapsed(false);
 

--- a/chromium_src/chrome/browser/ui/browser_tabrestore.cc
+++ b/chromium_src/chrome/browser/ui/browser_tabrestore.cc
@@ -5,10 +5,31 @@
 
 #include "chrome/browser/ui/browser_tabrestore.h"
 
+#include "brave/browser/ui/tabs/tree_tab_session_manager.h"
 #include "brave/components/containers/buildflags/buildflags.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 
 #if BUILDFLAG(ENABLE_CONTAINERS)
 #include "brave/components/containers/content/browser/tab_restore_utils.h"
 #endif  // BUILDFLAG(ENABLE_CONTAINERS)
+
+namespace {
+
+content::WebContents* MaybeRestoreTabTreeHierarchy(
+    Browser* browser,
+    content::WebContents* restored_web_contents,
+    const std::map<std::string, std::string>& extra_data) {
+  if (auto* tree_tab_session_manager =
+          browser->browser_window_features()->GetTreeTabSessionManager()) {
+    // tree tab session manager is only available when the browser is normal
+    // browser.
+    tree_tab_session_manager->MaybeRestoreTabTreeHierarchy(
+        restored_web_contents, extra_data);
+  }
+  return restored_web_contents;
+}
+
+}  // namespace
 
 #include <chrome/browser/ui/browser_tabrestore.cc>

--- a/components/tabs/impl/tree_tab_node.cc
+++ b/components/tabs/impl/tree_tab_node.cc
@@ -23,7 +23,7 @@ const TreeTabNode& TreeTabNode::GetEmptyTreeTabNode() {
       empty_tree_tab_node_tab_collection(
           tree_tab::TreeTabNodeId::GenerateNew(),
           base::WrapUnique<TabInterface>(nullptr), base::DoNothing(),
-          base::DoNothing());
+          base::DoNothing(), base::DoNothing());
   return empty_tree_tab_node_tab_collection->node();
 }
 

--- a/components/tabs/impl/tree_tab_node_tab_collection.cc
+++ b/components/tabs/impl/tree_tab_node_tab_collection.cc
@@ -65,7 +65,7 @@ void TreeTabNodeTabCollection::BuildTreeTabs(
           tree_tab::TreeTabNodeId::GenerateNew(),
           base::WrapUnique<SplitTabCollection>(
               static_cast<SplitTabCollection*>(removed.release())),
-          on_remove, on_move);
+          on_create, on_remove, on_move);
       TreeTabNode& node_ref = tree_node->node();
       grandparent->AddCollection(std::move(tree_node), index);
       on_create.Run(node_ref);
@@ -90,7 +90,7 @@ void TreeTabNodeTabCollection::BuildTreeTabs(
           tree_tab::TreeTabNodeId::GenerateNew(),
           base::WrapUnique<TabGroupTabCollection>(
               static_cast<TabGroupTabCollection*>(removed.release())),
-          on_remove, on_move);
+          on_create, on_remove, on_move);
       TreeTabNode& node_ref = tree_node->node();
       grandparent->AddCollection(std::move(tree_node), index);
       on_create.Run(node_ref);
@@ -103,7 +103,7 @@ void TreeTabNodeTabCollection::BuildTreeTabs(
 
     auto tree_node = std::make_unique<TreeTabNodeTabCollection>(
         tree_tab::TreeTabNodeId::GenerateNew(), std::move(owned_tab_interface),
-        on_remove, on_move);
+        on_create, on_remove, on_move);
     TreeTabNode& node_ref = tree_node->node();
     parent_collection->AddCollection(std::move(tree_node), index);
     on_create.Run(node_ref);
@@ -167,10 +167,21 @@ void TreeTabNodeTabCollection::FlattenTreeTabs(TabCollection& root) {
     std::ignore = parent_collection->MaybeRemoveCollection(tree_node);
   }
 }
+// static
+tabs::TreeTabNodeTabCollection*
+TreeTabNodeTabCollection::GetTreeTabNodeCollection(
+    const tabs::TabInterface* tab) {
+  tabs::TabCollection* parent = tab->GetParentCollection(GetPassKeyStatic());
+  if (parent && parent->type() == tabs::TabCollection::Type::TREE_NODE) {
+    return static_cast<tabs::TreeTabNodeTabCollection*>(parent);
+  }
+  return nullptr;
+}
 
 TreeTabNodeTabCollection::TreeTabNodeTabCollection(
     const tree_tab::TreeTabNodeId& tree_tab_node_id,
     std::unique_ptr<tabs::TabInterface> current_tab,
+    base::RepeatingCallback<void(TreeTabNode&)> on_create,
     base::RepeatingCallback<void(const tree_tab::TreeTabNodeId&)> on_remove,
     base::RepeatingCallback<void(const tree_tab::TreeTabNodeId&)> on_move)
     : TabCollection(TabCollection::Type::TREE_NODE,
@@ -179,6 +190,7 @@ TreeTabNodeTabCollection::TreeTabNodeTabCollection(
                      TabCollection::Type::TREE_NODE},
                     /*supports_tabs=*/true),
       current_value_type_(CurrentValueType::kTab),
+      on_create_(std::move(on_create)),
       on_remove_(std::move(on_remove)),
       on_move_(std::move(on_move)),
       node_(std::make_unique<TreeTabNode>(*this, tree_tab_node_id)) {
@@ -196,6 +208,7 @@ TreeTabNodeTabCollection::TreeTabNodeTabCollection(
 TreeTabNodeTabCollection::TreeTabNodeTabCollection(
     const tree_tab::TreeTabNodeId& tree_tab_node_id,
     std::unique_ptr<tabs::SplitTabCollection> current_collection,
+    base::RepeatingCallback<void(TreeTabNode&)> on_create,
     base::RepeatingCallback<void(const tree_tab::TreeTabNodeId&)> on_remove,
     base::RepeatingCallback<void(const tree_tab::TreeTabNodeId&)> on_move)
     : TabCollection(TabCollection::Type::TREE_NODE,
@@ -204,6 +217,7 @@ TreeTabNodeTabCollection::TreeTabNodeTabCollection(
                      TabCollection::Type::TREE_NODE},
                     /*supports_tabs=*/true),
       current_value_type_(CurrentValueType::kSplit),
+      on_create_(std::move(on_create)),
       on_remove_(std::move(on_remove)),
       on_move_(std::move(on_move)),
       node_(std::make_unique<TreeTabNode>(*this, tree_tab_node_id)) {
@@ -218,6 +232,7 @@ TreeTabNodeTabCollection::TreeTabNodeTabCollection(
 TreeTabNodeTabCollection::TreeTabNodeTabCollection(
     const tree_tab::TreeTabNodeId& tree_tab_node_id,
     std::unique_ptr<tabs::TabGroupTabCollection> current_collection,
+    base::RepeatingCallback<void(TreeTabNode&)> on_create,
     base::RepeatingCallback<void(const tree_tab::TreeTabNodeId&)> on_remove,
     base::RepeatingCallback<void(const tree_tab::TreeTabNodeId&)> on_move)
     : TabCollection(TabCollection::Type::TREE_NODE,
@@ -226,6 +241,7 @@ TreeTabNodeTabCollection::TreeTabNodeTabCollection(
                      TabCollection::Type::TREE_NODE},
                     /*supports_tabs=*/true),
       current_value_type_(CurrentValueType::kGroup),
+      on_create_(std::move(on_create)),
       on_remove_(std::move(on_remove)),
       on_move_(std::move(on_move)),
       node_(std::make_unique<TreeTabNode>(*this, tree_tab_node_id)) {
@@ -336,6 +352,12 @@ std::unique_ptr<TabCollection> TreeTabNodeTabCollection::MaybeRemoveCollection(
   }
 
   return removed;
+}
+
+void TreeTabNodeTabCollection::SetNodeId(const tree_tab::TreeTabNodeId& id) {
+  on_remove_.Run(node_->id());
+  node_->set_node_id(id);
+  on_create_.Run(*node_);
 }
 
 void TreeTabNodeTabCollection::OnReparented(TabCollection* new_parent) {

--- a/components/tabs/public/tree_tab_node.h
+++ b/components/tabs/public/tree_tab_node.h
@@ -31,6 +31,7 @@ class TreeTabNode {
   TreeTabNode& operator=(const TreeTabNode&) = delete;
   ~TreeTabNode() = default;
 
+  void set_node_id(const tree_tab::TreeTabNodeId& id) { id_ = id; }
   const tree_tab::TreeTabNodeId& id() const { return id_; }
 
   int height() const { return height_; }

--- a/components/tabs/public/tree_tab_node_tab_collection.h
+++ b/components/tabs/public/tree_tab_node_tab_collection.h
@@ -57,9 +57,15 @@ class TreeTabNodeTabCollection : public tabs::TabCollection {
   // to their parent collections and removing the TreeTabNodes themselves.
   static void FlattenTreeTabs(TabCollection& root);
 
+  // Finds the nearest TreeTabNodeTabCollection ancestor of |tab| and returns
+  // it, or nullptr if the tab is not inside a tree node.
+  static tabs::TreeTabNodeTabCollection* GetTreeTabNodeCollection(
+      const tabs::TabInterface* tab);
+
   TreeTabNodeTabCollection(
       const tree_tab::TreeTabNodeId& tree_tab_node_id,
       std::unique_ptr<tabs::TabInterface> current_tab,
+      base::RepeatingCallback<void(TreeTabNode&)> on_create,
       base::RepeatingCallback<void(const tree_tab::TreeTabNodeId&)> on_remove,
       base::RepeatingCallback<void(const tree_tab::TreeTabNodeId&)> on_move);
 
@@ -69,6 +75,7 @@ class TreeTabNodeTabCollection : public tabs::TabCollection {
   TreeTabNodeTabCollection(
       const tree_tab::TreeTabNodeId& tree_tab_node_id,
       std::unique_ptr<tabs::SplitTabCollection> current_collection,
+      base::RepeatingCallback<void(TreeTabNode&)> on_create,
       base::RepeatingCallback<void(const tree_tab::TreeTabNodeId&)> on_remove,
       base::RepeatingCallback<void(const tree_tab::TreeTabNodeId&)> on_move);
 
@@ -77,6 +84,7 @@ class TreeTabNodeTabCollection : public tabs::TabCollection {
   TreeTabNodeTabCollection(
       const tree_tab::TreeTabNodeId& tree_tab_node_id,
       std::unique_ptr<tabs::TabGroupTabCollection> current_collection,
+      base::RepeatingCallback<void(TreeTabNode&)> on_create,
       base::RepeatingCallback<void(const tree_tab::TreeTabNodeId&)> on_remove,
       base::RepeatingCallback<void(const tree_tab::TreeTabNodeId&)> on_move);
 
@@ -115,6 +123,10 @@ class TreeTabNodeTabCollection : public tabs::TabCollection {
 
   CurrentValueType current_value_type() const { return current_value_type_; }
 
+  // Sets the node id of this tree tab node. Used when restoring a tree tab node
+  // from a session after the node has already been created.
+  void SetNodeId(const tree_tab::TreeTabNodeId& id);
+
  private:
   // Returns all TreeTabNodeTabCollections recursively from the given parent
   // collection.
@@ -127,6 +139,9 @@ class TreeTabNodeTabCollection : public tabs::TabCollection {
   // The current value: tab (WeakPtr), TabGroupTabCollection, or
   // SplitTabCollection. Empty for the empty tree node.
   std::optional<CurrentValueVariant> current_value_;
+
+  // Callback invoked when this TreeTabNode is created or its node id changes.
+  base::RepeatingCallback<void(TreeTabNode&)> on_create_;
 
   // Callback invoked when this TreeTabNode is destroyed.
   base::RepeatingCallback<void(const tree_tab::TreeTabNodeId&)> on_remove_;

--- a/docs/chrome/browser/ui/tabs/tree_tabs_session_restore.md
+++ b/docs/chrome/browser/ui/tabs/tree_tabs_session_restore.md
@@ -57,6 +57,13 @@ existing
 **[`kCommandAddTabExtraData`](https://source.chromium.org/chromium/chromium/src/+/main:components/sessions/core/session_service_commands.h;l=111;drc=f9d29b4ce34d252f7a124d326331901c3b942ee5)**
 mechanism (id=33) rather than adding new fields to Chromium's `session_types.h`.
 
+The restore entry point for **both** browser-restart and close-tab-and-restore
+is the same: `MaybeRestoreTabTreeHierarchy` is injected into
+`chrome/browser/ui/browser_tabrestore.cc` via a plaster rewrite
+(`rewrite/chrome/browser/ui/browser_tabrestore.cc.toml`). It is called at the
+tail of `AddRestoredTab` (session restore path) and `ReplaceRestoredTab`
+(tab-restore path), after the tab has been inserted into the browser.
+
 ---
 
 ## Data Stored Per Tab
@@ -76,6 +83,13 @@ written on the first tab in the group/split, and `brave_tree_node_collapsed` is
 omitted (group/split nodes cannot be individually collapsed today).
 
 Keys are defined in `brave/browser/sessions/brave_session_keys.h`.
+
+The helper `TreeTabNodeTabCollection::GetTreeTabNodeCollection(tab)` returns the
+nearest `TreeTabNodeTabCollection` ancestor for a given `TabInterface*`. It was
+previously a file-local function inside `tree_tab_session_manager.cc`; it was
+promoted to a public static method on `TreeTabNodeTabCollection` so that both
+the session manager and any future callers can use it without duplicating the
+traversal logic.
 
 ---
 
@@ -127,25 +141,17 @@ Keys are defined in `brave/browser/sessions/brave_session_keys.h`.
 │    kCommandAddTabExtraData → SessionTab::extra_data populated       │
 │              │                                                      │
 │              ▼                                                      │
-│  BraveTabStripModel constructor                                     │
-│    OnTreeTabRelatedPrefChanged() → BuildTreeTabs()                  │
-│    → BraveTreeTabStripCollectionDelegate set on collection          │
+│  RestoreTabsToBrowser → AddRestoredTab (per tab)                    │
+│    tab inserted with a freshly generated TreeTabNodeTabCollection   │
 │              │                                                      │
-│              ▼                                                      │
-│  RestoreTabsToBrowser  (tabs added flat, each in its own            │
-│    TreeTabNodeTabCollection with a fresh generated ID)              │
-│              │                                                      │
-│              ▼                                                      │
-│  RestoreTabGroupMetadata  (existing, unchanged)                     │
-│              │                                                      │
-│              ▼                                                      │
-│  BRAVE_RESTORE_TREE_TAB_NODES                                       │
-│  → BraveRestoreTreeTabNodeMetadata                                  │
-│    1. Build old_id → TreeTabNodeTabCollection* map                  │
-│       (using initial_tab_count + tab_visual_index as browser index) │
-│    2. Reparent collections to recreate tree hierarchy               │
-│    3. Apply collapsed state via                                     │
-│    BraveTabStripModel::SetTreeTabNodeCollapsed                      │
+│              ▼ (tail of AddRestoredTab, plaster-injected)           │
+│  MaybeRestoreTabTreeHierarchy(browser, web_contents, extra_data)    │
+│  → TreeTabSessionManager::MaybeRestoreTabTreeHierarchy              │
+│    1. Read kBraveTreeNodeIdKey → call SetNodeId on the collection   │
+│       (fires on_remove_ for generated ID, on_create_ for saved ID)  │
+│    2. Read kBraveTreeParentNodeIdKey                                 │
+│    3. Scan strip for live collection whose node ID == parent id     │
+│    4. MaybeRemoveCollection + AddCollection to reparent             │
 └─────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────┐
@@ -163,13 +169,40 @@ Keys are defined in `brave/browser/sessions/brave_session_keys.h`.
 ┌─────────────────────────────────────────────────────────────────────┐
 │             RESTORE PATH — Restore (Ctrl+Shift+t)                   │
 │                                                                     │
-│  BrowserLiveTabContext::AddRestoredTab                              │
-│  (BRAVE_ADD_RESTORED_TAB chromium_src override)                     │
-│    → BraveRestoreTabTreeHierarchy                                   │
-│      scans live strip for parent by its current node ID             │
-│      → MaybeRemoveCollection + AddCollection to reparent            │
+│  ReplaceRestoredTab (tab re-inserted into browser)                  │
+│              │                                                      │
+│              ▼ (tail of ReplaceRestoredTab, plaster-injected)       │
+│  MaybeRestoreTabTreeHierarchy(browser, web_contents, extra_data)    │
+│  → TreeTabSessionManager::MaybeRestoreTabTreeHierarchy              │
+│    1. Read kBraveTreeNodeIdKey → SetNodeId on the collection        │
+│    2. Scan strip for parent collection by saved parent node ID      │
+│    3. MaybeRemoveCollection + AddCollection to reparent             │
+│    (if parent was also closed, step 3 is skipped gracefully)        │
 └─────────────────────────────────────────────────────────────────────┘
 ```
+
+---
+
+## Why One Restore Entry Point Handles Both Scenarios
+
+Both browser-restart (`AddRestoredTab`) and close-tab-and-restore
+(`ReplaceRestoredTab`) are plumbed through the same
+`TreeTabSessionManager::MaybeRestoreTabTreeHierarchy` method. The logic is
+identical: read the saved node and parent IDs from `extra_data`, update the
+freshly-created collection's ID via `SetNodeId`, then scan the live strip for
+the parent collection and reparent.
+
+### Why `SetNodeId` fires `on_remove_` then `on_create_`
+
+When `BuildTreeTabs` (or any constructor path) creates a
+`TreeTabNodeTabCollection`, it assigns a fresh generated `TreeTabNodeId`. The
+`TreeTabModel` indexes collections by this ID. On restore, we need to swap in
+the saved ID so that parent-lookup (which also uses `node().id().ToString()`)
+succeeds on sibling tabs that were restored before this one. `SetNodeId` does
+this atomically: it fires `on_remove_` with the old ID (removing it from the
+index), updates the node, then fires `on_create_` with the new ID (re-inserting
+it). Without this two-step swap, the index would hold the wrong key and
+parent-lookup would silently miss.
 
 ---
 

--- a/patches/chrome-browser-ui-browser_tabrestore.cc.patch
+++ b/patches/chrome-browser-ui-browser_tabrestore.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/browser_tabrestore.cc b/chrome/browser/ui/browser_tabrestore.cc
-index 9291009f10ea351d0a693a1c2c985470e4383ead..df79aeb84fa6aca7c1b542e32db4592ce2122dfb 100644
+index 9291009f10ea351d0a693a1c2c985470e4383ead..ede44df3741f3fbdc15a10a425c9594a60ac9b58 100644
 --- a/chrome/browser/ui/browser_tabrestore.cc
 +++ b/chrome/browser/ui/browser_tabrestore.cc
 @@ -72,7 +72,14 @@ std::unique_ptr<WebContents> CreateRestoredTab(
@@ -18,3 +18,23 @@ index 9291009f10ea351d0a693a1c2c985470e4383ead..df79aeb84fa6aca7c1b542e32db4592c
    create_params.initially_hidden = initially_hidden;
    create_params.desired_renderer_state =
        WebContents::CreateParams::kNoRendererProcess;
+@@ -286,9 +293,10 @@ WebContents* AddRestoredTab(
+       last_active_time_ticks, last_active_time, session_storage_namespace,
+       user_agent_override, extra_data, initially_hidden, from_session_restore);
+ 
+-  return AddRestoredTabImpl(std::move(web_contents), browser, tab_index, group,
++  content::WebContents* restored_contents = AddRestoredTabImpl(std::move(web_contents), browser, tab_index, group,
+                             select, pin, from_session_restore,
+                             is_active_browser);
++  return MaybeRestoreTabTreeHierarchy(browser, restored_contents, extra_data);
+ }
+ 
+ WebContents* ReplaceRestoredTab(
+@@ -327,6 +335,7 @@ WebContents* ReplaceRestoredTab(
+ 
+   LoadRestoredTabIfVisible(browser, raw_web_contents);
+ 
++  MaybeRestoreTabTreeHierarchy(browser, raw_web_contents, extra_data);
+   return raw_web_contents;
+ }
+ 

--- a/rewrite/chrome/browser/ui/browser_tabrestore.cc.yaml
+++ b/rewrite/chrome/browser/ui/browser_tabrestore.cc.yaml
@@ -15,3 +15,22 @@ substitutions:
                     browser->profile(), navigations, selected_navigation)
       #endif  // BUILDFLAG(ENABLE_CONTAINERS)
         ))
+
+  - description: |-
+      Try restoration of tree tab hierarchy when restoring a tab after calling 
+      AddRestoredTabImpl()
+    re_pattern: 'return (AddRestoredTabImpl\(.*?\);)'
+    re_flags: [DOTALL]
+    replace: |-
+      content::WebContents* restored_contents = \1
+        return MaybeRestoreTabTreeHierarchy(browser, restored_contents, extra_data);
+
+  - description: |-
+      Try restoration of tree tab hierarchy when restoring a tab in
+      ReplaceRestoredTab() right before returning the new contents
+    re_pattern:
+      '(WebContents\*\ ReplaceRestoredTab\(.*?)(return\ raw_web_contents;)'
+    re_flags: [DOTALL]
+    replace: |-
+      \1MaybeRestoreTabTreeHierarchy(browser, raw_web_contents, extra_data);
+        \2


### PR DESCRIPTION
This implements restoration in browser_tabrestore.cc.
The functions in it is used by both session restore and tab restore.
The former is used when the browser is launched, and the latter is used
when a tab is closed and then restored.

<!-- Add brave-browser issue below that this PR will resolve -->
Part of https://github.com/brave/brave-browser/issues/49792

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
