### PR TITLE
[Local AI] [WebSpeech] Add Controller for on device speech recognition

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -1621,6 +1621,9 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
       <message name="IDS_LOCAL_AI_TASK_MANAGER_TITLE" desc="The label for the on-device AI background process in the Task Manager.">
         On-Device AI
       </message>
+      <message name="IDS_ON_DEVICE_SPEECH_RECOGNITION_TASK_MANAGER_TITLE" desc="The label for the on-device speech recognition background process in the Task Manager.">
+        On-Device Speech Recognition
+      </message>
 
       <!-- History semantic search disclaimer. Upstream's text implies a
            round-trip to the vendor with human review; Brave's implementation

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -401,6 +401,7 @@ if (enable_email_aliases) {
 if (enable_local_ai) {
   brave_chrome_browser_deps += [
     "//brave/browser/history_embeddings",
+    "//brave/browser/speech",
     "//brave/browser/ui/webui/local_ai",
     "//brave/components/local_ai/core",
     "//brave/components/local_ai/core:features",

--- a/browser/speech/BUILD.gn
+++ b/browser/speech/BUILD.gn
@@ -27,3 +27,24 @@ static_library("speech") {
     "//url",
   ]
 }
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [ "on_device_speech_recognition_controller_unittest.cc" ]
+
+  deps = [
+    ":speech",
+    "//base",
+    "//base/test:test_support",
+    "//brave/components/local_ai/core",
+    "//brave/components/local_ai/core:speech_recognition_mojom",
+    "//chrome/browser/profiles:profile",
+    "//chrome/test:test_support",
+    "//content/test:test_support",
+    "//mojo/public/cpp/bindings",
+    "//services/on_device_model/public/mojom",
+    "//testing/gtest",
+    "//url",
+  ]
+}

--- a/browser/speech/BUILD.gn
+++ b/browser/speech/BUILD.gn
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/components/local_ai/buildflags/buildflags.gni")
+
+assert(enable_local_ai)
+
+static_library("speech") {
+  sources = [
+    "on_device_speech_recognition_controller.cc",
+    "on_device_speech_recognition_controller.h",
+  ]
+
+  deps = [
+    "//base",
+    "//brave/app:brave_generated_resources_grit",
+    "//brave/browser/local_ai",
+    "//brave/components/local_ai/core",
+    "//brave/components/local_ai/core:speech_recognition_mojom",
+    "//chrome/browser/profiles:profile",
+    "//mojo/public/cpp/base",
+    "//mojo/public/cpp/bindings",
+    "//services/network/public/mojom",
+    "//services/on_device_model/public/mojom",
+    "//url",
+  ]
+}

--- a/browser/speech/on_device_speech_recognition_controller.cc
+++ b/browser/speech/on_device_speech_recognition_controller.cc
@@ -5,18 +5,23 @@
 
 #include "brave/browser/speech/on_device_speech_recognition_controller.h"
 
+#include <optional>
 #include <utility>
 #include <vector>
 
 #include "base/functional/bind.h"
+#include "base/logging.h"
 #include "base/memory/ptr_util.h"
 #include "base/no_destructor.h"
 #include "base/task/sequenced_task_runner.h"
+#include "base/task/thread_pool.h"
 #include "brave/browser/local_ai/background_web_contents_factory.h"
 #include "brave/components/local_ai/core/on_device_speech_models_state.h"
 #include "brave/components/local_ai/core/url_constants.h"
+#include "brave/components/local_ai/core/utils.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/profiles/profile.h"
+#include "mojo/public/cpp/base/big_buffer.h"
 #include "services/network/public/mojom/web_sandbox_flags.mojom-shared.h"
 #include "url/gurl.h"
 
@@ -30,6 +35,59 @@ OnDeviceSpeechRecognitionController::PendingSession::operator=(
     PendingSession&&) = default;
 OnDeviceSpeechRecognitionController::PendingSession::~PendingSession() =
     default;
+
+namespace {
+
+// Runs on a ThreadPool blocking sequence. Reads the Nemotron 0.6B streaming
+// model's graphs (encoder/decoder), the 128-mel filterbank and the token
+// list, all in full, and packs them into an OrtModelFiles. The worker builds
+// its ORT sessions directly from these bytes. Only the .onnx + .onnx.data
+// (external-data) export is supported as it lets ORT-Web reference the weights
+// in place instead of making an extra copy of the model files in WASM memory.
+local_ai::mojom::OrtModelFilesPtr ReadNemotronOrtFiles(
+    const base::FilePath& model_dir) {
+  auto encoder =
+      local_ai::ReadFileToBigBuffer(model_dir.AppendASCII("encoder.onnx"));
+  if (!encoder) {
+    return nullptr;
+  }
+  auto decoder = local_ai::ReadFileToBigBuffer(
+      model_dir.AppendASCII("decoder_joint.onnx"));
+  if (!decoder) {
+    return nullptr;
+  }
+  auto encoder_data =
+      local_ai::ReadFileToBigBuffer(model_dir.AppendASCII("encoder.onnx.data"));
+  if (!encoder_data) {
+    return nullptr;
+  }
+  auto decoder_data = local_ai::ReadFileToBigBuffer(
+      model_dir.AppendASCII("decoder_joint.onnx.data"));
+  if (!decoder_data) {
+    return nullptr;
+  }
+  auto filterbank =
+      local_ai::ReadFileToBigBuffer(model_dir.AppendASCII("filterbank.bin"));
+  if (!filterbank) {
+    return nullptr;
+  }
+  auto tokens =
+      local_ai::ReadFileToBigBuffer(model_dir.AppendASCII("tokens.txt"));
+  if (!tokens) {
+    return nullptr;
+  }
+
+  auto files = local_ai::mojom::OrtModelFiles::New();
+  files->encoder = std::move(*encoder);
+  files->decoder = std::move(*decoder);
+  files->encoder_data = std::move(*encoder_data);
+  files->decoder_data = std::move(*decoder_data);
+  files->mel_filters = std::move(*filterbank);
+  files->tokens = std::move(*tokens);
+  return files;
+}
+
+}  // namespace
 
 // static
 OnDeviceSpeechRecognitionController*
@@ -79,6 +137,33 @@ OnDeviceSpeechRecognitionController::GetAsrSession() {
   asr_session_receivers_.Add(this, remote.InitWithNewPipeAndPassReceiver());
   idle_timer_.Stop();
   return remote;
+}
+
+void OnDeviceSpeechRecognitionController::BindFactoryHost(
+    mojo::PendingReceiver<local_ai::mojom::SpeechRecognitionFactoryHost>
+        receiver) {
+  // This is renderer-triggered (the worker page requests the interface) and a
+  // renderer cannot be assumed well-behaved, so it could request the interface
+  // again while already bound. Bind() DCHECKs on an already-bound receiver, and
+  // a renderer must never be able to trip a browser DCHECK, so reset first to
+  // supersede any existing connection.
+  factory_host_receiver_.reset();
+  factory_host_receiver_.Bind(std::move(receiver));
+}
+
+void OnDeviceSpeechRecognitionController::RegisterFactory(
+    mojo::PendingRemote<local_ai::mojom::SpeechRecognitionFactory> factory) {
+  if (state_ != State::kWorkerStarting || factory_.is_bound()) {
+    return;
+  }
+  startup_timer_.Stop();
+  factory_.Bind(std::move(factory));
+  // factory_ is a member, so its disconnect handler cannot outlive `this`.
+  factory_.set_disconnect_handler(base::BindOnce(
+      &OnDeviceSpeechRecognitionController::OnFactoryDisconnected,
+      base::Unretained(this)));
+  state_ = State::kModelLoading;
+  LoadOrtModel();
 }
 
 void OnDeviceSpeechRecognitionController::Start(
@@ -185,6 +270,52 @@ void OnDeviceSpeechRecognitionController::OnBackgroundContentsCreated(
   state_ = State::kWorkerStarting;
 }
 
+void OnDeviceSpeechRecognitionController::LoadOrtModel() {
+  auto* state = local_ai::OnDeviceSpeechModelsState::GetInstance();
+  // A ThreadPool reply is not stopped by resetting factory_, so bind it weakly.
+  // TearDown()'s InvalidateWeakPtrs() drops it before it can run against a
+  // reset or superseded factory.
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+      base::BindOnce(&ReadNemotronOrtFiles, state->GetModelDir()),
+      base::BindOnce(&OnDeviceSpeechRecognitionController::OnOrtFilesRead,
+                     weak_factory_.GetWeakPtr()));
+}
+
+void OnDeviceSpeechRecognitionController::OnOrtFilesRead(
+    local_ai::mojom::OrtModelFilesPtr files) {
+  if (!files) {
+    VLOG(1)
+        << "OnDeviceSpeechRecognition: failed to read ORT model files from "
+        << local_ai::OnDeviceSpeechModelsState::GetInstance()->GetModelDir();
+    TearDown();
+    return;
+  }
+
+  // Defensive deref guard. The weak binding (dropped by TearDown()) means this
+  // reply does not run after teardown, so factory_ is expected to be bound
+  // here, but guard the raw Remote deref anyway.
+  if (!factory_.is_bound()) {
+    return;
+  }
+
+  // The Init reply is owned by factory_ (a member), so it cannot outlive
+  // `this`; it is dropped if factory_ is reset.
+  factory_->Init(
+      std::move(files),
+      base::BindOnce(&OnDeviceSpeechRecognitionController::OnOrtInitResult,
+                     base::Unretained(this)));
+}
+
+void OnDeviceSpeechRecognitionController::OnOrtInitResult(bool success) {
+  if (!success) {
+    TearDown();
+    return;
+  }
+  state_ = State::kReady;
+  // Forwarding queued sessions to the worker lands in the routing change.
+}
+
 void OnDeviceSpeechRecognitionController::StartIdleTimer() {
   // idle_timer_ is a member, so it cannot fire after `this` is destroyed.
   idle_timer_.Start(
@@ -207,18 +338,24 @@ void OnDeviceSpeechRecognitionController::OnStartupTimeout() {
   TearDown();
 }
 
+void OnDeviceSpeechRecognitionController::OnFactoryDisconnected() {
+  TearDown();
+}
+
 void OnDeviceSpeechRecognitionController::TearDown() {
-  // Drop outstanding weak-bound replies (BWC creation, deferred teardown) so
-  // none from this cycle can land in a later one. The singleton is never
-  // destroyed, so nothing else invalidates them.
+  // Drop outstanding weak-bound replies (BWC creation, deferred teardown, the
+  // model-file read) so none from this cycle can land in a later one. The
+  // singleton is never destroyed, so nothing else invalidates them.
   weak_factory_.InvalidateWeakPtrs();
   startup_timer_.Stop();
   idle_timer_.Stop();
+  factory_.reset();
   background_web_contents_.reset();
   profile_observation_.Reset();
   otr_profile_ = nullptr;
   pending_sessions_.clear();
   asr_session_receivers_.Clear();
+  factory_host_receiver_.reset();
   state_ = State::kIdle;
 }
 

--- a/browser/speech/on_device_speech_recognition_controller.cc
+++ b/browser/speech/on_device_speech_recognition_controller.cc
@@ -171,12 +171,18 @@ void OnDeviceSpeechRecognitionController::Start(
     mojo::PendingReceiver<on_device_model::mojom::AsrStreamInput> stream,
     mojo::PendingRemote<on_device_model::mojom::AsrStreamResponder> responder) {
   // No model installed: don't spin up a guest profile + cross-origin-isolated
-  // renderer just to discover the files are missing. Dropping the
-  // stream/responder pipes here surfaces to the engine as a recognition
-  // failure, the same outcome as a failed load.
+  // renderer just to discover the files are missing in OnOrtFilesRead.
+  // Dropping the stream/responder pipes here surfaces to the engine as a
+  // recognition failure, the same outcome as a failed load.
   if (local_ai::OnDeviceSpeechModelsState::GetInstance()
           ->GetModelDir()
           .empty()) {
+    return;
+  }
+
+  // Worker is ready, forward session to worker.
+  if (state_ == State::kReady) {
+    ForwardSession(std::move(options), std::move(stream), std::move(responder));
     return;
   }
 
@@ -185,7 +191,7 @@ void OnDeviceSpeechRecognitionController::Start(
     StartWorker();
   }
 
-  // Queue the session until the worker is ready.
+  // Queue the session until worker is ready.
   PendingSession pending;
   pending.options = std::move(options);
   pending.stream = std::move(stream);
@@ -292,9 +298,10 @@ void OnDeviceSpeechRecognitionController::OnOrtFilesRead(
     return;
   }
 
-  // Defensive deref guard. The weak binding (dropped by TearDown()) means this
-  // reply does not run after teardown, so factory_ is expected to be bound
-  // here, but guard the raw Remote deref anyway.
+  // Defensive deref guard, consistent with ForwardSession(). The weak binding
+  // (dropped by TearDown()) means this reply does not run after teardown, so
+  // factory_ is expected to be bound here, but guard the raw Remote deref
+  // anyway.
   if (!factory_.is_bound()) {
     return;
   }
@@ -313,7 +320,27 @@ void OnDeviceSpeechRecognitionController::OnOrtInitResult(bool success) {
     return;
   }
   state_ = State::kReady;
-  // Forwarding queued sessions to the worker lands in the routing change.
+  ForwardPendingSessions();
+}
+
+void OnDeviceSpeechRecognitionController::ForwardPendingSessions() {
+  std::vector<PendingSession> drained;
+  drained.swap(pending_sessions_);
+  for (auto& pending : drained) {
+    ForwardSession(std::move(pending.options), std::move(pending.stream),
+                   std::move(pending.responder));
+  }
+}
+
+void OnDeviceSpeechRecognitionController::ForwardSession(
+    on_device_model::mojom::AsrStreamOptionsPtr options,
+    mojo::PendingReceiver<on_device_model::mojom::AsrStreamInput> stream,
+    mojo::PendingRemote<on_device_model::mojom::AsrStreamResponder> responder) {
+  if (!factory_.is_bound()) {
+    return;
+  }
+  factory_->CreateAsrStream(std::move(options), std::move(stream),
+                            std::move(responder));
 }
 
 void OnDeviceSpeechRecognitionController::StartIdleTimer() {

--- a/browser/speech/on_device_speech_recognition_controller.cc
+++ b/browser/speech/on_device_speech_recognition_controller.cc
@@ -137,6 +137,8 @@ mojo::PendingRemote<local_ai::mojom::AsrSession>
 OnDeviceSpeechRecognitionController::GetAsrSession() {
   mojo::PendingRemote<local_ai::mojom::AsrSession> remote;
   asr_session_receivers_.Add(this, remote.InitWithNewPipeAndPassReceiver());
+  // Handing out a session puts the worker in use, so make sure no idle
+  // teardown is pending.
   idle_timer_.Stop();
   return remote;
 }
@@ -144,8 +146,8 @@ OnDeviceSpeechRecognitionController::GetAsrSession() {
 void OnDeviceSpeechRecognitionController::BindFactoryHost(
     mojo::PendingReceiver<local_ai::mojom::SpeechRecognitionFactoryHost>
         receiver) {
-  // This is renderer-triggered (the worker page requests the interface) and a
-  // renderer cannot be assumed well-behaved, so it could request the interface
+  // The FactoryHost is exposed to the worker WebUI, a chrome-untrusted
+  // renderer that cannot be assumed well-behaved and may request the interface
   // again while already bound. Bind() DCHECKs on an already-bound receiver, and
   // a renderer must never be able to trip a browser DCHECK, so reset first to
   // supersede any existing connection.

--- a/browser/speech/on_device_speech_recognition_controller.cc
+++ b/browser/speech/on_device_speech_recognition_controller.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check_is_test.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
 #include "base/memory/ptr_util.h"
@@ -115,6 +116,7 @@ OnDeviceSpeechRecognitionController::Get() {
 std::unique_ptr<OnDeviceSpeechRecognitionController>
 OnDeviceSpeechRecognitionController::CreateForTesting(  // IN-TEST
     CreateBackgroundWebContentsCallback create_background_web_contents) {
+  CHECK_IS_TEST();
   return base::WrapUnique(new OnDeviceSpeechRecognitionController(
       std::move(create_background_web_contents)));
 }
@@ -153,7 +155,7 @@ void OnDeviceSpeechRecognitionController::BindFactoryHost(
 
 void OnDeviceSpeechRecognitionController::RegisterFactory(
     mojo::PendingRemote<local_ai::mojom::SpeechRecognitionFactory> factory) {
-  if (state_ != State::kWorkerStarting || factory_.is_bound()) {
+  if (state_ != State::kRendererStarting || factory_.is_bound()) {
     return;
   }
   startup_timer_.Stop();
@@ -232,7 +234,7 @@ void OnDeviceSpeechRecognitionController::StartWorker() {
   if (state_ != State::kIdle) {
     return;
   }
-  state_ = State::kBwcStarting;
+  state_ = State::kRendererStarting;
 
   // startup_timer_ is a member, so it cannot fire after `this` is destroyed.
   startup_timer_.Start(
@@ -255,7 +257,7 @@ void OnDeviceSpeechRecognitionController::StartWorker() {
 void OnDeviceSpeechRecognitionController::OnBackgroundContentsCreated(
     std::unique_ptr<local_ai::BackgroundWebContents> background_web_contents,
     Profile* otr_profile) {
-  if (state_ != State::kBwcStarting) {
+  if (state_ != State::kRendererStarting) {
     // Torn down while the worker environment was being created.
     return;
   }
@@ -272,8 +274,6 @@ void OnDeviceSpeechRecognitionController::OnBackgroundContentsCreated(
   // destruction so the WebContents never outlives its BrowserContext (which
   // would trip BrowserContextImpl's rph_with_bc_reference NOTREACHED).
   profile_observation_.Observe(otr_profile);
-
-  state_ = State::kWorkerStarting;
 }
 
 void OnDeviceSpeechRecognitionController::LoadOrtModel() {
@@ -359,7 +359,7 @@ void OnDeviceSpeechRecognitionController::OnIdleTimeout() {
 }
 
 void OnDeviceSpeechRecognitionController::OnStartupTimeout() {
-  if (state_ != State::kBwcStarting && state_ != State::kWorkerStarting) {
+  if (state_ != State::kRendererStarting) {
     return;
   }
   TearDown();

--- a/browser/speech/on_device_speech_recognition_controller.cc
+++ b/browser/speech/on_device_speech_recognition_controller.cc
@@ -1,0 +1,225 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/speech/on_device_speech_recognition_controller.h"
+
+#include <utility>
+#include <vector>
+
+#include "base/functional/bind.h"
+#include "base/memory/ptr_util.h"
+#include "base/no_destructor.h"
+#include "base/task/sequenced_task_runner.h"
+#include "brave/browser/local_ai/background_web_contents_factory.h"
+#include "brave/components/local_ai/core/on_device_speech_models_state.h"
+#include "brave/components/local_ai/core/url_constants.h"
+#include "brave/grit/brave_generated_resources.h"
+#include "chrome/browser/profiles/profile.h"
+#include "services/network/public/mojom/web_sandbox_flags.mojom-shared.h"
+#include "url/gurl.h"
+
+namespace speech {
+
+OnDeviceSpeechRecognitionController::PendingSession::PendingSession() = default;
+OnDeviceSpeechRecognitionController::PendingSession::PendingSession(
+    PendingSession&&) = default;
+OnDeviceSpeechRecognitionController::PendingSession&
+OnDeviceSpeechRecognitionController::PendingSession::operator=(
+    PendingSession&&) = default;
+OnDeviceSpeechRecognitionController::PendingSession::~PendingSession() =
+    default;
+
+// static
+OnDeviceSpeechRecognitionController*
+OnDeviceSpeechRecognitionController::Get() {
+  // The speech worker must be cross-origin isolated (COOP: same-origin +
+  // COEP: require-corp) so onnxruntime-web can use SharedArrayBuffer for
+  // multi-threaded WASM. Chromium blocks navigating a COOP (non unsafe-none)
+  // document that has ANY sandbox flag set — see
+  // CrossOriginOpenerPolicyStatus::SanitizeResponse,
+  // content/browser/security/coop/cross_origin_opener_policy_status.cc
+  // (returns kCoopSandboxedIFrameCannotNavigateToCoopPage when
+  // sandbox_flags != kNone). The check is binary (any flag triggers it), so a
+  // cross-origin-isolated worker MUST be fully unsandboxed; there is no
+  // narrower subset. It still lives in an isolated chrome-untrusted renderer
+  // process, which is where the real containment comes from.
+  static base::NoDestructor<OnDeviceSpeechRecognitionController> instance(
+      base::BindRepeating(&local_ai::CreateBackgroundWebContents,
+                          GURL(local_ai::kOnDeviceSpeechRecognitionWorkerURL),
+                          IDS_ON_DEVICE_SPEECH_RECOGNITION_TASK_MANAGER_TITLE,
+                          network::mojom::WebSandboxFlags::kNone));
+  return instance.get();
+}
+
+// static
+std::unique_ptr<OnDeviceSpeechRecognitionController>
+OnDeviceSpeechRecognitionController::CreateForTesting(  // IN-TEST
+    CreateBackgroundWebContentsCallback create_background_web_contents) {
+  return base::WrapUnique(new OnDeviceSpeechRecognitionController(
+      std::move(create_background_web_contents)));
+}
+
+OnDeviceSpeechRecognitionController::OnDeviceSpeechRecognitionController(
+    CreateBackgroundWebContentsCallback create_background_web_contents)
+    : create_background_web_contents_(
+          std::move(create_background_web_contents)) {
+  asr_session_receivers_.set_disconnect_handler(base::BindRepeating(
+      &OnDeviceSpeechRecognitionController::OnAsrSessionDisconnected,
+      base::Unretained(this)));
+}
+
+OnDeviceSpeechRecognitionController::~OnDeviceSpeechRecognitionController() =
+    default;
+
+mojo::PendingRemote<local_ai::mojom::AsrSession>
+OnDeviceSpeechRecognitionController::GetAsrSession() {
+  mojo::PendingRemote<local_ai::mojom::AsrSession> remote;
+  asr_session_receivers_.Add(this, remote.InitWithNewPipeAndPassReceiver());
+  idle_timer_.Stop();
+  return remote;
+}
+
+void OnDeviceSpeechRecognitionController::Start(
+    on_device_model::mojom::AsrStreamOptionsPtr options,
+    mojo::PendingReceiver<on_device_model::mojom::AsrStreamInput> stream,
+    mojo::PendingRemote<on_device_model::mojom::AsrStreamResponder> responder) {
+  // No model installed: don't spin up a guest profile + cross-origin-isolated
+  // renderer just to discover the files are missing. Dropping the
+  // stream/responder pipes here surfaces to the engine as a recognition
+  // failure, the same outcome as a failed load.
+  if (local_ai::OnDeviceSpeechModelsState::GetInstance()
+          ->GetModelDir()
+          .empty()) {
+    return;
+  }
+
+  // Worker is not ready yet, start the worker if not already starting.
+  if (state_ == State::kIdle) {
+    StartWorker();
+  }
+
+  // Queue the session until the worker is ready.
+  PendingSession pending;
+  pending.options = std::move(options);
+  pending.stream = std::move(stream);
+  pending.responder = std::move(responder);
+  pending_sessions_.push_back(std::move(pending));
+}
+
+void OnDeviceSpeechRecognitionController::OnAsrSessionDisconnected() {
+  // A consumer dropped its AsrSession remote, so that session ended. When the
+  // last one goes, arm the idle timer to tear the worker down.
+  if (asr_session_receivers_.empty()) {
+    StartIdleTimer();
+  }
+}
+
+void OnDeviceSpeechRecognitionController::OnBackgroundContentsDestroyed(
+    local_ai::BackgroundWebContents::DestroyReason reason) {
+  // Invoked from within BackgroundWebContents::NotifyDestroyed, which deletes
+  // the BackgroundWebContents immediately after this returns. Calling
+  // TearDown() synchronously would reset() that same BackgroundWebContents
+  // from inside its own call stack and destroy its WebContents while it is
+  // still notifying observers (trips WebContentsImpl's is_notifying_observers()
+  // CHECK). Defer it.
+  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+      FROM_HERE, base::BindOnce(&OnDeviceSpeechRecognitionController::TearDown,
+                                weak_factory_.GetWeakPtr()));
+}
+
+void OnDeviceSpeechRecognitionController::OnProfileWillBeDestroyed(
+    Profile* profile) {
+  if (profile != otr_profile_) {
+    return;
+  }
+  TearDown();
+}
+
+void OnDeviceSpeechRecognitionController::StartWorker() {
+  if (state_ != State::kIdle) {
+    return;
+  }
+  state_ = State::kBwcStarting;
+
+  // startup_timer_ is a member, so it cannot fire after `this` is destroyed.
+  startup_timer_.Start(
+      FROM_HERE, kStartupTimeout,
+      base::BindOnce(&OnDeviceSpeechRecognitionController::OnStartupTimeout,
+                     base::Unretained(this)));
+
+  // Worker creation is asynchronous and owned by the profile/WebContents
+  // creation pipeline, not by this controller, so it cannot be canceled once
+  // started. Bind the delegate and the reply weakly so that if TearDown() runs
+  // before creation finishes, InvalidateWeakPtrs() drops this reply and it
+  // cannot run against a later worker cycle.
+  create_background_web_contents_.Run(
+      weak_factory_.GetWeakPtr(),
+      base::BindOnce(
+          &OnDeviceSpeechRecognitionController::OnBackgroundContentsCreated,
+          weak_factory_.GetWeakPtr()));
+}
+
+void OnDeviceSpeechRecognitionController::OnBackgroundContentsCreated(
+    std::unique_ptr<local_ai::BackgroundWebContents> background_web_contents,
+    Profile* otr_profile) {
+  if (state_ != State::kBwcStarting) {
+    // Torn down while the worker environment was being created.
+    return;
+  }
+
+  if (!background_web_contents || !otr_profile) {
+    TearDown();
+    return;
+  }
+
+  background_web_contents_ = std::move(background_web_contents);
+  otr_profile_ = otr_profile;
+
+  // Observe the OTR profile the worker lives in and tear down on its
+  // destruction so the WebContents never outlives its BrowserContext (which
+  // would trip BrowserContextImpl's rph_with_bc_reference NOTREACHED).
+  profile_observation_.Observe(otr_profile);
+
+  state_ = State::kWorkerStarting;
+}
+
+void OnDeviceSpeechRecognitionController::StartIdleTimer() {
+  // idle_timer_ is a member, so it cannot fire after `this` is destroyed.
+  idle_timer_.Start(
+      FROM_HERE, kIdleTimeout,
+      base::BindOnce(&OnDeviceSpeechRecognitionController::OnIdleTimeout,
+                     base::Unretained(this)));
+}
+
+void OnDeviceSpeechRecognitionController::OnIdleTimeout() {
+  if (!asr_session_receivers_.empty()) {
+    return;
+  }
+  TearDown();
+}
+
+void OnDeviceSpeechRecognitionController::OnStartupTimeout() {
+  if (state_ != State::kBwcStarting && state_ != State::kWorkerStarting) {
+    return;
+  }
+  TearDown();
+}
+
+void OnDeviceSpeechRecognitionController::TearDown() {
+  // Drop outstanding weak-bound replies (BWC creation, deferred teardown) so
+  // none from this cycle can land in a later one. The singleton is never
+  // destroyed, so nothing else invalidates them.
+  weak_factory_.InvalidateWeakPtrs();
+  startup_timer_.Stop();
+  idle_timer_.Stop();
+  background_web_contents_.reset();
+  profile_observation_.Reset();
+  otr_profile_ = nullptr;
+  pending_sessions_.clear();
+  asr_session_receivers_.Clear();
+  state_ = State::kIdle;
+}
+
+}  // namespace speech

--- a/browser/speech/on_device_speech_recognition_controller.h
+++ b/browser/speech/on_device_speech_recognition_controller.h
@@ -22,7 +22,9 @@
 #include "chrome/browser/profiles/profile_observer.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/receiver.h"
 #include "mojo/public/cpp/bindings/receiver_set.h"
+#include "mojo/public/cpp/bindings/remote.h"
 #include "services/on_device_model/public/mojom/on_device_model.mojom.h"
 
 namespace base {
@@ -43,7 +45,8 @@ namespace speech {
 // Start() that arrives before kReady is queued in pending_sessions_ and
 // forwarded once Ready.
 class OnDeviceSpeechRecognitionController
-    : public local_ai::mojom::AsrSession,
+    : public local_ai::mojom::SpeechRecognitionFactoryHost,
+      public local_ai::mojom::AsrSession,
       public local_ai::BackgroundWebContents::Delegate,
       public ProfileObserver {
  public:
@@ -74,6 +77,16 @@ class OnDeviceSpeechRecognitionController
   // Returns a remote the engine holds for one recognition. Dropping it ends
   // the session.
   mojo::PendingRemote<local_ai::mojom::AsrSession> GetAsrSession();
+
+  // Binds the FactoryHost receiver for the ORT worker WebUI.
+  void BindFactoryHost(
+      mojo::PendingReceiver<local_ai::mojom::SpeechRecognitionFactoryHost>
+          receiver);
+
+  // local_ai::mojom::SpeechRecognitionFactoryHost:
+  void RegisterFactory(
+      mojo::PendingRemote<local_ai::mojom::SpeechRecognitionFactory> factory)
+      override;
 
   // local_ai::mojom::AsrSession:
   void Start(
@@ -120,9 +133,16 @@ class OnDeviceSpeechRecognitionController
       Profile* otr_profile);
   void OnStartupTimeout();
 
+  // Read the Nemotron graphs/companion files and whole-model weights off a
+  // blocking sequence, then build the worker's ORT sessions in Init.
+  void LoadOrtModel();
+  void OnOrtFilesRead(local_ai::mojom::OrtModelFilesPtr files);
+  void OnOrtInitResult(bool success);
+
   void StartIdleTimer();
   void OnIdleTimeout();
 
+  void OnFactoryDisconnected();
   void OnAsrSessionDisconnected();
   void TearDown();
 
@@ -137,7 +157,10 @@ class OnDeviceSpeechRecognitionController
 
   std::unique_ptr<local_ai::BackgroundWebContents> background_web_contents_;
 
+  mojo::Receiver<local_ai::mojom::SpeechRecognitionFactoryHost>
+      factory_host_receiver_{this};
   mojo::ReceiverSet<local_ai::mojom::AsrSession> asr_session_receivers_;
+  mojo::Remote<local_ai::mojom::SpeechRecognitionFactory> factory_;
 
   struct PendingSession {
     PendingSession();

--- a/browser/speech/on_device_speech_recognition_controller.h
+++ b/browser/speech/on_device_speech_recognition_controller.h
@@ -39,7 +39,7 @@ namespace speech {
 // per-recognition AsrSessions that it forwards to the worker once ready.
 //
 // State machine:
-//   kIdle -> kBwcStarting -> kWorkerStarting -> kModelLoading -> kReady
+//   kIdle -> kRendererStarting -> kModelLoading -> kReady
 //
 // TearDown() returns to kIdle from any state on idle/startup timeout, worker
 // crash, factory/session disconnect, or profile/contents destruction; the
@@ -108,15 +108,12 @@ class OnDeviceSpeechRecognitionController
 
   enum class State {
     // No live worker. The first Start() calls StartWorker() and advances to
-    // kBwcStarting.
+    // kRendererStarting.
     kIdle,
-    // The BackgroundWebContents is being created asynchronously. Advances to
-    // kWorkerStarting in OnBackgroundContentsCreated() once it exists.
-    kBwcStarting,
-    // The BackgroundWebContents exists and the worker page is booting.
-    // Advances to kModelLoading in RegisterFactory() once the worker
-    // registers its factory.
-    kWorkerStarting,
+    // The BackgroundWebContents is being created and the worker page is
+    // booting inside it. Advances to kModelLoading in RegisterFactory() once
+    // the worker registers its factory.
+    kRendererStarting,
     // The factory is bound and the model is loading. Advances to kReady in
     // OnOrtInitResult() on success.
     kModelLoading,

--- a/browser/speech/on_device_speech_recognition_controller.h
+++ b/browser/speech/on_device_speech_recognition_controller.h
@@ -1,0 +1,173 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_SPEECH_ON_DEVICE_SPEECH_RECOGNITION_CONTROLLER_H_
+#define BRAVE_BROWSER_SPEECH_ON_DEVICE_SPEECH_RECOGNITION_CONTROLLER_H_
+
+#include <memory>
+#include <vector>
+
+#include "base/functional/callback.h"
+#include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
+#include "base/scoped_observation.h"
+#include "base/time/time.h"
+#include "base/timer/timer.h"
+#include "brave/browser/local_ai/background_web_contents_factory.h"
+#include "brave/components/local_ai/core/background_web_contents.h"
+#include "brave/components/local_ai/core/on_device_speech_recognition.mojom.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/profiles/profile_observer.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/receiver_set.h"
+#include "services/on_device_model/public/mojom/on_device_model.mojom.h"
+
+namespace base {
+template <typename T>
+class NoDestructor;
+}  // namespace base
+
+namespace speech {
+
+// `base::NoDestructor` singleton that owns the BackgroundWebContents hosting
+// the WASM worker and hands out per-recognition AsrSessions.
+//
+// State machine:
+//   kIdle -> kBwcStarting -> kWorkerStarting -> kModelLoading -> kReady
+//
+// TearDown() returns to kIdle from any state on idle/startup timeout or
+// profile/contents destruction; the next Start() restarts the pipeline. A
+// Start() that arrives before kReady is queued in pending_sessions_ and
+// forwarded once Ready.
+class OnDeviceSpeechRecognitionController
+    : public local_ai::mojom::AsrSession,
+      public local_ai::BackgroundWebContents::Delegate,
+      public ProfileObserver {
+ public:
+  // Creates the BackgroundWebContents that hosts the worker. Production binds
+  // this to local_ai::CreateBackgroundWebContents; tests inject a fake so the
+  // state machine can be driven without a renderer or profile. The delegate is
+  // passed weakly to match the factory's contract.
+  using CreateBackgroundWebContentsCallback = base::RepeatingCallback<void(
+      base::WeakPtr<local_ai::BackgroundWebContents::Delegate> delegate,
+      local_ai::BackgroundWebContentsCreatedCallback created)>;
+
+  static OnDeviceSpeechRecognitionController* Get();
+
+  // Builds a standalone instance with an injected BackgroundWebContents
+  // factory, bypassing the Get() singleton. For tests only.
+  static std::unique_ptr<OnDeviceSpeechRecognitionController> CreateForTesting(
+      CreateBackgroundWebContentsCallback create_background_web_contents);
+
+  OnDeviceSpeechRecognitionController(
+      const OnDeviceSpeechRecognitionController&) = delete;
+  OnDeviceSpeechRecognitionController& operator=(
+      const OnDeviceSpeechRecognitionController&) = delete;
+
+  // Public so the CreateForTesting() std::unique_ptr can destroy the instance.
+  // The Get() singleton is a NoDestructor and is never destroyed.
+  ~OnDeviceSpeechRecognitionController() override;
+
+  // Returns a remote the engine holds for one recognition. Dropping it ends
+  // the session.
+  mojo::PendingRemote<local_ai::mojom::AsrSession> GetAsrSession();
+
+  // local_ai::mojom::AsrSession:
+  void Start(
+      on_device_model::mojom::AsrStreamOptionsPtr options,
+      mojo::PendingReceiver<on_device_model::mojom::AsrStreamInput> stream,
+      mojo::PendingRemote<on_device_model::mojom::AsrStreamResponder> responder)
+      override;
+
+  // local_ai::BackgroundWebContents::Delegate:
+  void OnBackgroundContentsDestroyed(
+      local_ai::BackgroundWebContents::DestroyReason reason) override;
+
+  // ProfileObserver:
+  void OnProfileWillBeDestroyed(Profile* profile) override;
+
+ private:
+  friend base::NoDestructor<OnDeviceSpeechRecognitionController>;
+
+  enum class State {
+    // No live worker. The first Start() calls StartWorker() and advances to
+    // kBwcStarting.
+    kIdle,
+    // The BackgroundWebContents is being created asynchronously. Advances to
+    // kWorkerStarting in OnBackgroundContentsCreated() once it exists.
+    kBwcStarting,
+    // The BackgroundWebContents exists and the worker page is booting.
+    // Advances to kModelLoading in RegisterFactory() once the worker
+    // registers its factory.
+    kWorkerStarting,
+    // The factory is bound and the model is loading. Advances to kReady in
+    // OnOrtInitResult() on success.
+    kModelLoading,
+    // The worker is initialized. A Start() is forwarded to the worker
+    // immediately instead of being queued.
+    kReady,
+  };
+
+  explicit OnDeviceSpeechRecognitionController(
+      CreateBackgroundWebContentsCallback create_background_web_contents);
+
+  void StartWorker();
+  void OnBackgroundContentsCreated(
+      std::unique_ptr<local_ai::BackgroundWebContents> background_web_contents,
+      Profile* otr_profile);
+  void OnStartupTimeout();
+
+  void StartIdleTimer();
+  void OnIdleTimeout();
+
+  void OnAsrSessionDisconnected();
+  void TearDown();
+
+  CreateBackgroundWebContentsCallback create_background_web_contents_;
+
+  State state_ = State::kIdle;
+
+  // The guest profile's primary OTR profile, which hosts the worker's
+  // BackgroundWebContents and is the profile we observe for destruction.
+  raw_ptr<Profile> otr_profile_ = nullptr;
+  base::ScopedObservation<Profile, ProfileObserver> profile_observation_{this};
+
+  std::unique_ptr<local_ai::BackgroundWebContents> background_web_contents_;
+
+  mojo::ReceiverSet<local_ai::mojom::AsrSession> asr_session_receivers_;
+
+  struct PendingSession {
+    PendingSession();
+    PendingSession(PendingSession&&);
+    PendingSession& operator=(PendingSession&&);
+    ~PendingSession();
+
+    on_device_model::mojom::AsrStreamOptionsPtr options;
+    mojo::PendingReceiver<on_device_model::mojom::AsrStreamInput> stream;
+    mojo::PendingRemote<on_device_model::mojom::AsrStreamResponder> responder;
+  };
+  std::vector<PendingSession> pending_sessions_;
+
+  // Tears the worker down if it never registers its factory. Cancelled in
+  // RegisterFactory(); crashes past that point are caught by factory_'s
+  // disconnect handler.
+  base::OneShotTimer startup_timer_;
+  static constexpr base::TimeDelta kStartupTimeout = base::Seconds(30);
+
+  // Tears the worker down after it has had no active AsrSession for
+  // kIdleTimeout. Armed when the last session disconnects
+  // (OnAsrSessionDisconnected); cancelled in GetAsrSession() when a new
+  // session is handed out. The fired timer re-checks for sessions before
+  // tearing down.
+  base::OneShotTimer idle_timer_;
+  static constexpr base::TimeDelta kIdleTimeout = base::Seconds(60);
+
+  base::WeakPtrFactory<OnDeviceSpeechRecognitionController> weak_factory_{this};
+};
+
+}  // namespace speech
+
+#endif  // BRAVE_BROWSER_SPEECH_ON_DEVICE_SPEECH_RECOGNITION_CONTROLLER_H_

--- a/browser/speech/on_device_speech_recognition_controller.h
+++ b/browser/speech/on_device_speech_recognition_controller.h
@@ -34,16 +34,17 @@ class NoDestructor;
 
 namespace speech {
 
-// `base::NoDestructor` singleton that owns the BackgroundWebContents hosting
-// the WASM worker and hands out per-recognition AsrSessions.
+// `base::NoDestructor` singleton that owns the BackgroundWebContents
+// hosting the WASM worker, drives model loading against it, and hands out
+// per-recognition AsrSessions that it forwards to the worker once ready.
 //
 // State machine:
 //   kIdle -> kBwcStarting -> kWorkerStarting -> kModelLoading -> kReady
 //
-// TearDown() returns to kIdle from any state on idle/startup timeout or
-// profile/contents destruction; the next Start() restarts the pipeline. A
-// Start() that arrives before kReady is queued in pending_sessions_ and
-// forwarded once Ready.
+// TearDown() returns to kIdle from any state on idle/startup timeout, worker
+// crash, factory/session disconnect, or profile/contents destruction; the
+// next Start() restarts the pipeline. A Start() that arrives before kReady is
+// queued in pending_sessions_ and forwarded once Ready.
 class OnDeviceSpeechRecognitionController
     : public local_ai::mojom::SpeechRecognitionFactoryHost,
       public local_ai::mojom::AsrSession,
@@ -138,6 +139,13 @@ class OnDeviceSpeechRecognitionController
   void LoadOrtModel();
   void OnOrtFilesRead(local_ai::mojom::OrtModelFilesPtr files);
   void OnOrtInitResult(bool success);
+
+  void ForwardPendingSessions();
+  void ForwardSession(
+      on_device_model::mojom::AsrStreamOptionsPtr options,
+      mojo::PendingReceiver<on_device_model::mojom::AsrStreamInput> stream,
+      mojo::PendingRemote<on_device_model::mojom::AsrStreamResponder>
+          responder);
 
   void StartIdleTimer();
   void OnIdleTimeout();

--- a/browser/speech/on_device_speech_recognition_controller_unittest.cc
+++ b/browser/speech/on_device_speech_recognition_controller_unittest.cc
@@ -288,7 +288,7 @@ class OnDeviceSpeechRecognitionControllerTest : public testing::Test {
 
   content::BrowserTaskEnvironment task_environment_;
   // The guest OTR profile the fake reports as the worker's home. A non-null
-  // profile lets the boot flow reach WorkerStarting.
+  // profile lets the boot flow proceed.
   TestingProfile otr_profile_;
   // A different profile, for asserting the observer ignores others.
   TestingProfile other_profile_;
@@ -421,7 +421,7 @@ TEST_F(OnDeviceSpeechRecognitionControllerTest, StartupTimeoutTearsDown) {
 // A creation reply from a torn-down cycle must not land in a later cycle and
 // adopt a stale worker. TearDown()'s InvalidateWeakPtrs() drops the reply; the
 // state check alone is insufficient because the later cycle is also
-// kBwcStarting.
+// kRendererStarting.
 TEST_F(OnDeviceSpeechRecognitionControllerTest, StaleBwcCreationReplyDropped) {
   SetInstalled(true);
   capture_created_ = true;
@@ -435,7 +435,7 @@ TEST_F(OnDeviceSpeechRecognitionControllerTest, StaleBwcCreationReplyDropped) {
   // The startup timer tears cycle 1 down, invalidating the captured reply.
   task_environment_.FastForwardBy(base::Seconds(31));
 
-  // Cycle 2: back in kBwcStarting (its reply is captured, not run).
+  // Cycle 2: back in kRendererStarting (its reply is captured, not run).
   Session s2 = StartSession();
 
   // Deliver the stale cycle-1 reply. It must be ignored (its weak pointer was
@@ -447,12 +447,12 @@ TEST_F(OnDeviceSpeechRecognitionControllerTest, StaleBwcCreationReplyDropped) {
   EXPECT_EQ(nullptr, stale_bwc);
 }
 
-// RegisterFactory is a no-op unless the controller is in kWorkerStarting. A
+// RegisterFactory is a no-op unless the controller is in kRendererStarting. A
 // register in kIdle is ignored, and a second register after the worker has
-// advanced past kWorkerStarting is ignored too (state has moved on), so the
+// advanced past kRendererStarting is ignored too (state has moved on), so the
 // live worker is untouched.
 TEST_F(OnDeviceSpeechRecognitionControllerTest,
-       RegisterFactoryIgnoredOutsideWorkerStarting) {
+       RegisterFactoryIgnoredOutsideRendererStarting) {
   SetInstalled(true);
 
   // In kIdle (no Start yet): registering a factory does nothing.

--- a/browser/speech/on_device_speech_recognition_controller_unittest.cc
+++ b/browser/speech/on_device_speech_recognition_controller_unittest.cc
@@ -1,0 +1,648 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/speech/on_device_speech_recognition_controller.h"
+
+#include <memory>
+#include <utility>
+
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
+#include "base/functional/bind.h"
+#include "base/functional/callback.h"
+#include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
+#include "base/run_loop.h"
+#include "base/task/sequenced_task_runner.h"
+#include "base/test/bind.h"
+#include "base/test/task_environment.h"
+#include "base/test/test_future.h"
+#include "base/time/time.h"
+#include "brave/components/local_ai/core/background_web_contents.h"
+#include "brave/components/local_ai/core/on_device_speech_models_state.h"
+#include "brave/components/local_ai/core/on_device_speech_recognition.mojom.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/test/base/testing_profile.h"
+#include "content/public/test/browser_task_environment.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "services/on_device_model/public/mojom/on_device_model.mojom.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace speech {
+
+namespace {
+
+// Renderer-side worker stand-in. Records how often the browser loaded the
+// model (Init) and manufactured a stream (CreateAsrStream), and lets a test
+// force a load failure or sever the pipe.
+class FakeSpeechRecognitionFactory
+    : public local_ai::mojom::SpeechRecognitionFactory {
+ public:
+  FakeSpeechRecognitionFactory() = default;
+  ~FakeSpeechRecognitionFactory() override = default;
+
+  // local_ai::mojom::SpeechRecognitionFactory:
+  void Init(local_ai::mojom::OrtModelFilesPtr files,
+            InitCallback callback) override {
+    ++init_count_;
+    if (on_call_) {
+      on_call_.Run();
+    }
+    std::move(callback).Run(init_success_);
+  }
+  void CreateAsrStream(
+      on_device_model::mojom::AsrStreamOptionsPtr options,
+      mojo::PendingReceiver<on_device_model::mojom::AsrStreamInput> stream,
+      mojo::PendingRemote<on_device_model::mojom::AsrStreamResponder> responder)
+      override {
+    ++created_asr_stream_count_;
+    if (on_call_) {
+      on_call_.Run();
+    }
+  }
+
+  mojo::PendingRemote<local_ai::mojom::SpeechRecognitionFactory> BindRemote() {
+    return receiver_.BindNewPipeAndPassRemote();
+  }
+  void ResetReceiver() { receiver_.reset(); }
+
+  void set_init_success(bool success) { init_success_ = success; }
+  int init_count() const { return init_count_; }
+  int created_asr_stream_count() const { return created_asr_stream_count_; }
+
+  // Runs on every Init/CreateAsrStream so a test can quit a RunLoop once the
+  // counts reach what it is waiting for.
+  void set_on_call(base::RepeatingClosure on_call) {
+    on_call_ = std::move(on_call);
+  }
+
+ private:
+  bool init_success_ = true;
+  int init_count_ = 0;
+  int created_asr_stream_count_ = 0;
+  base::RepeatingClosure on_call_;
+  mojo::Receiver<local_ai::mojom::SpeechRecognitionFactory> receiver_{this};
+};
+
+// Stand-in for the worker's BackgroundWebContents. Needs no renderer; runs an
+// on-destroyed closure so the fixture can observe teardown, and can simulate an
+// unexpected renderer loss.
+class FakeBackgroundWebContents : public local_ai::BackgroundWebContents {
+ public:
+  FakeBackgroundWebContents(Delegate* delegate, base::OnceClosure on_destroyed)
+      : delegate_(delegate), on_destroyed_(std::move(on_destroyed)) {}
+  ~FakeBackgroundWebContents() override { std::move(on_destroyed_).Run(); }
+
+  void SimulateDestroyed() {
+    delegate_->OnBackgroundContentsDestroyed(DestroyReason::kRendererGone);
+  }
+
+ private:
+  raw_ptr<Delegate> delegate_;
+  base::OnceClosure on_destroyed_;
+};
+
+}  // namespace
+
+class OnDeviceSpeechRecognitionControllerTest : public testing::Test {
+ protected:
+  OnDeviceSpeechRecognitionControllerTest()
+      : task_environment_(base::test::TaskEnvironment::TimeSource::MOCK_TIME) {}
+
+  // One recognition's worth of pipes, kept alive for the test's duration.
+  struct Session {
+    Session() = default;
+    Session(Session&&) = default;
+    Session& operator=(Session&&) = default;
+    ~Session() = default;
+
+    mojo::Remote<local_ai::mojom::AsrSession> session;
+    mojo::Remote<on_device_model::mojom::AsrStreamInput> input;
+    mojo::PendingReceiver<on_device_model::mojom::AsrStreamResponder>
+        responder_receiver;
+  };
+
+  void SetUp() override {
+    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
+    controller_ = OnDeviceSpeechRecognitionController::CreateForTesting(
+        base::BindRepeating(
+            &OnDeviceSpeechRecognitionControllerTest::CreateFakeBwc,
+            base::Unretained(this)));
+  }
+
+  void TearDown() override {
+    controller_.reset();
+    // The models state is a process-wide singleton, so clear it to avoid
+    // polluting other suites.
+    local_ai::OnDeviceSpeechModelsState::GetInstance()->SetInstallDir(
+        base::FilePath());
+  }
+
+  // Injected BackgroundWebContents factory. Three modes drive the states the
+  // production async pipeline produces: synchronous success, an async creation
+  // failure, and a captured (deferred) reply for stale-reply tests.
+  void CreateFakeBwc(
+      base::WeakPtr<local_ai::BackgroundWebContents::Delegate> delegate,
+      local_ai::BackgroundWebContentsCreatedCallback created) {
+    ++bwc_created_count_;
+    if (capture_created_) {
+      // Hold the reply plus delegate so a test can deliver a stale reply after
+      // a teardown or restart, without completing this cycle's creation.
+      captured_delegate_ = std::move(delegate);
+      captured_created_ = std::move(created);
+      return;
+    }
+    if (bwc_creation_fails_) {
+      // Production builds the worker asynchronously (guest profile creation),
+      // so the failure is reported on a later turn, not inline. Match that so
+      // Start() finishes queuing before the teardown happens.
+      base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+          FROM_HERE,
+          base::BindOnce(std::move(created),
+                         std::unique_ptr<local_ai::BackgroundWebContents>(),
+                         nullptr));
+      return;
+    }
+    std::move(created).Run(MakeFakeBwc(delegate, &last_bwc_), &otr_profile_);
+  }
+
+  // Builds a fake worker BackgroundWebContents that nulls `*tracker` when the
+  // controller drops it, so a test can observe teardown.
+  std::unique_ptr<FakeBackgroundWebContents> MakeFakeBwc(
+      base::WeakPtr<local_ai::BackgroundWebContents::Delegate> delegate,
+      raw_ptr<FakeBackgroundWebContents>* tracker) {
+    auto bwc = std::make_unique<FakeBackgroundWebContents>(
+        delegate.get(),
+        base::BindOnce(
+            [](raw_ptr<FakeBackgroundWebContents>* ref) { *ref = nullptr; },
+            tracker));
+    *tracker = bwc.get();
+    return bwc;
+  }
+
+  void SetInstalled(bool installed) {
+    auto* state = local_ai::OnDeviceSpeechModelsState::GetInstance();
+    if (!installed) {
+      state->SetInstallDir(base::FilePath());
+      return;
+    }
+    state->SetInstallDir(temp_dir_.GetPath());
+    base::FilePath model_dir = state->GetModelDir();
+    ASSERT_TRUE(base::CreateDirectory(model_dir));
+    // ReadNemotronOrtFiles only needs these to exist and be non-empty; the
+    // contents are ignored by the fake factory's Init.
+    for (const char* name :
+         {"encoder.onnx", "encoder.onnx.data", "decoder_joint.onnx",
+          "decoder_joint.onnx.data", "filterbank.bin", "tokens.txt"}) {
+      ASSERT_TRUE(base::WriteFile(model_dir.AppendASCII(name), "x"));
+    }
+  }
+
+  // Acts as the worker WebUI: registers the given factory so the browser can
+  // load the model. Does not wait for the load to finish.
+  void RegisterFactoryWith(FakeSpeechRecognitionFactory& factory) {
+    // Only one worker page ever holds the FactoryHost interface, so keep a
+    // single host remote and supersede any previous one, mirroring the
+    // controller's own single receiver that reset()s on each rebind.
+    factory_host_.reset();
+    controller_->BindFactoryHost(factory_host_.BindNewPipeAndPassReceiver());
+    factory_host_->RegisterFactory(factory.BindRemote());
+    factory_host_.FlushForTesting();
+  }
+
+  void RegisterFactory() { RegisterFactoryWith(fake_factory_); }
+
+  // Runs the loop until `factory` has loaded the model, quitting from the
+  // factory's own Init callback.
+  void WaitForInit(FakeSpeechRecognitionFactory& factory) {
+    if (factory.init_count() >= 1) {
+      return;
+    }
+    base::RunLoop loop;
+    factory.set_on_call(base::BindLambdaForTesting([&] {
+      if (factory.init_count() >= 1) {
+        loop.Quit();
+      }
+    }));
+    loop.Run();
+    factory.set_on_call(base::RepeatingClosure());
+  }
+
+  // Runs the loop until `factory` has created at least `count` ASR streams,
+  // quitting from its own CreateAsrStream callback.
+  void WaitForCreatedAsrStreams(FakeSpeechRecognitionFactory& factory,
+                                int count) {
+    if (factory.created_asr_stream_count() >= count) {
+      return;
+    }
+    base::RunLoop loop;
+    factory.set_on_call(base::BindLambdaForTesting([&] {
+      if (factory.created_asr_stream_count() >= count) {
+        loop.Quit();
+      }
+    }));
+    loop.Run();
+    factory.set_on_call(base::RepeatingClosure());
+  }
+
+  // Starts one session and drives the worker all the way to Ready, returning
+  // the (now-forwarded) session.
+  Session DriveToReady() {
+    SetInstalled(true);
+    Session s = StartSession();
+    RegisterFactory();
+    WaitForCreatedAsrStreams(fake_factory_, 1);
+    return s;
+  }
+
+  // Acts as the engine: takes an AsrSession and starts one recognition.
+  Session StartSession() {
+    Session s;
+    s.session.Bind(controller_->GetAsrSession());
+    mojo::PendingRemote<on_device_model::mojom::AsrStreamResponder> responder;
+    s.responder_receiver = responder.InitWithNewPipeAndPassReceiver();
+    s.session->Start(on_device_model::mojom::AsrStreamOptions::New(),
+                     s.input.BindNewPipeAndPassReceiver(),
+                     std::move(responder));
+    s.session.FlushForTesting();
+    return s;
+  }
+
+  // Runs the loop until `remote`'s peer closes, driven by the disconnect
+  // handler rather than by polling.
+  template <typename Interface>
+  void WaitForDisconnect(mojo::Remote<Interface>& remote) {
+    if (!remote.is_connected()) {
+      return;
+    }
+    base::test::TestFuture<void> disconnected;
+    remote.set_disconnect_handler(disconnected.GetCallback());
+    EXPECT_TRUE(disconnected.Wait());
+  }
+
+  content::BrowserTaskEnvironment task_environment_;
+  // The guest OTR profile the fake reports as the worker's home. A non-null
+  // profile lets the boot flow reach WorkerStarting.
+  TestingProfile otr_profile_;
+  // A different profile, for asserting the observer ignores others.
+  TestingProfile other_profile_;
+  base::ScopedTempDir temp_dir_;
+  FakeSpeechRecognitionFactory fake_factory_;
+  mojo::Remote<local_ai::mojom::SpeechRecognitionFactoryHost> factory_host_;
+  raw_ptr<FakeBackgroundWebContents> last_bwc_ = nullptr;
+  // When set, the injected factory reports an async creation failure.
+  bool bwc_creation_fails_ = false;
+  // When set, CreateFakeBwc captures the reply plus delegate instead of
+  // completing creation, so a test can deliver a stale reply later.
+  bool capture_created_ = false;
+  base::WeakPtr<local_ai::BackgroundWebContents::Delegate> captured_delegate_;
+  local_ai::BackgroundWebContentsCreatedCallback captured_created_;
+  int bwc_created_count_ = 0;
+  std::unique_ptr<OnDeviceSpeechRecognitionController> controller_;
+};
+
+// ---------- Working behavior ----------
+
+// The full working path: sessions that arrive before the worker is ready boot
+// one shared worker and queue, the model loads once, every queued session is
+// forwarded when ready, and a later session forwards immediately to the same
+// worker.
+TEST_F(OnDeviceSpeechRecognitionControllerTest,
+       ForwardsSessionsOnceWorkerReady) {
+  SetInstalled(true);
+  Session s1 = StartSession();
+  Session s2 = StartSession();
+  EXPECT_EQ(1, bwc_created_count_);
+  EXPECT_EQ(0, fake_factory_.created_asr_stream_count());
+
+  RegisterFactory();
+  WaitForCreatedAsrStreams(fake_factory_, 2);
+  EXPECT_EQ(1, fake_factory_.init_count());
+  EXPECT_EQ(2, fake_factory_.created_asr_stream_count());
+
+  // A session started on the now-ready worker is forwarded immediately, with
+  // no new worker booted.
+  Session s3 = StartSession();
+  WaitForCreatedAsrStreams(fake_factory_, 3);
+  EXPECT_EQ(1, bwc_created_count_);
+}
+
+// ---------- Error and edge handling ----------
+
+TEST_F(OnDeviceSpeechRecognitionControllerTest,
+       StartWithNoModelDropsSessionNoBoot) {
+  SetInstalled(false);
+  Session s = StartSession();
+  // No worker is spun up just to discover the files are missing.
+  EXPECT_EQ(nullptr, last_bwc_.get());
+  EXPECT_EQ(0, bwc_created_count_);
+  // The session's audio pipe is dropped, surfacing as a failure to the engine.
+  WaitForDisconnect(s.input);
+  EXPECT_FALSE(s.input.is_connected());
+}
+
+// A worker whose environment fails to come up tears down, drops the queued
+// session, and returns to idle so a later Start() reboots cleanly.
+TEST_F(OnDeviceSpeechRecognitionControllerTest, BwcCreationFailureTearsDown) {
+  SetInstalled(true);
+  bwc_creation_fails_ = true;
+
+  Session s = StartSession();
+  WaitForDisconnect(s.input);
+  EXPECT_EQ(nullptr, last_bwc_.get());
+
+  // Back to idle: a later attempt succeeds once creation works again.
+  bwc_creation_fails_ = false;
+  Session s2 = StartSession();
+  EXPECT_NE(nullptr, last_bwc_.get());
+  EXPECT_EQ(2, bwc_created_count_);
+}
+
+// Renderer loss is reported through the delegate. TearDown is deferred off the
+// observer callback (resetting the BackgroundWebContents synchronously would
+// destroy it from inside its own destroy notification), so the worker is still
+// present until the loop is pumped.
+TEST_F(OnDeviceSpeechRecognitionControllerTest,
+       BackgroundContentsDestroyedTearsDownDeferred) {
+  SetInstalled(true);
+  Session s = StartSession();
+  ASSERT_NE(nullptr, last_bwc_.get());
+
+  last_bwc_->SimulateDestroyed();
+  // The teardown is posted, not run inline, so the worker is still present.
+  EXPECT_NE(nullptr, last_bwc_.get());
+
+  // The deferred teardown disconnects the engine-held session and drops the
+  // worker.
+  WaitForDisconnect(s.session);
+  EXPECT_EQ(nullptr, last_bwc_.get());
+}
+
+// The controller observes the worker's OTR profile so it tears the worker down
+// before that profile is destroyed, and ignores any other profile.
+TEST_F(OnDeviceSpeechRecognitionControllerTest,
+       ProfileDestructionTearsDownObservedOnly) {
+  SetInstalled(true);
+  Session s = StartSession();
+  ASSERT_NE(nullptr, last_bwc_.get());
+
+  // A different profile's destruction is ignored.
+  controller_->OnProfileWillBeDestroyed(&other_profile_);
+  EXPECT_NE(nullptr, last_bwc_.get());
+
+  // The observed OTR profile's destruction tears the worker down. Invoking the
+  // callback directly exercises the controller's response without dragging in
+  // real profile-destruction machinery.
+  controller_->OnProfileWillBeDestroyed(&otr_profile_);
+  EXPECT_EQ(nullptr, last_bwc_.get());
+}
+
+// The worker environment comes up but the worker never registers its factory.
+// The 30s startup timer tears it down and drops the queued session so the
+// engine sees a failure instead of hanging.
+TEST_F(OnDeviceSpeechRecognitionControllerTest, StartupTimeoutTearsDown) {
+  SetInstalled(true);
+  Session s = StartSession();
+  ASSERT_NE(nullptr, last_bwc_.get());
+
+  task_environment_.FastForwardBy(base::Seconds(31));
+  EXPECT_EQ(nullptr, last_bwc_.get());
+  // The queued session's audio pipe is dropped, surfacing as a failure.
+  WaitForDisconnect(s.input);
+  EXPECT_FALSE(s.input.is_connected());
+}
+
+// A creation reply from a torn-down cycle must not land in a later cycle and
+// adopt a stale worker. TearDown()'s InvalidateWeakPtrs() drops the reply; the
+// state check alone is insufficient because the later cycle is also
+// kBwcStarting.
+TEST_F(OnDeviceSpeechRecognitionControllerTest, StaleBwcCreationReplyDropped) {
+  SetInstalled(true);
+  capture_created_ = true;
+
+  // Cycle 1: capture its weak-bound creation reply, then take it aside before
+  // the next cycle overwrites the captured slot.
+  Session s1 = StartSession();
+  auto stale_created = std::move(captured_created_);
+  auto stale_delegate = captured_delegate_;
+
+  // The startup timer tears cycle 1 down, invalidating the captured reply.
+  task_environment_.FastForwardBy(base::Seconds(31));
+
+  // Cycle 2: back in kBwcStarting (its reply is captured, not run).
+  Session s2 = StartSession();
+
+  // Deliver the stale cycle-1 reply. It must be ignored (its weak pointer was
+  // invalidated), so the worker it carries is dropped, not adopted into cycle
+  // 2. Were it adopted, the controller would hold the fake and keep it alive.
+  raw_ptr<FakeBackgroundWebContents> stale_bwc = nullptr;
+  std::move(stale_created)
+      .Run(MakeFakeBwc(stale_delegate, &stale_bwc), &otr_profile_);
+  EXPECT_EQ(nullptr, stale_bwc);
+}
+
+// RegisterFactory is a no-op unless the controller is in kWorkerStarting. A
+// register in kIdle is ignored, and a second register after the worker has
+// advanced past kWorkerStarting is ignored too (state has moved on), so the
+// live worker is untouched.
+TEST_F(OnDeviceSpeechRecognitionControllerTest,
+       RegisterFactoryIgnoredOutsideWorkerStarting) {
+  SetInstalled(true);
+
+  // In kIdle (no Start yet): registering a factory does nothing.
+  {
+    FakeSpeechRecognitionFactory early;
+    RegisterFactoryWith(early);
+    EXPECT_EQ(0, early.init_count());
+    EXPECT_EQ(nullptr, last_bwc_.get());
+  }
+
+  // Boot the worker and load the model, then a second register is ignored.
+  Session s = StartSession();
+  RegisterFactory();
+  WaitForInit(fake_factory_);
+  ASSERT_EQ(1, fake_factory_.init_count());
+  {
+    FakeSpeechRecognitionFactory late;
+    RegisterFactoryWith(late);
+    EXPECT_EQ(0, late.init_count());
+    // The original worker was not reloaded.
+    EXPECT_EQ(1, fake_factory_.init_count());
+    EXPECT_NE(nullptr, last_bwc_.get());
+  }
+}
+
+// A misbehaving renderer may request the FactoryHost interface again while
+// already bound. The second bind supersedes the first rather than tripping a
+// DCHECK, so the first host remote disconnects.
+TEST_F(OnDeviceSpeechRecognitionControllerTest,
+       BindFactoryHostSupersedesPrevious) {
+  mojo::Remote<local_ai::mojom::SpeechRecognitionFactoryHost> host1;
+  controller_->BindFactoryHost(host1.BindNewPipeAndPassReceiver());
+  host1.FlushForTesting();
+  ASSERT_TRUE(host1.is_connected());
+
+  mojo::Remote<local_ai::mojom::SpeechRecognitionFactoryHost> host2;
+  controller_->BindFactoryHost(host2.BindNewPipeAndPassReceiver());
+  host2.FlushForTesting();
+
+  WaitForDisconnect(host1);
+  EXPECT_FALSE(host1.is_connected());
+  EXPECT_TRUE(host2.is_connected());
+}
+
+TEST_F(OnDeviceSpeechRecognitionControllerTest, ModelFileReadFailureTearsDown) {
+  // Install dir is set (so Start proceeds) but the model files are absent, so
+  // ReadNemotronOrtFiles returns null and the worker tears down without Init.
+  local_ai::OnDeviceSpeechModelsState::GetInstance()->SetInstallDir(
+      temp_dir_.GetPath());
+  Session s = StartSession();
+  ASSERT_NE(nullptr, last_bwc_.get());
+  RegisterFactory();
+
+  // TearDown disconnects the engine-held session; the worker is gone by then.
+  WaitForDisconnect(s.session);
+  EXPECT_EQ(nullptr, last_bwc_.get());
+  EXPECT_EQ(0, fake_factory_.init_count());
+}
+
+TEST_F(OnDeviceSpeechRecognitionControllerTest, InitFailureTearsDown) {
+  SetInstalled(true);
+  fake_factory_.set_init_success(false);
+
+  Session s = StartSession();
+  RegisterFactory();
+
+  // TearDown disconnects the engine-held session; the worker is gone by then.
+  WaitForDisconnect(s.session);
+  EXPECT_EQ(nullptr, last_bwc_.get());
+}
+
+// The model-file read hops to a ThreadPool and replies weakly. If the cycle is
+// torn down while the read is in flight, the reply must not Init a later
+// cycle's factory. To prove the weak invalidation (and not the is_bound guard)
+// is what protects this, cycle 2 binds a fresh factory before the stale reply
+// lands: the guard would pass against that live factory, so only the weak drop
+// keeps it from being Init'd twice.
+TEST_F(OnDeviceSpeechRecognitionControllerTest,
+       StaleModelReadReplyDroppedAfterRestart) {
+  SetInstalled(true);
+
+  // Register the factory and tear down through the controller's public methods
+  // directly rather than over a mojo pipe. FlushForTesting on a pipe spins a
+  // nested loop that would let the tiny fixture read complete inline; a direct
+  // call posts the read and tears down with no pump in between, so the reply is
+  // genuinely in flight when InvalidateWeakPtrs() drops it.
+
+  // Cycle 1: reach kModelLoading, which posts the ThreadPool read.
+  Session s1 = StartSession();
+  controller_->RegisterFactory(fake_factory_.BindRemote());
+
+  // Tear cycle 1 down before the read reply is pumped.
+  controller_->OnProfileWillBeDestroyed(&otr_profile_);
+  ASSERT_EQ(nullptr, last_bwc_.get());
+
+  // Cycle 2: a fresh worker and factory, also reaching kModelLoading.
+  FakeSpeechRecognitionFactory fake2;
+  Session s2 = StartSession();
+  controller_->RegisterFactory(fake2.BindRemote());
+
+  // Drain the pool: both reads complete. Cycle 1's reply is weak-invalidated
+  // and dropped, so only cycle 2's reply runs and fake2 is Init'd exactly once.
+  // Were the stale reply not dropped, it would Init the now-live fake2 a second
+  // time, since the is_bound guard passes against the fresh factory.
+  WaitForInit(fake2);
+  EXPECT_EQ(1, fake2.init_count());
+  // The torn-down cycle-1 factory was never Init'd.
+  EXPECT_EQ(0, fake_factory_.init_count());
+}
+
+// A worker crash after Ready (its factory remote disconnects) tears the worker
+// down and disconnects the AsrSession the engine is holding.
+TEST_F(OnDeviceSpeechRecognitionControllerTest, FactoryDisconnectTearsDown) {
+  Session s = DriveToReady();
+  ASSERT_NE(nullptr, last_bwc_.get());
+  ASSERT_TRUE(s.session.is_connected());
+
+  // The controller tears down when it sees the factory remote drop, which
+  // disconnects the engine-held AsrSession.
+  fake_factory_.ResetReceiver();
+  WaitForDisconnect(s.session);
+  EXPECT_EQ(nullptr, last_bwc_.get());
+}
+
+// A worker that reached Ready must survive past the startup timeout: the timer
+// is stopped in RegisterFactory, and OnStartupTimeout's state guard would
+// ignore a stale fire regardless. Prove it is still serving by forwarding a new
+// session to the same worker.
+TEST_F(OnDeviceSpeechRecognitionControllerTest,
+       ReadyWorkerSurvivesStartupTimeout) {
+  Session s = DriveToReady();
+  ASSERT_NE(nullptr, last_bwc_.get());
+  ASSERT_EQ(1, fake_factory_.created_asr_stream_count());
+
+  task_environment_.FastForwardBy(base::Seconds(31));
+  ASSERT_NE(nullptr, last_bwc_.get());
+
+  Session s2 = StartSession();
+  WaitForCreatedAsrStreams(fake_factory_, 2);
+  EXPECT_EQ(1, bwc_created_count_);
+}
+
+TEST_F(OnDeviceSpeechRecognitionControllerTest,
+       IdleTimeoutTearsDownAfterLastSession) {
+  Session s = DriveToReady();
+  ASSERT_NE(nullptr, last_bwc_.get());
+
+  // Dropping the last AsrSession arms the idle timer. FastForwardBy runs the
+  // immediate disconnect task first, arming the timer, then advances past the
+  // 60s idle timeout so it fires.
+  s.session.reset();
+  task_environment_.FastForwardBy(base::Seconds(61));
+  EXPECT_EQ(nullptr, last_bwc_.get());
+}
+
+TEST_F(OnDeviceSpeechRecognitionControllerTest, NewSessionCancelsIdleTimeout) {
+  Session s = DriveToReady();
+  ASSERT_NE(nullptr, last_bwc_.get());
+
+  // Drop the session and advance a little so the disconnect is processed and
+  // the idle timer arms.
+  s.session.reset();
+  task_environment_.FastForwardBy(base::Seconds(1));
+
+  // A new session before the timeout stops the armed timer.
+  mojo::Remote<local_ai::mojom::AsrSession> reconnect(
+      controller_->GetAsrSession());
+
+  task_environment_.FastForwardBy(base::Seconds(61));
+  EXPECT_NE(nullptr, last_bwc_.get());
+}
+
+// With more than one session, the idle timer arms only when the last session
+// disconnects, not on each disconnect.
+TEST_F(OnDeviceSpeechRecognitionControllerTest,
+       IdleTimerArmedOnlyOnLastSession) {
+  Session s1 = DriveToReady();
+  Session s2 = StartSession();
+  WaitForCreatedAsrStreams(fake_factory_, 2);
+  ASSERT_NE(nullptr, last_bwc_.get());
+
+  // Dropping one of two sessions does not arm the timer.
+  s1.session.reset();
+  task_environment_.FastForwardBy(base::Seconds(61));
+  EXPECT_NE(nullptr, last_bwc_.get());
+
+  // Dropping the last session arms it, and the worker tears down.
+  s2.session.reset();
+  task_environment_.FastForwardBy(base::Seconds(61));
+  EXPECT_EQ(nullptr, last_bwc_.get());
+}
+
+}  // namespace speech

--- a/components/local_ai/core/on_device_speech_recognition.mojom
+++ b/components/local_ai/core/on_device_speech_recognition.mojom
@@ -48,3 +48,18 @@ interface SpeechRecognitionFactory {
 interface SpeechRecognitionFactoryHost {
   RegisterFactory(pending_remote<SpeechRecognitionFactory> factory);
 };
+
+// Browser-implemented, the engine's entry point. It is 1:1 with one
+// recognition. Brave's on-device speech recognition engine holds this remote
+// for the session's lifetime. The controller queues Start until the worker and
+// model are ready, then forwards to SpeechRecognitionFactory.CreateAsrStream.
+// Afterwards the AsrStream pipe runs between engine and worker directly.
+// Dropping this remote ends the session.
+interface AsrSession {
+  // Start the session. Payload types are reused verbatim from on_device_model.
+  // This mirrors upstream Session.AsrStream.
+  Start(
+      on_device_model.mojom.AsrStreamOptions options,
+      pending_receiver<on_device_model.mojom.AsrStreamInput> stream,
+      pending_remote<on_device_model.mojom.AsrStreamResponder> responder);
+};

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -403,6 +403,7 @@ test("brave_unit_tests") {
     deps += [
       "//brave/browser/history_embeddings:unit_tests",
       "//brave/browser/local_ai:unit_tests",
+      "//brave/browser/speech:unit_tests",
     ]
   }
 


### PR DESCRIPTION
Part of https://github.com/brave/brave-browser/issues/56487

Introduces `speech::OnDeviceSpeechRecognitionController`, the browser-side controller for Brave's on-device speech recognition. It owns the chrome-untrusted ORT-Web worker, loads the model into it, and routes per-recognition sessions from the engine (in a future PR) to the speech worker.

I ended up not splitting this into smaller PRs because it seems easier to me to look at the complete controller implementation for all the state transitions together. Implementation has been split into 3 commits (background webcontents management, model loading, and asr session routing), but might not be separated perfectly somewhere still, so maybe look at the final controller file directly might actually be easier to review.

Just for a look ahead, we still need https://github.com/brave/brave-core/commit/3c5b3de5872c093a94177d5bc764c29106233120 to wire the ORT-Web speech worker page to the recognition controller in another PR after this. And one separate PR for integrating into Chromium's WebSpeech via `OnDeviceSpeechRecognitionEngine` which would call into this controller to create ASR sessions.
