### PR TITLE
[Sync] [AI Chat] (4 of n) Add AI Chat sync serialization

### DIFF
--- a/chromium_src/components/sync/protocol/proto_visitors.h
+++ b/chromium_src/components/sync/protocol/proto_visitors.h
@@ -31,8 +31,6 @@ VISIT(brave_fields);
     VISIT(model_key);                                                      \
     VISIT(total_tokens);                                                   \
     VISIT(trimmed_tokens);                                                 \
-    VISIT(created_time_unix_epoch_micros);                                 \
-    VISIT(last_modified_time_unix_epoch_micros);                           \
   }                                                                        \
   VISIT_PROTO_FIELDS(                                                      \
       const sync_pb::AIChatConversationSpecifics_Entry& proto) {           \
@@ -65,10 +63,6 @@ VISIT(brave_fields);
     VISIT_BYTES(data);                                                     \
     VISIT(data_truncated_for_sync);                                        \
     VISIT(extracted_text);                                                 \
-  }                                                                        \
-  VISIT_PROTO_FIELDS(const sync_pb::AIChatPermissionChallenge& proto) {    \
-    VISIT(assessment);                                                     \
-    VISIT(plan);                                                           \
   }                                                                        \
   VISIT_PROTO_FIELDS(const sync_pb::AIChatEntryEventProto& proto) {        \
     VISIT(event_order);                                                    \
@@ -103,7 +97,6 @@ VISIT(brave_fields);
     VISIT_REP(output);                                                     \
     VISIT(is_server_result);                                               \
     VISIT_REP(artifacts);                                                  \
-    VISIT(permission_challenge);                                           \
   }                                                                        \
   VISIT_PROTO_FIELDS(const sync_pb::AIChatContentBlock& proto) {           \
     VISIT(image_content_block);                                            \

--- a/chromium_src/components/sync/protocol/proto_visitors.h
+++ b/chromium_src/components/sync/protocol/proto_visitors.h
@@ -18,7 +18,7 @@ VISIT(brave_fields);
   VISIT_PROTO_FIELDS(const sync_pb::AIChatCompressibleString& proto) {     \
     VISIT(raw);                                                            \
     VISIT_BYTES(gzipped);                                                  \
-    VISIT(was_truncated_for_sync);                                         \
+    VISIT(omitted_content_hash);                                           \
   }                                                                        \
   VISIT_PROTO_FIELDS(const sync_pb::AIChatConversationSpecifics& proto) {  \
     VISIT(conversation);                                                   \
@@ -47,6 +47,15 @@ VISIT(brave_fields);
     VISIT_REP(events);                                                     \
     VISIT_REP(associated_content);                                         \
     VISIT_REP(uploaded_files);                                             \
+    VISIT(skill);                                                          \
+    VISIT(near_verification_status);                                       \
+  }                                                                        \
+  VISIT_PROTO_FIELDS(const sync_pb::AIChatSkillEntry& proto) {             \
+    VISIT(shortcut);                                                       \
+    VISIT(prompt);                                                         \
+  }                                                                        \
+  VISIT_PROTO_FIELDS(const sync_pb::AIChatNEARVerificationStatus& proto) { \
+    VISIT(verified);                                                       \
   }                                                                        \
   VISIT_PROTO_FIELDS(const sync_pb::AIChatAssociatedContentProto& proto) { \
     VISIT(uuid);                                                           \
@@ -61,7 +70,7 @@ VISIT(brave_fields);
     VISIT(filesize);                                                       \
     VISIT(type);                                                           \
     VISIT_BYTES(data);                                                     \
-    VISIT(data_truncated_for_sync);                                        \
+    VISIT(omitted_data_hash);                                              \
     VISIT(extracted_text);                                                 \
   }                                                                        \
   VISIT_PROTO_FIELDS(const sync_pb::AIChatEntryEventProto& proto) {        \

--- a/components/ai_chat/core/browser/BUILD.gn
+++ b/components/ai_chat/core/browser/BUILD.gn
@@ -73,6 +73,8 @@ static_library("browser") {
     "remote_models_fetcher.h",
     "skills_metrics.cc",
     "skills_metrics.h",
+    "sync/ai_chat_sync_conversions.cc",
+    "sync/ai_chat_sync_conversions.h",
     "tab_tracker_service.cc",
     "tab_tracker_service.h",
     "tools/bignumber_code_plugin.cc",
@@ -147,6 +149,7 @@ static_library("browser") {
     "//sql",
     "//third_party/abseil-cpp:absl",
     "//third_party/re2",
+    "//third_party/zlib/google:compression_utils",
     "//ui/base",
     "//url",
   ]
@@ -232,7 +235,10 @@ source_set("unit_tests") {
   if (!is_ios) {
     # TODO(https://github.com/brave/brave-browser/issues/47827)
     # to initialize the database
-    sources += [ "ai_chat_database_unittest.cc" ]
+    sources += [
+      "ai_chat_database_unittest.cc",
+      "sync/ai_chat_sync_conversions_unittest.cc",
+    ]
   }
 }
 

--- a/components/ai_chat/core/browser/DEPS
+++ b/components/ai_chat/core/browser/DEPS
@@ -23,6 +23,7 @@ include_rules = [
   "+tensorflow_lite_support/cc/task/text/proto",
   "+third_party/re2/src/re2",
   "+third_party/skia/include",
+  "+third_party/zlib/google",
   "+ui/base",
   "+ui/gfx/image",
 ]

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h"
 
+#include <algorithm>
 #include <memory>
 #include <optional>
 #include <string>
@@ -14,7 +15,11 @@
 
 #include "base/containers/flat_map.h"
 #include "base/containers/map_util.h"
+#include "base/logging.h"
+#include "base/notreached.h"
+#include "base/numerics/safe_conversions.h"
 #include "base/strings/strcat.h"
+#include "base/system/sys_info.h"
 #include "base/time/time.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
@@ -32,17 +37,13 @@ void WriteCompressibleString(std::string_view value,
   // |out| (the merge path reuses an existing AIChatCompressibleString that
   // may have been marked truncated by the sender).
   out->clear_was_truncated_for_sync();
-  if (value.size() < kSyncCompressionThresholdBytes) {
-    out->set_raw(std::string(value));
+  if (std::string compressed; value.size() >= kSyncCompressionThresholdBytes &&
+                              compression::GzipCompress(value, &compressed) &&
+                              compressed.size() < value.size()) {
+    out->set_gzipped(std::move(compressed));
     return;
   }
-  std::string compressed;
-  if (compression::GzipCompress(value, &compressed) &&
-      compressed.size() < value.size()) {
-    out->set_gzipped(std::move(compressed));
-  } else {
-    out->set_raw(std::string(value));
-  }
+  out->set_raw(value);
 }
 
 void MarkCompressibleStringTruncated(sync_pb::AIChatCompressibleString* out) {
@@ -53,11 +54,26 @@ void MarkCompressibleStringTruncated(sync_pb::AIChatCompressibleString* out) {
 std::optional<std::string> ReadCompressibleString(
     const sync_pb::AIChatCompressibleString& in) {
   if (in.was_truncated_for_sync()) {
+    // The field was truncated by the sender, caller will preserve local value
+    // or use truncated.
     return std::nullopt;
   }
   if (in.has_gzipped()) {
+    // Limit maximum decompressed size to allowed maximum, or available memory.
+    if (compression::GetUncompressedSize(in.gzipped()) >
+        std::min(
+            kSyncCompressionMaxDecompressedBytes,
+            base::saturated_cast<size_t>(
+                base::SysInfo::AmountOfAvailablePhysicalMemory().InBytes()))) {
+      DVLOG(1) << "Rejecting uncompressed string of size "
+               << compression::GetUncompressedSize(in.gzipped())
+               << " bytes, exceeds max allowed "
+               << kSyncCompressionMaxDecompressedBytes;
+      return std::nullopt;
+    }
     std::string out;
     if (!compression::GzipUncompress(in.gzipped(), &out)) {
+      DVLOG(1) << "Rejecting gzipped string that failed to decompress";
       return std::nullopt;
     }
     return out;
@@ -65,6 +81,7 @@ std::optional<std::string> ReadCompressibleString(
   if (in.has_raw()) {
     return in.raw();
   }
+  DVLOG(1) << "Rejecting compressible string with no usable value";
   return std::nullopt;
 }
 
@@ -75,12 +92,15 @@ namespace {
 void WriteAssociatedContent(const mojom::AssociatedContent& content,
                             std::optional<std::string_view> last_contents,
                             sync_pb::AIChatAssociatedContentProto* proto) {
+  // Not synced: content_id and tools_attached are runtime-only. The parent
+  // linkage (conversation_turn_uuid) is implied by the entry this content is
+  // nested under, so it is not written here.
   proto->set_uuid(content.uuid);
   proto->set_title(content.title);
   if (content.url.is_valid()) {
     proto->set_url(content.url.spec());
   }
-  proto->set_content_type(static_cast<int32_t>(content.content_type));
+  proto->set_content_type(std::to_underlying(content.content_type));
   proto->set_content_used_percentage(content.content_used_percentage);
   // When |last_contents| is absent the receiver preserves any local text for
   // this UUID; we do not need to set the field at all.
@@ -124,6 +144,9 @@ void WriteWebSourcesContentBlock(const mojom::WebSourcesContentBlock& block,
 
 void WriteToolUse(const mojom::ToolUseEvent& tool_use,
                   sync_pb::AIChatToolUseEvent* proto) {
+  // Not synced: permission_challenge is transient (resolved during the live
+  // turn) and not persisted to the local store; each artifact's id is a local
+  // identifier.
   proto->set_tool_name(tool_use.tool_name);
   proto->set_id(tool_use.id);
   WriteCompressibleString(tool_use.arguments_json,
@@ -132,20 +155,39 @@ void WriteToolUse(const mojom::ToolUseEvent& tool_use,
   if (tool_use.output) {
     for (const auto& block : *tool_use.output) {
       auto* block_proto = proto->add_output();
-      if (block->is_text_content_block()) {
-        WriteCompressibleString(
-            block->get_text_content_block()->text,
-            block_proto->mutable_text_content_block()->mutable_text());
-      } else if (block->is_image_content_block()) {
-        block_proto->mutable_image_content_block()->set_image_url(
-            block->get_image_content_block()->image_url.spec());
-      } else if (block->is_web_sources_content_block()) {
-        WriteWebSourcesContentBlock(
-            *block->get_web_sources_content_block(),
-            block_proto->mutable_web_sources_content_block());
+      // No default case: adding a new ContentBlock variant must be an explicit
+      // decision here rather than silently not syncing.
+      switch (block->which()) {
+        case mojom::ContentBlock::Tag::kTextContentBlock:
+          WriteCompressibleString(
+              block->get_text_content_block()->text,
+              block_proto->mutable_text_content_block()->mutable_text());
+          break;
+        case mojom::ContentBlock::Tag::kImageContentBlock:
+          block_proto->mutable_image_content_block()->set_image_url(
+              block->get_image_content_block()->image_url.spec());
+          break;
+        case mojom::ContentBlock::Tag::kWebSourcesContentBlock:
+          WriteWebSourcesContentBlock(
+              *block->get_web_sources_content_block(),
+              block_proto->mutable_web_sources_content_block());
+          break;
+        // Runtime-only content blocks that are intentionally not synced.
+        case mojom::ContentBlock::Tag::kFileContentBlock:
+        case mojom::ContentBlock::Tag::kFileExtractedTextContentBlock:
+        case mojom::ContentBlock::Tag::kPageExcerptContentBlock:
+        case mojom::ContentBlock::Tag::kPageTextContentBlock:
+        case mojom::ContentBlock::Tag::kVideoTranscriptContentBlock:
+        case mojom::ContentBlock::Tag::kRequestTitleContentBlock:
+        case mojom::ContentBlock::Tag::kChangeToneContentBlock:
+        case mojom::ContentBlock::Tag::kMemoryContentBlock:
+        case mojom::ContentBlock::Tag::kFilterTabsContentBlock:
+        case mojom::ContentBlock::Tag::kSuggestFocusTopicsContentBlock:
+        case mojom::ContentBlock::Tag::kSuggestFocusTopicsWithEmojiContentBlock:
+        case mojom::ContentBlock::Tag::kReduceFocusTopicsContentBlock:
+        case mojom::ContentBlock::Tag::kSimpleRequestContentBlock:
+          break;
       }
-      // Other ContentBlock variants are runtime-only and intentionally not
-      // synced (see ai_chat_specifics.proto).
     }
   }
   if (tool_use.artifacts) {
@@ -162,7 +204,7 @@ void WriteUploadedFile(const mojom::UploadedFile& file,
                        sync_pb::AIChatUploadedFile* proto) {
   proto->set_filename(file.filename);
   proto->set_filesize(file.filesize);
-  proto->set_type(static_cast<int32_t>(file.type));
+  proto->set_type(std::to_underlying(file.type));
   // Raw bytes are inlined here; the truncation policy may later drop them
   // and set |data_truncated_for_sync| if the entry exceeds the size cap.
   if (!file.data.empty()) {
@@ -174,8 +216,55 @@ void WriteUploadedFile(const mojom::UploadedFile& file,
   }
 }
 
+void WriteEvent(const mojom::ConversationEntryEvent& event,
+                sync_pb::AIChatEntryEventProto* proto) {
+  // No default case: adding a new ConversationEntryEvent variant must be an
+  // explicit decision here rather than silently not syncing.
+  switch (event.which()) {
+    case mojom::ConversationEntryEvent::Tag::kCompletionEvent:
+      WriteCompressibleString(event.get_completion_event()->completion,
+                              proto->mutable_completion());
+      break;
+    case mojom::ConversationEntryEvent::Tag::kSearchQueriesEvent:
+      for (const auto& q : event.get_search_queries_event()->search_queries) {
+        proto->mutable_search_queries()->add_queries(q);
+      }
+      break;
+    case mojom::ConversationEntryEvent::Tag::kSourcesEvent: {
+      auto* ws = proto->mutable_web_sources();
+      const auto& sources_event = event.get_sources_event();
+      for (const auto& source : sources_event->sources) {
+        WriteWebSource(*source, ws->add_sources());
+      }
+      for (const auto& rr : sources_event->rich_results) {
+        WriteCompressibleString(rr, ws->add_rich_results());
+      }
+      break;
+    }
+    case mojom::ConversationEntryEvent::Tag::kInlineSearchEvent: {
+      auto* is = proto->mutable_inline_search();
+      is->set_query(event.get_inline_search_event()->query);
+      WriteCompressibleString(event.get_inline_search_event()->results_json,
+                              is->mutable_results_json());
+      break;
+    }
+    case mojom::ConversationEntryEvent::Tag::kToolUseEvent:
+      WriteToolUse(*event.get_tool_use_event(), proto->mutable_tool_use());
+      break;
+    // Runtime-only / engine-response events that are intentionally not synced.
+    case mojom::ConversationEntryEvent::Tag::kSearchStatusEvent:
+    case mojom::ConversationEntryEvent::Tag::kDeepResearchEvent:
+    case mojom::ConversationEntryEvent::Tag::kContentReceiptEvent:
+    case mojom::ConversationEntryEvent::Tag::kConversationTitleEvent:
+      break;
+  }
+}
+
 void WriteEntryFields(const mojom::ConversationTurn& entry,
                       sync_pb::AIChatConversationSpecifics::Entry* proto) {
+  // Not synced: skill, from_brave_search_SERP and near_verification_status are
+  // local/runtime metadata. edits are not written here; EntryToSpecifics
+  // collapses them into the latest revision before calling this.
   if (entry.uuid) {
     proto->set_uuid(*entry.uuid);
   }
@@ -185,8 +274,8 @@ void WriteEntryFields(const mojom::ConversationTurn& entry,
   if (entry.prompt) {
     proto->set_prompt(*entry.prompt);
   }
-  proto->set_character_type(static_cast<int32_t>(entry.character_type));
-  proto->set_action_type(static_cast<int32_t>(entry.action_type));
+  proto->set_character_type(std::to_underlying(entry.character_type));
+  proto->set_action_type(std::to_underlying(entry.action_type));
   if (entry.selected_text) {
     proto->set_selected_text(*entry.selected_text);
   }
@@ -195,37 +284,10 @@ void WriteEntryFields(const mojom::ConversationTurn& entry,
   }
 
   if (entry.events) {
-    int order = 0;
-    for (const auto& event : *entry.events) {
+    for (int order = 0; const auto& event : *entry.events) {
       auto* event_proto = proto->add_events();
       event_proto->set_event_order(order++);
-      if (event->is_completion_event()) {
-        WriteCompressibleString(event->get_completion_event()->completion,
-                                event_proto->mutable_completion());
-      } else if (event->is_search_queries_event()) {
-        const auto& queries = event->get_search_queries_event()->search_queries;
-        auto* sq = event_proto->mutable_search_queries();
-        for (const auto& q : queries) {
-          sq->add_queries(q);
-        }
-      } else if (event->is_sources_event()) {
-        auto* ws = event_proto->mutable_web_sources();
-        const auto& sources_event = event->get_sources_event();
-        for (const auto& source : sources_event->sources) {
-          WriteWebSource(*source, ws->add_sources());
-        }
-        for (const auto& rr : sources_event->rich_results) {
-          WriteCompressibleString(rr, ws->add_rich_results());
-        }
-      } else if (event->is_inline_search_event()) {
-        auto* is = event_proto->mutable_inline_search();
-        is->set_query(event->get_inline_search_event()->query);
-        WriteCompressibleString(event->get_inline_search_event()->results_json,
-                                is->mutable_results_json());
-      } else if (event->is_tool_use_event()) {
-        WriteToolUse(*event->get_tool_use_event(),
-                     event_proto->mutable_tool_use());
-      }
+      WriteEvent(*event, event_proto);
     }
   }
 
@@ -240,6 +302,9 @@ void WriteEntryFields(const mojom::ConversationTurn& entry,
 
 sync_pb::AIChatConversationSpecifics ConversationMetadataToSpecifics(
     const mojom::Conversation& conversation) {
+  // Not synced: updated_time and has_content are inferred locally from the
+  // entries; temporary conversations are excluded from sync entirely;
+  // associated_content is carried by the per-entry records, not here.
   sync_pb::AIChatConversationSpecifics specifics;
   auto* meta = specifics.mutable_conversation();
   meta->set_uuid(conversation.uuid);
@@ -325,7 +390,9 @@ std::string GetStorageKeyFromSpecifics(
   if (specifics.has_entry()) {
     return base::StrCat({kEntryStorageKeyPrefix, specifics.entry().uuid()});
   }
-  return std::string();
+  // Specifics with neither kind set are rejected by IsEntityDataValid before
+  // any storage-key/client-tag derivation runs.
+  NOTREACHED();
 }
 
 std::string GetClientTagFromSpecifics(

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
@@ -75,15 +75,15 @@ std::optional<std::string> ReadCompressibleString(
   }
   if (in.has_gzipped()) {
     // Limit maximum decompressed size to allowed maximum, or available memory.
-    if (compression::GetUncompressedSize(in.gzipped()) >
-        std::min(
-            kSyncCompressionMaxDecompressedBytes,
-            base::saturated_cast<size_t>(
-                base::SysInfo::AmountOfAvailablePhysicalMemory().InBytes()))) {
-      DVLOG(1) << "Rejecting uncompressed string of size "
-               << compression::GetUncompressedSize(in.gzipped())
-               << " bytes, exceeds max allowed "
-               << kSyncCompressionMaxDecompressedBytes;
+    const uint32_t uncompressed_size =
+        compression::GetUncompressedSize(in.gzipped());
+    const size_t max_allowed_size = std::min(
+        kSyncCompressionMaxDecompressedBytes,
+        base::saturated_cast<size_t>(
+            base::SysInfo::AmountOfAvailablePhysicalMemory().InBytes()));
+    if (uncompressed_size > max_allowed_size) {
+      DVLOG(1) << "Rejecting uncompressed string of size " << uncompressed_size
+               << " bytes, exceeds max allowed " << max_allowed_size;
       return std::nullopt;
     }
     std::string out;

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
@@ -15,6 +15,7 @@
 
 #include "base/containers/flat_map.h"
 #include "base/containers/map_util.h"
+#include "base/hash/hash.h"
 #include "base/logging.h"
 #include "base/notreached.h"
 #include "base/numerics/safe_conversions.h"
@@ -33,10 +34,9 @@ namespace ai_chat {
 
 void WriteCompressibleString(std::string_view value,
                              sync_pb::AIChatCompressibleString* out) {
-  // Writing a real value supersedes any previous truncation sentinel on
-  // |out| (the merge path reuses an existing AIChatCompressibleString that
-  // may have been marked truncated by the sender).
-  out->clear_was_truncated_for_sync();
+  // Setting a real value supersedes any previous omitted_content_hash on |out|
+  // (they share the same oneof), which matters on the merge path where an
+  // AIChatCompressibleString the sender omitted is being restored.
   if (std::string compressed; value.size() >= kSyncCompressionThresholdBytes &&
                               compression::GzipCompress(value, &compressed) &&
                               compressed.size() < value.size()) {
@@ -46,16 +46,23 @@ void WriteCompressibleString(std::string_view value,
   out->set_raw(value);
 }
 
-void MarkCompressibleStringTruncated(sync_pb::AIChatCompressibleString* out) {
-  out->clear_value();
-  out->set_was_truncated_for_sync(true);
+void OmitCompressibleString(sync_pb::AIChatCompressibleString* out) {
+  // Replace the (possibly large) value with a hash of its content so the
+  // receiver can restore it from a local copy that hashes identically. Reading
+  // the current value handles both raw and gzipped storage; an already-omitted
+  // or empty field hashes the empty string. Setting the hash arm of the oneof
+  // clears any existing value.
+  const std::string value =
+      ReadCompressibleString(*out).value_or(std::string());
+  out->set_omitted_content_hash(base::PersistentHash(value));
 }
 
 std::optional<std::string> ReadCompressibleString(
     const sync_pb::AIChatCompressibleString& in) {
-  if (in.was_truncated_for_sync()) {
-    // The field was truncated by the sender, caller will preserve local value
-    // or use truncated.
+  if (in.has_omitted_content_hash()) {
+    // The sender omitted this field to fit the record budget; the caller
+    // restores it from a local copy with identical content or preserves the
+    // existing local value.
     return std::nullopt;
   }
   if (in.has_gzipped()) {
@@ -205,8 +212,8 @@ void WriteUploadedFile(const mojom::UploadedFile& file,
   proto->set_filename(file.filename);
   proto->set_filesize(file.filesize);
   proto->set_type(std::to_underlying(file.type));
-  // Raw bytes are inlined here; the truncation policy may later drop them
-  // and set |data_truncated_for_sync| if the entry exceeds the size cap.
+  // Raw bytes are inlined here; the size-budget policy may later omit them
+  // and set |omitted_data_hash| if the entry exceeds the size cap.
   if (!file.data.empty()) {
     proto->set_data(file.data.data(), file.data.size());
   }
@@ -262,9 +269,9 @@ void WriteEvent(const mojom::ConversationEntryEvent& event,
 
 void WriteEntryFields(const mojom::ConversationTurn& entry,
                       sync_pb::AIChatConversationSpecifics::Entry* proto) {
-  // Not synced: skill, from_brave_search_SERP and near_verification_status are
-  // local/runtime metadata. edits are not written here; EntryToSpecifics
-  // collapses them into the latest revision before calling this.
+  // Not synced: from_brave_search_SERP is runtime-only (not persisted to the
+  // local store). edits are not written here; EntryToSpecifics collapses them
+  // into the latest revision before calling this.
   if (entry.uuid) {
     proto->set_uuid(*entry.uuid);
   }
@@ -295,6 +302,17 @@ void WriteEntryFields(const mojom::ConversationTurn& entry,
     for (const auto& file : *entry.uploaded_files) {
       WriteUploadedFile(*file, proto->add_uploaded_files());
     }
+  }
+
+  if (entry.skill) {
+    auto* skill_proto = proto->mutable_skill();
+    skill_proto->set_shortcut(entry.skill->shortcut);
+    skill_proto->set_prompt(entry.skill->prompt);
+  }
+
+  if (entry.near_verification_status) {
+    proto->mutable_near_verification_status()->set_verified(
+        entry.near_verification_status->verified);
   }
 }
 

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
@@ -20,6 +20,7 @@
 #include "base/notreached.h"
 #include "base/numerics/safe_conversions.h"
 #include "base/strings/strcat.h"
+#include "base/strings/string_view_util.h"
 #include "base/system/sys_info.h"
 #include "base/time/time.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
@@ -55,6 +56,13 @@ void OmitCompressibleString(sync_pb::AIChatCompressibleString* out) {
   const std::string value =
       ReadCompressibleString(*out).value_or(std::string());
   out->set_omitted_content_hash(base::PersistentHash(value));
+}
+
+void OmitUploadedFileData(sync_pb::AIChatUploadedFile* file) {
+  // Replace the raw bytes with a hash of them so the receiver can restore the
+  // file from a local copy with identical content. Setting the hash arm of the
+  // oneof clears |data|. Mirrors OmitCompressibleString for binary attachments.
+  file->set_omitted_data_hash(base::PersistentHash(file->data()));
 }
 
 std::optional<std::string> ReadCompressibleString(
@@ -215,7 +223,7 @@ void WriteUploadedFile(const mojom::UploadedFile& file,
   // Raw bytes are inlined here; the size-budget policy may later omit them
   // and set |omitted_data_hash| if the entry exceeds the size cap.
   if (!file.data.empty()) {
-    proto->set_data(file.data.data(), file.data.size());
+    proto->set_data(base::as_string_view(file.data));
   }
   if (file.extracted_text) {
     WriteCompressibleString(*file.extracted_text,

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
@@ -1,0 +1,341 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "base/containers/flat_map.h"
+#include "base/containers/map_util.h"
+#include "base/strings/strcat.h"
+#include "base/time/time.h"
+#include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
+#include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
+#include "brave/components/sync/protocol/ai_chat_specifics.pb.h"
+#include "components/sync/protocol/entity_data.h"
+#include "components/sync/protocol/entity_specifics.pb.h"
+#include "third_party/zlib/google/compression_utils.h"
+#include "url/gurl.h"
+
+namespace ai_chat {
+
+void WriteCompressibleString(std::string_view value,
+                             sync_pb::AIChatCompressibleString* out) {
+  // Writing a real value supersedes any previous truncation sentinel on
+  // |out| (the merge path reuses an existing AIChatCompressibleString that
+  // may have been marked truncated by the sender).
+  out->clear_was_truncated_for_sync();
+  if (value.size() < kSyncCompressionThresholdBytes) {
+    out->set_raw(std::string(value));
+    return;
+  }
+  std::string compressed;
+  if (compression::GzipCompress(value, &compressed) &&
+      compressed.size() < value.size()) {
+    out->set_gzipped(std::move(compressed));
+  } else {
+    out->set_raw(std::string(value));
+  }
+}
+
+void MarkCompressibleStringTruncated(sync_pb::AIChatCompressibleString* out) {
+  out->clear_value();
+  out->set_was_truncated_for_sync(true);
+}
+
+std::optional<std::string> ReadCompressibleString(
+    const sync_pb::AIChatCompressibleString& in) {
+  if (in.was_truncated_for_sync()) {
+    return std::nullopt;
+  }
+  if (in.has_gzipped()) {
+    std::string out;
+    if (!compression::GzipUncompress(in.gzipped(), &out)) {
+      return std::nullopt;
+    }
+    return out;
+  }
+  if (in.has_raw()) {
+    return in.raw();
+  }
+  return std::nullopt;
+}
+
+namespace {
+
+// --- Upload helpers: mojom → sync proto ---
+
+void WriteAssociatedContent(const mojom::AssociatedContent& content,
+                            std::optional<std::string_view> last_contents,
+                            sync_pb::AIChatAssociatedContentProto* proto) {
+  proto->set_uuid(content.uuid);
+  proto->set_title(content.title);
+  if (content.url.is_valid()) {
+    proto->set_url(content.url.spec());
+  }
+  proto->set_content_type(static_cast<int32_t>(content.content_type));
+  proto->set_content_used_percentage(content.content_used_percentage);
+  // When |last_contents| is absent the receiver preserves any local text for
+  // this UUID; we do not need to set the field at all.
+  if (last_contents) {
+    WriteCompressibleString(*last_contents, proto->mutable_last_contents());
+  }
+}
+
+void WriteWebSource(const mojom::WebSource& source,
+                    sync_pb::AIChatWebSource* proto) {
+  proto->set_title(source.title);
+  if (source.url.is_valid()) {
+    proto->set_url(source.url.spec());
+  }
+  if (source.favicon_url.is_valid()) {
+    proto->set_favicon_url(source.favicon_url.spec());
+  }
+  if (source.page_content) {
+    WriteCompressibleString(*source.page_content,
+                            proto->mutable_page_content());
+  }
+  if (source.extra_snippets) {
+    for (const auto& snippet : *source.extra_snippets) {
+      proto->add_extra_snippets(snippet);
+    }
+  }
+}
+
+void WriteWebSourcesContentBlock(const mojom::WebSourcesContentBlock& block,
+                                 sync_pb::AIChatWebSourcesContentBlock* proto) {
+  for (const auto& source : block.sources) {
+    WriteWebSource(*source, proto->add_sources());
+  }
+  for (const auto& q : block.queries) {
+    proto->add_queries(q);
+  }
+  for (const auto& rr : block.rich_results) {
+    WriteCompressibleString(rr, proto->add_rich_results());
+  }
+}
+
+void WriteToolUse(const mojom::ToolUseEvent& tool_use,
+                  sync_pb::AIChatToolUseEvent* proto) {
+  proto->set_tool_name(tool_use.tool_name);
+  proto->set_id(tool_use.id);
+  WriteCompressibleString(tool_use.arguments_json,
+                          proto->mutable_arguments_json());
+  proto->set_is_server_result(tool_use.is_server_result);
+  if (tool_use.output) {
+    for (const auto& block : *tool_use.output) {
+      auto* block_proto = proto->add_output();
+      if (block->is_text_content_block()) {
+        WriteCompressibleString(
+            block->get_text_content_block()->text,
+            block_proto->mutable_text_content_block()->mutable_text());
+      } else if (block->is_image_content_block()) {
+        block_proto->mutable_image_content_block()->set_image_url(
+            block->get_image_content_block()->image_url.spec());
+      } else if (block->is_web_sources_content_block()) {
+        WriteWebSourcesContentBlock(
+            *block->get_web_sources_content_block(),
+            block_proto->mutable_web_sources_content_block());
+      }
+      // Other ContentBlock variants are runtime-only and intentionally not
+      // synced (see ai_chat_specifics.proto).
+    }
+  }
+  if (tool_use.artifacts) {
+    for (const auto& artifact : *tool_use.artifacts) {
+      auto* a = proto->add_artifacts();
+      a->set_type(artifact->type);
+      WriteCompressibleString(artifact->content_json,
+                              a->mutable_content_json());
+    }
+  }
+}
+
+void WriteUploadedFile(const mojom::UploadedFile& file,
+                       sync_pb::AIChatUploadedFile* proto) {
+  proto->set_filename(file.filename);
+  proto->set_filesize(file.filesize);
+  proto->set_type(static_cast<int32_t>(file.type));
+  // Raw bytes are inlined here; the truncation policy may later drop them
+  // and set |data_truncated_for_sync| if the entry exceeds the size cap.
+  if (!file.data.empty()) {
+    proto->set_data(file.data.data(), file.data.size());
+  }
+  if (file.extracted_text) {
+    WriteCompressibleString(*file.extracted_text,
+                            proto->mutable_extracted_text());
+  }
+}
+
+void WriteEntryFields(const mojom::ConversationTurn& entry,
+                      sync_pb::AIChatConversationSpecifics::Entry* proto) {
+  if (entry.uuid) {
+    proto->set_uuid(*entry.uuid);
+  }
+  proto->set_date_unix_epoch_micros(
+      entry.created_time.ToDeltaSinceWindowsEpoch().InMicroseconds());
+  proto->set_entry_text(entry.text);
+  if (entry.prompt) {
+    proto->set_prompt(*entry.prompt);
+  }
+  proto->set_character_type(static_cast<int32_t>(entry.character_type));
+  proto->set_action_type(static_cast<int32_t>(entry.action_type));
+  if (entry.selected_text) {
+    proto->set_selected_text(*entry.selected_text);
+  }
+  if (entry.model_key) {
+    proto->set_model_key(*entry.model_key);
+  }
+
+  if (entry.events) {
+    int order = 0;
+    for (const auto& event : *entry.events) {
+      auto* event_proto = proto->add_events();
+      event_proto->set_event_order(order++);
+      if (event->is_completion_event()) {
+        WriteCompressibleString(event->get_completion_event()->completion,
+                                event_proto->mutable_completion());
+      } else if (event->is_search_queries_event()) {
+        const auto& queries = event->get_search_queries_event()->search_queries;
+        auto* sq = event_proto->mutable_search_queries();
+        for (const auto& q : queries) {
+          sq->add_queries(q);
+        }
+      } else if (event->is_sources_event()) {
+        auto* ws = event_proto->mutable_web_sources();
+        const auto& sources_event = event->get_sources_event();
+        for (const auto& source : sources_event->sources) {
+          WriteWebSource(*source, ws->add_sources());
+        }
+        for (const auto& rr : sources_event->rich_results) {
+          WriteCompressibleString(rr, ws->add_rich_results());
+        }
+      } else if (event->is_inline_search_event()) {
+        auto* is = event_proto->mutable_inline_search();
+        is->set_query(event->get_inline_search_event()->query);
+        WriteCompressibleString(event->get_inline_search_event()->results_json,
+                                is->mutable_results_json());
+      } else if (event->is_tool_use_event()) {
+        WriteToolUse(*event->get_tool_use_event(),
+                     event_proto->mutable_tool_use());
+      }
+    }
+  }
+
+  if (entry.uploaded_files) {
+    for (const auto& file : *entry.uploaded_files) {
+      WriteUploadedFile(*file, proto->add_uploaded_files());
+    }
+  }
+}
+
+}  // namespace
+
+sync_pb::AIChatConversationSpecifics ConversationMetadataToSpecifics(
+    const mojom::Conversation& conversation) {
+  sync_pb::AIChatConversationSpecifics specifics;
+  auto* meta = specifics.mutable_conversation();
+  meta->set_uuid(conversation.uuid);
+  meta->set_title(conversation.title);
+  if (conversation.model_key) {
+    meta->set_model_key(*conversation.model_key);
+  }
+  meta->set_total_tokens(conversation.total_tokens);
+  meta->set_trimmed_tokens(conversation.trimmed_tokens);
+  return specifics;
+}
+
+sync_pb::AIChatConversationSpecifics EntryToSpecifics(
+    const std::string& conversation_uuid,
+    const mojom::ConversationTurn& entry,
+    const std::vector<mojom::AssociatedContentPtr>& associated_content,
+    const base::flat_map<std::string, std::string>& associated_content_texts) {
+  sync_pb::AIChatConversationSpecifics specifics;
+  auto* entry_proto = specifics.mutable_entry();
+  entry_proto->set_conversation_uuid(conversation_uuid);
+
+  // A turn that has been edited keeps its original text in |entry.text| and
+  // stores each revision in |entry.edits|, with the most recent edit last.
+  // That most recent edit is what the UI displays (see the untrusted
+  // conversation UI, which renders `edits.at(-1)`), so it is the content we
+  // sync. We serialize that content but keep the ORIGINAL turn's identity
+  // (uuid + created_time) below, so the sync entity is stable across edits and
+  // keeps its position in the conversation. Edit history itself is not synced
+  // (only the latest revision); syncing the full edit/thread history is a
+  // planned follow-up.
+  const mojom::ConversationTurn& displayed =
+      (entry.edits && !entry.edits->empty()) ? *entry.edits->back() : entry;
+  WriteEntryFields(displayed, entry_proto);
+  // Identity always comes from the original turn, not the edit.
+  if (entry.uuid) {
+    entry_proto->set_uuid(*entry.uuid);
+  }
+  entry_proto->set_date_unix_epoch_micros(
+      entry.created_time.ToDeltaSinceWindowsEpoch().InMicroseconds());
+
+  // Filter associated content to items tied to this entry only. Associated
+  // content stays linked to the original turn's uuid even after an edit (the
+  // associated content manager records only the first turn a content appears
+  // with), so match on |entry.uuid|.
+  if (entry.uuid) {
+    for (const auto& content : associated_content) {
+      if (!content->conversation_turn_uuid ||
+          *content->conversation_turn_uuid != *entry.uuid) {
+        continue;
+      }
+      std::optional<std::string_view> text;
+      if (const std::string* found =
+              base::FindOrNull(associated_content_texts, content->uuid)) {
+        text = *found;
+      }
+      WriteAssociatedContent(*content, text,
+                             entry_proto->add_associated_content());
+    }
+  }
+
+  return specifics;
+}
+
+std::unique_ptr<syncer::EntityData> CreateEntityDataFromSpecifics(
+    const sync_pb::AIChatConversationSpecifics& specifics) {
+  auto entity_data = std::make_unique<syncer::EntityData>();
+  *entity_data->specifics.mutable_ai_chat_conversation() = specifics;
+  if (specifics.has_conversation()) {
+    entity_data->name =
+        base::StrCat({"conversation:", specifics.conversation().uuid()});
+  } else if (specifics.has_entry()) {
+    entity_data->name = base::StrCat({"entry:", specifics.entry().uuid()});
+  }
+  return entity_data;
+}
+
+std::string GetStorageKeyFromSpecifics(
+    const sync_pb::AIChatConversationSpecifics& specifics) {
+  if (specifics.has_conversation()) {
+    return base::StrCat(
+        {kConversationStorageKeyPrefix, specifics.conversation().uuid()});
+  }
+  if (specifics.has_entry()) {
+    return base::StrCat({kEntryStorageKeyPrefix, specifics.entry().uuid()});
+  }
+  return std::string();
+}
+
+std::string GetClientTagFromSpecifics(
+    const sync_pb::AIChatConversationSpecifics& specifics) {
+  return GetStorageKeyFromSpecifics(specifics);
+}
+
+std::string GetStorageKeyFromEntitySpecifics(
+    const sync_pb::EntitySpecifics& specifics) {
+  return GetStorageKeyFromSpecifics(specifics.ai_chat_conversation());
+}
+
+}  // namespace ai_chat

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h
@@ -42,6 +42,13 @@ inline constexpr size_t kSyncCompressionThresholdBytes = 256;
 // drops bytes from low-priority fields until it fits.
 inline constexpr size_t kSyncMaxRecordBytes = 350 * 1024;
 
+// Hard cap on the decompressed size of a single field. Protection against
+// malicious or corrupted data that might otherwise allocate unbounded memory.
+// Theoretical compression ratio max is approximately 1032:1 but upper limit on
+// practical data with high repetition is under 100:1.
+inline constexpr size_t kSyncCompressionMaxDecompressedBytes =
+    kSyncMaxRecordBytes * 100;
+
 // Writes |value| into |out|. Gzips when the input exceeds the threshold and
 // compression actually shrinks it; otherwise stores the raw string.
 void WriteCompressibleString(std::string_view value,
@@ -52,10 +59,12 @@ void WriteCompressibleString(std::string_view value,
 // it with empty.
 void MarkCompressibleStringTruncated(sync_pb::AIChatCompressibleString* out);
 
-// Reads a value from |in|. Returns std::nullopt when the field was marked
-// truncated for sync (preserve-local signal) or when gzip decompression
-// fails. Returns an empty string when the field was set to an empty raw
-// string.
+// Reads a value from |in|. Returns std::nullopt when there is no usable value
+// to apply, for any of three reasons: the field was marked truncated for sync
+// (preserve-local signal), gzip decompression failed, or no value was set at
+// all. Callers treat all three the same way — leave the target field unset and
+// preserve any existing local value. Returns an empty string (not nullopt) when
+// the field was set to an empty raw string.
 std::optional<std::string> ReadCompressibleString(
     const sync_pb::AIChatCompressibleString& in);
 

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h
@@ -19,6 +19,7 @@
 namespace sync_pb {
 class AIChatCompressibleString;
 class AIChatConversationSpecifics;
+class AIChatUploadedFile;
 class EntitySpecifics;
 }  // namespace sync_pb
 
@@ -38,8 +39,8 @@ inline constexpr size_t kSyncCompressionThresholdBytes = 256;
 
 // Soft cap on the serialized size of a single sync record. Leaves headroom
 // under the 400 KB-per-entity server limit for sync framing and encryption
-// overhead. When an Entry would exceed this size, the truncation policy
-// drops bytes from low-priority fields until it fits.
+// overhead. When an Entry would exceed this size, the size-budget policy omits
+// low-priority fields until it fits.
 inline constexpr size_t kSyncMaxRecordBytes = 350 * 1024;
 
 // Hard cap on the decompressed size of a single field. Protection against
@@ -59,6 +60,12 @@ void WriteCompressibleString(std::string_view value,
 // value from a local copy that hashes identically, or preserves any existing
 // local value.
 void OmitCompressibleString(sync_pb::AIChatCompressibleString* out);
+
+// Omits |file|'s raw bytes, replacing them with a hash of their content (see
+// AIChatUploadedFile::omitted_data_hash). Mirrors OmitCompressibleString for
+// the binary-attachment case; the receiver restores the bytes from a local
+// copy that hashes identically.
+void OmitUploadedFileData(sync_pb::AIChatUploadedFile* file);
 
 // Reads a value from |in|. Returns std::nullopt when there is no usable value
 // to apply, for any of three reasons: the value was omitted for sync

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h
@@ -54,17 +54,18 @@ inline constexpr size_t kSyncCompressionMaxDecompressedBytes =
 void WriteCompressibleString(std::string_view value,
                              sync_pb::AIChatCompressibleString* out);
 
-// Marks |out| as truncated for sync (no value bytes). The receiver MUST
-// preserve any existing local value for this field rather than overwriting
-// it with empty.
-void MarkCompressibleStringTruncated(sync_pb::AIChatCompressibleString* out);
+// Omits |out|'s value, replacing it with a hash of its current content (see
+// AIChatCompressibleString::omitted_content_hash). The receiver restores the
+// value from a local copy that hashes identically, or preserves any existing
+// local value.
+void OmitCompressibleString(sync_pb::AIChatCompressibleString* out);
 
 // Reads a value from |in|. Returns std::nullopt when there is no usable value
-// to apply, for any of three reasons: the field was marked truncated for sync
-// (preserve-local signal), gzip decompression failed, or no value was set at
-// all. Callers treat all three the same way — leave the target field unset and
-// preserve any existing local value. Returns an empty string (not nullopt) when
-// the field was set to an empty raw string.
+// to apply, for any of three reasons: the value was omitted for sync
+// (restore-from-local signal), gzip decompression failed, or no value was set
+// at all. Callers treat all three the same way — leave the target field unset
+// and preserve any existing local value. Returns an empty string (not nullopt)
+// when the field was set to an empty raw string.
 std::optional<std::string> ReadCompressibleString(
     const sync_pb::AIChatCompressibleString& in);
 

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h
@@ -1,0 +1,99 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_SYNC_AI_CHAT_SYNC_CONVERSIONS_H_
+#define BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_SYNC_AI_CHAT_SYNC_CONVERSIONS_H_
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "base/containers/flat_map.h"
+#include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom-forward.h"
+#include "brave/components/ai_chat/core/common/mojom/common.mojom-forward.h"
+
+namespace sync_pb {
+class AIChatCompressibleString;
+class AIChatConversationSpecifics;
+class EntitySpecifics;
+}  // namespace sync_pb
+
+namespace syncer {
+struct EntityData;
+}  // namespace syncer
+
+namespace ai_chat {
+
+// Storage key / client tag prefixes that distinguish the two record kinds.
+inline constexpr std::string_view kConversationStorageKeyPrefix = "c:";
+inline constexpr std::string_view kEntryStorageKeyPrefix = "e:";
+
+// Minimum input size at which it is worth attempting gzip. Short strings
+// gain little and may grow under compression overhead.
+inline constexpr size_t kSyncCompressionThresholdBytes = 256;
+
+// Soft cap on the serialized size of a single sync record. Leaves headroom
+// under the 400 KB-per-entity server limit for sync framing and encryption
+// overhead. When an Entry would exceed this size, the truncation policy
+// drops bytes from low-priority fields until it fits.
+inline constexpr size_t kSyncMaxRecordBytes = 350 * 1024;
+
+// Writes |value| into |out|. Gzips when the input exceeds the threshold and
+// compression actually shrinks it; otherwise stores the raw string.
+void WriteCompressibleString(std::string_view value,
+                             sync_pb::AIChatCompressibleString* out);
+
+// Marks |out| as truncated for sync (no value bytes). The receiver MUST
+// preserve any existing local value for this field rather than overwriting
+// it with empty.
+void MarkCompressibleStringTruncated(sync_pb::AIChatCompressibleString* out);
+
+// Reads a value from |in|. Returns std::nullopt when the field was marked
+// truncated for sync (preserve-local signal) or when gzip decompression
+// fails. Returns an empty string when the field was set to an empty raw
+// string.
+std::optional<std::string> ReadCompressibleString(
+    const sync_pb::AIChatCompressibleString& in);
+
+// Builds a sync entity containing only conversation metadata.
+sync_pb::AIChatConversationSpecifics ConversationMetadataToSpecifics(
+    const mojom::Conversation& conversation);
+
+// Builds a sync entity for a single conversation entry. |conversation_uuid|
+// is the parent conversation's UUID. |associated_content| is filtered to
+// only the items that belong to this entry. |associated_content_texts|
+// holds the optional extracted text for each AC, keyed by AC UUID; entries
+// without a text in the map have their last_contents field left absent on
+// the wire so the receiver preserves any existing local text.
+sync_pb::AIChatConversationSpecifics EntryToSpecifics(
+    const std::string& conversation_uuid,
+    const mojom::ConversationTurn& entry,
+    const std::vector<mojom::AssociatedContentPtr>& associated_content,
+    const base::flat_map<std::string, std::string>& associated_content_texts =
+        {});
+
+// Wraps an AIChatConversationSpecifics in EntityData for change_processor()
+// to consume. Sets the entity name to a human-readable string.
+std::unique_ptr<syncer::EntityData> CreateEntityDataFromSpecifics(
+    const sync_pb::AIChatConversationSpecifics& specifics);
+
+// Returns the storage key for the record, including the kind prefix.
+std::string GetStorageKeyFromSpecifics(
+    const sync_pb::AIChatConversationSpecifics& specifics);
+
+// Same as GetStorageKeyFromSpecifics — the client tag is identical to the
+// storage key since both are derived from a stable UUID + kind prefix.
+std::string GetClientTagFromSpecifics(
+    const sync_pb::AIChatConversationSpecifics& specifics);
+
+// Extracts the storage key from an EntitySpecifics wrapper.
+std::string GetStorageKeyFromEntitySpecifics(
+    const sync_pb::EntitySpecifics& specifics);
+
+}  // namespace ai_chat
+
+#endif  // BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_SYNC_AI_CHAT_SYNC_CONVERSIONS_H_

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions_unittest.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions_unittest.cc
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "base/hash/hash.h"
+#include "base/numerics/byte_conversions.h"
 #include "base/time/time.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
@@ -82,6 +83,18 @@ TEST(AIChatSyncConversionsTest, OmitCompressibleStringHashesGzippedPlaintext) {
   EXPECT_EQ(out.omitted_content_hash(), base::PersistentHash(value));
 }
 
+TEST(AIChatSyncConversionsTest, OmitUploadedFileDataStoresDataHash) {
+  sync_pb::AIChatUploadedFile file;
+  const std::string bytes = "some raw uploaded file bytes";
+  file.set_data(bytes);
+  OmitUploadedFileData(&file);
+  EXPECT_FALSE(file.has_data());
+  EXPECT_TRUE(file.has_omitted_data_hash());
+  // The hash is over the original bytes so a receiver can match it against a
+  // local copy.
+  EXPECT_EQ(file.omitted_data_hash(), base::PersistentHash(bytes));
+}
+
 TEST(AIChatSyncConversionsTest, ReadCompressibleStringRawRoundTrip) {
   sync_pb::AIChatCompressibleString in;
   in.set_raw("plain");
@@ -135,12 +148,9 @@ TEST(AIChatSyncConversionsTest,
 
   std::string gzipped = in.gzipped();
   ASSERT_GE(gzipped.size(), 4u);
-  const uint32_t forged_size =
-      static_cast<uint32_t>(kSyncCompressionMaxDecompressedBytes + 1);
-  gzipped[gzipped.size() - 4] = static_cast<char>(forged_size & 0xFF);
-  gzipped[gzipped.size() - 3] = static_cast<char>((forged_size >> 8) & 0xFF);
-  gzipped[gzipped.size() - 2] = static_cast<char>((forged_size >> 16) & 0xFF);
-  gzipped[gzipped.size() - 1] = static_cast<char>((forged_size >> 24) & 0xFF);
+  base::as_writable_byte_span(gzipped).last<4u>().copy_from(
+      base::U32ToLittleEndian(
+          static_cast<uint32_t>(kSyncCompressionMaxDecompressedBytes + 1)));
   in.set_gzipped(gzipped);
 
   EXPECT_EQ(ReadCompressibleString(in), std::nullopt);

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions_unittest.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions_unittest.cc
@@ -1,0 +1,487 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "base/time/time.h"
+#include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
+#include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
+#include "brave/components/sync/protocol/ai_chat_specifics.pb.h"
+#include "components/sync/protocol/entity_data.h"
+#include "components/sync/protocol/entity_specifics.pb.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace ai_chat {
+namespace {
+
+// A string long enough to cross kSyncCompressionThresholdBytes and highly
+// repetitive, so gzip is guaranteed to shrink it.
+std::string CompressibleString() {
+  return std::string(2 * kSyncCompressionThresholdBytes, 'a');
+}
+
+}  // namespace
+
+TEST(AIChatSyncConversionsTest, WriteCompressibleStringShortStaysRaw) {
+  sync_pb::AIChatCompressibleString out;
+  WriteCompressibleString("hello", &out);
+  EXPECT_TRUE(out.has_raw());
+  EXPECT_FALSE(out.has_gzipped());
+  EXPECT_EQ(out.raw(), "hello");
+  EXPECT_FALSE(out.was_truncated_for_sync());
+}
+
+TEST(AIChatSyncConversionsTest, WriteCompressibleStringBelowThresholdStaysRaw) {
+  // Exactly one byte under the threshold must not be compressed.
+  const std::string value(kSyncCompressionThresholdBytes - 1, 'a');
+  sync_pb::AIChatCompressibleString out;
+  WriteCompressibleString(value, &out);
+  EXPECT_TRUE(out.has_raw());
+  EXPECT_FALSE(out.has_gzipped());
+  EXPECT_EQ(out.raw(), value);
+}
+
+TEST(AIChatSyncConversionsTest, WriteCompressibleStringLongGetsGzipped) {
+  const std::string value = CompressibleString();
+  sync_pb::AIChatCompressibleString out;
+  WriteCompressibleString(value, &out);
+  EXPECT_TRUE(out.has_gzipped());
+  EXPECT_FALSE(out.has_raw());
+  EXPECT_LT(out.gzipped().size(), value.size());
+}
+
+TEST(AIChatSyncConversionsTest, MarkCompressibleStringTruncatedSetsSentinel) {
+  sync_pb::AIChatCompressibleString out;
+  WriteCompressibleString("some value", &out);
+  MarkCompressibleStringTruncated(&out);
+  EXPECT_TRUE(out.was_truncated_for_sync());
+  EXPECT_FALSE(out.has_raw());
+  EXPECT_FALSE(out.has_gzipped());
+}
+
+TEST(AIChatSyncConversionsTest, ReadCompressibleStringRawRoundTrip) {
+  sync_pb::AIChatCompressibleString in;
+  in.set_raw("plain");
+  EXPECT_EQ(ReadCompressibleString(in), "plain");
+}
+
+TEST(AIChatSyncConversionsTest, ReadCompressibleStringEmptyRawIsEmptyNotNull) {
+  // An explicitly-set empty raw string is distinct from an unset field: it
+  // reads back as "" rather than nullopt.
+  sync_pb::AIChatCompressibleString in;
+  in.set_raw("");
+  std::optional<std::string> result = ReadCompressibleString(in);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, "");
+}
+
+TEST(AIChatSyncConversionsTest, ReadCompressibleStringGzippedRoundTrip) {
+  const std::string value = CompressibleString();
+  sync_pb::AIChatCompressibleString wire;
+  WriteCompressibleString(value, &wire);
+  ASSERT_TRUE(wire.has_gzipped());
+  EXPECT_EQ(ReadCompressibleString(wire), value);
+}
+
+TEST(AIChatSyncConversionsTest, ReadCompressibleStringTruncatedReturnsNullopt) {
+  sync_pb::AIChatCompressibleString in;
+  MarkCompressibleStringTruncated(&in);
+  EXPECT_EQ(ReadCompressibleString(in), std::nullopt);
+}
+
+TEST(AIChatSyncConversionsTest, ReadCompressibleStringUnsetReturnsNullopt) {
+  sync_pb::AIChatCompressibleString in;
+  EXPECT_EQ(ReadCompressibleString(in), std::nullopt);
+}
+
+TEST(AIChatSyncConversionsTest, ReadCompressibleStringBadGzipReturnsNullopt) {
+  sync_pb::AIChatCompressibleString in;
+  in.set_gzipped("this is not valid gzip data");
+  EXPECT_EQ(ReadCompressibleString(in), std::nullopt);
+}
+
+TEST(AIChatSyncConversionsTest, ConversationMetadataToSpecifics) {
+  auto conversation = mojom::Conversation::New();
+  conversation->uuid = "conv-1";
+  conversation->title = "My conversation";
+  conversation->model_key = "model-key";
+  conversation->total_tokens = 1234;
+  conversation->trimmed_tokens = 56;
+
+  sync_pb::AIChatConversationSpecifics specifics =
+      ConversationMetadataToSpecifics(*conversation);
+
+  ASSERT_TRUE(specifics.has_conversation());
+  EXPECT_FALSE(specifics.has_entry());
+  const auto& meta = specifics.conversation();
+  EXPECT_EQ(meta.uuid(), "conv-1");
+  EXPECT_EQ(meta.title(), "My conversation");
+  EXPECT_EQ(meta.model_key(), "model-key");
+  EXPECT_EQ(meta.total_tokens(), 1234u);
+  EXPECT_EQ(meta.trimmed_tokens(), 56u);
+}
+
+TEST(AIChatSyncConversionsTest, ConversationMetadataToSpecificsNoModelKey) {
+  auto conversation = mojom::Conversation::New();
+  conversation->uuid = "conv-1";
+  conversation->title = "No model";
+  conversation->model_key = std::nullopt;
+
+  sync_pb::AIChatConversationSpecifics specifics =
+      ConversationMetadataToSpecifics(*conversation);
+
+  ASSERT_TRUE(specifics.has_conversation());
+  EXPECT_FALSE(specifics.conversation().has_model_key());
+}
+
+TEST(AIChatSyncConversionsTest, EntryToSpecificsMapsFields) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-1";
+  entry->character_type = mojom::CharacterType::HUMAN;
+  entry->action_type = mojom::ActionType::QUERY;
+  entry->text = "the entry text";
+  entry->prompt = "the prompt";
+  entry->selected_text = "selected";
+  entry->model_key = "model-key";
+  entry->created_time =
+      base::Time::FromDeltaSinceWindowsEpoch(base::Microseconds(42));
+
+  sync_pb::AIChatConversationSpecifics specifics =
+      EntryToSpecifics("conv-1", *entry, {});
+
+  ASSERT_TRUE(specifics.has_entry());
+  EXPECT_FALSE(specifics.has_conversation());
+  const auto& proto = specifics.entry();
+  EXPECT_EQ(proto.uuid(), "entry-1");
+  EXPECT_EQ(proto.conversation_uuid(), "conv-1");
+  EXPECT_EQ(proto.entry_text(), "the entry text");
+  EXPECT_EQ(proto.prompt(), "the prompt");
+  EXPECT_EQ(proto.selected_text(), "selected");
+  EXPECT_EQ(proto.model_key(), "model-key");
+  EXPECT_EQ(proto.character_type(),
+            static_cast<int32_t>(mojom::CharacterType::HUMAN));
+  EXPECT_EQ(proto.action_type(),
+            static_cast<int32_t>(mojom::ActionType::QUERY));
+  EXPECT_EQ(proto.date_unix_epoch_micros(), 42);
+}
+
+TEST(AIChatSyncConversionsTest,
+     EntryToSpecificsSyncsLatestEditUnderOriginalIdentity) {
+  // An edited turn keeps its original text in |text| and stores each revision
+  // in |edits| (most recent last). Sync must carry the latest edit's content,
+  // but under the original turn's identity (uuid + created_time), so the sync
+  // entity is stable across edits and keeps its conversation position.
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-1";
+  entry->character_type = mojom::CharacterType::HUMAN;
+  entry->action_type = mojom::ActionType::QUERY;
+  entry->text = "original text";
+  entry->model_key = "original-model";
+  entry->created_time =
+      base::Time::FromDeltaSinceWindowsEpoch(base::Microseconds(42));
+
+  auto first_edit = mojom::ConversationTurn::New();
+  first_edit->uuid = "edit-1";
+  first_edit->character_type = mojom::CharacterType::HUMAN;
+  first_edit->action_type = mojom::ActionType::QUERY;
+  first_edit->text = "first edit";
+  first_edit->created_time =
+      base::Time::FromDeltaSinceWindowsEpoch(base::Microseconds(100));
+
+  auto latest_edit = mojom::ConversationTurn::New();
+  latest_edit->uuid = "edit-2";
+  latest_edit->character_type = mojom::CharacterType::HUMAN;
+  latest_edit->action_type = mojom::ActionType::QUERY;
+  latest_edit->text = "latest edit";
+  latest_edit->model_key = "edited-model";
+  latest_edit->created_time =
+      base::Time::FromDeltaSinceWindowsEpoch(base::Microseconds(200));
+  latest_edit->events = std::vector<mojom::ConversationEntryEventPtr>{};
+  latest_edit->events->push_back(
+      mojom::ConversationEntryEvent::NewCompletionEvent(
+          mojom::CompletionEvent::New("latest answer")));
+
+  entry->edits = std::vector<mojom::ConversationTurnPtr>{};
+  entry->edits->push_back(std::move(first_edit));
+  entry->edits->push_back(std::move(latest_edit));
+
+  sync_pb::AIChatConversationSpecifics specifics =
+      EntryToSpecifics("conv-1", *entry, {});
+
+  ASSERT_TRUE(specifics.has_entry());
+  const auto& proto = specifics.entry();
+  // Identity: from the original turn.
+  EXPECT_EQ(proto.uuid(), "entry-1");
+  EXPECT_EQ(proto.date_unix_epoch_micros(), 42);
+  // Content: from the most recent edit, not the original or intermediate edit.
+  EXPECT_EQ(proto.entry_text(), "latest edit");
+  EXPECT_EQ(proto.model_key(), "edited-model");
+  ASSERT_EQ(proto.events_size(), 1);
+  ASSERT_TRUE(proto.events(0).has_completion());
+  EXPECT_EQ(ReadCompressibleString(proto.events(0).completion()),
+            "latest answer");
+}
+
+TEST(AIChatSyncConversionsTest, EntryToSpecificsFiltersAssociatedContent) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-1";
+  entry->character_type = mojom::CharacterType::HUMAN;
+  entry->action_type = mojom::ActionType::QUERY;
+  entry->created_time = base::Time::Now();
+
+  // One content tied to this entry, one tied to a different entry, and one
+  // with no entry association at all.
+  std::vector<mojom::AssociatedContentPtr> content;
+
+  auto mine = mojom::AssociatedContent::New();
+  mine->uuid = "content-mine";
+  mine->title = "Mine";
+  mine->url = GURL("https://example.com/mine");
+  mine->content_type = mojom::ContentType::PageContent;
+  mine->content_used_percentage = 50;
+  mine->conversation_turn_uuid = "entry-1";
+  content.push_back(std::move(mine));
+
+  auto other = mojom::AssociatedContent::New();
+  other->uuid = "content-other";
+  other->content_type = mojom::ContentType::PageContent;
+  other->conversation_turn_uuid = "entry-2";
+  content.push_back(std::move(other));
+
+  auto unattached = mojom::AssociatedContent::New();
+  unattached->uuid = "content-unattached";
+  unattached->content_type = mojom::ContentType::PageContent;
+  unattached->conversation_turn_uuid = std::nullopt;
+  content.push_back(std::move(unattached));
+
+  sync_pb::AIChatConversationSpecifics specifics =
+      EntryToSpecifics("conv-1", *entry, content);
+
+  ASSERT_TRUE(specifics.has_entry());
+  ASSERT_EQ(specifics.entry().associated_content_size(), 1);
+  const auto& proto_content = specifics.entry().associated_content(0);
+  EXPECT_EQ(proto_content.uuid(), "content-mine");
+  EXPECT_EQ(proto_content.title(), "Mine");
+  EXPECT_EQ(proto_content.url(), "https://example.com/mine");
+  EXPECT_EQ(proto_content.content_used_percentage(), 50);
+}
+
+TEST(AIChatSyncConversionsTest, EntryToSpecificsCompletionEventCompressed) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-1";
+  entry->character_type = mojom::CharacterType::ASSISTANT;
+  entry->action_type = mojom::ActionType::RESPONSE;
+  entry->created_time = base::Time::Now();
+  const std::string completion = CompressibleString();
+  entry->events = std::vector<mojom::ConversationEntryEventPtr>{};
+  entry->events->push_back(mojom::ConversationEntryEvent::NewCompletionEvent(
+      mojom::CompletionEvent::New(completion)));
+
+  sync_pb::AIChatConversationSpecifics specifics =
+      EntryToSpecifics("conv-1", *entry, {});
+
+  ASSERT_TRUE(specifics.has_entry());
+  ASSERT_EQ(specifics.entry().events_size(), 1);
+  const auto& event = specifics.entry().events(0);
+  ASSERT_TRUE(event.has_completion());
+  EXPECT_TRUE(event.completion().has_gzipped());
+  EXPECT_EQ(ReadCompressibleString(event.completion()), completion);
+}
+
+TEST(AIChatSyncConversionsTest, EntryToSpecificsSearchQueriesEvent) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-1";
+  entry->character_type = mojom::CharacterType::ASSISTANT;
+  entry->action_type = mojom::ActionType::RESPONSE;
+  entry->created_time = base::Time::Now();
+  entry->events = std::vector<mojom::ConversationEntryEventPtr>{};
+  entry->events->push_back(mojom::ConversationEntryEvent::NewSearchQueriesEvent(
+      mojom::SearchQueriesEvent::New(
+          std::vector<std::string>{"query one", "query two"})));
+
+  sync_pb::AIChatConversationSpecifics specifics =
+      EntryToSpecifics("conv-1", *entry, {});
+
+  ASSERT_TRUE(specifics.has_entry());
+  ASSERT_EQ(specifics.entry().events_size(), 1);
+  const auto& event = specifics.entry().events(0);
+  ASSERT_TRUE(event.has_search_queries());
+  ASSERT_EQ(event.search_queries().queries_size(), 2);
+  EXPECT_EQ(event.search_queries().queries(0), "query one");
+  EXPECT_EQ(event.search_queries().queries(1), "query two");
+}
+
+TEST(AIChatSyncConversionsTest, CreateEntityDataFromSpecificsConversation) {
+  sync_pb::AIChatConversationSpecifics specifics;
+  specifics.mutable_conversation()->set_uuid("conv-1");
+
+  auto entity_data = CreateEntityDataFromSpecifics(specifics);
+  ASSERT_TRUE(entity_data);
+  EXPECT_EQ(entity_data->name, "conversation:conv-1");
+  ASSERT_TRUE(entity_data->specifics.has_ai_chat_conversation());
+  EXPECT_EQ(entity_data->specifics.ai_chat_conversation().conversation().uuid(),
+            "conv-1");
+}
+
+TEST(AIChatSyncConversionsTest, CreateEntityDataFromSpecificsEntry) {
+  sync_pb::AIChatConversationSpecifics specifics;
+  specifics.mutable_entry()->set_uuid("entry-1");
+
+  auto entity_data = CreateEntityDataFromSpecifics(specifics);
+  ASSERT_TRUE(entity_data);
+  EXPECT_EQ(entity_data->name, "entry:entry-1");
+  ASSERT_TRUE(entity_data->specifics.has_ai_chat_conversation());
+  EXPECT_EQ(entity_data->specifics.ai_chat_conversation().entry().uuid(),
+            "entry-1");
+}
+
+TEST(AIChatSyncConversionsTest, StorageKeyAndClientTagForConversation) {
+  sync_pb::AIChatConversationSpecifics specifics;
+  specifics.mutable_conversation()->set_uuid("conv-1");
+
+  EXPECT_EQ(GetStorageKeyFromSpecifics(specifics), "c:conv-1");
+  // The client tag is identical to the storage key.
+  EXPECT_EQ(GetClientTagFromSpecifics(specifics),
+            GetStorageKeyFromSpecifics(specifics));
+}
+
+TEST(AIChatSyncConversionsTest, StorageKeyAndClientTagForEntry) {
+  sync_pb::AIChatConversationSpecifics specifics;
+  specifics.mutable_entry()->set_uuid("entry-1");
+
+  EXPECT_EQ(GetStorageKeyFromSpecifics(specifics), "e:entry-1");
+  EXPECT_EQ(GetClientTagFromSpecifics(specifics),
+            GetStorageKeyFromSpecifics(specifics));
+}
+
+TEST(AIChatSyncConversionsTest, StorageKeyEmptyForUnsetKind) {
+  sync_pb::AIChatConversationSpecifics specifics;
+  EXPECT_TRUE(GetStorageKeyFromSpecifics(specifics).empty());
+}
+
+TEST(AIChatSyncConversionsTest, GetStorageKeyFromEntitySpecifics) {
+  sync_pb::AIChatConversationSpecifics specifics;
+  specifics.mutable_entry()->set_uuid("entry-1");
+
+  sync_pb::EntitySpecifics entity_specifics;
+  *entity_specifics.mutable_ai_chat_conversation() = specifics;
+
+  EXPECT_EQ(GetStorageKeyFromEntitySpecifics(entity_specifics), "e:entry-1");
+}
+
+TEST(AIChatSyncConversionsTest, EntryToSpecificsWebSourcesEvent) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-web";
+  entry->created_time = base::Time::Now();
+  entry->character_type = mojom::CharacterType::ASSISTANT;
+  entry->action_type = mojom::ActionType::RESPONSE;
+
+  auto source = mojom::WebSource::New();
+  source->title = "Paris";
+  source->url = GURL("https://en.wikipedia.org/wiki/Paris");
+  source->favicon_url = GURL("https://en.wikipedia.org/favicon.ico");
+  source->page_content = "Paris is the capital of France.";
+  source->extra_snippets = std::vector<std::string>{"Snippet A", "Snippet B"};
+  auto sources_event = mojom::WebSourcesEvent::New();
+  sources_event->sources.push_back(std::move(source));
+  std::vector<mojom::ConversationEntryEventPtr> events;
+  events.push_back(
+      mojom::ConversationEntryEvent::NewSourcesEvent(std::move(sources_event)));
+  entry->events = std::move(events);
+
+  auto specifics = EntryToSpecifics("conv-1", *entry, {});
+  ASSERT_TRUE(specifics.has_entry());
+  ASSERT_EQ(specifics.entry().events_size(), 1);
+  const auto& event = specifics.entry().events(0);
+  ASSERT_TRUE(event.has_web_sources());
+  ASSERT_EQ(event.web_sources().sources_size(), 1);
+  EXPECT_EQ(event.web_sources().sources(0).title(), "Paris");
+  EXPECT_EQ(event.web_sources().sources(0).url(),
+            "https://en.wikipedia.org/wiki/Paris");
+  EXPECT_EQ(event.web_sources().sources(0).favicon_url(),
+            "https://en.wikipedia.org/favicon.ico");
+  EXPECT_EQ(
+      ReadCompressibleString(event.web_sources().sources(0).page_content()),
+      "Paris is the capital of France.");
+  EXPECT_EQ(event.web_sources().sources(0).extra_snippets_size(), 2);
+}
+
+TEST(AIChatSyncConversionsTest, EntryToSpecificsToolUseEvent) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-tool";
+  entry->created_time = base::Time::Now();
+  entry->character_type = mojom::CharacterType::ASSISTANT;
+  entry->action_type = mojom::ActionType::RESPONSE;
+
+  auto tool_use = mojom::ToolUseEvent::New();
+  tool_use->tool_name = "search";
+  tool_use->id = "tool-1";
+  tool_use->arguments_json = "{\"q\":\"test\"}";
+  tool_use->is_server_result = true;
+  std::vector<mojom::ContentBlockPtr> output;
+  auto text = mojom::TextContentBlock::New();
+  text->text = "result";
+  output.push_back(mojom::ContentBlock::NewTextContentBlock(std::move(text)));
+  tool_use->output = std::move(output);
+  std::vector<mojom::ConversationEntryEventPtr> events;
+  events.push_back(
+      mojom::ConversationEntryEvent::NewToolUseEvent(std::move(tool_use)));
+  entry->events = std::move(events);
+
+  auto specifics = EntryToSpecifics("conv-1", *entry, {});
+  ASSERT_TRUE(specifics.has_entry());
+  ASSERT_EQ(specifics.entry().events_size(), 1);
+  const auto& event = specifics.entry().events(0);
+  ASSERT_TRUE(event.has_tool_use());
+  EXPECT_EQ(event.tool_use().tool_name(), "search");
+  EXPECT_EQ(event.tool_use().id(), "tool-1");
+  EXPECT_TRUE(event.tool_use().is_server_result());
+  EXPECT_EQ(ReadCompressibleString(event.tool_use().arguments_json()),
+            "{\"q\":\"test\"}");
+  ASSERT_EQ(event.tool_use().output_size(), 1);
+  ASSERT_TRUE(event.tool_use().output(0).has_text_content_block());
+  EXPECT_EQ(ReadCompressibleString(
+                event.tool_use().output(0).text_content_block().text()),
+            "result");
+}
+
+TEST(AIChatSyncConversionsTest, EntryToSpecificsUploadedFiles) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-files";
+  entry->created_time = base::Time::Now();
+  entry->character_type = mojom::CharacterType::HUMAN;
+  entry->action_type = mojom::ActionType::QUERY;
+
+  std::vector<mojom::UploadedFilePtr> files;
+  auto img = mojom::UploadedFile::New();
+  img->filename = "cat.jpg";
+  img->filesize = 5;
+  img->type = mojom::UploadedFileType::kImage;
+  img->data = {0x89, 0x50, 0x4e, 0x47, 0x0a};
+  files.push_back(std::move(img));
+  auto pdf = mojom::UploadedFile::New();
+  pdf->filename = "spec.pdf";
+  pdf->filesize = 0;
+  pdf->type = mojom::UploadedFileType::kPdf;
+  pdf->extracted_text = std::string(2048, 'x');  // Triggers gzip.
+  files.push_back(std::move(pdf));
+  entry->uploaded_files = std::move(files);
+
+  auto specifics = EntryToSpecifics("conv-1", *entry, {});
+  ASSERT_TRUE(specifics.has_entry());
+  ASSERT_EQ(specifics.entry().uploaded_files_size(), 2);
+  EXPECT_EQ(specifics.entry().uploaded_files(0).filename(), "cat.jpg");
+  EXPECT_EQ(specifics.entry().uploaded_files(0).data().size(), 5u);
+  EXPECT_FALSE(specifics.entry().uploaded_files(0).data_truncated_for_sync());
+  EXPECT_TRUE(
+      specifics.entry().uploaded_files(1).extracted_text().has_gzipped());
+}
+
+}  // namespace ai_chat

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions_unittest.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions_unittest.cc
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "base/hash/hash.h"
 #include "base/time/time.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
@@ -36,7 +37,7 @@ TEST(AIChatSyncConversionsTest, WriteCompressibleStringShortStaysRaw) {
   EXPECT_TRUE(out.has_raw());
   EXPECT_FALSE(out.has_gzipped());
   EXPECT_EQ(out.raw(), "hello");
-  EXPECT_FALSE(out.was_truncated_for_sync());
+  EXPECT_FALSE(out.has_omitted_content_hash());
 }
 
 TEST(AIChatSyncConversionsTest, WriteCompressibleStringBelowThresholdStaysRaw) {
@@ -58,13 +59,27 @@ TEST(AIChatSyncConversionsTest, WriteCompressibleStringLongGetsGzipped) {
   EXPECT_LT(out.gzipped().size(), value.size());
 }
 
-TEST(AIChatSyncConversionsTest, MarkCompressibleStringTruncatedSetsSentinel) {
+TEST(AIChatSyncConversionsTest, OmitCompressibleStringStoresContentHash) {
   sync_pb::AIChatCompressibleString out;
   WriteCompressibleString("some value", &out);
-  MarkCompressibleStringTruncated(&out);
-  EXPECT_TRUE(out.was_truncated_for_sync());
+  OmitCompressibleString(&out);
+  EXPECT_TRUE(out.has_omitted_content_hash());
   EXPECT_FALSE(out.has_raw());
   EXPECT_FALSE(out.has_gzipped());
+  // The hash is over the original plaintext so a receiver can match it against
+  // a local copy.
+  EXPECT_EQ(out.omitted_content_hash(), base::PersistentHash("some value"));
+}
+
+TEST(AIChatSyncConversionsTest, OmitCompressibleStringHashesGzippedPlaintext) {
+  // Omitting a value that was stored gzipped must hash the decompressed
+  // plaintext, not the gzip bytes, so it matches the receiver's local copy.
+  const std::string value = CompressibleString();
+  sync_pb::AIChatCompressibleString out;
+  WriteCompressibleString(value, &out);
+  ASSERT_TRUE(out.has_gzipped());
+  OmitCompressibleString(&out);
+  EXPECT_EQ(out.omitted_content_hash(), base::PersistentHash(value));
 }
 
 TEST(AIChatSyncConversionsTest, ReadCompressibleStringRawRoundTrip) {
@@ -91,9 +106,10 @@ TEST(AIChatSyncConversionsTest, ReadCompressibleStringGzippedRoundTrip) {
   EXPECT_EQ(ReadCompressibleString(wire), value);
 }
 
-TEST(AIChatSyncConversionsTest, ReadCompressibleStringTruncatedReturnsNullopt) {
+TEST(AIChatSyncConversionsTest, ReadCompressibleStringOmittedReturnsNullopt) {
   sync_pb::AIChatCompressibleString in;
-  MarkCompressibleStringTruncated(&in);
+  WriteCompressibleString("some value", &in);
+  OmitCompressibleString(&in);
   EXPECT_EQ(ReadCompressibleString(in), std::nullopt);
 }
 
@@ -497,9 +513,43 @@ TEST(AIChatSyncConversionsTest, EntryToSpecificsUploadedFiles) {
   ASSERT_EQ(specifics.entry().uploaded_files_size(), 2);
   EXPECT_EQ(specifics.entry().uploaded_files(0).filename(), "cat.jpg");
   EXPECT_EQ(specifics.entry().uploaded_files(0).data().size(), 5u);
-  EXPECT_FALSE(specifics.entry().uploaded_files(0).data_truncated_for_sync());
+  EXPECT_TRUE(specifics.entry().uploaded_files(0).has_data());
+  EXPECT_FALSE(specifics.entry().uploaded_files(0).has_omitted_data_hash());
   EXPECT_TRUE(
       specifics.entry().uploaded_files(1).extracted_text().has_gzipped());
+}
+
+TEST(AIChatSyncConversionsTest,
+     EntryToSpecificsWritesSkillAndNearVerification) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-skill";
+  entry->created_time = base::Time::Now();
+  entry->character_type = mojom::CharacterType::HUMAN;
+  entry->action_type = mojom::ActionType::QUERY;
+  entry->skill = mojom::SkillEntry::New("/summarize", "Summarize this page");
+  entry->near_verification_status = mojom::NEARVerificationStatus::New(true);
+
+  auto specifics = EntryToSpecifics("conv-1", *entry, {});
+  ASSERT_TRUE(specifics.has_entry());
+  const auto& proto = specifics.entry();
+  ASSERT_TRUE(proto.has_skill());
+  EXPECT_EQ(proto.skill().shortcut(), "/summarize");
+  EXPECT_EQ(proto.skill().prompt(), "Summarize this page");
+  ASSERT_TRUE(proto.has_near_verification_status());
+  EXPECT_TRUE(proto.near_verification_status().verified());
+}
+
+TEST(AIChatSyncConversionsTest, EntryToSpecificsOmitsAbsentSkillAndNear) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-plain";
+  entry->created_time = base::Time::Now();
+  entry->character_type = mojom::CharacterType::HUMAN;
+  entry->action_type = mojom::ActionType::QUERY;
+
+  auto specifics = EntryToSpecifics("conv-1", *entry, {});
+  ASSERT_TRUE(specifics.has_entry());
+  EXPECT_FALSE(specifics.entry().has_skill());
+  EXPECT_FALSE(specifics.entry().has_near_verification_status());
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions_unittest.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions_unittest.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h"
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>
@@ -104,6 +105,28 @@ TEST(AIChatSyncConversionsTest, ReadCompressibleStringUnsetReturnsNullopt) {
 TEST(AIChatSyncConversionsTest, ReadCompressibleStringBadGzipReturnsNullopt) {
   sync_pb::AIChatCompressibleString in;
   in.set_gzipped("this is not valid gzip data");
+  EXPECT_EQ(ReadCompressibleString(in), std::nullopt);
+}
+
+TEST(AIChatSyncConversionsTest,
+     ReadCompressibleStringRejectsOversizedDecompressedSize) {
+  // A gzip stream's uncompressed-size trailer (ISIZE, the last 4 bytes) is
+  // attacker-controlled; a tiny blob can claim a huge size. Reading must reject
+  // a claim over kSyncCompressionMaxDecompressedBytes without decompressing.
+  sync_pb::AIChatCompressibleString in;
+  WriteCompressibleString(CompressibleString(), &in);
+  ASSERT_TRUE(in.has_gzipped());
+
+  std::string gzipped = in.gzipped();
+  ASSERT_GE(gzipped.size(), 4u);
+  const uint32_t forged_size =
+      static_cast<uint32_t>(kSyncCompressionMaxDecompressedBytes + 1);
+  gzipped[gzipped.size() - 4] = static_cast<char>(forged_size & 0xFF);
+  gzipped[gzipped.size() - 3] = static_cast<char>((forged_size >> 8) & 0xFF);
+  gzipped[gzipped.size() - 2] = static_cast<char>((forged_size >> 16) & 0xFF);
+  gzipped[gzipped.size() - 1] = static_cast<char>((forged_size >> 24) & 0xFF);
+  in.set_gzipped(gzipped);
+
   EXPECT_EQ(ReadCompressibleString(in), std::nullopt);
 }
 
@@ -359,11 +382,6 @@ TEST(AIChatSyncConversionsTest, StorageKeyAndClientTagForEntry) {
   EXPECT_EQ(GetStorageKeyFromSpecifics(specifics), "e:entry-1");
   EXPECT_EQ(GetClientTagFromSpecifics(specifics),
             GetStorageKeyFromSpecifics(specifics));
-}
-
-TEST(AIChatSyncConversionsTest, StorageKeyEmptyForUnsetKind) {
-  sync_pb::AIChatConversationSpecifics specifics;
-  EXPECT_TRUE(GetStorageKeyFromSpecifics(specifics).empty());
 }
 
 TEST(AIChatSyncConversionsTest, GetStorageKeyFromEntitySpecifics) {

--- a/components/sync/protocol/ai_chat_specifics.proto
+++ b/components/sync/protocol/ai_chat_specifics.proto
@@ -63,8 +63,6 @@ message AIChatConversationSpecifics {
     optional string model_key = 3;
     optional uint64 total_tokens = 4;
     optional uint64 trimmed_tokens = 5;
-    optional int64 created_time_unix_epoch_micros = 6;
-    optional int64 last_modified_time_unix_epoch_micros = 7;
   }
 
   // A single conversation turn (human or assistant message), with the
@@ -137,16 +135,6 @@ message AIChatUploadedFile {
   optional AIChatCompressibleString extracted_text = 6;
 }
 
-// Permission challenge attached to a tool use event. Set by the server
-// (alignment check) or by the client tool to block execution until the
-// user approves.
-message AIChatPermissionChallenge {
-  // Server alignment reasoning (when the server blocks the tool).
-  optional string assessment = 1;
-  // Tool's explanation for why it needs permission.
-  optional string plan = 2;
-}
-
 // An event within a conversation entry.
 message AIChatEntryEventProto {
   optional int32 event_order = 1;
@@ -194,7 +182,6 @@ message AIChatToolUseEvent {
   repeated AIChatContentBlock output = 4;
   optional bool is_server_result = 5;
   repeated AIChatToolArtifact artifacts = 6;
-  optional AIChatPermissionChallenge permission_challenge = 7;
 }
 
 // A persisted tool output content block. Mirrors the subset of

--- a/components/sync/protocol/ai_chat_specifics.proto
+++ b/components/sync/protocol/ai_chat_specifics.proto
@@ -12,9 +12,10 @@
 //
 // Large text fields are wrapped in AIChatCompressibleString so the sender
 // can optionally gzip them, and fields that cannot be inlined within the
-// per-record budget are dropped with a `was_truncated_for_sync` sentinel
-// so the receiver knows to preserve any existing local value instead of
-// overwriting it with an empty one.
+// per-record budget are omitted entirely — replaced by a content hash of the
+// original value — so the receiver can restore the value from a local copy
+// whose content hashes identically instead of overwriting it with an empty
+// one.
 
 syntax = "proto2";
 
@@ -28,20 +29,25 @@ package sync_pb;
 // A string-valued field that may be gzipped when long and may be omitted
 // when it would not fit in the per-record budget.
 //
-// On write the sender picks `raw` for short values, `gzipped` for long
-// ones, and sets `was_truncated_for_sync = true` (with no value bytes)
-// when the field had to be dropped to fit the record under the size cap.
+// Exactly one arm is set. On write the sender picks `raw` for short values,
+// `gzipped` for long ones, and `omitted_content_hash` when the field had to
+// be dropped to fit the record under the size cap.
 //
-// On read, the receiver MUST treat `was_truncated_for_sync = true` as
-// "preserve any existing local value for this field" rather than as an
-// empty string.
+// On read, the receiver MUST treat a set `omitted_content_hash` as "the value
+// was omitted; restore it from a local copy whose content hashes to this
+// value, or preserve any existing local value" rather than as an empty
+// string.
 message AIChatCompressibleString {
   oneof value {
     string raw = 1;
     // RFC 1952 gzip of the UTF-8 string bytes.
     bytes gzipped = 2;
+    // base::PersistentHash of the original UTF-8 string bytes. Present only
+    // when the value was omitted to keep the record under the size budget;
+    // lets the receiver restore the value from a local string with identical
+    // content.
+    fixed32 omitted_content_hash = 3;
   }
-  optional bool was_truncated_for_sync = 3;
 }
 
 // One sync entity is either a Conversation metadata record or a single
@@ -91,12 +97,32 @@ message AIChatConversationSpecifics {
     repeated AIChatEntryEventProto events = 11;
     repeated AIChatAssociatedContentProto associated_content = 12;
     repeated AIChatUploadedFile uploaded_files = 13;
+
+    // The skill (shortcut + prompt) this turn was invoked with, if any.
+    optional AIChatSkillEntry skill = 14;
+    // NEAR AI TEE attestation status for this turn. Absent when the turn has
+    // no attestation.
+    optional AIChatNEARVerificationStatus near_verification_status = 15;
   }
 
   oneof kind {
     Conversation conversation = 1;
     Entry entry = 2;
   }
+}
+
+// A skill (a saved shortcut + prompt) that a conversation turn was invoked
+// with. Mirrors mojom::SkillEntry.
+message AIChatSkillEntry {
+  optional string shortcut = 1;
+  optional string prompt = 2;
+}
+
+// NEAR AI TEE attestation status for a conversation turn. Mirrors
+// mojom::NEARVerificationStatus; the message being present means the turn
+// carries an attestation.
+message AIChatNEARVerificationStatus {
+  optional bool verified = 1;
 }
 
 // Content associated with a conversation entry (e.g. a web page). The
@@ -115,23 +141,26 @@ message AIChatAssociatedContentProto {
 
 // A file uploaded by the user to the conversation entry.
 //
-// File rows are matched between devices by ordinal position within the
-// entry (matching the local |file_order| primary key). Raw bytes go in
-// |data|; when the file is too large to fit within the per-record budget,
-// |data| is omitted and |data_truncated_for_sync| is set so the receiver
-// preserves any existing local bytes.
+// Raw bytes go in |data|; when the file is too large to fit within the
+// per-record budget, |data| is omitted and |omitted_data_hash| carries a
+// hash of the bytes so the receiver can restore them from a local copy with
+// identical content.
 message AIChatUploadedFile {
   optional string filename = 1;
   // Original file size in bytes (independent of whether |data| was synced).
   optional uint32 filesize = 2;
   // mojom::UploadedFileType
   optional int32 type = 3;
-  // Raw file bytes. May be absent when the bytes would not fit in the
-  // per-record budget; in that case |data_truncated_for_sync| is true.
-  optional bytes data = 4;
-  optional bool data_truncated_for_sync = 5;
+  // Raw file bytes. When the bytes would not fit in the per-record budget they
+  // are omitted and |omitted_data_hash| carries a base::PersistentHash of the
+  // bytes so the receiver can restore them from a local copy with identical
+  // content.
+  oneof data_or_hash {
+    bytes data = 4;
+    fixed32 omitted_data_hash = 5;
+  }
   // Text extracted from the file (for PDFs/text files). May be gzipped or
-  // truncated; see AIChatCompressibleString semantics.
+  // omitted; see AIChatCompressibleString semantics.
   optional AIChatCompressibleString extracted_text = 6;
 }
 


### PR DESCRIPTION
Serializes AI Chat mojom types to the `AIChatConversationSpecifics` sync
proto: conversation metadata and complete conversation entries, plus the
`AIChatCompressibleString` codec and storage-key/client-tag helpers.

- `ConversationMetadataToSpecifics` / `EntryToSpecifics` serialize every entry
  field and event variant (completion, search queries, web sources, inline
  search, tool use) and uploaded files.
- `WriteCompressibleString` gzips large fields above
  `kSyncCompressionThresholdBytes`; `ReadCompressibleString` /
  `MarkCompressibleStringTruncated` round out the codec.
- `CreateEntityDataFromSpecifics` + storage/client tag helpers.
- Unit tests for the codec, field/event serialization, content filtering,
  and key derivation.

Spec:
- https://github.com/brave/brave-core/blob/aichat-sync-flow/docs/aichat-sync.md

Based on:
- https://github.com/brave/brave-core/pull/35028
- https://github.com/brave/brave-core/pull/35242
- https://github.com/brave/brave-core/pull/37537
- https://github.com/brave/go-sync/pull/427 (server)

Series:
- https://github.com/brave/brave-browser/issues/53978
