### PR TITLE
[plaster][recipes] Build and package `ast-grep`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ patches/**/*.patchinfo
 /third_party/node/
 /third_party/opengrep/bin/
 /third_party/wintun/
+/third_party/ast-grep-intermediate/
+/third_party/ast-grep-src/
+/third_party/ast-grep/
 *.xcodeproj
 !/ios/brave-ios/App/*.xcodeproj
 *.swp

--- a/tools/cr/ast_grep/README.md
+++ b/tools/cr/ast_grep/README.md
@@ -1,0 +1,32 @@
+# `tools/cr/ast_grep`
+
+Clones [ast-grep](https://github.com/ast-grep/ast-grep) and builds it with the
+Rust toolchain Chromium already ships under `src/third_party/rust-toolchain/`.
+Nothing is fetched from rustup and nothing escapes the brave-core checkout, with
+`CARGO_HOME` and `CARGO_TARGET_DIR` are both pinned under
+`third_party/ast-grep-toolchain-intermediate/`.
+
+## Run
+
+```sh
+brave/tools/cr/ast_grep/build_ast_grep.py
+```
+
+Useful flags: `--clean` (wipe source and build dirs, start fresh), `-j N`,
+`--verbose`. `--help` lists everything.
+
+## Prerequisites
+
+The Chromium Rust toolchain must be available at
+`src/third_party/rust-toolchain/`, so only vanilla Chromium is required.
+
+No other OS-level dependencies are needed — ast-grep's tree-sitter parser builds
+use the C compiler already in the developer environment.
+
+## Outputs
+
+| Path                                           | Contents                 |
+| ---------------------------------------------- | ------------------------ |
+| `third_party/ast-grep-src/`                    | ast-grep source clone    |
+| `third_party/ast-grep-toolchain-intermediate/` | `cargo-home/`, `target/` |
+| `third_party/ast-grep-toolchain/bin/ast-grep`  | final ast-grep binary    |

--- a/tools/cr/ast_grep/build_ast_grep.py
+++ b/tools/cr/ast_grep/build_ast_grep.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Build [ast-grep](https://github.com/ast-grep/ast-grep) using the Rust
+toolchain Chromium ships under `src/third_party/rust-toolchain/`.
+
+The cargo invocation is delegated to Chromium's own wrapper,
+`src/tools/crates/run_cargo.py` (the same one `tools/crates/run_gnrt.py`
+uses). That wrapper runs the bundled `cargo`/`rustc` and, on Windows, wires in
+the hermetic Visual Studio toolchain via `//build/vs_toolchain.py` (linker and
+SDK include paths), so none of that has to be reimplemented here.
+
+Layout mirrors `tools/cr/comby/build_comby.py`:
+
+  * `third_party/ast-grep-src/`             source clone
+  * `third_party/ast-grep-intermediate/`    cargo target dir + cargo home
+                                            (build state only)
+  * `third_party/ast-grep/bin/ast-grep`     final binary
+
+Nothing leaks to `~/.cargo` or any rustup install: `run_cargo` pins
+`CARGO_HOME` and prepends the bundled toolchain to `PATH`, and the cargo
+`--target-dir` is pinned to the intermediate directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Roots derived from this file's location: brave-core is three directories up
+# (`tools/cr/ast_grep` -> brave) and Chromium's `src/` is its parent. Deriving
+# them from `__file__` keeps this script self-contained -- it imports no sibling
+# `tools/cr` modules, so a consumer can sparse-checkout just `tools/cr/ast_grep`
+# and still build.
+_BRAVE_ROOT = Path(__file__).resolve().parents[3]
+_CHROMIUM_ROOT = _BRAVE_ROOT.parent
+
+# Reuse Chromium's cargo wrapper rather than reimplementing toolchain and
+# Windows VS-toolchain handling. `RunCargo` runs the bundled toolchain pinned
+# by `DEFAULT_SYSROOT` (== src/third_party/rust-toolchain).
+sys.path.insert(0, str((_CHROMIUM_ROOT / 'tools' / 'crates').resolve()))
+from run_cargo import DEFAULT_SYSROOT, RunCargo  # noqa: E402
+
+# Upstream ast-grep checkout, pinned to a release tag for
+# reproducibility. Bump as needed; release notes live at
+# https://github.com/ast-grep/ast-grep/releases.
+AST_GREP_GIT_URL = 'https://github.com/ast-grep/ast-grep.git'
+AST_GREP_REF = '0.44.0'
+
+# Paths used by the build.
+_THIRD_PARTY = _BRAVE_ROOT / 'third_party'
+AST_GREP_SRC_DIR: Path = _THIRD_PARTY / 'ast-grep-src'
+AST_GREP_DIR: Path = _THIRD_PARTY / 'ast-grep'
+AST_GREP_INTERMEDIATE_DIR: Path = (_THIRD_PARTY / 'ast-grep-intermediate')
+
+_RUST_EXE = '.exe' if sys.platform == 'win32' else ''
+AST_GREP_BIN: Path = AST_GREP_DIR / 'bin' / f'ast-grep{_RUST_EXE}'
+
+# Third-party cargo subcommands (cargo-auditable, cargo-audit) are installed
+# here with the bundled toolchain, then resolved from this `bin/` on PATH.
+_CARGO_TOOLS_ROOT: Path = AST_GREP_INTERMEDIATE_DIR / 'cargo-tools'
+_CARGO_TOOLS_BIN: Path = _CARGO_TOOLS_ROOT / 'bin'
+
+
+def _check_rust_toolchain() -> None:
+    """Fail fast if the Chromium Rust toolchain isn't present.
+
+    The toolchain is normally pulled down by `gclient sync`; if a
+    developer is on a custom checkout that doesn't include it, the
+    error here points at the recovery path rather than letting the
+    cargo invocation produce a less obvious `cargo: command not found`.
+    """
+    cargo = DEFAULT_SYSROOT / 'bin' / f'cargo{_RUST_EXE}'
+    if not cargo.is_file():
+        raise RuntimeError(
+            f'Chromium Rust toolchain incomplete at {DEFAULT_SYSROOT}: '
+            f'missing {cargo}. Run `gclient sync`, or build it locally via '
+            f'`tools/rust/build_rust.py`.')
+
+
+def _clone_ast_grep() -> None:
+    """Shallow-clone ast-grep if not already present.
+
+    Pre-existing checkouts are left alone so local edits / a custom
+    branch survive across runs. `--clean` wipes and re-clones.
+    """
+    if AST_GREP_SRC_DIR.is_dir():
+        logging.info('ast-grep source already present at %s', AST_GREP_SRC_DIR)
+        return
+
+    AST_GREP_SRC_DIR.parent.mkdir(parents=True, exist_ok=True)
+    logging.info('Cloning ast-grep (%s) into %s', AST_GREP_REF,
+                 AST_GREP_SRC_DIR)
+    subprocess.run([
+        'git', 'clone', '--depth=1', '--branch', AST_GREP_REF,
+        AST_GREP_GIT_URL,
+        str(AST_GREP_SRC_DIR)
+    ],
+                   check=True)
+
+
+def _run_cargo_in_src(cargo_args: list[str]) -> int:
+    """Run cargo from the ast-grep source checkout, returning the exit code.
+
+    Runs cargo via `RunCargo` (bundled toolchain) from `AST_GREP_SRC_DIR` so the
+    checkout's `.cargo/config.toml` is honoured, with the installed
+    cargo-subcommand `bin/` on `PATH` so external subcommands (cargo-auditable,
+    cargo-audit) resolve. `RunCargo` has no cwd/env parameters, hence the manual
+    save/restore (`contextlib.chdir` would be cleaner but is unknown to our
+    pinned pylint).
+    """
+    home_dir = AST_GREP_INTERMEDIATE_DIR / 'cargo-home'
+    prev_cwd = Path.cwd()
+    prev_path = os.environ.get('PATH', '')
+    os.environ['PATH'] = os.pathsep.join([str(_CARGO_TOOLS_BIN), prev_path])
+    os.chdir(AST_GREP_SRC_DIR)
+    try:
+        return RunCargo(DEFAULT_SYSROOT, str(home_dir), cargo_args)
+    finally:
+        os.chdir(prev_cwd)
+        os.environ['PATH'] = prev_path
+
+
+def _install_cargo_tool(tool: str) -> None:
+    """Install a third-party cargo subcommand with the bundled toolchain.
+
+    Installs into `_CARGO_TOOLS_ROOT` (shared `bin/`), skipping the build when
+    the tool is already present. `_run_cargo_in_src` puts that `bin/` on `PATH`
+    so cargo resolves the subcommand.
+    """
+    if (_CARGO_TOOLS_BIN / f'{tool}{_RUST_EXE}').is_file():
+        return
+    home_dir = AST_GREP_INTERMEDIATE_DIR / 'cargo-home'
+    logging.info('Installing %s into %s', tool, _CARGO_TOOLS_ROOT)
+    returncode = RunCargo(
+        DEFAULT_SYSROOT, str(home_dir),
+        ['install', tool, '--locked', '--root',
+         str(_CARGO_TOOLS_ROOT)])
+    if returncode != 0:
+        raise RuntimeError(f'cargo install {tool} failed (exit {returncode})')
+
+
+def _build_ast_grep(jobs: int) -> None:
+    """Build the `ast-grep` binary, then copy it into place.
+
+    Delegates the cargo invocation to `run_cargo.RunCargo` (mirroring
+    `tools/crates/run_gnrt.py`) so the bundled toolchain, and on Windows the
+    hermetic VS toolchain flags, are applied. The build runs under
+    `cargo auditable` so the binary embeds its dependency tree, letting
+    `_audit_ast_grep` later scan exactly what was compiled in. All cargo state
+    is pinned under the intermediate dir (target dir, cargo home).
+    """
+    AST_GREP_INTERMEDIATE_DIR.mkdir(parents=True, exist_ok=True)
+    AST_GREP_DIR.mkdir(parents=True, exist_ok=True)
+
+    # cargo-auditable embeds the dependency graph into the binary so the audit
+    # scans only the crates actually compiled in (not unrelated workspace
+    # members such as the Python/Node/wasm bindings).
+    _install_cargo_tool('cargo-auditable')
+
+    target_dir = AST_GREP_INTERMEDIATE_DIR / 'target'
+    logging.info('Building ast-grep with the Chromium Rust toolchain (%s)',
+                 DEFAULT_SYSROOT)
+    returncode = _run_cargo_in_src([
+        'auditable', 'build', '--locked', '--release', '--bin', 'ast-grep',
+        '--target-dir',
+        str(target_dir), f'--jobs={jobs}'
+    ])
+    if returncode != 0:
+        raise RuntimeError(f'cargo build failed (exit {returncode})')
+
+    built_bin = target_dir / 'release' / f'ast-grep{_RUST_EXE}'
+    if not built_bin.is_file():
+        raise RuntimeError(
+            f'cargo build finished but binary not found at {built_bin}')
+
+    AST_GREP_BIN.parent.mkdir(parents=True, exist_ok=True)
+    logging.info('Installing %s -> %s', built_bin, AST_GREP_BIN)
+    shutil.copy2(built_bin, AST_GREP_BIN)
+
+
+def _audit_ast_grep() -> None:
+    """Audit the dependencies compiled into the ast-grep binary.
+
+    `cargo audit bin` reads the dependency tree embedded by `_build_ast_grep`'s
+    `cargo auditable` build and checks exactly those crates against the RustSec
+    advisory database -- so sibling workspace members we don't ship (the
+    Python/Node/wasm bindings) are excluded. A non-zero exit -- a known
+    vulnerability in a shipped dependency -- fails the build before the
+    toolchain is packaged.
+    """
+    _install_cargo_tool('cargo-audit')
+    logging.info('Auditing ast-grep binary dependencies with cargo audit')
+    returncode = _run_cargo_in_src(['audit', 'bin', str(AST_GREP_BIN)])
+    if returncode != 0:
+        raise RuntimeError(f'cargo audit reported issues (exit {returncode})')
+
+
+def _clean() -> None:
+    """Remove the source clone and both toolchain directories."""
+    for path in (AST_GREP_SRC_DIR, AST_GREP_INTERMEDIATE_DIR, AST_GREP_DIR):
+        if path.exists():
+            logging.info('Removing %s', path)
+            shutil.rmtree(path)
+
+
+def build(jobs: int, clean: bool = False) -> None:
+    """Build `ast-grep` into `third_party/ast-grep/`, then audit its deps.
+
+    Optionally removes the prior source/build directories first. Shared with
+    `package_ast_grep.py` so packaging reuses the exact same build and audit.
+    """
+    if clean:
+        _clean()
+    _check_rust_toolchain()
+    _clone_ast_grep()
+    _build_ast_grep(jobs)
+    _audit_ast_grep()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Build ast-grep with the Chromium Rust toolchain.')
+    parser.add_argument('--clean',
+                        action='store_true',
+                        help='Remove third_party/ast-grep-src/, '
+                        'third_party/ast-grep/ and '
+                        'third_party/ast-grep-intermediate/ before building.')
+    parser.add_argument('-j',
+                        '--jobs',
+                        type=int,
+                        default=os.cpu_count() or 1,
+                        help='Number of parallel build jobs (default: nproc).')
+    parser.add_argument('--verbose',
+                        action='store_true',
+                        help='Enable debug logging.')
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO,
+                        force=True)
+
+    build(args.jobs, clean=args.clean)
+
+    logging.info('Done.')
+    logging.info('ast-grep: %s', AST_GREP_BIN)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/cr/ast_grep/package_ast_grep.py
+++ b/tools/cr/ast_grep/package_ast_grep.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Build ast-grep and package `third_party/ast-grep/` into a versioned tarball.
+
+Runs the same build as `build_ast_grep.py`, then archives the *contents* of
+`third_party/ast-grep/` (the built binary tree) into a `.tar.gz` whose name
+carries the ast-grep version and host platform:
+
+    ast-grep-<version>-<platform>.tar.gz
+
+Members are stored relative to the ast-grep root (e.g. `bin/ast-grep`), so a
+consumer can extract the archive straight over `third_party/ast-grep/` during
+another sync to deploy it:
+
+    tar -xzf ast-grep-0.44.0-linux-x64.tar.gz -C src/third_party/ast-grep
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from pathlib import Path
+import platform
+import sys
+import tarfile
+
+import build_ast_grep
+
+
+def _platform_tag() -> str:
+    """GCS-style host platform tag, mirroring build_rust_toolchain.py."""
+    if sys.platform == 'darwin':
+        return 'mac-arm64' if platform.machine() == 'arm64' else 'mac'
+    if sys.platform == 'win32':
+        return 'win'
+    return 'linux-x64'
+
+
+def _package_name() -> str:
+    """Output archive filename: `ast-grep-<version>-<platform>.tar.gz`."""
+    return (f'ast-grep-{build_ast_grep.AST_GREP_REF}-{_platform_tag()}'
+            '.tar.gz')
+
+
+def _create_archive(out_dir: Path) -> Path:
+    """Archive the contents of `third_party/ast-grep/` into *out_dir*.
+
+    Top-level entries are added under their own names (e.g. `bin`), so the
+    archive holds the directory's contents -- not the `ast-grep` dir itself --
+    and extracts straight over a target `third_party/ast-grep/`.
+
+    Raises:
+        RuntimeError: If the ast-grep build output directory is missing.
+    """
+    source = build_ast_grep.AST_GREP_DIR
+    if not source.is_dir():
+        raise RuntimeError(f'ast-grep build output not found at {source}')
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    archive = out_dir / _package_name()
+
+    logging.info('Packaging contents of %s -> %s', source, archive)
+    with tarfile.open(archive, 'w:gz') as tar:
+        for entry in sorted(source.iterdir()):
+            tar.add(entry, arcname=entry.name)
+    return archive
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Build ast-grep and package third_party/ast-grep into a '
+        'versioned tar.gz.')
+    parser.add_argument('--out-dir',
+                        type=Path,
+                        default=Path.cwd(),
+                        help='Directory the tar.gz is written to '
+                        '(default: current directory).')
+    parser.add_argument('--clean',
+                        action='store_true',
+                        help='Remove prior ast-grep build dirs before '
+                        'building.')
+    parser.add_argument('-j',
+                        '--jobs',
+                        type=int,
+                        default=os.cpu_count() or 1,
+                        help='Number of parallel build jobs (default: nproc).')
+    parser.add_argument('--verbose',
+                        action='store_true',
+                        help='Enable debug logging.')
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO,
+                        force=True)
+
+    build_ast_grep.build(args.jobs, clean=args.clean)
+    archive = _create_archive(args.out_dir.expanduser().resolve())
+
+    logging.info('Done.')
+    logging.info('ast-grep package: %s', archive)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/recipes/README.md
+++ b/tools/recipes/README.md
@@ -14,11 +14,15 @@ instantiates each _recipe module_, and runs the recipe's `RunSteps`.
 
 ```sh
 python3 tools/recipes/engine.py toolchains/rust/package_rust \
-    --properties '{ "chromium_src": "~/dev/brave-next/src/", "brave_subrevision": 2, "chromium_ref": "151.0.7917.1" }'
+    --properties '{ "brave_subrevision": 2, "chromium_ref": "151.0.7917.1" }'
 ```
 
 The recipe name is a `/`-separated path under `recipes/`. `--properties` is a
-JSON object whose keys match the recipe's `PROPERTIES`.
+JSON object whose keys match the recipe's `PROPERTIES`. On-disk paths are not
+properties: recipes read them from the `path` module (`api.path.chromium_src`,
+`api.path.brave_core`, `api.path.out`), all derived from the job's workspace.
+Only the workspace is configurable, via `--workspace` (default: current
+directory).
 
 To run straight from a pipeline without a checkout, `engine_bootstrap.py`
 shallow-clones the engine from brave-core and forwards to `engine.py`:
@@ -26,5 +30,5 @@ shallow-clones the engine from brave-core and forwards to `engine.py`:
 ```sh
 curl -sL https://raw.githubusercontent.com/brave/brave-core/refs/heads/master/tools/recipes/engine_bootstrap.py \
     | python3 - toolchains/rust/package_rust \
-        --properties '{ "chromium_src": "~/dev/brave-next/src/", "brave_subrevision": 2, "chromium_ref": "151.0.7917.1" }'
+        --properties '{ "brave_subrevision": 2, "chromium_ref": "151.0.7917.1" }'
 ```

--- a/tools/recipes/engine.py
+++ b/tools/recipes/engine.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright (c) 2026 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
@@ -17,10 +18,11 @@ recipes_py that we will grow incrementally. Notable simplifications vs upstream:
   * No TEST_API / GenTests, no expectations, no warnings framework.
   * Properties are a plain object, not a protobuf message.
 
-Run a recipe directly (recipe names are `/`-separated paths under recipes/):
+Run a recipe directly (recipe names are `/`-separated paths under recipes/).
+`--workspace` sets the root the job runs in; recipe paths are derived from it:
 
     python3 engine.py toolchains/rust/package_rust \\
-        --properties '{"chromium_src": "~/dev/chromium/src"}'
+        --properties '{"chromium_ref": "151.0.7917.1", "brave_subrevision": 1}'
 """
 
 from __future__ import annotations
@@ -82,8 +84,17 @@ def _find_api_class(api_module: types.ModuleType,
 class _Engine:
     """Resolves DEPS and instantiates module APIs, caching by module name."""
 
-    def __init__(self) -> None:
+    def __init__(self,
+                 workspace: str | Path | None = None,
+                 brave_core_ref: str = 'master') -> None:
         _ensure_on_sys_path()
+        # Root directory the job runs in. Recipe paths (chromium/src, out, ...)
+        # are derived from it by the `path` module. Defaults to the cwd.
+        self._workspace: Path = (Path(workspace).expanduser().resolve()
+                                 if workspace else Path.cwd())
+        # brave-core ref the checkout modules clone. Defaults to `master`;
+        # overridable (mainly for testing against a non-master ref).
+        self._brave_core_ref: str = brave_core_ref
         # module name -> instantiated RecipeApi (one instance per run).
         self._cache: dict[str, RecipeApi] = {}
 
@@ -100,6 +111,11 @@ class _Engine:
         api_class = _find_api_class(api_module, name)
 
         inst = api_class()
+        # Seed engine-provided values (workspace, brave-core ref) so modules can
+        # use them. setattr keeps the engine out of the instance's protected
+        # members directly.
+        setattr(inst, '_workspace', self._workspace)
+        setattr(inst, '_brave_core_ref', self._brave_core_ref)
         for dep_name in deps:
             setattr(inst.m, dep_name,
                     self._instantiate_module(dep_name, chain + [name]))
@@ -145,9 +161,12 @@ def _build_properties(properties_def: type | None,
 
 
 def run_recipe(recipe_name: str,
-               properties: dict[str, object] | None = None) -> object:
+               properties: dict[str, object] | None = None,
+               workspace: str | Path | None = None,
+               brave_core_ref: str = 'master') -> object:
     """Resolve DEPS for *recipe_name* and run its `RunSteps`."""
-    return _Engine().run_recipe(recipe_name, properties)
+    return _Engine(workspace,
+                   brave_core_ref).run_recipe(recipe_name, properties)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -158,13 +177,23 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument('--properties',
                         default='{}',
                         help='JSON object of recipe properties')
+    parser.add_argument('--workspace',
+                        default=None,
+                        help='Root directory the job runs in; recipe paths '
+                        '(chromium/src, out, ...) are relative to it '
+                        '(default: current directory)')
+    parser.add_argument('--brave-core-ref',
+                        default='master',
+                        help='brave-core ref the recipe checks out '
+                        '(default: master; override for testing)')
     parser.add_argument('--verbose',
                         action='store_true',
                         help='Enable verbose (debug) logging')
     args = parser.parse_args(argv)
 
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
-    run_recipe(args.recipe, json.loads(args.properties))
+    run_recipe(args.recipe, json.loads(args.properties), args.workspace,
+               args.brave_core_ref)
     return 0
 
 

--- a/tools/recipes/recipe_api.py
+++ b/tools/recipes/recipe_api.py
@@ -14,6 +14,8 @@ module reaches each dependency as `self.m.<dep_name>` (and itself as
 
 from __future__ import annotations
 
+from pathlib import Path
+
 
 class ModuleInjectionSite:
     """Namespace holding a module's resolved DEPS (and the module itself).
@@ -37,6 +39,13 @@ class RecipeApi:
     def __init__(self) -> None:
         # Populated by the engine after construction with this module's DEPS.
         self.m: ModuleInjectionSite = ModuleInjectionSite()
+        # The job's workspace root, seeded by the engine after construction.
+        # The `path` module derives the named job paths from it; most modules
+        # ignore it. Defaults to `.` until the engine overrides it.
+        self._workspace: Path = Path()
+        # brave-core ref the checkout modules clone, seeded by the engine.
+        # `brave_core_shallow` uses it; defaults to `master` until overridden.
+        self._brave_core_ref: str = 'master'
 
     def initialize(self) -> None:
         """Hook run once after DEPS are injected. Override for setup."""

--- a/tools/recipes/recipe_modules/brave_core_shallow/api.py
+++ b/tools/recipes/recipe_modules/brave_core_shallow/api.py
@@ -43,8 +43,9 @@ class BraveCoreShallowApi(RecipeApi):
 
         Clones brave-core into *dest* (shallow + sparse) when it is not already
         a checkout, then restricts the working tree to *paths*. Re-running is
-        cheap: an existing checkout is reused and only the sparse set is
-        re-applied.
+        cheap: an existing checkout is reused, fetched to *ref*, and only the
+        sparse set is re-applied -- so a checkout left on a different ref by a
+        prior run is brought to the requested one rather than trusted as-is.
 
         Every requested path keeps its brave-core-relative layout beneath the
         returned root (a path `tools/a` lands at `<root>/tools/a`), so scripts
@@ -60,10 +61,12 @@ class BraveCoreShallowApi(RecipeApi):
             paths: A single repo-relative path, or an iterable of them, to
                 materialise (e.g. `'tools/cr/toolchains'`).
             url: Git remote to clone from; defaults to brave-core over SSH.
-            ref: Optional branch or tag to clone. Only applied on the initial
-                clone; an existing checkout is left on its current ref. A
+            ref: Branch or tag to check out. Defaults to the engine-provided
+                brave-core ref (`master`, or the `--brave-core-ref` override).
+                Applied whether the checkout is freshly cloned or reused (an
+                existing checkout is fetched and hard-checked-out to it). A
                 shallow clone cannot target a bare commit SHA.
-            depth: History depth for the shallow clone.
+            depth: History depth for the shallow clone/fetch.
 
         Returns:
             The absolute `Path` to the brave-core checkout root. Requested paths
@@ -79,19 +82,35 @@ class BraveCoreShallowApi(RecipeApi):
         if not rel_paths:
             raise ValueError('deploy() requires at least one path')
 
+        # Fall back to the engine-provided ref when the caller doesn't specify.
+        ref = ref if ref is not None else self._brave_core_ref
+
         dest = Path(dest).expanduser().resolve()
 
         if (dest / '.git').is_dir():
-            logging.info('brave-core checkout already present at %s', dest)
+            # Reuse the existing checkout, but bring it to *ref* -- it may have
+            # been cloned (here or by a prior run) at a different ref that lacks
+            # the requested paths, so fetch and hard-checkout rather than trust
+            # its current state.
+            logging.info('brave-core checkout present at %s; updating to %s',
+                         dest, ref)
+            self.m.step('fetch brave-core ref', [
+                'git', '-C',
+                str(dest), 'fetch', '--depth',
+                str(depth), 'origin', ref
+            ])
+            self.m.step(
+                'checkout brave-core ref',
+                ['git', '-C',
+                 str(dest), 'checkout', '--force', 'FETCH_HEAD'])
         else:
             dest.parent.mkdir(parents=True, exist_ok=True)
             clone_cmd = [
                 'git', 'clone', '--depth',
-                str(depth), '--filter=blob:none', '--sparse'
+                str(depth), '--filter=blob:none', '--sparse', '--branch', ref,
+                url,
+                str(dest)
             ]
-            if ref:
-                clone_cmd += ['--branch', ref]
-            clone_cmd += [url, str(dest)]
             self.m.step('clone brave-core (shallow, sparse)', clone_cmd)
 
         # Extend the sparse working tree with the requested subtrees. `add`

--- a/tools/recipes/recipe_modules/path/__init__.py
+++ b/tools/recipes/recipe_modules/path/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Core `path` module: engine-provided, workspace-relative job paths."""
+
+DEPS = []

--- a/tools/recipes/recipe_modules/path/api.py
+++ b/tools/recipes/recipe_modules/path/api.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""The core `path` module API."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from recipe_api import RecipeApi
+
+
+class PathApi(RecipeApi):
+    """Named, workspace-relative job paths, seeded by the engine.
+
+    Mirrors (in miniature) `recipe_engine/path`: recipes build paths from these
+    named roots instead of hardcoding them or taking them as properties. Only
+    the workspace root is configurable (engine `--workspace`); everything else
+    is derived from it, so the on-disk layout is fixed and consistent across
+    recipes.
+    """
+
+    @property
+    def workspace(self) -> Path:
+        """Root directory the job runs in (engine-provided)."""
+        return self._workspace
+
+    @property
+    def chromium_src(self) -> Path:
+        """Chromium `src/` checkout: `<workspace>/chromium/src`."""
+        return self._workspace / 'chromium' / 'src'
+
+    @property
+    def brave_core(self) -> Path:
+        """brave-core checkout inside Chromium: `<chromium_src>/brave`."""
+        return self.chromium_src / 'brave'
+
+    @property
+    def out(self) -> Path:
+        """Build output directory: `<workspace>/out`."""
+        return self._workspace / 'out'

--- a/tools/recipes/recipes/tools/__init__.py
+++ b/tools/recipes/recipes/tools/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Package marker for tool-building recipes."""

--- a/tools/recipes/recipes/tools/ast_grep/__init__.py
+++ b/tools/recipes/recipes/tools/ast_grep/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Package marker for ast-grep recipes."""

--- a/tools/recipes/recipes/tools/ast_grep/package_ast_grep.py
+++ b/tools/recipes/recipes/tools/ast_grep/package_ast_grep.py
@@ -15,9 +15,9 @@ DEPS = [
     'path', 'step', 'depot_tools', 'chromium_checkout', 'brave_core_shallow'
 ]
 
+
 @dataclass(frozen=True)
 class InputProperties:
-    brave_subrevision: int
     chromium_ref: str
     git_cache: str | None = None
 
@@ -32,19 +32,14 @@ def RunSteps(api: RecipeScriptApi, properties: InputProperties) -> None:
     chromium_src = api.chromium_checkout.ensure_checkout(
         api.path.chromium_src, ref=properties.chromium_ref)
 
-    brave_core_root = api.brave_core_shallow.deploy(api.path.brave_core,
-                                                    'tools/cr/toolchains')
+    brave_root = api.brave_core_shallow.deploy(api.path.brave_core,
+                                               'tools/cr/ast_grep')
 
     vpython3 = api.depot_tools.vpython3(chromium_src)
-    api.step('build rust toolchain', [
+    api.step('package ast-grep', [
         vpython3,
-        brave_core_root / 'tools/cr/toolchains/build_rust_toolchain.py',
+        brave_root / 'tools/cr/ast_grep/package_ast_grep.py',
+        '--clean',
         '--out-dir',
         api.path.out,
-        '--chromium-src',
-        chromium_src,
-        '--brave-subrevision',
-        str(properties.brave_subrevision),
-        '--clear',
-        '--no-full-toolchain',
     ])

--- a/tools/recipes/unittests/engine_bootstrap_test.py
+++ b/tools/recipes/unittests/engine_bootstrap_test.py
@@ -5,6 +5,10 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """Tests for the self-contained engine bootstrap."""
 
+# White-box tests: they exercise bootstrap internals (`_deploy_recipes`,
+# `_brave_core_dest`, `_run`), so protected-access is intentional.
+# pylint: disable=protected-access
+
 import os
 import sys
 import tempfile

--- a/tools/recipes/unittests/engine_test.py
+++ b/tools/recipes/unittests/engine_test.py
@@ -5,11 +5,17 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """Tests for the recipe engine's DEPS resolution and property binding."""
 
+# White-box tests: they exercise engine internals (`_Engine`,
+# `_instantiate_module`, `_build_properties`, ...), so protected-access is
+# intentional.
+# pylint: disable=protected-access
+
 import os
 import sys
 import types
 import unittest
 from dataclasses import dataclass
+from pathlib import Path
 from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -99,6 +105,33 @@ class RunRecipeTest(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 engine.run_recipe('group/sub/my_recipe', {})
         import_module.assert_called_once_with('recipes.group.sub.my_recipe')
+
+
+class WorkspaceTest(unittest.TestCase):
+    """The engine seeds its workspace; the `path` module derives job paths."""
+
+    def test_workspace_seeded_into_path_module(self):
+        eng = engine._Engine(workspace='/tmp/ws')
+        path = eng._instantiate_module('path', [])
+        workspace = Path('/tmp/ws').resolve()
+        self.assertEqual(path.workspace, workspace)
+        self.assertEqual(path.chromium_src, workspace / 'chromium/src')
+        self.assertEqual(path.brave_core, workspace / 'chromium/src/brave')
+        self.assertEqual(path.out, workspace / 'out')
+
+    def test_workspace_defaults_to_cwd(self):
+        path = engine._Engine()._instantiate_module('path', [])
+        self.assertEqual(path.workspace, Path.cwd())
+
+    def test_brave_core_ref_seeded_with_override(self):
+        module = engine._Engine(
+            brave_core_ref='feature/x')._instantiate_module(
+                'brave_core_shallow', [])
+        self.assertEqual(getattr(module, '_brave_core_ref'), 'feature/x')
+
+    def test_brave_core_ref_defaults_to_master(self):
+        module = engine._Engine()._instantiate_module('brave_core_shallow', [])
+        self.assertEqual(getattr(module, '_brave_core_ref'), 'master')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds scripts to build and package `ast-grep`. These scripts
require at least a vanilla Chromium checkout to be used.

Additionally, this change also introduces a recipe that can be used to
build this tool in CI.

Bug: https://github.com/brave/brave-browser/issues/56760
Bug: https://github.com/brave/brave-browser/issues/56748
