### PR TITLE
[iOS] Commit pending writes on profile prefs when app terminates

### DIFF
--- a/ios/app/brave_core_main.mm
+++ b/ios/app/brave_core_main.mm
@@ -211,6 +211,15 @@ const BraveCoreLogSeverity BraveCoreLogSeverityVerbose =
   // ApplicationContextImpl doesn't get teardown call at the moment because we
   // cannot dealloc this class yet without crashing.
   GetApplicationContext()->GetLocalState()->CommitPendingWrite();
+
+  ProfileManagerIOS* profile_manager =
+      GetApplicationContext()->GetProfileManager();
+  if (profile_manager) {
+    for (ProfileIOS* profile : profile_manager->GetLoadedProfiles()) {
+      profile->GetPrefs()->CommitPendingWrite();
+    }
+  }
+
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 


### PR DESCRIPTION
This commits any pending writes to any loaded profiles when the user or system kills Brave.

This is a stop-gap until we can properly teardown Chromium on termination instead.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56699

