### PR TITLE
Randomize wallpaper rotation on Android

### DIFF
--- a/components/ntp_background_images/browser/view_counter_model.cc
+++ b/components/ntp_background_images/browser/view_counter_model.cc
@@ -11,6 +11,7 @@
 #include "base/functional/bind.h"
 #include "base/rand_util.h"
 #include "brave/components/ntp_background_images/browser/features.h"
+#include "build/build_config.h"
 #include "components/prefs/pref_service.h"
 
 namespace ntp_background_images {
@@ -123,8 +124,23 @@ void ViewCounterModel::RotateBackgroundWallpaperImageIndex() {
     return;
   }
 
+#if BUILDFLAG(IS_ANDROID)
+  // On Android, show background images in a random order, avoiding an
+  // immediate repeat of the currently selected image.
+  if (total_image_count_ == 1) {
+    current_wallpaper_image_index_ = 0;
+    return;
+  }
+  // Choose uniformly among all indices except the current one.
+  int next_index = base::RandInt(0, total_image_count_ - 2);
+  if (next_index >= current_wallpaper_image_index_) {
+    ++next_index;
+  }
+  current_wallpaper_image_index_ = next_index;
+#else
   current_wallpaper_image_index_++;
   current_wallpaper_image_index_ %= total_image_count_;
+#endif
 }
 
 void ViewCounterModel::NextBrandedImage() {

--- a/components/ntp_background_images/browser/view_counter_model.cc
+++ b/components/ntp_background_images/browser/view_counter_model.cc
@@ -125,22 +125,31 @@ void ViewCounterModel::RotateBackgroundWallpaperImageIndex() {
   }
 
 #if BUILDFLAG(IS_ANDROID)
-  // On Android, show background images in a random order, avoiding an
-  // immediate repeat of the currently selected image.
+  RotateBackgroundWallpaperImageIndexRandom();
+#else
+  RotateBackgroundWallpaperImageIndexSequential();
+#endif
+}
+
+void ViewCounterModel::RotateBackgroundWallpaperImageIndexRandom() {
+  // Show background images in a random order, avoiding an immediate repeat of
+  // the currently displayed image.
   if (total_image_count_ == 1) {
     current_wallpaper_image_index_ = 0;
     return;
   }
+
   // Choose uniformly among all indices except the current one.
   int next_index = base::RandInt(0, total_image_count_ - 2);
   if (next_index >= current_wallpaper_image_index_) {
     ++next_index;
   }
   current_wallpaper_image_index_ = next_index;
-#else
+}
+
+void ViewCounterModel::RotateBackgroundWallpaperImageIndexSequential() {
   current_wallpaper_image_index_++;
   current_wallpaper_image_index_ %= total_image_count_;
-#endif
 }
 
 void ViewCounterModel::NextBrandedImage() {

--- a/components/ntp_background_images/browser/view_counter_model.h
+++ b/components/ntp_background_images/browser/view_counter_model.h
@@ -61,6 +61,10 @@ class ViewCounterModel {
                            NTPSponsoredImagesCountToBrandedWallpaperTest);
   FRIEND_TEST_ALL_PREFIXES(ViewCounterModelTest, NTPBackgroundImagesTest);
   FRIEND_TEST_ALL_PREFIXES(ViewCounterModelTest,
+                           NTPBackgroundImagesRandomRotationTest);
+  FRIEND_TEST_ALL_PREFIXES(ViewCounterModelTest,
+                           NTPBackgroundImagesRandomRotationSingleImageTest);
+  FRIEND_TEST_ALL_PREFIXES(ViewCounterModelTest,
                            NTPBackgroundImagesWithSIDisabledTest);
   FRIEND_TEST_ALL_PREFIXES(ViewCounterModelTest,
                            NTPBackgroundImagesWithEmptyCampaignTest);
@@ -72,6 +76,15 @@ class ViewCounterModel {
   void RegisterPageViewForBrandedImages();
 
   void RegisterPageViewForBackgroundImages();
+
+  // Picks the next background wallpaper index uniformly at random, excluding
+  // the currently displayed index so the same image is never shown twice in a
+  // row.
+  void RotateBackgroundWallpaperImageIndexRandom();
+
+  // Advances the background wallpaper index sequentially, wrapping around to
+  // the start once the last image is reached.
+  void RotateBackgroundWallpaperImageIndexSequential();
 
   void ScheduleNextBrandedWallpaperCountReset();
   void ResetBrandedWallpaperCountAndScheduleNextCountReset();

--- a/components/ntp_background_images/browser/view_counter_model_unittest.cc
+++ b/components/ntp_background_images/browser/view_counter_model_unittest.cc
@@ -6,6 +6,7 @@
 #include "brave/components/ntp_background_images/browser/view_counter_model.h"
 
 #include <cstddef>
+#include <set>
 
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
@@ -223,6 +224,41 @@ TEST_F(ViewCounterModelTest, NTPBackgroundImagesTest) {
   // Only |count_to_branded_wallpapaer_| is reset.
   EXPECT_NE(0, model.count_to_branded_wallpaper_);
   EXPECT_EQ(image_index, model.current_wallpaper_image_index());
+}
+
+// Verify the randomized rotation stays in bounds, never repeats the currently
+// displayed image, and eventually surfaces every available image.
+TEST_F(ViewCounterModelTest, NTPBackgroundImagesRandomRotationTest) {
+  ViewCounterModel model(prefs());
+  model.set_total_image_count(kTestImageCount);
+
+  std::set<int> seen_indices;
+  constexpr int kTestRotationCount = 1000;
+  for (int i = 0; i < kTestRotationCount; ++i) {
+    const int previous_index = model.current_wallpaper_image_index();
+    model.RotateBackgroundWallpaperImageIndexRandom();
+    const int current_index = model.current_wallpaper_image_index();
+
+    EXPECT_GE(current_index, 0);
+    EXPECT_LT(current_index, static_cast<int>(kTestImageCount));
+    EXPECT_NE(previous_index, current_index);
+    seen_indices.insert(current_index);
+  }
+
+  // Over many rotations every image index should be selected at least once.
+  EXPECT_EQ(kTestImageCount, seen_indices.size());
+}
+
+// Verify the randomized rotation handles the single-image case by keeping the
+// index at `0` instead of attempting to pick a different image.
+TEST_F(ViewCounterModelTest, NTPBackgroundImagesRandomRotationSingleImageTest) {
+  ViewCounterModel model(prefs());
+  model.set_total_image_count(1);
+
+  for (int i = 0; i < 10; ++i) {
+    model.RotateBackgroundWallpaperImageIndexRandom();
+    EXPECT_EQ(0, model.current_wallpaper_image_index());
+  }
 }
 
 // Test for background images only case (SI option is disabled)


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56662

## Summary

Randomizes the new tab page background wallpaper rotation on Android while leaving non-Android platforms on the existing sequential rotation.

## Changes

`components/ntp_background_images/browser/view_counter_model.cc`:
- Added `#include "build/build_config.h"` to access `BUILDFLAG(IS_ANDROID)`.
- Split rotation behavior into two helpers so the platform choice stays minimal in `RotateBackgroundWallpaperImageIndex()`:
  - `RotateBackgroundWallpaperImageIndexRandom()` — picks the next wallpaper index uniformly at random, excluding the currently displayed index so the same image never repeats back-to-back. The single-image case (`total_image_count_ == 1`) is handled explicitly to keep index `0`.
  - `RotateBackgroundWallpaperImageIndexSequential()` — unchanged existing behavior; advances the index sequentially with wraparound (`++` then `% total_image_count_`).
- `RotateBackgroundWallpaperImageIndex()` delegates to the random helper on Android and the sequential helper elsewhere.

`components/ntp_background_images/browser/view_counter_model.h`:
- Declared the two new private rotation helpers.

`components/ntp_background_images/browser/view_counter_model_unittest.cc`:
- Added `NTPBackgroundImagesRandomRotationTest` — verifies random rotation stays in bounds, never repeats the current index back-to-back, and eventually surfaces every image.
- Added `NTPBackgroundImagesRandomRotationSingleImageTest` — verifies the single-image edge case keeps index `0`.

## Test plan

- [ ] Run `view_counter_model_unittest` on desktop and Android builds
- [ ] On Android, open NTP repeatedly and confirm background wallpapers rotate in a non-sequential order without immediate repeats
- [ ] On desktop, confirm background wallpapers still rotate sequentially



<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->