### PR TITLE
[Android] Fix Brave icon on NTPs in tab switcher

### DIFF
--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -774,6 +774,14 @@
     *** getIconDrawableWithFilter(...);
 }
 
+-keep class org.chromium.chrome.browser.tab_ui.TabListFaviconProvider {
+    public <init>(...);
+}
+
+-keep class org.chromium.chrome.browser.ui.favicon.BraveTabListFaviconProvider {
+    public <init>(...);
+}
+
 -keep class org.chromium.chrome.browser.document.ChromeLauncherActivity {
     public <init>(...);
 }

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -130,6 +130,7 @@ import org.chromium.chrome.browser.suggestions.tile.TileRenderer;
 import org.chromium.chrome.browser.tab.Tab;
 import org.chromium.chrome.browser.tab.TabObscuringHandler;
 import org.chromium.chrome.browser.tab_ui.TabContentManager;
+import org.chromium.chrome.browser.tab_ui.TabListFaviconProvider;
 import org.chromium.chrome.browser.tabmodel.AsyncTabParamsManager;
 import org.chromium.chrome.browser.tabmodel.IncognitoStateProvider;
 import org.chromium.chrome.browser.tabmodel.TabCreator;
@@ -402,6 +403,9 @@ public class BytecodeTest {
         Assert.assertTrue(classExists("org/chromium/components/cached_flags/CachedFlagUtils"));
         Assert.assertTrue(classExists("org/chromium/chrome/browser/logo/LogoMediator"));
         Assert.assertTrue(classExists("org/chromium/chrome/browser/ui/favicon/FaviconUtils"));
+        Assert.assertTrue(classExists("org/chromium/chrome/browser/tab_ui/TabListFaviconProvider"));
+        Assert.assertTrue(
+                classExists("org/chromium/chrome/browser/ui/favicon/BraveTabListFaviconProvider"));
         Assert.assertTrue(
                 classExists("org/chromium/chrome/browser/tracing/settings/DeveloperSettings"));
         Assert.assertTrue(
@@ -1935,6 +1939,14 @@ public class BytecodeTest {
                         Callback.class,
                         LogoCoordinator.VisibilityObserver.class,
                         Drawable.class));
+        Assert.assertTrue(
+                constructorsMatch(
+                        "org/chromium/chrome/browser/tab_ui/TabListFaviconProvider",
+                        "org/chromium/chrome/browser/ui/favicon/BraveTabListFaviconProvider",
+                        Context.class,
+                        boolean.class,
+                        int.class,
+                        TabListFaviconProvider.TabWebContentsFaviconDelegate.class));
         Assert.assertTrue(
                 constructorsMatch(
                         "org/chromium/chrome/browser/notifications/permissions/NotificationPermissionRationaleDialogController", // presubmit: ignore-long-line

--- a/android/nala/icons.gni
+++ b/android/nala/icons.gni
@@ -152,6 +152,8 @@ nala_icons = [
   "ic_search.xml",
   "ic_shred_data.xml",
   "ic_shield_done.xml",
+  "ic_social_brave_carved_favicon_fullheight.xml",
+  "ic_social_brave_outline_favicon_fullheight.xml",
   "ic_social_brave_release_favicon_fullheight_color.xml",
   "ic_trash.xml",
   "ic_tune.xml",

--- a/browser/ui/android/favicon/BUILD.gn
+++ b/browser/ui/android/favicon/BUILD.gn
@@ -8,13 +8,43 @@ import("//build/config/android/rules.gni")
 android_library("java") {
   sources = [
     "java/src/org/chromium/chrome/browser/ui/favicon/BraveFaviconUtils.java",
+    "java/src/org/chromium/chrome/browser/ui/favicon/BraveTabListFaviconProvider.java",
   ]
 
   deps = [
+    ":java_resources",
     "//base:base_java",
     "//build/android:build_java",
+    "//chrome/browser/tab_ui/android:java",
     "//chrome/browser/ui/android/favicon:java",
     "//components/browser_ui/widget/android:java",
+    "//third_party/androidx:androidx_annotation_annotation_java",
+    "//third_party/androidx:androidx_appcompat_appcompat_resources_java",
+    "//ui/android:ui_java",
     "//url:gurl_java",
+  ]
+
+  resources_package = "org.chromium.chrome.browser.ui.favicon.brave"
+}
+
+android_resources("java_resources") {
+  deps = [ "//brave/android/nala:java_resources" ]
+}
+
+robolectric_library("junit") {
+  testonly = true
+  resources_package = "org.chromium.chrome.browser.ui.favicon.brave"
+
+  sources = [ "junit/src/org/chromium/chrome/browser/ui/favicon/BraveTabListFaviconProviderTest.java" ]
+
+  deps = [
+    ":java",
+    ":java_resources",
+    "//base:base_junit_test_support",
+    "//chrome/android/junit:chrome_junit_tests_helper",
+    "//chrome/browser/tab_ui/android:java",
+    "//chrome/browser/tab_ui/android:java_resources",
+    "//third_party/junit",
+    "//ui/android:ui_java",
   ]
 }

--- a/browser/ui/android/favicon/java/src/org/chromium/chrome/browser/ui/favicon/BraveTabListFaviconProvider.java
+++ b/browser/ui/android/favicon/java/src/org/chromium/chrome/browser/ui/favicon/BraveTabListFaviconProvider.java
@@ -1,0 +1,134 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.ui.favicon;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+
+import androidx.annotation.ColorInt;
+import androidx.appcompat.content.res.AppCompatResources;
+
+import org.chromium.build.annotations.NullMarked;
+import org.chromium.build.annotations.Nullable;
+import org.chromium.chrome.browser.tab_ui.TabCardThemeUtil;
+import org.chromium.chrome.browser.tab_ui.TabListFaviconProvider;
+import org.chromium.chrome.browser.tab_ui.TabListFaviconProvider.TabFavicon;
+import org.chromium.chrome.browser.tab_ui.TabListFaviconProvider.TabWebContentsFaviconDelegate;
+import org.chromium.chrome.browser.ui.favicon.brave.R;
+import org.chromium.ui.util.ColorUtils;
+
+import java.util.Objects;
+
+/** Provides Brave favicon variants for Chromium tab-list UI. */
+@NullMarked
+public class BraveTabListFaviconProvider extends TabListFaviconProvider {
+    private final Context mContext;
+    private final boolean mIsTabStrip;
+    private final int mDefaultFaviconSize;
+
+    public BraveTabListFaviconProvider(
+            Context context,
+            boolean isTabStrip,
+            int faviconCornerRadiusId,
+            @Nullable TabWebContentsFaviconDelegate tabWebContentsFaviconDelegate) {
+        super(context, isTabStrip, faviconCornerRadiusId, tabWebContentsFaviconDelegate);
+        mContext = context;
+        mIsTabStrip = isTabStrip;
+        mDefaultFaviconSize =
+                context.getResources()
+                        .getDimensionPixelSize(
+                                org.chromium.chrome.browser.tab_ui.R.dimen.tab_grid_favicon_size);
+    }
+
+    @Override
+    public TabFavicon getRoundedChromeFavicon(boolean isIncognito) {
+        if (mIsTabStrip) {
+            return super.getRoundedChromeFavicon(isIncognito);
+        }
+
+        int drawableId = getBraveNtpFaviconDrawableId();
+        @Nullable Drawable braveNtpSourceDrawable =
+                AppCompatResources.getDrawable(mContext, drawableId);
+        if (braveNtpSourceDrawable == null) {
+            return super.getRoundedChromeFavicon(isIncognito);
+        }
+
+        Bitmap braveNtpBitmap =
+                getResizedBitmapFromDrawable(braveNtpSourceDrawable, mDefaultFaviconSize);
+        @ColorInt
+        int defaultIconColor =
+                TabCardThemeUtil.getChromeOwnedFaviconTintColor(
+                        mContext, isIncognito, /* isSelected= */ false);
+        @ColorInt
+        int selectedIconColor =
+                TabCardThemeUtil.getChromeOwnedFaviconTintColor(
+                        mContext, isIncognito, /* isSelected= */ true);
+
+        return new BraveNtpTabFavicon(
+                createTintedDrawable(braveNtpBitmap, defaultIconColor),
+                createTintedDrawable(braveNtpBitmap, selectedIconColor),
+                drawableId,
+                defaultIconColor,
+                selectedIconColor);
+    }
+
+    private int getBraveNtpFaviconDrawableId() {
+        if (ColorUtils.inNightMode(mContext)) {
+            return R.drawable.ic_social_brave_carved_favicon_fullheight;
+        }
+        return R.drawable.ic_social_brave_outline_favicon_fullheight;
+    }
+
+    private Drawable createTintedDrawable(Bitmap bitmap, @ColorInt int color) {
+        Drawable drawable = new BitmapDrawable(mContext.getResources(), bitmap);
+        drawable.setColorFilter(new PorterDuffColorFilter(color, PorterDuff.Mode.SRC_IN));
+        return drawable;
+    }
+
+    private static Bitmap getResizedBitmapFromDrawable(Drawable drawable, int size) {
+        Bitmap bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        drawable.setBounds(0, 0, size, size);
+        drawable.draw(canvas);
+        return bitmap;
+    }
+
+    private static final class BraveNtpTabFavicon extends TabFavicon {
+        private final int mDrawableId;
+        private final @ColorInt int mDefaultIconColor;
+        private final @ColorInt int mSelectedIconColor;
+
+        BraveNtpTabFavicon(
+                Drawable defaultDrawable,
+                Drawable selectedDrawable,
+                int drawableId,
+                @ColorInt int defaultIconColor,
+                @ColorInt int selectedIconColor) {
+            super(defaultDrawable, selectedDrawable, true);
+            mDrawableId = drawableId;
+            mDefaultIconColor = defaultIconColor;
+            mSelectedIconColor = selectedIconColor;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getClass(), mDrawableId, mDefaultIconColor, mSelectedIconColor);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+            return obj instanceof BraveNtpTabFavicon other
+                    && mDrawableId == other.mDrawableId
+                    && mDefaultIconColor == other.mDefaultIconColor
+                    && mSelectedIconColor == other.mSelectedIconColor;
+        }
+    }
+}

--- a/browser/ui/android/favicon/junit/src/org/chromium/chrome/browser/ui/favicon/BraveTabListFaviconProviderTest.java
+++ b/browser/ui/android/favicon/junit/src/org/chromium/chrome/browser/ui/favicon/BraveTabListFaviconProviderTest.java
@@ -1,0 +1,120 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.ui.favicon;
+
+import android.app.Activity;
+import android.graphics.drawable.Drawable;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.annotation.Config;
+
+import org.chromium.base.test.BaseRobolectricTestRunner;
+import org.chromium.chrome.browser.tab_ui.TabListFaviconProvider.ResourceTabFavicon;
+import org.chromium.chrome.browser.tab_ui.TabListFaviconProvider.StaticTabFaviconType;
+import org.chromium.chrome.browser.tab_ui.TabListFaviconProvider.TabFavicon;
+import org.chromium.ui.util.ColorUtils;
+
+/** Unit tests for {@link BraveTabListFaviconProvider}. */
+@RunWith(BaseRobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class BraveTabListFaviconProviderTest {
+    private Activity mActivity;
+
+    @Before
+    public void setUp() {
+        mActivity = Robolectric.setupActivity(Activity.class);
+        mActivity.setTheme(org.chromium.chrome.R.style.Theme_BrowserUI_DayNight);
+        ColorUtils.setInNightModeForTesting(false);
+    }
+
+    @After
+    public void tearDown() {
+        ColorUtils.setInNightModeForTesting(null);
+    }
+
+    @Test
+    public void testGetRoundedChromeFaviconNonTabStripReturnsBraveNtpFavicon() {
+        TabFavicon favicon = createProvider(/* isTabStrip= */ false).getRoundedChromeFavicon(false);
+
+        assertBraveNtpFavicon(favicon);
+    }
+
+    @Test
+    public void testGetRoundedChromeFaviconUsesDistinctLightAndDarkBraveVariants() {
+        TabFavicon lightFavicon =
+                createProvider(/* isTabStrip= */ false).getRoundedChromeFavicon(false);
+
+        assertBraveNtpFavicon(lightFavicon);
+        Assert.assertEquals(
+                lightFavicon,
+                createProvider(/* isTabStrip= */ false).getRoundedChromeFavicon(false));
+
+        ColorUtils.setInNightModeForTesting(true);
+        TabFavicon darkFavicon =
+                createProvider(/* isTabStrip= */ false).getRoundedChromeFavicon(false);
+
+        assertBraveNtpFavicon(darkFavicon);
+        Assert.assertEquals(
+                darkFavicon,
+                createProvider(/* isTabStrip= */ false).getRoundedChromeFavicon(false));
+        Assert.assertNotEquals(lightFavicon, darkFavicon);
+    }
+
+    @Test
+    public void testGetRoundedChromeFaviconTabStripDelegatesToUpstream() {
+        TabFavicon favicon = createProvider(/* isTabStrip= */ true).getRoundedChromeFavicon(false);
+
+        Assert.assertTrue(favicon instanceof ResourceTabFavicon);
+        Assert.assertEquals(
+                new ResourceTabFavicon(
+                        favicon.getDefaultDrawable(),
+                        StaticTabFaviconType.ROUNDED_CHROME_FOR_STRIP),
+                favicon);
+    }
+
+    @Test
+    public void testBraveNtpFaviconHasUsableDefaultAndSelectedDrawablesInLightAndDarkModes() {
+        assertBraveNtpFaviconHasUsableDefaultAndSelectedDrawables(/* inNightMode= */ false);
+        assertBraveNtpFaviconHasUsableDefaultAndSelectedDrawables(/* inNightMode= */ true);
+    }
+
+    private void assertBraveNtpFaviconHasUsableDefaultAndSelectedDrawables(boolean inNightMode) {
+        ColorUtils.setInNightModeForTesting(inNightMode);
+
+        TabFavicon favicon = createProvider(/* isTabStrip= */ false).getRoundedChromeFavicon(false);
+
+        assertBraveNtpFavicon(favicon);
+        assertUsableDrawable(favicon.getDefaultDrawable());
+        assertUsableDrawable(favicon.getSelectedDrawable());
+        Assert.assertNotSame(favicon.getDefaultDrawable(), favicon.getSelectedDrawable());
+    }
+
+    private BraveTabListFaviconProvider createProvider(boolean isTabStrip) {
+        return new BraveTabListFaviconProvider(
+                mActivity,
+                isTabStrip,
+                org.chromium.chrome.R.dimen.default_favicon_corner_radius,
+                /* tabWebContentsFaviconDelegate= */ null);
+    }
+
+    private static void assertBraveNtpFavicon(TabFavicon favicon) {
+        Assert.assertFalse(favicon instanceof ResourceTabFavicon);
+        Assert.assertTrue(favicon.isRecolorAllowed());
+        Assert.assertTrue(favicon.hasSelectedState());
+        Assert.assertNotNull(favicon.getDefaultDrawable());
+        Assert.assertNotNull(favicon.getSelectedDrawable());
+    }
+
+    private static void assertUsableDrawable(Drawable drawable) {
+        Assert.assertTrue(drawable.getIntrinsicWidth() > 0);
+        Assert.assertTrue(drawable.getIntrinsicHeight() > 0);
+    }
+}

--- a/build/android/bytecode/BUILD.gn
+++ b/build/android/bytecode/BUILD.gn
@@ -144,6 +144,7 @@ java_binary("java_bytecode_rewriter") {
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabBrowserControlsConstraintsHelperClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabCollectionTabModelImplClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabGroupUiCoordinatorClassAdapter.java",
+    "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabListFaviconProviderClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabSwitcherPaneBaseClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabbedActivityClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabbedAdaptiveToolbarBehaviorClassAdapter.java",

--- a/build/android/bytecode/bytecode_rewriter.gni
+++ b/build/android/bytecode/bytecode_rewriter.gni
@@ -45,6 +45,7 @@ brave_bytecode_jars = [
   "obj/chrome/browser/settings/factory_java.javac.jar",
   "obj/chrome/browser/settings/internal_java.javac.jar",
   "obj/chrome/browser/site_settings/android/java.javac.jar",
+  "obj/chrome/browser/single_tab/android/java.javac.jar",
   "obj/chrome/browser/tabmodel/java.javac.jar",
   "obj/chrome/browser/customtabs/java.javac.jar",
   "obj/chrome/browser/tab_group_sync/java.javac.jar",

--- a/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
@@ -137,6 +137,7 @@ public class BraveClassAdapter {
         chain = new BraveStrictPreferenceKeyCheckerClassAdapter(chain);
         chain = new BraveSwipeRefreshHandlerClassAdapter(chain);
         chain = new BraveTabGroupUiCoordinatorClassAdapter(chain);
+        chain = new BraveTabListFaviconProviderClassAdapter(chain);
         chain = new BraveTabSwitcherPaneBaseClassAdapter(chain);
         chain = new BraveTabbedActivityClassAdapter(chain);
         chain = new BraveTabbedAdaptiveToolbarBehaviorClassAdapter(chain);

--- a/build/android/bytecode/java/org/brave/bytecode/BraveTabListFaviconProviderClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveTabListFaviconProviderClassAdapter.java
@@ -1,0 +1,22 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.brave.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+
+public class BraveTabListFaviconProviderClassAdapter extends BraveClassVisitor {
+    private static final String sTabListFaviconProviderClassName =
+            "org/chromium/chrome/browser/tab_ui/TabListFaviconProvider";
+    private static final String sBraveTabListFaviconProviderClassName =
+            "org/chromium/chrome/browser/ui/favicon/BraveTabListFaviconProvider";
+
+    public BraveTabListFaviconProviderClassAdapter(ClassVisitor visitor) {
+        super(visitor);
+
+        redirectConstructor(
+                sTabListFaviconProviderClassName, sBraveTabListFaviconProviderClassName);
+    }
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1752,6 +1752,7 @@ if (is_android) {
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.vpn",
       "//brave/browser/customize_menu/android:junit",
       "//brave/browser/first_run/android:junit",
+      "//brave/browser/ui/android/favicon:junit",
       "//brave/components/minidump_uploader:junit",
     ]
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56729.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->


The NTP uses different icon variants in light and dark theme as per the [ticket](https://github.com/brave/brave-browser/issues/56180):

<img width="444" height="987" alt="ntp_light_mode" src="https://github.com/user-attachments/assets/287abe42-364b-4a91-ab67-c9425d2e47c8" />
<img width="444" height="987" alt="ntp_dark_mode" src="https://github.com/user-attachments/assets/5c168a14-b6ff-4e18-88e3-0c06e016c6ed" />



Note: the initial version of this PR included changes to address behavior in two adjacent yet different features. I have split the ticket, and thus this PR, up. This PR is now focused on the NTP icon work. The media player icon change has moved resides in ticket https://github.com/brave/brave-browser/issues/56180, and PR https://github.com/brave/brave-core/pull/37587.

