### PR TITLE
[AI Chat] Conversation sharing - add feature flag and sharing button

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -690,6 +690,13 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
           kOsWin | kOsMac | kOsLinux | kOsAndroid,                             \
           FEATURE_VALUE_TYPE(                                                  \
               ai_chat::features::kAIChatDetailedPageContentExtraction),        \
+      },                                                                       \
+      {                                                                        \
+          "brave-ai-chat-conversation-share",                                  \
+          "Brave AI Chat Conversation Sharing",                                \
+          "Enables sharing a conversation from the conversation header.",      \
+          kOsWin | kOsMac | kOsLinux | kOsAndroid,                             \
+          FEATURE_VALUE_TYPE(ai_chat::features::kAIChatConversationShare),     \
       })
 #else
 #define BRAVE_AI_CHAT_FEATURE_ENTRIES

--- a/browser/ui/webui/ai_chat/ai_chat_ui.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.cc
@@ -11,6 +11,7 @@
 
 #include "base/check.h"
 #include "base/check_op.h"
+#include "base/feature_list.h"
 #include "brave/browser/ai_chat/ai_chat_service_factory.h"
 #include "brave/browser/ai_chat/tab_tracker_service_factory.h"
 #include "brave/browser/ui/side_panel/ai_chat/ai_chat_side_panel_utils.h"
@@ -101,7 +102,8 @@ AIChatUI::AIChatUI(content::WebUI* web_ui)
                      ai_chat::features::IsAIChatAgentProfileEnabled());
   source->AddBoolean("isAIChatAgentProfile", profile_->IsAIChatAgent());
   source->AddBoolean("isConversationShareEnabled",
-                     ai_chat::features::IsAIChatConversationShareEnabled());
+                     base::FeatureList::IsEnabled(
+                         ai_chat::features::kAIChatConversationShare));
 
   web_ui->AddRequestableScheme(content::kChromeUIUntrustedScheme);
   source->OverrideContentSecurityPolicy(

--- a/browser/ui/webui/ai_chat/ai_chat_ui.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.cc
@@ -100,6 +100,8 @@ AIChatUI::AIChatUI(content::WebUI* web_ui)
   source->AddBoolean("isAIChatAgentProfileFeatureEnabled",
                      ai_chat::features::IsAIChatAgentProfileEnabled());
   source->AddBoolean("isAIChatAgentProfile", profile_->IsAIChatAgent());
+  source->AddBoolean("isConversationShareEnabled",
+                     ai_chat::features::IsAIChatConversationShareEnabled());
 
   web_ui->AddRequestableScheme(content::kChromeUIUntrustedScheme);
   source->OverrideContentSecurityPolicy(

--- a/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_initializer.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_initializer.cc
@@ -252,6 +252,9 @@ void NewTabPageInitializer::AddLoadTimeValues() {
   source_->AddBoolean("isAIChatAgentProfileFeatureEnabled",
                       ai_chat::features::IsAIChatAgentProfileEnabled());
   source_->AddBoolean("isAIChatAgentProfile", profile->IsAIChatAgent());
+  source_->AddBoolean("isConversationShareEnabled",
+                      base::FeatureList::IsEnabled(
+                          ai_chat::features::kAIChatConversationShare));
 #endif
 
   source_->AddBoolean("aiChatInputEnabled", ai_chat_input_enabled);

--- a/components/ai_chat/core/common/features.cc
+++ b/components/ai_chat/core/common/features.cc
@@ -217,8 +217,4 @@ bool IsBraveSyncAIChatEnabled() {
 
 BASE_FEATURE(kAIChatConversationShare, base::FEATURE_DISABLED_BY_DEFAULT);
 
-bool IsAIChatConversationShareEnabled() {
-  return base::FeatureList::IsEnabled(features::kAIChatConversationShare);
-}
-
 }  // namespace ai_chat::features

--- a/components/ai_chat/core/common/features.cc
+++ b/components/ai_chat/core/common/features.cc
@@ -215,4 +215,10 @@ bool IsBraveSyncAIChatEnabled() {
   return base::FeatureList::IsEnabled(features::kBraveSyncAIChat);
 }
 
+BASE_FEATURE(kAIChatConversationShare, base::FEATURE_DISABLED_BY_DEFAULT);
+
+bool IsAIChatConversationShareEnabled() {
+  return base::FeatureList::IsEnabled(features::kAIChatConversationShare);
+}
+
 }  // namespace ai_chat::features

--- a/components/ai_chat/core/common/features.h
+++ b/components/ai_chat/core/common/features.h
@@ -173,7 +173,6 @@ COMPONENT_EXPORT(AI_CHAT_COMMON) bool IsBraveSyncAIChatEnabled();
 // Enables sharing a conversation from the conversation header.
 COMPONENT_EXPORT(AI_CHAT_COMMON)
 BASE_DECLARE_FEATURE(kAIChatConversationShare);
-COMPONENT_EXPORT(AI_CHAT_COMMON) bool IsAIChatConversationShareEnabled();
 
 }  // namespace ai_chat::features
 

--- a/components/ai_chat/core/common/features.h
+++ b/components/ai_chat/core/common/features.h
@@ -170,6 +170,11 @@ COMPONENT_EXPORT(AI_CHAT_COMMON) bool IsAIChatDeepResearchEnabled();
 COMPONENT_EXPORT(AI_CHAT_COMMON) BASE_DECLARE_FEATURE(kBraveSyncAIChat);
 COMPONENT_EXPORT(AI_CHAT_COMMON) bool IsBraveSyncAIChatEnabled();
 
+// Enables sharing a conversation from the conversation header.
+COMPONENT_EXPORT(AI_CHAT_COMMON)
+BASE_DECLARE_FEATURE(kAIChatConversationShare);
+COMPONENT_EXPORT(AI_CHAT_COMMON) bool IsAIChatConversationShareEnabled();
+
 }  // namespace ai_chat::features
 
 #endif  // BRAVE_COMPONENTS_AI_CHAT_CORE_COMMON_FEATURES_H_

--- a/components/ai_chat/resources/page/components/header/index.tsx
+++ b/components/ai_chat/resources/page/components/header/index.tsx
@@ -8,6 +8,7 @@ import Icon from '@brave/leo/react/icon'
 import Button from '@brave/leo/react/button'
 import Label from '@brave/leo/react/label'
 import { Conversation } from '../../../common/mojom'
+import { serializeConversationForSharing } from '../../../common/conversation_serialization'
 import useCanStartNewConversation from '../../hooks/useCanStartNewConversation'
 import FeatureButtonMenu, {
   Props as FeatureButtonMenuProps,
@@ -39,6 +40,9 @@ const getTitle = (activeConversation?: Conversation) =>
 const newChatButtonLabel = getLocale(S.CHAT_UI_NEW_CONVERSATION_BUTTON_LABEL)
 const closeButtonLabel = getLocale(S.CHAT_UI_LABEL_CLOSE)
 const openFullPageButtonLabel = getLocale(S.CHAT_UI_OPEN_LABEL)
+const shareConversationButtonLabel = getLocale(
+  S.CHAT_UI_SHARE_CONVERSATION_BUTTON_LABEL,
+)
 
 export const ConversationHeader = React.forwardRef(function (
   props: FeatureButtonMenuProps,
@@ -48,6 +52,7 @@ export const ConversationHeader = React.forwardRef(function (
   const conversationContext = useConversation()
   const { createNewConversation, isMainConversation, openMainConversation } =
     useActiveChat()
+  const conversationState = conversationContext.api.useGetStateData()
   const isMobile = useIsSmall() && aiChatContext.isMobile
 
   const canStartNewConversation = useCanStartNewConversation()
@@ -58,6 +63,21 @@ export const ConversationHeader = React.forwardRef(function (
   const activeConversation = aiChatContext.conversations.find(
     (c: Conversation) => c.uuid === conversationContext.conversationUuid,
   )
+
+  const conversationHistory = conversationContext.conversationHistory
+  const canShareConversation =
+    aiChatContext.isConversationShareEnabled
+    && conversationHistory.length > 0
+    && !conversationState.isRequestInProgress
+
+  const handleShareConversation = React.useCallback(() => {
+    // The serialized conversation will eventually be sent to the sharing
+    // server, which will encrypt it and return a shareable link. For now, copy
+    // the serialized string to the clipboard so the flow can be demoed.
+    const json = serializeConversationForSharing(conversationHistory)
+    navigator.clipboard.writeText(json)
+  }, [conversationHistory])
+
   const showTitle =
     (!isMainConversation || aiChatContext.isStandalone) && !isMobile
   const canShowFullScreenButton =
@@ -138,6 +158,17 @@ export const ConversationHeader = React.forwardRef(function (
                 }
               >
                 <Icon name='expand' />
+              </Button>
+            )}
+            {canShareConversation && (
+              <Button
+                fab
+                kind='plain-faint'
+                aria-label={shareConversationButtonLabel}
+                title={shareConversationButtonLabel}
+                onClick={handleShareConversation}
+              >
+                <Icon name='share' />
               </Button>
             )}
             <FeatureButtonMenu {...props} />

--- a/components/ai_chat/resources/page/components/header/index.tsx
+++ b/components/ai_chat/resources/page/components/header/index.tsx
@@ -70,13 +70,13 @@ export const ConversationHeader = React.forwardRef(function (
     && conversationHistory.length > 0
     && !conversationState.isRequestInProgress
 
-  const handleShareConversation = React.useCallback(() => {
+  const handleShareConversation = () => {
     // The serialized conversation will eventually be sent to the sharing
     // server, which will encrypt it and return a shareable link. For now, copy
     // the serialized string to the clipboard so the flow can be demoed.
     const json = serializeConversationForSharing(conversationHistory)
     navigator.clipboard.writeText(json)
-  }, [conversationHistory])
+  }
 
   const showTitle =
     (!isMainConversation || aiChatContext.isStandalone) && !isMobile

--- a/components/ai_chat/resources/page/state/ai_chat_context.tsx
+++ b/components/ai_chat/resources/page/state/ai_chat_context.tsx
@@ -63,6 +63,9 @@ export default function useProvideAIChatContext(props: AIChatContextProps) {
       'isAIChatAgentProfileFeatureEnabled',
     ),
     isAIChatAgentProfile: loadTimeData.getBoolean('isAIChatAgentProfile'),
+    isConversationShareEnabled: loadTimeData.getBoolean(
+      'isConversationShareEnabled',
+    ),
     isGlobalPanel:
       !initiallyTabAssociated && api.isStandalone.current() === false,
 

--- a/components/ai_chat/resources/shared_conversation_lib/demo.tsx
+++ b/components/ai_chat/resources/shared_conversation_lib/demo.tsx
@@ -15,7 +15,7 @@ interface DemoSharedConversationInputProps {
 
 /**
  * A development-only helper that lets you paste a conversation JSON export
- * (produced by the AI Chat page's "Export conversation" action) and render it.
+ * (produced by the AI Chat page's "Share conversation" action) and render it.
  * This is not part of the shipped shared conversation experience - it only
  * exists to exercise displayConversation() with local data.
  */

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -435,6 +435,9 @@
   <message name="IDS_CHAT_UI_NEW_CONVERSATION_BUTTON_LABEL" desc="A label for the button which starts a new conversation" formatter_data="webui=AiChat">
     Start a new conversation
   </message>
+  <message name="IDS_CHAT_UI_SHARE_CONVERSATION_BUTTON_LABEL" desc="A label for the button which shares the current conversation" formatter_data="webui=AiChat">
+    Share conversation
+  </message>
   <message name="IDS_CHAT_UI_MENU_RENAME_CONVERSATION" desc="Menu entry for renaming a conversation" formatter_data="webui=AiChat">
     Rename conversation
   </message>

--- a/ios/browser/ui/webui/ai_chat/ai_chat_ui.mm
+++ b/ios/browser/ui/webui/ai_chat/ai_chat_ui.mm
@@ -9,6 +9,7 @@
 #include <string_view>
 #include <utility>
 
+#include "base/feature_list.h"
 #include "base/functional/bind.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_service.h"
 #include "brave/components/ai_chat/core/browser/bookmarks_page_handler.h"
@@ -69,7 +70,8 @@ AIChatUI::AIChatUI(web::WebUIIOS* web_ui, const GURL& url)
                      ai_chat::features::IsAIChatAgentProfileEnabled());
   source->AddBoolean("isAIChatAgentProfile", false);
   source->AddBoolean("isConversationShareEnabled",
-                     ai_chat::features::IsAIChatConversationShareEnabled());
+                     base::FeatureList::IsEnabled(
+                         ai_chat::features::kAIChatConversationShare));
 
   source->OverrideContentSecurityPolicy(
       network::mojom::CSPDirectiveName::ScriptSrc,

--- a/ios/browser/ui/webui/ai_chat/ai_chat_ui.mm
+++ b/ios/browser/ui/webui/ai_chat/ai_chat_ui.mm
@@ -68,6 +68,8 @@ AIChatUI::AIChatUI(web::WebUIIOS* web_ui, const GURL& url)
   source->AddBoolean("isAIChatAgentProfileFeatureEnabled",
                      ai_chat::features::IsAIChatAgentProfileEnabled());
   source->AddBoolean("isAIChatAgentProfile", false);
+  source->AddBoolean("isConversationShareEnabled",
+                     ai_chat::features::IsAIChatConversationShareEnabled());
 
   source->OverrideContentSecurityPolicy(
       network::mojom::CSPDirectiveName::ScriptSrc,

--- a/ui/webui/resources/BUILD.gn
+++ b/ui/webui/resources/BUILD.gn
@@ -424,6 +424,7 @@ leo_icons_sources = [
   "send.svg",
   "settings.svg",
   "share-macos.svg",
+  "share.svg",
   "shield-disable.svg",
   "shield-done-filled.svg",
   "shield-done.svg",


### PR DESCRIPTION
Initial implementation:
- Feature flag introduction
- Pass feature flag to WebUI on all platforms
- Demo button on AI Chat toolbar which copies the serialized conversation to the clipboard

Does not include the real implementation of sending the encrypted conversation to the server and receiving and ID, then concatenating that URL with a decryption key only the local device knows.

<!-- Add brave-browser issue below that this PR will resolve -->
Series
- https://github.com/brave/brave-browser/issues/56444

<img width="245" height="109" alt="image" src="https://github.com/user-attachments/assets/9d20cd74-03e5-4345-80a7-04f63557e022" />


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
