### PR TITLE
[PSST] Return to the same page after applying PSST settings

### DIFF
--- a/browser/psst/psst_tab_web_contents_observer_browsertest.cc
+++ b/browser/psst/psst_tab_web_contents_observer_browsertest.cc
@@ -623,9 +623,12 @@ class PsstTabWebContentsObserverBrowserTest : public PlatformBrowserTest {
   // Navigates to `url`, waits for the PSST icon to appear in the location bar,
   // then clicks it with the specified `event_flags` to open its context menu
   // and waits for the menu to appear, or opens the consent dialog and waits
-  // for it to appear
-  void NavigateAndClickOnPsstLocationBarIcon(const GURL& url,
-                                             ui::EventFlags event_flags) {
+  // for it to appear. For a left-click, the opened consent dialog's WebContents
+  // is returned via `dialog_wc_out` when provided.
+  void NavigateAndClickOnPsstLocationBarIcon(
+      const GURL& url,
+      ui::EventFlags event_flags,
+      content::WebContents** dialog_wc_out = nullptr) {
     ASSERT_TRUE(event_flags == ui::EF_RIGHT_MOUSE_BUTTON ||
                 event_flags == ui::EF_LEFT_MOUSE_BUTTON);
     IconLabelBubbleView* const psst_view = GetPsstPageActionView();
@@ -668,6 +671,9 @@ class PsstTabWebContentsObserverBrowserTest : public PlatformBrowserTest {
           WaitForAndGetDialogWebContents(new_web_contents_observer);
       ASSERT_TRUE(dialog_wc);
       WaitForPsstDialogUIReady(dialog_wc);
+      if (dialog_wc_out) {
+        *dialog_wc_out = dialog_wc;
+      }
     }
   }
 
@@ -952,6 +958,62 @@ IN_PROC_BROWSER_TEST_F(PsstTabWebContentsObserverBrowserTest,
   const GURL url = GetEmbeddedTestServer().GetURL("a.test", "/a_test_0.html");
   ASSERT_NO_FATAL_FAILURE(
       NavigateAndClickOnPsstLocationBarIcon(url, ui::EF_LEFT_MOUSE_BUTTON));
+}
+
+// After navigating to the initial page and left-clicking the PSST location bar
+// icon, accepting the consent dialog runs both scripts across all task pages,
+// applies the PSST settings, and navigates the tab back to the initial page
+// where tuning started.
+IN_PROC_BROWSER_TEST_F(
+    PsstTabWebContentsObserverBrowserTest,
+    LocationBarIconLeftClickAppliesSettingsAndReturnsToPage) {
+  GetPrefs()->SetBoolean(prefs::kPsstEnabled, true);
+  ASSERT_TRUE(GetPrefs()->GetBoolean(prefs::kPsstEnabled));
+
+  const GURL url = GetEmbeddedTestServer().GetURL("a.test", "/a_test_0.html");
+
+  // Observe both scripts running across the initial page and each task page.
+  PsstWebContentsConsoleObserver console_observer(
+      web_contents(),
+      {base::StrCat({kUserScriptLogPrefix,
+                     CreateTestUtf16URL(https_server_, "/a_test_0.html")}),
+       base::StrCat({kUserScriptLogPrefix,
+                     CreateTestUtf16URL(https_server_, "/a_test_1.html")}),
+       base::StrCat({kUserScriptLogPrefix,
+                     CreateTestUtf16URL(https_server_, "/a_test_2.html")})},
+      {base::StrCat({kPolicyScriptLogPrefix,
+                     CreateTestUtf16URL(https_server_, "/a_test_0.html")}),
+       base::StrCat({kPolicyScriptLogPrefix,
+                     CreateTestUtf16URL(https_server_, "/a_test_1.html")}),
+       base::StrCat({kPolicyScriptLogPrefix,
+                     CreateTestUtf16URL(https_server_, "/a_test_2.html")})});
+
+  content::WebContents* dialog_wc = nullptr;
+  ASSERT_NO_FATAL_FAILURE(NavigateAndClickOnPsstLocationBarIcon(
+      url, ui::EF_LEFT_MOUSE_BUTTON, &dialog_wc));
+  ASSERT_TRUE(dialog_wc);
+
+  const std::vector<std::string> perform_uids = {"1", "2"};
+  ASSERT_TRUE(AcceptModalDialog(
+      dialog_wc, url::Origin::Create(url).GetURL().spec(), perform_uids));
+
+  // Both scripts ran on every page, confirming all tasks were processed.
+  ASSERT_TRUE(console_observer.Wait());
+  EXPECT_TRUE(console_observer.CheckMessages());
+
+  // Once tuning completes, the tab returns to the initial page.
+  ASSERT_TRUE(base::test::RunUntil(
+      [&]() { return web_contents()->GetLastCommittedURL() == url; }));
+
+  // PSST settings are applied for the signed-in user on this origin.
+  auto psst_website_settings = GetPsstSettingsService()->GetPsstWebsiteSettings(
+      url::Origin::Create(url), kASiteSignedInUserId);
+  ASSERT_TRUE(psst_website_settings);
+  EXPECT_EQ(psst_website_settings->consent_status, ConsentStatus::kAllow);
+  EXPECT_EQ(psst_website_settings->user_id, kASiteSignedInUserId);
+  EXPECT_EQ(psst_website_settings->uids_to_perform, perform_uids);
+
+  ASSERT_TRUE(CloseModalDialog(dialog_wc));
 }
 
 }  // namespace psst

--- a/components/psst/browser/content/psst_tab_web_contents_observer.cc
+++ b/components/psst/browser/content/psst_tab_web_contents_observer.cc
@@ -348,8 +348,7 @@ void PsstTabWebContentsObserver::OnPolicyScriptResult(
                             script_result_parsed->psst.applied_tasks, status);
 
   auto next_url =
-      (status != mojom::PsstStatus::kCompleted &&
-       script_result_parsed->next_url.has_value() &&
+      (script_result_parsed->next_url.has_value() &&
        !script_result_parsed->next_url->empty())
           ? std::optional<GURL>(GURL(*script_result_parsed->next_url))
           : std::nullopt;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56463

- Added a fix to navigate back to the page from which the PSST settings were applied, at the end of the flow.
- Covered with browser test.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
