### PR TITLE
[Brave News] Add sidebar feed frontend + Storybook story

### DIFF
--- a/components/brave_news/browser/resources/customize/SourcesListEntry.tsx
+++ b/components/brave_news/browser/resources/customize/SourcesListEntry.tsx
@@ -75,7 +75,7 @@ function FavIcon (props: { publisherId: string }) {
 
   return (
     <FavIconContainer>
-      {faviconUrl && !error && <img loading='lazy' src={`chrome://brave-image?url=${encodeURIComponent(faviconUrl)}`} onError={() => setError(true)} />}
+      {faviconUrl && !error && <img loading='lazy' src={`//brave-image?url=${encodeURIComponent(faviconUrl)}`} onError={() => setError(true)} />}
     </FavIconContainer>
   )
 }

--- a/components/brave_news/browser/resources/feed/Card.tsx
+++ b/components/brave_news/browser/resources/feed/Card.tsx
@@ -67,7 +67,7 @@ const HidableImage = ({
   }, [onLoad])
 
   if (src) {
-    src = 'chrome://brave-image?url=' + encodeURIComponent(src);
+    src = '//brave-image?url=' + encodeURIComponent(src);
   }
   if (targetHeight && targetWidth) {
     const width = Math.round(targetWidth * window.devicePixelRatio)

--- a/components/brave_news/browser/resources/shared/PublisherCard.tsx
+++ b/components/brave_news/browser/resources/shared/PublisherCard.tsx
@@ -73,7 +73,7 @@ export default function PublisherCard(props: {
 
   return <Flex direction="column" gap={8}>
     <Card backgroundColor={backgroundColor} data-feed-card-is-followed={followed}>
-      {coverUrl && <CoverImage backgroundImage={`chrome://brave-image?url=${encodeURIComponent(coverUrl)}`} />}
+      {coverUrl && <CoverImage backgroundImage={`//brave-image?url=${encodeURIComponent(coverUrl)}`} />}
       <StyledFollowButton fab size='tiny' following={followed} onClick={() => setFollowed(!followed)} />
     </Card>
     <Name>

--- a/components/brave_news/browser/resources/shared/api.ts
+++ b/components/brave_news/browser/resources/shared/api.ts
@@ -12,6 +12,14 @@ export * from 'gen/brave/components/brave_news/common/brave_news.mojom.m.js'
 export type Publishers = Record<string, BraveNews.Publisher>
 export type Channels = Record<string, BraveNews.Channel>
 
+declare global {
+  interface Window {
+    // In Storybook there's no Mojo backend, so a mock controller is registered
+    // here for getBraveNewsController() to return instead of a real connection.
+    storybookBraveNewsController?: BraveNews.BraveNewsControllerRemote
+  }
+}
+
 // Create singleton connection to browser interface
 let braveNewsControllerInstance: BraveNews.BraveNewsControllerRemote
 
@@ -22,10 +30,17 @@ export default function getBraveNewsController () {
   if (!braveNewsControllerInstance) {
     // In Storybook, we have a mocked BraveNewsController because none of the
     // mojo apis are available.
-    // @ts-expect-error
     braveNewsControllerInstance = window.storybookBraveNewsController || BraveNews.BraveNewsController.getRemote()
   }
   return braveNewsControllerInstance
+}
+
+// The listener wrappers (configuration/channels/publishers/feed) bind a Mojo
+// pipe to receive updates pushed from the browser. That isn't possible without
+// a real backend, which is absent both in unit tests and in Storybook (where a
+// mock controller stands in). Callers use this to skip binding in those cases.
+export function canBindMojoListeners () {
+  return process.env.NODE_ENV !== 'test' && !window.storybookBraveNewsController
 }
 
 export const isPublisherEnabled = (publisher: BraveNews.Publisher) => {

--- a/components/brave_news/browser/resources/shared/channelsCache.ts
+++ b/components/brave_news/browser/resources/shared/channelsCache.ts
@@ -10,7 +10,7 @@ import {
   ChannelsListenerInterface,
   ChannelsListenerReceiver
 } from 'gen/brave/components/brave_news/common/brave_news.mojom.m'
-import getBraveNewsController from './api'
+import getBraveNewsController, { canBindMojoListeners } from './api'
 
 let instance: ChannelsCachingWrapper | null = null
 
@@ -25,8 +25,8 @@ export class ChannelsCachingWrapper
 
     this.controller = getBraveNewsController()
 
-    // We can't setup the mojom pipe in the test environment.
-    if (process.env.NODE_ENV !== 'test') {
+    // We can't set up the mojom pipe in the test or Storybook environment.
+    if (canBindMojoListeners()) {
       this.controller.addChannelsListener(
         this.receiver.$.bindNewPipeAndPassRemote()
       )

--- a/components/brave_news/browser/resources/shared/configurationCache.ts
+++ b/components/brave_news/browser/resources/shared/configurationCache.ts
@@ -9,7 +9,7 @@ import {
   ConfigurationListenerInterface,
   ConfigurationListenerReceiver,
 } from 'gen/brave/components/brave_news/common/brave_news.mojom.m'
-import getBraveNewsController from './api'
+import getBraveNewsController, { canBindMojoListeners } from './api'
 
 import { CachingWrapper } from '$web-common/mojomCache'
 
@@ -30,8 +30,8 @@ export class ConfigurationCachingWrapper
 
     this.controller = getBraveNewsController()
 
-    // We can't set up  the mojo pipe in the test environment.
-    if (process.env.NODE_ENV !== 'test') {
+    // We can't set up the mojo pipe in the test or Storybook environment.
+    if (canBindMojoListeners()) {
       this.controller.addConfigurationListener(
         this.receiver.$.bindNewPipeAndPassRemote()
       )

--- a/components/brave_news/browser/resources/shared/feedListener.ts
+++ b/components/brave_news/browser/resources/shared/feedListener.ts
@@ -8,7 +8,7 @@ import {
   FeedListenerInterface,
   FeedListenerReceiver
 } from 'gen/brave/components/brave_news/common/brave_news.mojom.m'
-import getBraveNewsController from './api'
+import getBraveNewsController, { canBindMojoListeners } from './api'
 
 export const addFeedListener = (listener: (feedHash: string) => void) =>
   new (class implements FeedListenerInterface {
@@ -18,7 +18,7 @@ export const addFeedListener = (listener: (feedHash: string) => void) =>
     constructor() {
       this.#controller = getBraveNewsController()
 
-      if (process.env.NODE_ENV !== 'test') {
+      if (canBindMojoListeners()) {
         this.#controller.addFeedListener(
           this.#receiver.$.bindNewPipeAndPassRemote()
         )

--- a/components/brave_news/browser/resources/shared/publishersCache.ts
+++ b/components/brave_news/browser/resources/shared/publishersCache.ts
@@ -10,7 +10,7 @@ import {
   PublishersListenerReceiver,
   UserEnabled
 } from 'gen/brave/components/brave_news/common/brave_news.mojom.m'
-import getBraveNewsController, { isDirectFeed } from './api'
+import getBraveNewsController, { canBindMojoListeners, isDirectFeed } from './api'
 
 import { EntityCachingWrapper } from '$web-common/mojomCache'
 
@@ -27,8 +27,8 @@ export class PublishersCachingWrapper
 
     this.controller = getBraveNewsController()
 
-    // We can't set up  the mojo pipe in the test environment.
-    if (process.env.NODE_ENV !== 'test') {
+    // We can't set up the mojo pipe in the test or Storybook environment.
+    if (canBindMojoListeners()) {
       this.controller.addPublishersListener(
         this.receiver.$.bindNewPipeAndPassRemote()
       )

--- a/components/brave_news/browser/resources/sidebar.stories.tsx
+++ b/components/brave_news/browser/resources/sidebar.stories.tsx
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { BraveNewsContextProvider } from './shared/Context'
+import { Sidebar } from './sidebar'
+
+export default {
+  title: 'Brave News/Sidebar',
+}
+
+export const Default = () => (
+  <BraveNewsContextProvider>
+    <Sidebar />
+  </BraveNewsContextProvider>
+)

--- a/components/brave_news/browser/resources/sidebar.stories.tsx
+++ b/components/brave_news/browser/resources/sidebar.stories.tsx
@@ -3,6 +3,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+// Registers a mock BraveNewsController on `window` (and enables the feed), so
+// the story renders without connecting to a real Mojo backend. Must come first.
+import './storybook/mockBraveNewsController'
+
 import * as React from 'react'
 import { BraveNewsContextProvider } from './shared/Context'
 import { Sidebar } from './sidebar'
@@ -12,7 +16,9 @@ export default {
 }
 
 export const Default = () => (
-  <BraveNewsContextProvider>
-    <Sidebar />
-  </BraveNewsContextProvider>
+  <div style={{ background: '#000' }}>
+    <BraveNewsContextProvider>
+      <Sidebar />
+    </BraveNewsContextProvider>
+  </div>
 )

--- a/components/brave_news/browser/resources/sidebar.tsx
+++ b/components/brave_news/browser/resources/sidebar.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { setIconBasePath } from '@brave/leo/react/icon'
+import { spacing } from '@brave/leo/tokens/css/variables'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+import styled from 'styled-components'
+import Feed from './Feed'
+import Variables from './Variables'
+import { BraveNewsContextProvider, useBraveNews } from './shared/Context'
+import './strings'
+
+setIconBasePath('//resources/brave-icons')
+
+const Root = styled(Variables)`
+  margin-inline: auto;
+  max-width: 540px;
+  padding: ${spacing.xl} ${spacing.m};
+
+  .news-feed {
+    width: 100%;
+  }
+`
+
+export function Sidebar() {
+  const { feedV2, reportViewCount, reportSessionStart } = useBraveNews()
+  return (
+    <Root data-theme='dark'>
+      <Feed
+        feed={feedV2}
+        onViewCountChange={reportViewCount}
+        onSessionStart={reportSessionStart}
+      />
+    </Root>
+  )
+}
+
+// Only mount when running as the WebUI page. Guarding the lookup keeps the
+// module import-safe for Storybook, which renders <Sidebar /> directly.
+const root = document.getElementById('root')
+if (root) {
+  createRoot(root).render(
+    <BraveNewsContextProvider>
+      <Sidebar />
+    </BraveNewsContextProvider>
+  )
+}

--- a/components/brave_news/browser/resources/storybook/mockBraveNewsController.ts
+++ b/components/brave_news/browser/resources/storybook/mockBraveNewsController.ts
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Importing this module registers a mock BraveNewsController on `window` so
+// Storybook can render the Brave News frontend without a Mojo backend. It also
+// enables the FeedV2 feature flag and opts the configuration in, so the feed
+// actually loads. Import it (for its side effects) at the top of a story,
+// before anything that calls getBraveNewsController().
+import {
+  BraveNewsControllerRemote,
+  ClusterType,
+  FeedItemMetadata,
+  FeedItemV2,
+  FeedV2,
+  Image
+} from 'gen/brave/components/brave_news/common/brave_news.mojom.m'
+import getBraveNewsController from '../shared/api'
+import { ConfigurationCachingWrapper } from '../shared/configurationCache'
+import { loadTimeData } from '$web-common/loadTimeData'
+
+// The base::Time epoch (1601) is offset from the Unix epoch (1970) by this many
+// milliseconds. mojoTimeToJSDate() applies the inverse to read it back.
+const EPOCH_DELTA_MS = Date.UTC(1970, 0, 1) - Date.UTC(1601, 0, 1)
+const jsDateToMojoTime = (date: Date) => ({
+  internalValue: BigInt((date.getTime() + EPOCH_DELTA_MS) * 1000)
+})
+
+const image = (seed: string): Image => ({
+  paddedImageUrl: undefined,
+  imageUrl: { url: `https://picsum.photos/seed/${seed}/304/176` }
+})
+
+let nextId = 0
+const metadata = (
+  title: string,
+  publisherName: string,
+  description: string,
+  minutesAgo: number
+): FeedItemMetadata => {
+  const id = nextId++
+  return {
+    categoryName: 'Top News',
+    channels: ['Top News'],
+    publishTime: jsDateToMojoTime(new Date(Date.now() - minutesAgo * 60 * 1000)),
+    title,
+    description,
+    url: { url: `https://example.com/article/${id}` },
+    urlHash: `${id}`,
+    image: image(`bn-${id}`),
+    publisherId: `publisher-${id}`,
+    publisherName,
+    score: 100,
+    popScore: 0,
+    relativeTimeDescription: `${minutesAgo} minutes ago`
+  }
+}
+
+const article = (
+  title: string,
+  publisherName: string,
+  description: string,
+  minutesAgo: number
+): FeedItemV2 => ({
+  hero: undefined,
+  discover: undefined,
+  cluster: undefined,
+  article: { isDiscover: false, data: metadata(title, publisherName, description, minutesAgo) }
+})
+
+const items: FeedItemV2[] = [
+  {
+    article: undefined,
+    discover: undefined,
+    cluster: undefined,
+    hero: {
+      data: metadata(
+        'Brave News comes to the sidebar',
+        'Brave',
+        'Your personalized feed is now a click away, right inside the side panel.',
+        12
+      )
+    }
+  },
+  article(
+    'Why protocol-relative image URLs matter',
+    'The Verge',
+    'A small change lets the same components render under chrome:// and chrome-untrusted://.',
+    21
+  ),
+  article(
+    'Storybook without a browser process',
+    'Smashing Magazine',
+    'Mocking Mojo controllers keeps component stories fast and dependency-free.',
+    34
+  ),
+  {
+    article: undefined,
+    hero: undefined,
+    discover: undefined,
+    cluster: {
+      type: ClusterType.CHANNEL,
+      id: 'Technology',
+      articles: [
+        {
+          hero: undefined,
+          article: {
+            isDiscover: false,
+            data: metadata(
+              'A cluster groups related stories',
+              'Ars Technica',
+              'Clusters surface a channel or topic with several articles at once.',
+              45
+            )
+          }
+        },
+        {
+          hero: undefined,
+          article: {
+            isDiscover: false,
+            data: metadata(
+              'Second story in the cluster',
+              'Wired',
+              'More from the same channel, rendered together.',
+              48
+            )
+          }
+        }
+      ]
+    }
+  },
+  article(
+    'Following feed, channel feed, all feed',
+    'TechCrunch',
+    'The sidebar reuses the same FeedV2 surface as the new tab page.',
+    52
+  )
+]
+
+const feed: FeedV2 = {
+  constructTime: jsDateToMojoTime(new Date()),
+  sourceHash: 'storybook-mock',
+  type: undefined,
+  items,
+  error: undefined
+}
+
+export const mockBraveNewsController: Partial<BraveNewsControllerRemote> = {
+  async getLocale() {
+    return { locale: 'en_US' }
+  },
+
+  async getFeedV2() {
+    return { feed }
+  },
+
+  async getFollowingFeed() {
+    return { feed }
+  },
+
+  async getChannelFeed() {
+    return { feed }
+  },
+
+  async getPublisherFeed() {
+    return { feed }
+  },
+
+  ensureFeedV2IsUpdating() {},
+  async setConfiguration() {},
+  onNewCardsViewed() {},
+  onCardVisited() {},
+  onInteractionSessionStarted() {},
+  onSidebarFilterUsage() {}
+}
+
+// @ts-expect-error mockBraveNewsController only implements the methods the feed
+// frontend calls, not the full BraveNewsControllerRemote interface.
+window.storybookBraveNewsController = mockBraveNewsController
+
+// The feed only fetches when the V2 flag is on; the default Storybook
+// loadTimeData returns false for every boolean, so enable it here.
+const baseGetBoolean = loadTimeData.getBoolean.bind(loadTimeData)
+loadTimeData.getBoolean = (key: string) =>
+  key === 'featureFlagBraveNewsFeedV2Enabled' ? true : baseGetBoolean(key)
+
+// Make sure the controller singleton resolves to the mock before any listener
+// wrappers are constructed, then opt in so the feed is shown.
+getBraveNewsController()
+ConfigurationCachingWrapper.getInstance().set({ isOptedIn: true, showOnNTP: true })


### PR DESCRIPTION
Series https://github.com/brave/brave-browser/issues/29147

Adds the Brave News sidebar React entry point (`sidebar.tsx`) and a Storybook story, plus switches the shared feed components to the protocol-relative `//brave-image` source so they work under both `chrome://` and `chrome-untrusted://` hosts. Display-only (Storybook); the WebUI build target + C++ wiring land in PR 5.

### Stack (split of the Brave News sidebar feature)
1. https://github.com/brave/brave-core/pull/37419
2. https://github.com/brave/brave-core/pull/37420
3. https://github.com/brave/brave-core/pull/37421
4. https://github.com/brave/brave-core/pull/37422
5. https://github.com/brave/brave-core/pull/37423

This is PR **3/5**.