### PR TITLE
Add pref to hide screenshot button in toolbar

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -414,6 +414,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   // appearance
   registry->RegisterBooleanPref(kShowBookmarksButton, true);
   registry->RegisterBooleanPref(kShowSidePanelButton, true);
+  registry->RegisterBooleanPref(kShowScreenshotButton, true);
   registry->RegisterBooleanPref(kLocationBarIsWide, false);
   registry->RegisterBooleanPref(kMRUCyclingEnabled, false);
   registry->RegisterBooleanPref(kTabsSearchShow, true);

--- a/browser/prefs/brave_pref_service_incognito_allowlist.cc
+++ b/browser/prefs/brave_pref_service_incognito_allowlist.cc
@@ -33,6 +33,7 @@ base::span<const base::cstring_view> GetBravePersistentPrefNames() {
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
       brave_wallet::kShowWalletIconOnToolbar,
 #endif  // BUILDFLAG(ENABLE_BRAVE_WALLET)
+      kShowScreenshotButton,
       prefs::kSidePanelHorizontalAlignment,
       kTabMuteIndicatorNotClickable,
       brave_tabs::kVerticalTabsExpandedWidth,

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -374,6 +374,11 @@ void BraveToolbarView::Init() {
         AddChildViewAt(std::make_unique<ScreenshotButton>(browser()),
                        *GetIndexOf(app_menu_button()) - 1);
     SetBraveButtonFlexBehavior(screenshot_button_);
+    show_screenshot_button_.Init(
+        kShowScreenshotButton, profile->GetPrefs(),
+        base::BindRepeating(&BraveToolbarView::OnShowScreenshotButtonChanged,
+                            base::Unretained(this)));
+    screenshot_button_->SetVisible(show_screenshot_button_.GetValue());
   }
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
@@ -429,6 +434,11 @@ void BraveToolbarView::OnShowBookmarksButtonChanged() {
   }
 
   UpdateBookmarkVisibility();
+}
+
+void BraveToolbarView::OnShowScreenshotButtonChanged() {
+  CHECK(screenshot_button_);
+  screenshot_button_->SetVisible(show_screenshot_button_.GetValue());
 }
 
 void BraveToolbarView::OnLocationBarIsWideChanged() {

--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -64,6 +64,7 @@ class BraveToolbarView : public ToolbarView,
   void OnEditBookmarksEnabledChanged();
   void OnLocationBarIsWideChanged();
   void OnShowBookmarksButtonChanged();
+  void OnShowScreenshotButtonChanged();
   void ShowBookmarkBubble(const GURL& url, bool already_bookmarked) override;
   void VisibilityChanged(views::View* starting_from, bool visible) override;
 
@@ -116,6 +117,7 @@ class BraveToolbarView : public ToolbarView,
 #endif
 
   raw_ptr<ScreenshotButton> screenshot_button_ = nullptr;
+  BooleanPrefMember show_screenshot_button_;
 
   BooleanPrefMember show_wallet_button_;
   BooleanPrefMember wallet_disabled_by_policy_;

--- a/browser/ui/webui/side_panel/customize_chrome/BUILD.gn
+++ b/browser/ui/webui/side_panel/customize_chrome/BUILD.gn
@@ -18,6 +18,7 @@ source_set("customize_chrome") {
 
   deps = [
     "//base",
+    "//brave/browser/ui/screenshot",
     "//brave/components/ai_chat/core/common/buildflags",
     "//brave/components/brave_news/common/buildflags",
     "//brave/components/brave_rewards/core",
@@ -94,6 +95,7 @@ source_set("unit_tests") {
   deps = [
     ":customize_chrome",
     "//base",
+    "//brave/browser/ui/screenshot",
     "//brave/components/ai_chat/core/common/buildflags",
     "//brave/components/brave_news/common/buildflags",
     "//brave/components/brave_rewards/core",

--- a/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/brave_action.h
+++ b/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/brave_action.h
@@ -122,6 +122,14 @@ inline constexpr BraveAction kShowBraveNews = {
     .icon = kLeoRssIcon};
 #endif  // BUILDFLAG(ENABLE_BRAVE_NEWS)
 
+inline constexpr BraveAction kShowScreenshotAction = {
+    .id = side_panel::customize_chrome::mojom::ActionId::kShowScreenshot,
+    .display_name_resource_id = IDS_CUSTOMIZE_TOOLBAR_TOGGLE_SCREENSHOT,
+    .anchor = side_panel::customize_chrome::mojom::ActionId::kTabSearch,
+    .category = side_panel::customize_chrome::mojom::CategoryId::kNavigation,
+    .pref_name = kShowScreenshotButton,
+    .icon = kLeoScreenshotIcon};
+
 inline constexpr BraveAction kShowShareMenuAction = {
     .id = side_panel::customize_chrome::mojom::ActionId::kShowShareMenu,
     .display_name_resource_id = IDS_CUSTOMIZE_TOOLBAR_TOGGLE_SHARE_MENU,
@@ -146,6 +154,7 @@ inline constexpr auto kBraveActions =
                            const BraveAction*>({
         {kShowAddBookmarkButton.id, &kShowAddBookmarkButton},
         {kShowSidePanelAction.id, &kShowSidePanelAction},
+        {kShowScreenshotAction.id, &kShowScreenshotAction},
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
         {kShowWalletAction.id, &kShowWalletAction},
 #endif  // BUILDFLAG(ENABLE_BRAVE_WALLET)

--- a/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/list_action_modifiers.cc
+++ b/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/list_action_modifiers.cc
@@ -11,6 +11,7 @@
 #include "base/check_is_test.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/strings/utf_string_conversions.h"
+#include "brave/browser/ui/screenshot/features.h"
 #include "brave/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/brave_action.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
@@ -196,6 +197,7 @@ std::vector<ActionPtr> ApplyBraveSpecificModifications(
   //   kShowWallet,
   //   kShowAIChat,
   //   kShowVPN,
+  //   kShowScreenshot,
   // Address bar
   //   kShowReward
   //   kShowBraveNews
@@ -209,6 +211,10 @@ std::vector<ActionPtr> ApplyBraveSpecificModifications(
 
   // Followings are dynamic actions: anchor to TabSearchButton and append to
   // action list in reverse order.
+  if (screenshot::features::IsScreenshotEnabled()) {
+    brave_actions.push_back(kShowScreenshotAction);
+  }
+
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   if (brave_vpn::IsBraveVPNEnabled(web_contents->GetBrowserContext())) {
     brave_actions.push_back(kShowVPNAction);

--- a/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/list_action_modifiers.h
+++ b/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/list_action_modifiers.h
@@ -40,7 +40,7 @@ FilterUnsupportedChromiumActions(
 // 3. Adds Brave-specific actions.
 //   e.g. In 'Navigation' category:
 //        `kShowAddBookmarkButton`, `kShowSidePanel`, `kShowWallet`,
-//        `kShowAIChat`, `kShowVPN`.
+//        `kShowAIChat`, `kShowVPN`, `kShowScreenshot`.
 //        In 'Address bar' category: `kShowReward`,
 //        `kShowBraveNews`, `kShowShareMenu`.
 std::vector<side_panel::customize_chrome::mojom::ActionPtr>

--- a/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/list_action_modifiers_unittest.cc
+++ b/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/list_action_modifiers_unittest.cc
@@ -8,6 +8,8 @@
 #include <utility>
 
 #include "base/containers/fixed_flat_set.h"
+#include "base/test/scoped_feature_list.h"
+#include "brave/browser/ui/screenshot/features.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
@@ -370,6 +372,33 @@ TEST_F(ListActionModifiersUnitTest,
 #endif  // BUILDFLAG(ENABLE_BRAVE_REWARDS)
 
 TEST_F(ListActionModifiersUnitTest,
+       ApplyBraveSpecificModifications_ScreenshotNotAddedWhenFeatureDisabled) {
+  // Feature is disabled by default.
+  ASSERT_FALSE(screenshot::features::IsScreenshotEnabled());
+  auto modified_actions = customize_chrome::ApplyBraveSpecificModifications(
+      web_contents_.get(), GetBasicActions());
+  auto screenshot_it =
+      std::ranges::find(modified_actions, ActionId::kShowScreenshot,
+                        &side_panel::customize_chrome::mojom::Action::id);
+  EXPECT_EQ(screenshot_it, modified_actions.end());
+}
+
+TEST_F(ListActionModifiersUnitTest,
+       ApplyBraveSpecificModifications_ScreenshotAddedWhenFeatureEnabled) {
+  base::test::ScopedFeatureList feature_list(
+      screenshot::features::kBraveScreenshot);
+  ASSERT_TRUE(screenshot::features::IsScreenshotEnabled());
+  auto modified_actions = customize_chrome::ApplyBraveSpecificModifications(
+      web_contents_.get(), GetBasicActions());
+  auto screenshot_it =
+      std::ranges::find(modified_actions, ActionId::kShowScreenshot,
+                        &side_panel::customize_chrome::mojom::Action::id);
+  ASSERT_NE(screenshot_it, modified_actions.end());
+  EXPECT_EQ((*screenshot_it)->category,
+            side_panel::customize_chrome::mojom::CategoryId::kNavigation);
+}
+
+TEST_F(ListActionModifiersUnitTest,
        ApplyBraveSpecificModifications_ShareMenuShouldNotBeAddedWhenDisabled) {
   // Share Menu should be added by default (Sharing Hub enabled by default)
   ASSERT_FALSE(sharing_hub::SharingIsDisabledByPolicy(
@@ -397,6 +426,8 @@ TEST_F(ListActionModifiersUnitTest,
 
 TEST_F(ListActionModifiersUnitTest,
        ApplyBraveSpecificModifications_ComprehensiveOrderTest) {
+  base::test::ScopedFeatureList feature_list(
+      screenshot::features::kBraveScreenshot);
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   ASSERT_TRUE(brave_vpn::IsBraveVPNEnabled(web_contents_->GetBrowserContext()));
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
@@ -433,7 +464,8 @@ TEST_F(ListActionModifiersUnitTest,
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
           EqId(ActionId::kShowVPN),
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
-          EqId(ActionId::kShowBookmarks), EqId(ActionId::kDevTools),
+          EqId(ActionId::kShowScreenshot), EqId(ActionId::kShowBookmarks),
+          EqId(ActionId::kDevTools),
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
           EqId(ActionId::kShowReward),
 #endif

--- a/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar.mojom
+++ b/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar.mojom
@@ -13,6 +13,7 @@ enum ActionId {
   kShowAIChat,
   kShowVPN,
   kShowSidePanel,
+  kShowScreenshot,
 
   // Actions in the "Address bar" category.
   kShowReward,

--- a/components/constants/pref_names.h
+++ b/components/constants/pref_names.h
@@ -47,6 +47,7 @@ inline constexpr char kWidevineEnabled[] = "brave.widevine_opted_in";
 inline constexpr char kAskEnableWidvine[] = "brave.ask_widevine_install";
 inline constexpr char kShowBookmarksButton[] = "brave.show_bookmarks_button";
 inline constexpr char kShowSidePanelButton[] = "brave.show_side_panel_button";
+inline constexpr char kShowScreenshotButton[] = "brave.show_screenshot_button";
 inline constexpr char kLocationBarIsWide[] = "brave.location_bar_is_wide";
 inline constexpr char kReferralDownloadID[] = "brave.referral.download_id";
 inline constexpr char kReferralTimestamp[] = "brave.referral.timestamp";

--- a/components/resources/customize_toolbar_ui_strings.grdp
+++ b/components/resources/customize_toolbar_ui_strings.grdp
@@ -36,4 +36,7 @@
   <message name="IDS_CUSTOMIZE_TOOLBAR_TOGGLE_BOOKMARKS_PANEL" desc="Title for a toggle button to show or hide bookmarks panel">
     Bookmarks Panel
   </message>
+  <message name="IDS_CUSTOMIZE_TOOLBAR_TOGGLE_SCREENSHOT" desc="Title for a toggle button to show or hide screenshot button">
+    Screenshot
+  </message>
 </grit-part>


### PR DESCRIPTION
This pref will be controlled via customize toolbar web ui from side panel

<img width="934" height="1476" alt="image" src="https://github.com/user-attachments/assets/66048bfe-22aa-4d50-83d2-792edb4574fe" />


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56586

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
