### PR TITLE
[VPN 2.0] Add runtime feature flag for new VPN architecture

### DIFF
--- a/browser/brave_vpn/brave_vpn_service_factory.cc
+++ b/browser/brave_vpn/brave_vpn_service_factory.cc
@@ -18,6 +18,7 @@
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
+#include "brave/components/brave_vpn/common/features.h"
 #include "brave/components/skus/common/features.h"
 #include "build/build_config.h"
 #include "chrome/browser/browser_process.h"
@@ -54,7 +55,9 @@ std::unique_ptr<KeyedService> BuildVpnService_V2(
   return std::make_unique<v2::BraveVpnServiceImpl>();
 }
 
-#elif BUILDFLAG(ENABLE_BRAVE_VPN_V1)
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2)
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 
 std::unique_ptr<KeyedService> BuildVpnService_V1(
     content::BrowserContext* context) {
@@ -114,9 +117,14 @@ std::unique_ptr<KeyedService> BuildVpnService(
   if (!brave_vpn::IsAllowedForContext(context)) {
     return nullptr;
   }
+
 #if BUILDFLAG(ENABLE_BRAVE_VPN_V2)
-  return BuildVpnService_V2(context);
-#elif BUILDFLAG(ENABLE_BRAVE_VPN_V1)
+  if (base::FeatureList::IsEnabled(features::kBraveVPNExperimentalV2)) {
+    return BuildVpnService_V2(context);
+  }
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
   return BuildVpnService_V1(context);
 #else
   NOTREACHED() << "No VPN implementation available";

--- a/components/brave_vpn/common/features.cc
+++ b/components/brave_vpn/common/features.cc
@@ -20,6 +20,8 @@ BASE_FEATURE(kBraveVPN,
 #endif
 );
 
+BASE_FEATURE(kBraveVPNExperimentalV2, base::FEATURE_DISABLED_BY_DEFAULT);
+
 BASE_FEATURE(kBraveVPNLinkSubscriptionAndroidUI,
              base::FEATURE_ENABLED_BY_DEFAULT);
 

--- a/components/brave_vpn/common/features.h
+++ b/components/brave_vpn/common/features.h
@@ -13,6 +13,7 @@ namespace brave_vpn {
 namespace features {
 
 BASE_DECLARE_FEATURE(kBraveVPN);
+BASE_DECLARE_FEATURE(kBraveVPNExperimentalV2);
 BASE_DECLARE_FEATURE(kBraveVPNLinkSubscriptionAndroidUI);
 #if BUILDFLAG(IS_WIN)
 BASE_DECLARE_FEATURE(kBraveVPNDnsProtection);


### PR DESCRIPTION
The change adds a new experimental feature flag "BraveVPNExperimentalV2" available in CLI only, to pick architecture 2.0 at runtime when that architecture is enabled at compile time. The flag is disabled by default. If only architecture 1.0 is enabled, the flag is ignored.

Resolves https://github.com/brave/brave-browser/issues/54683

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
