### PR TITLE
[Settings] Update hiding of bookmarks bar toggle.

### DIFF
--- a/browser/resources/settings/br/appearance_page.ts
+++ b/browser/resources/settings/br/appearance_page.ts
@@ -34,15 +34,14 @@ RegisterPolymerTemplateModifications({
       homeButtonOptionsTemplate.remove()
     }
 
-    const bookmarkBarToggle = templateContent.querySelector(
-      '[pref="{{prefs.bookmark_bar.show_on_all_tabs}}"]')
-    if (!bookmarkBarToggle) {
+    const bookmarkBarTemplate = templateContent.querySelector(
+        'template[is=dom-if][if="[[!ntpSimplificationBookmarksBarEnabled_]]"]')
+    if (!bookmarkBarTemplate) {
       console.error(
-        `[Settings] Couldn't find bookmark bar toggle`)
+        `[Settings] Couldn't find !ntpSimplificationBookmarksBarEnabled_ ` +
+        `template`)
     } else {
-      // Remove Chromium bookmark toggle becasue it is replaced by
-      // settings-brave-appearance-bookmark-bar
-      bookmarkBarToggle.remove()
+      bookmarkBarTemplate.remove()
     }
 
     // Hide or remove upstream's font options.


### PR DESCRIPTION
Chromium change:
https://source.chromium.org/chromium/chromium/src/+/b11272017fce84e06b78ebe4b28c26c1027e702e

commit b11272017fce84e06b78ebe4b28c26c1027e702e
Author: Bofeng Chen <bofengchen@google.com>
Date:   Tue Jun 2 11:38:32 2026 -0700

    [ntp-bookmarks] Replace bookmarks bar toggle with a dropdown in settings

    Introduces a new dropdown menu in the Appearance settings page to
    control the visibility of the bookmarks bar. The dropdown replaces the
    existing "Show bookmarks bar" toggle when the
    `kNtpSimplificationBookmarkBar` feature is enabled. The dropdown
    provides three options: "Always show", "Only show on New Tab page", and
    "Always hide", which map to the
    `bookmarks::prefs::kBookmarkBarVisibilityState` preference. Add new
    localized strings for these options, and add the preference to the
    settings private API allowlist. Updated tests to cover the new dropdown
    functionality. Note: The mapping between the old and new bookmark
    visibility pref is not set up.

    When the flag is enabled, new UI is shown:
    https://screenshot.googleplex.com/3JekySwChpUkXUH

    When the flag is disabled, fall back to the toggle:
    https://screenshot.googleplex.com/8xwbeqi8k96yCT2

    Simulate continuous opt-in and opt-out the experiment, the changes to
    the new pref persist:
    https://screencast.googleplex.com/cast/NjQxNjIyNjgwMzc3NzUzNnw1YjkyN2FjOC00Mw

    Bug: b:515474231
    Change-Id: Idab9292d3e72107eca49dbc324d72678b0103799
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7881342

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56563

Cherry-pick of cr151 fix.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
