### PR TITLE
[asan] Add missing `TearDownGlobalFeaturesForTesting`

### DIFF
--- a/browser/ui/webui/settings/brave_site_settings_handler.h
+++ b/browser/ui/webui/settings/brave_site_settings_handler.h
@@ -11,6 +11,10 @@
 
 #include "chrome/browser/ui/webui/settings/site_settings_handler.h"
 
+namespace content {
+class WebUI;
+}  // namespace content
+
 namespace settings {
 
 class BraveSiteSettingsHandler : public SiteSettingsHandler {
@@ -33,8 +37,8 @@ class BraveSiteSettingsHandler : public SiteSettingsHandler {
 
   void RemoveNonModelData(const std::vector<url::Origin>& origins) override;
 
- private:
-  friend class TestBraveSiteSettingsHandlerUnittest;
+  // Exposes the protected WebUIMessageHandler::set_web_ui() to tests.
+  void set_web_ui_for_testing(content::WebUI* web_ui) { set_web_ui(web_ui); }
 };
 
 }  // namespace settings

--- a/browser/ui/webui/settings/brave_site_settings_handler_unittest.cc
+++ b/browser/ui/webui/settings/brave_site_settings_handler_unittest.cc
@@ -37,10 +37,10 @@ base::DictValue GetResponsePayload(bool valid, const std::string& message) {
 }
 }  // namespace
 
-class TestBraveSiteSettingsHandlerUnittest : public testing::Test {
+class BraveSiteSettingsHandlerTest : public testing::Test {
  public:
-  TestBraveSiteSettingsHandlerUnittest() = default;
-  ~TestBraveSiteSettingsHandlerUnittest() override = default;
+  BraveSiteSettingsHandlerTest() = default;
+  ~BraveSiteSettingsHandlerTest() override = default;
 
   void SetUp() override {
     TestingBrowserProcess::GetGlobal()->SetUpGlobalFeaturesForTesting(
@@ -54,7 +54,7 @@ class TestBraveSiteSettingsHandlerUnittest : public testing::Test {
     test_web_ui_.set_web_contents(web_contents_.get());
 
     handler_ = std::make_unique<BraveSiteSettingsHandler>(profile_.get());
-    handler_->set_web_ui(&test_web_ui_);
+    handler_->set_web_ui_for_testing(&test_web_ui_);
     handler_->RegisterMessages();
   }
 
@@ -62,8 +62,13 @@ class TestBraveSiteSettingsHandlerUnittest : public testing::Test {
     testing::Test::TearDown();
     // The test handler unusually owns its own TestWebUI, so we make sure to
     // unbind it from the base class before the derived class is destroyed.
-    handler_->set_web_ui(nullptr);
+    handler_->set_web_ui_for_testing(nullptr);
     handler_.reset();
+
+    web_contents_.reset();
+    profile_.reset();
+
+    TestingBrowserProcess::GetGlobal()->TearDownGlobalFeaturesForTesting();
   }
   content::TestWebUI* web_ui() { return &test_web_ui_; }
   PrefService* prefs() { return profile_->GetPrefs(); }
@@ -85,7 +90,7 @@ class TestBraveSiteSettingsHandlerUnittest : public testing::Test {
   content::TestWebUI test_web_ui_;
 };
 
-TEST_F(TestBraveSiteSettingsHandlerUnittest, InValidShieldsType) {
+TEST_F(BraveSiteSettingsHandlerTest, InValidShieldsType) {
   base::ListValue args;
   args.Append(base::Value("id"));
   args.Append(base::Value("[*.]brave.com"));
@@ -100,7 +105,7 @@ TEST_F(TestBraveSiteSettingsHandlerUnittest, InValidShieldsType) {
                 l10n_util::GetStringUTF8(IDS_BRAVE_SHIELDS_NOT_VALID_ADDRESS)));
 }
 
-TEST_F(TestBraveSiteSettingsHandlerUnittest, ValidShieldsType) {
+TEST_F(BraveSiteSettingsHandlerTest, ValidShieldsType) {
   base::ListValue args;
   args.Append(base::Value("id"));
   args.Append(base::Value("brave.com"));
@@ -112,7 +117,7 @@ TEST_F(TestBraveSiteSettingsHandlerUnittest, ValidShieldsType) {
   EXPECT_EQ(*data->arg3(), GetResponsePayload(true, std::string()));
 }
 
-TEST_F(TestBraveSiteSettingsHandlerUnittest, ValidNonShieldsType) {
+TEST_F(BraveSiteSettingsHandlerTest, ValidNonShieldsType) {
   base::ListValue args;
   args.Append(base::Value("id"));
   args.Append(base::Value("[*.]brave.com"));
@@ -124,8 +129,7 @@ TEST_F(TestBraveSiteSettingsHandlerUnittest, ValidNonShieldsType) {
   EXPECT_EQ(*data->arg3(), GetResponsePayload(true, std::string()));
 }
 
-TEST_F(TestBraveSiteSettingsHandlerUnittest,
-       IsPatternValidForBraveContentType) {
+TEST_F(BraveSiteSettingsHandlerTest, IsPatternValidForBraveContentType) {
   EXPECT_FALSE(IsPatternValidForBraveContentType(
       ContentSettingsType::BRAVE_SHIELDS, "*.*"));
   EXPECT_FALSE(IsPatternValidForBraveContentType(


### PR DESCRIPTION
`SetUpGlobalFeaturesForTesting` has to be paired with
`TearDownGlobalFeaturesForTesting`. This was lost in translation when
this transition was passed on by upstream, as the previous function
didn't have a pair.

Fixed: https://github.com/brave/internal/issues/1792
