### PR TITLE
[Nala]: Bump version to main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/brave-ui": "0.40.6",
-        "@brave/leo": "github:brave/leo#ed35a435ecd5b8f9a856d62db7ab07eb33f03c2d",
-        "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#ef5f17163d6775bdf322163b9c4ebc8889370960",
+        "@brave/leo": "github:brave/leo#171b814b205217d651a76080a0c50a80d1b0c257",
+        "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#2a1970d89bdefd92a6ad0a8f3fc61bf3c0047f87",
         "@brave/wallet-standard-brave": "0.0.16",
         "@dnd-kit/core": "6.0.5",
         "@dnd-kit/sortable": "7.0.1",
@@ -741,8 +741,8 @@
     },
     "node_modules/@brave/leo": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/brave/leo.git#ed35a435ecd5b8f9a856d62db7ab07eb33f03c2d",
-      "integrity": "sha512-yB6Rk3wkiMpkPgonNM6oZpEpFLQKQR33JzhCTkbWCPiOJ8xRa5xFWgjx6/UMLepospCeYh2Q0tiWgGCp8irUWw==",
+      "resolved": "git+ssh://git@github.com/brave/leo.git#171b814b205217d651a76080a0c50a80d1b0c257",
+      "integrity": "sha512-KxjO6m4Z5CNk1/L1vrDzy7HwH/bX4glw7Ewbzp1WY25xRsfTbcNsNlgyo0v5knPD3+0JcVbU0cAAFqnhUvIzzQ==",
       "license": "MIT",
       "dependencies": {
         "@storybook/test": "8.6.15",
@@ -772,9 +772,9 @@
       }
     },
     "node_modules/@brave/leo-sf-symbols": {
-      "version": "1.0.99",
-      "resolved": "git+ssh://git@github.com/brave/leo-sf-symbols.git#ef5f17163d6775bdf322163b9c4ebc8889370960",
-      "integrity": "sha512-4XCrfo7sGhHyzTSksNxEMnRMcpgJAK7a5mTGUKL5nku/bY4777AjK5pNAa/Tq9ZOFTrzQKsV15RPi7Xoq8xJaw==",
+      "version": "1.0.100",
+      "resolved": "git+ssh://git@github.com/brave/leo-sf-symbols.git#2a1970d89bdefd92a6ad0a8f3fc61bf3c0047f87",
+      "integrity": "sha512-9VsqEPLp7BLXRn5qqsTQIY5dMdgt6ur6iqT674XetIo6PCcfOTfvgMq4LyRBOsXy4S04e98w6VTdY4Oiy2YrLg==",
       "license": "MPL-2.0"
     },
     "node_modules/@brave/leo/node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -202,8 +202,8 @@
   },
   "dependencies": {
     "@brave/brave-ui": "0.40.6",
-    "@brave/leo": "github:brave/leo#ed35a435ecd5b8f9a856d62db7ab07eb33f03c2d",
-    "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#ef5f17163d6775bdf322163b9c4ebc8889370960",
+    "@brave/leo": "github:brave/leo#171b814b205217d651a76080a0c50a80d1b0c257",
+    "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#2a1970d89bdefd92a6ad0a8f3fc61bf3c0047f87",
     "@brave/wallet-standard-brave": "0.0.16",
     "@dnd-kit/core": "6.0.5",
     "@dnd-kit/sortable": "7.0.1",


### PR DESCRIPTION
Changes https://github.com/brave/leo/compare/ed35a435ecd5b8f9a856d62db7ab07eb33f03c2d...171b814b205217d651a76080a0c50a80d1b0c257
    - [dependencies]: Audit fix ([#1410](https://github.com/brave/leo/pull/1410))
    - [Checkbox]: Don't animate until mounted ([#1409](https://github.com/brave/leo/pull/1409))
    - [Icons]: Update icons from Figma ([#1408](https://github.com/brave/leo/pull/1408))
    - Update typography tokens, shadows & gradients ([#1404](https://github.com/brave/leo/pull/1404))
    - Update dialog.svelte ([#1406](https://github.com/brave/leo/pull/1406))