### PR TITLE
[iOS] Shutdown Brave policy provider correctly

### DIFF
--- a/chromium_src/ios/chrome/browser/policy/model/profile_policy_connector.h
+++ b/chromium_src/ios/chrome/browser/policy/model/profile_policy_connector.h
@@ -18,9 +18,13 @@
   ProfilePolicyConnectorMock;                          \
   std::unique_ptr<policy::ConfigurationPolicyProvider> \
       brave_profile_policy_provider_
+#define Shutdown \
+  Shutdown();    \
+  void Shutdown_ChromiumImpl
 
 #include <ios/chrome/browser/policy/model/profile_policy_connector.h>  // IWYU pragma: export
 
+#undef Shutdown
 #undef ProfilePolicyConnectorMock
 #undef UseLocalTestPolicyProvider
 

--- a/chromium_src/ios/chrome/browser/policy/model/profile_policy_connector.mm
+++ b/chromium_src/ios/chrome/browser/policy/model/profile_policy_connector.mm
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include "ios/chrome/browser/policy/model/profile_policy_connector.h"
+
 #include "components/policy/core/common/configuration_policy_provider.h"
 
 namespace brave_policy {
@@ -17,12 +19,19 @@ CreateBraveProfilePolicyProvider();
       brave_policy::CreateBraveProfilePolicyProvider();              \
   policy_providers_.push_back(brave_profile_policy_provider_.get()); \
   brave_profile_policy_provider_->Init(schema_registry);
+#define Shutdown Shutdown_ChromiumImpl
 
 #include <ios/chrome/browser/policy/model/profile_policy_connector.mm>
+
+#undef Shutdown
+#undef BRAVE_PROFILE_POLICY_CONNECTOR_INIT
 
 raw_ptr<policy::ConfigurationPolicyProvider>
 ProfilePolicyConnector::GetBraveProfilePolicyProvider() {
   return brave_profile_policy_provider_.get();
 }
 
-#undef BRAVE_PROFILE_POLICY_CONNECTOR_INIT
+void ProfilePolicyConnector::Shutdown() {
+  ProfilePolicyConnector::Shutdown_ChromiumImpl();
+  brave_profile_policy_provider_->Shutdown();
+}


### PR DESCRIPTION
Chromium's `ProfilePolicyConnector::Shutdown` never shutdown our Origin policy provider because we stored this policy provider separately, this makes sure that the provider is shutdown when the connector is shutdown.

This is technically not called yet on iOS as we dont teardown Profile correctly on app termination, but a future PR will add support for that