### PR TITLE
[bootstrap] Proof-of-Concept path resolution for tooling

### DIFF
--- a/chromium_presubmit_config.json5
+++ b/chromium_presubmit_config.json5
@@ -81,6 +81,10 @@
   // Files to skip per check.
   "per_check_files_to_skip": {
     // Permanent ignores.
+    // Disabling +x checks for `.bat` files, as bootstrap is introducing shims
+    // and setting +x on those polutes shell suggetions on POSIX systems.
+    "CheckFilePermissions": ["tools/cr/bootstrap/.*\\.bat$"],
+
     "CheckNewHeaderWithoutGnChangeOnUpload": ["chromium_src/.*\\.h"],
     "CheckForCcIncludes": ["chromium_src/"],
     "CheckForRelativeIncludes": ["chromium_src/"],

--- a/tools/cr/README.md
+++ b/tools/cr/README.md
@@ -46,6 +46,8 @@ Shared abstractions used by the entry points and tests:
 
 - `alias/` — `git cr` git-alias subcommands (`commit`, `mv`, `follow-renames`,
   ...). See [`alias/README.md`](alias/README.md).
+- `bootstrap/` — An experiment to boostrap some of our python utils in the
+  user's PATH.
 - `test/` — Shared test fixtures, including `FakeChromiumRepo`.
 - `toolchain/` — Scripts to build platform-specific toolchains when rebasing
   Chromium.

--- a/tools/cr/bootstrap/README.md
+++ b/tools/cr/bootstrap/README.md
@@ -1,0 +1,62 @@
+# `tools/cr/bootstrap`
+
+Provides shims for `plaster` and `brockit`, selecting them relative to the Brave
+repository in the current directory.
+
+## Install
+
+```sh
+# From any brave-core checkout:
+vpython3 tools/cr/bootstrap/bootstrap.py install
+```
+
+On macOS / Linux this configures your current shell (override with
+`--shell bash|zsh|fish|all`):
+
+- **bash** → a marked block in `~/.bashrc`
+- **zsh** → a marked block in `~/.zshrc`
+- **fish** → a drop-in at `~/.config/fish/conf.d/brave-bootstrap.fish` that
+  prepends to `$PATH` directly (it avoids `fish_add_path`, which would persist
+  the entry in the universal `fish_user_paths` variable and outlive the file)
+
+On Windows it adds this directory to the user `Path` under `HKCU\Environment`.
+
+In every case the directory is placed **first** on `$PATH`, so these shims take
+precedence over any other `brockit` / `plaster` on the system.
+
+**Open a new shell for the change to take effect.**
+
+## Uninstall
+
+```sh
+vpython3 tools/cr/bootstrap/bootstrap.py uninstall
+```
+
+Removes the managed block / drop-in from every known shell location (POSIX) or
+the `Path` entry (Windows). For fish it also scrubs any legacy entry left in the
+universal `fish_user_paths` variable by older versions of this script.
+
+The directory removed from `$PATH` is the one the live shim actually resolves to
+(via `shutil.which`), so `uninstall` works even when run from a different
+checkout than the one that was installed.
+
+## Usage
+
+```sh
+cd ~/browser/src/brave/components # anywhere inside a checkout
+plaster check                     # runs that checkout's plaster.py
+brockit lift --to=1.2.3.4         # runs that checkout's brockit.py
+```
+
+These shims are resolved relative to `brave-core`, so attempting to call these
+from a directory that is not inside `brave-core` will result in a failure.
+
+## How it works
+
+- `brockit`, `plaster` (POSIX) and `brockit.bat`, `plaster.bat` (Windows) are
+  thin wrappers that call `launcher.py <tool> <args…>`.
+- `launcher.py` resolves the brave-core root via `git rev-parse --show-toplevel`
+  (validating the root is a `brave` work tree, matching `repository.py`), then
+  execs `vpython3 <root>/tools/cr/<tool>.py <args…>` **without changing the
+  cwd**, so the tool runs relative to your current path.
+- `bootstrap.py` installs/uninstalls this directory on `$PATH`.

--- a/tools/cr/bootstrap/bootstrap.py
+++ b/tools/cr/bootstrap/bootstrap.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Install / uninstall the brave tool shims on the user's `$PATH`.
+
+Install tool shims (e.g. brockit, plaster) on `$PATH` and dispatch to the
+`brave-core` checkout the current directory is in (see `launcher.py`). A single
+install therefore serves every checkout on the machine.
+
+Usage::
+
+    vpython3 tools/cr/bootstrap/bootstrap.py install [--shell bash|zsh|fish|all]
+    vpython3 tools/cr/bootstrap/bootstrap.py uninstall
+
+On POSIX this edits the shell profile(s): an idempotent, marker-delimited block
+in `~/.bashrc` / `~/.zshrc`, or a drop-in file under `~/.config/fish/conf.d/`.
+On Windows it edits the user `Path` value under `HKCU\\Environment`. Stdlib-only
+so it can run before anything else is set up.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+import os
+from pathlib import Path
+import platform
+import re
+import shutil
+import subprocess
+import sys
+
+import launcher
+
+# The directory this script lives in — the one we add to `$PATH`.
+BOOTSTRAP_DIR = Path(__file__).resolve().parent
+
+# The shim commands this directory puts on `$PATH`, derived from the launcher's
+# tool registry so new tools only need to be added in one place
+# (`launcher.TOOL_PATHS`). Used to detect an existing install via `shutil.which`
+# (which also resolves the `.bat` variants on Windows through `PATHEXT`).
+SHIM_COMMANDS = tuple(launcher.TOOL_PATHS)
+
+# Markers delimiting the block we manage inside POSIX rc files. Fixed strings
+# (independent of the checkout) so re-installing from another checkout simply
+# repoints `$PATH`; the shims dispatch by cwd regardless of which checkout's
+# bootstrap dir is on `$PATH`.
+BEGIN_MARKER = '# >>> brave bootstrap >>>'
+END_MARKER = '# <<< brave bootstrap <<<'
+
+# Shells we know how to wire up on POSIX.
+SHELLS = ('bash', 'zsh', 'fish')
+
+# The fish drop-in file is owned entirely by this script: its presence is the
+# managed state, so uninstall just deletes it.
+_FISH_DROP_IN = Path('.config') / 'fish' / 'conf.d' / 'brave-bootstrap.fish'
+
+# -- Pure helpers (unit-tested) ----------------------------------------------
+
+
+def remove_block(text: str) -> str:
+    """Removes our managed block (and any blank lines before it) from `text`.
+
+    Returns `text` unchanged when no block is present.
+    """
+    pattern = re.compile(
+        r'\n*' + re.escape(BEGIN_MARKER) + r'.*?' + re.escape(END_MARKER) +
+        r'[^\n]*', re.DOTALL)
+    return pattern.sub('', text)
+
+
+def apply_block(text: str, bootstrap_dir: Path) -> str:
+    """Returns `text` with exactly one fresh managed block appended.
+
+    The marker-delimited block prepends `bootstrap_dir` to `$PATH` for
+    `~/.bashrc` / `~/.zshrc`. Idempotent: any existing block is stripped first,
+    so repeated installs do not accumulate duplicates.
+    """
+    block = (f'{BEGIN_MARKER}\n'
+             f'export PATH="{bootstrap_dir.as_posix()}:$PATH"\n'
+             f'{END_MARKER}')
+    base = remove_block(text)
+    if not base:
+        return block + '\n'
+    if not base.endswith('\n'):
+        base += '\n'
+    return f'{base}\n{block}\n'
+
+
+def fish_drop_in(bootstrap_dir: Path) -> str:
+    """Contents of the fish conf.d drop-in file.
+
+    Prepends the directory to `$PATH` (highest precedence) on each new shell,
+    dropping any pre-existing occurrence first so it lands exactly once at the
+    front. Everything lives in this file: it deliberately avoids
+    `fish_add_path`, which would persist the entry in the *universal*
+    `fish_user_paths` variable and survive deletion of this file (making
+    uninstall ineffective).
+    """
+    path = bootstrap_dir.as_posix()
+    line = f'set -gx PATH "{path}" (string match --invert -- "{path}" $PATH)'
+    return ('# Managed by brave bootstrap — do not edit.\n'
+            '# Remove with: bootstrap.py uninstall\n'
+            f'{line}\n')
+
+
+def _norm_win(entry: str | Path) -> str:
+    """Normalises a Windows PATH entry for case/slash-insensitive compares."""
+    return str(entry).rstrip('\\/').lower()
+
+
+def add_windows_entry(current: str, bootstrap_dir: Path) -> str:
+    """Returns `current` (a `;`-joined PATH) with `bootstrap_dir` placed first.
+
+    Any existing occurrence is dropped first, so the directory ends up at the
+    front (highest precedence) exactly once. Idempotent.
+    """
+    target = _norm_win(bootstrap_dir)
+    entries = [e for e in current.split(';') if e and _norm_win(e) != target]
+    return ';'.join([str(bootstrap_dir), *entries])
+
+
+def remove_windows_entry(current: str, bootstrap_dir: Path) -> str:
+    """Returns `current` (a `;`-joined PATH) with `bootstrap_dir` removed."""
+    entries = [
+        e for e in current.split(';')
+        if e and _norm_win(e) != _norm_win(bootstrap_dir)
+    ]
+    return ';'.join(entries)
+
+
+# -- POSIX install / uninstall ------------------------------------------------
+
+
+def _profile_path(shell: str) -> Path:
+    """The rc file (bash/zsh) or drop-in file (fish) for `shell`."""
+    home = Path.home()
+    if shell == 'bash':
+        return home / '.bashrc'
+    if shell == 'zsh':
+        return home / '.zshrc'
+    if shell == 'fish':
+        return home / _FISH_DROP_IN
+    raise ValueError(f'unsupported shell: {shell}')
+
+
+def _read(path: Path) -> str:
+    return path.read_bytes().decode('utf-8') if path.exists() else ''
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding='utf-8', newline='')
+
+
+def _install_posix(shells: list[str]) -> int:
+    for shell in shells:
+        path = _profile_path(shell)
+        if shell == 'fish':
+            _write(path, fish_drop_in(BOOTSTRAP_DIR))
+        else:
+            _write(path, apply_block(_read(path), BOOTSTRAP_DIR))
+        print(f'Installed: {path}')
+    print()
+    print('Open a new shell, or apply it to the current one now:')
+    print(f'  export PATH="{BOOTSTRAP_DIR.as_posix()}:$PATH"  # bash/zsh')
+    print(f'  set -gx PATH "{BOOTSTRAP_DIR.as_posix()}" $PATH  # fish')
+    return 0
+
+
+def _erase_fish_user_path(bootstrap_dir: Path) -> bool:
+    """Removes `bootstrap_dir` from the universal `fish_user_paths`, if present.
+
+    Older versions of this script wired fish up with `fish_add_path`, which
+    persists the entry in the universal `fish_user_paths` variable — deleting
+    the conf.d drop-in then left it on `$PATH`. This best-effort cleanup
+    scrubs that legacy state. Returns True only if an entry was actually
+    removed. No-op when fish isn't installed.
+    """
+    fish = shutil.which('fish')
+    if not fish:
+        return False
+    target = bootstrap_dir.as_posix()
+    try:
+        present = subprocess.run(
+            [fish, '-c', f'contains -- "{target}" $fish_user_paths'],
+            check=False,
+            capture_output=True)
+        if present.returncode != 0:
+            return False
+        # Rewrite the universal variable without `target`. Version-independent
+        # (avoids `fish_add_path --erase`, which is missing on older fish).
+        subprocess.run([
+            fish, '-c', f'set -U fish_user_paths '
+            f'(string match --invert -- "{target}" $fish_user_paths)'
+        ],
+                       check=False,
+                       capture_output=True)
+    except OSError:
+        return False
+    print(f'Removed from fish_user_paths: {target}')
+    return True
+
+
+def _uninstall_posix() -> int:
+    # Symmetric and safe: clean every known location regardless of $SHELL.
+    # Target the install actually on $PATH, not necessarily this checkout.
+    target_dir = installed_bootstrap_dir()
+    removed = False
+    for shell in SHELLS:
+        path = _profile_path(shell)
+        if shell == 'fish':
+            if path.exists():
+                path.unlink()
+                print(f'Removed: {path}')
+                removed = True
+            if _erase_fish_user_path(target_dir):
+                removed = True
+            continue
+        if not path.exists():
+            continue
+        original = _read(path)
+        stripped = remove_block(original)
+        if stripped != original:
+            _write(path, stripped)
+            print(f'Updated: {path}')
+            removed = True
+    if not removed:
+        print('Nothing to uninstall (no managed entries found).')
+    return 0
+
+
+# -- Windows install / uninstall ----------------------------------------------
+
+
+def _update_windows_path(transform: Callable[[str], str]) -> int:
+    # Deferred: `winreg`/`ctypes` are Windows-only and importing them at module
+    # scope would break this script on POSIX.
+    import winreg  # pylint: disable=import-outside-toplevel
+    with winreg.OpenKey(winreg.HKEY_CURRENT_USER, 'Environment', 0,
+                        winreg.KEY_READ | winreg.KEY_WRITE) as key:
+        try:
+            current, value_type = winreg.QueryValueEx(key, 'Path')
+        except FileNotFoundError:
+            current, value_type = '', winreg.REG_EXPAND_SZ
+        updated = transform(current)
+        if updated == current:
+            print('No change to user Path.')
+            return 0
+        winreg.SetValueEx(key, 'Path', 0, value_type, updated)
+
+    # Notify running processes so they pick up the change; without this, only
+    # newly-spawned shells see the updated PATH. Best-effort.
+    try:
+        import ctypes  # pylint: disable=import-outside-toplevel
+        HWND_BROADCAST = 0xFFFF
+        WM_SETTINGCHANGE = 0x001A
+        SMTO_ABORTIFHUNG = 0x0002
+        ctypes.windll.user32.SendMessageTimeoutW(HWND_BROADCAST,
+                                                 WM_SETTINGCHANGE, 0,
+                                                 'Environment',
+                                                 SMTO_ABORTIFHUNG, 5000, None)
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+    print(f'Updated user Path under HKCU\\Environment for {BOOTSTRAP_DIR}')
+    print('Open a new terminal for the change to take effect.')
+    return 0
+
+
+def _install_windows() -> int:
+    return _update_windows_path(
+        lambda cur: add_windows_entry(cur, BOOTSTRAP_DIR))
+
+
+def _uninstall_windows() -> int:
+    # Target the install actually on Path, not necessarily this checkout.
+    target = installed_bootstrap_dir()
+    return _update_windows_path(lambda cur: remove_windows_entry(cur, target))
+
+
+# -- CLI ----------------------------------------------------------------------
+
+
+def find_existing_bootstrap() -> str | None:
+    """Returns the path of a bootstrap shim already reachable on `$PATH`.
+
+    Resolves the shim command names via `shutil.which`, so it reports whatever
+    a freshly-spawned shell would actually run — the signal we use to refuse a
+    second, conflicting install. Returns None when nothing is found.
+    """
+    for command in SHIM_COMMANDS:
+        found = shutil.which(command)
+        if found:
+            return found
+    return None
+
+
+def installed_bootstrap_dir() -> Path:
+    """The bootstrap directory that is actually on `$PATH`.
+
+    Derived from the live shim located by `find_existing_bootstrap` (its parent
+    directory), so `uninstall` targets the install that is really in effect —
+    even when run from a different checkout than the one originally installed.
+    Falls back to this script's own directory when no shim is on `$PATH`.
+    """
+    found = find_existing_bootstrap()
+    if found:
+        return Path(found).resolve().parent
+    return BOOTSTRAP_DIR
+
+
+def _default_shell() -> str:
+    name = Path(os.environ.get('SHELL', '')).name
+    return name if name in SHELLS else 'bash'
+
+
+def _resolve_shells(selection: str | None) -> list[str]:
+    if selection == 'all':
+        return list(SHELLS)
+    return [selection or _default_shell()]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Install/uninstall the brave tool shims on $PATH.')
+    sub = parser.add_subparsers(dest='command', required=True)
+
+    install = sub.add_parser('install', help='Add the shims to $PATH.')
+    install.add_argument(
+        '--shell',
+        choices=[*SHELLS, 'all'],
+        default=None,
+        help='POSIX shell(s) to configure (default: current $SHELL).')
+    install.add_argument(
+        '--force',
+        action='store_true',
+        help='Install even if a bootstrap shim is already on $PATH.')
+    sub.add_parser('uninstall', help='Remove the shims from $PATH.')
+
+    args = parser.parse_args()
+    is_windows = platform.system() == 'Windows'
+
+    if args.command == 'install':
+        existing = find_existing_bootstrap()
+        if existing and not args.force:
+            sys.stderr.write(
+                'A bootstrap shim is already installed and on $PATH:\n'
+                f'  {existing}\n'
+                'Run "uninstall" first, or pass --force to install anyway.\n')
+            return 1
+        if is_windows:
+            return _install_windows()
+        return _install_posix(_resolve_shells(args.shell))
+    if args.command == 'uninstall':
+        if is_windows:
+            return _uninstall_windows()
+        return _uninstall_posix()
+    return 1
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/tools/cr/bootstrap/bootstrap_test.py
+++ b/tools/cr/bootstrap/bootstrap_test.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Unit tests for the tools/cr/bootstrap pure helpers."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import platform
+import stat
+import subprocess
+import tempfile
+import unittest
+
+import bootstrap
+import launcher
+
+
+class PosixBlockTest(unittest.TestCase):
+    DIR = Path('/home/dev/src/brave/tools/cr/bootstrap')
+
+    def test_apply_block_appends_single_block(self):
+        result = bootstrap.apply_block('existing line\n', self.DIR)
+        self.assertEqual(result.count(bootstrap.BEGIN_MARKER), 1)
+        self.assertEqual(result.count(bootstrap.END_MARKER), 1)
+        self.assertIn('existing line\n', result)
+        self.assertIn(f'export PATH="{self.DIR.as_posix()}:$PATH"', result)
+
+    def test_apply_block_is_idempotent(self):
+        once = bootstrap.apply_block('existing line\n', self.DIR)
+        twice = bootstrap.apply_block(once, self.DIR)
+        self.assertEqual(once, twice)
+        self.assertEqual(twice.count(bootstrap.BEGIN_MARKER), 1)
+
+    def test_apply_block_repoints_on_new_dir(self):
+        first = bootstrap.apply_block('', Path('/old/bootstrap'))
+        second = bootstrap.apply_block(first, Path('/new/bootstrap'))
+        self.assertEqual(second.count(bootstrap.BEGIN_MARKER), 1)
+        self.assertNotIn('/old/bootstrap', second)
+        self.assertIn('/new/bootstrap', second)
+
+    def test_remove_block_round_trips(self):
+        base = 'line one\nline two\n'
+        self.assertEqual(
+            bootstrap.remove_block(bootstrap.apply_block(base, self.DIR)),
+            base)
+
+    def test_remove_block_no_op_without_block(self):
+        text = 'nothing to see here\n'
+        self.assertEqual(bootstrap.remove_block(text), text)
+
+    def test_apply_block_on_empty(self):
+        result = bootstrap.apply_block('', self.DIR)
+        self.assertTrue(result.startswith(bootstrap.BEGIN_MARKER))
+        self.assertTrue(result.endswith('\n'))
+
+
+class FishDropInTest(unittest.TestCase):
+
+    def test_prepends_path_without_fish_add_path(self):
+        content = bootstrap.fish_drop_in(Path('/a/b/bootstrap'))
+        # Prepends to $PATH and drops any prior occurrence (lands first, once).
+        self.assertIn(
+            'set -gx PATH "/a/b/bootstrap" '
+            '(string match --invert -- "/a/b/bootstrap" $PATH)', content)
+        # Must NOT use fish_add_path: it persists universal state that would
+        # survive uninstall (deleting this file).
+        self.assertNotIn('fish_add_path', content)
+        self.assertIn('Managed by', content)
+
+
+class WindowsPathTest(unittest.TestCase):
+    DIR = Path(r'C:\dev\src\brave\tools\cr\bootstrap')
+
+    def test_add_prepends_first(self):
+        result = bootstrap.add_windows_entry(r'C:\Windows;C:\Tools', self.DIR)
+        self.assertEqual(result, rf'{self.DIR};C:\Windows;C:\Tools')
+
+    def test_add_moves_existing_to_front(self):
+        # Present (lowercased, trailing slash) but not first -> moved to front
+        # exactly once, in canonical form.
+        current = rf'C:\Windows;{str(self.DIR).lower()}\\;C:\Tools'
+        self.assertEqual(bootstrap.add_windows_entry(current, self.DIR),
+                         rf'{self.DIR};C:\Windows;C:\Tools')
+
+    def test_add_is_idempotent(self):
+        once = bootstrap.add_windows_entry(r'C:\Windows', self.DIR)
+        self.assertEqual(bootstrap.add_windows_entry(once, self.DIR), once)
+
+    def test_add_to_empty(self):
+        self.assertEqual(bootstrap.add_windows_entry('', self.DIR),
+                         str(self.DIR))
+
+    def test_remove_drops_entry(self):
+        current = rf'C:\Windows;{self.DIR};C:\Tools'
+        self.assertEqual(bootstrap.remove_windows_entry(current, self.DIR),
+                         r'C:\Windows;C:\Tools')
+
+    def test_remove_no_op(self):
+        current = r'C:\Windows;C:\Tools'
+        self.assertEqual(bootstrap.remove_windows_entry(current, self.DIR),
+                         current)
+
+
+class FindExistingBootstrapTest(unittest.TestCase):
+
+    def setUp(self):
+        self._saved_path = os.environ.get('PATH', '')
+
+    def tearDown(self):
+        os.environ['PATH'] = self._saved_path
+
+    def test_none_when_not_on_path(self):
+        os.environ['PATH'] = ''
+        self.assertIsNone(bootstrap.find_existing_bootstrap())
+
+    @unittest.skipIf(platform.system() == 'Windows',
+                     'POSIX exec-bit lookup; Windows uses PATHEXT')
+    def test_found_when_shim_on_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            shim_path = Path(tmp) / 'brockit'
+            shim_path.write_text('#!/bin/sh\n', encoding='utf-8', newline='')
+            shim_path.chmod(shim_path.stat().st_mode | stat.S_IXUSR)
+            os.environ['PATH'] = tmp
+            self.assertEqual(bootstrap.find_existing_bootstrap(),
+                             str(shim_path))
+
+    def test_installed_dir_falls_back_to_own_dir(self):
+        os.environ['PATH'] = ''
+        self.assertEqual(bootstrap.installed_bootstrap_dir(),
+                         bootstrap.BOOTSTRAP_DIR)
+
+    @unittest.skipIf(platform.system() == 'Windows',
+                     'POSIX exec-bit lookup; Windows uses PATHEXT')
+    def test_installed_dir_is_parent_of_on_path_shim(self):
+        # uninstall must target wherever the live shim actually resides, which
+        # may differ from this checkout's BOOTSTRAP_DIR.
+        with tempfile.TemporaryDirectory() as tmp:
+            other = Path(tmp).resolve() / 'other-checkout'
+            other.mkdir()
+            shim_path = other / 'plaster'
+            shim_path.write_text('#!/bin/sh\n', encoding='utf-8', newline='')
+            shim_path.chmod(shim_path.stat().st_mode | stat.S_IXUSR)
+            os.environ['PATH'] = str(other)
+            self.assertEqual(bootstrap.installed_bootstrap_dir(), other)
+
+
+class FindBraveCoreTest(unittest.TestCase):
+    """Exercises `launcher.find_brave_core` against real git work trees.
+
+    `find_brave_core` resolves the checkout from the current directory via
+    `git rev-parse`, so these tests build a throwaway repo and chdir into it
+    rather than mocking git.
+    """
+
+    def setUp(self):
+        self._cwd = Path.cwd()
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+
+    def _make_brave_repo(self,
+                         root: Path,
+                         *,
+                         name: str = 'brave',
+                         tool: str | None = 'brockit') -> Path:
+        repo = root / name
+        (repo / 'tools' / 'cr').mkdir(parents=True)
+        if tool:
+            (repo / 'tools' / 'cr' / f'{tool}.py').write_text('#',
+                                                              encoding='utf-8',
+                                                              newline='')
+        subprocess.run(['git', 'init', '-q', str(repo)], check=True)
+        return repo
+
+    _BROCKIT = launcher.TOOL_PATHS['brockit']
+    _PLASTER = launcher.TOOL_PATHS['plaster']
+
+    def test_valid_brave_checkout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self._make_brave_repo(Path(tmp))
+            os.chdir(repo / 'tools' / 'cr')  # any subdir of the work tree
+            self.assertEqual(
+                launcher.find_brave_core(self._BROCKIT).resolve(),
+                repo.resolve())
+
+    def test_rejects_non_brave_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self._make_brave_repo(Path(tmp), name='notbrave')
+            os.chdir(repo)
+            self.assertIsNone(launcher.find_brave_core(self._BROCKIT))
+
+    def test_rejects_missing_tool_script(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self._make_brave_repo(Path(tmp), tool='brockit')
+            os.chdir(repo)
+            self.assertIsNone(launcher.find_brave_core(self._PLASTER))
+
+    def test_rejects_outside_git_work_tree(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)  # not a git repo
+            self.assertIsNone(launcher.find_brave_core(self._BROCKIT))
+
+
+class ResolveVpython3Test(unittest.TestCase):
+
+    def test_resolves_to_a_vpython3_interpreter(self):
+        # pylint: disable=protected-access
+        # Whether found on $PATH or via the chromium-bundled fallback, the
+        # resolved interpreter is always a vpython3 (vpython3.bat on Windows).
+        resolved = launcher._resolve_vpython3(Path('/home/dev/src/brave'))
+        self.assertIn(resolved.name, ('vpython3', 'vpython3.bat'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/cr/bootstrap/brockit
+++ b/tools/cr/bootstrap/brockit
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Dispatches to tools/cr/brockit.py for the brave-core checkout the current
+# directory is in. See launcher.py for the resolution logic.
+exec python3 "$(dirname "$0")/launcher.py" brockit "$@"

--- a/tools/cr/bootstrap/brockit.bat
+++ b/tools/cr/bootstrap/brockit.bat
@@ -1,0 +1,9 @@
+@echo off
+:: Copyright (c) 2026 The Brave Authors. All rights reserved.
+:: This Source Code Form is subject to the terms of the Mozilla Public
+:: License, v. 2.0. If a copy of the MPL was not distributed with this file,
+:: You can obtain one at https://mozilla.org/MPL/2.0/.
+::
+:: Dispatches to tools/cr/brockit.py for the brave-core checkout the current
+:: directory is in. See launcher.py for the resolution logic.
+python3 "%~dp0launcher.py" brockit %*

--- a/tools/cr/bootstrap/launcher.py
+++ b/tools/cr/bootstrap/launcher.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Shared launcher behind the shims for our tooling
+
+This launcher provides a mechanism similar to how `depot_tools` routes `gn`
+call relative to the `gn` binary for the repository in the current directory.
+The main role of this script is path resolution. After that, all arguments are
+passed through verbatim:
+
+    python3 launcher.py brockit lift --to=1.2.3.4
+
+Resolution follows the same invariant as `tools/cr/repository.py`: the work
+tree containing the cwd must be a `brave` checkout. The cwd is never changed,
+so the tool runs relative to the current path, exactly as if it had been
+launched as `tools/cr/<tool>.py` from there.
+
+This runs under plain `python3` (not `vpython3`), so it must stay stdlib-only,
+and it should be kept self-contained from other python code.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import platform
+import shutil
+import subprocess
+import sys
+
+# The basename a brave-core work-tree root must have. Kept in sync with
+# `repository.BRAVE_DIR_NAME`.
+BRAVE_DIR_NAME = 'brave'
+
+# The tools this launcher knows how to dispatch, mapped to their script paths
+# relative to the brave-core root.
+TOOL_PATHS: dict[str, Path] = {
+    'brockit': Path('tools') / 'cr' / 'brockit.py',
+    'plaster': Path('tools') / 'cr' / 'plaster.py',
+}
+
+
+def find_brave_core(relpath: Path) -> Path | None:
+    """Locates the brave-core work tree containing the current directory.
+
+    `relpath` is the tool's script path relative to the brave-core root (a
+    value from `TOOL_PATHS`). Returns the resolved root when the cwd sits in a
+    `brave` work tree that actually ships that script, else None. Uses
+    `git rev-parse --show-toplevel`, so it honours the cwd (and any git work
+    tree / submodule boundaries) the same way the rest of tools/cr does.
+    """
+    try:
+        result = subprocess.run(['git', 'rev-parse', '--show-toplevel'],
+                                capture_output=True,
+                                text=True,
+                                check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    toplevel = result.stdout.strip()
+    if not toplevel:
+        return None
+    root = Path(toplevel)
+    if root.name != BRAVE_DIR_NAME:
+        return None
+    if not (root / relpath).is_file():
+        return None
+    return root
+
+
+def _resolve_vpython3(brave: Path) -> Path:
+    """Returns the `vpython3` interpreter to run the tool with.
+
+    Precedence mirrors `vpython_utils._compute_vpython3_path`: prefer a
+    `vpython3` already on `$PATH`, otherwise fall back to the Chromium-bundled
+    `third_party/depot_tools/vpython3` next to this checkout.
+    """
+    found = shutil.which('vpython3')
+    if found is not None:
+        return Path(found)
+    name = 'vpython3.bat' if platform.system() == 'Windows' else 'vpython3'
+    return brave.parent / 'third_party' / 'depot_tools' / name
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        sys.stderr.write(
+            'launcher.py: missing tool name (the tools/cr script to run)\n')
+        return 2
+    tool, args = sys.argv[1], sys.argv[2:]
+
+    relpath = TOOL_PATHS.get(tool)
+    if relpath is None:
+        known = ', '.join(sorted(TOOL_PATHS))
+        sys.stderr.write(f"launcher.py: unknown tool '{tool}' (known: "
+                         f'{known})\n')
+        return 2
+
+    brave = find_brave_core(relpath)
+    if brave is None:
+        sys.stderr.write(
+            f'{tool}: must be run inside a brave-core git work tree '
+            f'(could not locate {relpath.as_posix()} for the current '
+            f'directory).\n')
+        return 1
+
+    # Intentionally do not change cwd: the tool must run relative to the
+    # current path.
+    invocation = [str(_resolve_vpython3(brave)), str(brave / relpath), *args]
+    return subprocess.call(invocation)
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/tools/cr/bootstrap/plaster
+++ b/tools/cr/bootstrap/plaster
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Dispatches to tools/cr/plaster.py for the brave-core checkout the current
+# directory is in. See launcher.py for the resolution logic.
+exec python3 "$(dirname "$0")/launcher.py" plaster "$@"

--- a/tools/cr/bootstrap/plaster.bat
+++ b/tools/cr/bootstrap/plaster.bat
@@ -1,0 +1,9 @@
+@echo off
+:: Copyright (c) 2026 The Brave Authors. All rights reserved.
+:: This Source Code Form is subject to the terms of the Mozilla Public
+:: License, v. 2.0. If a copy of the MPL was not distributed with this file,
+:: You can obtain one at https://mozilla.org/MPL/2.0/.
+::
+:: Dispatches to tools/cr/plaster.py for the brave-core checkout the current
+:: directory is in. See launcher.py for the resolution logic.
+python3 "%~dp0launcher.py" plaster %*


### PR DESCRIPTION
This is a basic bootstrap setup to have some of our `tools/cr` binaries
accessible through `PATH` similar to how `depot_tools` provides shims
for various build tools, relative to the repository under CWD.

With this particular PR it is already possible to do:

```
brockit lift --to=@latest-for-branch --with-github
```

To install the path in your system, it can be done manually by adding `tools/cr/bootstrap` into `PATH`, or by running:

```
tools/cr/bootstrap/bootstrap.py install
```

Bug: https://github.com/brave/brave-browser/issues/56529