### PR TITLE
[Sidebar V2] Fixed narrow infobar width when panel opens

### DIFF
--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
@@ -104,6 +104,19 @@ gfx::Rect BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
   return result;
 }
 
+// static
+gfx::Rect BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedInfobarBounds(
+    const gfx::Rect& current_bounds,
+    int full_window_width,
+    std::optional<gfx::Insets> vtab_insets) {
+  gfx::Rect bounds = current_bounds;
+  bounds.set_width(full_window_width);
+  if (vtab_insets) {
+    bounds.Inset(*vtab_insets);
+  }
+  return bounds;
+}
+
 int BraveBrowserViewTabbedLayoutImpl::GetIdealSideBarWidth() const {
   if (!views().sidebar_container) {
     return 0;
@@ -196,20 +209,27 @@ BraveBrowserViewTabbedLayoutImpl::CalculateProposedLayout(
     layout.AddChild(views().vertical_tab_strip_host, gfx::Rect(), false);
   }
 
-  // Adjust infobar layout if vertical tabs are shown. i.e. sets insets to
-  // infobar_container considering vertical tab strip. On macOS, the insets can
-  // have bottom insets but it doesn't need for info bar.
-  if (views().vertical_tab_strip_host && delegate().IsInfobarVisible()) {
-    auto* infobar_layout = layout.GetLayoutFor(views().infobar_container);
-    CHECK(infobar_layout);
-    if (infobar_layout && infobar_layout->visibility.value_or(true)) {
-      gfx::Insets insets = GetInsetsConsideringVerticalTabHost();
-      insets.set_bottom(0);
-      infobar_layout->bounds.Inset(insets);
-    }
-  }
+  AdjustInfobarLayout(layout, params);
 
   return layout;
+}
+
+void BraveBrowserViewTabbedLayoutImpl::AdjustInfobarLayout(
+    ProposedLayout& layout,
+    const BrowserLayoutParams params) const {
+  if (!IsParentedTo(views().infobar_container, views().browser_view) ||
+      !delegate().IsInfobarVisible()) {
+    return;
+  }
+
+  auto* infobar_layout = layout.GetLayoutFor(views().infobar_container);
+  CHECK(infobar_layout);
+
+  infobar_layout->bounds = ComputeAdjustedInfobarBounds(
+      infobar_layout->bounds, params.visual_client_area.width(),
+      views().vertical_tab_strip_host
+          ? std::make_optional(GetInsetsConsideringVerticalTabHost())
+          : std::nullopt);
 }
 
 gfx::Rect BraveBrowserViewTabbedLayoutImpl::CalculateTopContainerLayout(

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
@@ -7,8 +7,10 @@
 #define BRAVE_BROWSER_UI_VIEWS_FRAME_LAYOUT_BRAVE_BROWSER_VIEW_TABBED_LAYOUT_IMPL_H_
 
 #include <memory>
+#include <optional>
 
 #include "chrome/browser/ui/views/frame/layout/browser_view_tabbed_layout_impl.h"
+#include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/rect.h"
 
 // Provides a specialized layout implementation for Brave tabbed browsers
@@ -51,6 +53,13 @@ class BraveBrowserViewTabbedLayoutImpl : public BrowserViewTabbedLayoutImpl {
       const gfx::Rect& sidebar_bounds,
       const gfx::Rect& panel_bounds,
       const gfx::Rect& visual_client_area);
+  // Returns the adjusted infobar bounds, resetting the width to
+  // |full_window_width| (undoing any panel-driven narrowing upstream applies)
+  // and then insetting by |vtab_insets| when vertical tabs are visible.
+  static gfx::Rect ComputeAdjustedInfobarBounds(
+      const gfx::Rect& current_bounds,
+      int full_window_width,
+      std::optional<gfx::Insets> vtab_insets);
 
   views::View* contents_container() { return views().contents_container; }
 
@@ -94,6 +103,8 @@ class BraveBrowserViewTabbedLayoutImpl : public BrowserViewTabbedLayoutImpl {
   void CalculateSideBarLayout(ProposedLayout& layout,
                               const BrowserLayoutParams& params) const;
   void InsetContentsContainerBounds(ProposedLayout& layout) const;
+  void AdjustInfobarLayout(ProposedLayout& layout,
+                           const BrowserLayoutParams params) const;
 
   void UpdateInsetsForVerticalTabStrip();
 

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl_unittest.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl_unittest.cc
@@ -6,10 +6,12 @@
 #include "brave/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h"
 
 #include <memory>
+#include <optional>
 
 #include "chrome/browser/ui/views/frame/layout/browser_view_layout_delegate.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/rect.h"
 
 namespace {
@@ -223,6 +225,62 @@ TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
           /*sidebar_leading=*/true, sidebar, panel, client);
   EXPECT_EQ(-110, adjusted.x());
   EXPECT_EQ(150, adjusted.right() - sidebar.right());  // 150px visible to user
+}
+
+// ---------------------------------------------------------------------------
+// ComputeAdjustedInfobarBounds
+//
+// Verifies that the infobar width is reset to the full browser window width
+// regardless of any panel-driven narrowing, and that vertical tab insets are
+// applied correctly on each side.
+// ---------------------------------------------------------------------------
+
+TEST(BraveBrowserViewTabbedLayoutImplInfobarTest,
+     FullWidthWhenPanelNarrowsContents) {
+  // Upstream narrowed the infobar to 700px (contents area with panel open).
+  // Full browser window is 1000px wide — the infobar must be reset to that.
+  gfx::Rect adjusted =
+      BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedInfobarBounds(
+          gfx::Rect(0, 50, 700, 30), /*full_window_width=*/1000,
+          /*vtab_insets=*/std::nullopt);
+  EXPECT_EQ(gfx::Rect(0, 50, 1000, 30), adjusted);
+}
+
+TEST(BraveBrowserViewTabbedLayoutImplInfobarTest,
+     UnchangedWhenAlreadyFullWidth) {
+  // When no panel is open the infobar already spans the full width; the call
+  // must be a no-op for width.
+  gfx::Rect adjusted =
+      BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedInfobarBounds(
+          gfx::Rect(0, 50, 1000, 30), /*full_window_width=*/1000,
+          /*vtab_insets=*/std::nullopt);
+  EXPECT_EQ(gfx::Rect(0, 50, 1000, 30), adjusted);
+}
+
+TEST(BraveBrowserViewTabbedLayoutImplInfobarTest, LeadingVtabInsetsFromLeft) {
+  // Vertical tabs on the left (leading) with width 150 → left inset of 150.
+  // Width is reset to 1000 first, then inset → x=150, width=850.
+  gfx::Insets insets;
+  insets.set_left(150);
+  gfx::Rect adjusted =
+      BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedInfobarBounds(
+          gfx::Rect(0, 50, 700, 30), /*full_window_width=*/1000,
+          std::make_optional(insets));
+  EXPECT_EQ(150, adjusted.x());
+  EXPECT_EQ(850, adjusted.width());
+}
+
+TEST(BraveBrowserViewTabbedLayoutImplInfobarTest, TrailingVtabInsetsFromRight) {
+  // Vertical tabs on the right (trailing) with width 150 → right inset of 150.
+  // Width is reset to 1000 first, then inset → x=0, width=850.
+  gfx::Insets insets;
+  insets.set_right(150);
+  gfx::Rect adjusted =
+      BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedInfobarBounds(
+          gfx::Rect(0, 50, 700, 30), /*full_window_width=*/1000,
+          std::make_optional(insets));
+  EXPECT_EQ(0, adjusted.x());
+  EXPECT_EQ(850, adjusted.width());
 }
 
 TEST(BraveBrowserViewTabbedLayoutImplTest,


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves no issue - use umbrella issue (https://github.com/brave/brave-browser/issues/51462)

Upstream sets the infobar width to match the contents area, which
shrinks when a side panel is open. but we want infobar spans the full
browser window width.
TEST=BraveBrowserViewTabbedLayoutImplInfobarTest.*

Manual test:
1. Launch brave with `--enable-automation` to make infobar visible
2. Open any panel and check infobar width is not affected by panel opening

<img width="1274" height="741" alt="image" src="https://github.com/user-attachments/assets/9bdf2a52-c79b-40be-9ec0-8e261a80a52c" />


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
