### PR TITLE
Select NTP background image at random

### DIFF
--- a/components/ntp_background_images/browser/view_counter_model.cc
+++ b/components/ntp_background_images/browser/view_counter_model.cc
@@ -15,7 +15,10 @@
 
 namespace ntp_background_images {
 
-ViewCounterModel::ViewCounterModel(PrefService* prefs) : prefs_(prefs) {
+ViewCounterModel::ViewCounterModel(PrefService* prefs)
+    : prefs_(prefs),
+      rand_int_inclusive_callback_(
+          base::BindRepeating(&base::RandIntInclusive)) {
   CHECK(prefs);
 
   // When browser is restarted we reset to "initial" count. This will also get
@@ -125,7 +128,7 @@ void ViewCounterModel::RotateBackgroundWallpaperImageIndex() {
 
   // Select a background image at random rather than rotating sequentially.
   current_wallpaper_image_index_ =
-      base::RandIntInclusive(0, total_image_count_ - 1);
+      rand_int_inclusive_callback_.Run(0, total_image_count_ - 1);
 }
 
 void ViewCounterModel::NextBrandedImage() {

--- a/components/ntp_background_images/browser/view_counter_model.cc
+++ b/components/ntp_background_images/browser/view_counter_model.cc
@@ -123,8 +123,9 @@ void ViewCounterModel::RotateBackgroundWallpaperImageIndex() {
     return;
   }
 
-  current_wallpaper_image_index_++;
-  current_wallpaper_image_index_ %= total_image_count_;
+  // Select a background image at random rather than rotating sequentially.
+  current_wallpaper_image_index_ =
+      base::RandIntInclusive(0, total_image_count_ - 1);
 }
 
 void ViewCounterModel::NextBrandedImage() {

--- a/components/ntp_background_images/browser/view_counter_model.h
+++ b/components/ntp_background_images/browser/view_counter_model.h
@@ -9,6 +9,7 @@
 #include <tuple>
 #include <vector>
 
+#include "base/functional/callback.h"
 #include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/timer/wall_clock_timer.h"
@@ -47,6 +48,13 @@ class ViewCounterModel {
   void NextBrandedImage();
   void Reset();
   void RotateBackgroundWallpaperImageIndex();
+
+  using RandIntInclusiveCallback =
+      base::RepeatingCallback<int(int min, int max)>;
+  void set_rand_int_inclusive_callback_for_testing(
+      RandIntInclusiveCallback callback) {
+    rand_int_inclusive_callback_ = std::move(callback);
+  }
 
  private:
   friend class ViewCounterServiceTest;
@@ -90,6 +98,10 @@ class ViewCounterModel {
   int current_wallpaper_image_index_ = 0;
   int total_image_count_ = 0;
   bool show_wallpaper_ = true;
+
+  // Random number generator used to pick a background image index. Indirected
+  // through a callback so tests can make the selection deterministic.
+  RandIntInclusiveCallback rand_int_inclusive_callback_;
 };
 
 }  // namespace ntp_background_images

--- a/components/ntp_background_images/browser/view_counter_model_unittest.cc
+++ b/components/ntp_background_images/browser/view_counter_model_unittest.cc
@@ -7,6 +7,8 @@
 
 #include <cstddef>
 
+#include "base/functional/callback.h"
+#include "base/test/bind.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
 #include "brave/components/ntp_background_images/browser/features.h"
@@ -49,10 +51,27 @@ class ViewCounterModelTest : public testing::Test {
 
   sync_preferences::TestingPrefServiceSyncable* prefs() { return &prefs_; }
 
+  // Installs a deterministic background-image RNG on `model` that returns
+  // `next_background_image_index_` and records the range it is queried with.
+  // This lets tests assert the exact index the model selects rather than only
+  // checking that it stays within range.
+  void InstallDeterministicBackgroundRng(ViewCounterModel* model) {
+    model->set_rand_int_inclusive_callback_for_testing(
+        base::BindLambdaForTesting([this](int min, int max) {
+          last_rand_min_ = min;
+          last_rand_max_ = max;
+          return next_background_image_index_;
+        }));
+  }
+
  protected:
   base::test::TaskEnvironment task_environment_;
   sync_preferences::TestingPrefServiceSyncable prefs_;
   base::test::ScopedFeatureList feature_list_;
+
+  int next_background_image_index_ = 0;
+  int last_rand_min_ = -1;
+  int last_rand_max_ = -1;
 };
 
 TEST_F(ViewCounterModelTest, NTPSponsoredImagesTest) {
@@ -194,14 +213,19 @@ TEST_F(ViewCounterModelTest, NTPBackgroundImagesTest) {
 
   model.SetCampaignsTotalBrandedImageCount(kTestCampaignsTotalImageCount);
   model.set_total_image_count(kTestImageCount);
+  InstallDeterministicBackgroundRng(&model);
 
-  // Loading initial count times. Background images are now selected randomly,
-  // so we only verify the index stays within range.
+  // Loading initial count times. Each page view selects a background image at
+  // random, so verify the model adopts exactly the index returned by the RNG
+  // and that the RNG is queried for the full image range.
   for (int i = 0; i < features::kInitialCountToBrandedWallpaper.Get() - 1;
        ++i) {
-    EXPECT_GE(model.current_wallpaper_image_index(), 0);
-    EXPECT_LT(model.current_wallpaper_image_index(), model.total_image_count_);
+    next_background_image_index_ = (i + 1) % static_cast<int>(kTestImageCount);
     model.RegisterPageView();
+    EXPECT_EQ(0, last_rand_min_);
+    EXPECT_EQ(static_cast<int>(kTestImageCount) - 1, last_rand_max_);
+    EXPECT_EQ(next_background_image_index_,
+              model.current_wallpaper_image_index());
   }
 
   // Skip next sponsored image
@@ -209,9 +233,10 @@ TEST_F(ViewCounterModelTest, NTPBackgroundImagesTest) {
 
   // Loading regular-count times.
   for (int i = 0; i < features::kCountToBrandedWallpaper.Get() - 1; ++i) {
-    EXPECT_GE(model.current_wallpaper_image_index(), 0);
-    EXPECT_LT(model.current_wallpaper_image_index(), model.total_image_count_);
+    next_background_image_index_ = (i + 2) % static_cast<int>(kTestImageCount);
     model.RegisterPageView();
+    EXPECT_EQ(next_background_image_index_,
+              model.current_wallpaper_image_index());
   }
 
   // It's time for sponsored image.
@@ -231,6 +256,7 @@ TEST_F(ViewCounterModelTest, NTPBackgroundImagesWithSIDisabledTest) {
 
   model.set_total_image_count(kTestImageCount);
   model.SetCampaignsTotalBrandedImageCount(kTestCampaignsTotalImageCount);
+  InstallDeterministicBackgroundRng(&model);
 
   // Check branded wallpaper index is not modified when only background images
   // are used.
@@ -240,11 +266,13 @@ TEST_F(ViewCounterModelTest, NTPBackgroundImagesWithSIDisabledTest) {
 
   constexpr int kTestPageViewCount = 30;
   for (int i = 0; i < kTestPageViewCount; ++i) {
-    // Background images are now selected randomly, so we only verify the index
-    // stays within range.
-    EXPECT_GE(model.current_wallpaper_image_index(), 0);
-    EXPECT_LT(model.current_wallpaper_image_index(), model.total_image_count_);
+    next_background_image_index_ = i % static_cast<int>(kTestImageCount);
     model.RegisterPageView();
+
+    // Each page view selects a background image at random, so verify the model
+    // adopts exactly the index returned by the RNG.
+    EXPECT_EQ(next_background_image_index_,
+              model.current_wallpaper_image_index());
 
     // Check branded wallpaper is not changed.
     EXPECT_EQ(initial_branded_wallpaper_index,
@@ -270,14 +298,16 @@ TEST_F(ViewCounterModelTest, NTPBackgroundImagesWithEmptyCampaignTest) {
   model.set_total_image_count(kTestImageCount);
   model.set_show_branded_wallpaper(true);
   model.count_to_branded_wallpaper_ = 0;
+  InstallDeterministicBackgroundRng(&model);
 
   constexpr int kTestPageViewCount = 30;
   for (int i = 0; i < kTestPageViewCount; ++i) {
-    // Background images are now selected randomly, so we only verify the index
-    // stays within range.
-    EXPECT_GE(model.current_wallpaper_image_index(), 0);
-    EXPECT_LT(model.current_wallpaper_image_index(), model.total_image_count_);
+    next_background_image_index_ = i % static_cast<int>(kTestImageCount);
     model.RegisterPageView();
+    // Each page view selects a background image at random, so verify the model
+    // adopts exactly the index returned by the RNG.
+    EXPECT_EQ(next_background_image_index_,
+              model.current_wallpaper_image_index());
   }
 }
 
@@ -286,14 +316,16 @@ TEST_F(ViewCounterModelTest, NTPFailedToLoadSponsoredImagesTest) {
 
   model.SetCampaignsTotalBrandedImageCount(kTestCampaignsTotalImageCount);
   model.set_total_image_count(kTestImageCount);
+  InstallDeterministicBackgroundRng(&model);
 
-  // Loading initial count model. Background images are now selected randomly,
-  // so we only verify the index stays within range.
+  // Loading initial count model. Each page view selects a background image at
+  // random, so verify the model adopts exactly the index returned by the RNG.
   for (int i = 0; i < features::kInitialCountToBrandedWallpaper.Get() - 1;
        ++i) {
-    EXPECT_GE(model.current_wallpaper_image_index(), 0);
-    EXPECT_LT(model.current_wallpaper_image_index(), model.total_image_count_);
+    next_background_image_index_ = (i + 1) % static_cast<int>(kTestImageCount);
     model.RegisterPageView();
+    EXPECT_EQ(next_background_image_index_,
+              model.current_wallpaper_image_index());
   }
   EXPECT_TRUE(model.ShouldShowSponsoredImages());
 
@@ -304,18 +336,24 @@ TEST_F(ViewCounterModelTest, NTPFailedToLoadSponsoredImagesTest) {
   // background image explicitely when background image is shown as ads was
   // frequency capped. Client(ViewCounterService) calls this increase method
   // when it's capped.
+  next_background_image_index_ = 2;
   model.RotateBackgroundWallpaperImageIndex();
+
+  // The explicit rotation selects the RNG-provided index over the full range.
+  EXPECT_EQ(0, last_rand_min_);
+  EXPECT_EQ(static_cast<int>(kTestImageCount) - 1, last_rand_max_);
+  EXPECT_EQ(2, model.current_wallpaper_image_index());
+
+  // The next page view shows the sponsored image, so the background index is
+  // left unchanged.
   model.RegisterPageView();
+  EXPECT_EQ(2, model.current_wallpaper_image_index());
 
-  // Check background index stays within range.
-  EXPECT_GE(model.current_wallpaper_image_index(), 0);
-  EXPECT_LT(model.current_wallpaper_image_index(), model.total_image_count_);
-
-  // Process register page view for sponsored image.
+  // Process register page view for sponsored image. The background image is
+  // selected at random again.
+  next_background_image_index_ = 1;
   model.RegisterPageView();
-
-  EXPECT_GE(model.current_wallpaper_image_index(), 0);
-  EXPECT_LT(model.current_wallpaper_image_index(), model.total_image_count_);
+  EXPECT_EQ(1, model.current_wallpaper_image_index());
 }
 
 }  // namespace ntp_background_images

--- a/components/ntp_background_images/browser/view_counter_model_unittest.cc
+++ b/components/ntp_background_images/browser/view_counter_model_unittest.cc
@@ -195,10 +195,12 @@ TEST_F(ViewCounterModelTest, NTPBackgroundImagesTest) {
   model.SetCampaignsTotalBrandedImageCount(kTestCampaignsTotalImageCount);
   model.set_total_image_count(kTestImageCount);
 
-  // Loading initial count times.
+  // Loading initial count times. Background images are now selected randomly,
+  // so we only verify the index stays within range.
   for (int i = 0; i < features::kInitialCountToBrandedWallpaper.Get() - 1;
        ++i) {
-    EXPECT_EQ(i, model.current_wallpaper_image_index());
+    EXPECT_GE(model.current_wallpaper_image_index(), 0);
+    EXPECT_LT(model.current_wallpaper_image_index(), model.total_image_count_);
     model.RegisterPageView();
   }
 
@@ -207,10 +209,8 @@ TEST_F(ViewCounterModelTest, NTPBackgroundImagesTest) {
 
   // Loading regular-count times.
   for (int i = 0; i < features::kCountToBrandedWallpaper.Get() - 1; ++i) {
-    const int expected_wallpaper_index =
-        (i + (features::kInitialCountToBrandedWallpaper.Get() - 1)) %
-        model.total_image_count_;
-    EXPECT_EQ(expected_wallpaper_index, model.current_wallpaper_image_index());
+    EXPECT_GE(model.current_wallpaper_image_index(), 0);
+    EXPECT_LT(model.current_wallpaper_image_index(), model.total_image_count_);
     model.RegisterPageView();
   }
 
@@ -238,11 +238,12 @@ TEST_F(ViewCounterModelTest, NTPBackgroundImagesWithSIDisabledTest) {
   const auto initial_branded_wallpaper_index =
       model.GetCurrentBrandedImageIndex();
 
-  int expected_wallpaper_index;
   constexpr int kTestPageViewCount = 30;
   for (int i = 0; i < kTestPageViewCount; ++i) {
-    expected_wallpaper_index = i % model.total_image_count_;
-    EXPECT_EQ(expected_wallpaper_index, model.current_wallpaper_image_index());
+    // Background images are now selected randomly, so we only verify the index
+    // stays within range.
+    EXPECT_GE(model.current_wallpaper_image_index(), 0);
+    EXPECT_LT(model.current_wallpaper_image_index(), model.total_image_count_);
     model.RegisterPageView();
 
     // Check branded wallpaper is not changed.
@@ -272,8 +273,10 @@ TEST_F(ViewCounterModelTest, NTPBackgroundImagesWithEmptyCampaignTest) {
 
   constexpr int kTestPageViewCount = 30;
   for (int i = 0; i < kTestPageViewCount; ++i) {
-    EXPECT_EQ(i % model.total_image_count_,
-              model.current_wallpaper_image_index());
+    // Background images are now selected randomly, so we only verify the index
+    // stays within range.
+    EXPECT_GE(model.current_wallpaper_image_index(), 0);
+    EXPECT_LT(model.current_wallpaper_image_index(), model.total_image_count_);
     model.RegisterPageView();
   }
 }
@@ -284,15 +287,15 @@ TEST_F(ViewCounterModelTest, NTPFailedToLoadSponsoredImagesTest) {
   model.SetCampaignsTotalBrandedImageCount(kTestCampaignsTotalImageCount);
   model.set_total_image_count(kTestImageCount);
 
-  // Loading initial count model.
+  // Loading initial count model. Background images are now selected randomly,
+  // so we only verify the index stays within range.
   for (int i = 0; i < features::kInitialCountToBrandedWallpaper.Get() - 1;
        ++i) {
-    EXPECT_EQ(i, model.current_wallpaper_image_index());
+    EXPECT_GE(model.current_wallpaper_image_index(), 0);
+    EXPECT_LT(model.current_wallpaper_image_index(), model.total_image_count_);
     model.RegisterPageView();
   }
   EXPECT_TRUE(model.ShouldShowSponsoredImages());
-  const int initial_wallpaper_image_index =
-      model.current_wallpaper_image_index();
 
   // Simulate that sponsored image ad was frequency capped by ads service.
   // If |count_to_branded_wallpaper_| is zero when RegisterPageView() is called,
@@ -304,17 +307,15 @@ TEST_F(ViewCounterModelTest, NTPFailedToLoadSponsoredImagesTest) {
   model.RotateBackgroundWallpaperImageIndex();
   model.RegisterPageView();
 
-  // Check background index is increased properly.
-  int expected_image_index =
-      (initial_wallpaper_image_index + 1) % model.total_image_count_;
-  EXPECT_EQ(expected_image_index, model.current_wallpaper_image_index());
+  // Check background index stays within range.
+  EXPECT_GE(model.current_wallpaper_image_index(), 0);
+  EXPECT_LT(model.current_wallpaper_image_index(), model.total_image_count_);
 
   // Process register page view for sponsored image.
   model.RegisterPageView();
 
-  expected_image_index =
-      (initial_wallpaper_image_index + 2) % model.total_image_count_;
-  EXPECT_EQ(expected_image_index, model.current_wallpaper_image_index());
+  EXPECT_GE(model.current_wallpaper_image_index(), 0);
+  EXPECT_LT(model.current_wallpaper_image_index(), model.total_image_count_);
 }
 
 }  // namespace ntp_background_images


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/56662

## Summary

Randomize built-in ("Brave") NTP background image selection on Android (and legacy desktop), matching the behavior introduced for the refreshed desktop NTP in brave-core#37536 (`abdce07`).

On desktop refresh, random selection lives in the WebUI layer (`background_store.ts`) and does not affect Android. Android picks backgrounds through shared C++ in `ViewCounterService` / `ViewCounterModel`, bridged via `NTPBackgroundImagesBridge`. Previously, `ViewCounterModel::RotateBackgroundWallpaperImageIndex()` advanced the index sequentially (`index++ % total_image_count_`), so backgrounds cycled in a fixed order.

This PR replaces sequential rotation with random selection using `base::RandIntInclusive(0, total_image_count_ - 1)`, consistent with how sponsored images are already randomized in the same model.

## What changed

### `view_counter_model.cc`
- `RotateBackgroundWallpaperImageIndex()` now picks a random index instead of incrementing sequentially.
- Guard clauses are unchanged: no selection when `total_image_count_ == 0` or `show_wallpaper_` is false.
- The random draw goes through an injectable `rand_int_inclusive_callback_`, initialized in the constructor to `base::BindRepeating(&base::RandIntInclusive)`. Production behavior is identical.

### `view_counter_model.h`
- Added a `RandIntInclusiveCallback` alias (`base::RepeatingCallback<int(int min, int max)>`), the `rand_int_inclusive_callback_` member, and a test-only setter `set_rand_int_inclusive_callback_for_testing()` so unit tests can make background selection deterministic.

### `view_counter_model_unittest.cc`
- Added an `InstallDeterministicBackgroundRng()` fixture helper that injects a callback returning a controlled index and records the `(min, max)` range it is queried with.
- Updated the four background-image tests (`NTPBackgroundImagesTest`, `NTPBackgroundImagesWithSIDisabledTest`, `NTPBackgroundImagesWithEmptyCampaignTest`, `NTPFailedToLoadSponsoredImagesTest`) to inject deterministic indices and assert the model adopts *exactly* the index returned by the RNG (and that the RNG is queried over the full image range), rather than only checking the index stays within range. The original behavioral coverage is preserved: index updates on page view, index unchanged when a sponsored image is shown, and index frozen when backgrounds are disabled.

No Java, JNI bridge, or production header API changes were needed (the new setter is test-only).

## Platform scope

| Platform | Before | After |
|---|---|---|
| Desktop NTP refresh (WebUI) | Random (`chooseRandom`) | Unchanged (already random) |
| Android NTP | Sequential (C++) | Random (C++) |
| Legacy desktop NTP | Sequential (C++) | Random (C++) |

## Behavior notes

- **First image is random too:** Android fetches via `GetNextWallpaperForDisplay()`, which calls `RotateBackgroundWallpaperImageIndex()` before returning the wallpaper, so the first background shown on a new tab is also randomly selected.
- **Per-tab caching:** `SponsoredTab` caches the wallpaper per tab, so revisiting the same tab does not re-randomize — only new tabs fetch a fresh image (existing behavior).
- **Sponsored images:** Unaffected; they already use random selection via `base::RandIntInclusive` in the same file.

## Test plan

- [ ] `ViewCounterModelTest.*` unit tests pass
- [ ] On Android, open several new tabs and confirm built-in backgrounds appear in non-sequential order
- [ ] Confirm sponsored images still rotate as before
- [ ] Confirm legacy desktop NTP (if applicable) shows randomized backgrounds


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
