### PR TITLE
Disable keyboard cache for data input in `OnboardingRestoreWalletFragment` (uplift to 1.93.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/onboarding/OnboardingRestoreWalletFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/onboarding/OnboardingRestoreWalletFragment.java
@@ -248,12 +248,17 @@ public class OnboardingRestoreWalletFragment extends BaseOnboardingWalletFragmen
                 new ContextThemeWrapper(requireContext(), R.style.BraveWalletEditTextTheme);
         PasteEditText pasteEditText = new PasteEditText(contextThemeWrapper);
         pasteEditText.setListener(this);
-        pasteEditText.setInputType(InputType.TYPE_CLASS_TEXT);
+        // Set no suggestions flag to prevent leakage of sensitive data.
+        pasteEditText.setInputType(
+                InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
         pasteEditText.setAutofillHints("recoveryPhrase");
-        // Set correct IME option to the last item, so the keyboard will
-        // jump to the next item or hide accordingly.
+        // Set no personalized learning flag and correct IME option to the last item,
+        // so the keyboard will jump to the next item or hide accordingly.
         pasteEditText.setImeOptions(
-                lastItem ? EditorInfo.IME_ACTION_DONE : EditorInfo.IME_ACTION_NEXT);
+                lastItem
+                        ? EditorInfo.IME_ACTION_DONE | EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
+                        : EditorInfo.IME_ACTION_NEXT
+                                | EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING);
         pasteEditText.setHint(
                 String.format(
                         getResources().getString(R.string.recovery_phrase_word_hint),


### PR DESCRIPTION
Uplift of #37554
Resolves https://github.com/brave/brave-browser/issues/56685

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.