### PR TITLE
[iOS] Introduce custom SwiftUI button styles for Nala buttons

### DIFF
--- a/ios/brave-ios/Sources/DesignSystem/Buttons/BraveButtonStyle.swift
+++ b/ios/brave-ios/Sources/DesignSystem/Buttons/BraveButtonStyle.swift
@@ -43,6 +43,7 @@ public struct BraveButtonSize {
   )
 }
 
+@available(iOS, deprecated, message: "Use FilledButtonStyle or GlassFilledButtonStyle")
 public struct BraveFilledButtonStyle: ButtonStyle {
   @Environment(\.isEnabled) private var isEnabled
 
@@ -77,6 +78,7 @@ public struct BraveFilledButtonStyle: ButtonStyle {
   }
 }
 
+@available(iOS, deprecated, message: "Use OutlineButtonStyle")
 public struct BraveOutlineButtonStyle: ButtonStyle {
   @Environment(\.isEnabled) private var isEnabled
 

--- a/ios/brave-ios/Sources/DesignSystem/Buttons/ButtonLabelModifier.swift
+++ b/ios/brave-ios/Sources/DesignSystem/Buttons/ButtonLabelModifier.swift
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+// The base set of modifiers used for all Brave styled buttons based on the control size
+struct ButtonLabelModifier: ViewModifier {
+  @Environment(\.controlSize) private var controlSize
+
+  private var padding: EdgeInsets {
+    switch controlSize {
+    case .mini: return .init(horizontal: 8, vertical: 6)
+    case .small: return .init(horizontal: 12, vertical: 9)
+    case .regular: return .init(horizontal: 12, vertical: 12)
+    case .large: return .init(horizontal: 16, vertical: 14)
+    case .extraLarge: return .init(horizontal: 16, vertical: 16)
+    @unknown default:
+      return .init(horizontal: 12, vertical: 12)
+    }
+  }
+
+  private var font: Font {
+    switch controlSize {
+    case .mini: return .caption
+    case .small: return .caption
+    case .regular: return .subheadline
+    case .large: return .callout
+    case .extraLarge: return .headline
+    @unknown default:
+      return .subheadline
+    }
+  }
+
+  private var minimumSize: Double {
+    switch controlSize {
+    case .mini: return 28
+    case .small: return 36
+    case .regular: return 44
+    case .large: return 52
+    case .extraLarge: return 60
+    @unknown default:
+      return 44
+    }
+  }
+
+  func body(content: Content) -> some View {
+    content
+      .labelStyle(BaseLabelStyle())
+      .font(font)
+      .fontWeight(.semibold)
+      .padding(padding)
+      .frame(minWidth: minimumSize, minHeight: minimumSize)
+      .multilineTextAlignment(.center)
+  }
+
+  private struct BaseLabelStyle: LabelStyle {
+    func makeBody(configuration: Configuration) -> some View {
+      if #available(iOS 26.0, *) {
+        Label(configuration)
+          .labelIconToTitleSpacing(4)
+      } else {
+        HStack(spacing: 4) {
+          configuration.icon
+          configuration.title
+        }
+      }
+    }
+  }
+}
+
+extension EdgeInsets {
+  fileprivate init(horizontal: Double, vertical: Double) {
+    self.init(top: vertical, leading: horizontal, bottom: vertical, trailing: horizontal)
+  }
+}

--- a/ios/brave-ios/Sources/DesignSystem/Buttons/ButtonStylePreviews.swift
+++ b/ios/brave-ios/Sources/DesignSystem/Buttons/ButtonStylePreviews.swift
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#if DEBUG
+
+import SwiftUI
+
+private struct ButtonGridRow: View {
+  var title: String
+
+  var body: some View {
+    Section {
+      ForEach(ControlSize.allCases, id: \.self) { size in
+        GridRow {
+          Text(String(describing: size))
+            .gridCellAnchor(.trailing)
+          ForEach([true, false], id: \.self) { isEnabled in
+            Button {
+            } label: {
+              Label("Text", braveSystemImage: "leo.copy")
+            }
+            .disabled(!isEnabled)
+            .gridCellAnchor(.leading)
+            .fixedSize()
+          }
+        }
+        .environment(\.controlSize, size)
+      }
+    } header: {
+      Text(title)
+        .frame(maxWidth: .infinity)
+        .font(.footnote.bold())
+        .padding(8)
+        .foregroundStyle(Color(braveSystemName: .systemfeedbackInfoText))
+        .background(Color(braveSystemName: .systemfeedbackInfoBackground), in: .capsule)
+        .background(.regularMaterial, in: .capsule)
+    }
+  }
+}
+
+struct ButtonPreviewGrid<Rows: View>: View {
+  var rows: Rows
+
+  init(@ViewBuilder rows: () -> Rows) {
+    self.rows = rows()
+  }
+
+  var body: some View {
+    ScrollView([.horizontal, .vertical]) {
+      Grid(horizontalSpacing: 24, verticalSpacing: 16) {
+        GridRow {
+          Text("Size")
+            .gridCellAnchor(.trailing)
+          Text("Default")
+            .gridCellAnchor(.leading)
+          Text("Disabled")
+            .gridCellAnchor(.leading)
+        }
+        .font(.footnote.bold())
+        .textCase(.uppercase)
+        rows
+      }
+      .padding()
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .scrollBounceBehavior(.basedOnSize, axes: [.horizontal, .vertical])
+  }
+}
+
+#Preview("Standard") {
+  ButtonPreviewGrid {
+    ButtonGridRow(title: "Filled")
+      .buttonStyle(.filled)
+    ButtonGridRow(title: "Hero")
+      .buttonStyle(.hero)
+    ButtonGridRow(title: "Outline")
+      .buttonStyle(.outline)
+    ButtonGridRow(title: "Plain")
+      .buttonStyle(.plainBordered)
+    ButtonGridRow(title: "Plain Faint")
+      .buttonStyle(.plainFaint)
+  }
+}
+
+#Preview("Glass") {
+  if #available(iOS 26.0, *) {
+    ButtonPreviewGrid {
+      ButtonGridRow(title: "Filled")
+        .buttonStyle(.glassFilled)
+      ButtonGridRow(title: "Hero")
+        .buttonStyle(.glassHero)
+      ButtonGridRow(title: "Plain Glass")
+        .buttonStyle(.plainGlass)
+    }
+    .background(Color(white: 0.9).gradient)
+  }
+}
+
+#endif

--- a/ios/brave-ios/Sources/DesignSystem/Buttons/FilledButtonStyle.swift
+++ b/ios/brave-ios/Sources/DesignSystem/Buttons/FilledButtonStyle.swift
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+/// A button style applies a standard background, padding and text styling
+///
+/// In Nala, this matches the "Filled" button component
+public struct FilledButtonStyle: ButtonStyle {
+  @Environment(\.isEnabled) private var isEnabled
+
+  public func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .modifier(ButtonLabelModifier())
+      .foregroundStyle(Color(braveSystemName: isEnabled ? .schemesOnPrimary : .textDisabled))
+      .background {
+        if isEnabled {
+          Color(braveSystemName: .buttonBackground)
+            .mix(
+              with: Color(braveSystemName: .fixedForeground),
+              by: configuration.isPressed ? 0.2 : 0
+            )
+        } else {
+          Color(braveSystemName: .buttonDisabled)
+        }
+      }
+      .clipShape(.capsule)
+      .contentShape(.capsule)
+      .hoverEffect()
+      .animation(.linear(duration: 0.15), value: isEnabled)
+  }
+}
+
+/// A button style applies standard padding and text styling on a tinted glass effect background,
+@available(iOS 26.0, *)
+public struct GlassFilledButtonStyle: ButtonStyle {
+  @Environment(\.isEnabled) private var isEnabled
+
+  public func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .modifier(ButtonLabelModifier())
+      // Glass buttons use a specific set of colours because text color adjusts dynamically based
+      // on content behind the button and disabled status matches Apple
+      .foregroundStyle(isEnabled ? AnyShapeStyle(.white) : AnyShapeStyle(.tertiary))
+      .glassEffect(
+        .regular
+          .tint(
+            isEnabled
+              ? Color(braveSystemName: .primitivePrimary40) : Color(uiColor: .tertiarySystemFill)
+          )
+          .interactive(isEnabled),
+        in: .capsule
+      )
+  }
+}
+
+extension ButtonStyle where Self == FilledButtonStyle {
+  public static var filled: Self { .init() }
+}
+
+@available(iOS 26.0, *)
+extension ButtonStyle where Self == GlassFilledButtonStyle {
+  public static var glassFilled: Self { .init() }
+}

--- a/ios/brave-ios/Sources/DesignSystem/Buttons/HeroButtonStyle.swift
+++ b/ios/brave-ios/Sources/DesignSystem/Buttons/HeroButtonStyle.swift
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+/// A button style applies a hero gradient background, padding and text styling
+///
+/// In Nala, this matches the "Hero" button component
+public struct HeroButtonStyle: ButtonStyle {
+  @Environment(\.isEnabled) private var isEnabled
+
+  public func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .modifier(ButtonLabelModifier())
+      .foregroundStyle(isEnabled ? .white : Color(braveSystemName: .textDisabled))
+      .background {
+        if isEnabled {
+          LinearGradient(braveSystemName: .hero)
+            .overlay {
+              Color(braveSystemName: .fixedForeground)
+                .opacity(configuration.isPressed ? 0.2 : 0)
+            }
+        } else {
+          Color(braveSystemName: .buttonDisabled)
+        }
+      }
+      .clipShape(.capsule)
+      .contentShape(.capsule)
+      .hoverEffect()
+      .animation(.linear(duration: 0.15), value: isEnabled)
+  }
+}
+
+/// A button style applies standard padding and text styling on a tinted glass effect background
+@available(iOS 26.0, *)
+public struct GlassHeroButtonStyle: ButtonStyle {
+  @Environment(\.isEnabled) private var isEnabled
+
+  public func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .modifier(ButtonLabelModifier())
+      // Glass buttons use a specific set of colours because text color adjusts dynamically based
+      // on content behind the button and disabled status matches Apple
+      .foregroundStyle(isEnabled ? AnyShapeStyle(.white) : AnyShapeStyle(.tertiary))
+      .glassEffect(
+        .regular
+          .tint(
+            isEnabled
+              ? Color(braveSystemName: .primitiveBrandsRorange2)
+              : Color(uiColor: .tertiarySystemFill)
+          )
+          .interactive(isEnabled),
+        in: .capsule
+      )
+  }
+}
+
+extension ButtonStyle where Self == HeroButtonStyle {
+  public static var hero: Self { .init() }
+}
+
+@available(iOS 26.0, *)
+extension ButtonStyle where Self == GlassHeroButtonStyle {
+  public static var glassHero: Self { .init() }
+}

--- a/ios/brave-ios/Sources/DesignSystem/Buttons/OutlineButtonStyle.swift
+++ b/ios/brave-ios/Sources/DesignSystem/Buttons/OutlineButtonStyle.swift
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+/// A button style applies a stroke border outline, padding and text styling
+///
+/// In Nala, this matches the "Outline" button component
+public struct OutlineButtonStyle: ButtonStyle {
+  @Environment(\.isEnabled) private var isEnabled
+
+  public func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .modifier(ButtonLabelModifier())
+      .foregroundStyle(Color(braveSystemName: isEnabled ? .textInteractive : .textDisabled))
+      .background {
+        if configuration.isPressed {
+          Color(braveSystemName: .buttonBackground).opacity(0.1)
+        }
+      }
+      .background(
+        Capsule()
+          .strokeBorder(
+            Color(braveSystemName: isEnabled ? .dividerInteractive : .buttonDisabled),
+            lineWidth: 1
+          )
+      )
+      .clipShape(.capsule)
+      .contentShape(.capsule)
+      .hoverEffect()
+      .animation(.linear(duration: 0.15), value: isEnabled)
+  }
+}
+
+extension ButtonStyle where Self == OutlineButtonStyle {
+  public static var outline: Self { .init() }
+}

--- a/ios/brave-ios/Sources/DesignSystem/Buttons/PlainButtonStyle.swift
+++ b/ios/brave-ios/Sources/DesignSystem/Buttons/PlainButtonStyle.swift
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+/// A button style that applies a more subtle button background and standard padding & text styling.
+///
+/// In Nala, this matches the "Plain" button component
+public struct PlainBorderedButtonStyle: ButtonStyle {
+  @Environment(\.isEnabled) private var isEnabled
+
+  public func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .modifier(ButtonLabelModifier())
+      .foregroundStyle(Color(braveSystemName: isEnabled ? .textInteractive : .textDisabled))
+      .background {
+        if isEnabled {
+          Color(braveSystemName: .buttonBackground)
+            .opacity(0.05)
+            .mix(
+              with: Color(braveSystemName: .fixedForeground),
+              by: configuration.isPressed ? 0.1 : 0
+            )
+        } else {
+          // 7% icon default is currently the background color used in Figma for this button styles
+          // disabled state
+          Color(braveSystemName: .iconDefault).opacity(0.07)
+        }
+      }
+      .clipShape(.capsule)
+      .contentShape(.capsule)
+      .hoverEffect()
+      .animation(.linear(duration: 0.15), value: isEnabled)
+  }
+}
+
+/// A button style that matches a Glass button style but with Nala standard padding & text styling
+@available(iOS 26.0, *)
+public struct PlainGlassButtonStyle: ButtonStyle {
+  @Environment(\.isEnabled) private var isEnabled
+
+  public func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .modifier(ButtonLabelModifier())
+      // Glass buttons use a specific set of colours because text color adjusts dynamically based
+      // on content behind the button and disabled status matches Apple
+      .foregroundStyle(isEnabled ? .primary : .tertiary)
+      .glassEffect(.regular.interactive(isEnabled), in: .capsule)
+  }
+}
+
+extension ButtonStyle where Self == PlainBorderedButtonStyle {
+  public static var plainBordered: Self { .init() }
+}
+
+@available(iOS 26.0, *)
+extension ButtonStyle where Self == PlainGlassButtonStyle {
+  public static var plainGlass: Self { .init() }
+}

--- a/ios/brave-ios/Sources/DesignSystem/Buttons/PlainFaintButtonStyle.swift
+++ b/ios/brave-ios/Sources/DesignSystem/Buttons/PlainFaintButtonStyle.swift
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+/// A button style that applies some standard text styling & padding but otherwise doesn't decorate
+/// its content while idle, but applies a visual effect to indicate the pressed or enabled state of
+/// the button.
+///
+/// In Nala, this matches the "Plain Faint" button component
+public struct PlainFaintButtonStyle: ButtonStyle {
+  @Environment(\.isEnabled) private var isEnabled
+
+  public func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .modifier(ButtonLabelModifier())
+      .foregroundStyle(Color(braveSystemName: isEnabled ? .textSecondary : .textDisabled))
+      .background {
+        if configuration.isPressed {
+          // 7% icon default is currently the background color used in Figma for this button styles
+          // highlighted state
+          Color(braveSystemName: .iconDefault).opacity(0.07)
+        }
+      }
+      .clipShape(.capsule)
+      .contentShape(.capsule)
+      .hoverEffect()
+      .animation(.linear(duration: 0.15), value: isEnabled)
+  }
+}
+
+extension ButtonStyle where Self == PlainFaintButtonStyle {
+  public static var plainFaint: Self { .init() }
+}


### PR DESCRIPTION
Including glass variants for filled, hero and plain buttons. This PR also deprecates the current `BraveFilledButtonStyle` and `BraveOutlineButtonStyle`, a future PR will replace usages with the new ones
