### PR TITLE
[CodeHealth] Remove wallet dep from `lookup_string_in_fixed_set.cc`

### DIFF
--- a/chromium_src/net/base/BUILD.gn
+++ b/chromium_src/net/base/BUILD.gn
@@ -3,6 +3,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+group("registry_controlled_domains_deps") {
+  public_deps = [ "//brave/components/brave_wallet/common/buildflags" ]
+}
+
 source_set("unit_tests") {
   testonly = true
   sources = [

--- a/patches/net-base-BUILD.gn.patch
+++ b/patches/net-base-BUILD.gn.patch
@@ -1,0 +1,10 @@
+diff --git a/net/base/BUILD.gn b/net/base/BUILD.gn
+index 9a9dbf4b16ea4bed083831991f49b3e39328178d..b24bc8c86cc9a0c937025f3414f6c761ab4e8686 100644
+--- a/net/base/BUILD.gn
++++ b/net/base/BUILD.gn
+@@ -59,4 +59,5 @@ source_set("registry_controlled_domains") {
+     "//base",
+     "//url",
+   ]
++  deps += [ "//brave/chromium_src/net/base:registry_controlled_domains_deps" ]
+ }

--- a/rewrite/net/base/BUILD.gn.yaml
+++ b/rewrite/net/base/BUILD.gn.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Add the brave_wallet buildflags dependency to registry_controlled_domains
+
+      `lookup_string_in_fixed_set.cc` uses  BUILDFLAG(ENABLE_BRAVE_WALLET),
+      which requires the depenendency to be added.
+
+      Appended as a `deps +=` line at the end of the target so it stays robust
+      to upstream changes to the existing `deps` list.
+    re_pattern: '(source_set\("registry_controlled_domains"\) \{.+?)(?=\n\})'
+    re_flags: [DOTALL]
+    replace: |-
+      \1
+        deps += [ "//brave/chromium_src/net/base:registry_controlled_domains_deps" ]


### PR DESCRIPTION
This PR removes any dependency to wallet code in
`lookup_string_in_fixed_set.cc`. This is causing intermittent build
failures, and it is also not the expected approach to handle something
like this in `//net`.

Bug: https://github.com/brave/brave-browser/issues/56458