### PR TITLE
Follow upstream and disable PIP on supported Android versions

### DIFF
--- a/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
+++ b/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 
+#include "base/android/android_info.h"
 #include "base/feature_list.h"
 #include "base/supports_user_data.h"
 #include "brave/browser/android/youtube_script_injector/brave_youtube_script_injector_native_helper.h"
@@ -191,6 +192,16 @@ bool IsBackgroundVideoPlaybackEnabled(content::WebContents* contents) {
           prefs->GetBoolean(kBackgroundVideoPlaybackEnabled));
 }
 
+// Mirrors the SDK gate that Java's PictureInPicture.isEnabled() applies before
+// any PiP entry attempt (see
+// chrome/android/java/src/.../media/PictureInPicture.java). PiP is
+// hard-disabled on Android < R to dodge a framework crash when entering PiP
+// immediately after exiting it.
+bool IsAndroidPictureInPictureSupported() {
+  return base::android::android_info::sdk_int() >=
+         base::android::android_info::SDK_VERSION_R;
+}
+
 }  // namespace
 
 YouTubeScriptInjectorTabHelper::YouTubeScriptInjectorTabHelper(
@@ -236,7 +247,8 @@ void YouTubeScriptInjectorTabHelper::PrimaryMainDocumentElementAvailable() {
         kYoutubeBackgroundPlayback, base::NullCallback());
   }
   if (base::FeatureList::IsEnabled(
-          ::preferences::features::kBravePictureInPictureForYouTubeVideos)) {
+          ::preferences::features::kBravePictureInPictureForYouTubeVideos) &&
+      IsAndroidPictureInPictureSupported()) {
     contents->GetPrimaryMainFrame()->ExecuteJavaScript(
         kYoutubePictureInPictureSupport, base::NullCallback());
   }
@@ -246,7 +258,8 @@ void YouTubeScriptInjectorTabHelper::MediaEffectivelyFullscreenChanged(
     bool is_fullscreen) {
   if (is_fullscreen && HasFullscreenBeenRequested()) {
     SetFullscreenRequested(false);
-    if (web_contents()->GetVisibility() == content::Visibility::VISIBLE) {
+    if (web_contents()->GetVisibility() == content::Visibility::VISIBLE &&
+        IsAndroidPictureInPictureSupported()) {
       ::youtube_script_injector::EnterPictureInPicture(web_contents());
     }
   }


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/56382

This PR mirrors the Android Picture in Picture availability gate on the native YouTube script injector side. Brave already avoids PiP entry on unsupported Android versions through the Java `PictureInPicture.isEnabled()` path. The native helper should also avoid preparing YouTube PiP support and avoid calling into the PiP entry path when the Android version is older than R.

## What changed

* Adds a native Android SDK support check using `base::android::android_info::sdk_int()`.
* Treats Android R and newer as supported for this YouTube PiP native path.
* Skips the YouTube PiP support script injection on unsupported Android versions.

## Why

The Java PiP path already blocks unsupported devices, including Android versions older than R. Without the same gate in the native script injector, Brave can still mutate the YouTube page for PiP support and proceed through the fullscreen callback even though the eventual PiP entry is not allowed.

The native side should match the same platform support boundary so the whole flow behaves consistently.

## User impact

* No user visible change on Android R and newer.
* Avoids unnecessary YouTube PiP setup on Android versions where PiP entry is disabled.
* Keeps native and Java PiP availability checks aligned.
* Reduces work and avoids unsafe platform paths on Android 10 API 29 and older.

## Test plan

* On Android R or newer, verify YouTube PiP still works from the toolbar on a mobile YouTube watch page.
* On Android 10 API 29, verify Brave does not inject YouTube PiP support or call the final PiP entry path.
* Verify background video playback script injection is unchanged.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
