### PR TITLE
[iOS] Add quickview option in settings Tabs Section

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/BraveSearchTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/BraveSearchTabHelper.swift
@@ -240,6 +240,7 @@ class BraveSearchTabHelper: TabObserver, TabPolicyDecider, BraveSearchMakeDefaul
     }
 
     if FeatureList.kQuickViewEnabled.enabled,
+      Preferences.General.openLinkInQuickViewMode.value,
       shouldOpenInQuickView(requestURL: requestURL, requestInfo: requestInfo, tab: tab)
     {
       presentInQuickView?(requestURL, tab)

--- a/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
@@ -142,6 +142,11 @@ extension Preferences {
       key: "general.open-keyboard-on-ntp-selection",
       default: false
     )
+    /// Whether or not open link in quickview mode
+    public static let openLinkInQuickViewMode: Option<Bool> = .init(
+      key: "general.open-link-in-quickview-mode",
+      default: true
+    )
   }
 
   final public class Search {

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -1087,7 +1087,7 @@ class SettingsViewController: TableViewController, BraveAccountAuthenticationObs
         accessory: .view(
           SwitchAccessoryView(
             initialValue: Preferences.General.openLinkInQuickViewMode.value,
-            valueChange: { [unowned self] newValue in
+            valueChange: { newValue in
               Preferences.General.openLinkInQuickViewMode.value = newValue
             }
           )

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -1079,6 +1079,25 @@ class SettingsViewController: TableViewController, BraveAccountAuthenticationObs
       tabs.rows.append(privateTabsRow)
     }
 
+    if FeatureList.kQuickViewEnabled.enabled {
+      var quickViewRow = Row(
+        text: Strings.TabsSettings.openLinkInQuickViewModeTitle,
+        detailText: Strings.TabsSettings.openLinkInQuickViewModeDescription,
+        image: UIImage(braveSystemNamed: "leo.browser.quick-view"),
+        accessory: .view(
+          SwitchAccessoryView(
+            initialValue: Preferences.General.openLinkInQuickViewMode.value,
+            valueChange: { [unowned self] newValue in
+              Preferences.General.openLinkInQuickViewMode.value = newValue
+            }
+          )
+        ),
+        cellClass: MultilineSubtitleCell.self,
+        uuid: Preferences.General.openLinkInQuickViewMode.key
+      )
+      tabs.rows.append(quickViewRow)
+    }
+
     var keyboardRow = Row(
       text: Strings.TabsSettings.autoOpenKeyboardTitle,
       detailText: Strings.TabsSettings.autoOpenKeyboardDescription,

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -6444,6 +6444,20 @@ extension Strings {
       value: "Automatically focus the address bar when creating a new tab",
       comment: "The description of the toggle for user to turn on auto-open keyboard when creating a new tab."
     )
+    public static let openLinkInQuickViewModeTitle = NSLocalizedString(
+      "tabs.settings.openLinkInQuickViewModeTitle",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Enable Quickview Tabs",
+      comment: "The title of the toggle for user to turn on open link in quick view mode."
+    )
+    public static let openLinkInQuickViewModeDescription = NSLocalizedString(
+      "tabs.settings.openLinkInQuickViewModeDescription",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Open links from Ask Brave and Brave Search in preview tabs",
+      comment: "The description of the toggle for user to turn on open link in quick view mode."
+    )
   }
 }
 

--- a/ios/nala/BUILD.gn
+++ b/ios/nala/BUILD.gn
@@ -40,6 +40,7 @@ nala_icons = [
   "leo.browser.mobile-tabs-bottom.svg",
   "leo.browser.mobile-tabs-top.svg",
   "leo.browser.mobile-tabs.svg",
+  "leo.browser.quick-view.svg",
   "leo.browser.refresh.svg",
   "leo.bug.svg",
   "leo.carat.down.svg",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56192

Test: 
1. enable quickview feature flag in brave://flags
2. verify there is a toggle option for quickview under Tabs Section
3. verify toggle is on by default
4. verify links from search.brave.com or ask brave will be opened in quickview mode if and only if toggle in settings is on
5. verify there is no such toggle in settings when quickview feature flag is off

<img width=40% alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-15 at 21 49 52" src="https://github.com/user-attachments/assets/7350bb43-7474-4e0a-8ec6-5def4555b7ed" />


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
