### PR TITLE
Allow ASK setting for sensors permission on Android

### DIFF
--- a/app/feature_defaults_unittest.cc
+++ b/app/feature_defaults_unittest.cc
@@ -300,6 +300,7 @@ TEST(FeatureDefaultsTest, EnabledFeatures) {
       &features::kDesktopPWAsTabStripSettings,
 #if !BUILDFLAG(IS_ANDROID)
       &features::kLocationProviderManager,
+      &features::kSensorsAllowAskBlockPermissionModel,
 #endif
       &history::kHistoryMoreSearchResults,
       &media::kEnableTabMuting,

--- a/browser/content_settings/brave_content_settings_registry_unittest.cc
+++ b/browser/content_settings/brave_content_settings_registry_unittest.cc
@@ -222,7 +222,17 @@ TEST_F(BraveContentSettingsRegistryTest, GetInitialDefaultSetting) {
     info = registry()->Get(ContentSettingsType::BRAVE_SPEEDREADER);
     EXPECT_EQ(CONTENT_SETTING_ASK, info->GetInitialDefaultSetting());
   }
-
+  {
+    SCOPED_TRACE("Content setting: SENSORS");
+    info = registry()->Get(ContentSettingsType::SENSORS);
+    ASSERT_TRUE(info);
+    EXPECT_EQ(CONTENT_SETTING_BLOCK, info->GetInitialDefaultSetting());
+    EXPECT_TRUE(info->IsSettingValid(CONTENT_SETTING_ALLOW));
+    EXPECT_TRUE(info->IsSettingValid(CONTENT_SETTING_ASK));
+    EXPECT_TRUE(info->IsSettingValid(CONTENT_SETTING_BLOCK));
+    EXPECT_EQ(ContentSettingsInfo::INHERIT_IF_LESS_PERMISSIVE,
+              info->incognito_behavior());
+  }
   {
     SCOPED_TRACE("Content setting: BRAVE_AUTO_SHRED");
     const WebsiteSettingsInfo* ws_info =

--- a/chromium_src/components/content_settings/core/browser/content_settings_registry.cc
+++ b/chromium_src/components/content_settings/core/browser/content_settings_registry.cc
@@ -289,11 +289,12 @@ void ContentSettingsRegistry::BraveInit() {
   website_settings_registry_->Unregister(ContentSettingsType::SENSORS);
   Register(ContentSettingsType::SENSORS, "sensors", CONTENT_SETTING_BLOCK,
            WebsiteSettingsInfo::UNSYNCABLE, /*allowlisted_schemes=*/{},
-           /*valid_settings=*/{CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK},
+           /*valid_settings=*/
+           {CONTENT_SETTING_ALLOW, CONTENT_SETTING_ASK, CONTENT_SETTING_BLOCK},
            WebsiteSettingsInfo::TOP_ORIGIN_ONLY_SCOPE,
            WebsiteSettingsRegistry::DESKTOP |
                WebsiteSettingsRegistry::PLATFORM_ANDROID,
-           ContentSettingsInfo::INHERIT_IN_INCOGNITO,
+           ContentSettingsInfo::INHERIT_IF_LESS_PERMISSIVE,
            PermissionSettingsInfo::EXCEPTIONS_ON_SECURE_AND_INSECURE_ORIGINS);
 
   // Disable idle detection by default (we used to disable feature flag

--- a/chromium_src/services/device/public/cpp/device_features.cc
+++ b/chromium_src/services/device/public/cpp/device_features.cc
@@ -15,6 +15,7 @@ namespace features {
 
 OVERRIDE_FEATURE_DEFAULT_STATES({{
     {kLocationProviderManager, base::FEATURE_ENABLED_BY_DEFAULT},
+    {kSensorsAllowAskBlockPermissionModel, base::FEATURE_ENABLED_BY_DEFAULT},
 }});
 
 const base::FeatureParam<device::mojom::LocationProviderManagerMode>


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/54884

## Summary
Currently, the Sensors permission on Android (and Desktop) only supports Allow or Block globally. This PR adds `CONTENT_SETTING_ASK` as a valid setting, allowing users to set sensors to "Ask" so they get a per-site permission prompt — matching the behavior already available for similar permissions like NFC and Idle Detection.

## Changes
- Added `CONTENT_SETTING_ASK` to valid settings for `SENSORS` in `content_settings_registry.cc`
- Changed incognito behavior from `INHERIT_IN_INCOGNITO` to `INHERIT_IF_LESS_PERMISSIVE` (consistent with other ASK-supporting permissions)
- Added unit test in `brave_content_settings_registry_unittest.cc` verifying the new valid settings and incognito behavior

## Test
- Unit test added: verifies SENSORS accepts ALLOW, ASK, and BLOCK, defaults to BLOCK, and uses INHERIT_IF_LESS_PERMISSIVE

Note: AI tools were used to help identify the relevant code and approach.