### PR TITLE
Hide StorageAccess notification from URL bar (uplift to 1.92.x)

### DIFF
--- a/browser/ui/content_settings/brave_content_setting_image_models.cc
+++ b/browser/ui/content_settings/brave_content_setting_image_models.cc
@@ -14,12 +14,15 @@ using ImageType = ContentSettingImageModel::ImageType;
 
 void BraveGenerateContentSettingImageModels(
     std::vector<std::unique_ptr<ContentSettingImageModel>>* result) {
-  // Remove the cookies and javascript content setting image model
-  // https://github.com/brave/brave-browser/issues/1197
-  // https://github.com/brave/brave-browser/issues/199
+  // Remove the following image models so that their related icons don't appear
+  // in the URL bar:
+  // - Cookies (https://github.com/brave/brave-browser/issues/1197)
+  // - JavaScript (https://github.com/brave/brave-browser/issues/199)
+  // - StorageAccess (https://github.com/brave/brave-browser/issues/56810)
   auto to_remove = std::ranges::remove_if(*result, [](const auto& m) {
     return m->image_type() == ImageType::kCookies ||
-           m->image_type() == ImageType::kJavaScript;
+           m->image_type() == ImageType::kJavaScript ||
+           m->image_type() == ImageType::kStorageAccess;
   });
   result->erase(to_remove.begin(), to_remove.end());
 


### PR DESCRIPTION
Uplift of #37675
Resolves https://github.com/brave/brave-browser/issues/56810

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.