### PR TITLE
[AI Chat] origin-purchased browsers create agentic profile with AI Chat policy enabled

### DIFF
--- a/browser/ai_chat/BUILD.gn
+++ b/browser/ai_chat/BUILD.gn
@@ -219,6 +219,7 @@ if (enable_brave_ai_chat_agent_profile) {
       "//brave/components/ai_chat/core/common",
       "//brave/components/ai_chat/core/common/buildflags",
       "//brave/components/ai_chat/core/common/mojom",
+      "//brave/components/brave_origin",
       "//chrome/browser:browser_process",
       "//chrome/browser:browser_public_dependencies",
       "//chrome/browser/actor",
@@ -230,6 +231,8 @@ if (enable_brave_ai_chat_agent_profile) {
       "//chrome/browser/ui",
       "//components/actor/core:task_id",
       "//components/optimization_guide/content/browser",
+      "//components/policy/core/common:common_constants",
+      "//components/prefs",
     ]
 
     if (!is_android) {
@@ -458,10 +461,13 @@ source_set("browser_tests") {
         ":content_agent_test_support",
         "//brave/browser/ai_chat:ai_chat_agent_profile",
         "//brave/browser/ui/webui/ai_chat",
+        "//brave/components/ai_chat/core/common",
         "//brave/components/ai_chat/core/common:test_support",
+        "//brave/components/brave_origin",
         "//chrome/browser/actor",
         "//chrome/browser/ui",
         "//components/optimization_guide/content/browser",
+        "//components/policy/core/common:common_constants",
       ]
 
       data += [ "//chrome/test/data/actor/" ]

--- a/browser/ai_chat/BUILD.gn
+++ b/browser/ai_chat/BUILD.gn
@@ -232,7 +232,6 @@ if (enable_brave_ai_chat_agent_profile) {
       "//components/actor/core:task_id",
       "//components/optimization_guide/content/browser",
       "//components/policy/core/common:common_constants",
-      "//components/prefs",
     ]
 
     if (!is_android) {

--- a/browser/ai_chat/ai_chat_agent_profile_browsertest.cc
+++ b/browser/ai_chat/ai_chat_agent_profile_browsertest.cc
@@ -4,6 +4,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "base/containers/fixed_flat_set.h"
+#include "base/path_service.h"
 #include "base/test/bind.h"
 #include "base/test/run_until.h"
 #include "base/test/scoped_feature_list.h"
@@ -31,6 +32,7 @@
 #include "chrome/browser/ui/profiles/profile_view_utils.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_coordinator.h"
+#include "chrome/common/chrome_paths.h"
 #include "chrome/common/pref_names.h"
 #include "chrome/common/webui_url_constants.h"
 #include "chrome/test/base/in_process_browser_test.h"
@@ -316,6 +318,74 @@ IN_PROC_BROWSER_TEST_F(AIChatAgentProfileBrowserTest,
       AIChatServiceFactory::GetForBrowserContext(agent_browser->profile()),
       nullptr);
   VerifyAIChatSidePanelShowing(agent_browser);
+}
+
+// Regression test for existing users: an agent profile created before this fix
+// shipped has AI Chat left disabled in its persisted Brave Origin policy.
+// Opening such a profile must repair it (re-enable AI Chat) rather than crash.
+// This pre-seeds the agent profile's stored policy as disabled to simulate that
+// state, since browser tests retain profiles in memory and cannot reload an
+// existing profile within a single test.
+IN_PROC_BROWSER_TEST_F(AIChatAgentProfileBrowserTest,
+                       DisabledAgentProfilePolicyIsRepairedUnderBraveOrigin) {
+  auto* origin_manager = brave_origin::BraveOriginPolicyManager::GetInstance();
+  ASSERT_TRUE(origin_manager->IsInitialized());
+
+  // The source profile has AI Chat enabled.
+  origin_manager->SetPolicyValue(
+      policy::key::kBraveAIChatEnabled, true,
+      brave_origin::GetProfileId(GetProfile()->GetPath()));
+
+  // Simulate an agent profile created before this fix: its persisted Brave
+  // Origin policy has AI Chat explicitly disabled.
+  const base::FilePath agent_path =
+      base::PathService::CheckedGet(chrome::DIR_USER_DATA)
+          .Append(brave::kAIChatAgentProfileDir);
+  origin_manager->SetPolicyValue(policy::key::kBraveAIChatEnabled, false,
+                                 brave_origin::GetProfileId(agent_path));
+
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    origin_manager->SetPurchased(true);
+    return GetProfile()->GetPrefs()->IsManagedPreference(
+               prefs::kEnabledByPolicy) &&
+           IsAIChatEnabled(GetProfile()->GetPrefs());
+  }));
+
+  // Opening the agent profile must repair the disabled state and not crash.
+  Browser* agent_browser =
+      CallOpenBrowserWindowForAiChatAgentProfile(GetProfile());
+  ASSERT_TRUE(agent_browser);
+  ASSERT_TRUE(agent_browser->profile()->IsAIChatAgent());
+  ASSERT_EQ(agent_browser->profile()->GetPath(), agent_path);
+  EXPECT_TRUE(IsAIChatEnabled(agent_browser->profile()->GetPrefs()));
+  VerifyAIChatSidePanelShowing(agent_browser);
+}
+
+// The agent profile manager observes every profile, so guard against it
+// accidentally enabling AI Chat for regular (non-agent) profiles: only the
+// dedicated agent profile should be enabled. A regular profile must keep Brave
+// Origin's default and never have its AI Chat policy written by the manager.
+IN_PROC_BROWSER_TEST_F(AIChatAgentProfileBrowserTest,
+                       RegularProfileNotEnabledForAIChatByAgentManager) {
+  auto* origin_manager = brave_origin::BraveOriginPolicyManager::GetInstance();
+  ASSERT_TRUE(origin_manager->IsInitialized());
+  origin_manager->SetPurchased(true);
+
+  // Create a regular, non-agent profile. The agent profile manager's
+  // OnProfileAdded() observer fires for it during creation.
+  ProfileManager* profile_manager = g_browser_process->profile_manager();
+  Profile& regular_profile = profiles::testing::CreateProfileSync(
+      profile_manager,
+      profile_manager->user_data_dir().AppendASCII("RegularTestProfile"));
+  ASSERT_FALSE(regular_profile.IsAIChatAgent());
+
+  // The manager must not have written an AI Chat policy value for the regular
+  // profile; it keeps Brave Origin's default (disabled).
+  EXPECT_FALSE(origin_manager
+                   ->GetPolicyValue(
+                       policy::key::kBraveAIChatEnabled,
+                       brave_origin::GetProfileId(regular_profile.GetPath()))
+                   .value_or(false));
 }
 
 // UI Tests for AI Chat Agent Profile features

--- a/browser/ai_chat/ai_chat_agent_profile_browsertest.cc
+++ b/browser/ai_chat/ai_chat_agent_profile_browsertest.cc
@@ -5,6 +5,7 @@
 
 #include "base/containers/fixed_flat_set.h"
 #include "base/test/bind.h"
+#include "base/test/run_until.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/ai_chat/ai_chat_agent_profile_helper.h"
 #include "brave/browser/ai_chat/ai_chat_service_factory.h"
@@ -13,6 +14,9 @@
 #include "brave/components/ai_chat/core/browser/conversation_handler.h"
 #include "brave/components/ai_chat/core/browser/utils.h"
 #include "brave/components/ai_chat/core/common/features.h"
+#include "brave/components/ai_chat/core/common/pref_names.h"
+#include "brave/components/brave_origin/brave_origin_policy_manager.h"
+#include "brave/components/brave_origin/profile_id.h"
 #include "brave/components/constants/brave_constants.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
@@ -31,6 +35,7 @@
 #include "chrome/common/webui_url_constants.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
+#include "components/policy/policy_constants.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -267,6 +272,52 @@ IN_PROC_BROWSER_TEST_F(AIChatAgentProfileBrowserTest,
   VerifyAIChatSidePanelShowing(third_opened_browser);
 }
 
+// Regression test for a crash seen on Brave Origin installs. Brave Origin
+// manages AI Chat as a profile-scoped policy that defaults to disabled for
+// newly-created profiles. When the source profile has AI Chat enabled but the
+// freshly-created agent profile inherits the default-disabled policy, the agent
+// profile's AIChatService is null, the kChatUI side panel entry is never
+// registered, and showing it used to CHECK-crash. The agent profile must
+// instead inherit the source profile's AI Chat policy value.
+IN_PROC_BROWSER_TEST_F(AIChatAgentProfileBrowserTest,
+                       OpenBrowserWindowInheritsAIChatPolicyUnderBraveOrigin) {
+  auto* origin_manager = brave_origin::BraveOriginPolicyManager::GetInstance();
+  ASSERT_TRUE(origin_manager->IsInitialized());
+
+  // Mark the source profile's AI Chat policy as enabled, like a Brave Origin
+  // user who has kept AI Chat on. New profiles still default to disabled.
+  origin_manager->SetPolicyValue(
+      policy::key::kBraveAIChatEnabled, true,
+      brave_origin::GetProfileId(GetProfile()->GetPath()));
+
+  // Re-assert the purchased state inside the wait loop: the source profile's
+  // BraveOriginService runs a SKU purchase check at startup that can reset it
+  // (there is no real purchase in tests), so keep setting it until the managed
+  // AI Chat policy has propagated to the source profile.
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    origin_manager->SetPurchased(true);
+    return GetProfile()->GetPrefs()->IsManagedPreference(
+               prefs::kEnabledByPolicy) &&
+           IsAIChatEnabled(GetProfile()->GetPrefs());
+  }));
+
+  SetUserOptedIn(GetProfile()->GetPrefs(), true);
+
+  // Before the fix this crashes while showing the agent profile's side panel.
+  Browser* agent_browser =
+      CallOpenBrowserWindowForAiChatAgentProfile(GetProfile());
+  ASSERT_TRUE(agent_browser);
+  ASSERT_TRUE(agent_browser->profile()->IsAIChatAgent());
+
+  // The agent profile must have inherited the source profile's enabled AI Chat
+  // policy, so the service is available and the side panel can be shown.
+  EXPECT_TRUE(IsAIChatEnabled(agent_browser->profile()->GetPrefs()));
+  EXPECT_NE(
+      AIChatServiceFactory::GetForBrowserContext(agent_browser->profile()),
+      nullptr);
+  VerifyAIChatSidePanelShowing(agent_browser);
+}
+
 // UI Tests for AI Chat Agent Profile features
 // TODO(https://github.com/brave/brave-browser/issues/48165): This should be
 // converted to an interactive_uitest.
@@ -460,7 +511,7 @@ IN_PROC_BROWSER_TEST_F(AIChatAgentProfileStartupBrowserTest,
   // Since they would have seen the profile picker before, this pref
   // will be true.
   g_browser_process->local_state()->SetBoolean(
-      prefs::kBrowserProfilePickerShown, true);
+      ::prefs::kBrowserProfilePickerShown, true);
 
   // Need to close the browser window manually so that the real test does not
   // treat it as session restore.

--- a/browser/ai_chat/ai_chat_agent_profile_helper.cc
+++ b/browser/ai_chat/ai_chat_agent_profile_helper.cc
@@ -17,16 +17,10 @@
 #if !BUILDFLAG(IS_ANDROID)
 #include "base/functional/callback_helpers.h"
 #include "base/logging.h"
-#include "brave/components/ai_chat/core/common/pref_names.h"
-#include "brave/components/brave_origin/brave_origin_policy_manager.h"
-#include "brave/components/brave_origin/brave_origin_utils.h"
-#include "brave/components/brave_origin/profile_id.h"
 #include "chrome/browser/profiles/profile_window.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/side_panel/side_panel_ui.h"
-#include "components/policy/policy_constants.h"
-#include "components/prefs/pref_service.h"
 #endif
 
 static_assert(BUILDFLAG(ENABLE_BRAVE_AI_CHAT_AGENT_PROFILE));
@@ -82,24 +76,6 @@ void OpenBrowserWindowForAIChatAgentProfileWithCallback(
   base::FilePath profile_path =
       base::PathService::CheckedGet(chrome::DIR_USER_DATA);
   profile_path = profile_path.Append(brave::kAIChatAgentProfileDir);
-
-  // Brave Origin manages AI Chat as a profile-scoped policy that defaults to
-  // disabled for newly-created profiles. The agent profile is created on behalf
-  // of a user whose source profile has AI Chat enabled (guaranteed by the CHECK
-  // above), so copy the source profile's managed value onto the soon-to-be
-  // created agent profile. Without this the agent profile would inherit Brave
-  // Origin's default-disabled value, which leaves AI Chat - and therefore the
-  // agent profile itself - non-functional (and previously crashed when its
-  // kChatUI side panel was shown for an unregistered entry). This is written
-  // before CreateProfileAsync() so the value is already present when the agent
-  // profile's policies are first loaded. When Brave Origin is not in use this
-  // is a no-op and the agent profile keeps the unmanaged default (enabled).
-  if (brave_origin::IsBraveOriginPurchased()) {
-    brave_origin::BraveOriginPolicyManager::GetInstance()->SetPolicyValue(
-        policy::key::kBraveAIChatEnabled,
-        from_profile.GetPrefs()->GetBoolean(prefs::kEnabledByPolicy),
-        brave_origin::GetProfileId(profile_path));
-  }
 
   g_browser_process->profile_manager()->CreateProfileAsync(
       profile_path,

--- a/browser/ai_chat/ai_chat_agent_profile_helper.cc
+++ b/browser/ai_chat/ai_chat_agent_profile_helper.cc
@@ -17,10 +17,16 @@
 #if !BUILDFLAG(IS_ANDROID)
 #include "base/functional/callback_helpers.h"
 #include "base/logging.h"
+#include "brave/components/ai_chat/core/common/pref_names.h"
+#include "brave/components/brave_origin/brave_origin_policy_manager.h"
+#include "brave/components/brave_origin/brave_origin_utils.h"
+#include "brave/components/brave_origin/profile_id.h"
 #include "chrome/browser/profiles/profile_window.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/side_panel/side_panel_ui.h"
+#include "components/policy/policy_constants.h"
+#include "components/prefs/pref_service.h"
 #endif
 
 static_assert(BUILDFLAG(ENABLE_BRAVE_AI_CHAT_AGENT_PROFILE));
@@ -76,6 +82,24 @@ void OpenBrowserWindowForAIChatAgentProfileWithCallback(
   base::FilePath profile_path =
       base::PathService::CheckedGet(chrome::DIR_USER_DATA);
   profile_path = profile_path.Append(brave::kAIChatAgentProfileDir);
+
+  // Brave Origin manages AI Chat as a profile-scoped policy that defaults to
+  // disabled for newly-created profiles. The agent profile is created on behalf
+  // of a user whose source profile has AI Chat enabled (guaranteed by the CHECK
+  // above), so copy the source profile's managed value onto the soon-to-be
+  // created agent profile. Without this the agent profile would inherit Brave
+  // Origin's default-disabled value, which leaves AI Chat - and therefore the
+  // agent profile itself - non-functional (and previously crashed when its
+  // kChatUI side panel was shown for an unregistered entry). This is written
+  // before CreateProfileAsync() so the value is already present when the agent
+  // profile's policies are first loaded. When Brave Origin is not in use this
+  // is a no-op and the agent profile keeps the unmanaged default (enabled).
+  if (brave_origin::IsBraveOriginPurchased()) {
+    brave_origin::BraveOriginPolicyManager::GetInstance()->SetPolicyValue(
+        policy::key::kBraveAIChatEnabled,
+        from_profile.GetPrefs()->GetBoolean(prefs::kEnabledByPolicy),
+        brave_origin::GetProfileId(profile_path));
+  }
 
   g_browser_process->profile_manager()->CreateProfileAsync(
       profile_path,

--- a/browser/ai_chat/ai_chat_agent_profile_manager.cc
+++ b/browser/ai_chat/ai_chat_agent_profile_manager.cc
@@ -62,45 +62,53 @@ void AIChatAgentProfileManager::OnProfileAdded(
 }
 
 void AIChatAgentProfileManager::OnProfileAdded(Profile* profile) {
-  if (is_added_profile_new_ai_chat_agent_profile_ && profile->IsAIChatAgent()) {
-    is_added_profile_new_ai_chat_agent_profile_ = false;
+  if (!profile->IsAIChatAgent()) {
+    return;
+  }
 
-    // Brave Origin manages AI Chat as a profile-scoped policy that defaults to
-    // disabled for newly-created profiles. The agent profile is only ever
-    // created from a source profile that already has AI Chat enabled, so enable
-    // it for the agent profile too. Without this the agent profile's
-    // AIChatService would be null, its kChatUI side panel entry would never be
-    // registered, and showing it would crash. The value is persisted per
-    // profile id in local state, so it survives the profile being destroyed and
-    // recreated (e.g. with kDestroyProfileOnBrowserClose). When Brave Origin is
-    // not in use this is skipped and the agent profile keeps the unmanaged
-    // default (enabled).
-    if (brave_origin::IsBraveOriginPurchased()) {
-      brave_origin::BraveOriginPolicyManager::GetInstance()->SetPolicyValue(
-          policy::key::kBraveAIChatEnabled, /*value=*/true,
-          brave_origin::GetProfileId(profile->GetPath()));
-    }
+  // Brave Origin manages AI Chat as a profile-scoped policy that defaults to
+  // disabled for newly-created profiles. The agent profile is only ever opened
+  // from a source profile that already has AI Chat enabled, so ensure AI Chat
+  // is enabled for the agent profile here. This runs every time the agent
+  // profile is loaded - not only when it is first created - so it also repairs
+  // agent profiles created before this fix shipped with AI Chat left disabled.
+  // Without it the agent profile's AIChatService would be null, its kChatUI
+  // side panel entry would never be registered, and showing it would crash. The
+  // value is persisted per profile id in local state. When Brave Origin is not
+  // in use this is skipped and the agent profile keeps the unmanaged default
+  // (enabled).
+  if (brave_origin::IsBraveOriginPurchased()) {
+    brave_origin::BraveOriginPolicyManager::GetInstance()->SetPolicyValue(
+        policy::key::kBraveAIChatEnabled, /*value=*/true,
+        brave_origin::GetProfileId(profile->GetPath()));
+  }
 
-    // Only opt the agent profile in to AI Chat if another (source) profile has
-    // already opted in. Otherwise the user should go through the opt-in flow in
-    // the agent profile itself.
-    if (HasAnyOtherProfileOptedIn(profile)) {
-      ai_chat::SetUserOptedIn(profile->GetPrefs(), true);
-    }
+  // The remaining setup only applies the first time the agent profile is
+  // created.
+  if (!is_added_profile_new_ai_chat_agent_profile_) {
+    return;
+  }
+  is_added_profile_new_ai_chat_agent_profile_ = false;
 
-    // Set profile name so that the user can identify the profile
-    // in the various profile list UIs.
-    // TODO(https://github.com/brave/brave-browser/issues/48164): set an avatar
-    profile_manager_->GetProfileAttributesStorage()
-        .GetProfileAttributesWithPath(profile->GetPath())
-        ->SetLocalProfileName(kAIChatAgentProfileName, false);
+  // Only opt the agent profile in to AI Chat if another (source) profile has
+  // already opted in. Otherwise the user should go through the opt-in flow in
+  // the agent profile itself.
+  if (HasAnyOtherProfileOptedIn(profile)) {
+    ai_chat::SetUserOptedIn(profile->GetPrefs(), true);
+  }
+
+  // Set profile name so that the user can identify the profile
+  // in the various profile list UIs.
+  // TODO(https://github.com/brave/brave-browser/issues/48164): set an avatar
+  profile_manager_->GetProfileAttributesStorage()
+      .GetProfileAttributesWithPath(profile->GetPath())
+      ->SetLocalProfileName(kAIChatAgentProfileName, false);
 
 #if !BUILDFLAG(IS_ANDROID)
-    // Set theme
-    auto* theme_service = ThemeServiceFactory::GetForProfile(profile);
-    theme_service->SetUserColor(kAIChatAgentProfileThemeColor);
+  // Set theme
+  auto* theme_service = ThemeServiceFactory::GetForProfile(profile);
+  theme_service->SetUserColor(kAIChatAgentProfileThemeColor);
 #endif
-  }
 }
 
 bool AIChatAgentProfileManager::HasAnyOtherProfileOptedIn(

--- a/browser/ai_chat/ai_chat_agent_profile_manager.cc
+++ b/browser/ai_chat/ai_chat_agent_profile_manager.cc
@@ -5,6 +5,8 @@
 
 #include "brave/browser/ai_chat/ai_chat_agent_profile_manager.h"
 
+#include <string>
+
 #include "brave/components/ai_chat/core/browser/utils.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/ai_chat/core/common/features.h"
@@ -66,21 +68,31 @@ void AIChatAgentProfileManager::OnProfileAdded(Profile* profile) {
     return;
   }
 
-  // Brave Origin manages AI Chat as a profile-scoped policy that defaults to
-  // disabled for newly-created profiles. The agent profile is only ever opened
-  // from a source profile that already has AI Chat enabled, so ensure AI Chat
-  // is enabled for the agent profile here. This runs every time the agent
+  // Brave Origin manages AI Chat as a profile-scoped policy that might default
+  // to disabled for newly-created profiles. The agent profile is only ever
+  // opened from a source profile that already has AI Chat enabled, so ensure AI
+  // Chat is enabled for the agent profile here. This runs every time the agent
   // profile is loaded - not only when it is first created - so it also repairs
   // agent profiles created before this fix shipped with AI Chat left disabled.
-  // Without it the agent profile's AIChatService would be null, its kChatUI
-  // side panel entry would never be registered, and showing it would crash. The
-  // value is persisted per profile id in local state. When Brave Origin is not
-  // in use this is skipped and the agent profile keeps the unmanaged default
-  // (enabled).
+  // Without it the agent profile's AIChatService would be null. The value is
+  // persisted per profile id in local state.
   if (brave_origin::IsBraveOriginPurchased()) {
-    brave_origin::BraveOriginPolicyManager::GetInstance()->SetPolicyValue(
-        policy::key::kBraveAIChatEnabled, /*value=*/true,
-        brave_origin::GetProfileId(profile->GetPath()));
+    auto* policy_manager =
+        brave_origin::BraveOriginPolicyManager::GetInstance();
+    const std::string profile_id =
+        brave_origin::GetProfileId(profile->GetPath());
+    // Only write when it isn't already enabled. OnProfileAdded runs on every
+    // agent profile load, and SetPolicyValue() always notifies observers (which
+    // triggers a policy refresh), so avoid the redundant notification when the
+    // value is unchanged.
+    // optional<bool> return is for unknown policy keys, not for unset values,
+    // so we can safely assume GetPolicyValue will return the set value or the
+    // default value itself.
+    if (policy_manager->GetPolicyValue(policy::key::kBraveAIChatEnabled,
+                                       profile_id) == false) {
+      policy_manager->SetPolicyValue(policy::key::kBraveAIChatEnabled,
+                                     /*value=*/true, profile_id);
+    }
   }
 
   // The remaining setup only applies the first time the agent profile is

--- a/browser/ai_chat/ai_chat_agent_profile_manager.cc
+++ b/browser/ai_chat/ai_chat_agent_profile_manager.cc
@@ -8,10 +8,14 @@
 #include "brave/components/ai_chat/core/browser/utils.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/ai_chat/core/common/features.h"
+#include "brave/components/brave_origin/brave_origin_policy_manager.h"
+#include "brave/components/brave_origin/brave_origin_utils.h"
+#include "brave/components/brave_origin/profile_id.h"
 #include "brave/components/constants/brave_constants.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/profiles/profile_manager.h"
+#include "components/policy/policy_constants.h"
 #include "third_party/skia/include/core/SkColor.h"
 
 #if !BUILDFLAG(IS_ANDROID)
@@ -60,6 +64,23 @@ void AIChatAgentProfileManager::OnProfileAdded(
 void AIChatAgentProfileManager::OnProfileAdded(Profile* profile) {
   if (is_added_profile_new_ai_chat_agent_profile_ && profile->IsAIChatAgent()) {
     is_added_profile_new_ai_chat_agent_profile_ = false;
+
+    // Brave Origin manages AI Chat as a profile-scoped policy that defaults to
+    // disabled for newly-created profiles. The agent profile is only ever
+    // created from a source profile that already has AI Chat enabled, so enable
+    // it for the agent profile too. Without this the agent profile's
+    // AIChatService would be null, its kChatUI side panel entry would never be
+    // registered, and showing it would crash. The value is persisted per
+    // profile id in local state, so it survives the profile being destroyed and
+    // recreated (e.g. with kDestroyProfileOnBrowserClose). When Brave Origin is
+    // not in use this is skipped and the agent profile keeps the unmanaged
+    // default (enabled).
+    if (brave_origin::IsBraveOriginPurchased()) {
+      brave_origin::BraveOriginPolicyManager::GetInstance()->SetPolicyValue(
+          policy::key::kBraveAIChatEnabled, /*value=*/true,
+          brave_origin::GetProfileId(profile->GetPath()));
+    }
+
     // Only opt the agent profile in to AI Chat if another (source) profile has
     // already opted in. Otherwise the user should go through the opt-in flow in
     // the agent profile itself.


### PR DESCRIPTION
`AIChatAgentProfileManager` already intercepts agent profile creation to perform AI Chat opt-in. Now it also detects if the browser is in an origin-purchase state and makes sure the agentic profile gets its AI Chat policy enabled.

Includes browser tests, and one which reproduced the reported crash.

I debated between directly manipulating the policy pref for the profile or using the Origin manager to do it only for the Origin enabled browsers. For now, I can't think of a way a profile could get a different managed preference from other profiles considering there are no cloud managed profiles in Brave (AFAIK). However, if reviewers think it's better to change the pref directly then I could do that and have the browser test still use Origin features to verify.

- Fix https://github.com/brave/brave-browser/issues/56796