### PR TITLE
[iOS] Fix wallet origin spoofing via WKScriptMessage race condition

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CardanoProviderScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CardanoProviderScriptHandler.swift
@@ -164,6 +164,9 @@ class CardanoProviderScriptHandler: TabContentScript {
       // Fail if there is no last committed URL yet
       !message.frameInfo.securityOrigin.host.isEmpty,
       message.frameInfo.isMainFrame,  // Fail the request came from 3p origin
+      // Guard against race: old page's JS message delivered after navigation commit
+      message.frameInfo.securityOrigin.host == tab.lastCommittedURL?.host,
+      message.frameInfo.securityOrigin.protocol == tab.lastCommittedURL?.scheme,
       JSONSerialization.isValidJSONObject(message.body),
       let messageData = try? JSONSerialization.data(withJSONObject: message.body, options: []),
       let body = try? JSONDecoder().decode(MessageBody.self, from: messageData)

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CardanoProviderScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CardanoProviderScriptHandler.swift
@@ -165,8 +165,8 @@ class CardanoProviderScriptHandler: TabContentScript {
       !message.frameInfo.securityOrigin.host.isEmpty,
       message.frameInfo.isMainFrame,  // Fail the request came from 3p origin
       // Guard against race: old page's JS message delivered after navigation commit
-      message.frameInfo.securityOrigin.host == tab.lastCommittedURL?.host,
-      message.frameInfo.securityOrigin.protocol == tab.lastCommittedURL?.scheme,
+      let committedURL = tab.lastCommittedURL,
+      URLOrigin(wkSecurityOrigin: message.frameInfo.securityOrigin) == committedURL.origin,
       JSONSerialization.isValidJSONObject(message.body),
       let messageData = try? JSONSerialization.data(withJSONObject: message.body, options: []),
       let body = try? JSONDecoder().decode(MessageBody.self, from: messageData)

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/EthereumProviderScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/EthereumProviderScriptHandler.swift
@@ -87,8 +87,8 @@ class EthereumProviderScriptHandler: TabContentScript {
       !message.frameInfo.securityOrigin.host.isEmpty,
       message.frameInfo.isMainFrame,  // Fail the request came from 3p origin
       // Guard against race: old page's JS message delivered after navigation commit
-      message.frameInfo.securityOrigin.host == tab.lastCommittedURL?.host,
-      message.frameInfo.securityOrigin.protocol == tab.lastCommittedURL?.scheme,
+      let committedURL = tab.lastCommittedURL,
+      URLOrigin(wkSecurityOrigin: message.frameInfo.securityOrigin) == committedURL.origin,
       JSONSerialization.isValidJSONObject(message.body),
       let messageData = try? JSONSerialization.data(withJSONObject: message.body, options: []),
       let body = try? JSONDecoder().decode(MessageBody.self, from: messageData)

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/EthereumProviderScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/EthereumProviderScriptHandler.swift
@@ -86,6 +86,9 @@ class EthereumProviderScriptHandler: TabContentScript {
       // Fail if there is no last committed URL yet
       !message.frameInfo.securityOrigin.host.isEmpty,
       message.frameInfo.isMainFrame,  // Fail the request came from 3p origin
+      // Guard against race: old page's JS message delivered after navigation commit
+      message.frameInfo.securityOrigin.host == tab.lastCommittedURL?.host,
+      message.frameInfo.securityOrigin.protocol == tab.lastCommittedURL?.scheme,
       JSONSerialization.isValidJSONObject(message.body),
       let messageData = try? JSONSerialization.data(withJSONObject: message.body, options: []),
       let body = try? JSONDecoder().decode(MessageBody.self, from: messageData)

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
@@ -88,8 +88,8 @@ class SolanaProviderScriptHandler: TabContentScript {
       !message.frameInfo.securityOrigin.host.isEmpty,
       message.frameInfo.isMainFrame,  // Fail the request came from 3p origin
       // Guard against race: old page's JS message delivered after navigation commit
-      message.frameInfo.securityOrigin.host == tab.lastCommittedURL?.host,
-      message.frameInfo.securityOrigin.protocol == tab.lastCommittedURL?.scheme,
+      let committedURL = tab.lastCommittedURL,
+      URLOrigin(wkSecurityOrigin: message.frameInfo.securityOrigin) == committedURL.origin,
       JSONSerialization.isValidJSONObject(message.body),
       let messageData = try? JSONSerialization.data(withJSONObject: message.body, options: []),
       let body = try? JSONDecoder().decode(MessageBody.self, from: messageData)

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
@@ -87,6 +87,9 @@ class SolanaProviderScriptHandler: TabContentScript {
       // Fail if there is no last committed URL yet
       !message.frameInfo.securityOrigin.host.isEmpty,
       message.frameInfo.isMainFrame,  // Fail the request came from 3p origin
+      // Guard against race: old page's JS message delivered after navigation commit
+      message.frameInfo.securityOrigin.host == tab.lastCommittedURL?.host,
+      message.frameInfo.securityOrigin.protocol == tab.lastCommittedURL?.scheme,
       JSONSerialization.isValidJSONObject(message.body),
       let messageData = try? JSONSerialization.data(withJSONObject: message.body, options: []),
       let body = try? JSONDecoder().decode(MessageBody.self, from: messageData)


### PR DESCRIPTION
Add security origin validation to Ethereum, Solana, and Cardano provider script handlers to prevent a race condition where a lingering WKScriptMessage from an old page is processed after tabDidCommitNavigation has already recreated the wallet provider with the new page's committed origin, causing wallet permission requests (e.g. eth_requestAccounts) to be attributed to the wrong origin.
The fix validates that message.frameInfo.securityOrigin matches the tab's lastCommittedURL before dispatching any wallet provider method, dropping messages whose security origin no longer matches the tab's current committed origin.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/internal/issues/1785

Test:
1. load  https://ghostxsec.github.io/spoof/bwspoof
2. tap `repro`
3. verify the tab will redirect to google.com
4. verify there is no wallet notification appears 

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
