### PR TITLE
[iOS] Replace request url checks for security origin in JS features

### DIFF
--- a/ios/browser/brave_search/brave_search_make_default_javascript_feature.mm
+++ b/ios/browser/brave_search/brave_search_make_default_javascript_feature.mm
@@ -65,10 +65,7 @@ void BraveSearchMakeDefaultJavaScriptFeature::ScriptMessageReceivedWithReply(
     web::WebState* web_state,
     const web::ScriptMessage& message,
     ScriptMessageReplyCallback callback) {
-  GURL request_url = message.request_url().value_or(GURL());
-
-  if (!message.is_main_frame() || !request_url.is_valid() ||
-      !request_url.SchemeIs(url::kHttpsScheme)) {
+  if (!message.is_main_frame()) {
     std::move(callback).Run(nullptr, nil);
     return;
   }

--- a/ios/browser/brave_talk/brave_talk_launcher_javascript_feature.mm
+++ b/ios/browser/brave_talk/brave_talk_launcher_javascript_feature.mm
@@ -55,9 +55,7 @@ BraveTalkLauncherJavaScriptFeature::GetScriptMessageHandlerName() const {
 void BraveTalkLauncherJavaScriptFeature::ScriptMessageReceived(
     web::WebState* web_state,
     const web::ScriptMessage& message) {
-  GURL request_url = message.request_url().value_or(GURL());
-
-  if (!message.is_main_frame() || !request_url.is_valid()) {
+  if (!message.is_main_frame()) {
     return;
   }
 

--- a/ios/browser/skus/skus_javascript_feature.mm
+++ b/ios/browser/skus/skus_javascript_feature.mm
@@ -150,8 +150,8 @@ void SkusJavaScriptFeature::ScriptMessageReceivedWithReply(
     web::WebState* web_state,
     const web::ScriptMessage& message,
     ScriptMessageReplyCallback callback) {
-  GURL request_url = message.request_url().value_or(GURL());
-  if (!message.is_main_frame() || !request_url.is_valid()) {
+  url::Origin security_origin = message.security_origin();
+  if (!message.is_main_frame() || security_origin.opaque()) {
     std::move(callback).Run(nullptr, nil);
     return;
   }
@@ -176,7 +176,7 @@ void SkusJavaScriptFeature::ScriptMessageReceivedWithReply(
     return;
   }
 
-  const std::string host = request_url.GetHost();
+  const std::string host = security_origin.host();
 
   if (*method_id == kMethodRefreshOrder) {
     const std::string* order_id = data->FindString(kOrderIdKey);

--- a/ios/browser/web/logins/logins_javascript_feature.mm
+++ b/ios/browser/web/logins/logins_javascript_feature.mm
@@ -79,15 +79,15 @@ void LoginsJavaScriptFeature::ScriptMessageReceivedWithReply(
   }
 
   if (*type == kMessageTypeRequest) {
-    const std::optional<GURL> request_url = message.request_url();
+    url::Origin security_origin = message.security_origin();
     const std::string* action_origin = body->FindString(kActionOriginKey);
-    if (!request_url || !action_origin) {
+    if (security_origin.opaque() || !action_origin) {
       std::move(callback).Run(nullptr, nil);
       return;
     }
 
     tab_helper->GetSavedLogins(
-        *request_url, *action_origin, message.is_main_frame(),
+        security_origin, *action_origin, message.is_main_frame(),
         base::BindOnce(
             [](ScriptMessageReplyCallback handler, std::string json) {
               auto parsed = base::JSONReader::Read(json, base::JSON_PARSE_RFC);

--- a/ios/browser/web/logins/logins_tab_helper.h
+++ b/ios/browser/web/logins/logins_tab_helper.h
@@ -13,11 +13,14 @@
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "ios/web/public/web_state_user_data.h"
-#include "url/gurl.h"
 
 @protocol LoginsTabHelperBridge;
 @class BravePasswordAPI;
 @class IOSPasswordForm;
+
+namespace url {
+class Origin;
+}
 
 // Tab helper for handling password operations triggered by the logins
 // JavaScript feature. Implementations bridge to the platform password API.
@@ -33,13 +36,13 @@ class LoginsTabHelper : public web::WebStateUserData<LoginsTabHelper> {
 
   void SetBridge(id<LoginsTabHelperBridge> bridge);
 
-  // Called when a page form requests saved logins for |frame_request_url| /
+  // Called when a page form requests saved logins for |security_origin| /
   // |action_origin|. |is_main_frame| mirrors ScriptMessage::is_main_frame()
   // and is used to strip passwords for cross-origin subframe requests.
   // The implementation invokes |callback| with a JSON array string of login
   // dictionaries keyed by hostname, formSubmitURL, httpRealm, username,
   // password, usernameField, and passwordField.
-  void GetSavedLogins(const GURL& frame_request_url,
+  void GetSavedLogins(url::Origin security_origin,
                       const std::string& action_origin,
                       bool is_main_frame,
                       base::OnceCallback<void(std::string)> callback);
@@ -57,7 +60,7 @@ class LoginsTabHelper : public web::WebStateUserData<LoginsTabHelper> {
   void OnGetSavedLogins(base::OnceCallback<void(std::string)> callback,
                         std::string action_origin,
                         bool is_main_frame,
-                        GURL frame_request_url,
+                        url::Origin security_origin,
                         NSArray<IOSPasswordForm*>* forms);
 
   __weak id<LoginsTabHelperBridge> bridge_;

--- a/ios/browser/web/logins/logins_tab_helper.mm
+++ b/ios/browser/web/logins/logins_tab_helper.mm
@@ -52,7 +52,7 @@ void LoginsTabHelper::SetBridge(id<LoginsTabHelperBridge> bridge) {
 }
 
 void LoginsTabHelper::GetSavedLogins(
-    const GURL& frame_request_url,
+    url::Origin security_origin,
     const std::string& action_origin,
     bool is_main_frame,
     base::OnceCallback<void(std::string)> callback) {
@@ -65,7 +65,7 @@ void LoginsTabHelper::GetSavedLogins(
 
   auto completion_handler = base::CallbackToBlock(base::BindOnce(
       &LoginsTabHelper::OnGetSavedLogins, weak_ptr_factory_.GetWeakPtr(),
-      std::move(callback), action_origin, is_main_frame, frame_request_url));
+      std::move(callback), action_origin, is_main_frame, security_origin));
 
   [password_api_ getSavedLoginsForURL:url
                            formScheme:PasswordFormSchemeTypeHtml
@@ -76,7 +76,7 @@ void LoginsTabHelper::OnGetSavedLogins(
     base::OnceCallback<void(std::string)> callback,
     std::string action_origin,
     bool is_main_frame,
-    GURL frame_request_url,
+    url::Origin security_origin,
     NSArray<IOSPasswordForm*>* forms) {
   NSMutableArray<NSDictionary<NSString*, NSString*>*>* login_dicts =
       [[NSMutableArray alloc] init];
@@ -86,7 +86,7 @@ void LoginsTabHelper::OnGetSavedLogins(
   // LoginsScriptHandler.swift). Password is always stripped for subframes.
   url::Origin tab_origin =
       url::Origin::Create(web_state_->GetLastCommittedURL());
-  bool same_origin = tab_origin.IsSameOriginWith(frame_request_url);
+  bool same_origin = tab_origin.IsSameOriginWith(security_origin);
 
   if (!is_main_frame && !same_origin) {
     std::move(callback).Run("[]");

--- a/ios/browser/youtube/youtube_quality_javascript_feature.mm
+++ b/ios/browser/youtube/youtube_quality_javascript_feature.mm
@@ -84,9 +84,7 @@ void YouTubeQualityJavaScriptFeature::ScriptMessageReceivedWithReply(
     web::WebState* web_state,
     const web::ScriptMessage& message,
     ScriptMessageReplyCallback callback) {
-  GURL request_url = message.request_url().value_or(GURL());
-
-  if (!message.is_main_frame() || !request_url.is_valid()) {
+  if (!message.is_main_frame()) {
     std::move(callback).Run(nullptr, nil);
     return;
   }


### PR DESCRIPTION
The security origin is now available in `ScriptMessage` in cr150+ so this replaces the usage of request url with the security origin. Also cleans up features with OriginFilter's to remove redundant checks
