### PR TITLE
Add a feature param to control default Containers enabled state. (uplift to 1.92.x)

### DIFF
--- a/browser/containers/BUILD.gn
+++ b/browser/containers/BUILD.gn
@@ -69,6 +69,7 @@ source_set("unit_tests") {
     ":containers",
     "//brave/components/containers/content/browser",
     "//brave/components/containers/core/browser",
+    "//brave/components/containers/core/browser:test_support",
     "//brave/components/containers/core/common:features",
     "//brave/components/containers/core/mojom",
     "//chrome/browser",

--- a/browser/containers/BUILD.gn
+++ b/browser/containers/BUILD.gn
@@ -28,6 +28,7 @@ source_set("containers") {
     "//chrome/browser/profiles:profile",
     "//chrome/browser/ui/tab_contents",
     "//chrome/browser/ui/tabs",
+    "//chrome/common",
     "//chrome/common:buildflags",
     "//components/sessions",
     "//content/public/browser",

--- a/browser/containers/containers_browsertest.cc
+++ b/browser/containers/containers_browsertest.cc
@@ -117,6 +117,7 @@ class ContainersBrowserTest : public InProcessBrowserTest {
   void SetUpOnMainThread() override {
     InProcessBrowserTest::SetUpOnMainThread();
     host_resolver()->AddRule("*", "127.0.0.1");
+    SetContainersEnabled(true, browser()->profile()->GetPrefs());
   }
 
   // JavaScript helper to set a cookie

--- a/browser/containers/containers_service_factory.cc
+++ b/browser/containers/containers_service_factory.cc
@@ -16,6 +16,7 @@
 #include "chrome/browser/profiles/profile_selections.h"
 #include "chrome/browser/sessions/tab_restore_service_factory.h"
 #include "chrome/common/buildflags.h"
+#include "chrome/common/channel_info.h"
 
 #if BUILDFLAG(ENABLE_SESSION_SERVICE)
 #include "chrome/browser/sessions/session_service_factory.h"
@@ -50,7 +51,7 @@ ContainersServiceFactory::~ContainersServiceFactory() = default;
 
 void ContainersServiceFactory::RegisterProfilePrefs(
     user_prefs::PrefRegistrySyncable* registry) {
-  containers::RegisterProfilePrefs(registry);
+  containers::RegisterProfilePrefs(registry, chrome::GetChannel());
 }
 
 bool ContainersServiceFactory::ServiceIsCreatedWithBrowserContext() const {

--- a/browser/ui/tabs/BUILD.gn
+++ b/browser/ui/tabs/BUILD.gn
@@ -171,6 +171,9 @@ source_set("browser_tests") {
   ]
 
   if (enable_containers) {
-    deps += [ "//brave/components/containers/core/common:features" ]
+    deps += [
+      "//brave/components/containers/core/browser:test_support",
+      "//brave/components/containers/core/common:features",
+    ]
   }
 }

--- a/browser/ui/tabs/brave_tab_menu_browsertest.cc
+++ b/browser/ui/tabs/brave_tab_menu_browsertest.cc
@@ -29,6 +29,7 @@
 #include "url/gurl.h"
 
 #if BUILDFLAG(ENABLE_CONTAINERS)
+#include "brave/components/containers/core/browser/containers_test_utils.h"
 #include "brave/components/containers/core/common/features.h"
 #endif  // BUILDFLAG(ENABLE_CONTAINERS)
 
@@ -482,6 +483,11 @@ class BraveTabMenuWithContainersBrowserTest : public BraveTabMenuBrowserTest {
  public:
   BraveTabMenuWithContainersBrowserTest() = default;
   ~BraveTabMenuWithContainersBrowserTest() override = default;
+
+  void SetUpOnMainThread() override {
+    BraveTabMenuBrowserTest::SetUpOnMainThread();
+    containers::SetContainersEnabled(true, browser()->profile()->GetPrefs());
+  }
 
  private:
   base::test::ScopedFeatureList feature_list_{

--- a/browser/ui/toolbar/brave_bookmark_context_menu_controller_unittest.cc
+++ b/browser/ui/toolbar/brave_bookmark_context_menu_controller_unittest.cc
@@ -14,6 +14,7 @@
 #include "base/values.h"
 #include "brave/browser/ui/bookmark/bookmark_helper.h"
 #include "brave/components/containers/buildflags/buildflags.h"
+#include "brave/components/containers/core/browser/containers_test_utils.h"
 #include "chrome/app/chrome_command_ids.h"
 #include "chrome/browser/bookmarks/bookmark_merged_surface_service_factory.h"
 #include "chrome/browser/bookmarks/bookmark_model_factory.h"
@@ -205,6 +206,7 @@ class BraveBookmarkContextMenuContainersTest
   void SetUp() override {
     feature_list_.InitAndEnableFeature(containers::features::kContainers);
     BraveBookmarkContextMenuControllerTest::SetUp();
+    containers::SetContainersEnabled(true, profile_->GetPrefs());
   }
 
  protected:

--- a/components/containers/core/browser/BUILD.gn
+++ b/components/containers/core/browser/BUILD.gn
@@ -34,6 +34,7 @@ static_library("browser") {
   friend = [
     "//brave/browser/containers:browser_tests",
     "//brave/browser/ui/containers:unit_tests",
+    ":test_support",
     ":unit_tests",
   ]
 
@@ -70,6 +71,8 @@ source_set("test_support") {
   public_deps = [ ":browser" ]
 
   deps = [
+    ":browser",
+    "//components/prefs",
     "//testing/gmock",
     "//testing/gtest",
     "//ui/color",

--- a/components/containers/core/browser/BUILD.gn
+++ b/components/containers/core/browser/BUILD.gn
@@ -71,7 +71,6 @@ source_set("test_support") {
   public_deps = [ ":browser" ]
 
   deps = [
-    ":browser",
     "//components/prefs",
     "//testing/gmock",
     "//testing/gtest",

--- a/components/containers/core/browser/BUILD.gn
+++ b/components/containers/core/browser/BUILD.gn
@@ -41,6 +41,7 @@ static_library("browser") {
 
   deps = [
     "//base",
+    "//base/version_info",
     "//brave/components/containers/core/common",
     "//brave/components/resources:strings",
     "//brave/third_party/bip39wally-core-native:bip39wally-core",

--- a/components/containers/core/browser/containers_test_utils.cc
+++ b/components/containers/core/browser/containers_test_utils.cc
@@ -7,6 +7,8 @@
 
 #include <utility>
 
+#include "brave/components/containers/core/browser/pref_names.h"
+#include "components/prefs/pref_service.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -41,6 +43,10 @@ void ExpectContainer(const mojom::ContainerPtr& container,
                      SkColor color) {
   ASSERT_TRUE(container);
   EXPECT_THAT(*container, testing::FieldsAre(id, name, icon, color));
+}
+
+void SetContainersEnabled(bool enabled, PrefService* prefs) {
+  prefs->SetBoolean(prefs::kContainersEnabled, enabled);
 }
 
 }  // namespace containers

--- a/components/containers/core/browser/containers_test_utils.h
+++ b/components/containers/core/browser/containers_test_utils.h
@@ -16,6 +16,8 @@
 #include "testing/gmock/include/gmock/gmock.h"
 #include "third_party/skia/include/core/SkColor.h"
 
+class PrefService;
+
 namespace containers {
 
 class MockContainersServiceDelegate : public ContainersService::Delegate {
@@ -57,6 +59,8 @@ void ExpectContainer(const mojom::ContainerPtr& container,
                      const std::string& name,
                      mojom::Icon icon = mojom::Icon::kDefault,
                      SkColor color = SK_ColorBLUE);
+
+void SetContainersEnabled(bool enabled, PrefService* prefs);
 
 }  // namespace containers
 

--- a/components/containers/core/browser/prefs_registration.cc
+++ b/components/containers/core/browser/prefs_registration.cc
@@ -5,15 +5,30 @@
 
 #include "brave/components/containers/core/browser/prefs_registration.h"
 
+#include "base/metrics/field_trial_params.h"
+#include "base/version_info/channel.h"
 #include "brave/components/containers/core/browser/default_containers_list.h"
 #include "brave/components/containers/core/browser/pref_names.h"
 #include "brave/components/containers/core/browser/prefs.h"
+#include "brave/components/containers/core/common/features.h"
 #include "components/pref_registry/pref_registry_syncable.h"
 
 namespace containers {
 
-void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
-  registry->RegisterBooleanPref(prefs::kContainersEnabled, true);
+namespace {
+
+bool GetContainersEnabledPrefDefault(version_info::Channel channel) {
+  const bool enabled_by_default = channel != version_info::Channel::STABLE;
+  return base::GetFieldTrialParamByFeatureAsBool(
+      features::kContainers, "enabled_by_default", enabled_by_default);
+}
+
+}  // namespace
+
+void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry,
+                          version_info::Channel channel) {
+  registry->RegisterBooleanPref(prefs::kContainersEnabled,
+                                GetContainersEnabledPrefDefault(channel));
   registry->RegisterListPref(
       prefs::kContainersList,
       ConvertContainersToListValue(CreateDefaultContainersList()),

--- a/components/containers/core/browser/prefs_registration.h
+++ b/components/containers/core/browser/prefs_registration.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_COMPONENTS_CONTAINERS_CORE_BROWSER_PREFS_REGISTRATION_H_
 #define BRAVE_COMPONENTS_CONTAINERS_CORE_BROWSER_PREFS_REGISTRATION_H_
 
+#include "base/version_info/channel.h"
+
 namespace user_prefs {
 class PrefRegistrySyncable;
 }
@@ -13,7 +15,9 @@ class PrefRegistrySyncable;
 namespace containers {
 
 // Registers container-related preferences with the profile's preference system.
-void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry);
+void RegisterProfilePrefs(
+    user_prefs::PrefRegistrySyncable* registry,
+    version_info::Channel channel = version_info::Channel::UNKNOWN);
 
 }  // namespace containers
 

--- a/components/containers/core/browser/prefs_unittest.cc
+++ b/components/containers/core/browser/prefs_unittest.cc
@@ -204,4 +204,33 @@ TEST_F(ContainersPrefsTest, ContainersEnabledDefaultsToTrue) {
   EXPECT_FALSE(prefs_.GetBoolean(prefs::kContainersEnabled));
 }
 
+TEST(ContainersPrefsRegistrationTest,
+     ContainersEnabledDefaultsToFalseOnStable) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeature(features::kContainers);
+  sync_preferences::TestingPrefServiceSyncable prefs;
+  RegisterProfilePrefs(prefs.registry(), version_info::Channel::STABLE);
+  EXPECT_FALSE(prefs.GetBoolean(prefs::kContainersEnabled));
+}
+
+TEST(ContainersPrefsRegistrationTest,
+     ContainersEnabledPrefDefaultFinchOverride) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kContainers, {{"enabled_by_default", "true"}});
+  sync_preferences::TestingPrefServiceSyncable prefs;
+  RegisterProfilePrefs(prefs.registry(), version_info::Channel::STABLE);
+  EXPECT_TRUE(prefs.GetBoolean(prefs::kContainersEnabled));
+}
+
+TEST(ContainersPrefsRegistrationTest,
+     ContainersEnabledPrefDefaultFinchOverrideOnUnknown) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kContainers, {{"enabled_by_default", "false"}});
+  sync_preferences::TestingPrefServiceSyncable prefs;
+  RegisterProfilePrefs(prefs.registry());
+  EXPECT_FALSE(prefs.GetBoolean(prefs::kContainersEnabled));
+}
+
 }  // namespace containers

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -644,6 +644,7 @@ test("brave_unit_tests") {
       "//brave/browser/ui/containers:unit_tests",
 
       # For brave_bookmark_context_menu_controller_unittest.cc
+      "//brave/components/containers/core/browser:test_support",
       "//brave/components/containers/core/common",
     ]
   }


### PR DESCRIPTION
Uplift of #37491
Uplift of #37505
Uplift of #37508
Resolves https://github.com/brave/brave-browser/issues/56597
Resolves https://github.com/brave/brave-browser/issues/56622
Resolves https://github.com/brave/brave-browser/issues/56625
Resolves https://github.com/brave/brave-browser/issues/56624
Resolves https://github.com/brave/brave-browser/issues/56623

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.