### PR TITLE
Fix keyed services doc: TestCreation -> TestingCreation

### DIFF
--- a/docs/keyed_services.md
+++ b/docs/keyed_services.md
@@ -69,8 +69,8 @@ On desktop/android you need to return false for
 `ServiceIsNULLWhileTesting`
 
 On iOS you need to either remove `ServiceCreation::kCreateWithProfile` or add
-`TestCreation::kNoServiceForTests` and inject a test factory in tests that need
-the service to exist.
+`TestingCreation::kNoServiceForTests` and inject a test factory in tests that
+need the service to exist.
 
 #### Keyed Services and Mojo
 


### PR DESCRIPTION
## Summary

The "Keyed Services and Unit Tests" section of `docs/keyed_services.md` referenced `TestCreation::kNoServiceForTests`, but no such enum exists.

The actual trait enum, defined in `ios/chrome/browser/shared/model/profile/profile_keyed_service_traits.h`, is:

```cpp
enum class TestingCreation {
  kCreateService,
  kNoServiceForTests,
  kDefault = kCreateService,
};
```

This updates the doc to reference `TestingCreation::kNoServiceForTests` so readers can actually find and use the trait. This matches the constructor traits (`ValidTraits = base::ParameterPack<ProfileSelection, ServiceCreation, TestingCreation>`) and the guidance comment already present in `profile_keyed_service_factory_ios.cc`.

## Verification

- Confirmed enum name against `profile_keyed_service_traits.h` and `profile_keyed_service_factory_ios.{h,cc}` in the current tree.
- `npm run presubmit -- --base master`: 0 messages, 0 warnings, 0 errors.
- Docs-only, single-line change.