### PR TITLE
Add best practice: inject dependencies at construction (ARCH-073)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ vendor/omaha/
 .cipd
 /chromium_src/.clang-format
 /.idea/
+/.repo-map/
 /browser/resources/brave_new_tab_page_refresh/state/background_images/LICENSE
 /components/brave_new_tab_ui/data/LICENSE
 /components/brave_wallet/browser/zcash/rust/librustzcash/src/

--- a/docs/best-practices/architecture.md
+++ b/docs/best-practices/architecture.md
@@ -1754,3 +1754,51 @@ BraveWalletServiceFactory::BuildServiceInstanceForBrowserContext(
 If a feature must be fully disable-able at runtime, the service should remain
 instantiated and expose an `IsEnabled()` accessor, or callers should observe the
 pref directly.
+
+<a id="ARCH-073"></a>
+
+## ✅ Inject Dependencies at Construction; Don't Reach for Global State or `Browser*`
+
+**Features should take exactly the dependencies they need as constructor
+parameters, rather than reaching out to global state (`g_browser_process`,
+singletons, `NoDestructor` globals) or accepting a `Browser*` and drilling
+through it.** Per the Chromium browser design principles, construction-time
+dependency injection is what makes a feature modular, testable, and free of
+hidden coupling — this is a design default for all features, not just a fix for
+`components/` layering violations (see [ARCH-002](#ARCH-002)).
+
+```cpp
+// ❌ WRONG - god-object Browser* drilled for whatever it needs (untestable,
+// hidden dependencies, makes modularization impossible)
+FooFeature(Browser* browser) : browser_(browser) {}
+void FooFeature::DoStuff() {
+  DoStuffWith(browser_->profile()->GetPrefs());
+}
+
+// ❌ ALSO WRONG - reaching for ambient global state
+void FooFeature::DoStuff() {
+  auto factory = g_browser_process->shared_url_loader_factory();
+}
+
+// ✅ CORRECT - inject exactly what the feature needs at construction
+FooFeature(tabs::TabInterface& tab,
+           page_actions::PageActionController& page_action_controller)
+    : tab_(tab), page_action_controller_(page_action_controller) {}
+```
+
+Why construction-time injection is the default:
+
+- **Testability:** dependencies can be substituted directly in unit tests,
+  reducing flakiness and preventing test behavior from diverging from
+  production.
+- **Exposes circular dependencies:** injecting deps surfaces cycles at
+  construction/BUILD.gn time — a common source of fragility — instead of hiding
+  them behind globals.
+- **Reduces coupling:** avoids "spooky action at a distance" where an innocuous
+  change breaks a seemingly unrelated feature.
+
+`class Browser` is a god-object anti-pattern; depending on it makes
+modularization impossible. Pass the narrow, specific objects a feature actually
+uses (see also [ARCH-003](#ARCH-003) on passing the most specific dependency).
+
+---

--- a/docs/best-practices/architecture.md
+++ b/docs/best-practices/architecture.md
@@ -1798,7 +1798,30 @@ Why construction-time injection is the default:
   change breaks a seemingly unrelated feature.
 
 `class Browser` is a god-object anti-pattern; depending on it makes
-modularization impossible. Pass the narrow, specific objects a feature actually
-uses (see also [ARCH-003](#ARCH-003) on passing the most specific dependency).
+modularization impossible. Prefer the narrow, specific objects a feature
+actually uses (see also [ARCH-003](#ARCH-003) on passing the most specific
+dependency).
+
+This applies even when a feature genuinely needs a broad object like `Profile`
+itself: inject it rather than reaching for a global. The point of DI is not only
+to narrow the dependency — the same benefits (testability, exposing circular
+dependencies, decoupling) apply to anything reachable from `Profile`, so inject
+`Profile` (or the thing looked up from it) instead of pulling it from ambient
+global state.
+
+```cpp
+// ❌ WRONG - reaching for the profile via global state
+void FooFeature::DoStuff() {
+  Profile* profile = ProfileManager::GetActiveUserProfile();
+  UseKeyedService(BarServiceFactory::GetForProfile(profile));
+}
+
+// ✅ CORRECT - inject Profile (still preferring the narrowest dependency, but
+// inject it when Profile itself is genuinely required)
+FooFeature(Profile& profile) : profile_(profile) {}
+void FooFeature::DoStuff() {
+  UseKeyedService(BarServiceFactory::GetForProfile(&profile_.get()));
+}
+```
 
 ---

--- a/docs/best-practices/architecture.md
+++ b/docs/best-practices/architecture.md
@@ -1802,26 +1802,29 @@ modularization impossible. Prefer the narrow, specific objects a feature
 actually uses (see also [ARCH-003](#ARCH-003) on passing the most specific
 dependency).
 
-This applies even when a feature genuinely needs a broad object like `Profile`
-itself: inject it rather than reaching for a global. The point of DI is not only
-to narrow the dependency — the same benefits (testability, exposing circular
-dependencies, decoupling) apply to anything reachable from `Profile`, so inject
-`Profile` (or the thing looked up from it) instead of pulling it from ambient
-global state.
+This applies to any "lookup key" object — a broad handle used to fetch a wide
+graph of services, such as `Profile`, `BrowserContext`, `WebContents`,
+`TabInterface`, or `Browser`. Prefer injecting the specific dependencies
+resolved from the key rather than the key itself, since injecting the key still
+lets a feature reach anything reachable from it (undermining testability and
+hiding coupling). When a feature genuinely needs the key, inject the key rather
+than pulling it from a global.
 
 ```cpp
-// ❌ WRONG - reaching for the profile via global state
+// ❌ WRONG - reaching for a lookup key via global state, then resolving from it
 void FooFeature::DoStuff() {
   Profile* profile = ProfileManager::GetActiveUserProfile();
   UseKeyedService(BarServiceFactory::GetForProfile(profile));
 }
 
-// ✅ CORRECT - inject Profile (still preferring the narrowest dependency, but
-// inject it when Profile itself is genuinely required)
+// ✅ BEST - inject the specific dependency resolved from the key
+FooFeature(BarService& bar_service) : bar_service_(bar_service) {}
+void FooFeature::DoStuff() { UseKeyedService(bar_service_); }
+
+// ✅ ACCEPTABLE - inject the key itself when it is genuinely required (e.g. tab
+// features taking TabInterface); still better than reaching for a global, but
+// prefer injecting the resolved dependencies above where practical
 FooFeature(Profile& profile) : profile_(profile) {}
-void FooFeature::DoStuff() {
-  UseKeyedService(BarServiceFactory::GetForProfile(&profile_.get()));
-}
 ```
 
 ---

--- a/tools/repo_map/README.md
+++ b/tools/repo_map/README.md
@@ -1,0 +1,72 @@
+# GN dependency-frequency repo map
+
+This tool generates a compact Brave/Chrome repo map from GN direct dependency
+frequency. It is intended for agents that need a fast-to-read orientation
+artifact before searching or opening source files.
+
+It is deliberately **not** a semantic repo map. It does not use PageRank, symbol
+extraction, git history, ownership data, semantic scoring, or task-specific
+ranking. The only score is the number of inbound direct GN dependency references
+from reachable non-testonly targets.
+
+## Generate
+
+From Chromium `src`:
+
+```sh
+python3 brave/tools/repo_map/generate_dependency_map.py \
+  --out-dir out/current_link \
+  --root //brave:brave \
+  --top-areas 100 \
+  --output brave/.repo-map
+```
+
+From `src/brave`:
+
+```sh
+python3 tools/repo_map/generate_dependency_map.py \
+  --out-dir ../out/current_link \
+  --root //brave:brave \
+  --top-areas 100 \
+  --output .repo-map
+```
+
+If `--out-dir` is omitted, the script defaults to `out/current_link` (or
+`../out/current_link` from `src/brave`) and falls back to `out/Component_arm64`
+when that directory exists locally.
+
+## Output
+
+The generated `.repo-map/` directory is ignored by git. Commit the generator and
+README, not generated snapshots, unless a task explicitly asks for a snapshot.
+
+- `.repo-map/default.md` — small entry point for agents. Includes generation
+  metadata, root targets, testonly exclusion, top depended-on areas, and links to
+  per-area files. Areas with zero inbound dependency references are omitted.
+- `.repo-map/areas/<area>.md` — compact area details: score, built target count,
+  top contributing GN targets, and common source/header directories when cheap
+  to get from GN metadata.
+- `.repo-map/data/dependency_frequency.json` and `.repo-map/data/targets.json` —
+  optional machine-readable data for later tooling.
+
+## Agent workflow
+
+1. Generate or update `.repo-map/`.
+2. Read `.repo-map/default.md` first.
+3. Read only the relevant `.repo-map/areas/*.md` files.
+4. Search or open actual source files as needed.
+
+## Counting model
+
+For every reachable GN target from the root target(s):
+
+1. Skip test-only targets entirely.
+2. Inspect the direct deps of each non-testonly target.
+3. Skip deps that are test-only.
+4. Increment the dep target's count by one.
+5. Roll target labels up into coarse area keys such as `base`, `components/prefs`,
+   `brave/components/brave_wallet`, `chrome/browser`, and `content/browser`.
+
+By default, most `//third_party` and `//brave/third_party` targets are excluded,
+including Blink. Use `--include-third-party` for non-Blink third-party deps and
+`--include-blink` for Blink deps when that noise is desired.

--- a/tools/repo_map/generate_dependency_map.py
+++ b/tools/repo_map/generate_dependency_map.py
@@ -1,0 +1,640 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Generate a compact GN dependency-frequency repo map.
+
+This tool uses one inspectable GN query per reached target. It walks reachable
+direct GN dependencies from one or more product roots, excludes test-only
+targets, counts inbound direct-dependency references, rolls labels up to coarse
+repo areas, and writes compact Markdown for agents.
+"""
+
+import argparse
+import collections
+import datetime
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+from typing import Dict, Iterable, List, NamedTuple, Sequence, Set, Tuple
+
+DEFAULT_TOP_AREAS = 100
+DEFAULT_TOP_TARGETS_PER_AREA = 12
+DEFAULT_EXCLUDED_PREFIXES = (
+    "//out/",
+    "//node_modules/",
+    "//vendor/",
+    "//brave/vendor/",
+)
+THIRD_PARTY_PREFIXES = ("//third_party", "//brave/third_party")
+BLINK_PREFIX = "//third_party/blink"
+
+
+class TargetInfo(NamedTuple):
+    label: str
+    deps: List[str]
+    testonly: bool
+    sources: List[str]
+
+
+class AreaInfo(NamedTuple):
+    area: str
+    count: int
+    target_count: int
+    top_targets: List[Tuple[str, int]]
+    common_paths: List[str]
+    path: str
+
+
+def src_root_from_cwd(cwd: pathlib.Path) -> pathlib.Path:
+    """Return Chromium src root when cwd is src or src/brave."""
+    cwd = cwd.resolve()
+    if (cwd / "brave" / "BUILD.gn").exists() and (cwd / "build").exists():
+        return cwd
+    if cwd.name == "brave" and (cwd / "BUILD.gn").exists():
+        return cwd.parent
+    if (cwd / "BUILD.gn").exists() and (cwd.parent / "build").exists():
+        return cwd.parent
+    return cwd
+
+
+def brave_root_from_src(src_root: pathlib.Path) -> pathlib.Path:
+    brave_root = src_root / "brave"
+    if brave_root.exists():
+        return brave_root
+    return src_root
+
+
+def default_out_dir(cwd: pathlib.Path, src_root: pathlib.Path) -> pathlib.Path:
+    candidates = []
+    if cwd.name == "brave":
+        candidates.extend([
+            cwd.parent / "out" / "current_link",
+            cwd.parent / "out" / "Component_arm64",
+        ])
+    candidates.extend([
+        src_root / "out" / "current_link",
+        src_root / "out" / "Component_arm64",
+    ])
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return src_root / "out" / "current_link"
+
+
+def default_output_dir(cwd: pathlib.Path,
+                       src_root: pathlib.Path) -> pathlib.Path:
+    if cwd.name == "brave":
+        return cwd / ".repo-map"
+    return brave_root_from_src(src_root) / ".repo-map"
+
+
+def default_gn_binary(src_root: pathlib.Path) -> str:
+    candidates = [
+        src_root / "buildtools" / "mac" / "gn",
+        src_root / "buildtools" / "linux64" / "gn",
+        src_root / "buildtools" / "win" / "gn.exe",
+        src_root / "third_party" / "depot_tools" / "gn",
+        src_root / "brave" / "vendor" / "depot_tools" / "gn",
+    ]
+    for candidate in candidates:
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    found = shutil.which("gn")
+    if found:
+        return found
+    return "gn"
+
+
+def normalize_out_dir(path: str, cwd: pathlib.Path,
+                      src_root: pathlib.Path) -> str:
+    out_path = pathlib.Path(path).expanduser()
+    if not out_path.is_absolute():
+        out_path = (cwd / out_path).resolve()
+    try:
+        return str(out_path.relative_to(src_root))
+    except ValueError:
+        return str(out_path)
+
+
+def normalize_label(label: str) -> str:
+    label = label.strip()
+    if not label:
+        raise ValueError("empty GN label")
+    if label.startswith(":"):
+        # Keep cwd-relative labels unsupported/explicit for reproducibility.
+        raise ValueError(f"root label must be absolute, got {label!r}")
+    if not label.startswith("//"):
+        label = f"//{label}"
+    return label
+
+
+def strip_toolchain(label: str) -> str:
+    if "(" in label:
+        return label.split("(", 1)[0]
+    return label
+
+
+def label_dir(label: str) -> str:
+    label = strip_toolchain(label)
+    if not label.startswith("//"):
+        return ""
+    body = label[2:]
+    if ":" in body:
+        return body.split(":", 1)[0]
+    return body
+
+
+def sanitize_area_filename(area: str) -> str:
+    name = area.strip("/").replace("/", "__") or "root"
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", name) + ".md"
+
+
+def parse_rollup_rules(values: Sequence[str]) -> List[Tuple[str, int]]:
+    default_rules = [
+        ("brave/components", 3),
+        ("brave", 2),
+        ("components", 2),
+        ("chrome", 2),
+        ("content", 2),
+        ("ui", 2),
+        ("services", 2),
+        ("net", 1),
+        ("base", 1),
+        ("url", 1),
+    ]
+    custom_rules = []
+    for value in values:
+        if "=" not in value:
+            raise ValueError(f"--rollup must be PREFIX=DEPTH, got {value!r}")
+        prefix, depth = value.split("=", 1)
+        prefix = prefix.strip().strip("/")
+        if prefix.startswith("//"):
+            prefix = prefix[2:]
+        custom_rules.append((prefix, int(depth)))
+    return custom_rules + default_rules
+
+
+def rollup_area(label: str, rules: Sequence[Tuple[str, int]]) -> str:
+    directory = label_dir(label)
+    if not directory:
+        return "root"
+    parts = directory.split("/")
+    for prefix, depth in rules:
+        prefix_parts = prefix.split("/") if prefix else []
+        if parts[:len(prefix_parts)] == prefix_parts:
+            return "/".join(parts[:max(1, min(depth, len(parts)))])
+    return parts[0]
+
+
+def is_excluded_label(label: str, include_third_party: bool,
+                      include_blink: bool) -> bool:
+    label = strip_toolchain(label)
+    if any(label.startswith(prefix) for prefix in DEFAULT_EXCLUDED_PREFIXES):
+        return True
+    if label == BLINK_PREFIX or label.startswith(
+            f"{BLINK_PREFIX}/") or label.startswith(f"{BLINK_PREFIX}:"):
+        return not include_blink
+    if any(label == prefix or label.startswith(f"{prefix}/")
+           or label.startswith(f"{prefix}:")
+           for prefix in THIRD_PARTY_PREFIXES):
+        return not include_third_party
+    return False
+
+
+def run_gn_desc(gn: str, src_root: pathlib.Path, out_dir: str,
+                label: str) -> str:
+    cmd = [gn, "desc", out_dir, label, "--format=json"]
+    proc = subprocess.run(
+        cmd,
+        cwd=str(src_root),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError("GN query failed:\n"
+                           f"  command: {' '.join(cmd)}\n"
+                           f"  cwd: {src_root}\n"
+                           f"  stdout: {proc.stdout.strip()}\n"
+                           f"  stderr: {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def parse_json_value(raw: str, fallback):
+    raw = raw.strip()
+    if not raw:
+        return fallback
+    return json.loads(raw)
+
+
+def parse_target_description(raw: str, query_label: str) -> Dict[str, object]:
+    """Return the target metadata object from `gn desc --format=json` output."""
+    value = parse_json_value(raw, {})
+    if not isinstance(value, dict):
+        raise RuntimeError(
+            f"Unexpected GN JSON for {query_label}: expected object, got "
+            f"{type(value).__name__}")
+
+    # GN returns either the target object directly or an object keyed by label,
+    # depending on the GN version/pattern used. Accept both shapes.
+    if any(key in value for key in ("deps", "testonly", "sources", "type")):
+        return value
+
+    canonical_label = strip_toolchain(query_label)
+    for key in (query_label, canonical_label):
+        target_value = value.get(key)
+        if isinstance(target_value, dict):
+            return target_value
+    if len(value) == 1:
+        only_value = next(iter(value.values()))
+        if isinstance(only_value, dict):
+            return only_value
+    raise RuntimeError(f"Unexpected GN JSON shape for {query_label}")
+
+
+def normalize_dep_label(label: str) -> str:
+    # Keep explicit toolchains distinct while traversing/counting. Area rollups
+    # and Markdown target summaries strip toolchains later for compactness.
+    return normalize_label(label)
+
+
+def unique_labels(labels: Iterable[str]) -> List[str]:
+    return list(dict.fromkeys(labels))
+
+
+def desc_target(
+    gn: str,
+    src_root: pathlib.Path,
+    out_dir: str,
+    query_label: str,
+    canonical_label: str,
+) -> Tuple[TargetInfo, List[str]]:
+    desc = parse_target_description(
+        run_gn_desc(gn, src_root, out_dir, query_label), query_label)
+    raw_deps = [str(dep) for dep in desc.get("deps", [])]
+    sources = [str(source) for source in desc.get("sources", [])]
+    return (
+        TargetInfo(
+            label=canonical_label,
+            deps=unique_labels(normalize_dep_label(dep) for dep in raw_deps),
+            testonly=bool(desc.get("testonly", False)),
+            sources=sources,
+        ),
+        raw_deps,
+    )
+
+
+def walk_targets(
+    gn: str,
+    src_root: pathlib.Path,
+    out_dir: str,
+    roots: Sequence[str],
+    include_third_party: bool,
+    include_blink: bool,
+) -> Dict[str, TargetInfo]:
+    targets: Dict[str, TargetInfo] = {}
+    queue = collections.deque(roots)
+    queued: Set[str] = {normalize_dep_label(root) for root in roots}
+
+    while queue:
+        query_label = queue.popleft()
+        canonical_label = normalize_dep_label(query_label)
+        if canonical_label in targets:
+            continue
+        if is_excluded_label(canonical_label, include_third_party,
+                             include_blink):
+            continue
+        info, raw_deps = desc_target(gn, src_root, out_dir, query_label,
+                                     canonical_label)
+        targets[canonical_label] = info
+        if info.testonly:
+            continue
+        for dep in raw_deps:
+            canonical_dep = normalize_dep_label(dep)
+            if (canonical_dep not in queued and not is_excluded_label(
+                    canonical_dep, include_third_party, include_blink)):
+                queued.add(canonical_dep)
+                queue.append(dep)
+    return targets
+
+
+def count_inbound_references(
+        targets: Dict[str, TargetInfo]) -> collections.Counter:
+    counts = collections.Counter()
+    for info in targets.values():
+        if info.testonly:
+            continue
+        for dep in info.deps:
+            dep_info = targets.get(dep)
+            if dep_info and not dep_info.testonly:
+                counts[dep] += 1
+    return counts
+
+
+def common_source_dirs(targets: Iterable[TargetInfo],
+                       limit: int = 6) -> List[str]:
+    counts = collections.Counter()
+    for info in targets:
+        for source in info.sources:
+            if not source.startswith("//"):
+                continue
+            directory = source[2:].rsplit(
+                "/", 1)[0] if "/" in source[2:] else source[2:]
+            if directory:
+                counts[directory] += 1
+    return [path for path, _ in counts.most_common(limit)]
+
+
+def build_area_infos(
+    targets: Dict[str, TargetInfo],
+    inbound_counts: collections.Counter,
+    rollup_rules: Sequence[Tuple[str, int]],
+    top_areas: int,
+    top_targets_per_area: int,
+) -> List[AreaInfo]:
+    area_targets: Dict[str, List[TargetInfo]] = collections.defaultdict(list)
+    area_counts = collections.Counter()
+    area_target_counts: Dict[str,
+                             collections.Counter] = collections.defaultdict(
+                                 collections.Counter)
+
+    for label, info in targets.items():
+        if info.testonly:
+            continue
+        area = rollup_area(label, rollup_rules)
+        area_targets[area].append(info)
+        count = inbound_counts.get(label, 0)
+        area_counts[area] += count
+        if count:
+            area_target_counts[area][strip_toolchain(label)] += count
+
+    infos = []
+    for area, count in area_counts.most_common():
+        if count <= 0:
+            continue
+        infos.append(
+            AreaInfo(
+                area=area,
+                count=count,
+                target_count=len(area_targets[area]),
+                top_targets=area_target_counts[area].most_common(
+                    top_targets_per_area),
+                common_paths=common_source_dirs(area_targets[area]),
+                path=f"areas/{sanitize_area_filename(area)}",
+            ))
+        if len(infos) >= top_areas:
+            break
+    return infos
+
+
+def prepare_output_dir(output: pathlib.Path) -> None:
+    """Remove previously generated files that could otherwise go stale."""
+    for child in (output / "areas", output / "data"):
+        if child.exists():
+            shutil.rmtree(child)
+    default_md = output / "default.md"
+    if default_md.exists():
+        default_md.unlink()
+
+
+def write_file(path: pathlib.Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents, encoding="utf-8")
+
+
+def write_markdown(
+    output: pathlib.Path,
+    area_infos: Sequence[AreaInfo],
+    targets: Dict[str, TargetInfo],
+    inbound_counts: collections.Counter,
+    metadata: Dict[str, object],
+) -> None:
+    areas_dir = output / "areas"
+    areas_dir.mkdir(parents=True, exist_ok=True)
+
+    generated_at = metadata["generated_at"]
+    root_targets = ", ".join(f"`{root}`" for root in metadata["roots"])
+    lines = [
+        "# Brave GN dependency frequency map",
+        "",
+        "Compact agent entry point: areas ranked by inbound direct GN deps.",
+        "Not semantic ranking, ownership, PageRank, symbols, or git history.",
+        "",
+        "## Metadata",
+        "",
+        f"- Generated: `{generated_at}`",
+        f"- GN output dir: `{metadata['out_dir']}`",
+        f"- Roots: {root_targets}",
+        f"- Non-testonly targets: `{metadata['non_testonly_targets']}`",
+        f"- Testonly targets skipped: `{metadata['testonly_targets']}`",
+        f"- Third-party included: `{metadata['include_third_party']}`; Blink included: `{metadata['include_blink']}`",
+        "- Count: each direct non-testonly dep from a reachable non-testonly target adds 1.",
+        "",
+        "## Top depended-on areas",
+        "",
+        "| Rank | Area | Refs | Targets | Map |",
+        "| ---: | --- | ---: | ---: | --- |",
+    ]
+    for index, info in enumerate(area_infos, start=1):
+        lines.append(
+            f"| {index} | `{info.area}` | {info.count} | {info.target_count} | [{info.path}]({info.path}) |"
+        )
+
+    lines.extend([
+        "",
+        "Read only the relevant per-area files, then inspect source as needed.",
+        "",
+    ])
+    write_file(output / "default.md", "\n".join(lines))
+
+    for info in area_infos:
+        lines = [
+            f"# {info.area}",
+            "",
+            f"- Direct dep refs: `{info.count}`",
+            f"- Built non-testonly targets: `{info.target_count}`",
+            "",
+            "## Top GN targets contributing to this area",
+            "",
+        ]
+        if info.top_targets:
+            lines.extend(["| Target | Direct dep refs |", "| --- | ---: |"])
+            for label, count in info.top_targets:
+                lines.append(f"| `{label}` | {count} |")
+        else:
+            lines.append(
+                "No inbound direct-dependency references were counted for individual targets in this area."
+            )
+        if info.common_paths:
+            lines.extend(["", "## Common source/header directories", ""])
+            for source_path in info.common_paths:
+                lines.append(f"- `//{source_path}`")
+        lines.append("")
+        write_file(output / info.path, "\n".join(lines))
+
+
+def write_json_data(
+    output: pathlib.Path,
+    area_infos: Sequence[AreaInfo],
+    targets: Dict[str, TargetInfo],
+    inbound_counts: collections.Counter,
+    metadata: Dict[str, object],
+) -> None:
+    data_dir = output / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    dependency_frequency = {
+        "metadata": {
+            k: v
+            for k, v in metadata.items() if k != "rollup_rules"
+        },
+        "areas": [info._asdict() for info in area_infos],
+        "target_counts": dict(inbound_counts.most_common()),
+    }
+    target_data = {
+        label: {
+            "deps": [
+                dep for dep in info.deps
+                if dep in targets and not targets[dep].testonly
+            ],
+            "sources": info.sources,
+            "inbound_count": inbound_counts.get(label, 0),
+        }
+        for label, info in sorted(targets.items()) if not info.testonly
+    }
+    write_file(
+        data_dir / "dependency_frequency.json",
+        json.dumps(dependency_frequency, indent=2, sort_keys=True) + "\n")
+    write_file(data_dir / "targets.json",
+               json.dumps(target_data, indent=2, sort_keys=True) + "\n")
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out-dir",
+        help="GN output dir. Defaults to out/current_link, falling back to "
+        "out/Component_arm64 when present.")
+    parser.add_argument(
+        "--root",
+        action="append",
+        dest="roots",
+        help="Root GN label to traverse. Repeatable. Defaults to //brave:brave."
+    )
+    parser.add_argument(
+        "--output",
+        help="Output directory. Defaults to brave/.repo-map from src or "
+        ".repo-map from src/brave.")
+    parser.add_argument("--top-areas",
+                        type=int,
+                        default=DEFAULT_TOP_AREAS,
+                        help="Number of top areas to include in Markdown.")
+    parser.add_argument("--top-targets-per-area",
+                        type=int,
+                        default=DEFAULT_TOP_TARGETS_PER_AREA,
+                        help="Number of top targets listed in each area file.")
+    parser.add_argument("--format",
+                        choices=("markdown", "json", "both"),
+                        default="both",
+                        help="Output format to write.")
+    parser.add_argument(
+        "--include-third-party",
+        action="store_true",
+        help="Include //third_party targets. Excluded by default.")
+    parser.add_argument(
+        "--include-blink",
+        action="store_true",
+        help=
+        "Include //third_party/blink targets. Excluded by default unless set.")
+    parser.add_argument(
+        "--rollup",
+        action="append",
+        default=[],
+        metavar="PREFIX=DEPTH",
+        help="Override/add area rollup rule, e.g. --rollup brave/components=3. "
+        "Earlier rules win.")
+    parser.add_argument(
+        "--gn",
+        help="Path to gn binary. Defaults to buildtools/depot_tools lookup.")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str]) -> int:
+    args = parse_args(argv)
+    cwd = pathlib.Path.cwd()
+    src_root = src_root_from_cwd(cwd)
+    if args.out_dir:
+        out_dir = normalize_out_dir(args.out_dir, cwd, src_root)
+    else:
+        out_dir = normalize_out_dir(str(default_out_dir(cwd, src_root)), cwd,
+                                    src_root)
+    roots = [
+        normalize_label(root) for root in (args.roots or ["//brave:brave"])
+    ]
+    for root in roots:
+        if is_excluded_label(root, args.include_third_party,
+                             args.include_blink):
+            print(
+                f"Warning: root target {root} is excluded by the current filters",
+                file=sys.stderr)
+    output = (pathlib.Path(args.output).expanduser()
+              if args.output else default_output_dir(cwd, src_root))
+    if not output.is_absolute():
+        output = (cwd / output).resolve()
+    rollup_rules = parse_rollup_rules(args.rollup)
+    gn = args.gn or default_gn_binary(src_root)
+
+    targets = walk_targets(
+        gn=gn,
+        src_root=src_root,
+        out_dir=out_dir,
+        roots=roots,
+        include_third_party=args.include_third_party,
+        include_blink=args.include_blink,
+    )
+    inbound_counts = count_inbound_references(targets)
+    area_infos = build_area_infos(
+        targets=targets,
+        inbound_counts=inbound_counts,
+        rollup_rules=rollup_rules,
+        top_areas=args.top_areas,
+        top_targets_per_area=args.top_targets_per_area,
+    )
+    prepare_output_dir(output)
+    metadata = {
+        "generated_at": datetime.datetime.now(
+            datetime.timezone.utc).isoformat(timespec="seconds"),
+        "src_root": str(src_root),
+        "out_dir": out_dir,
+        "roots": roots,
+        "include_third_party": args.include_third_party,
+        "include_blink": args.include_blink,
+        "rollup_rules": rollup_rules,
+        "total_targets": len(targets),
+        "non_testonly_targets": sum(1 for info in targets.values()
+                                    if not info.testonly),
+        "testonly_targets": sum(1 for info in targets.values()
+                                if info.testonly),
+    }
+
+    if args.format in ("markdown", "both"):
+        write_markdown(output, area_infos, targets, inbound_counts, metadata)
+    if args.format in ("json", "both"):
+        write_json_data(output, area_infos, targets, inbound_counts, metadata)
+
+    print(f"Wrote repo map to {output}")
+    print(
+        f"Reachable targets: {metadata['total_targets']} ({metadata['non_testonly_targets']} non-testonly)"
+    )
+    print(f"Areas written: {len(area_infos)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Adds a new architecture best practice, **ARCH-073: Inject Dependencies at Construction; Don't Reach for Global State or `Browser*`**, to `docs/best-practices/architecture.md`.

Sourced from Chromium's `docs/chrome_browser_design_principles.md` (Feature Design / Modularity sections): features should take exactly the dependencies they need as constructor parameters rather than reaching for global state (`g_browser_process`, singletons, `NoDestructor` globals) or a `Browser*` god-object.

## Why this is distinct from existing DI guidance

- **ARCH-002** covers DI specifically as a fix for `components/` → browser **layering violations**.
- **ARCH-003** covers passing the **most specific dependency** ("not bag-of-stuff").
- **ARCH-073** is the broader design default: prefer constructor injection over ambient global state / `Browser*` for **all** features, motivated by testability, exposing circular dependencies, and reduced coupling. It cross-references both existing rules.

## Notes

- ID `ARCH-073` assigned as highest existing ARCH id + 1.
- `manage-bp-ids.py --validate` shows only pre-existing MISSING ID failures in unrelated docs (`coding-standards-apis.md`, `nala.md`, `patches.md`); no new failures introduced by this change.
- Markdown formatted via `npm run format` (no changes required).