### PR TITLE
[iOS] Handle offer codes correctly in Origin paywall

### DIFF
--- a/ios/brave-ios/Sources/Origin/OriginPaywallView.swift
+++ b/ios/brave-ios/Sources/Origin/OriginPaywallView.swift
@@ -18,6 +18,8 @@ public struct OriginPaywallView: View {
   @Environment(\.dismiss) private var dismiss
   @Environment(\.openURL) private var openURL
 
+  @State private var isOfferCodeRedeemSheetPresented: Bool = false
+
   var didPurchase: (() -> Void)
 
   public init(viewModel: OriginPaywallViewModel, didPurchase: @escaping () -> Void = {}) {
@@ -50,8 +52,7 @@ public struct OriginPaywallView: View {
             AdditionalActionView(
               title: Strings.Origin.promoCodeTitle
             ) {
-              // Open the redeem code sheet
-              SKPaymentQueue.default().presentCodeRedemptionSheet()
+              isOfferCodeRedeemSheetPresented = true
             } label: {
               Text(Strings.Origin.redeemPromoCodeButton)
             }
@@ -60,6 +61,18 @@ public struct OriginPaywallView: View {
           .padding(16)
         }
         paywallActionContainerView
+      }
+      .offerCodeRedemption(isPresented: $isOfferCodeRedeemSheetPresented) { result in
+        if case .success = result {
+          Task {
+            // The result of the sheet is still successful if the user cancels, so we dont want to
+            // explicitly show an error if theres no receipt in this case.
+            if await viewModel.restore(presentErrorOnFailure: false) {
+              dismiss()
+              didPurchase()
+            }
+          }
+        }
       }
       .background(Color(braveSystemName: .primitiveBlurple10))
       .navigationTitle(Strings.Origin.originProductName)

--- a/ios/brave-ios/Sources/Origin/OriginPaywallViewModel.swift
+++ b/ios/brave-ios/Sources/Origin/OriginPaywallViewModel.swift
@@ -43,7 +43,7 @@ public class OriginPaywallViewModel {
     return false
   }
 
-  func restore() async -> Bool {
+  func restore(presentErrorOnFailure: Bool = true) async -> Bool {
     isStoreOperationActive = true
     defer { isStoreOperationActive = false }
 
@@ -60,7 +60,7 @@ public class OriginPaywallViewModel {
       group.cancelAll()
       return result
     }
-    if !success {
+    if !success, presentErrorOnFailure {
       isErrorPresented = true
     }
     return success


### PR DESCRIPTION
This attempts to process the users transaction receipt after they use the Apple code redemption UI

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56702
