### PR TITLE
[Local AI] [WebSpeech] Add feature flag and component installer

### DIFF
--- a/chromium_src/chrome/browser/component_updater/registration.cc
+++ b/chromium_src/chrome/browser/component_updater/registration.cc
@@ -38,6 +38,7 @@
 
 #if BUILDFLAG(ENABLE_LOCAL_AI)
 #include "brave/components/local_ai/core/local_models_updater.h"
+#include "brave/components/local_ai/core/on_device_speech_models_component_installer.h"
 #endif
 
 namespace component_updater {
@@ -61,6 +62,7 @@ void RegisterComponentsForUpdate() {
   brave_user_agent::RegisterBraveUserAgentComponent(cus);
 #if BUILDFLAG(ENABLE_LOCAL_AI)
   local_ai::ManageLocalModelsComponentRegistration(cus);
+  local_ai::RegisterOnDeviceSpeechModelsComponent(cus);
 #endif
   RegisterQueryFilterComponent(cus);
 }

--- a/components/local_ai/core/BUILD.gn
+++ b/components/local_ai/core/BUILD.gn
@@ -39,6 +39,8 @@ static_library("core") {
   public = [
     "background_web_contents.h",
     "local_models_updater.h",
+    "on_device_speech_models_component_installer.h",
+    "on_device_speech_models_state.h",
     "pref_names.h",
     "url_constants.h",
   ]
@@ -47,6 +49,10 @@ static_library("core") {
     "background_web_contents.h",
     "local_models_updater.cc",
     "local_models_updater.h",
+    "on_device_speech_models_component_installer.cc",
+    "on_device_speech_models_component_installer.h",
+    "on_device_speech_models_state.cc",
+    "on_device_speech_models_state.h",
     "pref_names.cc",
     "pref_names.h",
   ]
@@ -73,7 +79,10 @@ static_library("core") {
 
 source_set("unit_tests") {
   testonly = true
-  sources = [ "local_models_updater_unittest.cc" ]
+  sources = [
+    "local_models_updater_unittest.cc",
+    "on_device_speech_models_component_installer_unittest.cc",
+  ]
 
   deps = [
     ":core",

--- a/components/local_ai/core/BUILD.gn
+++ b/components/local_ai/core/BUILD.gn
@@ -21,7 +21,9 @@ mojom_component("mojom") {
   public_deps = [ "//mojo/public/mojom/base" ]
 }
 
-source_set("features") {
+component("features") {
+  defines = [ "IS_LOCAL_AI_FEATURES_IMPL" ]
+
   sources = [
     "features.cc",
     "features.h",

--- a/components/local_ai/core/features.cc
+++ b/components/local_ai/core/features.cc
@@ -4,3 +4,10 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "brave/components/local_ai/core/features.h"
+
+namespace local_ai {
+
+BASE_FEATURE(kBraveOnDeviceSpeechRecognition,
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
+}  // namespace local_ai

--- a/components/local_ai/core/features.h
+++ b/components/local_ai/core/features.h
@@ -6,4 +6,14 @@
 #ifndef BRAVE_COMPONENTS_LOCAL_AI_CORE_FEATURES_H_
 #define BRAVE_COMPONENTS_LOCAL_AI_CORE_FEATURES_H_
 
+#include "base/component_export.h"
+#include "base/feature_list.h"
+
+namespace local_ai {
+
+COMPONENT_EXPORT(LOCAL_AI_FEATURES)
+BASE_DECLARE_FEATURE(kBraveOnDeviceSpeechRecognition);
+
+}  // namespace local_ai
+
 #endif  // BRAVE_COMPONENTS_LOCAL_AI_CORE_FEATURES_H_

--- a/components/local_ai/core/on_device_speech_models_component_installer.cc
+++ b/components/local_ai/core/on_device_speech_models_component_installer.cc
@@ -1,0 +1,141 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/local_ai/core/on_device_speech_models_component_installer.h"
+
+#include <cstdint>
+#include <iterator>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "base/feature_list.h"
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/functional/bind.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/path_service.h"
+#include "base/values.h"
+#include "base/version.h"
+#include "brave/components/brave_component_updater/browser/brave_on_demand_updater.h"
+#include "brave/components/local_ai/core/features.h"
+#include "brave/components/local_ai/core/on_device_speech_models_state.h"
+#include "components/component_updater/component_installer.h"
+#include "components/component_updater/component_updater_paths.h"
+#include "components/component_updater/component_updater_service.h"
+#include "components/update_client/update_client.h"
+#include "components/update_client/update_client_errors.h"
+#include "crypto/sha2.h"
+
+namespace local_ai {
+
+namespace {
+
+constexpr base::FilePath::CharType kComponentInstallDir[] =
+    FILE_PATH_LITERAL("BraveOnDeviceSpeechModels");
+constexpr char kComponentName[] = "Brave On-Device Speech Models";
+constexpr char kComponentId[] = "nhkekccefdppopbldokibkoegppanbba";
+
+// SHA256 of the provisioned component's public key.
+constexpr uint8_t kPublicKeySHA256[32] = {
+    0xd7, 0xa4, 0xa2, 0x24, 0x53, 0xff, 0xef, 0x1b, 0x3e, 0xa8, 0x1a,
+    0xe4, 0x6f, 0xf0, 0xd1, 0x10, 0xac, 0xaa, 0x39, 0x3b, 0x03, 0xcd,
+    0xf1, 0x10, 0x04, 0x5e, 0xf9, 0x33, 0xf5, 0xe9, 0x6c, 0x4d};
+static_assert(std::size(kPublicKeySHA256) == crypto::kSHA256Length,
+              "Wrong hash length");
+
+base::FilePath GetComponentDir() {
+  base::FilePath components_dir =
+      base::PathService::CheckedGet(component_updater::DIR_COMPONENT_USER);
+
+  return components_dir.Append(kComponentInstallDir);
+}
+
+void DeleteComponentDirectory() {
+  base::DeletePathRecursively(GetComponentDir());
+}
+
+}  // namespace
+
+OnDeviceSpeechModelsComponentInstallerPolicy::
+    OnDeviceSpeechModelsComponentInstallerPolicy() = default;
+OnDeviceSpeechModelsComponentInstallerPolicy::
+    ~OnDeviceSpeechModelsComponentInstallerPolicy() = default;
+
+bool OnDeviceSpeechModelsComponentInstallerPolicy::VerifyInstallation(
+    const base::DictValue& manifest,
+    const base::FilePath& install_dir) const {
+  return true;
+}
+
+bool OnDeviceSpeechModelsComponentInstallerPolicy::
+    SupportsGroupPolicyEnabledComponentUpdates() const {
+  return false;
+}
+
+bool OnDeviceSpeechModelsComponentInstallerPolicy::RequiresNetworkEncryption()
+    const {
+  return false;
+}
+
+update_client::CrxInstaller::Result
+OnDeviceSpeechModelsComponentInstallerPolicy::OnCustomInstall(
+    const base::DictValue& manifest,
+    const base::FilePath& install_dir) {
+  return update_client::CrxInstaller::Result(update_client::InstallError::NONE);
+}
+
+void OnDeviceSpeechModelsComponentInstallerPolicy::OnCustomUninstall() {}
+
+void OnDeviceSpeechModelsComponentInstallerPolicy::ComponentReady(
+    const base::Version& version,
+    const base::FilePath& install_dir,
+    base::DictValue manifest) {
+  if (install_dir.empty()) {
+    return;
+  }
+  OnDeviceSpeechModelsState::GetInstance()->SetInstallDir(install_dir);
+}
+
+base::FilePath
+OnDeviceSpeechModelsComponentInstallerPolicy::GetRelativeInstallDir() const {
+  return base::FilePath(kComponentInstallDir);
+}
+
+void OnDeviceSpeechModelsComponentInstallerPolicy::GetHash(
+    std::vector<uint8_t>* hash) const {
+  hash->assign(std::begin(kPublicKeySHA256), std::end(kPublicKeySHA256));
+}
+
+std::string OnDeviceSpeechModelsComponentInstallerPolicy::GetName() const {
+  return kComponentName;
+}
+
+update_client::InstallerAttributes
+OnDeviceSpeechModelsComponentInstallerPolicy::GetInstallerAttributes() const {
+  return update_client::InstallerAttributes();
+}
+
+bool OnDeviceSpeechModelsComponentInstallerPolicy::IsBraveComponent() const {
+  return true;
+}
+
+void RegisterOnDeviceSpeechModelsComponent(
+    component_updater::ComponentUpdateService* cus) {
+  if (!base::FeatureList::IsEnabled(kBraveOnDeviceSpeechRecognition) || !cus) {
+    DeleteComponentDirectory();
+    return;
+  }
+
+  auto installer = base::MakeRefCounted<component_updater::ComponentInstaller>(
+      std::make_unique<OnDeviceSpeechModelsComponentInstallerPolicy>());
+  installer->Register(
+      cus, base::BindOnce([]() {
+        brave_component_updater::BraveOnDemandUpdater::GetInstance()
+            ->EnsureInstalled(kComponentId);
+      }));
+}
+
+}  // namespace local_ai

--- a/components/local_ai/core/on_device_speech_models_component_installer.h
+++ b/components/local_ai/core/on_device_speech_models_component_installer.h
@@ -1,0 +1,67 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_LOCAL_AI_CORE_ON_DEVICE_SPEECH_MODELS_COMPONENT_INSTALLER_H_
+#define BRAVE_COMPONENTS_LOCAL_AI_CORE_ON_DEVICE_SPEECH_MODELS_COMPONENT_INSTALLER_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "base/files/file_path.h"
+#include "base/values.h"
+#include "components/component_updater/component_installer.h"
+#include "components/update_client/update_client.h"
+
+namespace base {
+class Version;
+}  // namespace base
+
+namespace component_updater {
+class ComponentUpdateService;
+}  // namespace component_updater
+
+namespace local_ai {
+
+// Component Updater policy for Brave's on-device speech recognition model.
+// Exposed for testing - follows upstream Chromium pattern.
+class OnDeviceSpeechModelsComponentInstallerPolicy
+    : public component_updater::ComponentInstallerPolicy {
+ public:
+  OnDeviceSpeechModelsComponentInstallerPolicy();
+  ~OnDeviceSpeechModelsComponentInstallerPolicy() override;
+
+  OnDeviceSpeechModelsComponentInstallerPolicy(
+      const OnDeviceSpeechModelsComponentInstallerPolicy&) = delete;
+  OnDeviceSpeechModelsComponentInstallerPolicy& operator=(
+      const OnDeviceSpeechModelsComponentInstallerPolicy&) = delete;
+
+  // component_updater::ComponentInstallerPolicy:
+  bool VerifyInstallation(const base::DictValue& manifest,
+                          const base::FilePath& install_dir) const override;
+  bool SupportsGroupPolicyEnabledComponentUpdates() const override;
+  bool RequiresNetworkEncryption() const override;
+  update_client::CrxInstaller::Result OnCustomInstall(
+      const base::DictValue& manifest,
+      const base::FilePath& install_dir) override;
+  void OnCustomUninstall() override;
+  void ComponentReady(const base::Version& version,
+                      const base::FilePath& install_dir,
+                      base::DictValue manifest) override;
+  base::FilePath GetRelativeInstallDir() const override;
+  void GetHash(std::vector<uint8_t>* hash) const override;
+  std::string GetName() const override;
+  update_client::InstallerAttributes GetInstallerAttributes() const override;
+  bool IsBraveComponent() const override;
+};
+
+// Registers the on-device speech models component when the feature is enabled,
+// otherwise removes any previously installed copy. No-op if `cus` is null.
+void RegisterOnDeviceSpeechModelsComponent(
+    component_updater::ComponentUpdateService* cus);
+
+}  // namespace local_ai
+
+#endif  // BRAVE_COMPONENTS_LOCAL_AI_CORE_ON_DEVICE_SPEECH_MODELS_COMPONENT_INSTALLER_H_

--- a/components/local_ai/core/on_device_speech_models_component_installer_unittest.cc
+++ b/components/local_ai/core/on_device_speech_models_component_installer_unittest.cc
@@ -1,0 +1,158 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/local_ai/core/on_device_speech_models_component_installer.h"
+
+#include <memory>
+
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/path_service.h"
+#include "base/run_loop.h"
+#include "base/test/run_until.h"
+#include "base/test/scoped_feature_list.h"
+#include "base/test/scoped_path_override.h"
+#include "base/test/task_environment.h"
+#include "base/threading/thread_restrictions.h"
+#include "base/values.h"
+#include "base/version.h"
+#include "brave/components/brave_component_updater/browser/mock_on_demand_updater.h"
+#include "brave/components/local_ai/core/features.h"
+#include "brave/components/local_ai/core/on_device_speech_models_state.h"
+#include "components/component_updater/component_updater_paths.h"
+#include "components/component_updater/mock_component_updater_service.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace local_ai {
+
+namespace {
+
+constexpr base::FilePath::CharType kComponentInstallDir[] =
+    FILE_PATH_LITERAL("BraveOnDeviceSpeechModels");
+constexpr char kComponentId[] = "nhkekccefdppopbldokibkoegppanbba";
+// Model subdirectory within the install dir. Kept in sync with the
+// `kModelDir` constant in on_device_speech_models_state.cc.
+constexpr char kModelDir[] = "nemotron-speech-streaming-en-0.6b-int4-onnx";
+
+}  // namespace
+
+class OnDeviceSpeechModelsComponentInstallerUnitTest : public testing::Test {
+ public:
+  OnDeviceSpeechModelsComponentInstallerUnitTest()
+      : task_environment_(base::test::TaskEnvironment::TimeSource::MOCK_TIME) {
+    feature_list_.InitAndEnableFeature(kBraveOnDeviceSpeechRecognition);
+  }
+
+  ~OnDeviceSpeechModelsComponentInstallerUnitTest() override = default;
+
+  void SetUp() override {
+    cus_ = std::make_unique<component_updater::MockComponentUpdateService>();
+    auto component_dir =
+        base::PathService::CheckedGet(component_updater::DIR_COMPONENT_USER);
+    install_dir_ = component_dir.Append(kComponentInstallDir);
+  }
+
+  void TearDown() override {
+    // Clear singleton state to avoid polluting other test suites.
+    OnDeviceSpeechModelsState::GetInstance()->SetInstallDir(base::FilePath());
+  }
+
+  bool PathExists(const base::FilePath& file_path) {
+    base::ScopedAllowBlockingForTesting allow_blocking;
+    return base::PathExists(file_path);
+  }
+
+  bool CreateDirectory(const base::FilePath& dir_path) {
+    base::ScopedAllowBlockingForTesting allow_blocking;
+    return base::CreateDirectory(dir_path);
+  }
+
+ protected:
+  brave_component_updater::MockOnDemandUpdater on_demand_updater_;
+  std::unique_ptr<component_updater::MockComponentUpdateService> cus_;
+  base::test::TaskEnvironment task_environment_;
+  base::FilePath install_dir_;
+
+ private:
+  base::ScopedPathOverride scoped_path_override_{
+      component_updater::DIR_COMPONENT_USER};
+  base::test::ScopedFeatureList feature_list_;
+};
+
+// Tests that the component is registered and an on-demand install requested
+// when the feature is enabled.
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest, Register) {
+  base::RunLoop run_loop;
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  EXPECT_CALL(on_demand_updater_, EnsureInstalled(kComponentId, testing::_))
+      .Times(1)
+      .WillOnce([quit = run_loop.QuitClosure()]() { quit.Run(); });
+  RegisterOnDeviceSpeechModelsComponent(cus_.get());
+  run_loop.Run();
+}
+
+// Tests that ComponentReady sets up the install directory and model dir.
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest, ComponentReady) {
+  OnDeviceSpeechModelsComponentInstallerPolicy policy;
+  policy.ComponentReady(base::Version("1.0.0"), install_dir_,
+                        base::DictValue());
+
+  auto* state = OnDeviceSpeechModelsState::GetInstance();
+  EXPECT_EQ(state->GetInstallDir(), install_dir_);
+  EXPECT_EQ(state->GetModelDir(), install_dir_.AppendASCII(kModelDir));
+}
+
+// Tests that an empty install dir clears the model dir.
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest, EmptyInstallDirClears) {
+  auto* state = OnDeviceSpeechModelsState::GetInstance();
+  state->SetInstallDir(install_dir_);
+  ASSERT_FALSE(state->GetModelDir().empty());
+
+  state->SetInstallDir(base::FilePath());
+  EXPECT_TRUE(state->GetInstallDir().empty());
+  EXPECT_TRUE(state->GetModelDir().empty());
+}
+
+// Tests that the component directory is deleted when the feature is disabled.
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest, DeleteComponent) {
+  CreateDirectory(install_dir_);
+  EXPECT_TRUE(PathExists(install_dir_));
+
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndDisableFeature(kBraveOnDeviceSpeechRecognition);
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_)).Times(0);
+  EXPECT_CALL(on_demand_updater_, EnsureInstalled(kComponentId, testing::_))
+      .Times(0);
+  RegisterOnDeviceSpeechModelsComponent(cus_.get());
+  ASSERT_TRUE(
+      base::test::RunUntil([&]() { return !PathExists(install_dir_); }));
+  EXPECT_FALSE(PathExists(install_dir_));
+}
+
+// Tests that the component is not registered when the feature is disabled.
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest,
+       NoRegisterWhenFeatureDisabled) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndDisableFeature(kBraveOnDeviceSpeechRecognition);
+
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_)).Times(0);
+  EXPECT_CALL(on_demand_updater_, EnsureInstalled(kComponentId, testing::_))
+      .Times(0);
+  RegisterOnDeviceSpeechModelsComponent(cus_.get());
+}
+
+// Tests that the component is not registered when ComponentUpdateService is
+// null.
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest,
+       NoRegisterWhenCUSIsNull) {
+  EXPECT_CALL(on_demand_updater_, EnsureInstalled(kComponentId, testing::_))
+      .Times(0);
+  RegisterOnDeviceSpeechModelsComponent(nullptr);
+}
+
+}  // namespace local_ai

--- a/components/local_ai/core/on_device_speech_models_state.cc
+++ b/components/local_ai/core/on_device_speech_models_state.cc
@@ -1,0 +1,52 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/local_ai/core/on_device_speech_models_state.h"
+
+#include "base/files/file_path.h"
+#include "base/no_destructor.h"
+#include "base/sequence_checker.h"
+
+namespace local_ai {
+
+namespace {
+// Subdirectory within the component install dir that holds the model files.
+constexpr char kModelDir[] = "nemotron-speech-streaming-en-0.6b-int4-onnx";
+}  // namespace
+
+// static
+OnDeviceSpeechModelsState* OnDeviceSpeechModelsState::GetInstance() {
+  static base::NoDestructor<OnDeviceSpeechModelsState> instance;
+  return instance.get();
+}
+
+OnDeviceSpeechModelsState::OnDeviceSpeechModelsState() = default;
+OnDeviceSpeechModelsState::~OnDeviceSpeechModelsState() = default;
+
+void OnDeviceSpeechModelsState::SetInstallDir(
+    const base::FilePath& install_dir) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (install_dir_ == install_dir) {
+    return;
+  }
+  install_dir_ = install_dir;
+  if (install_dir.empty()) {
+    model_dir_ = base::FilePath();
+    return;
+  }
+  model_dir_ = install_dir_.AppendASCII(kModelDir);
+}
+
+const base::FilePath& OnDeviceSpeechModelsState::GetInstallDir() const {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  return install_dir_;
+}
+
+const base::FilePath& OnDeviceSpeechModelsState::GetModelDir() const {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  return model_dir_;
+}
+
+}  // namespace local_ai

--- a/components/local_ai/core/on_device_speech_models_state.h
+++ b/components/local_ai/core/on_device_speech_models_state.h
@@ -1,0 +1,49 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_LOCAL_AI_CORE_ON_DEVICE_SPEECH_MODELS_STATE_H_
+#define BRAVE_COMPONENTS_LOCAL_AI_CORE_ON_DEVICE_SPEECH_MODELS_STATE_H_
+
+#include "base/files/file_path.h"
+#include "base/no_destructor.h"
+#include "base/sequence_checker.h"
+
+namespace local_ai {
+
+// Singleton holding the install directory of Brave's on-device speech
+// recognition model. The component installer populates it on
+// `ComponentReady`.
+class OnDeviceSpeechModelsState {
+ public:
+  static OnDeviceSpeechModelsState* GetInstance();
+
+  OnDeviceSpeechModelsState(const OnDeviceSpeechModelsState&) = delete;
+  OnDeviceSpeechModelsState& operator=(const OnDeviceSpeechModelsState&) =
+      delete;
+
+  // Sets the install directory (the model directory itself). An empty path
+  // clears the state.
+  void SetInstallDir(const base::FilePath& install_dir);
+
+  const base::FilePath& GetInstallDir() const;
+
+  // Returns the model subdirectory within the install dir, or an empty path
+  // when no component is installed.
+  const base::FilePath& GetModelDir() const;
+
+ private:
+  friend base::NoDestructor<OnDeviceSpeechModelsState>;
+  OnDeviceSpeechModelsState();
+  ~OnDeviceSpeechModelsState();
+
+  base::FilePath install_dir_;
+  base::FilePath model_dir_;
+
+  SEQUENCE_CHECKER(sequence_checker_);
+};
+
+}  // namespace local_ai
+
+#endif  // BRAVE_COMPONENTS_LOCAL_AI_CORE_ON_DEVICE_SPEECH_MODELS_STATE_H_


### PR DESCRIPTION
This PR is a sub-task towards supporting on-device WebSpeech https://github.com/brave/brave-browser/issues/56487

In this PR, we:
  - add a BraveOnDeviceSpeechRecognition feature flag
  - add on-device speech models component installer and state for the component added in https://github.com/brave/brave-core-crx-packager/pull/1197, gated by above feature flag