### PR TITLE
[CodeHealth] Run gn format in all gn files

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -474,8 +474,8 @@ if (!is_mac && !is_android && !is_ios) {
 
       public_deps = []
       foreach(locale, platform_pak_locales) {
-        # public_deps is used intentionaly because ":create_dist_zip" needs the all dependency
-        # of all locale files.
+        # public_deps is used intentionaly because ":create_dist_zip" needs the
+        # all dependency of all locale files.
         public_deps += [ ":brave_shields_locales_${locale}" ]
       }
     }
@@ -582,7 +582,8 @@ if (should_generate_symbols) {
   create_dist_template("create_brave_symbols_dist") {
     if (is_android) {
       # TODO(https://github.com/brave/brave-browser/issues/51200)
-      # Cleanup Mono once cr144 reaches stable channel, CI also needs to be updated
+      # Cleanup Mono once cr144 reaches stable channel, CI also needs to be
+      # updated
       output = "$brave_dist_dir/$brave_dist_name-v$brave_version-$brave_platform-mono-$target_cpu-symbols-$target_android_output_format.zip"
     } else {
       output = "$brave_dist_dir/$brave_dist_name-v$brave_version-$brave_platform-$target_arch-symbols.zip"
@@ -628,8 +629,8 @@ action("create_dist_zips") {
   outputs = [ output ]
 
   if (is_win) {
-    # Repack a Chrome release archive to the Brave format.
-    # Besides changing from 7z to zip, the directory structure is a bit different.
+    # Repack a Chrome release archive to the Brave format. Besides changing from
+    # 7z to zip, the directory structure is a bit different.
     # TODO(atuchin): support other platforms.
 
     script = "//brave/script/repack-archive.py"

--- a/android/nala/BUILD.gn
+++ b/android/nala/BUILD.gn
@@ -8,8 +8,9 @@ import("//build/config/android/rules.gni")
 
 nala_base_path = "../../node_modules/@brave/leo/tokens/android"
 
-# Generate one copy() target per icon override and collect their dep labels.
-# To override a Chromium drawable, add an entry to nala_icon_overrides in icons.gni.
+# Generate one copy() target per icon override and collect their dep labels. To
+# override a Chromium drawable, add an entry to nala_icon_overrides in
+# icons.gni.
 _nala_override_deps = []
 foreach(override, nala_icon_overrides) {
   _name = "nala_override_" + string_replace(override.dest, ".xml", "")

--- a/browser/bookmarks/android/sources.gni
+++ b/browser/bookmarks/android/sources.gni
@@ -10,6 +10,7 @@ brave_browser_bookmarks_android_sources = [
   "//brave/browser/bookmarks/android/java/src/org/chromium/chrome/browser/bookmarks/BraveBookmarkUiPrefs.java",
 ]
 
-# Additional deps for //chrome/browser/bookmarks/android:impl to support bookmarks import on Android
+# Additional deps for //chrome/browser/bookmarks/android:impl to support
+# bookmarks import on Android
 brave_browser_bookmarks_android_impl_deps =
     [ "//components/user_data_importer/content" ]

--- a/browser/hub/internal/android/java/java_sources.gni
+++ b/browser/hub/internal/android/java/java_sources.gni
@@ -3,8 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# Since we make bytecode changes on the same component and extend it at the same time, we
-# have to patch it directly to avoid circular dependency.
+# Since we make bytecode changes on the same component and extend it at the same
+# time, we have to patch it directly to avoid circular dependency.
 brave_browser_hub_internal_java_sources = [
   "//brave/browser/hub/internal/android/java/src/org/chromium/chrome/browser/hub/BraveHubManagerImpl.java",
   "//brave/browser/hub/internal/android/java/src/org/chromium/chrome/browser/hub/BraveHubToolbarView.java",

--- a/browser/incognito/android/java_sources.gni
+++ b/browser/incognito/android/java_sources.gni
@@ -3,8 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# Since we make bytecode changes on the same component and extend it at the same time, we
-# have to patch it directly to avoid circular dependency.
+# Since we make bytecode changes on the same component and extend it at the same
+# time, we have to patch it directly to avoid circular dependency.
 brave_private_tab_reauth_java_sources = [ "//brave/browser/incognito/android/java/src/org/chromium/chrome/browser/incognito/reauth/BravePrivateTabReauthCoordinatorBase.java" ]
 brave_private_tab_reauth_java_deps =
     [ "//third_party/androidx:androidx_core_core_java" ]

--- a/browser/resources/settings/BUILD.gn
+++ b/browser/resources/settings/BUILD.gn
@@ -30,8 +30,8 @@ preprocess_folder = "preprocessed"
 
 # grit (and generate the GRD for) brave's own static resources, they don't need
 # to be part of the build_webui.gni compile.
-# TODO(petemill): It is no longer neccessary to make our own grd and pak, we can add to
-# chromium's static_files list.
+# TODO(petemill): It is no longer neccessary to make our own grd and pak, we can
+# add to chromium's static_files list.
 brave_grit("resources") {
   defines = chrome_grit_defines
   defines += [

--- a/browser/resources/tab_search/sources.gni
+++ b/browser/resources/tab_search/sources.gni
@@ -11,9 +11,9 @@ brave_tab_search_static_files = [
   # SVG and other static files
 ]
 
-# Here we could also define any .ts in relevant variables
-# e.g. brave_tab_search_web_component_files and brave_tab_search_non_web_component_files
-# when we have the need for them.
+# Here we could also define any .ts in relevant variables e.g.
+# brave_tab_search_web_component_files and
+# brave_tab_search_non_web_component_files when we have the need for them.
 brave_tab_search_ts_files = [
   "brave_tab_search_app.html.ts",
   "brave_tab_search_app.ts",

--- a/browser/ui/messages/android/java_sources.gni
+++ b/browser/ui/messages/android/java_sources.gni
@@ -3,8 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# Since we make bytecode changes on the same component and extend it at the same time, we
-# have to patch it directly to avoid circular dependency.
+# Since we make bytecode changes on the same component and extend it at the same
+# time, we have to patch it directly to avoid circular dependency.
 brave_browser_ui_messages_java_sources = [
   "//brave/browser/ui/messages/android/java/src/org/chromium/chrome/browser/ui/messages/snackbar/BraveSnackbarManager.java",
   "//brave/browser/ui/messages/android/java/src/org/chromium/chrome/browser/ui/messages/snackbar/BraveSnackbarView.java",

--- a/build/rust/rust_host_toolchain.gni
+++ b/build/rust/rust_host_toolchain.gni
@@ -6,7 +6,8 @@
 # Hermetic host toolchain for cargo invocations (see `build_crate.gni` and
 # `rust_to_wasm.gni`). On macOS, point cargo's host build scripts and linker at
 # the hermetic Clang/SDK instead of letting cc-rs discover the system Xcode via
-# `xcrun`. `rust_host_inputs` and `rust_host_response_file_contents` are empty on
+# `xcrun`. `rust_host_inputs` and `rust_host_response_file_contents` are empty
+# on
 # every other host, so callers can append them unconditionally.
 
 rust_host_inputs = []
@@ -31,8 +32,8 @@ if (host_os == "mac" && current_toolchain == host_toolchain) {
 
     # Route the host link through a wrapper that drives clang with the hermetic
     # `ld64.lld`. This is `_LINKER` rather than a rustflag deliberately: when
-    # cargo cross-compiles (e.g. `rust_to_wasm`), only `_LINKER` reaches the host
-    # build scripts without leaking into the target link. See the wrapper's
+    # cargo cross-compiles (e.g. `rust_to_wasm`), only `_LINKER` reaches the
+    # host build scripts without leaking into the target link. See the wrapper's
     # module docstring for the full rationale.
     "CARGO_TARGET_${_rust_host_triple}_LINKER=" +
         rebase_path("//brave/build/rust/rust_host_linker.py"),

--- a/components/brave_account/mojom/BUILD.gn
+++ b/components/brave_account/mojom/BUILD.gn
@@ -13,8 +13,8 @@ mojom("mojom") {
   sources = [ "brave_account.mojom" ]
 
   if (!is_android && !is_ios) {
-    # This is for desktop only.
-    # Mobile platforms should load the WebUI by navigating to it in a browser tab.
+    # This is for desktop only. Mobile platforms should load the WebUI by
+    # navigating to it in a browser tab.
     sources += [ "brave_account_row.mojom" ]
   }
 

--- a/components/brave_extension/extension/brave_extension/BUILD.gn
+++ b/components/brave_extension/extension/brave_extension/BUILD.gn
@@ -9,8 +9,9 @@ import("//build/config/locales.gni")
 transpile_web_ui("brave_extension") {
   output_module = false
 
-  # Need this to fire re-pack if changed, nevertheless extension is repacked on each 2nd build
-  # what is the output bundle called and what is the entry point file
+  # Need this to fire re-pack if changed, nevertheless extension is repacked on
+  # each 2nd build what is the output bundle called and what is the entry point
+  # file
   entry_points = [
     [
       "brave_extension_background",

--- a/components/cached_flags/brave_components_cached_flags_java_sources.gni
+++ b/components/cached_flags/brave_components_cached_flags_java_sources.gni
@@ -3,9 +3,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# Since CachedFlag that we extend and ChromeFeatureList that we patch are parts of the same
-# component, we have to embed our class to this component. Otherwise we will have cycled
-# dependency.
+# Since CachedFlag that we extend and ChromeFeatureList that we patch are parts
+# of the same component, we have to embed our class to this component. Otherwise
+# we will have cycled dependency.
 brave_components_cached_flags_java_sources = [
   "//brave/components/cached_flags/android/java/src/org/chromium/components/cached_flags/BraveCachedFeatureParam.java",
   "//brave/components/cached_flags/android/java/src/org/chromium/components/cached_flags/BraveCachedFlag.java",

--- a/components/common/rust_to_wasm.gni
+++ b/components/common/rust_to_wasm.gni
@@ -42,9 +42,10 @@ template("rust_to_wasm") {
       wasm_pack_target = invoker.wasm_pack_target
     }
 
-    # A note on --mode no-install: it's needed because we vendor our own wasm-bindgen-cli and wasm-opt.
-    # Without --mode no-install, wasm-pack attempts to download the binaries from the GitHub releases page,
-    # or via `cargo install`, which:
+    # A note on --mode no-install: it's needed because we vendor our own
+    # wasm-bindgen-cli and wasm-opt. Without --mode no-install, wasm-pack
+    # attempts to download the binaries from the GitHub releases page, or via
+    # `cargo install`, which:
     # - causes a race condition between the processes (that action_foreach forks) for wasm-pack's cache directory (if wasm-pack is run for the first time),
     # - makes our approach less self-contained.
     #

--- a/components/common/typescript.gni
+++ b/components/common/typescript.gni
@@ -44,8 +44,8 @@ brave_common_web_compile_inputs = [
   "$root_gen_dir/brave/components/common/package.json",
 ]
 
-# Runs a frontend compiler for the specified entry point(s) and outputs a GRD file
-# which includes all the generated files.
+# Runs a frontend compiler for the specified entry point(s) and outputs a GRD
+# file which includes all the generated files.
 #
 # Argument:
 #   entry_points
@@ -145,9 +145,10 @@ template("transpile_web_ui") {
     # https://chromium.googlesource.com/chromium/src/build/+/HEAD/docs/writing_gn_templates.md#inputs-and-depfiles
     depfile = "${target_gen_dir}/${target_name}.d"
 
-    # This file contains the webpack import paths which describe the folders and files (indirectly) imported by the entry point
-    # This is important to ensure gn knows about webpacks implicit dependencies.
-    # We write those to json and cross reference them in a later stage to ensure the list is complete
+    # This file contains the webpack import paths which describe the folders and
+    # files (indirectly) imported by the entry point This is important to ensure
+    # gn knows about webpacks implicit dependencies. We write those to json and
+    # cross reference them in a later stage to ensure the list is complete
     import_paths_file = "${target_gen_dir}/${target_name}.data_paths.json"
 
     resource_name = invoker.resource_name

--- a/components/speedreader/rust/lib/src/readability/BUILD.gn
+++ b/components/speedreader/rust/lib/src/readability/BUILD.gn
@@ -15,7 +15,6 @@ rust_static_library("lib") {
     "src/error.rs",
     "src/extractor.rs",
     "src/lib.rs",
-    "src/lib.rs",
     "src/nlp.rs",
     "src/scorer.rs",
     "src/statistics.rs",

--- a/ios/browser/component_updater/BUILD.gn
+++ b/ios/browser/component_updater/BUILD.gn
@@ -4,7 +4,8 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 # TODO(sszaloki): https://github.com/brave/brave-browser/issues/46286
-# Try to componentize zxcvbn_data_component_installer.{h,cc}, and upstream the change.
+# Try to componentize zxcvbn_data_component_installer.{h,cc}, and upstream the
+# change.
 source_set("zxcvbn_data_component_installer") {
   sources = [
     "//chrome/browser/component_updater/zxcvbn_data_component_installer.cc",

--- a/third_party/rust/proc_macro2/v1/BUILD.gn
+++ b/third_party/rust/proc_macro2/v1/BUILD.gn
@@ -7,8 +7,8 @@ group("lib") {
   public_deps = [ "//third_party/rust/proc_macro2/v1:lib" ]
 }
 
-# This is copied from //third_party/rust/proc_macro2/v1:lib for build dependencies
-# All deps should be changed from lib -> buildrs_support
+# This is copied from //third_party/rust/proc_macro2/v1:lib for build
+# dependencies All deps should be changed from lib -> buildrs_support
 # TODO(bridiver) find a better way to handle this
 import("//build/rust/cargo_crate.gni")
 cargo_crate("buildrs_support") {

--- a/third_party/rust/unicode_ident/v1/BUILD.gn
+++ b/third_party/rust/unicode_ident/v1/BUILD.gn
@@ -7,8 +7,8 @@ group("lib") {
   public_deps = [ "//third_party/rust/unicode_ident/v1:lib" ]
 }
 
-# This is copied from //third_party/rust/unicode_ident/v1:lib for build dependencies
-# All deps should be changed from lib -> buildrs_support
+# This is copied from //third_party/rust/unicode_ident/v1:lib for build
+# dependencies All deps should be changed from lib -> buildrs_support
 # TODO(bridiver) find a better way to handle this
 import("//build/rust/cargo_crate.gni")
 cargo_crate("buildrs_support") {

--- a/tools/crates/build_crate.gni
+++ b/tools/crates/build_crate.gni
@@ -58,8 +58,8 @@ template("build_crate") {
       "TEMP=" + rebase_path(cargo_target_dir),
       "TMP=" + rebase_path(cargo_target_dir),
 
-      # This `rebase_path` MUST stay absolute (new_base = ""). A relative
-      # entry like `../../third_party/rust-toolchain/bin` is resolved against the
+      # This `rebase_path` MUST stay absolute (new_base = ""). A relative entry
+      # like `../../third_party/rust-toolchain/bin` is resolved against the
       # process's CWD, so it may not resolve correctly and could silently fall
       # through to a local rustup proxy via `~/.cargo/bin`.
       "PATH=" + rebase_path("//third_party/rust-toolchain/bin") +

--- a/ui/webui/resources/sources.gni
+++ b/ui/webui/resources/sources.gni
@@ -19,9 +19,9 @@ brave_resources_extra_grdps = [
 brave_resources_extra_grdps_deps = [ "//brave/ui/webui/resources:grdp" ]
 
 # At the moment, all non-static resources are only required for polymer WebUI.
-# This could change and, when it does, the `include_polymer` conditional can be removed
-# here and the one in //brave/ui/webui/resources/BUILD.gn be relied on to only add
-# polymer-related files when appropriate.
+# This could change and, when it does, the `include_polymer` conditional can be
+# removed here and the one in //brave/ui/webui/resources/BUILD.gn be relied on
+# to only add polymer-related files when appropriate.
 if (!is_android && !is_ios) {
   brave_resources_extra_grdps +=
       [ "$brave_resources_extra_grdps_path/resources.grdp" ]


### PR DESCRIPTION
There has been some update to `gn format`, relating to comments, which
causing unrelated lines of a gn file to be formatted once a given file
is touched. This change mechanically applies `gn format` to all files,
to normalise our build files again.

This is a mechanical change generated with:

```sh
git ls-files -- "*.gn" | xargs gn format
git ls-files -- "*.gni" | xargs gn format
```

Bug: https://github.com/brave/brave-browser/issues/48161
