### PR TITLE
[plaster] Make `update_patches` use `--ignore-space-at-eol`

### DIFF
--- a/build/commands/lib/updatePatches.js
+++ b/build/commands/lib/updatePatches.js
@@ -66,6 +66,7 @@ async function writePatchFiles(modifiedPaths, gitRepoPath, patchDirPath) {
       '--dst-prefix=b/',
       '--default-prefix',
       '--full-index',
+      '--ignore-space-at-eol',
       old,
     ]
     const patchContents = await util.runAsync('git', singleDiffArgs, {

--- a/patches/components-history-core-browser-history_backend.cc.patch
+++ b/patches/components-history-core-browser-history_backend.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/components/history/core/browser/history_backend.cc b/components/history/core/browser/history_backend.cc
-index 9a8cd38cd00831675c1b7cd2fea7ff4fd7194ac8..d3784834acf15c2f52a5f2d288b94535d32f8048 100644
+index 0098d980cd83da221ebd29a2ca04af1f6fcf70ac..6ce068b27f68e0fe7c8e782f8f6a6d0310761575 100644
 --- a/components/history/core/browser/history_backend.cc
 +++ b/components/history/core/browser/history_backend.cc
 @@ -10,6 +10,7 @@
@@ -18,7 +18,7 @@ index 9a8cd38cd00831675c1b7cd2fea7ff4fd7194ac8..d3784834acf15c2f52a5f2d288b94535
  #include "build/build_config.h"
  #include "build/ios_buildflags.h"
  #include "components/favicon/core/favicon_backend.h"
-@@ -1988,6 +1990,18 @@ QueryURLResult HistoryBackend::QueryURL(const GURL& url) {
+@@ -2056,6 +2058,18 @@ QueryURLResult HistoryBackend::QueryURL(const GURL& url) {
    return result;
  }
  

--- a/patches/components-history-core-browser-history_service.cc.patch
+++ b/patches/components-history-core-browser-history_service.cc.patch
@@ -1,8 +1,8 @@
 diff --git a/components/history/core/browser/history_service.cc b/components/history/core/browser/history_service.cc
-index 30ab41fb9f8be24441cddc353d9246310489e6ff..c96fe6240cbac8de3ad058bc2f5cec45b1884734 100644
+index e998c7daf6ff7e0507fd9b9dcab79f689f1764bf..a202e1e96c0c26820168dd9860adecb03386ca0b 100644
 --- a/components/history/core/browser/history_service.cc
 +++ b/components/history/core/browser/history_service.cc
-@@ -1146,6 +1146,18 @@ base::CancelableTaskTracker::TaskId HistoryService::QueryURL(
+@@ -1144,6 +1144,18 @@ base::CancelableTaskTracker::TaskId HistoryService::QueryURL(
        std::move(callback));
  }
  


### PR DESCRIPTION
This argument is already used by `plaster` to make patch generation a
bit less sensitive to irrelevant changes. This PR adds this to
`update_patches` to, to make it match plaster in this regard.

Two patches have also been added to this PR, but this is not due to this
change, but merely because they are coming dirty whenever
`update_patches` is run.

Bug: https://github.com/brave/brave-browser/issues/56570
