### PR TITLE
[Cleanup] Unified to SplitViewBrowserTest test fixture name

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -203,19 +203,17 @@ class BraveBrowserView : public BrowserView,
   FRIEND_TEST_ALL_PREFIXES(SpeedReaderBrowserTest, ToolbarLangs);
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest, ExpandedState);
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest, ExpandedWidth);
-  FRIEND_TEST_ALL_PREFIXES(SideBySideEnabledBrowserTest,
-                           BraveMultiContentsViewTest);
+  FRIEND_TEST_ALL_PREFIXES(SplitViewBrowserTest, BraveMultiContentsViewTest);
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripHideCompletelyTest, GetMinimumWidth);
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripHideCompletelyTest,
                            ShouldBeInvisible);
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripHideCompletelyTest,
                            ShowVerticalTabOnMouseOverTest);
-  FRIEND_TEST_ALL_PREFIXES(SideBySideWithRoundedCornersTest,
+  FRIEND_TEST_ALL_PREFIXES(SplitViewWithRoundedCornersTest,
                            TabFullscreenStateTest);
   FRIEND_TEST_ALL_PREFIXES(BraveBrowserViewWithRoundedCornersTest,
                            ContentsBackgroundEventHandleTest);
-  FRIEND_TEST_ALL_PREFIXES(SideBySideWithRoundedCornersTest,
-                           ContentsShadowTest);
+  FRIEND_TEST_ALL_PREFIXES(SplitViewWithRoundedCornersTest, ContentsShadowTest);
   FRIEND_TEST_ALL_PREFIXES(sidebar::SidebarBrowserWithSplitViewTest,
                            ShowSidebarOnMouseOverTest);
 

--- a/browser/ui/views/frame/split_view/brave_contents_container_view.h
+++ b/browser/ui/views/frame/split_view/brave_contents_container_view.h
@@ -56,8 +56,7 @@ class BraveContentsContainerView :
 #endif
 
  private:
-  FRIEND_TEST_ALL_PREFIXES(SideBySideEnabledBrowserTest,
-                           BraveMultiContentsViewTest);
+  FRIEND_TEST_ALL_PREFIXES(SplitViewBrowserTest, BraveMultiContentsViewTest);
 
   gfx::RoundedCornersF GetCornerRadius(bool for_border) const;
 

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view.h
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view.h
@@ -53,10 +53,9 @@ class BraveMultiContentsView : public MultiContentsView {
       content::WebContents* web_contents) const override;
 
  private:
-  friend class SideBySideEnabledBrowserTest;
+  friend class SplitViewBrowserTest;
   friend class SpeedReaderWithSplitViewBrowserTest;
-  FRIEND_TEST_ALL_PREFIXES(SideBySideEnabledBrowserTest,
-                           BraveMultiContentsViewTest);
+  FRIEND_TEST_ALL_PREFIXES(SplitViewBrowserTest, BraveMultiContentsViewTest);
   FRIEND_TEST_ALL_PREFIXES(sidebar::SidebarBrowserWithWebPanelTest,
                            WebPanelTest);
 

--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -188,10 +188,10 @@ class SameDocumentCommitObserver : public content::WebContentsObserver {
 
 }  // namespace
 
-class SideBySideEnabledBrowserTest : public InProcessBrowserTest {
+class SplitViewBrowserTest : public InProcessBrowserTest {
  public:
-  SideBySideEnabledBrowserTest() = default;
-  ~SideBySideEnabledBrowserTest() override = default;
+  SplitViewBrowserTest() = default;
+  ~SplitViewBrowserTest() override = default;
 
   void SetUpOnMainThread() override {
     InProcessBrowserTest::SetUpOnMainThread();
@@ -226,12 +226,81 @@ class SideBySideEnabledBrowserTest : public InProcessBrowserTest {
     browser_non_client_frame_view()->DeprecatedLayoutImmediately();
   }
 
+  bool GetIsTabHiddenFromPermissionManagerFromTabAt(int index) {
+    auto* tab_strip_model = browser()->tab_strip_model();
+    return !permissions::PermissionRequestManager::FromWebContents(
+                tab_strip_model->GetWebContentsAt(index))
+                ->tab_is_active_for_testing();
+  }
+
+  // blocked(true) when tab at |index| has tab modal dialog.
+  bool GetIsWebContentsBlockedFromTabAt(int index) {
+    auto* tab_strip_model = browser()->tab_strip_model();
+    return static_cast<tabs::TabModel*>(tab_strip_model->GetTabAtIndex(index))
+        ->IsBlocked();
+  }
+
+  web_modal::WebContentsModalDialogManager* GetWebModalDialogManagerAt(
+      int index) {
+    return web_modal::WebContentsModalDialogManager::FromWebContents(
+        browser()->tab_strip_model()->GetWebContentsAt(index));
+  }
+
+  bool HasWebModalDialogAt(int index) {
+    return !GetWebModalDialogManagerAt(index)->child_dialogs_.empty();
+  }
+
+  bool IsWebModalDialogVisibleAt(int index) {
+    return views::Widget::GetWidgetForNativeWindow(
+               GetWebModalDialogManagerAt(index)
+                   ->child_dialogs_.front()
+                   .manager->dialog())
+        ->IsVisible();
+  }
+
+  javascript_dialogs::TabModalDialogManager* GetTabModalDialogManagerAt(
+      int index) {
+    return javascript_dialogs::TabModalDialogManager::FromWebContents(
+        browser()->tab_strip_model()->GetWebContentsAt(index));
+  }
+
+  content::WebContents* GetWebContentsAt(int index) {
+    return browser()->tab_strip_model()->GetWebContentsAt(index);
+  }
+
+  void NewSplitTab() {
+    chrome::NewSplitTab(browser(), split_tabs::SplitTabLayout::kSideBySide,
+                        split_tabs::SplitTabCreatedSource::kToolbarButton);
+  }
+
+  bool IsSplitTabAt(int index) {
+    return IsSplitWebContents(GetWebContentsAt(index));
+  }
+
+  void SwapActiveSplitTab() {
+    auto* tab_strip_model = browser()->tab_strip_model();
+    auto split_id =
+        tab_strip_model->GetSplitForTab(tab_strip_model->active_index());
+    ASSERT_TRUE(split_id);
+    tab_strip_model->ReverseTabsInSplit(split_id.value());
+  }
+
+  bool IsSplitWebContents(content::WebContents* web_contents) {
+    auto tab_handle =
+        tabs::TabInterface::GetFromContents(web_contents)->GetHandle();
+    return tab_handle.Get()->IsSplit();
+  }
+
+  ContentsWebView* GetContentsWebView() {
+    return BrowserView::GetBrowserViewForBrowser(browser())
+        ->contents_web_view();
+  }
+
  protected:
   base::test::ScopedFeatureList scoped_features_;
 };
 
-IN_PROC_BROWSER_TEST_F(SideBySideEnabledBrowserTest,
-                       BraveMultiContentsViewTest) {
+IN_PROC_BROWSER_TEST_F(SplitViewBrowserTest, BraveMultiContentsViewTest) {
   EXPECT_FALSE(split_view_separator()->GetVisible());
 
   auto* browser_view = brave_browser_view();
@@ -340,7 +409,7 @@ IN_PROC_BROWSER_TEST_F(SideBySideEnabledBrowserTest,
   }));
 }
 
-IN_PROC_BROWSER_TEST_F(SideBySideEnabledBrowserTest, SelectTabTest) {
+IN_PROC_BROWSER_TEST_F(SplitViewBrowserTest, SelectTabTest) {
   chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
   chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
   EXPECT_EQ(2, tab_strip()->GetActiveIndex());
@@ -406,10 +475,10 @@ IN_PROC_BROWSER_TEST_F(SideBySideEnabledBrowserTest, SelectTabTest) {
   EXPECT_TRUE(tab_strip()->tab_at(3)->IsActive());
 }
 
-class SideBySideWithRoundedCornersTest : public SideBySideEnabledBrowserTest {
+class SplitViewWithRoundedCornersTest : public SplitViewBrowserTest {
  public:
-  SideBySideWithRoundedCornersTest() = default;
-  ~SideBySideWithRoundedCornersTest() override = default;
+  SplitViewWithRoundedCornersTest() = default;
+  ~SplitViewWithRoundedCornersTest() override = default;
 
   void SetUpOnMainThread() override {
     InProcessBrowserTest::SetUpOnMainThread();
@@ -417,7 +486,7 @@ class SideBySideWithRoundedCornersTest : public SideBySideEnabledBrowserTest {
   }
 };
 
-IN_PROC_BROWSER_TEST_F(SideBySideWithRoundedCornersTest, ContentsShadowTest) {
+IN_PROC_BROWSER_TEST_F(SplitViewWithRoundedCornersTest, ContentsShadowTest) {
   // Shadow if split tab is not active.
   EXPECT_TRUE(brave_browser_view()->contents_shadow_);
 
@@ -458,7 +527,7 @@ IN_PROC_BROWSER_TEST_F(SideBySideWithRoundedCornersTest, ContentsShadowTest) {
 
 // Test multi contents view's rounded corners with fullscreen state w/o split
 // view.
-IN_PROC_BROWSER_TEST_F(SideBySideWithRoundedCornersTest,
+IN_PROC_BROWSER_TEST_F(SplitViewWithRoundedCornersTest,
                        TabFullscreenStateTest) {
   auto* contents_container = brave_browser_view()->contents_container();
   auto* contents_view = brave_browser_view()->GetContentsView();
@@ -491,92 +560,7 @@ IN_PROC_BROWSER_TEST_F(SideBySideWithRoundedCornersTest,
   EXPECT_EQ(contents_view->layer()->rounded_corner_radii(), border_radius);
 }
 
-// Use for testing brave split view and SideBySide together.
-class SplitViewCommonBrowserTest : public InProcessBrowserTest {
- public:
-  SplitViewCommonBrowserTest() = default;
-  ~SplitViewCommonBrowserTest() override = default;
-
-  bool GetIsTabHiddenFromPermissionManagerFromTabAt(int index) {
-    auto* tab_strip_model = browser()->tab_strip_model();
-    return !permissions::PermissionRequestManager::FromWebContents(
-                tab_strip_model->GetWebContentsAt(index))
-                ->tab_is_active_for_testing();
-  }
-
-  // blocked(true) when tab at |index| has tab modal dialog.
-  bool GetIsWebContentsBlockedFromTabAt(int index) {
-    auto* tab_strip_model = browser()->tab_strip_model();
-    return static_cast<tabs::TabModel*>(tab_strip_model->GetTabAtIndex(index))
-        ->IsBlocked();
-  }
-
-  web_modal::WebContentsModalDialogManager* GetWebModalDialogManagerAt(
-      int index) {
-    return web_modal::WebContentsModalDialogManager::FromWebContents(
-        browser()->tab_strip_model()->GetWebContentsAt(index));
-  }
-
-  bool HasWebModalDialogAt(int index) {
-    return !GetWebModalDialogManagerAt(index)->child_dialogs_.empty();
-  }
-
-  bool IsWebModalDialogVisibleAt(int index) {
-    return views::Widget::GetWidgetForNativeWindow(
-               GetWebModalDialogManagerAt(index)
-                   ->child_dialogs_.front()
-                   .manager->dialog())
-        ->IsVisible();
-  }
-
-  javascript_dialogs::TabModalDialogManager* GetTabModalDialogManagerAt(
-      int index) {
-    return javascript_dialogs::TabModalDialogManager::FromWebContents(
-        browser()->tab_strip_model()->GetWebContentsAt(index));
-  }
-
-  content::WebContents* GetWebContentsAt(int index) {
-    return browser()->tab_strip_model()->GetWebContentsAt(index);
-  }
-
-  void NewSplitTab() {
-    chrome::NewSplitTab(browser(), split_tabs::SplitTabLayout::kSideBySide,
-                        split_tabs::SplitTabCreatedSource::kToolbarButton);
-  }
-
-  bool IsSplitTabAt(int index) {
-    return IsSplitWebContents(GetWebContentsAt(index));
-  }
-
-  void SwapActiveSplitTab() {
-    auto* tab_strip_model = browser()->tab_strip_model();
-    auto split_id =
-        tab_strip_model->GetSplitForTab(tab_strip_model->active_index());
-    ASSERT_TRUE(split_id);
-    tab_strip_model->ReverseTabsInSplit(split_id.value());
-  }
-
-  bool IsSplitWebContents(content::WebContents* web_contents) {
-    auto tab_handle =
-        tabs::TabInterface::GetFromContents(web_contents)->GetHandle();
-    return tab_handle.Get()->IsSplit();
-  }
-
-  ContentsWebView* GetContentsWebView() {
-    return BrowserView::GetBrowserViewForBrowser(browser())
-        ->contents_web_view();
-  }
-
-  TabStrip* tab_strip() {
-    return BrowserView::GetBrowserViewForBrowser(browser())
-        ->horizontal_tab_strip_for_testing();
-  }
-
- private:
-  base::test::ScopedFeatureList scoped_features_;
-};
-
-IN_PROC_BROWSER_TEST_F(SplitViewCommonBrowserTest, SplitTabInsetsTest) {
+IN_PROC_BROWSER_TEST_F(SplitViewBrowserTest, SplitTabInsetsTest) {
   brave::ToggleVerticalTabStrip(browser());
 
   auto* tab_strip_model = browser()->tab_strip_model();
@@ -657,7 +641,7 @@ IN_PROC_BROWSER_TEST_F(SplitViewCommonBrowserTest, SplitTabInsetsTest) {
 }
 
 // Check split view works with pinned tabs.
-IN_PROC_BROWSER_TEST_F(SplitViewCommonBrowserTest, SplitViewWithPinnedTabTest) {
+IN_PROC_BROWSER_TEST_F(SplitViewBrowserTest, SplitViewWithPinnedTabTest) {
   auto* tab_strip_model = browser()->tab_strip_model();
   tab_strip_model->SetTabPinned(0, true);
   chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
@@ -676,7 +660,7 @@ IN_PROC_BROWSER_TEST_F(SplitViewCommonBrowserTest, SplitViewWithPinnedTabTest) {
   chrome::PinTab(browser());
 }
 
-IN_PROC_BROWSER_TEST_F(SplitViewCommonBrowserTest, BookmarksBarVisibilityTest) {
+IN_PROC_BROWSER_TEST_F(SplitViewBrowserTest, BookmarksBarVisibilityTest) {
   auto* prefs = browser()->profile()->GetPrefs();
   auto* tab_strip_model = browser()->tab_strip_model();
   NewSplitTab();
@@ -732,7 +716,7 @@ IN_PROC_BROWSER_TEST_F(SplitViewCommonBrowserTest, BookmarksBarVisibilityTest) {
 #endif
 }
 
-IN_PROC_BROWSER_TEST_F(SplitViewCommonBrowserTest, InactiveSplitTabTest) {
+IN_PROC_BROWSER_TEST_F(SplitViewBrowserTest, InactiveSplitTabTest) {
   NewSplitTab();
   auto* tab_strip_model = browser()->tab_strip_model();
 
@@ -808,7 +792,7 @@ class LoadObserver : public content::WebContentsObserver {
 
 }  // namespace
 
-IN_PROC_BROWSER_TEST_F(SplitViewCommonBrowserTest, SplitViewReloadTest) {
+IN_PROC_BROWSER_TEST_F(SplitViewBrowserTest, SplitViewReloadTest) {
   NewSplitTab();
   content::WaitForLoadStop(GetWebContentsAt(0));
   content::WaitForLoadStop(GetWebContentsAt(1));
@@ -892,7 +876,7 @@ IN_PROC_BROWSER_TEST_F(SplitViewCommonBrowserTest, SplitViewReloadTest) {
   }
 }
 
-IN_PROC_BROWSER_TEST_F(SplitViewCommonBrowserTest, SplitViewCloseTabTest) {
+IN_PROC_BROWSER_TEST_F(SplitViewBrowserTest, SplitViewCloseTabTest) {
   NewSplitTab();
 
   auto* tab_strip_model = browser()->tab_strip_model();
@@ -934,7 +918,7 @@ IN_PROC_BROWSER_TEST_F(SplitViewCommonBrowserTest, SplitViewCloseTabTest) {
 
 // Test class for testing link handling in split view (both normal links and
 // target="_blank" links).
-class SplitViewLinkTest : public SplitViewCommonBrowserTest {
+class SplitViewLinkTest : public SplitViewBrowserTest {
  public:
   SplitViewLinkTest() {
     // Enable the split view link feature for these tests
@@ -943,7 +927,7 @@ class SplitViewLinkTest : public SplitViewCommonBrowserTest {
   ~SplitViewLinkTest() override = default;
 
   void SetUpOnMainThread() override {
-    SplitViewCommonBrowserTest::SetUpOnMainThread();
+    SplitViewBrowserTest::SetUpOnMainThread();
     host_resolver()->AddRule("*", "127.0.0.1");
     embedded_test_server()->RegisterRequestHandler(base::BindRepeating(
         &SplitViewLinkTest::HandleRequest, base::Unretained(this)));

--- a/chromium_src/chrome/browser/ui/views/frame/multi_contents_view_mini_toolbar.h
+++ b/chromium_src/chrome/browser/ui/views/frame/multi_contents_view_mini_toolbar.h
@@ -22,7 +22,7 @@ struct VectorIcon;
   static std::unique_ptr<SplitTabMenuModel> CreateBraveSplitTabMenuModel(   \
       TabStripModel* tab_strip_model, SplitTabMenuModel::MenuSource source, \
       int split_tab_index);                                                 \
-  FRIEND_TEST_ALL_PREFIXES(SideBySideEnabledBrowserTest, SelectTabTest);    \
+  FRIEND_TEST_ALL_PREFIXES(SplitViewBrowserTest, SelectTabTest);            \
   friend class BraveMultiContentsViewMiniToolbar
 
 // Replace chrome scheme to brave for display.

--- a/chromium_src/components/permissions/permission_request_manager.h
+++ b/chromium_src/components/permissions/permission_request_manager.h
@@ -7,7 +7,7 @@
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_PERMISSIONS_PERMISSION_REQUEST_MANAGER_H_
 
 class WidevinePermissionAndroidTest;
-class SplitViewCommonBrowserTest;
+class SplitViewBrowserTest;
 
 #define set_view_factory_for_testing                                           \
   AcceptDenyCancel(const std::vector<PermissionRequest*>& accepted_requests,   \
@@ -20,7 +20,7 @@ class SplitViewCommonBrowserTest;
   void UpdateTabIsHiddenWithTabActivationState();                              \
   bool ShouldBeGrouppedInRequests(PermissionRequest* a) const;                 \
   friend class ::WidevinePermissionAndroidTest;                                \
-  friend class ::SplitViewCommonBrowserTest;                                   \
+  friend class ::SplitViewBrowserTest;                                         \
   bool tab_is_active_for_testing() const {                                     \
     return tab_is_active_;                                                     \
   }                                                                            \

--- a/chromium_src/components/web_modal/web_contents_modal_dialog_manager.h
+++ b/chromium_src/components/web_modal/web_contents_modal_dialog_manager.h
@@ -6,11 +6,11 @@
 #ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_WEB_MODAL_WEB_CONTENTS_MODAL_DIALOG_MANAGER_H_
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_WEB_MODAL_WEB_CONTENTS_MODAL_DIALOG_MANAGER_H_
 
-class SplitViewCommonBrowserTest;
+class SplitViewBrowserTest;
 
-#define FocusTopmostDialog                   \
-  OnTabActiveStateChanged();                 \
-  friend class ::SplitViewCommonBrowserTest; \
+#define FocusTopmostDialog             \
+  OnTabActiveStateChanged();           \
+  friend class ::SplitViewBrowserTest; \
   void FocusTopmostDialog
 
 #include <components/web_modal/web_contents_modal_dialog_manager.h>  // IWYU pragma: export


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves - no issue. simple renaming.

Test fixture name is unified to SplitViewBrowserTest.
When we did migration from brave's split view to upstream's,
we had to maintain different tests for both mode.
For that, we used two SplitViewCommonXXX and SideBySideXXX test fixture.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
