### PR TITLE
Vertical tabs 'New tab' now supports middle click to open from clipboard

### DIFF
--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -34,7 +34,6 @@
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/themes/theme_properties.h"
 #include "chrome/browser/ui/browser.h"
-#include "chrome/browser/ui/browser_commands.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
 #include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
@@ -133,12 +132,10 @@ class VerticalTabNewTabButton : public BraveNewTabButton {
  public:
   VerticalTabNewTabButton(PressedCallback callback,
                           const std::u16string& shortcut_text,
-                          Browser* browser,
                           BrowserWindowInterface* browser_window_interface)
       : BraveNewTabButton(std::move(callback),
                           kLeoPlusAddIcon,
-                          browser_window_interface),
-        browser_(browser) {
+                          browser_window_interface) {
     // Turn off inkdrop to have same bg color with tab's.
     views::InkDrop::Get(this)->SetMode(views::InkDropHost::InkDropMode::OFF);
 
@@ -213,10 +210,9 @@ class VerticalTabNewTabButton : public BraveNewTabButton {
   ~VerticalTabNewTabButton() override = default;
 
   void OnMouseEvent(ui::MouseEvent* event) override {
-    if (event->IsOnlyMiddleMouseButton()) {
-      if (event->type() == ui::EventType::kMousePressed) {
-        chrome::NewTabFromClipboardURL(browser_);
-      }
+    if (event->IsOnlyMiddleMouseButton() &&
+        event->type() == ui::EventType::kMousePressed) {
+      NotifyClick(*event);
       event->SetHandled();
       return;
     }
@@ -257,7 +253,6 @@ class VerticalTabNewTabButton : public BraveNewTabButton {
 
   raw_ptr<views::ImageView> plus_icon_ = nullptr;
   raw_ptr<views::Label> text_ = nullptr;
-  raw_ptr<Browser> browser_ = nullptr;
 };
 
 BEGIN_METADATA(VerticalTabNewTabButton)
@@ -333,7 +328,7 @@ BraveVerticalTabStripRegionView::BraveVerticalTabStripRegionView(
   new_tab_button_ = AddChildView(std::make_unique<VerticalTabNewTabButton>(
       base::BindRepeating(&TabStrip::NewTabButtonPressed,
                           base::Unretained(original_region_view_->tab_strip_)),
-      GetShortcutTextForNewTabButton(browser_view), browser_, browser_));
+      GetShortcutTextForNewTabButton(browser_view), browser_));
 
   resize_area_ = AddChildView(std::make_unique<ResettableResizeArea>(this));
   SetBackground(views::CreateSolidBackground(kColorToolbar));

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -34,6 +34,7 @@
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/themes/theme_properties.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_commands.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
 #include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
@@ -135,7 +136,8 @@ class VerticalTabNewTabButton : public BraveNewTabButton {
                           BrowserWindowInterface* browser_window_interface)
       : BraveNewTabButton(std::move(callback),
                           kLeoPlusAddIcon,
-                          browser_window_interface) {
+                          browser_window_interface),
+        browser_(browser_window_interface->GetBrowserForMigrationOnly()) {
     // Turn off inkdrop to have same bg color with tab's.
     views::InkDrop::Get(this)->SetMode(views::InkDropHost::InkDropMode::OFF);
 
@@ -209,6 +211,17 @@ class VerticalTabNewTabButton : public BraveNewTabButton {
 
   ~VerticalTabNewTabButton() override = default;
 
+  void OnMouseEvent(ui::MouseEvent* event) override {
+    if (event->IsOnlyMiddleMouseButton()) {
+      if (event->type() == ui::EventType::kMousePressed) {
+        chrome::NewTabFromClipboardURL(browser_);
+      }
+      event->SetHandled();
+      return;
+    }
+    BraveNewTabButton::OnMouseEvent(event);
+  }
+
   gfx::Insets GetInsets() const override {
     // This button doesn't need any insets. Invalidate parent's one.
     return gfx::Insets();
@@ -243,6 +256,7 @@ class VerticalTabNewTabButton : public BraveNewTabButton {
 
   raw_ptr<views::ImageView> plus_icon_ = nullptr;
   raw_ptr<views::Label> text_ = nullptr;
+  raw_ptr<Browser> browser_ = nullptr;
 };
 
 BEGIN_METADATA(VerticalTabNewTabButton)

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -133,11 +133,12 @@ class VerticalTabNewTabButton : public BraveNewTabButton {
  public:
   VerticalTabNewTabButton(PressedCallback callback,
                           const std::u16string& shortcut_text,
+                          Browser* browser,
                           BrowserWindowInterface* browser_window_interface)
       : BraveNewTabButton(std::move(callback),
                           kLeoPlusAddIcon,
                           browser_window_interface),
-        browser_(browser_window_interface->GetBrowserForMigrationOnly()) {
+        browser_(browser) {
     // Turn off inkdrop to have same bg color with tab's.
     views::InkDrop::Get(this)->SetMode(views::InkDropHost::InkDropMode::OFF);
 
@@ -332,7 +333,7 @@ BraveVerticalTabStripRegionView::BraveVerticalTabStripRegionView(
   new_tab_button_ = AddChildView(std::make_unique<VerticalTabNewTabButton>(
       base::BindRepeating(&TabStrip::NewTabButtonPressed,
                           base::Unretained(original_region_view_->tab_strip_)),
-      GetShortcutTextForNewTabButton(browser_view), browser_));
+      GetShortcutTextForNewTabButton(browser_view), browser_, browser_));
 
   resize_area_ = AddChildView(std::make_unique<ResettableResizeArea>(this));
   SetBackground(views::CreateSolidBackground(kColorToolbar));

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
@@ -93,6 +93,8 @@ class BraveVerticalTabStripRegionView : public views::View,
   int GetTabStripViewportMaxHeight() const;
   void UpdateBorder();
 
+  BraveNewTabButton* new_tab_button_for_testing() { return new_tab_button_; }
+
   void ResetExpandedWidth();
   bool IsMenuShowing() const;
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves: https://github.com/brave/brave-browser/issues/43695

Notes:
- Initial version (1st commit) was simpler but used `browser_window_interface->GetBrowserForMigrationOnly` which sounds like it should be avoided: 2nd commit addressed that
- I added tests but I couldn't find how to run them. I tried `npm test -- browser_tests --filter='*VerticalTabStrip*'`
- There are other places where middle click is not implemented, for ex in the history, middle click opens in a new window but out of scope for this PR.


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
