### PR TITLE
Make YouTube PiP fullscreen entry more reliable

### DIFF
--- a/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
+++ b/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
@@ -95,88 +95,143 @@ constexpr char16_t kYoutubePictureInPictureSupport[] =
 }());
 )";
 
+// Keep selector lists in sync so the exit path can target whichever fullscreen
+// button the YouTube player variant rendered on entry.
+//
+// The script tries to put the YouTube player into fullscreen. On a cold load
+// the player and its controls hydrate asynchronously, so the fullscreen button
+// may not be present in the DOM at injection time. Rather than poll on a
+// timer, we make a couple of synchronous attempts and then wait for a
+// MutationObserver to fire when the button is inserted. A single hard timeout
+// prevents the observer from leaking on broken pages.
 constexpr char16_t kYoutubeFullscreen[] =
     uR"(
 (function() {
   return new Promise((resolve) => {
-    const videoPlaySelector = "video.html5-main-video";
-    const fullscreenSelector = "button.fullscreen-icon";
-    function triggerFullscreen() {
-      // Check if the video is not in fullscreen mode already.
-      if (!document.fullscreenElement) {
-        var fullscreenBtn = document.querySelector(fullscreenSelector);
-        var videoPlayer = document.querySelector(videoPlaySelector);
-        // Check if fullscreen button and video are available.
-        if (fullscreenBtn && videoPlayer) {
-         requestFullscreen(fullscreenBtn, resolve, videoPlayer);
-        } else {
-          // When fullscreen button is not available
-          // clicking the movie player resume the UI.
-          var playerContainer = document.getElementById("player-container-id");
-          if (videoPlayer && playerContainer) {
-            let observerTimeout;
-            // Create a MutationObserver to watch for changes in the DOM.
-            const observer = new MutationObserver(
-            (_mutationsList, observer) => {
-              var fullscreenBtn = document.querySelector(fullscreenSelector);
-              var videoPlayer = document.querySelector(videoPlaySelector);
-              if (fullscreenBtn && videoPlayer) {
-                clearTimeout(observerTimeout);
-                observer.disconnect()
-                requestFullscreen(fullscreenBtn, resolve, videoPlayer);
-              }
-            });
-            // Auto-disconnect the observer after 30 seconds,
-            // a reasonable duration picked after some testing.
-            observerTimeout = setTimeout(() => {
-              observer.disconnect();
-              resolve('timeout');
-            }, 30000);
-            // Start observing the DOM.
-            observer.observe(playerContainer, {
-              childList: true, subtree: true
-            });
-            // Make sure the player is in focus or responsive.
-            videoPlayer.click();
-          } else {
-            // No fullscreen elements found, resolve immediately
-            resolve('no_elements');
-          }
+    const videoSelector = "video.html5-main-video";
+    const fullscreenSelector = "button.fullscreen-icon, "
+        + "button.ytp-fullscreen-button, .ytp-fullscreen-button";
+    const playerSelector = "#movie_player, .html5-video-player";
+    const playerContainerSelector = "#player-container-id, ytm-player, #player";
+    // Hard ceiling so the MutationObserver does not outlive a broken page.
+    // Healthy loads resolve in well under a second; 30 s is generous enough
+    // to absorb cold-cache loads on slow networks.
+    const TIMEOUT_MS = 30000;
+
+    let resolved = false;
+    function resolveOnce(value) {
+      if (resolved) return;
+      resolved = true;
+      resolve(value);
+    }
+
+    function isFullscreen() {
+      const player = document.querySelector(playerSelector);
+      return !!document.fullscreenElement || !!player?.isFullscreen?.();
+    }
+
+    // Click YouTube's fullscreen button if both it and the video are present.
+    // Returns true if the promise was resolved (fullscreen triggered or
+    // already in fullscreen) and the caller should stop trying.
+    function attempt() {
+      if (resolved) return true;
+      if (isFullscreen()) {
+        resolveOnce('already_fullscreen');
+        return true;
+      }
+      const btn = document.querySelector(fullscreenSelector);
+      const video = document.querySelector(videoSelector);
+      if (btn && video) {
+        if (video.readyState >= 3) {
+          // Video is decodable; tap it to give the player input focus before
+          // the button click is dispatched.
+          video.click();
         }
-      } else {
-        // Already in fullscreen, resolve immediately
-        resolve('already_fullscreen');
+        btn.click();
+        resolveOnce('fullscreen_triggered');
+        return true;
+      }
+      return false;
+    }
+
+    function tryYoutubeApi() {
+      const player = document.querySelector(playerSelector);
+      if (!player?.toggleFullscreen
+          || player.classList.contains('ytp-fullscreen')) {
+        return false;
+      }
+      // Use YouTube's own toggle. Do not also call requestFullscreen on the
+      // same element - the two APIs race on Android.
+      try {
+        player.toggleFullscreen();
+        return true;
+      } catch (e) {
+        return false;
       }
     }
-    // Attempts to request fullscreen mode for the given movie player element.
-    // Resolves with 'fullscreen_triggered' if successful, or
-    // 'requestFullscreen_failed' if the request fails.
-    function requestFullscreen(fullscreenBtn, resolve, videoPlayer) {
-      if (videoPlayer.readyState >= 3) {
-        videoPlayer.click();
-        clickFullscreenButton(fullscreenBtn, resolve);
-      } else {
-        videoPlayer.addEventListener("canplay", () => {
-          videoPlayer.click();
-          clickFullscreenButton(fullscreenBtn, resolve);
-        }, { once: true });
+
+    function tryElementFullscreen() {
+      const target = document.querySelector(playerSelector)
+          || document.querySelector(playerContainerSelector)
+          || document.querySelector(videoSelector);
+      if (!target?.requestFullscreen) return false;
+      try {
+        const result = target.requestFullscreen();
+        if (result?.then) {
+          result.then(() => resolveOnce('fullscreen_triggered')).catch(() => {});
+        } else {
+          resolveOnce('fullscreen_triggered');
+        }
+        return true;
+      } catch (e) {
+        return false;
       }
     }
-    function clickFullscreenButton(fullscreenBtn, resolve) {
-      if (fullscreenBtn && !document.hidden) {
-        fullscreenBtn.click();
-        resolve('fullscreen_triggered');
-      } else {
-        resolve('requestFullscreen_failed');
-      }
+
+    function start() {
+      // Fast path: button is already in the tree.
+      if (attempt()) return;
+
+      // Tap to reveal controls in case the button is hidden behind a YouTube
+      // overlay that only renders on first interaction.
+      (document.querySelector(videoSelector)
+          || document.querySelector(playerSelector)
+          || document.querySelector(playerContainerSelector))?.click();
+      if (attempt()) return;
+
+      // Fallbacks if the button never materialises but the player exposes its
+      // own fullscreen API or supports the standard requestFullscreen call.
+      if (tryYoutubeApi() || tryElementFullscreen()) return;
+
+      // Watch the player subtree for the button to be inserted or revealed
+      // (e.g. via a class/style change). The callback re-runs attempt() on
+      // every mutation - a cheap pair of querySelector calls.
+      const observerRoot = document.querySelector(playerContainerSelector)
+          || document.body;
+      const observer = new MutationObserver(() => {
+        if (resolved) {
+          observer.disconnect();
+          return;
+        }
+        if (attempt()) {
+          observer.disconnect();
+        }
+      });
+      // childList + subtree is sufficient: querySelector finds the button as
+      // soon as it is inserted into the tree regardless of visibility, so we
+      // do not need to observe attribute mutations.
+      observer.observe(observerRoot, { childList: true, subtree: true });
+
+      setTimeout(() => {
+        observer.disconnect();
+        resolveOnce('timeout');
+      }, TIMEOUT_MS);
     }
+
     if (document.readyState === "loading") {
-      // Loading hasn't finished yet.
-      document.addEventListener("DOMContentLoaded",
-      triggerFullscreen, { once: true });
+      document.addEventListener("DOMContentLoaded", start, { once: true });
     } else {
-      // `DOMContentLoaded` has already fired.
-      triggerFullscreen();
+      start();
     }
   });
 }());

--- a/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
+++ b/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
@@ -114,8 +114,8 @@ constexpr char16_t kYoutubeFullscreen[] =
     const playerSelector = "#movie_player, .html5-video-player";
     const playerContainerSelector = "#player-container-id, ytm-player, #player";
     // Hard ceiling so the MutationObserver does not outlive a broken page.
-    // Healthy loads resolve in well under a second; 30 s is generous enough
-    // to absorb cold-cache loads on slow networks.
+    // Healthy loads resolve in well under a second 30 seconds is generous
+    // enough to absorb cold-cache loads on slow networks.
     const TIMEOUT_MS = 30000;
 
     let resolved = false;
@@ -143,7 +143,7 @@ constexpr char16_t kYoutubeFullscreen[] =
       const video = document.querySelector(videoSelector);
       if (btn && video) {
         if (video.readyState >= 3) {
-          // Video is decodable; tap it to give the player input focus before
+          // Video is decodable, tap it to give the player input focus before
           // the button click is dispatched.
           video.click();
         }
@@ -161,7 +161,7 @@ constexpr char16_t kYoutubeFullscreen[] =
         return false;
       }
       // Use YouTube's own toggle. Do not also call requestFullscreen on the
-      // same element - the two APIs race on Android.
+      // same element as the two APIs race on Android.
       try {
         player.toggleFullscreen();
         return true;
@@ -178,7 +178,9 @@ constexpr char16_t kYoutubeFullscreen[] =
       try {
         const result = target.requestFullscreen();
         if (result?.then) {
-          result.then(() => resolveOnce('fullscreen_triggered')).catch(() => {});
+          result
+              .then(() => resolveOnce('fullscreen_triggered'))
+              .catch(() => {});
         } else {
           resolveOnce('fullscreen_triggered');
         }
@@ -217,9 +219,6 @@ constexpr char16_t kYoutubeFullscreen[] =
           observer.disconnect();
         }
       });
-      // childList + subtree is sufficient: querySelector finds the button as
-      // soon as it is inserted into the tree regardless of visibility, so we
-      // do not need to observe attribute mutations.
       observer.observe(observerRoot, { childList: true, subtree: true });
 
       setTimeout(() => {

--- a/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
+++ b/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
@@ -155,6 +155,14 @@ constexpr char16_t kYoutubeFullscreen[] =
     }
 
     function tryYoutubeApi() {
+      // Bail if the player or document already reports fullscreen. toggleFullscreen()
+      // is YouTube's undocumented API; calling it from a fullscreen state would flip
+      // us back out, which on the entry path would silently land us in PiP with no
+      // fullscreen content. The classList check alone is not enough: the player can
+      // be in document-level fullscreen without the ytp-fullscreen class set.
+      if (isFullscreen()) {
+        return false;
+      }
       const player = document.querySelector(playerSelector);
       if (!player?.toggleFullscreen
           || player.classList.contains('ytp-fullscreen')) {

--- a/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
+++ b/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
@@ -155,11 +155,13 @@ constexpr char16_t kYoutubeFullscreen[] =
     }
 
     function tryYoutubeApi() {
-      // Bail if the player or document already reports fullscreen. toggleFullscreen()
-      // is YouTube's undocumented API; calling it from a fullscreen state would flip
-      // us back out, which on the entry path would silently land us in PiP with no
-      // fullscreen content. The classList check alone is not enough: the player can
-      // be in document-level fullscreen without the ytp-fullscreen class set.
+      // Bail if the player or document already reports fullscreen.
+      // toggleFullscreen() is YouTube's undocumented API; calling it
+      // from a fullscreen state would flip us back out, which on the
+      // entry path would silently land us in PiP with no fullscreen
+      // content. The classList check alone is not enough: the player
+      // can be in document level fullscreen without the ytp-fullscreen
+      // class set.
       if (isFullscreen()) {
         return false;
       }

--- a/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
+++ b/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
@@ -98,9 +98,11 @@ constexpr char16_t kYoutubePictureInPictureSupport[] =
 // Drives the YouTube player into fullscreen so the caller can follow up with
 // Picture in Picture. On a cold load the player and its controls hydrate
 // asynchronously, so the fullscreen button may be absent at injection time: the
-// script makes a couple of synchronous attempts, then lets a MutationObserver
-// retry as the subtree hydrates. A find timeout stops the observer outliving a
-// broken page.
+// script makes a couple of synchronous attempts, then retries as the subtree
+// hydrates. Retries prefer a MutationObserver scoped to the player container;
+// only when that container does not exist yet do we fall back to short-interval
+// polling, so we never observe the entire document. A find timeout stops the
+// retries outliving a broken page.
 //
 // Crucially, success is never inferred from the click or API call. A
 // fullscreenchange listener resolves only once the page is actually fullscreen,
@@ -123,24 +125,39 @@ constexpr char16_t kYoutubeFullscreen[] =
     // because a real transition lands almost immediately; this bounds how long
     // the browser keeps a pending Picture in Picture request armed.
     const CONFIRM_TIMEOUT_MS = 2000;
+    // How often to re-query for the player when no specific container exists to
+    // observe. Polling is only used as a fallback so we never watch the whole
+    // document; it stops as soon as a trigger fires or the find timeout
+    // elapses.
+    const POLL_INTERVAL_MS = 100;
 
     let resolved = false;
     let triggered = false;
     let observer = null;
     let findTimeoutId = 0;
     let confirmTimeoutId = 0;
+    let pollIntervalId = 0;
 
     function isFullscreen() {
       const player = document.querySelector(playerSelector);
       return !!document.fullscreenElement || !!player?.isFullscreen?.();
     }
 
-    function cleanup() {
-      document.removeEventListener('fullscreenchange', onFullscreenChange);
+    // Stop looking for something to trigger fullscreen with: tear down the
+    // observer or poll and the find timeout. Leaves the confirm timeout and
+    // fullscreenchange listener in place so success can still be observed.
+    function stopSearching() {
       if (observer) {
         observer.disconnect();
+        observer = null;
       }
+      clearInterval(pollIntervalId);
       clearTimeout(findTimeoutId);
+    }
+
+    function cleanup() {
+      document.removeEventListener('fullscreenchange', onFullscreenChange);
+      stopSearching();
       clearTimeout(confirmTimeoutId);
     }
 
@@ -172,10 +189,7 @@ constexpr char16_t kYoutubeFullscreen[] =
         return;
       }
       triggered = true;
-      if (observer) {
-        observer.disconnect();
-      }
-      clearTimeout(findTimeoutId);
+      stopSearching();
       confirmTimeoutId = setTimeout(
           () => resolveOnce('requestFullscreen_failed'), CONFIRM_TIMEOUT_MS);
     }
@@ -241,13 +255,19 @@ constexpr char16_t kYoutubeFullscreen[] =
       if (attempt()) {
         return;
       }
-      // Watch the player subtree and retry as the button or player hydrates.
-      const root = document.querySelector(playerContainerSelector)
-          || document.body;
-      observer = new MutationObserver(() => {
-        attempt();
-      });
-      observer.observe(root, { childList: true, subtree: true });
+      // Retry as the button or player hydrates. Prefer a MutationObserver
+      // scoped to the player container so we watch a small subtree; if that
+      // container is not in the tree yet, fall back to short-interval polling
+      // rather than observing the entire document.
+      const root = document.querySelector(playerContainerSelector);
+      if (root) {
+        observer = new MutationObserver(() => {
+          attempt();
+        });
+        observer.observe(root, { childList: true, subtree: true });
+      } else {
+        pollIntervalId = setInterval(attempt, POLL_INTERVAL_MS);
+      }
       // Only reached while nothing has been triggered yet: give up if the
       // player never hydrates.
       findTimeoutId = setTimeout(() => resolveOnce('timeout'), FIND_TIMEOUT_MS);

--- a/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
+++ b/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
@@ -95,15 +95,18 @@ constexpr char16_t kYoutubePictureInPictureSupport[] =
 }());
 )";
 
-// Keep selector lists in sync so the exit path can target whichever fullscreen
-// button the YouTube player variant rendered on entry.
+// Drives the YouTube player into fullscreen so the caller can follow up with
+// Picture in Picture. On a cold load the player and its controls hydrate
+// asynchronously, so the fullscreen button may be absent at injection time: the
+// script makes a couple of synchronous attempts, then lets a MutationObserver
+// retry as the subtree hydrates. A find timeout stops the observer outliving a
+// broken page.
 //
-// The script tries to put the YouTube player into fullscreen. On a cold load
-// the player and its controls hydrate asynchronously, so the fullscreen button
-// may not be present in the DOM at injection time. Rather than poll on a
-// timer, we make a couple of synchronous attempts and then wait for a
-// MutationObserver to fire when the button is inserted. A single hard timeout
-// prevents the observer from leaking on broken pages.
+// Crucially, success is never inferred from the click or API call. A
+// fullscreenchange listener resolves only once the page is actually fullscreen,
+// and a short confirm timeout settles the promise as failed otherwise. This
+// keeps the reported result honest and guarantees the promise always settles,
+// which the browser relies on to clear its pending Picture in Picture request.
 constexpr char16_t kYoutubeFullscreen[] =
     uR"(
 (function() {
@@ -113,28 +116,78 @@ constexpr char16_t kYoutubeFullscreen[] =
         + "button.ytp-fullscreen-button, .ytp-fullscreen-button";
     const playerSelector = "#movie_player, .html5-video-player";
     const playerContainerSelector = "#player-container-id, ytm-player, #player";
-    // Hard ceiling so the MutationObserver does not outlive a broken page.
-    // Healthy loads resolve in well under a second 30 seconds is generous
-    // enough to absorb cold-cache loads on slow networks.
-    const TIMEOUT_MS = 30000;
+    // Wait for the player and its controls to hydrate before giving up on
+    // finding something to trigger fullscreen with.
+    const FIND_TIMEOUT_MS = 30000;
+    // Wait for fullscreen to actually engage once we have triggered it. Short,
+    // because a real transition lands almost immediately; this bounds how long
+    // the browser keeps a pending Picture in Picture request armed.
+    const CONFIRM_TIMEOUT_MS = 2000;
 
     let resolved = false;
-    function resolveOnce(value) {
-      if (resolved) return;
-      resolved = true;
-      resolve(value);
-    }
+    let triggered = false;
+    let observer = null;
+    let findTimeoutId = 0;
+    let confirmTimeoutId = 0;
 
     function isFullscreen() {
       const player = document.querySelector(playerSelector);
       return !!document.fullscreenElement || !!player?.isFullscreen?.();
     }
 
-    // Click YouTube's fullscreen button if both it and the video are present.
-    // Returns true if the promise was resolved (fullscreen triggered or
-    // already in fullscreen) and the caller should stop trying.
+    function cleanup() {
+      document.removeEventListener('fullscreenchange', onFullscreenChange);
+      if (observer) {
+        observer.disconnect();
+      }
+      clearTimeout(findTimeoutId);
+      clearTimeout(confirmTimeoutId);
+    }
+
+    function resolveOnce(value) {
+      if (resolved) {
+        return;
+      }
+      resolved = true;
+      cleanup();
+      resolve(value);
+    }
+
+    // Single source of truth for success: report 'fullscreen_triggered' only
+    // once the page has actually entered fullscreen, never on the click or API
+    // call alone.
+    function onFullscreenChange() {
+      if (isFullscreen()) {
+        resolveOnce('fullscreen_triggered');
+      }
+    }
+    document.addEventListener('fullscreenchange', onFullscreenChange);
+
+    // Once a trigger has fired, stop searching and start a short clock: if
+    // fullscreen has not engaged by the time it expires, report failure. This
+    // guarantees the promise always settles, even when an API call silently
+    // does nothing or its promise rejects.
+    function armConfirmTimeout() {
+      if (triggered) {
+        return;
+      }
+      triggered = true;
+      if (observer) {
+        observer.disconnect();
+      }
+      clearTimeout(findTimeoutId);
+      confirmTimeoutId = setTimeout(
+          () => resolveOnce('requestFullscreen_failed'), CONFIRM_TIMEOUT_MS);
+    }
+
+    // Fire a single fullscreen trigger if something is available to act on.
+    // Returns true once a trigger was fired (or we are already fullscreen) so
+    // the caller stops searching. Success is decided by onFullscreenChange, not
+    // by this return value.
     function attempt() {
-      if (resolved) return true;
+      if (resolved || triggered) {
+        return true;
+      }
       if (isFullscreen()) {
         resolveOnce('already_fullscreen');
         return true;
@@ -143,98 +196,61 @@ constexpr char16_t kYoutubeFullscreen[] =
       const video = document.querySelector(videoSelector);
       if (btn && video) {
         if (video.readyState >= 3) {
-          // Video is decodable, tap it to give the player input focus before
-          // the button click is dispatched.
           video.click();
         }
         btn.click();
-        resolveOnce('fullscreen_triggered');
+        armConfirmTimeout();
         return true;
+      }
+      // Fallbacks when the button is not in the tree: YouTube's own toggle,
+      // then the standard element fullscreen API. Only one fires per run.
+      const player = document.querySelector(playerSelector);
+      if (player?.toggleFullscreen
+          && !player.classList.contains('ytp-fullscreen')) {
+        try {
+          player.toggleFullscreen();
+          armConfirmTimeout();
+          return true;
+        } catch (e) {}
+      }
+      const target = player
+          || document.querySelector(playerContainerSelector)
+          || video;
+      if (target?.requestFullscreen) {
+        try {
+          const request = target.requestFullscreen();
+          // Success is observed via fullscreenchange; a rejection fails fast.
+          if (request?.catch) {
+            request.catch(() => resolveOnce('requestFullscreen_failed'));
+          }
+          armConfirmTimeout();
+          return true;
+        } catch (e) {}
       }
       return false;
     }
 
-    function tryYoutubeApi() {
-      // Bail if the player or document already reports fullscreen.
-      // toggleFullscreen() is YouTube's undocumented API; calling it
-      // from a fullscreen state would flip us back out, which on the
-      // entry path would silently land us in PiP with no fullscreen
-      // content. The classList check alone is not enough: the player
-      // can be in document level fullscreen without the ytp-fullscreen
-      // class set.
-      if (isFullscreen()) {
-        return false;
-      }
-      const player = document.querySelector(playerSelector);
-      if (!player?.toggleFullscreen
-          || player.classList.contains('ytp-fullscreen')) {
-        return false;
-      }
-      // Use YouTube's own toggle. Do not also call requestFullscreen on the
-      // same element as the two APIs race on Android.
-      try {
-        player.toggleFullscreen();
-        return true;
-      } catch (e) {
-        return false;
-      }
-    }
-
-    function tryElementFullscreen() {
-      const target = document.querySelector(playerSelector)
-          || document.querySelector(playerContainerSelector)
-          || document.querySelector(videoSelector);
-      if (!target?.requestFullscreen) return false;
-      try {
-        const result = target.requestFullscreen();
-        if (result?.then) {
-          result
-              .then(() => resolveOnce('fullscreen_triggered'))
-              .catch(() => {});
-        } else {
-          resolveOnce('fullscreen_triggered');
-        }
-        return true;
-      } catch (e) {
-        return false;
-      }
-    }
-
     function start() {
-      // Fast path: button is already in the tree.
-      if (attempt()) return;
-
-      // Tap to reveal controls in case the button is hidden behind a YouTube
-      // overlay that only renders on first interaction.
+      if (attempt()) {
+        return;
+      }
+      // Tap to reveal controls that only render on first interaction.
       (document.querySelector(videoSelector)
           || document.querySelector(playerSelector)
           || document.querySelector(playerContainerSelector))?.click();
-      if (attempt()) return;
-
-      // Fallbacks if the button never materialises but the player exposes its
-      // own fullscreen API or supports the standard requestFullscreen call.
-      if (tryYoutubeApi() || tryElementFullscreen()) return;
-
-      // Watch the player subtree for the button to be inserted or revealed
-      // (e.g. via a class/style change). The callback re-runs attempt() on
-      // every mutation - a cheap pair of querySelector calls.
-      const observerRoot = document.querySelector(playerContainerSelector)
+      if (attempt()) {
+        return;
+      }
+      // Watch the player subtree and retry as the button or player hydrates.
+      const root = document.querySelector(playerContainerSelector)
           || document.body;
-      const observer = new MutationObserver(() => {
-        if (resolved) {
-          observer.disconnect();
-          return;
-        }
-        if (attempt()) {
-          observer.disconnect();
-        }
+      observer = new MutationObserver(() => {
+        attempt();
       });
-      observer.observe(observerRoot, { childList: true, subtree: true });
-
-      setTimeout(() => {
-        observer.disconnect();
-        resolveOnce('timeout');
-      }, TIMEOUT_MS);
+      observer.observe(root, { childList: true, subtree: true });
+      // Only reached while nothing has been triggered yet: give up if the
+      // player never hydrates.
+      findTimeoutId = setTimeout(() => resolveOnce('timeout'), FIND_TIMEOUT_MS);
     }
 
     if (document.readyState === "loading") {


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/56383

This PR rewrites the JavaScript that Brave injects for the YouTube Picture in Picture toolbar flow, which must put the YouTube player into fullscreen before Android PiP is requested. The previous script depended on one YouTube player DOM shape and on timing that is not reliable during cold loads, slow network conditions, or delayed YouTube player hydration and it inferred success from the click itself rather than from the page actually entering fullscreen.

The new script uses a staged fullscreen entry algorithm and, crucially, reports success only once the page has really entered fullscreen. It checks the current fullscreen state first, tries the normal button path, taps the player to reveal controls, then falls back to YouTube's own and the standard fullscreen APIs. To catch controls that hydrate later it prefers a `MutationObserver` scoped to the player container, and only falls back to short-interval polling when that container is not in the tree yet, so it never observes the entire document. The flow has a single completion guard and always settles, which the browser relies on to clear its pending PiP request.

## What changed

* Adds broader selectors for YouTube fullscreen buttons, player elements, and player containers.
* Adds an `isFullscreen()` check that covers both document fullscreen and the YouTube player fullscreen state.
* Confirms success through a `fullscreenchange` listener, the result is `fullscreen_triggered` only once the page is really fullscreen, never on the click or API call alone.
* Uses a single `resolveOnce()` path so late asynchronous callbacks cannot resolve the script with conflicting results, and guarantees the promise always settles.
* Tries the fast path first when the video and fullscreen button are already present.
* Taps the player once to reveal controls, then retries the fast path.
* Falls back to YouTube's own fullscreen API when available and safe, then to the standard `requestFullscreen()` API on a suitable target.
* Reacts to controls that appear later with a `MutationObserver` scoped to the player container; when that container does not exist yet, falls back to 100 ms polling instead of observing `document.body`.
* Bounds the work with two timeouts: a thirty second find timeout so the retries cannot live forever on a broken page, and a short (two second) confirm timeout that settles the promise as failed if fullscreen never engages after a trigger fires.
* Starts after `DOMContentLoaded` when the document is still loading, otherwise starts immediately.

## Why

Android PiP needs Brave to put the YouTube player into fullscreen first so the PiP window captures the correct video surface. The old script could fail when the fullscreen button was not present at injection time, when YouTube had not finished hydrating controls, when the control used a different selector, or when video readiness and UI readiness did not line up and it could report success even when fullscreen never actually engaged.

The new algorithm makes the script resilient to those states without polling forever or watching the whole document. It makes immediate progress when the player is ready, waits for the real DOM mutation (or polls narrowly) when it is not, avoids toggling fullscreen off when the player is already fullscreen, and only reports success when the page truly entered fullscreen.

## User impact

* Tapping the toolbar PiP button should be more reliable on mobile YouTube.
* Cold loads and slow player hydration should still enter PiP once the fullscreen control appears.
* Already fullscreen YouTube pages should not be toggled back out by the fallback path.
* The flow should avoid entering PiP with no fullscreen video content, because success is confirmed from the actual fullscreen transition rather than the click.
* The async script work is bounded and always resolves through one controlled path.

## Test plan

* Open `m.youtube.com/watch?v=...` on Android R or newer.
* Wait for the player to fully load, then tap the toolbar PiP button.
* Repeat immediately after opening the watch page, before the player controls have fully appeared.
* Repeat on a slow network or after clearing cache.
* Manually enter fullscreen first, then trigger the Brave PiP flow.
* Verify Android PiP opens with the expected video surface.
* Verify the page does not leave fullscreen unexpectedly before PiP entry.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->