### PR TITLE
Fix edge case when exiting PIP

### DIFF
--- a/android/java/org/chromium/chrome/browser/media/BraveYouTubePictureInPictureController.java
+++ b/android/java/org/chromium/chrome/browser/media/BraveYouTubePictureInPictureController.java
@@ -595,6 +595,17 @@ public class BraveYouTubePictureInPictureController {
             return;
         }
 
+        // The session was already tearing down when the screen locked: the user had
+        // deliberately expanded out of PiP. Resurrecting it would drop them back into
+        // a PiP window with the player no longer in fullscreen. Finish the exit that
+        // the lock deferred instead of entering PiP again.
+        if (mExiting) {
+            mInterruptedByScreenLock = false;
+            maybeRestoreFullscreenUi(mSessionId, webContents);
+            maybeSuspendDismissed(mSessionId, webContents);
+            return;
+        }
+
         if (mActivity.isInPictureInPictureMode()) {
             // The PiP window survived the lock, so there is no re-entry to drive. Consume the
             // interrupt so the next screen-off can pause playback again (the user may resume


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/56590

Fixes a state machine bug in `BraveYouTubePictureInPictureController` where quickly toggling the device screen off and on while exiting PiP resurrected the PiP window with the player no longer in fullscreen.

### Root cause
`mInterruptedByScreenLock` is used both for "PiP is active and the screen locked → resume on unlock" and for "the screen locked while the session was tearing down". When the user expands out of PiP, `handleSessionExited()` sets `mExiting`, calls `WebContents.exitFullscreen()`, and keeps the session active for a short teardown window. A screen off/on during that window marks the session interrupted, and `maybeResumeAfterScreenLock()` then re-enters PiP — but the player has already left fullscreen.

### Change
In `maybeResumeAfterScreenLock()`, short-circuit when `mExiting` is set: the user deliberately left PiP, so finish the exit the lock deferred (`maybeRestoreFullscreenUi()` + `maybeSuspendDismissed()`, which clears the session) instead of re-entering PiP. Both calls run their normal bodies because the screen is on again and the session is still the exiting one.

### Test plan
1. **Repro:** YouTube video → enter PiP → expand back to the activity → toggle screen off/on during or just after the transition. Verify the activity stays non-PiP.
2. **Regression (keep-alive):** Watch in PiP → lock the screen → unlock. Verify PiP still resumes as before.
3. **Regression (media):** Confirm audio does not keep playing or get wrongly resumed after the exit completes, with background video playback both enabled and disabled.


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
