### PR TITLE
update_patches ignores components/omnibox/browser/vector_icons

### DIFF
--- a/build/update_patches_exclusions.cfg
+++ b/build/update_patches_exclusions.cfg
@@ -7,6 +7,7 @@ buildtools/reclient_cfgs/*
 chrome/app/theme/default/*
 chrome/app/theme/brave/*
 chrome/app/theme/chromium/*
+components/omnibox/browser/vector_icons/*
 third_party/win_build_output/midl/chrome/elevation_service/*
 third_party/win_build_output/midl/google_update/*
 *.png


### PR DESCRIPTION
- Fix https://github.com/brave/brave-browser/issues/56394

The following introduced a new resource copy location.
- https://github.com/brave/brave-core/pull/36482

This PR adds that location to the list of exclusions for patch creation.
