### PR TITLE
Reject inner WebContents for YouTube PiP availability

### DIFF
--- a/browser/android/youtube_script_injector/youtube_script_injector_browsertest.cc
+++ b/browser/android/youtube_script_injector/youtube_script_injector_browsertest.cc
@@ -17,6 +17,7 @@
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
 #include "content/public/test/content_mock_cert_verifier.h"
+#include "content/public/test/test_utils.h"
 #include "net/dns/mock_host_resolver.h"
 #include "net/test/embedded_test_server/embedded_test_server.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -326,6 +327,36 @@ IN_PROC_BROWSER_TEST_F(YouTubeScriptInjectorBrowserTest,
   // Wait for the mutation observer to complete and trigger fullscreen mode.
   EXPECT_TRUE(
       WaitForJsResult(web_contents(), "document.fullscreenElement !== null"));
+}
+
+IN_PROC_BROWSER_TEST_F(YouTubeScriptInjectorBrowserTest,
+                       PictureInPictureUnavailableForInnerWebContents) {
+  const GURL outer_url = https_server_.GetURL("example.com", "/iframe.html");
+  content::NavigateToURLBlockUntilNavigationsComplete(web_contents(), outer_url,
+                                                      1, true);
+
+  content::RenderFrameHost* iframe =
+      content::ChildFrameAt(web_contents()->GetPrimaryMainFrame(), 0);
+  ASSERT_TRUE(iframe);
+
+  content::WebContents* inner_contents =
+      content::CreateAndAttachInnerContents(iframe);
+  ASSERT_TRUE(inner_contents);
+  ASSERT_EQ(web_contents(), inner_contents->GetOuterWebContents());
+
+  YouTubeScriptInjectorTabHelper::CreateForWebContents(inner_contents);
+  YouTubeScriptInjectorTabHelper* inner_helper =
+      YouTubeScriptInjectorTabHelper::FromWebContents(inner_contents);
+  ASSERT_TRUE(inner_helper);
+
+  const GURL inner_url =
+      https_server_.GetURL("m.youtube.com", "/watch?v=abcdefg");
+  content::NavigateToURLBlockUntilNavigationsComplete(inner_contents, inner_url,
+                                                      1, true);
+
+  ASSERT_TRUE(inner_helper->IsYouTubeVideo(/*mobileOnly=*/true));
+  ASSERT_TRUE(inner_contents->IsDocumentOnLoadCompletedInPrimaryMainFrame());
+  EXPECT_FALSE(inner_helper->IsPictureInPictureAvailable());
 }
 
 // The test is flaky on CI, but succeed on local environment including physical

--- a/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
+++ b/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
@@ -378,9 +378,19 @@ void YouTubeScriptInjectorTabHelper::OnFullscreenScriptComplete(
 }
 
 bool YouTubeScriptInjectorTabHelper::IsPictureInPictureAvailable() const {
+  if (!web_contents()) {
+    return false;
+  }
+  // Reject inner WebContents (guest views, fenced frames, portals). PiP must be
+  // driven from the outermost tab WebContents; offering it on an embedded view
+  // would target the wrong frame tree and bypass the tab level lifecycle the
+  // controller depends on.
+  if (web_contents()->GetOuterWebContents() != nullptr) {
+    return false;
+  }
   return base::FeatureList::IsEnabled(
              preferences::features::kBravePictureInPictureForYouTubeVideos) &&
-         IsYouTubeVideo(true) && web_contents() &&
+         IsYouTubeVideo(true) &&
          web_contents()->IsDocumentOnLoadCompletedInPrimaryMainFrame();
 }
 


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/56384

This PR restricts YouTube Picture in Picture availability to the outer tab WebContents. The YouTube PiP controller, fullscreen state, script injector binding, and lifecycle cleanup are all designed around the top level tab. Inner WebContents should not be allowed to report YouTube PiP availability because the browser UI and Android PiP session are owned by the outer tab.

## What changed

Returns false when the WebContents has an outer WebContents.

## Why

Inner WebContents can represent embedded content rather than the browser tab that owns toolbar state, navigation observation, fullscreen tracking, and Android PiP session handling. If PiP availability succeeds for an inner WebContents, Brave can offer or trigger PiP from the wrong frame tree.

The fix makes the ownership model explicit. YouTube PiP can only be driven from the outer tab WebContents, where the controller can observe and clean up the full lifecycle correctly.

## User impact

* Prevents YouTube PiP from being offered for embedded WebContents.
* Keeps PiP ownership tied to the visible browser tab.
* Reduces the chance of fullscreen or PiP state being tracked against the wrong WebContents.

## Test plan

* Verify a normal mobile YouTube watch page in a top level tab still reports PiP availability.
* Verify an inner WebContents does not report YouTube PiP availability.
* Verify the toolbar PiP button remains available for valid top level YouTube watch pages.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
