### PR TITLE
Make "Bring all tabs to this window" feature flag

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -520,6 +520,14 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
           "Enables scrolling for horizontal tab strip when tabs overflow",   \
           kOsWin | kOsMac | kOsLinux,                                        \
           FEATURE_VALUE_TYPE(tabs::kBraveScrollableTabStrip),                \
+      },                                                                     \
+      {                                                                      \
+          "brave-bring-all-tabs-to-this-window",                             \
+          "Bring all tabs to this window",                                   \
+          "Enables 'Bringing all tabs from other windows to this window' "   \
+          "from tab context menu",                                           \
+          kOsWin | kOsMac | kOsLinux,                                        \
+          FEATURE_VALUE_TYPE(tabs::kBraveBringAllTabsToThisWindow),          \
       })
 
 #else

--- a/browser/ui/brave_browser_browsertest.cc
+++ b/browser/ui/brave_browser_browsertest.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/ui/brave_browser.h"
 
 #include "base/test/run_until.h"
+#include "base/test/scoped_feature_list.h"
 #include "brave/browser/ui/browser_commands.h"
 #include "brave/components/constants/pref_names.h"
 #include "chrome/browser/bookmarks/bookmark_model_factory.h"
@@ -23,6 +24,7 @@
 #include "chrome/browser/ui/startup/startup_browser_creator.h"
 #include "chrome/browser/ui/startup/startup_browser_creator_impl.h"
 #include "chrome/browser/ui/tab_ui_helper.h"
+#include "chrome/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/webui/ntp/new_tab_ui.h"
@@ -339,3 +341,32 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserBrowserTest, BookmarkBarOnNTPTestIncognito) {
   EXPECT_EQ(BookmarkBar::SHOW,
             BookmarkBarController::From(incognito)->bookmark_bar_state());
 }
+
+class BraveBrowserBrowserTestWithBringAllTabsFeature
+    : public BraveBrowserBrowserTest,
+      public ::testing::WithParamInterface<bool> {
+ public:
+  BraveBrowserBrowserTestWithBringAllTabsFeature() {
+    if (!GetParam()) {
+      feature_list_.InitAndDisableFeature(tabs::kBraveBringAllTabsToThisWindow);
+    }
+  }
+
+ private:
+  base::test::ScopedFeatureList feature_list_;
+};
+
+IN_PROC_BROWSER_TEST_P(BraveBrowserBrowserTestWithBringAllTabsFeature,
+                       CanBringAllTabs) {
+  Browser* new_browser = OpenNewBrowser(browser()->profile());
+  ASSERT_TRUE(new_browser);
+  if (GetParam()) {
+    EXPECT_TRUE(brave::CanBringAllTabs(browser()));
+  } else {
+    EXPECT_FALSE(brave::CanBringAllTabs(browser()));
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(All,
+                         BraveBrowserBrowserTestWithBringAllTabsFeature,
+                         ::testing::Bool());

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -789,6 +789,10 @@ void CloseGroup(Browser* browser) {
 }
 
 bool CanBringAllTabs(Browser* browser) {
+  if (!base::FeatureList::IsEnabled(tabs::kBraveBringAllTabsToThisWindow)) {
+    return false;
+  }
+
   if (!browser) {
     return false;
   }

--- a/chromium_src/chrome/browser/ui/tabs/features.cc
+++ b/chromium_src/chrome/browser/ui/tabs/features.cc
@@ -33,6 +33,8 @@ BASE_FEATURE(kBraveTreeTab, base::FEATURE_DISABLED_BY_DEFAULT);
 
 BASE_FEATURE(kBraveScrollableTabStrip, base::FEATURE_ENABLED_BY_DEFAULT);
 
+BASE_FEATURE(kBraveBringAllTabsToThisWindow, base::FEATURE_ENABLED_BY_DEFAULT);
+
 bool HorizontalTabsUpdateEnabled() {
   return base::FeatureList::IsEnabled(kBraveHorizontalTabsUpdate);
 }

--- a/chromium_src/chrome/browser/ui/tabs/features.h
+++ b/chromium_src/chrome/browser/ui/tabs/features.h
@@ -30,6 +30,8 @@ BASE_DECLARE_FEATURE(kBraveTreeTab);
 
 BASE_DECLARE_FEATURE(kBraveScrollableTabStrip);
 
+BASE_DECLARE_FEATURE(kBraveBringAllTabsToThisWindow);
+
 bool HorizontalTabsUpdateEnabled();
 
 }  // namespace tabs


### PR DESCRIPTION
This will let users enable/disable the "Bring all tabs to this window" feature from the about:flags page. The feature is enabled by default.

When the flag is disabled, tab menu model won't add a context menu item for "Bring all tabs to this window".

<!-- Add brave-browser issue below that this PR will resolve -->
Part of https://github.com/brave/brave-browser/issues/36380

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
