### PR TITLE
[recipes] Inital experiment with a recipe engine

### DIFF
--- a/tools/recipes/PRESUBMIT.py
+++ b/tools/recipes/PRESUBMIT.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Presubmit script for changes affecting tools/recipes/
+
+See http://dev.chromium.org/developers/how-tos/depottools/presubmit-scripts
+for more details about the presubmit API built into depot_tools.
+"""
+
+import os
+
+PRESUBMIT_VERSION = '2.0.0'
+
+
+def CheckTests(input_api, output_api):
+    script_dir = input_api.PresubmitLocalPath()
+    tests = []
+    for root, dirs, files in os.walk(script_dir):
+        dirs[:] = [d for d in dirs if d != '__pycache__']
+        if any(f.endswith('_test.py') for f in files):
+            tests.extend(
+                input_api.canned_checks.GetUnitTestsInDirectory(
+                    input_api,
+                    output_api,
+                    root,
+                    files_to_check=[r'.+_test\.py$']))
+    return input_api.RunTests(tests)

--- a/tools/recipes/README.md
+++ b/tools/recipes/README.md
@@ -1,0 +1,30 @@
+# Brave recipes
+
+> [!WARNING]
+>
+> Highly experimental. The engine, modules, and recipes here are a work in
+> progress and may change or be removed without notice.
+
+A very small recipe engine for Brave, loosely modelled on
+[chrome-infra's recipes_py](https://chromium.googlesource.com/infra/luci/recipes-py/).
+A _recipe_ describes a pipeline; the _engine_ resolves the recipe's `DEPS`,
+instantiates each _recipe module_, and runs the recipe's `RunSteps`.
+
+## Usage
+
+```sh
+python3 tools/recipes/engine.py toolchains/rust/package_rust \
+    --properties '{ "chromium_src": "~/dev/brave-next/src/", "brave_subrevision": 2, "chromium_ref": "151.0.7917.1" }'
+```
+
+The recipe name is a `/`-separated path under `recipes/`. `--properties` is a
+JSON object whose keys match the recipe's `PROPERTIES`.
+
+To run straight from a pipeline without a checkout, `engine_bootstrap.py`
+shallow-clones the engine from brave-core and forwards to `engine.py`:
+
+```sh
+curl -sL https://raw.githubusercontent.com/brave/brave-core/refs/heads/master/tools/recipes/engine_bootstrap.py \
+    | python3 - toolchains/rust/package_rust \
+        --properties '{ "chromium_src": "~/dev/brave-next/src/", "brave_subrevision": 2, "chromium_ref": "151.0.7917.1" }'
+```

--- a/tools/recipes/engine.py
+++ b/tools/recipes/engine.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""A very small recipe engine for Brave.
+
+Loads a recipe, resolves its `DEPS` (recursively, with caching and cycle
+detection), instantiates each recipe module's `RecipeApi`, wires dependencies
+onto each module's `.m` injection site, and finally calls the recipe's
+`RunSteps(api, properties)`.
+
+This is intentionally minimal -- a starting point modelled on chrome-infra's
+recipes_py that we will grow incrementally. Notable simplifications vs upstream:
+
+  * Single repo only; module names are bare directory names under
+    `recipe_modules/` (no `repo/module` qualification).
+  * No TEST_API / GenTests, no expectations, no warnings framework.
+  * Properties are a plain object, not a protobuf message.
+
+Run a recipe directly (recipe names are `/`-separated paths under recipes/):
+
+    python3 engine.py toolchains/rust/package_rust \\
+        --properties '{"chromium_src": "~/dev/chromium/src"}'
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import logging
+from pathlib import Path
+import sys
+import types
+
+from recipe_api import RecipeApi
+
+# Root of the recipes tree (this file's directory). Recipe modules live under
+# `recipe_modules/<name>/` and recipes under `recipes/<name>.py`.
+RECIPES_ROOT = Path(__file__).resolve().parent
+MODULES_PKG = 'recipe_modules'
+RECIPES_PKG = 'recipes'
+
+
+class RecipeScriptApi:
+    """The `api` object passed to a recipe's `RunSteps`.
+
+    Carries the recipe's top-level `DEPS`: each one is attached as an attribute
+    named after the module (e.g. `api.chromium_checkout`).
+    """
+
+    def __getattr__(self, name: str):
+        # DEPS are injected by the engine; a missing one means it was not
+        # declared in the recipe's DEPS. (Also tells static analysis that
+        # attributes are dynamic, so accessing a dep is not flagged no-member.)
+        raise AttributeError(
+            f'{name!r} is not a declared dependency (add it to DEPS?)')
+
+
+def _ensure_on_sys_path() -> None:
+    """Put the recipes root on `sys.path` so modules import as packages."""
+    root = str(RECIPES_ROOT)
+    if root not in sys.path:
+        sys.path.insert(0, root)
+
+
+def _find_api_class(api_module: types.ModuleType,
+                    module_name: str) -> type[RecipeApi]:
+    """Return the single `RecipeApi` subclass defined in *api_module*."""
+    classes = [
+        value for value in vars(api_module).values()
+        if isinstance(value, type) and issubclass(value, RecipeApi)
+        and value is not RecipeApi and value.__module__ == api_module.__name__
+    ]
+    if len(classes) != 1:
+        raise RuntimeError(
+            f"recipe module '{module_name}' must define exactly one RecipeApi "
+            f'subclass in api.py; found {len(classes)}')
+    return classes[0]
+
+
+class _Engine:
+    """Resolves DEPS and instantiates module APIs, caching by module name."""
+
+    def __init__(self) -> None:
+        _ensure_on_sys_path()
+        # module name -> instantiated RecipeApi (one instance per run).
+        self._cache: dict[str, RecipeApi] = {}
+
+    def _instantiate_module(self, name: str, chain: list[str]) -> RecipeApi:
+        if name in self._cache:
+            return self._cache[name]
+        if name in chain:
+            cycle = ' -> '.join(chain + [name])
+            raise RuntimeError(f'cyclical DEPS detected: {cycle}')
+
+        package = importlib.import_module(f'{MODULES_PKG}.{name}')
+        deps = list(getattr(package, 'DEPS', []))
+        api_module = importlib.import_module(f'{MODULES_PKG}.{name}.api')
+        api_class = _find_api_class(api_module, name)
+
+        inst = api_class()
+        for dep_name in deps:
+            setattr(inst.m, dep_name,
+                    self._instantiate_module(dep_name, chain + [name]))
+        # A module can reach itself via `self.m.<own_name>`, as in recipes_py.
+        setattr(inst.m, name, inst)
+
+        inst.initialize()
+        self._cache[name] = inst
+        return inst
+
+    def run_recipe(self,
+                   recipe_name: str,
+                   properties: dict[str, object] | None = None) -> object:
+        # Recipe names are `/`-separated paths under recipes/ (e.g.
+        # `toolchains/rust/package_rust`), mirroring recipes_py; map them to the
+        # dotted module path importlib expects.
+        module_path = recipe_name.replace('/', '.')
+        recipe = importlib.import_module(f'{RECIPES_PKG}.{module_path}')
+
+        api = RecipeScriptApi()
+        for dep_name in getattr(recipe, 'DEPS', []):
+            setattr(api, dep_name, self._instantiate_module(dep_name, []))
+
+        run_steps = getattr(recipe, 'RunSteps', None)
+        if run_steps is None:
+            raise RuntimeError(f"recipe '{recipe_name}' is missing RunSteps")
+
+        props_obj = _build_properties(getattr(recipe, 'PROPERTIES', None),
+                                      properties or {})
+        return run_steps(api, props_obj)
+
+
+def _build_properties(properties_def: type | None,
+                      properties: dict[str, object]) -> object:
+    """Build the properties object passed as `RunSteps`' second argument.
+
+    If the recipe declares `PROPERTIES` (any callable, e.g. a dataclass), it is
+    constructed from *properties*. Otherwise a plain namespace is returned.
+    """
+    if properties_def is None:
+        return types.SimpleNamespace(**properties)
+    return properties_def(**properties)
+
+
+def run_recipe(recipe_name: str,
+               properties: dict[str, object] | None = None) -> object:
+    """Resolve DEPS for *recipe_name* and run its `RunSteps`."""
+    return _Engine().run_recipe(recipe_name, properties)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description='Run a Brave recipe.')
+    parser.add_argument(
+        'recipe',
+        help='Recipe name under recipes/ (e.g. toolchains/rust/package_rust)')
+    parser.add_argument('--properties',
+                        default='{}',
+                        help='JSON object of recipe properties')
+    parser.add_argument('--verbose',
+                        action='store_true',
+                        help='Enable verbose (debug) logging')
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+    run_recipe(args.recipe, json.loads(args.properties))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/recipes/engine_bootstrap.py
+++ b/tools/recipes/engine_bootstrap.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Self-contained launcher for the Brave recipes engine.
+
+Lets a pipeline run a recipe straight from GitHub without a brave-core checkout:
+
+    curl -sL https://raw.githubusercontent.com/brave/brave-core/refs/heads/\\
+master/tools/recipes/engine_bootstrap.py \\
+        | python3 - toolchains/rust/package_rust \\
+            --properties '{"chromium_src": "~/dev/brave-next/src/",
+                           "brave_subrevision": 1,
+                           "chromium_ref": "151.0.7917.1"}'
+
+That is equivalent to running, from a checkout:
+
+    python3 tools/recipes/engine.py \\
+        toolchains/rust/package_rust --properties ...
+
+It shallow-, sparse-clones brave-core's `tools/recipes/` tree into the recipe's
+`brave_core_dest` (default `brave_core`), then re-dispatches the original
+arguments to the checked-out `engine.py`. Because it clones into the *same*
+destination the `brave_core_shallow` recipe module uses, the recipe reuses this
+checkout (adding its own paths to it) instead of cloning brave-core a second
+time.
+
+This script is intentionally dependency-free (standard library only) so it can
+run via `curl ... | python3 -` on a bare machine.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+import subprocess
+import sys
+
+# brave-core remote + branch the engine code is fetched from. SSH, matching the
+# `brave_core_shallow` recipe module.
+REPO_URL = 'git@github.com:brave/brave-core.git'
+BRAVE_CORE_REF = 'master'
+
+# Repo-relative path of the recipes engine tree, and the default checkout dir.
+# The default MUST match `recipes/toolchains/rust/package_rust.py`'s
+# `brave_core_dest` default (and the `brave_core_shallow` module) so the recipe
+# reuses this same checkout.
+RECIPES_PATH = 'tools/recipes'
+DEFAULT_BRAVE_CORE_DEST = 'brave_core'
+
+
+def _run(*cmd: str | Path, cwd: str | Path | None = None) -> None:
+    """Run *cmd*, logging the invocation, and raise on a non-zero exit."""
+    logging.info(' >>>> %s', ' '.join(str(arg) for arg in cmd))
+    subprocess.run([str(arg) for arg in cmd], cwd=cwd, check=True)
+
+
+def _brave_core_dest(properties_json: str) -> str:
+    """Read `brave_core_dest` from the --properties JSON, or the default.
+
+    The destination must agree with the recipe so both share one checkout. A
+    missing key or unparseable JSON falls back to the default; the engine
+    validates the properties for real once it runs.
+    """
+    try:
+        properties = json.loads(properties_json)
+    except json.JSONDecodeError:
+        return DEFAULT_BRAVE_CORE_DEST
+    if isinstance(properties, dict):
+        return properties.get('brave_core_dest') or DEFAULT_BRAVE_CORE_DEST
+    return DEFAULT_BRAVE_CORE_DEST
+
+
+def _deploy_recipes(dest: str | Path) -> Path:
+    """Shallow-, sparse-clone brave-core's `tools/recipes/` into *dest*.
+
+    Mirrors the `brave_core_shallow` recipe module (which it cannot import yet,
+    since nothing is checked out): clone when *dest* is not a checkout, then
+    `sparse-checkout add` the engine tree. `add` (not `set`) leaves the recipe
+    free to add its own paths (e.g. `tools/cr/toolchains`) to this checkout.
+
+    Returns the path to the checked-out `engine.py`.
+    """
+    dest = Path(dest).expanduser().resolve()
+
+    if (dest / '.git').is_dir():
+        logging.info('brave-core checkout already present at %s', dest)
+    else:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        _run('git', 'clone', '--depth', '2', '--filter=blob:none', '--sparse',
+             '--branch', BRAVE_CORE_REF, REPO_URL, dest)
+
+    _run('git', '-C', dest, 'sparse-checkout', 'add', RECIPES_PATH)
+
+    engine = dest / RECIPES_PATH / 'engine.py'
+    if not engine.is_file():
+        raise RuntimeError(f'engine not found after checkout: {engine}')
+    return engine
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+
+    # Peek at --properties to find the checkout destination, but forward the
+    # arguments to engine.py verbatim so the engine remains the source of truth
+    # for parsing and validation.
+    parser = argparse.ArgumentParser(
+        description='Bootstrap and run a Brave recipe from a shallow '
+        'brave-core checkout.')
+    parser.add_argument('recipe',
+                        help='Recipe name (e.g. toolchains/rust/package_rust)')
+    parser.add_argument('--properties',
+                        default='{}',
+                        help='JSON object of recipe properties')
+    parser.add_argument('--verbose', action='store_true')
+    args, _ = parser.parse_known_args(argv)
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+
+    engine = _deploy_recipes(_brave_core_dest(args.properties))
+
+    forwarded = [sys.executable, str(engine), *argv]
+    logging.info('Launching engine: %s', ' '.join(forwarded))
+    return subprocess.run(forwarded, check=False).returncode
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/recipes/recipe_api.py
+++ b/tools/recipes/recipe_api.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Base class for Brave recipe modules.
+
+Deliberately tiny mirror of `recipe_engine.recipe_api.RecipeApi` from
+chrome-infra's recipes_py. Every recipe module exposes exactly one `RecipeApi`
+subclass (in its `api.py`). After constructing it, the engine attaches the
+module's resolved `DEPS` onto `self.m` -- the "module injection site" -- so a
+module reaches each dependency as `self.m.<dep_name>` (and itself as
+`self.m.<own_name>`).
+"""
+
+from __future__ import annotations
+
+
+class ModuleInjectionSite:
+    """Namespace holding a module's resolved DEPS (and the module itself).
+
+    The engine populates one per module instance: each entry in the module's
+    `DEPS` becomes an attribute named after that dependency module. Attributes
+    are set dynamically by the engine, so the class declares no members itself.
+    """
+
+    def __getattr__(self, name: str):
+        # Dependencies are injected by the engine; a missing one means it was
+        # not declared in DEPS. (Also tells static analysis that attributes are
+        # dynamic, so accessing an injected dep is not flagged as no-member.)
+        raise AttributeError(
+            f'{name!r} is not a declared dependency (add it to DEPS?)')
+
+
+class RecipeApi:
+    """Base class every recipe module's API subclasses."""
+
+    def __init__(self) -> None:
+        # Populated by the engine after construction with this module's DEPS.
+        self.m: ModuleInjectionSite = ModuleInjectionSite()
+
+    def initialize(self) -> None:
+        """Hook run once after DEPS are injected. Override for setup."""

--- a/tools/recipes/recipe_modules/__init__.py
+++ b/tools/recipes/recipe_modules/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Package marker for Brave recipe modules.
+
+Each subdirectory is a recipe module: an `__init__.py` declaring `DEPS` and an
+`api.py` defining exactly one `RecipeApi` subclass.
+"""

--- a/tools/recipes/recipe_modules/brave_core_shallow/__init__.py
+++ b/tools/recipes/recipe_modules/brave_core_shallow/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""`brave_core_shallow` module: sparse-deploy brave-core subpaths."""
+
+DEPS = ['step']

--- a/tools/recipes/recipe_modules/brave_core_shallow/api.py
+++ b/tools/recipes/recipe_modules/brave_core_shallow/api.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""The `brave_core_shallow` module API."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+import logging
+from pathlib import Path
+
+from recipe_api import RecipeApi
+
+# Default SSH remote for the brave-core repository.
+REPO_URL = 'git@github.com:brave/brave-core.git'
+
+
+class BraveCoreShallowApi(RecipeApi):
+    """Deploys subpaths of brave-core via a shallow, sparse checkout.
+
+    Instead of cloning the whole (large) repository, this fetches just enough
+    history and only the requested subtrees, so a recipe can use a handful of
+    paths (scripts, configs, ...) without paying for a full checkout. The flow
+    matches a manual:
+
+        git clone --depth 2 --filter=blob:none --sparse <url> <dest>
+        git -C <dest> sparse-checkout set <path>...
+
+    `--filter=blob:none` defers blob downloads until checkout, `--sparse` starts
+    the working tree with only top-level files (cone mode), and
+    `sparse-checkout set` then materialises exactly the requested directories.
+    """
+
+    def deploy(self,
+               dest: str | Path,
+               paths: str | Path | Iterable[str | Path],
+               *,
+               url: str = REPO_URL,
+               ref: str | None = None,
+               depth: int = 2) -> Path:
+        """Ensure *paths* from brave-core are checked out under *dest*.
+
+        Clones brave-core into *dest* (shallow + sparse) when it is not already
+        a checkout, then restricts the working tree to *paths*. Re-running is
+        cheap: an existing checkout is reused and only the sparse set is
+        re-applied.
+
+        Every requested path keeps its brave-core-relative layout beneath the
+        returned root (a path `tools/a` lands at `<root>/tools/a`), so scripts
+        deployed in one path can reference sibling paths exactly as they do in a
+        full checkout, with no rewriting. Paths accumulate: each call extends
+        the working tree via `sparse-checkout add`, so subtrees checked out by
+        an earlier call -- or by an external bootstrap sharing this same
+        checkout -- coexist rather than being replaced.
+
+        Args:
+            dest: Directory the repo lives in (created if missing). This is the
+                brave-core root the returned tree is anchored at.
+            paths: A single repo-relative path, or an iterable of them, to
+                materialise (e.g. `'tools/cr/toolchains'`).
+            url: Git remote to clone from; defaults to brave-core over SSH.
+            ref: Optional branch or tag to clone. Only applied on the initial
+                clone; an existing checkout is left on its current ref. A
+                shallow clone cannot target a bare commit SHA.
+            depth: History depth for the shallow clone.
+
+        Returns:
+            The absolute `Path` to the brave-core checkout root. Requested paths
+            live beneath it at their original repo-relative locations.
+
+        Raises:
+            ValueError: If *paths* is empty.
+            RuntimeError: If a requested path is absent after the checkout
+                (e.g. a typo or a path that does not exist on *ref*).
+        """
+        single = isinstance(paths, (str, Path))
+        rel_paths = [str(paths)] if single else [str(p) for p in paths]
+        if not rel_paths:
+            raise ValueError('deploy() requires at least one path')
+
+        dest = Path(dest).expanduser().resolve()
+
+        if (dest / '.git').is_dir():
+            logging.info('brave-core checkout already present at %s', dest)
+        else:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            clone_cmd = [
+                'git', 'clone', '--depth',
+                str(depth), '--filter=blob:none', '--sparse'
+            ]
+            if ref:
+                clone_cmd += ['--branch', ref]
+            clone_cmd += [url, str(dest)]
+            self.m.step('clone brave-core (shallow, sparse)', clone_cmd)
+
+        # Extend the sparse working tree with the requested subtrees. `add`
+        # (rather than `set`) accumulates, so subtrees checked out by a prior
+        # call or an external bootstrap into this same checkout survive.
+        self.m.step(
+            'sparse-checkout add',
+            ['git', '-C',
+             str(dest), 'sparse-checkout', 'add', *rel_paths])
+
+        for rel in rel_paths:
+            if not (dest / rel).exists():
+                raise RuntimeError(
+                    f'brave-core path not found after sparse checkout: {rel!r} '
+                    f'(looked under {dest})')
+
+        return dest

--- a/tools/recipes/recipe_modules/chromium_checkout/__init__.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""`chromium_checkout` module: clone / sync / validate a Chromium src/ tree."""
+
+DEPS = ['step', 'depot_tools']

--- a/tools/recipes/recipe_modules/chromium_checkout/api.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/api.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""The `chromium_checkout` module API."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+from recipe_api import RecipeApi
+
+# A file that is reliably present in any Chromium checkout, used as a token to
+# decide whether a path holds a valid repo.
+CHROME_VERSION_FILE = Path('chrome/VERSION')
+
+# Hermetic Windows toolchain base URL, so the checkout can build without a local
+# Visual Studio install. Set only when not already configured by the caller.
+WIN_HERMETIC_TOOLCHAIN_BASE_URL = (
+    'https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-'
+    '2.on.aws/windows-hermetic-toolchain/')
+
+
+class ChromiumCheckoutApi(RecipeApi):
+    """Clones, syncs, and validates a Chromium `src/` checkout.
+
+    Extracted from the checkout-related helpers in `build_rust_toolchain.py`
+    (`_has_valid_chromium_path`, `_clone_chromium`, `_checkout_chromium_ref`).
+    """
+
+    def ensure_checkout(self,
+                        chromium_src: str | Path,
+                        ref: str | None = None) -> Path:
+        """Guarantee a Chromium checkout at *chromium_src*, optionally on *ref*.
+
+        Mirrors the checkout phase of `ToolchainBuilder.run`: validate the git
+        cache, ensure depot_tools is on PATH, clone a fresh checkout when none
+        is found, then check out *ref* if one is given.
+
+        Args:
+            chromium_src: Path to the Chromium `src/` directory.
+            ref: Optional git ref (branch, tag, or commit) to check out.
+
+        Returns:
+            The resolved absolute `src/` path.
+        """
+        chromium_src = Path(chromium_src).expanduser().resolve()
+
+        # A missing/invalid GIT_CACHE_PATH would silently break the clone/sync
+        # steps below, so fail fast before doing any work.
+        self.validate_git_cache()
+
+        # depot_tools provides `fetch`/`gclient`, needed whether we clone or
+        # operate on an existing checkout.
+        self.m.depot_tools.ensure_on_path(chromium_src)
+
+        # No valid checkout yet -> clone one.
+        if not self.has_valid_checkout(chromium_src):
+            logging.info('Chromium src not found at %s, cloning...',
+                         chromium_src)
+            self.clone(chromium_src)
+
+        if ref:
+            self.checkout_ref(chromium_src, ref)
+        return chromium_src
+
+    def validate_git_cache(self) -> str:
+        """Require `GIT_CACHE_PATH` to be set and point to a real directory.
+
+        git/gclient honour `GIT_CACHE_PATH` to share object storage across
+        checkouts. The pipeline mandates a cache, so a missing value is a hard
+        error -- we refuse to run an uncached checkout -- as is a value that
+        does not point at an existing directory.
+
+        Returns:
+            The current `GIT_CACHE_PATH` value.
+
+        Raises:
+            RuntimeError: If `GIT_CACHE_PATH` is unset or not a directory. Set
+                it in the environment or via `set_git_cache()` beforehand.
+        """
+        git_cache_path = os.environ.get('GIT_CACHE_PATH')
+        if not git_cache_path:
+            raise RuntimeError(
+                'GIT_CACHE_PATH is not set; a shared git cache is required. '
+                'Set it in the environment or via set_git_cache() before '
+                'running the checkout.')
+        if not Path(git_cache_path).is_dir():
+            raise RuntimeError(
+                f'GIT_CACHE_PATH is not a valid directory: {git_cache_path}')
+        logging.info('Using GIT_CACHE_PATH=%s', git_cache_path)
+        return git_cache_path
+
+    def set_git_cache(self, path: str | Path | None = None) -> Path:
+        """Set `GIT_CACHE_PATH` for subsequent git/gclient steps.
+
+        Mirrors `build_rust_toolchain.py`'s `--with-git-cache` handling: an
+        explicit *path* is used as-is (user-expanded); otherwise it defaults to
+        `<home>/cache` (`USERPROFILE` on Windows, `HOME` elsewhere), the layout
+        our CI bakes the cache under. The directory must already exist, and
+        `GIT_CACHE_PATH` must not already be set -- refusing to clobber an
+        existing value avoids masking a misconfiguration.
+
+        Args:
+            path: Explicit cache directory, or None/empty to use `<home>/cache`.
+
+        Returns:
+            The `Path` that `GIT_CACHE_PATH` was set to.
+
+        Raises:
+            RuntimeError: If `GIT_CACHE_PATH` is already set, or the resolved
+                directory does not exist.
+        """
+        if 'GIT_CACHE_PATH' in os.environ:
+            raise RuntimeError('GIT_CACHE_PATH is already set in the '
+                               'environment.')
+
+        if path:
+            git_cache_path = Path(path).expanduser()
+        else:
+            home_var = 'USERPROFILE' if sys.platform == 'win32' else 'HOME'
+            home = os.environ.get(home_var, str(Path.home()))
+            git_cache_path = Path(home) / 'cache'
+
+        if not git_cache_path.is_dir():
+            raise RuntimeError(
+                f'GIT_CACHE_PATH is not a valid directory: {git_cache_path}')
+
+        os.environ['GIT_CACHE_PATH'] = str(git_cache_path)
+        logging.info('Set GIT_CACHE_PATH=%s', git_cache_path)
+        return git_cache_path
+
+    def has_valid_checkout(self, chromium_src: str | Path) -> bool:
+        """Return whether *chromium_src* points to a valid Chromium repo."""
+        chromium_src = Path(chromium_src)
+        # `chrome/VERSION` is an unmistakable trait of a proper checkout.
+        if not (chromium_src / CHROME_VERSION_FILE).exists():
+            return False
+
+        logging.info('Checking for valid Chromium repo at %s', chromium_src)
+        try:
+            self.m.step(
+                'check chrome/VERSION',
+                ['git', 'log', '-1', '--oneline',
+                 str(CHROME_VERSION_FILE)],
+                cwd=chromium_src)
+        except (subprocess.CalledProcessError, OSError):
+            return False
+        return True
+
+    def clone(self, chromium_src: str | Path) -> None:
+        """Clone a fresh Chromium checkout at *chromium_src* via `fetch`."""
+        chromium_src = Path(chromium_src)
+        chromium_src.parent.mkdir(parents=True, exist_ok=True)
+        self.m.step('fetch chromium', ['fetch', '--nohooks', 'chromium'],
+                    cwd=chromium_src.parent)
+
+    def checkout_ref(self, chromium_src: str | Path, ref: str) -> None:
+        """Check out *ref* in *chromium_src* and resync dependencies."""
+        chromium_src = Path(chromium_src)
+        logging.info('Checking out Chromium ref %s', ref)
+        if (sys.platform == 'win32'
+                and 'DEPOT_TOOLS_WIN_TOOLCHAIN' not in os.environ):
+            # Build hermetically without a local VS install.
+            os.environ['DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL'] = (
+                WIN_HERMETIC_TOOLCHAIN_BASE_URL)
+
+        if re.fullmatch(r'\d+\.\d+\.\d+\.\d+', ref):
+            # Chromium release tag (e.g. `150.0.7850.1`): fetch it as a tag so
+            # it lands at `refs/tags/<ref>` in the local repo.
+            self.m.step('fetch tag', [
+                'git', 'fetch', '--no-tags', 'origin',
+                f'refs/tags/{ref}:refs/tags/{ref}'
+            ],
+                        cwd=chromium_src)
+        else:
+            self.m.step('fetch ref', ['git', 'fetch', 'origin', ref],
+                        cwd=chromium_src)
+
+        # A manual `git checkout --force` rather than `gclient sync -r <ref>`
+        # sidesteps a gclient bug; see
+        # https://github.com/brave/brave-browser/issues/44921.
+        self.m.step('checkout FETCH_HEAD',
+                    ['git', 'checkout', '--force', 'FETCH_HEAD'],
+                    cwd=chromium_src)
+        self.m.step('gclient sync', ['gclient', 'sync', '--force', '-D'],
+                    cwd=chromium_src)

--- a/tools/recipes/recipe_modules/depot_tools/__init__.py
+++ b/tools/recipes/recipe_modules/depot_tools/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""`depot_tools` module: ensure a usable depot_tools install is on PATH."""
+
+DEPS = ['step']

--- a/tools/recipes/recipe_modules/depot_tools/api.py
+++ b/tools/recipes/recipe_modules/depot_tools/api.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""The `depot_tools` module API."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+import shutil
+import sys
+
+from recipe_api import RecipeApi
+
+# Latest Chromium depot_tools bundle.
+DEPOT_TOOLS_URL = 'https://chromium.googlesource.com/chromium/tools/depot_tools'
+
+# vpython3 selected by depot_tools from `$PATH`, relative to the Chromium src/
+# root. On Windows the `.bat` shim is used (needed when calling from git bash).
+VPYTHON_PATH = Path('third_party/depot_tools') / (
+    'vpython3.bat' if sys.platform == 'win32' else 'vpython3')
+
+
+class DepotToolsApi(RecipeApi):
+    """Deploys depot_tools so `gclient`/`fetch` are available on PATH.
+
+    Extracted from `build_rust_toolchain.py::_bootstrap_depot_tools`.
+    """
+
+    def ensure_on_path(self, chromium_src: str | Path) -> None:
+        """Put depot_tools on PATH, cloning it beside src/ if necessary.
+
+        If `gclient` already resolves on PATH, this is a no-op. Otherwise it
+        reuses an existing checkout at `<chromium_src>/../depot_tools` or clones
+        a fresh one there, then prepends it to PATH and verifies `gclient` runs.
+
+        Args:
+            chromium_src: Path to the Chromium `src/` directory; depot_tools is
+                installed as its sibling.
+        """
+        chromium_src = Path(chromium_src).expanduser().resolve()
+
+        if shutil.which('gclient') is not None:
+            logging.debug('depot_tools already on PATH, skipping clone')
+            return
+
+        depot_tools_path = chromium_src.parent / 'depot_tools'
+        if (depot_tools_path / 'gclient').is_file():
+            # Already present at the expected install path; just add to PATH.
+            logging.info('depot_tools already present at %s, adding to PATH.',
+                         depot_tools_path)
+        else:
+            logging.info('Installing depot_tools under %s', depot_tools_path)
+            depot_tools_path.parent.mkdir(parents=True, exist_ok=True)
+            self.m.step(
+                'clone depot_tools',
+                ['git', 'clone', DEPOT_TOOLS_URL,
+                 str(depot_tools_path)])
+
+        os.environ['PATH'] = os.pathsep.join(
+            [str(depot_tools_path), os.environ['PATH']])
+        # Run once so depot_tools bootstraps itself (downloads its own deps).
+        self.m.step('verify gclient', ['gclient'])
+
+    def vpython3(self, chromium_src: str | Path) -> Path:
+        """Return the path to depot_tools' vpython3 inside *chromium_src*."""
+        return Path(chromium_src).expanduser().resolve() / VPYTHON_PATH

--- a/tools/recipes/recipe_modules/step/__init__.py
+++ b/tools/recipes/recipe_modules/step/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Core `step` module: run a subprocess as a named build step."""
+
+DEPS = []

--- a/tools/recipes/recipe_modules/step/api.py
+++ b/tools/recipes/recipe_modules/step/api.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""The core `step` module API."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import logging
+from pathlib import Path
+import platform
+import shutil
+import subprocess
+
+from recipe_api import RecipeApi
+
+
+class StepApi(RecipeApi):
+    """Runs a subprocess as a named build step.
+
+    The instance is callable, so recipes and modules invoke it as
+    `api.step(name, cmd, ...)`, mirroring `recipe_engine/step`. This is the one
+    place that actually shells out; everything else describes work in terms of
+    steps. Consolidates the logging and Windows command resolution that
+    `build_rust_toolchain.py::_check_call` did inline.
+    """
+
+    def __call__(
+            self,
+            name: str,
+            cmd: Sequence[str | Path],
+            *,
+            cwd: str | Path | None = None,
+            env: Mapping[str, str] | None = None,
+            check: bool = True,
+            capture_output: bool = False) -> subprocess.CompletedProcess[str]:
+        """Run *cmd* as the step named *name*.
+
+        Args:
+            name: Human-readable step name, logged before the command runs.
+            cmd: The program and its arguments as a sequence; each element is
+                stringified (so `Path` objects are fine).
+            cwd: Optional working directory for the subprocess.
+            env: Optional environment mapping; inherits the parent when `None`.
+            check: Raise `CalledProcessError` on non-zero exit when True.
+            capture_output: Capture stdout/stderr (as text) instead of
+                inheriting the parent's streams.
+
+        Returns:
+            The `subprocess.CompletedProcess` for the invocation.
+
+        Raises:
+            subprocess.CalledProcessError: If `check` and the process fails.
+            RuntimeError: On Windows, if the command cannot be resolved.
+        """
+        cmd = [str(arg) for arg in cmd]
+        logging.info('[step] %s\n >>>> %s', name, ' '.join(cmd))
+
+        if platform.system() == 'Windows':
+            # Resolve to an absolute path to avoid bat-file name mismatches
+            # (e.g. `gclient` vs `gclient.bat`) without using `shell=True`.
+            resolved = shutil.which(cmd[0])
+            if resolved is None:
+                raise RuntimeError(f'Command not found: {cmd[0]}')
+            cmd[0] = resolved
+
+        return subprocess.run(cmd,
+                              cwd=cwd,
+                              env=env,
+                              check=check,
+                              capture_output=capture_output,
+                              text=True)

--- a/tools/recipes/recipes/__init__.py
+++ b/tools/recipes/recipes/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Package marker for Brave recipes.
+
+Each module here is a recipe: it declares `DEPS`, an optional `PROPERTIES`, and
+a `RunSteps(api, properties)` entry point the engine invokes.
+"""

--- a/tools/recipes/recipes/toolchains/__init__.py
+++ b/tools/recipes/recipes/toolchains/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Package marker for toolchain recipes."""

--- a/tools/recipes/recipes/toolchains/rust/__init__.py
+++ b/tools/recipes/recipes/toolchains/rust/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Package marker for Rust toolchain recipes."""

--- a/tools/recipes/recipes/toolchains/rust/package_rust.py
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Recipe: build and package Brave's Rust toolchain overlay.
+
+Wires together the recipe modules to drive
+`tools/cr/toolchains/build_rust_toolchain.py`:
+
+  1. `chromium_checkout` prepares the Chromium `src/` tree -- cloning when
+     asked and checking out the requested ref/tag. The ref is handled here, NOT
+     by passing `--use-ref` to the build script, so the script always operates
+     on an already-prepared checkout.
+  2. `brave_core_shallow` sparse-deploys `tools/cr/toolchains/` from brave-core
+     so the build script is available without a full Brave checkout.
+  3. The build script is run with `--no-full-toolchain` to produce the minimal
+     rust-lld + wasm32 overlay archive.
+
+Run it via the engine (from tools/recipes/):
+
+    python3 engine.py toolchains/rust/package_rust \\
+        --properties '{"chromium_src": "~/dev/chromium/src",
+                       "brave_subrevision": 1,
+                       "chromium_ref": "refs/tags/150.0.7850.1"}'
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from engine import RecipeScriptApi
+
+DEPS = ['step', 'depot_tools', 'chromium_checkout', 'brave_core_shallow']
+
+# Repo-relative path of the toolchain scripts inside brave-core, and the build
+# entry point within it.
+BRAVE_TOOLCHAINS_PATH = 'tools/cr/toolchains'
+BUILD_SCRIPT = 'build_rust_toolchain.py'
+
+# brave-core branch the build script is always fetched from.
+BRAVE_CORE_REF = 'master'
+
+
+@dataclass(frozen=True)
+class InputProperties:
+    """Inputs for the package_rust recipe.
+
+    Attributes:
+        chromium_src: Path to the Chromium `src/` directory.
+        brave_subrevision: Integer respin counter passed as
+            `--brave-subrevision` to the build script.
+        chromium_ref: Git ref/tag for the Chromium checkout. Applied by
+            `chromium_checkout`, not by the build script.
+        out_dir: Output directory passed as `--out-dir` to the build script.
+        brave_core_dest: Directory the shallow brave-core checkout is deployed
+            to (the build script is run from within it).
+        git_cache: Sets `GIT_CACHE_PATH`. A shared git cache is required: if
+            None, `GIT_CACHE_PATH` must already be set in the environment or the
+            run aborts; an empty string sets it to the default `<home>/cache`;
+            any other value sets it to that explicit path. Mirrors
+            `--with-git-cache`.
+    """
+
+    chromium_src: str
+    brave_subrevision: int
+    chromium_ref: str
+    out_dir: str = 'out'
+    brave_core_dest: str = 'brave_core'
+    git_cache: str | None = None
+
+
+PROPERTIES = InputProperties
+
+
+def RunSteps(api: RecipeScriptApi, properties: InputProperties) -> None:
+    # A shared git cache is mandatory: ensure_checkout aborts if GIT_CACHE_PATH
+    # is not set. Seed it from the provided value when given; otherwise it must
+    # already be present in the environment.
+    if properties.git_cache is not None:
+        api.chromium_checkout.set_git_cache(properties.git_cache or None)
+
+    # Prepare the Chromium checkout and pin it to the requested ref. The build
+    # script is deliberately not told about the ref (no --use-ref); it just
+    # consumes the tree we hand it.
+    chromium_src = api.chromium_checkout.ensure_checkout(
+        properties.chromium_src, ref=properties.chromium_ref)
+
+    # Sparse-deploy the brave-core toolchain scripts. deploy() returns the
+    # brave-core root with the subtree at its original repo-relative path.
+    brave_core_root = api.brave_core_shallow.deploy(properties.brave_core_dest,
+                                                    BRAVE_TOOLCHAINS_PATH,
+                                                    ref=BRAVE_CORE_REF)
+    toolchains_dir = brave_core_root / BRAVE_TOOLCHAINS_PATH
+
+    # build_rust_toolchain.py carries a VPYTHON spec (it needs the pyyaml
+    # wheel), so it must run under depot_tools' vpython3.
+    vpython3 = api.depot_tools.vpython3(chromium_src)
+
+    # No cwd override: the script resolves --out-dir against the current
+    # working directory, so `out` lands relative to where the recipe is run.
+    api.step('build rust toolchain', [
+        vpython3,
+        toolchains_dir / BUILD_SCRIPT,
+        '--out-dir',
+        properties.out_dir,
+        '--chromium-src',
+        chromium_src,
+        '--brave-subrevision',
+        str(properties.brave_subrevision),
+        '--clear',
+        '--no-full-toolchain',
+    ])

--- a/tools/recipes/unittests/engine_bootstrap_test.py
+++ b/tools/recipes/unittests/engine_bootstrap_test.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for the self-contained engine bootstrap."""
+
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import engine_bootstrap as bootstrap  # pylint: disable=wrong-import-position
+
+
+class BraveCoreDestTest(unittest.TestCase):
+    """The checkout destination is read from --properties (or defaulted)."""
+
+    def test_default(self):
+        self.assertEqual(bootstrap._brave_core_dest('{}'), 'brave_core')
+
+    def test_explicit(self):
+        self.assertEqual(
+            bootstrap._brave_core_dest('{"brave_core_dest": "scratch/bc"}'),
+            'scratch/bc')
+
+    def test_unparseable_json_falls_back(self):
+        self.assertEqual(bootstrap._brave_core_dest('not json'), 'brave_core')
+
+    def test_non_object_json_falls_back(self):
+        self.assertEqual(bootstrap._brave_core_dest('[1, 2]'), 'brave_core')
+
+
+class MainForwardingTest(unittest.TestCase):
+    """main() deploys the engine and forwards argv to it verbatim."""
+
+    def test_forwards_argv_verbatim(self):
+        argv = [
+            'toolchains/rust/package_rust', '--properties',
+            '{"brave_core_dest": "bc"}'
+        ]
+        engine_path = Path('bc/tools/recipes/engine.py')
+        with mock.patch.object(bootstrap, '_deploy_recipes',
+                               return_value=engine_path) as deploy, \
+             mock.patch.object(bootstrap.subprocess, 'run') as run:
+            run.return_value = types.SimpleNamespace(returncode=0)
+            rc = bootstrap.main(argv)
+
+        self.assertEqual(rc, 0)
+        deploy.assert_called_once_with('bc')
+        forwarded = run.call_args[0][0]
+        self.assertEqual(forwarded[0], sys.executable)
+        self.assertEqual(forwarded[1:], [str(engine_path), *argv])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/recipes/unittests/engine_test.py
+++ b/tools/recipes/unittests/engine_test.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for the recipe engine's DEPS resolution and property binding."""
+
+import os
+import sys
+import types
+import unittest
+from dataclasses import dataclass
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import engine  # pylint: disable=wrong-import-position
+from recipe_api import RecipeApi  # pylint: disable=wrong-import-position
+
+
+class DepsResolutionTest(unittest.TestCase):
+    """The engine wires a module's DEPS onto its injection site."""
+
+    def test_wires_deps_onto_injection_site(self):
+        cc = engine._Engine()._instantiate_module('chromium_checkout', [])
+        self.assertTrue(hasattr(cc.m, 'depot_tools'))
+        self.assertTrue(hasattr(cc.m, 'step'))
+        # A module can reach itself via self.m.<own_name>.
+        self.assertIs(cc.m.chromium_checkout, cc)
+
+    def test_instances_are_cached_and_shared(self):
+        eng = engine._Engine()
+        cc = eng._instantiate_module('chromium_checkout', [])
+        dt = eng._instantiate_module('depot_tools', [])
+        # chromium_checkout and depot_tools share one `step` instance.
+        self.assertIs(cc.m.step, dt.m.step)
+
+
+class FindApiClassTest(unittest.TestCase):
+    """_find_api_class requires exactly one RecipeApi subclass."""
+
+    def test_zero_classes_raises(self):
+        module = types.ModuleType('fake')
+        with self.assertRaises(RuntimeError):
+            engine._find_api_class(module, 'fake')
+
+    def test_exactly_one_class(self):
+        module = types.ModuleType('fake')
+
+        class OnlyApi(RecipeApi):
+            pass
+
+        OnlyApi.__module__ = 'fake'
+        module.OnlyApi = OnlyApi
+        self.assertIs(engine._find_api_class(module, 'fake'), OnlyApi)
+
+    def test_two_classes_raises(self):
+        module = types.ModuleType('fake')
+
+        class ApiA(RecipeApi):
+            pass
+
+        class ApiB(RecipeApi):
+            pass
+
+        ApiA.__module__ = ApiB.__module__ = 'fake'
+        module.ApiA = ApiA
+        module.ApiB = ApiB
+        with self.assertRaises(RuntimeError):
+            engine._find_api_class(module, 'fake')
+
+
+class BuildPropertiesTest(unittest.TestCase):
+    """_build_properties maps a dict onto PROPERTIES (or a namespace)."""
+
+    def test_no_properties_def_returns_namespace(self):
+        obj = engine._build_properties(None, {'a': 1, 'b': 'x'})
+        self.assertEqual((obj.a, obj.b), (1, 'x'))
+
+    def test_dataclass_def_applies_defaults(self):
+
+        @dataclass
+        class Props:
+            a: int
+            b: str = 'default'
+
+        obj = engine._build_properties(Props, {'a': 5})
+        self.assertEqual((obj.a, obj.b), (5, 'default'))
+
+
+class RunRecipeTest(unittest.TestCase):
+    """run_recipe maps the slash path to a module and requires RunSteps."""
+
+    def test_slash_path_mapped_and_missing_run_steps_raises(self):
+        fake_recipe = types.SimpleNamespace(DEPS=[])
+        import_module = mock.Mock(return_value=fake_recipe)
+        with mock.patch.object(engine.importlib, 'import_module',
+                               import_module):
+            with self.assertRaises(RuntimeError):
+                engine.run_recipe('group/sub/my_recipe', {})
+        import_module.assert_called_once_with('recipes.group.sub.my_recipe')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR introduces a basic recipes engine modeled after the one used by
Chromium in their own infra.

This is a very modest infracture that is being provided to permit
experimenting with the pipelines we have for toolchains and other tools.
This experimental engine has a few features for now:

 - Shallow clones of brave paths
 - A basic support for a step API
 - Boostrapping of the engine in CI through curl.

There are couple of important features that need still to be introduced
in follow-ups, like testing, better property specs, etc.

Bug: https://github.com/brave/brave-browser/issues/56748
