### PR TITLE
[Brave News] Add feature flag for sidebar entry

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -272,6 +272,13 @@ const char* const kBraveSyncImplLink[1] = {"https://github.com/brave/go-sync"};
           "Use the updated Brave News feed",                                   \
           kOsDesktop,                                                          \
           FEATURE_VALUE_TYPE(brave_news::features::kBraveNewsFeedUpdate),      \
+      },                                                                       \
+      {                                                                        \
+          "brave-news-sidebar",                                                \
+          "Brave News Sidebar",                                                \
+          "Show a Brave News entry in the sidebar that opens a side panel.",   \
+          kOsDesktop,                                                          \
+          FEATURE_VALUE_TYPE(brave_news::features::kBraveNewsSidebar),         \
       })
 #else
 #define BRAVE_NEWS_FEATURE_ENTRIES

--- a/components/brave_news/common/features.cc
+++ b/components/brave_news/common/features.cc
@@ -15,6 +15,8 @@ BASE_FEATURE(kBraveNewsCardPeekFeature,
              "BraveNewsCardPeek",
              base::FEATURE_ENABLED_BY_DEFAULT);
 
+BASE_FEATURE(kBraveNewsSidebar, base::FEATURE_DISABLED_BY_DEFAULT);
+
 BASE_FEATURE(kBraveNewsFeedUpdate,
 #if BUILDFLAG(IS_ANDROID)
              base::FEATURE_DISABLED_BY_DEFAULT

--- a/components/brave_news/common/features.h
+++ b/components/brave_news/common/features.h
@@ -16,6 +16,8 @@ namespace brave_news::features {
 
 BASE_DECLARE_FEATURE(kBraveNewsCardPeekFeature);
 
+BASE_DECLARE_FEATURE(kBraveNewsSidebar);
+
 BASE_DECLARE_FEATURE(kBraveNewsFeedUpdate);
 // The minimum number of cards (following the hero) in a block.
 extern const base::FeatureParam<int> kBraveNewsMinBlockCards;


### PR DESCRIPTION
Series https://github.com/brave/brave-browser/issues/29147

Adds `kBraveNewsSidebar` (disabled by default) and a `chrome://flags` entry to gate the Brave News sidebar/side panel.

### Stack (split of the Brave News sidebar feature)
1. https://github.com/brave/brave-core/pull/37419
2. https://github.com/brave/brave-core/pull/37420
3. https://github.com/brave/brave-core/pull/37421
4. https://github.com/brave/brave-core/pull/37422
5. https://github.com/brave/brave-core/pull/37423

This is PR **1/5**.