### PR TITLE
[VPN 2.0] Fix Crashpad logic in Chromium for VPN apps

### DIFF
--- a/chromium_src/components/crash/core/app/crashpad.cc
+++ b/chromium_src/components/crash/core/app/crashpad.cc
@@ -5,8 +5,19 @@
 
 #include "components/crash/core/app/crashpad.h"
 
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_APPLE) || BUILDFLAG(IS_LINUX)
 namespace {
+// Split into two places to avoid patching:
+// components/brave_vpn/app/v2/agent/main.cc
+// Need keep it in sync
+constexpr char kBraveVpnAgentAppProcessType[] = "brave-vpn-agent-app";
+
+// Split into two places to avoid patching:
+// components/brave_vpn/app/v2/helper/main.cc
+// Need keep it in sync
+constexpr char kBraveVpnHelperAppProcessType[] = "brave-vpn-helper-app";
+
+#if BUILDFLAG(IS_WIN)
 // Split into two places to avoid patching:
 // NOLINTNEXTLINE
 // components\brave_vpn\browser\connection\win\brave_vpn_helper\brave_vpn_helper_crash_reporter_client.cc
@@ -18,14 +29,28 @@ constexpr char kBraveVPNHelperProcessType[] = "brave-vpn-helper";
 // components\brave_vpn\browser\connection\wireguard\win\brave_vpn_wireguard_service\brave_wireguard_service_crash_reporter_client.cc
 // Need keep it in sync
 constexpr char kBraveWireguardProcessType[] = "brave-vpn-wireguard-service";
+#endif  // BUILDFLAG(IS_WIN)
 }  // namespace
 
-#define BRAVE_INITIALIZE_CRASHPAD_IMPL_PROCESS_TYPE \
-  process_type == kBraveVPNHelperProcessType ||     \
+#if BUILDFLAG(IS_WIN)
+// CHROMIUM_SRC_INTERNAL_USE
+#define BRAVE_CRASHPAD_VPN_V1_PROCESS_TYPES     \
+  process_type == kBraveVPNHelperProcessType || \
       process_type == kBraveWireguardProcessType ||
-#endif
+#else
+// CHROMIUM_SRC_INTERNAL_USE
+#define BRAVE_CRASHPAD_VPN_V1_PROCESS_TYPES
+#endif  // BUILDFLAG(IS_WIN)
+
+#define BRAVE_INITIALIZE_CRASHPAD_IMPL_PROCESS_TYPE    \
+  process_type == kBraveVpnAgentAppProcessType ||      \
+      process_type == kBraveVpnHelperAppProcessType || \
+      BRAVE_CRASHPAD_VPN_V1_PROCESS_TYPES
+
+#endif  // BUILDFLAG(IS_WIN) || BUILDFLAG(IS_APPLE) || BUILDFLAG(IS_LINUX)
 
 #include <components/crash/core/app/crashpad.cc>
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_APPLE) || BUILDFLAG(IS_LINUX)
+#undef BRAVE_CRASHPAD_VPN_V1_PROCESS_TYPES
 #undef BRAVE_INITIALIZE_CRASHPAD_IMPL_PROCESS_TYPE
 #endif

--- a/components/brave_vpn/app/v2/agent/main.cc
+++ b/components/brave_vpn/app/v2/agent/main.cc
@@ -23,7 +23,11 @@ using brave_vpn::v2::AgentApp;
 using brave_vpn::v2::CrashReporterClient;
 
 namespace {
+// Split into two places to avoid patching:
+// chromium_src/components/crash/core/app/crashpad.cc
+// Need keep it in sync.
 constexpr char kBraveVpnAgentAppProcessType[] = "brave-vpn-agent-app";
+
 constexpr char kBraveVpnAgentAppProductName[] = "BraveVpnAgentApp";
 }  // namespace
 

--- a/components/brave_vpn/app/v2/helper/main.cc
+++ b/components/brave_vpn/app/v2/helper/main.cc
@@ -22,7 +22,11 @@ using brave_vpn::v2::CrashReporterClient;
 using brave_vpn::v2::HelperApp;
 
 namespace {
+// Split into two places to avoid patching:
+// chromium_src/components/crash/core/app/crashpad.cc
+// Need keep it in sync.
 constexpr char kBraveVpnHelperAppProcessType[] = "brave-vpn-helper-app";
+
 constexpr char kBraveVpnHelperAppProductName[] = "BraveVpnHelperApp";
 }  // namespace
 

--- a/patches/components-crash-core-app-crashpad.cc.patch
+++ b/patches/components-crash-core-app-crashpad.cc.patch
@@ -1,12 +1,24 @@
 diff --git a/components/crash/core/app/crashpad.cc b/components/crash/core/app/crashpad.cc
-index db68eaa22030aca74f31a9d8612b4952a3b25642..2b252b96dc22d063953eb0684fea1e0c04184451 100644
+index db68eaa22030aca74f31a9d8612b4952a3b25642..3cef6ec2b84702000bbd51d77ca8e4c8f60e4805 100644
 --- a/components/crash/core/app/crashpad.cc
 +++ b/components/crash/core/app/crashpad.cc
-@@ -95,6 +95,7 @@ bool InitializeCrashpadImpl(bool initial_client,
+@@ -85,6 +85,7 @@ bool InitializeCrashpadImpl(bool initial_client,
+     // component can't see Chrome's switches. This is only used for argument
+     // sanitization.
+     DCHECK(browser_process || process_type == "relauncher" ||
++           BRAVE_INITIALIZE_CRASHPAD_IMPL_PROCESS_TYPE
+            process_type == "app_shim");
+ #elif BUILDFLAG(IS_WIN)
+     // "Chrome Installer" is the name historically used for installer binaries
+@@ -95,8 +96,11 @@ bool InitializeCrashpadImpl(bool initial_client,
             process_type == "os-update-handler" ||
             process_type == "platform-experience-helper" ||
  #endif  // BUILDFLAG(GOOGLE_CHROME_BRANDING)
 +           BRAVE_INITIALIZE_CRASHPAD_IMPL_PROCESS_TYPE
             process_type == "GCPW Installer" || process_type == "GCPW DLL" ||
             process_type == "elevated-tracing-service");
++#elif BUILDFLAG(IS_LINUX)
++    DCHECK(BRAVE_INITIALIZE_CRASHPAD_IMPL_PROCESS_TYPE browser_process);
  #elif BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)
+     DCHECK(browser_process);
+ #else

--- a/patches/components-crash-core-app-crashpad_linux.cc.patch
+++ b/patches/components-crash-core-app-crashpad_linux.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/components/crash/core/app/crashpad_linux.cc b/components/crash/core/app/crashpad_linux.cc
+index d4d3555891b19d61676465c856055fb04e0168bc..253221445256c29b58e66c205e64fd6d747b350e 100644
+--- a/components/crash/core/app/crashpad_linux.cc
++++ b/components/crash/core/app/crashpad_linux.cc
+@@ -136,7 +136,7 @@ bool PlatformCrashpadInitialization(
+     const std::vector<std::string>& initial_arguments,
+     const std::vector<base::FilePath>& attachments,
+     base::FilePath* database_path) {
+-  DCHECK_EQ(initial_client, browser_process);
++  // DCHECK_EQ(initial_client, browser_process);  // fix for Brave VPN apps
+   DCHECK(initial_arguments.empty());
+ 
+   // Not used on Linux.


### PR DESCRIPTION
This change updates Crashpad's logic in Chromium, to allow new process types to initialize crash reporting. The changes are similar to what we currently have for Windows; but these changes are now cross-platform (Windows, macOS, Linux). The change has two Chromium source code patches that are required for the fix.

Resolves https://github.com/brave/brave-browser/issues/55909

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
