### PR TITLE
[presubmit] Allow url shorterns for `TODO` comments

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -920,22 +920,26 @@ def CheckTodoBugReferences(_original_check, input_api, output_api):
         return input_api.FilterSourceFile(affected_file,
                                           files_to_skip=files_to_skip)
 
-    # Check for bug link in TODO comments.
+    # Check for bug link in TODO comments. A valid reference is either a full
+    # brave-browser issue URL or a brave.dev short link (brave.dev/bug/<id> or
+    # brave.dev/b/<id>).
     pattern = input_api.re.compile(r'.*\bTODO\((.+)\).*')
+    bug_ref_pattern = input_api.re.compile(
+        r'(?:https://)?github\.com/brave/brave-browser/issues/'
+        r'|(?:https://)?brave\.dev/(?:bug|b)/\d+')
     problems = []
     for f in input_api.AffectedSourceFiles(_FilterFile):
         for line_number, line in f.ChangedContents():
             match = pattern.match(line)
-            if match and 'https://github.com/brave/brave-browser/issues/' not in match.group(
-                    1):
+            if match and not bug_ref_pattern.search(match.group(1)):
                 problems.append(f"{f.LocalPath()}:{line_number}\n    {line}")
 
     if problems:
         return [
             output_api.PresubmitPromptWarning(
                 'TODO comments must be accompanied with a valid brave-browser '
-                'issue. https://github.com/brave/brave-browser/issues',
-                problems)
+                'issue, e.g. https://github.com/brave/brave-browser/issues/123,'
+                ' brave.dev/bug/123 or brave.dev/b/123.', problems)
         ]
     return []
 

--- a/PRESUBMIT_test.py
+++ b/PRESUBMIT_test.py
@@ -152,5 +152,48 @@ class CheckJson5ParseErrorsTest(unittest.TestCase):
         self.assertEqual([], errors)
 
 
+class CheckTodoBugReferencesTest(unittest.TestCase):
+
+    def _Check(self, line):
+        input_api = MockInputApi()
+        input_api.files = [MockAffectedFile('brave/foo.cc', [line])]
+        # CheckTodoBugReferences is wrapped by @override_check, which injects
+        # the _original_check argument at runtime; pylint can't see that.
+        # pylint: disable=no-value-for-parameter
+        return PRESUBMIT.CheckTodoBugReferences(input_api, MockOutputApi())
+
+    def testAllowsGithubIssueUrl(self):
+        line = ('// TODO(https://github.com/brave/brave-browser/issues/123): '
+                'fix this')
+        self.assertEqual([], self._Check(line))
+
+    def testAllowsGithubIssueUrlWithoutScheme(self):
+        line = '// TODO(github.com/brave/brave-browser/issues/123): fix this'
+        self.assertEqual([], self._Check(line))
+
+    def testAllowsBraveDevBugLink(self):
+        self.assertEqual([], self._Check('// TODO(brave.dev/bug/55738): fix'))
+
+    def testAllowsBraveDevShortBugLink(self):
+        self.assertEqual([], self._Check('// TODO(brave.dev/b/55738): fix'))
+
+    def testAllowsBraveDevBugLinkWithScheme(self):
+        line = '// TODO(https://brave.dev/bug/55738): fix this'
+        self.assertEqual([], self._Check(line))
+
+    def testFlagsTodoWithoutBugReference(self):
+        warnings = self._Check('// TODO(bbondy): fix this')
+
+        self.assertEqual(1, len(warnings))
+        self.assertEqual(1, len(warnings[0].items))
+        self.assertIn('brave/foo.cc:1', warnings[0].items[0])
+
+    def testFlagsBraveDevLinkWithoutId(self):
+        self.assertEqual(1, len(self._Check('// TODO(brave.dev/bug/): fix')))
+
+    def testIgnoresLinesWithoutTodo(self):
+        self.assertEqual([], self._Check('// just a comment, no todo here'))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change adds `brave.dev/bug/` and `brave.dev/b/` to the list of
allowed TODO formats. It also makes the use of the schema in the url
optional.
