### PR TITLE
Fix component updater re-registration after deferred unregistration

### DIFF
--- a/patches/components-component_updater-component_updater_service.cc.patch
+++ b/patches/components-component_updater-component_updater_service.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/components/component_updater/component_updater_service.cc b/components/component_updater/component_updater_service.cc
+index 1e6dc0e114a1f87b60688a264adad20c072795bc..b8210dce96d8013c9a8f8e06f9647b1c17b71ede 100644
+--- a/components/component_updater/component_updater_service.cc
++++ b/components/component_updater/component_updater_service.cc
+@@ -206,6 +206,9 @@ bool CrxUpdateService::RegisterComponent(
+     return false;
+   }
+ 
++  // Cancel any pending unregistration for this component.
++  std::erase(components_pending_unregistration_, component.app_id);
++
+   // Update the registration data if the component has been registered before.
+   auto it = components_.find(component.app_id);
+   if (it != components_.end()) {

--- a/patches/components-component_updater-component_updater_service_unittest.cc.patch
+++ b/patches/components-component_updater-component_updater_service_unittest.cc.patch
@@ -1,0 +1,123 @@
+diff --git a/components/component_updater/component_updater_service_unittest.cc b/components/component_updater/component_updater_service_unittest.cc
+index bf00ff7b8676e54cf0868b0e3035f0941e73a8e9..13a79f8be26c1434fb6413dce9db69accae8f8b9 100644
+--- a/components/component_updater/component_updater_service_unittest.cc
++++ b/components/component_updater/component_updater_service_unittest.cc
+@@ -178,6 +178,7 @@ class ComponentUpdaterTest : public testing::Test {
+ 
+  protected:
+   void RunThreads();
++  void TriggerUpdateComplete(const std::string& id);
+ 
+  private:
+   void RunUpdateTask(const UpdateScheduler::UserTask& user_task);
+@@ -253,6 +254,24 @@ void ComponentUpdaterTest::RunThreads() {
+   runloop_.Run();
+ }
+ 
++void ComponentUpdaterTest::TriggerUpdateComplete(const std::string& id) {
++  update_client::Callback update_callback;
++  EXPECT_CALL(update_client(), Update)
++      .WillOnce([&update_callback](const std::vector<std::string>&,
++                                   UpdateClient::CrxDataCallback,
++                                   UpdateClient::CrxStateChangeCallback, bool,
++                                   update_client::Callback callback) {
++        update_callback = std::move(callback);
++      });
++
++  OnDemandTester tester;
++  tester.OnDemand(&component_updater(), id,
++                  OnDemandUpdater::Priority::FOREGROUND);
++
++  ASSERT_TRUE(update_callback);
++  std::move(update_callback).Run(update_client::Error::NONE);
++}
++
+ void ComponentUpdaterTest::RunUpdateTask(
+     const UpdateScheduler::UserTask& user_task) {
+   task_environment_.GetMainThreadTaskRunner()->PostTask(
+@@ -590,4 +609,85 @@ TEST_F(ComponentUpdaterTest, CriticalComponentAlwaysUpdates) {
+   EXPECT_TRUE(registered.updates_enabled);
+ }
+ 
++TEST_F(ComponentUpdaterTest,
++       RegisterCancelsPendingUnregistrationBeforeUpdateCompletes) {
++  const std::string id = "abagagagagagagagagagagagagagagag";
++  scoped_refptr<MockInstaller> installer =
++      base::MakeRefCounted<MockInstaller>();
++  EXPECT_CALL(*installer, Uninstall()).Times(0);
++
++  ComponentRegistration component(
++      id, /*name=*/{}, base::ToVector(update_client::abag_hash),
++      base::Version("1.0"), /*fingerprint=*/{}, /*installer_attributes=*/{},
++      /*action_handler=*/nullptr, installer,
++      /*requires_network_encryption=*/false,
++      /*supports_group_policy_enable_component_updates=*/true,
++      /*allow_cached_copies=*/true,
++      /*allow_updates_on_metered_connection=*/true,
++      /*allow_updates=*/true);
++
++  EXPECT_TRUE(component_updater().RegisterComponent(component));
++
++  // Unregister during an in-progress update adds component ID to the pending
++  // unregistration list.
++  EXPECT_CALL(update_client(), IsUpdating(id)).WillOnce(Return(true));
++  EXPECT_TRUE(component_updater().UnregisterComponent(id));
++
++  // Re-register removes the component ID from the pending unregistration list
++  // so the component is not uninstalled after the update completes.
++  EXPECT_TRUE(component_updater().RegisterComponent(component));
++
++  // The update does not uninstall the component.
++  TriggerUpdateComplete(id);
++
++  CrxUpdateItem item;
++  EXPECT_TRUE(component_updater().GetComponentDetails(id, &item));
++  EXPECT_TRUE(item.component);
++}
++
++TEST_F(ComponentUpdaterTest,
++       RegisterCancelsPendingUnregistrationAfterUpdateCompletes) {
++  const std::string id = "abagagagagagagagagagagagagagagag";
++  scoped_refptr<MockInstaller> installer =
++      base::MakeRefCounted<MockInstaller>();
++  // The component is uninstalled after the first update completes when
++  // processing the pending unregistration list.
++  EXPECT_CALL(*installer, Uninstall()).WillOnce(Return(true));
++
++  ComponentRegistration component(
++      id, /*name=*/{}, base::ToVector(update_client::abag_hash),
++      base::Version("1.0"), /*fingerprint=*/{}, /*installer_attributes=*/{},
++      /*action_handler=*/nullptr, installer,
++      /*requires_network_encryption=*/false,
++      /*supports_group_policy_enable_component_updates=*/true,
++      /*allow_cached_copies=*/true,
++      /*allow_updates_on_metered_connection=*/true,
++      /*allow_updates=*/true);
++
++  EXPECT_TRUE(component_updater().RegisterComponent(component));
++
++  // Unregister during an in progress update adds component ID to the pending
++  // unregistration list.
++  EXPECT_CALL(update_client(), IsUpdating(id)).WillOnce(Return(true));
++  EXPECT_TRUE(component_updater().UnregisterComponent(id));
++
++  EXPECT_CALL(update_client(), IsUpdating(id)).WillOnce(Return(false));
++  // When the first update completes the component is uninstalled.
++  TriggerUpdateComplete(id);
++
++  CrxUpdateItem item;
++  EXPECT_FALSE(component_updater().GetComponentDetails(id, &item));
++  EXPECT_FALSE(item.component);
++
++  // Re-register removes the component ID from the pending unregistration list
++  // so the component is not uninstalled after the update completes.
++  EXPECT_TRUE(component_updater().RegisterComponent(component));
++
++  // The second update does not uninstall the component.
++  TriggerUpdateComplete(id);
++
++  EXPECT_TRUE(component_updater().GetComponentDetails(id, &item));
++  EXPECT_TRUE(item.component);
++}
++
+ }  // namespace component_updater


### PR DESCRIPTION
Applies the upstream Chromium fix for the NTT component not being downloaded after changing the variation seed country.

Fix component updater re-registration after deferred unregistration When a component is unregistered during an update, the unregistration is deferred by adding the component ID to a pending list. If the same component is subsequently re-registered, the pending entry is not cancelled, so the next time an update cycle completes the component is silently removed even though it was intentionally re-registered. The fix cancels any pending unregistration entry when re-registering a component, allowing it to remain registered after subsequent updates complete.

This bug can affect "Speech On-Device API" models and any other component that can be unregistered during an update.

Change-Id: I92850bb0a8667fb91bc8b741024e1d4283e1a9bc
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7990635
Reviewed-by: Sorin Jianu <sorin@chromium.org>
Reviewed-by: Noah Rose Ledesma <noahrose@google.com>
Commit-Queue: Sorin Jianu <sorin@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1651851}

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56095
Resolves https://github.com/brave/brave-browser/issues/56379

## Test plan

Make sure that issues https://github.com/brave/brave-browser/issues/56095 and https://github.com/brave/brave-browser/issues/56379 are fixed.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
