### PR TITLE
[VPN 2.0] Plumb local state to BraveVpnServiceImpl v2

### DIFF
--- a/browser/brave_vpn/brave_vpn_service_factory.cc
+++ b/browser/brave_vpn/brave_vpn_service_factory.cc
@@ -51,9 +51,12 @@ namespace {
 
 std::unique_ptr<KeyedService> BuildVpnService_V2(
     content::BrowserContext* context) {
+  auto* local_state = g_browser_process->local_state();
+  auto* profile_prefs = user_prefs::UserPrefs::Get(context);
+  brave_vpn::MigrateVPNSettings(profile_prefs, local_state);
+
   // Return stub implementation.
-  return std::make_unique<v2::BraveVpnServiceImpl>(
-      user_prefs::UserPrefs::Get(context));
+  return std::make_unique<v2::BraveVpnServiceImpl>(local_state, profile_prefs);
 }
 
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2)

--- a/components/brave_vpn/browser/v2/DEPS
+++ b/components/brave_vpn/browser/v2/DEPS
@@ -5,6 +5,7 @@ include_rules = [
   "+brave/components/brave_vpn/browser/brave_vpn_service.h",
   "+brave/components/brave_vpn/common/brave_vpn_constants.h",
   "+brave/components/brave_vpn/common/brave_vpn_utils.h",
+  "+brave/components/brave_vpn/common/pref_names.h",
   "+brave/components/brave_vpn/common/buildflags",
   "+brave/components/brave_vpn/common/mojom",
 ]

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl.cc
@@ -9,14 +9,17 @@
 #include "base/notimplemented.h"
 #include "base/types/to_address.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
+#include "brave/components/brave_vpn/common/pref_names.h"
 #include "brave/components/skus/browser/skus_utils.h"
 #include "components/prefs/pref_service.h"
 
 namespace brave_vpn {
 namespace v2 {
 
-BraveVpnServiceImpl::BraveVpnServiceImpl(PrefService* profile_prefs)
-    : profile_prefs_(CHECK_DEREF(profile_prefs)),
+BraveVpnServiceImpl::BraveVpnServiceImpl(PrefService* local_prefs,
+                                         PrefService* profile_prefs)
+    : local_prefs_(CHECK_DEREF(local_prefs)),
+      profile_prefs_(CHECK_DEREF(profile_prefs)),
       connection_state_(mojom::ConnectionState::DISCONNECTED),
       purchased_state_(mojom::PurchasedState::NOT_PURCHASED) {
   DCHECK(IsBraveVPNFeatureEnabled());
@@ -38,8 +41,7 @@ void BraveVpnServiceImpl::ReloadPurchasedState() {
 }
 
 std::string BraveVpnServiceImpl::GetCurrentEnvironment() const {
-  NOTIMPLEMENTED();
-  return skus::kEnvProduction;
+  return local_prefs_->GetString(prefs::kBraveVPNEnvironment);
 }
 
 void BraveVpnServiceImpl::GetPurchasedState(

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl.h
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl.h
@@ -19,7 +19,8 @@ namespace v2 {
 
 class BraveVpnServiceImpl : public BraveVpnService {
  public:
-  explicit BraveVpnServiceImpl(PrefService* profile_prefs);
+  explicit BraveVpnServiceImpl(PrefService* local_prefs,
+                               PrefService* profile_prefs);
   ~BraveVpnServiceImpl() override;
 
   BraveVpnServiceImpl(const BraveVpnServiceImpl&) = delete;
@@ -119,6 +120,7 @@ class BraveVpnServiceImpl : public BraveVpnService {
 #endif  // !BUILDFLAG(IS_ANDROID)
 
  private:
+  const raw_ref<PrefService> local_prefs_;
   const raw_ref<PrefService> profile_prefs_;
   [[maybe_unused]] mojom::ConnectionState connection_state_;
   mojom::PurchasedState purchased_state_;


### PR DESCRIPTION
The preparatory change plumbs local state to BraveVpnServiceImpl v2 and implements `BraveVpnServiceImpl::GetCurrentEnvironment()` call using a local pref setting, the same one used in BraveVpnServiceImpl v1. Also, it enables v1 pref migration code on v2 path.

Implements part of https://github.com/brave/brave-browser/issues/56692

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
