### PR TITLE
Revert "[bots] `brave_services_key_id` gn default (#37481)"

### DIFF
--- a/build/util/version.py
+++ b/build/util/version.py
@@ -59,9 +59,6 @@ brave_version_build = "%(brave_version_build)s"
 # The full Brave version.
 brave_version = "%(brave_version)s"
 
-# The Chromium milestone (the MAJOR component of the upstream version).
-chromium_version_major = "%(chromium_version_major)s"
-
 # The full Chrome version.
 chrome_version_string = "%(chrome_version_string)s"
 """
@@ -174,9 +171,8 @@ class Versioner:
             'brave_version': (f"{patched['MINOR']}.{patched['BUILD']}."
                               f"{patched['PATCH']}"),
 
-            # The upstream Chromium milestone and full version come from the
-            # .chromium sidecar.
-            'chromium_version_major': upstream['MAJOR'],
+            # The full upstream Chromium version comes from the .chromium
+            # sidecar.
             'chrome_version_string': (
                 f"{upstream['MAJOR']}.{upstream['MINOR']}."
                 f"{upstream['BUILD']}.{upstream['PATCH']}"),

--- a/components/brave_service_keys/BUILD.gn
+++ b/components/brave_service_keys/BUILD.gn
@@ -8,41 +8,20 @@ import("//build/buildflag_header.gni")
 import("//testing/test.gni")
 
 declare_args() {
-  # TODO(https://github.com/brave/brave-browser/issues/56449): Remove this once
-  # a couple of releases have gone through and we've confirmed the derived value
-  # is correct.
+  # BRAVE_SERVICES_KEY_ID = TARGET_OS + '-' + CV_MAJOR + '-' + RELEASE_CHANNEL
+  # It is used (in combination with a secret seed) to generate service keys
+  # for each service, OS, chrominum version, release channel
+  # combination.
   brave_services_key_id = ""
 }
 
-if (is_mac) {
-  _platform = "macos"
-} else {
-  _platform = target_os
-}
-
-# Release channel comes up as an empty string in `brave_channel`, so we need to
-# check that first.
-if (is_release_channel && brave_channel == "") {
-  _channel = "release"
-} else {
-  _channel = brave_channel
-}
-
-_brave_services_key_id = "$_platform-$chromium_version_major-$_channel"
-
-# TODO(https://github.com/brave/brave-browser/issues/56449): Remove this once
-# a couple of releases have gone through and we've confirmed the derived value
-# is correct.
-if (is_official_build && brave_services_key_id != "") {
-  assert(
-      brave_services_key_id == _brave_services_key_id,
-      "brave_services_key_id mismatch: env='$brave_services_key_id' " +
-          "derived='$_brave_services_key_id'. Update your .env file to match")
+if (is_official_build) {
+  assert(brave_services_key_id != "")
 }
 
 buildflag_header("buildflags") {
   header = "buildflags.h"
-  flags = [ "BRAVE_SERVICES_KEY_ID=\"$_brave_services_key_id\"" ]
+  flags = [ "BRAVE_SERVICES_KEY_ID=\"$brave_services_key_id\"" ]
 }
 
 static_library("brave_service_keys") {


### PR DESCRIPTION
Reverting this as it has caused a breakage on master:

```
[2026-06-25T12:46:25.885Z] D:\ws\x86-nightly\src\brave\node_modules\@brave\leo\icons\browser-bookmark-normal.svg copied to D:\ws\x86-nightly\src\ui\webui\resources\images\icon_bookmark.svg
[2026-06-25T12:46:25.886Z] ...update branding done
[2026-06-25T12:46:25.886Z] generate ninja files...
[2026-06-25T12:46:25.886Z] Widevine cdm host verification is disabled
[2026-06-25T12:46:25.886Z] D:\ws\x86-nightly\src\out\Release_x86\args_generated.gni has been updated
[2026-06-25T12:46:25.886Z] D:\ws\x86-nightly\src\out\Release_x86\[args.gn](http://args.gn) has been updated
[2026-06-25T12:46:25.886Z] -------------------------------
[2026-06-25T12:46:25.886Z] D:\ws\x86-nightly\src
[2026-06-25T12:46:25.886Z] > gn gen D:\ws\x86-nightly\src\out\Release_x86 --check
[2026-06-25T12:46:26.452Z] ERROR at //brave/components/brave_service_keys/BUILD.gn:37:3: Assertion failed.
[2026-06-25T12:46:26.453Z]   assert(
[2026-06-25T12:46:26.453Z]   ^-----
[2026-06-25T12:46:26.453Z] brave_services_key_id mismatch: env='windows-150-nightly' derived='win-150-nightly'. Update your .env file to match
[2026-06-25T12:46:26.453Z] See //brave/components/brave_service_keys/BUILD.gn:38:7:
[2026-06-25T12:46:26.453Z]       brave_services_key_id == _brave_services_key_id,
[2026-06-25T12:46:26.453Z]       ^----------------------------------------------
[2026-06-25T12:46:26.453Z] This is where it was set.
[2026-06-25T12:46:26.453Z] See //brave/browser/net/sources.gni:72:3: which caused the file to be included.
[2026-06-25T12:46:26.453Z]   "//brave/components/brave_service_keys",
[2026-06-25T12:46:26.453Z]   ^--------------------------------------
[2026-06-25T12:46:26.709Z] null
[2026-06-25T12:46:26.709Z] powershell.exe : null
[2026-06-25T12:46:26.709Z] At D:\ws\x86-nightly@tmp\durable-5a87ff5d\powershellWrapper.ps1:3 char:1
[2026-06-25T12:46:26.710Z] + & powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Comm ...
[2026-06-25T12:46:26.710Z] + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[2026-06-25T12:46:26.710Z]     + CategoryInfo          : NotSpecified: (null:String) [], RemoteException
[2026-06-25T12:46:26.710Z]     + FullyQualifiedErrorId : NativeCommandError
[2026-06-25T12:46:26.710Z]
```

This reverts commit bb6d7e473b96196aa27de9dd99b95a3ea6de317e.
