### PR TITLE
[iOS] Require private browsing lock auth for open-url deep links

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/NavigationRouter.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/NavigationRouter.swift
@@ -108,52 +108,33 @@ public enum NavigationPath: Equatable {
   }
 
   private static func handleURL(url: URL?, isPrivate: Bool, with bvc: BrowserViewController) {
-    if !isPrivate {
-      if let newURL = url {
-        bvc.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false)
-      } else {
-        bvc.openBlankNewTab(
-          attemptLocationFieldFocus: Preferences.General.openKeyboardOnNTPSelection.value,
-          isPrivate: isPrivate
-        )
-      }
-      return
-    }
-
-    if Preferences.Privacy.lockWithPasscode.value {
-      if let newURL = url {
-        bvc.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false)
-      } else {
-        bvc.openBlankNewTab(
-          attemptLocationFieldFocus: Preferences.General.openKeyboardOnNTPSelection.value,
-          isPrivate: isPrivate
-        )
-      }
-    } else {
-      if Preferences.Privacy.privateBrowsingLock.value {
-        guard let windowProtection = bvc.windowProtection else { return }
-        bvc.askForLocalAuthentication(using: windowProtection, viewType: .external) {
-          [weak bvc] success, _ in
-          if success {
-            if let newURL = url {
-              bvc?.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false)
-            } else {
-              bvc?.openBlankNewTab(
-                attemptLocationFieldFocus: Preferences.General.openKeyboardOnNTPSelection.value,
-                isPrivate: isPrivate
-              )
-            }
+    // Skip private-tab auth when app passcode lock is on; the user must unlock the app first.
+    if isPrivate,
+      Preferences.Privacy.privateBrowsingLock.value,
+      !Preferences.Privacy.lockWithPasscode.value
+    {
+      guard let windowProtection = bvc.windowProtection else { return }
+      bvc.askForLocalAuthentication(using: windowProtection, viewType: .external) {
+        [weak bvc] success, _ in
+        if success {
+          if let newURL = url {
+            bvc?.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false)
+          } else {
+            bvc?.openBlankNewTab(
+              attemptLocationFieldFocus: Preferences.General.openKeyboardOnNTPSelection.value,
+              isPrivate: isPrivate
+            )
           }
         }
+      }
+    } else {
+      if let newURL = url {
+        bvc.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false)
       } else {
-        if let newURL = url {
-          bvc.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false)
-        } else {
-          bvc.openBlankNewTab(
-            attemptLocationFieldFocus: Preferences.General.openKeyboardOnNTPSelection.value,
-            isPrivate: isPrivate
-          )
-        }
+        bvc.openBlankNewTab(
+          attemptLocationFieldFocus: Preferences.General.openKeyboardOnNTPSelection.value,
+          isPrivate: isPrivate
+        )
       }
     }
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/NavigationRouter.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/NavigationRouter.swift
@@ -108,13 +108,53 @@ public enum NavigationPath: Equatable {
   }
 
   private static func handleURL(url: URL?, isPrivate: Bool, with bvc: BrowserViewController) {
-    if let newURL = url {
-      bvc.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false)
+    if !isPrivate {
+      if let newURL = url {
+        bvc.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false)
+      } else {
+        bvc.openBlankNewTab(
+          attemptLocationFieldFocus: Preferences.General.openKeyboardOnNTPSelection.value,
+          isPrivate: isPrivate
+        )
+      }
+      return
+    }
+
+    if Preferences.Privacy.lockWithPasscode.value {
+      if let newURL = url {
+        bvc.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false)
+      } else {
+        bvc.openBlankNewTab(
+          attemptLocationFieldFocus: Preferences.General.openKeyboardOnNTPSelection.value,
+          isPrivate: isPrivate
+        )
+      }
     } else {
-      bvc.openBlankNewTab(
-        attemptLocationFieldFocus: Preferences.General.openKeyboardOnNTPSelection.value,
-        isPrivate: isPrivate
-      )
+      if Preferences.Privacy.privateBrowsingLock.value {
+        guard let windowProtection = bvc.windowProtection else { return }
+        bvc.askForLocalAuthentication(using: windowProtection, viewType: .external) {
+          [weak bvc] success, _ in
+          if success {
+            if let newURL = url {
+              bvc?.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false)
+            } else {
+              bvc?.openBlankNewTab(
+                attemptLocationFieldFocus: Preferences.General.openKeyboardOnNTPSelection.value,
+                isPrivate: isPrivate
+              )
+            }
+          }
+        }
+      } else {
+        if let newURL = url {
+          bvc.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false)
+        } else {
+          bvc.openBlankNewTab(
+            attemptLocationFieldFocus: Preferences.General.openKeyboardOnNTPSelection.value,
+            isPrivate: isPrivate
+          )
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Fixes a security bypass where brave://open-url?private=true (and open-url links with private=true) could enter private browsing without biometric or pin when enabled. Applies the same external auth gate already used by the widget new-private-tab shortcut.


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56187

## Test Plan
### Preconditions:
- Require Face ID enabled
- Keep Private Tabs enabled

### Test Case: `open-url` deep links require private browsing lock auth
#### Setup
- [ ] Enable **Require Face ID** (or Touch ID / device PIN) and **Keep Private Tabs** in Brave settings.
- [ ] Open one or more tabs in private mode.
- [ ] Switch to normal mode, or close Brave.
#### Steps
- [ ] From Safari, Notes, Shortcuts, or another external app, open:
  - `brave://open-url?private=true`
  - `brave://open-url?url=https://example.com&private=true`
#### Expected
- [ ] Brave prompts for the device-specific auth challenge (PIN, Face ID, or Touch ID) before entering private mode.
- [ ] Private tabs are not shown until authentication succeeds.

| `isPrivate` | `privateBrowsingLock` | `lockWithPasscode` | Result |
|---|---|---|---|
| `false` | any | any | Open directly (non-private, unchanged) |
| `true` | `false` | any | Open directly (no lock configured) |
| `true` | `true` | `true` | Open directly (app passcode secures entry) |
| `true` | `true` | `false` | Prompt biometric/passcode auth first ✓ |

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
