### PR TITLE
[Android] Validate scheme and host for Origin promo deep link

### DIFF
--- a/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginDeepLinkHandler.java
+++ b/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginDeepLinkHandler.java
@@ -15,6 +15,7 @@ import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
 import org.chromium.chrome.browser.settings.BraveOriginPreferences;
 import org.chromium.chrome.browser.settings.SettingsNavigationFactory;
+import org.chromium.components.embedder_support.util.UrlConstants;
 
 /**
  * Routes the Origin promo deep link (https://brave.com/deeplink-android-origin-promo) to the right
@@ -26,18 +27,28 @@ public final class BraveOriginDeepLinkHandler {
     /** Path token used by both the App Link URL and the Play Install Referrer string. */
     public static final String PATH_TOKEN = "deeplink-android-origin-promo";
 
+    /** Only the verified brave.com App Link is allowed to trigger the first-party Origin flow. */
+    private static final String VERIFIED_HOST = "brave.com";
+
     private BraveOriginDeepLinkHandler() {}
 
     /**
      * If {@code intent} is the Origin promo deep link, neutralize its action/data so upstream URL
      * handling skips it and return {@code true}. Caller should then call {@link #open}.
+     *
+     * <p>The action is constrained to the verified App Link (https://brave.com/...) so that
+     * attacker-controlled links from arbitrary, non-verified hosts cannot trigger the first-party
+     * Origin purchase flow.
      */
     public static boolean consumeFromIntent(@Nullable Intent intent) {
         if (intent == null || !Intent.ACTION_VIEW.equals(intent.getAction())) {
             return false;
         }
         Uri data = intent.getData();
-        if (data == null || !PATH_TOKEN.equalsIgnoreCase(data.getLastPathSegment())) {
+        if (data == null
+                || !UrlConstants.HTTPS_SCHEME.equals(data.getScheme())
+                || !VERIFIED_HOST.equals(data.getHost())
+                || !PATH_TOKEN.equalsIgnoreCase(data.getLastPathSegment())) {
             return false;
         }
         intent.setData(null);

--- a/android/junit/src/org/chromium/chrome/browser/brave_origin/BraveOriginDeepLinkHandlerTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/brave_origin/BraveOriginDeepLinkHandlerTest.java
@@ -118,6 +118,46 @@ public class BraveOriginDeepLinkHandlerTest {
         assertFalse(BraveOriginDeepLinkHandler.consumeFromIntent(intent));
     }
 
+    @Test
+    @SmallTest
+    public void consumeFromIntent_arbitraryHost_returnsFalseAndDoesNotMutate() {
+        // An attacker-controlled host ending with the expected path segment must not trigger the
+        // first-party Origin flow, even though the last path segment matches.
+        Uri uri = Uri.parse("https://example.invalid/" + BraveOriginDeepLinkHandler.PATH_TOKEN);
+        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+
+        assertFalse(BraveOriginDeepLinkHandler.consumeFromIntent(intent));
+        // Intent must be left intact so normal navigation to the URL proceeds.
+        assertEquals(Intent.ACTION_VIEW, intent.getAction());
+        assertEquals(uri, intent.getData());
+    }
+
+    @Test
+    @SmallTest
+    public void consumeFromIntent_nonHttpsScheme_returnsFalse() {
+        // Only the verified https scheme is accepted; http (or any other scheme) is rejected.
+        Intent intent =
+                new Intent(
+                        Intent.ACTION_VIEW,
+                        Uri.parse("http://brave.com/" + BraveOriginDeepLinkHandler.PATH_TOKEN));
+
+        assertFalse(BraveOriginDeepLinkHandler.consumeFromIntent(intent));
+    }
+
+    @Test
+    @SmallTest
+    public void consumeFromIntent_subdomainHost_returnsFalse() {
+        // Host must match exactly; subdomains and look-alikes are rejected.
+        Intent intent =
+                new Intent(
+                        Intent.ACTION_VIEW,
+                        Uri.parse(
+                                "https://evil.brave.com.attacker.test/"
+                                        + BraveOriginDeepLinkHandler.PATH_TOKEN));
+
+        assertFalse(BraveOriginDeepLinkHandler.consumeFromIntent(intent));
+    }
+
     // consumeDeferred
 
     @Test


### PR DESCRIPTION
`consumeFromIntent` only matched the URI's last path segment, so any `VIEW` intent ending in `/deeplink-android-origin-promo` (regardless of scheme or host) was consumed and opened the first-party Origin purchase flow.

Constrain the handler to the verified App Link (`https` + `brave.com`) that the manifest declares, so attacker-controlled links from arbitrary, non-verified hosts can no longer trigger the Origin flow. Add regression tests for arbitrary host, non-https scheme, and look-alike host.

Resolves: https://github.com/brave/brave-browser/issues/56483

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
