### PR TITLE
[Refactor] Decouple SidePanelButton and SidebarContainerView

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -2292,7 +2292,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, ToolbarButtonPinning) {
         << "Precondition: sidebar hidden before pin";
 
     // Pin: sidebar snaps visible, button highlights (fade-in).
-    controller()->ToggleSidebarPinning();
+    button->button_controller()->NotifyClick();
     EXPECT_TRUE(controller()->sidebar_pinned()) << "Pin should set pinned=true";
     EXPECT_TRUE(sidebar_container->IsSidebarVisible())
         << "Pin should force sidebar visible regardless of show option";
@@ -2301,7 +2301,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, ToolbarButtonPinning) {
 
     // Unpin: pinned flips immediately; button highlight + sidebar visibility
     // unwind asynchronously (animations).
-    controller()->ToggleSidebarPinning();
+    button->button_controller()->NotifyClick();
     EXPECT_FALSE(controller()->sidebar_pinned())
         << "Unpin should set pinned=false";
     ASSERT_TRUE(base::test::RunUntil([&]() { return !button_highlighted(); }))
@@ -2335,7 +2335,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, ToolbarButtonPinning) {
   // Pin again, then change the show option → pinned must reset to false and
   // the sidebar must follow the new option (kShowOnMouseOver, mouse parked
   // outside sidebar → hidden).
-  controller()->ToggleSidebarPinning();
+  button->button_controller()->NotifyClick();
   ASSERT_TRUE(controller()->sidebar_pinned())
       << "Pinning again should set pinned=true (precondition for reset test)";
   ASSERT_TRUE(sidebar_container->IsSidebarVisible())

--- a/browser/ui/sidebar/sidebar_controller.cc
+++ b/browser/ui/sidebar/sidebar_controller.cc
@@ -64,7 +64,7 @@ SidebarController::SidebarController(Browser* browser, Profile* profile)
       profile_(profile),
       browser_(browser),
       sidebar_model_(new SidebarModel(profile_)) {
-  sidebar_service_observed_.Observe(GetSidebarService(profile_));
+  sidebar_service_observed_.Observe(::sidebar::GetSidebarService(profile_));
 }
 
 SidebarController::~SidebarController() = default;
@@ -262,7 +262,7 @@ void SidebarController::AddItemWithCurrentTab() {
   DCHECK(active_contents);
   const GURL url = active_contents->GetVisibleURL();
   const std::u16string title = active_contents->GetTitle();
-  GetSidebarService(profile_)->AddItem(SidebarItem::Create(
+  ::sidebar::GetSidebarService(profile_)->AddItem(SidebarItem::Create(
       url, title, SidebarItem::Type::kTypeWeb,
       SidebarItem::BuiltInItemType::kNone, IsWebPanelFeatureEnabled()));
 }
@@ -304,6 +304,10 @@ SidebarWebPanelController* SidebarController::GetWebPanelController() {
   }
 
   return web_panel_controller_.get();
+}
+
+SidebarService* SidebarController::GetSidebarService() {
+  return ::sidebar::GetSidebarService(profile_);
 }
 
 }  // namespace sidebar

--- a/browser/ui/sidebar/sidebar_controller.cc
+++ b/browser/ui/sidebar/sidebar_controller.cc
@@ -40,10 +40,6 @@ namespace sidebar {
 
 namespace {
 
-SidebarService* GetSidebarService(Profile* profile) {
-  return SidebarServiceFactory::GetForProfile(profile);
-}
-
 std::vector<int> GetAllExistingTabIndexForHost(TabStripModel* tab_strip_model,
                                                std::string_view host) {
   const int tab_count = tab_strip_model->count();
@@ -64,7 +60,7 @@ SidebarController::SidebarController(Browser* browser, Profile* profile)
       profile_(profile),
       browser_(browser),
       sidebar_model_(new SidebarModel(profile_)) {
-  sidebar_service_observed_.Observe(::sidebar::GetSidebarService(profile_));
+  sidebar_service_observed_.Observe(GetSidebarService());
 }
 
 SidebarController::~SidebarController() = default;
@@ -262,7 +258,7 @@ void SidebarController::AddItemWithCurrentTab() {
   DCHECK(active_contents);
   const GURL url = active_contents->GetVisibleURL();
   const std::u16string title = active_contents->GetTitle();
-  ::sidebar::GetSidebarService(profile_)->AddItem(SidebarItem::Create(
+  GetSidebarService()->AddItem(SidebarItem::Create(
       url, title, SidebarItem::Type::kTypeWeb,
       SidebarItem::BuiltInItemType::kNone, IsWebPanelFeatureEnabled()));
 }
@@ -307,7 +303,7 @@ SidebarWebPanelController* SidebarController::GetWebPanelController() {
 }
 
 SidebarService* SidebarController::GetSidebarService() {
-  return ::sidebar::GetSidebarService(profile_);
+  return SidebarServiceFactory::GetForProfile(profile_);
 }
 
 }  // namespace sidebar

--- a/browser/ui/sidebar/sidebar_controller.h
+++ b/browser/ui/sidebar/sidebar_controller.h
@@ -92,6 +92,7 @@ class SidebarController : public SidebarService::Observer {
   SidebarModel* model() const { return sidebar_model_.get(); }
 
   SidebarWebPanelController* GetWebPanelController();
+  SidebarService* GetSidebarService();
 
   // SidebarService::Observer overrides:
   void OnShowSidebarOptionChanged(

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -24,8 +24,6 @@
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
 #include "brave/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h"
 #include "brave/browser/ui/views/sidebar/sidebar_control_view.h"
-#include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
-#include "brave/browser/ui/views/toolbar/side_panel_button.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/sidebar/browser/sidebar_item.h"
@@ -39,7 +37,6 @@
 #include "chrome/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
-#include "chrome/browser/ui/views/toolbar/toolbar_view.h"
 #include "components/grit/brave_components_strings.h"
 #include "components/input/native_web_keyboard_event.h"
 #include "content/public/browser/browser_context.h"
@@ -123,13 +120,7 @@ SidebarContainerView::~SidebarContainerView() = default;
 void SidebarContainerView::Init() {
   initialized_ = true;
 
-  show_side_panel_button_.Init(
-      kShowSidePanelButton, browser_->profile()->GetPrefs(),
-      base::BindRepeating(&SidebarContainerView::UpdateToolbarButtonVisibility,
-                          base::Unretained(this)));
-
   AddChildViews();
-  UpdateToolbarButtonVisibility();
   SetSidebarShowOption(
       GetSidebarService(GetBraveBrowser())->GetSidebarShowOption());
 }
@@ -200,26 +191,23 @@ void SidebarContainerView::SetSidebarShowOption(ShowSidebarOption show_option) {
 
   show_sidebar_option_ = show_option;
 
-    // Toolbar button visibility depends on show options.
-    UpdateToolbarButtonVisibility();
-
-    if (show_sidebar_option_ == ShowSidebarOption::kShowAlways) {
-      if (!IsSidebarVisible()) {
-        ShowSidebar(AnimationStyle::kImmediate);
-      }
-      return;
-    }
-
-    if (show_sidebar_option_ == ShowSidebarOption::kShowNever) {
-      HideSidebar();
-      return;
-    }
-
-    // kShowOnMouseOver
-    if (!IsMouseHovered()) {
-      HideSidebar();
+  if (show_sidebar_option_ == ShowSidebarOption::kShowAlways) {
+    if (!IsSidebarVisible()) {
+      ShowSidebar(AnimationStyle::kImmediate);
     }
     return;
+  }
+
+  if (show_sidebar_option_ == ShowSidebarOption::kShowNever) {
+    HideSidebar();
+    return;
+  }
+
+  // kShowOnMouseOver
+  if (!IsMouseHovered()) {
+    HideSidebar();
+  }
+  return;
 }
 
 void SidebarContainerView::UpdateSidebarItemsState() {
@@ -228,8 +216,6 @@ void SidebarContainerView::UpdateSidebarItemsState() {
 }
 
 void SidebarContainerView::UpdateSidebarVisibility() {
-  UpdateToolbarButtonHighlight();
-
   // Pinning is an explicit user gesture, not a hover — snap to visible
   // without animation, mirroring kShowAlways above. Otherwise, fall through
   // and follow the current show option.
@@ -404,38 +390,6 @@ void SidebarContainerView::HideSidebar() {
 
 bool SidebarContainerView::ShouldUseAnimation() {
   return gfx::Animation::ShouldRenderRichAnimation();
-}
-
-void SidebarContainerView::UpdateToolbarButtonVisibility() {
-  auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser_);
-  // BraveToolbarView and SidebarContainerView are sibling children of
-  // BrowserView; their construction/destruction order is not strictly
-  // coordinated, so the toolbar pointer (or its side_panel_button child) may
-  // be null during early init or window teardown when this is invoked from
-  // pref/observer callbacks.
-  auto* brave_toolbar = static_cast<BraveToolbarView*>(browser_view->toolbar());
-  if (!brave_toolbar) {
-    return;
-  }
-
-  // We hide button when show always as pinning doesn't make sense
-  // when always visible.
-  if (auto* button = brave_toolbar->side_panel_button()) {
-    button->SetVisible(show_side_panel_button_.GetValue() &&
-                       show_sidebar_option_ != ShowSidebarOption::kShowAlways);
-  }
-  UpdateToolbarButtonHighlight();
-}
-
-void SidebarContainerView::UpdateToolbarButtonHighlight() {
-  auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser_);
-  // See UpdateToolbarButtonVisibility() for why brave_toolbar /
-  // side_panel_button() may be null here.
-  auto* brave_toolbar = static_cast<BraveToolbarView*>(browser_view->toolbar());
-  if (brave_toolbar && brave_toolbar->side_panel_button()) {
-    brave_toolbar->side_panel_button()->SetHighlighted(
-        browser_->GetFeatures().sidebar_controller()->sidebar_pinned());
-  }
 }
 
 void SidebarContainerView::StartBrowserWindowEventMonitoring() {

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -105,8 +105,6 @@ class SidebarContainerView : public sidebar::Sidebar,
   void HideSidebar();
 
   bool ShouldForceShowSidebar() const;
-  void UpdateToolbarButtonVisibility();
-  void UpdateToolbarButtonHighlight();
 
   // true when fullscreen is initiated by tab. (Ex, fullscreen mode in youtube)
   bool IsFullscreenByTab() const;
@@ -141,7 +139,6 @@ class SidebarContainerView : public sidebar::Sidebar,
   int animation_end_width_ = 0;
   std::unique_ptr<BrowserWindowEventObserver> browser_window_event_observer_;
   std::unique_ptr<views::EventMonitor> browser_window_event_monitor_;
-  BooleanPrefMember show_side_panel_button_;
   base::RepeatingClosure sidebar_control_view_visibility_changed_callback_;
 };
 

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -347,8 +347,11 @@ void BraveToolbarView::Init() {
   bookmark_->UpdateImageAndText();
   SetBraveButtonFlexBehavior(bookmark_);
 
-  side_panel_ = AddChildViewAt(std::make_unique<SidePanelButton>(browser()),
-                               *GetIndexOf(app_menu_button()) - 1);
+  side_panel_ = AddChildViewAt(
+      std::make_unique<SidePanelButton>(
+          browser()->browser_window_features()->sidebar_controller(),
+          profile->GetPrefs()),
+      *GetIndexOf(app_menu_button()) - 1);
   SetBraveButtonFlexBehavior(side_panel_);
 
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)

--- a/browser/ui/views/toolbar/side_panel_button.cc
+++ b/browser/ui/views/toolbar/side_panel_button.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "base/check_deref.h"
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/ui/sidebar/sidebar_controller.h"
 #include "brave/components/constants/pref_names.h"
@@ -59,7 +60,7 @@ SidePanelButton::SidePanelButton(sidebar::SidebarController* sidebar_controller,
                                  PrefService* prefs)
     : ToolbarButton(base::BindRepeating(&SidePanelButton::ButtonPressed,
                                         base::Unretained(this))),
-      sidebar_controller_(*sidebar_controller) {
+      sidebar_controller_(CHECK_DEREF(sidebar_controller)) {
   sidebar_service_observation_.Observe(
       sidebar_controller_->GetSidebarService());
   SetMenuModel(std::make_unique<SidePanelMenuModel>(prefs));

--- a/browser/ui/views/toolbar/side_panel_button.cc
+++ b/browser/ui/views/toolbar/side_panel_button.cc
@@ -11,9 +11,6 @@
 #include "brave/browser/ui/sidebar/sidebar_controller.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/grit/brave_generated_resources.h"
-#include "chrome/browser/profiles/profile.h"
-#include "chrome/browser/ui/browser.h"
-#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/side_panel/side_panel_ui.h"
 #include "chrome/common/pref_names.h"
 #include "components/prefs/pref_service.h"
@@ -58,20 +55,26 @@ class SidePanelMenuModel : public ui::SimpleMenuModel,
 
 }  // namespace
 
-SidePanelButton::SidePanelButton(Browser* browser)
+SidePanelButton::SidePanelButton(sidebar::SidebarController* sidebar_controller,
+                                 PrefService* prefs)
     : ToolbarButton(base::BindRepeating(&SidePanelButton::ButtonPressed,
                                         base::Unretained(this))),
-      browser_(*browser) {
-  auto* prefs = browser->profile()->GetOriginalProfile()->GetPrefs();
+      sidebar_controller_(*sidebar_controller) {
+  sidebar_service_observation_.Observe(
+      sidebar_controller_->GetSidebarService());
   SetMenuModel(std::make_unique<SidePanelMenuModel>(prefs));
 
-  // Visibility is managed by |SideBarContainerView|.
-  SetVisible(false);
   sidebar_alignment_.Init(
       prefs::kSidePanelHorizontalAlignment, prefs,
       base::BindRepeating(&SidePanelButton::UpdateToolbarButtonIcon,
                           base::Unretained(this)));
+  show_side_panel_button_.Init(
+      kShowSidePanelButton, prefs,
+      base::BindRepeating(&SidePanelButton::UpdateButtonVisibility,
+                          base::Unretained(this)));
+
   UpdateToolbarButtonIcon();
+  UpdateButtonVisibility();
   SetTooltipText(l10n_util::GetStringUTF16(IDS_TOOLTIP_SIDEBAR_SHOW));
   set_context_menu_controller(this);
   button_controller()->set_notify_action(
@@ -81,13 +84,34 @@ SidePanelButton::SidePanelButton(Browser* browser)
 
 SidePanelButton::~SidePanelButton() = default;
 
+void SidePanelButton::OnShowSidebarOptionChanged(
+    sidebar::SidebarService::ShowSidebarOption option) {
+  UpdateButtonVisibility();
+  UpdateButtonHighlight();
+}
+
 void SidePanelButton::ButtonPressed() {
-  browser_->GetFeatures().sidebar_controller()->ToggleSidebarPinning();
+  sidebar_controller_->ToggleSidebarPinning();
+  UpdateButtonHighlight();
 }
 
 void SidePanelButton::UpdateToolbarButtonIcon() {
   SetVectorIcon(sidebar_alignment_.GetValue() ? kSidebarToolbarButtonRightIcon
                                               : kSidebarToolbarButtonIcon);
+}
+
+void SidePanelButton::UpdateButtonVisibility() {
+  // We hide button when show always as pinning doesn't make sense
+  // when always visible.
+  const sidebar::SidebarService::ShowSidebarOption show_sidebar_option =
+      sidebar_controller_->GetSidebarService()->GetSidebarShowOption();
+  SetVisible(show_side_panel_button_.GetValue() &&
+             show_sidebar_option !=
+                 sidebar::SidebarService::ShowSidebarOption::kShowAlways);
+}
+
+void SidePanelButton::UpdateButtonHighlight() {
+  SetHighlighted(sidebar_controller_->sidebar_pinned());
 }
 
 BEGIN_METADATA(SidePanelButton)

--- a/browser/ui/views/toolbar/side_panel_button.h
+++ b/browser/ui/views/toolbar/side_panel_button.h
@@ -7,20 +7,31 @@
 #define BRAVE_BROWSER_UI_VIEWS_TOOLBAR_SIDE_PANEL_BUTTON_H_
 
 #include "base/memory/raw_ref.h"
+#include "brave/components/sidebar/browser/sidebar_service.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_button.h"
 #include "components/prefs/pref_member.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 
-class Browser;
+class PrefService;
 
-class SidePanelButton : public ToolbarButton {
+namespace sidebar {
+class SidebarController;
+}  // namespace sidebar
+
+class SidePanelButton : public ToolbarButton,
+                        public sidebar::SidebarService::Observer {
   METADATA_HEADER(SidePanelButton, ToolbarButton)
 
  public:
-  explicit SidePanelButton(Browser* browser);
+  SidePanelButton(sidebar::SidebarController* sidebar_controller,
+                  PrefService* prefs);
   SidePanelButton(const SidePanelButton&) = delete;
   SidePanelButton& operator=(const SidePanelButton&) = delete;
   ~SidePanelButton() override;
+
+  // SidebarService::Observer:
+  void OnShowSidebarOptionChanged(
+      sidebar::SidebarService::ShowSidebarOption option) override;
 
  private:
   void ButtonPressed();
@@ -30,11 +41,17 @@ class SidePanelButton : public ToolbarButton {
   // the default vector icon is used. When the side panel should open to the
   // left side of the browser the flipped vector icon is used.
   void UpdateToolbarButtonIcon();
+  void UpdateButtonVisibility();
+  void UpdateButtonHighlight();
 
-  const raw_ref<Browser> browser_;
+  const raw_ref<sidebar::SidebarController> sidebar_controller_;
 
   // Observes and listens to side panel alignment changes.
   BooleanPrefMember sidebar_alignment_;
+  BooleanPrefMember show_side_panel_button_;
+  base::ScopedObservation<sidebar::SidebarService,
+                          sidebar::SidebarService::Observer>
+      sidebar_service_observation_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TOOLBAR_SIDE_PANEL_BUTTON_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves no issue - refactoring w/o behavior change.

SidebarContainerView doesn't need to know about button.
Button can update its state by itself. Updated code is covered by existing test.

This change is prerequisite for fixing `side panel toolbar highlight is cleared after theme change`. 
(https://github.com/brave/brave-browser/issues/51462).

TEST=SidebarBrowserTest.ToolbarButtonPinning

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
