### PR TITLE
[Brave News]: Add opml import/export

### DIFF
--- a/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_initializer.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_initializer.cc
@@ -175,6 +175,13 @@ void NewTabPageInitializer::AddCSPOverrides() {
   source_->OverrideContentSecurityPolicy(
       network::mojom::CSPDirectiveName::FrameSrc,
       base::StrCat({"frame-src ", kNTPNewTabTakeoverRichMediaUrl, ";"}));
+
+  // Brave News uses a dedicated Trusted Types policy to parse imported OPML
+  // subscription files (see brave_news .../customize/opml.ts). Append it to the
+  // default policy allowlist so the default policies remain intact.
+  source_->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::TrustedTypes,
+      base::StrCat({webui::kDefaultTrustedTypesPolicies, " brave-news-opml;"}));
 }
 
 void NewTabPageInitializer::AddLoadTimeValues() {

--- a/browser/ui/webui/new_tab_page/brave_new_tab_ui.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_ui.cc
@@ -115,7 +115,7 @@ BraveNewTabUI::BraveNewTabUI(
   source->OverrideContentSecurityPolicy(
       network::mojom::CSPDirectiveName::TrustedTypes,
       "trusted-types static-types lottie-worker-script-loader "
-      "lit-html-desktop;");
+      "lit-html-desktop brave-news-opml;");
 
   source->AddBoolean("featureCustomBackgroundEnabled",
                      !profile->GetPrefs()->IsManagedPreference(

--- a/components/brave_news/browser/resources/customize/Configure.tsx
+++ b/components/brave_news/browser/resources/customize/Configure.tsx
@@ -15,6 +15,7 @@ import { useBraveNews } from '../shared/Context'
 import { BackArrow } from '../shared/Icons'
 import DisabledPlaceholder from './DisabledPlaceholder'
 import Discover from './Discover'
+import OpmlControls from './OpmlControls'
 import { PopularPage } from './Popular'
 import SourcesList from './SourcesList'
 import { SuggestionsPage } from './Suggestions'
@@ -73,10 +74,24 @@ const Hr = styled.hr`
 
 const Sidebar = styled.div`
   position: relative;
-  overflow: auto;
+  overflow: hidden;
   grid-area: sidebar;
-  padding: 28px 22px 28px 32px;
   background: ${color.page.background};
+
+  display: flex;
+  flex-direction: column;
+`
+
+const SidebarScroll = styled.div`
+  flex: 1;
+  overflow: auto;
+  padding: 28px 22px 28px 32px;
+`
+
+const SidebarFooter = styled.div`
+  flex-shrink: 0;
+  padding: ${spacing.s};
+  border-top: 1px solid ${color.divider.subtle};
 `
 
 // Overlay on top of the sidebar, shown when it is disabled.
@@ -163,7 +178,12 @@ export default function Configure() {
       </Header>
       <Hr />
       <Sidebar>
-        <SourcesList />
+        <SidebarScroll>
+          <SourcesList />
+        </SidebarScroll>
+        {isBraveNewsFullyEnabled && <SidebarFooter>
+          <OpmlControls />
+        </SidebarFooter>}
         {!isBraveNewsFullyEnabled && <SidebarOverlay />}
       </Sidebar>
       <Content>

--- a/components/brave_news/browser/resources/customize/OpmlControls.tsx
+++ b/components/brave_news/browser/resources/customize/OpmlControls.tsx
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Alert from '@brave/leo/react/alert'
+import Button from '@brave/leo/react/button'
+import { spacing } from '@brave/leo/tokens/css/variables'
+import { formatLocale, getLocale } from '$web-common/locale'
+import * as React from 'react'
+import styled from 'styled-components'
+import getBraveNewsController from '../shared/api'
+import { ChannelsCachingWrapper } from '../shared/channelsCache'
+import { useBraveNews } from '../shared/Context'
+import { PublishersCachingWrapper } from '../shared/publishersCache'
+import { downloadOpml, importOpml } from './opml'
+
+const Links = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${spacing.m};
+
+  & leo-button {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+`
+
+// The customize dialog has no toast host, so show the import result as a
+// fixed-position alert anchored to the bottom of the (modal) dialog.
+const StatusContainer = styled.div`
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1;
+  max-width: 520px;
+`
+
+type Status = { type: 'success' | 'error'; content: string }
+
+export default function OpmlControls() {
+  const { publishers, channels, locale } = useBraveNews()
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  const [status, setStatus] = React.useState<Status | null>(null)
+
+  // Auto-dismiss the status alert.
+  React.useEffect(() => {
+    if (!status) {
+      return
+    }
+    const timer = setTimeout(() => setStatus(null), 8000)
+    return () => clearTimeout(timer)
+  }, [status])
+
+  const onExport = () => {
+    downloadOpml(Object.values(publishers), Object.values(channels), locale)
+  }
+
+  const onFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const input = e.currentTarget
+    const file = input.files?.[0]
+    // Reset so selecting the same file again re-triggers the change event.
+    input.value = ''
+    if (!file) {
+      return
+    }
+
+    try {
+      const text = await file.text()
+      const result = await importOpml(text, {
+        publishers: Object.values(publishers),
+        channels: Object.values(channels),
+        locale,
+        followPublisher: (id) =>
+          PublishersCachingWrapper.getInstance().setPublisherFollowed(id, true),
+        addDirectFeed: (url) =>
+          getBraveNewsController().subscribeToNewDirectFeed({ url }),
+        subscribeChannel: (loc, name) =>
+          ChannelsCachingWrapper.getInstance().setChannelSubscribed(
+            loc,
+            name,
+            true
+          )
+      })
+      setStatus({
+        type: 'success',
+        content: formatLocale(S.BRAVE_NEWS_OPML_IMPORT_RESULT, {
+          $1: String(result.subscribedPublishers),
+          $2: String(result.addedDirectFeeds),
+          $3: String(result.subscribedChannels),
+          $4: String(result.skipped)
+        })
+      })
+    } catch (err) {
+      console.error('Brave News: failed to import OPML', err)
+      setStatus({
+        type: 'error',
+        content: getLocale(S.BRAVE_NEWS_OPML_IMPORT_ERROR)
+      })
+    }
+  }
+
+  return (
+    <>
+      <Links>
+        <Button kind='plain-faint' size='small' onClick={() => inputRef.current?.click()}>
+          {getLocale(S.BRAVE_NEWS_OPML_IMPORT)}
+        </Button>
+        <Button kind='plain-faint' size='small' onClick={onExport}>
+          {getLocale(S.BRAVE_NEWS_OPML_EXPORT)}
+        </Button>
+      </Links>
+      <input
+        ref={inputRef}
+        type='file'
+        accept='.opml,.xml,text/xml,application/xml,text/x-opml'
+        hidden
+        onChange={onFileChange}
+      />
+      {status && (
+        <StatusContainer>
+          <Alert type={status.type}>{status.content}</Alert>
+        </StatusContainer>
+      )}
+    </>
+  )
+}

--- a/components/brave_news/browser/resources/customize/opml.test.ts
+++ b/components/brave_news/browser/resources/customize/opml.test.ts
@@ -1,0 +1,316 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { Channel, Publisher, PublisherType, UserEnabled } from '../shared/api'
+import {
+  buildExportData,
+  importOpml,
+  ImportActions,
+  parseOpml,
+  publisherToOpmlItem,
+  serializeOpml
+} from './opml'
+
+const makePublisher = (overrides: Partial<Publisher>): Publisher =>
+  ({
+    publisherId: 'id',
+    publisherName: 'Name',
+    type: PublisherType.COMBINED_SOURCE,
+    categoryName: '',
+    isEnabled: true,
+    locales: [],
+    feedSource: { url: '' },
+    faviconUrl: undefined,
+    coverUrl: undefined,
+    backgroundColor: undefined,
+    siteUrl: { url: '' },
+    userEnabledStatus: UserEnabled.NOT_MODIFIED,
+    ...overrides
+  }) as Publisher
+
+const makeChannel = (overrides: Partial<Channel>): Channel =>
+  ({
+    channelName: 'Channel',
+    subscribedLocales: [],
+    ...overrides
+  }) as Channel
+
+const makeActions = (overrides: Partial<ImportActions>): ImportActions => ({
+  publishers: [],
+  channels: [],
+  locale: 'en_US',
+  followPublisher: jest.fn(),
+  addDirectFeed: jest.fn(async () => {}),
+  subscribeChannel: jest.fn(),
+  ...overrides
+})
+
+describe('serialize/parse round-trip', () => {
+  it('round-trips feeds, id-only publishers, direct feeds and channels', () => {
+    const data = {
+      items: [
+        {
+          title: 'Combined',
+          xmlUrl: 'https://combined.example/feed',
+          htmlUrl: 'https://combined.example',
+          publisherId: 'pub-1'
+        },
+        { title: 'No Feed', htmlUrl: 'https://nofeed.example', publisherId: 'pub-2' },
+        { title: 'My Blog', xmlUrl: 'https://blog.example/feed' }
+      ],
+      channels: ['Technology', 'Sports']
+    }
+
+    const parsed = parseOpml(serializeOpml(data))
+    expect(parsed).toEqual(data)
+  })
+
+  it('produces a well-formed OPML document', () => {
+    const xml = serializeOpml({
+      items: [{ title: 'X', xmlUrl: 'https://x.example/feed' }],
+      channels: []
+    })
+    expect(xml).toContain('<?xml')
+    expect(xml).toContain('<opml version="2.0"')
+    expect(xml).toContain('type="rss"')
+    expect(xml).toContain('xmlUrl="https://x.example/feed"')
+  })
+})
+
+describe('parseOpml', () => {
+  it('finds feeds nested inside category outlines', () => {
+    const xml = `<?xml version="1.0"?>
+      <opml version="2.0"><body>
+        <outline text="Tech">
+          <outline type="rss" text="A" xmlUrl="https://a.example/feed"/>
+        </outline>
+      </body></opml>`
+    const { items } = parseOpml(xml)
+    expect(items).toEqual([
+      { title: 'A', xmlUrl: 'https://a.example/feed', htmlUrl: undefined, publisherId: undefined }
+    ])
+  })
+
+  it('falls back to text when title is missing', () => {
+    const xml = `<opml><body>
+      <outline type="rss" text="Only Text" xmlUrl="https://t.example/feed"/>
+    </body></opml>`
+    expect(parseOpml(xml).items[0].title).toBe('Only Text')
+  })
+
+  it('ignores grouping outlines without a feed url or publisher id', () => {
+    const xml = `<opml><body>
+      <outline text="Just a folder"/>
+      <outline type="rss" text="Feed" xmlUrl="https://f.example/feed"/>
+    </body></opml>`
+    expect(parseOpml(xml).items).toHaveLength(1)
+  })
+
+  it('collects brave-channel outlines as channels', () => {
+    const xml = `<opml><body>
+      <outline text="Channels">
+        <outline type="brave-channel" text="Gaming"/>
+      </outline>
+    </body></opml>`
+    const { items, channels } = parseOpml(xml)
+    expect(items).toHaveLength(0)
+    expect(channels).toEqual(['Gaming'])
+  })
+
+  it('throws on malformed XML', () => {
+    expect(() => parseOpml('<opml><body></not-closed>')).toThrow()
+  })
+})
+
+describe('buildExportData', () => {
+  it('includes an id for combined publishers but not direct feeds', () => {
+    const combined = makePublisher({
+      publisherId: 'pub-1',
+      publisherName: 'Combined',
+      feedSource: { url: 'https://c.example/feed' },
+      siteUrl: { url: 'https://c.example' },
+      userEnabledStatus: UserEnabled.ENABLED
+    })
+    const direct = makePublisher({
+      publisherId: 'uuid-123',
+      publisherName: 'Direct',
+      type: PublisherType.DIRECT_SOURCE,
+      feedSource: { url: 'https://d.example/feed' }
+    })
+
+    expect(publisherToOpmlItem(combined)).toEqual({
+      title: 'Combined',
+      xmlUrl: 'https://c.example/feed',
+      htmlUrl: 'https://c.example',
+      publisherId: 'pub-1'
+    })
+    expect(publisherToOpmlItem(direct).publisherId).toBeUndefined()
+  })
+
+  it('exports a combined publisher with no feed url by id only', () => {
+    const item = publisherToOpmlItem(
+      makePublisher({
+        publisherId: 'pub-2',
+        feedSource: { url: '' },
+        userEnabledStatus: UserEnabled.ENABLED
+      })
+    )
+    expect(item.xmlUrl).toBeUndefined()
+    expect(item.publisherId).toBe('pub-2')
+  })
+
+  it('only exports subscribed publishers and channels for the locale', () => {
+    const subscribed = makePublisher({
+      publisherId: 'sub',
+      userEnabledStatus: UserEnabled.ENABLED,
+      feedSource: { url: 'https://sub.example/feed' }
+    })
+    const notSubscribed = makePublisher({ publisherId: 'no' })
+    const channels = [
+      makeChannel({ channelName: 'Tech', subscribedLocales: ['en_US'] }),
+      makeChannel({ channelName: 'Other', subscribedLocales: ['fr_FR'] })
+    ]
+
+    const data = buildExportData([subscribed, notSubscribed], channels, 'en_US')
+    expect(data.items.map((i) => i.publisherId)).toEqual(['sub'])
+    expect(data.channels).toEqual(['Tech'])
+  })
+})
+
+describe('importOpml', () => {
+  it('subscribes a publisher by id (even with no feed url) and adds no direct feed', async () => {
+    const publisher = makePublisher({
+      publisherId: 'pub-1',
+      feedSource: { url: '' }
+    })
+    const actions = makeActions({ publishers: [publisher] })
+    const xml = serializeOpml({
+      items: [{ title: 'No Feed', publisherId: 'pub-1' }],
+      channels: []
+    })
+
+    const result = await importOpml(xml, actions)
+    expect(actions.followPublisher).toHaveBeenCalledWith('pub-1')
+    expect(actions.addDirectFeed).not.toHaveBeenCalled()
+    expect(result.subscribedPublishers).toBe(1)
+    expect(result.addedDirectFeeds).toBe(0)
+  })
+
+  it('prefers a publisher matched by feed url over creating a direct feed', async () => {
+    const publisher = makePublisher({
+      publisherId: 'pub-1',
+      feedSource: { url: 'https://match.example/feed' }
+    })
+    const actions = makeActions({ publishers: [publisher] })
+    // No publisher id in the outline - must match by URL.
+    const xml = `<opml><body>
+      <outline type="rss" text="Match" xmlUrl="https://match.example/feed"/>
+    </body></opml>`
+
+    const result = await importOpml(xml, actions)
+    expect(actions.followPublisher).toHaveBeenCalledWith('pub-1')
+    expect(actions.addDirectFeed).not.toHaveBeenCalled()
+    expect(result.subscribedPublishers).toBe(1)
+  })
+
+  it('skips a url that is already a direct feed', async () => {
+    const existingDirect = makePublisher({
+      publisherId: 'uuid-1',
+      type: PublisherType.DIRECT_SOURCE,
+      feedSource: { url: 'https://blog.example/feed' }
+    })
+    const actions = makeActions({ publishers: [existingDirect] })
+    const xml = `<opml><body>
+      <outline type="rss" text="Dup" xmlUrl="https://blog.example/feed"/>
+    </body></opml>`
+
+    const result = await importOpml(xml, actions)
+    expect(actions.addDirectFeed).not.toHaveBeenCalled()
+    expect(result.addedDirectFeeds).toBe(0)
+    expect(result.skipped).toBe(1)
+  })
+
+  it('adds a brand new url as a direct feed', async () => {
+    const actions = makeActions({})
+    const xml = `<opml><body>
+      <outline type="rss" text="New" xmlUrl="https://new.example/feed"/>
+    </body></opml>`
+
+    const result = await importOpml(xml, actions)
+    expect(actions.addDirectFeed).toHaveBeenCalledWith('https://new.example/feed')
+    expect(result.addedDirectFeeds).toBe(1)
+  })
+
+  it('does not duplicate direct feeds within the same import', async () => {
+    const actions = makeActions({})
+    const xml = `<opml><body>
+      <outline type="rss" text="A" xmlUrl="https://dup.example/feed"/>
+      <outline type="rss" text="B" xmlUrl="https://dup.example/feed"/>
+    </body></opml>`
+
+    const result = await importOpml(xml, actions)
+    expect(actions.addDirectFeed).toHaveBeenCalledTimes(1)
+    expect(result.addedDirectFeeds).toBe(1)
+    expect(result.skipped).toBe(1)
+  })
+
+  it('skips an already-subscribed publisher', async () => {
+    const publisher = makePublisher({
+      publisherId: 'pub-1',
+      feedSource: { url: 'https://sub.example/feed' },
+      userEnabledStatus: UserEnabled.ENABLED
+    })
+    const actions = makeActions({ publishers: [publisher] })
+    const xml = serializeOpml({
+      items: [{ title: 'Sub', xmlUrl: 'https://sub.example/feed', publisherId: 'pub-1' }],
+      channels: []
+    })
+
+    const result = await importOpml(xml, actions)
+    expect(actions.followPublisher).not.toHaveBeenCalled()
+    expect(result.skipped).toBe(1)
+    expect(result.subscribedPublishers).toBe(0)
+  })
+
+  it('falls back to url handling when the publisher id is unknown', async () => {
+    const actions = makeActions({})
+    const xml = serializeOpml({
+      items: [
+        { title: 'Stale', xmlUrl: 'https://stale.example/feed', publisherId: 'gone' }
+      ],
+      channels: []
+    })
+
+    const result = await importOpml(xml, actions)
+    expect(actions.addDirectFeed).toHaveBeenCalledWith('https://stale.example/feed')
+    expect(result.addedDirectFeeds).toBe(1)
+  })
+
+  it('re-subscribes channels for the current locale', async () => {
+    const channels = [
+      makeChannel({ channelName: 'Tech', subscribedLocales: [] }),
+      makeChannel({ channelName: 'Already', subscribedLocales: ['en_US'] })
+    ]
+    const actions = makeActions({ channels, locale: 'en_US' })
+    const xml = `<opml><body>
+      <outline text="Channels">
+        <outline type="brave-channel" text="Tech"/>
+        <outline type="brave-channel" text="Already"/>
+        <outline type="brave-channel" text="Unknown"/>
+      </outline>
+    </body></opml>`
+
+    const result = await importOpml(xml, actions)
+    expect(actions.subscribeChannel).toHaveBeenCalledTimes(1)
+    expect(actions.subscribeChannel).toHaveBeenCalledWith('en_US', 'Tech')
+    expect(result.subscribedChannels).toBe(1)
+    // 'Already' (subscribed) and 'Unknown' (not in locale) are skipped.
+    expect(result.skipped).toBe(2)
+  })
+
+  it('rejects on malformed OPML', async () => {
+    await expect(importOpml('<opml></body>', makeActions({}))).rejects.toThrow()
+  })
+})

--- a/components/brave_news/browser/resources/customize/opml.ts
+++ b/components/brave_news/browser/resources/customize/opml.ts
@@ -1,0 +1,354 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import {
+  Channel,
+  Publisher,
+  PublisherType,
+  isDirectFeed,
+  isPublisherEnabled
+} from '../shared/api'
+
+// OPML (https://opml.org/spec2.opml) is the de-facto standard for exchanging
+// feed subscription lists. We use standard `type="rss"` outlines for feeds so
+// the file is portable to other readers, plus two Brave-specific extensions
+// that other readers ignore but that let subscriptions round-trip losslessly:
+//  - `type="brave-channel"`: a Brave News topic channel (has no feed URL).
+//  - `type="brave-publisher"`: a Brave News publisher that has no feed URL and
+//    can only be resolved by its publisher id.
+// Every combined-source publisher outline also carries `bravePublisherId` so it
+// re-subscribes to the exact publisher on import, even when a feed URL matches
+// nothing (or the publisher has no feed URL at all).
+const BRAVE_CHANNEL_TYPE = 'brave-channel'
+const BRAVE_PUBLISHER_TYPE = 'brave-publisher'
+const BRAVE_PUBLISHER_ID_ATTR = 'bravePublisherId'
+
+export interface OpmlItem {
+  title: string
+  xmlUrl?: string
+  htmlUrl?: string
+  // The Brave News publisher id, when the source is a known publisher. Absent
+  // for direct feeds, whose id is a random, profile-local UUID.
+  publisherId?: string
+}
+
+export interface OpmlData {
+  items: OpmlItem[]
+  channels: string[]
+}
+
+export interface ImportResult {
+  subscribedPublishers: number
+  addedDirectFeeds: number
+  subscribedChannels: number
+  // Items that were already subscribed, duplicates, or couldn't be resolved.
+  skipped: number
+}
+
+// The side effects import performs, injected so the pure matching logic can be
+// unit tested without a Mojo backend.
+export interface ImportActions {
+  // The full publisher catalog (all known publishers), used for matching.
+  publishers: Publisher[]
+  // All channels, used to validate channel names against the current locale.
+  channels: Channel[]
+  locale: string
+  followPublisher: (publisherId: string) => void
+  addDirectFeed: (url: string) => Promise<unknown>
+  subscribeChannel: (locale: string, channelName: string) => void
+}
+
+// Serializes subscriptions into an OPML 2.0 document.
+export function serializeOpml(data: OpmlData): string {
+  const doc = document.implementation.createDocument(null, 'opml', null)
+  const opml = doc.documentElement
+  opml.setAttribute('version', '2.0')
+
+  const head = doc.createElement('head')
+  const title = doc.createElement('title')
+  title.textContent = 'Brave News subscriptions'
+  head.appendChild(title)
+  opml.appendChild(head)
+
+  const body = doc.createElement('body')
+  opml.appendChild(body)
+
+  for (const item of data.items) {
+    const outline = doc.createElement('outline')
+    outline.setAttribute('text', item.title)
+    outline.setAttribute('title', item.title)
+    if (item.xmlUrl) {
+      outline.setAttribute('type', 'rss')
+      outline.setAttribute('xmlUrl', item.xmlUrl)
+    } else {
+      outline.setAttribute('type', BRAVE_PUBLISHER_TYPE)
+    }
+    if (item.htmlUrl) {
+      outline.setAttribute('htmlUrl', item.htmlUrl)
+    }
+    if (item.publisherId) {
+      outline.setAttribute(BRAVE_PUBLISHER_ID_ATTR, item.publisherId)
+    }
+    body.appendChild(outline)
+  }
+
+  if (data.channels.length) {
+    const group = doc.createElement('outline')
+    group.setAttribute('text', 'Channels')
+    group.setAttribute('title', 'Channels')
+    for (const channelName of data.channels) {
+      const outline = doc.createElement('outline')
+      outline.setAttribute('text', channelName)
+      outline.setAttribute('title', channelName)
+      outline.setAttribute('type', BRAVE_CHANNEL_TYPE)
+      group.appendChild(outline)
+    }
+    body.appendChild(group)
+  }
+
+  const xml = new XMLSerializer().serializeToString(doc)
+  return `<?xml version="1.0" encoding="UTF-8"?>\n${xml}`
+}
+
+// The New Tab Page enforces Trusted Types, and its `default` policy has no
+// `createHTML`, so DOMParser.parseFromString rejects a raw string. Route the
+// OPML text through a dedicated policy (allow-listed in the New Tab Page's
+// trusted-types CSP). The value is only ever parsed as XML and read for
+// attribute values - it is never inserted into the live document as HTML.
+let opmlTrustedTypesPolicy: { createHTML(input: string): string } | undefined
+function toTrustedXml(xml: string): string {
+  const trustedTypes = (window as any).trustedTypes
+  // This is the case in tests.
+  if (!trustedTypes) {
+    return xml
+  }
+
+  if (!opmlTrustedTypesPolicy) {
+    // Note: This policy performs no sanitization, so the results from it should never be inserted
+    // into the live document as HTML. It is only used for parsing OPML documents.
+    opmlTrustedTypesPolicy = trustedTypes.createPolicy('brave-news-opml', {
+      createHTML: (input: string) => input
+    })
+  }
+  return opmlTrustedTypesPolicy!.createHTML(xml)
+}
+
+// Parses an OPML document into feeds/publishers and channels. Throws if the
+// document isn't valid XML.
+export function parseOpml(xml: string): OpmlData {
+  const doc = new DOMParser().parseFromString(toTrustedXml(xml), 'text/xml')
+  if (doc.querySelector('parsererror')) {
+    throw new Error('Failed to parse OPML document')
+  }
+
+  const items: OpmlItem[] = []
+  const channels: string[] = []
+
+  // A flat walk handles both top-level outlines and outlines nested under
+  // category groups (e.g. the "Channels" group we emit, or category folders
+  // produced by other readers).
+  for (const outline of doc.querySelectorAll('outline')) {
+    const type = outline.getAttribute('type')
+    const title =
+      outline.getAttribute('title') || outline.getAttribute('text') || ''
+
+    if (type === BRAVE_CHANNEL_TYPE) {
+      if (title) {
+        channels.push(title)
+      }
+      continue
+    }
+
+    const xmlUrl = outline.getAttribute('xmlUrl') || undefined
+    const publisherId =
+      outline.getAttribute(BRAVE_PUBLISHER_ID_ATTR) || undefined
+
+    // Only outlines that reference a feed or a Brave publisher are
+    // subscriptions; category/grouping outlines are ignored.
+    if (!xmlUrl && !publisherId) {
+      continue
+    }
+
+    items.push({
+      title,
+      xmlUrl,
+      htmlUrl: outline.getAttribute('htmlUrl') || undefined,
+      publisherId
+    })
+  }
+
+  return { items, channels }
+}
+
+// Maps a subscribed publisher to an OPML outline.
+export function publisherToOpmlItem(publisher: Publisher): OpmlItem {
+  return {
+    title: publisher.publisherName,
+    xmlUrl: publisher.feedSource?.url || undefined,
+    htmlUrl: publisher.siteUrl?.url || undefined,
+    // A direct feed's id is a random, per-profile UUID that is meaningless
+    // elsewhere, so only combined publishers export their id.
+    publisherId:
+      publisher.type === PublisherType.COMBINED_SOURCE
+        ? publisher.publisherId
+        : undefined
+  }
+}
+
+export function getSubscribedChannelNames(
+  channels: Channel[],
+  locale: string
+): string[] {
+  return channels
+    .filter((c) => c.subscribedLocales.includes(locale))
+    .map((c) => c.channelName)
+}
+
+// Builds the OPML payload from the current subscriptions.
+export function buildExportData(
+  publishers: Publisher[],
+  channels: Channel[],
+  locale: string
+): OpmlData {
+  return {
+    items: publishers.filter(isPublisherEnabled).map(publisherToOpmlItem),
+    channels: getSubscribedChannelNames(channels, locale)
+  }
+}
+
+// Serializes the current subscriptions and triggers a file download.
+export function downloadOpml(
+  publishers: Publisher[],
+  channels: Channel[],
+  locale: string
+) {
+  const xml = serializeOpml(buildExportData(publishers, channels, locale))
+  const blob = new Blob([xml], { type: 'text/x-opml' })
+  const url = URL.createObjectURL(blob)
+
+  const a = document.createElement('a')
+  a.download = `brave-news-subscriptions-${new Date().toISOString()}.opml`
+  a.href = url
+
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+
+  URL.revokeObjectURL(url)
+}
+
+// Normalizes a feed URL the same way the search box does (useSearch.ts), so our
+// duplicate/publisher matching agrees with how feeds are added elsewhere.
+function normalizeFeedUrl(raw: string): string | null {
+  let url = raw.trim()
+  if (!url) {
+    return null
+  }
+  if (!url.includes('://')) {
+    url = 'https://' + url
+  }
+  try {
+    const parsed = new URL(url)
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return null
+    }
+  } catch {
+    return null
+  }
+  return url
+}
+
+// Imports an OPML document, subscribing to matching publishers, adding new
+// direct feeds (without duplicating existing ones), and re-subscribing channels.
+export async function importOpml(
+  xml: string,
+  actions: ImportActions
+): Promise<ImportResult> {
+  const { items, channels } = parseOpml(xml)
+
+  const result: ImportResult = {
+    subscribedPublishers: 0,
+    addedDirectFeeds: 0,
+    subscribedChannels: 0,
+    skipped: 0
+  }
+
+  const publishersById = new Map(
+    actions.publishers.map((p) => [p.publisherId, p])
+  )
+  // Track existing direct feed URLs plus any we add during this import, so we
+  // never create duplicates. The browser also dedupes by URL as a safety net.
+  const directFeedUrls = new Set(
+    actions.publishers
+      .filter(isDirectFeed)
+      .map((p) => p.feedSource?.url)
+      .filter((u): u is string => !!u)
+  )
+
+  const subscribePublisher = (publisher: Publisher) => {
+    if (isPublisherEnabled(publisher)) {
+      result.skipped++
+    } else {
+      actions.followPublisher(publisher.publisherId)
+      result.subscribedPublishers++
+    }
+  }
+
+  const pending: Array<Promise<unknown>> = []
+
+  for (const item of items) {
+    // 1. Prefer an exact publisher id match. This is the only way to resolve a
+    //    publisher that has no feed URL. An unknown id (e.g. a stale catalog)
+    //    falls through to URL-based handling.
+    if (item.publisherId) {
+      const publisher = publishersById.get(item.publisherId)
+      if (publisher) {
+        subscribePublisher(publisher)
+        continue
+      }
+    }
+
+    const url = item.xmlUrl ? normalizeFeedUrl(item.xmlUrl) : null
+    if (!url) {
+      result.skipped++
+      continue
+    }
+
+    // 2. Prefer a known publisher whose feed URL matches over creating a
+    //    redundant direct feed (mirrors useSearch.ts).
+    const publisherMatch = actions.publishers.find(
+      (p) => p.feedSource?.url === url
+    )
+    if (publisherMatch) {
+      subscribePublisher(publisherMatch)
+      continue
+    }
+
+    // 3. Otherwise add a direct feed, skipping duplicates.
+    if (directFeedUrls.has(url)) {
+      result.skipped++
+      continue
+    }
+    directFeedUrls.add(url)
+    pending.push(Promise.resolve(actions.addDirectFeed(url)))
+    result.addedDirectFeeds++
+  }
+
+  const channelByName = new Map(actions.channels.map((c) => [c.channelName, c]))
+  for (const channelName of channels) {
+    const channel = channelByName.get(channelName)
+    // Channels are per-locale; only subscribe ones that exist in the current
+    // locale and aren't already subscribed.
+    if (!channel || channel.subscribedLocales.includes(actions.locale)) {
+      result.skipped++
+      continue
+    }
+    actions.subscribeChannel(actions.locale, channelName)
+    result.subscribedChannels++
+  }
+
+  await Promise.all(pending)
+  return result
+}

--- a/components/resources/brave_news_strings.grdp
+++ b/components/resources/brave_news_strings.grdp
@@ -246,4 +246,18 @@
   <message name="IDS_BRAVE_NEWS_NEW_CONTENT_AVAILABLE" desc="Indicates that new content is available, and prompts the user to load the new data" formatter_data="webui=BraveNews">
     New content available. Reload?
   </message>
+
+  <!-- OPML import / export -->
+  <message name="IDS_BRAVE_NEWS_OPML_IMPORT" desc="Link to import feed subscriptions from an OPML file. OPML is a file format name and should not be translated." formatter_data="webui=BraveNews">
+    Import from OPML
+  </message>
+  <message name="IDS_BRAVE_NEWS_OPML_EXPORT" desc="Link to export feed subscriptions to an OPML file. OPML is a file format name and should not be translated." formatter_data="webui=BraveNews">
+    Export to OPML
+  </message>
+  <message name="IDS_BRAVE_NEWS_OPML_IMPORT_RESULT" desc="Message shown after importing an OPML file, summarizing how many publishers, direct feeds, and channels were added, and how many entries were skipped because they were already subscribed or duplicated." formatter_data="webui=BraveNews">
+    Added <ph name="PUBLISHER_COUNT">$1<ex>3</ex></ph> publishers, <ph name="FEED_COUNT">$2<ex>2</ex></ph> direct feeds and <ph name="CHANNEL_COUNT">$3<ex>1</ex></ph> channels. Skipped <ph name="SKIPPED_COUNT">$4<ex>4</ex></ph> already added.
+  </message>
+  <message name="IDS_BRAVE_NEWS_OPML_IMPORT_ERROR" desc="Error message shown when an OPML file couldn't be imported" formatter_data="webui=BraveNews">
+    Couldn't import that file. Make sure it's a valid OPML file.
+  </message>
 </grit-part>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 
- https://github.com/brave/brave-browser/issues/27596
- https://github.com/brave/brave-browser/issues/25695

IDS_BRAVE_NEWS_OPML_IMPORT
<img width="212" height="123" alt="image" src="https://github.com/user-attachments/assets/25443e4e-9fb9-44ea-9f70-012bc1cc8001" />


IDS_BRAVE_NEWS_OPML_EXPORT
<img width="199" height="107" alt="image" src="https://github.com/user-attachments/assets/317b653b-e60f-491c-a05d-e6e7ecd23b1d" />


IDS_BRAVE_NEWS_OPML_IMPORT_RESULT
<img width="902" height="223" alt="image" src="https://github.com/user-attachments/assets/283399cb-cc22-4642-b31e-28339a793e75" />


IDS_BRAVE_NEWS_OPML_IMPORT_ERROR
<img width="667" height="143" alt="image" src="https://github.com/user-attachments/assets/0321dbe9-bc0d-4243-9817-d81208ad63a2" />

@diracdeltas do you mind taking a look at this because I'm touching the CSP? I needed to add a new TrustedTypes policy for parsing the XML input files - however, I think it should be fine because none of the parsed XML is assigned to an HTML sink (so can't result in any XSS vulnerabilities). 

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan

1. Add some subscriptions to Channels, Publishers and Direct Feeds
2. Open the Brave News Configure Dialog from the NTP and click the `Export to OPML` button, under the sources list and save the file.
3. In a new profile, enable Brave News
4. Click the Import from OPML button

Expected:
All the Channels/Publishers/Feeds from the old profile should be added.
