### PR TITLE
[iOS] Gate Brave News widget on Brave News admin policy (uplift to 1.91.x)

### DIFF
--- a/ios/brave-ios/App/BraveWidgets/NewsTopics/NewsTopicsModel.swift
+++ b/ios/brave-ios/App/BraveWidgets/NewsTopics/NewsTopicsModel.swift
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import BraveWidgetsModels
 import CodableHelpers
 import Foundation
 import OrderedCollections
@@ -10,6 +11,7 @@ import UIKit
 
 /// Handles fetching Brave News Topics for widgets
 struct NewsTopicsModel {
+  var isNewsAvailable: @Sendable () async -> Bool
   var fetchNewsTopics: @Sendable (Locale) async -> [NewsTopic]
   var fetchImageThumbnailsForTopics:
     @Sendable ([NewsTopic], CGSize) async -> [NewsTopic.ID: UIImage]
@@ -24,6 +26,11 @@ extension NewsTopicsModel {
   /// from there.
   static var live: Self {
     .init(
+      isNewsAvailable: {
+        let isDisabledByPolicy = await DisabledShortcutsWidgetData.loadDisabledShortcuts()
+          .contains(.braveNews)
+        return !isDisabledByPolicy
+      },
       fetchNewsTopics: { currentLocale in
         do {
           let supportedLocales = [
@@ -102,7 +109,7 @@ extension NewsTopicsModel {
 }
 
 extension NewsTopicsModel {
-  static var mock: Self {
+  static func mock(isAvailable: Bool = true) -> Self {
     let data = try! Data(
       contentsOf: Bundle.main.url(
         forResource: "topics_news.en_US",
@@ -111,6 +118,9 @@ extension NewsTopicsModel {
       )!
     )
     return .init(
+      isNewsAvailable: {
+        return isAvailable
+      },
       fetchNewsTopics: { _ in
         do {
           let topics = Dictionary(

--- a/ios/brave-ios/App/BraveWidgets/TopNewsListWidget.swift
+++ b/ios/brave-ios/App/BraveWidgets/TopNewsListWidget.swift
@@ -28,6 +28,7 @@ struct TopNewsListWidget: Widget {
 
 private struct TopNewsListEntry: TimelineEntry {
   var date: Date = .now
+  var isDisabledByPolicy: Bool = false
   var topics: [NewsTopic]?
   var images: [NewsTopic.ID: UIImage] = [:]
 }
@@ -38,6 +39,11 @@ private struct TopNewsListWidgetProvider: TimelineProvider {
 
   func getSnapshot(in context: Context, completion: @escaping (TopNewsListEntry) -> Void) {
     Task {
+      let isAvailable = await model.isNewsAvailable()
+      if !isAvailable {
+        completion(.init(isDisabledByPolicy: true))
+        return
+      }
       let grouping = context.family == .systemMedium ? 2 : 5
       // No need to load more than the grouping in the snapshot
       let topics = Array(await model.fetchNewsTopics(Locale.autoupdatingCurrent).prefix(grouping))
@@ -48,6 +54,11 @@ private struct TopNewsListWidgetProvider: TimelineProvider {
   func getTimeline(in context: Context, completion: @escaping (Timeline<TopNewsListEntry>) -> Void)
   {
     Task {
+      let isAvailable = await model.isNewsAvailable()
+      if !isAvailable {
+        completion(.init(entries: [.init(isDisabledByPolicy: true)], policy: .never))
+        return
+      }
       let grouping = context.family == .systemMedium ? 2 : 5
       let interval = context.family == .systemMedium ? 15 : 20
       let allTopics = Array(
@@ -89,15 +100,17 @@ private struct TopNewsListView: View {
           .font(.system(size: 14, weight: .bold, design: .rounded))
       }
       Spacer()
-      Link(
-        destination: URL(
-          string:
-            "\(AppURLScheme.appURLScheme)://shortcut?path=\(WidgetShortcut.braveNews.rawValue)"
-        )!
-      ) {
-        Text(Strings.Widgets.newsClusteringReadMoreButtonTitle)
-          .foregroundColor(Color(.braveBlurpleTint))
-          .font(.system(size: 13, weight: .semibold, design: .rounded))
+      if !entry.isDisabledByPolicy {
+        Link(
+          destination: URL(
+            string:
+              "\(AppURLScheme.appURLScheme)://shortcut?path=\(WidgetShortcut.braveNews.rawValue)"
+          )!
+        ) {
+          Text(Strings.Widgets.newsClusteringReadMoreButtonTitle)
+            .foregroundColor(Color(.braveBlurpleTint))
+            .font(.system(size: 13, weight: .semibold, design: .rounded))
+        }
       }
     }
     .padding(.horizontal)
@@ -163,27 +176,22 @@ private struct TopNewsListView: View {
         .padding(.bottom)
       } else {
         ZStack(alignment: .top) {
-          Text(Strings.Widgets.newsClusteringErrorLabel)
-            .font(
-              .system(
-                size: widgetFamily == .systemLarge ? 26 : 18,
-                weight: .semibold,
-                design: .rounded
-              )
-            )
-            .padding()
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background {
-              LinearGradient(braveGradient: .darkGradient01)
-                .mask {
-                  Image("brave-today-error")
-                    .renderingMode(.template)
-                    .resizable(resizingMode: .tile)
-                    .opacity(0.1)
-                    .rotationEffect(.degrees(-45))
-                    .scaleEffect(x: 2.1, y: 2.1)
-                }
+          VStack(spacing: 8) {
+            Image(braveSystemName: "leo.disable.outline")
+              .imageScale(.large)
+            VStack {
+              Text(Strings.Widgets.newsUnavailableByPolicy)
+                .font(.headline)
+                .fontDesign(.rounded)
+              Text(Strings.Widgets.newsUnavailableByPolicyDescription)
+                .font(.subheadline)
+                .fontDesign(.rounded)
+                .foregroundStyle(Color(braveSystemName: .textTertiary))
             }
+          }
+          .foregroundStyle(Color(braveSystemName: .textSecondary))
+          .padding()
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
           headerView
             .background {
               LinearGradient(
@@ -203,7 +211,7 @@ private struct TopNewsListView: View {
 #if DEBUG
 struct TopNewsListView_PreviewProvider: PreviewProvider {
   struct PreviewView: View {
-    let model = NewsTopicsModel.mock
+    let model = NewsTopicsModel.mock(isAvailable: true)
     @State private var topics: [NewsTopic] = []
 
     var body: some View {
@@ -220,4 +228,15 @@ struct TopNewsListView_PreviewProvider: PreviewProvider {
       .previewContext(WidgetPreviewContext(family: .systemMedium))
   }
 }
+
+#Preview(
+  as: .systemMedium,
+  widget: {
+    TopNewsListWidget()
+  },
+  timeline: {
+    TopNewsListEntry(isDisabledByPolicy: true)
+  }
+)
+
 #endif

--- a/ios/brave-ios/App/BraveWidgets/TopNewsWidget.swift
+++ b/ios/brave-ios/App/BraveWidgets/TopNewsWidget.swift
@@ -30,15 +30,10 @@ struct TopNewsWidget: Widget {
 }
 
 private struct TopNewsEntry: TimelineEntry {
-  var date: Date
+  var date: Date = .now
+  var isDisabledByPolicy: Bool = false
   var topic: NewsTopic?
   var image: UIImage?
-
-  init(date: Date = .now, topic: NewsTopic?, image: UIImage? = nil) {
-    self.date = date
-    self.topic = topic
-    self.image = image
-  }
 }
 
 extension WidgetFamily {
@@ -65,6 +60,11 @@ private struct TopNewsWidgetProvider: TimelineProvider {
 
   func getSnapshot(in context: Context, completion: @escaping (TopNewsEntry) -> Void) {
     Task {
+      let isNewsAvailable = await model.isNewsAvailable()
+      if !isNewsAvailable {
+        completion(.init(isDisabledByPolicy: true))
+        return
+      }
       let topics = await model.fetchNewsTopics(Locale.autoupdatingCurrent)
       var entry: TopNewsEntry = .init(topic: topics.first)
       if let topic = entry.topic, !context.family.isLockScreen {
@@ -81,6 +81,11 @@ private struct TopNewsWidgetProvider: TimelineProvider {
 
   func getTimeline(in context: Context, completion: @escaping (Timeline<TopNewsEntry>) -> Void) {
     Task {
+      let isNewsAvailable = await model.isNewsAvailable()
+      if !isNewsAvailable {
+        completion(.init(entries: [.init(isDisabledByPolicy: true)], policy: .never))
+        return
+      }
       let topics = Array(await model.fetchNewsTopics(Locale.autoupdatingCurrent).prefix(6))
       var images: [NewsTopic.ID: UIImage] = [:]
       if !context.family.isLockScreen {
@@ -148,20 +153,31 @@ private struct LockScreenTopNewsView: View {
       .widgetBackground { Color.clear }
     } else {
       VStack(spacing: 4) {
-        Image("brave-today-error")
-          .resizable()
-          .renderingMode(.template)
-          .aspectRatio(contentMode: .fit)
-          .frame(height: 32)
-          .foregroundColor(.black)
-        HStack(spacing: 3) {
-          Text(Strings.Widgets.newsClusteringErrorLabel)
+        if entry.isDisabledByPolicy {
+          Image(braveSystemName: "leo.disable.outline")
+            .imageScale(.large)
+            .foregroundColor(.black)
+          Text(Strings.Widgets.newsUnavailableByPolicy)
             .lineLimit(1)
             .font(.system(size: 11, weight: .semibold, design: .rounded))
             .foregroundColor(.secondary)
             .minimumScaleFactor(0.75)
+        } else {
+          Image("brave-today-error")
+            .resizable()
+            .renderingMode(.template)
+            .aspectRatio(contentMode: .fit)
+            .frame(height: 32)
+            .foregroundColor(.black)
+          HStack(spacing: 3) {
+            Text(Strings.Widgets.newsClusteringErrorLabel)
+              .lineLimit(1)
+              .font(.system(size: 11, weight: .semibold, design: .rounded))
+              .foregroundColor(.secondary)
+              .minimumScaleFactor(0.75)
+          }
+          .frame(maxWidth: .infinity)
         }
-        .frame(maxWidth: .infinity)
       }
       .allowsTightening(true)
       .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -233,23 +249,32 @@ private struct WidgetTopNewsView: View {
             Color(.white).clipShape(Circle()).shadow(color: .black.opacity(0.2), radius: 2, y: 1)
           )
         Spacer()
-        Text(Strings.Widgets.newsClusteringErrorLabel)
-          .font(.system(size: 14, weight: .medium, design: .rounded))
+        Text(
+          entry.isDisabledByPolicy
+            ? Strings.Widgets.newsUnavailableByPolicy : Strings.Widgets.newsClusteringErrorLabel
+        )
+        .font(.system(size: 14, weight: .medium, design: .rounded))
+        if entry.isDisabledByPolicy {
+          Text(Strings.Widgets.newsUnavailableByPolicyDescription)
+            .font(.system(size: 12, design: .rounded))
+            .foregroundStyle(Color(braveSystemName: .textTertiary))
+        }
       }
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
       .padding()
       .widgetBackground {
-        LinearGradient(braveGradient: .darkGradient01)
-          .mask {
-            Image("brave-today-error")
-              .renderingMode(.template)
-              .resizable(resizingMode: .tile)
-              .opacity(0.1)
-              .rotationEffect(.degrees(-45))
-              .scaleEffect(x: 1.5, y: 1.5)
-          }
+        if !entry.isDisabledByPolicy {
+          LinearGradient(braveGradient: .darkGradient01)
+            .mask {
+              Image("brave-today-error")
+                .renderingMode(.template)
+                .resizable(resizingMode: .tile)
+                .opacity(0.1)
+                .rotationEffect(.degrees(-45))
+                .scaleEffect(x: 1.5, y: 1.5)
+            }
+        }
       }
-      //      .background(Color(.braveBackground))
     }
   }
 }
@@ -297,4 +322,25 @@ struct TopNewsView_PreviewProvider: PreviewProvider {
       .previewContext(WidgetPreviewContext(family: .systemSmall))
   }
 }
+
+#Preview(
+  as: .systemSmall,
+  widget: {
+    TopNewsWidget()
+  },
+  timeline: {
+    TopNewsEntry(isDisabledByPolicy: true)
+  }
+)
+
+#Preview(
+  as: .accessoryRectangular,
+  widget: {
+    TopNewsWidget()
+  },
+  timeline: {
+    TopNewsEntry(isDisabledByPolicy: true)
+  }
+)
+
 #endif

--- a/ios/brave-ios/App/BraveWidgets/WidgetStrings.swift
+++ b/ios/brave-ios/App/BraveWidgets/WidgetStrings.swift
@@ -198,5 +198,17 @@ extension Strings {
       comment:
         "Title for Ask Brave shortcut. Brave is the company name and should not be translated"
     )
+    public static let newsUnavailableByPolicy = NSLocalizedString(
+      "widgets.newsUnavailableByPolicy",
+      bundle: widgetBundle,
+      value: "Brave News is Disabled",
+      comment: "Displayed on a news widget wont load due to admin policies"
+    )
+    public static let newsUnavailableByPolicyDescription = NSLocalizedString(
+      "widgets.newsUnavailableByPolicyDescription",
+      bundle: widgetBundle,
+      value: "Turned off by your organization's policy",
+      comment: "Displayed on a news widget wont load due to admin policies"
+    )
   }
 }

--- a/ios/brave-ios/Sources/BraveWidgetsModels/DisabledShortcutsWidgetData.swift
+++ b/ios/brave-ios/Sources/BraveWidgetsModels/DisabledShortcutsWidgetData.swift
@@ -62,6 +62,8 @@ public class DisabledShortcutsWidgetData {
       }
       WidgetCenter.shared.reloadTimelines(ofKind: "ShortcutsWidget")
       WidgetCenter.shared.reloadTimelines(ofKind: "LockScreenShortcutWidget")
+      WidgetCenter.shared.reloadTimelines(ofKind: "TopNewsWidget")
+      WidgetCenter.shared.reloadTimelines(ofKind: "TopNewsListWidget")
     } catch {
       Logger.module.error("updateDisabledShortcuts error: \(error.localizedDescription)")
     }


### PR DESCRIPTION
Uplift of #37074
Uplift of #37121
Uplift of #37301
Resolves brave/brave-browser#56182

## Included PRs
- #37074 - [iOS] Gate Brave News widget on Brave News admin policy
- #37121 - [iOS] Evaluate News widget gate correctly

Pre-approval checklist:
- [x] You have tested your change on Nightly.
- [ ] This contains text which needs to be translated.
    - [ ] There are more than 7 days before the release.
    - [ ] I've notified folks in #l10n on Slack that translations are needed.
- [x] The PR milestones match the branch they are landing to.


Pre-merge checklist:
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.

Post-merge checklist:
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.