### PR TITLE
[cr150][Android] Fix --variations-pr= seed not applying

### DIFF
--- a/android/java/org/chromium/base/BraveCommandLineInitUtil.java
+++ b/android/java/org/chromium/base/BraveCommandLineInitUtil.java
@@ -9,6 +9,7 @@ import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import org.chromium.build.annotations.NullMarked;
 
@@ -39,14 +40,15 @@ public abstract class BraveCommandLineInitUtil {
 
     // Suppress to access SharedPreferences, which is discouraged; we cannot depend on //chrome from
     // //base to use ChromeSharedPreferences
+    @VisibleForTesting
     @SuppressWarnings("UseSharedPreferencesManagerFromChromeCheck")
-    private static void appendBraveSwitchesAndArguments() {
+    static void appendBraveSwitchesAndArguments() {
         SharedPreferences sharedPreferences = ContextUtils.getAppSharedPreferences();
         String qaCommandLine = sharedPreferences.getString(PREF_QA_COMMAND_LINE, "");
         if (sharedPreferences.getBoolean(PREF_QA_VLOG_REWARDS, false)) {
             qaCommandLine += " --enable-logging=stderr";
             qaCommandLine +=
-                    " --vmodule=*/brave_ads/*=6,*/brave_user_model/*=6,*/bat_ads/*=6,*/brave_rewards/*=6";
+                    " --vmodule=*/brave_ads/*=6,*/brave_user_model/*=6,*/bat_ads/*=6,*/brave_rewards/*=6"; // presubmit: ignore-long-line
         }
 
         // For testing we need custom variations server url prior to the first time run, so we try
@@ -90,5 +92,15 @@ public abstract class BraveCommandLineInitUtil {
         @SuppressLint("VisibleForTests")
         String[] args = CommandLine.tokenizeQuotedArguments(qaCommandLine.toCharArray());
         CommandLine.getInstance().appendSwitchesAndArguments(args);
+
+        // In cr150, CreateFeatureList() (and thus VerifyAndParseSeedImpl) is now called
+        // from Java via InitializeFeatureList.initializeFeatureList() before
+        // BraveMainDelegate::BasicStartupComplete() runs AppendBraveCommandLineOptions.
+        // If --variations-pr= is set, the PR test seed has no signature, so we must
+        // add accept-empty-variations-seed-signature here — before any native code
+        // touches the seed — otherwise signature verification wipes the stored seed.
+        if (CommandLine.getInstance().hasSwitch("variations-pr")) {
+            CommandLine.getInstance().appendSwitch("accept-empty-variations-seed-signature");
+        }
     }
 }

--- a/android/junit/BUILD.gn
+++ b/android/junit/BUILD.gn
@@ -10,6 +10,12 @@ import("//third_party/jni_zero/jni_zero.gni")
 testonly = true
 
 if (is_android) {
+  robolectric_library("brave_junit_tests_org.chromium.base") {
+    sources = [ "src/org/chromium/base/BraveCommandLineInitUtilTest.java" ]
+
+    deps = [ "//chrome/android/junit:chrome_junit_tests_helper" ]
+  }
+
   robolectric_library(
       "brave_junit_tests_org.chromium.chrome.browser.homepage") {
     sources = [

--- a/android/junit/src/org/chromium/base/BraveCommandLineInitUtilTest.java
+++ b/android/junit/src/org/chromium/base/BraveCommandLineInitUtilTest.java
@@ -1,0 +1,73 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.base;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import org.chromium.base.test.BaseRobolectricTestRunner;
+
+/** Unit tests for {@link BraveCommandLineInitUtil}. */
+@RunWith(BaseRobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class BraveCommandLineInitUtilTest {
+    private static final String PREF_QA_COMMAND_LINE = "qa_command_line";
+    private static final String SWITCH_VARIATIONS_PR = "variations-pr";
+    private static final String SWITCH_ACCEPT_EMPTY_SIGNATURE =
+            "accept-empty-variations-seed-signature";
+
+    @Before
+    public void setUp() {
+        // Reset CommandLine to a clean empty state so each test starts fresh.
+        CommandLine.resetForTesting(/* initialize= */ true);
+        clearQaPref();
+    }
+
+    @After
+    public void tearDown() {
+        clearQaPref();
+    }
+
+    @Test
+    public void testVariationsPrAddsAcceptEmptySeedSignature() {
+        // Simulate the user setting --variations-pr= via BraveQAPreferences.
+        ContextUtils.getAppSharedPreferences()
+                .edit()
+                .putString(PREF_QA_COMMAND_LINE, "--" + SWITCH_VARIATIONS_PR + "=1739")
+                .apply();
+
+        BraveCommandLineInitUtil.appendBraveSwitchesAndArguments();
+
+        assertTrue(
+                "variations-pr should be present after reading qa_command_line pref",
+                CommandLine.getInstance().hasSwitch(SWITCH_VARIATIONS_PR));
+        assertTrue(
+                "accept-empty-variations-seed-signature must be added when variations-pr is set,"
+                        + " so that unsigned PR test seeds pass verification during early feature"
+                        + " list initialization (before BraveMainDelegate::BasicStartupComplete)",
+                CommandLine.getInstance().hasSwitch(SWITCH_ACCEPT_EMPTY_SIGNATURE));
+    }
+
+    @Test
+    public void testWithoutVariationsPrNoAcceptEmptySeedSignature() {
+        // No variations-pr switch set anywhere.
+        BraveCommandLineInitUtil.appendBraveSwitchesAndArguments();
+
+        assertFalse(
+                "accept-empty-variations-seed-signature should not be added without variations-pr",
+                CommandLine.getInstance().hasSwitch(SWITCH_ACCEPT_EMPTY_SIGNATURE));
+    }
+
+    private void clearQaPref() {
+        ContextUtils.getAppSharedPreferences().edit().remove(PREF_QA_COMMAND_LINE).apply();
+    }
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1714,6 +1714,7 @@ if (is_android) {
     ]
 
     deps = [
+      "//brave/android/junit:brave_junit_tests_org.chromium.base",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.app",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.autofill",


### PR DESCRIPTION
In upstream commit  `kLoadNativeEarly` was enabled by default. This causes `InitializeFeatureList.initializeFeatureList()` to be called from Java early in startup — before `BraveMainDelegate::BasicStartupComplete()` runs `AppendBraveCommandLineOptions()`.

As a result, `CreateFeatureList()` → `SetUpFieldTrials()` → `CreateTrialsFromSeed()` → `VerifyAndParseSeedImpl()` now executes while `--accept-empty-variations-seed-signature` is not yet on the command line. The PR test seed (fetched via `--variations-pr=`) has an empty signature, so signature verification fails, `ClearPrefs()` wipes the stored seed, and the seed is never applied on subsequent startups.

Fix is to add  `--accept-empty-variations-seed-signature` in `BraveCommandLineInitUtil.appendBraveSwitchesAndArguments()` immediately after detecting `--variations-pr=` on the command line. This runs during Java command line initialization, well before any native code touches the variations seed.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56600

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
