### PR TITLE
[iOS] Use valid translation state based on existing tab helper

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/BraveTranslate/BraveTranslateTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/BraveTranslate/BraveTranslateTabHelper.swift
@@ -43,6 +43,12 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
   private var translationSession: BraveTranslateSession?
   private var translationTask: (() async throws -> Void)?
   private var canShowToast = false
+  private(set) var translationState: TranslationState = .unavailable {
+    didSet {
+      guard oldValue != translationState, let tab else { return }
+      delegate?.updateTranslateURLBar(tab: tab, state: translationState)
+    }
+  }
 
   var currentLanguageInfo = BraveTranslateLanguageInfo()
 
@@ -97,12 +103,8 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
   }
 
   func startTranslation(canShowToast: Bool) {
-    guard let tab = tab else {
-      return
-    }
-
     // Translation already in progress
-    if tab.translationState == .pending {
+    if translationState == .pending {
       return
     }
 
@@ -123,8 +125,8 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
         throw BraveTranslateError.invalidLanguage
       }
 
-      let previousState = tab.translationState
-      delegate.updateTranslateURLBar(tab: tab, state: .pending)
+      let previousState = translationState
+      translationState = .pending
 
       // TranslateAgent::TranslateFrame
       try Task.checkCancellation()
@@ -140,7 +142,7 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
         try Task.checkCancellation()
 
         if !(await isTranslateLibAvailable()) {
-          delegate.updateTranslateURLBar(tab: tab, state: previousState)
+          translationState = previousState
           throw BraveTranslateError.otherError
         }
       }
@@ -153,7 +155,7 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
 
         let error = await getTranslationErrorCode()
         if error != .noError {
-          delegate.updateTranslateURLBar(tab: tab, state: previousState)
+          translationState = previousState
           delegate.presentTranslateError(tab: tab)
           return
         }
@@ -165,7 +167,7 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
         // This matches Chromium's TranslateAgent::kMaxTranslateInitCheckAttempts
         attempts += 1
         if attempts >= 5 {
-          delegate.updateTranslateURLBar(tab: tab, state: previousState)
+          translationState = previousState
           delegate.presentTranslateError(tab: tab)
           return
         }
@@ -230,10 +232,7 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
         tasks.removeValue(forKey: taskId)
       }
 
-      guard let tab = self.tab,
-        let delegate = delegate,
-        tab.translationState == .active
-      else {
+      guard translationState == .active else {
         return
       }
 
@@ -248,10 +247,10 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
         return
       }
 
-      await undoTranslate()
+      undoTranslate()
       try Task.checkCancellation()
 
-      delegate.updateTranslateURLBar(tab: tab, state: .available)
+      translationState = .available
     }
 
     tasks[taskId] = task
@@ -266,7 +265,7 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
     }
 
     if status == .noError {
-      delegate.updateTranslateURLBar(tab: tab, state: .active)
+      translationState = .active
 
       if canShowToast {
         delegate.presentTranslateToast(tab: tab, languageInfo: currentLanguageInfo)
@@ -275,10 +274,10 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
     }
 
     if [.translationError, .translationTimeout].contains(status) {
-      delegate.updateTranslateURLBar(tab: tab, state: .available)
+      translationState = .available
       delegate.presentTranslateError(tab: tab)
     } else {
-      delegate.updateTranslateURLBar(tab: tab, state: .unavailable)
+      translationState = .unavailable
     }
   }
 
@@ -308,14 +307,14 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
     }
 
     guard let pageLanguage = currentLanguageInfo.pageLanguage else {
-      delegate.updateTranslateURLBar(tab: tab, state: .unavailable)
+      translationState = .unavailable
       return
     }
 
     // Check if the page is already translated
     let isTranslatedAlready = await isPageTranslated()
     if isTranslatedAlready {
-      delegate.updateTranslateURLBar(tab: tab, state: .active)
+      translationState = .active
       return
     }
 
@@ -327,10 +326,7 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
 
     try Task.checkCancellation()
 
-    delegate.updateTranslateURLBar(
-      tab: tab,
-      state: isTranslationSupported ? .available : .unavailable
-    )
+    translationState = isTranslationSupported ? .available : .unavailable
 
     // Translation is not supported on this page, so do not show onboarding
     // Return immediately
@@ -342,11 +338,7 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
 
     // Check if the user can view the translation onboarding
     guard delegate.canShowTranslateOnboarding(tab: tab) else {
-      delegate.updateTranslateURLBar(
-        tab: tab,
-        state: Preferences.Translate.translateEnabled.value ? .available : .unavailable
-      )
-
+      translationState = Preferences.Translate.translateEnabled.value ? .available : .unavailable
       return
     }
 
@@ -359,10 +351,7 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
 
     try Task.checkCancellation()
 
-    delegate.updateTranslateURLBar(
-      tab: tab,
-      state: translateEnabled ? .available : .unavailable
-    )
+    translationState = translateEnabled ? .available : .unavailable
 
     // User enabled translation via onboarding
     if translateEnabled {
@@ -429,10 +418,8 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
       currentLanguageInfo.currentLanguage = .init(identifier: Locale.current.identifier)
       currentLanguageInfo.pageLanguage = nil
 
-      if let delegate = self.delegate {
-        delegate.updateTranslateURLBar(tab: tab, state: .unavailable)
-        BraveTranslateScriptHandler.checkTranslate(tab: tab)
-      }
+      translationState = .unavailable
+      BraveTranslateScriptHandler.checkTranslate(tab: tab)
     }
   }
 
@@ -490,7 +477,7 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
 
     while Date().timeIntervalSince(startTime) < TimeInterval(timeout) {
       if await hasTranslationFailed() {
-        delegate.updateTranslateURLBar(tab: tab, state: .available)
+        translationState = .available
         delegate.presentTranslateError(tab: tab)
         throw BraveTranslateError.otherError
       }
@@ -503,12 +490,12 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
           || actualSourceLanguage
             == currentLanguageInfo.currentLanguage.braveTranslateLanguageIdentifier
         {
-          delegate.updateTranslateURLBar(tab: tab, state: .available)
+          translationState = .available
           delegate.presentTranslateError(tab: tab)
           return
         }
 
-        delegate.updateTranslateURLBar(tab: tab, state: .active)
+        translationState = .active
         delegate.presentTranslateToast(tab: tab, languageInfo: currentLanguageInfo)
         return
       }
@@ -517,7 +504,7 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
       try Task.checkCancellation()
     }
 
-    delegate.updateTranslateURLBar(tab: tab, state: .available)
+    translationState = .available
     delegate.presentTranslateError(tab: tab)
 
     throw BraveTranslateError.otherError

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -280,9 +280,9 @@ extension BrowserViewController: TopToolbarDelegate {
     if let translateHelper = tab.legacyTranslateHelper {
       translateHelper.presentUI(on: self)
 
-      if tab.translationState == .active {
+      if translateHelper.translationState == .active {
         translateHelper.revertTranslation()
-      } else if tab.translationState != .active {
+      } else if translateHelper.translationState != .active {
         translateHelper.startTranslation(canShowToast: true)
       }
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Translate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Translate.swift
@@ -13,11 +13,7 @@ import UIKit
 import Web
 
 extension BrowserViewController: BraveTranslateScriptHandlerDelegate {
-  func updateTranslateURLBar(tab: some TabState, state: TranslateURLBarButton.TranslateState) {
-    if tab.translationState != state {
-      tab.translationState = state
-    }
-
+  func updateTranslateURLBar(tab: some TabState, state: TranslationState) {
     if tab === tabManager.selectedTab {
       topToolbar.updateTranslateButtonState(state)
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -2961,10 +2961,12 @@ extension BrowserViewController: PreferencesObserver {
         screenTimeViewController = nil
       }
     case Preferences.Translate.translateEnabled.key:
-      tabManager.selectedTab?.translationState = .unavailable
-      tabManager.selectedTab?.browserData?.setScripts(scripts: [
-        .braveTranslate: Preferences.Translate.translateEnabled.value != false
-      ])
+      if let tab = tabManager.selectedTab {
+        updateTranslateURLBar(tab: tab, state: .unavailable)
+        tab.browserData?.setScripts(scripts: [
+          .braveTranslate: Preferences.Translate.translateEnabled.value != false
+        ])
+      }
       // Only reload the tab if the setting was changed from the settings controller
       if presentedViewController is SettingsNavigationController {
         tabManager.reloadSelectedTab()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TranslateTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TranslateTabHelper.swift
@@ -16,14 +16,23 @@ extension TabDataValues {
     set { self[TranslateTabHelperKey.self] = newValue }
   }
 
-  private struct TranslationStateKey: TabDataKey {
-    static var defaultValue: TranslateURLBarButton.TranslateState = .unavailable
+  var translationState: TranslationState {
+    self.translate?.translationState ?? self.legacyTranslateHelper?.translationState ?? .unavailable
   }
+}
 
-  var translationState: TranslateURLBarButton.TranslateState {
-    get { self[TranslationStateKey.self] }
-    set { self[TranslationStateKey.self] = newValue }
-  }
+enum TranslationState {
+  // Page cannot be translated
+  case unavailable
+
+  // Translation is available, the page hasn't been translated yet
+  case available
+
+  // Translation is in progress
+  case pending
+
+  // Translation complete or partially complete
+  case active
 }
 
 class TranslateTabHelper: TabObserver {
@@ -31,7 +40,7 @@ class TranslateTabHelper: TabObserver {
   weak var delegate: (any BraveTranslateScriptHandlerDelegate)?
   private let translationControllerDelegate: TranslationControllerDelegate = .init()
 
-  private var translationState: TranslateURLBarButton.TranslateState = .unavailable {
+  private(set) var translationState: TranslationState = .unavailable {
     didSet {
       guard oldValue != translationState, let tab else { return }
       delegate?.updateTranslateURLBar(tab: tab, state: translationState)
@@ -99,7 +108,7 @@ class TranslateTabHelper: TabObserver {
   /// nothing if a translation is already running.
   func startTranslation(with languageInfo: BraveTranslateLanguageInfo? = nil) {
     guard let tab, let translationController = BraveWebView.from(tab: tab)?.translationController,
-      tab.translationState != .pending
+      translationState != .pending
     else { return }
 
     var fromLanguage = translationControllerDelegate.pageLanguage
@@ -119,7 +128,7 @@ class TranslateTabHelper: TabObserver {
       return
     }
 
-    tab.translationState = .pending
+    translationState = .pending
     translationController.translatePage(from: fromLanguage, to: toLanguage, userInitiated: true)
   }
 
@@ -127,7 +136,7 @@ class TranslateTabHelper: TabObserver {
   /// not `.active`.
   func revertTranslation() {
     guard let tab, let translationController = BraveWebView.from(tab: tab)?.translationController,
-      tab.translationState == .active
+      translationState == .active
     else { return }
     translationController.revertTranslation()
     translationState = .available

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/ShareActivity.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/ShareActivity.swift
@@ -133,9 +133,9 @@ extension UIViewController {
             if let translateHelper = tab.legacyTranslateHelper {
               translateHelper.presentUI(on: self)
 
-              if tab.translationState == .active {
+              if translateHelper.translationState == .active {
                 translateHelper.revertTranslation()
-              } else if tab.translationState != .active {
+              } else if translateHelper.translationState != .active {
                 translateHelper.startTranslation(canShowToast: true)
               }
             }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -170,7 +170,7 @@ class TabLocationView: UIView {
     }
   }
 
-  var translationState: TranslateURLBarButton.TranslateState {
+  var translationState: TranslationState {
     get {
       return translateButton.translateState
     }
@@ -179,7 +179,7 @@ class TabLocationView: UIView {
       if state != self.translateButton.translateState {
         let wasHidden = leadingItemView == nil
         self.translateButton.translateState = state
-        if wasHidden != (state == TranslateURLBarButton.TranslateState.unavailable) {
+        if wasHidden != (state == .unavailable) {
           UIAccessibility.post(notification: .layoutChanged, argument: nil)
           if !translateButton.isHidden {
             // Delay the Translation Button accessibility announcement briefly to prevent interruptions.

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -718,7 +718,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
     updateURLBarButtonsVisibility()
   }
 
-  func updateTranslateButtonState(_ state: TranslateURLBarButton.TranslateState) {
+  func updateTranslateButtonState(_ state: TranslationState) {
     locationView.translationState = state
     updateURLBarButtonsVisibility()
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TranslateURLBarButton.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TranslateURLBarButton.swift
@@ -79,7 +79,7 @@ class TranslateURLBarButton: UIButton {
     )
   }
 
-  var translateState: TranslateState = .unavailable {
+  var translateState: TranslationState = .unavailable {
     didSet {
       switch translateState {
       case .unavailable:
@@ -117,19 +117,5 @@ class TranslateURLBarButton: UIButton {
       setImage(imageIcon, for: .normal)
       updateIconSize()
     }
-  }
-
-  enum TranslateState {
-    // Page cannot be translated
-    case unavailable
-
-    // Translation is available, the page hasn't been translated yet
-    case available
-
-    // Translation is in progress
-    case pending
-
-    // Translation complete or partially complete
-    case active
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/BraveTranslateScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/BraveTranslateScriptHandler.swift
@@ -12,7 +12,7 @@ import WebKit
 import os.log
 
 protocol BraveTranslateScriptHandlerDelegate: NSObject {
-  func updateTranslateURLBar(tab: some TabState, state: TranslateURLBarButton.TranslateState)
+  func updateTranslateURLBar(tab: some TabState, state: TranslationState)
   func canShowTranslateOnboarding(tab: some TabState) -> Bool
   func showTranslateOnboarding(
     tab: some TabState,


### PR DESCRIPTION
This moves the legacy translation state into its tab helper and ensures each flow uses the correct state based on the `UseProfileWebViewConfiguration` feature flag

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55478

### Test
In addition to testing the issue, test the same thing with `UseProfileWebViewConfiguration` disabled
