### PR TITLE
[Android] Use FLAG_IMMUTABLE for app-owned PendingIntents that don't need mutability

### DIFF
--- a/android/java/org/chromium/chrome/browser/notifications/BraveOnboardingNotification.java
+++ b/android/java/org/chromium/chrome/browser/notifications/BraveOnboardingNotification.java
@@ -69,7 +69,7 @@ public class BraveOnboardingNotification extends BroadcastReceiver {
         Intent intent = new Intent(context, BraveOnboardingNotification.class);
         intent.setAction(DEEP_LINK);
         return PendingIntentProvider.getBroadcast(
-                context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT, true);
+                context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT, false);
     }
 
     @Override

--- a/android/java/org/chromium/chrome/browser/notifications/retention/RetentionNotificationUtil.java
+++ b/android/java/org/chromium/chrome/browser/notifications/retention/RetentionNotificationUtil.java
@@ -147,10 +147,13 @@ public class RetentionNotificationUtil {
         launchIntent.putExtra(NOTIFICATION_TYPE, notificationType);
         launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
-        PendingIntent resultPendingIntent = PendingIntent.getActivity(context,
-                retentionNotification.getNotificationId(), launchIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT
-                        | IntentUtils.getPendingIntentMutabilityFlag(true));
+        PendingIntent resultPendingIntent =
+                PendingIntent.getActivity(
+                        context,
+                        retentionNotification.getNotificationId(),
+                        launchIntent,
+                        PendingIntent.FLAG_UPDATE_CURRENT
+                                | IntentUtils.getPendingIntentMutabilityFlag(false));
 
         builder.setContentIntent(resultPendingIntent);
 
@@ -221,8 +224,11 @@ public class RetentionNotificationUtil {
         Intent notificationIntent = new Intent(context, RetentionNotificationPublisher.class);
         notificationIntent.putExtra(NOTIFICATION_TYPE, notificationType);
         PendingIntent pendingIntent =
-                PendingIntent.getBroadcast(context, retentionNotification.getNotificationId(),
-                        notificationIntent, 0 | IntentUtils.getPendingIntentMutabilityFlag(true));
+                PendingIntent.getBroadcast(
+                        context,
+                        retentionNotification.getNotificationId(),
+                        notificationIntent,
+                        0 | IntentUtils.getPendingIntentMutabilityFlag(false));
         Calendar calendar = Calendar.getInstance();
         calendar.setTimeInMillis(System.currentTimeMillis());
         calendar.add(Calendar.MINUTE, retentionNotification.getNotificationTime());
@@ -239,8 +245,11 @@ public class RetentionNotificationUtil {
         Intent notificationIntent = new Intent(context, RetentionNotificationPublisher.class);
         notificationIntent.putExtra(NOTIFICATION_TYPE, notificationType);
         PendingIntent pendingIntent =
-                PendingIntent.getBroadcast(context, retentionNotification.getNotificationId(),
-                        notificationIntent, 0 | IntentUtils.getPendingIntentMutabilityFlag(true));
+                PendingIntent.getBroadcast(
+                        context,
+                        retentionNotification.getNotificationId(),
+                        notificationIntent,
+                        0 | IntentUtils.getPendingIntentMutabilityFlag(false));
         AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
         assert alarmManager != null;
         alarmManager.set(AlarmManager.RTC_WAKEUP, timeInMilliseconds, pendingIntent);
@@ -260,8 +269,11 @@ public class RetentionNotificationUtil {
         Intent notificationIntent = new Intent(context, RetentionNotificationPublisher.class);
         notificationIntent.putExtra(NOTIFICATION_TYPE, notificationType);
         PendingIntent pendingIntent =
-                PendingIntent.getBroadcast(context, retentionNotification.getNotificationId(),
-                        notificationIntent, 0 | IntentUtils.getPendingIntentMutabilityFlag(true));
+                PendingIntent.getBroadcast(
+                        context,
+                        retentionNotification.getNotificationId(),
+                        notificationIntent,
+                        0 | IntentUtils.getPendingIntentMutabilityFlag(false));
         AlarmManager am = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
         assert am != null;
         am.setRepeating(AlarmManager.RTC_WAKEUP, currentDate.getTimeInMillis(), AlarmManager.INTERVAL_DAY * 7, pendingIntent);

--- a/android/java/org/chromium/chrome/browser/vpn/timer/TimerUtils.java
+++ b/android/java/org/chromium/chrome/browser/vpn/timer/TimerUtils.java
@@ -25,7 +25,7 @@ public class TimerUtils {
                         context,
                         sVpnActionRequestCode,
                         vpnActionIntent,
-                        0 | IntentUtils.getPendingIntentMutabilityFlag(true));
+                        0 | IntentUtils.getPendingIntentMutabilityFlag(false));
         Calendar calendar = Calendar.getInstance();
         calendar.setTimeInMillis(System.currentTimeMillis());
         calendar.add(Calendar.MINUTE, minutes);
@@ -43,7 +43,7 @@ public class TimerUtils {
                         context,
                         sVpnActionRequestCode,
                         vpnActionIntent,
-                        0 | IntentUtils.getPendingIntentMutabilityFlag(true));
+                        0 | IntentUtils.getPendingIntentMutabilityFlag(false));
 
         AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
         assert alarmManager != null;

--- a/android/java/org/chromium/chrome/browser/vpn/wireguard/WireguardServiceImpl.java
+++ b/android/java/org/chromium/chrome/browser/vpn/wireguard/WireguardServiceImpl.java
@@ -113,9 +113,12 @@ public class WireguardServiceImpl extends SplitCompatService.Impl
         Intent disconnectVpnIntent = new Intent(mContext, DisconnectVpnBroadcastReceiver.class);
         disconnectVpnIntent.setAction(DisconnectVpnBroadcastReceiver.DISCONNECT_VPN_ACTION);
         PendingIntent disconnectVpnPendingIntent =
-                PendingIntent.getBroadcast(mContext, 0, disconnectVpnIntent,
+                PendingIntent.getBroadcast(
+                        mContext,
+                        0,
+                        disconnectVpnIntent,
                         PendingIntent.FLAG_UPDATE_CURRENT
-                                | IntentUtils.getPendingIntentMutabilityFlag(true));
+                                | IntentUtils.getPendingIntentMutabilityFlag(false));
 
         NotificationCompat.Builder notificationBuilder =
                 new NotificationCompat.Builder(mContext, BraveActivity.CHANNEL_ID);

--- a/browser/brave_ads/android/java/org/chromium/chrome/browser/dialogs/BraveAdsSignupDialog.java
+++ b/browser/brave_ads/android/java/org/chromium/chrome/browser/dialogs/BraveAdsSignupDialog.java
@@ -110,7 +110,7 @@ public class BraveAdsSignupDialog {
                             0,
                             intent,
                             PendingIntent.FLAG_UPDATE_CURRENT
-                                    | IntentUtils.getPendingIntentMutabilityFlag(true)));
+                                    | IntentUtils.getPendingIntentMutabilityFlag(false)));
         }
     }
 


### PR DESCRIPTION
Several app-owned alarm/notification `PendingIntents` passed `getPendingIntentMutabilityFlag(true)` even though their intents are fully specified at creation and target explicit, app-private receivers, so they do not need to be mutable. Pass false (immutable) at these call sites:

- `BraveAdsSignupDialog`: onboarding notification alarm
- `BraveOnboardingNotification`: deep-link content intent
- `RetentionNotificationUtil`: retention scheduling (3) + content intent (1)
- `TimerUtils`: VPN pause-timer schedule/cancel
- `WireguardServiceImpl`: VPN disconnect notification action

Resolves: https://github.com/brave/brave-browser/issues/56522

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
