### PR TITLE
[reland][revert][reland] [bots] brave_services_key_id gn default (#37481) (#37525)

### DIFF
--- a/build/util/version.py
+++ b/build/util/version.py
@@ -59,6 +59,9 @@ brave_version_build = "%(brave_version_build)s"
 # The full Brave version.
 brave_version = "%(brave_version)s"
 
+# The Chromium milestone (the MAJOR component of the upstream version).
+chromium_version_major = "%(chromium_version_major)s"
+
 # The full Chrome version.
 chrome_version_string = "%(chrome_version_string)s"
 """
@@ -171,8 +174,9 @@ class Versioner:
             'brave_version': (f"{patched['MINOR']}.{patched['BUILD']}."
                               f"{patched['PATCH']}"),
 
-            # The full upstream Chromium version comes from the .chromium
-            # sidecar.
+            # The upstream Chromium milestone and full version come from the
+            # .chromium sidecar.
+            'chromium_version_major': upstream['MAJOR'],
             'chrome_version_string': (
                 f"{upstream['MAJOR']}.{upstream['MINOR']}."
                 f"{upstream['BUILD']}.{upstream['PATCH']}"),

--- a/components/brave_service_keys/BUILD.gn
+++ b/components/brave_service_keys/BUILD.gn
@@ -8,20 +8,49 @@ import("//build/buildflag_header.gni")
 import("//testing/test.gni")
 
 declare_args() {
-  # BRAVE_SERVICES_KEY_ID = TARGET_OS + '-' + CV_MAJOR + '-' + RELEASE_CHANNEL
-  # It is used (in combination with a secret seed) to generate service keys
-  # for each service, OS, chrominum version, release channel
-  # combination.
+  # TODO(https://github.com/brave/brave-browser/issues/56449): Remove this once
+  # a couple of releases have gone through and we've confirmed the derived value
+  # is correct.
   brave_services_key_id = ""
 }
 
-if (is_official_build) {
-  assert(brave_services_key_id != "")
+if (target_os == "android") {
+  _platform = "android"
+} else if (target_os == "ios") {
+  _platform = "ios"
+} else if (target_os == "linux") {
+  _platform = "linux"
+} else if (target_os == "mac") {
+  _platform = "macos"
+} else if (target_os == "win") {
+  _platform = "windows"
+} else {
+  assert(false, "Unsupported target_os: $target_os")
+}
+
+# Release channel is always `""` for `brave_channel`, so we check
+# `is_release_channel`.
+if (is_release_channel) {
+  _channel = "release"
+} else {
+  _channel = brave_channel
+}
+
+_brave_services_key_id = "$_platform-$chromium_version_major-$_channel"
+
+# TODO(https://github.com/brave/brave-browser/issues/56449): Remove this once
+# a couple of releases have gone through and we've confirmed the derived value
+# is correct.
+if (is_official_build && brave_services_key_id != "") {
+  assert(
+      brave_services_key_id == _brave_services_key_id,
+      "brave_services_key_id mismatch: env='$brave_services_key_id' " +
+          "derived='$_brave_services_key_id'. Update your .env file to match")
 }
 
 buildflag_header("buildflags") {
   header = "buildflags.h"
-  flags = [ "BRAVE_SERVICES_KEY_ID=\"$brave_services_key_id\"" ]
+  flags = [ "BRAVE_SERVICES_KEY_ID=\"$_brave_services_key_id\"" ]
 }
 
 static_library("brave_service_keys") {


### PR DESCRIPTION
This reland is safe now https://github.com/brave/brave-core/pull/37731
has been merged.

This reverts commit d8a0337713b80cdeaf6b211fdee5b1cee6c4dc50.

> Reverting due to:
>
> ```
> generate ninja files...
> Widevine cdm host verification is disabled
> /Users/jenkins/jenkins/workspace/brave-browser-build-ios-nightly/src/out/ios_Release_arm64/args_generated.gni has been > updated
> -------------------------------
> /Users/jenkins/jenkins/workspace/brave-browser-build-ios-nightly/src
> > gn gen /Users/jenkins/jenkins/workspace/brave-browser-build-ios-nightly/src/out/ios_Release_arm64
> ERROR at //brave/components/brave_service_keys/BUILD.gn:45:3: Assertion failed.
>   assert(
>   ^-----
> brave_services_key_id mismatch: env='ios-150-nightly' derived='ios-150-release'. Update your .env file to match
> See //brave/components/brave_service_keys/BUILD.gn:46:7:
>       brave_services_key_id == _brave_services_key_id,
>       ^----------------------------------------------
> This is where it was set.
> See //brave/components/oblivious_http/BUILD.gn:28:5: which caused the file to be included.
>     "//brave/components/brave_service_keys",
>     ^--------------------------------------
> null
> null
> ```
>
> Revert reason: The value used in the triplet for the windows target
> differs from `target_os`, and is `windows`. This change corrects that.
>
> This PR disconnects the use of `.env` to initialise the value of
> `brave_services_key_id`, and constructs the expected value from
> information that is already present in the build.
>
> The removal is not done yet, as we ought to be sure the derived value
> works as expected, but the value being used by the build is the one we
> are deriving in `gn`.
>
> Bug: brave/brave-browser#56449

Bug: brave/brave-browser#56449