### PR TITLE
[VPN 2.0] Enable architecture 2.0 at compile time

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -148,7 +148,7 @@ group("all") {
   }
 }
 
-if (enable_brave_vpn_v2) {
+if (enable_brave_vpn_v2_apps) {
   group("brave_vpn_data_deps") {
     data_deps = [
       "//brave/components/brave_vpn/app/v2/agent",
@@ -178,7 +178,7 @@ if (!is_ios) {
 
     data_deps = [ ":unpacked_resources" ]
 
-    if (enable_brave_vpn_v2) {
+    if (enable_brave_vpn_v2_apps) {
       data_deps += [ ":brave_vpn_data_deps" ]
     }
 

--- a/app/BUILD.gn
+++ b/app/BUILD.gn
@@ -122,7 +122,7 @@ source_set("unit_tests") {
   if (!is_android) {
     sources += [ "command_utils_unittest.cc" ]
   }
-  if (enable_brave_vpn_v2) {
+  if (enable_brave_vpn_v2_apps) {
     sources += [ "vpn_apps_branding_unittest.cc" ]
   }
   deps = [
@@ -218,7 +218,7 @@ source_set("unit_tests") {
   if (is_win) {
     deps += [ "//chrome/browser/startup" ]
   }
-  if (enable_brave_vpn_v2) {
+  if (enable_brave_vpn_v2_apps) {
     deps += [ "//brave/components/brave_vpn/app/v2/shared" ]
   }
 }

--- a/components/BUILD.gn
+++ b/components/BUILD.gn
@@ -86,7 +86,7 @@ test("brave_components_unittests") {
     ]
   }
 
-  if (enable_brave_vpn_v2) {
+  if (enable_brave_vpn_v2_apps) {
     deps += [
       "//brave/components/brave_vpn/app/v2/agent:unit_tests",
       "//brave/components/brave_vpn/app/v2/shared:unit_tests",

--- a/components/brave_vpn/app/v2/agent/BUILD.gn
+++ b/components/brave_vpn/app/v2/agent/BUILD.gn
@@ -13,7 +13,7 @@ if (is_win) {
   import("//chrome/process_version_rc_template.gni")
 }
 
-assert(enable_brave_vpn_v2)
+assert(enable_brave_vpn_v2_apps)
 
 source_set("core") {
   sources = [

--- a/components/brave_vpn/app/v2/helper/BUILD.gn
+++ b/components/brave_vpn/app/v2/helper/BUILD.gn
@@ -13,7 +13,7 @@ if (is_win) {
   import("//chrome/process_version_rc_template.gni")
 }
 
-assert(enable_brave_vpn_v2)
+assert(enable_brave_vpn_v2_apps)
 
 source_set("core") {
   sources = [

--- a/components/brave_vpn/app/v2/shared/BUILD.gn
+++ b/components/brave_vpn/app/v2/shared/BUILD.gn
@@ -5,7 +5,7 @@
 
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 
-assert(enable_brave_vpn_v2)
+assert(enable_brave_vpn_v2_apps)
 
 static_library("shared") {
   sources = [

--- a/components/brave_vpn/common/buildflags/buildflags.gni
+++ b/components/brave_vpn/common/buildflags/buildflags.gni
@@ -12,12 +12,13 @@ declare_args() {
       (is_win || is_android || is_mac || is_ios) && !is_brave_origin_branded
 
   # Build with Brave VPN architecture 2.0 support.
-  enable_brave_vpn_v2 = false
+  enable_brave_vpn_v2 =
+      (is_win || is_android || is_mac || is_ios) && !is_brave_origin_branded
 }
 
 # Brave VPN is enabled, if at least one VPN architecture is enabled.
 # Both architectures can be enabled at compile time; in that case, the
-# right architecture will be selected at runtime.
+# right architecture will be selected at runtime using a feature flag.
 enable_brave_vpn = enable_brave_vpn_v1 || enable_brave_vpn_v2
 
 declare_args() {
@@ -27,6 +28,10 @@ declare_args() {
   # Wireguard is available only on Windows.
   enable_brave_vpn_wireguard = (is_mac || is_win) && enable_brave_vpn
 }
+
+# Enable VPN apps only on desktop platforms (Windows, Linux, and macOS)
+# which also support architecture 2.0.
+enable_brave_vpn_v2_apps = (is_win || is_linux || is_mac) && enable_brave_vpn_v2
 
 # Enable bundling of the dependencies for VPN architecture 2.0 into the final
 # package distributed to the customers. This should be set to 'false' until

--- a/third_party/boringtun/BUILD.gn
+++ b/third_party/boringtun/BUILD.gn
@@ -8,8 +8,8 @@ import("//build/config/clang/clang.gni")
 import("//build/config/rust.gni")
 import("//build/config/sysroot.gni")
 
-assert(enable_brave_vpn_v2,
-       "BoringTun is only buildable when Brave VPN 2.0 architecture is enabled")
+assert(enable_brave_vpn_v2_apps,
+       "BoringTun is only buildable when Brave VPN apps are enabled")
 
 action("boringtun") {
   script = "build.py"


### PR DESCRIPTION
The change enables the new architecture at compile time. It is off by default, but can be enabled using a CLI toggle (feature flag). No binaries are shipped with the browser for now; also macOS bundles are not added to the browser's bundle (for that, one must additionally set enable_brave_vpn_v2_bundling=true in GN args).

The change is mostly to ensure that the VPN is getting built and tested in the CI.

Implements part of https://github.com/brave/brave-browser/issues/56053

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
