### PR TITLE
[rust] Build indexmap 1.x with std via `CARGO_FEATURE_STD`

### DIFF
--- a/third_party/rust/chromium_crates_io/gnrt_config.toml
+++ b/third_party/rust/chromium_crates_io/gnrt_config.toml
@@ -515,12 +515,11 @@ extra_kv = { allow_unsafe = false }
 extra_kv = { allow_unsafe = false }
 
 [crate.indexmap]
-license_files = ['../../../../../../third_party/rust/chromium_crates_io/vendor/indexmap-v2/LICENSE-APACHE']
 # indexmap 1.x's build.rs uses autocfg to probe for `std`, which does not work
 # under gnrt (the probe rustc invocation fails). Set the cfg directly so the
 # crate builds with std support (default hasher + `IndexMap::new`). Harmless for
 # indexmap 2.x which does not read this cfg.
-extra_kv = { rustflags = [ "--cfg", "has_std" ], allow_unsafe = true }
+extra_kv = { rustenv = [ "CARGO_FEATURE_STD=1" ], allow_unsafe = true }
 
 [crate.inout]
 extra_kv = { allow_unsafe = true }

--- a/third_party/rust/indexmap/v1/BUILD.gn
+++ b/third_party/rust/indexmap/v1/BUILD.gn
@@ -50,11 +50,8 @@ cargo_crate("lib") {
   build_sources = [
     "//brave/third_party/rust/chromium_crates_io/vendor/indexmap-v1/build.rs",
   ]
-  rustenv = []
-  rustflags = [
-    "--cfg",
-    "has_std",
-  ]
+  rustenv = [ "CARGO_FEATURE_STD=1" ]
+  rustflags = []
 
   #####################################################################
   # Tweaking which GN `config`s apply to this target.

--- a/third_party/rust/indexmap/v1/README.chromium
+++ b/third_party/rust/indexmap/v1/README.chromium
@@ -3,7 +3,7 @@ URL: https://crates.io/crates/indexmap
 Version: 1.9.3
 Revision: 861fad73de14b7f08d2dc56ed83607aef621b42e
 License: Apache-2.0
-License File: //brave/third_party/rust/chromium_crates_io/vendor/indexmap-v1/../../../../../../third_party/rust/chromium_crates_io/vendor/indexmap-v2/LICENSE-APACHE
+License File: //brave/third_party/rust/chromium_crates_io/vendor/indexmap-v1/LICENSE-APACHE
 Shipped: yes
 Security Critical: yes
 


### PR DESCRIPTION
indexmap 1.x's build.rs uses autocfg to probe for `std`, which does not
work under gnrt (the probe rustc invocation fails). Previously we forced
the `has_std` cfg via rustflags to get std support (default hasher +
`IndexMap::new`).

Switch to setting `CARGO_FEATURE_STD=1` via rustenv instead, which lets
the crate's build.rs emit the cfg itself rather than us hardcoding the
internal cfg name. Update gnrt_config.toml and the generated BUILD.gn to
match.
