### PR TITLE
[iOS] Open Origin settings when activating via Brave Account

### DIFF
--- a/ios/BUILD.gn
+++ b/ios/BUILD.gn
@@ -92,6 +92,7 @@ brave_core_public_headers = [
   "//brave/ios/browser/brave_account/brave_account_authentication_provider.h",
   "//brave/ios/browser/brave_account/brave_account_constants_bridge.h",
   "//brave/ios/browser/brave_account/brave_account_feature_bridge.h",
+  "//brave/ios/browser/brave_origin/brave_origin_navigation_bridge.h",
   "//brave/ios/browser/brave_origin/brave_origin_service_bridge.h",
   "//brave/ios/browser/brave_origin/brave_origin_service_factory_bridge.h",
   "//brave/ios/browser/brave_news/brave_news_pref_names_bridge.h",

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -597,6 +597,15 @@ public class BrowserViewController: UIViewController {
         topToolbar.updateViewsForOverlayModeAndToolbarChanges()
       }
     }
+
+    BraveOriginNavigation.openOriginSettings = { [weak self] in
+      guard let self else { return }
+      // Only present Origin settings if the user activated from the browser. Activating via Origin
+      // IAP paywall will already present Origin settings via settings
+      if presentedViewController == nil {
+        presentBraveOriginDeepLink()
+      }
+    }
   }
 
   private func setupAdsNotificationHandler() {

--- a/ios/browser/brave_origin/BUILD.gn
+++ b/ios/browser/brave_origin/BUILD.gn
@@ -12,6 +12,9 @@ import("//brave/components/email_aliases/buildflags/buildflags.gni")
 
 source_set("brave_origin") {
   sources = [
+    "brave_origin_navigation_bridge.h",
+    "brave_origin_navigation_bridge_impl.h",
+    "brave_origin_navigation_bridge_impl.mm",
     "brave_origin_service_bridge.h",
     "brave_origin_service_bridge.mm",
     "brave_origin_service_bridge_impl.h",

--- a/ios/browser/brave_origin/brave_origin_navigation_bridge.h
+++ b/ios/browser/brave_origin/brave_origin_navigation_bridge.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_BRAVE_ORIGIN_BRAVE_ORIGIN_NAVIGATION_BRIDGE_H_
+#define BRAVE_IOS_BROWSER_BRAVE_ORIGIN_BRAVE_ORIGIN_NAVIGATION_BRIDGE_H_
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// A navigation handler for Brave Origin's service delegate.
+// Currently only opens the Origin settings page when a purchase is detected.
+NS_SWIFT_NAME(BraveOriginNavigation)
+OBJC_EXPORT
+@interface BraveOriginNavigationBridge : NSObject
+@property(nonatomic, class, copy) void (^openOriginSettings)();
+- (instancetype)init NS_UNAVAILABLE;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // BRAVE_IOS_BROWSER_BRAVE_ORIGIN_BRAVE_ORIGIN_NAVIGATION_BRIDGE_H_

--- a/ios/browser/brave_origin/brave_origin_navigation_bridge_impl.h
+++ b/ios/browser/brave_origin/brave_origin_navigation_bridge_impl.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_BRAVE_ORIGIN_BRAVE_ORIGIN_NAVIGATION_BRIDGE_IMPL_H_
+#define BRAVE_IOS_BROWSER_BRAVE_ORIGIN_BRAVE_ORIGIN_NAVIGATION_BRIDGE_IMPL_H_
+
+#import <Foundation/Foundation.h>
+
+#include "base/memory/raw_ref.h"
+#include "brave/components/brave_origin/brave_origin_service.h"
+#include "brave/ios/browser/brave_origin/brave_origin_navigation_bridge.h"
+
+class ProfileIOS;
+
+namespace brave_origin {
+
+// iOS delegate for BraveOriginService. Provides SKU service access and forwards
+// other calls like OpenOriginSettings through BraveOriginNavigationBridge
+class BraveOriginDelegateIOS : public BraveOriginService::Delegate {
+ public:
+  explicit BraveOriginDelegateIOS(ProfileIOS& profile);
+
+  // BraveOriginService::Delegate:
+  void OpenOriginSettings() override;
+  mojo::PendingRemote<skus::mojom::SkusService> GetSkusService() override;
+
+ private:
+  const raw_ref<ProfileIOS> profile_;
+};
+
+}  // namespace brave_origin
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BraveOriginNavigationBridge (Private)
++ (void)onOpenOriginSettings;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // BRAVE_IOS_BROWSER_BRAVE_ORIGIN_BRAVE_ORIGIN_NAVIGATION_BRIDGE_IMPL_H_

--- a/ios/browser/brave_origin/brave_origin_navigation_bridge_impl.h
+++ b/ios/browser/brave_origin/brave_origin_navigation_bridge_impl.h
@@ -8,11 +8,10 @@
 
 #import <Foundation/Foundation.h>
 
+#include "base/functional/bind.h"
 #include "base/memory/raw_ref.h"
 #include "brave/components/brave_origin/brave_origin_service.h"
 #include "brave/ios/browser/brave_origin/brave_origin_navigation_bridge.h"
-
-class ProfileIOS;
 
 namespace brave_origin {
 
@@ -20,14 +19,18 @@ namespace brave_origin {
 // other calls like OpenOriginSettings through BraveOriginNavigationBridge
 class BraveOriginDelegateIOS : public BraveOriginService::Delegate {
  public:
-  explicit BraveOriginDelegateIOS(ProfileIOS& profile);
+  using SkusServiceGetter =
+      base::RepeatingCallback<mojo::PendingRemote<skus::mojom::SkusService>()>;
+
+  explicit BraveOriginDelegateIOS(SkusServiceGetter skus_service_getter);
+  ~BraveOriginDelegateIOS() override;
 
   // BraveOriginService::Delegate:
   void OpenOriginSettings() override;
   mojo::PendingRemote<skus::mojom::SkusService> GetSkusService() override;
 
  private:
-  const raw_ref<ProfileIOS> profile_;
+  SkusServiceGetter skus_service_getter_;
 };
 
 }  // namespace brave_origin

--- a/ios/browser/brave_origin/brave_origin_navigation_bridge_impl.mm
+++ b/ios/browser/brave_origin/brave_origin_navigation_bridge_impl.mm
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/brave_origin/brave_origin_navigation_bridge_impl.h"
+
+#include "brave/ios/browser/skus/skus_service_factory.h"
+#include "ios/chrome/browser/shared/model/profile/profile_ios.h"
+
+namespace brave_origin {
+
+BraveOriginDelegateIOS::BraveOriginDelegateIOS(ProfileIOS& profile)
+    : profile_(profile) {}
+
+void BraveOriginDelegateIOS::OpenOriginSettings() {
+  [BraveOriginNavigationBridge onOpenOriginSettings];
+}
+
+mojo::PendingRemote<skus::mojom::SkusService>
+BraveOriginDelegateIOS::GetSkusService() {
+  return skus::SkusServiceFactory::GetForProfile(&*profile_);
+}
+
+}  // namespace brave_origin
+
+static void (^_openOriginSettings)() = nil;
+
+@implementation BraveOriginNavigationBridge
+
++ (void (^)())openOriginSettings {
+  return _openOriginSettings;
+}
+
++ (void)setOpenOriginSettings:(void (^)())openOriginSettings {
+  _openOriginSettings = [openOriginSettings copy];
+}
+
++ (void)onOpenOriginSettings {
+  if (self.openOriginSettings) {
+    self.openOriginSettings();
+  }
+}
+
+@end

--- a/ios/browser/brave_origin/brave_origin_navigation_bridge_impl.mm
+++ b/ios/browser/brave_origin/brave_origin_navigation_bridge_impl.mm
@@ -10,8 +10,11 @@
 
 namespace brave_origin {
 
-BraveOriginDelegateIOS::BraveOriginDelegateIOS(ProfileIOS& profile)
-    : profile_(profile) {}
+BraveOriginDelegateIOS::BraveOriginDelegateIOS(
+    SkusServiceGetter skus_service_getter)
+    : skus_service_getter_(std::move(skus_service_getter)) {}
+
+BraveOriginDelegateIOS::~BraveOriginDelegateIOS() = default;
 
 void BraveOriginDelegateIOS::OpenOriginSettings() {
   [BraveOriginNavigationBridge onOpenOriginSettings];
@@ -19,7 +22,7 @@ void BraveOriginDelegateIOS::OpenOriginSettings() {
 
 mojo::PendingRemote<skus::mojom::SkusService>
 BraveOriginDelegateIOS::GetSkusService() {
-  return skus::SkusServiceFactory::GetForProfile(&*profile_);
+  return skus_service_getter_.Run();
 }
 
 }  // namespace brave_origin

--- a/ios/browser/brave_origin/brave_origin_service_factory.mm
+++ b/ios/browser/brave_origin/brave_origin_service_factory.mm
@@ -179,12 +179,14 @@ BraveOriginServiceFactory::~BraveOriginServiceFactory() = default;
 std::unique_ptr<KeyedService>
 BraveOriginServiceFactory::BuildServiceInstanceFor(ProfileIOS* profile) const {
   std::string profile_id = GetProfileId(profile->GetStatePath());
+  auto skus_service_getter =
+      base::BindRepeating(&skus::SkusServiceFactory::GetForProfile, profile);
   return std::make_unique<BraveOriginService>(
       GetApplicationContext()->GetLocalState(),
       user_prefs::UserPrefs::Get(profile), profile_id,
       profile->GetPolicyConnector()->GetPolicyService(),
       GetApplicationContext()->GetBrowserPolicyConnector()->GetPolicyService(),
-      std::make_unique<BraveOriginDelegateIOS>(*profile));
+      std::make_unique<BraveOriginDelegateIOS>(std::move(skus_service_getter)));
 }
 
 // static

--- a/ios/browser/brave_origin/brave_origin_service_factory.mm
+++ b/ios/browser/brave_origin/brave_origin_service_factory.mm
@@ -23,6 +23,7 @@
 #include "brave/components/email_aliases/buildflags/buildflags.h"
 #include "brave/components/p3a/pref_names.h"
 #include "brave/components/playlist/core/common/pref_names.h"
+#include "brave/ios/browser/brave_origin/brave_origin_navigation_bridge_impl.h"
 #include "brave/ios/browser/policy/brave_simple_policy_map_ios.h"
 #include "brave/ios/browser/skus/skus_service_factory.h"
 #include "components/keyed_service/core/keyed_service.h"
@@ -59,26 +60,6 @@
 namespace brave_origin {
 
 namespace {
-
-// iOS delegate for BraveOriginService. Provides SKU service access but does
-// not open settings (no equivalent UI surface on iOS).
-class BraveOriginDelegateIOS : public BraveOriginService::Delegate {
- public:
-  using SkusServiceGetter =
-      base::RepeatingCallback<mojo::PendingRemote<skus::mojom::SkusService>()>;
-
-  explicit BraveOriginDelegateIOS(SkusServiceGetter skus_service_getter)
-      : skus_service_getter_(std::move(skus_service_getter)) {}
-
-  void OpenOriginSettings() override { NOTIMPLEMENTED(); }
-
-  mojo::PendingRemote<skus::mojom::SkusService> GetSkusService() override {
-    return skus_service_getter_.Run();
-  }
-
- private:
-  SkusServiceGetter skus_service_getter_;
-};
 
 // Define BraveOrigin-specific metadata for browser-level prefs
 constexpr auto kBraveOriginBrowserMetadata =
@@ -197,16 +178,13 @@ BraveOriginServiceFactory::~BraveOriginServiceFactory() = default;
 
 std::unique_ptr<KeyedService>
 BraveOriginServiceFactory::BuildServiceInstanceFor(ProfileIOS* profile) const {
-  auto skus_service_getter =
-      base::BindRepeating(&skus::SkusServiceFactory::GetForProfile, profile);
-
   std::string profile_id = GetProfileId(profile->GetStatePath());
   return std::make_unique<BraveOriginService>(
       GetApplicationContext()->GetLocalState(),
       user_prefs::UserPrefs::Get(profile), profile_id,
       profile->GetPolicyConnector()->GetPolicyService(),
       GetApplicationContext()->GetBrowserPolicyConnector()->GetPolicyService(),
-      std::make_unique<BraveOriginDelegateIOS>(std::move(skus_service_getter)));
+      std::make_unique<BraveOriginDelegateIOS>(*profile));
 }
 
 // static


### PR DESCRIPTION
This exposes the `BraveOriginService::Delegate` via a bridge so that we can handle `OpenOriginSettings` on the Swift side

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56700
