### PR TITLE
Make "Reset to Default" work for for Brave actions

### DIFF
--- a/browser/ui/webui/side_panel/customize_chrome/customize_chrome_browsertest.cc
+++ b/browser/ui/webui/side_panel/customize_chrome/customize_chrome_browsertest.cc
@@ -5,13 +5,17 @@
 
 #include "base/task/current_thread.h"
 #include "base/test/bind.h"
+#include "base/values.h"
+#include "chrome/browser/ui/actions/chrome_action_id.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_actions.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/customize_chrome/side_panel_controller.h"
 #include "chrome/browser/ui/tabs/public/tab_features.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/side_panel/side_panel.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h"
+#include "chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar.mojom.h"
 #include "chrome/common/webui_url_constants.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
@@ -19,6 +23,7 @@
 #include "content/public/browser/web_contents.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
+#include "ui/actions/actions.h"
 #include "ui/views/controls/webview/webview.h"
 
 class CustomizeChromeSidePanelBrowserTest : public InProcessBrowserTest {
@@ -44,6 +49,57 @@ class CustomizeChromeSidePanelBrowserTest : public InProcessBrowserTest {
       return nullptr;
     }
     return static_cast<views::WebView*>(view)->web_contents();
+  }
+
+  // Opens the customize chrome side panel and returns its WebContents.
+  content::WebContents* OpenCustomizeChromeSidePanel() {
+    CHECK(ui_test_utils::NavigateToURL(browser(),
+                                       GURL(chrome::kChromeUINewTabURL)));
+
+    GetSidePanelController(browser())->OpenSidePanel(
+        SidePanelOpenTrigger::kAppMenu, CustomizeChromeSection::kAppearance);
+
+    content::WebContents* const web_contents = GetCustomizeChromeWebContents();
+    CHECK(web_contents);
+    content::WaitForLoadStop(web_contents);
+    return web_contents;
+  }
+
+  // Calls the real CustomizeToolbarHandler already created by the page's own
+  // JS (a second C++-side mojo::Remote can't be created: the handler only
+  // allows one pipe per WebUI, see CustomizeChromeUI::
+  // CreateCustomizeToolbarHandler()) and returns the ids/categories of the
+  // actions it lists.
+  base::ListValue ListActions(content::WebContents* web_contents) {
+    constexpr char kScript[] = R"(
+        (async () => {
+          const {CustomizeToolbarApiProxy} = await import(
+              'chrome://customize-chrome-side-panel.top-chrome/' +
+              'customize_toolbar/customize_toolbar_api_proxy.js');
+          const {actions} =
+              await CustomizeToolbarApiProxy.getInstance().handler
+                  .listActions();
+          return actions.map(a => ({id: a.id, category: a.category}));
+        })()
+    )";
+    const content::EvalJsResult result = content::EvalJs(web_contents, kScript);
+    EXPECT_TRUE(result.is_ok()) << result.ExtractError();
+    return result.ExtractList().Clone();
+  }
+
+  bool ContainsAction(
+      const base::ListValue& actions,
+      side_panel::customize_chrome::mojom::ActionId id,
+      std::optional<side_panel::customize_chrome::mojom::CategoryId> category =
+          std::nullopt) {
+    return std::ranges::any_of(actions, [&](const base::Value& action) {
+      const auto& dict = action.GetDict();
+      if (dict.FindInt("id") != static_cast<int>(id)) {
+        return false;
+      }
+      return !category.has_value() ||
+             dict.FindInt("category") == static_cast<int>(*category);
+    });
   }
 };
 
@@ -80,4 +136,85 @@ IN_PROC_BROWSER_TEST_F(CustomizeChromeSidePanelBrowserTest, CloseButton) {
     return !customize_chrome_side_panel_controller
                 ->IsCustomizeChromeEntryShowing();
   }));
+}
+
+// This covers disabled upstream's unit test:
+// CustomizeToolbarHandlerTest.ListActions.
+// Note that we use this browser test as the upstream unit test depend on banned
+// BrowserWithTestWindowTest, which is practically a browser test.
+IN_PROC_BROWSER_TEST_F(CustomizeChromeSidePanelBrowserTest,
+                       ListActionsFiltersAndAddsBraveActions) {
+  content::WebContents* const web_contents = OpenCustomizeChromeSidePanel();
+  const base::ListValue actions = ListActions(web_contents);
+
+  using ActionId = side_panel::customize_chrome::mojom::ActionId;
+  using CategoryId = side_panel::customize_chrome::mojom::CategoryId;
+
+  // Sanity check: unmodified Chromium actions are still listed.
+  EXPECT_TRUE(ContainsAction(actions, ActionId::kHome));
+  EXPECT_TRUE(ContainsAction(actions, ActionId::kForward));
+  EXPECT_TRUE(ContainsAction(actions, ActionId::kDevTools));
+
+  // Unsupported Chromium actions are filtered out.
+  EXPECT_FALSE(ContainsAction(actions, ActionId::kShowPaymentMethods));
+  EXPECT_FALSE(ContainsAction(actions, ActionId::kShowTranslate));
+  EXPECT_FALSE(ContainsAction(actions, ActionId::kShowReadAnything));
+  EXPECT_FALSE(ContainsAction(actions, ActionId::kShowAddresses));
+
+  // LensOverlay is disabled in Brave, so its action is never created upstream
+  // in the first place (this is the reason
+  // CustomizeToolbarHandlerTest.ListActions/ActionsUpdatedOnVisibilityChange
+  // are disabled in unit_tests.filter).
+  EXPECT_FALSE(ContainsAction(actions, ActionId::kShowLensOverlay));
+
+  // Brave-specific actions are added.
+  EXPECT_TRUE(ContainsAction(actions, ActionId::kShowAddBookmarkButton,
+                             CategoryId::kNavigation));
+  EXPECT_TRUE(ContainsAction(actions, ActionId::kShowSidePanel,
+                             CategoryId::kNavigation));
+}
+
+// This covers disabled upstream's unit test:
+// CustomizeToolbarHandlerTest.ActionsUpdatedOnVisibilityChange.
+// Note that we use this browser test as the upstream unit test depend on banned
+// BrowserWithTestWindowTest, which is practically a browser test.
+IN_PROC_BROWSER_TEST_F(CustomizeChromeSidePanelBrowserTest,
+                       ActionsUpdatedOnVisibilityChange) {
+  content::WebContents* const web_contents = OpenCustomizeChromeSidePanel();
+
+  using ActionId = side_panel::customize_chrome::mojom::ActionId;
+
+  // Devtools is initially present in the actions list.
+  ASSERT_TRUE(ContainsAction(ListActions(web_contents), ActionId::kDevTools));
+
+  // Listen for the WebUI client being notified that actions changed.
+  ASSERT_TRUE(content::ExecJs(web_contents, R"(
+      (async () => {
+        const {CustomizeToolbarApiProxy} = await import(
+            'chrome://customize-chrome-side-panel.top-chrome/' +
+            'customize_toolbar/customize_toolbar_api_proxy.js');
+        window.notified = false;
+        CustomizeToolbarApiProxy.getInstance()
+            .callbackRouter.notifyActionsUpdated.addListener(() => {
+              window.notified = true;
+            });
+      })()
+  )"));
+
+  // Set visibility of devtools to false, and...
+  actions::ActionItem* const scope_action =
+      browser()->browser_actions()->root_action_item();
+  actions::ActionItem* const devtools_action_item =
+      actions::ActionManager::Get().FindAction(kActionDevTools, scope_action);
+  ASSERT_TRUE(devtools_action_item);
+
+  // The WebUI client is notified, and...
+  devtools_action_item->SetVisible(false);
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return content::EvalJs(web_contents, "window.notified === true")
+        .ExtractBool();
+  }));
+
+  // Devtools is now absent from the actions list.
+  EXPECT_FALSE(ContainsAction(ListActions(web_contents), ActionId::kDevTools));
 }

--- a/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler_unittest.cc
+++ b/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler_unittest.cc
@@ -6,6 +6,7 @@
 #include "chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler.h"
 
 #include "base/functional/bind.h"
+#include "base/test/mock_callback.h"
 #include "brave/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/brave_action.h"
 #include "chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar.mojom.h"
 #include "chrome/test/base/testing_profile.h"
@@ -72,6 +73,12 @@ class CustomizeToolbarHandlerUnitTest : public testing::Test {
     return testing_profile_.GetTestingPrefService();
   }
 
+  bool IsPrefDefaultValue(const char* pref_name) {
+    const auto* pref = GetTestingPrefService()->FindPreference(pref_name);
+    CHECK(pref);
+    return pref->IsDefaultValue();
+  }
+
   content::BrowserTaskEnvironment task_environment_;
   TestingProfile testing_profile_;
 
@@ -104,6 +111,51 @@ TEST_F(CustomizeToolbarHandlerUnitTest, YourChromeLabelShouldBeBraveMenu) {
             (*your_chrome_it)->display_name,
             l10n_util::GetStringUTF8(IDS_CUSTOMIZE_TOOLBAR_CATEGORY_TOOLBAR));
       }));
+}
+
+TEST_F(CustomizeToolbarHandlerUnitTest, PinAction_TogglesBraveActionPref) {
+  // kShowAddBookmarkButton is pinned by default, so pinning it again should
+  // be a no-op on the pref, and unpinning it should set the pref to false.
+  ASSERT_TRUE(
+      GetTestingPrefService()->GetBoolean(kShowAddBookmarkButton.pref_name));
+
+  EXPECT_CALL(mock_page_, SetActionPinned(kShowAddBookmarkButton.id, false));
+  handler_->PinAction(kShowAddBookmarkButton.id, /*pin=*/false);
+  EXPECT_FALSE(
+      GetTestingPrefService()->GetBoolean(kShowAddBookmarkButton.pref_name));
+
+  EXPECT_CALL(mock_page_, SetActionPinned(kShowAddBookmarkButton.id, true));
+  handler_->PinAction(kShowAddBookmarkButton.id, /*pin=*/true);
+  EXPECT_TRUE(IsPrefDefaultValue(kShowAddBookmarkButton.pref_name));
+}
+
+TEST_F(CustomizeToolbarHandlerUnitTest,
+       GetIsCustomized_TrueWhenBraveActionPrefChanged) {
+  base::MockCallback<CustomizeToolbarHandler::GetIsCustomizedCallback> callback;
+
+  EXPECT_CALL(callback, Run(false));
+  handler_->GetIsCustomized(callback.Get());
+
+  handler_->PinAction(kShowAddBookmarkButton.id, /*pin=*/false);
+
+  EXPECT_CALL(callback, Run(true));
+  handler_->GetIsCustomized(callback.Get());
+}
+
+TEST_F(CustomizeToolbarHandlerUnitTest, ResetToDefault_ClearsBraveActionPrefs) {
+  EXPECT_CALL(mock_page_, SetActionPinned(kShowAddBookmarkButton.id, false));
+  handler_->PinAction(kShowAddBookmarkButton.id, /*pin=*/false);
+  ASSERT_FALSE(
+      GetTestingPrefService()->GetBoolean(kShowAddBookmarkButton.pref_name));
+
+  EXPECT_CALL(mock_page_, SetActionPinned(kShowAddBookmarkButton.id, true));
+  handler_->ResetToDefault();
+
+  EXPECT_TRUE(IsPrefDefaultValue(kShowAddBookmarkButton.pref_name));
+
+  base::MockCallback<CustomizeToolbarHandler::GetIsCustomizedCallback> callback;
+  EXPECT_CALL(callback, Run(false));
+  handler_->GetIsCustomized(callback.Get());
 }
 
 }  // namespace customize_chrome

--- a/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/list_action_modifiers.cc
+++ b/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/list_action_modifiers.cc
@@ -205,6 +205,36 @@ std::vector<ActionPtr> ApplyBraveSpecificModifications(
   auto* prefs = user_prefs::UserPrefs::Get(web_contents->GetBrowserContext());
   CHECK(prefs) << "Browser context does not have prefs";
 
+  auto brave_actions = ListBraveSpecificActions(web_contents);
+
+  for (const auto& brave_action : brave_actions) {
+    // Find the anchor action. If anchor action is not found, just append to the
+    // end of the list.
+    auto anchor_it =
+        std::ranges::find(actions, brave_action.anchor, get_action_id);
+
+    // Create the new action.
+    auto new_action = Action::New(
+        brave_action.id,
+        base::UTF16ToUTF8(
+            l10n_util::GetStringUTF16(brave_action.display_name_resource_id)),
+        /*pinned=*/prefs->GetBoolean(brave_action.pref_name),
+        /*has_enterprise_controlled_pinned_state=*/false, brave_action.category,
+        get_icon_url(brave_action.icon));
+
+    // Insert the new action after the anchor or end of the list.
+    actions.insert(anchor_it == actions.end() ? actions.end() : anchor_it + 1,
+                   std::move(new_action));
+  }
+
+  return actions;
+}
+
+std::vector<BraveAction> ListBraveSpecificActions(
+    content::WebContents* web_contents) {
+  auto* prefs = user_prefs::UserPrefs::Get(web_contents->GetBrowserContext());
+  CHECK(prefs) << "Browser context does not have prefs";
+
   std::vector<BraveAction> brave_actions;
   brave_actions.push_back(kShowAddBookmarkButton);
   brave_actions.push_back(kShowSidePanelAction);
@@ -237,27 +267,7 @@ std::vector<ActionPtr> ApplyBraveSpecificModifications(
       Profile::FromBrowserContext(web_contents->GetBrowserContext()),
       brave_actions);
 
-  for (const auto& brave_action : brave_actions) {
-    // Find the anchor action. If anchor action is not found, just append to the
-    // end of the list.
-    auto anchor_it =
-        std::ranges::find(actions, brave_action.anchor, get_action_id);
-
-    // Create the new action.
-    auto new_action = Action::New(
-        brave_action.id,
-        base::UTF16ToUTF8(
-            l10n_util::GetStringUTF16(brave_action.display_name_resource_id)),
-        /*pinned=*/prefs->GetBoolean(brave_action.pref_name),
-        /*has_enterprise_controlled_pinned_state=*/false, brave_action.category,
-        get_icon_url(brave_action.icon));
-
-    // Insert the new action after the anchor or end of the list.
-    actions.insert(anchor_it == actions.end() ? actions.end() : anchor_it + 1,
-                   std::move(new_action));
-  }
-
-  return actions;
+  return brave_actions;
 }
 
 }  // namespace customize_chrome

--- a/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/list_action_modifiers.h
+++ b/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/list_action_modifiers.h
@@ -16,6 +16,8 @@ class WebContents;
 
 namespace customize_chrome {
 
+struct BraveAction;
+
 // Append Brave-specific categories to the list of categories.
 //  * We have our own "Address bar" category that contains actions like
 //    `kShowReward`.
@@ -47,6 +49,12 @@ std::vector<side_panel::customize_chrome::mojom::ActionPtr>
 ApplyBraveSpecificModifications(
     content::WebContents* web_contents,
     std::vector<side_panel::customize_chrome::mojom::ActionPtr> actions);
+
+// Returns a list of Brave-specific actions that could be added to the toolbar.
+// Use to check if the prefs are touched by user customization or reset them to
+// default.
+std::vector<BraveAction> ListBraveSpecificActions(
+    content::WebContents* web_contents);
 
 }  // namespace customize_chrome
 

--- a/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler.cc
+++ b/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler.cc
@@ -10,19 +10,48 @@
 #include "base/notreached.h"
 #include "brave/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/brave_action.h"
 #include "brave/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/list_action_modifiers.h"
+#include "chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/grit/branded_strings.h"
 #include "components/grit/brave_components_strings.h"
+#include "components/user_prefs/user_prefs.h"
+#include "content/public/browser/browser_context.h"
 
 namespace {
 
 bool PinBraveAction(side_panel::customize_chrome::mojom::ActionId action_id,
-                    PrefService* prefs) {
+                    PrefService* prefs,
+                    bool pin) {
   if (const auto* brave_action =
           base::FindPtrOrNull(customize_chrome::kBraveActions, action_id)) {
     // Brave specific actions are handled here.
-    prefs->SetBoolean(brave_action->pref_name,
-                      !prefs->GetBoolean(brave_action->pref_name));
+    auto* pref = prefs->FindPreference(brave_action->pref_name);
+    CHECK(pref);
+    bool is_default_value_is_pinned = false;
+    if (pref->IsDefaultValue()) {
+      is_default_value_is_pinned = pref->GetValue()->GetBool();
+    } else {
+      is_default_value_is_pinned = !pref->GetValue()->GetBool();
+    }
+
+    // In order to make it easy to detect if user has set a customized value for
+    // Brave specific actions, we clear the pref when user want the state back
+    // to default, instead of setting the pref with the same value as the
+    // default value. This will help IsBraveActionCustomized() to detect if user
+    // has set a customized value for Brave specific actions.
+    if (is_default_value_is_pinned) {
+      if (pin) {
+        prefs->ClearPref(brave_action->pref_name);
+      } else {
+        prefs->SetBoolean(brave_action->pref_name, false);
+      }
+    } else {
+      if (pin) {
+        prefs->SetBoolean(brave_action->pref_name, true);
+      } else {
+        prefs->ClearPref(brave_action->pref_name);
+      }
+    }
     return true;
   }
 
@@ -52,6 +81,26 @@ void ObserveBraveActions(
                   base::BindRepeating(&OnBraveActionPinnedChanged,
                                       base::Unretained(client),
                                       base::Unretained(registrar.prefs()), id));
+  }
+}
+
+bool IsBraveActionCustomized(content::WebContents* web_contents) {
+  auto brave_actions = customize_chrome::ListBraveSpecificActions(web_contents);
+  auto* prefs = user_prefs::UserPrefs::Get(web_contents->GetBrowserContext());
+  CHECK(prefs) << "Browser context does not have prefs";
+  return std::ranges::any_of(brave_actions, [prefs](const auto& action) {
+    auto* pref = prefs->FindPreference(action.pref_name);
+    return pref && !pref->IsDefaultValue();
+  });
+}
+
+void ResetBraveActionsToDefault(content::WebContents* web_contents) {
+  auto brave_actions = customize_chrome::ListBraveSpecificActions(web_contents);
+  auto* prefs = user_prefs::UserPrefs::Get(web_contents->GetBrowserContext());
+  CHECK(prefs) << "Browser context does not have prefs";
+
+  for (const auto& action : brave_actions) {
+    prefs->ClearPref(action.pref_name);
   }
 }
 

--- a/patches/chrome-browser-ui-webui-side_panel-customize_chrome-customize_toolbar-customize_toolbar_handler.cc.patch
+++ b/patches/chrome-browser-ui-webui-side_panel-customize_chrome-customize_toolbar-customize_toolbar_handler.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler.cc b/chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler.cc
-index 70ce4930a1bebfa6b87bb96fc372f82a13e93cad..2f189dca4b9dab6e464089495986268258d327b8 100644
+index 70ce4930a1bebfa6b87bb96fc372f82a13e93cad..677caf9ea64f20f931b51800ef76552b21f530cf 100644
 --- a/chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler.cc
 +++ b/chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler.cc
 @@ -197,6 +197,7 @@ CustomizeToolbarHandler::CustomizeToolbarHandler(
@@ -44,9 +44,25 @@ index 70ce4930a1bebfa6b87bb96fc372f82a13e93cad..2f189dca4b9dab6e4640894959862682
  void CustomizeToolbarHandler::PinAction(
      side_panel::customize_chrome::mojom::ActionId action_id,
      bool pin) {
-+  if (PinBraveAction(action_id, prefs())) {
++  if (PinBraveAction(action_id, prefs(), pin)) {
 +    return;
 +  }
    const std::optional<actions::ActionId> chrome_action =
        ChromeActionForMojoAction(action_id);
    if (!chrome_action.has_value()) {
+@@ -428,10 +439,15 @@ void CustomizeToolbarHandler::PinAction(
+ 
+ void CustomizeToolbarHandler::GetIsCustomized(
+     GetIsCustomizedCallback callback) {
++  if (IsBraveActionCustomized(web_contents_.get())) {
++    std::move(callback).Run(true);
++    return;
++  }
+   std::move(callback).Run(!model_->IsDefault());
+ }
+ 
+ void CustomizeToolbarHandler::ResetToDefault() {
++  ResetBraveActionsToDefault(web_contents_.get());
+   model_->ResetToDefault();
+ }
+ 

--- a/rewrite/chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler.cc.yaml
+++ b/rewrite/chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler.cc.yaml
@@ -59,7 +59,7 @@ substitutions:
     re_flags: [DOTALL]
     replace: |-
       \1
-        if (PinBraveAction(action_id, prefs())) {
+        if (PinBraveAction(action_id, prefs(), pin)) {
           return;
         }
 
@@ -71,3 +71,28 @@ substitutions:
       IDS_CUSTOMIZE_TOOLBAR_CATEGORY_TOOLBAR.
     pattern: IDS_NTP_CUSTOMIZE_TOOLBAR_CATEGORY_YOUR_CHROME
     replace: IDS_CUSTOMIZE_TOOLBAR_CATEGORY_TOOLBAR
+
+  - description: |
+      Check if Brave specific actions are customized in GetIsCustomized().
+
+      Inserts a call to IsBraveActionCustomized() before upstream logic.
+
+    re_pattern: (void CustomizeToolbarHandler::GetIsCustomized\(.*?{)
+    re_flags: [DOTALL]
+    replace: |-
+      \1
+        if (IsBraveActionCustomized(web_contents_.get())) {
+          std::move(callback).Run(true);
+          return;
+        }
+
+  - description: |
+      Reset Brave specific actions to default in ResetToDefault().
+
+      Inserts a call to ResetBraveActionsToDefault() before upstream logic.
+
+    re_pattern: (void CustomizeToolbarHandler::ResetToDefault\(.*?{)
+    re_flags: [DOTALL]
+    replace: |-
+      \1
+        ResetBraveActionsToDefault(web_contents_.get());


### PR DESCRIPTION
Detect brave specific action prefs and reset them to default when "Reset to Default" is clicked.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56733
 
<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
