### PR TITLE
[Brave News] Add Brave News entry to the sidebar

### DIFF
--- a/browser/ui/brave_browser_actions.cc
+++ b/browser/ui/brave_browser_actions.cc
@@ -5,10 +5,12 @@
 
 #include "brave/browser/ui/brave_browser_actions.h"
 
+#include "base/feature_list.h"
 #include "base/functional/callback_helpers.h"
 #include "base/types/to_address.h"
 #include "brave/browser/ui/browser_commands.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_news/common/buildflags/buildflags.h"
 #include "brave/components/containers/buildflags/buildflags.h"
 #include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/psst/buildflags/buildflags.h"
@@ -29,6 +31,10 @@
 #include "brave/components/ai_chat/core/browser/utils.h"
 #endif
 
+#if BUILDFLAG(ENABLE_BRAVE_NEWS)
+#include "brave/components/brave_news/common/features.h"
+#endif
+
 #if BUILDFLAG(ENABLE_CONTAINERS)
 #include "brave/components/containers/core/common/features.h"
 #endif
@@ -44,7 +50,8 @@
 
 namespace {
 
-#if BUILDFLAG(ENABLE_PLAYLIST) || BUILDFLAG(ENABLE_AI_CHAT)
+#if BUILDFLAG(ENABLE_PLAYLIST) || BUILDFLAG(ENABLE_AI_CHAT) || \
+    BUILDFLAG(ENABLE_BRAVE_NEWS)
 actions::ActionItem::ActionItemBuilder SidePanelAction(
     SidePanelEntryId id,
     int title_id,
@@ -61,7 +68,8 @@ actions::ActionItem::ActionItemBuilder SidePanelAction(
       .SetImage(ui::ImageModel::FromVectorIcon(icon, ui::kColorIcon))
       .SetProperty(actions::kActionItemPinnableKey, is_pinnable);
 }
-#endif  // BUILDFLAG(ENABLE_PLAYLIST) || BUILDFLAG(ENABLE_AI_CHAT)
+#endif  // BUILDFLAG(ENABLE_PLAYLIST) || BUILDFLAG(ENABLE_AI_CHAT) ||
+        // BUILDFLAG(ENABLE_BRAVE_NEWS)
 
 }  // namespace
 
@@ -110,6 +118,16 @@ void BraveBrowserActions::InitializeBrowserActions() {
         SidePanelAction(SidePanelEntryId::kChatUI, IDS_CHAT_UI_TITLE,
                         IDS_CHAT_UI_TITLE, kLeoProductBraveLeoIcon,
                         kActionSidePanelShowChatUI, bwi, true)
+            .Build());
+  }
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_NEWS)
+  if (base::FeatureList::IsEnabled(brave_news::features::kBraveNewsSidebar)) {
+    root_action_item_->AddChild(
+        SidePanelAction(SidePanelEntryId::kBraveNews, IDS_BRAVE_NEWS_TITLE,
+                        IDS_BRAVE_NEWS_TITLE, kLeoRssIcon,
+                        kActionSidePanelShowBraveNews, bwi, true)
             .Build());
   }
 #endif

--- a/browser/ui/sidebar/BUILD.gn
+++ b/browser/ui/sidebar/BUILD.gn
@@ -4,6 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
+import("//brave/components/brave_news/common/buildflags/buildflags.gni")
 import("//brave/components/brave_origin/buildflags/buildflags.gni")
 import("//brave/components/brave_talk/buildflags/buildflags.gni")
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
@@ -93,6 +94,7 @@ source_set("browser_tests") {
     "//brave/browser/ui/views/side_panel",
     "//brave/browser/ui/views/sidebar",
     "//brave/components/ai_chat/core/common/buildflags",
+    "//brave/components/brave_news/common/buildflags",
     "//brave/components/brave_talk/buildflags",
     "//brave/components/brave_wallet/common/buildflags",
     "//brave/components/playlist/core/common/buildflags",
@@ -119,6 +121,10 @@ source_set("browser_tests") {
 
   if (enable_ai_chat) {
     deps += [ "//brave/components/ai_chat/core/common" ]
+  }
+
+  if (enable_brave_news) {
+    deps += [ "//brave/components/brave_news/common" ]
   }
 
   if (enable_playlist) {

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -43,6 +43,7 @@
 #include "brave/browser/ui/views/toolbar/side_panel_button.h"
 #include "brave/common/pref_names.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_news/common/buildflags/buildflags.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/constants/brave_switches.h"
@@ -98,6 +99,10 @@
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/core/common/features.h"
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_NEWS)
+#include "brave/components/brave_news/common/features.h"
 #endif
 
 #if BUILDFLAG(ENABLE_PLAYLIST)
@@ -298,6 +303,13 @@ class SidebarBrowserTest : public InProcessBrowserTest {
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
     if (!ai_chat::features::IsAIChatEnabled()) {
+      item_count -= 1;
+    }
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_NEWS)
+    if (!base::FeatureList::IsEnabled(
+            brave_news::features::kBraveNewsSidebar)) {
       item_count -= 1;
     }
 #endif

--- a/browser/ui/sidebar/sidebar_service_factory.h
+++ b/browser/ui/sidebar/sidebar_service_factory.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_news/common/buildflags/buildflags.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
 #include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/sidebar/browser/sidebar_item.h"
@@ -52,6 +53,9 @@ class SidebarServiceFactory : public BrowserContextKeyedServiceFactory {
           SidebarItem::BuiltInItemType::kHistory,
 #if BUILDFLAG(ENABLE_PLAYLIST)
           SidebarItem::BuiltInItemType::kPlaylist,
+#endif
+#if BUILDFLAG(ENABLE_BRAVE_NEWS)
+          SidebarItem::BuiltInItemType::kBraveNews,
 #endif
       });
 

--- a/browser/ui/sidebar/sidebar_utils.cc
+++ b/browser/ui/sidebar/sidebar_utils.cc
@@ -15,6 +15,7 @@
 #include "brave/browser/ui/sidebar/sidebar_model.h"
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_news/common/buildflags/buildflags.h"
 #include "brave/components/brave_origin/buildflags/buildflags.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
@@ -172,6 +173,10 @@ SidePanelEntryId SidePanelIdFromSideBarItemType(BuiltInItemType type) {
     case BuiltInItemType::kChatUI:
       return SidePanelEntryId::kChatUI;
 #endif
+#if BUILDFLAG(ENABLE_BRAVE_NEWS)
+    case BuiltInItemType::kBraveNews:
+      return SidePanelEntryId::kBraveNews;
+#endif
     case BuiltInItemType::kWallet:
       [[fallthrough]];
 #if BUILDFLAG(ENABLE_BRAVE_TALK)
@@ -202,6 +207,10 @@ std::optional<BuiltInItemType> BuiltInItemTypeFromSidePanelId(
 #if BUILDFLAG(ENABLE_AI_CHAT)
     case SidePanelEntryId::kChatUI:
       return BuiltInItemType::kChatUI;
+#endif
+#if BUILDFLAG(ENABLE_BRAVE_NEWS)
+    case SidePanelEntryId::kBraveNews:
+      return BuiltInItemType::kBraveNews;
 #endif
     default:
       break;
@@ -255,6 +264,11 @@ void SetLastUsedSidePanel(PrefService* prefs,
         type = BuiltInItemType::kChatUI;
         break;
 #endif
+#if BUILDFLAG(ENABLE_BRAVE_NEWS)
+      case SidePanelEntryId::kBraveNews:
+        type = BuiltInItemType::kBraveNews;
+        break;
+#endif
       default:
         break;
     }
@@ -285,6 +299,10 @@ bool IsDisabledItemForPrivate(SidebarItem::BuiltInItemType type) {
     case SidebarItem::BuiltInItemType::kPlaylist:
       return true;
 #endif
+#if BUILDFLAG(ENABLE_BRAVE_NEWS)
+    case SidebarItem::BuiltInItemType::kBraveNews:
+      return true;
+#endif
     default:
       break;
   }
@@ -302,6 +320,10 @@ bool IsDisabledItemForGuest(SidebarItem::BuiltInItemType type) {
 #endif
 #if BUILDFLAG(ENABLE_PLAYLIST)
     case SidebarItem::BuiltInItemType::kPlaylist:
+      return true;
+#endif
+#if BUILDFLAG(ENABLE_BRAVE_NEWS)
+    case SidebarItem::BuiltInItemType::kBraveNews:
       return true;
 #endif
     default:

--- a/browser/ui/views/sidebar/sidebar_items_contents_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.cc
@@ -31,6 +31,7 @@
 #include "brave/browser/ui/views/sidebar/sidebar_item_added_feedback_bubble.h"
 #include "brave/browser/ui/views/sidebar/sidebar_item_view.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_news/common/buildflags/buildflags.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
 #include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/sidebar/browser/pref_names.h"
@@ -604,6 +605,10 @@ ui::ImageModel SidebarItemsContentsView::GetImageForBuiltInItems(
 #if BUILDFLAG(ENABLE_AI_CHAT)
     case sidebar::SidebarItem::BuiltInItemType::kChatUI:
       return get_image_model(kLeoProductBraveLeoIcon, state);
+#endif
+#if BUILDFLAG(ENABLE_BRAVE_NEWS)
+    case sidebar::SidebarItem::BuiltInItemType::kBraveNews:
+      return get_image_model(kLeoRssIcon, state);
 #endif
     default:
       break;

--- a/components/sidebar/browser/BUILD.gn
+++ b/components/sidebar/browser/BUILD.gn
@@ -4,6 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
+import("//brave/components/brave_news/common/buildflags/buildflags.gni")
 import("//brave/components/brave_talk/buildflags/buildflags.gni")
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
 import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
@@ -25,6 +26,7 @@ static_library("browser") {
 
   public_deps = [
     "//brave/components/ai_chat/core/common/buildflags",
+    "//brave/components/brave_news/common/buildflags",
     "//brave/components/brave_talk/buildflags",
     "//brave/components/brave_wallet/common/buildflags",
     "//brave/components/playlist/core/common/buildflags",
@@ -66,6 +68,10 @@ static_library("browser") {
 
   if (enable_brave_talk) {
     deps += [ "//brave/components/brave_talk" ]
+  }
+
+  if (enable_brave_news) {
+    deps += [ "//brave/components/brave_news/common" ]
   }
 }
 

--- a/components/sidebar/browser/sidebar_item.h
+++ b/components/sidebar/browser/sidebar_item.h
@@ -7,6 +7,7 @@
 #define BRAVE_COMPONENTS_SIDEBAR_BROWSER_SIDEBAR_ITEM_H_
 
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_news/common/buildflags/buildflags.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
 #include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/sidebar/common/features.h"
@@ -37,6 +38,9 @@ struct SidebarItem {
 #if BUILDFLAG(ENABLE_AI_CHAT)
     kChatUI = 7,
 #endif
+#if BUILDFLAG(ENABLE_BRAVE_NEWS)
+    kBraveNews = 8,
+#endif
   };
 
   // Count of built-in items based on enabled features.
@@ -47,6 +51,9 @@ struct SidebarItem {
 #endif
 #if BUILDFLAG(ENABLE_AI_CHAT)
       + 1  // kChatUI
+#endif
+#if BUILDFLAG(ENABLE_BRAVE_NEWS)
+      + 1  // kBraveNews
 #endif
 #if BUILDFLAG(ENABLE_BRAVE_TALK)
       + 1  // kBraveTalk

--- a/components/sidebar/browser/sidebar_service.cc
+++ b/components/sidebar/browser/sidebar_service.cc
@@ -21,6 +21,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "base/values.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_news/common/buildflags/buildflags.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
@@ -55,6 +56,10 @@
 #if BUILDFLAG(ENABLE_PLAYLIST)
 #include "brave/components/playlist/core/browser/utils.h"
 #include "brave/components/playlist/core/common/pref_names.h"
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_NEWS)
+#include "brave/components/brave_news/common/features.h"
 #endif
 
 namespace sidebar {
@@ -501,6 +506,9 @@ std::optional<SidebarItem> SidebarService::GetDefaultPanelItem() const {
 #if BUILDFLAG(ENABLE_AI_CHAT)
       SidebarItem::BuiltInItemType::kChatUI,
 #endif
+#if BUILDFLAG(ENABLE_BRAVE_NEWS)
+      SidebarItem::BuiltInItemType::kBraveNews,
+#endif
       SidebarItem::BuiltInItemType::kReadingList,
       SidebarItem::BuiltInItemType::kBookmarks,
 #if BUILDFLAG(ENABLE_PLAYLIST)
@@ -730,6 +738,20 @@ SidebarItem SidebarService::GetBuiltInItemForType(
       return SidebarItem();
     }
 #endif  // BUILDFLAG(ENABLE_AI_CHAT)
+#if BUILDFLAG(ENABLE_BRAVE_NEWS)
+    case SidebarItem::BuiltInItemType::kBraveNews: {
+      if (base::FeatureList::IsEnabled(
+              brave_news::features::kBraveNewsSidebar)) {
+        return SidebarItem::Create(
+            GURL(kBraveNewsURL),
+            l10n_util::GetStringUTF16(IDS_BRAVE_NEWS_TITLE),
+            SidebarItem::Type::kTypeBuiltIn,
+            SidebarItem::BuiltInItemType::kBraveNews,
+            /* open_in_panel = */ true);
+      }
+      return SidebarItem();
+    }
+#endif  // BUILDFLAG(ENABLE_BRAVE_NEWS)
     case SidebarItem::BuiltInItemType::kNone:
       break;
   }


### PR DESCRIPTION
Series https://github.com/brave/brave-browser/issues/29147

Adds the `BuiltInItemType::kBraveNews` sidebar item, its side panel id mapping, icon, and a pinnable toolbar action so the Brave News side panel can be opened. Gated behind `kBraveNewsSidebar`.

**The Glorious Brave News Sidebar UI** :laughing: 
<img width="1752" height="1355" alt="image" src="https://github.com/user-attachments/assets/52a4f21c-db3f-4225-9eed-678e54c9526f" />


### Stack (split of the Brave News sidebar feature)
1. https://github.com/brave/brave-core/pull/37419
2. https://github.com/brave/brave-core/pull/37420
3. https://github.com/brave/brave-core/pull/37421
4. https://github.com/brave/brave-core/pull/37422
5. https://github.com/brave/brave-core/pull/37423

This is PR **4/5**. Base: `bn-sidebar-2-webui`.