### PR TITLE
[iOS] Fix off-sequence PrefService read when clearing private data (uplift to 1.93.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdvancedShieldSettings.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdvancedShieldSettings.swift
@@ -336,10 +336,12 @@ import os
       }
     }
 
-    let prefs = self.prefs
+    // PrefService is bound to the main sequence so let's read it here (on the main actor)
+    // and capture the primitive so the @Sendable closure never touches PrefService off-sequence.
+    let blockAllCookiesEnabled = self.prefs.boolean(forPath: kBlockAllCookiesEnabled)
     @Sendable func _toggleFolderAccessForBlockCookies(locked: Bool) async {
       do {
-        if prefs.boolean(forPath: kBlockAllCookiesEnabled),
+        if blockAllCookiesEnabled,
           try await AsyncFileManager.default.isWebDataLocked(atPath: .cookie) != locked
         {
           try await AsyncFileManager.default.setWebDataAccess(atPath: .cookie, lock: locked)


### PR DESCRIPTION
Uplift of #37668
Resolves https://github.com/brave/brave-browser/issues/56802

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.