### PR TITLE
[Android] Don't run on-exit actions on fold/unfold recreation

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -362,6 +362,11 @@ public abstract class BraveActivity extends ChromeActivity
 
     private ApplicationStateListener mApplicationStateListener;
     private IncognitoReauthController mIncognitoReauthController;
+    // Genuine cold start vs an in-process recreation (e.g. foldable fold/unfold). Set once in
+    // initializeState() and never mutated: several cold-start-only behaviors read it.
+    private boolean mIsColdStart;
+    // One-shot guard so the app-close shred notification fires at most once per cold start.
+    private boolean mAppCloseShredTriggered;
 
     /** Serves as a general exception for failed attempts to get BraveActivity. */
     public static class BraveActivityNotFoundException extends Exception {
@@ -1007,7 +1012,11 @@ public abstract class BraveActivity extends ChromeActivity
             mIsDeepLink = true;
             BraveOriginDeepLinkHandler.open(this);
         }
-        if (isNoRestoreState()) {
+        // Null savedInstanceState = real cold start; non-null = in-process recreation such as
+        // a fold/unfold. The app-exit behaviors below must run only on a real cold start,
+        // otherwise folding/unfolding wipes the live session.
+        mIsColdStart = getSavedInstanceState() == null;
+        if (isNoRestoreState() && mIsColdStart) {
             CommandLine.getInstance().appendSwitch(ChromeSwitches.NO_RESTORE_STATE);
         }
 
@@ -1519,7 +1528,10 @@ public abstract class BraveActivity extends ChromeActivity
 
         ContextUtils.getAppSharedPreferences().registerOnSharedPreferenceChangeListener(this);
 
-        if (isClearBrowsingDataOnExit()) {
+        // Clear only on a real cold start; otherwise a fold/unfold recreation would re-run
+        // this and wipe history/site data/cache mid-session. Use mIsColdStart (captured in
+        // initializeState()) since getSavedInstanceState() is already reset to null here.
+        if (isClearBrowsingDataOnExit() && mIsColdStart) {
             int[] dataTypesArray =
                     CollectionUtil.integerCollectionToIntArray(
                             Arrays.asList(
@@ -3155,10 +3167,18 @@ public abstract class BraveActivity extends ChromeActivity
 
     @Override
     public void onTabStateInitializedHandler() {
+        // NO_RESTORE_STATE is a process-global sticky switch. Remove it here so a later
+        // fold/unfold recreation does not re-run ChromeTabbedActivity.clearState() and wipe
+        // the session. Safe: both readers (CTA#initializeState, which consumes it before the
+        // async onTabStateInitialized, and IncognitoRestoreAppLaunchDrawBlocker) run earlier.
+        CommandLine.getInstance().removeSwitch(ChromeSwitches.NO_RESTORE_STATE);
+
         Profile profile = getCurrentProfile();
-        if (profile != null) {
-            // Triggers current app state notification to make sure the first-party storage cleanup
-            // is scheduled on startup if needed.
+        if (profile != null && mIsColdStart && !mAppCloseShredTriggered) {
+            // Schedule the first-party storage cleanup only on a real cold start; on a
+            // fold/unfold recreation it would shred and close every APP_EXIT ("App close")
+            // tab mid-session. One-shot guard so it runs at most once per cold start.
+            mAppCloseShredTriggered = true;
             BraveFirstPartyStorageCleanerUtils.triggerCurrentAppStateNotification(profile);
         }
     }


### PR DESCRIPTION
On foldable devices, folding/unfolding migrates the activity to another display, which destroys and recreates ChromeTabbedActivity in the same process. Several "on exit" privacy behaviors were keyed off activity initialization, so each fold was mistaken for an app exit:

- "Close tabs on exit": the sticky --no-restore-state switch made ChromeTabbedActivity.clearState() wipe the live session's tabs.
- Auto Shred "App close" (APP_EXIT): triggerCurrentAppStateNotification closed every APP_EXIT-mode tab.
- "Clear all data on exit": finishNativeInitialization() cleared history, site data and cache for ALL_TIME mid-session.

Gate all three on a genuine cold start. A null savedInstanceState means a fresh launch; a non-null one means an in-process recreation (fold/unfold). The flag is captured in initializeState() because getSavedInstanceState() is already reset by the time the later sites run. The sticky --no-restore-state switch is also removed after its cold-start consumer runs so a later recreation cannot re-trigger clearState().

Resolves: https://github.com/brave/brave-browser/issues/48934

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
