### PR TITLE
[iOS] Reload news widgets when updating disabled features widget data

### DIFF
--- a/ios/brave-ios/Sources/BraveWidgetsModels/DisabledShortcutsWidgetData.swift
+++ b/ios/brave-ios/Sources/BraveWidgetsModels/DisabledShortcutsWidgetData.swift
@@ -62,6 +62,8 @@ public class DisabledShortcutsWidgetData {
       }
       WidgetCenter.shared.reloadTimelines(ofKind: "ShortcutsWidget")
       WidgetCenter.shared.reloadTimelines(ofKind: "LockScreenShortcutWidget")
+      WidgetCenter.shared.reloadTimelines(ofKind: "TopNewsWidget")
+      WidgetCenter.shared.reloadTimelines(ofKind: "TopNewsListWidget")
     } catch {
       Logger.module.error("updateDisabledShortcuts error: \(error.localizedDescription)")
     }


### PR DESCRIPTION
The news widgets also read this data now so we should reload them manually
