### PR TITLE
Skip Chrome logo in dino game restart animation

### DIFF
--- a/patches/components-neterror-resources-dino_game-game_over_panel.ts.patch
+++ b/patches/components-neterror-resources-dino_game-game_over_panel.ts.patch
@@ -1,0 +1,16 @@
+diff --git a/components/neterror/resources/dino_game/game_over_panel.ts b/components/neterror/resources/dino_game/game_over_panel.ts
+index 28ff5d7dcc380dc6a9e1ea01a9576442dbc12c17..268df6829f8696300a777c400bc8105d88f3f621 100644
+--- a/components/neterror/resources/dino_game/game_over_panel.ts
++++ b/components/neterror/resources/dino_game/game_over_panel.ts
+@@ -20,8 +20,8 @@ const FLASH_ITERATIONS: number = 5;
+ const animConfig: {
+   frames: number[],
+   msPerFrame: number,
+ } = {
+-  frames: [0, 36, 72, 108, 144, 180, 216, 252],
+-  msPerFrame: RESTART_ANIM_DURATION / 8,
++  frames: [72, 108, 144, 180, 216, 252],
++  msPerFrame: RESTART_ANIM_DURATION / 6,
+ };
+ 
+ interface BaseGameOverPanelDimensions {


### PR DESCRIPTION
Resolves brave/brave-browser#56137

## Summary
- Skips the Chrome-logo frames in the offline dino game restart animation.
- Starts the game-over restart control on the replay button frame instead.

## Root cause
The Chromium offline sprite sheet still contains two Chrome-logo frames before the replay button animation frames. Brave was drawing the restart animation from frame offset `0`, so the game-over screen briefly showed Chrome branding.

## Verification
- Inspected Chromium `150.0.7871.63`'s offline sprite sheet and confirmed restart frame offsets `0` and `36` are Chrome-logo frames, while offset `72` is the first replay-button frame.
- Verified the patch applies cleanly to Chromium `150.0.7871.63`'s `components/neterror/resources/dino_game/game_over_panel.ts`.
- Ran `git diff --check`.
