### PR TITLE
[Android] Icons for disabled settings should appear disabled

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -369,6 +369,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveSyncCodeCountdownFragment.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveTabsAndTabGroupsSettings.java",
+  "../../brave/android/java/org/chromium/chrome/browser/settings/BraveTintedIconSwitchPreference.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveWalletAddNetworksFragment.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveWalletAutoLockPreferences.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveWalletNetworksPreference.java",

--- a/android/java/brave-res/xml/brave_tabs_and_tab_groups_preferences.xml
+++ b/android/java/brave-res/xml/brave_tabs_and_tab_groups_preferences.xml
@@ -34,17 +34,17 @@
         android:key="enable_tab_groups"
         android:icon="@drawable/ic_browser_group"
         android:title="@string/tab_groups_enable_title" />
-    <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
+    <org.chromium.chrome.browser.settings.BraveTintedIconSwitchPreference
         android:key="auto_open_synced_tab_groups_switch"
         android:icon="@drawable/ic_smartphone_laptop"
         android:title="@string/auto_open_synced_tab_groups_summary"
         app:isPreferenceVisible="false" />
-    <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
+    <org.chromium.chrome.browser.settings.BraveTintedIconSwitchPreference
         android:key="tab_groups_bar_switch"
         android:icon="@drawable/ic_browser_mobile_bottom_tab_groups"
         android:title="@string/tab_groups_bar_title"
         android:summary="@string/tab_groups_bar_summary" />
-    <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
+    <org.chromium.chrome.browser.settings.BraveTintedIconSwitchPreference
         android:key="brave_enable_tab_groups"
         android:icon="@drawable/ic_link_normal"
         android:title="@string/open_links_in_current_tab_group_title"

--- a/android/java/org/chromium/chrome/browser/settings/BraveTintedIconSwitchPreference.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveTintedIconSwitchPreference.java
@@ -1,0 +1,42 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.settings;
+
+import static org.chromium.build.NullUtil.assertNonNull;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.ImageView;
+
+import androidx.appcompat.content.res.AppCompatResources;
+import androidx.core.widget.ImageViewCompat;
+import androidx.preference.PreferenceViewHolder;
+
+import org.chromium.build.annotations.NullMarked;
+import org.chromium.build.annotations.Nullable;
+import org.chromium.chrome.R;
+import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
+
+/** A Brave switch preference that tints its icon for enabled and disabled states. */
+@NullMarked
+public class BraveTintedIconSwitchPreference extends ChromeSwitchPreference {
+    public BraveTintedIconSwitchPreference(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    public void onBindViewHolder(PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+
+        if (holder.findViewById(android.R.id.icon) instanceof ImageView icon) {
+            ImageViewCompat.setImageTintList(
+                    icon,
+                    assertNonNull(
+                            AppCompatResources.getColorStateList(
+                                    getContext(), R.color.default_icon_color_tint_list)));
+        }
+    }
+}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56451.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

To verify the behavior at runtime: 

0. Enable the new `brave-android-tab-groups-settings` flag set via `brave://flags`
1. Open the new "Tabs and tab groups" screen from the settings
2. Toggle the "Enable tab groups" setting to disabled state.

Observe that the icons for these preferences appear in a "disabled" state matching the rest of the preference appearance.

<img width="538" height="1197" alt="Screenshot_1782955770" src="https://github.com/user-attachments/assets/7c782505-1263-40f5-80ea-05dbed39867e" />


Demo clip:


https://github.com/user-attachments/assets/b4557cd0-1cad-4072-a734-55a56f3793dd





Note: this PR intentionally adds `BraveTintedIconSwitchPreference.java` to `android/brave_java_sources.gni`, which will likely trigger the [`java_sources_gni.yaml`](https://github.com/brave/security-action/blob/main/assets/opengrep_rules/client/java_sources_gni.yaml) opengrep rule.

This matches the recently approved precedent in [#37323](https://github.com/brave/brave-core/pull/37323#discussion_r3427432719), where `BraveTabsAndTabGroupsSettings.java` was added to the same `brave/android/java/org/chromium/chrome/browser/settings` source list. @AlexeyBarabash's approved this previously with [this rationale](https://github.com/brave/brave-core/pull/37323#discussion_r3427432719):
> we still don't have a separate target for `brave/android/java/org/chromium/chrome/browser/settings` classes, so still ok to have it here.

Keeping this class in `brave_java_sources.gni` follows the same pattern.