### PR TITLE
[strings] Enable translation support for BRAVE_WEBCOMPAT_* strings

### DIFF
--- a/components/brave_shields/resources/panel_new/components/fingerprinting_details.tsx
+++ b/components/brave_shields/resources/panel_new/components/fingerprinting_details.tsx
@@ -26,6 +26,84 @@ const webcompatSettingNames = new Map(
     })
     .map(([key, value]) => {
       switch (value) {
+        case ContentSettingsType.BRAVE_WEBCOMPAT_AUDIO:
+          return [
+            value,
+            getString('BRAVE_SHIELDS_BLOCK_FINGERPRINTING_AUDIO_LABEL'),
+          ]
+        case ContentSettingsType.BRAVE_WEBCOMPAT_CANVAS:
+          return [
+            value,
+            getString('BRAVE_SHIELDS_BLOCK_FINGERPRINTING_CANVAS_LABEL'),
+          ]
+        case ContentSettingsType.BRAVE_WEBCOMPAT_DEVICE_MEMORY:
+          return [
+            value,
+            getString('BRAVE_SHIELDS_BLOCK_FINGERPRINTING_DEVICE_MEMORY_LABEL'),
+          ]
+        case ContentSettingsType.BRAVE_WEBCOMPAT_EVENT_SOURCE_POOL:
+          return [
+            value,
+            getString(
+              'BRAVE_SHIELDS_BLOCK_FINGERPRINTING_EVENT_SOURCE_POOL_LABEL',
+            ),
+          ]
+        case ContentSettingsType.BRAVE_WEBCOMPAT_FONT:
+          return [
+            value,
+            getString('BRAVE_SHIELDS_BLOCK_FINGERPRINTING_FONT_LABEL'),
+          ]
+        case ContentSettingsType.BRAVE_WEBCOMPAT_HARDWARE_CONCURRENCY:
+          return [
+            value,
+            getString(
+              'BRAVE_SHIELDS_BLOCK_FINGERPRINTING_HARDWARE_CONCURRENCY_LABEL',
+            ),
+          ]
+        case ContentSettingsType.BRAVE_WEBCOMPAT_KEYBOARD:
+          return [
+            value,
+            getString('BRAVE_SHIELDS_BLOCK_FINGERPRINTING_KEYBOARD_LABEL'),
+          ]
+        case ContentSettingsType.BRAVE_WEBCOMPAT_LANGUAGE:
+          return [
+            value,
+            getString('BRAVE_SHIELDS_BLOCK_FINGERPRINTING_LANGUAGE_LABEL'),
+          ]
+        case ContentSettingsType.BRAVE_WEBCOMPAT_MEDIA_DEVICES:
+          return [
+            value,
+            getString('BRAVE_SHIELDS_BLOCK_FINGERPRINTING_MEDIA_DEVICES_LABEL'),
+          ]
+        case ContentSettingsType.BRAVE_WEBCOMPAT_PLUGINS:
+          return [
+            value,
+            getString('BRAVE_SHIELDS_BLOCK_FINGERPRINTING_PLUGINS_LABEL'),
+          ]
+        case ContentSettingsType.BRAVE_WEBCOMPAT_SCREEN:
+          return [
+            value,
+            getString('BRAVE_SHIELDS_BLOCK_FINGERPRINTING_SCREEN_LABEL'),
+          ]
+        case ContentSettingsType.BRAVE_WEBCOMPAT_SPEECH_SYNTHESIS:
+          return [
+            value,
+            getString(
+              'BRAVE_SHIELDS_BLOCK_FINGERPRINTING_SPEECH_SYNTHESIS_LABEL',
+            ),
+          ]
+        case ContentSettingsType.BRAVE_WEBCOMPAT_USB_DEVICE_SERIAL_NUMBER:
+          return [
+            value,
+            getString(
+              'BRAVE_SHIELDS_BLOCK_FINGERPRINTING_USB_DEVICE_SERIAL_NUMBER_LABEL',
+            ),
+          ]
+        case ContentSettingsType.BRAVE_WEBCOMPAT_USER_AGENT:
+          return [
+            value,
+            getString('BRAVE_SHIELDS_BLOCK_FINGERPRINTING_USER_AGENT_LABEL'),
+          ]
         case ContentSettingsType.BRAVE_WEBCOMPAT_WEBGL:
           return [
             value,
@@ -40,6 +118,13 @@ const webcompatSettingNames = new Map(
           return [
             value,
             getString('BRAVE_SHIELDS_BLOCK_FINGERPRINTING_WEBGPU_LABEL'),
+          ]
+        case ContentSettingsType.BRAVE_WEBCOMPAT_WEB_SOCKETS_POOL:
+          return [
+            value,
+            getString(
+              'BRAVE_SHIELDS_BLOCK_FINGERPRINTING_WEB_SOCKETS_POOL_LABEL',
+            ),
           ]
         default: {
           const name = key

--- a/components/resources/brave_shields_strings.grdp
+++ b/components/resources/brave_shields_strings.grdp
@@ -392,7 +392,7 @@
   </message>
 
   <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_DEVICE_MEMORY_LABEL" desc="This label is associated with the Device Memory toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to Device Memory APIs." formatter_data="webui=BraveShields" >
-    Device memory
+    Device Memory
   </message>
 
   <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_EVENT_SOURCE_POOL_LABEL" desc="This label is associated with the Event Source Pool toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to Event Source Pool APIs." formatter_data="webui=BraveShields" >

--- a/components/resources/brave_shields_strings.grdp
+++ b/components/resources/brave_shields_strings.grdp
@@ -436,7 +436,7 @@
   </message>
 
   <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_USER_AGENT_LABEL" desc="This label is associated with the User Agent toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to User Agent APIs." formatter_data="webui=BraveShields" >
-    User agent
+    User Agent
   </message>
 
   <!-- WebGL is an abbreviation referring to a specific technical library and therefore is not translatable. -->

--- a/components/resources/brave_shields_strings.grdp
+++ b/components/resources/brave_shields_strings.grdp
@@ -380,7 +380,64 @@
     Open settings
   </message>
 
-  <!-- Fingerprinting related strings corresponding to the different web compat types. -->
+  <!-- Fingerprinting related strings corresponding to the different web compat types specified at chromium_src/components/content_settings/core/common/content_settings_types.mojom. 
+  Please note that the fingerprinting_details.style.ts auto applies capitalization on every word of these texts so we may need special attention when translating. -->
+
+  <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_AUDIO_LABEL" desc="This label is associated with the Audio toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to Audio APIs." formatter_data="webui=BraveShields">
+    Audio
+  </message>
+
+  <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_CANVAS_LABEL" desc="This label is associated with the Canvas toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to Canvas APIs." formatter_data="webui=BraveShields" >
+    Canvas
+  </message>
+
+  <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_DEVICE_MEMORY_LABEL" desc="This label is associated with the Device Memory toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to Device Memory APIs." formatter_data="webui=BraveShields" >
+    Device memory
+  </message>
+
+  <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_EVENT_SOURCE_POOL_LABEL" desc="This label is associated with the Event Source Pool toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to Event Source Pool APIs." formatter_data="webui=BraveShields" >
+    Event Source Pool
+  </message>
+
+  <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_FONT_LABEL" desc="This label is associated with the Font toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to Font APIs." formatter_data="webui=BraveShields" >
+    Font
+  </message>
+
+  <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_HARDWARE_CONCURRENCY_LABEL" desc="This label is associated with the Hardware Concurrency toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to Hardware Concurrency APIs." formatter_data="webui=BraveShields" >
+    Hardware Concurrency
+  </message>
+
+  <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_KEYBOARD_LABEL" desc="This label is associated with the Keyboard toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to Keyboard APIs." formatter_data="webui=BraveShields" >
+    Keyboard
+  </message>
+
+  <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_LANGUAGE_LABEL" desc="This label is associated with the Language toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to Language APIs." formatter_data="webui=BraveShields" >
+    Language
+  </message>
+
+  <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_MEDIA_DEVICES_LABEL" desc="This label is associated with the Media Devices toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to Media Devices APIs." formatter_data="webui=BraveShields" >
+    Media Devices
+  </message>
+
+  <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_PLUGINS_LABEL" desc="This label is associated with the Plugins toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to Plugins APIs." formatter_data="webui=BraveShields" >
+    Plugins
+  </message>
+
+  <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_SCREEN_LABEL" desc="This label is associated with the Screen toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to Screen APIs." formatter_data="webui=BraveShields" >
+    Screen
+  </message>
+
+  <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_SPEECH_SYNTHESIS_LABEL" desc="This label is associated with the Speech Synthesis toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to Speech Synthesis APIs." formatter_data="webui=BraveShields" >
+    Speech Synthesis
+  </message>
+
+  <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_USB_DEVICE_SERIAL_NUMBER_LABEL" desc="This label is associated with the USB Device Serial Number toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to USB Device Serial Number APIs." formatter_data="webui=BraveShields" >
+    Usb Device Serial Number
+  </message>
+
+  <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_USER_AGENT_LABEL" desc="This label is associated with the User Agent toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to User Agent APIs." formatter_data="webui=BraveShields" >
+    User agent
+  </message>
 
   <!-- WebGL is an abbreviation referring to a specific technical library and therefore is not translatable. -->
   <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_WEBGL_LABEL" desc="This label is associated with the WebGL toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to WebGL APIs." formatter_data="webui=BraveShields" translateable="false">
@@ -395,6 +452,10 @@
   <!-- WebGPU is an abbreviation referring to a specific technical library and therefore is not translatable. -->
   <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_WEBGPU_LABEL" desc="This label is associated with the WebGPU toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to WebGPU APIs." formatter_data="webui=BraveShields" translateable="false">
     WebGPU
+  </message>
+
+  <message name="IDS_BRAVE_SHIELDS_BLOCK_FINGERPRINTING_WEB_SOCKETS_POOL_LABEL" desc="This label is associated with the Web Sockets Pool toggle inside the Brave shields panel > Block Fingerprinting. It allows users to turn on / off the fingerprinting protections we have applied to Web Sockets Pool APIs." formatter_data="webui=BraveShields" >
+    Web Sockets Pool
   </message>
 
 </grit-part>


### PR DESCRIPTION
This change is the final change required to be able to translate the various fingerprinting protection strings we show in the Brave shields UI. The actual translation would be followed-up asynchronously with our translators.

Resolves: https://github.com/brave/brave-browser/issues/56593

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
