### PR TITLE
Update Sparkle to 1.24.4

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ deps = {
     "condition": "checkout_win",
   },
   "vendor/sparkle": {
-    "url": "https://github.com/brave/Sparkle.git@85c560460b44b98a933a18549dcb655550c37349",
+    "url": "https://github.com/brave/Sparkle.git@6e8b614d26f96cf5a146ba005d3429172500a1d7",
     "condition": "checkout_mac",
   },
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@8b424ccf29957fe01c88c36076fd32006a357887",

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ deps = {
     "condition": "checkout_win",
   },
   "vendor/sparkle": {
-    "url": "https://github.com/brave/Sparkle.git@v1.24.4",
+    "url": "https://github.com/brave/Sparkle.git@85c560460b44b98a933a18549dcb655550c37349",
     "condition": "checkout_mac",
   },
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@8b424ccf29957fe01c88c36076fd32006a357887",

--- a/DEPS
+++ b/DEPS
@@ -75,7 +75,7 @@ hooks = [
     'pattern': '.',
     'condition': 'checkout_mac and download_prebuilt_sparkle',
     'action': ['vpython3', 'build/download_dep.py',
-               'sparkle/sparkle-1.24.3.tar.gz',
+               'sparkle/sparkle-1.24.4.tar.gz',
                '//build/mac_files/sparkle_binaries'],
   },
   {

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ deps = {
     "condition": "checkout_win",
   },
   "vendor/sparkle": {
-    "url": "https://github.com/brave/Sparkle.git@8721f93f694244f9ff41fe975a92617ac5f63f9a",
+    "url": "https://github.com/brave/Sparkle.git@v1.24.4",
     "condition": "checkout_mac",
   },
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@8b424ccf29957fe01c88c36076fd32006a357887",


### PR DESCRIPTION
(Sparkle is our automatic update framework on macOS, at least until we migrate to Omaha 4.)

Resolves https://github.com/brave/brave-browser/issues/45447.

# Test plan

Please make sure that automatic updates on macOS still work on x64 and arm64 macOS when you launch the browser with command-line argument `--disable-features=BraveUseOmaha4`.