### PR TITLE
[reland][recipes][plaster] `ast-grep` building scripts"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ patches/**/*.patchinfo
 /third_party/node/.*.stamp
 /third_party/opengrep/bin/
 /third_party/wintun/
+/third_party/ast-grep-intermediate/
+/third_party/ast-grep-src/
+/third_party/ast-grep/ast-grep-*
 *.xcodeproj
 !/ios/brave-ios/App/*.xcodeproj
 *.swp

--- a/script/brave_license_helper.py
+++ b/script/brave_license_helper.py
@@ -177,6 +177,10 @@ def AddBraveCredits(root, prune_paths, special_cases, prune_dirs,
         os.path.join('brave', 'third_party', 'libdmg-hfsplus'),
         os.path.join('brave', 'tools', 'crates', 'vendor'),
 
+        # ast-grep is used only by plaster, and it is not part of the final
+        # binary.
+        os.path.join('brave', 'third_party', 'ast-grep'),
+
         # Node.js for tooling, and not shipped with the browser.
         os.path.join('brave', 'third_party', 'node'),
 

--- a/third_party/ast-grep/README.md
+++ b/third_party/ast-grep/README.md
@@ -1,0 +1,29 @@
+# `third_party/ast-grep`
+
+Clones [ast-grep](https://github.com/ast-grep/ast-grep) and builds it with the
+Rust toolchain Chromium already ships using Chromium's rust toolchain.
+
+## Run
+
+```sh
+brave/third_party/ast-grep/build_ast_grep.py
+```
+
+Useful flags: `--clean` (wipe source and build dirs, start fresh), `-j N`,
+`--verbose`. `--help` lists everything.
+
+## Prerequisites
+
+The Chromium Rust toolchain must be available at
+`src/third_party/rust-toolchain/`, so only vanilla Chromium is required.
+
+No other OS-level dependencies are needed — ast-grep's tree-sitter parser builds
+use the C compiler already in the developer environment.
+
+## Outputs
+
+| Path                                           | Contents                 |
+| ---------------------------------------------- | ------------------------ |
+| `third_party/ast-grep-src/`                    | ast-grep source clone    |
+| `third_party/ast-grep-intermediate/`           | `cargo-home/`, `target/` |
+| `third_party/ast-grep/ast-grep-<os>/bin/ast-grep` | final ast-grep binary |

--- a/third_party/ast-grep/build_ast_grep.py
+++ b/third_party/ast-grep/build_ast_grep.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Build [ast-grep](https://github.com/ast-grep/ast-grep) using the Rust
+toolchain Chromium ships under `src/third_party/rust-toolchain/`.
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Anchoring a few paths
+_BRAVE_ROOT = Path(__file__).resolve().parents[2]
+_CHROMIUM_ROOT = _BRAVE_ROOT.parent
+
+# We reuse Chromium's cargo wrapper.
+sys.path.insert(0, str((_CHROMIUM_ROOT / 'tools' / 'crates').resolve()))
+from run_cargo import DEFAULT_SYSROOT, RunCargo  # noqa: E402
+
+# ast-grep upstream details.
+AST_GREP_GIT_URL = 'https://github.com/ast-grep/ast-grep.git'
+AST_GREP_REF = '0.44.0'
+
+# Additional paths under `third_party/` for the source checkout, intermediate
+# build state, and final binary output.
+_THIRD_PARTY = _BRAVE_ROOT / 'third_party'
+AST_GREP_SRC_DIR: Path = _THIRD_PARTY / 'ast-grep-src'
+AST_GREP_DIR: Path = _THIRD_PARTY / 'ast-grep'
+AST_GREP_INTERMEDIATE_DIR: Path = (_THIRD_PARTY / 'ast-grep-intermediate')
+
+_RUST_EXE = '.exe' if sys.platform == 'win32' else ''
+
+
+def _platform_dir() -> str:
+    """Host-OS token used in the per-platform subdirectory name.
+
+    The binary is installed under `ast-grep-<os>/`.
+    """
+    if sys.platform == 'darwin':
+        return 'mac_arm64' if platform.machine() == 'arm64' else 'mac'
+    if sys.platform == 'win32':
+        return 'win'
+    return 'linux'
+
+
+# Per-OS install root, so e.g. Linux and mac builds land in sibling dirs.
+AST_GREP_PLATFORM_DIR: Path = AST_GREP_DIR / f'ast-grep-{_platform_dir()}'
+AST_GREP_BIN: Path = AST_GREP_PLATFORM_DIR / 'bin' / f'ast-grep{_RUST_EXE}'
+
+# Third-party cargo subcommands (cargo-auditable, cargo-audit) are installed
+# here with the bundled toolchain, then resolved from this `bin/` on PATH.
+_CARGO_TOOLS_ROOT: Path = AST_GREP_INTERMEDIATE_DIR / 'cargo-tools'
+_CARGO_TOOLS_BIN: Path = _CARGO_TOOLS_ROOT / 'bin'
+
+
+def _check_rust_toolchain() -> None:
+    """Fail fast if the Chromium Rust toolchain isn't present.
+    """
+    cargo = DEFAULT_SYSROOT / 'bin' / f'cargo{_RUST_EXE}'
+    if not cargo.is_file():
+        raise RuntimeError(
+            f'Chromium Rust toolchain incomplete at {DEFAULT_SYSROOT}: '
+            f'missing {cargo}. Run `gclient sync`, or build it locally via '
+            f'`tools/rust/build_rust.py`.')
+
+
+def _clone_ast_grep() -> None:
+    """Shallow-clone ast-grep if not already present.
+
+    Pre-existing checkouts are left alone so local edits / a custom
+    branch survive across runs. `--clean` wipes and re-clones.
+    """
+    if AST_GREP_SRC_DIR.is_dir():
+        logging.info('ast-grep source already present at %s', AST_GREP_SRC_DIR)
+        return
+
+    AST_GREP_SRC_DIR.parent.mkdir(parents=True, exist_ok=True)
+    logging.info('Cloning ast-grep (%s) into %s', AST_GREP_REF,
+                 AST_GREP_SRC_DIR)
+    subprocess.run([
+        'git', 'clone', '--depth=1', '--branch', AST_GREP_REF,
+        AST_GREP_GIT_URL,
+        str(AST_GREP_SRC_DIR)
+    ],
+                   check=True)
+
+
+def _run_cargo_in_src(cargo_args: list[str]) -> int:
+    """Run cargo from the ast-grep source checkout, returning the exit code.
+
+    Runs cargo via `RunCargo` (bundled toolchain) from `AST_GREP_SRC_DIR` so the
+    checkout's `.cargo/config.toml` is honoured, with the installed
+    cargo-subcommand `bin/` on `PATH` so external subcommands (cargo-auditable,
+    cargo-audit) resolve. `RunCargo` has no cwd/env parameters, hence the manual
+    save/restore.
+    """
+    home_dir = AST_GREP_INTERMEDIATE_DIR / 'cargo-home'
+    prev_cwd = Path.cwd()
+    prev_path = os.environ.get('PATH', '')
+    os.environ['PATH'] = os.pathsep.join([str(_CARGO_TOOLS_BIN), prev_path])
+    os.chdir(AST_GREP_SRC_DIR)
+    try:
+        return RunCargo(DEFAULT_SYSROOT, str(home_dir), cargo_args)
+    finally:
+        os.chdir(prev_cwd)
+        os.environ['PATH'] = prev_path
+
+
+def _install_cargo_tool(tool: str) -> None:
+    """Install a third-party cargo subcommand with the bundled toolchain.
+
+    Installs into `_CARGO_TOOLS_ROOT` (shared `bin/`), skipping the build when
+    the tool is already present. `_run_cargo_in_src` puts that `bin/` on `PATH`
+    so cargo resolves the subcommand.
+    """
+    if (_CARGO_TOOLS_BIN / f'{tool}{_RUST_EXE}').is_file():
+        return
+    home_dir = AST_GREP_INTERMEDIATE_DIR / 'cargo-home'
+    logging.info('Installing %s into %s', tool, _CARGO_TOOLS_ROOT)
+    returncode = RunCargo(
+        DEFAULT_SYSROOT, str(home_dir),
+        ['install', tool, '--locked', '--root',
+         str(_CARGO_TOOLS_ROOT)])
+    if returncode != 0:
+        raise RuntimeError(f'cargo install {tool} failed (exit {returncode})')
+
+
+def _build_ast_grep(jobs: int) -> None:
+    """Build the `ast-grep` binary, then copy it into place.
+    """
+    AST_GREP_INTERMEDIATE_DIR.mkdir(parents=True, exist_ok=True)
+    AST_GREP_PLATFORM_DIR.mkdir(parents=True, exist_ok=True)
+
+    # cargo-auditable embeds the dependency graph into the binary so the audit
+    # scans only the crates actually compiled in.
+    _install_cargo_tool('cargo-auditable')
+
+    target_dir = AST_GREP_INTERMEDIATE_DIR / 'target'
+    logging.info('Building ast-grep with the Chromium Rust toolchain (%s)',
+                 DEFAULT_SYSROOT)
+    returncode = _run_cargo_in_src([
+        'auditable', 'build', '--locked', '--release', '--bin', 'ast-grep',
+        '--target-dir',
+        str(target_dir), f'--jobs={jobs}'
+    ])
+    if returncode != 0:
+        raise RuntimeError(f'cargo build failed (exit {returncode})')
+
+    built_bin = target_dir / 'release' / f'ast-grep{_RUST_EXE}'
+    if not built_bin.is_file():
+        raise RuntimeError(
+            f'cargo build finished but binary not found at {built_bin}')
+
+    AST_GREP_BIN.parent.mkdir(parents=True, exist_ok=True)
+    logging.info('Installing %s -> %s', built_bin, AST_GREP_BIN)
+    shutil.copy2(built_bin, AST_GREP_BIN)
+
+
+def _audit_ast_grep() -> None:
+    """Audit the dependencies compiled into the ast-grep binary.
+
+    `cargo audit bin` reads the dependency tree embedded by `_build_ast_grep`'s
+    `cargo auditable` build and checks exactly those crates against the RustSec
+    advisory database.
+    """
+    _install_cargo_tool('cargo-audit')
+    logging.info('Auditing ast-grep binary dependencies with cargo audit')
+    returncode = _run_cargo_in_src(['audit', 'bin', str(AST_GREP_BIN)])
+    if returncode != 0:
+        raise RuntimeError(f'cargo audit reported issues (exit {returncode})')
+
+
+def _clean() -> None:
+    """Remove the source clone, intermediate build state, and binary output.
+    """
+    paths = [AST_GREP_SRC_DIR, AST_GREP_INTERMEDIATE_DIR]
+    if AST_GREP_DIR.is_dir():
+        paths += [p for p in AST_GREP_DIR.glob('ast-grep-*') if p.is_dir()]
+    for path in paths:
+        if path.exists():
+            logging.info('Removing %s', path)
+            shutil.rmtree(path)
+
+
+def build(jobs: int, clean: bool = False) -> None:
+    """Build `ast-grep` into `third_party/ast-grep/`, then audit its deps.
+    """
+    if clean:
+        _clean()
+    _check_rust_toolchain()
+    _clone_ast_grep()
+    _build_ast_grep(jobs)
+    _audit_ast_grep()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Build ast-grep with the Chromium Rust toolchain.')
+    parser.add_argument('--clean',
+                        action='store_true',
+                        help='Remove third_party/ast-grep-src/, '
+                        'third_party/ast-grep/ and '
+                        'third_party/ast-grep-intermediate/ before building.')
+    parser.add_argument('-j',
+                        '--jobs',
+                        type=int,
+                        default=os.cpu_count() or 1,
+                        help='Number of parallel build jobs (default: nproc).')
+    parser.add_argument('--verbose',
+                        action='store_true',
+                        help='Enable debug logging.')
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO,
+                        force=True)
+
+    build(args.jobs, clean=args.clean)
+
+    logging.info('Done.')
+    logging.info('ast-grep: %s', AST_GREP_BIN)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/third_party/ast-grep/package_ast_grep.py
+++ b/third_party/ast-grep/package_ast_grep.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Build ast-grep and package `third_party/ast-grep/` into a versioned tarball.
+
+Runs the same build as `build_ast_grep.py`, then archives the *contents* of
+`third_party/ast-grep/` (the built binary tree) into a `.tar.gz` whose name
+carries the ast-grep version and host platform:
+
+    ast-grep-<version>-<platform>.tar.gz
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from pathlib import Path
+import platform
+import sys
+import tarfile
+
+import build_ast_grep
+
+
+def _platform_tag() -> str:
+    """GCS-style host platform tag, mirroring build_rust_toolchain.py."""
+    if sys.platform == 'darwin':
+        return 'mac-arm64' if platform.machine() == 'arm64' else 'mac'
+    if sys.platform == 'win32':
+        return 'win'
+    return 'linux-x64'
+
+
+def _package_name() -> str:
+    """Output archive filename: `ast-grep-<version>-<platform>.tar.gz`."""
+    return (f'ast-grep-{build_ast_grep.AST_GREP_REF}-{_platform_tag()}'
+            '.tar.gz')
+
+
+def _create_archive(out_dir: Path) -> Path:
+    """Archive this host's `ast-grep-<os>/` binary tree into *out_dir*.
+
+    Raises:
+        RuntimeError: If the ast-grep build output directory is missing.
+    """
+    source = build_ast_grep.AST_GREP_PLATFORM_DIR
+    if not source.is_dir():
+        raise RuntimeError(f'ast-grep build output not found at {source}')
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    archive = out_dir / _package_name()
+
+    logging.info('Packaging %s -> %s', source, archive)
+    with tarfile.open(archive, 'w:gz') as tar:
+        tar.add(source, arcname=source.name)
+    return archive
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Build ast-grep and package third_party/ast-grep into a '
+        'versioned tar.gz.')
+    parser.add_argument('--out-dir',
+                        type=Path,
+                        default=Path.cwd(),
+                        help='Directory the tar.gz is written to '
+                        '(default: current directory).')
+    parser.add_argument('--clean',
+                        action='store_true',
+                        help='Remove prior ast-grep build dirs before '
+                        'building.')
+    parser.add_argument('-j',
+                        '--jobs',
+                        type=int,
+                        default=os.cpu_count() or 1,
+                        help='Number of parallel build jobs (default: nproc).')
+    parser.add_argument('--verbose',
+                        action='store_true',
+                        help='Enable debug logging.')
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO,
+                        force=True)
+
+    build_ast_grep.build(args.jobs, clean=args.clean)
+    archive = _create_archive(args.out_dir.expanduser().resolve())
+
+    logging.info('Done.')
+    logging.info('ast-grep package: %s', archive)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/recipes/recipes/tools/__init__.py
+++ b/tools/recipes/recipes/tools/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Package marker for tool-building recipes."""

--- a/tools/recipes/recipes/tools/ast_grep/__init__.py
+++ b/tools/recipes/recipes/tools/ast_grep/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Package marker for ast-grep recipes."""

--- a/tools/recipes/recipes/tools/ast_grep/package_ast_grep.py
+++ b/tools/recipes/recipes/tools/ast_grep/package_ast_grep.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from engine import RecipeScriptApi
+
+DEPS = [
+    'path', 'step', 'depot_tools', 'chromium_checkout', 'brave_core_shallow'
+]
+
+
+@dataclass(frozen=True)
+class InputProperties:
+    chromium_ref: str
+    git_cache: str | None = None
+
+
+PROPERTIES = InputProperties
+
+
+def RunSteps(api: RecipeScriptApi, properties: InputProperties) -> None:
+    if properties.git_cache is not None:
+        api.chromium_checkout.set_git_cache(properties.git_cache or None)
+
+    chromium_src = api.chromium_checkout.ensure_checkout(
+        api.path.chromium_src, ref=properties.chromium_ref)
+
+    brave_root = api.brave_core_shallow.deploy(api.path.brave_core,
+                                               'third_party/ast-grep')
+
+    vpython3 = api.depot_tools.vpython3(chromium_src)
+    api.step('package ast-grep', [
+        vpython3,
+        brave_root / 'third_party/ast-grep/package_ast_grep.py',
+        '--clean',
+        '--out-dir',
+        api.path.out,
+    ])


### PR DESCRIPTION
This is a reland of the revert for the `ast-grep` recipes and
build/packaging scripts, as we now have security approval

Original message:

This PR adds scripts to build and package `ast-grep`. These scripts
require at least a vanilla Chromium checkout to be used.

Additionally, this change also introduces a recipe that can be used to
build this tool in CI.

Bug: https://github.com/brave/brave-browser/issues/56760
Bug: https://github.com/brave/brave-browser/issues/56748
Bug: https://github.com/brave/reviews/issues/2286
