### PR TITLE
[VPN 2.0] Add v2 purchased-state management for BraveVpnService v2

### DIFF
--- a/browser/brave_vpn/brave_vpn_service_factory.cc
+++ b/browser/brave_vpn/brave_vpn_service_factory.cc
@@ -56,7 +56,13 @@ std::unique_ptr<KeyedService> BuildVpnService_V2(
   brave_vpn::MigrateVPNSettings(profile_prefs, local_state);
 
   // Return stub implementation.
-  return std::make_unique<v2::BraveVpnServiceImpl>(local_state, profile_prefs);
+  return std::make_unique<v2::BraveVpnServiceImpl>(
+      local_state, profile_prefs,
+      base::BindRepeating(
+          [](content::BrowserContext* context) {
+            return skus::SkusServiceFactory::GetForContext(context);
+          },
+          context));
 }
 
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2)

--- a/components/brave_vpn/browser/v2/BUILD.gn
+++ b/components/brave_vpn/browser/v2/BUILD.gn
@@ -11,6 +11,14 @@ static_library("browser") {
   sources = [
     "brave_vpn_service_impl.cc",
     "brave_vpn_service_impl.h",
+    "credential_store.cc",
+    "credential_store.h",
+    "credential_summary.cc",
+    "credential_summary.h",
+    "purchased_state_manager.cc",
+    "purchased_state_manager.h",
+    "skus_service_client.cc",
+    "skus_service_client.h",
   ]
 
   if (is_android) {
@@ -28,6 +36,33 @@ static_library("browser") {
   deps = [
     "//base",
     "//brave/components/brave_vpn/common",
+    "//brave/components/resources:strings",
     "//components/prefs",
+    "//mojo/public/cpp/bindings",
+    "//net",
+    "//ui/base",
+  ]
+}
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [
+    "credential_store_unittest.cc",
+    "credential_summary_unittest.cc",
+    "purchased_state_manager_unittest.cc",
+    "skus_service_client_unittest.cc",
+  ]
+
+  deps = [
+    ":browser",
+    "//base",
+    "//base/test:test_support",
+    "//brave/components/brave_vpn/common",
+    "//brave/components/skus/browser:test_support",
+    "//brave/components/skus/common:mojom",
+    "//components/prefs:test_support",
+    "//mojo/public/cpp/bindings",
+    "//testing/gtest",
   ]
 }

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl.cc
@@ -5,24 +5,33 @@
 
 #include "brave/components/brave_vpn/browser/v2/brave_vpn_service_impl.h"
 
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "base/check.h"
 #include "base/check_deref.h"
 #include "base/notimplemented.h"
-#include "base/types/to_address.h"
+#include "brave/components/brave_vpn/browser/v2/purchased_state_manager.h"
+#include "brave/components/brave_vpn/browser/v2/skus_service_client.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
-#include "brave/components/brave_vpn/common/pref_names.h"
-#include "brave/components/skus/browser/skus_utils.h"
 #include "components/prefs/pref_service.h"
 
-namespace brave_vpn {
-namespace v2 {
+namespace brave_vpn::v2 {
 
-BraveVpnServiceImpl::BraveVpnServiceImpl(PrefService* local_prefs,
-                                         PrefService* profile_prefs)
-    : local_prefs_(CHECK_DEREF(local_prefs)),
-      profile_prefs_(CHECK_DEREF(profile_prefs)),
-      connection_state_(mojom::ConnectionState::DISCONNECTED),
-      purchased_state_(mojom::PurchasedState::NOT_PURCHASED) {
+BraveVpnServiceImpl::BraveVpnServiceImpl(
+    PrefService* local_prefs,
+    PrefService* profile_prefs,
+    GetSkusServiceCallback skus_service_getter)
+    : profile_prefs_(CHECK_DEREF(profile_prefs)),
+      skus_client_(
+          std::make_unique<SkusServiceClient>(std::move(skus_service_getter))),
+      connection_state_(mojom::ConnectionState::DISCONNECTED) {
   DCHECK(IsBraveVPNFeatureEnabled());
+  purchased_state_manager_ = std::make_unique<PurchasedStateManager>(
+      local_prefs, skus_client_.get(),
+      base::BindRepeating(&BraveVpnServiceImpl::OnPurchasedStateChanged,
+                          base::Unretained(this)));
 }
 
 BraveVpnServiceImpl::~BraveVpnServiceImpl() = default;
@@ -32,27 +41,24 @@ bool BraveVpnServiceImpl::IsBraveVPNEnabled() const {
 }
 
 bool BraveVpnServiceImpl::IsPurchased() const {
-  NOTIMPLEMENTED();
-  return purchased_state_ == mojom::PurchasedState::PURCHASED;
+  return purchased_state_manager_->IsPurchased();
 }
 
 void BraveVpnServiceImpl::ReloadPurchasedState() {
-  NOTIMPLEMENTED();
+  purchased_state_manager_->Reload();
 }
 
 std::string BraveVpnServiceImpl::GetCurrentEnvironment() const {
-  return local_prefs_->GetString(prefs::kBraveVPNEnvironment);
+  return purchased_state_manager_->GetCurrentEnvironment();
 }
 
 void BraveVpnServiceImpl::GetPurchasedState(
     GetPurchasedStateCallback callback) {
-  NOTIMPLEMENTED();
-  std::move(callback).Run(
-      mojom::PurchasedInfo::New(purchased_state_, std::nullopt));
+  std::move(callback).Run(purchased_state_manager_->GetInfo().Clone());
 }
 
 void BraveVpnServiceImpl::LoadPurchasedState(const std::string& domain) {
-  NOTIMPLEMENTED();
+  purchased_state_manager_->Load(domain);
 }
 
 void BraveVpnServiceImpl::GetAllRegions(GetAllRegionsCallback callback) {
@@ -61,8 +67,21 @@ void BraveVpnServiceImpl::GetAllRegions(GetAllRegionsCallback callback) {
 }
 
 void BraveVpnServiceImpl::Shutdown() {
+  purchased_state_manager_.reset();
+  skus_client_->Reset();
   BraveVpnService::Shutdown();
 }
 
-}  // namespace v2
-}  // namespace brave_vpn
+void BraveVpnServiceImpl::OnPurchasedStateChanged(
+    mojom::PurchasedState state,
+    const std::optional<std::string>& description) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  NotifyPurchasedStateChanged(state, description);
+
+  // TODO: If purchased state changed to PURCHASED on desktop, we can attempt to
+  // install VPN apps, connect to the agent, etc. We also need to make sure
+  // agent gets connected and fetches the region data - BEFORE we actually send
+  // a notification to the UI.
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl.h
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl.h
@@ -6,21 +6,28 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_BRAVE_VPN_SERVICE_IMPL_H_
 #define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_BRAVE_VPN_SERVICE_IMPL_H_
 
+#include <memory>
 #include <string>
 
+#include "base/functional/callback_forward.h"
 #include "base/memory/raw_ref.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"
+#include "brave/components/brave_vpn/browser/v2/skus_service_client.h"
 #include "build/build_config.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
 
 class PrefService;
 
-namespace brave_vpn {
-namespace v2 {
+namespace brave_vpn::v2 {
+
+class PurchasedStateManager;
+class SkusServiceClient;
 
 class BraveVpnServiceImpl : public BraveVpnService {
  public:
   explicit BraveVpnServiceImpl(PrefService* local_prefs,
-                               PrefService* profile_prefs);
+                               PrefService* profile_prefs,
+                               GetSkusServiceCallback skus_service_getter);
   ~BraveVpnServiceImpl() override;
 
   BraveVpnServiceImpl(const BraveVpnServiceImpl&) = delete;
@@ -120,13 +127,15 @@ class BraveVpnServiceImpl : public BraveVpnService {
 #endif  // !BUILDFLAG(IS_ANDROID)
 
  private:
-  const raw_ref<PrefService> local_prefs_;
+  void OnPurchasedStateChanged(mojom::PurchasedState state,
+                               const std::optional<std::string>& description);
+
   const raw_ref<PrefService> profile_prefs_;
+  std::unique_ptr<SkusServiceClient> skus_client_;
+  std::unique_ptr<PurchasedStateManager> purchased_state_manager_;
   [[maybe_unused]] mojom::ConnectionState connection_state_;
-  mojom::PurchasedState purchased_state_;
 };
 
-}  // namespace v2
-}  // namespace brave_vpn
+}  // namespace brave_vpn::v2
 
 #endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_BRAVE_VPN_SERVICE_IMPL_H_

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl_desktop.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl_desktop.cc
@@ -3,13 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include <utility>
+
 #include "base/notimplemented.h"
 #include "brave/components/brave_vpn/browser/v2/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/v2/purchased_state_manager.h"
 #include "brave/components/brave_vpn/common/brave_vpn_constants.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 
-namespace brave_vpn {
-namespace v2 {
+namespace brave_vpn::v2 {
 
 bool BraveVpnServiceImpl::IsConnected() const {
   NOTIMPLEMENTED();
@@ -64,7 +66,7 @@ void BraveVpnServiceImpl::ClearSelectedRegion() {
 }
 
 void BraveVpnServiceImpl::GetProductUrls(GetProductUrlsCallback callback) {
-  NOTIMPLEMENTED();
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   std::move(callback).Run(mojom::ProductUrls::New(
       kFeedbackUrl, kAboutUrl, GetManageUrl(GetCurrentEnvironment())));
 }
@@ -115,9 +117,7 @@ void BraveVpnServiceImpl::SetConnectionStateForTesting(  // IN-TEST
 void BraveVpnServiceImpl::SetPurchasedStateForTesting(  // IN-TEST
     const std::string& env,
     mojom::PurchasedState state) {
-  purchased_state_ = state;
-  NotifyPurchasedStateChanged(state, std::nullopt);
+  purchased_state_manager_->SetPurchasedState(env, state);
 }
 
-}  // namespace v2
-}  // namespace brave_vpn
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/credential_store.cc
+++ b/components/brave_vpn/browser/v2/credential_store.cc
@@ -1,0 +1,131 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/credential_store.h"
+
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "base/check_deref.h"
+#include "base/json/values_util.h"
+#include "base/types/to_address.h"
+#include "base/values.h"
+#include "brave/components/brave_vpn/common/brave_vpn_constants.h"
+#include "brave/components/brave_vpn/common/brave_vpn_utils.h"
+#include "brave/components/brave_vpn/common/pref_names.h"
+#include "components/prefs/pref_service.h"
+
+namespace brave_vpn::v2 {
+namespace {
+
+// Shared validity check for a single keyed credential in the slot dictionary:
+// the credential string must be present and non-empty, and the (shared)
+// expiration must be present and in the future.
+bool IsCredentialValid(const base::DictValue& dict,
+                       std::string_view credential_key) {
+  if (dict.empty()) {
+    return false;
+  }
+
+  const std::string* credential = dict.FindString(credential_key);
+  if (!credential || credential->empty()) {
+    return false;
+  }
+
+  const base::Value* expiration_value =
+      dict.Find(kSubscriberCredentialExpirationKey);
+  if (!expiration_value) {
+    return false;
+  }
+
+  const std::optional<base::Time> expiration =
+      base::ValueToTime(expiration_value);
+  return expiration.has_value() && *expiration >= base::Time::Now();
+}
+
+std::string GetCredential(const base::DictValue& dict,
+                          std::string_view credential_key) {
+  const std::string* credential = dict.FindString(credential_key);
+  return credential ? *credential : std::string();
+}
+
+}  // namespace
+
+CredentialStore::CredentialStore(PrefService* local_prefs)
+    : local_prefs_(CHECK_DEREF(local_prefs)) {}
+
+CredentialStore::~CredentialStore() = default;
+
+bool CredentialStore::HasValidSubscriberCredential() const {
+  return IsCredentialValid(
+      local_prefs_->GetDict(prefs::kBraveVPNSubscriberCredential),
+      kSubscriberCredentialKey);
+}
+
+std::string CredentialStore::GetSubscriberCredential() const {
+  if (!HasValidSubscriberCredential()) {
+    return std::string();
+  }
+  return GetCredential(
+      local_prefs_->GetDict(prefs::kBraveVPNSubscriberCredential),
+      kSubscriberCredentialKey);
+}
+
+void CredentialStore::SetSubscriberCredential(const std::string& credential,
+                                              base::Time expiration) {
+  base::DictValue dict;
+  dict.Set(kSubscriberCredentialKey, credential);
+  dict.Set(kSubscriberCredentialExpirationKey, base::TimeToValue(expiration));
+  local_prefs_->SetDict(prefs::kBraveVPNSubscriberCredential, std::move(dict));
+}
+
+bool CredentialStore::HasValidSkusCredential() const {
+  return IsCredentialValid(
+      local_prefs_->GetDict(prefs::kBraveVPNSubscriberCredential),
+      kSkusCredentialKey);
+}
+
+std::string CredentialStore::GetSkusCredential() const {
+  if (!HasValidSkusCredential()) {
+    return std::string();
+  }
+  return GetCredential(
+      local_prefs_->GetDict(prefs::kBraveVPNSubscriberCredential),
+      kSkusCredentialKey);
+}
+
+void CredentialStore::SetSkusCredential(const std::string& credential,
+                                        base::Time expiration) {
+  base::DictValue dict;
+  dict.Set(kSkusCredentialKey, credential);
+  dict.Set(kSubscriberCredentialExpirationKey, base::TimeToValue(expiration));
+  local_prefs_->SetDict(prefs::kBraveVPNSubscriberCredential, std::move(dict));
+  local_prefs_->SetTime(prefs::kBraveVPNLastCredentialExpiry, expiration);
+}
+
+bool CredentialStore::HasAnyCredential() const {
+  return !local_prefs_->GetDict(prefs::kBraveVPNSubscriberCredential).empty();
+}
+
+std::optional<base::Time> CredentialStore::GetExpirationTime() const {
+  if (!HasValidSubscriberCredential()) {
+    return std::nullopt;
+  }
+  const base::DictValue& dict =
+      local_prefs_->GetDict(prefs::kBraveVPNSubscriberCredential);
+  const base::Value* expiration_value =
+      dict.Find(kSubscriberCredentialExpirationKey);
+  if (!expiration_value) {
+    return std::nullopt;
+  }
+  return base::ValueToTime(expiration_value);
+}
+
+void CredentialStore::Clear() {
+  ::brave_vpn::ClearSubscriberCredential(base::to_address(local_prefs_));
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/credential_store.h
+++ b/components/brave_vpn/browser/v2/credential_store.h
@@ -1,0 +1,76 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_CREDENTIAL_STORE_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_CREDENTIAL_STORE_H_
+
+#include <optional>
+#include <string>
+
+#include "base/memory/raw_ref.h"
+#include "base/time/time.h"
+
+class PrefService;
+
+namespace brave_vpn::v2 {
+
+// CredentialStore owns the on-disk credential slot used by VPN purchase flow.
+// The slot is a single pref dictionary that, depending on where we are in the
+// credential chain, holds *either* a SKUS credential awaiting exchange *or* the
+// subscriber credential it was exchanged for, but never both, and both share
+// one expiration entry. Because the two occupy one slot, each SetXXXCredential
+// rewrites the entire dictionary, and so drops the other credential.
+class CredentialStore final {
+ public:
+  explicit CredentialStore(PrefService* local_prefs);
+  ~CredentialStore();
+
+  CredentialStore(const CredentialStore&) = delete;
+  CredentialStore& operator=(const CredentialStore&) = delete;
+
+  // Subscriber credential: the ready-to-use credential.
+  bool HasValidSubscriberCredential() const;
+  std::string GetSubscriberCredential() const;
+
+  // Replaces the slot with this subscriber credential, dropping any cached
+  // SKUS credential.
+  void SetSubscriberCredential(const std::string& credential,
+                               base::Time expiration);
+
+  // SKUS credential: obtained from the presentation cookie, awaiting exchange
+  // for a subscriber credential.
+  bool HasValidSkusCredential() const;
+  std::string GetSkusCredential() const;
+
+  // Replaces the slot with this SKUS credential (dropping any cached subscriber
+  // credential) and stamps the last credential expiry.
+  void SetSkusCredential(const std::string& credential, base::Time expiration);
+
+  // True if anything at all is cached, valid or not.
+  bool HasAnyCredential() const;
+
+  // Expiration of the currently cached subscriber credential, used to drive the
+  // refresh timer. Returns nullopt unless a valid subscriber credential is
+  // present.
+  std::optional<base::Time> GetExpirationTime() const;
+
+  // Drops the cached credential only. Delegates to the common utility
+  // ClearSubscriberCredential() so other existing callers won't drift.
+  void Clear();
+
+  // Exchange-retry guard needed to stop the re-exchange loop within a single
+  // resolution cycle, which is inherently per-session, so it lives in memory
+  // and is intentionally not persisted.
+  bool IsExchangeRetried() const { return exchange_retried_; }
+  void SetExchangeRetried(bool retried) { exchange_retried_ = retried; }
+
+ private:
+  const raw_ref<PrefService> local_prefs_;
+  bool exchange_retried_ = false;
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_CREDENTIAL_STORE_H_

--- a/components/brave_vpn/browser/v2/credential_store_unittest.cc
+++ b/components/brave_vpn/browser/v2/credential_store_unittest.cc
@@ -1,0 +1,151 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/credential_store.h"
+
+#include <utility>
+
+#include "base/json/values_util.h"
+#include "base/test/task_environment.h"
+#include "base/time/time.h"
+#include "base/values.h"
+#include "brave/components/brave_vpn/common/brave_vpn_constants.h"
+#include "brave/components/brave_vpn/common/pref_names.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/testing_pref_service.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn::v2 {
+namespace {
+constexpr char kTestCredential[] = "test-credential";
+constexpr char kTestSkusCredential[] = "test-skus-credential";
+}  // namespace
+
+class CredentialStoreTest : public testing::Test {
+ public:
+  CredentialStoreTest() {
+    prefs_.registry()->RegisterDictionaryPref(
+        prefs::kBraveVPNSubscriberCredential);
+    prefs_.registry()->RegisterTimePref(prefs::kBraveVPNLastCredentialExpiry,
+                                        base::Time());
+  }
+
+  base::Time Future() const { return base::Time::Now() + base::Days(30); }
+  base::Time Past() const { return base::Time::Now() - base::Days(1); }
+
+ protected:
+  base::test::TaskEnvironment task_environment_{
+      base::test::TaskEnvironment::TimeSource::MOCK_TIME};
+  TestingPrefServiceSimple prefs_;
+  CredentialStore store_{&prefs_};
+};
+
+TEST_F(CredentialStoreTest, EmptyByDefault) {
+  EXPECT_FALSE(store_.HasAnyCredential());
+  EXPECT_FALSE(store_.HasValidSubscriberCredential());
+  EXPECT_FALSE(store_.HasValidSkusCredential());
+  EXPECT_TRUE(store_.GetSubscriberCredential().empty());
+  EXPECT_TRUE(store_.GetSkusCredential().empty());
+  EXPECT_FALSE(store_.GetExpirationTime().has_value());
+  EXPECT_FALSE(store_.IsExchangeRetried());
+}
+
+TEST_F(CredentialStoreTest, SubscriberCredentialRoundTrip) {
+  store_.SetSubscriberCredential(kTestCredential, Future());
+
+  EXPECT_TRUE(store_.HasAnyCredential());
+  EXPECT_TRUE(store_.HasValidSubscriberCredential());
+  EXPECT_EQ(store_.GetSubscriberCredential(), kTestCredential);
+  ASSERT_TRUE(store_.GetExpirationTime().has_value());
+  EXPECT_EQ(*store_.GetExpirationTime(), Future());
+}
+
+TEST_F(CredentialStoreTest, ExpiredSubscriberCredentialIsInvalid) {
+  store_.SetSubscriberCredential(kTestCredential, Past());
+
+  EXPECT_TRUE(store_.HasAnyCredential());               // present but...
+  EXPECT_FALSE(store_.HasValidSubscriberCredential());  // ...expired.
+  EXPECT_TRUE(store_.GetSubscriberCredential().empty());
+  EXPECT_FALSE(store_.GetExpirationTime().has_value());
+}
+
+TEST_F(CredentialStoreTest, SkusCredentialRoundTripAndLastExpiryStamp) {
+  store_.SetSkusCredential(kTestSkusCredential, Future());
+
+  EXPECT_TRUE(store_.HasValidSkusCredential());
+  EXPECT_EQ(store_.GetSkusCredential(), kTestSkusCredential);
+  EXPECT_EQ(prefs_.GetTime(prefs::kBraveVPNLastCredentialExpiry), Future());
+}
+
+TEST_F(CredentialStoreTest, ExpirationTimeRequiresSubscriberCredential) {
+  store_.SetSkusCredential(kTestSkusCredential, Future());
+  EXPECT_TRUE(store_.HasValidSkusCredential());
+  EXPECT_FALSE(store_.GetExpirationTime().has_value());
+}
+
+TEST_F(CredentialStoreTest, SettingSubscriberDropsSkus) {
+  store_.SetSkusCredential(kTestSkusCredential, Future());
+  ASSERT_TRUE(store_.HasValidSkusCredential());
+
+  store_.SetSubscriberCredential(kTestCredential, Future());
+
+  EXPECT_TRUE(store_.HasValidSubscriberCredential());
+  EXPECT_FALSE(store_.HasValidSkusCredential());
+  EXPECT_TRUE(store_.GetSkusCredential().empty());
+}
+
+TEST_F(CredentialStoreTest, SettingSkusDropsSubscriber) {
+  store_.SetSubscriberCredential(kTestCredential, Future());
+  ASSERT_TRUE(store_.HasValidSubscriberCredential());
+
+  store_.SetSkusCredential(kTestSkusCredential, Future());
+
+  EXPECT_TRUE(store_.HasValidSkusCredential());
+  EXPECT_FALSE(store_.HasValidSubscriberCredential());
+  EXPECT_TRUE(store_.GetSubscriberCredential().empty());
+}
+
+TEST_F(CredentialStoreTest, ClearEmptiesTheSlot) {
+  store_.SetSubscriberCredential(kTestCredential, Future());
+  ASSERT_TRUE(store_.HasAnyCredential());
+
+  store_.Clear();
+
+  EXPECT_FALSE(store_.HasAnyCredential());
+  EXPECT_FALSE(store_.HasValidSubscriberCredential());
+  EXPECT_FALSE(store_.HasValidSkusCredential());
+}
+
+TEST_F(CredentialStoreTest, ExchangeRetryGuardSurvivesClear) {
+  // The whole point of keeping the guard in memory: the re-fetch path calls
+  // Clear(), and the guard must NOT be reset by it, or the "one extra attempt"
+  // logic would loop forever.
+  store_.SetExchangeRetried(true);
+  store_.Clear();
+  EXPECT_TRUE(store_.IsExchangeRetried());
+}
+
+TEST_F(CredentialStoreTest, ExchangeRetryGuardResettable) {
+  store_.SetExchangeRetried(true);
+  store_.SetExchangeRetried(false);
+  EXPECT_FALSE(store_.IsExchangeRetried());
+}
+
+TEST_F(CredentialStoreTest, ReadsPreexistingV1Credential) {
+  // Seamless takeover: a credential written by v1 (including a now-defunct
+  // retry key in the dict) is read as valid by the v2 store.
+  base::DictValue v1_dict;
+  v1_dict.Set(kSubscriberCredentialKey, kTestCredential);
+  v1_dict.Set(kSubscriberCredentialExpirationKey, base::TimeToValue(Future()));
+  v1_dict.Set(kRetriedSkusCredentialKey, true);
+  prefs_.SetDict(prefs::kBraveVPNSubscriberCredential, std::move(v1_dict));
+
+  EXPECT_TRUE(store_.HasValidSubscriberCredential());
+  EXPECT_EQ(store_.GetSubscriberCredential(), kTestCredential);
+  // The stale persisted retry key does not feed the in-memory guard.
+  EXPECT_FALSE(store_.IsExchangeRetried());
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/credential_summary.cc
+++ b/components/brave_vpn/browser/v2/credential_summary.cc
@@ -1,0 +1,48 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/credential_summary.h"
+
+#include <optional>
+#include <string_view>
+
+#include "base/json/json_reader.h"
+#include "base/strings/string_util.h"
+#include "base/values.h"
+
+namespace brave_vpn::v2 {
+
+// static
+std::optional<CredentialSummary> CredentialSummary::FromMessage(
+    std::string_view message) {
+  const std::string_view trimmed =
+      base::TrimWhitespaceASCII(message, base::TrimPositions::TRIM_ALL);
+
+  // Empty/whitespace-only body: no subscription on record.
+  if (trimmed.empty()) {
+    return CredentialSummary{};
+  }
+
+  std::optional<base::DictValue> records =
+      base::JSONReader::ReadDict(trimmed, base::JSON_PARSE_RFC);
+  if (!records) {
+    // Non-empty body that does not parse as a JSON object: genuine failure.
+    return std::nullopt;
+  }
+
+  // Parsed, but to an empty object: also "no subscription on record".
+  if (records->empty()) {
+    return CredentialSummary{};
+  }
+
+  CredentialSummary summary;
+  summary.empty_ = false;
+  summary.active_ = records->FindBool("active").value_or(false);
+  summary.remaining_credential_count_ =
+      records->FindInt("remaining_credential_count").value_or(0);
+  return summary;
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/credential_summary.h
+++ b/components/brave_vpn/browser/v2/credential_summary.h
@@ -1,0 +1,42 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_CREDENTIAL_SUMMARY_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_CREDENTIAL_SUMMARY_H_
+
+#include <optional>
+#include <string_view>
+
+namespace brave_vpn::v2 {
+
+// Parsed SKUS credential-summary response. This is a pure value type with no
+// dependencies: it describes the server's view of the subscription, which is a
+// different concept from the credential cached on disk.
+class CredentialSummary final {
+ public:
+  // Parses a raw summary message.
+  // Returns std::nullopt if the body was non-empty but not valid JSON (a
+  // genuine parse failure). Returns an empty summary if the body was
+  // empty/whitespace-only, or parsed to an empty object (no subscription on
+  // record). Otherwise returns a populated summary; inspect the predicates.
+  static std::optional<CredentialSummary> FromMessage(std::string_view message);
+
+  bool IsEmpty() const { return empty_; }
+  bool IsValid() const { return active_ && remaining_credential_count_ > 0; }
+  bool NeedsActivation() const {
+    return !active_ && remaining_credential_count_ > 0;
+  }
+
+ private:
+  CredentialSummary() = default;
+
+  bool empty_ = true;
+  bool active_ = false;
+  int remaining_credential_count_ = 0;
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_CREDENTIAL_SUMMARY_H_

--- a/components/brave_vpn/browser/v2/credential_summary_unittest.cc
+++ b/components/brave_vpn/browser/v2/credential_summary_unittest.cc
@@ -1,0 +1,99 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/credential_summary.h"
+
+#include <optional>
+
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn::v2 {
+
+TEST(CredentialSummaryTest, EmptyMessageIsEmpty) {
+  std::optional<CredentialSummary> summary = CredentialSummary::FromMessage("");
+  ASSERT_TRUE(summary);
+  EXPECT_TRUE(summary->IsEmpty());
+  EXPECT_FALSE(summary->IsValid());
+  EXPECT_FALSE(summary->NeedsActivation());
+}
+
+TEST(CredentialSummaryTest, WhitespaceOnlyMessageIsEmpty) {
+  // Trimming is the parser's responsibility, so a whitespace body is "empty",
+  // not "malformed".
+  std::optional<CredentialSummary> summary =
+      CredentialSummary::FromMessage("   \n\t ");
+  ASSERT_TRUE(summary);
+  EXPECT_TRUE(summary->IsEmpty());
+}
+
+TEST(CredentialSummaryTest, EmptyJsonObjectIsEmpty) {
+  std::optional<CredentialSummary> summary =
+      CredentialSummary::FromMessage("{}");
+  ASSERT_TRUE(summary);
+  EXPECT_TRUE(summary->IsEmpty());
+}
+
+TEST(CredentialSummaryTest, MalformedJsonReturnsNullopt) {
+  // Non-empty body that is not a JSON object means a genuine parse failure.
+  EXPECT_FALSE(CredentialSummary::FromMessage("not json").has_value());
+  EXPECT_FALSE(CredentialSummary::FromMessage("[1, 2, 3]").has_value());
+}
+
+TEST(CredentialSummaryTest, ActiveWithRemainingIsValid) {
+  std::optional<CredentialSummary> summary = CredentialSummary::FromMessage(
+      R"({"active": true, "remaining_credential_count": 3})");
+  ASSERT_TRUE(summary);
+  EXPECT_FALSE(summary->IsEmpty());
+  EXPECT_TRUE(summary->IsValid());
+  EXPECT_FALSE(summary->NeedsActivation());
+}
+
+TEST(CredentialSummaryTest, InactiveWithRemainingNeedsActivation) {
+  std::optional<CredentialSummary> summary = CredentialSummary::FromMessage(
+      R"({"active": false, "remaining_credential_count": 3})");
+  ASSERT_TRUE(summary);
+  EXPECT_FALSE(summary->IsEmpty());
+  EXPECT_FALSE(summary->IsValid());
+  EXPECT_TRUE(summary->NeedsActivation());
+}
+
+TEST(CredentialSummaryTest, InactiveNoRemainingFallsThroughAllPredicates) {
+  // The out-of-credentials case: a real subscription record, but nothing left
+  // to redeem. It must be reported as none of empty/valid/needs-activation so
+  // the caller routes it to the session-expired path.
+  std::optional<CredentialSummary> summary = CredentialSummary::FromMessage(
+      R"({"active": false, "remaining_credential_count": 0})");
+  ASSERT_TRUE(summary);
+  EXPECT_FALSE(summary->IsEmpty());
+  EXPECT_FALSE(summary->IsValid());
+  EXPECT_FALSE(summary->NeedsActivation());
+}
+
+TEST(CredentialSummaryTest, ActiveNoRemainingFallsThroughAllPredicates) {
+  std::optional<CredentialSummary> summary = CredentialSummary::FromMessage(
+      R"({"active": true, "remaining_credential_count": 0})");
+  ASSERT_TRUE(summary);
+  EXPECT_FALSE(summary->IsEmpty());
+  EXPECT_FALSE(summary->IsValid());
+  EXPECT_FALSE(summary->NeedsActivation());
+}
+
+TEST(CredentialSummaryTest, MissingFieldsDefaultToOutOfCredentials) {
+  std::optional<CredentialSummary> summary =
+      CredentialSummary::FromMessage(R"({"unrelated": "value"})");
+  ASSERT_TRUE(summary);
+  EXPECT_FALSE(summary->IsEmpty());
+  EXPECT_FALSE(summary->IsValid());
+  EXPECT_FALSE(summary->NeedsActivation());
+}
+
+TEST(CredentialSummaryTest, SurroundingWhitespaceIsTolerated) {
+  std::optional<CredentialSummary> summary = CredentialSummary::FromMessage(
+      "\n  {\"active\": true, \"remaining_credential_count\": 1}  \n");
+  ASSERT_TRUE(summary);
+  EXPECT_TRUE(summary->IsValid());
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/purchased_state_manager.cc
+++ b/components/brave_vpn/browser/v2/purchased_state_manager.cc
@@ -1,0 +1,445 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/purchased_state_manager.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "base/check_deref.h"
+#include "base/functional/bind.h"
+#include "base/logging.h"
+#include "base/notimplemented.h"
+#include "base/task/sequenced_task_runner.h"
+#include "base/time/time.h"
+#include "brave/components/brave_vpn/browser/v2/credential_store.h"
+#include "brave/components/brave_vpn/browser/v2/credential_summary.h"
+#include "brave/components/brave_vpn/browser/v2/skus_service_client.h"
+#include "brave/components/brave_vpn/common/brave_vpn_constants.h"
+#include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"
+#include "brave/components/brave_vpn/common/pref_names.h"
+#include "brave/components/skus/browser/skus_utils.h"
+#include "brave/components/skus/common/skus_sdk.mojom.h"
+#include "components/grit/brave_components_strings.h"
+#include "components/prefs/pref_service.h"
+#include "net/cookies/cookie_inclusion_status.h"
+#include "net/cookies/cookie_util.h"
+#include "net/cookies/parsed_cookie.h"
+#include "ui/base/l10n/l10n_util.h"
+#include "url/url_util.h"
+
+namespace brave_vpn::v2 {
+
+PurchasedStateManager::PurchasedStateManager(
+    PrefService* local_prefs,
+    SkusServiceClient* skus_client,
+    PurchasedStateChangedCallback callback)
+    : local_prefs_(CHECK_DEREF(local_prefs)),
+      skus_client_(CHECK_DEREF(skus_client)),
+      purchased_state_changed_callback_(std::move(callback)),
+      credential_store_(std::make_unique<CredentialStore>(local_prefs)),
+      current_environment_(
+          local_prefs_->GetString(prefs::kBraveVPNEnvironment)) {
+  // Defer initial state resolution off the constructor, since it can
+  // synchronously run a callback which would reenter the still-constructing
+  // BraveVpnServiceImpl, and push a change before any client can observe it.
+  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+      FROM_HERE, base::BindOnce(&PurchasedStateManager::CheckInitialState,
+                                weak_factory_.GetWeakPtr()));
+}
+
+PurchasedStateManager::~PurchasedStateManager() = default;
+
+void PurchasedStateManager::Reload() {
+  Load(skus::GetDomain(skus::GetVpnProductPrefix(), current_environment_));
+}
+
+void PurchasedStateManager::Load(const std::string& domain) {
+  if (!skus::DomainIsForProduct(domain, skus::GetVpnProductPrefix())) {
+    VLOG(2) << __func__ << ": Called for non-vpn product";
+    return;
+  }
+
+  // Set current environment if not set yet. This can happen if the user has
+  // never used VPN before, and the environment is not set in local state.
+  const std::string request_environment = skus::GetEnvironmentForDomain(domain);
+  if (current_environment_.empty()) {
+    current_environment_ = request_environment;
+    UpdateCurrentEnvironment();
+  }
+
+  // Check if already loading the same environment.
+  if (current_environment_ == request_environment &&
+      GetInfo().state == mojom::PurchasedState::LOADING) {
+    VLOG(2) << __func__ << ": Already loading the same environment";
+    return;
+  }
+
+  // Clear the retry flag since this is a new resolution cycle.
+  credential_store_->SetExchangeRetried(false);
+
+  SetPurchasedState(request_environment, mojom::PurchasedState::LOADING);
+
+  if (credential_store_->HasValidSubscriberCredential()) {
+    // Already have a valid subscriber credential, so we are purchased. Schedule
+    // a refresh of the credential before it expires.
+    VLOG(2) << "Already have a valid subscriber credential, scheduling refresh";
+    ScheduleSubscriberCredentialRefresh();
+    SetPurchasedState(request_environment, mojom::PurchasedState::PURCHASED);
+    return;
+  }
+
+  if (credential_store_->HasValidSkusCredential()) {
+    // Previous attempt to exchange the skus credential for a subscriber
+    // credential failed. Try again with the cached skus credential.
+    VLOG(2) << "Trying to exchange cached skus credential for subscriber "
+               "credential";
+
+    // TODO(https://github.com/brave/brave-browser/issues/54600)
+    // The API request class is intentionally not wired up yet.
+    // Once it is, this will call GetSubscriberCredentialV12.
+    NOTIMPLEMENTED();
+    return;
+  }
+
+  // No valid credentials, so request a new credential summary from SKUS.
+  VLOG(2) << "Requesting credential summary from SKUS";
+  RequestCredentialSummary(domain);
+}
+
+mojom::PurchasedInfo PurchasedStateManager::GetInfo() const {
+  return purchased_state_.value_or(
+      mojom::PurchasedInfo(mojom::PurchasedState::NOT_PURCHASED, std::nullopt));
+}
+
+bool PurchasedStateManager::IsPurchased() const {
+  return GetInfo().state == mojom::PurchasedState::PURCHASED;
+}
+
+std::string PurchasedStateManager::GetCurrentEnvironment() const {
+  return current_environment_;
+}
+
+void PurchasedStateManager::SetPurchasedState(
+    const std::string& env,
+    mojom::PurchasedState state,
+    const std::optional<std::string>& description) {
+  if (GetInfo().state != state && env == current_environment_) {
+    VLOG(2) << "Changing purchased state to " << state;
+    purchased_state_ = mojom::PurchasedInfo(state, description);
+    purchased_state_changed_callback_.Run(state, description);
+  }
+}
+
+void PurchasedStateManager::CheckInitialState() {
+  if (credential_store_->HasValidSubscriberCredential()) {
+    // Have a valid subscriber credential, so we are purchased. Schedule a
+    // refresh of the credential before it expires.
+    VLOG(2) << "Have valid subscriber credential, scheduling refresh";
+    ScheduleSubscriberCredentialRefresh();
+    SetPurchasedState(current_environment_, mojom::PurchasedState::PURCHASED);
+  } else if (credential_store_->HasValidSkusCredential()) {
+    // There is a cached SKUS credential - exchange it for a subscriber
+    // credential up front.
+    VLOG(2) << "Reloading purchased state due to cached SKUS credential";
+    Reload();
+  } else {
+    // A stored subscriber credential may have been invalidated while we were
+    // not running. Always clear whatever is cached; if something stale was
+    // present, reload to re-derive state.
+    const bool has_stale_credential = credential_store_->HasAnyCredential();
+    credential_store_->Clear();
+    if (has_stale_credential) {
+      VLOG(2) << "Reloading purchased state due to stale credential";
+      Reload();
+    }
+  }
+}
+
+void PurchasedStateManager::UpdateCurrentEnvironment() {
+  local_prefs_->SetString(prefs::kBraveVPNEnvironment, current_environment_);
+  purchased_state_.reset();
+}
+
+void PurchasedStateManager::RequestCredentialSummary(
+    const std::string& domain) {
+  // As we request a new credential, clear the cached value.
+  credential_store_->Clear();
+
+  skus_client_->GetCredentialSummary(
+      domain, base::BindOnce(&PurchasedStateManager::OnCredentialSummary,
+                             weak_factory_.GetWeakPtr(), domain));
+}
+
+void PurchasedStateManager::OnCredentialSummary(
+    const std::string& domain,
+    skus::mojom::SkusResultPtr summary) {
+  if (!skus::DomainIsForProduct(domain, skus::GetVpnProductPrefix())) {
+    VLOG(2) << __func__ << ": Called for non-vpn product";
+    return;
+  }
+
+  const std::string request_environment = skus::GetEnvironmentForDomain(domain);
+
+  const std::optional<CredentialSummary> parsed =
+      CredentialSummary::FromMessage(summary->message);
+  if (!parsed) {
+    // Non-empty but unparseable summary.
+    VLOG(2) << "Got invalid credential summary";
+    SetPurchasedState(request_environment, mojom::PurchasedState::FAILED);
+    return;
+  }
+
+  if (parsed->IsEmpty()) {
+    // No subscription on record: the user needs to log in (or never had one).
+    VLOG(2) << "Got empty credential summary";
+    SetPurchasedState(request_environment,
+                      mojom::PurchasedState::NOT_PURCHASED);
+    return;
+  }
+
+  if (parsed->IsValid()) {
+    // Active credential: present it so we can read the credential cookie.
+    VLOG(2) << "Got valid credential summary";
+    skus_client_->PrepareCredentialsPresentation(
+        domain, "*",
+        base::BindOnce(&PurchasedStateManager::OnPrepareCredentialsPresentation,
+                       weak_factory_.GetWeakPtr(), domain));
+#if !BUILDFLAG(IS_ANDROID)
+    // Clear expired state data as we have active credentials.
+    local_prefs_->SetTime(prefs::kBraveVPNSessionExpiredDate, {});
+#endif
+    return;
+  }
+
+  if (parsed->NeedsActivation()) {
+    // Needs activation from account; treat as not purchased until activated.
+    VLOG(2) << "Got credential summary but needs activation";
+    SetPurchasedState(request_environment,
+                      mojom::PurchasedState::NOT_PURCHASED);
+    return;
+  }
+
+  // Subscription on record but no remaining credential: the purchase is
+  // expired.
+#if BUILDFLAG(IS_ANDROID)
+  SetPurchasedState(request_environment, mojom::PurchasedState::NOT_PURCHASED);
+#else
+  UpdatePurchasedStateForSessionExpired(request_environment);
+#endif
+}
+
+void PurchasedStateManager::OnPrepareCredentialsPresentation(
+    const std::string& domain,
+    skus::mojom::SkusResultPtr credential_as_cookie) {
+  if (!skus::DomainIsForProduct(domain, skus::GetVpnProductPrefix())) {
+    VLOG(2) << __func__ << ": Called for non-vpn product";
+    return;
+  }
+
+  const std::string request_environment = skus::GetEnvironmentForDomain(domain);
+
+  // The credential is returned in cookie format.
+  net::CookieInclusionStatus status;
+  net::ParsedCookie credential_cookie(credential_as_cookie->message, &status);
+  if (!credential_cookie.IsValid() || !status.IsInclude() ||
+      !credential_cookie.Expires()) {
+    VLOG(2) << "Got invalid credential cookie";
+    SetPurchasedState(request_environment, mojom::PurchasedState::FAILED);
+    return;
+  }
+
+  // The value is URL-encoded; decode it to recover the Base64 credential blob.
+  const base::Time time =
+      net::cookie_util::ParseCookieExpirationTime(*credential_cookie.Expires());
+  const std::string credential = url::DecodeUrlEscapeSequences(
+      credential_cookie.Value(), url::DecodeUrlMode::kUtf8OrIsomorphic);
+  if (credential.empty()) {
+    VLOG(2) << "Got empty credential cookie";
+    SetPurchasedState(request_environment,
+                      mojom::PurchasedState::NOT_PURCHASED);
+    return;
+  }
+
+  // Already expired.
+  if (time < base::Time::Now()) {
+    VLOG(2) << "Got expired credential cookie";
+    SetPurchasedState(
+        request_environment, mojom::PurchasedState::FAILED,
+        l10n_util::GetStringUTF8(IDS_BRAVE_VPN_PURCHASE_CREDENTIALS_EXPIRED));
+    return;
+  }
+
+  // Update the cached skus credential and its expiration time.
+  credential_store_->SetSkusCredential(credential, time);
+
+  // We have successfully authorized with a new environment.
+  if (current_environment_ != request_environment) {
+    current_environment_ = request_environment;
+    UpdateCurrentEnvironment();
+  }
+
+  // TODO(https://github.com/brave/brave-browser/issues/54600)
+  // The API request class is intentionally not wired up yet.
+  // Once it is, this will call GetSubscriberCredentialV12.
+  NOTIMPLEMENTED();
+}
+
+void PurchasedStateManager::OnGetSubscriberCredentialV12(
+    base::Time expiration_time,
+    const std::string& subscriber_credential,
+    bool success) {
+  if (!success) {
+    VLOG(1) << "Failed to get subscriber credential";
+#if BUILDFLAG(IS_ANDROID)
+    SetPurchasedState(current_environment_,
+                      mojom::PurchasedState::NOT_PURCHASED);
+#else   // BUILDFLAG(IS_ANDROID)
+    const bool token_no_longer_valid =
+        subscriber_credential == ::brave_vpn::kTokenNoLongerValid;
+
+    // "Token no longer valid" means the credential was already consumed. Make
+    // one more attempt with a fresh SKUS credential (two attempts total).
+    // Set the retried flag before re-requesting so a synchronous callback
+    // won't loop forever.
+    if (token_no_longer_valid && !credential_store_->IsExchangeRetried()) {
+      VLOG(2) << "Token no longer valid, retrying with fresh SKUS credential";
+      credential_store_->SetExchangeRetried(true);
+      RequestCredentialSummary(
+          skus::GetDomain(skus::GetVpnProductPrefix(), current_environment_));
+      return;
+    }
+
+    // The retry also came back invalid: the token is definitively no good.
+    if (token_no_longer_valid) {
+      VLOG(2) << "Token no longer valid after retry";
+      SetPurchasedState(
+          current_environment_, mojom::PurchasedState::FAILED,
+          l10n_util::GetStringUTF8(IDS_BRAVE_VPN_PURCHASE_TOKEN_NOT_VALID));
+      return;
+    }
+
+    // Otherwise it's a transient vendor/network error. The cached credential
+    // will eventually expire and a new one will be fetched.
+    VLOG(2) << "Transient error, will retry later";
+    SetPurchasedState(current_environment_, mojom::PurchasedState::FAILED,
+                      l10n_util::GetStringUTF8(
+                          IDS_BRAVE_VPN_PURCHASE_CREDENTIALS_FETCH_FAILED));
+#endif  // BUILDFLAG(IS_ANDROID)
+    return;
+  }
+
+  // Got a valid subscriber credential. Clear the retry flag, cache it, and
+  // schedule a refresh before it expires.
+  credential_store_->SetExchangeRetried(false);
+  credential_store_->SetSubscriberCredential(subscriber_credential,
+                                             expiration_time);
+  ScheduleSubscriberCredentialRefresh();
+  SetPurchasedState(current_environment_, mojom::PurchasedState::PURCHASED);
+}
+
+void PurchasedStateManager::ScheduleSubscriberCredentialRefresh() {
+  if (subs_cred_refresh_timer_.IsRunning()) {
+    subs_cred_refresh_timer_.Stop();
+  }
+
+  const std::optional<base::Time> expiration_time =
+      credential_store_->GetExpirationTime();
+  if (!expiration_time) {
+    VLOG(2) << "No expiration time available for subscriber credential";
+    return;
+  }
+
+  // Safe to pass unretained here, because the timer is a member and cannot
+  // outlive the manager.
+  subs_cred_refresh_timer_.Start(
+      FROM_HERE, *expiration_time - base::Time::Now(),
+      base::BindOnce(&PurchasedStateManager::RefreshSubscriberCredential,
+                     base::Unretained(this)));
+}
+
+void PurchasedStateManager::RefreshSubscriberCredential() {
+  VLOG(2) << "Refresh subscriber credential";
+  // Clear current credentials to get newer one.
+  credential_store_->Clear();
+  Reload();
+}
+
+#if !BUILDFLAG(IS_ANDROID)
+
+void PurchasedStateManager::UpdatePurchasedStateForSessionExpired(
+    const std::string& env) {
+  // TODO(https://github.com/brave/brave-browser/issues/54601)
+  // BraveVpnService v1 first guarded against marking a *fresh* user as
+  // session-expired by checking connection-manager region-data readiness
+  // (treating "no region data" as a brand-new user -> NOT_PURCHASED). In v2,
+  // until the agent is properly plumbed, a brand-new user who reaches this path
+  // would be reported SESSION_EXPIRED rather than NOT_PURCHASED.
+
+  // If the last credential expiry is in the future, the user redeemed their
+  // credentials but we lost communication with the vendor: out of credentials.
+  // kBraveVPNLastCredentialExpiry is only set after obtaining a valid
+  // credential, so checking it first is safe.
+  const base::Time last_credential_expiry =
+      local_prefs_->GetTime(prefs::kBraveVPNLastCredentialExpiry);
+  const base::Time current_time = base::Time::Now();
+  if (!last_credential_expiry.is_null() &&
+      last_credential_expiry > current_time) {
+    base::TimeDelta delta = (last_credential_expiry - current_time);
+    if (delta.InHours() == 0) {
+      VLOG(2) << "Out of credentials; check again in " << delta.InMinutes()
+              << " minutes.";
+    } else {
+      const int delta_hours = delta.InHours();
+      base::TimeDelta delta_minutes = (delta - base::Hours(delta_hours));
+      VLOG(2) << "Out of credentials; check again in " << delta_hours
+              << " hours " << delta_minutes.InMinutes() << " minutes.";
+    }
+    SetPurchasedState(env, mojom::PurchasedState::OUT_OF_CREDENTIALS,
+                      l10n_util::GetStringUTF8(
+                          IDS_BRAVE_VPN_MAIN_PANEL_OUT_OF_CREDENTIALS_CONTENT));
+    return;
+  }
+
+  const base::Time session_expired_time =
+      local_prefs_->GetTime(prefs::kBraveVPNSessionExpiredDate);
+  // First session expiration since the last purchase (this pref is cleared when
+  // we get a valid credential summary): stamp it now and report expired.
+  if (session_expired_time.is_null()) {
+    VLOG(2) << "First session expiration since last purchase";
+    local_prefs_->SetTime(prefs::kBraveVPNSessionExpiredDate,
+                          base::Time::Now());
+    SetPurchasedState(env, mojom::PurchasedState::SESSION_EXPIRED);
+    return;
+  }
+
+  // Stamp in the future (clock weirdness): treat as not purchased.
+  if (session_expired_time > base::Time::Now()) {
+    VLOG(2) << "Session expired time is in the future";
+    SetPurchasedState(env, mojom::PurchasedState::NOT_PURCHASED);
+    return;
+  }
+
+  // If the session-expired state has been held for more than the configured
+  // duration, treat as not purchased.
+  constexpr int kSessionExpiredCheckingDurationInDays = 30;
+  if ((base::Time::Now() - session_expired_time).InDays() >
+      kSessionExpiredCheckingDurationInDays) {
+    VLOG(2) << "Session expired state held for more than "
+            << kSessionExpiredCheckingDurationInDays << " days";
+    SetPurchasedState(env, mojom::PurchasedState::NOT_PURCHASED);
+    return;
+  }
+
+  // Expiry is in the past - the user must log into account.brave.com again.
+  VLOG(2) << "Session expired, user must log in again";
+  SetPurchasedState(env, mojom::PurchasedState::SESSION_EXPIRED);
+}
+
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/purchased_state_manager.h
+++ b/components/brave_vpn/browser/v2/purchased_state_manager.h
@@ -1,0 +1,91 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_PURCHASED_STATE_MANAGER_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_PURCHASED_STATE_MANAGER_H_
+
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "base/functional/callback.h"
+#include "base/memory/raw_ref.h"
+#include "base/memory/weak_ptr.h"
+#include "base/time/time.h"
+#include "base/timer/timer.h"
+#include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"
+#include "brave/components/skus/common/skus_sdk.mojom-forward.h"
+#include "build/build_config.h"
+
+class PrefService;
+
+namespace brave_vpn::v2 {
+
+class CredentialStore;
+class SkusServiceClient;
+
+// PurchasedStateManager owns the purchased-state value and the current
+// environment, and runs the credential chain that produces that state. Also
+// runs a timer that refreshes the subscriber credential before it expires.
+class PurchasedStateManager final {
+ public:
+  using PurchasedStateChangedCallback =
+      base::RepeatingCallback<void(mojom::PurchasedState,
+                                   const std::optional<std::string>&)>;
+
+  PurchasedStateManager(PrefService* local_prefs,
+                        SkusServiceClient* skus_client,
+                        PurchasedStateChangedCallback callback);
+  ~PurchasedStateManager();
+
+  PurchasedStateManager(const PurchasedStateManager&) = delete;
+  PurchasedStateManager& operator=(const PurchasedStateManager&) = delete;
+
+  void Reload();
+  void Load(const std::string& domain);
+  mojom::PurchasedInfo GetInfo() const;
+  bool IsPurchased() const;
+  std::string GetCurrentEnvironment() const;
+
+  void SetPurchasedState(
+      const std::string& env,
+      mojom::PurchasedState state,
+      const std::optional<std::string>& description = std::nullopt);
+
+ private:
+  friend class PurchasedStateManagerTest;
+
+  void CheckInitialState();
+  void UpdateCurrentEnvironment();
+  void RequestCredentialSummary(const std::string& domain);
+  void OnCredentialSummary(const std::string& domain,
+                           skus::mojom::SkusResultPtr summary);
+  void OnPrepareCredentialsPresentation(
+      const std::string& domain,
+      skus::mojom::SkusResultPtr credential_as_cookie);
+  void OnGetSubscriberCredentialV12(base::Time expiration_time,
+                                    const std::string& subscriber_credential,
+                                    bool success);
+
+  void ScheduleSubscriberCredentialRefresh();
+  void RefreshSubscriberCredential();
+
+#if !BUILDFLAG(IS_ANDROID)
+  void UpdatePurchasedStateForSessionExpired(const std::string& env);
+#endif
+
+  const raw_ref<PrefService> local_prefs_;
+  const raw_ref<SkusServiceClient> skus_client_;
+  PurchasedStateChangedCallback purchased_state_changed_callback_;
+  std::unique_ptr<CredentialStore> credential_store_;
+  std::string current_environment_;
+  std::optional<mojom::PurchasedInfo> purchased_state_;
+  base::OneShotTimer subs_cred_refresh_timer_;
+  base::WeakPtrFactory<PurchasedStateManager> weak_factory_{this};
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_PURCHASED_STATE_MANAGER_H_

--- a/components/brave_vpn/browser/v2/purchased_state_manager_unittest.cc
+++ b/components/brave_vpn/browser/v2/purchased_state_manager_unittest.cc
@@ -1,0 +1,524 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/purchased_state_manager.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "base/functional/bind.h"
+#include "base/functional/callback.h"
+#include "base/location.h"
+#include "base/run_loop.h"
+#include "base/task/sequenced_task_runner.h"
+#include "base/test/task_environment.h"
+#include "base/time/time.h"
+#include "brave/components/brave_vpn/browser/v2/credential_store.h"
+#include "brave/components/brave_vpn/browser/v2/skus_service_client.h"
+#include "brave/components/brave_vpn/common/brave_vpn_constants.h"
+#include "brave/components/brave_vpn/common/brave_vpn_utils.h"
+#include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"
+#include "brave/components/brave_vpn/common/pref_names.h"
+#include "brave/components/skus/browser/skus_utils.h"
+#include "brave/components/skus/common/skus_sdk.mojom.h"
+#include "build/build_config.h"
+#include "components/prefs/pref_service.h"
+#include "components/prefs/testing_pref_service.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn::v2 {
+namespace {
+
+using PurchasedState = mojom::PurchasedState;
+
+// Cookie expiry strings, evaluated against the fixed mock clock.
+constexpr char kFutureCookieExpiry[] = "Sat, 01 Jan 2050 00:00:00 GMT";
+constexpr char kPastCookieExpiry[] = "Fri, 01 Jan 2010 00:00:00 GMT";
+
+std::string MakeCredentialCookie(const std::string& value,
+                                 const std::string& expires) {
+  return "credential=" + value + "; Expires=" + expires;
+}
+
+class FakeSkusServiceClient : public SkusServiceClient {
+ public:
+  FakeSkusServiceClient()
+      : SkusServiceClient(base::BindRepeating(
+            [] { return mojo::PendingRemote<skus::mojom::SkusService>(); })) {}
+  ~FakeSkusServiceClient() override = default;
+
+  void GetCredentialSummary(
+      const std::string& domain,
+      skus::mojom::SkusService::CredentialSummaryCallback /*callback*/)
+      override {
+    ++credential_summary_calls_;
+    last_domain_ = domain;
+  }
+
+  void PrepareCredentialsPresentation(
+      const std::string& domain,
+      const std::string& /*path*/,
+      skus::mojom::SkusService::PrepareCredentialsPresentationCallback
+      /*callback*/) override {
+    ++prepare_presentation_calls_;
+    last_domain_ = domain;
+  }
+
+  int credential_summary_calls() const { return credential_summary_calls_; }
+  int prepare_presentation_calls() const { return prepare_presentation_calls_; }
+  const std::string& last_domain() const { return last_domain_; }
+
+ private:
+  int credential_summary_calls_ = 0;
+  int prepare_presentation_calls_ = 0;
+  std::string last_domain_;
+};
+
+}  // namespace
+
+class PurchasedStateManagerTest : public testing::Test {
+ public:
+  PurchasedStateManagerTest()
+      : task_environment_(base::test::TaskEnvironment::TimeSource::MOCK_TIME) {}
+
+  void SetUp() override {
+    // Pin the clock so cookie/credential expirations are deterministic.
+    base::Time fixed_time;
+    ASSERT_TRUE(base::Time::FromString("2023-01-04", &fixed_time));
+    task_environment_.AdvanceClock(fixed_time - base::Time::Now());
+
+    brave_vpn::RegisterLocalStatePrefs(local_pref_service_.registry());
+  }
+
+  void CreateManager() {
+    manager_ = std::make_unique<PurchasedStateManager>(
+        &local_pref_service_, &fake_skus_client_,
+        base::BindRepeating(&PurchasedStateManagerTest::OnPurchasedStateChanged,
+                            base::Unretained(this)));
+    base::RunLoop run_loop;
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE, run_loop.QuitClosure());
+    run_loop.Run();
+  }
+
+  void CreateAndLoadManager() {
+    CreateManager();
+    ASSERT_TRUE(manager_);
+    manager_->Load(domain());
+  }
+
+  void SeedEnvironment() {
+    local_pref_service_.SetString(prefs::kBraveVPNEnvironment, env_);
+  }
+
+  void SeedValidSubscriberCredential() {
+    CredentialStore(&local_pref_service_)
+        .SetSubscriberCredential("subscriber-credential", Future());
+  }
+
+  void SeedExpiredSubscriberCredential() {
+    CredentialStore(&local_pref_service_)
+        .SetSubscriberCredential("subscriber-credential", Past());
+  }
+
+  void SeedValidSkusCredential() {
+    CredentialStore(&local_pref_service_)
+        .SetSkusCredential("skus-credential", Future());
+  }
+
+  void OnCredentialSummary(const std::string& domain,
+                           const std::string& message) {
+    manager_->OnCredentialSummary(domain, MakeResult(message));
+  }
+
+  void OnPrepareCredentialsPresentation(const std::string& domain,
+                                        const std::string& cookie) {
+    manager_->OnPrepareCredentialsPresentation(domain, MakeResult(cookie));
+  }
+
+  void OnGetSubscriberCredentialV12(const std::string& credential,
+                                    bool success) {
+    manager_->OnGetSubscriberCredentialV12(Future(), credential, success);
+  }
+
+  CredentialStore* credential_store() {
+    return manager_->credential_store_.get();
+  }
+
+  PurchasedState GetState() const { return manager_->GetInfo().state; }
+
+  void OnPurchasedStateChanged(PurchasedState state,
+                               const std::optional<std::string>& description) {
+    ++state_change_count_;
+    last_state_ = state;
+    last_description_ = description;
+  }
+
+  std::string DomainFor(const std::string& env) const {
+    return skus::GetDomain(skus::GetVpnProductPrefix(), env);
+  }
+
+  std::string domain() const { return DomainFor(env_); }
+
+  // An environment guaranteed to differ from env_.
+  std::string OtherEnvironment() const {
+    return env_ == skus::kEnvProduction ? skus::kEnvStaging
+                                        : skus::kEnvProduction;
+  }
+
+  skus::mojom::SkusResultPtr MakeResult(const std::string& message) {
+    return skus::mojom::SkusResult::New(skus::mojom::SkusResultCode::Ok,
+                                        message);
+  }
+
+  base::Time Future() const { return base::Time::Now() + base::Days(30); }
+  base::Time Past() const { return base::Time::Now() - base::Days(1); }
+
+ protected:
+  const std::string env_ = skus::GetDefaultEnvironment();
+
+  base::test::TaskEnvironment task_environment_;
+  TestingPrefServiceSimple local_pref_service_;
+  FakeSkusServiceClient fake_skus_client_;
+  std::unique_ptr<PurchasedStateManager> manager_;
+
+  int state_change_count_ = 0;
+  std::optional<PurchasedState> last_state_;
+  std::optional<std::string> last_description_;
+};
+
+TEST_F(PurchasedStateManagerTest, FreshUserStaysNotPurchased) {
+  CreateManager();
+
+  EXPECT_EQ(GetState(), PurchasedState::NOT_PURCHASED);
+  EXPECT_EQ(state_change_count_, 0);
+  EXPECT_EQ(fake_skus_client_.credential_summary_calls(), 0);
+}
+
+TEST_F(PurchasedStateManagerTest,
+       ValidSubscriberCredentialIsPurchasedAtStartup) {
+  SeedEnvironment();
+  SeedValidSubscriberCredential();
+  CreateManager();
+
+  EXPECT_EQ(GetState(), PurchasedState::PURCHASED);
+  ASSERT_TRUE(last_state_.has_value());
+  EXPECT_EQ(*last_state_, PurchasedState::PURCHASED);
+}
+
+TEST_F(PurchasedStateManagerTest,
+       ValidSubscriberCredentialAtStartupArmsRefreshTimer) {
+  SeedEnvironment();
+  SeedValidSubscriberCredential();
+  CreateManager();
+
+  ASSERT_EQ(GetState(), PurchasedState::PURCHASED);
+  task_environment_.FastForwardBy(base::Days(31));
+  EXPECT_FALSE(credential_store()->HasValidSubscriberCredential());
+  EXPECT_EQ(fake_skus_client_.credential_summary_calls(), 1);
+}
+
+TEST_F(PurchasedStateManagerTest, CachedSkusCredentialAtStartupParksInLoading) {
+  // A cached SKUS credential at startup reaches Load's SKUS branch, which is
+  // NOTIMPLEMENTED. It should park at LOADING without requesting a summary or a
+  // presentation, and leave the SKUS credential cached. When the exchange is
+  // wired, this test is expected to change.
+  SeedEnvironment();
+  SeedValidSkusCredential();
+  CreateManager();
+
+  EXPECT_EQ(GetState(), PurchasedState::LOADING);
+  EXPECT_EQ(fake_skus_client_.credential_summary_calls(), 0);
+  EXPECT_EQ(fake_skus_client_.prepare_presentation_calls(), 0);
+  EXPECT_TRUE(credential_store()->HasValidSkusCredential());
+}
+
+TEST_F(PurchasedStateManagerTest,
+       StaleSubscriberCredentialIsClearedAndReloaded) {
+  SeedEnvironment();
+  SeedExpiredSubscriberCredential();
+  CreateManager();
+
+  EXPECT_FALSE(credential_store()->HasAnyCredential());
+  EXPECT_GE(fake_skus_client_.credential_summary_calls(), 1);
+  EXPECT_EQ(GetState(), PurchasedState::LOADING);
+}
+
+TEST_F(PurchasedStateManagerTest, NotifiesOnlyWhenStateChanges) {
+  SeedEnvironment();
+  CreateManager();
+
+  manager_->SetPurchasedState(env_, PurchasedState::PURCHASED);
+  EXPECT_EQ(state_change_count_, 1);
+  EXPECT_EQ(GetState(), PurchasedState::PURCHASED);
+
+  manager_->SetPurchasedState(env_, PurchasedState::PURCHASED);
+  EXPECT_EQ(state_change_count_, 1);
+}
+
+TEST_F(PurchasedStateManagerTest, GettersTrackPurchasedState) {
+  SeedEnvironment();
+  CreateManager();
+
+  EXPECT_EQ(GetState(), PurchasedState::NOT_PURCHASED);
+  EXPECT_FALSE(manager_->IsPurchased());
+
+  manager_->SetPurchasedState(env_, PurchasedState::PURCHASED);
+  EXPECT_EQ(GetState(), PurchasedState::PURCHASED);
+  EXPECT_TRUE(manager_->IsPurchased());
+
+  manager_->SetPurchasedState(env_, PurchasedState::FAILED);
+  EXPECT_EQ(GetState(), PurchasedState::FAILED);
+  EXPECT_FALSE(manager_->IsPurchased());
+}
+
+TEST_F(PurchasedStateManagerTest, LoadWithoutCredentialsRequestsSummary) {
+  CreateAndLoadManager();
+
+  EXPECT_EQ(GetState(), PurchasedState::LOADING);
+  EXPECT_EQ(fake_skus_client_.credential_summary_calls(), 1);
+  EXPECT_EQ(fake_skus_client_.last_domain(), domain());
+}
+
+TEST_F(PurchasedStateManagerTest, EmptySummaryIsNotPurchased) {
+  CreateAndLoadManager();
+  OnCredentialSummary(domain(), "");
+  EXPECT_EQ(GetState(), PurchasedState::NOT_PURCHASED);
+}
+
+TEST_F(PurchasedStateManagerTest, MalformedSummaryIsFailed) {
+  CreateAndLoadManager();
+  OnCredentialSummary(domain(), "not-json");
+  EXPECT_EQ(GetState(), PurchasedState::FAILED);
+}
+
+TEST_F(PurchasedStateManagerTest, NeedsActivationSummaryIsNotPurchased) {
+  CreateAndLoadManager();
+  OnCredentialSummary(domain(),
+                      R"({"active": false, "remaining_credential_count": 3})");
+  EXPECT_EQ(GetState(), PurchasedState::NOT_PURCHASED);
+}
+
+TEST_F(PurchasedStateManagerTest, ValidSummaryPresentsAndCachesSkusCredential) {
+  CreateAndLoadManager();
+
+  OnCredentialSummary(domain(),
+                      R"({"active": true, "remaining_credential_count": 3})");
+  // Active summary triggers a presentation request.
+  EXPECT_EQ(fake_skus_client_.prepare_presentation_calls(), 1);
+
+  OnPrepareCredentialsPresentation(
+      domain(), MakeCredentialCookie("skus-credential", kFutureCookieExpiry));
+
+  // The SKUS credential is cached. The exchange is not wired yet, so the state
+  // remains LOADING.
+  EXPECT_TRUE(credential_store()->HasValidSkusCredential());
+  EXPECT_EQ(credential_store()->GetSkusCredential(), "skus-credential");
+  EXPECT_EQ(GetState(), PurchasedState::LOADING);
+}
+
+TEST_F(PurchasedStateManagerTest, InvalidPresentationCookieIsFailed) {
+  CreateAndLoadManager();
+  OnCredentialSummary(domain(),
+                      R"({"active": true, "remaining_credential_count": 3})");
+
+  OnPrepareCredentialsPresentation(domain(), "this-is-not-a-cookie");
+  EXPECT_EQ(GetState(), PurchasedState::FAILED);
+  EXPECT_FALSE(credential_store()->HasValidSkusCredential());
+}
+
+TEST_F(PurchasedStateManagerTest, ExpiredPresentationCookieIsFailed) {
+  CreateAndLoadManager();
+  OnCredentialSummary(domain(),
+                      R"({"active": true, "remaining_credential_count": 3})");
+
+  OnPrepareCredentialsPresentation(
+      domain(), MakeCredentialCookie("skus-credential", kPastCookieExpiry));
+  EXPECT_EQ(GetState(), PurchasedState::FAILED);
+  EXPECT_FALSE(credential_store()->HasValidSkusCredential());
+}
+
+TEST_F(PurchasedStateManagerTest, EmptyPresentationCredentialIsNotPurchased) {
+  CreateAndLoadManager();
+  OnCredentialSummary(domain(),
+                      R"({"active": true, "remaining_credential_count": 3})");
+
+  OnPrepareCredentialsPresentation(
+      domain(), MakeCredentialCookie("", kFutureCookieExpiry));
+  EXPECT_EQ(GetState(), PurchasedState::NOT_PURCHASED);
+  EXPECT_FALSE(credential_store()->HasValidSkusCredential());
+}
+
+TEST_F(PurchasedStateManagerTest, SuccessfulExchangeIsPurchasedAndFillsStore) {
+  SeedEnvironment();
+  CreateManager();
+
+  OnGetSubscriberCredentialV12("valid-subscriber-credential", /*success=*/true);
+
+  EXPECT_EQ(GetState(), PurchasedState::PURCHASED);
+  EXPECT_TRUE(credential_store()->HasValidSubscriberCredential());
+  EXPECT_EQ(credential_store()->GetSubscriberCredential(),
+            "valid-subscriber-credential");
+  // Filling the subscriber credential drops any SKUS credential, and the retry
+  // guard is reset on success.
+  EXPECT_FALSE(credential_store()->HasValidSkusCredential());
+  EXPECT_FALSE(credential_store()->IsExchangeRetried());
+}
+
+#if !BUILDFLAG(IS_ANDROID)
+
+TEST_F(PurchasedStateManagerTest, TokenNoLongerValidRetriesExactlyOnce) {
+  SeedEnvironment();
+  CreateManager();
+  manager_->SetPurchasedState(env_, PurchasedState::LOADING);
+
+  // First "token no longer valid" arms the guard and re-requests a summary;
+  // state is unchanged while the retry is in flight.
+  OnGetSubscriberCredentialV12(::brave_vpn::kTokenNoLongerValid,
+                               /*success=*/false);
+  EXPECT_EQ(GetState(), PurchasedState::LOADING);
+  EXPECT_TRUE(credential_store()->IsExchangeRetried());
+  const int calls_after_first = fake_skus_client_.credential_summary_calls();
+  EXPECT_GE(calls_after_first, 1);
+
+  // Second failure: the guard is set, so we give up rather than loop.
+  OnGetSubscriberCredentialV12(::brave_vpn::kTokenNoLongerValid,
+                               /*success=*/false);
+  EXPECT_EQ(GetState(), PurchasedState::FAILED);
+  // No additional summary request was made on the second failure.
+  EXPECT_EQ(fake_skus_client_.credential_summary_calls(), calls_after_first);
+
+  // A later successful exchange clears the guard.
+  OnGetSubscriberCredentialV12("valid-subscriber-credential", /*success=*/true);
+  EXPECT_FALSE(credential_store()->IsExchangeRetried());
+  EXPECT_EQ(GetState(), PurchasedState::PURCHASED);
+}
+
+TEST_F(PurchasedStateManagerTest, OutOfCredentialsSummaryIsSessionExpired) {
+  CreateAndLoadManager();
+  // Subscription on record but nothing left to redeem.
+  OnCredentialSummary(domain(),
+                      R"({"active": false, "remaining_credential_count": 0})");
+  EXPECT_EQ(GetState(), PurchasedState::SESSION_EXPIRED);
+}
+
+TEST_F(PurchasedStateManagerTest,
+       OutOfCredentialsWithFutureExpiryIsOutOfCredentials) {
+  // A future last-credential expiry means the user redeemed but we lost the
+  // vendor: out of credentials rather than session expired.
+  local_pref_service_.SetTime(prefs::kBraveVPNLastCredentialExpiry, Future());
+  CreateAndLoadManager();
+  OnCredentialSummary(domain(),
+                      R"({"active": false, "remaining_credential_count": 0})");
+  EXPECT_EQ(GetState(), PurchasedState::OUT_OF_CREDENTIALS);
+  EXPECT_TRUE(last_description_.has_value());
+}
+
+TEST_F(PurchasedStateManagerTest,
+       SessionExpiredWithinWindowStaysSessionExpired) {
+  // A stamp in the past but within the checking window keeps SESSION_EXPIRED.
+  local_pref_service_.SetTime(prefs::kBraveVPNSessionExpiredDate,
+                              base::Time::Now() - base::Days(5));
+  CreateAndLoadManager();
+  OnCredentialSummary(domain(),
+                      R"({"active": false, "remaining_credential_count": 0})");
+  EXPECT_EQ(GetState(), PurchasedState::SESSION_EXPIRED);
+}
+
+TEST_F(PurchasedStateManagerTest,
+       SessionExpiredBeyondWindowBecomesNotPurchased) {
+  // First out-of-credentials stamps "now" and reports SESSION_EXPIRED.
+  CreateAndLoadManager();
+  OnCredentialSummary(domain(),
+                      R"({"active": false, "remaining_credential_count": 0})");
+  ASSERT_EQ(GetState(), PurchasedState::SESSION_EXPIRED);
+
+  // After more than the checking duration elapses, a fresh out-of-credentials
+  // result is treated as not purchased.
+  task_environment_.FastForwardBy(base::Days(31));
+  manager_->Load(domain());
+  OnCredentialSummary(domain(),
+                      R"({"active": false, "remaining_credential_count": 0})");
+  EXPECT_EQ(GetState(), PurchasedState::NOT_PURCHASED);
+}
+
+TEST_F(PurchasedStateManagerTest,
+       SessionExpiredStampInFutureBecomesNotPurchased) {
+  // Defensive clock-skew branch: a stamp in the future is treated as not
+  // purchased rather than session expired.
+  local_pref_service_.SetTime(prefs::kBraveVPNSessionExpiredDate, Future());
+  CreateAndLoadManager();
+  OnCredentialSummary(domain(),
+                      R"({"active": false, "remaining_credential_count": 0})");
+  EXPECT_EQ(GetState(), PurchasedState::NOT_PURCHASED);
+}
+
+TEST_F(PurchasedStateManagerTest, ValidSummaryClearsSessionExpiredDate) {
+  // A stale session-expired stamp is cleared once an active summary arrives.
+  local_pref_service_.SetTime(prefs::kBraveVPNSessionExpiredDate, Past());
+  CreateAndLoadManager();
+  OnCredentialSummary(domain(),
+                      R"({"active": true, "remaining_credential_count": 3})");
+  EXPECT_TRUE(local_pref_service_.GetTime(prefs::kBraveVPNSessionExpiredDate)
+                  .is_null());
+}
+
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+TEST_F(PurchasedStateManagerTest, RefreshTimerClearsAndReloadsAfterExpiry) {
+  SeedEnvironment();
+  CreateManager();
+
+  OnGetSubscriberCredentialV12("valid-subscriber-credential", /*success=*/true);
+  ASSERT_EQ(GetState(), PurchasedState::PURCHASED);
+  const int calls_before = fake_skus_client_.credential_summary_calls();
+
+  // Advance past the credential's expiration to fire the refresh timer.
+  task_environment_.FastForwardBy(base::Days(31));
+
+  // Refresh clears the cached credential and reloads, which requests a fresh
+  // summary.
+  EXPECT_FALSE(credential_store()->HasValidSubscriberCredential());
+  EXPECT_EQ(fake_skus_client_.credential_summary_calls(), calls_before + 1);
+}
+
+TEST_F(PurchasedStateManagerTest,
+       LoadingAnotherEnvironmentDoesNotDisturbCurrentState) {
+  SeedEnvironment();
+  CreateManager();
+
+  OnGetSubscriberCredentialV12("subscriber-credential", /*success=*/true);
+  ASSERT_EQ(GetState(), PurchasedState::PURCHASED);
+  const int changes_before = state_change_count_;
+
+  // A load for a different environment is ignored for the current env's state:
+  // SetPurchasedState only acts when the environment matches.
+  manager_->Load(DomainFor(OtherEnvironment()));
+  EXPECT_EQ(GetState(), PurchasedState::PURCHASED);
+  EXPECT_EQ(state_change_count_, changes_before);
+}
+
+TEST_F(PurchasedStateManagerTest,
+       AuthorizingInNewEnvironmentSwitchesCurrentEnvironment) {
+  local_pref_service_.SetString(prefs::kBraveVPNEnvironment, "");
+  CreateManager();  // current environment is unset.
+
+  // First load adopts that environment (the current one was empty).
+  manager_->Load(DomainFor(skus::kEnvStaging));
+  ASSERT_EQ(manager_->GetCurrentEnvironment(), skus::kEnvStaging);
+
+  // A successful presentation for a different environment switches current.
+  OnCredentialSummary(DomainFor(skus::kEnvProduction),
+                      R"({"active": true, "remaining_credential_count": 3})");
+  OnPrepareCredentialsPresentation(
+      DomainFor(skus::kEnvProduction),
+      MakeCredentialCookie("skus-credential", kFutureCookieExpiry));
+  EXPECT_EQ(manager_->GetCurrentEnvironment(), skus::kEnvProduction);
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/skus_service_client.cc
+++ b/components/brave_vpn/browser/v2/skus_service_client.cc
@@ -1,0 +1,61 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/skus_service_client.h"
+
+#include <string>
+#include <utility>
+
+#include "base/check.h"
+#include "base/logging.h"
+#include "brave/components/skus/common/skus_sdk.mojom.h"
+
+namespace brave_vpn::v2 {
+
+SkusServiceClient::SkusServiceClient(GetSkusServiceCallback getter)
+    : getter_(std::move(getter)) {
+  DCHECK(getter_);
+}
+
+SkusServiceClient::~SkusServiceClient() = default;
+
+void SkusServiceClient::GetCredentialSummary(
+    const std::string& domain,
+    skus::mojom::SkusService::CredentialSummaryCallback callback) {
+  EnsureConnected();
+  service_->CredentialSummary(domain, std::move(callback));
+}
+
+void SkusServiceClient::PrepareCredentialsPresentation(
+    const std::string& domain,
+    const std::string& path,
+    skus::mojom::SkusService::PrepareCredentialsPresentationCallback callback) {
+  EnsureConnected();
+  service_->PrepareCredentialsPresentation(domain, path, std::move(callback));
+}
+
+void SkusServiceClient::Reset() {
+  service_.reset();
+}
+
+void SkusServiceClient::EnsureConnected() {
+  if (service_) {
+    return;
+  }
+  VLOG(2) << "Connecting to SkusService";
+  auto pending = getter_.Run();
+  service_.Bind(std::move(pending));
+  DCHECK(service_);
+  service_.set_disconnect_handler(base::BindOnce(
+      &SkusServiceClient::OnConnectionError, base::Unretained(this)));
+}
+
+void SkusServiceClient::OnConnectionError() {
+  VLOG(2) << "Reconnecting to SkusService";
+  service_.reset();
+  EnsureConnected();
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/skus_service_client.h
+++ b/components/brave_vpn/browser/v2/skus_service_client.h
@@ -1,0 +1,55 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_SKUS_SERVICE_CLIENT_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_SKUS_SERVICE_CLIENT_H_
+
+#include <string>
+
+#include "base/functional/callback.h"
+#include "brave/components/skus/common/skus_sdk.mojom.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/remote.h"
+
+namespace brave_vpn::v2 {
+
+using GetSkusServiceCallback =
+    base::RepeatingCallback<mojo::PendingRemote<skus::mojom::SkusService>()>;
+
+// SkusServiceClient owns the connection to the SKUS mojom service and hides its
+// lifecycle from BraveVpnService. Callers ask for a credential summary or a
+// presentation; this class lazily binds the remote, re-binds it on disconnect,
+// and forwards the call.
+class SkusServiceClient {
+ public:
+  explicit SkusServiceClient(GetSkusServiceCallback getter);
+  virtual ~SkusServiceClient();
+
+  SkusServiceClient(const SkusServiceClient&) = delete;
+  SkusServiceClient& operator=(const SkusServiceClient&) = delete;
+
+  virtual void GetCredentialSummary(
+      const std::string& domain,
+      skus::mojom::SkusService::CredentialSummaryCallback callback);
+
+  virtual void PrepareCredentialsPresentation(
+      const std::string& domain,
+      const std::string& path,
+      skus::mojom::SkusService::PrepareCredentialsPresentationCallback
+          callback);
+
+  void Reset();
+
+ private:
+  void EnsureConnected();
+  void OnConnectionError();
+
+  GetSkusServiceCallback getter_;
+  mojo::Remote<skus::mojom::SkusService> service_;
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_SKUS_SERVICE_CLIENT_H_

--- a/components/brave_vpn/browser/v2/skus_service_client_unittest.cc
+++ b/components/brave_vpn/browser/v2/skus_service_client_unittest.cc
@@ -1,0 +1,128 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/skus_service_client.h"
+
+#include <string>
+
+#include "base/functional/bind.h"
+#include "base/test/run_until.h"
+#include "base/test/task_environment.h"
+#include "base/test/test_future.h"
+#include "brave/components/skus/browser/test/fake_skus_service.h"
+#include "brave/components/skus/common/skus_sdk.mojom.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn::v2 {
+
+class SkusServiceClientTest : public testing::Test {
+ protected:
+  mojo::PendingRemote<skus::mojom::SkusService> GetService() {
+    ++bind_count_;
+    return fake_service_.MakeRemote();
+  }
+
+  GetSkusServiceCallback ServiceGetter() {
+    return base::BindRepeating(&SkusServiceClientTest::GetService,
+                               base::Unretained(this));
+  }
+
+  base::test::TaskEnvironment task_environment_;
+  skus::FakeSkusService fake_service_;
+  int bind_count_ = 0;
+  SkusServiceClient client_{ServiceGetter()};
+};
+
+// Constructing the client must not touch the getter; the remote is bound lazily
+// on first use.
+TEST_F(SkusServiceClientTest, DoesNotConnectUntilFirstCall) {
+  EXPECT_EQ(bind_count_, 0);
+}
+
+// The configured response travels back out through the client untouched,
+// proving the call reaches the service and the result is forwarded to the
+// caller's callback.
+TEST_F(SkusServiceClientTest, GetCredentialSummaryReturnsConfiguredResponse) {
+  fake_service_.SetCredentialSummaryResponse(R"({"active":true})");
+
+  base::test::TestFuture<skus::mojom::SkusResultPtr> future;
+  client_.GetCredentialSummary("vpn.brave.com", future.GetCallback());
+
+  skus::mojom::SkusResultPtr result = future.Take();
+  ASSERT_TRUE(result);
+  EXPECT_EQ(result->code, skus::mojom::SkusResultCode::Ok);
+  EXPECT_EQ(result->message, R"({"active":true})");
+  EXPECT_EQ(bind_count_, 1);
+}
+
+TEST_F(SkusServiceClientTest, PrepareCredentialsPresentationCompletes) {
+  base::test::TestFuture<skus::mojom::SkusResultPtr> future;
+  client_.PrepareCredentialsPresentation("vpn.brave.com", "/credentials/path",
+                                         future.GetCallback());
+
+  skus::mojom::SkusResultPtr result = future.Take();
+  ASSERT_TRUE(result);
+  EXPECT_EQ(result->code, skus::mojom::SkusResultCode::Ok);
+  EXPECT_EQ(bind_count_, 1);
+}
+
+// Repeated calls share a single bound remote.
+TEST_F(SkusServiceClientTest, ReusesConnectionAcrossCalls) {
+  {
+    base::test::TestFuture<skus::mojom::SkusResultPtr> future;
+    client_.GetCredentialSummary("vpn.brave.com", future.GetCallback());
+    EXPECT_TRUE(future.Wait());
+  }
+  {
+    base::test::TestFuture<skus::mojom::SkusResultPtr> future;
+    client_.GetCredentialSummary("vpn.brave.com", future.GetCallback());
+    EXPECT_TRUE(future.Wait());
+  }
+  EXPECT_EQ(bind_count_, 1);
+}
+
+// On disconnect the client eagerly re-binds (OnConnectionError ->
+// EnsureConnected) and keeps serving requests on the new pipe.
+TEST_F(SkusServiceClientTest, ReconnectsAfterDisconnect) {
+  {
+    base::test::TestFuture<skus::mojom::SkusResultPtr> future;
+    client_.GetCredentialSummary("vpn.brave.com", future.GetCallback());
+    EXPECT_TRUE(future.Wait());
+  }
+  EXPECT_EQ(bind_count_, 1);
+
+  fake_service_.CloseConnection();
+
+  // The disconnect handler fires asynchronously, so wait for rebind.
+  EXPECT_TRUE(base::test::RunUntil([this]() { return bind_count_ == 2; }));
+  {
+    base::test::TestFuture<skus::mojom::SkusResultPtr> future;
+    client_.GetCredentialSummary("vpn.brave.com", future.GetCallback());
+    EXPECT_TRUE(future.Wait());
+  }
+  EXPECT_EQ(bind_count_, 2);
+}
+
+// Reset() drops the remote but, unlike a disconnect, does not eagerly rebind;
+// the connection is re-established lazily on the next call.
+TEST_F(SkusServiceClientTest, ResetForcesLazyReconnectOnNextCall) {
+  {
+    base::test::TestFuture<skus::mojom::SkusResultPtr> future;
+    client_.GetCredentialSummary("vpn.brave.com", future.GetCallback());
+    EXPECT_TRUE(future.Wait());
+  }
+  EXPECT_EQ(bind_count_, 1);
+  client_.Reset();
+  EXPECT_EQ(bind_count_, 1);
+  {
+    base::test::TestFuture<skus::mojom::SkusResultPtr> future;
+    client_.GetCredentialSummary("vpn.brave.com", future.GetCallback());
+    EXPECT_TRUE(future.Wait());
+  }
+  EXPECT_EQ(bind_count_, 2);
+}
+
+}  // namespace brave_vpn::v2

--- a/components/skus/browser/test/fake_skus_service.cc
+++ b/components/skus/browser/test/fake_skus_service.cc
@@ -19,6 +19,10 @@ mojo::PendingRemote<skus::mojom::SkusService> FakeSkusService::MakeRemote() {
   return remote;
 }
 
+void FakeSkusService::CloseConnection() {
+  receiver_.reset();
+}
+
 void FakeSkusService::SetCredentialSummaryResponse(
     const std::string& response) {
   credential_summary_response_ = response;

--- a/components/skus/browser/test/fake_skus_service.h
+++ b/components/skus/browser/test/fake_skus_service.h
@@ -29,6 +29,10 @@ class FakeSkusService : public skus::mojom::SkusService {
   // times (resets the previous binding).
   mojo::PendingRemote<skus::mojom::SkusService> MakeRemote();
 
+  // Closes the bound pipe without handing out a new one, simulating the
+  // service disconnecting. A subsequent MakeRemote() rebinds.
+  void CloseConnection();
+
   // Sets the JSON string that CredentialSummary will return.
   void SetCredentialSummaryResponse(const std::string& response);
 

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -449,6 +449,9 @@ test("brave_unit_tests") {
       ]
     }
   }
+  if (enable_brave_vpn_v2) {
+    deps += [ "//brave/components/brave_vpn/browser/v2:unit_tests" ]
+  }
   if (toolkit_views) {
     deps += [ "//chrome/browser/ui/views" ]
   }


### PR DESCRIPTION
Introduce a v2 implementation of the VPN purchase flow, decomposed into focused, independently testable pieces:

- CredentialSummary: dependency-free parser for the SKUS summary response.
- CredentialStore: owns the on-disk credential slot (either subscriber or skus credential, shared expiry) plus an in-memory exchange-retry guard.
- SkusServiceClient: owns the SKUS mojo remote, binding it lazily and re-binding on disconnect so callers don't see the connection lifecycle.
- PurchasedStateManager: drives the credential chain, derives purchased state, and refreshes the subscriber credential before it expires.

BraveVpnServiceImpl delegates purchase concerns to PurchasedStateManager and notifies observers on state changes.

The GetSubscriberCredentialV12 API request is intentionally not wired up yet; the SKUS-credential exchange points are stubbed (NOTIMPLEMENTED). The fresh-user vs session-expired guard that v1 derived from region-data readiness is likewise deferred.

Includes unit tests for each component.

Resolves https://github.com/brave/brave-browser/issues/56692

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
