### PR TITLE
[iOS] Dont show order ID in app store receipt viewer when unavailable

### DIFF
--- a/ios/brave-ios/Sources/BraveStore/Debug/StoreKitReceiptView.swift
+++ b/ios/brave-ios/Sources/BraveStore/Debug/StoreKitReceiptView.swift
@@ -181,7 +181,9 @@ public struct StoreKitReceiptView: View {
         value: purchase.originalTransactionId
       )
 
-      StoreKitReceiptLineView(title: "Line Item ID", value: "\(purchase.webOrderLineItemId)")
+      if purchase.webOrderLineItemId != 0 {
+        StoreKitReceiptLineView(title: "Line Item ID", value: "\(purchase.webOrderLineItemId)")
+      }
 
       StoreKitReceiptLineView(title: "Quantity", value: "\(purchase.quantity)")
 

--- a/ios/brave-ios/Sources/BraveStore/Views/StoreKitReceiptSimpleView.swift
+++ b/ios/brave-ios/Sources/BraveStore/Views/StoreKitReceiptSimpleView.swift
@@ -143,10 +143,12 @@ public struct StoreKitReceiptSimpleView: View {
   @ViewBuilder
   private func purchaseView(for purchase: BraveStoreKitPurchase) -> some View {
     VStack {
-      StoreKitReceiptSimpleLineView(
-        title: Strings.ReceiptViewer.receiptOrderIDTitle,
-        value: "\(purchase.webOrderLineItemId)"
-      )
+      if purchase.webOrderLineItemId != 0 {
+        StoreKitReceiptSimpleLineView(
+          title: Strings.ReceiptViewer.receiptOrderIDTitle,
+          value: "\(purchase.webOrderLineItemId)"
+        )
+      }
 
       StoreKitReceiptSimpleLineView(
         title: Strings.ReceiptViewer.receiptTransactionIDTitle,


### PR DESCRIPTION
This hides the "Order ID"/web order line id from displaying in the App Store Receipt viewers for Origins since web order line item id's are only present for subscriptions

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56701
