### PR TITLE
[VPN 2.0] Plumb IsBraveVPNEnabled call to BraveVpnServiceImpl v2

### DIFF
--- a/browser/brave_vpn/brave_vpn_service_factory.cc
+++ b/browser/brave_vpn/brave_vpn_service_factory.cc
@@ -52,7 +52,8 @@ namespace {
 std::unique_ptr<KeyedService> BuildVpnService_V2(
     content::BrowserContext* context) {
   // Return stub implementation.
-  return std::make_unique<v2::BraveVpnServiceImpl>();
+  return std::make_unique<v2::BraveVpnServiceImpl>(
+      user_prefs::UserPrefs::Get(context));
 }
 
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2)

--- a/components/brave_vpn/browser/v2/BUILD.gn
+++ b/components/brave_vpn/browser/v2/BUILD.gn
@@ -28,5 +28,6 @@ static_library("browser") {
   deps = [
     "//base",
     "//brave/components/brave_vpn/common",
+    "//components/prefs",
   ]
 }

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl.cc
@@ -5,21 +5,27 @@
 
 #include "brave/components/brave_vpn/browser/v2/brave_vpn_service_impl.h"
 
+#include "base/check_deref.h"
 #include "base/notimplemented.h"
+#include "base/types/to_address.h"
+#include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/skus/browser/skus_utils.h"
+#include "components/prefs/pref_service.h"
 
 namespace brave_vpn {
 namespace v2 {
 
-BraveVpnServiceImpl::BraveVpnServiceImpl()
-    : connection_state_(mojom::ConnectionState::DISCONNECTED),
-      purchased_state_(mojom::PurchasedState::NOT_PURCHASED) {}
+BraveVpnServiceImpl::BraveVpnServiceImpl(PrefService* profile_prefs)
+    : profile_prefs_(CHECK_DEREF(profile_prefs)),
+      connection_state_(mojom::ConnectionState::DISCONNECTED),
+      purchased_state_(mojom::PurchasedState::NOT_PURCHASED) {
+  DCHECK(IsBraveVPNFeatureEnabled());
+}
 
 BraveVpnServiceImpl::~BraveVpnServiceImpl() = default;
 
 bool BraveVpnServiceImpl::IsBraveVPNEnabled() const {
-  NOTIMPLEMENTED();
-  return false;
+  return ::brave_vpn::IsBraveVPNEnabled(base::to_address(profile_prefs_));
 }
 
 bool BraveVpnServiceImpl::IsPurchased() const {

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl.h
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl.h
@@ -6,15 +6,20 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_BRAVE_VPN_SERVICE_IMPL_H_
 #define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_BRAVE_VPN_SERVICE_IMPL_H_
 
+#include <string>
+
+#include "base/memory/raw_ref.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "build/build_config.h"
+
+class PrefService;
 
 namespace brave_vpn {
 namespace v2 {
 
 class BraveVpnServiceImpl : public BraveVpnService {
  public:
-  BraveVpnServiceImpl();
+  explicit BraveVpnServiceImpl(PrefService* profile_prefs);
   ~BraveVpnServiceImpl() override;
 
   BraveVpnServiceImpl(const BraveVpnServiceImpl&) = delete;
@@ -114,6 +119,7 @@ class BraveVpnServiceImpl : public BraveVpnService {
 #endif  // !BUILDFLAG(IS_ANDROID)
 
  private:
+  const raw_ref<PrefService> profile_prefs_;
   [[maybe_unused]] mojom::ConnectionState connection_state_;
   mojom::PurchasedState purchased_state_;
 };


### PR DESCRIPTION
The change implements `BraveVpnServiceImpl::IsBraveVPNEnabled()` call using an existing utility function, the same one used in BraveVpnServiceImpl v1.

Implements part of https://github.com/brave/brave-browser/issues/56692

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
