### PR TITLE
[android] Implement "Clear all blocked elements" option in new ShieldsUI

### DIFF
--- a/android/java/brave-res/layout/brave_shields_tab_content.xml
+++ b/android/java/brave-res/layout/brave_shields_tab_content.xml
@@ -474,12 +474,32 @@
             </LinearLayout>
 
             <View
+                android:id="@+id/clear_blocked_elements_divider"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="?attr/colorSurfaceContainer"/>
+
+            <!-- 8. Clear all blocked elements button -->
+            <TextView
+                android:id="@+id/clear_blocked_elements_button"
+                style="@style/LargeRegular"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/show_all_blocked_elements"
+                android:textColor="@color/systemfeedback_warning_text"
+                android:paddingHorizontal="16dp"
+                android:paddingVertical="12dp"
+                android:clickable="true"
+                android:focusable="true"
+                android:background="?android:attr/selectableItemBackground"/>
+
+            <View
                 android:id="@+id/reset_shields_divider"
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:background="?attr/colorSurfaceContainer"/>
 
-            <!-- 8. Reset to defaults button -->
+            <!-- 9. Reset to defaults button -->
             <TextView
                 android:id="@+id/reset_shields_button"
                 style="@style/LargeRegular"

--- a/android/java/org/chromium/chrome/browser/shields/BraveUnifiedPanelHandler.java
+++ b/android/java/org/chromium/chrome/browser/shields/BraveUnifiedPanelHandler.java
@@ -184,6 +184,8 @@ public class BraveUnifiedPanelHandler {
     private @Nullable ImageView mAdvancedOptionsArrow;
     private @Nullable TextView mResetShieldsButton;
     private @Nullable View mResetShieldsDivider;
+    private @Nullable TextView mClearBlockedElementsButton;
+    private @Nullable View mClearBlockedElementsDivider;
     private boolean mIsAdvancedOptionsExpanded;
 
     // Advanced options switches (no Forget Me in new design)
@@ -341,6 +343,7 @@ public class BraveUnifiedPanelHandler {
         }
 
         updateAdvancedOptionsSwitches(isShieldsUp);
+        updateClearBlockedElementsState();
     }
 
     private @Nullable PopupWindow showPopupMenu(@Nullable View anchorView) {
@@ -570,6 +573,15 @@ public class BraveUnifiedPanelHandler {
             }
         }
 
+        mClearBlockedElementsButton =
+                (TextView) mAdvancedOptionsContent.findViewById(R.id.clear_blocked_elements_button);
+        mClearBlockedElementsDivider =
+                mAdvancedOptionsContent.findViewById(R.id.clear_blocked_elements_divider);
+        if (mClearBlockedElementsButton != null) {
+            mClearBlockedElementsButton.setOnClickListener(v -> clearBlockedElements());
+        }
+        updateClearBlockedElementsState();
+
         mResetShieldsButton =
                 (TextView) mAdvancedOptionsContent.findViewById(R.id.reset_shields_button);
         mResetShieldsDivider = mAdvancedOptionsContent.findViewById(R.id.reset_shields_divider);
@@ -611,6 +623,23 @@ public class BraveUnifiedPanelHandler {
         int visibility = matchesDefaults ? View.GONE : View.VISIBLE;
         mResetShieldsButton.setVisibility(visibility);
         if (mResetShieldsDivider != null) mResetShieldsDivider.setVisibility(visibility);
+    }
+
+    private void clearBlockedElements() {
+        if (mUrl == null) return;
+        BraveShieldsContentSettings.resetCosmeticFilter(mUrl.getSpec());
+        updateClearBlockedElementsState();
+    }
+
+    private void updateClearBlockedElementsState() {
+        if (mClearBlockedElementsButton == null
+                || mClearBlockedElementsDivider == null
+                || mUrl == null) return;
+        boolean hasBlockedElements =
+                BraveShieldsContentSettings.areAnyBlockedElementsPresent(mUrl.getSpec());
+        int visibility = hasBlockedElements ? View.VISIBLE : View.GONE;
+        mClearBlockedElementsButton.setVisibility(visibility);
+        mClearBlockedElementsDivider.setVisibility(visibility);
     }
 
     private void openGlobalShieldsSettings() {

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -1488,6 +1488,9 @@ Are you sure you want to do this?
       <message name="IDS_BRAVE_SHIELDS_BLOCK_ELEMENT_TEXT" desc="Shields block element button label.">
         Block element
       </message>
+      <message name="IDS_SHOW_ALL_BLOCKED_ELEMENTS" desc="Text for show all block elements button.">
+        Clear all blocked elements
+      </message>
       <message name="IDS_BRAVE_SHIELDS_AUTO_SHRED_NEVER_MODE_TEXT" desc="Shields menu auto shred never mode item text.">
         Never
       </message>


### PR DESCRIPTION
The option to reset cosmetic blocked elements was not implemented in the new shields UI - this commit adds it. The option only displays if the site the user is on actually has some elements filtered out, otherwise, it simply doesn't show itself.

Resolves brave/brave-browser#56642

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
