### PR TITLE
Fix Playlist streaming fallback webview regression

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCacheLoader.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCacheLoader.swift
@@ -41,14 +41,15 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
       initialConfiguration = WKWebViewConfiguration().then {
         $0.preferences = WKPreferences()
         $0.preferences.javaScriptCanOpenWindowsAutomatically = false
-        $0.websiteDataStore = .nonPersistent()
         $0.allowsInlineMediaPlayback = true
         $0.ignoresViewportScaleLimits = true
       }
     }
+    // Use the user's regular profile so pageSrc re-resolution sees login or consent cookies
+    // Note that this load is visible to the site as a visit.
     let tab = TabStateFactory.create(
       with: .init(
-        profile: profile.offTheRecordProfile,
+        profile: profile,
         initialConfiguration: initialConfiguration
       )
     )

--- a/ios/brave-ios/Sources/Playlist/PlaylistMediaStreamer.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistMediaStreamer.swift
@@ -108,7 +108,7 @@ public class PlaylistMediaStreamer {
         throw PlaybackError.cannotLoadMedia
       }
 
-      var newItem = await webLoader.load(url: url)
+      let newItem = await webLoader.load(url: url)
       webLoader.removeFromSuperview()
       self.webLoader = nil
 
@@ -143,14 +143,17 @@ public class PlaylistMediaStreamer {
     }
   }
 
-  // Would be nice if AVPlayer could detect the mime-type from the URL for my delegate without a head request..
-  // This function only exists because I can't figure out why videos from URLs don't play unless I explicitly specify a mime-type..
+  // Probes whether `url` can be streamed directly. The mime check is an inexpensive reachability
+  // gate; `loadAssetPlayability` is the authoritative check, since a HEAD/mime success can
+  // still occur on expired or bad/poisoned URLs (e.g. an HTML consent page) AVPlayer can't play.
+  // `defaultOptions` sends the same User-Agent as real playback (some hosts gate on it).
   private func canStreamURL(_ url: URL) async -> Bool {
     guard let mimeType = await PlaylistMediaStreamer.getMimeType(url), !mimeType.isEmpty else {
       return false
     }
 
-    return true
+    let asset = AVURLAsset(url: url, options: AVAsset.defaultOptions)
+    return await PlaylistMediaStreamer.loadAssetPlayability(asset: asset)
   }
 
   // MARK: - Static


### PR DESCRIPTION
Fixes a regression where Playlist items fail to play with an error message ("Sorry" / "Cannot load media"). Streaming items don't need to be cached (they re-resolve their media URL on playback), and that fallback path broke.

Resolves https://github.com/brave/brave-browser/issues/56709

**Root cause:** #34197 (first shipped in **v1.90.2**, Mar 2026) migrated `LivePlaylistWebLoader`, the hidden webview that re-resolves a saved item's `pageSrc` when its stored `src` URL has expired, to an **off-the-record profile** with a **non-persistent** data store. Without the user's session cookies, many sites resolve to a degraded/expired stream URL or fail detection entirely, so `streamingFallback()` returns nothing and the player surfaces a playback error. 1.88.x is unaffected.

## Changes
- **`PlaylistCacheLoader.swift`**: Construct the fallback web loader tab with the user's regular `profile` instead of `profile.offTheRecordProfile`, and drop the forced `.nonPersistent()` data store. This lets `pageSrc` re-resolution use real login state or consented state to get at a right URL from the site.
- **`PlaylistMediaStreamer.swift`**: Before skipping fallback when `canStreamURL` (a HEAD check) succeeds, verify `AVPlayer` can actually play the URL via `loadAssetPlayability`. A HEAD can succeed on an expired signed URL that AVPlayer can't play; this routes those cases to the webview re-resolution instead of handing the player a dead URL. The probe asset uses `AVAsset.defaultOptions` so it sends the same User-Agent as real playback (consistent with every other playlist asset construction).
## Privacy note for reviewers
The fallback loader now loads `pageSrc` using the user's real cookies, so the content site can log it as a page visit. The prior off-the-record tab isolated this load. This is the intended trade-off to restore authenticated stream resolution.
## Test plan
- [ ] Save a streaming item to Playlist, and confirm playback streaming.
- [ ] Verify playback from CarPlay.
- [ ] Connect to YouTube from an EU nation. Play an item saved in the Playlist. Confirm that it plays.
- [ ] Connect to Youtube from an EU nation. Add an item to the playlist, open playlist and play the item. Confirm that it plays.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
