### PR TITLE
[iOS] [CI] Store fastlane build logs in workspace

### DIFF
--- a/ios/brave-ios/fastlane/Fastfile
+++ b/ios/brave-ios/fastlane/Fastfile
@@ -165,6 +165,7 @@ platform :ios do
       clean: true,
       output_directory: "build",
       derived_data_path: "../../../out/DerivedData",
+      buildlog_path: "../../../out/fastlane_logs/gym",
     }
   end
 
@@ -177,6 +178,7 @@ platform :ios do
       output_types: "junit",
       output_files: "junit.xml",
       derived_data_path: "../../../out/DerivedData",
+      buildlog_path: "../../../out/fastlane_logs/scan",
       number_of_retries: 1,
       output_remove_retry_attempts: true
     }


### PR DESCRIPTION
This updates the `fastlane` commands we use for building/testing to output logs to the nodes workspace instead of to the default `~/Library/Logs` folder.
