### PR TITLE
Disable flaky vertical tab context menu tests on macOS (uplift to 1.92.x)

### DIFF
--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_root_view_browsertest.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_root_view_browsertest.cc
@@ -169,8 +169,13 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripRootViewBrowserTest,
 }
 
 // System menu is used on Windows, so the menu_runner_ path under test does not
-// apply there.
-#if BUILDFLAG(IS_WIN)
+// apply there. On macOS, `views::MenuRunner` shows a native NSMenu whose
+// tracking event loop (`-[NSMenu popUpContextMenu:]` via `ui::ShowContextMenu`)
+// runs synchronously and blocks `RunMenuAt()` until the menu is dismissed. A
+// browser test has no user to dismiss it, so the run loop hangs until the test
+// harness terminates it (SIGTERM), making the test flaky. See
+// https://github.com/brave/brave-browser/issues/56403.
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC)
 #define MAYBE_ContextMenuInUnobscuredRegion \
   DISABLED_ContextMenuInUnobscuredRegion
 #else
@@ -193,9 +198,13 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripRootViewBrowserTest,
   EXPECT_TRUE(vtab_strip_root_view->IsMenuShowing());
 }
 
-// Teesting menu tear down for `menu_runner_`, which is only used on
-// non-Windows platforms.
-#if BUILDFLAG(IS_WIN)
+// Testing menu tear down for `menu_runner_`, which is only used on non-Windows
+// platforms. Disabled on macOS for the same reason as the
+// MAYBE_ContextMenuInUnobscuredRegion test: the native NSMenu tracking loop
+// blocks `RunMenuAt()` synchronously until dismissed, hanging the test until it
+// is terminated (SIGTERM). See
+// https://github.com/brave/brave-browser/issues/56402.
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC)
 #define MAYBE_CloseBrowserWithContextMenuOpen \
   DISABLED_CloseBrowserWithContextMenuOpen
 #else


### PR DESCRIPTION
Uplift of #37277
Resolves https://github.com/brave/brave-browser/issues/56402
Resolves https://github.com/brave/brave-browser/issues/56403

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.