### PR TITLE
[iOS] Require private browsing lock auth for open-url deep links (uplift to 1.92.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/NavigationRouter.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/NavigationRouter.swift
@@ -108,13 +108,34 @@ public enum NavigationPath: Equatable {
   }
 
   private static func handleURL(url: URL?, isPrivate: Bool, with bvc: BrowserViewController) {
-    if let newURL = url {
-      bvc.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false)
+    // Skip private-tab auth when app passcode lock is on; the user must unlock the app first.
+    if isPrivate,
+      Preferences.Privacy.privateBrowsingLock.value,
+      !Preferences.Privacy.lockWithPasscode.value
+    {
+      guard let windowProtection = bvc.windowProtection else { return }
+      bvc.askForLocalAuthentication(using: windowProtection, viewType: .external) {
+        [weak bvc] success, _ in
+        if success {
+          if let newURL = url {
+            bvc?.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false)
+          } else {
+            bvc?.openBlankNewTab(
+              attemptLocationFieldFocus: Preferences.General.openKeyboardOnNTPSelection.value,
+              isPrivate: isPrivate
+            )
+          }
+        }
+      }
     } else {
-      bvc.openBlankNewTab(
-        attemptLocationFieldFocus: Preferences.General.openKeyboardOnNTPSelection.value,
-        isPrivate: isPrivate
-      )
+      if let newURL = url {
+        bvc.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false)
+      } else {
+        bvc.openBlankNewTab(
+          attemptLocationFieldFocus: Preferences.General.openKeyboardOnNTPSelection.value,
+          isPrivate: isPrivate
+        )
+      }
     }
   }
 


### PR DESCRIPTION
Uplift of #37469
Resolves https://github.com/brave/brave-browser/issues/56187

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.