### PR TITLE
[iOS] Assign correct prefs for Leo/Origin after successful IAP

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
@@ -497,7 +497,7 @@ extension SceneDelegate {
     Task { @MainActor in
       let isPrivateBrowsing =
         scene.browserViewController?.privateBrowsingManager.isPrivateBrowsing == true
-      await Skus.SkusServiceFactory.get(privateMode: isPrivateBrowsing)?.refreshVPNCredentials()
+      await Skus.SkusServiceFactory.get(privateMode: isPrivateBrowsing)?.refreshSkusCredentials()
     }
   }
 

--- a/ios/brave-ios/Sources/AIChat/Preferences/Preferences.swift
+++ b/ios/brave-ios/Sources/AIChat/Preferences/Preferences.swift
@@ -14,12 +14,6 @@ extension Preferences {
       default: false
     )
 
-    /// The date the user's current AI-Chat subscription expires
-    public static let subscriptionExpirationDate = Option<Date?>(
-      key: "aichat.expiration-date",
-      default: nil
-    )
-
     /// A boolean indicating whether or not the user has dismissed the Premium Prompt on the Feedback Form
     public static let showPremiumFeedbackAd = Option<Bool>(
       key: "aichat.show-premium-feedback-ad",

--- a/ios/brave-ios/Sources/Brave/BraveSkus/BraveSkusServiceHelpers.swift
+++ b/ios/brave-ios/Sources/Brave/BraveSkus/BraveSkusServiceHelpers.swift
@@ -14,8 +14,9 @@ import os.log
 
 extension SkusSkusService {
   @MainActor
-  public func refreshVPNCredentials() async {
-    if let domain = Preferences.VPN.skusCredentialDomain.value {
+  public func refreshSkusCredentials() async {
+    let domains = BraveStoreProductGroup.allCases.map(\.skusDomain)
+    for domain in domains {
       // Always refresh credentials and trust the credentials from Brave-Core rather than cached credentials
       let summary = await credentialSummary(domain: domain).message
       if !summary.isEmpty, summary != "{}" {
@@ -51,22 +52,12 @@ extension SkusSkusService {
           if Preferences.AIChat.subscriptionOrderId.value == nil {
             Preferences.AIChat.subscriptionOrderId.value = credentialSummary.orderId
           }
-
-          if Preferences.AIChat.subscriptionOrderId.value != nil {
-            Logger.module.debug("[SkusManager] - Preparing Leo Credentials")
-            _ = await prepareCredentialsPresentation(domain: domain, path: "*")
-
-            Preferences.AIChat.subscriptionExpirationDate.value = credentialSummary.expiresAt
-          }
+          Preferences.AIChat.subscriptionProductId.value = credentialSummary.product?.rawValue
         case .origin:
           if Preferences.BraveOrigin.purchaseOrderId.value == nil {
             Preferences.BraveOrigin.purchaseOrderId.value = credentialSummary.orderId
           }
-
-          if Preferences.BraveOrigin.purchaseOrderId.value != nil {
-            Logger.module.debug("[SkusManager] - Preparing Origin Credentials")
-            _ = await prepareCredentialsPresentation(domain: domain, path: "*")
-          }
+          Preferences.BraveOrigin.purchaseProductId.value = credentialSummary.product?.rawValue
         case .unknown:
           Logger.module.debug("[SkusManager] - Unknown Credentials")
           break

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -982,7 +982,7 @@ public class BrowserViewController: UIViewController {
         let skusService = Skus.SkusServiceFactory.get(
           privateMode: self.privateBrowsingManager.isPrivateBrowsing
         )
-        await skusService?.refreshVPNCredentials()
+        await skusService?.refreshSkusCredentials()
 
         self.vpnProductInfo.load()
         if let customCredential = Preferences.VPN.skusCredential.value,

--- a/ios/brave-ios/Sources/BraveStore/Subscription/SDK/BraveStoreSDK.swift
+++ b/ios/brave-ios/Sources/BraveStore/Subscription/SDK/BraveStoreSDK.swift
@@ -558,9 +558,9 @@ public class BraveStoreSDK: AppStoreSDK {
     case .vpn:
       break
     case .leo:
-      Preferences.AIChat.subscriptionProductId.value = orderId
+      Preferences.AIChat.subscriptionOrderId.value = orderId
     case .origin:
-      Preferences.BraveOrigin.purchaseProductId.value = orderId
+      Preferences.BraveOrigin.purchaseOrderId.value = orderId
     }
 
     Logger.module.info("[BraveStoreSDK] - Order Completed")


### PR DESCRIPTION
This also ensures that we update the order & product ID prefs of users who may have purchased Leo after 1.87. This change also removes the calls to `PrepareCredentialsPresentation` as this is not needed for Origin and is already called for Leo in the `AIChatService` constructor

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56589
