### PR TITLE
[c150][Android] Fix download location dialog crash on single-storage devices

### DIFF
--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -503,6 +503,10 @@
 -keep class org.chromium.chrome.browser.download.dialogs.DownloadLocationDialogCoordinator {
     public <init>(...);
     *** mController;
+    *** mContext;
+    *** mModalDialogManager;
+    *** mSuggestedPath;
+    *** mProfile;
     *** onDirectoryOptionsRetrieved(...);
 }
 

--- a/android/javatests/BUILD.gn
+++ b/android/javatests/BUILD.gn
@@ -45,10 +45,27 @@ android_library("brave_test_java_helper") {
 }
 
 android_library("brave_test_java_org.chromium.chrome.browser.download") {
-  sources =
-      [ "org/chromium/chrome/browser/download/BraveDownloadSettingsTest.java" ]
+  resources_package = "org.chromium.chrome.test"
 
-  deps = [ ":brave_test_java_helper" ]
+  sources = [
+    "org/chromium/chrome/browser/download/BraveDownloadSettingsTest.java",
+    "org/chromium/chrome/browser/download/dialogs/BraveDownloadLocationDialogTest.java",
+  ]
+
+  deps = [
+    ":brave_test_java_helper",
+    "//brave/browser/download/android:java",
+    "//chrome/android:chrome_app_java_resources",
+    "//chrome/android:chrome_unit_test_util_java",
+    "//chrome/browser/download/android:file_provider_java",
+    "//chrome/browser/download/android:java",
+    "//components/browser_ui/modaldialog/android:java",
+    "//content/public/android:content_full_java",
+    "//third_party/androidx:androidx_annotation_annotation_jvm_java",
+    "//third_party/hamcrest:hamcrest_core_java",
+    "//third_party/mockito:mockito_java",
+    "//ui/android:ui_no_recycler_view_java",
+  ]
 }
 
 android_library("brave_test_java_org.chromium.chrome.browser.site_settings") {

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -2607,6 +2607,22 @@ public class BytecodeTest {
                         "mController"));
         Assert.assertTrue(
                 fieldExists(
+                        "org/chromium/chrome/browser/download/dialogs/DownloadLocationDialogCoordinator", // presubmit: ignore-long-line
+                        "mContext"));
+        Assert.assertTrue(
+                fieldExists(
+                        "org/chromium/chrome/browser/download/dialogs/DownloadLocationDialogCoordinator", // presubmit: ignore-long-line
+                        "mModalDialogManager"));
+        Assert.assertTrue(
+                fieldExists(
+                        "org/chromium/chrome/browser/download/dialogs/DownloadLocationDialogCoordinator", // presubmit: ignore-long-line
+                        "mSuggestedPath"));
+        Assert.assertTrue(
+                fieldExists(
+                        "org/chromium/chrome/browser/download/dialogs/DownloadLocationDialogCoordinator", // presubmit: ignore-long-line
+                        "mProfile"));
+        Assert.assertTrue(
+                fieldExists(
                         "org/chromium/chrome/browser/omnibox/LocationBarCoordinator",
                         "mLocationBarMediator"));
         Assert.assertTrue(

--- a/android/javatests/org/chromium/chrome/browser/download/dialogs/BraveDownloadLocationDialogTest.java
+++ b/android/javatests/org/chromium/chrome/browser/download/dialogs/BraveDownloadLocationDialogTest.java
@@ -1,0 +1,225 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.download.dialogs;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import androidx.annotation.StringRes;
+import androidx.test.filters.MediumTest;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import org.chromium.base.ThreadUtils;
+import org.chromium.base.test.BaseActivityTestRule;
+import org.chromium.base.test.util.CommandLineFlags;
+import org.chromium.base.test.util.DoNotBatch;
+import org.chromium.base.test.util.Features.DisableFeatures;
+import org.chromium.chrome.browser.download.DirectoryOption;
+import org.chromium.chrome.browser.download.DownloadDialogBridge;
+import org.chromium.chrome.browser.download.DownloadDialogBridgeJni;
+import org.chromium.chrome.browser.download.DownloadDirectoryProvider;
+import org.chromium.chrome.browser.download.DownloadLocationDialogType;
+import org.chromium.chrome.browser.download.DownloadPromptStatus;
+import org.chromium.chrome.browser.download.TestDownloadDirectoryProvider;
+import org.chromium.chrome.browser.flags.ChromeFeatureList;
+import org.chromium.chrome.browser.flags.ChromeSwitches;
+import org.chromium.chrome.browser.preferences.Pref;
+import org.chromium.chrome.browser.profiles.Profile;
+import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
+import org.chromium.chrome.test.R;
+import org.chromium.components.browser_ui.modaldialog.AppModalPresenter;
+import org.chromium.components.prefs.PrefService;
+import org.chromium.components.user_prefs.UserPrefs;
+import org.chromium.components.user_prefs.UserPrefsJni;
+import org.chromium.ui.modaldialog.ModalDialogManager;
+import org.chromium.ui.test.util.BlankUiTestActivity;
+
+import java.util.ArrayList;
+
+/**
+ * Tests for {@link BraveDownloadLocationDialogCoordinator}, the Brave override that shows the
+ * download location dialog even when only a single storage directory is available, provided the
+ * user has opted in via settings.
+ */
+@RunWith(ChromeJUnit4ClassRunner.class)
+@CommandLineFlags.Add({ChromeSwitches.DISABLE_FIRST_RUN_EXPERIENCE})
+@DoNotBatch(reason = "Shows modal dialogs and overrides global JNI/provider state per test.")
+@DisableFeatures(ChromeFeatureList.SMART_SUGGESTION_FOR_LARGE_DOWNLOADS)
+public class BraveDownloadLocationDialogTest {
+    private static final long TOTAL_BYTES = 1024L;
+    private static final String SUGGESTED_PATH = "download.png";
+    private static final String PRIMARY_STORAGE_PATH = "/sdcard";
+    private static final String SECONDARY_STORAGE_PATH = "/android/Download";
+    private static final long ASYNC_TIMEOUT_MS = 10000L;
+
+    @Rule public final MockitoRule mMockitoRule = MockitoJUnit.rule();
+
+    @Rule
+    public BaseActivityTestRule<BlankUiTestActivity> mActivityTestRule =
+            new BaseActivityTestRule<>(BlankUiTestActivity.class);
+
+    @Mock private DownloadLocationDialogController mController;
+    @Mock private Profile mProfileMock;
+    @Mock private PrefService mPrefService;
+    @Mock private UserPrefs.Natives mUserPrefsJniMock;
+    @Mock private DownloadDialogBridge.Natives mDownloadDialogBridgeJniMock;
+
+    private AppModalPresenter mAppModalPresenter;
+    private ModalDialogManager mModalDialogManager;
+    private BraveDownloadLocationDialogCoordinator mDialogCoordinator;
+
+    @Before
+    public void setUp() throws Exception {
+        UserPrefsJni.setInstanceForTesting(mUserPrefsJniMock);
+        when(mUserPrefsJniMock.get(any())).thenReturn(mPrefService);
+        DownloadDialogBridgeJni.setInstanceForTesting(mDownloadDialogBridgeJniMock);
+        when(mPrefService.getString(Pref.DOWNLOAD_DEFAULT_DIRECTORY))
+                .thenReturn(PRIMARY_STORAGE_PATH);
+
+        mActivityTestRule.launchActivity(null);
+
+        mAppModalPresenter = new AppModalPresenter(mActivityTestRule.getActivity());
+        mModalDialogManager =
+                ThreadUtils.runOnUiThreadBlocking(
+                        () ->
+                                new ModalDialogManager(
+                                        mAppModalPresenter,
+                                        ModalDialogManager.ModalDialogType.APP));
+
+        mDialogCoordinator = new BraveDownloadLocationDialogCoordinator();
+        mDialogCoordinator.initialize(mController);
+    }
+
+    private DirectoryOption buildDirectoryOption(
+            @DirectoryOption.DownloadLocationDirectoryType int type, String directoryPath) {
+        return new DirectoryOption("Download", directoryPath, 1024000, 1024000, type);
+    }
+
+    /** Provide exactly one storage directory, mimicking a device with no SD card. */
+    private void setSingleDirectory() {
+        ArrayList<DirectoryOption> dirs = new ArrayList<>();
+        dirs.add(
+                buildDirectoryOption(
+                        DirectoryOption.DownloadLocationDirectoryType.DEFAULT,
+                        PRIMARY_STORAGE_PATH));
+        setDirectories(dirs);
+    }
+
+    /** Provide two storage directories, mimicking a device with an SD card. */
+    private void setTwoDirectories() {
+        ArrayList<DirectoryOption> dirs = new ArrayList<>();
+        dirs.add(
+                buildDirectoryOption(
+                        DirectoryOption.DownloadLocationDirectoryType.DEFAULT,
+                        PRIMARY_STORAGE_PATH));
+        dirs.add(
+                buildDirectoryOption(
+                        DirectoryOption.DownloadLocationDirectoryType.ADDITIONAL,
+                        SECONDARY_STORAGE_PATH));
+        setDirectories(dirs);
+    }
+
+    private void setDirectories(ArrayList<DirectoryOption> dirs) {
+        ThreadUtils.runOnUiThreadBlocking(
+                () ->
+                        DownloadDirectoryProvider.getInstance()
+                                .setDirectoryProviderForTesting(
+                                        new TestDownloadDirectoryProvider(dirs)));
+    }
+
+    private void setDownloadPromptStatus(@DownloadPromptStatus int promptStatus) {
+        when(mPrefService.getInteger(Pref.PROMPT_FOR_DOWNLOAD_ANDROID)).thenReturn(promptStatus);
+    }
+
+    private void showDialog(
+            long totalBytes,
+            @DownloadLocationDialogType int dialogType,
+            String suggestedPath,
+            Profile profile) {
+        ThreadUtils.runOnUiThreadBlocking(
+                () ->
+                        mDialogCoordinator.showDialog(
+                                mActivityTestRule.getActivity(),
+                                mModalDialogManager,
+                                totalBytes,
+                                dialogType,
+                                suggestedPath,
+                                profile));
+    }
+
+    private void assertTitle(@StringRes int titleId) {
+        onView(withText(mActivityTestRule.getActivity().getString(titleId)))
+                .inRoot(isDialog())
+                .check(matches(isDisplayed()));
+    }
+
+    /**
+     * Regression test for the NPE crash where, on a single-directory device, the upstream skip
+     * called {@code resetDialogState()} (nulling mProfile/mContext) before Brave's asynchronous
+     * re-fetch re-entered {@code onDirectoryOptionsRetrieved}. With the user opted in, the dialog
+     * must be forced to show without crashing.
+     */
+    @Test
+    @MediumTest
+    public void testSingleDirectoryForcesDialogWhenPromptEnabled() throws Exception {
+        setSingleDirectory();
+        setDownloadPromptStatus(DownloadPromptStatus.SHOW_PREFERENCE);
+
+        showDialog(TOTAL_BYTES, DownloadLocationDialogType.DEFAULT, SUGGESTED_PATH, mProfileMock);
+
+        // The dialog must appear. Before the fix this NPE'd in the async re-trigger and never
+        // showed. The wrapper must not complete (skip) the dialog when it is forcing a re-show.
+        assertTitle(R.string.download_location_dialog_title);
+        verify(mController, never()).onDownloadLocationDialogComplete(any(), anyBoolean());
+    }
+
+    /** With more than one directory the dialog shows normally; the override must not interfere. */
+    @Test
+    @MediumTest
+    public void testMultipleDirectoriesShowDialogWhenPromptEnabled() throws Exception {
+        setTwoDirectories();
+        setDownloadPromptStatus(DownloadPromptStatus.SHOW_PREFERENCE);
+
+        showDialog(TOTAL_BYTES, DownloadLocationDialogType.DEFAULT, SUGGESTED_PATH, mProfileMock);
+
+        assertTitle(R.string.download_location_dialog_title);
+        verify(mController, never()).onDownloadLocationDialogComplete(any(), anyBoolean());
+    }
+
+    /**
+     * When the user has not opted in, the override defers to upstream, which skips the dialog for a
+     * single directory and completes directly. Guards against breaking the opt-out path.
+     */
+    @Test
+    @MediumTest
+    public void testSingleDirectorySkipsDialogWhenPromptDisabled() throws Exception {
+        setSingleDirectory();
+        setDownloadPromptStatus(DownloadPromptStatus.DONT_SHOW);
+
+        showDialog(TOTAL_BYTES, DownloadLocationDialogType.DEFAULT, SUGGESTED_PATH, mProfileMock);
+
+        verify(mController, timeout(ASYNC_TIMEOUT_MS))
+                .onDownloadLocationDialogComplete(any(), eq(false));
+    }
+}

--- a/browser/download/android/java/src/org/chromium/chrome/browser/download/dialogs/BraveDownloadLocationDialogCoordinator.java
+++ b/browser/download/android/java/src/org/chromium/chrome/browser/download/dialogs/BraveDownloadLocationDialogCoordinator.java
@@ -8,6 +8,7 @@ package org.chromium.chrome.browser.download.dialogs;
 import android.content.Context;
 
 import org.chromium.build.annotations.NullMarked;
+import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.browser.download.DirectoryOption;
 import org.chromium.chrome.browser.download.DownloadDialogBridge;
 import org.chromium.chrome.browser.download.DownloadDirectoryProvider;
@@ -29,6 +30,10 @@ import java.util.ArrayList;
  * onDirectoryOptionsRetrieved} with a modified directory list ({@code dirs.size() > 1}) so the
  * parent's dialog display code runs normally. The actual directory UI is populated independently by
  * {@link org.chromium.chrome.browser.download.settings.DownloadLocationHelperImpl}.
+ *
+ * <p>Because the parent clears its per-dialog state ({@code resetDialogState()}) on the
+ * single-directory skip, and our re-fetch completes asynchronously after that, the wrapper restores
+ * the per-dialog fields it depends on before re-triggering the dialog.
  */
 @NullMarked
 public class BraveDownloadLocationDialogCoordinator extends DownloadLocationDialogCoordinator {
@@ -37,6 +42,23 @@ public class BraveDownloadLocationDialogCoordinator extends DownloadLocationDial
     // Suppressed because this field is removed by bytecode rewriting and never actually exists.
     @SuppressWarnings("NullAway")
     private DownloadLocationDialogController mController;
+
+    // Shadow the parent's private per-dialog fields, in the same way as mController above. These
+    // are written from the re-fetch callback in showDialog() to restore the state that the parent
+    // clears on the single-directory skip; the bytecode adapter deletes these declarations and
+    // makes the parent's fields protected, so the writes target the parent's fields at runtime.
+    // Suppressed because Brave only writes them — the parent reads them — so they look unused here.
+    @SuppressWarnings("UnusedVariable")
+    private @Nullable Context mContext;
+
+    @SuppressWarnings("UnusedVariable")
+    private @Nullable ModalDialogManager mModalDialogManager;
+
+    @SuppressWarnings("UnusedVariable")
+    private @Nullable String mSuggestedPath;
+
+    @SuppressWarnings("UnusedVariable")
+    private @Nullable Profile mProfile;
 
     // Stub matching parent's private method. The bytecode adapter deletes this and makes the
     // parent's method public, so calls resolve to the parent's implementation at runtime.
@@ -102,6 +124,17 @@ public class BraveDownloadLocationDialogCoordinator extends DownloadLocationDial
                                                 if (copy.size() == 1) {
                                                     copy.add(copy.get(0));
                                                 }
+                                                // The parent's onDirectoryOptionsRetrieved()
+                                                // ran resetDialogState() synchronously after the
+                                                // single-directory skip, nulling its per-dialog
+                                                // fields. Restore the ones the dialog needs before
+                                                // we re-enter onDirectoryOptionsRetrieved on this
+                                                // async callback, otherwise it dereferences a null
+                                                // profile/context.
+                                                mContext = context;
+                                                mModalDialogManager = modalDialogManager;
+                                                mSuggestedPath = suggestedPath;
+                                                mProfile = profile;
                                                 onDirectoryOptionsRetrieved(copy);
                                             });
                         } else {

--- a/build/android/bytecode/java/org/brave/bytecode/BraveDownloadLocationDialogCoordinatorClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveDownloadLocationDialogCoordinatorClassAdapter.java
@@ -23,6 +23,18 @@ public class BraveDownloadLocationDialogCoordinatorClassAdapter extends BraveCla
         deleteField(sBraveDownloadLocationDialogCoordinatorClassName, "mController");
         makeProtectedField(sDownloadLocationDialogCoordinatorClassName, "mController");
 
+        deleteField(sBraveDownloadLocationDialogCoordinatorClassName, "mContext");
+        makeProtectedField(sDownloadLocationDialogCoordinatorClassName, "mContext");
+
+        deleteField(sBraveDownloadLocationDialogCoordinatorClassName, "mModalDialogManager");
+        makeProtectedField(sDownloadLocationDialogCoordinatorClassName, "mModalDialogManager");
+
+        deleteField(sBraveDownloadLocationDialogCoordinatorClassName, "mSuggestedPath");
+        makeProtectedField(sDownloadLocationDialogCoordinatorClassName, "mSuggestedPath");
+
+        deleteField(sBraveDownloadLocationDialogCoordinatorClassName, "mProfile");
+        makeProtectedField(sDownloadLocationDialogCoordinatorClassName, "mProfile");
+
         deleteMethod(
                 sBraveDownloadLocationDialogCoordinatorClassName, "onDirectoryOptionsRetrieved");
         makePublicMethod(


### PR DESCRIPTION
`BraveDownloadLocationDialogCoordinator` forces the download location dialog to show on single-directory devices for opted-in users by re-triggering `onDirectoryOptionsRetrieved` after the upstream single-directory skip. That skip now runs `resetDialogState()`, which nulls the per-dialog fields (`mProfile`, `mContext`, `mModalDialogManager`, `mSuggestedPath`) before our async re-fetch re-enters the dialog code, causing a NullPointerException.

Restore those fields in the re-fetch callback before re-triggering the dialog, exposing them via the bytecode adapter alongside `mController`. Adds a regression test `BraveDownloadLocationDialogTest`.

Resolves: https://github.com/brave/brave-browser/issues/56567

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
