### PR TITLE
[iOS] Fix wallet button style regressions from Nala button style migration

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Panels/AddSuggestedNetwork/SuggestedNetworkView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Panels/AddSuggestedNetwork/SuggestedNetworkView.swift
@@ -216,6 +216,7 @@ struct SuggestedNetworkView: View {
           .frame(maxWidth: .infinity)
       }
       .listRowInsets(.zero)
+      .listRowBackground(Color.clear)
       .opacity(sizeCategory.isAccessibilityCategory ? 0 : 1)
       .accessibility(hidden: sizeCategory.isAccessibilityCategory)
     }

--- a/ios/brave-ios/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -96,6 +96,7 @@ public struct NewSiteConnectionView: View {
         Section {
           headerView
         }
+        .listRowBackground(Color.clear)
         Section {
           ForEach(accountInfos) { account in
             Button {
@@ -165,6 +166,7 @@ public struct NewSiteConnectionView: View {
             .hidden()
           )
         }
+        .listRowBackground(Color.clear)
       }
       .listStyle(InsetGroupedListStyle())
       .navigationBarTitleDisplayMode(.inline)
@@ -221,6 +223,7 @@ public struct NewSiteConnectionView: View {
             .foregroundColor(Color(braveSystemName: .textPrimary))
         }
       }
+      .listRowBackground(Color.clear)
       Section {
         HStack(spacing: 12) {
           Image(braveSystemName: "leo.check.circle-filled")
@@ -234,6 +237,7 @@ public struct NewSiteConnectionView: View {
       } footer: {
         cautionFooterView
       }
+      .listRowBackground(Color.clear)
       Section {
         Button {
           let accounts =
@@ -248,6 +252,7 @@ public struct NewSiteConnectionView: View {
         .controlSize(.large)
         .frame(maxWidth: .infinity)
       }
+      .listRowBackground(Color.clear)
     }
     .listStyle(InsetGroupedListStyle())
     .navigationTitle(Strings.Wallet.newSiteConnectScreenTitle)

--- a/ios/brave-ios/Sources/BraveWallet/WalletLoadingButton.swift
+++ b/ios/brave-ios/Sources/BraveWallet/WalletLoadingButton.swift
@@ -30,9 +30,11 @@ struct WalletLoadingButton<Label: View>: View {
       ZStack {
         label
           .opacity(isLoading ? 0 : 1)
-        ProgressView()
-          .tint(Color(braveSystemName: .schemesOnPrimary))
-          .opacity(isLoading ? 1 : 0)
+          .overlay {
+            ProgressView()
+              .tint(Color(braveSystemName: .schemesOnPrimary))
+              .opacity(isLoading ? 1 : 0)
+          }
       }
     }
   }


### PR DESCRIPTION
Fix two visual regressions caused by the new SwiftUI button styles. 

- WalletLoadingButton: With .controlSize(.large) now propagated via the environment, the circular spinner rendered slightly taller than the cancel button. fix by using overlay instead of zstack to display progressView. 

-  SuggestedNetworkView / NewSiteConnectionView: the new Capsule clip shape has larger corner curves, exposing more of the list row's white card background around action buttons in InsetGroupedListStyle lists. Fix by adding clear row background to the affected sections.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
