### PR TITLE
Normalize empty tool-call arguments to an empty JSON object

### DIFF
--- a/components/ai_chat/content/browser/content_tool.cc
+++ b/components/ai_chat/content/browser/content_tool.cc
@@ -121,8 +121,12 @@ void ContentTool::UseTool(const std::string& input_json,
   rfh->GetRemoteInterfaces()->GetInterface(
       extractor.BindNewPipeAndPassReceiver());
   auto* extractor_ptr = extractor.get();
+  // Models may emit an empty string for a tool that takes no parameters. The
+  // renderer parses this as JSON and fails ("Failed to parse input arguments"),
+  // so normalize it to an empty object.
+  const std::string& tool_input = input_json.empty() ? "{}" : input_json;
   extractor_ptr->ExecuteContentTool(
-      internal_tool_name_, input_json,
+      internal_tool_name_, tool_input,
       base::BindOnce(
           [](UseToolCallback cb, mojo::Remote<mojom::PageContentExtractor>,
              const std::optional<std::string>& result) {

--- a/components/ai_chat/content/browser/content_tool_unittest.cc
+++ b/components/ai_chat/content/browser/content_tool_unittest.cc
@@ -8,12 +8,16 @@
 #include <string>
 #include <vector>
 
+#include "base/functional/callback_helpers.h"
 #include "base/test/test_future.h"
 #include "brave/components/ai_chat/core/browser/tools/tool.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
+#include "brave/components/ai_chat/core/common/mojom/page_content_extractor.mojom.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/test/test_renderer_host.h"
 #include "content/public/test/web_contents_tester.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+#include "services/service_manager/public/cpp/interface_provider.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/blink/public/mojom/content_extraction/script_tools.mojom.h"
@@ -41,6 +45,39 @@ blink::mojom::ScriptToolPtr MakeScriptTool(
   return tool;
 }
 
+class MockPageContentExtractor : public mojom::PageContentExtractor {
+ public:
+  MockPageContentExtractor() = default;
+  ~MockPageContentExtractor() override = default;
+
+  MOCK_METHOD(void,
+              ExtractPageContent,
+              (ExtractPageContentCallback),
+              (override));
+  MOCK_METHOD(void,
+              GetSearchSummarizerKey,
+              (GetSearchSummarizerKeyCallback),
+              (override));
+  MOCK_METHOD(void,
+              GetOpenAIChatButtonNonce,
+              (GetOpenAIChatButtonNonceCallback),
+              (override));
+  MOCK_METHOD(void,
+              ExecuteContentTool,
+              (const std::string& name,
+               const std::string& input_json,
+               ExecuteContentToolCallback),
+              (override));
+
+  void Bind(mojo::ScopedMessagePipeHandle handle) {
+    receiver_.Bind(
+        mojo::PendingReceiver<mojom::PageContentExtractor>(std::move(handle)));
+  }
+
+ private:
+  mojo::Receiver<mojom::PageContentExtractor> receiver_{this};
+};
+
 }  // namespace
 
 class ContentToolTest : public content::RenderViewHostTestHarness {
@@ -54,6 +91,44 @@ class ContentToolTest : public content::RenderViewHostTestHarness {
   content::WeakDocumentPtr weak_document() {
     return main_rfh()->GetWeakDocumentPtr();
   }
+
+  // Binds a mock PageContentExtractor for the main frame so UseTool's mojo call
+  // can be intercepted.
+  MockPageContentExtractor* SetUpMockExtractor() {
+    content::RenderFrameHostTester::For(web_contents()->GetPrimaryMainFrame())
+        ->InitializeRenderFrameIfNeeded();
+    service_manager::InterfaceProvider::TestApi test_api(
+        web_contents()->GetPrimaryMainFrame()->GetRemoteInterfaces());
+    mock_extractor_ = std::make_unique<MockPageContentExtractor>();
+    test_api.SetBinderForName(
+        mojom::PageContentExtractor::Name_,
+        base::BindRepeating(&MockPageContentExtractor::Bind,
+                            base::Unretained(mock_extractor_.get())));
+    return mock_extractor_.get();
+  }
+
+  // Runs UseTool with `input_json` against a freshly-bound mock extractor and
+  // returns the input_json the tool actually forwarded to the renderer.
+  std::string ForwardedInputFor(const std::string& input_json) {
+    MockPageContentExtractor* extractor = SetUpMockExtractor();
+    auto mojo_tool = MakeScriptTool("noop", "");
+    ContentTool tool(*mojo_tool, weak_document());
+
+    base::test::TestFuture<std::string> input_future;
+    EXPECT_CALL(*extractor,
+                ExecuteContentTool(::testing::_, ::testing::_, ::testing::_))
+        .WillOnce(
+            [&](const std::string& name, const std::string& forwarded,
+                mojom::PageContentExtractor::ExecuteContentToolCallback cb) {
+              input_future.SetValue(forwarded);
+              std::move(cb).Run("ok");
+            });
+    tool.UseTool(input_json, base::DoNothing());
+    return input_future.Get();
+  }
+
+ private:
+  std::unique_ptr<MockPageContentExtractor> mock_extractor_;
 };
 
 TEST_F(ContentToolTest, NamePrefixesHostAndSanitizes) {
@@ -146,6 +221,26 @@ TEST_F(ContentToolTest, RequiresPermissionChallengeUntilGranted) {
   auto after = tool.RequiresUserInteractionBeforeHandling(*tool_use);
   ASSERT_TRUE(std::holds_alternative<bool>(after));
   EXPECT_FALSE(std::get<bool>(after));
+}
+
+TEST_F(ContentToolTest, UseToolNormalizesEmptyInputToObject) {
+  // Models may emit an empty string for a tool that takes no parameters. The
+  // renderer fails to parse "" as JSON, so UseTool must forward "{}" instead.
+  EXPECT_EQ(ForwardedInputFor(/*input_json=*/""), "{}");
+}
+
+TEST_F(ContentToolTest, UseToolForwardsNonEmptyInputUnchanged) {
+  EXPECT_EQ(ForwardedInputFor(R"({"query":"weather"})"),
+            R"({"query":"weather"})");
+}
+
+TEST_F(ContentToolTest, UseToolForwardsEmptyIshJsonValuesUnchanged) {
+  // Only a truly empty string is normalized. Valid JSON values that merely look
+  // "empty" (null, an empty JSON string, an empty array, an empty object) are
+  // non-empty strings and must be forwarded verbatim.
+  for (const std::string args : {"null", R"("")", "[]", "{}"}) {
+    EXPECT_EQ(ForwardedInputFor(args), args) << "args=" << args;
+  }
 }
 
 TEST_F(ContentToolTest, UseToolAfterDocumentGoneReturnsEmpty) {

--- a/components/ai_chat/core/browser/engine/oai_serialization_utils.cc
+++ b/components/ai_chat/core/browser/engine/oai_serialization_utils.cc
@@ -51,7 +51,12 @@ void SerializeToolCallsOnMessageDict(const OAIMessage& message,
 
       base::DictValue function_dict;
       function_dict.Set("name", tool_event->tool_name);
-      function_dict.Set("arguments", tool_event->arguments_json);
+      // Some models emit an empty string for the arguments of a tool that takes
+      // no parameters. An empty string is not valid JSON, so the server rejects
+      // the tool call ("invalid json arguments"). Normalize to an empty object.
+      function_dict.Set("arguments", tool_event->arguments_json.empty()
+                                         ? "{}"
+                                         : tool_event->arguments_json);
 
       tool_call_dict.Set("function", std::move(function_dict));
       tool_call_dicts.Append(std::move(tool_call_dict));

--- a/components/ai_chat/core/browser/engine/oai_serialization_utils_unittest.cc
+++ b/components/ai_chat/core/browser/engine/oai_serialization_utils_unittest.cc
@@ -5,13 +5,38 @@
 
 #include "brave/components/ai_chat/core/browser/engine/oai_serialization_utils.h"
 
+#include <string>
+
 #include "brave/components/ai_chat/core/browser/engine/oai_message_utils.h"
-#include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "url/gurl.h"
 
 namespace ai_chat {
+
+namespace {
+
+// Serializes a single tool call with the given `arguments_json` and returns the
+// resulting "arguments" string written to the message dict.
+std::string SerializeToolCallArguments(const std::string& arguments_json) {
+  OAIMessage message;
+  message.tool_calls.push_back(
+      mojom::ToolUseEvent::New("tool", "call_1", arguments_json, std::nullopt,
+                               std::nullopt, nullptr, false));
+
+  base::DictValue dict;
+  SerializeToolCallsOnMessageDict(message, dict);
+
+  const base::ListValue* tool_calls = dict.FindList("tool_calls");
+  EXPECT_TRUE(tool_calls);
+  EXPECT_EQ(tool_calls->size(), 1u);
+  const base::DictValue* function =
+      (*tool_calls)[0].GetDict().FindDict("function");
+  EXPECT_TRUE(function);
+  return *function->FindString("arguments");
+}
+
+}  // namespace
 
 TEST(OAISerializationUtilsTest, MemoryContentBlockToDict_StringValues) {
   auto block = mojom::MemoryContentBlock::New();
@@ -159,41 +184,14 @@ TEST(OAISerializationUtilsTest,
   // Some models emit an empty string for the arguments of a tool that takes no
   // parameters. An empty string is not valid JSON, so it must be normalized to
   // an empty object before being echoed back to the server.
-  OAIMessage message;
-  message.tool_calls.push_back(
-      mojom::ToolUseEvent::New("no_args_tool", "call_1", /*arguments_json=*/"",
-                               std::nullopt, std::nullopt, nullptr, false));
-
-  base::DictValue dict;
-  SerializeToolCallsOnMessageDict(message, dict);
-
-  const base::ListValue* tool_calls = dict.FindList("tool_calls");
-  ASSERT_TRUE(tool_calls);
-  ASSERT_EQ(tool_calls->size(), 1u);
-  const base::DictValue* function =
-      (*tool_calls)[0].GetDict().FindDict("function");
-  ASSERT_TRUE(function);
-  EXPECT_EQ(*function->FindString("arguments"), "{}");
+  EXPECT_EQ(SerializeToolCallArguments(""), "{}");
 }
 
 TEST(OAISerializationUtilsTest,
      SerializeToolCallsOnMessageDict_NonEmptyArgumentsUnchanged) {
   // Non-empty arguments must be passed through verbatim.
-  OAIMessage message;
-  message.tool_calls.push_back(
-      mojom::ToolUseEvent::New("search", "call_1", R"({"query":"weather"})",
-                               std::nullopt, std::nullopt, nullptr, false));
-
-  base::DictValue dict;
-  SerializeToolCallsOnMessageDict(message, dict);
-
-  const base::ListValue* tool_calls = dict.FindList("tool_calls");
-  ASSERT_TRUE(tool_calls);
-  ASSERT_EQ(tool_calls->size(), 1u);
-  const base::DictValue* function =
-      (*tool_calls)[0].GetDict().FindDict("function");
-  ASSERT_TRUE(function);
-  EXPECT_EQ(*function->FindString("arguments"), R"({"query":"weather"})");
+  EXPECT_EQ(SerializeToolCallArguments(R"({"query":"weather"})"),
+            R"({"query":"weather"})");
 }
 
 TEST(OAISerializationUtilsTest,
@@ -202,20 +200,7 @@ TEST(OAISerializationUtilsTest,
   // "empty" (null, an empty JSON string, an empty array, an empty object) are
   // non-empty strings and must be passed through verbatim.
   for (const char* args : {"null", R"("")", "[]", "{}"}) {
-    OAIMessage message;
-    message.tool_calls.push_back(mojom::ToolUseEvent::New(
-        "tool", "call_1", args, std::nullopt, std::nullopt, nullptr, false));
-
-    base::DictValue dict;
-    SerializeToolCallsOnMessageDict(message, dict);
-
-    const base::ListValue* tool_calls = dict.FindList("tool_calls");
-    ASSERT_TRUE(tool_calls);
-    ASSERT_EQ(tool_calls->size(), 1u);
-    const base::DictValue* function =
-        (*tool_calls)[0].GetDict().FindDict("function");
-    ASSERT_TRUE(function);
-    EXPECT_EQ(*function->FindString("arguments"), args) << "args=" << args;
+    EXPECT_EQ(SerializeToolCallArguments(args), args) << "args=" << args;
   }
 }
 

--- a/components/ai_chat/core/browser/engine/oai_serialization_utils_unittest.cc
+++ b/components/ai_chat/core/browser/engine/oai_serialization_utils_unittest.cc
@@ -154,4 +154,69 @@ TEST(OAISerializationUtilsTest,
   EXPECT_EQ(*tool_call_id, "call_0");
 }
 
+TEST(OAISerializationUtilsTest,
+     SerializeToolCallsOnMessageDict_EmptyArgumentsNormalizedToObject) {
+  // Some models emit an empty string for the arguments of a tool that takes no
+  // parameters. An empty string is not valid JSON, so it must be normalized to
+  // an empty object before being echoed back to the server.
+  OAIMessage message;
+  message.tool_calls.push_back(
+      mojom::ToolUseEvent::New("no_args_tool", "call_1", /*arguments_json=*/"",
+                               std::nullopt, std::nullopt, nullptr, false));
+
+  base::DictValue dict;
+  SerializeToolCallsOnMessageDict(message, dict);
+
+  const base::ListValue* tool_calls = dict.FindList("tool_calls");
+  ASSERT_TRUE(tool_calls);
+  ASSERT_EQ(tool_calls->size(), 1u);
+  const base::DictValue* function =
+      (*tool_calls)[0].GetDict().FindDict("function");
+  ASSERT_TRUE(function);
+  EXPECT_EQ(*function->FindString("arguments"), "{}");
+}
+
+TEST(OAISerializationUtilsTest,
+     SerializeToolCallsOnMessageDict_NonEmptyArgumentsUnchanged) {
+  // Non-empty arguments must be passed through verbatim.
+  OAIMessage message;
+  message.tool_calls.push_back(
+      mojom::ToolUseEvent::New("search", "call_1", R"({"query":"weather"})",
+                               std::nullopt, std::nullopt, nullptr, false));
+
+  base::DictValue dict;
+  SerializeToolCallsOnMessageDict(message, dict);
+
+  const base::ListValue* tool_calls = dict.FindList("tool_calls");
+  ASSERT_TRUE(tool_calls);
+  ASSERT_EQ(tool_calls->size(), 1u);
+  const base::DictValue* function =
+      (*tool_calls)[0].GetDict().FindDict("function");
+  ASSERT_TRUE(function);
+  EXPECT_EQ(*function->FindString("arguments"), R"({"query":"weather"})");
+}
+
+TEST(OAISerializationUtilsTest,
+     SerializeToolCallsOnMessageDict_EmptyIshJsonValuesUnchanged) {
+  // Only a truly empty string is normalized. Valid JSON values that merely look
+  // "empty" (null, an empty JSON string, an empty array, an empty object) are
+  // non-empty strings and must be passed through verbatim.
+  for (const char* args : {"null", R"("")", "[]", "{}"}) {
+    OAIMessage message;
+    message.tool_calls.push_back(mojom::ToolUseEvent::New(
+        "tool", "call_1", args, std::nullopt, std::nullopt, nullptr, false));
+
+    base::DictValue dict;
+    SerializeToolCallsOnMessageDict(message, dict);
+
+    const base::ListValue* tool_calls = dict.FindList("tool_calls");
+    ASSERT_TRUE(tool_calls);
+    ASSERT_EQ(tool_calls->size(), 1u);
+    const base::DictValue* function =
+        (*tool_calls)[0].GetDict().FindDict("function");
+    ASSERT_TRUE(function);
+    EXPECT_EQ(*function->FindString("arguments"), args) << "args=" << args;
+  }
+}
+
 }  // namespace ai_chat


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/56601
Series https://github.com/brave/brave-browser/issues/55232

Some models emit an empty string for the `arguments` of a tool that takes no parameters. An empty string is not valid JSON, which was causing the tool call to fail