### PR TITLE
Disable wallet panel interaction while occluded by PIP

### DIFF
--- a/browser/brave_wallet/brave_wallet_tab_helper.cc
+++ b/browser/brave_wallet/brave_wallet_tab_helper.cc
@@ -35,6 +35,7 @@
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"  // nogncheck
 #include "chrome/browser/ui/browser_window/public/browser_window_interface_iterator.h"  // nogncheck
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "ui/views/widget/widget.h"
 #endif
 
 namespace brave_wallet {
@@ -316,6 +317,11 @@ GURL BraveWalletTabHelper::GetBubbleURL() {
 
 content::WebContents* BraveWalletTabHelper::GetBubbleWebContentsForTesting() {
   return wallet_bubble_manager_delegate_->GetWebContentsForTesting();
+}
+
+views::Widget* BraveWalletTabHelper::GetBubbleWidgetForTesting() {
+  return wallet_bubble_manager_delegate_
+      ->GetBubbleWidgetForTesting();  // IN-TEST
 }
 
 GURL BraveWalletTabHelper::GetApproveBubbleURL() {

--- a/browser/brave_wallet/brave_wallet_tab_helper.h
+++ b/browser/brave_wallet/brave_wallet_tab_helper.h
@@ -20,6 +20,13 @@
 #include "url/gurl.h"
 
 static_assert(BUILDFLAG(ENABLE_BRAVE_WALLET));
+
+#if !BUILDFLAG(IS_ANDROID)
+namespace views {
+class Widget;
+}  // namespace views
+#endif  // !BUILDFLAG(IS_ANDROID)
+
 namespace content {
 class BrowserContext;
 struct GlobalRenderFrameHostId;
@@ -66,6 +73,7 @@ class BraveWalletTabHelper
   bool IsShowingBubble();
   bool IsBubbleClosedForTesting();
   content::WebContents* GetBubbleWebContentsForTesting();
+  views::Widget* GetBubbleWidgetForTesting();
   void SetShowBubbleCallbackForTesting(base::OnceClosure callback) {
     show_bubble_callback_for_testing_ = std::move(callback);
   }

--- a/browser/brave_wallet/brave_wallet_tab_helper.h
+++ b/browser/brave_wallet/brave_wallet_tab_helper.h
@@ -21,11 +21,9 @@
 
 static_assert(BUILDFLAG(ENABLE_BRAVE_WALLET));
 
-#if !BUILDFLAG(IS_ANDROID)
 namespace views {
 class Widget;
 }  // namespace views
-#endif  // !BUILDFLAG(IS_ANDROID)
 
 namespace content {
 class BrowserContext;

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -169,6 +169,7 @@ source_set("ui") {
         "//brave/browser/ui/webui/brave_wallet/ledger",
         "//brave/browser/ui/webui/brave_wallet/trezor",
         "//brave/browser/ui/webui/brave_wallet/wallet_panel",
+        "//chrome/browser/picture_in_picture",
       ]
     }
   }

--- a/browser/ui/brave_wallet/wallet_bubble_manager_delegate.h
+++ b/browser/ui/brave_wallet/wallet_bubble_manager_delegate.h
@@ -14,6 +14,10 @@ namespace content {
 class WebContents;
 }  // namespace content
 
+namespace views {
+class Widget;
+}  // namespace views
+
 namespace brave_wallet {
 
 class WalletBubbleManagerDelegate {
@@ -33,6 +37,7 @@ class WalletBubbleManagerDelegate {
   virtual bool IsShowingBubble() = 0;
   virtual bool IsBubbleClosedForTesting() = 0;
   virtual content::WebContents* GetWebContentsForTesting() = 0;
+  virtual views::Widget* GetBubbleWidgetForTesting() = 0;
 
  protected:
   WalletBubbleManagerDelegate() = default;

--- a/browser/ui/views/toolbar/wallet_button.cc
+++ b/browser/ui/views/toolbar/wallet_button.cc
@@ -273,7 +273,13 @@ bool WalletButton::IsShowingBubble() {
 bool WalletButton::IsBubbleClosedForTesting() {
   return brave_wallet::BraveWalletTabHelper::FromWebContents(
              GetActiveWebContents())
-      ->IsBubbleClosedForTesting();
+      ->IsBubbleClosedForTesting();  // IN-TEST
+}
+
+views::Widget* WalletButton::GetBubbleWidgetForTesting() {
+  return brave_wallet::BraveWalletTabHelper::FromWebContents(
+             GetActiveWebContents())
+      ->GetBubbleWidgetForTesting();  // IN-TEST
 }
 
 views::View* WalletButton::GetAsAnchorView() {

--- a/browser/ui/views/toolbar/wallet_button.h
+++ b/browser/ui/views/toolbar/wallet_button.h
@@ -38,6 +38,7 @@ class WalletButton : public ToolbarButton {
   void CloseWalletBubble();
   bool IsShowingBubble();
   bool IsBubbleClosedForTesting();
+  views::Widget* GetBubbleWidgetForTesting();
 
   void UpdateImageAndText(bool activated = false);
 

--- a/browser/ui/views/toolbar/wallet_button_browsertest.cc
+++ b/browser/ui/views/toolbar/wallet_button_browsertest.cc
@@ -5,13 +5,18 @@
 
 #include "brave/browser/ui/views/toolbar/wallet_button.h"
 
+#include "base/test/run_until.h"
+#include "brave/browser/brave_wallet/brave_wallet_tab_helper.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "chrome/browser/picture_in_picture/picture_in_picture_occlusion_tracker.h"
+#include "chrome/browser/picture_in_picture/picture_in_picture_window_manager.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/test/test_browser_dialog.h"
-#include "chrome/browser/ui/views/bubble/webui_bubble_manager.h"
 #include "chrome/test/base/in_process_browser_test.h"
+#include "content/public/browser/web_contents.h"
 #include "content/public/test/browser_test.h"
 #include "ui/views/test/button_test_api.h"
+#include "ui/views/widget/widget.h"
 
 namespace {
 ui::MouseEvent GetDummyEvent() {
@@ -67,6 +72,36 @@ IN_PROC_BROWSER_TEST_F(WalletButtonButtonBrowserTest,
 
   wallet_button()->CloseWalletBubble();
   ASSERT_TRUE(wallet_button()->IsBubbleClosedForTesting());
+}
+
+IN_PROC_BROWSER_TEST_F(WalletButtonButtonBrowserTest,
+                       BubbleIgnoresInputWhenOccludedByPip) {
+  views::test::ButtonTestApi(wallet_button()).NotifyClick(GetDummyEvent());
+  ASSERT_TRUE(base::test::RunUntil(
+      [&]() { return wallet_button()->IsShowingBubble(); }));
+
+  auto* widget = wallet_button()->GetBubbleWidgetForTesting();
+  ASSERT_TRUE(widget);
+  auto* web_contents = brave_wallet::BraveWalletTabHelper::FromWebContents(
+                           browser()->tab_strip_model()->GetActiveWebContents())
+                           ->GetBubbleWebContentsForTesting();
+  ASSERT_TRUE(web_contents);
+
+  EXPECT_FALSE(web_contents->ShouldIgnoreInputEventsForTesting());
+
+  auto* tracker =
+      PictureInPictureWindowManager::GetInstance()->GetOcclusionTracker();
+  ASSERT_TRUE(tracker);
+
+  // Simulate occlusion — WebContents input should be suppressed.
+  tracker->SetWidgetOcclusionStateForTesting(widget, true);
+  EXPECT_TRUE(web_contents->ShouldIgnoreInputEventsForTesting());
+
+  // Simulate PIP moving away — input should be restored.
+  tracker->SetWidgetOcclusionStateForTesting(widget, false);
+  EXPECT_FALSE(web_contents->ShouldIgnoreInputEventsForTesting());
+
+  wallet_button()->CloseWalletBubble();
 }
 
 class WalletButtonBrowserUITest : public DialogBrowserTest {

--- a/browser/ui/wallet_bubble_manager_delegate_impl.cc
+++ b/browser/ui/wallet_bubble_manager_delegate_impl.cc
@@ -17,6 +17,8 @@
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/webui/brave_wallet/wallet_panel/wallet_panel_ui.h"
 #include "chrome/browser/file_select_helper.h"
+#include "chrome/browser/picture_in_picture/picture_in_picture_occlusion_observer.h"
+#include "chrome/browser/picture_in_picture/scoped_picture_in_picture_occlusion_observation.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 #include "chrome/browser/ui/browser_window/public/global_browser_collection.h"
@@ -32,7 +34,8 @@
 
 namespace brave_wallet {
 
-class WalletWebUIBubbleDialogView : public WebUIBubbleDialogView {
+class WalletWebUIBubbleDialogView : public WebUIBubbleDialogView,
+                                    public PictureInPictureOcclusionObserver {
   METADATA_HEADER(WalletWebUIBubbleDialogView, WebUIBubbleDialogView)
  public:
   WalletWebUIBubbleDialogView(
@@ -63,6 +66,25 @@ class WalletWebUIBubbleDialogView : public WebUIBubbleDialogView {
                                      params);
   }
 
+  // views::BubbleDialogDelegateView:
+  void AddedToWidget() override {
+    WebUIBubbleDialogView::AddedToWidget();
+    occlusion_observation_.Observe(GetWidget());
+  }
+
+  // PictureInPictureOcclusionObserver:
+  void OnOcclusionStateChanged(bool occluded) override {
+    auto* web_contents = web_view()->GetWebContents();
+    if (!web_contents) {
+      return;
+    }
+    if (occluded) {
+      ignore_input_events_ = web_contents->IgnoreInputEvents(std::nullopt);
+    } else {
+      ignore_input_events_.reset();
+    }
+  }
+
  private:
   // WidgetObserver:
   void OnWidgetTreeActivated(views::Widget* root_widget,
@@ -77,6 +99,11 @@ class WalletWebUIBubbleDialogView : public WebUIBubbleDialogView {
       GetWidget()->CloseWithReason(views::Widget::ClosedReason::kLostFocus);
     }
   }
+
+  std::optional<content::WebContents::ScopedIgnoreInputEvents>
+      ignore_input_events_;
+
+  ScopedPictureInPictureOcclusionObservation occlusion_observation_{this};
 
   base::ScopedObservation<views::Widget, views::WidgetObserver>
       anchor_widget_observation_{this};
@@ -128,7 +155,6 @@ class WalletWebUIBubbleManager : public WebUIBubbleManagerImpl<WalletPanelUI>,
     auto* widget =
         views::BubbleDialogDelegateView::CreateBubble(std::move(bubble_view));
     CHECK(widget);
-    widget->SetZOrderLevel(ui::ZOrderLevel::kSecuritySurface);
 
     // Checking if we create WalletPanelUI instance of WebUI and
     // extracting WebUIContentsWrapper class to pass real browser delegate
@@ -168,6 +194,8 @@ class WalletWebUIBubbleManager : public WebUIBubbleManagerImpl<WalletPanelUI>,
     }
     return bubble_view_->web_view()->GetWebContents();
   }
+
+  views::Widget* GetBubbleWidgetForTesting() { return GetBubbleWidget(); }
 
  private:
   const raw_ptr<BrowserWindowInterface> browser_;
@@ -236,6 +264,13 @@ bool WalletBubbleManagerDelegateImpl::IsShowingBubble() {
 bool WalletBubbleManagerDelegateImpl::IsBubbleClosedForTesting() {
   return !webui_bubble_manager_ || !webui_bubble_manager_->GetBubbleWidget() ||
          webui_bubble_manager_->GetBubbleWidget()->IsClosed();
+}
+
+views::Widget* WalletBubbleManagerDelegateImpl::GetBubbleWidgetForTesting() {
+  if (!webui_bubble_manager_) {
+    return nullptr;
+  }
+  return webui_bubble_manager_->GetBubbleWidgetForTesting();  // IN-TEST
 }
 
 }  // namespace brave_wallet

--- a/browser/ui/wallet_bubble_manager_delegate_impl.h
+++ b/browser/ui/wallet_bubble_manager_delegate_impl.h
@@ -12,6 +12,10 @@
 #include "brave/browser/ui/brave_wallet/wallet_bubble_manager_delegate.h"
 #include "url/gurl.h"
 
+namespace views {
+class Widget;
+}  // namespace views
+
 namespace brave_wallet {
 
 class WalletWebUIBubbleManager;
@@ -31,6 +35,7 @@ class WalletBubbleManagerDelegateImpl : public WalletBubbleManagerDelegate {
   bool IsShowingBubble() override;
   bool IsBubbleClosedForTesting() override;
   content::WebContents* GetWebContentsForTesting() override;
+  views::Widget* GetBubbleWidgetForTesting() override;
 
  private:
   // `this` never outlives `web_contents_` instance.

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1416,6 +1416,7 @@ test("brave_browser_tests") {
     if (enable_brave_wallet) {
       sources +=
           [ "//brave/browser/ui/views/toolbar/wallet_button_browsertest.cc" ]
+      deps += [ "//chrome/browser/picture_in_picture" ]
     }
 
     if (enable_brave_vpn) {


### PR DESCRIPTION
Ignore input event to the web ui when the wallet panel is occluded by
PIP window. This prevents the user from interacting with the wallet
panel when it is not fully visible, which can lead to hijacking of 
the wallet panel by malicious websites. 

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/48487

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
