### PR TITLE
Add /plaster-from-patch skill to convert a Chromium patch to a Plaster config

### DIFF
--- a/.claude/skills/plaster-from-patch/SKILL.md
+++ b/.claude/skills/plaster-from-patch/SKILL.md
@@ -128,6 +128,13 @@ for simple global **symbol** replacement (`kOldConst` → `kNewConst`,
 `ChromiumMethod` → `BraveMethod`). Use `re_pattern` the moment you need context,
 capture groups, or whitespace flexibility.
 
+Mind the subtlety: `pattern` is a **literal substring** match, so
+`pattern: 'value'` also matches `value` _inside_ `kMyValueThing` or `valueXyz` —
+any larger identifier containing it. When you mean the whole symbol and nothing
+else, use a regex with word boundaries instead: `re_pattern: '\bvalue\b'`.
+Prefer `pattern` only when the substring is unique enough that an embedded match
+can't happen; otherwise reach for `\b…\b`.
+
 **Whitespace.** Don't depend on specific spacing — prefer `\s*` / `\s+` over
 literal runs, and pair flexible whitespace with `re_flags: [DOTALL]` so `.`
 crosses newlines (and the regex reads better). A single literal space is
@@ -204,6 +211,7 @@ cp patches/<dashed>.patch /tmp/plaster-original.patch
 
 # 2. Regenerate the patch from the config: this rewrites the source from
 #    git + the plaster and writes patches/<dashed>.patch + .patchinfo.
+#    ALWAYS pass the specific rewrite/<path>.yaml — never run `apply` bare.
 tools/cr/plaster.py apply rewrite/<path>.yaml
 
 # 3. The regenerated patch MUST equal the original — empty diff.
@@ -216,9 +224,13 @@ matched the wrong region, the replacement is off, or `count` didn't match (found
 0 or several). Fix the substitution and re-run the apply+diff. Iterate until the
 diff is empty.
 
-`apply` / `check` take the **plaster or patch path**, never the chromium source
-path — passing `../<source_path>` raises `ValueError: Unexpected file path`.
-Accepted forms are `rewrite/<path>.yaml` and `patches/<dashed>.patch`.
+**Always run `apply` against the specific `rewrite/<path>.yaml`, never bare.** A
+bare `tools/cr/plaster.py apply` (no file argument) reapplies _every_ plaster in
+the tree, touching sources and patches far beyond the one you're working on —
+scope it to your file every time. `apply` / `check` take the **plaster or patch
+path**, never the chromium source path — passing `../<source_path>` raises
+`ValueError: Unexpected file path`. Accepted forms are `rewrite/<path>.yaml` and
+`patches/<dashed>.patch`.
 
 `plaster.py` needs PyYAML. If it fails with
 `ModuleNotFoundError: No module named 'yaml'`, retry with the depot_tools

--- a/.claude/skills/plaster-from-patch/SKILL.md
+++ b/.claude/skills/plaster-from-patch/SKILL.md
@@ -1,0 +1,303 @@
+---
+name: plaster-from-patch
+description:
+  "Convert an existing Brave-core Chromium `.patch` into a Plaster
+  (`rewrite/*.yaml`) config that reproduces the same change, following the
+  Plaster Dos and Don'ts. Triages each hunk (plaster vs chromium_src), authors
+  intent-conveying substitutions, then verifies with `plaster.py`. Triggers on:
+  plaster from patch, convert patch to plaster, plasterize, make a plaster."
+argument-hint:
+  '<patch file, source path, or nothing to infer from working tree>'
+disable-model-invocation: true
+allowed-tools:
+  Bash(python3:*), Bash(vpython3:*), Bash(git:*), Bash(npm:*), Bash(ls:*),
+  Bash(cat:*), Bash(grep:*), Bash(diff:*), Bash(find:*), Read, Grep, Glob, Edit,
+  Write, Agent
+---
+
+# Plaster From Patch
+
+Turn a regular Brave-core Chromium patch into a 🩹 Plaster config. The user has
+already produced a normal patch the usual way — edited an upstream source under
+`src/`, then ran `npm run update_patches` to generate
+`patches/<dashed-path>.patch`. This skill reads that change and writes the
+equivalent `rewrite/<path>.yaml`, following the rules below, so the same effect
+is achieved through a robust regex substitution instead of a brittle context
+patch.
+
+## Required reading
+
+The conversion rules come from two docs. Read them if present — they are the
+source of truth and may be updated:
+
+- `docs/plaster.md` — how Plaster works, file layout, the substitution schema.
+- `docs/plaster_dos_and_donts.md` — the dos and don'ts (introduced in
+  brave/brave-core#36525). If this file is not yet on your branch, the
+  **Conversion rules** section below embeds its essentials so the skill still
+  works.
+
+## Mental model
+
+| Artifact        | Location                                      | Role                                         |
+| --------------- | --------------------------------------------- | -------------------------------------------- |
+| Upstream source | `../<path>` (e.g. `../components/foo/foo.cc`) | The pristine Chromium file, from `git`       |
+| Patch           | `./patches/<path-with-/-as->.patch`           | Encodes upstream → modified                  |
+| Plaster         | `./rewrite/<path>.yaml`                       | Regex substitutions you author               |
+| `chromium_src`  | `./chromium_src/<path>`                       | Shadow file for file-scope / substantive C++ |
+
+Key facts that drive everything:
+
+- **Plaster loads the source from `git`, not disk.** Your regex must match the
+  **pristine upstream** text (the patch's `a/` side) and transform it into the
+  **modified** text (the `b/` side). Running `plaster.py apply` regenerates the
+  `.patch` from the plaster.
+- The patch stem replaces `/` with `-`: `components/foo/foo.cc` →
+  `patches/components-foo-foo.cc.patch`. The plaster keeps the real path:
+  `rewrite/components/foo/foo.cc.yaml`.
+
+## Step 1 — Resolve the input and gather the change
+
+This skill runs from `src/brave`. Confirm with `git rev-parse --show-toplevel`.
+
+Resolve the argument into one or more `(source_path, patch_path)` pairs:
+
+- **A `.patch` file** (e.g. `patches/components-foo-foo.cc.patch`): read it; the
+  `diff --git a/<src> b/<src>` header gives the source path.
+- **A source path** (e.g. `components/foo/foo.cc`): the patch is
+  `patches/<path with / → ->.patch`. If there is no patch yet but the working
+  tree under `../` has uncommitted edits to that source, treat the working-tree
+  diff (`git -C .. diff -- <path>`) as the change.
+- **No argument**: infer. List candidate patches via `git status --short` in
+  this repo (new/modified files under `patches/`) and modified sources via
+  `git -C .. status --short`. If there is exactly one clear candidate, use it;
+  if several, list them and ask which to convert.
+
+For each pair, obtain three things:
+
+1. **The unified diff** — `cat patches/<...>.patch`, or
+   `git -C .. diff -- <path>`.
+2. **The pristine upstream text** of every region the diff touches — the patch's
+   `a/` side, or `git -C .. show HEAD:<path>`. This is what your regex matches
+   against. Read enough surrounding context (the whole enclosing function, enum,
+   switch, or gn target) to anchor on intent, not coincidence.
+3. **The intended modified text** — the `b/` side, or the working-tree file.
+
+If `plaster.py` cannot resolve the source from `git` (uncommitted, or the file
+is not in Chromium's `src` repo — only `src` is supported), say so and stop:
+Plaster cannot patch it.
+
+## Step 2 — Triage each hunk: plaster, `chromium_src`, or both
+
+**Not every patch belongs in a plaster.** Before writing any regex, classify
+each hunk. This is the single most important step — getting it wrong produces a
+plaster the reviewers will reject.
+
+- **Mere file-scope addition** — a new `#include`, an anonymous-namespace
+  constant or helper, a new type, anything that can live _before or after_ the
+  upstream `#include` of the file. → **Do NOT plaster.** Put it in a
+  `chromium_src/<path>` shadow file that re-includes the upstream source.
+  Plaster is only for changes that cannot be made at file scope.
+
+- **Substantive C++ injected into a function/class** — more than a trivial
+  one-liner. → Put the substantive code in a `chromium_src` shadow helper
+  (anonymous-namespace function, etc.) so it gets `clang-format`, presubmit,
+  DEPS, and semgrep coverage; keep the plaster a **minimal call-site insertion**
+  (`MaybeApplyBar(this);`).
+
+- **Trivial in-place change** — flipping a value, redirecting a constant,
+  inserting one short line, extending an enum/switch, extending a gn array,
+  renaming one definition. → **Author a plaster substitution** (Step 3). Be
+  pragmatic: if the whole change is one clear line, let the plaster carry it
+  directly rather than splitting it across a `chromium_src` file for no gain.
+
+Produce an explicit triage list: for each hunk, which bucket and why. Show it to
+the user before writing files — this is where the human judgment lives.
+
+## Step 3 — Author the plaster substitutions
+
+Write `rewrite/<path>.yaml`. Start from the standard MPL header (copy it from
+any existing `rewrite/**/*.yaml`), then a `substitutions:` list. Apply these
+rules — they come straight from the dos and don'ts.
+
+### Conversion rules
+
+**Convey intent, match the minimal uniquely-identifying context.** The regex is
+how the change's intent is recorded. Anchor on the things that describe _what_
+is changing — the function name, the switch variable, the gn target, the
+position (top / before `kMaxValue` / before `default:`) — and nothing more.
+Every extra incidental particular is a future false break; every missing one is
+an accidental match elsewhere.
+
+**`pattern` vs `re_pattern`.** Use `pattern` (a literal string, auto-escaped)
+for simple global **symbol** replacement (`kOldConst` → `kNewConst`,
+`ChromiumMethod` → `BraveMethod`). Use `re_pattern` the moment you need context,
+capture groups, or whitespace flexibility.
+
+**Whitespace.** Don't depend on specific spacing — prefer `\s*` / `\s+` over
+literal runs, and pair flexible whitespace with `re_flags: [DOTALL]` so `.`
+crosses newlines (and the regex reads better). A single literal space is
+acceptable only when it materially improves readability, the file is
+auto-formatted, and that space can never become a newline. Use single-quoted
+YAML for patterns so `\s` stays two characters.
+
+**Enums.** Anchor at the top or just before `kMaxValue`; do **not** anchor on a
+neighbor key (it may be renamed/removed). Take care of `kMaxValue` and trailing
+commas. If the enum value is serialized/persisted, key positions are not free —
+handle case by case.
+
+```yaml
+- description: 'Append Brave entries before kMaxValue'
+  re_pattern: '(enum class RequestType \{.+?,)(\s+)kMaxValue = \w+'
+  re_flags: [DOTALL]
+  replace: |-
+    \1
+      kBraveOne,
+      kBraveTwo,
+      kMaxValue = kBraveTwo
+```
+
+**Switch statements.** Match the **function**, then the **switch block**, to
+place the insertion — never anchor on a sibling `case` key. If a `default:`
+exists (or could), treat it as the end boundary and insert before it. To group a
+new case with fall-through siblings, anchor on the shared outcome (the
+`return`), not on a case key.
+
+```yaml
+- description: 'Add ECDSA_SHA384 handling to VerifyInit'
+  re_pattern: '(VerifyInit\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
+  re_flags: [DOTALL]
+  replace: |-
+    \1
+        case ECDSA_SHA384:
+          digest = EVP_sha384();
+          break;\2
+```
+
+**gn arrays.** Extend `sources` / `deps` / `public_deps` with `+=` **immediately
+after instantiation** (they get passed onward, so extend before any use). One
+substitution per array — don't bundle. Scope the match to the specific target.
+
+```yaml
+- description: 'Append Brave sources to component("foo")'
+  re_pattern: '(component\("foo"\).*?sources\s*=\s*\[.*?\])'
+  re_flags: [DOTALL]
+  replace: '\1\n  sources += brave_foo_sources'
+```
+
+**`count`.** Defaults to `1` and shouldn't be spelled out. Intentional breakage
+is a feature: when the count stops matching, the change gets re-reviewed. Use
+`count: 0` only when occurrences legitimately vary over time **and** every match
+is inherently safe to substitute — and add a comment saying why. Never raise
+`count` just to silence a "matched N times" failure; investigate it.
+
+**Prefer plaster over the alternatives, and remember why** — so the description
+can carry it: a `.patch` breaks when adjacent lines move; a `#define` silently
+rewrites every occurrence including ones pulled in by `#include`. A scoped
+plaster substitution rewrites exactly the one place its match describes.
+
+### Descriptions
+
+Give each substitution a `description` that states the intent — what is changing
+and why — not a restatement of the regex mechanics. Use a `|` / `|-` block
+scalar for multi-line text. This is the recovery note for whoever hits a future
+break.
+
+## Step 4 — Write any `chromium_src` shadow file
+
+For hunks triaged to `chromium_src` in Step 2, create/extend
+`chromium_src/<path>`: file-scope additions and helpers go before, then
+`#include <path>` re-includes the upstream source (angle-bracket include of the
+original). Match the surrounding conventions of existing `chromium_src` files
+(MPL header, include guards where relevant). Keep the matching plaster down to
+the minimal call-site insertion.
+
+## Step 5 — Apply and verify (the acid test)
+
+The plaster is correct **iff** applying it to the pristine upstream source
+reproduces the user's intended modified source exactly. Verify, don't assume.
+
+`apply` / `check` take the **plaster or patch path**, never the chromium source
+path — passing `../<source_path>` raises `ValueError: Unexpected file path`.
+Accepted forms are `rewrite/<path>.yaml` and `patches/<dashed>.patch` (or no
+argument to process every plaster):
+
+```bash
+tools/cr/plaster.py check rewrite/<path>.yaml   # dry run
+tools/cr/plaster.py apply rewrite/<path>.yaml   # rewrite ../<source>, regen patch + .patchinfo
+```
+
+`apply` writes the transformed text back to the chromium source on disk at
+`../<source_path>` and regenerates `patches/<dashed>.patch` + `.patchinfo`.
+
+- `plaster.py` needs PyYAML. If it fails with
+  `ModuleNotFoundError: No module named 'yaml'`, retry with the depot_tools
+  interpreter (`vpython3 tools/cr/plaster.py ...`) or install into the active
+  env (`python3 -m pip install pyyaml`). If it still cannot run here, **do not
+  claim success** — manually simulate each substitution against the pristine
+  text (Python `re` reasoning), state that local verification was unavailable,
+  and flag that CI / the user must run `plaster.py check`.
+
+**Compare results.** Stash the user's intended modified source first (so
+`apply`, which rewrites the source from `git` + the plaster, doesn't clobber
+it), then compare what the plaster produced against it:
+
+```bash
+cp ../<source_path> /tmp/intended.txt        # the user's hand-edited target
+tools/cr/plaster.py apply rewrite/<path>.yaml # rewrites ../<source_path> from git+plaster
+diff /tmp/intended.txt ../<source_path>       # must be empty
+```
+
+The plaster-produced source must be byte-identical to the intended modified
+source (empty `diff`). If it differs, the regex matched the wrong region or the
+replacement is off — fix the substitution and re-run. Iterate until the match is
+exact and `count` matched as expected (the default `1`).
+
+Once it matches, the original hand-written `patches/<dashed>.patch` is now
+**generated by the plaster** — it stays (plaster maintains it), but it is no
+longer hand-maintained. Make sure `.patchinfo` was written alongside it.
+
+## Step 6 — Self-review
+
+Before declaring done, run the `/code-review` skill (or an Agent review) over
+the new/changed files (`rewrite/<path>.yaml`, any `chromium_src/<path>`, the
+regenerated patch). Specifically check the conversion-rule violations that are
+easy to miss:
+
+- Anchoring on a removable neighbor key (enum/switch) instead of structure.
+- A `re_pattern` that depends on incidental whitespace or unrelated lines.
+- A `count: 0` without a justifying comment, or a silenced count mismatch.
+- File-scope additions that should have been `chromium_src`, not plaster.
+- Substantive C++ inlined in `replace` that belongs in a shadow helper.
+- Bundled gn array extensions, or extensions not placed right after declaration.
+
+Fix anything it surfaces before moving on.
+
+## Step 7 — Commit, branch, PR
+
+Stage the plaster, any `chromium_src` file, and the regenerated
+patch/`.patchinfo`. Commit on the working branch (new commit; don't squash onto
+unrelated work):
+
+```bash
+git add rewrite/<path>.yaml chromium_src/<path> patches/<dashed>.patch patches/<dashed>.patchinfo
+git commit -m "Convert <path> patch to plaster"
+```
+
+End the commit message with the standard trailer:
+`Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+Then offer to push and open a PR (`gh pr create`). Report the URL.
+
+## Guidelines
+
+- **Triage first, author second.** Most rejected plasters are changes that never
+  belonged in a plaster. Decide plaster vs `chromium_src` before touching regex.
+- **Match the pristine upstream, not the patched file** — Plaster reads the
+  source from `git`.
+- **Verify by reproduction.** A plaster that "looks right" but doesn't reproduce
+  the exact modified source is wrong. Run `plaster.py` and compare.
+- **Let intentional breakage stand.** Don't paper over a `count` mismatch; it is
+  the safety mechanism working.
+- **Keep the regex minimal and intent-bearing.** The smallest match that is
+  still unique is the most robust across rebases.
+- **Format docs/markdown with `npm run format`** if you touch any.

--- a/.claude/skills/plaster-from-patch/SKILL.md
+++ b/.claude/skills/plaster-from-patch/SKILL.md
@@ -3,9 +3,9 @@ name: plaster-from-patch
 description:
   "Create a Plaster (`rewrite/*.yaml`) config for an existing Brave-core
   Chromium `.patch`, authoring an intent-conveying regex match per the Plaster
-  Dos and Don'ts, then verifying it reproduces the patch with `plaster.py
-  check`. Does not modify sources or create other files — its only output is the
-  plaster config. Triggers on: plaster from patch, convert patch to plaster,
+  Dos and Don'ts, then verifying it by running `plaster.py apply` and diffing
+  the regenerated patch against the original. Does not modify sources or create
+  other files. Triggers on: plaster from patch, convert patch to plaster,
   plasterize, make a plaster."
 argument-hint:
   '<patch file, source path, or nothing to infer from working tree>'
@@ -36,8 +36,11 @@ instead of a brittle context patch.
   already decided that by writing the patch. Author a config that reproduces the
   patch, following the guidelines.
 
-The single exception is verification: `plaster.py check` is a **dry run** that
-makes no changes (details in Step 3).
+The one thing it does beyond writing the config is **verify** (Step 3): it runs
+`plaster.py apply` to regenerate the patch from the config and confirms it is
+identical to the patch the user wrote. That regenerates the patch and its
+`.patchinfo` (plaster's own output) — it still never hand-edits sources or
+creates `chromium_src` files.
 
 ## Required reading
 
@@ -189,40 +192,40 @@ and why — not a restatement of the regex mechanics. Use a `|` / `|-` block
 scalar for multi-line text. This is the recovery note for whoever hits a future
 break.
 
-## Step 3 — Verify with `plaster.py check` (dry run)
+## Step 3 — Verify by regenerating the patch and diffing against the original
 
-The config is correct **iff** applying it to the pristine upstream source
-reproduces the patch. `check` confirms exactly that, as a **dry run that writes
-nothing**:
+The config is correct **iff** running plaster produces a patch byte-identical to
+the one the user wrote. Don't settle for a dry-run `check` — actually regenerate
+the patch and compare it to the original:
 
 ```bash
-tools/cr/plaster.py check rewrite/<path>.yaml
+# 1. Keep the user's original patch as the ground truth.
+cp patches/<dashed>.patch /tmp/plaster-original.patch
+
+# 2. Regenerate the patch from the config: this rewrites the source from
+#    git + the plaster and writes patches/<dashed>.patch + .patchinfo.
+tools/cr/plaster.py apply rewrite/<path>.yaml
+
+# 3. The regenerated patch MUST equal the original — empty diff.
+diff /tmp/plaster-original.patch patches/<dashed>.patch
 ```
 
-`check` / `apply` take the **plaster or patch path**, never the chromium source
-path — passing `../<source_path>` raises `ValueError: Unexpected file path`.
-Accepted forms are `rewrite/<path>.yaml` and `patches/<dashed>.patch` (or no
-argument to process every plaster).
+An empty `diff` means the plaster reproduces the user's change exactly — done. A
+non-empty diff (or a `count`/match error raised by `apply`) means the regex
+matched the wrong region, the replacement is off, or `count` didn't match (found
+0 or several). Fix the substitution and re-run the apply+diff. Iterate until the
+diff is empty.
 
-- A clean `check` means the plaster reproduces the user's existing patch/source
-  — done.
-- A mismatch means the regex matched the wrong region or the replacement is off,
-  or `count` didn't match (e.g. found 0 or several). Fix the substitution and
-  re-run `check`. Iterate until it is clean.
+`apply` / `check` take the **plaster or patch path**, never the chromium source
+path — passing `../<source_path>` raises `ValueError: Unexpected file path`.
+Accepted forms are `rewrite/<path>.yaml` and `patches/<dashed>.patch`.
 
 `plaster.py` needs PyYAML. If it fails with
 `ModuleNotFoundError: No module named 'yaml'`, retry with the depot_tools
 interpreter (`vpython3 tools/cr/plaster.py ...`) or install into the active env
 (`python3 -m pip install pyyaml`). If it still cannot run here, **do not claim
-success** — manually simulate each substitution against the pristine text
-(Python `re` reasoning), state that local verification was unavailable, and flag
-that the user must run `plaster.py check`.
-
-> Note: `plaster.py apply` is how the change becomes plaster-managed — it
-> rewrites the source from `git` + the plaster and regenerates
-> `patches/<dashed>.patch` + `.patchinfo`. That step **does** modify files, so
-> it is the user's to run (or run it only with their explicit go-ahead). This
-> skill stops at a verified config.
+success** — say local verification was unavailable and that the user must run
+the apply+diff above.
 
 ## Step 4 — Self-review
 
@@ -241,21 +244,20 @@ Fix anything it surfaces before moving on.
 
 ## Step 5 — Commit and offer a PR
 
-Stage and commit just the plaster config on the working branch (new commit;
-don't squash onto unrelated work):
+Stage the config plus the patch artifacts that `apply` regenerated in Step 3,
+and commit on the working branch (new commit; don't squash onto unrelated work):
 
 ```bash
-git add rewrite/<path>.yaml
+git add rewrite/<path>.yaml patches/<dashed>.patch patches/<dashed>.patchinfo
 git commit -m "Add plaster config for <path>"
 ```
 
 End the commit message with the standard trailer:
 `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
 
-If the user wants the change wired in as a plaster-managed patch, run
-`tools/cr/plaster.py apply rewrite/<path>.yaml` (with their go-ahead) and
-include the regenerated `patches/<dashed>.patch` + `.patchinfo` in the commit.
-Then offer to push and open a PR (`gh pr create`). Report the URL.
+The original hand-written patch is now plaster-managed (regenerated from the
+config and tied to it by `.patchinfo`). Then offer to push and open a PR
+(`gh pr create`). Report the URL.
 
 ## Guidelines
 
@@ -263,8 +265,9 @@ Then offer to push and open a PR (`gh pr create`). Report the URL.
   don't create `chromium_src` files, don't restructure the change.
 - **Match the pristine upstream, not the patched file** — Plaster reads the
   source from `git`.
-- **Verify with `check`** — a dry run. A config that "looks right" but doesn't
-  reproduce the patch is wrong.
+- **Verify by regeneration** — run `plaster.py apply` and diff the regenerated
+  patch against the original; they must be identical. A config that "looks
+  right" but doesn't reproduce the patch is wrong.
 - **Let intentional breakage stand.** Don't paper over a `count` mismatch; it is
   the safety mechanism working.
 - **Keep the regex minimal and intent-bearing.** The smallest match that is

--- a/.claude/skills/plaster-from-patch/SKILL.md
+++ b/.claude/skills/plaster-from-patch/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: plaster-from-patch
 description:
-  "Convert an existing Brave-core Chromium `.patch` into a Plaster
-  (`rewrite/*.yaml`) config that reproduces the same change, following the
-  Plaster Dos and Don'ts. Triages each hunk (plaster vs chromium_src), authors
-  intent-conveying substitutions, then verifies with `plaster.py`. Triggers on:
-  plaster from patch, convert patch to plaster, plasterize, make a plaster."
+  "Create a Plaster (`rewrite/*.yaml`) config for an existing Brave-core
+  Chromium `.patch`, authoring an intent-conveying regex match per the Plaster
+  Dos and Don'ts, then verifying it reproduces the patch with `plaster.py
+  check`. Does not modify sources or create other files — its only output is the
+  plaster config. Triggers on: plaster from patch, convert patch to plaster,
+  plasterize, make a plaster."
 argument-hint:
   '<patch file, source path, or nothing to infer from working tree>'
 disable-model-invocation: true
@@ -17,47 +18,59 @@ allowed-tools:
 
 # Plaster From Patch
 
-Turn a regular Brave-core Chromium patch into a 🩹 Plaster config. The user has
-already produced a normal patch the usual way — edited an upstream source under
+Create a 🩹 Plaster config for a patch the user has already written. The user
+made a normal Brave-core change the usual way — edited an upstream source under
 `src/`, then ran `npm run update_patches` to generate
-`patches/<dashed-path>.patch`. This skill reads that change and writes the
-equivalent `rewrite/<path>.yaml`, following the rules below, so the same effect
-is achieved through a robust regex substitution instead of a brittle context
-patch.
+`patches/<dashed-path>.patch` — and now wants the equivalent
+`rewrite/<path>.yaml` so the change is expressed as a robust regex substitution
+instead of a brittle context patch.
+
+## Scope — read this first
+
+**The only thing this skill produces is the plaster config**
+(`rewrite/<path>.yaml`).
+
+- It does **not** modify the Chromium source, the patch, or any other file.
+- It does **not** create `chromium_src` shadow files or move code around.
+- It does **not** decide whether the change _should_ be a plaster — the user
+  already decided that by writing the patch. Author a config that reproduces the
+  patch, following the guidelines.
+
+The single exception is verification: `plaster.py check` is a **dry run** that
+makes no changes (details in Step 3).
 
 ## Required reading
 
-The conversion rules come from two docs. Read them if present — they are the
+The matching rules come from two docs. Read them if present — they are the
 source of truth and may be updated:
 
 - `docs/plaster.md` — how Plaster works, file layout, the substitution schema.
 - `docs/plaster_dos_and_donts.md` — the dos and don'ts (introduced in
   brave/brave-core#36525). If this file is not yet on your branch, the
-  **Conversion rules** section below embeds its essentials so the skill still
+  **Matching rules** section below embeds its essentials so the skill still
   works.
 
 ## Mental model
 
-| Artifact        | Location                                      | Role                                         |
-| --------------- | --------------------------------------------- | -------------------------------------------- |
-| Upstream source | `../<path>` (e.g. `../components/foo/foo.cc`) | The pristine Chromium file, from `git`       |
-| Patch           | `./patches/<path-with-/-as->.patch`           | Encodes upstream → modified                  |
-| Plaster         | `./rewrite/<path>.yaml`                       | Regex substitutions you author               |
-| `chromium_src`  | `./chromium_src/<path>`                       | Shadow file for file-scope / substantive C++ |
+| Artifact        | Location                                      | Role                                   |
+| --------------- | --------------------------------------------- | -------------------------------------- |
+| Upstream source | `../<path>` (e.g. `../components/foo/foo.cc`) | The pristine Chromium file, from `git` |
+| Patch           | `./patches/<path-with-/-as->.patch`           | Encodes upstream → modified            |
+| Plaster         | `./rewrite/<path>.yaml`                       | The regex config you author            |
 
-Key facts that drive everything:
+Key facts that drive the match:
 
 - **Plaster loads the source from `git`, not disk.** Your regex must match the
   **pristine upstream** text (the patch's `a/` side) and transform it into the
-  **modified** text (the `b/` side). Running `plaster.py apply` regenerates the
-  `.patch` from the plaster.
+  **modified** text (the `b/` side).
 - The patch stem replaces `/` with `-`: `components/foo/foo.cc` →
   `patches/components-foo-foo.cc.patch`. The plaster keeps the real path:
   `rewrite/components/foo/foo.cc.yaml`.
 
-## Step 1 — Resolve the input and gather the change
+## Step 1 — Resolve the input and read the change
 
 This skill runs from `src/brave`. Confirm with `git rev-parse --show-toplevel`.
+This step only reads — it changes nothing.
 
 Resolve the argument into one or more `(source_path, patch_path)` pairs:
 
@@ -82,44 +95,23 @@ For each pair, obtain three things:
    switch, or gn target) to anchor on intent, not coincidence.
 3. **The intended modified text** — the `b/` side, or the working-tree file.
 
-If `plaster.py` cannot resolve the source from `git` (uncommitted, or the file
-is not in Chromium's `src` repo — only `src` is supported), say so and stop:
-Plaster cannot patch it.
+If the source is not in Chromium's `src` repo (only `src` is supported), say so
+and stop: Plaster cannot patch it.
 
-## Step 2 — Triage each hunk: plaster, `chromium_src`, or both
+If a hunk is a pure file-scope addition (a new `#include`, an
+anonymous-namespace helper) that the dos and don'ts say is better hosted in a
+`chromium_src` shadow file than in a plaster, you may **mention** that to the
+user as a heads-up — but still author the config you were asked for and create
+no other files. The choice is the user's.
 
-**Not every patch belongs in a plaster.** Before writing any regex, classify
-each hunk. This is the single most important step — getting it wrong produces a
-plaster the reviewers will reject.
+## Step 2 — Author the plaster config
 
-- **Mere file-scope addition** — a new `#include`, an anonymous-namespace
-  constant or helper, a new type, anything that can live _before or after_ the
-  upstream `#include` of the file. → **Do NOT plaster.** Put it in a
-  `chromium_src/<path>` shadow file that re-includes the upstream source.
-  Plaster is only for changes that cannot be made at file scope.
+Write `rewrite/<path>.yaml` and nothing else. Start from the standard MPL header
+(copy it from any existing `rewrite/**/*.yaml`), then a `substitutions:` list.
+One substitution per logical change in the patch. Apply these rules — they come
+straight from the dos and don'ts.
 
-- **Substantive C++ injected into a function/class** — more than a trivial
-  one-liner. → Put the substantive code in a `chromium_src` shadow helper
-  (anonymous-namespace function, etc.) so it gets `clang-format`, presubmit,
-  DEPS, and semgrep coverage; keep the plaster a **minimal call-site insertion**
-  (`MaybeApplyBar(this);`).
-
-- **Trivial in-place change** — flipping a value, redirecting a constant,
-  inserting one short line, extending an enum/switch, extending a gn array,
-  renaming one definition. → **Author a plaster substitution** (Step 3). Be
-  pragmatic: if the whole change is one clear line, let the plaster carry it
-  directly rather than splitting it across a `chromium_src` file for no gain.
-
-Produce an explicit triage list: for each hunk, which bucket and why. Show it to
-the user before writing files — this is where the human judgment lives.
-
-## Step 3 — Author the plaster substitutions
-
-Write `rewrite/<path>.yaml`. Start from the standard MPL header (copy it from
-any existing `rewrite/**/*.yaml`), then a `substitutions:` list. Apply these
-rules — they come straight from the dos and don'ts.
-
-### Conversion rules
+### Matching rules
 
 **Convey intent, match the minimal uniquely-identifying context.** The regex is
 how the change's intent is recorded. Anchor on the things that describe _what_
@@ -190,11 +182,6 @@ is a feature: when the count stops matching, the change gets re-reviewed. Use
 is inherently safe to substitute — and add a comment saying why. Never raise
 `count` just to silence a "matched N times" failure; investigate it.
 
-**Prefer plaster over the alternatives, and remember why** — so the description
-can carry it: a `.patch` breaks when adjacent lines move; a `#define` silently
-rewrites every occurrence including ones pulled in by `#include`. A scoped
-plaster substitution rewrites exactly the one place its match describes.
-
 ### Descriptions
 
 Give each substitution a `description` that states the intent — what is changing
@@ -202,100 +189,82 @@ and why — not a restatement of the regex mechanics. Use a `|` / `|-` block
 scalar for multi-line text. This is the recovery note for whoever hits a future
 break.
 
-## Step 4 — Write any `chromium_src` shadow file
+## Step 3 — Verify with `plaster.py check` (dry run)
 
-For hunks triaged to `chromium_src` in Step 2, create/extend
-`chromium_src/<path>`: file-scope additions and helpers go before, then
-`#include <path>` re-includes the upstream source (angle-bracket include of the
-original). Match the surrounding conventions of existing `chromium_src` files
-(MPL header, include guards where relevant). Keep the matching plaster down to
-the minimal call-site insertion.
+The config is correct **iff** applying it to the pristine upstream source
+reproduces the patch. `check` confirms exactly that, as a **dry run that writes
+nothing**:
 
-## Step 5 — Apply and verify (the acid test)
+```bash
+tools/cr/plaster.py check rewrite/<path>.yaml
+```
 
-The plaster is correct **iff** applying it to the pristine upstream source
-reproduces the user's intended modified source exactly. Verify, don't assume.
-
-`apply` / `check` take the **plaster or patch path**, never the chromium source
+`check` / `apply` take the **plaster or patch path**, never the chromium source
 path — passing `../<source_path>` raises `ValueError: Unexpected file path`.
 Accepted forms are `rewrite/<path>.yaml` and `patches/<dashed>.patch` (or no
-argument to process every plaster):
+argument to process every plaster).
 
-```bash
-tools/cr/plaster.py check rewrite/<path>.yaml   # dry run
-tools/cr/plaster.py apply rewrite/<path>.yaml   # rewrite ../<source>, regen patch + .patchinfo
-```
+- A clean `check` means the plaster reproduces the user's existing patch/source
+  — done.
+- A mismatch means the regex matched the wrong region or the replacement is off,
+  or `count` didn't match (e.g. found 0 or several). Fix the substitution and
+  re-run `check`. Iterate until it is clean.
 
-`apply` writes the transformed text back to the chromium source on disk at
-`../<source_path>` and regenerates `patches/<dashed>.patch` + `.patchinfo`.
+`plaster.py` needs PyYAML. If it fails with
+`ModuleNotFoundError: No module named 'yaml'`, retry with the depot_tools
+interpreter (`vpython3 tools/cr/plaster.py ...`) or install into the active env
+(`python3 -m pip install pyyaml`). If it still cannot run here, **do not claim
+success** — manually simulate each substitution against the pristine text
+(Python `re` reasoning), state that local verification was unavailable, and flag
+that the user must run `plaster.py check`.
 
-- `plaster.py` needs PyYAML. If it fails with
-  `ModuleNotFoundError: No module named 'yaml'`, retry with the depot_tools
-  interpreter (`vpython3 tools/cr/plaster.py ...`) or install into the active
-  env (`python3 -m pip install pyyaml`). If it still cannot run here, **do not
-  claim success** — manually simulate each substitution against the pristine
-  text (Python `re` reasoning), state that local verification was unavailable,
-  and flag that CI / the user must run `plaster.py check`.
+> Note: `plaster.py apply` is how the change becomes plaster-managed — it
+> rewrites the source from `git` + the plaster and regenerates
+> `patches/<dashed>.patch` + `.patchinfo`. That step **does** modify files, so
+> it is the user's to run (or run it only with their explicit go-ahead). This
+> skill stops at a verified config.
 
-**Compare results.** Stash the user's intended modified source first (so
-`apply`, which rewrites the source from `git` + the plaster, doesn't clobber
-it), then compare what the plaster produced against it:
-
-```bash
-cp ../<source_path> /tmp/intended.txt        # the user's hand-edited target
-tools/cr/plaster.py apply rewrite/<path>.yaml # rewrites ../<source_path> from git+plaster
-diff /tmp/intended.txt ../<source_path>       # must be empty
-```
-
-The plaster-produced source must be byte-identical to the intended modified
-source (empty `diff`). If it differs, the regex matched the wrong region or the
-replacement is off — fix the substitution and re-run. Iterate until the match is
-exact and `count` matched as expected (the default `1`).
-
-Once it matches, the original hand-written `patches/<dashed>.patch` is now
-**generated by the plaster** — it stays (plaster maintains it), but it is no
-longer hand-maintained. Make sure `.patchinfo` was written alongside it.
-
-## Step 6 — Self-review
+## Step 4 — Self-review
 
 Before declaring done, run the `/code-review` skill (or an Agent review) over
-the new/changed files (`rewrite/<path>.yaml`, any `chromium_src/<path>`, the
-regenerated patch). Specifically check the conversion-rule violations that are
-easy to miss:
+the new `rewrite/<path>.yaml`. Specifically check the matching-rule violations
+that are easy to miss:
 
 - Anchoring on a removable neighbor key (enum/switch) instead of structure.
 - A `re_pattern` that depends on incidental whitespace or unrelated lines.
 - A `count: 0` without a justifying comment, or a silenced count mismatch.
-- File-scope additions that should have been `chromium_src`, not plaster.
-- Substantive C++ inlined in `replace` that belongs in a shadow helper.
-- Bundled gn array extensions, or extensions not placed right after declaration.
+- A `replace` that diverges from the patch's intended text (re-diff against the
+  patch).
+- An overly broad `pattern` that would match in more places than intended.
 
 Fix anything it surfaces before moving on.
 
-## Step 7 — Commit, branch, PR
+## Step 5 — Commit and offer a PR
 
-Stage the plaster, any `chromium_src` file, and the regenerated
-patch/`.patchinfo`. Commit on the working branch (new commit; don't squash onto
-unrelated work):
+Stage and commit just the plaster config on the working branch (new commit;
+don't squash onto unrelated work):
 
 ```bash
-git add rewrite/<path>.yaml chromium_src/<path> patches/<dashed>.patch patches/<dashed>.patchinfo
-git commit -m "Convert <path> patch to plaster"
+git add rewrite/<path>.yaml
+git commit -m "Add plaster config for <path>"
 ```
 
 End the commit message with the standard trailer:
 `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
 
+If the user wants the change wired in as a plaster-managed patch, run
+`tools/cr/plaster.py apply rewrite/<path>.yaml` (with their go-ahead) and
+include the regenerated `patches/<dashed>.patch` + `.patchinfo` in the commit.
 Then offer to push and open a PR (`gh pr create`). Report the URL.
 
 ## Guidelines
 
-- **Triage first, author second.** Most rejected plasters are changes that never
-  belonged in a plaster. Decide plaster vs `chromium_src` before touching regex.
+- **Config only.** The deliverable is `rewrite/<path>.yaml`. Don't edit sources,
+  don't create `chromium_src` files, don't restructure the change.
 - **Match the pristine upstream, not the patched file** — Plaster reads the
   source from `git`.
-- **Verify by reproduction.** A plaster that "looks right" but doesn't reproduce
-  the exact modified source is wrong. Run `plaster.py` and compare.
+- **Verify with `check`** — a dry run. A config that "looks right" but doesn't
+  reproduce the patch is wrong.
 - **Let intentional breakage stand.** Don't paper over a `count` mismatch; it is
   the safety mechanism working.
 - **Keep the regex minimal and intent-bearing.** The smallest match that is

--- a/docs/claude_code_skills.md
+++ b/docs/claude_code_skills.md
@@ -18,6 +18,7 @@ Claude Code skills are slash commands that automate common development tasks in
 | `/force-push-downstream`  | Force-push branch + all downstream branches                                       |
 | `/impl-review`            | Implement PR review feedback                                                      |
 | `/make-ci-green`          | Re-run failed CI jobs (Experimental)                                              |
+| `/plaster-from-patch`     | Convert an existing Chromium `.patch` into a Plaster (`rewrite/*.yaml`) config    |
 | `/pr`                     | Create a pull request for the current branch                                      |
 | `/preflight`              | Run all preflight checks (format, build, test)                                    |
 | `/rebase-downstream`      | Rebase a tree of dependent branches                                               |


### PR DESCRIPTION
## Summary

Adds a Claude Code skill, `/plaster-from-patch`, that converts an existing
Brave-core Chromium `.patch` (or a working-tree edit to an upstream source) into
the equivalent 🩹 Plaster config (`rewrite/<path>.yaml`).

The workflow it automates: the developer makes a change the normal way (edit an
upstream source under `src/`, `npm run update_patches`), then runs the skill to
mechanically turn that patch into a robust, intent-conveying Plaster
substitution.

## What it does

- **Resolves the input** — a `patches/*.patch` path, a source path, or infers
  from the working tree.
- **Triages each hunk** — plaster vs `chromium_src` shadow file. File-scope
  additions and substantive C++ go to `chromium_src`; only changes that can't be
  made at file scope (enum/switch insertion, gn array extension, in-place edits)
  become plaster substitutions.
- **Authors the substitutions** following the rules in
  `docs/plaster_dos_and_donts.md` (#36525): match minimal intent-bearing
  context, `pattern` vs `re_pattern`, flexible whitespace + `DOTALL`, enum/switch
  anchoring, `gn` `+=` placement, and `count` discipline.
- **Verifies by reproduction** — runs `tools/cr/plaster.py apply` and diffs the
  plaster-produced source against the intended modified source; they must be
  byte-identical.
- **Self-review, commit, PR.**

The conversion rules are embedded directly in the skill so it works even before
the `plaster_dos_and_donts.md` doc lands, with a pointer to that doc as the
source of truth.

Also adds the skill to the `docs/claude_code_skills.md` index.

## Notes

- The dos-and-don'ts doc it references is in #36525.