### PR TITLE
[asan] Fix wallet delegate test only callback setup

### DIFF
--- a/browser/brave_wallet/BUILD.gn
+++ b/browser/brave_wallet/BUILD.gn
@@ -213,6 +213,8 @@ source_set("unit_tests") {
   if (!is_android) {
     sources += [
       "brave_wallet_hid_chooser_unittest.cc",
+      "brave_wallet_provider_delegate_impl_helper_test_util.cc",
+      "brave_wallet_provider_delegate_impl_helper_test_util.h",
       "brave_wallet_tab_helper_unittest.cc",
       "ethereum_provider_impl_unittest.cc",
       "solana_provider_impl_unittest.cc",

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.cc
@@ -7,6 +7,8 @@
 
 #include <utility>
 
+#include "base/auto_reset.h"
+#include "base/check_is_test.h"
 #include "base/containers/fixed_flat_map.h"
 #include "base/notreached.h"
 #include "brave/browser/brave_wallet/brave_wallet_tab_helper.h"
@@ -17,18 +19,9 @@
 
 namespace {
 
-// TODO(https://github.com/brave/brave-browser/issues/48713): This is a case of
-// `-Wexit-time-destructors` violation and `[[clang::no_destroy]]` has been
-// added in the meantime to fix the build error. Remove this attribute and
-// provide a proper fix.
-[[clang::no_destroy]] base::OnceCallback<void()>
-    g_new_setup_needed_callback_for_testing;
-// TODO(https://github.com/brave/brave-browser/issues/48713): This is a case of
-// `-Wexit-time-destructors` violation and `[[clang::no_destroy]]` has been
-// added in the meantime to fix the build error. Remove this attribute and
-// provide a proper fix.
-[[clang::no_destroy]] base::OnceCallback<void(std::string_view coin_name)>
-    g_account_creation_callback_for_testing;
+base::OnceCallback<void()>* g_new_setup_needed_callback_for_testing = nullptr;
+base::OnceCallback<void(std::string_view coin_name)>*
+    g_account_creation_callback_for_testing = nullptr;
 
 // These are names of coins used by `create-account-options.ts`. We support only
 // Solana and Cardano account creation triggered by dApp.
@@ -67,7 +60,9 @@ void ShowWalletOnboarding(content::WebContents* web_contents) {
   if (browser) {
     brave::ShowBraveWalletOnboarding(browser);
   } else if (g_new_setup_needed_callback_for_testing) {
-    std::move(g_new_setup_needed_callback_for_testing).Run();
+    CHECK_IS_TEST();
+    CHECK(*g_new_setup_needed_callback_for_testing);
+    std::move(*g_new_setup_needed_callback_for_testing).Run();
   }
 }
 
@@ -85,7 +80,9 @@ void ShowAccountCreation(content::WebContents* web_contents,
   if (browser) {
     brave::ShowBraveWalletAccountCreation(browser, it->second);
   } else if (g_account_creation_callback_for_testing) {
-    std::move(g_account_creation_callback_for_testing).Run(it->second);
+    CHECK_IS_TEST();
+    CHECK(*g_account_creation_callback_for_testing);
+    std::move(*g_account_creation_callback_for_testing).Run(it->second);
   }
 }
 
@@ -97,14 +94,19 @@ bool IsWeb3NotificationAllowed() {
   return true;
 }
 
-void SetCallbackForNewSetupNeededForTesting(
-    base::OnceCallback<void()> callback) {
-  g_new_setup_needed_callback_for_testing = std::move(callback);
+base::AutoReset<base::OnceCallback<void()>*>
+SetNewSetupNeededCallbackForTesting(base::OnceCallback<void()>* callback) {
+  CHECK_IS_TEST();
+  return base::AutoReset<base::OnceCallback<void()>*>(
+      &g_new_setup_needed_callback_for_testing, callback);
 }
 
-void SetCallbackForAccountCreationForTesting(
-    base::OnceCallback<void(std::string_view)> callback) {
-  g_account_creation_callback_for_testing = std::move(callback);
+base::AutoReset<base::OnceCallback<void(std::string_view)>*>
+SetAccountCreationCallbackForTesting(
+    base::OnceCallback<void(std::string_view)>* callback) {
+  CHECK_IS_TEST();
+  return base::AutoReset<base::OnceCallback<void(std::string_view)>*>(
+      &g_account_creation_callback_for_testing, callback);
 }
 
 }  // namespace brave_wallet

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.h
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.h
@@ -6,6 +6,9 @@
 #ifndef BRAVE_BROWSER_BRAVE_WALLET_BRAVE_WALLET_PROVIDER_DELEGATE_IMPL_HELPER_H_
 #define BRAVE_BROWSER_BRAVE_WALLET_BRAVE_WALLET_PROVIDER_DELEGATE_IMPL_HELPER_H_
 
+#include <string_view>
+
+#include "base/auto_reset.h"
 #include "base/functional/callback.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom-forward.h"
 #include "build/build_config.h"
@@ -42,10 +45,16 @@ void WalletInteractionDetected(content::WebContents* web_contents);
 // show or not a permissions prompt dialog
 bool IsWeb3NotificationAllowed();
 
-void SetCallbackForNewSetupNeededForTesting(base::OnceCallback<void()>);
+// These are test only functions for certain events, however prefer to use the
+// scope managers in
+// `brave_wallet_provider_delegate_impl_helper_test_util.h` rather than these
+// functions directly.
+[[nodiscard]] base::AutoReset<base::OnceCallback<void()>*>
+SetNewSetupNeededCallbackForTesting(base::OnceCallback<void()>* callback);
 
-void SetCallbackForAccountCreationForTesting(
-    base::OnceCallback<void(std::string_view)>);
+[[nodiscard]] base::AutoReset<base::OnceCallback<void(std::string_view)>*>
+SetAccountCreationCallbackForTesting(
+    base::OnceCallback<void(std::string_view)>* callback);
 
 }  // namespace brave_wallet
 

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper_test_util.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper_test_util.cc
@@ -1,0 +1,31 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper_test_util.h"
+
+#include <utility>
+
+#include "brave/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.h"
+
+namespace brave_wallet {
+
+ScopedNewSetupNeededCallbackForTesting::ScopedNewSetupNeededCallbackForTesting(
+    base::OnceCallback<void()> callback)
+    : callback_(std::move(callback)),
+      resetter_(SetNewSetupNeededCallbackForTesting(&callback_)) {}
+
+ScopedNewSetupNeededCallbackForTesting::
+    ~ScopedNewSetupNeededCallbackForTesting() = default;
+
+ScopedAccountCreationCallbackForTesting::
+    ScopedAccountCreationCallbackForTesting(
+        base::OnceCallback<void(std::string_view)> callback)
+    : callback_(std::move(callback)),
+      resetter_(SetAccountCreationCallbackForTesting(&callback_)) {}
+
+ScopedAccountCreationCallbackForTesting::
+    ~ScopedAccountCreationCallbackForTesting() = default;
+
+}  // namespace brave_wallet

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper_test_util.h
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper_test_util.h
@@ -1,0 +1,51 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_BRAVE_WALLET_BRAVE_WALLET_PROVIDER_DELEGATE_IMPL_HELPER_TEST_UTIL_H_
+#define BRAVE_BROWSER_BRAVE_WALLET_BRAVE_WALLET_PROVIDER_DELEGATE_IMPL_HELPER_TEST_UTIL_H_
+
+#include <string_view>
+
+#include "base/auto_reset.h"
+#include "base/functional/callback.h"
+
+namespace brave_wallet {
+
+// These are scope managers to set specific callbacks for certain test-only
+// events.
+
+class ScopedNewSetupNeededCallbackForTesting {
+ public:
+  explicit ScopedNewSetupNeededCallbackForTesting(
+      base::OnceCallback<void()> callback);
+  ScopedNewSetupNeededCallbackForTesting(
+      const ScopedNewSetupNeededCallbackForTesting&) = delete;
+  ScopedNewSetupNeededCallbackForTesting& operator=(
+      const ScopedNewSetupNeededCallbackForTesting&) = delete;
+  ~ScopedNewSetupNeededCallbackForTesting();
+
+ private:
+  base::OnceCallback<void()> callback_;
+  base::AutoReset<base::OnceCallback<void()>*> resetter_;
+};
+
+class ScopedAccountCreationCallbackForTesting {
+ public:
+  explicit ScopedAccountCreationCallbackForTesting(
+      base::OnceCallback<void(std::string_view)> callback);
+  ScopedAccountCreationCallbackForTesting(
+      const ScopedAccountCreationCallbackForTesting&) = delete;
+  ScopedAccountCreationCallbackForTesting& operator=(
+      const ScopedAccountCreationCallbackForTesting&) = delete;
+  ~ScopedAccountCreationCallbackForTesting();
+
+ private:
+  base::OnceCallback<void(std::string_view)> callback_;
+  base::AutoReset<base::OnceCallback<void(std::string_view)>*> resetter_;
+};
+
+}  // namespace brave_wallet
+
+#endif  // BRAVE_BROWSER_BRAVE_WALLET_BRAVE_WALLET_PROVIDER_DELEGATE_IMPL_HELPER_TEST_UTIL_H_

--- a/browser/brave_wallet/ethereum_provider_impl_unittest.cc
+++ b/browser/brave_wallet/ethereum_provider_impl_unittest.cc
@@ -25,7 +25,7 @@
 #include "base/test/values_test_util.h"
 #include "base/values.h"
 #include "brave/browser/brave_wallet/brave_wallet_provider_delegate_impl.h"
-#include "brave/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.h"
+#include "brave/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper_test_util.h"
 #include "brave/browser/brave_wallet/brave_wallet_service_delegate_impl.h"
 #include "brave/browser/brave_wallet/brave_wallet_tab_helper.h"
 #include "brave/components/brave_wallet/browser/asset_ratio_service.h"
@@ -197,10 +197,6 @@ class EthereumProviderImplUnitTest : public testing::Test {
   }
 
   void SetUp() override {
-    // Resetting this test callback, as it gets stored in a discreet global, and
-    // in some cases it was causing stack-use-after-return.
-    SetCallbackForNewSetupNeededForTesting(base::OnceCallback<void()>());
-
     brave_wallet::RegisterLocalStatePrefs(local_state_.registry());
 
     web_contents_ =
@@ -1381,7 +1377,7 @@ TEST_F(EthereumProviderImplUnitTest, AddAndApprove1559TransactionNoPermission) {
 
 TEST_F(EthereumProviderImplUnitTest, RequestEthereumPermissionNotNewSetup) {
   bool new_setup_callback_called = false;
-  SetCallbackForNewSetupNeededForTesting(
+  ScopedNewSetupNeededCallbackForTesting new_setup_callback(
       base::BindLambdaForTesting([&]() { new_setup_callback_called = true; }));
   CreateWallet();
   auto account_0 = GetAccountUtils().EnsureEthAccount(0);
@@ -1412,7 +1408,7 @@ TEST_F(EthereumProviderImplUnitTest, RequestEthereumPermissionsNoPermission) {
   host_content_settings_map()->SetContentSettingDefaultScope(
       url, url, ContentSettingsType::BRAVE_ETHEREUM, CONTENT_SETTING_BLOCK);
 
-  SetCallbackForNewSetupNeededForTesting(
+  ScopedNewSetupNeededCallbackForTesting new_setup_callback(
       base::BindLambdaForTesting([&]() { new_setup_callback_called = true; }));
 
   provider()->RequestEthereumPermissions(
@@ -1438,7 +1434,8 @@ TEST_F(EthereumProviderImplUnitTest, RequestEthereumPermissionsNoWallet) {
   Navigate(url);
 
   bool new_setup_callback_called = false;
-  SetCallbackForNewSetupNeededForTesting(
+  std::optional<ScopedNewSetupNeededCallbackForTesting> new_setup_callback;
+  new_setup_callback.emplace(
       base::BindLambdaForTesting([&]() { new_setup_callback_called = true; }));
   base::RunLoop run_loop;
   provider()->RequestEthereumPermissions(
@@ -1458,7 +1455,7 @@ TEST_F(EthereumProviderImplUnitTest, RequestEthereumPermissionsNoWallet) {
 
   // Setup is called at most once
   new_setup_callback_called = false;
-  SetCallbackForNewSetupNeededForTesting(
+  new_setup_callback.emplace(
       base::BindLambdaForTesting([&]() { new_setup_callback_called = true; }));
   base::RunLoop run_loop2;
   provider()->RequestEthereumPermissions(

--- a/browser/brave_wallet/solana_provider_impl_unittest.cc
+++ b/browser/brave_wallet/solana_provider_impl_unittest.cc
@@ -17,7 +17,7 @@
 #include "base/memory/scoped_refptr.h"
 #include "base/test/bind.h"
 #include "brave/browser/brave_wallet/brave_wallet_provider_delegate_impl.h"
-#include "brave/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.h"
+#include "brave/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper_test_util.h"
 #include "brave/browser/brave_wallet/brave_wallet_service_delegate_impl.h"
 #include "brave/browser/brave_wallet/brave_wallet_tab_helper.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_service.h"
@@ -637,7 +637,7 @@ TEST_F(SolanaProviderImplUnitTest, EagerlyConnect) {
 
 TEST_F(SolanaProviderImplUnitTest, ConnectWithNoSolanaAccount) {
   bool onboarding_callback_called = false;
-  SetCallbackForNewSetupNeededForTesting(
+  ScopedNewSetupNeededCallbackForTesting new_setup_callback(
       base::BindLambdaForTesting([&]() { onboarding_callback_called = true; }));
   Navigate(GURL("https://brave.com"));
 
@@ -651,7 +651,9 @@ TEST_F(SolanaProviderImplUnitTest, ConnectWithNoSolanaAccount) {
   EXPECT_TRUE(onboarding_callback_called);
 
   base::test::TestFuture<std::string_view> account_creation_callback_future;
-  SetCallbackForAccountCreationForTesting(
+  std::optional<ScopedAccountCreationCallbackForTesting>
+      account_creation_callback;
+  account_creation_callback.emplace(
       account_creation_callback_future.GetCallback());
   // No solana account
   CreateWallet();
@@ -665,7 +667,7 @@ TEST_F(SolanaProviderImplUnitTest, ConnectWithNoSolanaAccount) {
   EXPECT_TRUE(provider_->account_creation_shown_);
 
   // It should be shown at most once.
-  SetCallbackForAccountCreationForTesting(
+  account_creation_callback.emplace(
       account_creation_callback_future.GetCallback());
   account = Connect(std::nullopt, &error, &error_message);
   EXPECT_TRUE(account.empty());
@@ -673,8 +675,6 @@ TEST_F(SolanaProviderImplUnitTest, ConnectWithNoSolanaAccount) {
   EXPECT_FALSE(IsConnected());
   EXPECT_FALSE(account_creation_callback_future.IsReady());
   EXPECT_TRUE(provider_->account_creation_shown_);
-  // Clear previous set callback which won't run in this test suite
-  SetCallbackForAccountCreationForTesting(base::DoNothing());
 }
 
 TEST_F(SolanaProviderImplUnitTest, Disconnect) {


### PR DESCRIPTION
This PR improves around the setup we have for test-only code doing
callback setup. The underlying objects in place have been migrated from
`no-destroy` to trivial pointers, and scope managers have been
introduced to make sure these are being set/unset adequately.

Bug: https://github.com/brave/brave-browser/issues/48713
Fixed: https://github.com/brave/internal/issues/1791
