### PR TITLE
[Sidebar V2] Fixed button highlight is cleared after theme change

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -56,6 +56,8 @@
 #include "build/build_config.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/search_engines/template_url_service_factory.h"
+#include "chrome/browser/themes/theme_service.h"
+#include "chrome/browser/themes/theme_service_factory.h"
 #include "chrome/browser/ui/browser_command_controller.h"
 #include "chrome/browser/ui/browser_commands.h"
 #include "chrome/browser/ui/browser_finder.h"
@@ -2367,6 +2369,47 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, ToolbarButtonPinning) {
       << "Toolbar button must be hidden again under kShowAlways";
   EXPECT_FALSE(controller()->sidebar_pinned())
       << "Pinned state must remain false after returning to kShowAlways";
+}
+
+// Verifies that pinning the sidebar highlights the toolbar button and that the
+// highlight survives theme changes (regression test for when OnThemeChanged()
+// was clearing the ink-drop highlight state).
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
+                       ButtonHighlightPersistedAfterThemeChange) {
+  auto* service = SidebarServiceFactory::GetForProfile(browser()->profile());
+  auto* theme_service =
+      ThemeServiceFactory::GetForProfile(browser()->profile());
+  auto* button = GetSidePanelToolbarButton();
+  ASSERT_TRUE(button);
+
+  // Set initial theme.
+  theme_service->SetBrowserColorScheme(
+      ThemeService::BrowserColorScheme::kLight);
+
+  auto button_highlighted = [&]() {
+    return views::InkDrop::Get(button)->GetHighlighted();
+  };
+
+  // Switch to kShowNever so the toolbar button is visible.
+  service->SetSidebarShowOption(SidebarService::ShowSidebarOption::kShowNever);
+  ASSERT_TRUE(button->GetVisible());
+
+  // Pin the sidebar — button should become highlighted.
+  button->button_controller()->NotifyClick();
+  ASSERT_TRUE(controller()->sidebar_pinned());
+  ASSERT_TRUE(base::test::RunUntil([&]() { return button_highlighted(); }))
+      << "Button should be highlighted after pinning";
+
+  // Switch to dark theme — this previously cleared the ink-drop highlight.
+  theme_service->SetBrowserColorScheme(ThemeService::BrowserColorScheme::kDark);
+  EXPECT_TRUE(button_highlighted())
+      << "Button highlight should be preserved after switching to dark theme";
+
+  // Switch back to light theme — highlight must survive this change too.
+  theme_service->SetBrowserColorScheme(
+      ThemeService::BrowserColorScheme::kLight);
+  EXPECT_TRUE(button_highlighted())
+      << "Button highlight should be preserved after switching to light theme";
 }
 
 // Exercises the side-panel drop shadow (BraveSidePanelShadowOverlayView):

--- a/browser/ui/views/toolbar/side_panel_button.cc
+++ b/browser/ui/views/toolbar/side_panel_button.cc
@@ -85,6 +85,13 @@ SidePanelButton::SidePanelButton(sidebar::SidebarController* sidebar_controller,
 
 SidePanelButton::~SidePanelButton() = default;
 
+void SidePanelButton::OnThemeChanged() {
+  ToolbarButton::OnThemeChanged();
+
+  // Theme change clears button's highlight state.
+  UpdateButtonHighlight();
+}
+
 void SidePanelButton::OnShowSidebarOptionChanged(
     sidebar::SidebarService::ShowSidebarOption option) {
   UpdateButtonVisibility();

--- a/browser/ui/views/toolbar/side_panel_button.h
+++ b/browser/ui/views/toolbar/side_panel_button.h
@@ -29,6 +29,9 @@ class SidePanelButton : public ToolbarButton,
   SidePanelButton& operator=(const SidePanelButton&) = delete;
   ~SidePanelButton() override;
 
+  // ToolbarButton:
+  void OnThemeChanged() override;
+
   // SidebarService::Observer:
   void OnShowSidebarOptionChanged(
       sidebar::SidebarService::ShowSidebarOption option) override;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves no issue - use umbrella issue (https://github.com/brave/brave-browser/issues/51462)

sidebar button should refresh its highlight state after theme changed
because theme change clears highlight state.

TEST=idebarBrowserTest.ButtonHighlightPersistedAfterThemeChange

[Screencast from 2026-07-01 11-40-38.webm](https://github.com/user-attachments/assets/089a4b6e-b602-4ba8-8e00-4cd78efa78bd)


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
