### PR TITLE
[iOS] Shift cosmetic filtering arguments and selectors to hide to tab helper

### DIFF
--- a/ios/brave-ios/Package.swift
+++ b/ios/brave-ios/Package.swift
@@ -563,7 +563,7 @@ var package = Package(
     .testTarget(name: "DataTests", dependencies: ["Data", "TestHelpers", "BraveShields"]),
     .testTarget(
       name: "ClientTests",
-      dependencies: ["Brave", "BraveStrings", "TestHelpers"],
+      dependencies: ["Brave", "BraveStrings", "TestHelpers", "Web"],
       resources: [
         .copy("Resources/debouncing.json"),
         .copy("Resources/content-blocking.json"),

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -93,6 +93,7 @@ extension BrowserViewController: TabManagerDelegate {
     // When `BraveShieldsTabHelper+TabPolicyDecider` is moved to `BraveShields` target,
     // we should add it as a policy decider at initialization.
     tab.addPolicyDecider(braveShieldsHelper)
+    tab.cosmeticFilteringTabHelper = .init(tab: tab)
     tab.logins = .init(tab: tab, passwordAPI: profileController.passwordAPI)
     tab.protectionStats = .init(tab: tab)
     tab.nightMode = .init(tab: tab)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -452,7 +452,7 @@ extension BrowserViewController: TopToolbarDelegate {
         if $0.visibleURL?.baseDomain == currentDomain {
           $0.reload()
           // Domain specific shield setting changed, reset selectors cache.
-          $0.contentBlocker?.resetSelectorsCache()
+          $0.cosmeticFilteringTabHelper?.resetSelectorsCache()
         }
       }
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -389,7 +389,7 @@ public class BrowserViewController: UIViewController {
     braveCore.adblockService.registerFilterListChanges { [weak self] _ in
       // Filter lists updated, reset selectors cache(s).
       self?.tabManager.allTabs.forEach {
-        $0.contentBlocker?.resetSelectorsCache()
+        $0.cosmeticFilteringTabHelper?.resetSelectorsCache()
       }
     }
 
@@ -398,7 +398,7 @@ public class BrowserViewController: UIViewController {
       .sink { [weak self] _ in
         // Filter lists selections changed, reset selectors cache(s).
         self?.tabManager.allTabs.forEach {
-          $0.contentBlocker?.resetSelectorsCache()
+          $0.cosmeticFilteringTabHelper?.resetSelectorsCache()
         }
       }
       .store(in: &cancellables)
@@ -2885,7 +2885,7 @@ extension BrowserViewController: PreferencesObserver {
       recordGlobalAdBlockShieldsP3A()
       // Global shield setting changed, reset selectors cache.
       tabManager.allTabs.forEach({
-        $0.contentBlocker?.resetSelectorsCache()
+        $0.cosmeticFilteringTabHelper?.resetSelectorsCache()
       })
     case Preferences.Shields.fingerprintingProtection.key:
       tabManager.reloadSelectedTab()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/CosmeticFilteringTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/CosmeticFilteringTabHelper.swift
@@ -1,0 +1,193 @@
+// Copyright 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveCore
+import BraveShields
+import Web
+import os.log
+
+extension TabDataValues {
+  private struct CosmeticFilteringTabHelperKey: TabDataKey {
+    static var defaultValue: CosmeticFilteringTabHelper?
+  }
+  public var cosmeticFilteringTabHelper: CosmeticFilteringTabHelper? {
+    get { self[CosmeticFilteringTabHelperKey.self] }
+    set { self[CosmeticFilteringTabHelperKey.self] = newValue }
+  }
+}
+
+public class CosmeticFilteringTabHelper {
+
+  private weak var tab: (any TabState)?
+  /// Cached standard selectors. Key is the URL's `baseDomain`.
+  private var hiddenStandardSelectors: [String: Set<String>] = [:]
+  /// Cached aggressive selectors. Key is the URL's `baseDomain`.
+  private var hiddenAggressiveSelectors: [String: Set<String>] = [:]
+
+  public init(
+    tab: some TabState
+  ) {
+    self.tab = tab
+  }
+
+  /// Removes all selectors from the selectors caches.
+  func resetSelectorsCache() {
+    hiddenStandardSelectors.removeAll()
+    hiddenAggressiveSelectors.removeAll()
+  }
+
+  /// Get the cached selectors for the given URL.
+  func cachedSelectors(for url: URL) -> (standard: Set<String>, aggressive: Set<String>)? {
+    guard let baseDomain = url.baseDomain else {
+      return nil
+    }
+    return (hiddenStandardSelectors[baseDomain] ?? [], hiddenAggressiveSelectors[baseDomain] ?? [])
+  }
+
+  /// Cache the given selectors for the given URL.
+  func cacheSelectors(
+    for url: URL,
+    standardSelectors: Set<String>,
+    aggressiveSelectors: Set<String>
+  ) {
+    guard let baseDomain = url.baseDomain else {
+      return
+    }
+    var cachedStandardSelectors = hiddenStandardSelectors[baseDomain] ?? .init()
+    cachedStandardSelectors.formUnion(standardSelectors)
+    var cachedAggressiveSelectors = hiddenAggressiveSelectors[baseDomain] ?? .init()
+    cachedAggressiveSelectors.formUnion(aggressiveSelectors)
+    hiddenStandardSelectors[baseDomain] = cachedStandardSelectors
+    hiddenAggressiveSelectors[baseDomain] = cachedAggressiveSelectors
+  }
+
+  /// Combine new selectors with the cached selectors for the tab's visibleURL.
+  @MainActor func standardAndAggressiveSelectors(
+    from models: [AdBlockGroupsManager.CosmeticFilterModelTuple]
+  ) -> (Set<String>, Set<String>) {
+    var cachedStandardSelectors: Set<String> = .init()
+    var cachedAggressiveSelectors: Set<String> = .init()
+    if let mainFrameURL = tab?.currentPageData?.mainFrameURL,
+      let (standard, aggressive) = cachedSelectors(for: mainFrameURL)
+    {
+      cachedStandardSelectors = standard
+      cachedAggressiveSelectors = aggressive
+    }
+    var standardSelectors: Set<String> = cachedStandardSelectors
+    var aggressiveSelectors: Set<String> = cachedAggressiveSelectors
+    for modelTuple in models {
+      if modelTuple.isAlwaysAggressive {
+        aggressiveSelectors = aggressiveSelectors.union(modelTuple.model.hideSelectors)
+      } else {
+        standardSelectors = standardSelectors.union(modelTuple.model.hideSelectors)
+      }
+    }
+    return (standardSelectors, aggressiveSelectors)
+  }
+
+  /// Given a `frameURL`, retrieves the cosmetic filtering setup and procedural
+  /// actions for the frame using the Tab's main-frame shield level.
+  /// - returns a tuple containing the `ContentCosmeticSetup` and a
+  /// `Set<String>` of the procedural actions, or nil if Shields is disabled or
+  /// unavailable
+  @MainActor func cosmeticFilteringSetup(
+    for frameURL: URL
+  ) async -> (UserScriptType.ContentCosmeticSetup, Set<String>)? {
+    guard let tab = tab,
+      let mainFrameURL = tab.currentPageData?.mainFrameURL,
+      let braveShieldsHelper = tab.braveShieldsHelper,
+      // shield level is determined by the main frame
+      case let mainFrameShieldLevel = braveShieldsHelper.shieldLevel(
+        for: mainFrameURL,
+        considerAllShieldsOption: true
+      ),
+      mainFrameShieldLevel.isEnabled,
+      mainFrameURL.isWebPage(includeDataURIs: false)
+    else {
+      return nil
+    }
+
+    let models = await AdBlockGroupsManager.shared.cosmeticFilterModels(
+      forFrameURL: frameURL,
+      isAdBlockEnabled: mainFrameShieldLevel.isEnabled
+    )
+    let (standardSelectors, aggressiveSelectors) = standardAndAggressiveSelectors(from: models)
+
+    var proceduralActions: Set<String> = []
+    for modelTuple in models {
+      proceduralActions = proceduralActions.union(modelTuple.model.proceduralActions)
+    }
+
+    let setup = UserScriptType.ContentCosmeticSetup(
+      hideFirstPartyContent: mainFrameShieldLevel.isAggressive,
+      genericHide: models.contains { $0.model.genericHide },
+      firstSelectorsPollingDelayMs: nil,
+      switchToSelectorsPollingThreshold: 1000,
+      fetchNewClassIdRulesThrottlingMs: 100,
+      aggressiveSelectors: aggressiveSelectors,
+      standardSelectors: standardSelectors
+    )
+    return (setup, proceduralActions)
+  }
+
+  /// Given a `frameURL` and `Set<String>`'s of `ids` and `classes`, determines
+  /// which ids and classes should be hidden for the frame using the Tab's
+  /// main-frame shield level.
+  /// - returns a tuple containing a `Set<String>` of standard selectors and
+  /// aggressive selectors to hide.
+  @MainActor public func selectorsToHide(
+    for frameURL: URL,
+    ids: Set<String>,
+    classes: Set<String>,
+  ) async -> (Set<String>, Set<String>) {
+    guard let tabPageData = tab?.currentPageData else {
+      return (.init(), .init())
+    }
+    let cachedEngines = AdBlockGroupsManager.shared.cachedEngines(
+      isAdBlockEnabled: tab?.braveShieldsHelper?.shieldLevel(
+        for: tabPageData.mainFrameURL,
+        considerAllShieldsOption: true
+      ).isEnabled ?? true
+    )
+
+    let selectorArrays = await cachedEngines.asyncCompactMap {
+      cachedEngine -> (selectors: Set<String>, isAlwaysAggressive: Bool)? in
+      do {
+        guard
+          let selectors = try await cachedEngine.selectorsForCosmeticRules(
+            frameURL: frameURL,
+            ids: Array(ids),
+            classes: Array(classes)
+          )
+        else {
+          return nil
+        }
+
+        return await (selectors, cachedEngine.type.isAlwaysAggressive)
+      } catch {
+        Logger.module.error("\(error.localizedDescription)")
+        return nil
+      }
+    }
+
+    var standardSelectors: Set<String> = []
+    var aggressiveSelectors: Set<String> = []
+    for tuple in selectorArrays {
+      if tuple.isAlwaysAggressive {
+        aggressiveSelectors = aggressiveSelectors.union(tuple.selectors)
+      } else {
+        standardSelectors = standardSelectors.union(tuple.selectors)
+      }
+    }
+
+    // cache blocked selectors
+    cacheSelectors(
+      for: tabPageData.mainFrameURL,
+      standardSelectors: standardSelectors,
+      aggressiveSelectors: aggressiveSelectors
+    )
+    return (standardSelectors, aggressiveSelectors)
+  }
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/CosmeticFilteringTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/CosmeticFilteringTabHelper.swift
@@ -136,20 +136,28 @@ public class CosmeticFilteringTabHelper {
   /// which ids and classes should be hidden for the frame using the Tab's
   /// main-frame shield level.
   /// - returns a tuple containing a `Set<String>` of standard selectors and
-  /// aggressive selectors to hide.
+  /// aggressive selectors to hide, or nil if Shields is disabled or
+  /// unavailable
   @MainActor public func selectorsToHide(
     for frameURL: URL,
     ids: Set<String>,
     classes: Set<String>,
-  ) async -> (Set<String>, Set<String>) {
-    guard let tabPageData = tab?.currentPageData else {
-      return (.init(), .init())
-    }
-    let cachedEngines = AdBlockGroupsManager.shared.cachedEngines(
-      isAdBlockEnabled: tab?.braveShieldsHelper?.shieldLevel(
+  ) async -> (Set<String>, Set<String>)? {
+    guard let tab = tab,
+      let tabPageData = tab.currentPageData,
+      let braveShieldsHelper = tab.braveShieldsHelper,
+      // shield level is determined by the main frame
+      case let mainFrameShieldLevel = braveShieldsHelper.shieldLevel(
         for: tabPageData.mainFrameURL,
         considerAllShieldsOption: true
-      ).isEnabled ?? true
+      ),
+      mainFrameShieldLevel.isEnabled,
+      tabPageData.mainFrameURL.isWebPage(includeDataURIs: false)
+    else {
+      return nil
+    }
+    let cachedEngines = AdBlockGroupsManager.shared.cachedEngines(
+      isAdBlockEnabled: mainFrameShieldLevel.isEnabled
     )
 
     let selectorArrays = await cachedEngines.asyncCompactMap {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
@@ -268,7 +268,7 @@ class QuickViewController: UIViewController {
       browser.tabManager.allTabs.forEach {
         if $0.visibleURL?.baseDomain == currentDomain {
           $0.reload()
-          $0.contentBlocker?.resetSelectorsCache()
+          $0.cosmeticFilteringTabHelper?.resetSelectorsCache()
         }
       }
     }
@@ -276,7 +276,7 @@ class QuickViewController: UIViewController {
     // Update shield status, reload the this tab, reset selectors cache in quickview mode
     refreshShieldStatus(url: currentTab?.visibleURL ?? url)
     currentTab?.reload()
-    currentTab?.contentBlocker?.resetSelectorsCache()
+    currentTab?.cosmeticFilteringTabHelper?.resetSelectorsCache()
   }
 
   private func refreshShieldStatus(url: URL) {

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CosmeticFiltersScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CosmeticFiltersScriptHandler.swift
@@ -46,59 +46,18 @@ class CosmeticFiltersScriptHandler: TabContentScript {
       let data = try JSONSerialization.data(withJSONObject: message.body)
       let dto = try JSONDecoder().decode(CosmeticFiltersDTO.self, from: data)
 
-      guard let mainFrameURL = tab.currentPageData?.mainFrameURL,
-        let frameURL = URLOrigin(wkSecurityOrigin: message.frameInfo.securityOrigin).url
-      else {
+      guard let frameURL = URLOrigin(wkSecurityOrigin: message.frameInfo.securityOrigin).url else {
         replyHandler(nil, nil)
         return
       }
 
       Task { @MainActor in
-        let cachedEngines = AdBlockGroupsManager.shared.cachedEngines(
-          isAdBlockEnabled: tab.braveShieldsHelper?.shieldLevel(
-            for: mainFrameURL,
-            considerAllShieldsOption: true
-          ).isEnabled ?? true
-        )
-
-        let selectorArrays = await cachedEngines.asyncCompactMap {
-          cachedEngine -> (selectors: Set<String>, isAlwaysAggressive: Bool)? in
-          do {
-            guard
-              let selectors = try await cachedEngine.selectorsForCosmeticRules(
-                frameURL: frameURL,
-                ids: dto.data.ids,
-                classes: dto.data.classes
-              )
-            else {
-              return nil
-            }
-
-            return await (selectors, cachedEngine.type.isAlwaysAggressive)
-          } catch {
-            Logger.module.error("\(error.localizedDescription)")
-            return nil
-          }
-        }
-
-        var standardSelectors: Set<String> = []
-        var aggressiveSelectors: Set<String> = []
-        for tuple in selectorArrays {
-          if tuple.isAlwaysAggressive {
-            aggressiveSelectors = aggressiveSelectors.union(tuple.selectors)
-          } else {
-            standardSelectors = standardSelectors.union(tuple.selectors)
-          }
-        }
-
-        // cache blocked selectors
-        if let url = tab.visibleURL {
-          tab.contentBlocker?.cacheSelectors(
-            for: url,
-            standardSelectors: standardSelectors,
-            aggressiveSelectors: aggressiveSelectors
-          )
-        }
+        let (standardSelectors, aggressiveSelectors) =
+          await tab.cosmeticFilteringTabHelper?.selectorsToHide(
+            for: frameURL,
+            ids: Set(dto.data.ids),
+            classes: Set(dto.data.classes)
+          ) ?? (.init(), .init())
 
         replyHandler(
           [

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/SiteStateListenerScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/SiteStateListenerScriptHandler.swift
@@ -51,86 +51,21 @@ class SiteStateListenerScriptHandler: TabContentScript {
     }
 
     Task { @MainActor in
-      if let pageData = tab.currentPageData {
-        guard let braveShieldsHelper = tab.braveShieldsHelper,
-          case let shieldLevel = braveShieldsHelper.shieldLevel(
-            for: pageData.mainFrameURL,
-            considerAllShieldsOption: true
-          ),
-          shieldLevel.isEnabled,
-          pageData.mainFrameURL.isWebPage(includeDataURIs: false)
-        else {
-          return
-        }
-
-        let models = await AdBlockGroupsManager.shared.cosmeticFilterModels(
-          forFrameURL: frameURL,
-          isAdBlockEnabled: shieldLevel.isEnabled
-        )
-
-        var cachedStandardSelectors: Set<String> = .init()
-        var cachedAggressiveSelectors: Set<String> = .init()
-        if let url = tab.visibleURL,
-          let (standard, aggressive) = tab.contentBlocker?.cachedSelectors(for: url)
-        {
-          cachedStandardSelectors = standard
-          cachedAggressiveSelectors = aggressive
-        }
-        let setup = UserScriptType.ContentCosmeticSetup.makeSetup(
-          from: models,
-          isAggressive: shieldLevel.isAggressive,
-          cachedStandardSelectors: cachedStandardSelectors,
-          cachedAggressiveSelectors: cachedAggressiveSelectors
-        )
-
-        // Join the procedural actions
-        // Note: they can't be part of `UserScriptType.ContentCosmeticSetup`
-        // As this is encoded and therefore the JSON will be escaped
-        var proceduralActions: Set<String> = []
-        for modelTuple in models {
-          proceduralActions = proceduralActions.union(modelTuple.model.proceduralActions)
-        }
-        let script = try ScriptFactory.shared.makeScript(
-          for: .contentCosmetic(setup, proceduralActions: proceduralActions)
-        )
-
-        try await tab.evaluateJavaScript(
-          functionName: script.source,
-          frame: message.frameInfo,
-          contentWorld: CosmeticFiltersScriptHandler.scriptSandbox,
-          asFunction: false
-        )
+      guard
+        let (setup, proceduralActions) = await tab.cosmeticFilteringTabHelper?
+          .cosmeticFilteringSetup(for: frameURL)
+      else {
+        return
       }
+      let script = try ScriptFactory.shared.makeScript(
+        for: .contentCosmetic(setup, proceduralActions: proceduralActions)
+      )
+      try await tab.evaluateJavaScript(
+        functionName: script.source,
+        frame: message.frameInfo,
+        contentWorld: CosmeticFiltersScriptHandler.scriptSandbox,
+        asFunction: false
+      )
     }
-  }
-}
-
-extension UserScriptType.ContentCosmeticSetup {
-  public static func makeSetup(
-    from modelTuples: [AdBlockGroupsManager.CosmeticFilterModelTuple],
-    isAggressive: Bool,
-    cachedStandardSelectors: Set<String>,
-    cachedAggressiveSelectors: Set<String>
-  ) -> UserScriptType.ContentCosmeticSetup {
-    var standardSelectors = cachedStandardSelectors
-    var aggressiveSelectors = cachedAggressiveSelectors
-
-    for modelTuple in modelTuples {
-      if modelTuple.isAlwaysAggressive {
-        aggressiveSelectors = aggressiveSelectors.union(modelTuple.model.hideSelectors)
-      } else {
-        standardSelectors = standardSelectors.union(modelTuple.model.hideSelectors)
-      }
-    }
-
-    return UserScriptType.ContentCosmeticSetup(
-      hideFirstPartyContent: isAggressive,
-      genericHide: modelTuples.contains { $0.model.genericHide },
-      firstSelectorsPollingDelayMs: nil,
-      switchToSelectorsPollingThreshold: 1000,
-      fetchNewClassIdRulesThrottlingMs: 100,
-      aggressiveSelectors: aggressiveSelectors,
-      standardSelectors: standardSelectors
-    )
   }
 }

--- a/ios/brave-ios/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerHelper.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerHelper.swift
@@ -80,10 +80,6 @@ class ContentBlockerHelper: ObservableObject {
 
   var statsDidChange: ((TPPageStats) -> Void)?
   @Published var blockedRequests: OrderedSet<BlockedRequestInfo> = []
-  /// Cached standard selectors. Key is the URL's `baseDomain`.
-  private var hiddenStandardSelectors: [String: Set<String>] = [:]
-  /// Cached aggressive selectors. Key is the URL's `baseDomain`.
-  private var hiddenAggressiveSelectors: [String: Set<String>] = [:]
 
   init(tab: (any TabState)?) {
     self.tab = tab
@@ -120,35 +116,5 @@ class ContentBlockerHelper: ObservableObject {
     ]
 
     ContentBlockerManager.log.debug("Set rule lists:\n\(parts.joined(separator: "\n"))")
-  }
-
-  func resetSelectorsCache() {
-    hiddenStandardSelectors.removeAll()
-    hiddenAggressiveSelectors.removeAll()
-  }
-
-  /// Get the cached selectors for the given URL.
-  func cachedSelectors(for url: URL) -> (standard: Set<String>, aggressive: Set<String>)? {
-    guard let baseDomain = url.baseDomain else {
-      return nil
-    }
-    return (hiddenStandardSelectors[baseDomain] ?? [], hiddenAggressiveSelectors[baseDomain] ?? [])
-  }
-
-  /// Cache the given selectors for the given URL.
-  func cacheSelectors(
-    for url: URL,
-    standardSelectors: Set<String>,
-    aggressiveSelectors: Set<String>
-  ) {
-    guard let baseDomain = url.baseDomain else {
-      return
-    }
-    var cachedStandardSelectors = hiddenStandardSelectors[baseDomain] ?? .init()
-    cachedStandardSelectors.formUnion(standardSelectors)
-    var cachedAggressiveSelectors = hiddenAggressiveSelectors[baseDomain] ?? .init()
-    cachedAggressiveSelectors.formUnion(aggressiveSelectors)
-    hiddenStandardSelectors[baseDomain] = cachedStandardSelectors
-    hiddenAggressiveSelectors[baseDomain] = cachedAggressiveSelectors
   }
 }

--- a/ios/brave-ios/Tests/ClientTests/UserScripts/ScriptExecutionTests.swift
+++ b/ios/brave-ios/Tests/ClientTests/UserScripts/ScriptExecutionTests.swift
@@ -7,6 +7,7 @@ import BraveCore
 import CryptoKit
 import Preferences
 import SnapKit
+import Web
 import WebKit
 import XCTest
 
@@ -270,6 +271,7 @@ final class ScriptExecutionTests: XCTestCase {
     let setup = UserScriptType.ContentCosmeticSetup.makeSetup(
       from: models,
       isAggressive: false,
+      mainFrameURL: siteURL,
       cachedStandardSelectors: initialStandardSelectors.union(invalidSelectors),
       cachedAggressiveSelectors: initialAggressiveSelectors
     )
@@ -560,5 +562,38 @@ final class ScriptExecutionTests: XCTestCase {
     }
     XCTAssertEqual(mainFrameResult, "First party body: 1")
     XCTAssertEqual(localFrameResult, "First local frame body: 1")
+  }
+}
+
+extension UserScriptType.ContentCosmeticSetup {
+  @MainActor public static func makeSetup(
+    from modelTuples: [AdBlockGroupsManager.CosmeticFilterModelTuple],
+    isAggressive: Bool,
+    mainFrameURL: URL,
+    cachedStandardSelectors: Set<String>,
+    cachedAggressiveSelectors: Set<String>
+  ) -> UserScriptType.ContentCosmeticSetup {
+    let tab = FakeTabState()
+    tab.browserData = TabBrowserData(tab: tab)
+    tab.currentPageData = PageData(mainFrameURL: mainFrameURL)
+    let tabHelper = CosmeticFilteringTabHelper(tab: tab)
+    tabHelper.cacheSelectors(
+      for: mainFrameURL,
+      standardSelectors: cachedStandardSelectors,
+      aggressiveSelectors: cachedAggressiveSelectors
+    )
+    let (standardSelectors, aggressiveSelectors) = tabHelper.standardAndAggressiveSelectors(
+      from: modelTuples
+    )
+
+    return UserScriptType.ContentCosmeticSetup(
+      hideFirstPartyContent: isAggressive,
+      genericHide: modelTuples.contains { $0.model.genericHide },
+      firstSelectorsPollingDelayMs: nil,
+      switchToSelectorsPollingThreshold: 1000,
+      fetchNewClassIdRulesThrottlingMs: 100,
+      aggressiveSelectors: aggressiveSelectors,
+      standardSelectors: standardSelectors
+    )
   }
 }


### PR DESCRIPTION
- Add new `CosmeticFilteringTabHelper` for building the cosmetic filtering arguments and fetching async selectors to hide.
   - This pulls the logic out of `SiteStateListenerScriptHandler` (arguments) and `CosmeticFiltersScriptHandler` (async selectors to hide) so it can be shared with the [Cosmetic Filtering JavaScript Feature](https://github.com/brave/brave-browser/issues/53981)
- Pull cached selectors from `ContentBlockerHelper` into the `CosmeticFilteringTabHelper` where they are used.

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### Testplan

1) Do a sanity pass on a few websites and verify cosmetic filtering is still working as expected.
2) Add these rules to custom rules
```
stephenheaps.github.io/$first-party
stephenheaps.github.io##should-be-hidden
example.com##h1:has-text(Example)
```


3) Visit https://stephenheaps.github.io/local-frames/test.html
4) Verify `This should be hidden` text is not displayed.
    - Other elements on page are hidden via request blocking or scriptlets so they don't need verified for this test.
5) Visit https://example.com
6) Verify `Example Domain` header is hidden.
