### PR TITLE
[iOS] Shift playlist item processing/delegates into tab helper

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Playlist.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Playlist.swift
@@ -17,7 +17,7 @@ import UIKit
 import Web
 import os.log
 
-extension BrowserViewController: PlaylistScriptHandlerDelegate {
+extension BrowserViewController: PlaylistTabHelperDelegate {
   static var didShowStorageFullWarning = false
   func createPlaylistPopover(item: PlaylistInfo, tab: (any TabState)?) -> PopoverController {
 
@@ -40,8 +40,8 @@ extension BrowserViewController: PlaylistScriptHandlerDelegate {
           switch action {
           case .openPlaylist:
             DispatchQueue.main.async {
-              if let tab {
-                PlaylistScriptHandler.getCurrentTime(tab: tab, nodeTag: item.tagId) {
+              if let tab, let playlist = tab.playlist {
+                playlist.getCurrentTime(nodeTag: item.tagId) {
                   [weak self] currentTime in
                   self?.openPlaylist(tab: tab, item: item, playbackOffset: currentTime)
                 }
@@ -202,8 +202,8 @@ extension BrowserViewController: PlaylistScriptHandlerDelegate {
     if !profileController.profile.prefs.isPlaylistAvailable {
       return
     }
-    if let item, let tab {
-      PlaylistScriptHandler.getCurrentTime(tab: tab, nodeTag: item.tagId) {
+    if let item, let tab, let playlist = tab.playlist {
+      playlist.getCurrentTime(nodeTag: item.tagId) {
         [weak self] currentTime in
         self?.openPlaylist(
           tab: tab,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -24,7 +24,7 @@ extension BrowserViewController: TabManagerDelegate {
     tab.browserData?.miscDelegate = self
     tab.pullToRefresh = .init(tab: tab)
     if tab.profile.prefs.isPlaylistAvailable {
-      tab.playlist = .init(tab: tab)
+      tab.playlist = .init(tab: tab, delegate: self)
     }
     if !FeatureList.kUseProfileWebViewConfiguration.enabled {
       tab.youtubeQualityTabHelper = .init(tab: tab)
@@ -108,7 +108,7 @@ extension BrowserViewController: TabManagerDelegate {
       tab.showContent(true)
     }
     tab.readerMode?.onReaderModeToggled = { [weak self] tab in
-      PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: tab.playlistItem)
+      tab.playlist?.processPlaylistInfo(item: tab.playlistItem)
       self?.updateTranslateURLBar(tab: tab, state: tab.translationState)
     }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
@@ -417,7 +417,7 @@ extension BrowserViewController {
 
     if tab.profile.prefs.isPlaylistAvailable {
       injectedScripts.append(contentsOf: [
-        PlaylistScriptHandler(tab: tab)
+        PlaylistScriptHandler()
       ])
     }
 
@@ -465,9 +465,6 @@ extension BrowserViewController {
       )
     }
 
-    (tab.browserData?.getContentScript(name: PlaylistScriptHandler.scriptName)
-      as? PlaylistScriptHandler)?
-      .delegate = self
     (tab.browserData?.getContentScript(name: Web3NameServiceScriptHandler.scriptName)
       as? Web3NameServiceScriptHandler)?.delegate = self
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/PlaylistTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/PlaylistTabHelper.swift
@@ -4,10 +4,27 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import BraveShared
+import Data
 import OSLog
 import Preferences
 import UIKit
 import Web
+
+enum PlaylistItemAddedState {
+  case none
+  case newItem
+  case existingItem
+}
+
+protocol PlaylistTabHelperDelegate: AnyObject {
+  func updatePlaylistURLBar(
+    tab: (any TabState)?,
+    state: PlaylistItemAddedState,
+    item: PlaylistInfo?
+  )
+  func showPlaylistAlert(tab: (any TabState)?, state: PlaylistItemAddedState, item: PlaylistInfo?)
+  func showPlaylistOnboarding(tab: (any TabState)?)
+}
 
 extension TabDataValues {
   private struct PlaylistTabHelperKey: TabDataKey {
@@ -20,16 +37,152 @@ extension TabDataValues {
 }
 
 class PlaylistTabHelper: NSObject, TabObserver {
+  weak var delegate: PlaylistTabHelperDelegate?
   private weak var tab: (any TabState)?
+  private var url: URL?
+  private static let queue = DispatchQueue(label: "com.playlisthelper.queue", qos: .userInitiated)
 
-  init(tab: some TabState) {
+  init(tab: some TabState, delegate: PlaylistTabHelperDelegate?) {
     self.tab = tab
+    self.url = tab.visibleURL
+    self.delegate = delegate
     super.init()
     tab.addObserver(self)
 
     let longPress = UILongPressGestureRecognizer(target: self, action: #selector(longPressed(_:)))
     longPress.delegate = self
     tab.view.addGestureRecognizer(longPress)
+  }
+
+  /// Processes a detected media item, updating the URL bar and prompting the
+  /// user as needed. Shared by the legacy `PlaylistScript` and the
+  /// `PlaylistJavaScriptFeature`, both of which deliver the same payload.
+  func processPlaylistInfo(item: PlaylistInfo?) {
+    guard let tab = self.tab else { return }
+
+    // If this URL is blocked from Playlist support, do nothing
+    if url?.isPlaylistBlockedSiteURL == true {
+      return
+    }
+
+    guard var item = item, !item.src.isEmpty else {
+      DispatchQueue.main.async { [weak self] in
+        self?.delegate?.updatePlaylistURLBar(tab: tab, state: .none, item: nil)
+      }
+      return
+    }
+
+    if url?.baseDomain != "soundcloud.com", item.isInvisible {
+      DispatchQueue.main.async { [weak self] in
+        self?.delegate?.updatePlaylistURLBar(tab: tab, state: .none, item: nil)
+      }
+      return
+    }
+
+    // Copy the item but use the web-view's title and location instead, if available
+    // This is due to a iFrames security
+    item.pageSrc = tab.visibleURL?.absoluteString ?? item.pageSrc
+    item.pageTitle = tab.title ?? item.pageTitle
+    item.lastPlayedOffset = 0.0
+
+    Self.queue.async { [weak self] in
+      guard let self = self else { return }
+
+      if item.duration <= 0.0 && !item.detected || item.src.isEmpty {
+        DispatchQueue.main.async { [weak self] in
+          self?.delegate?.updatePlaylistURLBar(tab: tab, state: .none, item: nil)
+        }
+        return
+      }
+
+      if URL(string: item.src) != nil {
+        DispatchQueue.main.async { [weak self] in
+          guard let self = self,
+            let delegate = self.delegate
+          else { return }
+
+          if PlaylistItem.itemExists(pageSrc: item.pageSrc) {
+            // Item already exists, so just update the database with new token or URL.
+            self.updateItem(item, detected: item.detected)
+          } else if item.detected {
+            // Automatic Detection
+            delegate.updatePlaylistURLBar(tab: tab, state: .newItem, item: item)
+            delegate.showPlaylistOnboarding(tab: tab)
+          } else {
+            // Long-Press
+            delegate.showPlaylistAlert(tab: tab, state: .newItem, item: item)
+          }
+        }
+      }
+    }
+  }
+
+  private func updateItem(_ item: PlaylistInfo, detected: Bool) {
+    guard let tab = self.tab else { return }
+    if detected {
+      delegate?.updatePlaylistURLBar(tab: tab, state: .existingItem, item: item)
+    }
+
+    PlaylistItem.updateItem(item) { [weak self] in
+      guard let self = self, let tab = self.tab else { return }
+
+      // We need to use the Database version of this object
+      // because when the fallback streamer updates the object, it uses the database ID.
+      // When the download starts, it uses the database ID.
+      // If we suddenly change the ID, downloads and updates get out of wack
+      var item = item
+
+      // Use the ID that it was saved as in the database, rather than the Javascript ID
+      item.tagId = $0
+
+      if detected, let delegate = self.delegate {
+        delegate.updatePlaylistURLBar(tab: tab, state: .existingItem, item: item)
+      }
+    }
+  }
+
+  /// Queries the current playback time of the media element tagged with
+  /// `nodeTag` in the legacy `PlaylistScript`.
+  func getCurrentTime(nodeTag: String, completion: @escaping (Double) -> Void) {
+    guard let tab = self.tab else {
+      completion(0.0)
+      return
+    }
+
+    guard UUID(uuidString: nodeTag) != nil else {
+      Logger.module.error("Unsanitized NodeTag.")
+      completion(0.0)
+      return
+    }
+
+    tab.evaluateJavaScript(
+      functionName: "window.__firefox__.\(PlaylistScriptHandler.mediaCurrentTimeFromTag)",
+      args: [nodeTag, PlaylistScriptHandler.scriptId],
+      contentWorld: PlaylistScriptHandler.scriptSandbox,
+      asFunction: true
+    ) { value, error in
+
+      if let error = error {
+        Logger.module.error(
+          "Error Retrieving Playlist Page Media Current Time: \(error.localizedDescription)"
+        )
+      }
+
+      DispatchQueue.main.async {
+        if let value = value as? Double {
+          completion(value)
+        } else {
+          completion(0.0)
+        }
+      }
+    }
+  }
+
+  // MARK: - TabObserver
+
+  func tabDidUpdateURL(_ tab: some TabState) {
+    url = tab.visibleURL
+    delegate?.updatePlaylistURLBar(tab: tab, state: .none, item: nil)
   }
 
   func tabWillBeDestroyed(_ tab: some TabState) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCacheLoader.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCacheLoader.swift
@@ -206,7 +206,8 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
         return
       }
 
-      guard let item = PlaylistInfo.from(message: message),
+      guard let body = message.body as? [String: Any],
+        let item = PlaylistInfo.from(dictionary: body),
         item.detected
       else {
         cancelRequest()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCoordinator.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCoordinator.swift
@@ -162,9 +162,10 @@ public class PlaylistCoordinator: NSObject {
   ) {
     if let tab = tab,
       let item = tab.playlistItem,
-      let tag = tab.playlistItem?.tagId
+      let tag = tab.playlistItem?.tagId,
+      let playlist = tab.playlist
     {
-      PlaylistScriptHandler.getCurrentTime(tab: tab, nodeTag: tag) {
+      playlist.getCurrentTime(nodeTag: tag) {
         [unowned self] currentTime in
         completion(
           self.getPlaylistController(

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
@@ -3,50 +3,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import AVKit
-import BraveShared
 import Data
 import Foundation
-import Playlist
-import Preferences
-import Shared
 import Web
 import WebKit
-import os.log
 
-enum PlaylistItemAddedState {
-  case none
-  case newItem
-  case existingItem
-}
-
-protocol PlaylistScriptHandlerDelegate: NSObject {
-  func updatePlaylistURLBar(
-    tab: (any TabState)?,
-    state: PlaylistItemAddedState,
-    item: PlaylistInfo?
-  )
-  func showPlaylistAlert(tab: (any TabState)?, state: PlaylistItemAddedState, item: PlaylistInfo?)
-  func showPlaylistOnboarding(tab: (any TabState)?)
-}
-
-class PlaylistScriptHandler: NSObject, TabContentScript, TabObserver {
-  public weak var delegate: PlaylistScriptHandlerDelegate?
-  private var url: URL?
-  private var asset: AVURLAsset?
-  private static let queue = DispatchQueue(label: "com.playlisthelper.queue", qos: .userInitiated)
-
-  init(tab: some TabState) {
-    self.url = tab.visibleURL
-    super.init()
-
-    tab.addObserver(self)
-  }
-
-  deinit {
-    asset?.cancelLoading()
-  }
-
+/// Injects the legacy `PlaylistScript` and forwards detected media to the
+/// tab's `PlaylistTabHelper`. All processing of the payload lives on the tab
+/// helper so that it can be shared with `PlaylistJavaScriptFeature`; this
+/// handler only parses the legacy `WKScriptMessage`.
+class PlaylistScriptHandler: NSObject, TabContentScript {
   static let playlistLongPressed = "playlistLongPressed_\(uniqueID)"
   static let playlistProcessDocumentLoad = "playlistProcessDocumentLoad_\(uniqueID)"
   static let mediaCurrentTimeFromTag = "mediaCurrentTimeFromTag_\(uniqueID)"
@@ -91,175 +57,13 @@ class PlaylistScriptHandler: NSObject, TabContentScript, TabObserver {
       return
     }
 
-    // If this URL is blocked from Playlist support, do nothing
-    if url?.isPlaylistBlockedSiteURL == true {
-      return
-    }
-
+    // Ready state messages are informational only and require no processing.
     if ReadyState.from(message: message) != nil {
       return
     }
 
-    Self.processPlaylistInfo(
-      tab: tab,
-      handler: self,
-      item: PlaylistInfo.from(message: message)
-    )
-  }
-
-  private class func processPlaylistInfo(
-    tab: some TabState,
-    handler: PlaylistScriptHandler,
-    item: PlaylistInfo?
-  ) {
-    guard var item = item, !item.src.isEmpty else {
-      DispatchQueue.main.async {
-        handler.delegate?.updatePlaylistURLBar(tab: tab, state: .none, item: nil)
-      }
-      return
-    }
-
-    if handler.url?.baseDomain != "soundcloud.com", item.isInvisible {
-      DispatchQueue.main.async {
-        handler.delegate?.updatePlaylistURLBar(tab: tab, state: .none, item: nil)
-      }
-      return
-    }
-
-    // Copy the item but use the web-view's title and location instead, if available
-    // This is due to a iFrames security
-    item.pageSrc = tab.visibleURL?.absoluteString ?? item.pageSrc
-    item.pageTitle = tab.title ?? item.pageTitle
-    item.lastPlayedOffset = 0.0
-
-    Self.queue.async { [weak handler] in
-      guard let handler = handler else { return }
-
-      if item.duration <= 0.0 && !item.detected || item.src.isEmpty {
-        DispatchQueue.main.async {
-          handler.delegate?.updatePlaylistURLBar(tab: tab, state: .none, item: nil)
-        }
-        return
-      }
-
-      if URL(string: item.src) != nil {
-        DispatchQueue.main.async { [weak handler] in
-          guard let handler = handler,
-            let delegate = handler.delegate
-          else { return }
-
-          if PlaylistItem.itemExists(pageSrc: item.pageSrc) {
-            // Item already exists, so just update the database with new token or URL.
-            handler.updateItem(item, detected: item.detected, tab: tab)
-          } else if item.detected {
-            // Automatic Detection
-            delegate.updatePlaylistURLBar(tab: tab, state: .newItem, item: item)
-            delegate.showPlaylistOnboarding(tab: tab)
-          } else {
-            // Long-Press
-            delegate.showPlaylistAlert(tab: tab, state: .newItem, item: item)
-          }
-        }
-      }
-    }
-  }
-
-  private func loadAssetPlayability(url: URL) async -> Bool {
-    if asset == nil {
-      // We have to create an AVURLAsset here to determine if the item is playable
-      // because otherwise it will add an invalid item to playlist that can't be played.
-      // IE: WebM videos aren't supported so can't be played.
-      // Therefore we shouldn't prompt the user to add to playlist.
-      asset = AVURLAsset(url: url, options: AVAsset.defaultOptions)
-    }
-
-    guard let asset = asset else {
-      return false
-    }
-
-    return await PlaylistMediaStreamer.loadAssetPlayability(asset: asset)
-  }
-
-  private func updateItem(_ item: PlaylistInfo, detected: Bool, tab: some TabState) {
-    if detected {
-      self.delegate?.updatePlaylistURLBar(tab: tab, state: .existingItem, item: item)
-    }
-
-    PlaylistItem.updateItem(item) { [weak self] in
-      guard let self = self else { return }
-
-      // We need to use the Database version of this object
-      // because when the fallback streamer updates the object, it uses the database ID.
-      // When the download starts, it uses the database ID.
-      // If we suddenly change the ID, downloads and updates get out of wack
-      var item = item
-
-      // Use the ID that it was saved as in the database, rather than the Javascript ID
-      item.tagId = $0
-
-      if detected, let delegate = self.delegate {
-        delegate.updatePlaylistURLBar(tab: tab, state: .existingItem, item: item)
-      }
-    }
-  }
-
-  // MARK: - TabObserver
-
-  func tabDidUpdateURL(_ tab: some TabState) {
-    url = tab.visibleURL
-    asset?.cancelLoading()
-    asset = nil
-
-    delegate?.updatePlaylistURLBar(tab: tab, state: .none, item: nil)
-  }
-
-  func tabWillBeDestroyed(_ tab: some TabState) {
-    tab.removeObserver(self)
-  }
-}
-
-extension PlaylistScriptHandler {
-  static func getCurrentTime(
-    tab: some TabState,
-    nodeTag: String,
-    completion: @escaping (Double) -> Void
-  ) {
-    guard UUID(uuidString: nodeTag) != nil else {
-      Logger.module.error("Unsanitized NodeTag.")
-      return
-    }
-
-    tab.evaluateJavaScript(
-      functionName: "window.__firefox__.\(mediaCurrentTimeFromTag)",
-      args: [nodeTag, Self.scriptId],
-      contentWorld: Self.scriptSandbox,
-      asFunction: true
-    ) { value, error in
-
-      if let error = error {
-        Logger.module.error(
-          "Error Retrieving Playlist Page Media Current Time: \(error.localizedDescription)"
-        )
-      }
-
-      DispatchQueue.main.async {
-        if let value = value as? Double {
-          completion(value)
-        } else {
-          completion(0.0)
-        }
-      }
-    }
-  }
-}
-
-extension PlaylistScriptHandler {
-  static func updatePlaylistTab(tab: some TabState, item: PlaylistInfo?) {
-    if let handler = tab.browserData?.getContentScript(name: Self.scriptName)
-      as? PlaylistScriptHandler
-    {
-      Self.processPlaylistInfo(tab: tab, handler: handler, item: item)
-    }
+    let info = (message.body as? [String: Any]).flatMap(PlaylistInfo.from(dictionary:))
+    tab.playlist?.processPlaylistInfo(item: info)
   }
 }
 

--- a/ios/brave-ios/Sources/Data/models/PlaylistInfo.swift
+++ b/ios/brave-ios/Sources/Data/models/PlaylistInfo.swift
@@ -5,7 +5,6 @@
 
 import Foundation
 import Shared
-import WebKit
 import os.log
 
 public struct PlaylistInfo: Codable, Identifiable, Hashable, Equatable {
@@ -102,14 +101,14 @@ public struct PlaylistInfo: Codable, Identifiable, Hashable, Equatable {
     self.isInvisible = try container.decodeIfPresent(Bool.self, forKey: .isInvisible) ?? false
   }
 
-  public static func from(message: WKScriptMessage) -> PlaylistInfo? {
-    if !JSONSerialization.isValidJSONObject(message.body) {
+  public static func from(dictionary: [String: Any]) -> PlaylistInfo? {
+    if !JSONSerialization.isValidJSONObject(dictionary) {
       return nil
     }
 
     do {
       let data = try JSONSerialization.data(
-        withJSONObject: message.body,
+        withJSONObject: dictionary,
         options: [.fragmentsAllowed]
       )
       return try JSONDecoder().decode(PlaylistInfo.self, from: data)


### PR DESCRIPTION
This shifts all of the logic that was happening in the Playlist script handler into the tab helper. This will allow the tab helper to be used when the `UseProfileWebViewConfiguration` feature flag is enabled
