### PR TITLE
update adblock-rust feature name to `single-thread` (uplift to 1.92.x)

### DIFF
--- a/components/brave_shields/core/common/adblock/rs/Cargo.toml
+++ b/components/brave_shields/core/common/adblock/rs/Cargo.toml
@@ -12,7 +12,7 @@ thiserror = "1.0"
 
 [features]
 ios = ["adblock/content-blocking"]
-single_thread_optimizations = ["adblock/unsync-regex-caching"]
+single_thread_optimizations = ["adblock/single-thread"]
 
 [lib]
 name = "adblock_cxx"

--- a/third_party/rust/adblock/v0_12/BUILD.gn
+++ b/third_party/rust/adblock/v0_12/BUILD.gn
@@ -104,7 +104,7 @@ cargo_crate("lib") {
     features += [
       "object-pooling",
       "lifeguard",
-      "unsync-regex-caching",
+      "single-thread",
     ]
     deps += [ "//brave/third_party/rust/lifeguard/v0_6:lib" ]
   }

--- a/third_party/rust/chromium_crates_io/gnrt_config.toml
+++ b/third_party/rust/chromium_crates_io/gnrt_config.toml
@@ -115,7 +115,7 @@ if (is_ios) {
     features += [
       "object-pooling",
       "lifeguard",
-      "unsync-regex-caching",
+      "single-thread",
     ]
     deps += [ "//brave/third_party/rust/lifeguard/v0_6:lib" ]
   }


### PR DESCRIPTION
Uplift of #37271
Resolves https://github.com/brave/brave-browser/issues/56393

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.