### PR TITLE
Support kHorizontalTabStripComboButton [3/N]

### DIFF
--- a/app/feature_defaults_unittest.cc
+++ b/app/feature_defaults_unittest.cc
@@ -274,7 +274,6 @@ TEST(FeatureDefaultsTest, DisabledFeatures) {
       &switches::kSyncEnableBookmarksInTransportMode,
       &syncer::kSyncDetermineAccountManagedStatus,
 #if !BUILDFLAG(IS_ANDROID)
-      &tabs::kHorizontalTabStripComboButton,
       &tabs::kVerticalTabsLaunch,
 #endif  // !BUILDFLAG(IS_ANDROID)
       &variations::kReportOmniboxAutofocusHeader,
@@ -329,5 +328,7 @@ TEST(FeatureDefaultsTest, IsOmniboxEntryPointEnabled) {
 }
 
 TEST(FeatureDefaultsTest, HasTabSearchToolbarButton) {
-  EXPECT_TRUE(features::HasTabSearchToolbarButton());
+#if !BUILDFLAG(IS_ANDROID)
+  EXPECT_FALSE(features::HasTabSearchToolbarButton());
+#endif
 }

--- a/browser/ui/brave_browser_actions_browsertest.cc
+++ b/browser/ui/brave_browser_actions_browsertest.cc
@@ -3,13 +3,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/test/scoped_feature_list.h"
 #include "chrome/browser/ui/actions/chrome_action_id.h"
 #include "chrome/browser/ui/tab_search_feature.h"
+#include "chrome/browser/ui/tabs/features.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "content/public/test/browser_test.h"
 #include "ui/actions/actions.h"
 
-using BraveBrowserActionsBrowserTest = InProcessBrowserTest;
+class BraveBrowserActionsBrowserTest : public InProcessBrowserTest {
+ public:
+  BraveBrowserActionsBrowserTest() {
+    scoped_feature_list_.InitAndDisableFeature(
+        tabs::kHorizontalTabStripComboButton);
+  }
+
+ protected:
+  base::test::ScopedFeatureList scoped_feature_list_;
+};
 
 // Regression test for https://github.com/brave/brave-browser/issues/54449
 //

--- a/browser/ui/views/frame/brave_tabs_search_button_browsertest.cc
+++ b/browser/ui/views/frame/brave_tabs_search_button_browsertest.cc
@@ -9,6 +9,7 @@
 #include "chrome/browser/ui/browser_element_identifiers.h"
 #include "chrome/browser/ui/frame/window_frame_util.h"
 #include "chrome/browser/ui/tab_search_feature.h"
+#include "chrome/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.h"
 #include "chrome/browser/ui/views/interaction/browser_elements_views.h"
@@ -24,8 +25,14 @@
 class BraveTabsSearchButtonTest : public InProcessBrowserTest,
                                   public ::testing::WithParamInterface<bool> {
  public:
-  BraveTabsSearchButtonTest() = default;
+  BraveTabsSearchButtonTest() {
+    scoped_feature_list_.InitAndDisableFeature(
+        tabs::kHorizontalTabStripComboButton);
+  }
   ~BraveTabsSearchButtonTest() override = default;
+
+ protected:
+  base::test::ScopedFeatureList scoped_feature_list_;
 };
 
 IN_PROC_BROWSER_TEST_F(BraveTabsSearchButtonTest, HideShowSettingTest) {

--- a/chromium_src/chrome/browser/ui/tabs/features.cc
+++ b/chromium_src/chrome/browser/ui/tabs/features.cc
@@ -13,7 +13,6 @@
 namespace tabs {
 
 OVERRIDE_FEATURE_DEFAULT_STATES({{
-    {kHorizontalTabStripComboButton, base::FEATURE_DISABLED_BY_DEFAULT},
     {kVerticalTabsLaunch, base::FEATURE_DISABLED_BY_DEFAULT},
 }});
 

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -1838,15 +1838,6 @@
 # kClearCrossSiteCrossBrowsingContextGroupWindowName is set to
 -All/ClearWindowNameForNewBrowsingContextGroupTestP.ClearWindowNameCrossSite/0
 
-# These tests fail because we enable features::kTabstripComboButton and stub
-# features::HasTabSearchToolbarButton() to return true
--HorizontalTabStripRegionViewWithTabstripTabSearchTest.TabSearchPositionLoggedOnConstruction
-
-# These tests fail because we stub features::HasTabSearchToolbarButton() to
-# return true
--TabSearchButtonBrowserTest.ButtonClickCreatesBubble
--TabSearchButtonBrowserUITest.InvokeUi_default
-
 # These tests fail because we default to saving bookmarks in the "Bookmarks"
 # folder, not in "Other bookmarks"
 -BookmarkBrowsertest.BookmarkCurrentTab_WithAccountNodes
@@ -2131,10 +2122,6 @@
 
 # This test fails because we don't show avatar button with a single profile.
 -ProfileMenuViewBrowserTest.ProfileMenuDoubleOpenBeforeBatchUploadResults
-
-# These tests fail because we disable kHorizontalTabStripComboButton, but it's
-# required for the WebUIPinnedToolbarActions
--WebUIToolbarUIBrowserTest.*
 
 # These tests fail because they expect the hardcoded view name BrowserRootView,
 # but instead get BraveBrowserRootView.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves no issue. Part of https://github.com/brave/brave-browser/issues/56579

Enable kHorizontalTabStripComboButton by default.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
