### PR TITLE
[bootstrap] Fix node path single ownership

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,11 @@ patches/**/*.patchinfo
 /third_party/macholib
 /third_party/libdmg-hfsplus/
 /third_party/node/node-*/
+/third_party/node/linux/
+/third_party/node/mac/
+/third_party/node/mac_arm64/
+/third_party/node/win/
 /third_party/node/*.tar.gz
-/third_party/node/.*.stamp
 /third_party/opengrep/bin/
 /third_party/wintun/
 /third_party/ast-grep-intermediate/
@@ -49,6 +52,7 @@ patches/**/*.patchinfo
 !/ios/brave-ios/App/*.xcodeproj
 *.swp
 *.pyc
+*.stamp
 *.VC.db
 *.VC.VC.opendb
 .vs/

--- a/DEPS
+++ b/DEPS
@@ -209,7 +209,10 @@ hooks = [
     'pattern': '.',
     'action': ['vpython3',
                'tools/cr/install_extra_deps.py',
-               'src/brave/third_party/node']
+               'src/brave/third_party/node/linux',
+               'src/brave/third_party/node/mac',
+               'src/brave/third_party/node/mac_arm64',
+               'src/brave/third_party/node/win']
   },
 ]
 

--- a/tools/cr/bootstrap/launcher.py
+++ b/tools/cr/bootstrap/launcher.py
@@ -52,24 +52,25 @@ SHIM_TARGETS: dict[str, Shim] = {
     'brockit': Shim('src/brave/tools/cr/brockit.py', 'vpython'),
     'plaster': Shim('src/brave/tools/cr/plaster.py', 'vpython'),
     'node-linux': Shim(
-        'src/brave/third_party/node/node-v24.17.0-linux-x64/bin/node'),
+        'src/brave/third_party/node/linux/node-v24.17.0-linux-x64/bin/node'),
     'node-mac': Shim(
-        'src/brave/third_party/node/node-v24.17.0-darwin-x64/bin/node'),
+        'src/brave/third_party/node/mac/node-v24.17.0-darwin-x64/bin/node'),
     'node-mac_arm64': Shim(
-        'src/brave/third_party/node/node-v24.17.0-darwin-arm64/bin/node'),
+        'src/brave/third_party/node/mac_arm64/node-v24.17.0-darwin-arm64/bin/node'
+    ),
     'node-win': Shim(
-        'src/brave/third_party/node/node-v24.17.0-win-x64/node.exe'),
+        'src/brave/third_party/node/win/node-v24.17.0-win-x64/node.exe'),
     'npm-linux': Shim(
-        'src/brave/third_party/node/node-v24.17.0-linux-x64/lib/node_modules/npm/bin/npm-cli.js',
+        'src/brave/third_party/node/linux/node-v24.17.0-linux-x64/lib/node_modules/npm/bin/npm-cli.js',
         'node'),
     'npm-mac': Shim(
-        'src/brave/third_party/node/node-v24.17.0-darwin-x64/lib/node_modules/npm/bin/npm-cli.js',
+        'src/brave/third_party/node/mac/node-v24.17.0-darwin-x64/lib/node_modules/npm/bin/npm-cli.js',
         'node'),
     'npm-mac_arm64': Shim(
-        'src/brave/third_party/node/node-v24.17.0-darwin-arm64/lib/node_modules/npm/bin/npm-cli.js',
+        'src/brave/third_party/node/mac_arm64/node-v24.17.0-darwin-arm64/lib/node_modules/npm/bin/npm-cli.js',
         'node'),
     'npm-win': Shim(
-        'src/brave/third_party/node/node-v24.17.0-win-x64/node_modules/npm/bin/npm-cli.js',
+        'src/brave/third_party/node/win/node-v24.17.0-win-x64/node_modules/npm/bin/npm-cli.js',
         'node'),
 }
 

--- a/tools/cr/install_extra_deps.py
+++ b/tools/cr/install_extra_deps.py
@@ -12,13 +12,16 @@ it deployed more generic, and reusable for other cases.
 
 `EXTRA_DEPS` mirrors the shape of a gclient `gcs` dependency, keyed by the
 checkout-relative destination path. Each object lists an `object_name`, its
-`sha256sum`, a `condition`, and optionally `overlayed_on`, which selects how it
-is installed:
+`sha256sum`, an optional per-object `condition`, and optionally `overlayed_on`,
+which selects how it is installed:
 
   * Overlay (with `overlayed_on`) -- extracted on top of the upstream archive it
     names, which is validated against DEPS so we never overlay a rolled base.
   * Owned (without `overlayed_on`) -- fully owns its destination, which is wiped
     and re-extracted each install so no stale extraction lingers.
+
+An entry with a single object may omit its per-object `condition` and gate on
+the dep-level `condition` alone.
 
 `bucket` is just an HTTPS prefix `object_name` is appended to: one of Brave's
 buckets, or an upstream distribution (e.g. `nodejs.org/dist`) used as one.
@@ -101,29 +104,43 @@ EXTRA_DEPS = {
             },
         ],
     },
-    'src/brave/third_party/node': {
+    'src/brave/third_party/node/linux': {
         'bucket': 'https://brave-build-deps-public.s3.brave.com/nodejs/',
-        'condition': 'checkout_linux or checkout_mac or checkout_win',
+        'condition': 'host_os == "linux"',
         'objects': [
             {
                 'object_name': 'node-v24.17.0-linux-x64.tar.gz',
                 'sha256sum': 'e0472427aa791ad80bdc426ff7cc73cdd28ed0f616d1ff9689a23a7f47f1265f',
-                'condition': 'host_os == "linux"',
             },
-            {
-                'object_name': 'node-v24.17.0-darwin-arm64.tar.gz',
-                'sha256sum': '4fc3266a3702eebc39cc37661cf4eeceeade307e242ab64e4d7ce7949197e11f',
-                'condition': 'host_os == "mac" and host_cpu == "arm64"',
-            },
+        ],
+    },
+    'src/brave/third_party/node/mac': {
+        'bucket': 'https://brave-build-deps-public.s3.brave.com/nodejs/',
+        'condition': 'host_os == "mac" and host_cpu == "x64"',
+        'objects': [
             {
                 'object_name': 'node-v24.17.0-darwin-x64.tar.gz',
                 'sha256sum': '80da552fe037290cb130e9dea590f5eeeb7aa450636f0c89ab41415511c1ec27',
-                'condition': 'host_os == "mac" and host_cpu == "x64"',
             },
+        ],
+    },
+    'src/brave/third_party/node/mac_arm64': {
+        'bucket': 'https://brave-build-deps-public.s3.brave.com/nodejs/',
+        'condition': 'host_os == "mac" and host_cpu == "arm64"',
+        'objects': [
+            {
+                'object_name': 'node-v24.17.0-darwin-arm64.tar.gz',
+                'sha256sum': '4fc3266a3702eebc39cc37661cf4eeceeade307e242ab64e4d7ce7949197e11f',
+            },
+        ],
+    },
+    'src/brave/third_party/node/win': {
+        'bucket': 'https://brave-build-deps-public.s3.brave.com/nodejs/',
+        'condition': 'host_os == "win"',
+        'objects': [
             {
                 'object_name': 'node-v24.17.0-win-x64.zip',
                 'sha256sum': 'f2aa33b35b75aca5f3f7b85675a6f6423201053e9381911e64961f3bda2528ab',
-                'condition': 'host_os == "win"',
             },
         ],
     },
@@ -139,8 +156,8 @@ def _select_object(objects: list[dict],
     host platform).
     """
     matches = [
-        obj for obj in objects
-        if gclient_eval.EvaluateCondition(obj['condition'], variables)
+        obj for obj in objects if 'condition' not in obj
+        or gclient_eval.EvaluateCondition(obj['condition'], variables)
     ]
     if not matches:
         return None
@@ -404,17 +421,21 @@ def main() -> int:
     _LOG.setLevel(logging.INFO)
 
     parser = argparse.ArgumentParser(
-        description='Download and install the bucket-hosted archive for the '
-        'given EXTRA_DEPS entry.')
+        description='Download and install the bucket-hosted archive(s) for the '
+        'given EXTRA_DEPS entries.')
     parser.add_argument(
-        'dep',
+        'deps',
+        nargs='+',
         choices=sorted(EXTRA_DEPS),
         metavar='DEP_PATH',
-        help='Path key in EXTRA_DEPS identifying the entry to install '
-        '(e.g. src/third_party/rust-toolchain).')
+        help='One or more path keys in EXTRA_DEPS identifying the entries to '
+        'install. Entries whose condition is false on this host are skipped, '
+        'so a single invocation may list every per-platform variant.')
     args = parser.parse_args()
 
-    ExtraDepsRunner.from_checkout().install(args.dep, EXTRA_DEPS[args.dep])
+    runner = ExtraDepsRunner.from_checkout()
+    for dep in args.deps:
+        runner.install(dep, EXTRA_DEPS[dep])
     return 0
 
 

--- a/tools/cr/install_extra_deps_test.py
+++ b/tools/cr/install_extra_deps_test.py
@@ -118,6 +118,13 @@ class SelectObjectTest(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, 'Multiple objects match'):
             m._select_object(objects, {'host_os': 'linux'})
 
+    def test_object_without_condition_always_matches(self):
+        """A single object with no `condition` selects unconditionally, as our
+        per-platform node deps gate on the dep-level condition instead."""
+        objects = [{'object_name': 'node-linux-x64.tar.gz'}]
+        picked = m._select_object(objects, {'host_os': 'mac'})
+        self.assertEqual(picked['object_name'], 'node-linux-x64.tar.gz')
+
 
 class TarballInstallerTest(unittest.TestCase):
     """Tests for `TarballInstaller` download/extract/sidecar mechanics."""
@@ -575,6 +582,14 @@ class MainTest(unittest.TestCase):
                 'condition': 'True',
             }],
         },
+        'src/path/to/other': {
+            'bucket': 'https://downloads.invalid/',
+            'objects': [{
+                'object_name': 'other.tar.gz',
+                'sha256sum': 'b',
+                'condition': 'True',
+            }],
+        },
     }
 
     def test_dispatches_selected_dep_to_runner(self):
@@ -589,6 +604,22 @@ class MainTest(unittest.TestCase):
                                        ['install_extra_deps', dep]):
                     self.assertEqual(m.main(), 0)
         runner.install.assert_called_once_with(dep, self._FAKE_EXTRA_DEPS[dep])
+
+    def test_dispatches_every_dep_in_order(self):
+        """Multiple dep keys install each entry's spec, in the given order, on
+        the one shared runner (as the per-platform node hook does)."""
+        runner = mock.Mock()
+        deps = ['src/path/to/dep', 'src/path/to/other']
+        with mock.patch.object(m, 'EXTRA_DEPS', self._FAKE_EXTRA_DEPS):
+            with mock.patch.object(m.ExtraDepsRunner,
+                                   'from_checkout',
+                                   return_value=runner):
+                with mock.patch.object(sys, 'argv',
+                                       ['install_extra_deps', *deps]):
+                    self.assertEqual(m.main(), 0)
+        self.assertEqual(
+            runner.install.call_args_list,
+            [mock.call(dep, self._FAKE_EXTRA_DEPS[dep]) for dep in deps])
 
     def test_rejects_unknown_dep(self):
         """An unknown dep key is rejected by argparse before any work runs."""


### PR DESCRIPTION
We recently landed:

 - https://github.com/brave/brave-core/pull/37655

This PR added build scripts to `third_party/node`, and that conflicts
with node being deployed during sync and the path being cleared out for
that.

This change corrects this by deploying each node file under particular
platform paths.

Bug: https://github.com/brave/brave-browser/issues/56529
