### PR TITLE
[bootstrap] Fix launcher version mismatch

### DIFF
--- a/tools/cr/bootstrap/README.md
+++ b/tools/cr/bootstrap/README.md
@@ -21,9 +21,8 @@ On macOS / Linux this configures your current shell (override with
 
 - **bash** → a marked block in `~/.bashrc`
 - **zsh** → a marked block in `~/.zshrc`
-- **fish** → a drop-in at `~/.config/fish/conf.d/brave-bootstrap.fish` that
-  prepends to `$PATH` directly (it avoids `fish_add_path`, which would persist
-  the entry in the universal `fish_user_paths` variable and outlive the file)
+- **fish** → a drop-in at `~/.config/fish/conf.d/zzz-brave-bootstrap.fish` that
+  prepends to `$PATH` directly.
 
 On Windows it adds this directory to the user `Path` under `HKCU\Environment`.
 

--- a/tools/cr/bootstrap/bootstrap.py
+++ b/tools/cr/bootstrap/bootstrap.py
@@ -47,7 +47,16 @@ SHELLS = ('bash', 'zsh', 'fish')
 
 # The fish drop-in file is owned entirely by this script: its presence is the
 # managed state, so uninstall just deletes it.
-_FISH_DROP_IN = Path('.config') / 'fish' / 'conf.d' / 'brave-bootstrap.fish'
+#
+# fish sources `conf.d/*.fish` alphabetically, *before* `config.fish`. Node
+# version managers (fnm, nvm, ...) ship their own conf.d snippet that prepends
+# their node to `$PATH`, so to win we must sort *after* them: the `zzz-` prefix
+# puts us last. See `fish_drop_in` for the prepend itself.
+_FISH_CONF_D = Path('.config') / 'fish' / 'conf.d'
+_FISH_DROP_IN = _FISH_CONF_D / 'zzz-brave-bootstrap.fish'
+
+# A legacy name that we used to use.
+_FISH_DROP_IN_LEGACY = _FISH_CONF_D / 'brave-bootstrap.fish'
 
 # -- Pure helpers (unit-tested) ----------------------------------------------
 
@@ -86,10 +95,8 @@ def fish_drop_in(bootstrap_dir: Path) -> str:
 
     Prepends the directory to `$PATH` (highest precedence) on each new shell,
     dropping any pre-existing occurrence first so it lands exactly once at the
-    front. Everything lives in this file: it deliberately avoids
-    `fish_add_path`, which would persist the entry in the *universal*
-    `fish_user_paths` variable and survive deletion of this file (making
-    uninstall ineffective).
+    front. The file name (see `_FISH_DROP_IN`) sorts last in `conf.d` so this
+    runs *after* version-manager snippets like fnm's and wins.
     """
     path = bootstrap_dir.as_posix()
     line = f'set -gx PATH "{path}" (string match --invert -- "{path}" $PATH)'
@@ -178,6 +185,10 @@ def _install_posix(shells: list[str]) -> int:
     for shell in shells:
         path = _profile_path(shell)
         if shell == 'fish':
+            # if the old file is found, we delete it too.
+            legacy = Path.home() / _FISH_DROP_IN_LEGACY
+            if legacy.exists():
+                legacy.unlink()
             _write(path, fish_drop_in(BOOTSTRAP_DIR))
         else:
             _write(path, apply_block(_read(path), BOOTSTRAP_DIR))
@@ -231,10 +242,12 @@ def _uninstall_posix() -> int:
     for shell in SHELLS:
         path = _profile_path(shell)
         if shell == 'fish':
-            if path.exists():
-                path.unlink()
-                print(f'Removed: {path}')
-                removed = True
+            # Remove the current drop-in and any leftover under the old name.
+            for drop_in in (path, Path.home() / _FISH_DROP_IN_LEGACY):
+                if drop_in.exists():
+                    drop_in.unlink()
+                    print(f'Removed: {drop_in}')
+                    removed = True
             if _erase_fish_user_path(target_dir):
                 removed = True
             continue

--- a/tools/cr/bootstrap/bootstrap_test.py
+++ b/tools/cr/bootstrap/bootstrap_test.py
@@ -74,6 +74,16 @@ class FishDropInTest(unittest.TestCase):
         self.assertNotIn('fish_add_path', content)
         self.assertIn('Managed by', content)
 
+    def test_drop_in_sorts_after_version_managers(self):
+        # fish sources conf.d/*.fish alphabetically; our drop-in must sort
+        # *after* version-manager snippets (e.g. fnm) so it prepends last and
+        # wins. Guard the name against a regression to an earlier-sorting one.
+        name = bootstrap._FISH_DROP_IN.name
+        self.assertGreater(name, 'fnm.fish')
+        self.assertGreater(name, 'nvm.fish')
+        # Upgrades must clean up the old, too-early name.
+        self.assertLess(bootstrap._FISH_DROP_IN_LEGACY.name, 'fnm.fish')
+
 
 class WindowsPathTest(unittest.TestCase):
     """Exercises the Windows PATH add/remove helpers."""

--- a/tools/cr/bootstrap/launcher.py
+++ b/tools/cr/bootstrap/launcher.py
@@ -52,24 +52,24 @@ SHIM_TARGETS: dict[str, Shim] = {
     'brockit': Shim('src/brave/tools/cr/brockit.py', 'vpython'),
     'plaster': Shim('src/brave/tools/cr/plaster.py', 'vpython'),
     'node-linux': Shim(
-        'src/brave/third_party/node/node-v24.16.0-linux-x64/bin/node'),
+        'src/brave/third_party/node/node-v24.17.0-linux-x64/bin/node'),
     'node-mac': Shim(
-        'src/brave/third_party/node/node-v24.16.0-darwin-x64/bin/node'),
+        'src/brave/third_party/node/node-v24.17.0-darwin-x64/bin/node'),
     'node-mac_arm64': Shim(
-        'src/brave/third_party/node/node-v24.16.0-darwin-arm64/bin/node'),
+        'src/brave/third_party/node/node-v24.17.0-darwin-arm64/bin/node'),
     'node-win': Shim(
-        'src/brave/third_party/node/node-v24.16.0-win-x64/node.exe'),
+        'src/brave/third_party/node/node-v24.17.0-win-x64/node.exe'),
     'npm-linux': Shim(
-        'src/brave/third_party/node/node-v24.16.0-linux-x64/lib/node_modules/npm/bin/npm-cli.js',
+        'src/brave/third_party/node/node-v24.17.0-linux-x64/lib/node_modules/npm/bin/npm-cli.js',
         'node'),
     'npm-mac': Shim(
-        'src/brave/third_party/node/node-v24.16.0-darwin-x64/lib/node_modules/npm/bin/npm-cli.js',
+        'src/brave/third_party/node/node-v24.17.0-darwin-x64/lib/node_modules/npm/bin/npm-cli.js',
         'node'),
     'npm-mac_arm64': Shim(
-        'src/brave/third_party/node/node-v24.16.0-darwin-arm64/lib/node_modules/npm/bin/npm-cli.js',
+        'src/brave/third_party/node/node-v24.17.0-darwin-arm64/lib/node_modules/npm/bin/npm-cli.js',
         'node'),
     'npm-win': Shim(
-        'src/brave/third_party/node/node-v24.16.0-win-x64/node_modules/npm/bin/npm-cli.js',
+        'src/brave/third_party/node/node-v24.17.0-win-x64/node_modules/npm/bin/npm-cli.js',
         'node'),
 }
 


### PR DESCRIPTION
This PR fixes the node version mismatch between the launcher used by the
shims, and the actual version being synced with `brave-core`. As the
lanucher was referring to the wrong version, this was causing the shim
to always degrede to the system node.

Additionally, this change does a small fix for fish terminal setup, as
`fnm` has some aggressive system to try to come on top for path
resolution.

Bug: https://github.com/brave/brave-browser/issues/56529
