### PR TITLE
[bootstrap][recipes] Packaging provisioning fixes

### DIFF
--- a/third_party/ast-grep/package_ast_grep.py
+++ b/third_party/ast-grep/package_ast_grep.py
@@ -3,13 +3,12 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Build ast-grep and package `third_party/ast-grep/` into a versioned tarball.
+"""Build ast-grep and package its per-platform tree into a versioned tarball.
 
-Runs the same build as `build_ast_grep.py`, then archives the *contents* of
-`third_party/ast-grep/` (the built binary tree) into a `.tar.gz` whose name
-carries the ast-grep version and host platform:
+Runs the same build as `build_ast_grep.py`, then archives the contents of this
+host's `third_party/ast-grep/ast-grep-<os>/` tree into a tar.gz named:
 
-    ast-grep-<version>-<platform>.tar.gz
+    ast-grep-<version>-<platform>.tar.gz  (members: bin/ast-grep, ...)
 """
 
 from __future__ import annotations
@@ -41,7 +40,7 @@ def _package_name() -> str:
 
 
 def _create_archive(out_dir: Path) -> Path:
-    """Archive this host's `ast-grep-<os>/` binary tree into *out_dir*.
+    """Archive the *contents* of this host's `ast-grep-<os>/` tree into *out_dir*.
 
     Raises:
         RuntimeError: If the ast-grep build output directory is missing.
@@ -53,9 +52,10 @@ def _create_archive(out_dir: Path) -> Path:
     out_dir.mkdir(parents=True, exist_ok=True)
     archive = out_dir / _package_name()
 
-    logging.info('Packaging %s -> %s', source, archive)
+    logging.info('Packaging contents of %s -> %s', source, archive)
     with tarfile.open(archive, 'w:gz') as tar:
-        tar.add(source, arcname=source.name)
+        for child in sorted(source.iterdir()):
+            tar.add(child, arcname=child.name)
     return archive
 
 

--- a/third_party/node/download_node.py
+++ b/third_party/node/download_node.py
@@ -34,12 +34,16 @@ _NODE_DIR = Path(__file__).resolve().parent
 # Verify TLS against the system trust store with hostname checking.
 _TLS_CONTEXT = ssl.create_default_context()
 
-PLATFORMS: dict[str, str] = {
-    f'node-{NODE_VERSION}-linux-x64.tar.gz': f'node-{NODE_VERSION}-linux-x64.tar.gz',
-    f'node-{NODE_VERSION}-darwin-x64.tar.gz': f'node-{NODE_VERSION}-mac-x64.tar.gz',
-    f'node-{NODE_VERSION}-darwin-arm64.tar.gz': f'node-{NODE_VERSION}-mac-arm64.tar.gz',
-    f'node-{NODE_VERSION}-win-x64.zip': f'node-{NODE_VERSION}-win-x64.tar.gz',
-}
+PLATFORMS: frozenset[tuple[str, str, str]] = frozenset({
+    (f'node-{NODE_VERSION}-linux-x64.tar.gz',
+     f'node-{NODE_VERSION}-linux-x64.tar.gz', 'node-linux-x64'),
+    (f'node-{NODE_VERSION}-darwin-x64.tar.gz',
+     f'node-{NODE_VERSION}-mac-x64.tar.gz', 'node-mac-x64'),
+    (f'node-{NODE_VERSION}-darwin-arm64.tar.gz',
+     f'node-{NODE_VERSION}-mac-arm64.tar.gz', 'node-mac-arm64'),
+    (f'node-{NODE_VERSION}-win-x64.zip', f'node-{NODE_VERSION}-win-x64.tar.gz',
+     'node-win-x64'),
+})
 
 
 class _HttpsOnlyRedirectHandler(urllib.request.HTTPRedirectHandler):
@@ -75,15 +79,6 @@ def urlopen(url: str):
 def _strip_archive_ext(name: str) -> str:
     """`name` without its `.tar.gz`/`.zip` archive extension."""
     return name.removesuffix('.tar.gz').removesuffix('.zip')
-
-
-def deployed_dir(tarball: str) -> str:
-    """The version-free directory a tarball packages (and we deploy into).
-
-    Drops the extension and the version, e.g.
-    `node-v24.17.0-mac-x64.tar.gz` -> `node-mac-x64`.
-    """
-    return _strip_archive_ext(tarball).replace(f'-{NODE_VERSION}', '')
 
 
 def fetch_shasums() -> dict[str, str]:
@@ -122,12 +117,12 @@ def extract(archive: Path, dest: Path) -> None:
         tar.extractall(path=dest, filter='data')
 
 
-def deploy(archive: str, tarball: str, shasums: dict[str, str]) -> None:
+def deploy(archive: str, deployed_dir: str, shasums: dict[str, str]) -> None:
     """Download, verify and deploy one platform's Node into its dir.
 
     Any previous deployment is wiped so no stale tree lingers, then the upstream
     archive is extracted and its versioned top-level directory renamed to the
-    version-free directory `tarball` packages.
+    version-free `deployed_dir`.
     """
     expected = shasums.get(archive)
     if expected is None:
@@ -137,7 +132,7 @@ def deploy(archive: str, tarball: str, shasums: dict[str, str]) -> None:
     # The archive's top-level dir is its name without the extension, e.g.
     # node-v24.17.0-darwin-x64; we rename it to the version-free deployed dir.
     versioned = _NODE_DIR / _strip_archive_ext(archive)
-    dest = _NODE_DIR / deployed_dir(tarball)
+    dest = _NODE_DIR / deployed_dir
 
     url = f'{BASE_URL}/{NODE_VERSION}/{archive}'
     print(f'Downloading {url}')
@@ -185,8 +180,8 @@ def main() -> int:
         clear_existing()
 
     shasums = fetch_shasums()
-    for archive, tarball in PLATFORMS.items():
-        deploy(archive, tarball, shasums)
+    for archive, _tarball, deployed_dir in PLATFORMS:
+        deploy(archive, deployed_dir, shasums)
 
     print('\nDone. Run package_node.py to package these for upload.')
     return 0

--- a/third_party/node/package_node.py
+++ b/third_party/node/package_node.py
@@ -5,10 +5,12 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """Package the version-free Node directories deployed by `download_node.py`.
 
-For each platform, this packs the version-free `node-<suffix>` directory into a
-single gzipped tarball:
+For each platform, this packs the *contents* of the version-free `node-<suffix>`
+directory (its `bin/`, `lib/`, ... entries) into a single gzipped tarball, so
+extracting it does not recreate the `node-<suffix>/` wrapper directory:
 
-    third_party/node/node-linux-x64/...  ->  node-v24.17.0-linux-x64.tar.gz
+    third_party/node/node-linux-x64/{bin,lib,...}
+        ->  node-v24.17.0-linux-x64.tar.gz  (members: bin/, lib/, ...)
 """
 
 from __future__ import annotations
@@ -24,30 +26,32 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 # pylint: disable=wrong-import-position
-from download_node import NODE_VERSION, PLATFORMS, deployed_dir
+from download_node import NODE_VERSION, PLATFORMS
 
 # This directory: third_party/node.
 _NODE_DIR = Path(__file__).resolve().parent
 
 
-def package(tarball_name: str, output_dir: Path) -> Path | None:
-    """Pack the version-free directory `tarball_name` packages into it.
+def package(tarball_name: str, deployed_dir: str,
+            output_dir: Path) -> Path | None:
+    """Pack the *contents* of `deployed_dir` into `tarball_name`.
 
     Returns the tarball path, or None when the platform has not been deployed
     yet (run `download_node.py` first).
     """
-    dir_name = deployed_dir(tarball_name)
-    dest_dir = _NODE_DIR / dir_name
+    dest_dir = _NODE_DIR / deployed_dir
     if not dest_dir.is_dir():
         print(f'Skipping {tarball_name}: {dest_dir} does not exist '
               f'(run download_node.py first).')
         return None
 
     tarball = output_dir / tarball_name
-    # arcname is the version-free dir, so members are 'node-linux-x64/...' —
-    # version-free paths, version only in `tarball`'s name.
+    # Archive the contents of the deployed dir (bin/, lib/, ...) at the archive
+    # root, so extracting the tarball does not recreate the node-<suffix>/
+    # wrapper directory.
     with tarfile.open(tarball, mode='w:gz') as tar:
-        tar.add(dest_dir, arcname=dir_name)
+        for child in sorted(dest_dir.iterdir()):
+            tar.add(child, arcname=child.name)
     return tarball
 
 
@@ -77,8 +81,8 @@ def main() -> int:
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
     results: list[tuple[str, str, int]] = []
-    for tarball_name in PLATFORMS.values():
-        tarball = package(tarball_name, args.output_dir)
+    for _archive, tarball_name, deployed_dir in PLATFORMS:
+        tarball = package(tarball_name, deployed_dir, args.output_dir)
         if tarball is None:
             continue
         sha256, size = sha256_and_size(tarball)

--- a/tools/recipes/engine.py
+++ b/tools/recipes/engine.py
@@ -31,11 +31,13 @@ import argparse
 import importlib
 import json
 import logging
+import os
 from pathlib import Path
 import sys
 import types
 
 from recipe_api import RecipeApi
+from recipe_properties import apply_environ
 
 # Root of the recipes tree (this file's directory). Recipe modules live under
 # `recipe_modules/<name>/` and recipes under `recipes/<name>.py`.
@@ -122,7 +124,7 @@ class _Engine:
         # A module can reach itself via `self.m.<own_name>`, as in recipes_py.
         setattr(inst.m, name, inst)
 
-        inst.initialize()
+        inst.initialise()
         self._cache[name] = inst
         return inst
 
@@ -153,11 +155,14 @@ def _build_properties(properties_def: type | None,
     """Build the properties object passed as `RunSteps`' second argument.
 
     If the recipe declares `PROPERTIES` (any callable, e.g. a dataclass), it is
-    constructed from *properties*. Otherwise a plain namespace is returned.
+    constructed from *properties*, with any `Property(from_environ=...)` fields
+    backfilled from the environment when not passed explicitly. Otherwise a
+    plain namespace is returned.
     """
     if properties_def is None:
         return types.SimpleNamespace(**properties)
-    return properties_def(**properties)
+    values = apply_environ(properties_def, properties, os.environ)
+    return properties_def(**values)
 
 
 def run_recipe(recipe_name: str,

--- a/tools/recipes/recipe_api.py
+++ b/tools/recipes/recipe_api.py
@@ -47,5 +47,5 @@ class RecipeApi:
         # `brave_core_shallow` uses it; defaults to `master` until overridden.
         self._brave_core_ref: str = 'master'
 
-    def initialize(self) -> None:
+    def initialise(self) -> None:
         """Hook run once after DEPS are injected. Override for setup."""

--- a/tools/recipes/recipe_modules/brave_core_shallow/__init__.py
+++ b/tools/recipes/recipe_modules/brave_core_shallow/__init__.py
@@ -4,4 +4,4 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """`brave_core_shallow` module: sparse-deploy brave-core subpaths."""
 
-DEPS = ['step']
+DEPS = ['path', 'step']

--- a/tools/recipes/recipe_modules/brave_core_shallow/api.py
+++ b/tools/recipes/recipe_modules/brave_core_shallow/api.py
@@ -33,9 +33,9 @@ class BraveCoreShallowApi(RecipeApi):
     """
 
     def deploy(self,
-               dest: str | Path,
                paths: str | Path | Iterable[str | Path],
                *,
+               dest: str | Path | None = None,
                url: str = REPO_URL,
                ref: str | None = None,
                depth: int = 2) -> Path:
@@ -56,10 +56,10 @@ class BraveCoreShallowApi(RecipeApi):
         checkout -- coexist rather than being replaced.
 
         Args:
-            dest: Directory the repo lives in (created if missing). This is the
-                brave-core root the returned tree is anchored at.
             paths: A single repo-relative path, or an iterable of them, to
                 materialise (e.g. `'tools/cr/toolchains'`).
+            dest: Directory the repo lives in (created if missing). Defaults to
+                the `path` module's `brave_core`, the standard job layout.
             url: Git remote to clone from; defaults to brave-core over SSH.
             ref: Branch or tag to check out. Defaults to the engine-provided
                 brave-core ref (`master`, or the `--brave-core-ref` override).
@@ -77,6 +77,8 @@ class BraveCoreShallowApi(RecipeApi):
             RuntimeError: If a requested path is absent after the checkout
                 (e.g. a typo or a path that does not exist on *ref*).
         """
+        if dest is None:
+            dest = self.m.path.brave_core
         single = isinstance(paths, (str, Path))
         rel_paths = [str(paths)] if single else [str(p) for p in paths]
         if not rel_paths:

--- a/tools/recipes/recipe_modules/chromium_checkout/__init__.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/__init__.py
@@ -4,4 +4,4 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """`chromium_checkout` module: clone / sync / validate a Chromium src/ tree."""
 
-DEPS = ['step', 'depot_tools']
+DEPS = ['path', 'step', 'depot_tools']

--- a/tools/recipes/recipe_modules/chromium_checkout/api.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/api.py
@@ -34,30 +34,37 @@ class ChromiumCheckoutApi(RecipeApi):
     """
 
     def ensure_checkout(self,
-                        chromium_src: str | Path,
-                        ref: str | None = None) -> Path:
+                        *,
+                        chromium_src: str | Path | None = None,
+                        ref: str | None = None,
+                        git_cache: str | Path | None = None) -> Path:
         """Guarantee a Chromium checkout at *chromium_src*, optionally on *ref*.
 
-        Mirrors the checkout phase of `ToolchainBuilder.run`: validate the git
-        cache, ensure depot_tools is on PATH, clone a fresh checkout when none
-        is found, then check out *ref* if one is given.
+        Clones a fresh checkout if *chromium_src* is not already a valid
+        Chromium repo, then checks out *ref* if given.
 
         Args:
-            chromium_src: Path to the Chromium `src/` directory.
+            chromium_src: Path to the Chromium `src/` directory. Defaults to the
+                `path` module's `chromium_src`, the standard job layout.
             ref: Optional git ref (branch, tag, or commit) to check out.
+            git_cache: Optional explicit git cache directory. When given it sets
+                `GIT_CACHE_PATH`; otherwise an existing `GIT_CACHE_PATH` in the
+                environment is used as-is.
 
         Returns:
             The resolved absolute `src/` path.
         """
+        if chromium_src is None:
+            chromium_src = self.m.path.chromium_src
         chromium_src = Path(chromium_src).expanduser().resolve()
 
-        # A missing/invalid GIT_CACHE_PATH would silently break the clone/sync
-        # steps below, so fail fast before doing any work.
+        if git_cache is not None:
+            self.set_git_cache(git_cache or None)
         self.validate_git_cache()
 
         # depot_tools provides `fetch`/`gclient`, needed whether we clone or
         # operate on an existing checkout.
-        self.m.depot_tools.ensure_on_path(chromium_src)
+        self.m.depot_tools.ensure_on_path()
 
         # No valid checkout yet -> clone one.
         if not self.has_valid_checkout(chromium_src):

--- a/tools/recipes/recipe_modules/depot_tools/__init__.py
+++ b/tools/recipes/recipe_modules/depot_tools/__init__.py
@@ -4,4 +4,4 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """`depot_tools` module: ensure a usable depot_tools install is on PATH."""
 
-DEPS = ['step']
+DEPS = ['path', 'step']

--- a/tools/recipes/recipe_modules/depot_tools/api.py
+++ b/tools/recipes/recipe_modules/depot_tools/api.py
@@ -14,13 +14,14 @@ import sys
 
 from recipe_api import RecipeApi
 
-# Latest Chromium depot_tools bundle.
+# the urls we clone from
 DEPOT_TOOLS_URL = 'https://chromium.googlesource.com/chromium/tools/depot_tools'
 
-# vpython3 selected by depot_tools from `$PATH`, relative to the Chromium src/
-# root. On Windows the `.bat` shim is used (needed when calling from git bash).
-VPYTHON_PATH = Path('third_party/depot_tools') / (
-    'vpython3.bat' if sys.platform == 'win32' else 'vpython3')
+# vpython3 entry point.
+VPYTHON3 = 'vpython3.bat' if sys.platform == 'win32' else 'vpython3'
+
+# the relative path for depot_tools in the chromium checkout.
+DEPOT_TOOLS_PATH = Path('third_party') / 'depot_tools'
 
 
 class DepotToolsApi(RecipeApi):
@@ -29,41 +30,56 @@ class DepotToolsApi(RecipeApi):
     Extracted from `build_rust_toolchain.py::_bootstrap_depot_tools`.
     """
 
-    def ensure_on_path(self, chromium_src: str | Path) -> None:
-        """Put depot_tools on PATH, cloning it beside src/ if necessary.
+    def __init__(self) -> None:
+        super().__init__()
+        # Resolved path to depot_tools, or None if no `depot_tools` has been
+        # deployed yet.
+        self._depot_tools_path: Path | None = None
 
-        If `gclient` already resolves on PATH, this is a no-op. Otherwise it
-        reuses an existing checkout at `<chromium_src>/../depot_tools` or clones
-        a fresh one there, then prepends it to PATH and verifies `gclient` runs.
-
-        Args:
-            chromium_src: Path to the Chromium `src/` directory; depot_tools is
-                installed as its sibling.
+    def ensure_on_path(self) -> None:
+        """Deploy depot_tools and put it on PATH. Successive calls are no-ops.
         """
-        chromium_src = Path(chromium_src).expanduser().resolve()
+        if self._depot_tools_path is not None:
+            return  # Already deployed this run.
 
         if shutil.which('gclient') is not None:
             logging.debug('depot_tools already on PATH, skipping clone')
+            # Using whatever depot_tools is already on PATH.
+            self._depot_tools_path = Path(shutil.which('gclient')).parent
             return
 
-        depot_tools_path = chromium_src.parent / 'depot_tools'
+        # Checking for a standalone depot_tools under what would be a supposed
+        # Chromium checkout.
+        depot_tools_path = (self.m.path.chromium_src.parent /
+                            DEPOT_TOOLS_PATH).resolve()
         if (depot_tools_path / 'gclient').is_file():
-            # Already present at the expected install path; just add to PATH.
+            # If Chromium has already been deployed, we just use whatever
+            # is in place.
             logging.info('depot_tools already present at %s, adding to PATH.',
                          depot_tools_path)
         else:
             logging.info('Installing depot_tools under %s', depot_tools_path)
             depot_tools_path.parent.mkdir(parents=True, exist_ok=True)
-            self.m.step(
-                'clone depot_tools',
-                ['git', 'clone', DEPOT_TOOLS_URL,
-                 str(depot_tools_path)])
+            self.m.step('clone depot_tools', [
+                'git', 'clone', '--depth', '1', DEPOT_TOOLS_URL,
+                str(depot_tools_path)
+            ])
 
         os.environ['PATH'] = os.pathsep.join(
             [str(depot_tools_path), os.environ['PATH']])
         # Run once so depot_tools bootstraps itself (downloads its own deps).
         self.m.step('verify gclient', ['gclient'])
+        self._depot_tools_path = depot_tools_path
 
-    def vpython3(self, chromium_src: str | Path) -> Path:
-        """Return the path to depot_tools' vpython3 inside *chromium_src*."""
-        return Path(chromium_src).expanduser().resolve() / VPYTHON_PATH
+    def vpython3(self) -> Path:
+        """Return depot_tools' `vpython3`.
+
+        This function ensures that depot_tools is deployed and on PATH, if that
+        hasn't already been done.
+
+        Returns:
+            The absolute `Path` to depot_tools' `vpython3` entry point.
+        """
+        self.ensure_on_path()
+        assert self._depot_tools_path is not None
+        return self._depot_tools_path / VPYTHON3

--- a/tools/recipes/recipe_properties.py
+++ b/tools/recipes/recipe_properties.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Recipe property declarations with optional environment-variable defaults.
+
+Environment properties allow the pipeline to pass property values via the
+environment.
+
+Recipes declare properties as a frozen dataclass whose fields use `Property()`:
+
+    @dataclass(frozen=True)
+    class InputProperties:
+        chromium_ref: str = Property(from_environ='CHROMIUM_REF')
+        git_cache: str | None = Property(default=None)
+
+Environment values are strings, so `from_environ` best suits string-typed
+properties. `int` and `bool` fields are coerced from their string form.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Mapping
+
+# Metadata key under which a field stores the env var it may be sourced from.
+_FROM_ENVIRON = 'from_environ'
+
+
+def Property(*,
+             default: Any = dataclasses.MISSING,
+             from_environ: str | None = None) -> Any:
+    """Declare a recipe property field, optionally sourced from an env var.
+
+    Args:
+        default: The value used when the property is neither passed explicitly
+            nor found in the environment. Omit to make the property required.
+        from_environ: Name of an environment variable to read the value from
+            when it is not passed explicitly.
+
+    Returns:
+        A `dataclasses.field` carrying the `from_environ` metadata. A field
+        without a `default` stays required: if neither the properties payload
+        nor the environment supplies it, constructing the dataclass raises.
+    """
+    metadata = {_FROM_ENVIRON: from_environ} if from_environ else {}
+    if default is dataclasses.MISSING:
+        return dataclasses.field(metadata=metadata)
+    return dataclasses.field(default=default, metadata=metadata)
+
+
+def apply_environ(properties_def: type | None, values: Mapping[str, Any],
+                  environ: Mapping[str, str]) -> dict[str, Any]:
+    """Return *values* augmented with env-sourced properties.
+
+    For each dataclass field declaring `from_environ`, if the property was not
+    given explicitly in *values* but its env var is set, take (and coerce) the
+    value from *environ*. Explicit values always win over the environment.
+    """
+    merged = dict(values)
+    if not dataclasses.is_dataclass(properties_def):
+        return merged
+    for field in dataclasses.fields(properties_def):
+        env = field.metadata.get(_FROM_ENVIRON)
+        if env and field.name not in merged and env in environ:
+            merged[field.name] = _coerce(environ[env], field.type)
+    return merged
+
+
+def _coerce(value: str, field_type: Any) -> Any:
+    """Coerce an environment string to a field's simple scalar type.
+
+    `field_type` is the field's annotation. It may be a string (under
+    `from __future__ import annotations`, e.g. `'int'`) or the actual type
+    object (e.g. `int`), so match on the type name to handle both.
+    """
+    name = getattr(field_type, '__name__', field_type)
+    if name == 'int':
+        return int(value)
+    if name == 'bool':
+        return value.strip().lower() in ('1', 'true', 'yes', 'on')
+    return value

--- a/tools/recipes/recipes/toolchains/rust/package_rust.py
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from recipe_properties import Property
+
 if TYPE_CHECKING:
     from engine import RecipeScriptApi
 
@@ -19,23 +21,19 @@ DEPS = [
 class InputProperties:
     brave_subrevision: int
     chromium_ref: str
-    git_cache: str | None = None
+    git_cache: str | None = Property(default=None, from_environ='GIT_CACHE')
 
 
 PROPERTIES = InputProperties
 
 
 def RunSteps(api: RecipeScriptApi, properties: InputProperties) -> None:
-    if properties.git_cache is not None:
-        api.chromium_checkout.set_git_cache(properties.git_cache or None)
-
     chromium_src = api.chromium_checkout.ensure_checkout(
-        api.path.chromium_src, ref=properties.chromium_ref)
+        ref=properties.chromium_ref, git_cache=properties.git_cache)
 
-    brave_core_root = api.brave_core_shallow.deploy(api.path.brave_core,
-                                                    'tools/cr/toolchains')
+    brave_core_root = api.brave_core_shallow.deploy('tools/cr/toolchains')
 
-    vpython3 = api.depot_tools.vpython3(chromium_src)
+    vpython3 = api.depot_tools.vpython3()
     api.step('build rust toolchain', [
         vpython3,
         brave_core_root / 'tools/cr/toolchains/build_rust_toolchain.py',

--- a/tools/recipes/recipes/tools/ast_grep/package_ast_grep.py
+++ b/tools/recipes/recipes/tools/ast_grep/package_ast_grep.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from recipe_properties import Property
+
 if TYPE_CHECKING:
     from engine import RecipeScriptApi
 
@@ -19,23 +21,19 @@ DEPS = [
 @dataclass(frozen=True)
 class InputProperties:
     chromium_ref: str
-    git_cache: str | None = None
+    git_cache: str | None = Property(default=None, from_environ='GIT_CACHE')
 
 
 PROPERTIES = InputProperties
 
 
 def RunSteps(api: RecipeScriptApi, properties: InputProperties) -> None:
-    if properties.git_cache is not None:
-        api.chromium_checkout.set_git_cache(properties.git_cache or None)
+    api.chromium_checkout.ensure_checkout(ref=properties.chromium_ref,
+                                          git_cache=properties.git_cache)
 
-    chromium_src = api.chromium_checkout.ensure_checkout(
-        api.path.chromium_src, ref=properties.chromium_ref)
+    brave_root = api.brave_core_shallow.deploy('third_party/ast-grep')
 
-    brave_root = api.brave_core_shallow.deploy(api.path.brave_core,
-                                               'third_party/ast-grep')
-
-    vpython3 = api.depot_tools.vpython3(chromium_src)
+    vpython3 = api.depot_tools.vpython3()
     api.step('package ast-grep', [
         vpython3,
         brave_root / 'third_party/ast-grep/package_ast_grep.py',

--- a/tools/recipes/recipes/tools/node/package_node.py
+++ b/tools/recipes/recipes/tools/node/package_node.py
@@ -4,42 +4,31 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """Download and package Node into version-free tarballs for the build-deps
 bucket.
-
-Runs `third_party/node/download_node.py` (which fetches the official Node
-archives from nodejs.org and lays them out version-free) followed by
-`package_node.py` (which tars each into `node-<version>-<suffix>.tar.gz` under
-the job's output dir).
-
-Unlike the ast-grep/rust recipes, this needs neither a Chromium checkout nor
-depot_tools/vpython3: the scripts are stdlib-only `python3` and download
-prebuilt binaries, so all this recipe needs is the scripts themselves (a sparse
-brave-core checkout) and the interpreter already running the engine.
 """
 
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from engine import RecipeScriptApi
 
-DEPS = ['path', 'step', 'brave_core_shallow']
+DEPS = ['path', 'step', 'depot_tools', 'brave_core_shallow']
 
 
 def RunSteps(api: RecipeScriptApi, _: object) -> None:
-    brave_root = api.brave_core_shallow.deploy(api.path.brave_core,
-                                               'third_party/node')
+    brave_root = api.brave_core_shallow.deploy('third_party/node')
 
+    vpython3 = api.depot_tools.vpython3()
     node_dir = brave_root / 'third_party/node'
     # `--clear` wipes any prior node-* deployment so every run starts clean.
     api.step('download node', [
-        sys.executable,
+        vpython3,
         node_dir / 'download_node.py',
         '--clear',
     ])
     api.step('package node', [
-        sys.executable,
+        vpython3,
         node_dir / 'package_node.py',
         '--output-dir',
         api.path.out,

--- a/tools/recipes/unittests/recipe_properties_test.py
+++ b/tools/recipes/unittests/recipe_properties_test.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for the `from_environ` recipe property mechanism."""
+
+# White-box tests: they exercise internals (`_coerce`), so protected-access is
+# intentional.
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from dataclasses import dataclass
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# pylint: disable=wrong-import-position
+import engine
+import recipe_properties
+from recipe_properties import Property, apply_environ
+
+
+@dataclass(frozen=True)
+class _Props:
+    chromium_ref: str = Property(from_environ='CHROMIUM_REF')
+    subrevision: int = Property(default=0, from_environ='SUBREVISION')
+    flag: bool = Property(default=False, from_environ='FLAG')
+    git_cache: str | None = Property(default=None)
+
+
+class ApplyEnvironTest(unittest.TestCase):
+    """apply_environ backfills fields from the environment."""
+
+    def test_explicit_value_wins_over_environ(self):
+        merged = apply_environ(_Props, {'chromium_ref': 'explicit'},
+                               {'CHROMIUM_REF': 'from_env'})
+        self.assertEqual(merged['chromium_ref'], 'explicit')
+
+    def test_reads_from_environ_when_absent(self):
+        merged = apply_environ(_Props, {}, {'CHROMIUM_REF': 'main'})
+        self.assertEqual(merged['chromium_ref'], 'main')
+
+    def test_missing_env_leaves_field_unset(self):
+        merged = apply_environ(_Props, {}, {})
+        self.assertNotIn('chromium_ref', merged)
+
+    def test_coerces_int_and_bool(self):
+        merged = apply_environ(_Props, {}, {
+            'SUBREVISION': '7',
+            'FLAG': 'true'
+        })
+        self.assertEqual(merged['subrevision'], 7)
+        self.assertIs(merged['flag'], True)
+
+    def test_field_without_from_environ_is_ignored(self):
+        merged = apply_environ(_Props, {}, {'GIT_CACHE': '/tmp/cache'})
+        self.assertNotIn('git_cache', merged)
+
+    def test_non_dataclass_returns_values_unchanged(self):
+        merged = apply_environ(None, {'a': 1}, {'CHROMIUM_REF': 'main'})
+        self.assertEqual(merged, {'a': 1})
+
+
+class BuildPropertiesEnvironTest(unittest.TestCase):
+    """_build_properties honours from_environ end to end."""
+
+    def test_env_backfills_required_property(self):
+        with mock.patch.dict(os.environ, {'CHROMIUM_REF': 'main'}, clear=True):
+            obj = engine._build_properties(_Props, {})
+        self.assertEqual(obj.chromium_ref, 'main')
+        self.assertEqual(obj.subrevision, 0)
+
+    def test_explicit_overrides_env(self):
+        with mock.patch.dict(os.environ, {'CHROMIUM_REF': 'from_env'},
+                             clear=True):
+            obj = engine._build_properties(_Props,
+                                           {'chromium_ref': 'explicit'})
+        self.assertEqual(obj.chromium_ref, 'explicit')
+
+    def test_missing_required_property_raises(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(TypeError):
+                engine._build_properties(_Props, {})
+
+
+class CoerceTest(unittest.TestCase):
+    """_coerce converts environment strings to simple scalar types."""
+
+    def test_int(self):
+        self.assertEqual(recipe_properties._coerce('42', 'int'), 42)
+
+    def test_bool_truthy(self):
+        for value in ('1', 'true', 'YES', 'On'):
+            self.assertIs(recipe_properties._coerce(value, 'bool'), True)
+
+    def test_bool_falsey(self):
+        for value in ('0', 'false', '', 'no'):
+            self.assertIs(recipe_properties._coerce(value, 'bool'), False)
+
+    def test_str_passthrough(self):
+        self.assertEqual(recipe_properties._coerce('main', 'str'), 'main')
+        self.assertEqual(recipe_properties._coerce('x', 'str | None'), 'x')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR fixes several aspects of packaging provisioning. It corrects the
use of python for the node recipe, to make sure it uses vpython. It also
improves the way how `depot_tool` is being delivered, when `vpython` is
used, guaranteeing that we have a checkout for it.

There are additional changes to the way we are packaging both `node` and
`ast-grep`, as we have identified problems with this packagers, as
`EXTRA_DEPS` was causing deletions of scripts under `third_party`.

Bug: https://github.com/brave/brave-browser/issues/56529
Bug: https://github.com/brave/brave-browser/issues/56748
