### PR TITLE
[Brave News]: Make is possible to override whether articles are forced to open in a new tab

### DIFF
--- a/components/brave_news/browser/resources/feed/Article.tsx
+++ b/components/brave_news/browser/resources/feed/Article.tsx
@@ -25,12 +25,12 @@ const Container = styled(Card)`
 `
 
 export default function Article({ info, hideChannel, feedDepth }: Props) {
-  const { reportVisit } = useBraveNews()
+  const { reportVisit, openArticlesInNewTab } = useBraveNews()
   const url = info.data.url.url;
 
   return <Container
     onClick={e => {
-      braveNewsCardClickHandler(url)(e)
+      braveNewsCardClickHandler(url, openArticlesInNewTab)(e)
       if (feedDepth !== undefined) {
         reportVisit(feedDepth)
       }

--- a/components/brave_news/browser/resources/feed/Card.tsx
+++ b/components/brave_news/browser/resources/feed/Card.tsx
@@ -7,7 +7,6 @@ import * as React from 'react';
 import { color, effect, font, radius, spacing } from '@brave/leo/tokens/css/variables';
 import styled from "styled-components";
 import SecureLink, { SecureLinkProps, defaultAllowedSchemes, validateScheme } from '$web-common/SecureLink';
-import { ConfigurationCachingWrapper } from '../shared/configurationCache';
 import { useBraveNews } from '../shared/Context';
 
 export const Header = styled.h2`
@@ -124,11 +123,10 @@ export default styled.div`
   ${p => p.onClick && 'cursor: pointer'}
 `
 
-export const braveNewsCardClickHandler = (href: string | undefined, allowedSchemes: string[] = defaultAllowedSchemes) => (e: React.MouseEvent) => {
+export const braveNewsCardClickHandler = (href: string | undefined, openArticlesInNewTab: boolean, allowedSchemes: string[] = defaultAllowedSchemes) => (e: React.MouseEvent) => {
   validateScheme(href, allowedSchemes)
 
-  const configurationCache = ConfigurationCachingWrapper.getInstance()
-  if (configurationCache.value.openArticlesInNewTab || e.ctrlKey || e.metaKey || e.buttons & 4) {
+  if (openArticlesInNewTab || e.ctrlKey || e.metaKey || e.buttons & 4) {
     window.open(href, '_blank', 'noopener noreferrer')
   } else {
     window.location.href = href!

--- a/components/brave_news/browser/resources/feed/Hero.tsx
+++ b/components/brave_news/browser/resources/feed/Hero.tsx
@@ -26,10 +26,10 @@ const Container = styled(Card)`
 `
 
 export default function HeroArticle({ info, feedDepth }: Props) {
-  const { reportVisit } = useBraveNews()
+  const { reportVisit, openArticlesInNewTab } = useBraveNews()
   return <Container
     onClick={e => {
-      braveNewsCardClickHandler(info.data.url.url)(e)
+      braveNewsCardClickHandler(info.data.url.url, openArticlesInNewTab)(e)
       if (feedDepth !== undefined) {
         reportVisit(feedDepth)
       }

--- a/components/brave_news/browser/resources/shared/Context.tsx
+++ b/components/brave_news/browser/resources/shared/Context.tsx
@@ -79,7 +79,15 @@ export const BraveNewsContext = React.createContext<BraveNewsContext>({
   shouldRenderImages: false,
 })
 
-export function BraveNewsContextProvider(props: { children: React.ReactNode }) {
+interface BraveNewsContextProviderProps {
+  children: React.ReactNode
+  // When set, overrides the user's `openArticlesInNewTab` preference for this
+  // subtree. Used by surfaces like the sidebar, where articles must always open
+  // in the main browser tab regardless of the configured preference.
+  openArticlesInNewTab?: boolean
+}
+
+export function BraveNewsContextProvider(props: BraveNewsContextProviderProps) {
   const configurationCache = ConfigurationCachingWrapper.getInstance()
   const channelsCache = ChannelsCachingWrapper.getInstance()
   const publishersCache = PublishersCachingWrapper.getInstance()
@@ -206,14 +214,14 @@ export function BraveNewsContextProvider(props: { children: React.ReactNode }) {
     isOptInPrefEnabled: configuration.isOptedIn,
     isShowOnNTPPrefEnabled: configuration.showOnNTP,
     toggleBraveNewsOnNTP,
-    openArticlesInNewTab: configuration.openArticlesInNewTab,
+    openArticlesInNewTab: props.openArticlesInNewTab ?? configuration.openArticlesInNewTab,
     setOpenArticlesInNewTab,
     reportViewCount,
     reportVisit,
     reportSidebarFilterUsage,
     reportSessionStart,
     shouldRenderImages,
-  }), [customizePage, setFeedView, feedV2, feedV2UpdatesAvailable, channels, publishers, suggestedPublisherIds, filteredPublisherIds, updateSuggestedPublisherIds, configuration, toggleBraveNewsOnNTP, reportSidebarFilterUsage, reportViewCount, reportVisit, reportSessionStart, shouldRenderImages])
+  }), [customizePage, setFeedView, feedV2, feedV2UpdatesAvailable, channels, publishers, suggestedPublisherIds, filteredPublisherIds, updateSuggestedPublisherIds, configuration, props.openArticlesInNewTab, toggleBraveNewsOnNTP, reportSidebarFilterUsage, reportViewCount, reportVisit, reportSessionStart, shouldRenderImages])
 
   return <BraveNewsContext.Provider value={context}>
     {props.children}

--- a/components/brave_news/browser/resources/sidebar.stories.tsx
+++ b/components/brave_news/browser/resources/sidebar.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const Default = () => (
   <div style={{ background: '#000' }}>
-    <BraveNewsContextProvider>
+    <BraveNewsContextProvider openArticlesInNewTab={false}>
       <Sidebar />
     </BraveNewsContextProvider>
   </div>

--- a/components/brave_news/browser/resources/sidebar.tsx
+++ b/components/brave_news/browser/resources/sidebar.tsx
@@ -43,7 +43,7 @@ export function Sidebar() {
 const root = document.getElementById('root')
 if (root) {
   createRoot(root).render(
-    <BraveNewsContextProvider>
+    <BraveNewsContextProvider openArticlesInNewTab={false}>
       <Sidebar />
     </BraveNewsContextProvider>
   )


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Series https://github.com/brave/brave-browser/issues/29147

This will let us support Ctrl+Click in the sidebar :smile:

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
