### PR TITLE
Apply pacing before round-robin in NTP and notification ad pipelines

### DIFF
--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/new_tab_page_ads/eligible_new_tab_page_ads_v2.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/new_tab_page_ads/eligible_new_tab_page_ads_v2.cc
@@ -261,16 +261,20 @@ void EligibleNewTabPageAdsV2::FilterAndMaybePredictCreativeAdCallback(
   LogNumberOfCreativeAdsPerBucket(creative_ad_buckets);
 
   // For each bucket of prioritized ads attempt to predict the most suitable ad
-  // for the user in priority order. Round-robin is applied per bucket after
-  // exclusion rules but before pacing so that lower-priority campaigns are
-  // never served while higher-priority campaigns still have eligible ads.
+  // for the user in priority order. Pacing is applied before round-robin so
+  // that rotation only considers ads that are eligible to serve right now.
+  // Running round-robin after pacing means its reset logic is driven by
+  // pacing-eligible ads, preventing a fully-paced campaign from consuming
+  // served-set slots and blocking other campaigns in the same bucket.
   for (auto& [priority, creative_ad_bucket] : creative_ad_buckets) {
-    // Round-robin after exclusion rules ensures rotation operates on the
-    // actually-eligible set. Running it before pacing ensures rotation resets
-    // are driven by which ads have been served rather than pacing suppression.
+    PaceCreativeAds(creative_ad_bucket);
+
     creative_ad_round_robin_->Filter(creative_ad_bucket);
 
-    PaceCreativeAds(creative_ad_bucket);
+    if (creative_ad_bucket.empty()) {
+      BLOG(1, "No eligible ads in priority " << priority);
+      continue;
+    }
 
     if (creative_ad_bucket.empty()) {
       continue;

--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/new_tab_page_ads/eligible_new_tab_page_ads_v2_unittest.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/new_tab_page_ads/eligible_new_tab_page_ads_v2_unittest.cc
@@ -10,6 +10,7 @@
 #include "base/test/scoped_feature_list.h"
 #include "base/test/test_future.h"
 #include "base/time/time.h"
+#include "base/uuid.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/common/test/time_test_util.h"
 #include "brave/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ad_info.h"
@@ -702,33 +703,213 @@ TEST_F(
 }
 
 TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,
-       FallThroughToLowerPriorityBucketWhenPacingDrainsHigherPriorityBucket) {
-  // Arrange: `creative_ad_1` (priority 1) has a zero pass-through rate so
-  // pacing always removes it, leaving an empty bucket. The pipeline must fall
-  // through to `creative_ad_2` (priority 2).
+       LowPtrCampaignDoesNotBlockHighPtrCampaignInSamePriorityBucket) {
+  // Arrange: an ad passes pacing when roll < `pass_through_rate` and is paced
+  // out when roll >= `pass_through_rate`.
+
+  // Campaign 1 (priority 1): two ads with a `pass_through_rate` of 0.01.
+  const std::string campaign_1_id =
+      base::Uuid::GenerateRandomV4().AsLowercaseString();
+
   CreativeNewTabPageAdInfo creative_ad_1 =
       test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
                                       /*use_random_uuids=*/true);
+  creative_ad_1.campaign_id = campaign_1_id;
   creative_ad_1.priority = 1;
-  creative_ad_1.pass_through_rate = 0.0;
+  creative_ad_1.pass_through_rate = 0.01;
 
   CreativeNewTabPageAdInfo creative_ad_2 =
       test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
                                       /*use_random_uuids=*/true);
-  creative_ad_2.priority = 2;
-  creative_ad_2.pass_through_rate = 1.0;
+  creative_ad_2.campaign_id = campaign_1_id;
+  creative_ad_2.priority = 1;
+  creative_ad_2.pass_through_rate = 0.01;
 
-  test::SaveCreativeNewTabPageAds({creative_ad_1, creative_ad_2});
+  // Campaign 2 (priority 1): one ad with a `pass_through_rate` of 0.42.
+  CreativeNewTabPageAdInfo creative_ad_3 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_3.priority = 1;
+  creative_ad_3.pass_through_rate = 0.42;
 
-  const ScopedPacingRandomNumberSetterForTesting scoped_setter(0.5);
+  // Campaign 3 (priority 2): one ad with a `pass_through_rate` of 1.0.
+  CreativeNewTabPageAdInfo creative_ad_4 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_4.priority = 2;
+  creative_ad_4.pass_through_rate = 1.0;
 
-  // Act & Assert
-  base::test::TestFuture<CreativeNewTabPageAdList> test_future;
-  eligible_ads_->GetForUserModel(
-      UserModelInfo{IntentUserModelInfo{}, LatentInterestUserModelInfo{},
-                    InterestUserModelInfo{}},
-      test_future.GetCallback());
-  EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_2));
+  test::SaveCreativeNewTabPageAds(
+      {creative_ad_1, creative_ad_2, creative_ad_3, creative_ad_4});
+
+  const UserModelInfo user_model{
+      IntentUserModelInfo{}, LatentInterestUserModelInfo{},
+      InterestUserModelInfo{SegmentList{"untargeted"}}};
+
+  // NTT 1: cold start (no prior served state). Roll of 0.005 passes all three
+  // priority 1 ads. The round-robin starts fresh with no exclusions, so any
+  // priority 1 ad is eligible. `creative_ad_4` (priority 2) is not
+  // eligible while priority 1 has eligible ads. No ad is marked as served so
+  // the round-robin state remains empty for the regression sequence below.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.005);
+    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(
+        test_future.Take(),
+        ::testing::AllOf(::testing::SizeIs(1),
+                         ::testing::Not(::testing::Contains(creative_ad_4))));
+  }
+
+  // NTT 2: roll of 0.2 paces campaign 1 out (its `pass_through_rate`
+  // of 0.01, 0.2 >= 0.01). Campaign 2's ad passes pacing (its
+  // `pass_through_rate` of 0.42, 0.2 < 0.42) and is served.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.2);
+    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    ASSERT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_3));
+    SimulateServeAd(creative_ad_3);
+  }
+
+  // NTT 3: roll of 0.005 is below campaign 1's `pass_through_rate` (0.01) so
+  // all three priority 1 ads pass pacing. The round-robin removes
+  // `creative_ad_3` (already served), leaving `[creative_ad_1, creative_ad_2]`.
+  // `creative_ad_4` (priority 2) is not eligible while priority 1 has eligible
+  // ads. A campaign 1 ad is eligible.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.005);
+    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    const CreativeNewTabPageAdList creative_ads = test_future.Take();
+    EXPECT_THAT(creative_ads,
+                ::testing::AllOf(::testing::SizeIs(1),
+                                 ::testing::Not(::testing::AnyOf(
+                                     ::testing::Contains(creative_ad_3),
+                                     ::testing::Contains(creative_ad_4)))));
+    SimulateServeAd(creative_ads);
+  }
+
+  // NTT 4: roll of 0.2 paces campaign 1 out again. Pacing produces
+  // `[creative_ad_3]`. The round-robin sees that all candidates in the
+  // post-pacing bucket have been served and resets, making `creative_ad_3`
+  // eligible. `creative_ad_3` serves.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.2);
+    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_3));
+    SimulateServeAd(creative_ad_3);
+  }
+
+  // NTT 5: roll of 0.2 again; the same reset-and-serve pattern from NTT 4
+  // repeats. Pacing produces `[creative_ad_3]`, the round-robin resets on the
+  // single-element bucket, and `creative_ad_3` serves.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.2);
+    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_3));
+    SimulateServeAd(creative_ad_3);
+  }
+
+  // NTT 6: all three priority 1 ads pass pacing. The round-robin removes
+  // `creative_ad_3` (served in NTT 5), leaving `[creative_ad_1,
+  // creative_ad_2]`. `creative_ad_4` (priority 2) is not eligible. A campaign 1
+  // ad serves, confirming campaign 1 is not permanently blocked.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.005);
+    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    const CreativeNewTabPageAdList creative_ads = test_future.Take();
+    EXPECT_THAT(creative_ads,
+                ::testing::AllOf(::testing::SizeIs(1),
+                                 ::testing::Not(::testing::AnyOf(
+                                     ::testing::Contains(creative_ad_3),
+                                     ::testing::Contains(creative_ad_4)))));
+    SimulateServeAd(creative_ads);
+  }
+
+  // NTT 7: roll of 0.2 paces campaign 1 out; only `creative_ad_3` passes
+  // pacing. The round-robin resets because `creative_ad_3` is the only
+  // candidate in the post-pacing bucket and has already been served, starting
+  // the second rotation.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.2);
+    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_3));
+    SimulateServeAd(creative_ad_3);
+  }
+
+  // NTT 8: campaign 1 resumes in the second rotation. `creative_ad_3` is
+  // excluded by the round-robin (last served in NTT 7); `creative_ad_4`
+  // (priority 2) is not eligible. A campaign 1 ad serves.
+  CreativeNewTabPageAdList ntt8_creative_ads;
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.005);
+    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    ntt8_creative_ads = test_future.Take();
+    EXPECT_THAT(ntt8_creative_ads,
+                ::testing::AllOf(::testing::SizeIs(1),
+                                 ::testing::Not(::testing::AnyOf(
+                                     ::testing::Contains(creative_ad_3),
+                                     ::testing::Contains(creative_ad_4)))));
+    SimulateServeAd(ntt8_creative_ads);
+  }
+
+  // NTT 9: the other campaign 1 ad serves, confirming the full three-ad cycle
+  // repeats correctly after the reset. `creative_ad_4` (priority 2) is not
+  // eligible while priority 1 has eligible ads.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.005);
+    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    const CreativeNewTabPageAdList creative_ads = test_future.Take();
+    EXPECT_THAT(creative_ads,
+                ::testing::AllOf(::testing::SizeIs(1),
+                                 ::testing::Not(::testing::AnyOf(
+                                     ::testing::Contains(creative_ad_3),
+                                     ::testing::Contains(creative_ad_4)))));
+    EXPECT_NE(ntt8_creative_ads, creative_ads);
+    SimulateServeAd(creative_ads);
+  }
+
+  // NTT 10: roll of 0.5 paces out all priority 1 ads; campaign 1 has a
+  // `pass_through_rate` of 0.01 and campaign 2 a `pass_through_rate` of 0.42.
+  // The priority 1 bucket is empty so the pipeline falls through to the
+  // priority 2 bucket where `creative_ad_4` (a `pass_through_rate` of 1.0)
+  // serves.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.5);
+    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_4));
+    SimulateServeAd(creative_ad_4);
+  }
+
+  // NTT 11: priority 1 immediately resumes serving as soon as it has an
+  // eligible ad. Roll of 0.2 paces campaign 1 out but campaign 2 passes
+  // pacing (`pass_through_rate` of 0.42, 0.2 < 0.42). `creative_ad_3` serves
+  // from priority 1 rather than `creative_ad_4` from priority 2.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.2);
+    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_3));
+  }
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/notification_ads/eligible_notification_ads_v2.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/notification_ads/eligible_notification_ads_v2.cc
@@ -160,16 +160,20 @@ void EligibleNotificationAdsV2::FilterAndMaybePredictCreativeAd(
   LogNumberOfCreativeAdsPerBucket(creative_ad_buckets);
 
   // For each bucket of prioritized ads attempt to predict the most suitable ad
-  // for the user in priority order. Round-robin is applied per bucket after
-  // exclusion rules but before pacing so that lower-priority campaigns are
-  // never served while higher-priority campaigns still have eligible ads.
+  // for the user in priority order. Pacing is applied before round-robin so
+  // that rotation only considers ads that are eligible to serve right now.
+  // Running round-robin after pacing means its reset logic is driven by
+  // pacing-eligible ads, preventing a fully-paced campaign from consuming
+  // served-set slots and blocking other campaigns in the same bucket.
   for (auto& [priority, creative_ad_bucket] : creative_ad_buckets) {
-    // Round-robin after exclusion rules ensures rotation operates on the
-    // actually-eligible set. Running it before pacing ensures rotation resets
-    // are driven by which ads have been served rather than pacing suppression.
+    PaceCreativeAds(creative_ad_bucket);
+
     creative_ad_round_robin_->Filter(creative_ad_bucket);
 
-    PaceCreativeAds(creative_ad_bucket);
+    if (creative_ad_bucket.empty()) {
+      BLOG(1, "No eligible ads in priority " << priority);
+      continue;
+    }
 
     if (creative_ad_bucket.empty()) {
       continue;

--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/notification_ads/eligible_notification_ads_v2_unittest.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/notification_ads/eligible_notification_ads_v2_unittest.cc
@@ -10,6 +10,7 @@
 #include "base/test/scoped_feature_list.h"
 #include "base/test/test_future.h"
 #include "base/time/time.h"
+#include "base/uuid.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/common/test/time_test_util.h"
 #include "brave/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ad_info.h"
@@ -659,31 +660,209 @@ TEST_F(
 }
 
 TEST_F(BraveAdsEligibleNotificationAdsV2Test,
-       FallThroughToLowerPriorityBucketWhenPacingDrainsHigherPriorityBucket) {
-  // Arrange: `creative_ad_1` (priority 1) has a zero pass-through rate so
-  // pacing always removes it, leaving an empty bucket. The pipeline must fall
-  // through to `creative_ad_2` (priority 2).
+       LowPtrCampaignDoesNotBlockHighPtrCampaignInSamePriorityBucket) {
+  // Arrange: an ad passes pacing when roll < `pass_through_rate` and is paced
+  // out when roll >= `pass_through_rate`.
+
+  // Campaign 1 (priority 1): two ads with a `pass_through_rate` of 0.01.
+  const std::string campaign_1_id =
+      base::Uuid::GenerateRandomV4().AsLowercaseString();
+
   CreativeNotificationAdInfo creative_ad_1 =
       test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_1.campaign_id = campaign_1_id;
   creative_ad_1.priority = 1;
-  creative_ad_1.pass_through_rate = 0.0;
+  creative_ad_1.pass_through_rate = 0.01;
 
   CreativeNotificationAdInfo creative_ad_2 =
       test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
-  creative_ad_2.priority = 2;
-  creative_ad_2.pass_through_rate = 1.0;
+  creative_ad_2.campaign_id = campaign_1_id;
+  creative_ad_2.priority = 1;
+  creative_ad_2.pass_through_rate = 0.01;
 
-  database::SaveCreativeNotificationAds({creative_ad_1, creative_ad_2});
+  // Campaign 2 (priority 1): one ad with a `pass_through_rate` of 0.42.
+  CreativeNotificationAdInfo creative_ad_3 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_3.priority = 1;
+  creative_ad_3.pass_through_rate = 0.42;
 
-  const ScopedPacingRandomNumberSetterForTesting scoped_setter(0.5);
+  // Campaign 3 (priority 2): one ad with a `pass_through_rate` of 1.0.
+  CreativeNotificationAdInfo creative_ad_4 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_4.priority = 2;
+  creative_ad_4.pass_through_rate = 1.0;
 
-  // Act & Assert
-  base::test::TestFuture<CreativeNotificationAdList> test_future;
-  eligible_ads_->GetForUserModel(
-      UserModelInfo{IntentUserModelInfo{}, LatentInterestUserModelInfo{},
-                    InterestUserModelInfo{}},
-      test_future.GetCallback());
-  EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_2));
+  database::SaveCreativeNotificationAds(
+      {creative_ad_1, creative_ad_2, creative_ad_3, creative_ad_4});
+
+  const UserModelInfo user_model{
+      IntentUserModelInfo{}, LatentInterestUserModelInfo{},
+      InterestUserModelInfo{SegmentList{"untargeted"}}};
+
+  // Serve 1: cold start (no prior served state). Roll of 0.005 passes all three
+  // priority 1 ads. The round-robin starts fresh with no exclusions, so any
+  // priority 1 ad is eligible. `creative_ad_4` (priority 2) is not
+  // eligible while priority 1 has eligible ads. No ad is marked as served so
+  // the round-robin state remains empty for the regression sequence below.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.005);
+    base::test::TestFuture<CreativeNotificationAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(
+        test_future.Take(),
+        ::testing::AllOf(::testing::SizeIs(1),
+                         ::testing::Not(::testing::Contains(creative_ad_4))));
+  }
+
+  // Serve 2: roll of 0.2 paces campaign 1 out (its `pass_through_rate`
+  // of 0.01, 0.2 >= 0.01). Campaign 2's ad passes pacing (its
+  // `pass_through_rate` of 0.42, 0.2 < 0.42) and is served.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.2);
+    base::test::TestFuture<CreativeNotificationAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    ASSERT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_3));
+    SimulateServeAd(creative_ad_3);
+  }
+
+  // Serve 3: roll of 0.005 is below campaign 1's `pass_through_rate` (0.01)
+  // so all three priority 1 ads pass pacing. The round-robin removes
+  // `creative_ad_3` (already served), leaving `[creative_ad_1, creative_ad_2]`.
+  // `creative_ad_4` (priority 2) is not eligible while priority 1 has eligible
+  // ads. A campaign 1 ad is eligible.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.005);
+    base::test::TestFuture<CreativeNotificationAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    const CreativeNotificationAdList creative_ads = test_future.Take();
+    EXPECT_THAT(creative_ads,
+                ::testing::AllOf(::testing::SizeIs(1),
+                                 ::testing::Not(::testing::AnyOf(
+                                     ::testing::Contains(creative_ad_3),
+                                     ::testing::Contains(creative_ad_4)))));
+    SimulateServeAd(creative_ads);
+  }
+
+  // Serve 4: roll of 0.2 paces campaign 1 out again. Pacing produces
+  // `[creative_ad_3]`. The round-robin sees that all candidates in the
+  // post-pacing bucket have been served and resets, making `creative_ad_3`
+  // eligible. `creative_ad_3` serves.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.2);
+    base::test::TestFuture<CreativeNotificationAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_3));
+    SimulateServeAd(creative_ad_3);
+  }
+
+  // Serve 5: roll of 0.2 again; the same reset-and-serve pattern from serve 4
+  // repeats. Pacing produces `[creative_ad_3]`, the round-robin resets on the
+  // single-element bucket, and `creative_ad_3` serves.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.2);
+    base::test::TestFuture<CreativeNotificationAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_3));
+    SimulateServeAd(creative_ad_3);
+  }
+
+  // Serve 6: all three priority 1 ads pass pacing. The round-robin removes
+  // `creative_ad_3` (served in serve 5), leaving `[creative_ad_1,
+  // creative_ad_2]`. `creative_ad_4` (priority 2) is not eligible. A campaign 1
+  // ad serves, confirming campaign 1 is not permanently blocked.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.005);
+    base::test::TestFuture<CreativeNotificationAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    const CreativeNotificationAdList creative_ads = test_future.Take();
+    EXPECT_THAT(creative_ads,
+                ::testing::AllOf(::testing::SizeIs(1),
+                                 ::testing::Not(::testing::AnyOf(
+                                     ::testing::Contains(creative_ad_3),
+                                     ::testing::Contains(creative_ad_4)))));
+    SimulateServeAd(creative_ads);
+  }
+
+  // Serve 7: roll of 0.2 paces campaign 1 out; only `creative_ad_3` passes
+  // pacing. The round-robin resets because `creative_ad_3` is the only
+  // candidate in the post-pacing bucket and has already been served, starting
+  // the second rotation.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.2);
+    base::test::TestFuture<CreativeNotificationAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_3));
+    SimulateServeAd(creative_ad_3);
+  }
+
+  // Serve 8: campaign 1 resumes in the second rotation. `creative_ad_3` is
+  // excluded by the round-robin (last served in serve 7); `creative_ad_4`
+  // (priority 2) is not eligible. A campaign 1 ad serves.
+  CreativeNotificationAdList serve8_creative_ads;
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.005);
+    base::test::TestFuture<CreativeNotificationAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    serve8_creative_ads = test_future.Take();
+    EXPECT_THAT(serve8_creative_ads,
+                ::testing::AllOf(::testing::SizeIs(1),
+                                 ::testing::Not(::testing::AnyOf(
+                                     ::testing::Contains(creative_ad_3),
+                                     ::testing::Contains(creative_ad_4)))));
+    SimulateServeAd(serve8_creative_ads);
+  }
+
+  // Serve 9: the other campaign 1 ad serves, confirming the full three-ad
+  // cycle repeats correctly after the reset. `creative_ad_4` (priority 2) is
+  // not eligible while priority 1 has eligible ads.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.005);
+    base::test::TestFuture<CreativeNotificationAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    const CreativeNotificationAdList creative_ads = test_future.Take();
+    EXPECT_THAT(creative_ads,
+                ::testing::AllOf(::testing::SizeIs(1),
+                                 ::testing::Not(::testing::AnyOf(
+                                     ::testing::Contains(creative_ad_3),
+                                     ::testing::Contains(creative_ad_4)))));
+    EXPECT_NE(serve8_creative_ads, creative_ads);
+    SimulateServeAd(creative_ads);
+  }
+
+  // Serve 10: roll of 0.5 paces out all priority 1 ads; campaign 1 has a
+  // `pass_through_rate` of 0.01 and campaign 2 a `pass_through_rate` of 0.42.
+  // The priority 1 bucket is empty so the pipeline falls through to the
+  // priority 2 bucket where `creative_ad_4` (a `pass_through_rate` of 1.0)
+  // serves.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.5);
+    base::test::TestFuture<CreativeNotificationAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_4));
+    SimulateServeAd(creative_ad_4);
+  }
+
+  // Serve 11: priority 1 immediately resumes serving as soon as it has an
+  // eligible ad. Roll of 0.2 paces campaign 1 out but campaign 2 passes
+  // pacing (`pass_through_rate` of 0.42, 0.2 < 0.42). `creative_ad_3` serves
+  // from priority 1 rather than `creative_ad_4` from priority 2.
+  {
+    const ScopedPacingRandomNumberSetterForTesting scoped_pacing_random_number(
+        0.2);
+    base::test::TestFuture<CreativeNotificationAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_3));
+  }
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/serving/eligible_ads/round_robin/creative_ad_round_robin.h
+++ b/components/brave_ads/core/internal/serving/eligible_ads/round_robin/creative_ad_round_robin.h
@@ -56,7 +56,10 @@ class CreativeAdRoundRobin final {
 
       if (last_served_creative_instance_id_ && creative_ads.size() > 1) {
         // Exclude the last served creative ad to avoid an immediate repeat if
-        // there is more than one creative ad.
+        // there is more than one ad. `last_served_creative_instance_id_` may
+        // refer to a creative no longer in the candidate set; inserting it is
+        // safe because `erase_if` only removes creative instance IDs present in
+        // `creative_ads`.
         served_creative_instance_ids_.insert(
             *last_served_creative_instance_id_);
       }


### PR DESCRIPTION
A fully-paced campaign was consuming round-robin served-set slots, preventing other campaigns in the same priority bucket from serving. Pacing now runs first so the round-robin only rotates ads that are eligible to serve at the current time, and adds a regression test covering the multi-campaign same-bucket scenario.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56375

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
