### PR TITLE
[Sync] kEncryptSyncCompat for os_crypt under flag

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -1366,6 +1366,15 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
               brave_sync::features::kBraveSyncDefaultPasswords),               \
       },                                                                       \
       {                                                                        \
+          "brave-sync-encrypt-sync-compat",                                    \
+          "Use sync-compatible encryption for sync seed",                      \
+          "Encrypt the sync seed using the legacy OSCrypt-compatible key "     \
+          "provider instead of the newer OS-level key provider.",              \
+          kOsWin | kOsLinux | kOsMac,                                          \
+          FEATURE_VALUE_TYPE(                                                  \
+              brave_sync::features::kBraveSyncEncryptSyncCompat),              \
+      },                                                                       \
+      {                                                                        \
           "brave-shred",                                                       \
           "Enable Brave 'Shred' Feature",                                      \
           "Enable the Brave 'Shred' feature which will allow a user to "       \

--- a/components/brave_sync/features.cc
+++ b/components/brave_sync/features.cc
@@ -12,5 +12,6 @@ namespace brave_sync::features {
 BASE_FEATURE(kBraveSync, base::FEATURE_ENABLED_BY_DEFAULT);
 BASE_FEATURE(kBraveSyncDefaultPasswords,
              base::FEATURE_ENABLED_BY_DEFAULT);
+BASE_FEATURE(kBraveSyncEncryptSyncCompat, base::FEATURE_DISABLED_BY_DEFAULT);
 
 }  // namespace brave_sync::features

--- a/components/brave_sync/features.h
+++ b/components/brave_sync/features.h
@@ -13,6 +13,7 @@ namespace features {
 
 BASE_DECLARE_FEATURE(kBraveSync);
 BASE_DECLARE_FEATURE(kBraveSyncDefaultPasswords);
+BASE_DECLARE_FEATURE(kBraveSyncEncryptSyncCompat);
 
 }  // namespace features
 }  // namespace brave_sync

--- a/components/sync/service/brave_sync_service_impl.cc
+++ b/components/sync/service/brave_sync_service_impl.cc
@@ -51,9 +51,15 @@ BraveSyncServiceImpl::BraveSyncServiceImpl(
       brave_sync_prefs_(sync_client_->GetPrefService()),
       sync_service_impl_delegate_(std::move(sync_service_impl_delegate)),
       weak_ptr_factory_(this) {
+  const auto encryptor_option =
+      base::FeatureList::IsEnabled(
+          brave_sync::features::kBraveSyncEncryptSyncCompat)
+          ? os_crypt_async::Encryptor::Option::kEncryptSyncCompat
+          : os_crypt_async::Encryptor::Option::kNone;
   os_crypt_async->GetInstance(
       base::BindOnce(&BraveSyncServiceImpl::OnOsCryptAsyncReady,
-                     weak_ptr_factory_.GetWeakPtr()));
+                     weak_ptr_factory_.GetWeakPtr()),
+      encryptor_option);
   sync_service_impl_delegate_->set_profile_sync_service(this);
 }
 

--- a/components/sync/service/brave_sync_service_impl_unittest.cc
+++ b/components/sync/service/brave_sync_service_impl_unittest.cc
@@ -13,6 +13,7 @@
 #include "base/memory/raw_ptr.h"
 #include "base/notreached.h"
 #include "base/run_loop.h"
+#include "base/strings/string_util.h"
 #include "base/test/bind.h"
 #include "base/test/gtest_util.h"
 #include "base/test/metrics/histogram_tester.h"
@@ -993,5 +994,52 @@ INSTANTIATE_TEST_SUITE_P(
       }
       NOTREACHED();
     });
+
+TEST_F(BraveSyncServiceImplTest, SetSeedUsesDefaultEncryptionProvider) {
+  CreateSyncService();
+
+  ASSERT_TRUE(brave_sync_service_impl()->SetSyncCode(kValidSyncCode));
+
+  const std::string& encoded_seed =
+      pref_service()->GetString(brave_sync::Prefs::GetSeedPath());
+  std::string encrypted_seed;
+  ASSERT_TRUE(base::Base64Decode(encoded_seed, &encrypted_seed));
+
+  // Without kBraveSyncEncryptSyncCompat the seed must be encrypted with the
+  // default provider ("k1"), not the sync-compat one ("k2").
+  EXPECT_TRUE(base::StartsWith(encrypted_seed,
+                               os_crypt_async::kDefaultTestKeyPrefix,
+                               base::CompareCase::SENSITIVE));
+}
+
+class BraveSyncServiceImplTest_EncryptSyncCompatTest
+    : public BraveSyncServiceImplTest {
+ public:
+  BraveSyncServiceImplTest_EncryptSyncCompatTest() {
+    scoped_feature_list_.InitAndEnableFeature(
+        brave_sync::features::kBraveSyncEncryptSyncCompat);
+  }
+
+ protected:
+  base::test::ScopedFeatureList scoped_feature_list_;
+};
+
+TEST_F(BraveSyncServiceImplTest_EncryptSyncCompatTest,
+       SetSeedUsesSyncCompatEncryptionProvider) {
+  CreateSyncService();
+
+  ASSERT_TRUE(brave_sync_service_impl()->SetSyncCode(kValidSyncCode));
+
+  const std::string& encoded_seed =
+      pref_service()->GetString(brave_sync::Prefs::GetSeedPath());
+  std::string encrypted_seed;
+  ASSERT_TRUE(base::Base64Decode(encoded_seed, &encrypted_seed));
+
+  // With kBraveSyncEncryptSyncCompat enabled the seed must be encrypted with
+  // the sync-compatible provider ("k2"), not the default one ("k1").
+  EXPECT_TRUE(base::StartsWith(
+      encrypted_seed, os_crypt_async::kOsCryptSyncCompatibleTestKeyPrefix,
+      base::CompareCase::SENSITIVE));
+}
 
 }  // namespace syncer


### PR DESCRIPTION
Some users have issues after oscrypt/async migration. This commit adds possibility to enable new
`brave-sync-encrypt-sync-compat` flag which will cause `os_crypt_async::Encryptor::Option::kEncryptSyncCompat` argument will be set for encryptor for Brave Sync.

Resolves https://github.com/brave/brave-browser/issues/56497

### Test plan:

1. On the desktop browser open brave://flags/
2. Enable `Use sync-compatible encryption for sync seed` flag `brave://flags/#brave-sync-encrypt-sync-compat` - expected this flag to be found 

<!-- Add brave-browser issue below that this PR will resolve -->


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
