### PR TITLE
[iOS] Read Swift package directory correctly with Swift 6 tooling

### DIFF
--- a/ios/brave-ios/Package.swift
+++ b/ios/brave-ios/Package.swift
@@ -662,7 +662,7 @@ var package = Package(
   cxxLanguageStandard: .cxx17
 )
 
-let iosRootDirectory = URL(string: #file)!.deletingLastPathComponent().absoluteString.dropLast()
+let iosRootDirectory = URL(string: PackageDescription.Context.packageDirectory)!.absoluteString
 let isStripAbsolutePathsFromDebugSymbolsEnabled = {
   do {
     let env = try String(contentsOfFile: "\(iosRootDirectory)/../../.env", encoding: .utf8)


### PR DESCRIPTION
`#file` is no longer valid when using Swift 6 tooling which we recently switched to, which meant breakpoints didn't function when building with RBE.
