### PR TITLE
[recipes] Nuke shallow `brave-core` on bootstrap

### DIFF
--- a/tools/recipes/engine_bootstrap.py
+++ b/tools/recipes/engine_bootstrap.py
@@ -36,6 +36,7 @@ import argparse
 import json
 import logging
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 
@@ -77,22 +78,22 @@ def _brave_core_dest(properties_json: str) -> str:
 def _deploy_recipes(dest: str | Path) -> Path:
     """Shallow-, sparse-clone brave-core's `tools/recipes/` into *dest*.
 
-    Mirrors the `brave_core_shallow` recipe module (which it cannot import yet,
-    since nothing is checked out): clone when *dest* is not a checkout, then
-    `sparse-checkout add` the engine tree. `add` (not `set`) leaves the recipe
-    free to add its own paths (e.g. `tools/cr/toolchains`) to this checkout.
+    *dest* is always wiped first so every run starts from a clean checkout --
+    no stale sparse state, and no partial clone left by a failed prior run. The
+    recipe then reuses this fresh checkout (the `brave_core_shallow` module
+    `sparse-checkout add`s its own paths, e.g. `tools/cr/toolchains`).
 
     Returns the path to the checked-out `engine.py`.
     """
     dest = Path(dest).expanduser().resolve()
 
-    if (dest / '.git').is_dir():
-        logging.info('brave-core checkout already present at %s', dest)
-    else:
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        _run('git', 'clone', '--depth', '2', '--filter=blob:none', '--sparse',
-             '--branch', BRAVE_CORE_REF, REPO_URL, dest)
+    if dest.exists():
+        logging.info('Removing existing checkout at %s', dest)
+        shutil.rmtree(dest)
 
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    _run('git', 'clone', '--depth', '2', '--filter=blob:none', '--sparse',
+         '--branch', BRAVE_CORE_REF, REPO_URL, dest)
     _run('git', '-C', dest, 'sparse-checkout', 'add', RECIPES_PATH)
 
     engine = dest / RECIPES_PATH / 'engine.py'

--- a/tools/recipes/unittests/engine_bootstrap_test.py
+++ b/tools/recipes/unittests/engine_bootstrap_test.py
@@ -7,6 +7,7 @@
 
 import os
 import sys
+import tempfile
 import types
 import unittest
 from pathlib import Path
@@ -55,6 +56,25 @@ class MainForwardingTest(unittest.TestCase):
         forwarded = run.call_args[0][0]
         self.assertEqual(forwarded[0], sys.executable)
         self.assertEqual(forwarded[1:], [str(engine_path), *argv])
+
+
+class DeployRecipesTest(unittest.TestCase):
+    """_deploy_recipes wipes the destination before cloning."""
+
+    def test_nukes_existing_dest(self):
+        with tempfile.TemporaryDirectory() as work:
+            dest = Path(work) / 'bc'
+            engine_file = dest / bootstrap.RECIPES_PATH / 'engine.py'
+            engine_file.parent.mkdir(parents=True)
+            engine_file.write_text('', encoding='utf-8', newline='')
+            # rmtree is mocked, so the pre-created engine file survives the
+            # is_file() check; _run is mocked so no real git runs.
+            with mock.patch.object(bootstrap, '_run') as run, \
+                 mock.patch.object(bootstrap.shutil, 'rmtree') as rmtree:
+                result = bootstrap._deploy_recipes(dest)
+        rmtree.assert_called_once_with(dest.resolve())
+        self.assertTrue(run.called)
+        self.assertEqual(result, engine_file.resolve())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR changes the bootstrap code to always nuke brave-core when
running a task. This is potentially not necessary, but it is done just
in case the workspace is not found empty.

Bug: https://github.com/brave/brave-browser/issues/56748
