### PR TITLE
Add best practice: inject dependencies at construction (ARCH-073)

### DIFF
--- a/docs/best-practices/architecture.md
+++ b/docs/best-practices/architecture.md
@@ -1754,3 +1754,77 @@ BraveWalletServiceFactory::BuildServiceInstanceForBrowserContext(
 If a feature must be fully disable-able at runtime, the service should remain
 instantiated and expose an `IsEnabled()` accessor, or callers should observe the
 pref directly.
+
+<a id="ARCH-073"></a>
+
+## ✅ Inject Dependencies at Construction; Don't Reach for Global State or `Browser*`
+
+**Features should take exactly the dependencies they need as constructor
+parameters, rather than reaching out to global state (`g_browser_process`,
+singletons, `NoDestructor` globals) or accepting a `Browser*` and drilling
+through it.** Per the Chromium browser design principles, construction-time
+dependency injection is what makes a feature modular, testable, and free of
+hidden coupling — this is a design default for all features, not just a fix for
+`components/` layering violations (see [ARCH-002](#ARCH-002)).
+
+```cpp
+// ❌ WRONG - god-object Browser* drilled for whatever it needs (untestable,
+// hidden dependencies, makes modularization impossible)
+FooFeature(Browser* browser) : browser_(browser) {}
+void FooFeature::DoStuff() {
+  DoStuffWith(browser_->profile()->GetPrefs());
+}
+
+// ❌ ALSO WRONG - reaching for ambient global state
+void FooFeature::DoStuff() {
+  auto factory = g_browser_process->shared_url_loader_factory();
+}
+
+// ✅ CORRECT - inject exactly what the feature needs at construction
+FooFeature(tabs::TabInterface& tab,
+           page_actions::PageActionController& page_action_controller)
+    : tab_(tab), page_action_controller_(page_action_controller) {}
+```
+
+Why construction-time injection is the default:
+
+- **Testability:** dependencies can be substituted directly in unit tests,
+  reducing flakiness and preventing test behavior from diverging from
+  production.
+- **Exposes circular dependencies:** injecting deps surfaces cycles at
+  construction/BUILD.gn time — a common source of fragility — instead of hiding
+  them behind globals.
+- **Reduces coupling:** avoids "spooky action at a distance" where an innocuous
+  change breaks a seemingly unrelated feature.
+
+`class Browser` is a god-object anti-pattern; depending on it makes
+modularization impossible. Prefer the narrow, specific objects a feature
+actually uses (see also [ARCH-003](#ARCH-003) on passing the most specific
+dependency).
+
+This applies to any "lookup key" object — a broad handle used to fetch a wide
+graph of services, such as `Profile`, `BrowserContext`, `WebContents`,
+`TabInterface`, or `Browser`. Prefer injecting the specific dependencies
+resolved from the key rather than the key itself, since injecting the key still
+lets a feature reach anything reachable from it (undermining testability and
+hiding coupling). When a feature genuinely needs the key, inject the key rather
+than pulling it from a global.
+
+```cpp
+// ❌ WRONG - reaching for a lookup key via global state, then resolving from it
+void FooFeature::DoStuff() {
+  Profile* profile = ProfileManager::GetActiveUserProfile();
+  UseKeyedService(BarServiceFactory::GetForProfile(profile));
+}
+
+// ✅ BEST - inject the specific dependency resolved from the key
+FooFeature(BarService& bar_service) : bar_service_(bar_service) {}
+void FooFeature::DoStuff() { UseKeyedService(bar_service_); }
+
+// ✅ ACCEPTABLE - inject the key itself when it is genuinely required (e.g. tab
+// features taking TabInterface); still better than reaching for a global, but
+// prefer injecting the resolved dependencies above where practical
+FooFeature(Profile& profile) : profile_(profile) {}
+```
+
+---


### PR DESCRIPTION
## Summary

Adds a new architecture best practice, **ARCH-073: Inject Dependencies at Construction; Don't Reach for Global State or `Browser*`**, to `docs/best-practices/architecture.md`.

Sourced from Chromium's `docs/chrome_browser_design_principles.md` (Feature Design / Modularity sections): features should take exactly the dependencies they need at construction rather than reaching for global state (`g_browser_process`, singletons, `NoDestructor` globals) or a `Browser*` god-object.

## Why this is distinct from existing DI guidance

- **ARCH-002** covers DI specifically as a fix for `components/` → browser **layering violations**.
- **ARCH-003** covers passing the **most specific dependency** ("not bag-of-stuff").
- **ARCH-073** is the broader design default: prefer constructor injection over ambient global state / `Browser*` for **all** features, motivated by testability, exposing circular dependencies, and reduced coupling. It also covers "lookup key" objects generally (`Profile`, `BrowserContext`, `WebContents`, `TabInterface`, `Browser`): prefer injecting the specific resolved dependencies over the key itself, and inject the key rather than pulling it from a global when the key is genuinely required. Cross-references ARCH-002 and ARCH-003.

## Notes

- ID `ARCH-073` = highest existing ARCH id + 1.
- `manage-bp-ids.py --validate` shows only pre-existing MISSING ID failures in unrelated docs; none introduced here.
- Markdown formatted via `npm run format`.