### PR TITLE
[bootstrap] `node`/`npm` shims

### DIFF
--- a/tools/cr/bootstrap/README.md
+++ b/tools/cr/bootstrap/README.md
@@ -1,7 +1,13 @@
 # `tools/cr/bootstrap`
 
-Provides shims for `plaster` and `brockit`, selecting them relative to the Brave
-repository in the current directory.
+Provides shims for `plaster`, `brockit`, `node` and `npm`, selecting them
+relative to the Brave repository in the current directory.
+
+`plaster` / `brockit` dispatch to the matching `tools/cr` script. `node` / `npm`
+are a prototype front-end for the node delivered into `third_party/node` by
+`gclient sync` (see [Node delivery](#node-delivery) below): inside a checkout
+that has a downloaded node they run _that_ node, and everywhere else they fall
+back transparently to the system `node` / `npm`.
 
 ## Install
 
@@ -48,15 +54,13 @@ plaster check                     # runs that checkout's plaster.py
 brockit lift --to=1.2.3.4         # runs that checkout's brockit.py
 ```
 
-These shims are resolved relative to `brave-core`, so attempting to call these
-from a directory that is not inside `brave-core` will result in a failure.
+`plaster` / `brockit` are resolved relative to `brave-core`, so calling them
+from a directory that is not inside `brave-core` will fail. `node` / `npm`
+instead fall back to the system tool in that case (see below).
 
-## How it works
-
-- `brockit`, `plaster` (POSIX) and `brockit.bat`, `plaster.bat` (Windows) are
-  thin wrappers that call `launcher.py <tool> <args…>`.
-- `launcher.py` resolves the brave-core root via `git rev-parse --show-toplevel`
-  (validating the root is a `brave` work tree, matching `repository.py`), then
-  execs `vpython3 <root>/tools/cr/<tool>.py <args…>` **without changing the
-  cwd**, so the tool runs relative to your current path.
-- `bootstrap.py` installs/uninstalls this directory on `$PATH`.
+```sh
+cd ~/browser/src/brave
+node --version                    # runs third_party/node's node
+cd /tmp
+node --version                    # falls back to the system node
+```

--- a/tools/cr/bootstrap/bootstrap.py
+++ b/tools/cr/bootstrap/bootstrap.py
@@ -32,21 +32,13 @@ import shutil
 import subprocess
 import sys
 
-import launcher
-
 # The directory this script lives in — the one we add to `$PATH`.
 BOOTSTRAP_DIR = Path(__file__).resolve().parent
 
-# The shim commands this directory puts on `$PATH`, derived from the launcher's
-# tool registry so new tools only need to be added in one place
-# (`launcher.TOOL_PATHS`). Used to detect an existing install via `shutil.which`
-# (which also resolves the `.bat` variants on Windows through `PATHEXT`).
-SHIM_COMMANDS = tuple(launcher.TOOL_PATHS)
+# The marker in path used to detect an existing boostrap install.
+_INSTALL_MARKER = 'brockit'
 
-# Markers delimiting the block we manage inside POSIX rc files. Fixed strings
-# (independent of the checkout) so re-installing from another checkout simply
-# repoints `$PATH`; the shims dispatch by cwd regardless of which checkout's
-# bootstrap dir is on `$PATH`.
+# Delimiters used to identify the managed block in rc files.
 BEGIN_MARKER = '# >>> brave bootstrap >>>'
 END_MARKER = '# <<< brave bootstrap <<<'
 
@@ -129,6 +121,33 @@ def remove_windows_entry(current: str, bootstrap_dir: Path) -> str:
         if e and _norm_win(e) != _norm_win(bootstrap_dir)
     ]
     return ';'.join(entries)
+
+
+# -- Install detection --------------------------------------------------------
+
+
+def find_existing_bootstrap() -> str | None:
+    """Returns the path of the bootstrap marker shim reachable on `$PATH`.
+
+    Resolves the marker via `shutil.which`, so it reports whatever a
+    freshly-spawned shell would actually run — the signal we use to refuse a
+    second, conflicting install. Returns None when nothing is found.
+    """
+    return shutil.which(_INSTALL_MARKER)
+
+
+def installed_bootstrap_dir() -> Path:
+    """The bootstrap directory that is actually on `$PATH`.
+
+    Derived from the live shim located by `find_existing_bootstrap` (its parent
+    directory), so `uninstall` targets the install that is really in effect —
+    even when run from a different checkout than the one originally installed.
+    Falls back to this script's own directory when no shim is on `$PATH`.
+    """
+    found = find_existing_bootstrap()
+    if found:
+        return Path(found).resolve().parent
+    return BOOTSTRAP_DIR
 
 
 # -- POSIX install / uninstall ------------------------------------------------
@@ -284,34 +303,6 @@ def _uninstall_windows() -> int:
 # -- CLI ----------------------------------------------------------------------
 
 
-def find_existing_bootstrap() -> str | None:
-    """Returns the path of a bootstrap shim already reachable on `$PATH`.
-
-    Resolves the shim command names via `shutil.which`, so it reports whatever
-    a freshly-spawned shell would actually run — the signal we use to refuse a
-    second, conflicting install. Returns None when nothing is found.
-    """
-    for command in SHIM_COMMANDS:
-        found = shutil.which(command)
-        if found:
-            return found
-    return None
-
-
-def installed_bootstrap_dir() -> Path:
-    """The bootstrap directory that is actually on `$PATH`.
-
-    Derived from the live shim located by `find_existing_bootstrap` (its parent
-    directory), so `uninstall` targets the install that is really in effect —
-    even when run from a different checkout than the one originally installed.
-    Falls back to this script's own directory when no shim is on `$PATH`.
-    """
-    found = find_existing_bootstrap()
-    if found:
-        return Path(found).resolve().parent
-    return BOOTSTRAP_DIR
-
-
 def _default_shell() -> str:
     name = Path(os.environ.get('SHELL', '')).name
     return name if name in SHELLS else 'bash'
@@ -324,6 +315,7 @@ def _resolve_shells(selection: str | None) -> list[str]:
 
 
 def main() -> int:
+    """Dispatch the install/uninstall subcommand for the host platform."""
     parser = argparse.ArgumentParser(
         description='Install/uninstall the brave tool shims on $PATH.')
     sub = parser.add_subparsers(dest='command', required=True)

--- a/tools/cr/bootstrap/bootstrap_test.py
+++ b/tools/cr/bootstrap/bootstrap_test.py
@@ -11,15 +11,17 @@ import os
 from pathlib import Path
 import platform
 import stat
-import subprocess
 import tempfile
 import unittest
+from unittest import mock
 
 import bootstrap
 import launcher
 
 
 class PosixBlockTest(unittest.TestCase):
+    """Exercises the bash/zsh managed-block helpers."""
+
     DIR = Path('/home/dev/src/brave/tools/cr/bootstrap')
 
     def test_apply_block_appends_single_block(self):
@@ -59,6 +61,7 @@ class PosixBlockTest(unittest.TestCase):
 
 
 class FishDropInTest(unittest.TestCase):
+    """Exercises the fish conf.d drop-in helper."""
 
     def test_prepends_path_without_fish_add_path(self):
         content = bootstrap.fish_drop_in(Path('/a/b/bootstrap'))
@@ -73,6 +76,8 @@ class FishDropInTest(unittest.TestCase):
 
 
 class WindowsPathTest(unittest.TestCase):
+    """Exercises the Windows PATH add/remove helpers."""
+
     DIR = Path(r'C:\dev\src\brave\tools\cr\bootstrap')
 
     def test_add_prepends_first(self):
@@ -106,6 +111,7 @@ class WindowsPathTest(unittest.TestCase):
 
 
 class FindExistingBootstrapTest(unittest.TestCase):
+    """Exercises install detection via the marker shim on `$PATH`."""
 
     def setUp(self):
         self._saved_path = os.environ.get('PATH', '')
@@ -121,7 +127,7 @@ class FindExistingBootstrapTest(unittest.TestCase):
                      'POSIX exec-bit lookup; Windows uses PATHEXT')
     def test_found_when_shim_on_path(self):
         with tempfile.TemporaryDirectory() as tmp:
-            shim_path = Path(tmp) / 'brockit'
+            shim_path = Path(tmp) / bootstrap._INSTALL_MARKER
             shim_path.write_text('#!/bin/sh\n', encoding='utf-8', newline='')
             shim_path.chmod(shim_path.stat().st_mode | stat.S_IXUSR)
             os.environ['PATH'] = tmp
@@ -141,71 +147,15 @@ class FindExistingBootstrapTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             other = Path(tmp).resolve() / 'other-checkout'
             other.mkdir()
-            shim_path = other / 'plaster'
+            shim_path = other / bootstrap._INSTALL_MARKER
             shim_path.write_text('#!/bin/sh\n', encoding='utf-8', newline='')
             shim_path.chmod(shim_path.stat().st_mode | stat.S_IXUSR)
             os.environ['PATH'] = str(other)
             self.assertEqual(bootstrap.installed_bootstrap_dir(), other)
 
 
-class FindBraveCoreTest(unittest.TestCase):
-    """Exercises `launcher.find_brave_core` against real git work trees.
-
-    `find_brave_core` resolves the checkout from the current directory via
-    `git rev-parse`, so these tests build a throwaway repo and chdir into it
-    rather than mocking git.
-    """
-
-    def setUp(self):
-        self._cwd = Path.cwd()
-
-    def tearDown(self):
-        os.chdir(self._cwd)
-
-    def _make_brave_repo(self,
-                         root: Path,
-                         *,
-                         name: str = 'brave',
-                         tool: str | None = 'brockit') -> Path:
-        repo = root / name
-        (repo / 'tools' / 'cr').mkdir(parents=True)
-        if tool:
-            (repo / 'tools' / 'cr' / f'{tool}.py').write_text('#',
-                                                              encoding='utf-8',
-                                                              newline='')
-        subprocess.run(['git', 'init', '-q', str(repo)], check=True)
-        return repo
-
-    _BROCKIT = launcher.TOOL_PATHS['brockit']
-    _PLASTER = launcher.TOOL_PATHS['plaster']
-
-    def test_valid_brave_checkout(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            repo = self._make_brave_repo(Path(tmp))
-            os.chdir(repo / 'tools' / 'cr')  # any subdir of the work tree
-            self.assertEqual(
-                launcher.find_brave_core(self._BROCKIT).resolve(),
-                repo.resolve())
-
-    def test_rejects_non_brave_name(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            repo = self._make_brave_repo(Path(tmp), name='notbrave')
-            os.chdir(repo)
-            self.assertIsNone(launcher.find_brave_core(self._BROCKIT))
-
-    def test_rejects_missing_tool_script(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            repo = self._make_brave_repo(Path(tmp), tool='brockit')
-            os.chdir(repo)
-            self.assertIsNone(launcher.find_brave_core(self._PLASTER))
-
-    def test_rejects_outside_git_work_tree(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            os.chdir(tmp)  # not a git repo
-            self.assertIsNone(launcher.find_brave_core(self._BROCKIT))
-
-
 class ResolveVpython3Test(unittest.TestCase):
+    """Exercises `launcher._resolve_vpython3` interpreter selection."""
 
     def test_resolves_to_a_vpython3_interpreter(self):
         # pylint: disable=protected-access
@@ -213,6 +163,223 @@ class ResolveVpython3Test(unittest.TestCase):
         # resolved interpreter is always a vpython3 (vpython3.bat on Windows).
         resolved = launcher._resolve_vpython3(Path('/home/dev/src/brave'))
         self.assertIn(resolved.name, ('vpython3', 'vpython3.bat'))
+
+
+class FindBraveCheckoutTest(unittest.TestCase):
+    """Exercises `launcher.find_brave_checkout`.
+
+    The node/npm shims resolve the checkout from the conventional
+    `<workspace>/src/brave` layout (not git), so a single rule covers being
+    inside the checkout, inside a nested DEPS repo, and above `src/brave`.
+    """
+
+    def _make_workspace(self, root: Path) -> Path:
+        brave = root / 'src' / 'brave'
+        (brave / 'tools' / 'cr' / 'bootstrap').mkdir(parents=True)
+        (brave / 'tools' / 'cr' / 'bootstrap' / 'launcher.py').write_text(
+            '#', encoding='utf-8', newline='')
+        return brave
+
+    def test_resolves_from_inside_the_checkout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            brave = self._make_workspace(Path(tmp))
+            inside = brave / 'components' / 'foo'
+            inside.mkdir(parents=True)
+            self.assertEqual(
+                launcher.find_brave_checkout(inside).resolve(),
+                brave.resolve())
+
+    def test_resolves_from_nested_deps_repo(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            brave = self._make_workspace(Path(tmp))
+            nested = brave / 'vendor' / 'web-discovery-project' / 'src'
+            nested.mkdir(parents=True)
+            self.assertEqual(
+                launcher.find_brave_checkout(nested).resolve(),
+                brave.resolve())
+
+    def test_resolves_from_above_src_brave(self):
+        # The `npm run init` case: cwd is the workspace root, src/brave a child.
+        with tempfile.TemporaryDirectory() as tmp:
+            brave = self._make_workspace(Path(tmp))
+            workspace = Path(tmp)
+            self.assertEqual(
+                launcher.find_brave_checkout(workspace).resolve(),
+                brave.resolve())
+
+    def test_resolves_from_sibling_chromium_dir(self):
+        # A chromium dir like src/chrome resolves to the sibling src/brave.
+        with tempfile.TemporaryDirectory() as tmp:
+            brave = self._make_workspace(Path(tmp))
+            chrome = Path(tmp) / 'src' / 'chrome'
+            chrome.mkdir(parents=True)
+            self.assertEqual(
+                launcher.find_brave_checkout(chrome).resolve(),
+                brave.resolve())
+
+    def test_none_outside_any_workspace(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            outside = Path(tmp) / 'elsewhere'
+            outside.mkdir()
+            self.assertIsNone(launcher.find_brave_checkout(outside))
+
+    def test_requires_sentinel(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # A bare src/brave without the bootstrap sentinel is not a checkout.
+            (Path(tmp) / 'src' / 'brave').mkdir(parents=True)
+            self.assertIsNone(launcher.find_brave_checkout(Path(tmp)))
+
+
+class ResolveSystemBinaryTest(unittest.TestCase):
+    """Exercises `launcher._resolve_system_binary`'s self-exclusion.
+
+    The shim directory sits first on `$PATH`; the resolver must skip it so the
+    node/npm shims never recurse into themselves and instead find the real
+    system tool.
+    """
+
+    def _make_exe(self, directory: Path, name: str) -> Path:
+        directory.mkdir(parents=True, exist_ok=True)
+        exe = directory / name
+        exe.write_text('#!/bin/sh\n', encoding='utf-8', newline='')
+        exe.chmod(exe.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP
+                  | stat.S_IXOTH)
+        return exe
+
+    def test_skips_excluded_shim_dir(self):
+        if platform.system() == 'Windows':
+            self.skipTest('POSIX exec-bit semantics')
+        with tempfile.TemporaryDirectory() as tmp:
+            shim = Path(tmp) / 'shim'
+            real = Path(tmp) / 'real'
+            self._make_exe(shim, 'node')  # would be picked without exclusion
+            real_node = self._make_exe(real, 'node')
+            old_path = os.environ.get('PATH', '')
+            os.environ['PATH'] = os.pathsep.join([str(shim), str(real)])
+            try:
+                # pylint: disable=protected-access
+                resolved = launcher._resolve_system_binary('node',
+                                                           exclude_dir=shim)
+            finally:
+                os.environ['PATH'] = old_path
+            self.assertEqual(Path(resolved).resolve(), real_node.resolve())
+
+    def test_returns_none_when_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            old_path = os.environ.get('PATH', '')
+            os.environ['PATH'] = str(Path(tmp) / 'empty')
+            try:
+                # pylint: disable=protected-access
+                self.assertIsNone(
+                    launcher._resolve_system_binary('definitely-not-a-tool'))
+            finally:
+                os.environ['PATH'] = old_path
+
+
+class FindShimTargetTest(unittest.TestCase):
+    """Exercises `launcher.find_shim_target` token-to-entry resolution."""
+
+    def test_qualified_name_is_used_as_is(self):
+        # A shim that knows its platform passes a key listed verbatim (the
+        # `.bat` variants pass `node-win` / `npm-win`).
+        self.assertEqual(launcher.find_shim_target('node-win'),
+                         launcher.SHIM_TARGETS['node-win'])
+        self.assertEqual(launcher.find_shim_target('npm-mac_arm64'),
+                         launcher.SHIM_TARGETS['npm-mac_arm64'])
+
+    def test_listed_token_is_used_as_is(self):
+        self.assertEqual(launcher.find_shim_target('brockit'),
+                         launcher.SHIM_TARGETS['brockit'])
+
+    def test_bare_family_gets_host_suffix(self):
+        # A POSIX shim passes the bare family; the launcher appends the host.
+        key = launcher.host_platform_key()
+        if key is None:
+            self.skipTest('unsupported host platform')
+        self.assertEqual(launcher.find_shim_target('node'),
+                         launcher.SHIM_TARGETS[f'node-{key}'])
+
+    def test_unknown_token_raises(self):
+        with self.assertRaises(launcher.UnknownShimError):
+            launcher.find_shim_target('bogus')
+
+
+class ResolveInvocationTest(unittest.TestCase):
+    """Exercises `launcher.resolve_invocation` against a faked checkout tree."""
+
+    def _key(self) -> str:
+        key = launcher.host_platform_key()
+        if key is None:
+            self.skipTest('unsupported host platform')
+        return key
+
+    def _checkout(self, root: Path) -> Path:
+        # resolve_invocation treats checkout.parent.parent as the workspace
+        # root, joining the src/brave-prefixed target paths onto it.
+        return root / 'src' / 'brave'
+
+    def _make_target(self, root: Path, key: str) -> Path:
+        target = root / launcher.SHIM_TARGETS[key].path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text('', encoding='utf-8', newline='')
+        return target
+
+    def test_resolves_repo_node(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root, key = Path(tmp), self._key()
+            node = self._make_target(root, f'node-{key}')
+            self.assertEqual(
+                launcher.resolve_invocation(f'node-{key}',
+                                            self._checkout(root), False),
+                [str(node)])
+
+    def test_npm_runs_through_node_on_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root, key = Path(tmp), self._key()
+            npm_cli = self._make_target(root, f'npm-{key}')
+            # npm runs as `<node from $PATH> npm-cli.js` — never bare npm.
+            with mock.patch.object(launcher.shutil,
+                                   'which',
+                                   return_value='/usr/bin/node'):
+                invocation = launcher.resolve_invocation(
+                    f'npm-{key}', self._checkout(root), True)
+            self.assertEqual(invocation, ['/usr/bin/node', str(npm_cli)])
+
+    def test_vpython_tool_runs_through_vpython3(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_target(root, 'brockit')
+            invocation = launcher.resolve_invocation('brockit',
+                                                     self._checkout(root),
+                                                     False)
+            self.assertIsNotNone(invocation)
+            # brockit is launched as: <vpython3> <brockit.py>.
+            self.assertEqual(len(invocation), 2)
+            self.assertTrue(invocation[1].endswith('brockit.py'))
+
+    def test_falls_back_to_system_when_allowed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # No checkout-local node, but fallback is allowed → system node.
+            with mock.patch.object(launcher.shutil,
+                                   'which',
+                                   return_value='/usr/bin/node'):
+                invocation = launcher.resolve_invocation(
+                    'node', self._checkout(Path(tmp)), True)
+            self.assertEqual(invocation, ['/usr/bin/node'])
+
+    def test_none_without_target_and_no_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # Known tool, no checkout-local target, no fallback → None.
+            self.assertIsNone(
+                launcher.resolve_invocation(f'node-{self._key()}',
+                                            self._checkout(Path(tmp)), False))
+
+    def test_unknown_tool_always_raises(self):
+        # A token that is not a shim is rejected outright — fallback or not.
+        with self.assertRaises(launcher.UnknownShimError):
+            launcher.resolve_invocation('bogus', None, False)
+        with self.assertRaises(launcher.UnknownShimError):
+            launcher.resolve_invocation('bogus', None, True)
 
 
 if __name__ == '__main__':

--- a/tools/cr/bootstrap/launcher.py
+++ b/tools/cr/bootstrap/launcher.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Shared launcher behind the shims for our tooling
+"""Shared launcher behind the shims for our tooling.
 
 This launcher provides a mechanism similar to how `depot_tools` routes `gn`
 call relative to the `gn` binary for the repository in the current directory.
@@ -12,102 +12,219 @@ passed through verbatim:
 
     python3 launcher.py brockit lift --to=1.2.3.4
 
-Resolution follows the same invariant as `tools/cr/repository.py`: the work
-tree containing the cwd must be a `brave` checkout. The cwd is never changed,
-so the tool runs relative to the current path, exactly as if it had been
-launched as `tools/cr/<tool>.py` from there.
-
 This runs under plain `python3` (not `vpython3`), so it must stay stdlib-only,
 and it should be kept self-contained from other python code.
 """
 
 from __future__ import annotations
 
+import argparse
+from dataclasses import dataclass
+import os
 from pathlib import Path
 import platform
 import shutil
 import subprocess
 import sys
 
-# The basename a brave-core work-tree root must have. Kept in sync with
-# `repository.BRAVE_DIR_NAME`.
-BRAVE_DIR_NAME = 'brave'
+# A brave checkout's path relative to the workspace root.
+_SRC_BRAVE = Path('src') / 'brave'
 
-# The tools this launcher knows how to dispatch, mapped to their script paths
-# relative to the brave-core root.
-TOOL_PATHS: dict[str, Path] = {
-    'brockit': Path('tools') / 'cr' / 'brockit.py',
-    'plaster': Path('tools') / 'cr' / 'plaster.py',
+
+@dataclass(frozen=True)
+class Shim:
+    """A shim target listed in SHIM_TARGETS."""
+
+    # The workspace-root-relative path the shim runs.
+    path: str
+
+    # How the target is run:
+    #   'vpython' — a vpython3 script
+    #   'node'    — a script run with `node` from `$PATH`
+    #   None      — `path` is itself the executable (node)
+    runtime: str | None = None
+
+
+# SHIM_TARGETS maps the shims we have with their desired targets. The keys are
+# the names of the shims. Platform-specific suffixes are used for shims that
+# have different paths in different platforms.
+SHIM_TARGETS: dict[str, Shim] = {
+    'brockit': Shim('src/brave/tools/cr/brockit.py', 'vpython'),
+    'plaster': Shim('src/brave/tools/cr/plaster.py', 'vpython'),
+    'node-linux': Shim(
+        'src/brave/third_party/node/node-v24.16.0-linux-x64/bin/node'),
+    'node-mac': Shim(
+        'src/brave/third_party/node/node-v24.16.0-darwin-x64/bin/node'),
+    'node-mac_arm64': Shim(
+        'src/brave/third_party/node/node-v24.16.0-darwin-arm64/bin/node'),
+    'node-win': Shim(
+        'src/brave/third_party/node/node-v24.16.0-win-x64/node.exe'),
+    'npm-linux': Shim(
+        'src/brave/third_party/node/node-v24.16.0-linux-x64/lib/node_modules/npm/bin/npm-cli.js',
+        'node'),
+    'npm-mac': Shim(
+        'src/brave/third_party/node/node-v24.16.0-darwin-x64/lib/node_modules/npm/bin/npm-cli.js',
+        'node'),
+    'npm-mac_arm64': Shim(
+        'src/brave/third_party/node/node-v24.16.0-darwin-arm64/lib/node_modules/npm/bin/npm-cli.js',
+        'node'),
+    'npm-win': Shim(
+        'src/brave/third_party/node/node-v24.16.0-win-x64/node_modules/npm/bin/npm-cli.js',
+        'node'),
 }
 
 
-def find_brave_core(relpath: Path) -> Path | None:
-    """Locates the brave-core work tree containing the current directory.
+def find_brave_checkout(start: Path) -> Path | None:
+    """The `src/brave` checkout at or above `start`, or None.
 
-    `relpath` is the tool's script path relative to the brave-core root (a
-    value from `TOOL_PATHS`). Returns the resolved root when the cwd sits in a
-    `brave` work tree that actually ships that script, else None. Uses
-    `git rev-parse --show-toplevel`, so it honours the cwd (and any git work
-    tree / submodule boundaries) the same way the rest of tools/cr does.
+    By layout, not git: the first ancestor `src/brave` carrying our sentinel.
     """
-    try:
-        result = subprocess.run(['git', 'rev-parse', '--show-toplevel'],
-                                capture_output=True,
-                                text=True,
-                                check=True)
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return None
-    toplevel = result.stdout.strip()
-    if not toplevel:
-        return None
-    root = Path(toplevel)
-    if root.name != BRAVE_DIR_NAME:
-        return None
-    if not (root / relpath).is_file():
-        return None
-    return root
+    start = start.resolve()
+    sentinel = _SRC_BRAVE / 'tools' / 'cr' / 'bootstrap' / 'launcher.py'
+    for directory in (start, *start.parents):
+        if (directory / sentinel).is_file():
+            return directory / _SRC_BRAVE
+    return None
 
 
-def _resolve_vpython3(brave: Path) -> Path:
-    """Returns the `vpython3` interpreter to run the tool with.
+def _find_cwd_checkout() -> Path | None:
+    """The `brave-core` checkout governing the current working directory."""
+    return find_brave_checkout(Path.cwd())
 
-    Precedence mirrors `vpython_utils._compute_vpython3_path`: prefer a
-    `vpython3` already on `$PATH`, otherwise fall back to the Chromium-bundled
-    `third_party/depot_tools/vpython3` next to this checkout.
+
+def host_platform_key() -> str | None:
+    """The SHIM_TARGETS platform suffix for the host, or None if unsupported."""
+    system = platform.system()
+    if system == 'Linux':
+        return 'linux'
+    if system == 'Darwin':
+        is_arm = platform.machine().lower() in ('arm64', 'aarch64')
+        return 'mac_arm64' if is_arm else 'mac'
+    if system == 'Windows':
+        return 'win'
+    return None
+
+
+class UnknownShimError(Exception):
+    """Raised when a shim token resolves to no `SHIM_TARGETS` entry."""
+
+
+def find_shim_target(tool: str) -> Shim:
+    """The SHIM_TARGETS entry for `tool`, or raise UnknownShimError.
+
+    Matches the token directly, else with the host suffix appended (`node` ->
+    `node-linux`).
     """
+    if tool in SHIM_TARGETS:
+        return SHIM_TARGETS[tool]
+    host = host_platform_key()
+    if host is not None and f'{tool}-{host}' in SHIM_TARGETS:
+        return SHIM_TARGETS[f'{tool}-{host}']
+    raise UnknownShimError(tool)
+
+
+def _resolve_vpython3(src: Path) -> Path:
+    """The `vpython3` to run tools with: one on `$PATH`, else the depot_tools
+    copy under `src` (mirrors `vpython_utils._compute_vpython3_path`)."""
     found = shutil.which('vpython3')
     if found is not None:
         return Path(found)
     name = 'vpython3.bat' if platform.system() == 'Windows' else 'vpython3'
-    return brave.parent / 'third_party' / 'depot_tools' / name
+    return src / 'third_party' / 'depot_tools' / name
+
+
+def _resolve_system_binary(tool: str,
+                           exclude_dir: Path | None = None) -> str | None:
+    """Locate `tool` on `$PATH`, minus the shim dir.
+
+    The shim dir is first on `$PATH`, so a plain `which` would find our own shim
+    and recurse; drop it (this file's dir by default) before searching.
+    """
+    here = (exclude_dir or Path(__file__).parent).resolve()
+    entries = [
+        entry for entry in os.environ.get('PATH', '').split(os.pathsep)
+        if entry and Path(entry).resolve() != here
+    ]
+    return shutil.which(tool, path=os.pathsep.join(entries))
+
+
+def resolve_invocation(tool: str, checkout: Path | None,
+                       allow_fallback: bool) -> list[str] | None:
+    """The argv prefix to run `tool` from `checkout`.
+
+    This function attempts to resolve the invocation for a given tool. Tools
+    are usually run from checkout, but certain tools are allowed to fallback to
+    system binaries if nothing is found in checkout, when `allow_fallback` is
+    True.
+    """
+    shim = find_shim_target(tool)
+    invocation = None
+    if checkout is not None:
+        target = checkout.parent.parent / shim.path
+        if target.is_file():
+            if shim.runtime == 'vpython':
+                invocation = [
+                    str(_resolve_vpython3(checkout.parent)),
+                    str(target)
+                ]
+            elif shim.runtime == 'node':
+                # Run with whatever `node` is on $PATH (our node shim, which
+                # resolves the right node in turn).
+                node = shutil.which('node')
+                if node is not None:
+                    invocation = [node, str(target)]
+            else:
+                invocation = [str(target)]
+
+    if invocation is None and allow_fallback:
+        system = _resolve_system_binary(tool.split('-', 1)[0])
+        if system is not None:
+            invocation = [system]
+    return invocation
 
 
 def main() -> int:
-    if len(sys.argv) < 2:
-        sys.stderr.write(
-            'launcher.py: missing tool name (the tools/cr script to run)\n')
-        return 2
-    tool, args = sys.argv[1], sys.argv[2:]
+    """Resolve the tool from argv and run it, or report why it cannot."""
+    parser = argparse.ArgumentParser(
+        prog='launcher.py',
+        description='Run a brave tool shim against the checkout in the cwd.',
+        epilog='Arguments after TOOL are forwarded to it verbatim.',
+        allow_abbrev=False)
+    parser.add_argument(
+        '--allow-fallback',
+        action='store_true',
+        help='Allows falling back to a binary in %PATH if outside a checkout.')
+    parser.add_argument('tool',
+                        metavar='TOOL',
+                        help='shim to run (e.g. brockit, plaster, node, npm)')
+    parsed, tool_args = parser.parse_known_args()
+    tool = parsed.tool
 
-    relpath = TOOL_PATHS.get(tool)
-    if relpath is None:
-        known = ', '.join(sorted(TOOL_PATHS))
-        sys.stderr.write(f"launcher.py: unknown tool '{tool}' (known: "
-                         f'{known})\n')
+    checkout = _find_cwd_checkout()
+    try:
+        invocation = resolve_invocation(tool, checkout, parsed.allow_fallback)
+    except UnknownShimError:
+        sys.stderr.write(f"launcher.py: unknown tool '{tool}'\n")
         return 2
 
-    brave = find_brave_core(relpath)
-    if brave is None:
-        sys.stderr.write(
-            f'{tool}: must be run inside a brave-core git work tree '
-            f'(could not locate {relpath.as_posix()} for the current '
-            f'directory).\n')
+    if invocation is not None:
+        # Intentionally do not change cwd: the tool runs relative to the current
+        # path.
+        return subprocess.call([*invocation, *tool_args])
+
+    # Resolved a known tool but produced nothing to run — report why.
+    if parsed.allow_fallback:
+        family = tool.split('-', 1)[0]
+        sys.stderr.write(f'{family}: no checkout-local binary found and no '
+                         f'{family} on $PATH.\n')
         return 1
-
-    # Intentionally do not change cwd: the tool must run relative to the
-    # current path.
-    invocation = [str(_resolve_vpython3(brave)), str(brave / relpath), *args]
-    return subprocess.call(invocation)
+    if checkout is None:
+        sys.stderr.write(f'{tool}: must be run inside a brave checkout '
+                         f'(no src/brave found for the current directory).\n')
+    else:
+        sys.stderr.write(
+            f'{tool}: target not found in the resolved checkout.\n')
+    return 2
 
 
 if __name__ == '__main__':

--- a/tools/cr/bootstrap/node
+++ b/tools/cr/bootstrap/node
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Runs the node delivered into third_party/node for the brave-core checkout the
+# current directory is in, falling back to the system node when there is none.
+# See launcher.py for the resolution logic.
+exec python3 "$(dirname "$0")/launcher.py" --allow-fallback node "$@"

--- a/tools/cr/bootstrap/node.bat
+++ b/tools/cr/bootstrap/node.bat
@@ -1,0 +1,10 @@
+@echo off
+:: Copyright (c) 2026 The Brave Authors. All rights reserved.
+:: This Source Code Form is subject to the terms of the Mozilla Public
+:: License, v. 2.0. If a copy of the MPL was not distributed with this file,
+:: You can obtain one at https://mozilla.org/MPL/2.0/.
+::
+:: Runs the node delivered into third_party/node for the brave-core checkout the
+:: current directory is in, falling back to the system node when there is none.
+:: See launcher.py for the resolution logic.
+python3 "%~dp0launcher.py" --allow-fallback node-win %*

--- a/tools/cr/bootstrap/npm
+++ b/tools/cr/bootstrap/npm
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Runs the npm delivered into third_party/node for the brave-core checkout the
+# current directory is in, falling back to the system npm when there is none.
+# See launcher.py for the resolution logic.
+exec python3 "$(dirname "$0")/launcher.py" --allow-fallback npm "$@"

--- a/tools/cr/bootstrap/npm.bat
+++ b/tools/cr/bootstrap/npm.bat
@@ -1,0 +1,10 @@
+@echo off
+:: Copyright (c) 2026 The Brave Authors. All rights reserved.
+:: This Source Code Form is subject to the terms of the Mozilla Public
+:: License, v. 2.0. If a copy of the MPL was not distributed with this file,
+:: You can obtain one at https://mozilla.org/MPL/2.0/.
+::
+:: Runs the npm delivered into third_party/node for the brave-core checkout the
+:: current directory is in, falling back to the system npm when there is none.
+:: See launcher.py for the resolution logic.
+python3 "%~dp0launcher.py" --allow-fallback npm-win %*


### PR DESCRIPTION
This change adds shims for `node` and `npm` that resolve back at the
deployed version we are now syncing under `third_party/node`.

There a few important changes with how shim work. In particular, the
launcher now takes an option, `--allow-fallback`, that can be used to
redirect the shim to the system wide fallback, when the shim is called
outside a workspace. This is important when shimming `node`/`npm`, as we
don't want to interfere with system installs when outside the workspace.

This PR also introduces the concept of runtimes. Python scripts are now
being routed to vpython as a runtime, whilst `npm` is routed through
`node`, and `node` itself being a native binary requires no runtime.

This PR still doesn't solve the chicken-egg problem of what happens when
the node version is changed, and an `npm` call should self update before
running the `npm` code that requires a newer version. This will be
figured later down the line.

Bug: https://github.com/brave/brave-browser/issues/56529
