### PR TITLE
Add best practice: ban RenderFrameHost::AllowInjectingJavaScript

### DIFF
--- a/docs/best-practices/coding-standards.md
+++ b/docs/best-practices/coding-standards.md
@@ -1344,3 +1344,39 @@ This is a mojom-specific application of [CS-014](#CS-014). The
 target produces it.
 
 ---
+
+<a id="CS-071"></a>
+
+## ✅ Inject Scripts via `ScriptInjector`, Never `AllowInjectingJavaScript`
+
+**Do not call `content::RenderFrameHost::AllowInjectingJavaScript()` followed by
+`RenderFrameHost::ExecuteJavaScript()`. Inject through
+`script_injector::mojom::ScriptInjector` instead.** `AllowInjectingJavaScript()`
+flips a global, process-wide switch that upstream restricts to Android WebView,
+Fuchsia, and CastOS ("must not be used in other configurations"), and it only
+enables injection into the page's **main world** — so the script shares the
+page's JavaScript context, where it can collide with and be observed by page
+scripts. `ScriptInjector::RequestAsyncExecuteScript` runs in a chosen (isolated)
+world per-frame, with user-activation and promise-result control, and returns
+the result — with no global flag.
+
+```cpp
+// ❌ WRONG - global process-wide switch + main-world injection
+content::RenderFrameHost::AllowInjectingJavaScript();
+rfh->ExecuteJavaScript(kScript, base::NullCallback());
+
+// ✅ CORRECT - per-frame injection into an isolated world via the mojo interface
+mojo::AssociatedRemote<script_injector::mojom::ScriptInjector> injector;
+rfh->GetRemoteAssociatedInterfaces()->GetInterface(&injector);
+injector->RequestAsyncExecuteScript(
+    ISOLATED_WORLD_ID_BRAVE_INTERNAL, base::UTF8ToUTF16(kScript),
+    blink::mojom::UserActivationOption::kDoNotActivate,
+    blink::mojom::PromiseResultOption::kDoNotWait,
+    base::BindOnce(&OnScriptResult));
+```
+
+`AllowInjectingJavaScript()` is a one-way global enable, so even a single call
+weakens main-world isolation process-wide. See `script_injector_browsertest.cc`
+for a complete example.
+
+---

--- a/docs/best-practices/coding-standards.md
+++ b/docs/best-practices/coding-standards.md
@@ -1345,7 +1345,7 @@ target produces it.
 
 ---
 
-<a id="CS-071"></a>
+<a id="CS-077"></a>
 
 ## ✅ Inject Scripts via `ScriptInjector`, Never `AllowInjectingJavaScript`
 

--- a/docs/best-practices/coding-standards.md
+++ b/docs/best-practices/coding-standards.md
@@ -1349,7 +1349,7 @@ target produces it.
 
 ## ✅ Inject Scripts via `ScriptInjector`, Never `AllowInjectingJavaScript`
 
-**Do not call `content::RenderFrameHost::AllowInjectingJavaScript()` followed by
+**Do not call `content::RenderFrameHost::AllowInjectingJavaScript()` or
 `RenderFrameHost::ExecuteJavaScript()`. Inject through
 `script_injector::mojom::ScriptInjector` instead.** `AllowInjectingJavaScript()`
 flips a global, process-wide switch that upstream restricts to Android WebView,


### PR DESCRIPTION
## Summary

Adds a new C++ best practice (`CS-077`) to `docs/best-practices/coding-standards.md`:

**Inject Scripts via `ScriptInjector`, Never `AllowInjectingJavaScript`**

`content::RenderFrameHost::AllowInjectingJavaScript()` flips a global,
process-wide switch that upstream restricts to Android WebView, Fuchsia, and
CastOS — its own header says it *"must not be used in other configurations"* — and
it only enables injection into the page's **main world**, where the script shares
the page's JS context and can collide with / be observed by page scripts.

The rule directs new code to `script_injector::mojom::ScriptInjector::RequestAsyncExecuteScript`
instead, which injects into a chosen (isolated) world per-frame, supports
user-activation and promise-result options, and returns a result — with no global
flag.

## Context

There is one current in-tree caller of `AllowInjectingJavaScript()`
(`browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc`);
this best practice documents the preferred mechanism so new code doesn't add more,
and flags it for eventual migration. The `script_injector` component and its
browsertest (`browser/script_injector/script_injector_browsertest.cc`) show the
recommended pattern.

This is distinct from the existing `CS-057` (sanitizing data before injection) —
this rule is about *which API* to use.
