### PR TITLE
[Local AI] [WebSpeech] Add onnxruntime-web dependency and bundle its runtime for the on-device speech worker

### DIFF
--- a/components/local_ai/resources/speech_worker_ort/BUILD.gn
+++ b/components/local_ai/resources/speech_worker_ort/BUILD.gn
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/components/local_ai/buildflags/buildflags.gni")
+import("//brave/resources/brave_grit.gni")
+
+assert(enable_local_ai)
+
+# Bundles the stock onnxruntime-web distribution (loader bundle, pthread
+# worker glue, threaded WASM) from node_modules into a pak served by the ORT
+# speech worker WebUI under /ort-dist/. Files are taken from
+# node_modules/onnxruntime-web/dist whose version is pinned in
+# brave/package.json.
+brave_grit("ort_dist_generated") {
+  source = "ort_dist_resources.grd"
+  output_dir = "$root_gen_dir/brave/components/local_ai/resources"
+  outputs = [
+    "grit/ort_dist_generated.h",
+    "grit/ort_dist_generated_map.cc",
+    "grit/ort_dist_generated_map.h",
+    "ort_dist_generated.pak",
+  ]
+}

--- a/components/local_ai/resources/speech_worker_ort/ort_dist_resources.grd
+++ b/components/local_ai/resources/speech_worker_ort/ort_dist_resources.grd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<grit latest_public_release="0" current_release="1">
+  <outputs>
+    <output filename="grit/ort_dist_generated.h" type="rc_header">
+      <emit emit_type='prepend'></emit>
+    </output>
+    <output filename="grit/ort_dist_generated_map.cc"
+            type="resource_file_map_source" />
+    <output filename="grit/ort_dist_generated_map.h"
+            type="resource_map_header" />
+    <output filename="ort_dist_generated.pak" type="data_package" />
+  </outputs>
+  <release seq="1">
+    <includes>
+      <!-- onnxruntime-web runtime dist files from node_modules, bundled into
+        the ORT speech worker pak. .mjs sources are served under .js names to
+        be identified as application/javascript mime type instead of text/html,
+        since .mjs is not handled (falling back to text/html) in Chromium's
+        WebUIDataSourceImpl::GetMimeType. -->
+      <include name="IDR_ORT_DIST_ORT_WASM_BUNDLE_MIN_JS"
+               file="../../../../node_modules/onnxruntime-web/dist/ort.wasm.bundle.min.mjs"
+               resource_path="ort-dist/ort.wasm.bundle.min.js"
+               type="BINDATA" />
+      <include name="IDR_ORT_DIST_ORT_WASM_SIMD_THREADED_JS"
+               file="../../../../node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.mjs"
+               resource_path="ort-dist/ort-wasm-simd-threaded.js"
+               type="BINDATA" />
+      <include name="IDR_ORT_DIST_ORT_WASM_SIMD_THREADED_WASM"
+               file="../../../../node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.wasm"
+               resource_path="ort-dist/ort-wasm-simd-threaded.wasm"
+               type="BINDATA" />
+    </includes>
+  </release>
+</grit>

--- a/components/resources/BUILD.gn
+++ b/components/resources/BUILD.gn
@@ -108,10 +108,12 @@ repack("resources") {
     deps += [
       "//brave/components/local_ai/resources:local_ai_generated",
       "//brave/components/local_ai/resources/candle_embedding_gemma:candle_embedding_module_generated",
+      "//brave/components/local_ai/resources/speech_worker_ort:ort_dist_generated",
     ]
     sources += [
       "$root_gen_dir/brave/components/local_ai/resources/candle_embedding_module_generated.pak",
       "$root_gen_dir/brave/components/local_ai/resources/local_ai_generated.pak",
+      "$root_gen_dir/brave/components/local_ai/resources/ort_dist_generated.pak",
     ]
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "darkreader": "4.9.125",
         "date-fns": "2.28.0",
         "jszip": "3.8.0",
+        "onnxruntime-web": "1.26.0",
         "prettier-bytes": "1.0.4",
         "qr-image": "3.2.0",
         "react-json-view-lite": "0.9.5",
@@ -13455,6 +13456,12 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/flatted": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -13974,6 +13981,12 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "devOptional": true
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -19462,6 +19475,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/onnxruntime-common": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.26.0.tgz",
+      "integrity": "sha512-qVyMR4lcWgbkc4getFV+GQijsTnbg/siteoqcDwa3sI/LxbrMSNw4ePyvCq/ymdQaRomCA7YuWmhzsswxvymdw==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0.tgz",
+      "integrity": "sha512-LbRr/8zZt2xilI2smrVQGGKINo0U46i8qJp+UXyMBGfqN7KjnH1BiwCwLwyNIVV4i9CKFv7Sf4PwLKWnT8/bEA==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.26.0",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
     "node_modules/open": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
@@ -20024,6 +20057,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
     },
     "node_modules/polished": {
       "version": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -229,6 +229,7 @@
     "darkreader": "4.9.125",
     "date-fns": "2.28.0",
     "jszip": "3.8.0",
+    "onnxruntime-web": "1.26.0",
     "prettier-bytes": "1.0.4",
     "qr-image": "3.2.0",
     "react-json-view-lite": "0.9.5",

--- a/resources/resource_ids.spec
+++ b/resources/resource_ids.spec
@@ -267,6 +267,10 @@
     "META": {"sizes": {"includes": [10]}},
     "includes": [54150],
   },
+  "brave/components/local_ai/resources/speech_worker_ort/ort_dist_resources.grd": {
+    "META": {"sizes": {"includes": [5]}},
+    "includes": [54160],
+  },
   # WARNING: The IDs range is 2^16-1. Check
   # out/<BUILD_TYPE>/gen/brave/resources/brave_resource_ids for how much the
   # ids got expanded for the build.

--- a/third_party/npm_onnxruntime-web/LICENSE
+++ b/third_party/npm_onnxruntime-web/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/npm_onnxruntime-web/README.chromium
+++ b/third_party/npm_onnxruntime-web/README.chromium
@@ -1,0 +1,3 @@
+Name: onnxruntime-web
+URL: https://github.com/microsoft/onnxruntime
+License: MIT


### PR DESCRIPTION
Part of the on-device WebSpeech API work: https://github.com/brave/brave-browser/issues/56487

Adding the dependency has been approved via https://github.com/brave/reviews/issues/2268.

This is a foundation PR in the stack. It adds onnxruntime-web (ORT-Web) as a dependency and bundles its prebuilt WASM runtime into a component resource, so later PRs can run the Nemotron speech model in a chrome-untrusted:// worker. Nothing consumes the runtime yet, the worker WebUI that serves it comes in a subsequent PR. It is grouped this way so the dependency and its shipped binaries are reviewed together.

What's included:
  - npm dependency for onnxruntime-web
  - License: third_party/npm_onnxruntime-web/ with the MIT LICENSE and README.chromium
  - Runtime resources: repacks the stock ORT-Web dist files from node_modules into ort_dist_generated.pak, wired into components/resources/BUILD.gn and resource_ids.spec