### PR TITLE
[iOS] Use main frame shield status for all frames when cosmetic filtering

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CosmeticFiltersScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CosmeticFiltersScriptHandler.swift
@@ -46,7 +46,9 @@ class CosmeticFiltersScriptHandler: TabContentScript {
       let data = try JSONSerialization.data(withJSONObject: message.body)
       let dto = try JSONDecoder().decode(CosmeticFiltersDTO.self, from: data)
 
-      guard let frameURL = URLOrigin(wkSecurityOrigin: message.frameInfo.securityOrigin).url else {
+      guard let mainFrameURL = tab.currentPageData?.mainFrameURL,
+        let frameURL = URLOrigin(wkSecurityOrigin: message.frameInfo.securityOrigin).url
+      else {
         replyHandler(nil, nil)
         return
       }
@@ -54,7 +56,7 @@ class CosmeticFiltersScriptHandler: TabContentScript {
       Task { @MainActor in
         let cachedEngines = AdBlockGroupsManager.shared.cachedEngines(
           isAdBlockEnabled: tab.braveShieldsHelper?.shieldLevel(
-            for: frameURL,
+            for: mainFrameURL,
             considerAllShieldsOption: true
           ).isEnabled ?? true
         )


### PR DESCRIPTION
- Fix sub-frame URL used for shield status (enabled/disabled) of cosmetic filtering on iOS instead of main frame. The main frame should determine shield status of all sub-frames on the site.
- This only applies to classes and ids hidden after the first pass, as [SiteStateListenerScriptHandler](https://github.com/brave/brave-core/blob/934aacb2267885ede7664d31eb31189ad9ec672f/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/SiteStateListenerScriptHandler.swift#L57) which injects `content_cosmetic_ios.js` correctly uses main frame url for shield status (enabled/disabled)

Resolves https://github.com/brave/brave-browser/issues/56780

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### Testplan
1. Add `###contact` to custom filters in Settings > Shields & Privacy > Content Filtering
2. Visit `kylehickinson.com`
3. Verify contact buttons (Github, Mastodon, Email) are hidden.
4. Disable shields on `kylehickinson.com`
5. Verify contact buttons (Github, Mastodon, Email) are visible
6. Visit `https://stephenheaps.github.io/shields/shield-status.html`
7. Verify Shields is enabled for `stephenheaps.github.io`
8. Verify contact buttons (Github, Mastodon, Email) in the iframe for `kylehickinson.com` is hidden (Shields is enabled on `stephenheaps.github.io`).

Can confirm test plan on desktop to verify logic as needed. 