### PR TITLE
[iOS] Add Playlist JavaScriptFeatures

### DIFF
--- a/ios/BUILD.gn
+++ b/ios/BUILD.gn
@@ -135,6 +135,7 @@ brave_core_public_headers = [
   "//brave/ios/browser/web/logins/logins_tab_helper_bridge.h",
   "//brave/ios/browser/brave_talk/brave_talk_tab_helper_bridge.h",
   "//brave/ios/browser/brave_search/brave_search_make_default_tab_helper_bridge.h",
+  "//brave/ios/browser/playlist/playlist_tab_helper_bridge.h",
   "//ios/chrome/browser/web/model/print/print_handler.h",
   "//brave/ios/browser/youtube/youtube_pref_names_bridge.h",
   "//brave/ios/browser/global_privacy_control/gpc_pref_names_bridge.h",

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/PlaylistTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/PlaylistTabHelper.swift
@@ -3,12 +3,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import BraveCore
 import BraveShared
 import Data
 import OSLog
 import Preferences
 import UIKit
-import Web
+@_spi(ChromiumWebViewAccess) import Web
 
 enum PlaylistItemAddedState {
   case none
@@ -36,7 +37,7 @@ extension TabDataValues {
   }
 }
 
-class PlaylistTabHelper: NSObject, TabObserver {
+class PlaylistTabHelper: NSObject, TabObserver, PlaylistTabHelperBridge {
   weak var delegate: PlaylistTabHelperDelegate?
   private weak var tab: (any TabState)?
   private var url: URL?
@@ -142,10 +143,23 @@ class PlaylistTabHelper: NSObject, TabObserver {
   }
 
   /// Queries the current playback time of the media element tagged with
-  /// `nodeTag` in the legacy `PlaylistScript`.
+  /// `nodeTag`
   func getCurrentTime(nodeTag: String, completion: @escaping (Double) -> Void) {
     guard let tab = self.tab else {
       completion(0.0)
+      return
+    }
+
+    if FeatureList.kUseProfileWebViewConfiguration.enabled {
+      guard let webView = BraveWebView.from(tab: tab) else {
+        completion(0.0)
+        return
+      }
+      webView.playlistCurrentTime(forTag: nodeTag) { currentTime in
+        DispatchQueue.main.async {
+          completion(currentTime)
+        }
+      }
       return
     }
 
@@ -178,7 +192,20 @@ class PlaylistTabHelper: NSObject, TabObserver {
     }
   }
 
+  /// Receives a media item detected by `PlaylistJavaScriptFeature`. The payload
+  /// mirrors `PlaylistInfo` so it can be processed identically to the legacy
+  /// `PlaylistScript` messages.
+  func onMediaDetected(_ info: [String: Any]) {
+    processPlaylistInfo(item: PlaylistInfo.from(dictionary: info))
+  }
+
   // MARK: - TabObserver
+
+  func tabDidCreateWebView(_ tab: some TabState) {
+    if FeatureList.kUseProfileWebViewConfiguration.enabled {
+      BraveWebView.from(tab: tab)?.setPlaylistHelper(self)
+    }
+  }
 
   func tabDidUpdateURL(_ tab: some TabState) {
     url = tab.visibleURL
@@ -196,11 +223,16 @@ class PlaylistTabHelper: NSObject, TabObserver {
     {
 
       // If this URL is blocked from Playlist support, do nothing
-      if tab.url?.isPlaylistBlockedSiteURL == true {
+      if tab.visibleURL?.isPlaylistBlockedSiteURL == true {
         return
       }
 
       let touchPoint = gestureRecognizer.location(in: tab.view)
+
+      if FeatureList.kUseProfileWebViewConfiguration.enabled {
+        BraveWebView.from(tab: tab)?.playlistLongPressed(at: touchPoint)
+        return
+      }
 
       tab.evaluateJavaScript(
         functionName: "window.__firefox__.\(PlaylistScriptHandler.playlistLongPressed)",

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCacheLoader.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCacheLoader.swift
@@ -13,7 +13,7 @@ import Playlist
 import Preferences
 import Shared
 import Storage
-import Web
+@_spi(ChromiumWebViewAccess) import Web
 import WebKit
 import os.log
 
@@ -34,6 +34,7 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
 
   private weak var certStore: CertStore?
   private var handler: ((PlaylistInfo?) -> Void)?
+  private var timeoutTask: Task<Void, Error>?
 
   init(profile: any Profile) {
     var initialConfiguration: WKWebViewConfiguration?
@@ -57,11 +58,18 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
     super.init(frame: .zero)
 
     tab.browserData = .init(tab: tab)
+    if !FeatureList.kUseProfileWebViewConfiguration.enabled {
+      tab.browserData?.setScript(
+        script: .playlistMediaSource,
+        enabled: true
+      )
+    } else {
+      tab.playlist = .init(tab: tab, delegate: self)
+    }
     tab.createWebView()
-    tab.browserData?.setScript(
-      script: .playlistMediaSource,
-      enabled: true
-    )
+    if FeatureList.kUseProfileWebViewConfiguration.enabled {
+      BraveWebView.from(tab: tab)?.enablePlaylistCompatibilityMode()
+    }
     tab.webViewProxy?.scrollView?.layer.masksToBounds = true
 
     self.addSubview(tab.view)
@@ -84,6 +92,8 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
       self.handler = { [weak self] in
         // Handler cannot be called more than once!
         self?.handler = nil
+        self?.timeoutTask?.cancel()
+        self?.timeoutTask = nil
         continuation.resume(returning: $0)
       }
 
@@ -94,15 +104,18 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
       }
 
       self.certStore = browserViewController.profile.certStore
-      browserViewController.tabDidCreateWebView(AnyTabState(tab))
-
       tab.addObserver(self)
       tab.addPolicyDecider(self)
-      tab.browserData?.replaceContentScript(
-        PlaylistWebLoaderContentHelper(self),
-        name: PlaylistWebLoaderContentHelper.scriptName,
-        forTab: AnyTabState(tab)
-      )
+
+      if !FeatureList.kUseProfileWebViewConfiguration.enabled {
+        // Install content script handlers
+        browserViewController.tabDidCreateWebView(AnyTabState(tab))
+        tab.browserData?.replaceContentScript(
+          PlaylistWebLoaderContentHelper(self),
+          name: PlaylistWebLoaderContentHelper.scriptName,
+          forTab: AnyTabState(tab)
+        )
+      }
 
       tab.view.frame = superview?.bounds ?? self.bounds
       tab.loadRequest(
@@ -115,7 +128,7 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
     tab.removeObserver(self)
     tab.removePolicyDecider(self)
     tab.stopLoading()
-    self.handler?(nil)
+    handler?(nil)
     tab.loadHTMLString("<html><body>PlayList</body></html>", baseURL: nil)
   }
 
@@ -268,15 +281,62 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
   }
 }
 
+extension LivePlaylistWebLoader: PlaylistTabHelperDelegate {
+  func updatePlaylistURLBar(
+    tab: (any Web.TabState)?,
+    state: PlaylistItemAddedState,
+    item: PlaylistInfo?
+  ) {
+    guard let item else { return }
+
+    if item.src.hasPrefix("data:") || item.src.hasPrefix("blob:") {
+      handler?(nil)
+      tab?.stopLoading()
+      return
+    }
+
+    handler?(item)
+    tab?.stopLoading()
+  }
+
+  func showPlaylistAlert(
+    tab: (any Web.TabState)?,
+    state: PlaylistItemAddedState,
+    item: PlaylistInfo?
+  ) {
+    // Not handled
+  }
+
+  func showPlaylistOnboarding(tab: (any Web.TabState)?) {
+    // Not handled
+  }
+}
+
 extension LivePlaylistWebLoader: TabObserver {
   func tabDidCommitNavigation(_ tab: some TabState) {
-    tab.evaluateJavaScript(
-      functionName:
-        "window.__firefox__.\(PlaylistWebLoaderContentHelper.playlistProcessDocumentLoad)()",
-      args: [],
-      contentWorld: PlaylistWebLoaderContentHelper.scriptSandbox,
-      asFunction: false
-    )
+    if !FeatureList.kUseProfileWebViewConfiguration.enabled {
+      tab.evaluateJavaScript(
+        functionName:
+          "window.__firefox__.\(PlaylistWebLoaderContentHelper.playlistProcessDocumentLoad)()",
+        args: [],
+        contentWorld: PlaylistWebLoaderContentHelper.scriptSandbox,
+        asFunction: false
+      )
+    }
+  }
+
+  func tabDidFinishNavigation(_ tab: some TabState) {
+    if FeatureList.kUseProfileWebViewConfiguration.enabled {
+      // Start timeout if handler hasn't already been called
+      guard handler != nil else {
+        return
+      }
+      timeoutTask = Task { @MainActor [weak self] in
+        guard !Task.isCancelled, let self else { return }
+        try await Task.sleep(for: .seconds(Self.pageLoadTimeout))
+        handler?(nil)
+      }
+    }
   }
 
   func tab(_ tab: some TabState, didFailNavigationWithError error: any Error) {
@@ -323,7 +383,9 @@ extension LivePlaylistWebLoader: TabPolicyDecider {
             isBlockFingerprintingEnabled: true,
             isGPCEnabled: true
           ) ?? []
-        tab.browserData?.setCustomUserScript(scripts: scriptTypes)
+        if !FeatureList.kUseProfileWebViewConfiguration.enabled {
+          tab.browserData?.setCustomUserScript(scripts: scriptTypes)
+        }
       }
     }
 
@@ -359,11 +421,13 @@ extension LivePlaylistWebLoader: TabPolicyDecider {
         tab.contentBlocker?.set(ruleLists: ruleLists)
       }
 
-      // Cookie Blocking code below
-      tab.browserData?.setScript(
-        script: .cookieBlocking,
-        enabled: tab.profile.prefs.boolean(forPath: kBlockAllCookiesEnabled)
-      )
+      if !FeatureList.kUseProfileWebViewConfiguration.enabled {
+        // Cookie Blocking code below
+        tab.browserData?.setScript(
+          script: .cookieBlocking,
+          enabled: tab.profile.prefs.boolean(forPath: kBlockAllCookiesEnabled)
+        )
+      }
     }
     return .allow
   }

--- a/ios/browser/api/web_view/BUILD.gn
+++ b/ios/browser/api/web_view/BUILD.gn
@@ -4,6 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/components/brave_talk/buildflags/buildflags.gni")
+import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
 
 config("config") {
   # For our own public headers to be able to import the official public headers
@@ -33,6 +34,7 @@ source_set("web_view") {
     "//brave/components/ai_chat/core/common",
     "//brave/components/ai_chat/ios/browser",
     "//brave/components/brave_talk/buildflags",
+    "//brave/components/playlist/core/common/buildflags",
     "//brave/components/serp_metrics:features",
     "//brave/ios/browser/ai_chat",
     "//brave/ios/browser/api/profile",
@@ -73,6 +75,9 @@ source_set("web_view") {
   ]
   if (enable_brave_talk) {
     deps += [ "//brave/ios/browser/brave_talk" ]
+  }
+  if (enable_playlist) {
+    deps += [ "//brave/ios/browser/playlist" ]
   }
   frameworks = [
     "Foundation.framework",

--- a/ios/browser/api/web_view/DEPS
+++ b/ios/browser/api/web_view/DEPS
@@ -1,5 +1,6 @@
 include_rules = [
   "+brave/components/ai_chat/core/common",
   "+brave/components/ai_chat/ios/browser",
+  "+brave/components/playlist/core/common",
   "+brave/components/serp_metrics",
 ]

--- a/ios/browser/api/web_view/brave_web_view.h
+++ b/ios/browser/api/web_view/brave_web_view.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol LoginsTabHelperBridge;
 @protocol BraveTalkTabHelperBridge;
 @protocol BraveSearchMakeDefaultTabHelperBridge;
+@protocol PlaylistTabHelperBridge;
 @protocol PrintHandler;
 
 typedef void (^ResetConfigurationCallback)(id<ProfileBridge>,
@@ -236,6 +237,21 @@ CWV_EXPORT
 @interface BraveWebView (Print)
 /// A bridge for handling window.print script messages
 - (void)setPrintHandler:(id<PrintHandler>)printHandler;
+@end
+
+CWV_EXPORT
+@interface BraveWebView (Playlist)
+/// A bridge for handling Playlist media detection messages
+- (void)setPlaylistHelper:(id<PlaylistTabHelperBridge>)playlistHelper;
+/// Queries the current playback time, in seconds, of the media element tagged
+/// with `tag`. `completion` receives 0 when no matching element exists.
+- (void)playlistCurrentTimeForTag:(NSString*)tag
+                       completion:(void (^)(double currentTime))completion;
+/// Detects media at the long-pressed `point` and reports it through the
+/// registered playlist helper.
+- (void)playlistLongPressedAtPoint:(CGPoint)point;
+/// Enables playlist compatibility mode for this web view
+- (void)enablePlaylistCompatibilityMode;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/browser/api/web_view/brave_web_view.mm
+++ b/ios/browser/api/web_view/brave_web_view.mm
@@ -10,12 +10,14 @@
 #include <memory>
 
 #include "base/apple/foundation_util.h"
+#include "base/functional/bind.h"
 #include "base/notreached.h"
 #include "base/strings/sys_string_conversions.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_chat/ios/browser/ai_chat_associated_content_page_fetcher.h"
 #include "brave/components/ai_chat/ios/browser/ai_chat_tab_helper.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/serp_metrics/serp_metrics_feature.h"
 #include "brave/ios/browser/ai_chat/ai_chat_distiller_javascript_feature.h"
 #include "brave/ios/browser/ai_chat/ai_chat_ui_handler_bridge_holder.h"
@@ -92,6 +94,13 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_TALK)
 #include "brave/ios/browser/brave_talk/brave_talk_tab_helper.h"
+#endif
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/ios/browser/playlist/playlist_compatibility_flag_data.h"
+#include "brave/ios/browser/playlist/playlist_javascript_feature.h"
+#include "brave/ios/browser/playlist/playlist_tab_helper.h"
+#include "brave/ios/browser/playlist/playlist_tab_helper_bridge.h"
 #endif
 
 @interface BraveNavigationAction ()
@@ -262,6 +271,10 @@ class FaviconDriverObserver : public favicon::FaviconDriverObserver {
 #if BUILDFLAG(ENABLE_BRAVE_TALK)
 @property(nonatomic, weak) id<BraveTalkTabHelperBridge> braveTalkHelper;
 #endif
+#if BUILDFLAG(ENABLE_PLAYLIST)
+@property(nonatomic, weak) id<PlaylistTabHelperBridge> playlistHelper;
+@property(nonatomic) BOOL isPlaylistCompatibilityModeEnabled;
+#endif
 @property(nonatomic, weak) id<BraveSearchMakeDefaultTabHelperBridge>
     braveSearchHelper;
 @property(nonatomic, weak) id<PrintHandler> printHandler;
@@ -389,6 +402,15 @@ class FaviconDriverObserver : public favicon::FaviconDriverObserver {
   BraveTalkTabHelper::CreateForWebState(self.webState);
   BraveTalkTabHelper::FromWebState(self.webState)
       ->SetBridge(self.braveTalkHelper);
+#endif
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+  playlist::PlaylistTabHelper::CreateForWebState(self.webState);
+  playlist::PlaylistTabHelper::FromWebState(self.webState)
+      ->SetBridge(self.playlistHelper);
+  if (self.isPlaylistCompatibilityModeEnabled) {
+    playlist::PlaylistCompatibilityFlagData::CreateForWebState(self.webState);
+  }
 #endif
 
   BraveSearchMakeDefaultTabHelper::CreateForWebState(self.webState);
@@ -745,6 +767,47 @@ class FaviconDriverObserver : public favicon::FaviconDriverObserver {
     tab_helper->SetBridge(braveTalkHelper);
   }
 #endif  // BUILDFLAG(ENABLE_BRAVE_TALK)
+}
+
+@end
+
+@implementation BraveWebView (Playlist)
+
+- (void)setPlaylistHelper:(id<PlaylistTabHelperBridge>)playlistHelper {
+#if BUILDFLAG(ENABLE_PLAYLIST)
+  _playlistHelper = playlistHelper;
+  playlist::PlaylistTabHelper* tab_helper =
+      playlist::PlaylistTabHelper::FromWebState(self.webState);
+  if (tab_helper) {
+    tab_helper->SetBridge(playlistHelper);
+  }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
+}
+
+- (void)playlistCurrentTimeForTag:(NSString*)tag
+                       completion:(void (^)(double currentTime))completion {
+#if BUILDFLAG(ENABLE_PLAYLIST)
+  playlist::PlaylistJavaScriptFeature::GetInstance()
+      ->GetCurrentTimeForVideoWithTag(self.webState,
+                                      base::SysNSStringToUTF8(tag),
+                                      base::BindOnce(^(double currentTime) {
+                                        completion(currentTime);
+                                      }));
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
+}
+
+- (void)playlistLongPressedAtPoint:(CGPoint)point {
+#if BUILDFLAG(ENABLE_PLAYLIST)
+  playlist::PlaylistJavaScriptFeature::GetInstance()->LongPressedAtLocation(
+      self.webState, point.x, point.y);
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
+}
+
+- (void)enablePlaylistCompatibilityMode {
+#if BUILDFLAG(ENABLE_PLAYLIST)
+  _isPlaylistCompatibilityModeEnabled = YES;
+  playlist::PlaylistCompatibilityFlagData::CreateForWebState(self.webState);
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 }
 
 @end

--- a/ios/browser/playlist/BUILD.gn
+++ b/ios/browser/playlist/BUILD.gn
@@ -3,22 +3,43 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//ios/web/public/js_messaging/optimize_ts.gni")
+
 source_set("playlist") {
   sources = [
+    "playlist_compatibility_flag_data.h",
+    "playlist_compatibility_flag_data.mm",
+    "playlist_compatibility_javascript_feature.h",
+    "playlist_compatibility_javascript_feature.mm",
     "playlist_exclusions_bridge.h",
     "playlist_exclusions_bridge_impl.h",
     "playlist_exclusions_bridge_impl.mm",
     "playlist_exclusions_factory.h",
     "playlist_exclusions_factory.mm",
+    "playlist_javascript_feature.h",
+    "playlist_javascript_feature.mm",
     "playlist_pref_names_bridge.h",
     "playlist_pref_names_bridge.mm",
+    "playlist_tab_helper.h",
+    "playlist_tab_helper.mm",
+    "playlist_tab_helper_bridge.h",
   ]
   deps = [
-    "//base",
+    ":playlist_compatibility_js",
+    ":playlist_event_listeners_js",
+    ":playlist_js",
     "//brave/components/playlist/core/browser",
     "//brave/components/playlist/core/common",
+    "//components/prefs",
+    "//ios/chrome/browser/shared/model/profile",
     "//net",
     "//url",
+  ]
+  public_deps = [
+    "//base",
+    "//brave/ios/web/js_messaging:message_handler_token",
+    "//ios/web/public",
+    "//ios/web/public/js_messaging",
   ]
   frameworks = [ "Foundation.framework" ]
 }
@@ -29,4 +50,39 @@ source_set("features") {
     "features.mm",
   ]
   public_deps = [ "//base" ]
+}
+
+compile_ts("playlist_utils") {
+  sources = [ "resources/playlist_utils.ts" ]
+  deps = [ "//ios/web/public/js_messaging:util_scripts" ]
+}
+
+optimize_ts("playlist_js") {
+  visibility = [ ":playlist" ]
+
+  sources = [ "resources/playlist.ts" ]
+
+  deps = [
+    ":playlist_utils",
+    "//ios/web/public/js_messaging:gcrweb",
+  ]
+}
+
+optimize_ts("playlist_event_listeners_js") {
+  visibility = [ ":playlist" ]
+
+  sources = [ "resources/playlist_event_listeners.ts" ]
+
+  deps = [
+    ":playlist_utils",
+    "//ios/web/public/js_messaging:util_scripts",
+  ]
+}
+
+optimize_ts("playlist_compatibility_js") {
+  visibility = [ ":playlist" ]
+
+  sources = [ "resources/playlist_compatibility.ts" ]
+
+  deps = [ "//brave/ios/web/js_messaging:util_scripts" ]
 }

--- a/ios/browser/playlist/playlist_compatibility_flag_data.h
+++ b/ios/browser/playlist/playlist_compatibility_flag_data.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_PLAYLIST_PLAYLIST_COMPATIBILITY_FLAG_DATA_H_
+#define BRAVE_IOS_BROWSER_PLAYLIST_PLAYLIST_COMPATIBILITY_FLAG_DATA_H_
+
+#include "ios/web/public/web_state.h"
+#include "ios/web/public/web_state_user_data.h"
+
+namespace playlist {
+
+// A piece of data that when stored on WebState indicates that the page should
+// run in playlist compatibility mode.
+class PlaylistCompatibilityFlagData
+    : public web::WebStateUserData<PlaylistCompatibilityFlagData> {
+ public:
+  ~PlaylistCompatibilityFlagData() override;
+
+ private:
+  explicit PlaylistCompatibilityFlagData(web::WebState* web_state);
+  friend class web::WebStateUserData<PlaylistCompatibilityFlagData>;
+};
+
+}  // namespace playlist
+
+#endif  // BRAVE_IOS_BROWSER_PLAYLIST_PLAYLIST_COMPATIBILITY_FLAG_DATA_H_

--- a/ios/browser/playlist/playlist_compatibility_flag_data.mm
+++ b/ios/browser/playlist/playlist_compatibility_flag_data.mm
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/playlist/playlist_compatibility_flag_data.h"
+
+namespace playlist {
+
+PlaylistCompatibilityFlagData::PlaylistCompatibilityFlagData(
+    web::WebState* web_state) {}
+
+PlaylistCompatibilityFlagData::~PlaylistCompatibilityFlagData() = default;
+
+}  // namespace playlist

--- a/ios/browser/playlist/playlist_compatibility_javascript_feature.h
+++ b/ios/browser/playlist/playlist_compatibility_javascript_feature.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_PLAYLIST_PLAYLIST_COMPATIBILITY_JAVASCRIPT_FEATURE_H_
+#define BRAVE_IOS_BROWSER_PLAYLIST_PLAYLIST_COMPATIBILITY_JAVASCRIPT_FEATURE_H_
+
+#include <optional>
+#include <string>
+
+#include "base/no_destructor.h"
+#include "brave/ios/web/js_messaging/message_handler_token.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+
+namespace web {
+class ScriptMessage;
+class WebState;
+}  // namespace web
+
+namespace playlist {
+
+class PlaylistCompatibilityJavaScriptFeature : public web::JavaScriptFeature {
+ public:
+  // This feature holds no state, so only a single static instance is ever
+  // needed.
+  static PlaylistCompatibilityJavaScriptFeature* GetInstance();
+
+  PlaylistCompatibilityJavaScriptFeature(
+      const PlaylistCompatibilityJavaScriptFeature&) = delete;
+  PlaylistCompatibilityJavaScriptFeature& operator=(
+      const PlaylistCompatibilityJavaScriptFeature&) = delete;
+
+  // JavaScriptFeature:
+  bool GetFeatureRepliesToPrompts() const override;
+  std::optional<std::string> GetScriptMessageHandlerName() const override;
+  void ScriptMessageReceivedWithReply(
+      web::WebState* web_state,
+      const web::ScriptMessage& message,
+      ScriptMessageReplyCallback callback) override;
+
+ private:
+  friend class base::NoDestructor<PlaylistCompatibilityJavaScriptFeature>;
+
+  web::MessageHandlerToken token_;
+
+  PlaylistCompatibilityJavaScriptFeature();
+  ~PlaylistCompatibilityJavaScriptFeature() override;
+};
+
+}  // namespace playlist
+
+#endif  // BRAVE_IOS_BROWSER_PLAYLIST_PLAYLIST_COMPATIBILITY_JAVASCRIPT_FEATURE_H_

--- a/ios/browser/playlist/playlist_compatibility_javascript_feature.mm
+++ b/ios/browser/playlist/playlist_compatibility_javascript_feature.mm
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/playlist/playlist_compatibility_javascript_feature.h"
+
+#include "base/functional/bind.h"
+#include "base/no_destructor.h"
+#include "base/values.h"
+#include "brave/ios/browser/playlist/playlist_compatibility_flag_data.h"
+#include "brave/ios/web/js_messaging/message_handler_token.h"
+#include "ios/web/public/js_messaging/script_message.h"
+#include "ios/web/public/js_messaging/web_frame.h"
+#include "ios/web/public/js_messaging/web_frames_manager.h"
+#include "ios/web/public/web_state.h"
+
+namespace playlist {
+
+namespace {
+
+constexpr char kScriptName[] = "playlist_compatibility";
+constexpr char kScriptHandlerName[] = "PlaylistCompatibilityMessageHandler";
+
+}  // namespace
+
+PlaylistCompatibilityJavaScriptFeature::PlaylistCompatibilityJavaScriptFeature()
+    : JavaScriptFeature(
+          web::ContentWorld::kPageContentWorld,
+          {FeatureScript::CreateWithFilename(
+              kScriptName,
+              FeatureScript::InjectionTime::kDocumentStart,
+              FeatureScript::TargetFrames::kAllFrames,
+              FeatureScript::ReinjectionBehavior::kInjectOncePerWindow,
+              base::BindRepeating(
+                  &web::MessageHandlerToken::GetPlaceholderReplacements,
+                  base::Unretained(&token_)))}) {}
+
+PlaylistCompatibilityJavaScriptFeature::
+    ~PlaylistCompatibilityJavaScriptFeature() = default;
+
+// static
+PlaylistCompatibilityJavaScriptFeature*
+PlaylistCompatibilityJavaScriptFeature::GetInstance() {
+  static base::NoDestructor<PlaylistCompatibilityJavaScriptFeature> instance;
+  return instance.get();
+}
+
+bool PlaylistCompatibilityJavaScriptFeature::GetFeatureRepliesToPrompts()
+    const {
+  return true;
+}
+
+std::optional<std::string>
+PlaylistCompatibilityJavaScriptFeature::GetScriptMessageHandlerName() const {
+  return kScriptHandlerName;
+}
+
+void PlaylistCompatibilityJavaScriptFeature::ScriptMessageReceivedWithReply(
+    web::WebState* web_state,
+    const web::ScriptMessage& message,
+    ScriptMessageReplyCallback callback) {
+  if (!token_.GetValidatedScriptMessageBody(message)) {
+    base::Value value(false);
+    std::move(callback).Run(&value, nullptr);
+    return;
+  }
+  // Check if compatiblity marker is in web_state and return that value
+  bool is_compatibility_mode_enabled =
+      PlaylistCompatibilityFlagData::FromWebState(web_state) != nullptr;
+  base::Value value(is_compatibility_mode_enabled);
+  std::move(callback).Run(&value, nullptr);
+}
+
+}  // namespace playlist

--- a/ios/browser/playlist/playlist_javascript_feature.h
+++ b/ios/browser/playlist/playlist_javascript_feature.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_PLAYLIST_PLAYLIST_JAVASCRIPT_FEATURE_H_
+#define BRAVE_IOS_BROWSER_PLAYLIST_PLAYLIST_JAVASCRIPT_FEATURE_H_
+
+#include <optional>
+#include <string>
+
+#include "base/functional/callback.h"
+#include "base/no_destructor.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+
+namespace web {
+class ScriptMessage;
+class WebState;
+}  // namespace web
+
+namespace playlist {
+
+// A JavaScriptFeature that detects playable media (<video>/<audio>) on a page
+// and reports each detected item to the browser. It injects two scripts into
+// the page content world:
+//   * `playlist` — exposes the media query API and installs hooks that catch
+//     media added to the page dynamically. Injected once per window.
+//   * `playlist_event_listeners` — scans the document for media when it loads.
+//     Re-injected on every document recreation.
+// Ported from the original //brave-ios `PlaylistScript.js`.
+class PlaylistJavaScriptFeature : public web::JavaScriptFeature {
+ public:
+  // This feature holds no state, so only a single static instance is ever
+  // needed.
+  static PlaylistJavaScriptFeature* GetInstance();
+
+  PlaylistJavaScriptFeature(const PlaylistJavaScriptFeature&) = delete;
+  PlaylistJavaScriptFeature& operator=(const PlaylistJavaScriptFeature&) =
+      delete;
+
+  // Queries the current playback time, in seconds, of the media element in the
+  // main frame of `web_state` that was tagged with `tag`. `callback` receives
+  // 0 when no matching element exists or the call fails.
+  void GetCurrentTimeForVideoWithTag(web::WebState* web_state,
+                                     const std::string& tag,
+                                     base::OnceCallback<void(double)> callback);
+
+  // Detects media at the (`x`, `y`) point that the user long pressed, in the
+  // main frame's coordinate space of `web_state`. Any detected media is
+  // reported asynchronously through the registered message handler (see
+  // ScriptMessageReceived), flagged as not automatically detected.
+  void LongPressedAtLocation(web::WebState* web_state, double x, double y);
+
+  // JavaScriptFeature:
+  std::optional<std::string> GetScriptMessageHandlerName() const override;
+  void ScriptMessageReceived(web::WebState* web_state,
+                             const web::ScriptMessage& message) override;
+
+ private:
+  friend class base::NoDestructor<PlaylistJavaScriptFeature>;
+
+  PlaylistJavaScriptFeature();
+  ~PlaylistJavaScriptFeature() override;
+};
+
+}  // namespace playlist
+
+#endif  // BRAVE_IOS_BROWSER_PLAYLIST_PLAYLIST_JAVASCRIPT_FEATURE_H_

--- a/ios/browser/playlist/playlist_javascript_feature.mm
+++ b/ios/browser/playlist/playlist_javascript_feature.mm
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/playlist/playlist_javascript_feature.h"
+
+#include <optional>
+#include <utility>
+
+#include "base/feature_list.h"
+#include "base/functional/bind.h"
+#include "base/no_destructor.h"
+#include "base/time/time.h"
+#include "base/values.h"
+#include "brave/components/playlist/core/common/features.h"
+#include "brave/components/playlist/core/common/pref_names.h"
+#include "brave/ios/browser/playlist/playlist_tab_helper.h"
+#include "components/prefs/pref_service.h"
+#include "ios/chrome/browser/shared/model/profile/profile_ios.h"
+#include "ios/web/public/js_messaging/script_message.h"
+#include "ios/web/public/js_messaging/web_frame.h"
+#include "ios/web/public/js_messaging/web_frames_manager.h"
+#include "ios/web/public/web_state.h"
+
+namespace playlist {
+
+namespace {
+constexpr char kScriptName[] = "playlist";
+constexpr char kEventListenersScriptName[] = "playlist_event_listeners";
+constexpr char kScriptHandlerName[] = "PlaylistMessageHandler";
+
+// JavaScript functions exposed on the `playlist` API in playlist.ts.
+constexpr char kGetCurrentTimeFunction[] =
+    "playlist.getCurrentTimeForVideoWithTag";
+constexpr char kLongPressedAtLocationFunction[] =
+    "playlist.longPressedAtLocation";
+
+// Time allowed for the page to reply to a getCurrentTimeForVideoWithTag query.
+constexpr base::TimeDelta kFunctionCallTimeout = base::Seconds(5);
+
+bool IsPlaylistAvailable(PrefService* prefs) {
+  bool is_disabled_by_policy =
+      prefs->IsManagedPreference(kPlaylistEnabledPref) &&
+      !prefs->GetBoolean(kPlaylistEnabledPref);
+  return base::FeatureList::IsEnabled(features::kPlaylist) &&
+         !is_disabled_by_policy;
+}
+
+}  // namespace
+
+PlaylistJavaScriptFeature::PlaylistJavaScriptFeature()
+    : JavaScriptFeature(
+          web::ContentWorld::kPageContentWorld,
+          {FeatureScript::CreateWithFilename(
+               kScriptName,
+               FeatureScript::InjectionTime::kDocumentStart,
+               FeatureScript::TargetFrames::kAllFrames,
+               FeatureScript::ReinjectionBehavior::kInjectOncePerWindow),
+           FeatureScript::CreateWithFilename(
+               kEventListenersScriptName,
+               FeatureScript::InjectionTime::kDocumentStart,
+               FeatureScript::TargetFrames::kAllFrames,
+               FeatureScript::ReinjectionBehavior::
+                   kReinjectOnDocumentRecreation)}) {}
+
+PlaylistJavaScriptFeature::~PlaylistJavaScriptFeature() = default;
+
+// static
+PlaylistJavaScriptFeature* PlaylistJavaScriptFeature::GetInstance() {
+  static base::NoDestructor<PlaylistJavaScriptFeature> instance;
+  return instance.get();
+}
+
+void PlaylistJavaScriptFeature::GetCurrentTimeForVideoWithTag(
+    web::WebState* web_state,
+    const std::string& tag,
+    base::OnceCallback<void(double)> callback) {
+  web::WebFrame* main_frame = GetWebFramesManager(web_state)->GetMainWebFrame();
+  if (!main_frame) {
+    std::move(callback).Run(0.0);
+    return;
+  }
+
+  CallJavaScriptFunction(main_frame, kGetCurrentTimeFunction,
+                         base::ListValue().Append(tag),
+                         base::BindOnce(
+                             [](base::OnceCallback<void(double)> callback,
+                                const base::Value* value) {
+                               std::optional<double> result =
+                                   value ? value->GetIfDouble() : std::nullopt;
+                               std::move(callback).Run(result.value_or(0.0));
+                             },
+                             std::move(callback)),
+                         kFunctionCallTimeout);
+}
+
+void PlaylistJavaScriptFeature::LongPressedAtLocation(web::WebState* web_state,
+                                                      double x,
+                                                      double y) {
+  web::WebFrame* main_frame = GetWebFramesManager(web_state)->GetMainWebFrame();
+  if (!main_frame) {
+    return;
+  }
+
+  CallJavaScriptFunction(main_frame, kLongPressedAtLocationFunction,
+                         base::ListValue().Append(x).Append(y));
+}
+
+std::optional<std::string>
+PlaylistJavaScriptFeature::GetScriptMessageHandlerName() const {
+  return kScriptHandlerName;
+}
+
+void PlaylistJavaScriptFeature::ScriptMessageReceived(
+    web::WebState* web_state,
+    const web::ScriptMessage& message) {
+  PrefService* prefs =
+      ProfileIOS::FromBrowserState(web_state->GetBrowserState())->GetPrefs();
+  if (!IsPlaylistAvailable(prefs)) {
+    return;
+  }
+
+  const base::DictValue* item =
+      message.body() ? message.body()->GetIfDict() : nullptr;
+  if (!item) {
+    return;
+  }
+
+  PlaylistTabHelper* tab_helper = PlaylistTabHelper::FromWebState(web_state);
+  if (!tab_helper) {
+    return;
+  }
+  tab_helper->OnMediaDetected(*item);
+}
+
+}  // namespace playlist

--- a/ios/browser/playlist/playlist_tab_helper.h
+++ b/ios/browser/playlist/playlist_tab_helper.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_PLAYLIST_PLAYLIST_TAB_HELPER_H_
+#define BRAVE_IOS_BROWSER_PLAYLIST_PLAYLIST_TAB_HELPER_H_
+
+#include "base/values.h"
+#include "ios/web/public/web_state_user_data.h"
+
+@protocol PlaylistTabHelperBridge;
+
+namespace web {
+class WebState;
+}  // namespace web
+
+namespace playlist {
+
+// Holds the bridge to the Swift `PlaylistTabHelper` and forwards media detected
+// by `PlaylistJavaScriptFeature` to it. Mirrors the per-WebState ownership used
+// by other Brave tab helpers (e.g. BraveTalkTabHelper).
+class PlaylistTabHelper : public web::WebStateUserData<PlaylistTabHelper> {
+ public:
+  ~PlaylistTabHelper() override;
+
+  void SetBridge(id<PlaylistTabHelperBridge> bridge);
+
+  // Forwards a detected media item to the registered bridge, if any. `item` is
+  // the `PlaylistItem` payload produced by playlist_utils.ts.
+  void OnMediaDetected(const base::DictValue& item);
+
+ private:
+  friend class web::WebStateUserData<PlaylistTabHelper>;
+
+  explicit PlaylistTabHelper(web::WebState* web_state);
+
+  __weak id<PlaylistTabHelperBridge> bridge_;
+};
+
+}  // namespace playlist
+
+#endif  // BRAVE_IOS_BROWSER_PLAYLIST_PLAYLIST_TAB_HELPER_H_

--- a/ios/browser/playlist/playlist_tab_helper.mm
+++ b/ios/browser/playlist/playlist_tab_helper.mm
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/playlist/playlist_tab_helper.h"
+
+#import <Foundation/Foundation.h>
+
+#include <optional>
+#include <string>
+
+#include "base/json/json_writer.h"
+#include "base/strings/sys_string_conversions.h"
+#include "brave/ios/browser/playlist/playlist_tab_helper_bridge.h"
+
+namespace playlist {
+
+PlaylistTabHelper::PlaylistTabHelper(web::WebState* web_state) {}
+
+PlaylistTabHelper::~PlaylistTabHelper() = default;
+
+void PlaylistTabHelper::SetBridge(id<PlaylistTabHelperBridge> bridge) {
+  bridge_ = bridge;
+}
+
+void PlaylistTabHelper::OnMediaDetected(const base::DictValue& item) {
+  if (!bridge_) {
+    return;
+  }
+
+  // The bridge consumes the item as an NSDictionary so it can be decoded into a
+  // `PlaylistInfo` on the Swift side. Round-trip through JSON to convert the
+  // base::Value into Foundation objects.
+  std::optional<std::string> json = base::WriteJson(item);
+  if (!json) {
+    return;
+  }
+
+  NSData* data =
+      [base::SysUTF8ToNSString(*json) dataUsingEncoding:NSUTF8StringEncoding];
+  id object = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+  if (![object isKindOfClass:[NSDictionary class]]) {
+    return;
+  }
+
+  [bridge_ onMediaDetected:object];
+}
+
+}  // namespace playlist

--- a/ios/browser/playlist/playlist_tab_helper_bridge.h
+++ b/ios/browser/playlist/playlist_tab_helper_bridge.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_PLAYLIST_PLAYLIST_TAB_HELPER_BRIDGE_H_
+#define BRAVE_IOS_BROWSER_PLAYLIST_PLAYLIST_TAB_HELPER_BRIDGE_H_
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol PlaylistTabHelperBridge
+@required
+
+// Called when media is detected on the page by PlaylistJavaScriptFeature.
+// `info` mirrors the `PlaylistItem` payload produced by playlist_utils.ts and
+// can be decoded into a `PlaylistInfo`.
+- (void)onMediaDetected:(NSDictionary<NSString*, id>*)info;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // BRAVE_IOS_BROWSER_PLAYLIST_PLAYLIST_TAB_HELPER_BRIDGE_H_

--- a/ios/browser/playlist/resources/playlist.ts
+++ b/ios/browser/playlist/resources/playlist.ts
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import {
+  CrWebApi,
+  gCrWeb,
+} from '//ios/web/public/js_messaging/resources/gcrweb.js'
+
+import {
+  checkPageForMedia,
+  clampDuration,
+  getAllMediaElements,
+  kTagPropertyName,
+  notifyNode,
+} from '//brave/ios/browser/playlist/resources/playlist_utils.js'
+
+// Returns the current playback time of the media element previously tagged
+// with `tag`, or 0 when no such element exists.
+function getCurrentTimeForVideoWithTag(tag: string): number {
+  for (const element of getAllMediaElements()) {
+    if ((element as any)[kTagPropertyName] === tag) {
+      return clampDuration(element.currentTime)
+    }
+  }
+  return 0.0
+}
+
+// Determines whether `element` is visible within `view`. Used to ignore media
+// hidden behind overlays or collapsed to zero size when resolving a long press.
+function isElementVisible(view: Window, element: Element): boolean {
+  const htmlElement = element as HTMLElement
+  if (
+    htmlElement.offsetWidth
+    && htmlElement.offsetHeight
+    && element.getClientRects().length
+  ) {
+    return true
+  }
+
+  const style = view.getComputedStyle(element)
+  return (
+    style.width !== '0px'
+    && style.height !== '0px'
+    && Number(style.opacity) > 0
+    && style.display !== 'none'
+    && style.visibility !== 'hidden'
+  )
+}
+
+// Detects media at the (`x`, `y`) point that the user long pressed and reports
+// it with `detected = false`, indicating an explicit user action rather than
+// automatic detection. Both the top document and same-origin iframes are
+// searched; cross-origin frames can't be inspected and are skipped.
+function longPressedAtLocation(x: number, y: number): void {
+  const detectMediaAtPoint = (
+    view: Window,
+    offsetX: number,
+    offsetY: number,
+  ): void => {
+    const targets = view.document
+      .elementsFromPoint(x - offsetX, y - offsetY)
+      .filter(
+        (element) =>
+          element instanceof HTMLVideoElement
+          || element instanceof HTMLAudioElement,
+      )
+      .filter((element) => isElementVisible(view, element))
+
+    // When no media is directly under the point, fall back to any audio
+    // element in the document (e.g. detached players with no visible node).
+    if (targets.length === 0) {
+      const audio = view.document.querySelector('audio')
+      if (audio) {
+        notifyNode(audio, '', false, false)
+      }
+      return
+    }
+
+    notifyNode(targets[0] as HTMLMediaElement, '', false, false)
+  }
+
+  // Media in the current document is at offset (0, 0) relative to the window.
+  detectMediaAtPoint(window, 0, 0)
+
+  // Media inside an iframe is at offset (0, 0) relative to the iframe's content
+  // window, but the iframe itself is offset by its bounds relative to the
+  // current window.
+  try {
+    for (const frame of document.querySelectorAll('iframe')) {
+      const bounds = frame.getBoundingClientRect()
+      if (frame.contentWindow) {
+        detectMediaAtPoint(frame.contentWindow, bounds.left, bounds.top)
+      }
+    }
+  } catch (error) {}
+}
+
+// Installs hooks that detect media attached to the page dynamically (after the
+// initial document scan). This patches the shared HTMLMediaElement prototype
+function installMediaDetection(): void {
+  // Reserve a non-enumerable identifier slot on every media element so that
+  // tags don't leak into property enumeration or serialization.
+  Object.defineProperty(HTMLMediaElement.prototype, kTagPropertyName, {
+    enumerable: false,
+    configurable: false,
+    writable: true,
+    value: null,
+  })
+
+  const descriptor = Object.getOwnPropertyDescriptor(
+    HTMLMediaElement.prototype,
+    'src',
+  )
+  if (descriptor && descriptor.get && descriptor.set) {
+    const getter = descriptor.get
+    const setter = descriptor.set
+    Object.defineProperty(HTMLMediaElement.prototype, 'src', {
+      enumerable: descriptor.enumerable,
+      configurable: descriptor.configurable,
+      get(this: HTMLMediaElement) {
+        return getter.call(this)
+      },
+      set(this: HTMLMediaElement, value: string) {
+        setter.call(this, value)
+        if (this instanceof HTMLVideoElement) {
+          notifyNode(this, 'video', true, false)
+        } else if (this instanceof HTMLAudioElement) {
+          notifyNode(this, 'audio', true, false)
+          // Re-scan shortly after an audio source is attached instead of
+          // polling on an interval.
+          setTimeout(() => checkPageForMedia(false), 100)
+        }
+      },
+    })
+  }
+
+  const setVideoAttribute = HTMLVideoElement.prototype.setAttribute
+  HTMLVideoElement.prototype.setAttribute = function (
+    this: HTMLVideoElement,
+    key: string,
+    value: string,
+  ): void {
+    setVideoAttribute.call(this, key, value)
+    if (key.toLowerCase() === 'src') {
+      notifyNode(this, 'video', true, false)
+    }
+  }
+
+  const setAudioAttribute = HTMLAudioElement.prototype.setAttribute
+  HTMLAudioElement.prototype.setAttribute = function (
+    this: HTMLAudioElement,
+    key: string,
+    value: string,
+  ): void {
+    setAudioAttribute.call(this, key, value)
+    if (key.toLowerCase() === 'src') {
+      notifyNode(this, 'audio', true, false)
+      setTimeout(() => checkPageForMedia(false), 100)
+    }
+  }
+}
+
+const playlistApi = new CrWebApi('playlist')
+
+// Gets the current time for a media element with the tag provided or 0 if that
+// element does not exist.
+playlistApi.addFunction(
+  'getCurrentTimeForVideoWithTag',
+  getCurrentTimeForVideoWithTag,
+)
+
+// Detects and reports media at a point the user long pressed. Pushed media is
+// flagged with `detected = false` to distinguish it from automatic detection.
+playlistApi.addFunction('longPressedAtLocation', longPressedAtLocation)
+
+gCrWeb.registerApi(playlistApi)
+
+installMediaDetection()

--- a/ios/browser/playlist/resources/playlist_compatibility.ts
+++ b/ios/browser/playlist/resources/playlist_compatibility.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { sendTokenizedWebKitMessageSynchronously } from '//brave/ios/web/js_messaging/resources/utils.js'
+
+declare global {
+  interface Window {
+    ManagedMediaSource: any
+    MediaSource: any
+  }
+}
+
+const isRunningCompatibilityMode = sendTokenizedWebKitMessageSynchronously(
+  'PlaylistCompatibilityMessageHandler',
+  {},
+) as boolean
+
+if (isRunningCompatibilityMode) {
+  if (window.MediaSource || window.ManagedMediaSource) {
+    delete window.MediaSource
+    delete window.ManagedMediaSource
+  }
+}

--- a/ios/browser/playlist/resources/playlist_event_listeners.ts
+++ b/ios/browser/playlist/resources/playlist_event_listeners.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { checkPageForMedia } from '//brave/ios/browser/playlist/resources/playlist_utils.js'
+
+// Scan the document for media once it is ready. This script is re-injected on
+// every document recreation, so it re-runs detection for each navigation.
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => checkPageForMedia())
+} else {
+  checkPageForMedia()
+}

--- a/ios/browser/playlist/resources/playlist_utils.ts
+++ b/ios/browser/playlist/resources/playlist_utils.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { sendWebKitMessage } from '//ios/web/public/js_messaging/resources/utils.js'
+
+// Non-enumerable property used to stamp media elements with a unique
+// identifier so a specific element can later be resolved from native code
+// (e.g. to query its current playback time). The value lives on the element
+// itself, which keeps it consistent across the separately injected feature
+// scripts.
+export const kTagPropertyName = '__brave_playlist_tag_id'
+
+// A detected media item reported to the browser. The keys mirror the native
+// `PlaylistInfo` decoder so the same payload can be consumed by both the
+// legacy PlaylistScript handler and PlaylistJavaScriptFeature.
+export interface PlaylistItem {
+  tagId: string
+  name: string
+  src: string
+  pageSrc: string
+  pageTitle: string
+  mimeType: string
+  duration: number
+  detected: boolean
+  invisible: boolean
+}
+
+function isInfinite(value: number): boolean {
+  return value === Infinity || value === -Infinity
+}
+
+// Clamps a media duration into a finite value the browser can consume. NaN
+// durations (unknown) become 0 and infinite durations (live streams) are
+// capped to the maximum representable value.
+export function clampDuration(value: number): number {
+  if (Number.isNaN(value)) {
+    return 0.0
+  }
+  if (isInfinite(value)) {
+    return Number.MAX_VALUE
+  }
+  return value
+}
+
+// Obtains all of the media elements on the page (video/audio) in reverse
+// document order.
+export function getAllMediaElements(): HTMLMediaElement[] {
+  return [
+    ...document.querySelectorAll<HTMLMediaElement>('video, audio'),
+  ].reverse()
+}
+
+// Stamps a media element with a unique identifier (if it doesn't already have
+// one) and suppresses presentation mode change events that would otherwise
+// interfere with native playback. The identifier is regenerated on every call
+// to match the original script's behavior: websites frequently reuse a single
+// media element across in-page navigations, so re-tagging forces the element
+// to be treated as newly detected media.
+function tagNode(node: HTMLMediaElement): void {
+  if (!(node as any)[kTagPropertyName]) {
+    node.addEventListener(
+      'webkitpresentationmodechanged',
+      (event) => event.stopPropagation(),
+      true,
+    )
+  }
+  ;(node as any)[kTagPropertyName] = window.crypto.randomUUID()
+}
+
+// Reports a single detected media item to the browser. `sourceNode` provides
+// the media `src` (which may be a child <source> element), while `target` is
+// the owning <video>/<audio> element used for duration, tagging and
+// visibility.
+function reportMedia(
+  name: string,
+  sourceNode: HTMLMediaElement | HTMLSourceElement,
+  target: HTMLMediaElement,
+  mimeType: string,
+  detected: boolean,
+): void {
+  // Prefer the top frame's location/title, falling back to the current frame
+  // when cross-origin access throws.
+  let pageSrc = ''
+  let pageTitle = ''
+  try {
+    pageSrc = window.top!.location.href
+    pageTitle = window.top!.document.title
+  } catch (error) {
+    pageSrc = window.location.href
+    pageTitle = document.title
+  }
+
+  const item: PlaylistItem = {
+    tagId: (target as any)[kTagPropertyName] ?? '',
+    name: name,
+    src: sourceNode.src,
+    pageSrc: pageSrc,
+    pageTitle: pageTitle,
+    mimeType: mimeType,
+    duration: clampDuration(target.duration),
+    detected: detected,
+    invisible: !target.parentNode,
+  }
+  sendWebKitMessage('PlaylistMessageHandler', item)
+}
+
+// Detects media on `target` and reports it. When the element has no direct
+// `src`, its child <source> elements are inspected instead (unless
+// `ignoreSource` forces direct reporting).
+export function notifyNode(
+  target: HTMLMediaElement,
+  mimeType: string,
+  detected: boolean,
+  ignoreSource: boolean,
+): void {
+  let name = target.title
+  if (!name) {
+    try {
+      name = window.top!.document.title
+    } catch (error) {
+      name = document.title
+    }
+  }
+
+  // Infer the media type from the element when one wasn't provided.
+  if (!mimeType) {
+    if (target instanceof HTMLVideoElement) {
+      mimeType = 'video'
+    } else if (target instanceof HTMLAudioElement) {
+      mimeType = 'audio'
+    }
+  }
+
+  if (ignoreSource || target.src) {
+    tagNode(target)
+    reportMedia(name, target, target, mimeType, detected)
+    return
+  }
+
+  for (const node of target.children) {
+    if (node instanceof HTMLSourceElement && node.src) {
+      tagNode(target)
+      reportMedia(name, node, target, mimeType, detected)
+    }
+  }
+}
+
+// Scans the document for media elements and reports each to the browser.
+// `ignoreSource` forces elements without a resolved `src` to still be
+// inspected via their child <source> elements.
+export function checkPageForMedia(ignoreSource: boolean = false): void {
+  const fetchMedia = () => {
+    for (const node of getAllMediaElements()) {
+      const mimeType = node instanceof HTMLVideoElement ? 'video' : 'audio'
+      notifyNode(node, mimeType, true, ignoreSource)
+    }
+  }
+
+  fetchMedia()
+
+  // Some pages (e.g. slow or lazily initialized players such as DailyMotion)
+  // only attach their media well after load, so re-scan once more after a
+  // short delay.
+  setTimeout(fetchMedia, 5000)
+}

--- a/ios/browser/web/BUILD.gn
+++ b/ios/browser/web/BUILD.gn
@@ -5,6 +5,7 @@
 
 import("//brave/components/brave_talk/buildflags/buildflags.gni")
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
+import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
 
 source_set("web") {
   sources = [
@@ -20,6 +21,7 @@ source_set("web") {
     "//brave/components/brave_talk/buildflags",
     "//brave/components/brave_user_agent/browser",
     "//brave/components/constants",
+    "//brave/components/playlist/core/common/buildflags",
     "//brave/components/query_filter/browser",
     "//brave/components/query_filter/common",
     "//brave/ios/browser/ai_chat",
@@ -31,6 +33,7 @@ source_set("web") {
     "//brave/ios/browser/brave_shields",
     "//brave/ios/browser/component_updater:zxcvbn_data_component_installer",
     "//brave/ios/browser/global_privacy_control",
+    "//brave/ios/browser/playlist",
     "//brave/ios/browser/skus",
     "//brave/ios/browser/ui/web_view:features",
     "//brave/ios/browser/web/de_amp",
@@ -67,6 +70,9 @@ source_set("web") {
   }
   if (enable_brave_wallet) {
     deps += [ "//brave/components/brave_wallet/browser" ]
+  }
+  if (enable_playlist) {
+    deps += [ "//brave/components/playlist/core/common" ]
   }
   frameworks = [ "Foundation.framework" ]
 }

--- a/ios/browser/web/DEPS
+++ b/ios/browser/web/DEPS
@@ -3,4 +3,5 @@ include_rules = [
   # Try to componentize zxcvbn_data_component_installer.{h,cc}, and upstream the change.
   # That's technically not a layering violation, as there's nothing browser-specific in:
   "+chrome/browser/component_updater/zxcvbn_data_component_installer.h",
+  "+brave/components/playlist/core/common",
 ]

--- a/ios/browser/web/brave_web_client.mm
+++ b/ios/browser/web/brave_web_client.mm
@@ -15,6 +15,7 @@
 #include "base/strings/sys_string_conversions.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
 #include "brave/components/constants/url_constants.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/ios/browser/ai_chat/ai_chat_distiller_javascript_feature.h"
 #include "brave/ios/browser/api/profile/profile_bridge_impl.h"
 #include "brave/ios/browser/api/web_view/brave_web_view_internal.h"
@@ -24,6 +25,8 @@
 #include "brave/ios/browser/brave_shields/cookie_control_javascript_feature.h"
 #include "brave/ios/browser/brave_shields/farbling_javascript_feature.h"
 #include "brave/ios/browser/global_privacy_control/gpc_javascript_feature.h"
+#include "brave/ios/browser/playlist/playlist_compatibility_javascript_feature.h"
+#include "brave/ios/browser/playlist/playlist_javascript_feature.h"
 #include "brave/ios/browser/skus/skus_javascript_feature.h"
 #include "brave/ios/browser/ui/web_view/features.h"
 #include "brave/ios/browser/web/brave_web_main_parts.h"
@@ -64,6 +67,10 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_TALK)
 #include "brave/ios/browser/brave_talk/brave_talk_launcher_javascript_feature.h"
+#endif
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/components/playlist/core/common/features.h"
 #endif
 
 BraveWebClient::BraveWebClient() {}
@@ -160,6 +167,13 @@ std::vector<web::JavaScriptFeature*> BraveWebClient::GetJavaScriptFeatures(
         MediaBackgroundingJavaScriptFeature::FromBrowserState(browser_state));
     features.push_back(NightModeJavaScriptFeature::GetInstance());
     features.push_back(PageMetadataJavaScriptFeature::GetInstance());
+#if BUILDFLAG(ENABLE_PLAYLIST)
+    if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
+      features.push_back(playlist::PlaylistJavaScriptFeature::GetInstance());
+      features.push_back(
+          playlist::PlaylistCompatibilityJavaScriptFeature::GetInstance());
+    }
+#endif
     features.push_back(brave::ReaderModeJavaScriptFeature::GetInstance());
     features.push_back(
         skus::SkusJavaScriptFeature::FromBrowserState(browser_state));


### PR DESCRIPTION
This adds 2 JavaScriptFeatures that are used when the `UseProfileWebViewConfiguration` feature flag is enabled. The two JavaScriptFeatures are based on the 2 playlist scripts: `PlaylistScript.js` and `PlaylistSwizzlerScript.js`.

The swizzler script is now always injected so we have to use prompts to check if the current WebState is actually a background tab used by Playlist to fetch streaming URLs.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56775

### Test

- Enable the `UseProfileWebViewConfiguration` feature flag
- Verify visiting video/audio pages like on YouTube, Vimeo, Soundcloud, etc still display playlist in the URL bar to add said video
- Verify adding items still works correctly
- Verify newly added items are streamable in Playlist

Note: adblock on certain media sites may not function correctly yet with the `UseProfileWebViewConfiguration` feature flag enabled due to those associated scripts not being fully ported yet 
