### PR TITLE
[Brave News]: Add the header bar to the sidebar

### DIFF
--- a/browser/brave_news/BUILD.gn
+++ b/browser/brave_news/BUILD.gn
@@ -9,6 +9,7 @@ assert(enable_brave_news)
 
 source_set("brave_news") {
   sources = [
+    "brave_news_controller_delegate_impl.h",
     "brave_news_controller_factory.h",
     "brave_news_tab_helper.h",
     "direct_feed_fetcher_delegate_impl.h",
@@ -65,6 +66,16 @@ source_set("impl") {
     "//services/service_manager/public/cpp",
     "//url",
   ]
+
+  if (!is_android) {
+    # The controller delegate opens the New Tab Page, which requires
+    # //chrome/browser/ui/navigator (desktop only).
+    sources += [ "brave_news_controller_delegate_impl.cc" ]
+    deps += [
+      "//brave/components/constants",
+      "//chrome/browser/ui/navigator",
+    ]
+  }
 
   if (is_android) {
     # brave_news_controller_factory_android.cc includes the generated

--- a/browser/brave_news/brave_news_controller_delegate_impl.cc
+++ b/browser/brave_news/brave_news_controller_delegate_impl.cc
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/brave_news/brave_news_controller_delegate_impl.h"
+
+#include "base/check.h"
+#include "base/strings/strcat.h"
+#include "brave/components/constants/webui_url_constants.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/navigator/browser_navigator.h"
+#include "chrome/browser/ui/navigator/browser_navigator_params.h"
+#include "ui/base/page_transition_types.h"
+#include "ui/base/window_open_disposition.h"
+#include "url/gurl.h"
+
+namespace brave_news {
+
+BraveNewsControllerDelegateImpl::BraveNewsControllerDelegateImpl(
+    Profile* profile)
+    : profile_(profile) {
+  CHECK(profile_);
+}
+
+BraveNewsControllerDelegateImpl::~BraveNewsControllerDelegateImpl() = default;
+
+void BraveNewsControllerDelegateImpl::OpenSettings() {
+  // The New Tab Page shows the Brave News customize modal when opened with this
+  // query param (see the `openSettings` handling in the New Tab Page).
+  NavigateParams params(
+      profile_,
+      GURL(base::StrCat({kBraveUINewTabURL, "?openSettings=BraveNews"})),
+      ui::PAGE_TRANSITION_AUTO_TOPLEVEL);
+  params.disposition = WindowOpenDisposition::NEW_FOREGROUND_TAB;
+  Navigate(&params);
+}
+
+}  // namespace brave_news

--- a/browser/brave_news/brave_news_controller_delegate_impl.cc
+++ b/browser/brave_news/brave_news_controller_delegate_impl.cc
@@ -5,7 +5,7 @@
 
 #include "brave/browser/brave_news/brave_news_controller_delegate_impl.h"
 
-#include "base/check.h"
+#include "base/check_deref.h"
 #include "base/strings/strcat.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "chrome/browser/profiles/profile.h"
@@ -19,9 +19,7 @@ namespace brave_news {
 
 BraveNewsControllerDelegateImpl::BraveNewsControllerDelegateImpl(
     Profile* profile)
-    : profile_(profile) {
-  CHECK(profile_);
-}
+    : profile_(CHECK_DEREF(profile)) {}
 
 BraveNewsControllerDelegateImpl::~BraveNewsControllerDelegateImpl() = default;
 
@@ -29,7 +27,7 @@ void BraveNewsControllerDelegateImpl::OpenSettings() {
   // The New Tab Page shows the Brave News customize modal when opened with this
   // query param (see the `openSettings` handling in the New Tab Page).
   NavigateParams params(
-      profile_,
+      &profile_.get(),
       GURL(base::StrCat({kBraveUINewTabURL, "?openSettings=BraveNews"})),
       ui::PAGE_TRANSITION_AUTO_TOPLEVEL);
   params.disposition = WindowOpenDisposition::NEW_FOREGROUND_TAB;

--- a/browser/brave_news/brave_news_controller_delegate_impl.h
+++ b/browser/brave_news/brave_news_controller_delegate_impl.h
@@ -6,7 +6,7 @@
 #ifndef BRAVE_BROWSER_BRAVE_NEWS_BRAVE_NEWS_CONTROLLER_DELEGATE_IMPL_H_
 #define BRAVE_BROWSER_BRAVE_NEWS_BRAVE_NEWS_CONTROLLER_DELEGATE_IMPL_H_
 
-#include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "brave/components/brave_news/browser/brave_news_controller.h"
 
 class Profile;
@@ -30,7 +30,7 @@ class BraveNewsControllerDelegateImpl : public BraveNewsController::Delegate {
   void OpenSettings() override;
 
  private:
-  raw_ptr<Profile> profile_;
+  const raw_ref<Profile> profile_;
 };
 
 }  // namespace brave_news

--- a/browser/brave_news/brave_news_controller_delegate_impl.h
+++ b/browser/brave_news/brave_news_controller_delegate_impl.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_BROWSER_BRAVE_NEWS_BRAVE_NEWS_CONTROLLER_DELEGATE_IMPL_H_
+#define BRAVE_BROWSER_BRAVE_NEWS_BRAVE_NEWS_CONTROLLER_DELEGATE_IMPL_H_
+
+#include "base/memory/raw_ptr.h"
+#include "brave/components/brave_news/browser/brave_news_controller.h"
+
+class Profile;
+
+namespace brave_news {
+
+// Browser-layer implementation of BraveNewsController::Delegate. Lives here
+// rather than in components/ because opening browser UI requires
+// //chrome/browser/ui.
+class BraveNewsControllerDelegateImpl : public BraveNewsController::Delegate {
+ public:
+  explicit BraveNewsControllerDelegateImpl(Profile* profile);
+  ~BraveNewsControllerDelegateImpl() override;
+
+  BraveNewsControllerDelegateImpl(const BraveNewsControllerDelegateImpl&) =
+      delete;
+  BraveNewsControllerDelegateImpl& operator=(
+      const BraveNewsControllerDelegateImpl&) = delete;
+
+  // BraveNewsController::Delegate:
+  void OpenSettings() override;
+
+ private:
+  raw_ptr<Profile> profile_;
+};
+
+}  // namespace brave_news
+
+#endif  // BRAVE_BROWSER_BRAVE_NEWS_BRAVE_NEWS_CONTROLLER_DELEGATE_IMPL_H_

--- a/browser/brave_news/brave_news_controller_factory.cc
+++ b/browser/brave_news/brave_news_controller_factory.cc
@@ -11,6 +11,7 @@
 #include "brave/browser/brave_news/direct_feed_fetcher_delegate_impl.h"
 #include "brave/components/brave_news/browser/brave_news_controller.h"
 #include "brave/components/brave_policy/policy_initialization_waiter.h"
+#include "build/build_config.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/favicon/favicon_service_factory.h"
 #include "chrome/browser/history/history_service_factory.h"
@@ -21,6 +22,10 @@
 #include "components/keyed_service/core/service_access_type.h"
 #include "components/policy/core/common/policy_service.h"
 #include "content/public/browser/browser_context.h"
+
+#if !BUILDFLAG(IS_ANDROID)
+#include "brave/browser/brave_news/brave_news_controller_delegate_impl.h"
+#endif
 
 namespace brave_news {
 
@@ -86,11 +91,19 @@ BraveNewsControllerFactory::BuildServiceInstanceForBrowserContext(
       std::make_unique<brave_policy::PolicyInitializationWaiter>(
           policy_service);
 
+  // The settings delegate opens the New Tab Page, which only exists on desktop;
+  // a null delegate is fine, BraveNewsController::OpenSettings() no-ops then.
+  std::unique_ptr<BraveNewsController::Delegate> delegate;
+#if !BUILDFLAG(IS_ANDROID)
+  delegate = std::make_unique<BraveNewsControllerDelegateImpl>(profile);
+#endif
+
   return std::make_unique<BraveNewsController>(
       profile->GetPrefs(), std::move(policy_initialization_waiter),
       history_service, profile->GetURLLoaderFactory(),
       std::make_unique<DirectFeedFetcherDelegateImpl>(
-          host_content_settings_map));
+          host_content_settings_map),
+      std::move(delegate));
 }
 
 bool BraveNewsControllerFactory::ServiceIsNULLWhileTesting() const {

--- a/components/brave_news/browser/brave_news_controller.cc
+++ b/components/brave_news/browser/brave_news_controller.cc
@@ -103,7 +103,8 @@ BraveNewsController::BraveNewsController(
         policy_initialization_waiter,
     history::HistoryService* history_service,
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
-    std::unique_ptr<DirectFeedFetcher::Delegate> direct_feed_fetcher_delegate)
+    std::unique_ptr<DirectFeedFetcher::Delegate> direct_feed_fetcher_delegate,
+    std::unique_ptr<Delegate> delegate)
     :
 #if BUILDFLAG(IS_ANDROID)
       private_cdn_request_helper_(GetNetworkTrafficAnnotationTag(),
@@ -112,6 +113,7 @@ BraveNewsController::BraveNewsController(
       history_service_(history_service),
       url_loader_factory_(url_loader_factory),
       direct_feed_fetcher_delegate_(std::move(direct_feed_fetcher_delegate)),
+      delegate_(std::move(delegate)),
       policy_initialization_waiter_(std::move(policy_initialization_waiter)),
       pref_manager_(*prefs),
       news_metrics_(prefs, pref_manager_),
@@ -593,6 +595,13 @@ void BraveNewsController::OnCardVisited(uint32_t depth) {
 void BraveNewsController::OnSidebarFilterUsage() {
   DVLOG(1) << __FUNCTION__;
   news_metrics_.RecordTotalActionCount(p3a::ActionType::kSidebarFilterUsage, 1);
+}
+
+void BraveNewsController::OpenSettings() {
+  DVLOG(1) << __FUNCTION__;
+  if (delegate_) {
+    delegate_->OpenSettings();
+  }
 }
 
 void BraveNewsController::GetVisitedSites(GetVisitedSitesCallback callback) {

--- a/components/brave_news/browser/brave_news_controller.h
+++ b/components/brave_news/browser/brave_news_controller.h
@@ -61,14 +61,24 @@ class BraveNewsController
       public net::NetworkChangeNotifier::NetworkChangeObserver,
       public BraveNewsPrefManager::PrefObserver {
  public:
+  // Handles UI actions that components/ cannot perform itself (e.g. opening a
+  // tab). Implemented in the //chrome browser layer.
+  class Delegate {
+   public:
+    virtual ~Delegate() = default;
+
+    // Opens the New Tab Page and shows the Brave News customize modal.
+    virtual void OpenSettings() = 0;
+  };
+
   BraveNewsController(
       PrefService* prefs,
       std::unique_ptr<brave_policy::PolicyInitializationWaiter>
           policy_initialization_waiter,
       history::HistoryService* history_service,
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
-      std::unique_ptr<DirectFeedFetcher::Delegate>
-          direct_feed_fetcher_delegate);
+      std::unique_ptr<DirectFeedFetcher::Delegate> direct_feed_fetcher_delegate,
+      std::unique_ptr<Delegate> delegate);
   ~BraveNewsController() override;
   BraveNewsController(const BraveNewsController&) = delete;
   BraveNewsController& operator=(const BraveNewsController&) = delete;
@@ -132,6 +142,7 @@ class BraveNewsController
   void OnNewCardsViewed(uint16_t card_views) override;
   void OnCardVisited(uint32_t depth) override;
   void OnSidebarFilterUsage() override;
+  void OpenSettings() override;
 
   // mojom::BraveNewsInternals
   void GetVisitedSites(GetVisitedSitesCallback callback) override;
@@ -174,6 +185,7 @@ class BraveNewsController
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
 
   std::unique_ptr<DirectFeedFetcher::Delegate> direct_feed_fetcher_delegate_;
+  std::unique_ptr<Delegate> delegate_;
   std::unique_ptr<brave_policy::PolicyInitializationWaiter>
       policy_initialization_waiter_;
 

--- a/components/brave_news/browser/resources/FeedControls.tsx
+++ b/components/brave_news/browser/resources/FeedControls.tsx
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { getLocale } from '$web-common/locale'
+import Icon from '@brave/leo/react/icon'
+import { spacing } from '@brave/leo/tokens/css/variables'
+import * as React from 'react'
+import styled from 'styled-components'
+import SettingsButton from './SettingsButton'
+import { useBraveNews } from './shared/Context'
+
+const SidebarMenu = React.lazy(() => import('./SidebarMenu'))
+
+const Container = styled.div`
+  max-width: min(540px, 100vw);
+
+  display: flex;
+  justify-content: flex-end;
+  gap: ${spacing.m};
+
+  margin-left: auto;
+  margin-right: auto;
+`
+
+interface Props {
+  // Invoked when the customize ("tune") button is pressed. Surfaces differ in
+  // where customization lives: the feed opens its inline modal, while the side
+  // panel opens the New Tab Page.
+  onCustomize: () => void
+  // Whether to show the feed-list menu. The feed only needs it on small
+  // viewports (it has a dedicated sidebar otherwise), whereas narrow surfaces
+  // like the side panel always show it.
+  showMenu?: boolean
+  className?: string
+}
+
+// The Brave News feed controls: an optional feed-list menu plus customize and
+// refresh buttons. Shared by the feed page and the side panel so both expose
+// the same actions; each surface supplies its own positioning container.
+export default function FeedControls({
+  onCustomize,
+  showMenu,
+  className,
+}: Props) {
+  const { feedV2, refreshFeedV2 } = useBraveNews()
+  return (
+    <Container className={className}>
+      {showMenu && (
+        <React.Suspense fallback={null}>
+          <SidebarMenu />
+        </React.Suspense>
+      )}
+      <SettingsButton
+        onClick={onCustomize}
+        title={getLocale(S.BRAVE_NEWS_CUSTOMIZE_FEED)}
+      >
+        <Icon name='tune' />
+      </SettingsButton>
+      <SettingsButton
+        isLoading={!feedV2}
+        title={getLocale(S.BRAVE_NEWS_REFRESH_FEED)}
+        onClick={() => refreshFeedV2()}
+      >
+        <Icon name='refresh' />
+      </SettingsButton>
+    </Container>
+  )
+}

--- a/components/brave_news/browser/resources/Page.tsx
+++ b/components/brave_news/browser/resources/Page.tsx
@@ -4,18 +4,16 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 import Flex from '$web-common/Flex'
 import { getLocale } from '$web-common/locale'
-import Icon from '@brave/leo/react/icon'
 import { radius, spacing } from '@brave/leo/tokens/css/variables'
 import * as React from 'react'
 import styled from 'styled-components'
 import Feed from './Feed'
+import FeedControls from './FeedControls'
 import NewsButton from './NewsButton'
 import Variables from './Variables'
 import { useBraveNews } from './shared/Context'
-import SettingsButton from './SettingsButton'
 import useMediaQuery from '$web-common/useMediaQuery'
 
-const SidebarMenu = React.lazy(() => import('./SidebarMenu'))
 const FeedNavigation = React.lazy(() => import('./FeedNavigation'))
 
 const isSmallQuery = '(max-width: 1024px)'
@@ -53,17 +51,6 @@ const ButtonsContainer = styled.div`
     padding: ${spacing['2Xl']} ${spacing.xl};
     border-radius: 0;
   }
-`
-
-const ButtonSpacer = styled.div`
-  max-width: min(540px, 100vw);
-
-  display: flex;
-  justify-content: flex-end;
-  gap: ${spacing.m};
-
-  margin-left: auto;
-  margin-right: auto;
 `
 
 const LoadNewContentButton = styled(NewsButton)`
@@ -111,15 +98,10 @@ export default function FeedV2() {
     </Flex>
 
     <ButtonsContainer className='brave-news-feed-controls'>
-      <ButtonSpacer>
-        {isSmall && <React.Suspense fallback={null}><SidebarMenu /></React.Suspense>}
-        <SettingsButton onClick={() => setCustomizePage('news')} title={getLocale(S.BRAVE_NEWS_CUSTOMIZE_FEED)}>
-          <Icon name="tune" />
-        </SettingsButton>
-        <SettingsButton isLoading={!feedV2} title={getLocale(S.BRAVE_NEWS_REFRESH_FEED)} onClick={() => {
-          refreshFeedV2()
-        }}><Icon name="refresh" /></SettingsButton>
-      </ButtonSpacer>
+      <FeedControls
+        onCustomize={() => setCustomizePage('news')}
+        showMenu={isSmall}
+      />
     </ButtonsContainer>
   </Root>
 }

--- a/components/brave_news/browser/resources/sidebar.tsx
+++ b/components/brave_news/browser/resources/sidebar.tsx
@@ -9,14 +9,40 @@ import * as React from 'react'
 import { createRoot } from 'react-dom/client'
 import styled from 'styled-components'
 import Feed from './Feed'
+import FeedControls from './FeedControls'
 import Variables from './Variables'
+import getBraveNewsController from './shared/api'
 import { BraveNewsContextProvider, useBraveNews } from './shared/Context'
 import './strings'
 
 setIconBasePath('//resources/brave-icons')
 
 const Root = styled(Variables)`
+  /* Consumed by SidebarMenu to position its slide-out beneath the header. */
+  --bn-top-bar-height: 56px;
+
+  display: flex;
+  flex-direction: column;
+`
+
+const Header = styled.div`
+  position: sticky;
+  top: 0;
+  z-index: 1;
+
+  height: var(--bn-top-bar-height);
+  display: flex;
+  align-items: center;
+  gap: ${spacing.m};
+  padding-inline: ${spacing.xl};
+
+  background: var(--bn-glass-container);
+  backdrop-filter: blur(64px);
+`
+
+const Content = styled.div`
   margin-inline: auto;
+  width: 100%;
   max-width: 540px;
   padding: ${spacing.xl} ${spacing.m};
 
@@ -25,15 +51,29 @@ const Root = styled(Variables)`
   }
 `
 
+// Fill the header so the controls' internal alignment (feed-list menu on the
+// left, actions on the right) has the full width to spread across.
+const Controls = styled(FeedControls)`
+  flex: 1;
+`
+
 export function Sidebar() {
   const { feedV2, reportViewCount, reportSessionStart } = useBraveNews()
   return (
     <Root data-theme='dark'>
-      <Feed
-        feed={feedV2}
-        onViewCountChange={reportViewCount}
-        onSessionStart={reportSessionStart}
-      />
+      <Header>
+        <Controls
+          onCustomize={() => getBraveNewsController().openSettings()}
+          showMenu
+        />
+      </Header>
+      <Content>
+        <Feed
+          feed={feedV2}
+          onViewCountChange={reportViewCount}
+          onSessionStart={reportSessionStart}
+        />
+      </Content>
     </Root>
   )
 }

--- a/components/brave_news/browser/resources/storybook/mockBraveNewsController.ts
+++ b/components/brave_news/browser/resources/storybook/mockBraveNewsController.ts
@@ -172,7 +172,8 @@ export const mockBraveNewsController: Partial<BraveNewsControllerRemote> = {
   onNewCardsViewed() {},
   onCardVisited() {},
   onInteractionSessionStarted() {},
-  onSidebarFilterUsage() {}
+  onSidebarFilterUsage() {},
+  openSettings() {}
 }
 
 // @ts-expect-error mockBraveNewsController only implements the methods the feed

--- a/components/brave_news/common/brave_news.mojom
+++ b/components/brave_news/common/brave_news.mojom
@@ -310,4 +310,9 @@ interface BraveNewsController {
   OnNewCardsViewed(uint16 card_views);
   OnCardVisited(uint32 depth);
   OnSidebarFilterUsage();
+
+  // Opens the New Tab Page and shows the Brave News customize modal. Used by
+  // surfaces that don't host the customize UI themselves (e.g. the side
+  // panel), which delegate settings to the New Tab Page.
+  OpenSettings();
 };


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Series https://github.com/brave/brave-browser/issues/29147

Rather than showing the `Configure` dialog for Brave News in the side bar we open a new tab pointed at the configure dialog.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
