### PR TITLE
Auto-replace known Web Store MV2 extensions with Brave-hosted equivalents (uplift to 1.93.x)

### DIFF
--- a/browser/extensions/manifest_v2/brave_extensions_manifest_v2_installer.cc
+++ b/browser/extensions/manifest_v2/brave_extensions_manifest_v2_installer.cc
@@ -11,6 +11,7 @@
 
 #include "base/check_is_test.h"
 #include "base/json/json_reader.h"
+#include "base/memory/ptr_util.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/strings/escape.h"
 #include "base/strings/string_util.h"
@@ -100,17 +101,48 @@ GURL GetCrxDownloadUrl(const base::DictValue& update_manifest,
 
 ExtensionManifestV2Installer::ExtensionManifestV2Installer(
     const std::string& extension_id,
+    content::BrowserContext* browser_context,
     content::WebContents* web_contents,
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     extensions::WebstoreInstallWithPrompt::Callback callback)
     : extension_id_(extension_id),
-      web_contents_(web_contents->GetWeakPtr()),
+      browser_context_(browser_context),
+      web_contents_(web_contents ? web_contents->GetWeakPtr() : nullptr),
       url_loader_factory_(std::move(url_loader_factory)),
       callback_(std::move(callback)) {
+  CHECK(browser_context_);
+  silent_ = browser_context && !web_contents;
+  if (web_contents_) {
+    CHECK_EQ(web_contents->GetBrowserContext(), browser_context_);
+  }
   CHECK(IsKnownBraveHostedExtension(extension_id));
 }
 
 ExtensionManifestV2Installer::~ExtensionManifestV2Installer() = default;
+
+// static
+std::unique_ptr<ExtensionManifestV2Installer>
+ExtensionManifestV2Installer::Create(
+    const extensions::ExtensionId& extension_id,
+    content::WebContents* web_contents,
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    extensions::WebstoreInstallWithPrompt::Callback callback) {
+  return base::WrapUnique(new ExtensionManifestV2Installer(
+      extension_id, web_contents->GetBrowserContext(), web_contents,
+      std::move(url_loader_factory), std::move(callback)));
+}
+
+// static
+std::unique_ptr<ExtensionManifestV2Installer>
+ExtensionManifestV2Installer::CreateSilent(
+    const extensions::ExtensionId& extension_id,
+    content::BrowserContext* browser_context,
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    extensions::WebstoreInstallWithPrompt::Callback callback) {
+  return base::WrapUnique(new ExtensionManifestV2Installer(
+      extension_id, browser_context, nullptr, std::move(url_loader_factory),
+      std::move(callback)));
+}
 
 void ExtensionManifestV2Installer::BeginInstall() {
   auto request = std::make_unique<network::ResourceRequest>();
@@ -196,7 +228,7 @@ void ExtensionManifestV2Installer::OnCrxDownloaded(base::FilePath path) {
         false, "Failed to download extension.",
         extensions::webstore_install::Result::OTHER_ERROR);
   }
-  if (!web_contents_) {
+  if (!web_contents_ && !silent_) {
     return std::move(callback_).Run(
         false, "Installation cancelled.",
         extensions::webstore_install::Result::USER_CANCELLED);
@@ -206,9 +238,15 @@ void ExtensionManifestV2Installer::OnCrxDownloaded(base::FilePath path) {
   crx.path = std::move(path);
   crx.required_format = crx_file::VerifierFormat::CRX3;
 
-  crx_installer_ = extensions::CrxInstaller::Create(
-      web_contents_->GetBrowserContext(),
-      std::make_unique<ExtensionInstallPrompt>(web_contents_.get()));
+  if (!silent_) {
+    crx_installer_ = extensions::CrxInstaller::Create(
+        browser_context_,
+        std::make_unique<ExtensionInstallPrompt>(web_contents_.get()));
+  } else {
+    crx_installer_ = extensions::CrxInstaller::CreateSilent(browser_context_);
+    crx_installer_->set_allow_silent_install(true);
+  }
+
   crx_installer_->set_expected_id(extension_id_);
   crx_installer_->set_is_gallery_install(true);
   crx_installer_->AddInstallerCallback(base::BindOnce(

--- a/browser/extensions/manifest_v2/brave_extensions_manifest_v2_installer.h
+++ b/browser/extensions/manifest_v2/brave_extensions_manifest_v2_installer.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 
+#include "base/memory/raw_ptr.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
 #include "chrome/browser/extensions/webstore_install_with_prompt.h"
@@ -30,28 +31,46 @@ namespace extensions_mv2 {
 
 class ExtensionManifestV2Installer {
  public:
-  ExtensionManifestV2Installer(
+  ~ExtensionManifestV2Installer();
+
+  static std::unique_ptr<ExtensionManifestV2Installer> Create(
       const extensions::ExtensionId& extension_id,
       content::WebContents* web_contents,
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
       extensions::WebstoreInstallWithPrompt::Callback callback);
-  ~ExtensionManifestV2Installer();
+
+  static std::unique_ptr<ExtensionManifestV2Installer> CreateSilent(
+      const extensions::ExtensionId& extension_id,
+      content::BrowserContext* browser_context,
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+      extensions::WebstoreInstallWithPrompt::Callback callback);
+
+  const extensions::ExtensionId& extension_id() const { return extension_id_; }
 
   void BeginInstall();
 
  private:
+  ExtensionManifestV2Installer(
+      const extensions::ExtensionId& extension_id,
+      content::BrowserContext* browser_context,
+      content::WebContents* web_contents,
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+      extensions::WebstoreInstallWithPrompt::Callback callback);
+
   void OnUpdateManifestResponse(std::optional<std::string> body);
   void DownloadCrx(const GURL& url);
   void OnCrxDownloaded(base::FilePath path);
   void OnInstalled(const std::optional<extensions::CrxInstallError>& error);
 
   const extensions::ExtensionId extension_id_;
+  raw_ptr<content::BrowserContext> browser_context_ = nullptr;
   base::WeakPtr<content::WebContents> web_contents_;
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
   extensions::WebstoreInstallWithPrompt::Callback callback_;
 
   std::unique_ptr<network::SimpleURLLoader> url_loader_;
   scoped_refptr<extensions::CrxInstaller> crx_installer_;
+  bool silent_ = false;
   base::WeakPtrFactory<ExtensionManifestV2Installer> weak_factory_{this};
 };
 

--- a/browser/extensions/manifest_v2/brave_extensions_manifest_v2_migrator.cc
+++ b/browser/extensions/manifest_v2/brave_extensions_manifest_v2_migrator.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/extensions/manifest_v2/brave_extensions_manifest_v2_migrator.h"
 
+#include <algorithm>
 #include <utility>
 
 #include "base/files/file_enumerator.h"
@@ -13,6 +14,7 @@
 #include "base/functional/callback_helpers.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
+#include "brave/browser/extensions/manifest_v2/brave_extensions_manifest_v2_installer.h"
 #include "chrome/browser/profiles/profile.h"
 #include "extensions/browser/disable_reason.h"
 #include "extensions/browser/extension_file_task_runner.h"
@@ -25,6 +27,7 @@
 #include "extensions/browser/extension_util.h"
 #include "extensions/common/constants.h"
 #include "extensions/common/extension_features.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
 
 namespace {
 
@@ -327,7 +330,34 @@ void ExtensionsManifestV2Migrator::BackupExtensionSettings(
       base::BindOnce(&BackupExtensionSettingsOnFileThread,
                      webstore_extension_id, webstore_extension_version,
                      profile_->GetPath()),
-      base::BindOnce([](const base::Version&) {}));
+      base::BindOnce(&ExtensionsManifestV2Migrator::OnBackupSettingsCompleted,
+                     weak_factory_.GetWeakPtr(), webstore_extension_id));
+}
+
+void ExtensionsManifestV2Migrator::OnBackupSettingsCompleted(
+    const extensions::ExtensionId& webstore_extension_id,
+    const base::Version& backup_version) {
+  if (!features::IsExtensionReplacementEnabled()) {
+    return;
+  }
+  const auto brave_hosted_extension_id =
+      GetBraveHostedExtensionId(webstore_extension_id);
+  if (!brave_hosted_extension_id) {
+    return;
+  }
+  auto* registry = extensions::ExtensionRegistry::Get(profile_);
+  const auto* extension =
+      registry->GetInstalledExtension(*brave_hosted_extension_id);
+  if (extension) {
+    // Already installed.
+    return;
+  }
+  auto installer = ExtensionManifestV2Installer::CreateSilent(
+      *brave_hosted_extension_id, profile_, profile_->GetURLLoaderFactory(),
+      base::BindOnce(&ExtensionsManifestV2Migrator::OnSilentInstall,
+                     weak_factory_.GetWeakPtr(), *brave_hosted_extension_id));
+  installer->BeginInstall();
+  silent_installers_.push_back(std::move(installer));
 }
 
 void ExtensionsManifestV2Migrator::OnSettingsImported(
@@ -338,6 +368,31 @@ void ExtensionsManifestV2Migrator::OnSettingsImported(
       ->RemoveDisableReasonAndMaybeEnable(
           brave_hosted_extension_id,
           extensions::disable_reason::DISABLE_RELOAD);
+}
+
+void ExtensionsManifestV2Migrator::OnSilentInstall(
+    const extensions::ExtensionId& extension_id,
+    bool success,
+    const std::string& error,
+    extensions::webstore_install::Result result) {
+  auto installer =
+      std::ranges::find_if(silent_installers_, [&extension_id](const auto& i) {
+        return i->extension_id() == extension_id;
+      });
+  if (installer != silent_installers_.end()) {
+    silent_installers_.erase(installer);
+  }
+
+  if (success) {
+    const auto webstore_extension_id =
+        GetWebStoreHostedExtensionId(extension_id);
+    if (webstore_extension_id) {
+      extensions::ExtensionRegistrar::Get(profile_)->UninstallExtension(
+          *webstore_extension_id,
+          extensions::UninstallReason::UNINSTALL_REASON_INTERNAL_MANAGEMENT,
+          nullptr);
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/browser/extensions/manifest_v2/brave_extensions_manifest_v2_migrator.h
+++ b/browser/extensions/manifest_v2/brave_extensions_manifest_v2_migrator.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "base/memory/raw_ptr.h"
 #include "base/memory/singleton.h"
@@ -21,6 +22,8 @@
 class Profile;
 
 namespace extensions_mv2 {
+
+class ExtensionManifestV2Installer;
 
 class ExtensionsManifestV2Migrator
     : public KeyedService,
@@ -52,8 +55,15 @@ class ExtensionsManifestV2Migrator
 
   void BackupExtensionSettings(
       const extensions::ExtensionId& webstore_extension_id);
+  void OnBackupSettingsCompleted(
+      const extensions::ExtensionId& webstore_extension_id,
+      const base::Version& version);
   void OnSettingsImported(
       const extensions::ExtensionId& brave_hosted_extension_id);
+  void OnSilentInstall(const extensions::ExtensionId& extension_id,
+                       bool success,
+                       const std::string& error,
+                       extensions::webstore_install::Result result);
 
   const raw_ptr<Profile> profile_ = nullptr;
   base::ScopedObservation<extensions::ExtensionPrefs,
@@ -62,6 +72,7 @@ class ExtensionsManifestV2Migrator
   base::ScopedObservation<extensions::ExtensionRegistry,
                           extensions::ExtensionRegistryObserver>
       registry_observation_{this};
+  std::vector<std::unique_ptr<ExtensionManifestV2Installer>> silent_installers_;
 
   base::WeakPtrFactory<ExtensionsManifestV2Migrator> weak_factory_{this};
 };

--- a/browser/extensions/manifest_v2/brave_extensions_manifest_v2_unittest.cc
+++ b/browser/extensions/manifest_v2/brave_extensions_manifest_v2_unittest.cc
@@ -144,12 +144,11 @@ class BraveExtensionsManifestV2SettingsBackupTest
       feature_list_.InitAndEnableFeatureWithParameters(
           extensions_mv2::features::kExtensionsManifestV2,
           {
-              {extensions_mv2::features::kExtensionsManifestV2BackupSettings
-                   .name,
+              {extensions_mv2::features::kBackupSettings.name,
                (GetParam().backup_enabled ? "true" : "false")},
-              {extensions_mv2::features::
-                   kExtensionsManifestV2BImportSettingsOnInstall.name,
+              {extensions_mv2::features::kImportSettingsOnInstall.name,
                (GetParam().import_enabled ? "true" : "false")},
+              {extensions_mv2::features::kAutoInstallBraveHosted.name, "false"},
           });
     } else {
       feature_list_.InitAndDisableFeature(

--- a/browser/ui/webui/settings/brave_extensions_manifest_v2_browsertest.cc
+++ b/browser/ui/webui/settings/brave_extensions_manifest_v2_browsertest.cc
@@ -27,6 +27,7 @@
 #include "extensions/browser/extension_system.h"
 #include "extensions/browser/extension_util.h"
 #include "extensions/browser/install_verifier.h"
+#include "extensions/common/constants.h"
 #include "extensions/common/extension.h"
 #include "extensions/common/extension_builder.h"
 #include "extensions/common/extension_features.h"
@@ -370,4 +371,43 @@ IN_PROC_BROWSER_TEST_F(BraveExtensionsManifestV2InstallerBrowserTest,
   EXPECT_TRUE(base::PathExists(extension->path()
                                    .AppendASCII("_metadata")
                                    .AppendASCII("computed_hashes.json")));
+}
+
+class BraveExtensionsManifestV2ReplaceBrowserTest
+    : public BraveExtensionsManifestV2InstallerBrowserTest {
+ public:
+  BraveExtensionsManifestV2ReplaceBrowserTest() {
+    feature_list_.InitAndEnableFeatureWithParameters(
+        extensions_mv2::features::kExtensionsManifestV2,
+        {{extensions_mv2::features::kBackupSettings.name, "true"},
+         {extensions_mv2::features::kImportSettingsOnInstall.name, "true"},
+         {extensions_mv2::features::kAutoInstallBraveHosted.name, "true"}});
+  }
+
+ private:
+  base::test::ScopedFeatureList feature_list_;
+};
+
+IN_PROC_BROWSER_TEST_F(BraveExtensionsManifestV2ReplaceBrowserTest,
+                       AutoReplaceWithBraveHosted) {
+  auto extension =
+      extensions::ExtensionBuilder("test")
+          .SetID(extensions_mv2::kWebStoreNoScriptId)
+          .AddFlags(extensions::Extension::FROM_WEBSTORE)
+          .SetLocation(extensions::mojom::ManifestLocation::kExternalPolicy)
+          .Build();
+
+  auto* registrar = extensions::ExtensionRegistrar::Get(browser()->profile());
+  registrar->AddExtension(extension);
+  extensions::ExtensionRegistry::Get(browser()->profile())
+      ->TriggerOnInstalled(extension.get(), false);
+  registrar->DisableExtension(
+      extensions_mv2::kWebStoreNoScriptId,
+      {extensions::disable_reason::DISABLE_UNSUPPORTED_MANIFEST_VERSION});
+  WaitExtensionInstalled();
+
+  auto* registry = extensions::ExtensionRegistry::Get(browser()->profile());
+  EXPECT_FALSE(
+      registry->GetInstalledExtension(extensions_mv2::kWebStoreNoScriptId));
+  EXPECT_TRUE(registry->GetInstalledExtension(extensions_mv2::kNoScriptId));
 }

--- a/browser/ui/webui/settings/brave_extensions_manifest_v2_handler.cc
+++ b/browser/ui/webui/settings/brave_extensions_manifest_v2_handler.cc
@@ -24,9 +24,6 @@
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "ui/base/l10n/l10n_util.h"
 
-BASE_FEATURE(kExtensionsManifestV2,
-             base::FEATURE_DISABLED_BY_DEFAULT);
-
 struct ExtensionManifestV2 {
   std::string id;
   std::string sources;
@@ -188,8 +185,7 @@ void BraveExtensionsManifestV2Handler::EnableExtensionManifestV2(
         ResolveJavascriptCallback(args[0], base::Value(false));
         return;
       }
-      installer_ = std::make_unique<
-          extensions_mv2::ExtensionManifestV2Installer>(
+      installer_ = extensions_mv2::ExtensionManifestV2Installer::Create(
           id, web_ui()->GetWebContents(), profile->GetURLLoaderFactory(),
           base::BindOnce(
               &BraveExtensionsManifestV2Handler::OnExtensionManifestV2Installed,

--- a/browser/ui/webui/settings/brave_extensions_manifest_v2_handler.h
+++ b/browser/ui/webui/settings/brave_extensions_manifest_v2_handler.h
@@ -18,8 +18,6 @@
 #include "extensions/browser/extension_registry_observer.h"
 #include "extensions/browser/webstore_install_result.h"
 
-BASE_DECLARE_FEATURE(kExtensionsManifestV2);
-
 namespace extensions_mv2 {
 class ExtensionManifestV2Installer;
 }

--- a/chromium_src/chrome/browser/ui/extensions/mv2_disabled_dialog_controller.cc
+++ b/chromium_src/chrome/browser/ui/extensions/mv2_disabled_dialog_controller.cc
@@ -1,0 +1,31 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/extensions/mv2_disabled_dialog_controller.h"
+
+#include <algorithm>
+#include <vector>
+
+#include "chrome/browser/ui/browser.h"
+#include "extensions/common/constants.h"
+#include "extensions/common/extension_features.h"
+
+namespace {
+
+void MaybeEraseKnownMV2Extensions(
+    std::vector<extensions::Mv2DisabledDialogController::ExtensionInfo>&
+        extensions) {
+  if (!extensions_mv2::features::IsExtensionReplacementEnabled()) {
+    return;
+  }
+
+  std::erase_if(extensions, [](const auto& e) {
+    return extensions_mv2::IsKnownWebStoreHostedExtension(e.id);
+  });
+}
+
+}  // namespace
+
+#include <chrome/browser/ui/extensions/mv2_disabled_dialog_controller.cc>

--- a/chromium_src/extensions/common/extension_features.cc
+++ b/chromium_src/extensions/common/extension_features.cc
@@ -21,39 +21,28 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
 // upstream GN files with dependencies.
 namespace extensions_mv2::features {
 
-BASE_FEATURE(kExtensionsManifestV2, base::FEATURE_DISABLED_BY_DEFAULT);
+BASE_FEATURE(kExtensionsManifestV2, base::FEATURE_ENABLED_BY_DEFAULT);
+
+BASE_FEATURE_PARAM(bool, kBackupSettings, &kExtensionsManifestV2, true);
 
 BASE_FEATURE_PARAM(bool,
-                   kExtensionsManifestV2BackupSettings,
+                   kImportSettingsOnInstall,
                    &kExtensionsManifestV2,
-                   "backup_settings",
-                   false);
+                   true);
 
-BASE_FEATURE_PARAM(bool,
-                   kExtensionsManifestV2BImportSettingsOnInstall,
-                   &kExtensionsManifestV2,
-                   "import_settings",
-                   false);
-
-BASE_FEATURE_PARAM(bool,
-                   kExtensionsManifestV2AutoInstallBraveHosted,
-                   &kExtensionsManifestV2,
-                   "auto_install_brave_hosted",
-                   false);
+BASE_FEATURE_PARAM(bool, kAutoInstallBraveHosted, &kExtensionsManifestV2, true);
 
 bool IsSettingsBackupEnabled() {
   return base::FeatureList::IsEnabled(features::kExtensionsManifestV2) &&
-         features::kExtensionsManifestV2BackupSettings.Get();
+         features::kBackupSettings.Get();
 }
 
 bool IsSettingsImportEnabled() {
-  return IsSettingsBackupEnabled() &&
-         features::kExtensionsManifestV2BImportSettingsOnInstall.Get();
+  return IsSettingsBackupEnabled() && features::kImportSettingsOnInstall.Get();
 }
 
 bool IsExtensionReplacementEnabled() {
-  return IsSettingsImportEnabled() &&
-         features::kExtensionsManifestV2AutoInstallBraveHosted.Get();
+  return IsSettingsImportEnabled() && features::kAutoInstallBraveHosted.Get();
 }
 
 }  // namespace extensions_mv2::features

--- a/chromium_src/extensions/common/extension_features.h
+++ b/chromium_src/extensions/common/extension_features.h
@@ -16,9 +16,9 @@
 namespace extensions_mv2::features {
 
 BASE_DECLARE_FEATURE(kExtensionsManifestV2);
-BASE_DECLARE_FEATURE_PARAM(bool, kExtensionsManifestV2BackupSettings);
-BASE_DECLARE_FEATURE_PARAM(bool, kExtensionsManifestV2BImportSettingsOnInstall);
-BASE_DECLARE_FEATURE_PARAM(bool, kExtensionsManifestV2AutoInstallBraveHosted);
+BASE_DECLARE_FEATURE_PARAM(bool, kBackupSettings);
+BASE_DECLARE_FEATURE_PARAM(bool, kImportSettingsOnInstall);
+BASE_DECLARE_FEATURE_PARAM(bool, kAutoInstallBraveHosted);
 
 bool IsSettingsBackupEnabled();
 bool IsSettingsImportEnabled();

--- a/patches/chrome-browser-ui-extensions-mv2_disabled_dialog_controller.cc.patch
+++ b/patches/chrome-browser-ui-extensions-mv2_disabled_dialog_controller.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/extensions/mv2_disabled_dialog_controller.cc b/chrome/browser/ui/extensions/mv2_disabled_dialog_controller.cc
+index b18abdf6e1f1388b95bac0b64faa7c58ce4ac545..da805a5de59c58719c95a6be3e78c375731e79d5 100644
+--- a/chrome/browser/ui/extensions/mv2_disabled_dialog_controller.cc
++++ b/chrome/browser/ui/extensions/mv2_disabled_dialog_controller.cc
+@@ -188,6 +188,7 @@ void Mv2DisabledDialogController::MaybeShowDisabledDialog() {
+   if (!browser_->window()) {
+     return;
+   }
++  MaybeEraseKnownMV2Extensions(affected_extensions_info_);
+ 
+   // Extensions can be updated while this call happens. Only include extensions
+   // that are still affected.


### PR DESCRIPTION
Uplift of #37500
Resolves https://github.com/brave/brave-browser/issues/56654

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.