### PR TITLE
[bootstrap] Fetch `node` on sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ patches/**/*.patchinfo
 /third_party/cryptography
 /third_party/macholib
 /third_party/libdmg-hfsplus/
+/third_party/node/
 /third_party/opengrep/bin/
 /third_party/wintun/
 *.xcodeproj

--- a/DEPS
+++ b/DEPS
@@ -205,6 +205,13 @@ hooks = [
                'tools/cr/install_extra_deps.py',
                'src/third_party/rust-toolchain']
   },
+  {
+    'name': 'download_node',
+    'pattern': '.',
+    'action': ['vpython3',
+               'tools/cr/install_extra_deps.py',
+               'src/brave/third_party/node']
+  },
 ]
 
 include_rules = [

--- a/script/brave_license_helper.py
+++ b/script/brave_license_helper.py
@@ -177,6 +177,9 @@ def AddBraveCredits(root, prune_paths, special_cases, prune_dirs,
         os.path.join('brave', 'third_party', 'libdmg-hfsplus'),
         os.path.join('brave', 'tools', 'crates', 'vendor'),
 
+        # Node.js for tooling, and not shipped with the browser.
+        os.path.join('brave', 'third_party', 'node'),
+
         # plaster .toml file location should be skipped.
         os.path.join('brave', 'rewrite', 'third_party'),
 

--- a/tools/cr/install_extra_deps.py
+++ b/tools/cr/install_extra_deps.py
@@ -101,6 +101,32 @@ EXTRA_DEPS = {
             },
         ],
     },
+    'src/brave/third_party/node': {
+        'bucket': 'https://brave-build-deps-public.s3.brave.com/nodejs/',
+        'condition': 'checkout_linux or checkout_mac or checkout_win',
+        'objects': [
+            {
+                'object_name': 'node-v24.17.0-linux-x64.tar.gz',
+                'sha256sum': 'e0472427aa791ad80bdc426ff7cc73cdd28ed0f616d1ff9689a23a7f47f1265f',
+                'condition': 'host_os == "linux"',
+            },
+            {
+                'object_name': 'node-v24.17.0-darwin-arm64.tar.gz',
+                'sha256sum': '4fc3266a3702eebc39cc37661cf4eeceeade307e242ab64e4d7ce7949197e11f',
+                'condition': 'host_os == "mac" and host_cpu == "arm64"',
+            },
+            {
+                'object_name': 'node-v24.17.0-darwin-x64.tar.gz',
+                'sha256sum': '80da552fe037290cb130e9dea590f5eeeb7aa450636f0c89ab41415511c1ec27',
+                'condition': 'host_os == "mac" and host_cpu == "x64"',
+            },
+            {
+                'object_name': 'node-v24.17.0-win-x64.zip',
+                'sha256sum': 'f2aa33b35b75aca5f3f7b85675a6f6423201053e9381911e64961f3bda2528ab',
+                'condition': 'host_os == "win"',
+            },
+        ],
+    },
 }
 
 


### PR DESCRIPTION
This is part of the boostrap experiment, to have node delivered during
sync, and managed as any other dependency.

This change introduces downloads for the particular node version we are
using under `third_party/node`. This is not wired to anything yet, so it
has no effect on anyone's environment.

Bug: https://github.com/brave/brave-browser/issues/56529
