### PR TITLE
[VPN 2.0] Implement Agent single-instance enforcement (Win, Mac)

### DIFF
--- a/components/BUILD.gn
+++ b/components/BUILD.gn
@@ -90,7 +90,10 @@ test("brave_components_unittests") {
   }
 
   if (enable_brave_vpn_v2) {
-    deps += [ "//brave/components/brave_vpn/app/v2/shared:unit_tests" ]
+    deps += [
+      "//brave/components/brave_vpn/app/v2/agent:unit_tests",
+      "//brave/components/brave_vpn/app/v2/shared:unit_tests",
+    ]
   }
 
   if (enable_email_aliases) {

--- a/components/brave_vpn/app/v2/agent/BUILD.gn
+++ b/components/brave_vpn/app/v2/agent/BUILD.gn
@@ -19,7 +19,16 @@ source_set("core") {
   sources = [
     "agent_app.cc",
     "agent_app.h",
+    "single_instance.h",
   ]
+
+  if (is_win) {
+    sources += [ "win/single_instance_win.cc" ]
+  }
+
+  if (is_mac) {
+    sources += [ "posix/single_instance_posix.cc" ]
+  }
 
   public_deps = [ "//base" ]
 }
@@ -120,4 +129,16 @@ if (is_mac) {
         [ "{{bundle_contents_dir}}/Library/LaunchAgents/{{source_file_part}}" ]
     public_deps = [ ":brave_vpn_agent_launchd_plist" ]
   }
+}
+
+source_set("unit_tests") {
+  testonly = true
+  sources = [ "single_instance_unittest.cc" ]
+
+  deps = [
+    ":core",
+    "//base",
+    "//base/test:test_support",
+    "//testing/gtest",
+  ]
 }

--- a/components/brave_vpn/app/v2/agent/agent_app.cc
+++ b/components/brave_vpn/app/v2/agent/agent_app.cc
@@ -7,8 +7,7 @@
 
 #include "base/logging.h"
 
-namespace brave_vpn {
-namespace v2 {
+namespace brave_vpn::v2 {
 
 AgentApp::AgentApp() = default;
 
@@ -19,5 +18,4 @@ int AgentApp::Run() {
   return 0;
 }
 
-}  // namespace v2
-}  // namespace brave_vpn
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/agent_app.h
+++ b/components/brave_vpn/app/v2/agent/agent_app.h
@@ -6,8 +6,7 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_AGENT_APP_H_
 #define BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_AGENT_APP_H_
 
-namespace brave_vpn {
-namespace v2 {
+namespace brave_vpn::v2 {
 
 // The AgentApp class encapsulates the main application logic for the Brave VPN
 // agent process. It provides a stub method for running the main event loop.
@@ -25,7 +24,6 @@ class AgentApp final {
   int Run();
 };
 
-}  // namespace v2
-}  // namespace brave_vpn
+}  // namespace brave_vpn::v2
 
 #endif  // BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_AGENT_APP_H_

--- a/components/brave_vpn/app/v2/agent/main.cc
+++ b/components/brave_vpn/app/v2/agent/main.cc
@@ -5,10 +5,12 @@
 
 #include "base/at_exit.h"
 #include "base/command_line.h"
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
 #include "base/logging.h"
-#include "base/logging/logging_settings.h"
 #include "base/process/memory.h"
 #include "brave/components/brave_vpn/app/v2/agent/agent_app.h"
+#include "brave/components/brave_vpn/app/v2/agent/single_instance.h"
 #include "brave/components/brave_vpn/app/v2/shared/app_utils.h"
 #include "brave/components/brave_vpn/app/v2/shared/crash_reporter_client.h"
 #include "brave/components/brave_vpn/app/v2/shared/switches.h"
@@ -21,6 +23,7 @@
 
 using brave_vpn::v2::AgentApp;
 using brave_vpn::v2::CrashReporterClient;
+using brave_vpn::v2::SingleInstance;
 
 namespace {
 // Split into two places to avoid patching:
@@ -68,6 +71,21 @@ int main(int argc, char* argv[]) {
   brave_vpn::v2::app_utils::ConfigureFrameworkBundlePath();
 #endif
 
+  // Create the user data directory for the agent process.
+  base::FilePath user_data_dir = brave_vpn::v2::app_utils::GetUserDataDir(
+      kBraveVpnAgentAppProductName, /*is_privileged_process=*/false);
+  if (!base::CreateDirectory(user_data_dir)) {
+    LOG(ERROR) << "Failed to create user-data dir " << user_data_dir;
+    return 1;
+  }
+
+  // Only one instance of the agent is allowed to run per OS session. Try to
+  // acquire the single-instance slot. If it fails, exit cleanly.
+  auto single_instance = SingleInstance::TryAcquire(user_data_dir);
+  if (!single_instance) {
+    return 0;
+  }
+
   if (process_type.empty()) {
     process_type = kBraveVpnAgentAppProcessType;
   }
@@ -77,9 +95,7 @@ int main(int argc, char* argv[]) {
     channel_name = "unknown";
   }
   CrashReporterClient::InitializeForProcess(
-      process_type, kBraveVpnAgentAppProductName, channel_name,
-      brave_vpn::v2::app_utils::GetUserDataDir(
-          kBraveVpnAgentAppProductName, /*is_privileged_process=*/false));
+      process_type, kBraveVpnAgentAppProductName, channel_name, user_data_dir);
 
   AgentApp agent_app;
   return agent_app.Run();

--- a/components/brave_vpn/app/v2/agent/posix/single_instance_posix.cc
+++ b/components/brave_vpn/app/v2/agent/posix/single_instance_posix.cc
@@ -1,0 +1,97 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/single_instance.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <memory>
+#include <utility>
+
+#include "base/check.h"
+#include "base/files/file_path.h"
+#include "base/files/scoped_file.h"
+#include "base/logging.h"
+#include "base/posix/eintr_wrapper.h"
+#include "build/build_config.h"
+
+namespace brave_vpn::v2 {
+
+namespace {
+// Linux has Open File Description locks. These are owned by the open file
+// description rather than the [process, inode] pair, so an unrelated open/close
+// of the lock file elsewhere in the process cannot drop the lock. macOS has no
+// real OFD locks (OFD locking is not actually implemented in the Darwin
+// kernel), so we fall back to classic fcntl record locks. The lock file must
+// stay private to the module, since closing any descriptor to it in this
+// process would release the lock.
+#if BUILDFLAG(IS_LINUX)
+constexpr int kSetLockCommand = F_OFD_SETLK;
+#else
+constexpr int kSetLockCommand = F_SETLK;
+#endif
+
+// Name of the lock file placed inside the caller-supplied user data directory.
+constexpr char kLockFileName[] = "agent.lock";
+
+class SingleInstancePosix : public SingleInstance {
+ public:
+  explicit SingleInstancePosix(base::ScopedFD fd) : fd_(std::move(fd)) {}
+
+ private:
+  base::ScopedFD fd_;
+};
+
+}  // namespace
+
+// static
+std::unique_ptr<SingleInstance> SingleInstance::TryAcquire(
+    const base::FilePath& user_data_dir) {
+  CHECK(!user_data_dir.empty());
+  const base::FilePath path = user_data_dir.Append(kLockFileName);
+
+  // O_CLOEXEC matters in particular for OFD locks: the lock follows the open
+  // file description, so a child process that inherited this descriptor would
+  // keep the lock alive past our death. O_CLOEXEC prevents the descriptor from
+  // surviving an exec, so only this process can hold the lock.
+  base::ScopedFD fd(HANDLE_EINTR(
+      open(path.value().c_str(),
+           O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW, 0600)));
+  if (!fd.is_valid() && errno == EEXIST) {
+    fd.reset(HANDLE_EINTR(
+        open(path.value().c_str(), O_RDWR | O_CLOEXEC | O_NOFOLLOW)));
+  }
+  if (!fd.is_valid()) {
+    // The error could be ELOOP if this is a symlink which might mean a security
+    // issue. Symlinks as lock files are not allowed, so we treat this as a
+    // failure to acquire the lock.
+    PLOG(ERROR) << "Could not open single-instance lock file " << path;
+    return nullptr;
+  }
+
+  struct flock fl = {};
+  fl.l_type = F_WRLCK;
+  fl.l_whence = SEEK_SET;
+  fl.l_start = 0;
+  fl.l_len = 0;  // 0 == whole file.
+  if (HANDLE_EINTR(fcntl(fd.get(), kSetLockCommand, &fl)) == -1) {
+    // EAGAIN and EACCES are the only errnos that mean "another process holds a
+    // conflicting lock", i.e. another agent is already running. POSIX permits
+    // F_SETLK to report contention as either. Everything else is a genuine
+    // failure with no second agent involved.
+    if (errno == EAGAIN || errno == EACCES) {
+      LOG(WARNING) << "Another agent is already running in this session";
+    } else {
+      PLOG(ERROR) << "Could not acquire single-instance lock on " << path;
+    }
+    return nullptr;
+  }
+
+  return std::make_unique<SingleInstancePosix>(std::move(fd));
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/single_instance.h
+++ b/components/brave_vpn/app/v2/agent/single_instance.h
@@ -1,0 +1,45 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_SINGLE_INSTANCE_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_SINGLE_INSTANCE_H_
+
+#include <memory>
+
+#include "base/files/file_path.h"
+
+namespace brave_vpn::v2 {
+
+// Enforces that at most one VPN agent runs per OS session.
+//
+// The agent calls TryAcquire() once at startup and holds the returned owner
+// object for its entire lifetime. When the object is destroyed -- or when the
+// process exits, is killed, or crashes -- the underlying OS primitive is
+// released by the kernel, so there is never any stale state to clean up.
+class SingleInstance {
+ public:
+  SingleInstance() = default;
+  SingleInstance(const SingleInstance&) = delete;
+  SingleInstance& operator=(const SingleInstance&) = delete;
+  virtual ~SingleInstance() = default;
+
+  // Attempts to claim the single-instance slot for the current OS session.
+  // |user_data_dir| is the directory in which the lock file is created on
+  // platforms that back single-instance with a file (macOS: "agent.lock" is
+  // placed directly inside it; the directory is expected to already exist).
+  // Platforms that use a kernel-named object (Windows) ignore it.
+  //
+  // Returns a non-null owner if this process is now the sole instance.
+  // The caller must keep it alive for as long as the agent runs.
+  // Returns nullptr if another instance already holds the slot, or if the
+  // OS primitive could not be created. In both cases the caller must not
+  // proceed as the agent. The concrete reason is logged internally.
+  static std::unique_ptr<SingleInstance> TryAcquire(
+      const base::FilePath& user_data_dir);
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_SINGLE_INSTANCE_H_

--- a/components/brave_vpn/app/v2/agent/single_instance_unittest.cc
+++ b/components/brave_vpn/app/v2/agent/single_instance_unittest.cc
@@ -1,0 +1,180 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/single_instance.h"
+
+#include <memory>
+#include <string>
+
+#include "base/check.h"
+#include "base/command_line.h"
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
+#include "base/process/process.h"
+#include "base/test/gtest_util.h"
+#include "base/test/multiprocess_test.h"
+#include "base/test/test_timeouts.h"
+#include "base/threading/platform_thread.h"
+#include "base/time/time.h"
+#include "build/build_config.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "testing/multiprocess_func_list.h"
+
+namespace brave_vpn::v2 {
+
+namespace {
+
+// Switch used to hand the lock directory (a per-test temp dir) to the child.
+constexpr char kLockDirSwitch[] = "single-instance-lock-dir";
+
+// Filesystem "events" used to hand-shake between parent and child, since the
+// two processes share no memory. Same pattern as base's file_locking_unittest.
+constexpr base::FilePath::CharType kChildLockedSignal[] =
+    FILE_PATH_LITERAL("child_locked");
+constexpr base::FilePath::CharType kParentReleaseSignal[] =
+    FILE_PATH_LITERAL("parent_release");
+
+// Creates an empty marker file. Returns false on failure.
+bool SignalEvent(const base::FilePath& path) {
+  return base::WriteFile(path, "");
+}
+
+// Polls for |path| to appear, up to the standard action timeout.
+bool WaitForEvent(const base::FilePath& path) {
+  const base::TimeTicks deadline =
+      base::TimeTicks::Now() + TestTimeouts::action_timeout();
+  while (base::TimeTicks::Now() < deadline) {
+    if (base::PathExists(path)) {
+      return true;
+    }
+    base::PlatformThread::Sleep(base::Milliseconds(10));
+  }
+  return false;
+}
+
+// Tries to acquire, retrying briefly. Used after a holder dies, because the OS
+// may take a moment to reap the process and release its lock.
+std::unique_ptr<SingleInstance> AcquireWithRetry(const base::FilePath& dir) {
+  const base::TimeTicks deadline =
+      base::TimeTicks::Now() + TestTimeouts::action_timeout();
+  for (;;) {
+    if (auto instance = SingleInstance::TryAcquire(dir)) {
+      return instance;
+    }
+    if (base::TimeTicks::Now() >= deadline) {
+      return nullptr;
+    }
+    base::PlatformThread::Sleep(base::Milliseconds(10));
+  }
+}
+
+}  // namespace
+
+// Child entry point: acquire the lock, tell the parent we hold it, then hold it
+// until the parent releases us. Any failure CHECK-fails with a message; the
+// parent keys off the "locked" marker file appearing, not the exit code.
+MULTIPROCESS_TEST_MAIN(SingleInstanceChildHolder) {
+  const base::FilePath dir =
+      base::CommandLine::ForCurrentProcess()->GetSwitchValuePath(
+          kLockDirSwitch);
+  CHECK(!dir.empty());
+
+  std::unique_ptr<SingleInstance> instance = SingleInstance::TryAcquire(dir);
+  CHECK(instance) << "child could not acquire the single-instance lock";
+
+  CHECK(SignalEvent(dir.Append(kChildLockedSignal)));
+  CHECK(WaitForEvent(dir.Append(kParentReleaseSignal)));
+
+  return 0;  // The lock is released as the process exits.
+}
+
+class SingleInstanceTest : public base::MultiProcessTest {
+ protected:
+  void SetUp() override {
+    base::MultiProcessTest::SetUp();
+    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
+  }
+
+  // Inject the per-test lock directory into every spawned child.
+  base::CommandLine MakeCmdLine(const std::string& procname) override {
+    base::CommandLine command_line =
+        base::MultiProcessTest::MakeCmdLine(procname);
+    command_line.AppendSwitchPath(kLockDirSwitch, dir());
+    return command_line;
+  }
+
+  base::FilePath dir() const { return temp_dir_.GetPath(); }
+  base::FilePath locked_signal() const {
+    return dir().Append(kChildLockedSignal);
+  }
+  base::FilePath release_signal() const {
+    return dir().Append(kParentReleaseSignal);
+  }
+
+  base::ScopedTempDir temp_dir_;
+};
+
+TEST_F(SingleInstanceTest, AcquireSucceedsOnFreshDirectory) {
+  EXPECT_TRUE(SingleInstance::TryAcquire(dir()));
+}
+
+TEST_F(SingleInstanceTest, ReacquireSucceedsAfterOwnerDestroyed) {
+  {
+    std::unique_ptr<SingleInstance> instance =
+        SingleInstance::TryAcquire(dir());
+    ASSERT_TRUE(instance);
+  }
+  // Destroying the owner releases the lock, so the slot is free again.
+  EXPECT_TRUE(SingleInstance::TryAcquire(dir()));
+}
+
+// Contention is only meaningful across processes: lock ownership is per
+// process, so a second TryAcquire() in this process would not reliably
+// reproduce it (classic POSIX record locks let the same process relock, and the
+// per-platform primitives differ). Spawn a holder and verify we are refused.
+TEST_F(SingleInstanceTest, SecondInstanceRejectedWhileHeldByOtherProcess) {
+  base::Process child = SpawnChild("SingleInstanceChildHolder");
+  ASSERT_TRUE(child.IsValid());
+  ASSERT_TRUE(WaitForEvent(locked_signal()));
+
+  // The child holds the lock; this process must be refused.
+  EXPECT_FALSE(SingleInstance::TryAcquire(dir()));
+
+  // Let the child exit cleanly, releasing the lock.
+  ASSERT_TRUE(SignalEvent(release_signal()));
+  int exit_code = -1;
+  ASSERT_TRUE(
+      child.WaitForExitWithTimeout(TestTimeouts::action_timeout(), &exit_code));
+  EXPECT_EQ(0, exit_code);
+
+  // With the holder gone, the slot is free again.
+  EXPECT_TRUE(AcquireWithRetry(dir()));
+}
+
+// Crash-resistance: the kernel releases the lock when the holder dies, even
+// without a graceful release. Kill the holder and confirm we can acquire.
+TEST_F(SingleInstanceTest, LockReleasedWhenHolderIsKilled) {
+  base::Process child = SpawnChild("SingleInstanceChildHolder");
+  ASSERT_TRUE(child.IsValid());
+  ASSERT_TRUE(WaitForEvent(locked_signal()));
+  EXPECT_FALSE(SingleInstance::TryAcquire(dir()));
+
+  // Terminate without signaling release -- stands in for a crash.
+  ASSERT_TRUE(child.Terminate(/*exit_code=*/1, /*wait=*/true));
+
+  EXPECT_TRUE(AcquireWithRetry(dir()));
+}
+
+#if BUILDFLAG(IS_POSIX)
+// The empty-dir CHECK lives in the POSIX implementation (the lock file path is
+// derived from the directory). The Windows mutex backend ignores the directory,
+// so this contract is POSIX-only.
+TEST(SingleInstanceDeathTest, EmptyDirectoryChecks) {
+  EXPECT_CHECK_DEATH(SingleInstance::TryAcquire(base::FilePath()));
+}
+#endif  // BUILDFLAG(IS_POSIX)
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/win/single_instance_win.cc
+++ b/components/brave_vpn/app/v2/agent/win/single_instance_win.cc
@@ -1,0 +1,59 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/single_instance.h"
+
+#include <windows.h>
+
+#include <memory>
+#include <utility>
+
+#include "base/files/file_path.h"
+#include "base/logging.h"
+#include "base/win/scoped_handle.h"
+
+namespace brave_vpn::v2 {
+namespace {
+
+// Name of the single-instance mutex.
+constexpr wchar_t kAgentMutexName[] = L"Local\\BraveVpnAgentSingleInstance";
+
+class SingleInstanceWin : public SingleInstance {
+ public:
+  explicit SingleInstanceWin(base::win::ScopedHandle handle)
+      : handle_(std::move(handle)) {}
+
+ private:
+  base::win::ScopedHandle handle_;
+};
+
+}  // namespace
+
+// static
+std::unique_ptr<SingleInstance> SingleInstance::TryAcquire(
+    const base::FilePath& /*user_data_dir*/) {
+  // |user_data_dir| is unused on Windows: single-instance is enforced with a
+  // session-local named mutex, not a lock file.
+  base::win::ScopedHandle handle(::CreateMutexW(
+      /*lpMutexAttributes=*/nullptr, /*bInitialOwner=*/FALSE, kAgentMutexName));
+  const DWORD error = ::GetLastError();
+
+  if (!handle.is_valid()) {
+    // Could not create the object at all. This is a fatal error, because we
+    // cannot guarantee single-instance.
+    LOG(ERROR) << "Failed to create single-instance mutex, error=" << error;
+    return nullptr;
+  }
+
+  if (error == ERROR_ALREADY_EXISTS) {
+    // Another agent in this session already owns the name.
+    LOG(WARNING) << "Another agent is already running in this session";
+    return nullptr;
+  }
+
+  return std::make_unique<SingleInstanceWin>(std::move(handle));
+}
+
+}  // namespace brave_vpn::v2


### PR DESCRIPTION
Ensure at most one VPN agent runs per OS session. The agent calls SingleInstance::TryAcquire() once at startup and holds the returned owner for its lifetime; if another instance already holds the slot, the acquire fails and the process exits cleanly. The underlying OS primitive is released by the kernel on normal exit, kill, or crash, so there is no stale state to clean up and no lock file to garbage-collect.

Platform mechanisms:
- Windows: a named mutex in the session-local ("Local\\") namespace, which scopes uniqueness to the current login session.
- POSIX (macOS now, Linux is a future follow-up): a non-blocking, whole-file advisory lock on "agent.lock" in the user-data directory. The lock is taken with raw fcntl rather than base::File::Lock() so the errno can be classified: EAGAIN/EACCES mean another agent holds the lock, while anything else (e.g. ENOTSUP on a filesystem without lock support) is surfaced as a real error instead of being mistaken for contention. base::File flattens EAGAIN into FILE_ERROR_FAILED and so cannot make that distinction. Linux uses Open File Description locks (F_OFD_SETLK) for fd-scoped ownership; macOS falls back to classic record locks, as Darwin defines the F_OFD_* constants but does not implement them.

Resolves https://github.com/brave/brave-browser/issues/54620

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
