### PR TITLE
[toolchain] Wrap Rust/WASM runs in `script`

### DIFF
--- a/tools/cr/toolchains/bootstrap_depot_tools.py
+++ b/tools/cr/toolchains/bootstrap_depot_tools.py
@@ -43,6 +43,7 @@ import contextlib
 import logging
 import os
 import platform
+import shlex
 import shutil
 import subprocess
 import sys
@@ -57,6 +58,12 @@ DEPOT_TOOLS_URL = 'https://chromium.googlesource.com/chromium/tools/depot_tools'
 
 # Name of the vpython3 launcher shipped inside depot_tools.
 VPYTHON_NAME = 'vpython3.bat' if sys.platform == 'win32' else 'vpython3'
+
+# Target script whose invocation is wrapped in a PTY on Linux (see
+# _maybe_wrap_pty). Gated on purpose so this experimental workaround stays
+# limited to the build that needs it and never affects other callers of this
+# generic bootstrap.
+RUST_TOOLCHAIN_RUNNER = 'build_rust_toolchain.py'
 
 
 def _check_call(*command: str, cwd: Path | None = None) -> None:
@@ -134,6 +141,43 @@ def _resolve_script(script: str) -> Iterator[Path]:
     yield local
 
 
+def _maybe_wrap_pty(cmd: tuple[str, ...],
+                    script_path: Path) -> tuple[str, ...]:
+    """Re-exec *cmd* under a pseudo-tty via util-linux `script`, when gated.
+
+    Experimental workaround, intentionally gated to Linux *and* the rust
+    toolchain runner (`RUST_TOOLCHAIN_RUNNER`) so its blast radius stays
+    limited to the build that needs it -- this keeps the test limited and
+    leaves every other caller of this generic bootstrap untouched.
+
+    Some upstream `library/std` process/session tests (e.g.
+    `sys::process::unix::common::tests::test_setsid_*`) hang for a very long
+    time when run without a controlling terminal -- e.g. under a cron-launched,
+    TTY-less Jenkins swarm agent with stdin wired to /dev/null. Allocating a
+    PTY with `script` makes the environment resemble an interactive shell
+    closely enough to avoid the hang.
+
+    Outside the gate, or when `script` is unavailable, *cmd* is returned
+    unchanged so behaviour is never worse than today.
+    """
+    if platform.system() != 'Linux':
+        return cmd
+    if script_path.name != RUST_TOOLCHAIN_RUNNER:
+        return cmd
+    script_bin = shutil.which('script')
+    if script_bin is None:
+        logging.warning('PTY workaround skipped: `script` not found on PATH.')
+        return cmd
+    logging.info('Wrapping %s in a PTY via `script` (Linux workaround).',
+                 RUST_TOOLCHAIN_RUNNER)
+    inner = ' '.join(shlex.quote(a) for a in cmd)
+    # util-linux `script`: -q quiet, -e return the child's exit code (so build
+    # failures still propagate), -f flush output after each write (keeps CI log
+    # streaming responsive), -c run the given command. The typescript itself is
+    # discarded to /dev/null.
+    return (script_bin, '-qefc', inner, '/dev/null')
+
+
 def _split_argv(argv: list[str]) -> tuple[list[str], list[str]]:
     """Split *argv* on the first `--`.
 
@@ -180,6 +224,7 @@ def main() -> int:
 
     with _resolve_script(args.run) as script_path:
         cmd = (str(vpython), str(script_path), *forwarded)
+        cmd = _maybe_wrap_pty(cmd, script_path)
         logging.info(' >>>> %s', ' '.join(cmd))
         result = subprocess.run(cmd, check=False)
         return result.returncode


### PR DESCRIPTION
This is an experiment to see if we can attenuate some of the halts
occurring in CI when running rust tests, when building the full
toolchain.

This may not be the best place to place this, but it will be used just
as a test, and this PR will be reverted once can confirm if this
improves the issue or not.
