### PR TITLE
[VPN 2.0] Replace hardcoded SKUS VPN product name

### DIFF
--- a/components/brave_vpn/browser/brave_vpn_service_impl.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_impl.cc
@@ -141,7 +141,8 @@ bool BraveVpnServiceImpl::is_purchased_user() const {
 }
 
 void BraveVpnServiceImpl::ReloadPurchasedState() {
-  LoadPurchasedState(skus::GetDomain("vpn", GetCurrentEnvironment()));
+  LoadPurchasedState(
+      skus::GetDomain(skus::GetVpnProductPrefix(), GetCurrentEnvironment()));
 }
 
 #if !BUILDFLAG(IS_ANDROID)
@@ -568,7 +569,7 @@ void BraveVpnServiceImpl::GetPurchasedState(
 
 void BraveVpnServiceImpl::LoadPurchasedState(const std::string& domain) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (!skus::DomainIsForProduct(domain, "vpn")) {
+  if (!skus::DomainIsForProduct(domain, skus::GetVpnProductPrefix())) {
     VLOG(2) << __func__ << ": LoadPurchasedState called for non-vpn product";
     return;
   }
@@ -640,7 +641,7 @@ void BraveVpnServiceImpl::RequestCredentialSummary(const std::string& domain) {
 void BraveVpnServiceImpl::OnCredentialSummary(
     const std::string& domain,
     skus::mojom::SkusResultPtr summary) {
-  if (!skus::DomainIsForProduct(domain, "vpn")) {
+  if (!skus::DomainIsForProduct(domain, skus::GetVpnProductPrefix())) {
     VLOG(2) << __func__ << ": CredentialSummary called for non-vpn product";
     return;
   }
@@ -785,7 +786,8 @@ void BraveVpnServiceImpl::OnGetSubscriberCredentialV12(
       VLOG(2) << __func__
               << " : Re-trying to fetch subscriber-credential by fetching "
                  "newer skus-credential.";
-      RequestCredentialSummary(skus::GetDomain("vpn", GetCurrentEnvironment()));
+      RequestCredentialSummary(skus::GetDomain(skus::GetVpnProductPrefix(),
+                                               GetCurrentEnvironment()));
       SetSkusCredentialFetchingRetried(local_prefs_, true);
       return;
     }

--- a/components/brave_vpn/browser/brave_vpn_service_impl_unittest.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_impl_unittest.cc
@@ -575,7 +575,7 @@ class BraveVpnServiceImplV1Test : public testing::Test {
 
   std::string SetupTestingStoreForEnv(const std::string& env,
                                       bool active_subscription = true) {
-    std::string domain = skus::GetDomain("vpn", env);
+    std::string domain = skus::GetDomain(skus::GetVpnProductPrefix(), env);
     auto testing_payload = GenerateTestingCreds(domain, active_subscription);
     base::DictValue state;
     state.Set("skus:" + env, testing_payload);
@@ -631,7 +631,7 @@ TEST_F(BraveVpnServiceImplV1Test, ResponseSanitizingTest) {
 #if !BUILDFLAG(IS_ANDROID)
 TEST_F(BraveVpnServiceImplV1Test, SkusCredentialCacheTest) {
   std::string env = skus::GetDefaultEnvironment();
-  std::string domain = skus::GetDomain("vpn", env);
+  std::string domain = skus::GetDomain(skus::GetVpnProductPrefix(), env);
 
   SetPurchasedState(env, PurchasedState::LOADING);
   OnCredentialSummary(
@@ -654,7 +654,7 @@ TEST_F(BraveVpnServiceImplV1Test, SkusCredentialCacheTest) {
 
 TEST_F(BraveVpnServiceImplV1Test, LoadPurchasedStateSessionExpiredTest) {
   std::string env = skus::GetDefaultEnvironment();
-  std::string domain = skus::GetDomain("vpn", env);
+  std::string domain = skus::GetDomain(skus::GetVpnProductPrefix(), env);
 
   // Treat as not purchased when active is false but there is remained
   // credentials. In this situation, user should activate vpn account.
@@ -704,7 +704,7 @@ TEST_F(BraveVpnServiceImplV1Test, LoadPurchasedStateSessionExpiredTest) {
 
 TEST_F(BraveVpnServiceImplV1Test, LoadPurchasedStateOutOfCredentialsTest) {
   std::string env = skus::GetDefaultEnvironment();
-  std::string domain = skus::GetDomain("vpn", env);
+  std::string domain = skus::GetDomain(skus::GetVpnProductPrefix(), env);
 
   // Set an expiry in the future - this would be when the last redeemed
   // credential (whether it was successful  or not) expires.
@@ -720,7 +720,7 @@ TEST_F(BraveVpnServiceImplV1Test, LoadPurchasedStateOutOfCredentialsTest) {
 
 TEST_F(BraveVpnServiceImplV1Test, LoadPurchasedStateTest) {
   std::string env = skus::GetDefaultEnvironment();
-  std::string domain = skus::GetDomain("vpn", env);
+  std::string domain = skus::GetDomain(skus::GetVpnProductPrefix(), env);
   // Service try loading
   SetPurchasedState(env, PurchasedState::LOADING);
   // Treat not purchased When empty credential string received.
@@ -954,7 +954,8 @@ TEST_F(BraveVpnServiceImplV1Test, LoadPurchasedStateForAnotherEnvFailed) {
 
   observer.ResetStates();
   SetInterceptorResponse("");
-  std::string staging = skus::GetDomain("vpn", skus::kEnvStaging);
+  std::string staging =
+      skus::GetDomain(skus::GetVpnProductPrefix(), skus::kEnvStaging);
   EXPECT_EQ(GetCurrentEnvironment(), skus::GetDefaultEnvironment());
   EXPECT_FALSE(observer.GetPurchasedState().has_value());
   // no order found for staging.
@@ -1092,7 +1093,7 @@ TEST_F(BraveVpnServiceImplV1Test, SetPurchasedState) {
 
 TEST_F(BraveVpnServiceImplV1Test, LoadPurchasedStateNotifications) {
   std::string env = skus::GetDefaultEnvironment();
-  std::string domain = skus::GetDomain("vpn", env);
+  std::string domain = skus::GetDomain(skus::GetVpnProductPrefix(), env);
   TestBraveVpnServiceObserver observer;
   AddObserver(observer.GetReceiver());
   EXPECT_EQ(PurchasedState::NOT_PURCHASED, GetPurchasedInfoSync());

--- a/components/skus/browser/skus_utils.cc
+++ b/components/skus/browser/skus_utils.cc
@@ -33,6 +33,10 @@ std::string GetDefaultEnvironment() {
 #endif
 }
 
+std::string GetVpnProductPrefix() {
+  return kProductVPN;
+}
+
 std::string GetDomain(const std::string& prefix,
                       const std::string& environment) {
   DCHECK(prefix == kProductTalk || prefix == kProductVPN);

--- a/components/skus/browser/skus_utils.h
+++ b/components/skus/browser/skus_utils.h
@@ -18,6 +18,7 @@ inline constexpr char kEnvStaging[] = "staging";
 inline constexpr char kEnvDevelopment[] = "development";
 
 std::string GetDefaultEnvironment();
+std::string GetVpnProductPrefix();
 std::string GetDomain(const std::string& prefix, const std::string& domain);
 std::string GetEnvironmentForDomain(const std::string& domain);
 bool DomainIsForProduct(const std::string& domain, const std::string& product);


### PR DESCRIPTION
The change adds a helper function `skus::GetVpnProductPrefix`, to retrieve VPN product name, to avoid hardcoding in both v1 and v2 service implementations and tests.

Implements part of https://github.com/brave/brave-browser/issues/56692

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
