### PR TITLE
[Origin] Compile out local AI in Brave Origin builds

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -5,6 +5,7 @@
 
 import("//brave/browser/updater/buildflags.gni")
 import("//brave/build/config.gni")
+import("//brave/components/local_ai/buildflags/buildflags.gni")
 import("//build/buildflag_header.gni")
 import("//build/config/features.gni")
 import("//chrome/common/features.gni")
@@ -33,13 +34,17 @@ source_set("browser_process") {
     "//brave/browser/brave_stats:buildflags",
     "//brave/components/brave_ads/buildflags",
     "//brave/components/brave_vpn/common/buildflags",
-    "//brave/components/local_ai/core",
+    "//brave/components/local_ai/buildflags",
     "//brave/components/request_otr/common/buildflags",
     "//brave/components/speedreader/common/buildflags",
     "//brave/components/tor/buildflags",
     "//chrome/browser:browser_process",
     "//extensions/buildflags",
   ]
+
+  if (enable_local_ai) {
+    deps += [ "//brave/components/local_ai/core" ]
+  }
 }
 
 source_set("brave_global_features") {

--- a/browser/DEPS
+++ b/browser/DEPS
@@ -57,6 +57,7 @@ include_rules += [
   "+brave/components/email_aliases/browser",
   "+brave/components/global_privacy_control",
   "+brave/components/google_sign_in_permission",
+  "+brave/components/local_ai/buildflags",
   "+brave/components/local_ai/content",
   "+brave/components/local_ai/core",
   "+brave/components/ntp_background_images/browser",

--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -27,6 +27,7 @@
 #include "brave/components/debounce/core/common/features.h"
 #include "brave/components/email_aliases/buildflags/buildflags.h"
 #include "brave/components/google_sign_in_permission/features.h"
+#include "brave/components/local_ai/buildflags/buildflags.h"
 #include "brave/components/ntp_background_images/browser/features.h"
 #include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/psst/buildflags/buildflags.h"
@@ -708,6 +709,7 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
 // The upstream "history-embeddings" flag expired at M145. Use a
 // different name to bypass the expiry system while controlling the
 // same underlying kHistoryEmbeddings feature.
+#if BUILDFLAG(ENABLE_LOCAL_AI)
 #define BRAVE_HISTORY_EMBEDDINGS_FLAG                             \
   EXPAND_FEATURE_ENTRIES({                                        \
       "brave-history-embeddings",                                 \
@@ -716,6 +718,9 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
       kOsDesktop,                                                 \
       FEATURE_VALUE_TYPE(history_embeddings::kHistoryEmbeddings), \
   })
+#else
+#define BRAVE_HISTORY_EMBEDDINGS_FLAG
+#endif
 
 #define BRAVE_OMNIBOX_FEATURES                                                \
   EXPAND_FEATURE_ENTRIES(                                                     \

--- a/browser/ai_chat/BUILD.gn
+++ b/browser/ai_chat/BUILD.gn
@@ -4,6 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
+import("//brave/components/local_ai/buildflags/buildflags.gni")
 import("//build/buildflag_header.gni")
 import("//pdf/features.gni")
 import("//printing/buildflags/buildflags.gni")
@@ -363,7 +364,6 @@ source_set("browser_tests") {
       "code_execution_tool_browsertest.cc",
       "page_content_fetcher_browsertest.cc",
       "text_file_extractor_browsertest.cc",
-      "tools/history_search_tool_browsertest.cc",
       "web_mcp_browsertest.cc",
     ]
 
@@ -385,7 +385,6 @@ source_set("browser_tests") {
       "//brave/components/ai_chat/core/common/mojom",
       "//brave/components/constants",
       "//brave/components/l10n/common:test_support",
-      "//brave/components/local_ai/core",
       "//brave/components/resources:strings_grit",
       "//brave/components/sidebar/browser",
       "//brave/components/text_recognition/common/buildflags",
@@ -407,6 +406,11 @@ source_set("browser_tests") {
       "//ui/accessibility:ax_base",
       "//ui/accessibility:ax_features_mojo",
     ]
+
+    if (enable_local_ai) {
+      sources += [ "tools/history_search_tool_browsertest.cc" ]
+      deps += [ "//brave/components/local_ai/core" ]
+    }
 
     if (enable_ai_chat_tab_management_tool) {
       sources += [ "tools/tab_management_tool_browsertest.cc" ]

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -42,7 +42,6 @@
 #include "brave/browser/profiles/brave_renderer_updater_factory.h"
 #include "brave/browser/skus/skus_service_factory.h"
 #include "brave/browser/ui/brave_ui_features.h"
-#include "brave/browser/ui/webui/local_ai/local_ai_ui.h"
 #include "brave/browser/ui/webui/skus_internals_ui.h"
 #include "brave/browser/updater/buildflags.h"
 #include "brave/browser/url_sanitizer/url_sanitizer_service_factory.h"
@@ -85,7 +84,7 @@
 #include "brave/components/global_privacy_control/global_privacy_control_utils.h"
 #include "brave/components/google_sign_in_permission/google_sign_in_permission_throttle.h"
 #include "brave/components/google_sign_in_permission/google_sign_in_permission_util.h"
-#include "brave/components/local_ai/core/local_ai.mojom.h"
+#include "brave/components/local_ai/buildflags/buildflags.h"
 #include "brave/components/ntp_background_images/browser/mojom/ntp_background_images.mojom.h"
 #include "brave/components/password_strength_meter/password_strength_meter.mojom.h"
 #include "brave/components/playlist/core/common/buildflags/buildflags.h"
@@ -160,13 +159,20 @@
 #include "brave/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page_ui.h"
 #include "brave/browser/ui/webui/brave_settings_ui.h"
 #include "brave/browser/ui/webui/brave_shields/shields_panel_ui.h"
-#include "brave/browser/ui/webui/history/brave_history_embeddings.mojom.h"
-#include "brave/browser/ui/webui/history/brave_history_ui.h"
 #include "brave/browser/ui/webui/new_tab_page/brave_new_tab_ui.h"
 #include "brave/browser/ui/webui/private_new_tab_page/brave_private_new_tab_ui.h"
 #include "brave/components/brave_new_tab_ui/brave_new_tab_page.mojom.h"
 #include "brave/components/brave_private_new_tab_ui/common/brave_private_new_tab.mojom.h"
+#if BUILDFLAG(ENABLE_LOCAL_AI)
+#include "brave/browser/ui/webui/history/brave_history_embeddings.mojom.h"
+#include "brave/browser/ui/webui/history/brave_history_ui.h"
+#endif
 #endif  // !BUILDFLAG(IS_ANDROID)
+
+#if BUILDFLAG(ENABLE_LOCAL_AI)
+#include "brave/browser/ui/webui/local_ai/local_ai_ui.h"
+#include "brave/components/local_ai/core/local_ai.mojom.h"
+#endif
 
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
 #include "brave/browser/ui/webui/ads_internals/ads_internals_ui.h"
@@ -951,18 +957,22 @@ void BraveContentBrowserClient::RegisterBrowserInterfaceBindersForFrame(
 
   map->Add<skus::mojom::SkusService>(
       base::BindRepeating(&MaybeBindSkusSdkImpl));
+#if BUILDFLAG(ENABLE_LOCAL_AI)
   if (base::FeatureList::IsEnabled(history_embeddings::kHistoryEmbeddings)) {
     content::RegisterWebUIControllerInterfaceBinder<
         local_ai::mojom::LocalAIService, local_ai::UntrustedLocalAIUI>(map);
   }
+#endif
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   map->Add<brave_vpn::mojom::ServiceHandler>(
       base::BindRepeating(&MaybeBindBraveVpnImpl));
 #endif
 
 #if !BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(ENABLE_LOCAL_AI)
   content::RegisterWebUIControllerInterfaceBinder<
       brave_history_embeddings::mojom::PageHandlerFactory, BraveHistoryUI>(map);
+#endif
   content::RegisterWebUIControllerInterfaceBinder<
       brave_private_new_tab::mojom::PageHandler, BravePrivateNewTabUI>(map);
   content::RegisterWebUIControllerInterfaceBinder<

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -159,13 +159,13 @@
 #include "brave/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page_ui.h"
 #include "brave/browser/ui/webui/brave_settings_ui.h"
 #include "brave/browser/ui/webui/brave_shields/shields_panel_ui.h"
+#include "brave/browser/ui/webui/history/brave_history_ui.h"
 #include "brave/browser/ui/webui/new_tab_page/brave_new_tab_ui.h"
 #include "brave/browser/ui/webui/private_new_tab_page/brave_private_new_tab_ui.h"
 #include "brave/components/brave_new_tab_ui/brave_new_tab_page.mojom.h"
 #include "brave/components/brave_private_new_tab_ui/common/brave_private_new_tab.mojom.h"
 #if BUILDFLAG(ENABLE_LOCAL_AI)
 #include "brave/browser/ui/webui/history/brave_history_embeddings.mojom.h"
-#include "brave/browser/ui/webui/history/brave_history_ui.h"
 #endif
 #endif  // !BUILDFLAG(IS_ANDROID)
 

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -43,7 +43,7 @@
 #include "brave/components/debounce/core/browser/debounce_service.h"
 #include "brave/components/global_privacy_control/pref_names.h"
 #include "brave/components/ipfs/ipfs_prefs.h"
-#include "brave/components/local_ai/core/pref_names.h"
+#include "brave/components/local_ai/buildflags/buildflags.h"
 #include "brave/components/ntp_background_images/browser/view_counter_service.h"
 #include "brave/components/ntp_background_images/buildflags/buildflags.h"
 #include "brave/components/ntp_background_images/common/view_counter_pref_registry.h"
@@ -167,6 +167,10 @@ using extensions::FeatureSwitch;
 
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
 #include "brave/components/brave_wallet/browser/pref_names.h"
+#endif
+
+#if BUILDFLAG(ENABLE_LOCAL_AI)
+#include "brave/components/local_ai/core/pref_names.h"
 #endif
 
 namespace brave {
@@ -561,7 +565,9 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   ai_chat::ModelService::RegisterProfilePrefs(registry);
 #endif
 
+#if BUILDFLAG(ENABLE_LOCAL_AI)
   local_ai::prefs::RegisterProfilePrefs(registry);
+#endif
 
   brave_account::prefs::RegisterPrefs(registry);
   brave_origin::prefs::RegisterProfilePrefs(registry);

--- a/browser/component_updater/BUILD.gn
+++ b/browser/component_updater/BUILD.gn
@@ -3,6 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import("//brave/components/local_ai/buildflags/buildflags.gni")
+
 source_set("component_updater") {
   sources = [
     "brave_component_updater_configurator.cc",
@@ -12,7 +14,7 @@ source_set("component_updater") {
   deps = [
     "//base",
     "//brave/components/constants",
-    "//brave/components/local_ai/core",
+    "//brave/components/local_ai/buildflags",
     "//chrome/common",
     "//components/component_updater",
     "//components/prefs",
@@ -25,6 +27,10 @@ source_set("component_updater") {
     "//content/public/browser",
     "//services/network/public/cpp",
   ]
+
+  if (enable_local_ai) {
+    deps += [ "//brave/components/local_ai/core" ]
+  }
 
   if (is_win) {
     deps += [ "//chrome/installer/util:with_no_strings" ]

--- a/browser/history_embeddings/BUILD.gn
+++ b/browser/history_embeddings/BUILD.gn
@@ -3,6 +3,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/local_ai/buildflags/buildflags.gni")
+
+assert(enable_local_ai)
+
 source_set("unit_tests") {
   testonly = true
   sources = [

--- a/browser/resources/history/sources.gni
+++ b/browser/resources/history/sources.gni
@@ -3,12 +3,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-brave_history_mojo_files = [ "$root_gen_dir/brave/browser/ui/webui/history/brave_history_embeddings.mojom-webui.ts" ]
+import("//brave/components/local_ai/buildflags/buildflags.gni")
 
+brave_history_preprocessor_defines = [ "enable_local_ai=$enable_local_ai" ]
+brave_history_mojo_files = [ "$root_gen_dir/brave/browser/ui/webui/history/brave_history_embeddings.mojom-webui.ts" ]
 brave_history_mojo_files_deps =
     [ "//brave/browser/ui/webui/history:mojom_ts__generator" ]
+brave_history_ts_files = []
+brave_history_preprocess_deps = []
 
-brave_history_ts_files = [ "brave_history_embeddings_browser_proxy.ts" ]
-
-brave_history_preprocess_deps =
-    [ "//brave/browser/resources/history:preprocess" ]
+if (enable_local_ai) {
+  brave_history_ts_files += [ "brave_history_embeddings_browser_proxy.ts" ]
+  brave_history_preprocess_deps +=
+      [ "//brave/browser/resources/history:preprocess" ]
+}

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -48,6 +48,7 @@ import("//brave/components/commander/common/buildflags/buildflags.gni")
 import("//brave/components/containers/buildflags/buildflags.gni")
 import("//brave/components/email_aliases/buildflags/buildflags.gni")
 import("//brave/components/ipfs/buildflags/buildflags.gni")
+import("//brave/components/local_ai/buildflags/buildflags.gni")
 import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
 import("//brave/components/psst/buildflags/buildflags.gni")
 import("//brave/components/tor/buildflags/buildflags.gni")
@@ -148,7 +149,6 @@ brave_chrome_browser_deps = [
   "//brave/browser/brave_shields:brave_shields_impl",
   "//brave/browser/brave_stats",
   "//brave/browser/component_updater",
-  "//brave/browser/history_embeddings",
   "//brave/browser/metrics/buildflags",
   "//brave/browser/misc_metrics",
   "//brave/browser/misc_metrics:misc_metrics_impl",
@@ -162,7 +162,6 @@ brave_chrome_browser_deps = [
   "//brave/browser/themes",
   "//brave/browser/ui",
   "//brave/browser/ui/webui/brave_account",
-  "//brave/browser/ui/webui/local_ai",
   "//brave/browser/updater:buildflags",
   "//brave/common",
   "//brave/common:mojo_bindings",
@@ -227,9 +226,7 @@ brave_chrome_browser_deps = [
   "//brave/components/ipfs",
   "//brave/components/ipfs/buildflags",
   "//brave/components/l10n/common",
-  "//brave/components/local_ai/core",
-  "//brave/components/local_ai/core:features",
-  "//brave/components/local_ai/core:mojom",
+  "//brave/components/local_ai/buildflags",
   "//brave/components/ntp_background_images/browser",
   "//brave/components/ntp_background_images/buildflags",
   "//brave/components/ntp_background_images/common",
@@ -369,6 +366,16 @@ if (enable_email_aliases) {
     "//brave/components/email_aliases:mojom",
     "//brave/components/email_aliases:pref_names",
     "//brave/components/email_aliases:service",
+  ]
+}
+
+if (enable_local_ai) {
+  brave_chrome_browser_deps += [
+    "//brave/browser/history_embeddings",
+    "//brave/browser/ui/webui/local_ai",
+    "//brave/components/local_ai/core",
+    "//brave/components/local_ai/core:features",
+    "//brave/components/local_ai/core:mojom",
   ]
 }
 
@@ -771,13 +778,17 @@ brave_chrome_browser_ui_allow_circular_includes_from +=
 
 brave_chrome_browser_allow_circular_includes_from += [
   "//brave/browser/brave_shields:brave_shields_impl",
-  "//brave/browser/history_embeddings",
   "//brave/browser/ui",
   "//brave/browser/brave_stats",
   "//brave/browser/ntp_background",
   "//brave/browser/serp_metrics:impl",
   "//brave/browser:brave_global_features_impl",
 ]
+
+if (enable_local_ai) {
+  brave_chrome_browser_allow_circular_includes_from +=
+      [ "//brave/browser/history_embeddings" ]
+}
 
 if (enable_ai_chat) {
   # TODO(https://github.com/brave/brave-browser/issues/50507):

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -19,6 +19,7 @@ import("//brave/components/brave_wayback_machine/buildflags/buildflags.gni")
 import("//brave/components/commander/common/buildflags/buildflags.gni")
 import("//brave/components/containers/buildflags/buildflags.gni")
 import("//brave/components/email_aliases/buildflags/buildflags.gni")
+import("//brave/components/local_ai/buildflags/buildflags.gni")
 import("//brave/components/ntp_background_images/buildflags/buildflags.gni")
 import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
 import("//brave/components/psst/buildflags/buildflags.gni")
@@ -66,7 +67,6 @@ source_set("ui") {
     "//brave/browser/skus",
     "//brave/browser/ui/page_info",
     "//brave/browser/ui/webui/brave_account",
-    "//brave/browser/ui/webui/local_ai",
     "//brave/components/ai_chat/core/common/buildflags",
 
     # Unconditional for gn check as the NTP WebUI always needs the mojom
@@ -106,6 +106,10 @@ source_set("ui") {
 
   if (is_mac) {
     deps += [ "//chrome/browser:global_keyboard_shortcuts_mac" ]
+  }
+
+  if (enable_local_ai) {
+    deps += [ "//brave/browser/ui/webui/local_ai" ]
   }
 
   allow_circular_includes_from = brave_ui_allow_circular_includes_from

--- a/browser/ui/webui/history/BUILD.gn
+++ b/browser/ui/webui/history/BUILD.gn
@@ -9,7 +9,10 @@ import("//mojo/public/tools/bindings/mojom.gni")
 assert(!is_android)
 
 source_set("history") {
-  sources = []
+  sources = [
+    "brave_history_ui.cc",
+    "brave_history_ui.h",
+  ]
 
   public_deps = [
     ":mojom",
@@ -22,6 +25,7 @@ source_set("history") {
 
   deps = [
     "//base",
+    "//brave/components/local_ai/buildflags",
     "//chrome/browser/profiles:profile",
     "//chrome/common:constants",
     "//components/prefs",
@@ -32,8 +36,6 @@ source_set("history") {
     sources += [
       "brave_history_embeddings_page_handler.cc",
       "brave_history_embeddings_page_handler.h",
-      "brave_history_ui.cc",
-      "brave_history_ui.h",
     ]
 
     deps += [ "//brave/components/local_ai/core" ]

--- a/browser/ui/webui/history/BUILD.gn
+++ b/browser/ui/webui/history/BUILD.gn
@@ -3,22 +3,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/local_ai/buildflags/buildflags.gni")
 import("//mojo/public/tools/bindings/mojom.gni")
 
 assert(!is_android)
 
-mojom("mojom") {
-  sources = [ "brave_history_embeddings.mojom" ]
-  webui_module_path = "/"
-}
-
 source_set("history") {
-  sources = [
-    "brave_history_embeddings_page_handler.cc",
-    "brave_history_embeddings_page_handler.h",
-    "brave_history_ui.cc",
-    "brave_history_ui.h",
-  ]
+  sources = []
 
   public_deps = [
     ":mojom",
@@ -31,10 +22,25 @@ source_set("history") {
 
   deps = [
     "//base",
-    "//brave/components/local_ai/core",
     "//chrome/browser/profiles:profile",
     "//chrome/common:constants",
     "//components/prefs",
     "//content/public/common",
   ]
+
+  if (enable_local_ai) {
+    sources += [
+      "brave_history_embeddings_page_handler.cc",
+      "brave_history_embeddings_page_handler.h",
+      "brave_history_ui.cc",
+      "brave_history_ui.h",
+    ]
+
+    deps += [ "//brave/components/local_ai/core" ]
+  }
+}
+
+mojom("mojom") {
+  sources = [ "brave_history_embeddings.mojom" ]
+  webui_module_path = "/"
 }

--- a/browser/ui/webui/history/brave_history_ui.cc
+++ b/browser/ui/webui/history/brave_history_ui.cc
@@ -5,14 +5,17 @@
 
 #include "brave/browser/ui/webui/history/brave_history_ui.h"
 
-#include "brave/browser/ui/webui/history/brave_history_embeddings_page_handler.h"
 #include "chrome/browser/profiles/profile.h"
-#include "components/prefs/pref_service.h"
+
+#if BUILDFLAG(ENABLE_LOCAL_AI)
+#include "brave/browser/ui/webui/history/brave_history_embeddings_page_handler.h"
+#endif
 
 BraveHistoryUI::BraveHistoryUI(content::WebUI* web_ui) : HistoryUI(web_ui) {}
 
 BraveHistoryUI::~BraveHistoryUI() = default;
 
+#if BUILDFLAG(ENABLE_LOCAL_AI)
 void BraveHistoryUI::BindInterface(
     mojo::PendingReceiver<brave_history_embeddings::mojom::PageHandlerFactory>
         receiver) {
@@ -28,3 +31,4 @@ void BraveHistoryUI::CreatePageHandler(
       std::move(receiver), std::move(page),
       Profile::FromWebUI(web_ui())->GetPrefs());
 }
+#endif

--- a/browser/ui/webui/history/brave_history_ui.h
+++ b/browser/ui/webui/history/brave_history_ui.h
@@ -9,6 +9,7 @@
 #include <memory>
 
 #include "brave/browser/ui/webui/history/brave_history_embeddings.mojom.h"
+#include "brave/components/local_ai/buildflags/buildflags.h"
 #include "chrome/browser/ui/webui/history/history_ui.h"
 #include "chrome/common/url_constants.h"
 #include "chrome/common/webui_url_constants.h"
@@ -17,7 +18,10 @@
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 
+#if BUILDFLAG(ENABLE_LOCAL_AI)
 class BraveHistoryEmbeddingsPageHandler;
+#endif
+
 class BraveHistoryUI;
 
 class BraveHistoryUIConfig
@@ -28,18 +32,23 @@ class BraveHistoryUIConfig
                            chrome::kChromeUIHistoryHost) {}
 };
 
-// Brave subclass of the chrome://history WebUI controller that adds a
-// Mojo interface (Semantic History Search toggle handler) on top of
-// upstream's bindings.
+// Brave subclass of the chrome://history WebUI controller. When local AI is
+// enabled it also hosts the Semantic History Search toggle's Mojo
+// PageHandlerFactory on top of upstream's bindings.
 class BraveHistoryUI
-    : public HistoryUI,
-      public brave_history_embeddings::mojom::PageHandlerFactory {
+    : public HistoryUI
+#if BUILDFLAG(ENABLE_LOCAL_AI)
+    ,
+      public brave_history_embeddings::mojom::PageHandlerFactory
+#endif
+{
  public:
   explicit BraveHistoryUI(content::WebUI* web_ui);
   BraveHistoryUI(const BraveHistoryUI&) = delete;
   BraveHistoryUI& operator=(const BraveHistoryUI&) = delete;
   ~BraveHistoryUI() override;
 
+#if BUILDFLAG(ENABLE_LOCAL_AI)
   void BindInterface(
       mojo::PendingReceiver<brave_history_embeddings::mojom::PageHandlerFactory>
           receiver);
@@ -54,6 +63,7 @@ class BraveHistoryUI
   mojo::Receiver<brave_history_embeddings::mojom::PageHandlerFactory>
       page_handler_factory_receiver_{this};
   std::unique_ptr<BraveHistoryEmbeddingsPageHandler> page_handler_;
+#endif
 };
 
 #endif  // BRAVE_BROWSER_UI_WEBUI_HISTORY_BRAVE_HISTORY_UI_H_

--- a/browser/ui/webui/local_ai/BUILD.gn
+++ b/browser/ui/webui/local_ai/BUILD.gn
@@ -3,6 +3,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/local_ai/buildflags/buildflags.gni")
+
+assert(enable_local_ai)
+
 source_set("local_ai") {
   sources = [
     "local_ai_ui.cc",

--- a/chromium_src/chrome/browser/DEPS
+++ b/chromium_src/chrome/browser/DEPS
@@ -10,6 +10,7 @@ include_rules += [
   "+brave/components/brave_origin/buildflags",
   "+brave/components/constants",
   "+brave/components/history_embeddings",
+  "+brave/components/local_ai/buildflags",
   "+brave/components/local_ai/core",
   "+brave/components/playlist/core/common/buildflags",
   "+brave/components/version_info",

--- a/chromium_src/chrome/browser/component_updater/registration.cc
+++ b/chromium_src/chrome/browser/component_updater/registration.cc
@@ -16,7 +16,7 @@
 #include "brave/browser/brave_browser_process.h"
 #include "brave/components/brave_user_agent/browser/brave_user_agent_component_installer.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
-#include "brave/components/local_ai/core/local_models_updater.h"
+#include "brave/components/local_ai/buildflags/buildflags.h"
 #include "brave/components/p3a/component_installer.h"
 #include "brave/components/p3a/p3a_service.h"
 #include "brave/components/psst/buildflags/buildflags.h"
@@ -35,6 +35,10 @@
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
 #include "brave/components/brave_wallet/browser/wallet_data_files_installer.h"
 #endif  // BUILDFLAG(ENABLE_BRAVE_WALLET)
+
+#if BUILDFLAG(ENABLE_LOCAL_AI)
+#include "brave/components/local_ai/core/local_models_updater.h"
+#endif
 
 namespace component_updater {
 
@@ -55,7 +59,9 @@ void RegisterComponentsForUpdate() {
   RegisterZxcvbnDataComponent(cus);
 #endif  // BUILDFLAG(IS_ANDROID)
   brave_user_agent::RegisterBraveUserAgentComponent(cus);
+#if BUILDFLAG(ENABLE_LOCAL_AI)
   local_ai::ManageLocalModelsComponentRegistration(cus);
+#endif
   RegisterQueryFilterComponent(cus);
 }
 

--- a/chromium_src/chrome/browser/history_embeddings/history_embeddings_service_factory.cc
+++ b/chromium_src/chrome/browser/history_embeddings/history_embeddings_service_factory.cc
@@ -5,13 +5,19 @@
 
 #include "chrome/browser/history_embeddings/history_embeddings_service_factory.h"
 
+#include "brave/components/local_ai/buildflags/buildflags.h"
+
+#if BUILDFLAG(ENABLE_LOCAL_AI)
 #include "brave/browser/history_embeddings/brave_history_embeddings_service.h"
 
 // Swap Chrome's service for Brave's concrete subclass. Brave overrides
 // OnPassageVisibilityCalculated to synthesize a passing visibility score
 // since Brave doesn't use PageContentAnnotationsService.
 #define ChromeHistoryEmbeddingsService BraveHistoryEmbeddingsService
+#endif
 
 #include <chrome/browser/history_embeddings/history_embeddings_service_factory.cc>
 
+#if BUILDFLAG(ENABLE_LOCAL_AI)
 #undef ChromeHistoryEmbeddingsService
+#endif

--- a/chromium_src/chrome/browser/history_embeddings/history_embeddings_utils.cc
+++ b/chromium_src/chrome/browser/history_embeddings/history_embeddings_utils.cc
@@ -15,11 +15,15 @@
 // referenced after the swap.
 #include "base/feature_list.h"
 #include "base/feature_override.h"
-#include "brave/components/local_ai/core/pref_names.h"
+#include "brave/components/local_ai/buildflags/buildflags.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/profiles/profile.h"
 #include "components/history_embeddings/core/history_embeddings_features.h"
 #include "components/prefs/pref_service.h"
+
+#if BUILDFLAG(ENABLE_LOCAL_AI)
+#include "brave/components/local_ai/core/pref_names.h"
+#endif
 
 #define IsHistoryEmbeddingsEnabledForProfile \
   IsHistoryEmbeddingsEnabledForProfile_ChromiumImpl
@@ -38,11 +42,15 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
 }});
 
 bool IsHistoryEmbeddingsEnabledForProfile(Profile* profile) {
+#if BUILDFLAG(ENABLE_LOCAL_AI)
   if (!IsHistoryEmbeddingsFeatureEnabled()) {
     return false;
   }
   return profile->GetPrefs()->GetBoolean(
       local_ai::prefs::kBraveHistoryEmbeddingsEnabled);
+#else
+  return false;
+#endif
 }
 
 bool IsHistoryEmbeddingsSettingVisible(Profile* profile) {

--- a/chromium_src/chrome/browser/passage_embeddings/chrome_passage_embeddings_service_controller.cc
+++ b/chromium_src/chrome/browser/passage_embeddings/chrome_passage_embeddings_service_controller.cc
@@ -5,6 +5,10 @@
 
 #include "chrome/browser/passage_embeddings/chrome_passage_embeddings_service_controller.h"
 
+#include "brave/components/local_ai/buildflags/buildflags.h"
+
+#if BUILDFLAG(ENABLE_LOCAL_AI)
+
 #include "base/process/process.h"
 #include "brave/browser/history_embeddings/brave_passage_embeddings_service_controller.h"
 
@@ -53,3 +57,11 @@ void ChromePassageEmbeddingsServiceController::OnServiceLaunched(
 void ChromePassageEmbeddingsServiceController::InitializeCpuLogger() {}
 
 }  // namespace passage_embeddings
+
+#else  // BUILDFLAG(ENABLE_LOCAL_AI)
+
+// Fall back to upstream's implementation when local AI is compiled out
+// (e.g., Brave Origin builds).
+#include <chrome/browser/passage_embeddings/chrome_passage_embeddings_service_controller.cc>
+
+#endif  // BUILDFLAG(ENABLE_LOCAL_AI)

--- a/chromium_src/chrome/browser/resources/history/app.ts
+++ b/chromium_src/chrome/browser/resources/history/app.ts
@@ -4,20 +4,15 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import {injectStyle} from '//resources/brave/lit_overriding.js'
-import {loadTimeData} from '//resources/js/load_time_data.js'
 import {css} from '//resources/lit/v3_0/lit.rollup.js'
 
 import {HistoryAppElement} from './app-chromium.js'
+
+// <if expr="enable_local_ai">
+import {loadTimeData} from '//resources/js/load_time_data.js'
 import {
   getBraveHistoryEmbeddingsBrowserProxy,
 } from './brave_history_embeddings_browser_proxy.js'
-
-injectStyle(HistoryAppElement, css`
-        #tabs-content, #tabs-content>* {
-            height: 100%;
-        }
-    </style>
-`)
 
 // Subscribe directly to the Mojo `onEnabledChanged` notification so the
 // chrome://history UI reacts even when the side bar isn't rendered. Update
@@ -41,5 +36,13 @@ getBraveHistoryEmbeddingsBrowserProxy()
         ;(el as unknown as {requestUpdate?: () => void}).requestUpdate?.()
       }
     })
+// </if>
+
+injectStyle(HistoryAppElement, css`
+        #tabs-content, #tabs-content>* {
+            height: 100%;
+        }
+    </style>
+`)
 
 export * from './app-chromium.js'

--- a/chromium_src/chrome/browser/resources/history/side_bar.ts
+++ b/chromium_src/chrome/browser/resources/history/side_bar.ts
@@ -13,9 +13,12 @@ import type {PropertyValues} from '//resources/lit/v3_0/lit.rollup.js'
 import {
   HistorySideBarElement as HistorySideBarElementChromium,
 } from './side_bar-chromium.js'
+
+// <if expr="enable_local_ai">
 import {
   getBraveHistoryEmbeddingsBrowserProxy,
 } from './brave_history_embeddings_browser_proxy.js'
+// </if>
 
 injectStyle(HistorySideBarElementChromium, css`
   .cr-nav-menu-item {
@@ -95,9 +98,11 @@ class HistorySideBarElement extends HistorySideBarElementChromium {
         loadTimeData.getBoolean('enableHistoryEmbeddings')
   }
 
+  // <if expr="enable_local_ai">
   override onBraveHistoryEmbeddingsToggleChange(e: CustomEvent<boolean>) {
     getBraveHistoryEmbeddingsBrowserProxy().pageHandler.setEnabled(e.detail)
   }
+  // </if>
 }
 
 export {HistorySideBarElement}

--- a/chromium_src/chrome/browser/sources.gni
+++ b/chromium_src/chrome/browser/sources.gni
@@ -5,6 +5,7 @@
 
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
+import("//brave/components/local_ai/buildflags/buildflags.gni")
 import("//brave/components/text_recognition/common/buildflags/buildflags.gni")
 import("//build/config/ui.gni")
 import("//extensions/buildflags/buildflags.gni")
@@ -14,6 +15,7 @@ brave_chromium_src_chrome_browser_deps = [
   "//brave/components/ai_chat/core/common/buildflags",
   "//brave/components/brave_vpn/common/buildflags",
   "//brave/components/commander/common/buildflags",
+  "//brave/components/local_ai/buildflags",
   "//brave/components/playlist/core/common/buildflags",
   "//brave/components/text_recognition/common/buildflags",
   "//chrome/common:channel_info",

--- a/chromium_src/chrome/browser/ui/webui/chrome_untrusted_web_ui_configs.cc
+++ b/chromium_src/chrome/browser/ui/webui/chrome_untrusted_web_ui_configs.cc
@@ -6,11 +6,11 @@
 #include "chrome/browser/ui/webui/chrome_untrusted_web_ui_configs.h"
 
 #include "base/feature_list.h"
-#include "brave/browser/ui/webui/local_ai/local_ai_ui.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
+#include "brave/components/local_ai/buildflags/buildflags.h"
 #include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "build/build_config.h"
 #include "components/history_embeddings/core/history_embeddings_features.h"
@@ -48,6 +48,10 @@
 #include "brave/components/playlist/core/common/features.h"
 #endif
 
+#if BUILDFLAG(ENABLE_LOCAL_AI)
+#include "brave/browser/ui/webui/local_ai/local_ai_ui.h"
+#endif
+
 #define RegisterChromeUntrustedWebUIConfigs \
   RegisterChromeUntrustedWebUIConfigs_ChromiumImpl
 
@@ -71,10 +75,12 @@ void RegisterChromeUntrustedWebUIConfigs() {
       std::make_unique<trezor::UntrustedTrezorUIConfig>());
 #endif  // !BUILDFLAG(IS_ANDROID)
 #endif  // BUILDFLAG(ENABLE_BRAVE_WALLET)
+#if BUILDFLAG(ENABLE_LOCAL_AI)
   if (base::FeatureList::IsEnabled(history_embeddings::kHistoryEmbeddings)) {
     content::WebUIConfigMap::GetInstance().AddUntrustedWebUIConfig(
         std::make_unique<local_ai::UntrustedLocalAIUIConfig>());
   }
+#endif
 #if !BUILDFLAG(IS_ANDROID)
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   if (brave_vpn::IsBraveVPNFeatureEnabled()) {

--- a/chromium_src/chrome/browser/ui/webui/chrome_web_ui_configs.cc
+++ b/chromium_src/chrome/browser/ui/webui/chrome_web_ui_configs.cc
@@ -12,6 +12,7 @@
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/email_aliases/buildflags/buildflags.h"
+#include "brave/components/local_ai/buildflags/buildflags.h"
 #include "brave/components/psst/buildflags/buildflags.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
 #include "content/public/browser/webui_config_map.h"
@@ -41,7 +42,9 @@
 #include "brave/browser/ui/webui/brave_settings_ui.h"
 #include "brave/browser/ui/webui/brave_shields/shields_panel_ui.h"
 #include "brave/browser/ui/webui/brave_welcome_page/brave_welcome_page_ui.h"
+#if BUILDFLAG(ENABLE_LOCAL_AI)
 #include "brave/browser/ui/webui/history/brave_history_ui.h"
+#endif
 #include "brave/browser/ui/webui/private_new_tab_page/brave_private_new_tab_ui.h"
 #include "brave/browser/ui/webui/webcompat_reporter/webcompat_reporter_ui.h"
 
@@ -97,9 +100,11 @@ void RemoveOverridenWebUIs(content::WebUIConfigMap& map) {
   // Remove SettingsUIConfig. It will be replaced with BraveSettingsUIConfig.
   map.RemoveConfig(GetWebUIConfigURL(content::kChromeUIScheme,
                                      chrome::kChromeUISettingsHost));
+#if BUILDFLAG(ENABLE_LOCAL_AI)
   // Remove HistoryUIConfig. It will be replaced with BraveHistoryUIConfig.
   map.RemoveConfig(GetWebUIConfigURL(content::kChromeUIScheme,
                                      chrome::kChromeUIHistoryHost));
+#endif
 #endif  // !BUILDFLAG(IS_ANDROID)
 }
 
@@ -127,7 +132,9 @@ void RegisterChromeWebUIConfigs() {
 #endif
   map.AddWebUIConfig(std::make_unique<BravePrivateNewTabUIConfig>());
   map.AddWebUIConfig(std::make_unique<BraveSettingsUIConfig>());
+#if BUILDFLAG(ENABLE_LOCAL_AI)
   map.AddWebUIConfig(std::make_unique<BraveHistoryUIConfig>());
+#endif
   map.AddWebUIConfig(std::make_unique<BraveWelcomePageUIConfig>());
   map.AddWebUIConfig(std::make_unique<ShieldsPanelUIConfig>());
 #if BUILDFLAG(ENABLE_SPEEDREADER)

--- a/chromium_src/chrome/browser/ui/webui/chrome_web_ui_configs.cc
+++ b/chromium_src/chrome/browser/ui/webui/chrome_web_ui_configs.cc
@@ -12,7 +12,6 @@
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/email_aliases/buildflags/buildflags.h"
-#include "brave/components/local_ai/buildflags/buildflags.h"
 #include "brave/components/psst/buildflags/buildflags.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
 #include "content/public/browser/webui_config_map.h"
@@ -42,9 +41,7 @@
 #include "brave/browser/ui/webui/brave_settings_ui.h"
 #include "brave/browser/ui/webui/brave_shields/shields_panel_ui.h"
 #include "brave/browser/ui/webui/brave_welcome_page/brave_welcome_page_ui.h"
-#if BUILDFLAG(ENABLE_LOCAL_AI)
 #include "brave/browser/ui/webui/history/brave_history_ui.h"
-#endif
 #include "brave/browser/ui/webui/private_new_tab_page/brave_private_new_tab_ui.h"
 #include "brave/browser/ui/webui/webcompat_reporter/webcompat_reporter_ui.h"
 
@@ -100,11 +97,9 @@ void RemoveOverridenWebUIs(content::WebUIConfigMap& map) {
   // Remove SettingsUIConfig. It will be replaced with BraveSettingsUIConfig.
   map.RemoveConfig(GetWebUIConfigURL(content::kChromeUIScheme,
                                      chrome::kChromeUISettingsHost));
-#if BUILDFLAG(ENABLE_LOCAL_AI)
   // Remove HistoryUIConfig. It will be replaced with BraveHistoryUIConfig.
   map.RemoveConfig(GetWebUIConfigURL(content::kChromeUIScheme,
                                      chrome::kChromeUIHistoryHost));
-#endif
 #endif  // !BUILDFLAG(IS_ANDROID)
 }
 
@@ -132,9 +127,7 @@ void RegisterChromeWebUIConfigs() {
 #endif
   map.AddWebUIConfig(std::make_unique<BravePrivateNewTabUIConfig>());
   map.AddWebUIConfig(std::make_unique<BraveSettingsUIConfig>());
-#if BUILDFLAG(ENABLE_LOCAL_AI)
   map.AddWebUIConfig(std::make_unique<BraveHistoryUIConfig>());
-#endif
   map.AddWebUIConfig(std::make_unique<BraveWelcomePageUIConfig>());
   map.AddWebUIConfig(std::make_unique<ShieldsPanelUIConfig>());
 #if BUILDFLAG(ENABLE_SPEEDREADER)

--- a/chromium_src/chrome/browser/ui/webui/history/history_ui.cc
+++ b/chromium_src/chrome/browser/ui/webui/history/history_ui.cc
@@ -11,7 +11,6 @@
 // Mojo interface for write/observer plumbing lives in BraveHistoryUI; this
 // override only augments the data source.
 
-#include "brave/components/local_ai/core/pref_names.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/history_embeddings/history_embeddings_utils.h"
 #include "chrome/browser/profiles/profile.h"

--- a/components/BUILD.gn
+++ b/components/BUILD.gn
@@ -9,6 +9,7 @@ import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
 import("//brave/components/brave_wayback_machine/buildflags/buildflags.gni")
 import("//brave/components/containers/buildflags/buildflags.gni")
 import("//brave/components/email_aliases/buildflags/buildflags.gni")
+import("//brave/components/local_ai/buildflags/buildflags.gni")
 import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
 import("//brave/components/psst/buildflags/buildflags.gni")
 import("//brave/components/speedreader/common/buildflags/buildflags.gni")
@@ -42,7 +43,6 @@ test("brave_components_unittests") {
     "//brave/components/component_updater:unit_tests",
     "//brave/components/https_upgrade_exceptions/browser:unit_tests",
     "//brave/components/json:unit_tests",
-    "//brave/components/local_ai/core:unit_tests",
     "//brave/components/oblivious_http:unit_tests",
     "//brave/components/screenshot/core/browser:unit_tests",
     "//brave/components/static_redirect_helper:unit_tests",
@@ -97,12 +97,18 @@ test("brave_components_unittests") {
     deps += [ "//brave/components/email_aliases:unit_tests" ]
   }
 
+  if (enable_local_ai) {
+    deps += [ "//brave/components/local_ai/core:unit_tests" ]
+  }
+
   if (enable_playlist) {
     deps += [ "//brave/components/playlist/core/browser:unit_tests" ]
   }
 
   if (use_blink) {
-    deps += [ "//brave/components/local_ai/content:unit_tests" ]
+    if (enable_local_ai) {
+      deps += [ "//brave/components/local_ai/content:unit_tests" ]
+    }
     if (enable_ai_chat) {
       deps += [ "//brave/components/ai_chat/content/browser:unit_tests" ]
     }

--- a/components/local_ai/buildflags/BUILD.gn
+++ b/components/local_ai/buildflags/BUILD.gn
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//build/buildflag_header.gni")
+import("buildflags.gni")
+
+buildflag_header("buildflags") {
+  header = "buildflags.h"
+  flags = [ "ENABLE_LOCAL_AI=$enable_local_ai" ]
+}

--- a/components/local_ai/buildflags/buildflags.gni
+++ b/components/local_ai/buildflags/buildflags.gni
@@ -1,0 +1,10 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/components/brave_origin/buildflags/buildflags.gni")
+
+declare_args() {
+  enable_local_ai = !is_brave_origin_branded
+}

--- a/components/local_ai/content/BUILD.gn
+++ b/components/local_ai/content/BUILD.gn
@@ -3,6 +3,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/local_ai/buildflags/buildflags.gni")
+
+assert(enable_local_ai)
+
 static_library("content") {
   sources = [
     "background_web_contents_impl.cc",

--- a/components/local_ai/core/BUILD.gn
+++ b/components/local_ai/core/BUILD.gn
@@ -3,7 +3,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/local_ai/buildflags/buildflags.gni")
 import("//mojo/public/tools/bindings/mojom.gni")
+
+assert(enable_local_ai)
 
 mojom_component("mojom") {
   output_prefix = "local_ai_mojom"

--- a/components/local_ai/resources/BUILD.gn
+++ b/components/local_ai/resources/BUILD.gn
@@ -4,9 +4,12 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/components/common/typescript.gni")
+import("//brave/components/local_ai/buildflags/buildflags.gni")
 import("//mojo/public/tools/bindings/mojom.gni")
 import("//tools/grit/preprocess_if_expr.gni")
 import("//tools/grit/repack.gni")
+
+assert(enable_local_ai)
 
 # Untrusted WebUI for WASM execution at
 # chrome-untrusted://local-ai/

--- a/components/local_ai/resources/candle_embedding_gemma/BUILD.gn
+++ b/components/local_ai/resources/candle_embedding_gemma/BUILD.gn
@@ -4,7 +4,10 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/components/common/typescript.gni")
+import("//brave/components/local_ai/buildflags/buildflags.gni")
 import("//tools/grit/repack.gni")
+
+assert(enable_local_ai)
 
 transpile_web_ui("candle_embedding_module") {
   resource_name = "candle_embedding_module"

--- a/components/resources/BUILD.gn
+++ b/components/resources/BUILD.gn
@@ -11,6 +11,7 @@ import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
 import("//brave/components/containers/buildflags/buildflags.gni")
 import("//brave/components/email_aliases/buildflags/buildflags.gni")
+import("//brave/components/local_ai/buildflags/buildflags.gni")
 import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
 import("//brave/components/psst/buildflags/buildflags.gni")
 import("//brave/components/speedreader/common/buildflags/buildflags.gni")
@@ -94,18 +95,25 @@ repack("resources") {
     ":static_resources",
     "//brave/components/brave_account/resources",
     "//brave/components/cosmetic_filters/resources/data:generated_resources",
-    "//brave/components/local_ai/resources:local_ai_generated",
-    "//brave/components/local_ai/resources/candle_embedding_gemma:candle_embedding_module_generated",
     "//brave/components/skus/browser/resources:generated_resources",
   ]
   sources = [
     "$root_gen_dir/brave/components/brave_account/resources/brave_account_resources.pak",
     "$root_gen_dir/brave/components/cosmetic_filters/resources/cosmetic_filters_generated.pak",
-    "$root_gen_dir/brave/components/local_ai/resources/candle_embedding_module_generated.pak",
-    "$root_gen_dir/brave/components/local_ai/resources/local_ai_generated.pak",
     "$root_gen_dir/brave/components/skus/browser/resources/skus_internals_generated.pak",
     "$root_gen_dir/components/brave_components_static.pak",
   ]
+
+  if (enable_local_ai) {
+    deps += [
+      "//brave/components/local_ai/resources:local_ai_generated",
+      "//brave/components/local_ai/resources/candle_embedding_gemma:candle_embedding_module_generated",
+    ]
+    sources += [
+      "$root_gen_dir/brave/components/local_ai/resources/candle_embedding_module_generated.pak",
+      "$root_gen_dir/brave/components/local_ai/resources/local_ai_generated.pak",
+    ]
+  }
 
   if (enable_brave_ads) {
     deps +=

--- a/patches/chrome-browser-resources-history-BUILD.gn.patch
+++ b/patches/chrome-browser-resources-history-BUILD.gn.patch
@@ -1,10 +1,10 @@
 diff --git a/chrome/browser/resources/history/BUILD.gn b/chrome/browser/resources/history/BUILD.gn
-index 0ce5aa85cb189af25caf345abb45b2a69f44e204..a54f507cce86639e429e7dfa1f5a0e65b292b8eb 100644
+index 0ce5aa85cb189af25caf345abb45b2a69f44e204..9efe662157268f458f4a99ab14e0e71017929041 100644
 --- a/chrome/browser/resources/history/BUILD.gn
 +++ b/chrome/browser/resources/history/BUILD.gn
 @@ -107,4 +107,5 @@ build_webui("build") {
      optimize_webui_host = "history"
      optimize_webui_in_files = [ "history.js" ]
    }
-+  import("//brave/browser/resources/history/sources.gni") mojo_files = brave_history_mojo_files mojo_files_deps = brave_history_mojo_files_deps ts_files += brave_history_ts_files exclude_ts_preprocess_files = brave_history_ts_files preprocess_deps = brave_history_preprocess_deps
++  import("//brave/browser/resources/history/sources.gni") preprocessor_defines = brave_history_preprocessor_defines mojo_files = brave_history_mojo_files mojo_files_deps = brave_history_mojo_files_deps ts_files += brave_history_ts_files exclude_ts_preprocess_files = brave_history_ts_files preprocess_deps = brave_history_preprocess_deps
  }

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -20,6 +20,7 @@ import("//brave/components/brave_wayback_machine/buildflags/buildflags.gni")
 import("//brave/components/commander/common/buildflags/buildflags.gni")
 import("//brave/components/containers/buildflags/buildflags.gni")
 import("//brave/components/email_aliases/buildflags/buildflags.gni")
+import("//brave/components/local_ai/buildflags/buildflags.gni")
 import("//brave/components/ntp_background_images/buildflags/buildflags.gni")
 import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
 import("//brave/components/psst/buildflags/buildflags.gni")
@@ -176,7 +177,6 @@ test("brave_unit_tests") {
     "//brave/browser/content_settings:unit_tests",
     "//brave/browser/ephemeral_storage:unit_tests",
     "//brave/browser/global_privacy_control:unit_tests",
-    "//brave/browser/history_embeddings:unit_tests",
     "//brave/browser/metrics:brave_metrics_unit_tests",
     "//brave/browser/misc_metrics:unit_tests",
     "//brave/browser/net:unit_tests",
@@ -395,6 +395,10 @@ test("brave_unit_tests") {
       "//brave/browser/autocomplete:unit_tests",
       "//brave/browser/ui/webui/ai_chat:unit_tests",
     ]
+  }
+
+  if (enable_local_ai) {
+    deps += [ "//brave/browser/history_embeddings:unit_tests" ]
   }
 
   if (enable_print_preview) {


### PR DESCRIPTION
## Summary

- Introduce `enable_local_ai` GN buildflag (default `!is_brave_origin_branded`) exposed as `ENABLE_LOCAL_AI`.
- Wrap brave-side local-AI targets (`//brave/components/local_ai/*`, `//brave/browser/history_embeddings`, `//brave/browser/ui/webui/local_ai`, the embeddings-specific half of `//brave/browser/ui/webui/history`) with `assert(enable_local_ai)`; gate every BUILD.gn dep, C++ include/usage, pref registration, and the `brave-history-embeddings` `chrome://flags` entry on the buildflag.
- Gate the brave chromium_src TS overrides for `chrome://history` (`app.ts`, `side_bar.ts`) with `<if expr="enable_local_ai">` markers — the brave `HistorySideBarElement` subclass and `customElements.define` stay always present so eslint and the lit_mangler-injected toggle see a consistent class shape, while the `getBraveHistoryEmbeddingsBrowserProxy` import, the Mojo subscription, and the `proxy.setEnabled()` call are stripped. The `chrome/browser/resources/history/BUILD.gn` patch forwards `enable_local_ai` as a `preprocess_if_expr` define.
- Split `BraveHistoryUI` into an always-present shell + a `#if BUILDFLAG(ENABLE_LOCAL_AI)`-gated `brave_history_embeddings::mojom::PageHandlerFactory` mixin. `BraveHistoryUIConfig` is registered unconditionally so `chrome://history` is served by `BraveHistoryUI` in every configuration; in Origin the shell carries no embeddings glue.
- Adapt the chromium_src overrides that referenced local AI types so the brave-specific code path is skipped when the buildflag is off.

Net effect: in Brave Origin builds (`is_brave_origin_branded=true`), local AI is compiled out — no EmbeddingGemma model component install, no LocalAI WebUI, no Brave entry point into history embeddings. `BraveHistoryUI` still serves `chrome://history` but is a thin `HistoryUI` subclass with no embeddings PageHandlerFactory. The lit_mangler-injected toggle row on `chrome://history`'s side bar stays hidden because `IsHistoryEmbeddingsFeatureEnabled()` returns false, so the `isHistoryEmbeddingsFeatureEnabled` loadTimeData value read by the brave subclass is false in Origin.

- Resolves https://github.com/brave/brave-browser/issues/56443

## Test plan

- Launch a Brave Origin binary and confirm: no `brave-history-embeddings` flag in `chrome://flags`, no `Brave Local AI Models Updater` component listed in `chrome://components`, the toggle row on `chrome://history`'s side bar is hidden.
- Launch a standard Brave Browser binary and confirm the `brave-history-embeddings` flag is visible in `chrome://flags`; enable it, then verify the `chrome://history` side bar toggle is visible, the `Brave Local AI Models Updater` component installs from `chrome://components`, and semantic history search returns results end-to-end.