### PR TITLE
Fix hue slider dialog horizontal overflow

### DIFF
--- a/chromium_src/ui/webui/resources/cr_components/theme_color_picker/theme_hue_slider_dialog.ts
+++ b/chromium_src/ui/webui/resources/cr_components/theme_color_picker/theme_hue_slider_dialog.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/chromium_src/ui/webui/resources/cr_components/theme_color_picker/theme_hue_slider_dialog.ts
+++ b/chromium_src/ui/webui/resources/cr_components/theme_color_picker/theme_hue_slider_dialog.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { ThemeHueSliderDialogElement } from './theme_hue_slider_dialog-chromium.js';
+
+const showAtChromium = ThemeHueSliderDialogElement.prototype.showAt;
+
+// Upstream showAt() only clamps the popup vertically within the window. On
+// narrow WebUI surfaces (e.g. the 512px wide profile customization modal) the
+// right-aligned popup can overflow horizontally and get clipped, so re-clamp
+// its left position within the viewport after upstream positioning runs.
+ThemeHueSliderDialogElement.prototype.showAt = function(
+    this: ThemeHueSliderDialogElement, anchor: HTMLElement) {
+  showAtChromium.call(this, anchor);
+
+  const padding = 8;
+  const dialog = this.$.dialog;
+  const left = parseFloat(dialog.style.left);
+  dialog.style.left = `${
+      Math.max(
+          padding,
+          Math.min(left, window.innerWidth - dialog.offsetWidth - padding))}px`;
+};
+
+export * from './theme_hue_slider_dialog-chromium.js';


### PR DESCRIPTION
Add a Brave-specific override for ThemeHueSliderDialogElement.showAt() to clamp the popup's horizontal position within the viewport. The upstream implementation only clamps vertically, causing the right-aligned popup to overflow and get clipped on narrow WebUI surfaces like the profile customization modal.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56808

## Result
<img width="1122" height="970" alt="image" src="https://github.com/user-attachments/assets/e153d2a2-4137-497e-91f9-cd4854824e36" />

<img width="1484" height="1042" alt="image" src="https://github.com/user-attachments/assets/f5ec5800-0eb4-459e-a027-85877a28b66a" />


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
