### PR TITLE
[deps] `EXTRA_DEPS` better handling full deployments

### DIFF
--- a/tools/cr/README.md
+++ b/tools/cr/README.md
@@ -45,13 +45,20 @@ Shared abstractions used by the entry points and tests:
 ## gclient hooks
 
 - `install_extra_deps.py` — a gclient hook (wired up from `DEPS`) that installs
-  archives Brave publishes to its own download buckets. It downloads the
-  archive, verifies its `sha256sum`, and extracts it straight on top of the
-  destination path. Unlike the toolchain builders in `toolchain/`, this hook is
-  not self-contained: it imports gclient code to evaluate condition statements
-  so they are interpreted consistently as if they were in a `DEPS` file.
+  archives declared in the `EXTRA_DEPS` table. It downloads the archive,
+  verifies its `sha256sum`, and extracts it into the destination path..
 
-  Downloads are declared in the `EXTRA_DEPS` table, as follows:
+  Dependencies come into ownership flavours:
+
+  - **Overlay** (with `overlayed_on`): the archive lays its members out relative
+    to the destination root and is extracted straight on top of the existing
+    upstream tree named by `overlayed_on` (validated against `DEPS`, so we never
+    overlay onto a rolled base).
+  - **Owned** (without `overlayed_on`): the object fully owns its destination
+    directory, which is wiped and re-extracted on every install so nothing from
+    a prior install lingers.
+
+  Downloads are declared as follows:
 
   ```python
   EXTRA_DEPS = {
@@ -62,6 +69,7 @@ Shared abstractions used by the entry points and tests:
         {
           'object_name': '<archive-name>.tar.xz',
           'sha256sum': '<hex sha256>',
+          # 'overlayed_on': '<upstream archive>',  # omit for an owned dep
           'condition': 'host_os == "linux"',  # one matching object per host
         },
       ],
@@ -69,8 +77,7 @@ Shared abstractions used by the entry points and tests:
   }
   ```
 
-  The archive must lay its members out relative to the destination root so it
-  can be extracted directly over it. Invoke with the target path, e.g.
+  Invoke with the target path, e.g.
   `install_extra_deps.py src/path/to/install/dir`.
 
 ## Subdirectories

--- a/tools/cr/install_extra_deps.py
+++ b/tools/cr/install_extra_deps.py
@@ -12,10 +12,16 @@ it deployed more generic, and reusable for other cases.
 
 `EXTRA_DEPS` mirrors the shape of a gclient `gcs` dependency, keyed by the
 checkout-relative destination path. Each object lists an `object_name`, its
-`sha256sum`, a `condition`, and `overlayed_on` -- the upstream Chromium archive
-the object is layered on top of (informational; recorded for traceability). The
-archive is expected to lay its members out relative to the destination root, so
-it can be extracted straight on top of it.
+`sha256sum`, a `condition`, and optionally `overlayed_on`, which selects how it
+is installed:
+
+  * Overlay (with `overlayed_on`) -- extracted on top of the upstream archive it
+    names, which is validated against DEPS so we never overlay a rolled base.
+  * Owned (without `overlayed_on`) -- fully owns its destination, which is wiped
+    and re-extracted each install so no stale extraction lingers.
+
+`bucket` is just an HTTPS prefix `object_name` is appended to: one of Brave's
+buckets, or an upstream distribution (e.g. `nodejs.org/dist`) used as one.
 
 `condition` strings (both dep-level and per-object) are resolved with
 depot_tools by loading the checkout's `.gclient` config and the owning
@@ -27,10 +33,14 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Mapping
+from dataclasses import dataclass
+import json
 import logging
+import shutil
 import sys
 import tarfile
 import tempfile
+import zipfile
 from pathlib import Path
 
 # `src/` directory (this script lives at src/brave/tools/cr/).
@@ -54,6 +64,11 @@ import gclient_utils  # pylint: disable=wrong-import-position,import-error
 # notice that most logs are DEBUG. No-op runs should not produce any output in
 # normal runs, to avoid cluttering the sync output.
 _LOG = logging.getLogger('install_extra_deps')
+
+# The extension we use for all sidecar files. Using stamp is deliberate to avoid
+# having gclient trying to read our sidecars.
+_STAMP = '.stamp'
+
 
 EXTRA_DEPS = {
     'src/third_party/rust-toolchain': {
@@ -109,50 +124,105 @@ def _select_object(objects: list[dict],
     return matches[0]
 
 
-def _extract(archive_path: Path, dest_dir: Path) -> None:
-    """Overlay the archive onto the destination directory.
+@dataclass(frozen=True)
+class TarballInstaller:
+    """Installs one resolved `EXTRA_DEPS` object into its destination.
 
-    This function extracts the archive in-place. Artefacts are supposed to be
-    laid out into the archive with the relative paths where they should be
-    installed. Furthermore, this function does not attempt to handle staleness
-    from previous extractions.
+    Handles the mechanics for a single object: download, sha256 verification,
+    extraction (wiping the destination first when it owns it), and the
+    gclient-style sidecar bookkeeping used to detect an existing install.
 
-    Extraction uses tarfile's `data` filter (PEP 706) so a malformed archive
-    cannot escape `dest_dir` via absolute paths, `..` traversal, or links
-    pointing outside it. The archive is only extracted though based on the
-    verified sha256, so this is just extra defense.
+    gclient drops a set of dotfile "sidecars" next to each `gcs` dep's extracted
+    tree (see `GcsDependency` in gclient.py and `GcsRoot` in gclient_scm.py),
+    keyed by a prefix that is the object name with `/` and `.` replaced by `_`:
+
+      .{prefix}_hash                the object's sha256
+      .{prefix}_content_names       JSON list of the archive's members
+
+    We deploy the very same files so our install state mirrors gclient's, but
+    append `.stamp` so gclient's own globs (`.*_hash`, `.*_content_names`)
+    never read or clobber ours.
     """
-    with tarfile.open(archive_path, mode='r:*') as tar:
-        tar.extractall(path=dest_dir, filter='data')
+
+    # The checkout directory the archive is extracted into.
+    dest_dir: Path
+    # The full URL the archive is downloaded from.
+    url: str
+    # The bucket object name; drives sidecar naming and diagnostics.
+    object_name: str
+    # The expected sha256 of the archive.
+    sha256sum: str
+    # True when the dep owns dest_dir (wiped before extract); False when it
+    # overlays an existing upstream tree (extracted on top).
+    owns_dest: bool
+
+    def is_installed(self) -> bool:
+        """True when the `_hash` sidecar already records `sha256sum`."""
+        return self._installed_hash() == self.sha256sum
+
+    def install(self) -> bool:
+        """Download and extract the object, writing the sidecars on success.
+
+        Returns False when the sidecar already records `sha256sum` and nothing
+        needed to be done.
+        """
+        if self.is_installed():
+            return False
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            archive_path = Path(tmp_dir) / self.object_name
+            with archive_path.open('wb') as archive_file:
+                deps.DownloadUrl(self.url, archive_file)
+            deps.VerifySHA256(str(archive_path), self.sha256sum, self.url)
+            if self.owns_dest and self.dest_dir.exists():
+                # Drop the previous extraction so nothing stale lingers;
+                # overlays deliberately keep the upstream tree they sit on.
+                shutil.rmtree(self.dest_dir)
+            member_names = self._extract(archive_path)
+        self._write_sidecars(member_names)
+        return True
+
+    def _extract(self, archive_path: Path) -> list[str]:
+        """Extract the archive (tar or zip) into `dest_dir`.
+
+        Returns the archive's member names, as gclient records them in its
+        `.*_content_names` sidecar (`ZipFile.namelist()` / `tar.getnames()`).
+        """
+        if zipfile.is_zipfile(archive_path):
+            with zipfile.ZipFile(archive_path) as archive:
+                names = archive.namelist()
+                archive.extractall(path=self.dest_dir)
+                return names
+        with tarfile.open(archive_path, mode='r:*') as tar:
+            names = tar.getnames()
+            tar.extractall(path=self.dest_dir, filter='data')
+            return names
+
+    def _sidecar(self, suffix: str) -> Path:
+        """The `.{prefix}{suffix}.stamp` sidecar path in `dest_dir`."""
+        prefix = self.object_name.replace('/', '_').replace('.', '_')
+        return self.dest_dir / f'.{prefix}{suffix}{_STAMP}'
+
+    def _installed_hash(self) -> str:
+        """The sha256 from the `_hash` sidecar, or '' when absent."""
+        hash_file = self._sidecar('_hash')
+        if hash_file.is_file():
+            return hash_file.read_bytes().decode('utf-8').strip()
+        return ''
+
+    def _write_sidecars(self, member_names: list[str]) -> None:
+        """Write the gclient-equivalent sidecar set, each with a `.stamp` tail.
+        """
+        contents = {
+            '_hash': self.sha256sum,
+            '_content_names': json.dumps(member_names),
+        }
+        for suffix, content in contents.items():
+            self._sidecar(suffix).write_text(f'{content}\n',
+                                             encoding='utf-8',
+                                             newline='')
 
 
-def _marker_file_name(object_name: str) -> str:
-    """Return the install-marker filename for *object_name*.
-
-    The marker's name takes into account potential collisions with `gclient`s
-    own naming scheme for this type of source, to avoid stepping on each others
-    markers, specially as the rust WASM toolchain is deployed as a overlay on
-    top of a `gcs`-type dependency.
-    """
-    file_prefix = object_name.replace('/', '_').replace('.', '_')
-    return f'.extra_dep_{file_prefix}.stamp'
-
-
-def _installed_hash(dest_dir: Path, object_name: str) -> str:
-    """Return the sha256 recorded by the last successful install, or ''."""
-    marker_file = dest_dir / _marker_file_name(object_name)
-    if marker_file.is_file():
-        return marker_file.read_bytes().decode('utf-8').strip()
-    return ''
-
-
-def _record_hash(dest_dir: Path, object_name: str, sha256sum: str) -> None:
-    """Persist the installed sha256 for subsequent freshness checks."""
-    marker_file = dest_dir / _marker_file_name(object_name)
-    marker_file.write_text(f'{sha256sum}\n', encoding='utf-8', newline='')
-
-
-class ExtraDepsInstaller:
+class ExtraDepsRunner:
     """Installs `EXTRA_DEPS` entries with gclient-resolved conditions.
 
     Holds the loaded `.gclient` context for a run so each solution's variables
@@ -166,7 +236,7 @@ class ExtraDepsInstaller:
         self._scope_by_solution: dict[str, dict[str, object]] = {}
 
     @classmethod
-    def from_checkout(cls) -> ExtraDepsInstaller:
+    def from_checkout(cls) -> ExtraDepsRunner:
         """Build an installer from the checkout's `.gclient` config.
 
         This installer emulates DEPS as an environmnet. `_SRC_DIR.parent` is
@@ -280,29 +350,23 @@ class ExtraDepsInstaller:
             _LOG.debug('No matching object for %s on this host', path)
             return
 
-        # An overlay must only be applied on top of the upstream base it was
-        # built against. Verify that base is still the one pinned in DEPS before
-        # touching the destination.
+        # An overlay must sit on the base it was built against: validate it
+        # still matches DEPS before touching the destination. No `overlayed_on`
+        # means the dep owns its destination, so there is no base to validate.
         overlayed_on = obj.get('overlayed_on')
         if overlayed_on:
             self._validate_overlay_target(path, overlayed_on)
 
-        dest_dir = _SRC_DIR.parent / path
-        object_name = obj['object_name']
-        sha256sum = obj['sha256sum']
-        if _installed_hash(dest_dir, object_name) == sha256sum:
-            _LOG.debug('%s already up to date (%s)', path, object_name)
-            return
-
-        url = spec['bucket'] + object_name
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            archive_path = Path(tmp_dir) / object_name
-            with archive_path.open('wb') as archive_file:
-                deps.DownloadUrl(url, archive_file)
-            deps.VerifySHA256(str(archive_path), sha256sum, url)
-            _extract(archive_path, dest_dir)
-        _record_hash(dest_dir, object_name, sha256sum)
-        _LOG.info('Installed %s into %s', object_name, dest_dir)
+        installer = TarballInstaller(dest_dir=_SRC_DIR.parent / path,
+                                     url=spec['bucket'] + obj['object_name'],
+                                     object_name=obj['object_name'],
+                                     sha256sum=obj['sha256sum'],
+                                     owns_dest=not overlayed_on)
+        if installer.install():
+            _LOG.info('Installed %s into %s', obj['object_name'],
+                      installer.dest_dir)
+        else:
+            _LOG.debug('%s already up to date (%s)', path, obj['object_name'])
 
 
 def main() -> int:
@@ -324,7 +388,7 @@ def main() -> int:
         '(e.g. src/third_party/rust-toolchain).')
     args = parser.parse_args()
 
-    ExtraDepsInstaller.from_checkout().install(args.dep, EXTRA_DEPS[args.dep])
+    ExtraDepsRunner.from_checkout().install(args.dep, EXTRA_DEPS[args.dep])
     return 0
 
 

--- a/tools/cr/install_extra_deps_test.py
+++ b/tools/cr/install_extra_deps_test.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `install_extra_deps`.
+
+The file is split into layers, from pure units to a full checkout integration:
+
+* `SelectObjectTest` covers the pure `_select_object` condition picker.
+
+* `TarballInstallerTest` drives a single `TarballInstaller` against real
+  on-disk archives (built in-memory). `deps.DownloadUrl` is faked so no network
+  is touched, but the real `deps.VerifySHA256` and the real tar/zip extraction
+  run, exercising download verification, the owned-vs-overlay wipe behaviour,
+  idempotency, and the gclient-equivalent sidecar bookkeeping.
+
+* `ValidateOverlayTargetTest` and `InstallTest` exercise `ExtraDepsRunner`
+  without the gclient machinery by pre-seeding its resolved-scope cache, so the
+  overlay-base validation and the install dispatch can be checked in isolation.
+
+* `FromCheckoutIntegrationTest` drives `ExtraDepsRunner.from_checkout` against a
+  `FakeChromiumRepo` with a minimal `.gclient` + `DEPS` written into it, so the
+  real depot_tools `gclient`/`gclient_eval` stack resolves the conditions and
+  the overlay base exactly as it would during a `gclient sync` -- end to end,
+  still with the download faked.
+
+* `MainTest` covers the `main()` CLI dispatch and argument validation.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import json
+import logging
+import sys
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest import mock
+
+# `FakeChromiumRepo` lives in the `test` package at the `tools/cr` root; add it
+# to the path so it resolves regardless of the working directory.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import install_extra_deps as m
+from test.fake_chromium_repo import FakeChromiumRepo
+
+
+def _sha256(data: bytes) -> str:
+    """The hex sha256 of `data`, as the installer records in its sidecar."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def _make_tar(members: list[tuple[str, bytes]],
+              compression: str = 'gz') -> bytes:
+    """Build a tar archive (default gzip) from `(name, content)` members."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode=f'w:{compression}') as tar:
+        for name, content in members:
+            info = tarfile.TarInfo(name)
+            info.size = len(content)
+            tar.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def _make_zip(members: list[tuple[str, bytes]]) -> bytes:
+    """Build a zip archive from `(name, content)` members."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as archive:
+        for name, content in members:
+            archive.writestr(name, content)
+    return buf.getvalue()
+
+
+class SelectObjectTest(unittest.TestCase):
+    """Tests for the `_select_object` per-host condition picker."""
+
+    def test_returns_none_when_nothing_matches(self):
+        """No object whose condition holds yields `None` (host not covered)."""
+        objects = [{
+            'object_name': 'linux.tar.gz',
+            'condition': 'host_os == "linux"',
+        }]
+        self.assertIsNone(m._select_object(objects, {'host_os': 'mac'}))
+
+    def test_returns_the_single_match(self):
+        """Exactly one matching condition returns that object."""
+        objects = [
+            {
+                'object_name': 'linux.tar.gz',
+                'condition': 'host_os == "linux"'
+            },
+            {
+                'object_name': 'mac.tar.gz',
+                'condition': 'host_os == "mac"'
+            },
+        ]
+        picked = m._select_object(objects, {'host_os': 'mac'})
+        self.assertEqual(picked['object_name'], 'mac.tar.gz')
+
+    def test_raises_when_multiple_match(self):
+        """More than one matching object is ambiguous and must raise."""
+        objects = [
+            {
+                'object_name': 'a.tar.gz',
+                'condition': 'host_os == "linux"'
+            },
+            {
+                'object_name': 'b.tar.gz',
+                'condition': 'host_os == "linux"'
+            },
+        ]
+        with self.assertRaisesRegex(RuntimeError, 'Multiple objects match'):
+            m._select_object(objects, {'host_os': 'linux'})
+
+
+class TarballInstallerTest(unittest.TestCase):
+    """Tests for `TarballInstaller` download/extract/sidecar mechanics."""
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        self.dest = self.root / 'dest'
+
+    def _installer(self,
+                   data: bytes,
+                   *,
+                   object_name: str = 'pkg.tar.gz',
+                   sha256sum: str | None = None,
+                   owns_dest: bool = True) -> m.TarballInstaller:
+        """A `TarballInstaller` for `data`, defaulting to its true sha256."""
+        return m.TarballInstaller(
+            dest_dir=self.dest,
+            url=f'https://downloads.invalid/{object_name}',
+            object_name=object_name,
+            sha256sum=_sha256(data) if sha256sum is None else sha256sum,
+            owns_dest=owns_dest)
+
+    def _faked_download(self, data: bytes) -> mock._patch:
+        """Patch `deps.DownloadUrl` to write `data` into the output file."""
+
+        def _write(_url, output_file):
+            output_file.write(data)
+
+        return mock.patch.object(m.deps, 'DownloadUrl', side_effect=_write)
+
+    def test_install_extracts_tarball_and_writes_sidecars(self):
+        """A fresh install extracts the tar members and records the sidecars."""
+        data = _make_tar([('bin/node', b'node'), ('README.md', b'hi')])
+        installer = self._installer(data)
+        with self._faked_download(data):
+            self.assertTrue(installer.install())
+        self.assertEqual((self.dest / 'bin/node').read_bytes(), b'node')
+        self.assertEqual((self.dest / 'README.md').read_bytes(), b'hi')
+        self.assertTrue(installer.is_installed())
+
+    def test_install_extracts_zip(self):
+        """Zip archives take the `ZipFile` branch and extract the same way."""
+        data = _make_zip([('node.exe', b'MZ'), ('LICENSE', b'mpl')])
+        installer = self._installer(data, object_name='node.zip')
+        with self._faked_download(data):
+            self.assertTrue(installer.install())
+        self.assertEqual((self.dest / 'node.exe').read_bytes(), b'MZ')
+        self.assertEqual((self.dest / 'LICENSE').read_bytes(), b'mpl')
+
+    def test_install_is_idempotent(self):
+        """A second install is a no-op: it returns False and re-downloads
+        nothing once the `_hash` sidecar already records the sha."""
+        data = _make_tar([('f', b'x')])
+        installer = self._installer(data)
+        with self._faked_download(data) as download:
+            self.assertTrue(installer.install())
+            self.assertFalse(installer.install())
+            download.assert_called_once()
+
+    def test_is_installed_is_false_without_sidecar(self):
+        """With no `_hash` sidecar present nothing is considered installed."""
+        self.assertFalse(
+            self._installer(_make_tar([('f', b'x')])).is_installed())
+
+    def test_owned_dest_is_wiped_before_extract(self):
+        """An owned dep wipes its destination first, so stale files are gone."""
+        self.dest.mkdir()
+        (self.dest / 'stale.txt').write_text('old')
+        data = _make_tar([('fresh.txt', b'new')])
+        installer = self._installer(data, owns_dest=True)
+        with self._faked_download(data):
+            installer.install()
+        self.assertFalse((self.dest / 'stale.txt').exists())
+        self.assertTrue((self.dest / 'fresh.txt').exists())
+
+    def test_overlay_keeps_existing_tree(self):
+        """An overlay (owns_dest=False) extracts on top, preserving the base."""
+        self.dest.mkdir()
+        (self.dest / 'base.txt').write_text('upstream')
+        data = _make_tar([('overlay.txt', b'brave')])
+        installer = self._installer(data, owns_dest=False)
+        with self._faked_download(data):
+            installer.install()
+        self.assertEqual((self.dest / 'base.txt').read_text(), 'upstream')
+        self.assertTrue((self.dest / 'overlay.txt').exists())
+
+    def test_sha256_mismatch_raises_and_installs_nothing(self):
+        """A hash mismatch surfaces from the real `VerifySHA256` and leaves the
+        destination untouched (no extraction, no sidecars)."""
+        data = _make_tar([('f', b'x')])
+        installer = self._installer(data, sha256sum='0' * 64)
+        with self._faked_download(data):
+            with self.assertRaises(ValueError):
+                installer.install()
+        self.assertFalse(self.dest.exists())
+        self.assertFalse(installer.is_installed())
+
+    def test_sidecar_contents(self):
+        """The written sidecars mirror gclient's set: the sha256 and the JSON
+        list of archive members, each `.stamp`."""
+        members = [('a', b'1'), ('b/c', b'2')]
+        data = _make_tar(members)
+        installer = self._installer(data, object_name='pkg.tar.gz')
+        with self._faked_download(data):
+            installer.install()
+        prefix = '.pkg_tar_gz'
+        hash_file = self.dest / f'{prefix}_hash.stamp'
+        names_file = self.dest / f'{prefix}_content_names.stamp'
+        self.assertTrue(hash_file.is_file())
+        self.assertEqual(hash_file.read_text().strip(), _sha256(data))
+        self.assertEqual(json.loads(names_file.read_text()), ['a', 'b/c'])
+        # The first-class-gcs migration toggle is deliberately not written.
+        self.assertFalse(
+            (self.dest / f'{prefix}_is_first_class_gcs.stamp').exists())
+
+    def test_sidecar_name_maps_dots_and_slashes(self):
+        """The sidecar prefix maps every `/` and `.` in the object name to `_`
+        (matching gclient's keying) and carries the `.stamp` tail."""
+        installer = self._installer(b'', object_name='Linux_x64/pkg.tar.gz')
+        self.assertEqual(
+            installer._sidecar('_hash').name,
+            '.Linux_x64_pkg_tar_gz_hash.stamp')
+
+
+class ValidateOverlayTargetTest(unittest.TestCase):
+    """Tests for `ExtraDepsRunner._validate_overlay_target`.
+
+    The runner's resolved-scope cache is seeded directly so these tests never
+    touch gclient: only the DEPS cross-check logic is under test here.
+    """
+
+    PATH = 'src/third_party/rust-toolchain'
+    BASE = 'Linux_x64/base.tar.xz'
+
+    def _runner(self, deps_map: dict) -> m.ExtraDepsRunner:
+        runner = m.ExtraDepsRunner(mock.Mock())
+        runner._scope_by_solution['src'] = {'vars': {}, 'deps': deps_map}
+        return runner
+
+    def test_passes_when_deps_pins_the_base(self):
+        """No error when DEPS still pins the expected overlay base as gcs."""
+        runner = self._runner({
+            self.PATH: {
+                'dep_type': 'gcs',
+                'objects': [{
+                    'object_name': self.BASE
+                }],
+            }
+        })
+        runner._validate_overlay_target(self.PATH, self.BASE)  # no raise
+
+    def test_raises_when_path_absent_from_deps(self):
+        """A path missing from DEPS cannot be verified, so it must raise."""
+        runner = self._runner({})
+        with self.assertRaisesRegex(RuntimeError, 'not a `gcs` dependency'):
+            runner._validate_overlay_target(self.PATH, self.BASE)
+
+    def test_raises_when_dep_is_not_gcs(self):
+        """A non-gcs dep at the path cannot anchor an overlay base."""
+        runner = self._runner({self.PATH: {'dep_type': 'git'}})
+        with self.assertRaisesRegex(RuntimeError, 'not a `gcs` dependency'):
+            runner._validate_overlay_target(self.PATH, self.BASE)
+
+    def test_raises_when_base_not_pinned(self):
+        """A gcs dep that no longer pins the expected base must raise (upstream
+        likely rolled the toolchain)."""
+        runner = self._runner({
+            self.PATH: {
+                'dep_type': 'gcs',
+                'objects': [{
+                    'object_name': 'Linux_x64/rolled.tar.xz'
+                }],
+            }
+        })
+        with self.assertRaisesRegex(RuntimeError, 'does not pin the expected'):
+            runner._validate_overlay_target(self.PATH, self.BASE)
+
+
+class InstallTest(unittest.TestCase):
+    """Tests for `ExtraDepsRunner.install` dispatch.
+
+    The resolved-scope cache is seeded directly (no gclient), `_SRC_DIR` is
+    pointed at a temp tree so destinations land there, and the download is
+    faked, so the focus is purely the skip/select/validate/install branching.
+    """
+
+    def setUp(self):
+        # Silence the script's own INFO line ("Installed ... into ...").
+        logging.disable(logging.WARNING)
+        self.addCleanup(logging.disable, logging.NOTSET)
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        # `install` derives dest as `_SRC_DIR.parent / path`; with _SRC_DIR at
+        # <root>/src, a 'src/...' path resolves under <root>/src/...
+        patcher = mock.patch.object(m, '_SRC_DIR', self.root / 'src')
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _runner(self,
+                variables: dict,
+                deps_map: dict | None = None) -> m.ExtraDepsRunner:
+        runner = m.ExtraDepsRunner(mock.Mock())
+        runner._scope_by_solution['src'] = {
+            'vars': variables,
+            'deps': deps_map or {},
+        }
+        return runner
+
+    def _faked_download(self, data: bytes) -> mock._patch:
+
+        def _write(_url, output_file):
+            output_file.write(data)
+
+        return mock.patch.object(m.deps, 'DownloadUrl', side_effect=_write)
+
+    def test_skips_when_dep_condition_is_false(self):
+        """A false dep-level condition skips entirely; nothing downloads."""
+        runner = self._runner({'checkout_linux': False})
+        spec = {
+            'bucket': 'https://x/',
+            'condition': 'checkout_linux',
+            'objects': [{
+                'object_name': 'pkg.tar.gz',
+                'sha256sum': 'a',
+                'condition': 'True'
+            }],
+        }
+        with self._faked_download(b'') as download:
+            runner.install('src/foo', spec)
+            download.assert_not_called()
+
+    def test_skips_when_no_object_matches_host(self):
+        """When no per-object condition matches this host, nothing downloads."""
+        runner = self._runner({'host_os': 'linux'})
+        spec = {
+            'bucket': 'https://x/',
+            'objects': [{
+                'object_name': 'mac.tar.gz',
+                'sha256sum': 'a',
+                'condition': 'host_os == "mac"'
+            }],
+        }
+        with self._faked_download(b'') as download:
+            runner.install('src/foo', spec)
+            download.assert_not_called()
+
+    def test_installs_owned_object_without_overlay_validation(self):
+        """An owned object installs straight through; the overlay validation is
+        never consulted (there is no base to check)."""
+        data = _make_tar([('bin/node', b'node')])
+        runner = self._runner({'host_os': 'linux'})
+        spec = {
+            'bucket': 'https://downloads.invalid/',
+            'objects': [{
+                'object_name': 'node.tar.gz',
+                'sha256sum': _sha256(data),
+                'condition': 'host_os == "linux"'
+            }],
+        }
+        with mock.patch.object(runner, '_validate_overlay_target') as validate:
+            with self._faked_download(data):
+                runner.install('src/brave/third_party/node', spec)
+            validate.assert_not_called()
+        dest = self.root / 'src/brave/third_party/node'
+        self.assertEqual((dest / 'bin/node').read_bytes(), b'node')
+
+    def test_validates_overlay_base_before_installing(self):
+        """An overlay object validates its base against DEPS before extracting,
+        passing the object's `overlayed_on` to the check."""
+        data = _make_tar([('lib/std', b'rlib')])
+        runner = self._runner({'host_os': 'linux'})
+        spec = {
+            'bucket': 'https://downloads.invalid/',
+            'objects': [{
+                'object_name': 'overlay.tar.gz',
+                'sha256sum': _sha256(data),
+                'overlayed_on': 'Linux_x64/base.tar.xz',
+                'condition': 'host_os == "linux"',
+            }],
+        }
+        with mock.patch.object(runner, '_validate_overlay_target') as validate:
+            with self._faked_download(data):
+                runner.install('src/third_party/rust-toolchain', spec)
+            validate.assert_called_once_with('src/third_party/rust-toolchain',
+                                             'Linux_x64/base.tar.xz')
+
+    def test_overlay_validation_failure_prevents_download(self):
+        """If the overlay base no longer validates, the install aborts before
+        touching the network."""
+        runner = self._runner({'host_os': 'linux'})
+        spec = {
+            'bucket': 'https://downloads.invalid/',
+            'objects': [{
+                'object_name': 'overlay.tar.gz',
+                'sha256sum': 'a',
+                'overlayed_on': 'Linux_x64/base.tar.xz',
+                'condition': 'host_os == "linux"',
+            }],
+        }
+        with mock.patch.object(runner,
+                               '_validate_overlay_target',
+                               side_effect=RuntimeError('rolled')):
+            with self._faked_download(b'') as download:
+                with self.assertRaises(RuntimeError):
+                    runner.install('src/third_party/rust-toolchain', spec)
+                download.assert_not_called()
+
+
+class FromCheckoutIntegrationTest(unittest.TestCase):
+    """End-to-end tests over a fake checkout with the real gclient stack.
+
+    A `FakeChromiumRepo` provides the `src/` layout; a minimal `.gclient` and
+    `DEPS` written into it let depot_tools resolve variables and the overlay
+    base exactly as a real `gclient sync` would. `host_os`/`host_cpu` are pinned
+    via `.gclient` custom_vars so conditions resolve deterministically on any
+    test host. Only the download is faked.
+    """
+
+    def setUp(self):
+        # gclient logs very verbosely on the root logger while resolving DEPS;
+        # silence it (and the script's own INFO line) for clean test output.
+        logging.disable(logging.WARNING)
+        self.addCleanup(logging.disable, logging.NOTSET)
+
+        self.repo = FakeChromiumRepo()
+        self.addCleanup(self.repo.cleanup)
+        (self.repo.base_path / '.gclient').write_text(
+            'solutions = [{'
+            '"name": "src", '
+            '"url": "https://example.invalid/src.git", '
+            '"custom_vars": {'
+            '"host_os": "linux", "host_cpu": "x64", "checkout_linux": True}}]\n'
+        )
+        (self.repo.chromium / 'DEPS').write_text(
+            "deps = {\n"
+            "  'src/third_party/rust-toolchain': {\n"
+            "    'dep_type': 'gcs', 'bucket': 'chromium-bucket',\n"
+            "    'objects': [{'object_name': 'Linux_x64/base.tar.xz',\n"
+            "                 'sha256sum': 'aa', 'size_bytes': 1,\n"
+            "                 'generation': 1}],\n"
+            "  },\n"
+            "}\n")
+        patcher = mock.patch.object(m, '_SRC_DIR', self.repo.chromium)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _faked_download(self, data: bytes) -> mock._patch:
+
+        def _write(_url, output_file):
+            output_file.write(data)
+
+        return mock.patch.object(m.deps, 'DownloadUrl', side_effect=_write)
+
+    def test_resolves_solution_vars_and_caches(self):
+        """`from_checkout` loads the config and resolves the solution's vars,
+        merging in the `.gclient` custom_vars and caching the parsed scope."""
+        runner = m.ExtraDepsRunner.from_checkout()
+        variables = runner._solution_vars('src')
+        self.assertEqual(variables['host_os'], 'linux')
+        self.assertEqual(variables['host_cpu'], 'x64')
+        self.assertTrue(variables['checkout_linux'])
+        # Second lookup hits the cache and returns the very same scope object.
+        self.assertIs(runner._solution_scope('src'),
+                      runner._solution_scope('src'))
+
+    def test_unknown_solution_raises(self):
+        """Asking for a solution the `.gclient` does not declare is an error."""
+        runner = m.ExtraDepsRunner.from_checkout()
+        with self.assertRaisesRegex(RuntimeError, 'No gclient solution'):
+            runner._solution_vars('nonexistent')
+
+    def test_missing_gclient_root_raises(self):
+        """`from_checkout` raises when no `.gclient` is found walking upward."""
+        with tempfile.TemporaryDirectory() as orphan:
+            with mock.patch.object(m, '_SRC_DIR', Path(orphan) / 'src'):
+                with self.assertRaisesRegex(RuntimeError,
+                                            'Could not find a .gclient root'):
+                    m.ExtraDepsRunner.from_checkout()
+
+    def test_validate_overlay_target_against_real_deps(self):
+        """The overlay base resolves against the DEPS parsed from the checkout:
+        the pinned base passes, a different one raises."""
+        runner = m.ExtraDepsRunner.from_checkout()
+        runner._validate_overlay_target('src/third_party/rust-toolchain',
+                                        'Linux_x64/base.tar.xz')  # no raise
+        with self.assertRaisesRegex(RuntimeError, 'does not pin the expected'):
+            runner._validate_overlay_target('src/third_party/rust-toolchain',
+                                            'Linux_x64/rolled.tar.xz')
+
+    def test_install_end_to_end(self):
+        """A full install resolves the host condition through gclient, extracts
+        the archive into the checkout path, and writes the sidecars."""
+        data = _make_tar([('bin/node', b'node')])
+        spec = {
+            'bucket': 'https://downloads.invalid/',
+            'condition': 'checkout_linux',
+            'objects': [
+                {
+                    'object_name': 'node-linux.tar.gz',
+                    'sha256sum': _sha256(data),
+                    'condition': 'host_os == "linux"',
+                },
+                {
+                    'object_name': 'node-mac.tar.gz',
+                    'sha256sum': 'unused',
+                    'condition': 'host_os == "mac"',
+                },
+            ],
+        }
+        runner = m.ExtraDepsRunner.from_checkout()
+        with self._faked_download(data):
+            runner.install('src/brave/third_party/node', spec)
+        dest = self.repo.chromium / 'brave/third_party/node'
+        self.assertEqual((dest / 'bin/node').read_bytes(), b'node')
+        self.assertTrue((dest / '.node-linux_tar_gz_hash.stamp').is_file())
+
+    def test_install_skips_when_dep_condition_is_false(self):
+        """A dep-level condition that is false for the checkout installs
+        nothing, even though an object would otherwise match the host."""
+        data = _make_tar([('f', b'x')])
+        spec = {
+            'bucket': 'https://downloads.invalid/',
+            'condition': 'checkout_android',
+            'objects': [{
+                'object_name': 'node.tar.gz',
+                'sha256sum': _sha256(data),
+                'condition': 'host_os == "linux"',
+            }],
+        }
+        runner = m.ExtraDepsRunner.from_checkout()
+        with self._faked_download(data) as download:
+            runner.install('src/brave/third_party/node', spec)
+            download.assert_not_called()
+        self.assertFalse(
+            (self.repo.chromium / 'brave/third_party/node').exists())
+
+
+class MainTest(unittest.TestCase):
+    """Tests for the `main()` CLI dispatch.
+
+    `main()` reads `EXTRA_DEPS` for both the argparse `choices` and the spec
+    lookup, so these tests patch in their own fixture rather than depending on
+    whatever the live table happens to declare.
+    """
+
+    _FAKE_EXTRA_DEPS = {
+        'src/path/to/dep': {
+            'bucket': 'https://downloads.invalid/',
+            'objects': [{
+                'object_name': 'pkg.tar.gz',
+                'sha256sum': 'a',
+                'condition': 'True',
+            }],
+        },
+    }
+
+    def test_dispatches_selected_dep_to_runner(self):
+        """A valid dep key resolves a runner and installs that entry's spec."""
+        runner = mock.Mock()
+        dep = 'src/path/to/dep'
+        with mock.patch.object(m, 'EXTRA_DEPS', self._FAKE_EXTRA_DEPS):
+            with mock.patch.object(m.ExtraDepsRunner,
+                                   'from_checkout',
+                                   return_value=runner):
+                with mock.patch.object(sys, 'argv',
+                                       ['install_extra_deps', dep]):
+                    self.assertEqual(m.main(), 0)
+        runner.install.assert_called_once_with(dep, self._FAKE_EXTRA_DEPS[dep])
+
+    def test_rejects_unknown_dep(self):
+        """An unknown dep key is rejected by argparse before any work runs."""
+        with mock.patch.object(m, 'EXTRA_DEPS', self._FAKE_EXTRA_DEPS):
+            with mock.patch.object(m.ExtraDepsRunner,
+                                   'from_checkout') as checkout:
+                with mock.patch.object(
+                        sys, 'argv',
+                    ['install_extra_deps', 'src/does/not/exist']):
+                    # argparse prints a usage error to stderr before exiting;
+                    # keep it out of the test output.
+                    with contextlib.redirect_stderr(io.StringIO()):
+                        with self.assertRaises(SystemExit):
+                            m.main()
+                checkout.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The use of `EXTRA_DEPS` has been limited to rust toolchains. Those
dependencies have this quirk of not being full dependencies that own the
destination path, but rather they just overlay onto an existing path.

This PR further improves the delivery method for each component, making
sure to check the sidecar values in a normalised way, and providing an
option for dependencies to fully own a path. This should be the most
common type of dependency being deployed during sync.

This change also introduces test coverage for this code.

Bug: https://github.com/brave/brave-browser/issues/55812
