### PR TITLE
[iOS] Aggressive Cache-first Playlist system

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/PlaylistSettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/PlaylistSettingsViewController.swift
@@ -45,8 +45,11 @@ struct PlaylistSettingsView: View {
         Text(Strings.PlayList.playlistAutoPlaySettingsOptionFooterText)
       }
 
+      // Only surface the cache preference for the opt-in offline-cache path. Cache-first
+      // ignores this preference (it caches every item), so hide it when cache-first is enabled or
+      // when offline caching isn't enabled at all.
       if FeatureList.kPlaylistOfflineCacheEnabled.enabled
-        || FeatureList.kPlaylistCacheFirstEnabled.enabled
+        && !FeatureList.kPlaylistCacheFirstEnabled.enabled
       {
         Section {
           Picker(

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/PlaylistSettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/PlaylistSettingsViewController.swift
@@ -44,7 +44,10 @@ struct PlaylistSettingsView: View {
       } footer: {
         Text(Strings.PlayList.playlistAutoPlaySettingsOptionFooterText)
       }
-      if FeatureList.kPlaylistOfflineCacheEnabled.enabled {
+
+      if FeatureList.kPlaylistOfflineCacheEnabled.enabled
+        || FeatureList.kPlaylistCacheFirstEnabled.enabled
+      {
         Section {
           Picker(
             Strings.PlayList.playlistAutoSaveSettingsTitle,

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdvancedShieldSettings.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdvancedShieldSettings.swift
@@ -19,7 +19,7 @@ import os
   struct ClearableSetting: Identifiable {
     enum ClearableType: String {
       case history, cache, cookiesAndCache, passwords, siteAndShieldsSettings,
-        downloads, braveNews, recentSearches, braveAdsData
+        downloads, braveNews, recentSearches, braveAdsData, playlistCache
     }
 
     var id: ClearableType
@@ -255,6 +255,12 @@ import os
           clearable: BraveNewsClearable(feedDataSource: feedDataSource),
           isEnabled: true
         )
+      )
+    }
+
+    if braveCore.profile.prefs.isPlaylistAvailable {
+      clearableSettings.append(
+        ClearableSetting(id: .playlistCache, clearable: PlayListCacheClearable(), isEnabled: false)
       )
     }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/Clearables.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/Clearables.swift
@@ -8,6 +8,7 @@ import BraveShared
 import Data
 import Favicon
 import Foundation
+import Playlist
 import Shared
 import Web
 import WebKit
@@ -212,6 +213,28 @@ class BraveNewsClearable: Clearable {
 
   func clear() async throws {
     await feedDataSource.clearCachedFiles()
+  }
+}
+
+class PlayListCacheClearable: Clearable {
+
+  init() {}
+
+  var label: String {
+    return Strings.PlayList.playlistOfflineDataToggleOption
+  }
+
+  func clear() async throws {
+    await PlaylistManager.shared.deleteAllItems(cacheOnly: true)
+
+    // Backup in case there is folder corruption, so we delete the cache anyway
+    if let playlistDirectory = await PlaylistDownloadManager.playlistDirectory {
+      do {
+        try await AsyncFileManager.default.removeItem(at: playlistDirectory)
+      } catch {
+        Logger.module.error("Error Deleting Playlist directory: \(error.localizedDescription)")
+      }
+    }
   }
 }
 

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -4762,6 +4762,16 @@ extension Strings {
         comment: "Description for load resources error alert"
       )
 
+    public static let playlistOfflineDataToggleOption =
+      NSLocalizedString(
+        "playlist.playlistOfflineDataToggleOption",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Playlist Data",
+        comment:
+          "Text for Playlist Data Toggle for clearing the offline data storage in settings"
+      )
+
     public static let addToPlayListAlertTitle =
       NSLocalizedString(
         "playList.addToPlayListAlertTitle",

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -5006,7 +5006,7 @@ extension Strings {
         "playlist.playlistResetPlaylistOptionFooterText",
         tableName: "BraveShared",
         bundle: .module,
-        value: "This option will remove all videos from Playlist as well as Offline mode storage.",
+        value: "This option will remove all Playlist data.",
         comment: "Footer Text for the Playlist Settings Option for resetting Playlist."
       )
 

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -4666,7 +4666,7 @@ extension Strings {
         tableName: "BraveShared",
         bundle: .module,
         value: "Remove",
-        comment: "Title for removing offline mode storage"
+        comment: "Title for removing cached media from the playlist"
       )
 
     public static let addedToPlaylistMessage =
@@ -4928,9 +4928,9 @@ extension Strings {
         tableName: "BraveShared",
         bundle: .module,
         value:
-          "Adding video and audio files for offline use can use a lot of storage on your device as well as use your cellular data",
+          "Caching video and audio files use can use a lot of storage on your device as well as use your cellular data",
         comment:
-          "Description for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wi-fi)"
+          "Description for the Playlist Settings Option for Auto Caching media (Off/On/Only Wi-fi)"
       )
 
     public static let playlistAutoSaveSettingsFooterText =
@@ -4941,7 +4941,7 @@ extension Strings {
         value:
           "Once you've opened content in Playlist, this option will keep opened playlist items on your device so you can play them without an internet connection.",
         comment:
-          "Footer Text for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wi-fi))"
+          "Footer Text for the Playlist Settings Option for media Auto Cache (Off/On/Only Wi-fi))"
       )
 
     public static let playlistStartPlaybackSettingsOptionTitle =
@@ -4979,7 +4979,7 @@ extension Strings {
         tableName: "BraveShared",
         bundle: .module,
         value: "Off",
-        comment: "Auto Download turn Off Option"
+        comment: "Auto Cache turn Off Option"
       )
 
     public static let playlistAutoSaveOptionOnlyWifi =
@@ -4998,7 +4998,7 @@ extension Strings {
         bundle: .module,
         value: "Reset",
         comment:
-          "The title for the alert that shows up when removing all videos and their offline mode storage."
+          "The title for the alert that shows up when removing all playlist data."
       )
 
     public static let playlistResetPlaylistOptionFooterText =
@@ -5025,7 +5025,7 @@ extension Strings {
         tableName: "BraveShared",
         bundle: .module,
         value:
-          "Your device is low on space. Adding this video to Playlist may fail or affect other downloads.",
+          "Your device is low on space. Adding this video to Playlist may fail or affect other cached videos.",
         comment: "When the user's disk space is almost full"
       )
 

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -4769,7 +4769,7 @@ extension Strings {
         bundle: .module,
         value: "Playlist Data",
         comment:
-          "Text for Playlist Data Toggle for clearing the offline data storage in settings"
+          "Text for Playlist Data Toggle for clearing the cache in settings"
       )
 
     public static let addToPlayListAlertTitle =

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -4928,7 +4928,7 @@ extension Strings {
         tableName: "BraveShared",
         bundle: .module,
         value:
-          "Caching video and audio files use can use a lot of storage on your device as well as use your cellular data",
+          "Caching video and audio files can consume both cellular data and storage space on your device",
         comment:
           "Description for the Playlist Settings Option for Auto Caching media (Off/On/Only Wi-fi)"
       )

--- a/ios/brave-ios/Sources/Playlist/PlaylistDownloadManager.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistDownloadManager.swift
@@ -15,7 +15,7 @@ protocol PlaylistDownloadManagerDelegate: AnyObject {
   func onDownloadProgressUpdate(id: String, percentComplete: Double)
   func onDownloadStateChanged(
     id: String,
-    state: PlaylistDownloadManager.DownloadState,
+    state: PlaylistDownloadManager.CacheState,
     displayName: String?,
     error: Error?
   )
@@ -29,7 +29,7 @@ private protocol PlaylistStreamDownloadManagerDelegate: AnyObject {
   func onDownloadStateChanged(
     streamDownloader: Any,
     id: String,
-    state: PlaylistDownloadManager.DownloadState,
+    state: PlaylistDownloadManager.CacheState,
     displayName: String?,
     error: Error?
   )
@@ -70,8 +70,8 @@ public class PlaylistDownloadManager: PlaylistStreamDownloadManagerDelegate {
     }
   }
 
-  public enum DownloadState: String {
-    case downloaded
+  public enum CacheState: String {
+    case cached
     case inProgress
     case invalid
   }
@@ -290,7 +290,7 @@ public class PlaylistDownloadManager: PlaylistStreamDownloadManagerDelegate {
   fileprivate func onDownloadStateChanged(
     streamDownloader: Any,
     id: String,
-    state: PlaylistDownloadManager.DownloadState,
+    state: PlaylistDownloadManager.CacheState,
     displayName: String?,
     error: Error?
   ) {
@@ -527,7 +527,7 @@ private class PlaylistHLSDownloadManager: NSObject, AVAssetDownloadDelegate {
       let temporaryUrl = temporaryUrl
     else { return }
 
-    // This method will delete the downloaded file immediately after this delegate method returns
+    // This method will delete the cached file immediately after this delegate method returns
     // so we must synchonously move the file to a temporary directory first before processing it
     // on a different thread since the Task will execute after this method returns
     let assetUrl = FileManager.default.temporaryDirectory
@@ -643,7 +643,7 @@ private class PlaylistHLSDownloadManager: NSObject, AVAssetDownloadDelegate {
               self.delegate?.onDownloadStateChanged(
                 streamDownloader: self,
                 id: asset.id,
-                state: .downloaded,
+                state: .cached,
                 displayName: nil,
                 error: nil
               )
@@ -877,7 +877,7 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
         }
       } catch {
         Logger.module.error(
-          "Error mapping downloaded playlist file to virtual memory: \(error.localizedDescription)"
+          "Error mapping cached playlist file to virtual memory: \(error.localizedDescription)"
         )
       }
     }
@@ -917,7 +917,7 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
     if let response = downloadTask.response as? HTTPURLResponse,
       response.statusCode == 302 || response.statusCode >= 200 && response.statusCode <= 299
     {
-      // This method will delete the downloaded file immediately after this delegate method returns
+      // This method will delete the cached file immediately after this delegate method returns
       // so we must synchonously move the file to a temporary directory first before processing it
       // on a different thread since the Task will execute after this method returns
       let temporaryLocation = FileManager.default.temporaryDirectory
@@ -957,7 +957,7 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
               self.delegate?.onDownloadStateChanged(
                 streamDownloader: self,
                 id: asset.id,
-                state: .downloaded,
+                state: .cached,
                 displayName: nil,
                 error: nil
               )
@@ -1190,7 +1190,7 @@ private class PlaylistDataDownloadManager: NSObject, URLSessionDataDelegate {
             self.delegate?.onDownloadStateChanged(
               streamDownloader: self,
               id: asset.id,
-              state: .downloaded,
+              state: .cached,
               displayName: nil,
               error: nil
             )

--- a/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
@@ -346,7 +346,9 @@ public class PlaylistManager: NSObject {
   }
 
   public func download(item: PlaylistInfo) {
-    guard FeatureList.kPlaylistOfflineCacheEnabled.enabled,
+    guard
+      FeatureList.kPlaylistOfflineCacheEnabled.enabled
+        || FeatureList.kPlaylistCacheFirstEnabled.enabled,
       downloadManager.downloadTask(for: item.tagId) == nil,
       let assetUrl = URL(string: item.src)
     else { return }
@@ -359,7 +361,11 @@ public class PlaylistManager: NSObject {
       }
 
       let mimeType = await PlaylistMediaStreamer.getMimeType(assetUrl)
-      guard let mimeType = mimeType?.lowercased() else { return }
+      guard let mimeType = mimeType?.lowercased() else {
+        // Could not resolve the asset. Emit an explicit failure so cache-first tap-to-play can surface an error instead of waiting forever.
+        onDownloadStateChanged(id: item.tagId, state: .invalid, displayName: nil, error: nil)
+        return
+      }
 
       if mimeType.contains("x-mpegurl") || mimeType.contains("application/vnd.apple.mpegurl")
         || mimeType.contains("mpegurl")

--- a/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
@@ -655,6 +655,10 @@ public class PlaylistManager: NSObject {
       return false
     }
 
+    if FeatureList.kPlaylistCacheFirstEnabled.enabled {
+      return true
+    }
+
     let downloadType = PlayListDownloadType(
       rawValue: Preferences.Playlist.autoDownloadVideo.value
     )

--- a/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
@@ -656,7 +656,7 @@ public class PlaylistManager: NSObject {
     }
 
     if FeatureList.kPlaylistCacheFirstEnabled.enabled {
-      return true
+      return Reachability.shared.status.connectionType == .wifi
     }
 
     let downloadType = PlayListDownloadType(

--- a/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
@@ -345,6 +345,11 @@ public class PlaylistManager: NSObject {
     }
   }
 
+  public static var usesLegacyCaching: Bool {
+    FeatureList.kPlaylistOfflineCacheEnabled.enabled
+      && !FeatureList.kPlaylistCacheFirstEnabled.enabled
+  }
+
   public func download(item: PlaylistInfo) {
     guard
       FeatureList.kPlaylistOfflineCacheEnabled.enabled

--- a/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
@@ -21,7 +21,7 @@ public class PlaylistManager: NSObject {
   public static let shared = PlaylistManager()
 
   private var assetInformation = [PlaylistAssetFetcher]()
-  private let downloadManager = PlaylistDownloadManager()
+  private let cacheManager = PlaylistDownloadManager()
   private var frc = PlaylistItem.frc()
   private var didRestoreSession = false
 
@@ -59,7 +59,7 @@ public class PlaylistManager: NSObject {
   private let onDownloadStateChanged = PassthroughSubject<
     (
       id: String,
-      state: PlaylistDownloadManager.DownloadState,
+      state: PlaylistDownloadManager.CacheState,
       displayName: String?,
       error: Error?
     ), Never
@@ -70,7 +70,7 @@ public class PlaylistManager: NSObject {
   private override init() {
     super.init()
 
-    downloadManager.delegate = self
+    cacheManager.delegate = self
     frc.delegate = self
 
     let sevenDays =
@@ -137,7 +137,7 @@ public class PlaylistManager: NSObject {
   public var downloadStateChanged:
     AnyPublisher<
       (
-        id: String, state: PlaylistDownloadManager.DownloadState, displayName: String?,
+        id: String, state: PlaylistDownloadManager.CacheState, displayName: String?,
         error: Error?
       ), Never
     >
@@ -240,30 +240,15 @@ public class PlaylistManager: NSObject {
     }
   }
 
-  @available(*, deprecated, renamed: "downloadState(for:)", message: "Use async version")
-  public func state(for itemId: String) -> PlaylistDownloadManager.DownloadState {
-    if downloadManager.downloadTask(for: itemId) != nil {
+  public func cacheState(for itemId: String) async -> PlaylistDownloadManager.CacheState {
+    if cacheManager.downloadTask(for: itemId) != nil {
       return .inProgress
     }
 
-    if let assetUrl = downloadManager.localAssetSynchronous(for: itemId)?.url {
-      if FileManager.default.fileExists(atPath: assetUrl.path) {
-        return .downloaded
-      }
-    }
-
-    return .invalid
-  }
-
-  public func downloadState(for itemId: String) async -> PlaylistDownloadManager.DownloadState {
-    if downloadManager.downloadTask(for: itemId) != nil {
-      return .inProgress
-    }
-
-    if let assetUrl = await downloadManager.localAsset(for: itemId)?.url,
+    if let assetUrl = await cacheManager.localAsset(for: itemId)?.url,
       await AsyncFileManager.default.fileExists(atPath: assetUrl.path)
     {
-      return .downloaded
+      return .cached
     }
 
     return .invalid
@@ -272,7 +257,7 @@ public class PlaylistManager: NSObject {
   @available(iOS, deprecated)
   public func sizeOfDownloadedItemSynchronous(for itemId: String) -> String? {
     var isDirectory: ObjCBool = false
-    if let asset = downloadManager.localAssetSynchronous(for: itemId),
+    if let asset = cacheManager.localAssetSynchronous(for: itemId),
       FileManager.default.fileExists(atPath: asset.url.path, isDirectory: &isDirectory)
     {
 
@@ -323,7 +308,7 @@ public class PlaylistManager: NSObject {
 
   public func restoreSession() {
     if !didRestoreSession {
-      downloadManager.restoreSession { [weak self] in
+      cacheManager.restoreSession { [weak self] in
         self?.reloadData()
       }
     }
@@ -345,49 +330,40 @@ public class PlaylistManager: NSObject {
     }
   }
 
-  public static var usesLegacyCaching: Bool {
-    FeatureList.kPlaylistOfflineCacheEnabled.enabled
-      && !FeatureList.kPlaylistCacheFirstEnabled.enabled
-  }
-
   public func download(item: PlaylistInfo) {
     guard
       FeatureList.kPlaylistOfflineCacheEnabled.enabled
         || FeatureList.kPlaylistCacheFirstEnabled.enabled,
-      downloadManager.downloadTask(for: item.tagId) == nil,
+      cacheManager.downloadTask(for: item.tagId) == nil,
       let assetUrl = URL(string: item.src)
     else { return }
     Task {
       if assetUrl.scheme == "data" {
         DispatchQueue.main.async {
-          self.downloadManager.downloadDataAsset(assetUrl, for: item)
+          self.cacheManager.downloadDataAsset(assetUrl, for: item)
         }
         return
       }
 
       let mimeType = await PlaylistMediaStreamer.getMimeType(assetUrl)
-      guard let mimeType = mimeType?.lowercased() else {
-        // Could not resolve the asset. Emit an explicit failure so cache-first tap-to-play can surface an error instead of waiting forever.
-        onDownloadStateChanged(id: item.tagId, state: .invalid, displayName: nil, error: nil)
-        return
-      }
+      guard let mimeType = mimeType?.lowercased() else { return }
 
       if mimeType.contains("x-mpegurl") || mimeType.contains("application/vnd.apple.mpegurl")
         || mimeType.contains("mpegurl")
       {
         DispatchQueue.main.async {
-          self.downloadManager.downloadHLSAsset(assetUrl, for: item)
+          self.cacheManager.downloadHLSAsset(assetUrl, for: item)
         }
       } else {
         DispatchQueue.main.async {
-          self.downloadManager.downloadFileAsset(assetUrl, for: item)
+          self.cacheManager.downloadFileAsset(assetUrl, for: item)
         }
       }
     }
   }
 
   public func cancelDownload(itemId: String) {
-    downloadManager.cancelDownload(itemId: itemId)
+    cacheManager.cancelDownload(itemId: itemId)
   }
 
   @MainActor public func delete(folder: PlaylistFolder) async -> Bool {
@@ -727,7 +703,7 @@ public class PlaylistManager: NSObject {
     return nil
   }
 
-  /// Clears the persisted `cachedData` bookmark for `itemId` and notifies observers that the item is no longer downloaded.
+  /// Clears the persisted `cachedData` bookmark for `itemId` and notifies observers that the item is no longer cached.
   /// Cancels any in-flight download as well so the item ends up in a fully invalid state.
   /// No-op if the item is gone or already has no cached bookmark.
   @MainActor private func invalidateCachedState(for itemId: String) {
@@ -748,11 +724,11 @@ public class PlaylistManager: NSObject {
 extension PlaylistManager {
   @available(*, deprecated, renamed: "asset(for:mediaSrc:)", message: "Use async version")
   private func assetSynchronous(for itemId: String, mediaSrc: String) -> AVURLAsset {
-    if let task = downloadManager.downloadTask(for: itemId) {
+    if let task = cacheManager.downloadTask(for: itemId) {
       return task.asset
     }
 
-    if let asset = downloadManager.localAssetSynchronous(for: itemId) {
+    if let asset = cacheManager.localAssetSynchronous(for: itemId) {
       return asset
     }
 
@@ -760,11 +736,11 @@ extension PlaylistManager {
   }
 
   private func asset(for itemId: String, mediaSrc: String) async -> AVURLAsset {
-    if let task = downloadManager.downloadTask(for: itemId) {
+    if let task = cacheManager.downloadTask(for: itemId) {
       return task.asset
     }
 
-    if let asset = await downloadManager.localAsset(for: itemId) {
+    if let asset = await cacheManager.localAsset(for: itemId) {
       return asset
     }
 
@@ -779,7 +755,7 @@ extension PlaylistManager: PlaylistDownloadManagerDelegate {
 
   func onDownloadStateChanged(
     id: String,
-    state: PlaylistDownloadManager.DownloadState,
+    state: PlaylistDownloadManager.CacheState,
     displayName: String?,
     error: Error?
   ) {

--- a/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
@@ -657,6 +657,7 @@ public class PlaylistManager: NSObject {
 
     if FeatureList.kPlaylistCacheFirstEnabled.enabled {
       return Reachability.shared.status.connectionType == .wifi
+        || Reachability.shared.status.connectionType == .ethernet
     }
 
     let downloadType = PlayListDownloadType(

--- a/ios/brave-ios/Sources/Playlist/PlaylistMediaStreamer.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistMediaStreamer.swift
@@ -4,6 +4,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import AVFoundation
+import BraveCore
 import BraveShared
 import Combine
 import Data
@@ -58,6 +59,13 @@ public class PlaylistMediaStreamer {
     // It's possible the URL expired..
     if !isStreamable {
       return try await streamingFallback(item)
+    }
+
+    // Cache-first: the stored URL is still valid, so `streamingFallback` (which would otherwise kick off caching via `autoDownload`)
+    // isn't reached. Start a background cache here so the item is available locally next time. Gated on the kPlaylistCacheFirstEnabled
+    // flag so the kPlaylistOfflineCacheEnabled offline-cache path  is unaffected.
+    if FeatureList.kPlaylistCacheFirstEnabled.enabled {
+      PlaylistManager.shared.autoDownload(item: item)
     }
 
     return item

--- a/ios/brave-ios/Sources/Playlist/PlaylistMediaStreamer.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistMediaStreamer.swift
@@ -36,11 +36,12 @@ public class PlaylistMediaStreamer {
 
   @MainActor
   public func loadMediaStreamingAsset(_ item: PlaylistInfo) async throws -> PlaylistInfo {
-    // We need to check if the item is cached locally.
-    // If the item is cached (downloaded)
-    // then we can play it directly without having to stream it.
-    let cacheState = await PlaylistManager.shared.downloadState(for: item.tagId)
-    if cacheState != .invalid {
+    // If the item is fully cached we can play it directly without streaming.
+    // A cache that is only *in progress* must NOT short-circuit here because the item's stored `src`
+    // may be stale or not directly playable. So we still resolve a fresh streamable
+    // URL while the cache continues downloading in the background.
+    let cacheState = await PlaylistManager.shared.cacheState(for: item.tagId)
+    if cacheState == .cached {
       return item
     }
 

--- a/ios/brave-ios/Sources/PlaylistUI/CarPlayController.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/CarPlayController.swift
@@ -72,7 +72,7 @@ public class CarPlayController {
   private var currentItemListTemplate: CPListTemplate?
   private var selectedFolderID: PlaylistFolder.ID?
   private var isErrorPresented: Bool = false
-  private var downloadStates: [String: PlaylistDownloadManager.DownloadState] = [:]
+  private var downloadStates: [String: PlaylistDownloadManager.CacheState] = [:]
 
   @MainActor private func updateFoldersList() {
     let folderListTemplate = self.folderListTemplate
@@ -204,7 +204,7 @@ public class CarPlayController {
         guard let itemUUID = item.uuid else { return nil }
         let listItem = item.listItem
         listItem.accessoryType =
-          downloadStates[itemUUID] != .downloaded ? .cloud : .none
+          downloadStates[itemUUID] != .cached ? .cloud : .none
         listItem.isPlaying = player.isPlaying && player.selectedItemID == item.id
         listItem.playingIndicatorLocation = .trailing
         listItem.userInfo = ["id": item.id, "uuid": itemUUID]
@@ -293,14 +293,14 @@ public class CarPlayController {
 
     // Fetch each item's download state concurrently so list refresh stays O(1) wall-clock in the number of items.
     let resolvedStates = await withTaskGroup(
-      of: (String, PlaylistDownloadManager.DownloadState).self
+      of: (String, PlaylistDownloadManager.CacheState).self
     ) { group in
       for uuid in uuids {
         group.addTask {
-          (uuid, await PlaylistManager.shared.downloadState(for: uuid))
+          (uuid, await PlaylistManager.shared.cacheState(for: uuid))
         }
       }
-      var result: [String: PlaylistDownloadManager.DownloadState] = [:]
+      var result: [String: PlaylistDownloadManager.CacheState] = [:]
       for await (uuid, state) in group {
         result[uuid] = state
       }

--- a/ios/brave-ios/Sources/PlaylistUI/CarPlayController.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/CarPlayController.swift
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import BraveCore
 import BraveStrings
 import CarPlay
 import Combine
@@ -204,7 +205,8 @@ public class CarPlayController {
         guard let itemUUID = item.uuid else { return nil }
         let listItem = item.listItem
         listItem.accessoryType =
-          downloadStates[itemUUID] != .cached ? .cloud : .none
+          !FeatureList.kPlaylistCacheFirstEnabled.enabled && downloadStates[itemUUID] != .cached
+          ? .cloud : .none
         listItem.isPlaying = player.isPlaying && player.selectedItemID == item.id
         listItem.playingIndicatorLocation = .trailing
         listItem.userInfo = ["id": item.id, "uuid": itemUUID]

--- a/ios/brave-ios/Sources/PlaylistUI/EditFolderView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/EditFolderView.swift
@@ -56,7 +56,7 @@ struct EditFolderView: View {
             duration: .init(item.duration),
             isSelected: false,
             isPlaying: false,
-            downloadState: nil
+            cacheState: nil
           )
         }
         .onMove { indexSet, offset in

--- a/ios/brave-ios/Sources/PlaylistUI/MediaContentView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/MediaContentView.swift
@@ -32,7 +32,7 @@ struct MediaContentView: View {
         .zIndex(1)
         .playlistSheetDetentAnchor(id: .mediaPlayer)
         .overlay {
-          if model.isLoadingStreamingURL || model.isCachingAssetForPlayback {
+          if model.isLoadingStreamingURL {
             ProgressView()
               .progressViewStyle(.circular)
               .transition(.opacity.animation(.default))

--- a/ios/brave-ios/Sources/PlaylistUI/MediaContentView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/MediaContentView.swift
@@ -32,7 +32,7 @@ struct MediaContentView: View {
         .zIndex(1)
         .playlistSheetDetentAnchor(id: .mediaPlayer)
         .overlay {
-          if model.isLoadingStreamingURL {
+          if model.isLoadingStreamingURL || model.isCachingAssetForPlayback {
             ProgressView()
               .progressViewStyle(.circular)
               .transition(.opacity.animation(.default))

--- a/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
@@ -639,7 +639,6 @@ public final class PlayerModel: ObservableObject {
           playerItemToReplace = await Task.detached {
             .init(asset: AVURLAsset(url: url))
           }.value
-          startCachingForPlayback(item: newItem)
         }
       } catch {
         if isPictureInPictureActive {
@@ -687,15 +686,6 @@ public final class PlayerModel: ObservableObject {
         play()
       }
     }
-  }
-
-  /// Cache-first: start a background caching task so the item becomes available locally for the next playback.
-  /// Playback begins streaming while caching. Call this only with a freshly resolved item (post-streaming), so that the download uses a valid URL.
-  /// A cache already in progress (or a completed one) is a no-op.
-  @MainActor private func startCachingForPlayback(item: PlaylistInfo) {
-    guard FeatureList.kPlaylistCacheFirstEnabled.enabled else { return }
-    guard Reachability.shared.status.connectionType != .offline else { return }
-    PlaylistManager.shared.download(item: item)
   }
 
   private func itemDurationForAssetDuration(_ duration: CMTime) -> ItemDuration {

--- a/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
@@ -4,6 +4,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import AVKit
+import BraveCore
+import BraveShared
 import BraveStrings
 import Combine
 import Data
@@ -419,6 +421,14 @@ public final class PlayerModel: ObservableObject {
   @MainActor @Published var selectedFolderID: PlaylistFolder.ID = PlaylistFolder.savedFolderUUID
   @MainActor @Published var isLoadingStreamingURL: Bool = false
 
+  /// Whether a cache-first tap-to-play is currently downloading the selected item before playback.
+  @MainActor @Published var isCachingAssetForPlayback: Bool = false
+
+  /// The `uuid` of the item whose download we started for cache-first playback, alongside whether playback should begin automatically once the download finishes.
+  /// Tracked so the download-state observer can resume the exact tap-to-play the user initiated.
+  @MainActor private var pendingPlaybackItemID: String?
+  @MainActor private var pendingPlaybackPlayImmediately: Bool = false
+
   var itemQueue: OrderedSet<PlaylistItem.ID> = []
   var seekToInitialTimestamp: TimeInterval?
 
@@ -576,6 +586,7 @@ public final class PlayerModel: ObservableObject {
   struct PlayerModelError: LocalizedError {
     enum Reason {
       case loadingStreamingURLFailed(PlaylistMediaStreamer.PlaybackError)
+      case cacheForPlaybackFailed(offline: Bool)
       case unknown
     }
     var reason: Reason
@@ -588,6 +599,8 @@ public final class PlayerModel: ObservableObject {
         return Strings.PlayList.expiredAlertTitle
       case .loadingStreamingURLFailed(.cannotLoadMedia):
         return Strings.PlayList.sorryAlertTitle
+      case .cacheForPlaybackFailed:
+        return Strings.PlayList.sorryAlertTitle
       default:
         return Strings.Playlist.somethingWentWrong
       }
@@ -598,6 +611,8 @@ public final class PlayerModel: ObservableObject {
       case .loadingStreamingURLFailed(.expired):
         return Strings.PlayList.expiredAlertDescription
       case .loadingStreamingURLFailed(.cannotLoadMedia):
+        return Strings.PlayList.loadResourcesErrorAlertDescription
+      case .cacheForPlaybackFailed:
         return Strings.PlayList.loadResourcesErrorAlertDescription
       default:
         return nil
@@ -615,6 +630,10 @@ public final class PlayerModel: ObservableObject {
     playImmediately: Bool
   ) async {
     guard let item = selectedItem else { return }
+    // The user has moved on so drop any cache-first download we were waiting on.
+    if let pendingID = pendingPlaybackItemID, pendingID != item.uuid {
+      clearPendingPlayback()
+    }
     duration = .unknown
     var playerItemToReplace: AVPlayerItem?
     if let cachedData = item.cachedData {
@@ -622,6 +641,11 @@ public final class PlayerModel: ObservableObject {
         playerItemToReplace = await Task.detached {
           .init(asset: .init(url: cachedDataURL))
         }.value
+      }
+    }
+    if playerItemToReplace == nil, FeatureList.kPlaylistCacheFirstEnabled.enabled {
+      if await beginCacheFirstPlayback(item: item, playImmediately: playImmediately) {
+        return
       }
     }
     if playerItemToReplace == nil, let mediaStreamer {
@@ -684,6 +708,105 @@ public final class PlayerModel: ObservableObject {
         play()
       }
     }
+  }
+
+  /// Cache-first playback entry point for an item that is not yet cached on disk.
+  ///
+  /// Returns `true` when it takes ownership of playback (download kicked off/queued, or an offline error surfaced) and the caller should stop.
+  /// Returns `false` when the caller should fall through to streaming (cellular without the cache-on-cellular preference).
+  @MainActor private func beginCacheFirstPlayback(
+    item: PlaylistItem,
+    playImmediately: Bool
+  ) async -> Bool {
+    guard let itemID = item.uuid else { return true }
+    let info = PlaylistInfo(item: item)
+
+    // If the asset is already downloading, just wait for the existing task to finish.
+    if await PlaylistManager.shared.downloadState(for: info.tagId) == .inProgress {
+      markPendingPlayback(itemID: itemID, playImmediately: playImmediately)
+      return true
+    }
+
+    let autoDownloadType = PlayListDownloadType(
+      rawValue: Preferences.Playlist.autoDownloadVideo.value
+    )
+    let action = Self.cacheFirstPlaybackAction(
+      connectionType: Reachability.shared.status.connectionType,
+      autoDownloadType: autoDownloadType
+    )
+
+    switch action {
+    case .offlineError:
+      presentCacheForPlaybackError(offline: true)
+      return true
+    case .stream:
+      clearPendingPlayback()
+      return false
+    case .cache:
+      startDownloadForPlayback(item: info, itemID: itemID, playImmediately: playImmediately)
+      return true
+    }
+  }
+
+  /// The action to take when a cache-first tap-to-play targets an item that is not stored locally.
+  enum CacheFirstPlaybackAction: Equatable {
+    case offlineError
+    case stream
+    case cache
+  }
+
+  /// On cellular only download when the auto-download preference permits cellular (`.on`),
+  /// otherwise stream so as not toconsume cellular data caching the full asset.
+  static func cacheFirstPlaybackAction(
+    connectionType: ReachabilityType,
+    autoDownloadType: PlayListDownloadType?
+  ) -> CacheFirstPlaybackAction {
+    if connectionType == .offline {
+      return .offlineError
+    }
+    if connectionType == .cellular {
+      return autoDownloadType == .on ? .cache : .stream
+    }
+    return .cache
+  }
+
+  @MainActor private func startDownloadForPlayback(
+    item: PlaylistInfo,
+    itemID: String,
+    playImmediately: Bool
+  ) {
+    if !isPictureInPictureActive {
+      // Clear any stale player item so a subsequent tap doesn't seek+play against the wrong asset.
+      Task { await updateCurrentItem(nil) }
+    }
+    markPendingPlayback(itemID: itemID, playImmediately: playImmediately)
+    PlaylistManager.shared.download(item: item)
+  }
+
+  @MainActor private func markPendingPlayback(itemID: String, playImmediately: Bool) {
+    pendingPlaybackItemID = itemID
+    pendingPlaybackPlayImmediately = playImmediately
+    isCachingAssetForPlayback = true
+    isLoadingStreamingURL = true
+  }
+
+  @MainActor private func clearPendingPlayback() {
+    pendingPlaybackItemID = nil
+    pendingPlaybackPlayImmediately = false
+    isCachingAssetForPlayback = false
+    isLoadingStreamingURL = false
+  }
+
+  @MainActor private func presentCacheForPlaybackError(offline: Bool) {
+    clearPendingPlayback()
+    if isPictureInPictureActive {
+      Task { await playNextItem() }
+      return
+    }
+    error = .init(
+      reason: .cacheForPlaybackFailed(offline: offline),
+      handler: nil
+    )
   }
 
   private func itemDurationForAssetDuration(_ duration: CMTime) -> ItemDuration {
@@ -839,11 +962,42 @@ public final class PlayerModel: ObservableObject {
   private func setupPlaylistManagerObservation() {
     PlaylistManager.shared.downloadStateChanged
       .sink { [weak self] event in
-        guard let self, event.state == .downloaded else { return }
+        guard let self else { return }
         Task { @MainActor in
-          // Skip when an initial prepare is still in flight: it would race ours and could
-          // overwrite the local `AVPlayerItem` we install with a streaming one once it
-          // finishes resolving. The user can tap play once the original prepare settles.
+          let isAwaitingCacheFirstPlayback = event.id == self.pendingPlaybackItemID
+          guard event.state == .downloaded || isAwaitingCacheFirstPlayback else { return }
+          if isAwaitingCacheFirstPlayback {
+            switch event.state {
+            case .downloaded:
+              let playImmediately = self.pendingPlaybackPlayImmediately
+              let stillSelected = event.id == self.selectedItem?.uuid
+              self.clearPendingPlayback()
+              if stillSelected {
+                let resumeOffset = self.currentTime
+                await self.prepareToPlaySelectedItem(
+                  initialOffset: resumeOffset > 0 ? resumeOffset : nil,
+                  playImmediately: playImmediately
+                )
+              }
+            case .invalid:
+              // The download failed before completion; surface the standard load error, but only
+              // if the user is still waiting on this item.
+              let stillSelected = event.id == self.selectedItem?.uuid
+              self.clearPendingPlayback()
+              if stillSelected {
+                self.presentCacheForPlaybackError(offline: false)
+              }
+            case .inProgress:
+              break
+            }
+            return
+          }
+
+          // "Save offline data" path (reached only for `.downloaded` events): when the user makes
+          // the selected item available offline, the player may be holding a stale `AVPlayerItem`.
+          // Rebind it to the freshly downloaded file. Skip when an initial prepare is still in flight
+          // to prevent a data race that would overwrite the local `AVPlayerItem` we install.
+          // The user can tap play once it settles.
           guard event.id == self.selectedItem?.uuid,
             !self.isPlaying,
             !self.isLoadingStreamingURL

--- a/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
@@ -626,6 +626,26 @@ public final class PlayerModel: ObservableObject {
         }.value
       }
     }
+    if playerItemToReplace == nil,
+      Reachability.shared.status.connectionType == .offline
+    {
+      // Completely offline with no local cache to fall back on, so surface error immediately instead
+      // of waiting on a doomed stream resolution.
+      if isPictureInPictureActive {
+        // Can't show any error in PiP, so skip to the next item
+        await playNextItem()
+      } else {
+        self.error = .init(
+          reason: .loadingStreamingURLFailed(.cannotLoadMedia),
+          handler: { [weak self] in
+            Task {
+              await self?.playNextItem()
+            }
+          }
+        )
+      }
+      return
+    }
     if playerItemToReplace == nil, let mediaStreamer {
       if !isPictureInPictureActive {
         // Stop the current video and start loading the streaming video, but only if we're not

--- a/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
@@ -639,11 +639,6 @@ public final class PlayerModel: ObservableObject {
           playerItemToReplace = await Task.detached {
             .init(asset: AVURLAsset(url: url))
           }.value
-          // Cache-first: now that streaming has resolved a fresh, playable URL, kick off a
-          // background download so the item is available locally next time. This runs *after*
-          // resolution on purpose — caching the item's stored `src` up-front can hit a stale or
-          // expired URL (e.g. an old googlevideo link), which both fails the download and disrupts
-          // the live stream that shares that URL. Playback is never blocked on caching.
           startCachingForPlayback(item: newItem)
         }
       } catch {

--- a/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
@@ -696,18 +696,10 @@ public final class PlayerModel: ObservableObject {
 
   /// Cache-first: start a background caching task so the item becomes available locally for the next playback.
   /// Playback begins streaming while caching. Call this only with a freshly resolved item (post-streaming), so that the download uses a valid URL.
-  /// On cellular we only cache when the auto-download preference explicitly allows it, to avoid spending cellular data.
-  /// A cache already in progress (or a completed one) is a no-op thanks to.
+  /// A cache already in progress (or a completed one) is a no-op.
   @MainActor private func startCachingForPlayback(item: PlaylistInfo) {
     guard FeatureList.kPlaylistCacheFirstEnabled.enabled else { return }
-    let connectionType = Reachability.shared.status.connectionType
-    guard connectionType != .offline else { return }
-    if connectionType == .cellular {
-      let autoDownloadType = PlayListDownloadType(
-        rawValue: Preferences.Playlist.autoDownloadVideo.value
-      )
-      guard autoDownloadType == .on else { return }
-    }
+    guard Reachability.shared.status.connectionType != .offline else { return }
     PlaylistManager.shared.download(item: item)
   }
 

--- a/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
@@ -421,14 +421,6 @@ public final class PlayerModel: ObservableObject {
   @MainActor @Published var selectedFolderID: PlaylistFolder.ID = PlaylistFolder.savedFolderUUID
   @MainActor @Published var isLoadingStreamingURL: Bool = false
 
-  /// Whether a cache-first tap-to-play is currently downloading the selected item before playback.
-  @MainActor @Published var isCachingAssetForPlayback: Bool = false
-
-  /// The `uuid` of the item whose download we started for cache-first playback, alongside whether playback should begin automatically once the download finishes.
-  /// Tracked so the download-state observer can resume the exact tap-to-play the user initiated.
-  @MainActor private var pendingPlaybackItemID: String?
-  @MainActor private var pendingPlaybackPlayImmediately: Bool = false
-
   var itemQueue: OrderedSet<PlaylistItem.ID> = []
   var seekToInitialTimestamp: TimeInterval?
 
@@ -586,7 +578,6 @@ public final class PlayerModel: ObservableObject {
   struct PlayerModelError: LocalizedError {
     enum Reason {
       case loadingStreamingURLFailed(PlaylistMediaStreamer.PlaybackError)
-      case cacheForPlaybackFailed(offline: Bool)
       case unknown
     }
     var reason: Reason
@@ -599,8 +590,6 @@ public final class PlayerModel: ObservableObject {
         return Strings.PlayList.expiredAlertTitle
       case .loadingStreamingURLFailed(.cannotLoadMedia):
         return Strings.PlayList.sorryAlertTitle
-      case .cacheForPlaybackFailed:
-        return Strings.PlayList.sorryAlertTitle
       default:
         return Strings.Playlist.somethingWentWrong
       }
@@ -611,8 +600,6 @@ public final class PlayerModel: ObservableObject {
       case .loadingStreamingURLFailed(.expired):
         return Strings.PlayList.expiredAlertDescription
       case .loadingStreamingURLFailed(.cannotLoadMedia):
-        return Strings.PlayList.loadResourcesErrorAlertDescription
-      case .cacheForPlaybackFailed:
         return Strings.PlayList.loadResourcesErrorAlertDescription
       default:
         return nil
@@ -630,10 +617,6 @@ public final class PlayerModel: ObservableObject {
     playImmediately: Bool
   ) async {
     guard let item = selectedItem else { return }
-    // The user has moved on so drop any cache-first download we were waiting on.
-    if let pendingID = pendingPlaybackItemID, pendingID != item.uuid {
-      clearPendingPlayback()
-    }
     duration = .unknown
     var playerItemToReplace: AVPlayerItem?
     if let cachedData = item.cachedData {
@@ -641,11 +624,6 @@ public final class PlayerModel: ObservableObject {
         playerItemToReplace = await Task.detached {
           .init(asset: .init(url: cachedDataURL))
         }.value
-      }
-    }
-    if playerItemToReplace == nil, FeatureList.kPlaylistCacheFirstEnabled.enabled {
-      if await beginCacheFirstPlayback(item: item, playImmediately: playImmediately) {
-        return
       }
     }
     if playerItemToReplace == nil, let mediaStreamer {
@@ -661,6 +639,12 @@ public final class PlayerModel: ObservableObject {
           playerItemToReplace = await Task.detached {
             .init(asset: AVURLAsset(url: url))
           }.value
+          // Cache-first: now that streaming has resolved a fresh, playable URL, kick off a
+          // background download so the item is available locally next time. This runs *after*
+          // resolution on purpose — caching the item's stored `src` up-front can hit a stale or
+          // expired URL (e.g. an old googlevideo link), which both fails the download and disrupts
+          // the live stream that shares that URL. Playback is never blocked on caching.
+          startCachingForPlayback(item: newItem)
         }
       } catch {
         if isPictureInPictureActive {
@@ -710,103 +694,21 @@ public final class PlayerModel: ObservableObject {
     }
   }
 
-  /// Cache-first playback entry point for an item that is not yet cached on disk.
-  ///
-  /// Returns `true` when it takes ownership of playback (download kicked off/queued, or an offline error surfaced) and the caller should stop.
-  /// Returns `false` when the caller should fall through to streaming (cellular without the cache-on-cellular preference).
-  @MainActor private func beginCacheFirstPlayback(
-    item: PlaylistItem,
-    playImmediately: Bool
-  ) async -> Bool {
-    guard let itemID = item.uuid else { return true }
-    let info = PlaylistInfo(item: item)
-
-    // If the asset is already downloading, just wait for the existing task to finish.
-    if await PlaylistManager.shared.downloadState(for: info.tagId) == .inProgress {
-      markPendingPlayback(itemID: itemID, playImmediately: playImmediately)
-      return true
-    }
-
-    let autoDownloadType = PlayListDownloadType(
-      rawValue: Preferences.Playlist.autoDownloadVideo.value
-    )
-    let action = Self.cacheFirstPlaybackAction(
-      connectionType: Reachability.shared.status.connectionType,
-      autoDownloadType: autoDownloadType
-    )
-
-    switch action {
-    case .offlineError:
-      presentCacheForPlaybackError(offline: true)
-      return true
-    case .stream:
-      clearPendingPlayback()
-      return false
-    case .cache:
-      startDownloadForPlayback(item: info, itemID: itemID, playImmediately: playImmediately)
-      return true
-    }
-  }
-
-  /// The action to take when a cache-first tap-to-play targets an item that is not stored locally.
-  enum CacheFirstPlaybackAction: Equatable {
-    case offlineError
-    case stream
-    case cache
-  }
-
-  /// On cellular only download when the auto-download preference permits cellular (`.on`),
-  /// otherwise stream so as not toconsume cellular data caching the full asset.
-  static func cacheFirstPlaybackAction(
-    connectionType: ReachabilityType,
-    autoDownloadType: PlayListDownloadType?
-  ) -> CacheFirstPlaybackAction {
-    if connectionType == .offline {
-      return .offlineError
-    }
+  /// Cache-first: start a background caching task so the item becomes available locally for the next playback.
+  /// Playback begins streaming while caching. Call this only with a freshly resolved item (post-streaming), so that the download uses a valid URL.
+  /// On cellular we only cache when the auto-download preference explicitly allows it, to avoid spending cellular data.
+  /// A cache already in progress (or a completed one) is a no-op thanks to.
+  @MainActor private func startCachingForPlayback(item: PlaylistInfo) {
+    guard FeatureList.kPlaylistCacheFirstEnabled.enabled else { return }
+    let connectionType = Reachability.shared.status.connectionType
+    guard connectionType != .offline else { return }
     if connectionType == .cellular {
-      return autoDownloadType == .on ? .cache : .stream
+      let autoDownloadType = PlayListDownloadType(
+        rawValue: Preferences.Playlist.autoDownloadVideo.value
+      )
+      guard autoDownloadType == .on else { return }
     }
-    return .cache
-  }
-
-  @MainActor private func startDownloadForPlayback(
-    item: PlaylistInfo,
-    itemID: String,
-    playImmediately: Bool
-  ) {
-    if !isPictureInPictureActive {
-      // Clear any stale player item so a subsequent tap doesn't seek+play against the wrong asset.
-      Task { await updateCurrentItem(nil) }
-    }
-    markPendingPlayback(itemID: itemID, playImmediately: playImmediately)
     PlaylistManager.shared.download(item: item)
-  }
-
-  @MainActor private func markPendingPlayback(itemID: String, playImmediately: Bool) {
-    pendingPlaybackItemID = itemID
-    pendingPlaybackPlayImmediately = playImmediately
-    isCachingAssetForPlayback = true
-    isLoadingStreamingURL = true
-  }
-
-  @MainActor private func clearPendingPlayback() {
-    pendingPlaybackItemID = nil
-    pendingPlaybackPlayImmediately = false
-    isCachingAssetForPlayback = false
-    isLoadingStreamingURL = false
-  }
-
-  @MainActor private func presentCacheForPlaybackError(offline: Bool) {
-    clearPendingPlayback()
-    if isPictureInPictureActive {
-      Task { await playNextItem() }
-      return
-    }
-    error = .init(
-      reason: .cacheForPlaybackFailed(offline: offline),
-      handler: nil
-    )
   }
 
   private func itemDurationForAssetDuration(_ duration: CMTime) -> ItemDuration {
@@ -956,48 +858,17 @@ public final class PlayerModel: ObservableObject {
   /// from an earlier prepare — typically a streaming URL that was resolved because the item's `cachedData` bookmark survived an
   /// eviction of the actual file. In that state, `play()`'s smart recovery doesn't fire (it only triggers when `currentItem == nil`),
   /// so a tap on play just runs `seek+play` against the stale asset and the user sees nothing happen. Replacing `currentItem`
-  /// with one backed by the freshly downloaded file unblocks the next play tap deterministically.
+  /// with one backed by the freshly cached file unblocks the next play tap deterministically.
   ///
   /// Note: The player is not interrupted if it is actively playing a different content
   private func setupPlaylistManagerObservation() {
     PlaylistManager.shared.downloadStateChanged
       .sink { [weak self] event in
-        guard let self else { return }
+        guard let self, event.state == .cached else { return }
         Task { @MainActor in
-          let isAwaitingCacheFirstPlayback = event.id == self.pendingPlaybackItemID
-          guard event.state == .downloaded || isAwaitingCacheFirstPlayback else { return }
-          if isAwaitingCacheFirstPlayback {
-            switch event.state {
-            case .downloaded:
-              let playImmediately = self.pendingPlaybackPlayImmediately
-              let stillSelected = event.id == self.selectedItem?.uuid
-              self.clearPendingPlayback()
-              if stillSelected {
-                let resumeOffset = self.currentTime
-                await self.prepareToPlaySelectedItem(
-                  initialOffset: resumeOffset > 0 ? resumeOffset : nil,
-                  playImmediately: playImmediately
-                )
-              }
-            case .invalid:
-              // The download failed before completion; surface the standard load error, but only
-              // if the user is still waiting on this item.
-              let stillSelected = event.id == self.selectedItem?.uuid
-              self.clearPendingPlayback()
-              if stillSelected {
-                self.presentCacheForPlaybackError(offline: false)
-              }
-            case .inProgress:
-              break
-            }
-            return
-          }
-
-          // "Save offline data" path (reached only for `.downloaded` events): when the user makes
-          // the selected item available offline, the player may be holding a stale `AVPlayerItem`.
-          // Rebind it to the freshly downloaded file. Skip when an initial prepare is still in flight
-          // to prevent a data race that would overwrite the local `AVPlayerItem` we install.
-          // The user can tap play once it settles.
+          // Skip when an initial prepare is still in flight: it would race ours and could
+          // overwrite the local `AVPlayerItem` we install with a streaming one once it
+          // finishes resolving. The user can tap play once the original prepare settles.
           guard event.id == self.selectedItem?.uuid,
             !self.isPlaying,
             !self.isLoadingStreamingURL

--- a/ios/brave-ios/Sources/PlaylistUI/PlaylistItemList.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaylistItemList.swift
@@ -3,7 +3,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import BraveCore
 import Data
 import Foundation
 import Playlist
@@ -90,7 +89,8 @@ struct PlaylistItemList: View {
             } label: {
               Label(Strings.Playlist.removeOfflineData, braveSystemImage: "leo.cloud.off")
             }
-          } else if FeatureList.kPlaylistOfflineCacheEnabled.enabled {
+          } else if PlaylistManager.usesLegacyCaching {
+            // Only meaningful under legacy opt-in caching; Cache-first auto-downloads every item.
             Button {
               PlaylistManager.shared.download(item: .init(item: item))
             } label: {

--- a/ios/brave-ios/Sources/PlaylistUI/PlaylistItemList.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaylistItemList.swift
@@ -56,6 +56,11 @@ struct PlaylistItemList: View {
             isSelected: selectedItemID == item.id,
             isPlaying: isPlaying,
             cacheState: {
+              // Cache-first caches every item automatically, so per-item cache status
+              // the "Preparing" progress and the ready checkmark is visual noise.
+              if FeatureList.kPlaylistCacheFirstEnabled.enabled {
+                return nil
+              }
               guard let uuid = item.uuid, let state = cacheStates[uuid] else {
                 return nil
               }
@@ -81,8 +86,10 @@ struct PlaylistItemList: View {
         .contextMenu {
           // Mirror the badge's source of truth: only offer "Remove offline data" when the cached file
           // actually exists on disk. Otherwise we'd offer to remove a phantom download for an item whose bookmark
-          // survived but whose file was wiped (e.g. by iOS reclaiming `com.apple.UserManagedAssets*`).
-          if let uuid = item.uuid, cacheStates[uuid] == .cached {
+          // survived but whose file was wiped (e.g. by iOS reclaiming `com.apple.UserManagedAssets*`). Cache-first manages the cache automatically
+          if let uuid = item.uuid, cacheStates[uuid] == .cached,
+            !FeatureList.kPlaylistCacheFirstEnabled.enabled
+          {
             Button {
               Task { @MainActor in
                 await PlaylistManager.shared.deleteCache(item: .init(item: item))

--- a/ios/brave-ios/Sources/PlaylistUI/PlaylistItemList.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaylistItemList.swift
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import BraveCore
 import Data
 import Foundation
 import Playlist
@@ -20,8 +21,8 @@ struct PlaylistItemList: View {
 
   @Environment(\.openTabURL) private var openTabURL
   private typealias PlaylistItemUUID = String
-  @State private var downloadStates: [PlaylistItemUUID: PlaylistDownloadManager.DownloadState] = [:]
-  @State private var downloadProgress: [PlaylistItemUUID: Double] = [:]
+  @State private var cacheStates: [PlaylistItemUUID: PlaylistDownloadManager.CacheState] = [:]
+  @State private var cacheProgress: [PlaylistItemUUID: Double] = [:]
 
   init(
     items: [PlaylistItem],
@@ -54,16 +55,16 @@ struct PlaylistItemList: View {
             duration: .init(item.duration),
             isSelected: selectedItemID == item.id,
             isPlaying: isPlaying,
-            downloadState: {
-              guard let uuid = item.uuid, let state = downloadStates[uuid] else {
+            cacheState: {
+              guard let uuid = item.uuid, let state = cacheStates[uuid] else {
                 return nil
               }
-              if state == .downloaded {
+              if state == .cached {
                 return .completed
               }
               if state == .inProgress {
                 // PlaylistDownloadManager reports percent as 0...100 not 0...1
-                let percentCompleted = downloadProgress[uuid, default: 0.0] / 100.0
+                let percentCompleted = cacheProgress[uuid, default: 0.0] / 100.0
                 return .downloading(percentComplete: percentCompleted)
               }
               return nil
@@ -81,7 +82,7 @@ struct PlaylistItemList: View {
           // Mirror the badge's source of truth: only offer "Remove offline data" when the cached file
           // actually exists on disk. Otherwise we'd offer to remove a phantom download for an item whose bookmark
           // survived but whose file was wiped (e.g. by iOS reclaiming `com.apple.UserManagedAssets*`).
-          if let uuid = item.uuid, downloadStates[uuid] == .downloaded {
+          if let uuid = item.uuid, cacheStates[uuid] == .cached {
             Button {
               Task { @MainActor in
                 await PlaylistManager.shared.deleteCache(item: .init(item: item))
@@ -89,8 +90,7 @@ struct PlaylistItemList: View {
             } label: {
               Label(Strings.Playlist.removeOfflineData, braveSystemImage: "leo.cloud.off")
             }
-          } else if PlaylistManager.usesLegacyCaching {
-            // Only meaningful under legacy opt-in caching; Cache-first auto-downloads every item.
+          } else if FeatureList.kPlaylistOfflineCacheEnabled.enabled {
             Button {
               PlaylistManager.shared.download(item: .init(item: item))
             } label: {
@@ -155,17 +155,17 @@ struct PlaylistItemList: View {
     .task {
       for item in items {
         guard let uuid = item.uuid else { continue }
-        downloadStates[uuid] = await PlaylistManager.shared.downloadState(for: uuid)
+        cacheStates[uuid] = await PlaylistManager.shared.cacheState(for: uuid)
       }
     }
     .onReceive(PlaylistManager.shared.downloadStateChanged) { output in
-      downloadStates[output.id] = output.state
-      if output.state == .downloaded, let item = items.first(where: { $0.uuid == output.id }) {
+      cacheStates[output.id] = output.state
+      if output.state == .cached, let item = items.first(where: { $0.uuid == output.id }) {
         PlaylistManager.shared.getAssetDuration(item: .init(item: item)) { _ in }
       }
     }
     .onReceive(PlaylistManager.shared.downloadProgressUpdated) { output in
-      downloadProgress[output.id] = output.percentComplete
+      cacheProgress[output.id] = output.percentComplete
     }
   }
 }

--- a/ios/brave-ios/Sources/PlaylistUI/PlaylistItemView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaylistItemView.swift
@@ -7,7 +7,7 @@ import Foundation
 import Strings
 import SwiftUI
 
-enum ItemDownloadState {
+enum ItemCacheState {
   case downloading(percentComplete: Double)
   case completed
 }
@@ -19,7 +19,7 @@ struct PlaylistItemView: View {
   var duration: PlayerModel.ItemDuration
   var isSelected: Bool
   var isPlaying: Bool
-  var downloadState: ItemDownloadState?
+  var cacheState: ItemCacheState?
 
   @ScaledMetric private var progressViewSize = 16
   // Don't need to scale the guage line width, but it looks better when it does
@@ -66,8 +66,8 @@ struct PlaylistItemView: View {
           case .unknown:
             EmptyView()
           }
-          if let downloadState {
-            switch downloadState {
+          if let cacheState {
+            switch cacheState {
             case .downloading(let percentCompleted):
               Label {
                 Text(Strings.Playlist.itemDownloadStatusPreparing)
@@ -207,7 +207,7 @@ struct LeoPlayingSoundView: View {
         duration: .seconds(3081),
         isSelected: true,
         isPlaying: false,
-        downloadState: .completed
+        cacheState: .completed
       )
     }
     Button {
@@ -217,7 +217,7 @@ struct LeoPlayingSoundView: View {
         duration: .seconds(1641),
         isSelected: false,
         isPlaying: false,
-        downloadState: .downloading(percentComplete: 0.33)
+        cacheState: .downloading(percentComplete: 0.33)
       )
     }
   }

--- a/ios/brave-ios/Sources/PlaylistUI/PlaylistSidebarList.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaylistSidebarList.swift
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import BraveCore
 import BraveShared
 import Data
 import DesignSystem
@@ -97,6 +98,11 @@ struct PlaylistSidebarListHeader: View {
   }
 
   @MainActor private func calculateTotalSizeOnDisk(for folder: PlaylistFolder) async {
+    // Cache-first hides the total size in the header, so skip the (potentially expensive) disk scan.
+    if FeatureList.kPlaylistCacheFirstEnabled.enabled {
+      totalSizeOnDisk = .init(value: 0, unit: .bytes)
+      return
+    }
     // Since we're consuming CoreData we need to make sure those accesses happen on main
     let items = selectedFolderItems
     var totalSize: Int = 0
@@ -190,7 +196,8 @@ struct PlaylistSidebarListHeader: View {
           if !items.isEmpty {
             Text(totalDuration, format: .units(width: .narrow, maximumUnitCount: 2))
           }
-          if !totalSize.value.isZero {
+          // Cache-first manages the cache automatically, so the on-disk size isn't surfaced.
+          if !totalSize.value.isZero, !FeatureList.kPlaylistCacheFirstEnabled.enabled {
             Text(totalSizeOnDisk, format: .byteCount(style: .file))
           }
         }

--- a/ios/browser/api/features/features.h
+++ b/ios/browser/api/features/features.h
@@ -95,6 +95,7 @@ OBJC_EXPORT
 @property(class, nonatomic, readonly) Feature* kSerpMetricsFeature;
 @property(class, nonatomic, readonly) Feature* kPlaylist;
 @property(class, nonatomic, readonly) Feature* kPlaylistOfflineCacheEnabled;
+@property(class, nonatomic, readonly) Feature* kPlaylistCacheFirstEnabled;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/browser/api/features/features.mm
+++ b/ios/browser/api/features/features.mm
@@ -407,4 +407,9 @@
       initWithFeature:&playlist::features::kPlaylistOfflineCacheEnabled];
 }
 
++ (Feature*)kPlaylistCacheFirstEnabled {
+  return [[Feature alloc]
+      initWithFeature:&playlist::features::kPlaylistCacheFirstEnabled];
+}
+
 @end

--- a/ios/browser/flags/about_flags.mm
+++ b/ios/browser/flags/about_flags.mm
@@ -251,23 +251,14 @@ const flags_ui::FeatureEntry::FeatureVariation
 #define BRAVE_WALLET_FEATURE_ENTRIES
 #endif
 
-#define BRAVE_PLAYLIST_FEATURE_ENTRIES                                        \
-  EXPAND_FEATURE_ENTRIES(                                                     \
-      {                                                                       \
-          "brave-playlist",                                                   \
-          "Enable Brave Playlist",                                            \
-          "Enables the Brave Playlist feature.",                              \
-          flags_ui::kOsIos,                                                   \
-          FEATURE_VALUE_TYPE(playlist::features::kPlaylist),                  \
-      },                                                                      \
-      {                                                                       \
-          "brave-playlist-cache-first",                                       \
-          "Enable Brave Playlist cache-first playback",                       \
-          "Prioritze Playlist item cache for enhanced playback"               \
-          "experience. Each item is cached to guarantee playback.",           \
-          flags_ui::kOsIos,                                                   \
-          FEATURE_VALUE_TYPE(playlist::features::kPlaylistCacheFirstEnabled), \
-      })
+#define BRAVE_PLAYLIST_FEATURE_ENTRIES                   \
+  EXPAND_FEATURE_ENTRIES({                               \
+      "brave-playlist",                                  \
+      "Enable Brave Playlist",                           \
+      "Enables the Brave Playlist feature.",             \
+      flags_ui::kOsIos,                                  \
+      FEATURE_VALUE_TYPE(playlist::features::kPlaylist), \
+  })
 
 // Keep the last item empty.
 #define LAST_BRAVE_FEATURE_ENTRIES_ITEM

--- a/ios/browser/flags/about_flags.mm
+++ b/ios/browser/flags/about_flags.mm
@@ -18,6 +18,7 @@
 #include "brave/components/playlist/core/common/features.h"
 #include "brave/components/skus/common/features.h"
 #include "brave/ios/browser/api/translate/features.h"
+#include "brave/ios/browser/playlist/features.h"
 #include "brave/ios/browser/ui/quick_view/features.h"
 #include "brave/ios/browser/ui/web_view/features.h"
 #include "build/build_config.h"
@@ -250,14 +251,23 @@ const flags_ui::FeatureEntry::FeatureVariation
 #define BRAVE_WALLET_FEATURE_ENTRIES
 #endif
 
-#define BRAVE_PLAYLIST_FEATURE_ENTRIES                   \
-  EXPAND_FEATURE_ENTRIES({                               \
-      "brave-playlist",                                  \
-      "Enable Brave Playlist",                           \
-      "Enables the Brave Playlist feature.",             \
-      flags_ui::kOsIos,                                  \
-      FEATURE_VALUE_TYPE(playlist::features::kPlaylist), \
-  })
+#define BRAVE_PLAYLIST_FEATURE_ENTRIES                                        \
+  EXPAND_FEATURE_ENTRIES(                                                     \
+      {                                                                       \
+          "brave-playlist",                                                   \
+          "Enable Brave Playlist",                                            \
+          "Enables the Brave Playlist feature.",                              \
+          flags_ui::kOsIos,                                                   \
+          FEATURE_VALUE_TYPE(playlist::features::kPlaylist),                  \
+      },                                                                      \
+      {                                                                       \
+          "brave-playlist-cache-first",                                       \
+          "Enable Brave Playlist cache-first playback",                       \
+          "Prioritze Playlist item cache for enhanced playback"               \
+          "experience. Each item is cached to guarantee playback.",           \
+          flags_ui::kOsIos,                                                   \
+          FEATURE_VALUE_TYPE(playlist::features::kPlaylistCacheFirstEnabled), \
+      })
 
 // Keep the last item empty.
 #define LAST_BRAVE_FEATURE_ENTRIES_ITEM

--- a/ios/browser/playlist/features.h
+++ b/ios/browser/playlist/features.h
@@ -11,6 +11,7 @@
 namespace playlist::features {
 
 BASE_DECLARE_FEATURE(kPlaylistOfflineCacheEnabled);
+BASE_DECLARE_FEATURE(kPlaylistCacheFirstEnabled);
 
 }  // namespace playlist::features
 

--- a/ios/browser/playlist/features.mm
+++ b/ios/browser/playlist/features.mm
@@ -10,5 +10,5 @@
 namespace playlist::features {
 
 BASE_FEATURE(kPlaylistOfflineCacheEnabled, base::FEATURE_DISABLED_BY_DEFAULT);
-
+BASE_FEATURE(kPlaylistCacheFirstEnabled, base::FEATURE_ENABLED_BY_DEFAULT);
 }

--- a/ios/browser/playlist/features.mm
+++ b/ios/browser/playlist/features.mm
@@ -10,5 +10,5 @@
 namespace playlist::features {
 
 BASE_FEATURE(kPlaylistOfflineCacheEnabled, base::FEATURE_DISABLED_BY_DEFAULT);
-BASE_FEATURE(kPlaylistCacheFirstEnabled, base::FEATURE_ENABLED_BY_DEFAULT);
+BASE_FEATURE(kPlaylistCacheFirstEnabled, base::FEATURE_DISABLED_BY_DEFAULT);
 }


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/56793

## Summary

Implements a **cache-first playback** strategy for iOS Playlist behind a new feature flag, `kPlaylistCacheFirstEnabled`. When enabled, playback checks for a locally cached copy of the item first. If one exists, it plays straight from the cache; if not, it **streams the item immediately** and **caches it in the background** so subsequent plays come from the local file.

## Test Plan

### Precondition
Enable Aggressive Caching feature: 
`Debug Settings → BraveCore Switches → Enable Features → PlaylistCacheFirstEnabled`

**Wi-Fi**
- With Cache First on and Offline Cache off, adding an item and tapping to play it works either way: if caching already finished, it plays from the local file; if caching is still in progress, it streams immediately while the cache finishes in the background. (This is the only scenario where turning Wi-Fi off matters for testing.)

**Cellular**
- With Cache First on and Offline Cache off, tapping an uncached item streams it immediately. You can confirm the item isn't cached by switching to Airplane Mode (cutting Cellular) and seeing that it fails.

**Offline (no connection)**
- With Cache First on and Offline Cache off, tapping an uncached item shows the standard load error. In PiP mode, playback just advances to the next item instead. Nothing gets cached in this case.

**Network-independent**
1. With Cache First on and Offline Cache off, opening an item's context menu or the Playlist settings hides the relevant caching controls: "Save offline data" doesn't appear in the item menu, and the auto-cache picker is hidden in Playlist settings.
2. With Cache First on and Offline Cache off, going to Settings → Clear Private Data → selecting Playlist Data removes cached files but leaves the Playlist items themselves intact.
