### PR TITLE
Fix UAF in BraveAppearanceHandler on relaunch (dangling command_updater_)

### DIFF
--- a/browser/ui/webui/settings/BUILD.gn
+++ b/browser/ui/webui/settings/BUILD.gn
@@ -69,6 +69,7 @@ source_set("browser_tests") {
     testonly = true
 
     sources = [
+      "brave_appearance_handler_browsertest.cc",
       "brave_manage_profile_browsertest.cc",
       "settings_secure_dns_handler_browsertest.cc",
     ]
@@ -78,6 +79,7 @@ source_set("browser_tests") {
       "//chrome/browser/ui/webui/settings",
       "//chrome/test:test_support",
       "//chrome/test:test_support_ui",
+      "//content/test:test_support",
     ]
 
     if (enable_email_aliases) {

--- a/browser/ui/webui/settings/brave_appearance_handler.cc
+++ b/browser/ui/webui/settings/brave_appearance_handler.cc
@@ -64,6 +64,12 @@ void BraveAppearanceHandler::RegisterMessages() {
     command_updater_ = tab->GetBrowserWindowInterface()
                            ->GetFeatures()
                            .browser_command_controller();
+    // `command_updater_` is owned by the browser window's features and is
+    // destroyed during window teardown (e.g. on relaunch), before this WebUI
+    // handler's OnJavascriptDisallowed() runs. Clear the cached pointer while
+    // the controller is still alive so it is never dereferenced after free.
+    tab_will_detach_subscription_ = tab->RegisterWillDetach(base::BindRepeating(
+        &BraveAppearanceHandler::OnTabWillDetach, base::Unretained(this)));
   }
 }
 
@@ -123,4 +129,21 @@ void BraveAppearanceHandler::GetIsVerticalTabsToggleEnabled(
   const bool enabled = !command_updater_ || command_updater_->IsCommandEnabled(
                                                 IDC_TOGGLE_VERTICAL_TABS);
   ResolveJavascriptCallback(args[0], base::Value(enabled));
+}
+
+void BraveAppearanceHandler::OnTabWillDetach(
+    tabs::TabInterface* tab,
+    tabs::TabInterface::DetachReason reason) {
+  if (!command_updater_) {
+    return;
+  }
+  // The command observer is registered only while JavaScript is allowed (see
+  // OnJavascriptAllowed/OnJavascriptDisallowed). Remove it now, while the
+  // controller is still alive, to keep AddCommandObserver/RemoveCommandObserver
+  // balanced and avoid a use-after-free when OnJavascriptDisallowed() runs
+  // later during WebContents teardown.
+  if (IsJavascriptAllowed()) {
+    command_updater_->RemoveCommandObserver(IDC_TOGGLE_VERTICAL_TABS, this);
+  }
+  command_updater_ = nullptr;
 }

--- a/browser/ui/webui/settings/brave_appearance_handler.h
+++ b/browser/ui/webui/settings/brave_appearance_handler.h
@@ -8,10 +8,12 @@
 
 #include <string>
 
+#include "base/callback_list.h"
 #include "base/memory/raw_ptr.h"
 #include "chrome/browser/command_observer.h"
 #include "chrome/browser/ui/webui/settings/settings_page_ui_handler.h"
 #include "components/prefs/pref_change_registrar.h"
+#include "components/tabs/public/tab_interface.h"
 
 class CommandUpdater;
 class Profile;
@@ -39,9 +41,15 @@ class BraveAppearanceHandler : public settings::SettingsPageUIHandler,
   void ShouldShowNewTabDashboardSettings(const base::ListValue& args);
   void GetIsVerticalTabsToggleEnabled(const base::ListValue& args);
 
+  // Clears `command_updater_` (removing the command observer first, while the
+  // controller is still alive) before the owning browser window is torn down.
+  void OnTabWillDetach(tabs::TabInterface* tab,
+                       tabs::TabInterface::DetachReason reason);
+
   raw_ptr<Profile> profile_ = nullptr;
   raw_ptr<CommandUpdater> command_updater_ = nullptr;
   PrefChangeRegistrar profile_state_change_registrar_;
+  base::CallbackListSubscription tab_will_detach_subscription_;
 };
 
 #endif  // BRAVE_BROWSER_UI_WEBUI_SETTINGS_BRAVE_APPEARANCE_HANDLER_H_

--- a/browser/ui/webui/settings/brave_appearance_handler_browsertest.cc
+++ b/browser/ui/webui/settings/brave_appearance_handler_browsertest.cc
@@ -1,0 +1,96 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/webui/settings/brave_appearance_handler.h"
+
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/tabs/public/tab_interface.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/test_web_ui.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace settings {
+
+// Exposes the protected hooks the test needs to drive the handler directly,
+// the same way the WebUI framework would.
+class TestBraveAppearanceHandler : public BraveAppearanceHandler {
+ public:
+  using BraveAppearanceHandler::set_web_ui;
+  using content::WebUIMessageHandler::RegisterMessages;
+};
+
+class BraveAppearanceHandlerBrowserTest : public InProcessBrowserTest {
+ protected:
+  // Attaches a freshly created handler to `contents` and allows JavaScript,
+  // which registers the IDC_TOGGLE_VERTICAL_TABS command observer.
+  void AttachHandler(content::WebContents* contents) {
+    ASSERT_TRUE(contents);
+    // Precondition for the regression below: the tab must resolve to a real
+    // BrowserCommandController via the exact path RegisterMessages() uses,
+    // otherwise the handler caches a null command_updater_ and the test would
+    // pass vacuously without ever exercising the use-after-free path.
+    tabs::TabInterface* tab = tabs::TabInterface::GetFromContents(contents);
+    ASSERT_TRUE(tab);
+    ASSERT_TRUE(tab->GetBrowserWindowInterface()
+                    ->GetFeatures()
+                    .browser_command_controller());
+
+    web_ui_.set_web_contents(contents);
+    handler_.set_web_ui(&web_ui_);
+    handler_.RegisterMessages();
+    handler_.AllowJavascriptForTesting();
+  }
+
+  content::TestWebUI web_ui_;
+  TestBraveAppearanceHandler handler_;
+};
+
+// Regression test for https://github.com/brave/brave-browser/issues/56696.
+//
+// On relaunch/shutdown the browser window (and its BrowserCommandController)
+// is destroyed before the settings WebUI handler's OnJavascriptDisallowed()
+// runs. Before the fix, the cached `command_updater_` raw_ptr dangled and
+// OnJavascriptDisallowed() dereferenced freed memory (a use-after-free that
+// raw_ptr/ASAN turns into a crash). The fix clears the pointer via
+// TabInterface::RegisterWillDetach while the controller is still alive.
+IN_PROC_BROWSER_TEST_F(BraveAppearanceHandlerBrowserTest,
+                       NoUseAfterFreeWhenWindowTornDownBeforeDisallow) {
+  // A dedicated window whose BrowserCommandController will be torn down while
+  // the handler is still alive. The test's main browser() keeps the process up.
+  Browser* browser2 = CreateBrowser(browser()->profile());
+  ASSERT_TRUE(browser2);
+  AttachHandler(browser2->tab_strip_model()->GetActiveWebContents());
+
+  // Tearing the window down fires WillDetach (while the controller is alive),
+  // which clears the cached command_updater_ pointer.
+  CloseBrowserSynchronously(browser2);
+
+  // Without the fix this dereferenced the freed BrowserCommandController. With
+  // the fix command_updater_ is null, so this is a safe no-op.
+  handler_.DisallowJavascript();
+
+  EXPECT_FALSE(handler_.IsJavascriptAllowed());
+}
+
+// While the window stays alive, repeated allow/disallow cycles must keep
+// AddCommandObserver/RemoveCommandObserver balanced (a double-remove or stale
+// observer would DCHECK/crash).
+IN_PROC_BROWSER_TEST_F(BraveAppearanceHandlerBrowserTest,
+                       BalancedObserverAcrossAllowDisallowCycles) {
+  AttachHandler(browser()->tab_strip_model()->GetActiveWebContents());
+
+  handler_.DisallowJavascript();
+  handler_.AllowJavascriptForTesting();
+  handler_.DisallowJavascript();
+
+  EXPECT_FALSE(handler_.IsJavascriptAllowed());
+}
+
+}  // namespace settings


### PR DESCRIPTION
## Summary
Fixes a use-after-free crash in `BraveAppearanceHandler::OnJavascriptDisallowed()` that occurs when relaunching Brave from settings. Reported on Windows but the root cause is cross-platform C++.

Resolves https://github.com/brave/brave-browser/issues/56696

## Root Cause
`BraveAppearanceHandler` caches `command_updater_` (a `raw_ptr<CommandUpdater>` pointing at the browser window's `BrowserCommandController`) once in `RegisterMessages()`. That controller is owned by the browser window's features. During relaunch/shutdown the browser window — and its `BrowserCommandController` — is destroyed **before** the settings WebUI handler's `OnJavascriptDisallowed()` runs (the relaunch is triggered from the WebUI via `chrome.send`, so the handler is still alive with a registered command observer).

By the time `OnJavascriptDisallowed()` runs, `command_updater_` dangles. The existing `if (command_updater_)` guard does not help: the pointer is non-null, just freed. `command_updater_->RemoveCommandObserver(...)` then dereferences freed memory, and `raw_ptr` (MiraclePtr/BackupRefPtr) crashes by design.

## Fix
Register a `tabs::TabInterface::RegisterWillDetach` callback (`OnTabWillDetach`) in `RegisterMessages()`. When the tab is detached — which happens while the window/controller is still alive, before the WebContents teardown that triggers `OnJavascriptDisallowed()` — it removes the command observer (only while JavaScript is allowed, keeping `AddCommandObserver`/`RemoveCommandObserver` balanced) and clears `command_updater_`. The existing null-check then correctly guards the later teardown call. The subscription is held in a `base::CallbackListSubscription` member. This mirrors the established pattern in `chrome/browser/ui/webui/searchbox/webui_omnibox_handler.cc`.

The live-window path (add observer on `OnJavascriptAllowed`, remove on `OnJavascriptDisallowed`) is unchanged.

## Test Plan
- [x] Added regression browser test `brave_appearance_handler_browsertest.cc`:
  - `NoUseAfterFreeWhenWindowTornDownBeforeDisallow` — attaches the handler to a dedicated window's tab (asserting it resolves to a real `BrowserCommandController` so the UAF path is genuinely set up), tears the window (and controller) down via `CloseBrowserSynchronously`, then calls `DisallowJavascript()` and verifies no use-after-free.
  - `BalancedObserverAcrossAllowDisallowCycles` — verifies allow/disallow cycles keep the observer balanced with a live window.
- [x] `npm run format` — passed
- [x] `npm run presubmit` — passed (0 errors, 0 warnings)
- [x] `npm run gn_check` — passed
- [x] `npm run build` (`brave_browser_tests`) — passed
- [x] `brave_browser_tests --gtest_filter=BraveAppearanceHandlerBrowserTest.*` — passed (2/2)
- [x] Browser sanity: `brave://settings/appearance` loads and the "Use vertical tabs" toggle works in both directions
- [ ] CI passes cleanly