### PR TITLE
[AI Chat] shared conversation lib loads icons at the script-relative path

### DIFF
--- a/components/ai_chat/resources/shared_conversation_lib/render_conversation.tsx
+++ b/components/ai_chat/resources/shared_conversation_lib/render_conversation.tsx
@@ -25,7 +25,13 @@ import {
   createMockUntrustedUIHandler,
 } from '../untrusted_conversation_frame/api/mock_interfaces'
 
-setIconBasePath('./nala-icons')
+// Set the nala icon path to be relative to this script, which should be
+// the root of the output bundle.
+// Need to store import.meta.url in a separate variable to the URL building
+// otherwise webpack will try to resolve '.' locally (and probably fail).
+const scriptUrl = import.meta.url
+const relativePathUrl = new URL('./nala-icons', scriptUrl)
+setIconBasePath(relativePathUrl.toString())
 
 /**
  * Create a minimal local-only read-only version of the AI Chat API interfaces.

--- a/components/ai_chat/resources/shared_conversation_lib/webpack.config.ts
+++ b/components/ai_chat/resources/shared_conversation_lib/webpack.config.ts
@@ -24,7 +24,6 @@ import {
   cssRules,
   tsLoaderRule,
   fileLoaderRule,
-  braveUiFullySpecifiedRule,
   htmlAssetRule,
 } from '../../../webpack/rules.ts'
 
@@ -78,7 +77,9 @@ export default async function (
     path: outputPath,
     filename: '[name].js',
     chunkFilename: '[name].chunk.js',
-    publicPath: '/',
+    // Need publicPath: 'auto' to have file-loader resolve to script bundle URL,
+    // not the loading-websites URL.
+    publicPath: 'auto',
     clean: true,
     library: { type: 'module' },
     iife: false,
@@ -99,6 +100,7 @@ export default async function (
   }
 
   return {
+    target: 'web',
     entry,
     devtool: isDevMode ? 'inline-source-map' : false,
     devServer: {
@@ -126,6 +128,14 @@ export default async function (
       }),
     ],
     module: {
+      parser: {
+        // Leave import.meta.url untransformed so that we can use the runtime
+        // value instead of webpack's hardcoded build-time value of the local
+        // file path. Needed for loading assets from the output bundle path.
+        javascript: {
+          importMeta: false,
+        },
+      },
       rules: [
         ...cssRules({ isDevMode }),
         tsLoaderRule({ configFile: tsConfigPath }),


### PR DESCRIPTION
And not the loading site-relative

