### PR TITLE
[iOS] Add protection stats JavaScriptFeature

### DIFF
--- a/ios/BUILD.gn
+++ b/ios/BUILD.gn
@@ -136,6 +136,7 @@ brave_core_public_headers = [
   "//brave/ios/browser/brave_talk/brave_talk_tab_helper_bridge.h",
   "//brave/ios/browser/brave_search/brave_search_make_default_tab_helper_bridge.h",
   "//brave/ios/browser/playlist/playlist_tab_helper_bridge.h",
+  "//brave/ios/browser/brave_shields/protection_stats_tab_helper_bridge.h",
   "//ios/chrome/browser/web/model/print/print_handler.h",
   "//brave/ios/browser/youtube/youtube_pref_names_bridge.h",
   "//brave/ios/browser/global_privacy_control/gpc_pref_names_bridge.h",

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ProtectionStatsTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ProtectionStatsTabHelper.swift
@@ -8,7 +8,7 @@ import BraveShields
 import Data
 import Preferences
 import Shared
-import Web
+@_spi(ChromiumWebViewAccess) import Web
 import os.log
 
 extension TabDataValues {
@@ -26,7 +26,7 @@ extension TabDataValues {
 /// legacy `TrackingProtectionStats` script handler and the
 /// `ProtectionStatsJavaScriptFeature` bridge.
 @MainActor
-class ProtectionStatsTabHelper {
+class ProtectionStatsTabHelper: TabObserver, @preconcurrency ProtectionStatsTabHelperBridge {
   /// A single resource reported by the page.
   struct BlockedResource {
     let resourceURL: String
@@ -42,6 +42,41 @@ class ProtectionStatsTabHelper {
 
   init(tab: some TabState) {
     self.tab = tab
+
+    tab.addObserver(self)
+  }
+
+  deinit {
+    tab?.removeObserver(self)
+  }
+
+  // MARK: - TabObserver
+
+  func tabDidCreateWebView(_ tab: some TabState) {
+    if FeatureList.kUseProfileWebViewConfiguration.enabled {
+      BraveWebView.from(tab: tab)?.protectionStatsHelper = self
+    }
+  }
+
+  func tabWillBeDestroyed(_ tab: some TabState) {
+    tab.removeObserver(self)
+  }
+
+  // MARK: - ProtectionStatsTabHelperBridge
+
+  func handleBlockedResources(
+    _ resources: [ProtectionStatsResource],
+    securityOrigin: URL
+  ) {
+    let blockedResources = resources.compactMap { resource -> BlockedResource? in
+      guard let resourceType = AdblockEngine.ResourceType(rawValue: resource.resourceType)
+      else {
+        return nil
+      }
+      return BlockedResource(resourceURL: resource.resourceURL, resourceType: resourceType)
+    }
+
+    handleBlockedResources(blockedResources, sourceURL: securityOrigin)
   }
 
   // MARK: -

--- a/ios/browser/api/web_view/BUILD.gn
+++ b/ios/browser/api/web_view/BUILD.gn
@@ -43,6 +43,7 @@ source_set("web_view") {
     "//brave/ios/browser/api/web_view/passwords",
     "//brave/ios/browser/brave_ads",
     "//brave/ios/browser/brave_search",
+    "//brave/ios/browser/brave_shields",
     "//brave/ios/browser/brave_shields/request_blocking",
     "//brave/ios/browser/favicon",
     "//brave/ios/browser/serp_metrics",

--- a/ios/browser/api/web_view/brave_web_view.h
+++ b/ios/browser/api/web_view/brave_web_view.h
@@ -29,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol BraveTalkTabHelperBridge;
 @protocol BraveSearchMakeDefaultTabHelperBridge;
 @protocol PlaylistTabHelperBridge;
+@protocol ProtectionStatsTabHelperBridge;
 @protocol PrintHandler;
 @protocol RequestBlockingTabHelperBridge;
 
@@ -232,6 +233,13 @@ CWV_EXPORT
 /// A bridge for handling Brave Search helper script messages
 @property(nonatomic, weak, nullable) id<BraveSearchMakeDefaultTabHelperBridge>
     braveSearchHelper;
+@end
+
+CWV_EXPORT
+@interface BraveWebView (ProtectionStats)
+/// A bridge for handling Shields protection stats script messages
+@property(nonatomic, weak, nullable) id<ProtectionStatsTabHelperBridge>
+    protectionStatsHelper;
 @end
 
 CWV_EXPORT

--- a/ios/browser/api/web_view/brave_web_view.mm
+++ b/ios/browser/api/web_view/brave_web_view.mm
@@ -31,6 +31,8 @@
 #include "brave/ios/browser/brave_search/brave_search_ad_results_javascript_feature.h"
 #include "brave/ios/browser/brave_search/brave_search_make_default_tab_helper.h"
 #include "brave/ios/browser/brave_search/brave_search_make_default_tab_helper_bridge.h"
+#include "brave/ios/browser/brave_shields/protection_stats_tab_helper.h"
+#include "brave/ios/browser/brave_shields/protection_stats_tab_helper_bridge.h"
 #include "brave/ios/browser/brave_shields/request_blocking/request_blocking_tab_helper.h"
 #include "brave/ios/browser/brave_talk/brave_talk_tab_helper_bridge.h"
 #include "brave/ios/browser/favicon/brave_ios_web_favicon_driver.h"
@@ -278,6 +280,8 @@ class FaviconDriverObserver : public favicon::FaviconDriverObserver {
 #endif
 @property(nonatomic, weak) id<BraveSearchMakeDefaultTabHelperBridge>
     braveSearchHelper;
+@property(nonatomic, weak) id<ProtectionStatsTabHelperBridge>
+    protectionStatsHelper;
 @property(nonatomic, weak) id<PrintHandler> printHandler;
 @property(nonatomic, weak) id<RequestBlockingTabHelperBridge>
     requestBlockingTabHelperBridge;
@@ -419,6 +423,10 @@ class FaviconDriverObserver : public favicon::FaviconDriverObserver {
   BraveSearchMakeDefaultTabHelper::CreateForWebState(self.webState);
   BraveSearchMakeDefaultTabHelper::FromWebState(self.webState)
       ->SetBridge(self.braveSearchHelper);
+
+  brave_shields::ProtectionStatsTabHelper::CreateForWebState(self.webState);
+  brave_shields::ProtectionStatsTabHelper::FromWebState(self.webState)
+      ->SetBridge(self.protectionStatsHelper);
 
   LoginsTabHelper::MaybeCreateForWebState(self.webState, _loginsHelper);
 
@@ -839,6 +847,20 @@ class FaviconDriverObserver : public favicon::FaviconDriverObserver {
   if (BraveSearchMakeDefaultTabHelper* tab_helper =
           BraveSearchMakeDefaultTabHelper::FromWebState(self.webState)) {
     tab_helper->SetBridge(braveSearchHelper);
+  }
+}
+
+@end
+
+@implementation BraveWebView (ProtectionStats)
+
+- (void)setProtectionStatsHelper:
+    (id<ProtectionStatsTabHelperBridge>)protectionStatsHelper {
+  _protectionStatsHelper = protectionStatsHelper;
+  if (brave_shields::ProtectionStatsTabHelper* tab_helper =
+          brave_shields::ProtectionStatsTabHelper::FromWebState(
+              self.webState)) {
+    tab_helper->SetBridge(protectionStatsHelper);
   }
 }
 

--- a/ios/browser/brave_shields/BUILD.gn
+++ b/ios/browser/brave_shields/BUILD.gn
@@ -17,11 +17,18 @@ source_set("brave_shields") {
     "farbling_args.mm",
     "farbling_javascript_feature.h",
     "farbling_javascript_feature.mm",
+    "protection_stats_javascript_feature.h",
+    "protection_stats_javascript_feature.mm",
+    "protection_stats_tab_helper.h",
+    "protection_stats_tab_helper.mm",
+    "protection_stats_tab_helper_bridge.h",
+    "protection_stats_tab_helper_bridge.mm",
   ]
 
   deps = [
     ":cookie_control_js",
     ":farbling_js",
+    ":protection_stats_js",
     "//base",
     "//brave/components/brave_shields/core/browser",
     "//brave/components/brave_shields/core/common",
@@ -40,6 +47,7 @@ source_set("brave_shields") {
     "//ios/chrome/browser/shared/model/profile:profile_keyed_service_factory",
     "//ios/web/public",
     "//ios/web/web_state/ui:wk_web_view_configuration_provider_header",
+    "//net",
     "//third_party/abseil-cpp:absl",
     "//url",
   ]
@@ -78,4 +86,10 @@ optimize_ts("farbling_js") {
   visibility = [ ":brave_shields" ]
   sources = [ "resources/farbling.ts" ]
   deps = [ "//brave/ios/web/js_messaging:util_scripts" ]
+}
+
+optimize_ts("protection_stats_js") {
+  visibility = [ ":brave_shields" ]
+  sources = [ "resources/protection_stats.ts" ]
+  deps = [ "//ios/web/public/js_messaging:util_scripts" ]
 }

--- a/ios/browser/brave_shields/protection_stats_javascript_feature.h
+++ b/ios/browser/brave_shields/protection_stats_javascript_feature.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_BRAVE_SHIELDS_PROTECTION_STATS_JAVASCRIPT_FEATURE_H_
+#define BRAVE_IOS_BROWSER_BRAVE_SHIELDS_PROTECTION_STATS_JAVASCRIPT_FEATURE_H_
+
+#include <optional>
+#include <string>
+
+#include "base/no_destructor.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+
+namespace web {
+class WebState;
+}  // namespace web
+
+namespace brave_shields {
+
+// Injects the protection stats script which reports the resources loaded by a
+// page so Shields can track and block trackers, ads, and images.
+class ProtectionStatsJavaScriptFeature : public web::JavaScriptFeature {
+ public:
+  static ProtectionStatsJavaScriptFeature* GetInstance();
+
+  // JavaScriptFeature:
+  std::optional<std::string> GetScriptMessageHandlerName() const override;
+  void ScriptMessageReceived(web::WebState* web_state,
+                             const web::ScriptMessage& message) override;
+
+ private:
+  friend class base::NoDestructor<ProtectionStatsJavaScriptFeature>;
+
+  ProtectionStatsJavaScriptFeature();
+  ~ProtectionStatsJavaScriptFeature() override;
+
+  ProtectionStatsJavaScriptFeature(const ProtectionStatsJavaScriptFeature&) =
+      delete;
+  ProtectionStatsJavaScriptFeature& operator=(
+      const ProtectionStatsJavaScriptFeature&) = delete;
+};
+
+}  // namespace brave_shields
+
+#endif  // BRAVE_IOS_BROWSER_BRAVE_SHIELDS_PROTECTION_STATS_JAVASCRIPT_FEATURE_H_

--- a/ios/browser/brave_shields/protection_stats_javascript_feature.mm
+++ b/ios/browser/brave_shields/protection_stats_javascript_feature.mm
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/brave_shields/protection_stats_javascript_feature.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "base/containers/flat_map.h"
+#include "base/values.h"
+#include "brave/ios/browser/brave_shields/protection_stats_tab_helper.h"
+#include "ios/web/public/js_messaging/script_message.h"
+#include "ios/web/public/web_state.h"
+#include "url/gurl.h"
+#include "url/origin.h"
+
+namespace brave_shields {
+
+namespace {
+constexpr char kScriptName[] = "protection_stats";
+constexpr char kScriptHandlerName[] = "ProtectionStatsMessageHandler";
+constexpr char kResourceURLKey[] = "resourceURL";
+constexpr char kResourceTypeKey[] = "resourceType";
+}  // namespace
+
+ProtectionStatsJavaScriptFeature::ProtectionStatsJavaScriptFeature()
+    : JavaScriptFeature(web::ContentWorld::kPageContentWorld,
+                        {FeatureScript::CreateWithFilename(
+                            kScriptName,
+                            FeatureScript::InjectionTime::kDocumentStart,
+                            FeatureScript::TargetFrames::kAllFrames,
+                            FeatureScript::ReinjectionBehavior::
+                                kReinjectOnDocumentRecreation)}) {}
+
+ProtectionStatsJavaScriptFeature::~ProtectionStatsJavaScriptFeature() = default;
+
+// static
+ProtectionStatsJavaScriptFeature*
+ProtectionStatsJavaScriptFeature::GetInstance() {
+  static base::NoDestructor<ProtectionStatsJavaScriptFeature> instance;
+  return instance.get();
+}
+
+std::optional<std::string>
+ProtectionStatsJavaScriptFeature::GetScriptMessageHandlerName() const {
+  return kScriptHandlerName;
+}
+
+void ProtectionStatsJavaScriptFeature::ScriptMessageReceived(
+    web::WebState* web_state,
+    const web::ScriptMessage& message) {
+  const base::ListValue* body =
+      message.body() ? message.body()->GetIfList() : nullptr;
+  if (!body) {
+    return;
+  }
+
+  auto* tab_helper = ProtectionStatsTabHelper::FromWebState(web_state);
+  if (!tab_helper) {
+    return;
+  }
+
+  std::vector<BlockedResource> resources;
+  for (const base::Value& value : *body) {
+    const base::DictValue* resource = value.GetIfDict();
+    if (!resource) {
+      continue;
+    }
+    const std::string* resource_url = resource->FindString(kResourceURLKey);
+    const std::string* resource_type = resource->FindString(kResourceTypeKey);
+    if (!resource_url || !resource_type) {
+      continue;
+    }
+    resources.push_back({*resource_url, *resource_type});
+  }
+
+  if (resources.empty()) {
+    return;
+  }
+
+  tab_helper->HandleBlockedResources(resources,
+                                     message.security_origin().GetURL());
+}
+
+}  // namespace brave_shields

--- a/ios/browser/brave_shields/protection_stats_tab_helper.h
+++ b/ios/browser/brave_shields/protection_stats_tab_helper.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_BRAVE_SHIELDS_PROTECTION_STATS_TAB_HELPER_H_
+#define BRAVE_IOS_BROWSER_BRAVE_SHIELDS_PROTECTION_STATS_TAB_HELPER_H_
+
+#import <Foundation/Foundation.h>
+
+#include <string>
+#include <vector>
+
+#include "base/containers/flat_map.h"
+#include "ios/web/public/web_state_user_data.h"
+
+@protocol ProtectionStatsTabHelperBridge;
+
+class GURL;
+
+namespace web {
+class WebState;
+}  // namespace web
+
+namespace brave_shields {
+
+struct BlockedResource {
+  std::string resource_url;
+  std::string resource_type;
+};
+
+// Tab helper that bridges blocked resource reports from the
+// ProtectionStatsJavaScriptFeature to the platform Shields stats handler.
+class ProtectionStatsTabHelper
+    : public web::WebStateUserData<ProtectionStatsTabHelper> {
+ public:
+  ~ProtectionStatsTabHelper() override;
+
+  void SetBridge(id<ProtectionStatsTabHelperBridge> bridge);
+
+  // Forwards the resources reported by `frame_origin` to the bridge.
+  // `resources` is a list of maps each containing a "resourceURL" and a
+  // "resourceType" key.
+  void HandleBlockedResources(const std::vector<BlockedResource>& resources,
+                              const GURL& frame_origin);
+
+ private:
+  friend class web::WebStateUserData<ProtectionStatsTabHelper>;
+
+  explicit ProtectionStatsTabHelper(web::WebState* web_state);
+
+  __weak id<ProtectionStatsTabHelperBridge> bridge_;
+};
+
+}  // namespace brave_shields
+
+#endif  // BRAVE_IOS_BROWSER_BRAVE_SHIELDS_PROTECTION_STATS_TAB_HELPER_H_

--- a/ios/browser/brave_shields/protection_stats_tab_helper.mm
+++ b/ios/browser/brave_shields/protection_stats_tab_helper.mm
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/brave_shields/protection_stats_tab_helper.h"
+
+#include "base/strings/sys_string_conversions.h"
+#include "brave/ios/browser/brave_shields/protection_stats_tab_helper_bridge.h"
+#include "net/base/apple/url_conversions.h"
+#include "url/gurl.h"
+
+namespace brave_shields {
+
+ProtectionStatsTabHelper::ProtectionStatsTabHelper(web::WebState* web_state) {}
+
+ProtectionStatsTabHelper::~ProtectionStatsTabHelper() = default;
+
+void ProtectionStatsTabHelper::SetBridge(
+    id<ProtectionStatsTabHelperBridge> bridge) {
+  bridge_ = bridge;
+}
+
+void ProtectionStatsTabHelper::HandleBlockedResources(
+    const std::vector<BlockedResource>& resources,
+    const GURL& frame_origin) {
+  if (!bridge_) {
+    return;
+  }
+
+  NSMutableArray<ProtectionStatsResource*>* ns_resources =
+      [[NSMutableArray alloc] initWithCapacity:resources.size()];
+  for (const auto& resource : resources) {
+    [ns_resources
+        addObject:[[ProtectionStatsResource alloc]
+                      initWithURL:base::SysUTF8ToNSString(resource.resource_url)
+                             type:base::SysUTF8ToNSString(
+                                      resource.resource_type)]];
+  }
+
+  [bridge_ handleBlockedResources:ns_resources
+                   securityOrigin:net::NSURLWithGURL(frame_origin)];
+}
+
+}  // namespace brave_shields

--- a/ios/browser/brave_shields/protection_stats_tab_helper_bridge.h
+++ b/ios/browser/brave_shields/protection_stats_tab_helper_bridge.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_BRAVE_SHIELDS_PROTECTION_STATS_TAB_HELPER_BRIDGE_H_
+#define BRAVE_IOS_BROWSER_BRAVE_SHIELDS_PROTECTION_STATS_TAB_HELPER_BRIDGE_H_
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+OBJC_EXPORT
+@interface ProtectionStatsResource : NSObject
+@property(readonly) NSString* resourceURL;
+@property(readonly) NSString* resourceType;
+- (instancetype)initWithURL:(NSString*)url
+                       type:(NSString*)type NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+@end
+
+@protocol ProtectionStatsTabHelperBridge
+@required
+// Called when a frame reports resources that may be blocked by Shields.
+// `resources` is an array of dictionaries each containing a "resourceURL" and
+// a "resourceType" key. `securityOrigin` is the security origin of the frame
+// that reported the resources.
+- (void)handleBlockedResources:(NSArray<ProtectionStatsResource*>*)resources
+                securityOrigin:(NSURL*)securityOrigin;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // BRAVE_IOS_BROWSER_BRAVE_SHIELDS_PROTECTION_STATS_TAB_HELPER_BRIDGE_H_

--- a/ios/browser/brave_shields/protection_stats_tab_helper_bridge.mm
+++ b/ios/browser/brave_shields/protection_stats_tab_helper_bridge.mm
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/brave_shields/protection_stats_tab_helper_bridge.h"
+
+@implementation ProtectionStatsResource
+
+- (instancetype)initWithURL:(NSString*)url type:(NSString*)type {
+  if ((self = [super init])) {
+    _resourceURL = [url copy];
+    _resourceType = [type copy];
+  }
+  return self;
+}
+
+@end

--- a/ios/browser/brave_shields/resources/protection_stats.ts
+++ b/ios/browser/brave_shields/resources/protection_stats.ts
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { sendWebKitMessage } from '//ios/web/public/js_messaging/resources/utils.js'
+
+const messageHandlerName = 'ProtectionStatsMessageHandler'
+
+interface BlockedResource {
+  resourceURL: string
+  resourceType: string
+}
+
+let sendInfo: BlockedResource[] = []
+let sendInfoTimeout: ReturnType<typeof setTimeout> | null = null
+
+function sendMessage(
+  urlString: string | null | undefined,
+  resourceType: string,
+): void {
+  // String is empty, null, undefined, ...
+  if (!urlString) {
+    return
+  }
+
+  let resourceURL: URL
+  try {
+    resourceURL = new URL(urlString, document.location.href)
+
+    // First party urls or invalid URLs are not blocked
+    if (document.location.host === resourceURL.host) {
+      return
+    }
+  } catch (error) {
+    console.error(error)
+    return
+  }
+
+  sendInfo.push({ resourceURL: resourceURL.href, resourceType })
+
+  if (sendInfoTimeout) {
+    return
+  }
+
+  // Send the URLs in batches every 500ms to avoid perf issues from calling
+  // js-to-native too frequently.
+  sendInfoTimeout = setTimeout(() => {
+    sendInfoTimeout = null
+    if (sendInfo.length === 0) {
+      return
+    }
+
+    sendWebKitMessage(messageHandlerName, sendInfo)
+    sendInfo = []
+  }, 500)
+}
+
+function onLoad(): void {
+  // Send back the sources of every script and image in the DOM back to the
+  // host application.
+  Array.prototype.slice
+    .apply(document.scripts)
+    .forEach((el: HTMLScriptElement) => sendMessage(el.src, 'script'))
+  Array.prototype.slice
+    .apply(document.images)
+    .forEach((el: HTMLImageElement) => sendMessage(el.src, 'image'))
+  Array.prototype.slice
+    .apply(document.getElementsByTagName('subdocument'))
+    .forEach((el: any) => sendMessage(el.src, 'subdocument'))
+}
+
+window.addEventListener('load', onLoad, false)
+
+// A property used to track the URL of a synchronous XMLHttpRequest.
+const localURLProp = Symbol('url')
+// A property used to track whether an error handler has already been attached
+// to an XMLHttpRequest or Image instance.
+const localErrorHandlerProp = Symbol('tpErrorHandler')
+
+// -------------------------------------------------
+// Send XHR requests URLs to the host application
+// -------------------------------------------------
+const originalXHROpen = XMLHttpRequest.prototype.open
+const originalXHRSend = XMLHttpRequest.prototype.send
+
+XMLHttpRequest.prototype.open = function (this: any, ...args: any[]): void {
+  const url = args[1]
+  const isAsync = args[2]
+
+  // Blocked async XMLHttpRequest are handled via RequestBlocking.js. We only
+  // handle sync requests.
+  if (isAsync === undefined || isAsync) {
+    return originalXHROpen.apply(this, args as any)
+  }
+
+  this[localURLProp] = url
+  return originalXHROpen.apply(this, args as any)
+}
+
+XMLHttpRequest.prototype.send = function (this: any, ...args: any[]): void {
+  const url = this[localURLProp]
+  if (!url) {
+    return originalXHRSend.apply(this, args as any)
+  }
+
+  // Only attach the `error` event listener once for this `XMLHttpRequest`
+  // instance.
+  if (!this[localErrorHandlerProp]) {
+    // If this `XMLHttpRequest` instance fails to load, we can assume it has
+    // been blocked.
+    this[localErrorHandlerProp] = () => {
+      sendMessage(url, 'xmlhttprequest')
+    }
+
+    this.addEventListener('error', this[localErrorHandlerProp])
+  }
+  return originalXHRSend.apply(this, args as any)
+}
+
+// -------------------------------------------------
+// Send `fetch()` request URLs to the host application
+// -------------------------------------------------
+const originalFetch = window.fetch
+
+window.fetch = function (...args: any[]) {
+  const input = args[0]
+  if (typeof input === 'string') {
+    sendMessage(input, 'xmlhttprequest')
+  } else if (input instanceof Request) {
+    sendMessage(input.url, 'xmlhttprequest')
+  }
+
+  return originalFetch.apply(window, args as any)
+}
+
+// -------------------------------------------------
+// Detect when new sources get set on Image and send them to the host
+// application
+// -------------------------------------------------
+const originalImageSrc = Object.getOwnPropertyDescriptor(Image.prototype, 'src')
+
+if (originalImageSrc && originalImageSrc.get && originalImageSrc.set) {
+  delete (Image.prototype as any).src
+
+  Object.defineProperty(Image.prototype, 'src', {
+    get: function (): string {
+      return originalImageSrc.get!.call(this)
+    },
+
+    set: function (this: any, value: string): void {
+      // Only attach the `error` event listener once for this Image instance.
+      if (!this[localErrorHandlerProp]) {
+        // If this `Image` instance fails to load, we can assume it has been
+        // blocked.
+        this[localErrorHandlerProp] = () => {
+          sendMessage(this.src, 'image')
+        }
+
+        this.addEventListener('error', this[localErrorHandlerProp])
+      }
+
+      originalImageSrc.set!.call(this, value)
+    },
+    enumerable: true,
+    configurable: true,
+  })
+}
+
+// -------------------------------------------------
+// Listen to when new <script> elements get added to the DOM and send the
+// source to the host application
+// -------------------------------------------------
+const mutationObserver = new MutationObserver((mutations: MutationRecord[]) => {
+  mutations.forEach((mutation: MutationRecord) => {
+    mutation.addedNodes.forEach((node: Node) => {
+      const element = node as HTMLElement
+
+      // `<script src="*">` elements.
+      if (element.tagName === 'SCRIPT' && (element as HTMLScriptElement).src) {
+        sendMessage((element as HTMLScriptElement).src, 'script')
+        return
+      }
+
+      if (element.tagName === 'IMG' && (element as HTMLImageElement).src) {
+        sendMessage((element as HTMLImageElement).src, 'image')
+        return
+      }
+
+      // `<iframe src="*">` elements where [src] is not "about:blank".
+      if (element.tagName === 'IFRAME' && (element as HTMLIFrameElement).src) {
+        if ((element as HTMLIFrameElement).src === 'about:blank') {
+          return
+        }
+
+        sendMessage((element as HTMLIFrameElement).src, 'subdocument')
+      }
+    })
+  })
+})
+
+mutationObserver.observe(document.documentElement, {
+  childList: true,
+  subtree: true,
+})

--- a/ios/browser/web/brave_web_client.mm
+++ b/ios/browser/web/brave_web_client.mm
@@ -24,6 +24,7 @@
 #include "brave/ios/browser/brave_search/brave_search_make_default_javascript_feature.h"
 #include "brave/ios/browser/brave_shields/cookie_control_javascript_feature.h"
 #include "brave/ios/browser/brave_shields/farbling_javascript_feature.h"
+#include "brave/ios/browser/brave_shields/protection_stats_javascript_feature.h"
 #include "brave/ios/browser/brave_shields/request_blocking/request_blocking_javascript_feature.h"
 #include "brave/ios/browser/global_privacy_control/gpc_javascript_feature.h"
 #include "brave/ios/browser/playlist/playlist_compatibility_javascript_feature.h"
@@ -179,11 +180,16 @@ std::vector<web::JavaScriptFeature*> BraveWebClient::GetJavaScriptFeatures(
     features.push_back(
         skus::SkusJavaScriptFeature::FromBrowserState(browser_state));
     features.push_back(youtube::YouTubeQualityJavaScriptFeature::GetInstance());
-    features.push_back(RequestBlockingJavaScriptFeature::GetInstance());
     if (!base::FeatureList::IsEnabled(
             brave::features::kUseChromiumWebViewsAutofill)) {
       features.push_back(LoginsJavaScriptFeature::GetInstance());
     }
+
+    // Some privacy related features need to be injected in a specific order
+    // as they may override similar JavaScript APIs
+    features.push_back(RequestBlockingJavaScriptFeature::GetInstance());
+    features.push_back(
+        brave_shields::ProtectionStatsJavaScriptFeature::GetInstance());
   }
   return features;
 }


### PR DESCRIPTION
Adds support for shields stats tracking when using the `UseProfileWebViewConfiguration` feature flag. This change is a port of the original `TrackingProtectionStats.js` script

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56783


### Test
- Enable the `UseProfileWebViewConfiguration` feature flag
- Load a page known to have tons of ads/trackers like theverge.com
- Verify the counter in the Brave Shields panel goes up accordingly
