### PR TITLE
[iOS] Shut down WebMain and profiles correctly on app termination

### DIFF
--- a/ios/app/brave_core_main.h
+++ b/ios/app/brave_core_main.h
@@ -76,6 +76,9 @@ OBJC_EXPORT
 + (bool)initializeICUForTesting;
 
 + (void)initializeResourceBundleForTesting;
+
+- (void)shutDown;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/app/brave_core_main.mm
+++ b/ios/app/brave_core_main.mm
@@ -103,11 +103,6 @@ const BraveCoreLogSeverity BraveCoreLogSeverityVerbose =
            selector:@selector(onAppEnterForeground:)
                name:UIApplicationWillEnterForegroundNotification
              object:nil];
-    [[NSNotificationCenter defaultCenter]
-        addObserver:self
-           selector:@selector(onAppWillTerminate:)
-               name:UIApplicationWillTerminateNotification
-             object:nil];
 
     @autoreleasepool {
       ios::RegisterPathProvider();
@@ -183,11 +178,7 @@ const BraveCoreLogSeverity BraveCoreLogSeverityVerbose =
 }
 
 - (void)dealloc {
-  _profileController = nil;
-
-  _webMain.reset();
-  _delegate.reset();
-  _webClient.reset();
+  [self shutDown];
 }
 
 - (void)onAppEnterBackground:(NSNotification*)notification {
@@ -207,20 +198,13 @@ const BraveCoreLogSeverity BraveCoreLogSeverityVerbose =
   }
 }
 
-- (void)onAppWillTerminate:(NSNotification*)notification {
-  // ApplicationContextImpl doesn't get teardown call at the moment because we
-  // cannot dealloc this class yet without crashing.
-  GetApplicationContext()->GetLocalState()->CommitPendingWrite();
+- (void)shutDown {
+  [_profileController shutDown];
+  _profileController = nil;
 
-  ProfileManagerIOS* profile_manager =
-      GetApplicationContext()->GetProfileManager();
-  if (profile_manager) {
-    for (ProfileIOS* profile : profile_manager->GetLoadedProfiles()) {
-      profile->GetPrefs()->CommitPendingWrite();
-    }
-  }
-
-  [[NSNotificationCenter defaultCenter] removeObserver:self];
+  _webMain.reset();
+  _delegate.reset();
+  _webClient.reset();
 }
 
 - (void)setUserAgent:(NSString*)userAgent {

--- a/ios/app/brave_profile_controller+private.h
+++ b/ios/app/brave_profile_controller+private.h
@@ -14,6 +14,7 @@ class ScopedProfileKeepAliveIOS;
 @interface BraveProfileController (Private)
 - (instancetype)initWithProfileKeepAlive:
     (ScopedProfileKeepAliveIOS)profileKeepAlive;
+- (void)shutDown;
 @end
 
 #endif  // BRAVE_IOS_APP_BRAVE_PROFILE_CONTROLLER_PRIVATE_H_

--- a/ios/app/brave_profile_controller.mm
+++ b/ios/app/brave_profile_controller.mm
@@ -168,31 +168,46 @@
   return self;
 }
 
-- (void)dealloc {
+- (void)shutDown {
   _downloadManager.reset();
   _otrDownloadManager.reset();
 
-  _otr_browserList =
-      BrowserListFactory::GetForProfile(_otr_browser->GetProfile());
-  [_otr_browser->GetCommandDispatcher() prepareForShutdown];
-  _otr_browserList->RemoveBrowser(_otr_browser.get());
-  SessionRestorationServiceFactory::GetForProfile(_otr_browser->GetProfile())
-      ->Disconnect(_otr_browser.get());
-  CloseAllWebStates(*_otr_browser->GetWebStateList(),
-                    WebStateList::ClosingReason::kDefault);
+  // CWVWebView's must be closed via the CWVWebViewConfigurations as they don't
+  // live in the WebStateList.
+  if (_profile) {
+    [self.defaultWebViewConfiguration shutDown];
+    [self.nonPersistentWebViewConfiguration shutDown];
+  }
+
+  if (_otr_browser) {
+    _otr_browserList =
+        BrowserListFactory::GetForProfile(_otr_browser->GetProfile());
+    [_otr_browser->GetCommandDispatcher() prepareForShutdown];
+    _otr_browserList->RemoveBrowser(_otr_browser.get());
+    SessionRestorationServiceFactory::GetForProfile(_otr_browser->GetProfile())
+        ->Disconnect(_otr_browser.get());
+    CloseAllWebStates(*_otr_browser->GetWebStateList(),
+                      WebStateList::ClosingReason::kDefault);
+  }
   _otr_browser.reset();
 
-  _browserList = BrowserListFactory::GetForProfile(_browser->GetProfile());
-  [_browser->GetCommandDispatcher() prepareForShutdown];
-  _browserList->RemoveBrowser(_browser.get());
-  SessionRestorationServiceFactory::GetForProfile(_browser->GetProfile())
-      ->Disconnect(_browser.get());
-  CloseAllWebStates(*_browser->GetWebStateList(),
-                    WebStateList::ClosingReason::kDefault);
+  if (_browser) {
+    _browserList = BrowserListFactory::GetForProfile(_browser->GetProfile());
+    [_browser->GetCommandDispatcher() prepareForShutdown];
+    _browserList->RemoveBrowser(_browser.get());
+    SessionRestorationServiceFactory::GetForProfile(_browser->GetProfile())
+        ->Disconnect(_browser.get());
+    CloseAllWebStates(*_browser->GetWebStateList(),
+                      WebStateList::ClosingReason::kDefault);
+  }
   _browser.reset();
 
   _profile = nil;
   _profileKeepAlive.Reset();
+}
+
+- (void)dealloc {
+  [self shutDown];
 }
 
 #if BUILDFLAG(IOS_CREDENTIAL_PROVIDER_ENABLED)

--- a/ios/brave-ios/App/Client.xcodeproj/Brave.xctestplan
+++ b/ios/brave-ios/App/Client.xcodeproj/Brave.xctestplan
@@ -163,6 +163,20 @@
         "identifier" : "PlaylistUITests",
         "name" : "PlaylistUITests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..",
+        "identifier" : "BraveCoreTests",
+        "name" : "BraveCoreTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..",
+        "identifier" : "OnboardingTests",
+        "name" : "OnboardingTests"
+      }
     }
   ],
   "version" : 1

--- a/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
@@ -355,9 +355,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   func applicationWillTerminate(_ application: UIApplication) {
     SKPaymentQueue.default().remove(BraveVPN.iapObserver)
 
-    // Clean up BraveCore
-    AppState.shared.braveCore.profileController?.syncAPI.removeAllObservers()
-
     log.debug("Cleanly Terminated the Application")
   }
 

--- a/ios/brave-ios/Package.swift
+++ b/ios/brave-ios/Package.swift
@@ -657,6 +657,7 @@ var package = Package(
         .product(name: "Introspect", package: "SwiftUI-Introspect"),
       ]
     ),
+    .testTarget(name: "BraveCoreTests", dependencies: ["BraveCore"]),
   ],
   swiftLanguageModes: [.v5],
   cxxLanguageStandard: .cxx17

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -751,6 +751,8 @@ public class BrowserViewController: UIViewController {
 
   @objc func appWillTerminateNotification() {
     tabManager.saveAllTabs(synchronously: true)
+
+    braveCore.shutDown()
   }
 
   @objc private func tappedCollapsedURLBar() {

--- a/ios/brave-ios/Tests/BraveCoreTests/BraveCoreTests.swift
+++ b/ios/brave-ios/Tests/BraveCoreTests/BraveCoreTests.swift
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveCore
+import XCTest
+
+final class BraveCoreTests: XCTestCase {
+  @MainActor func testBraveCoreSetupAndTearDown() async {
+    let main = BraveCoreMain()
+    let profile = await main.loadDefaultProfile()
+    XCTAssertFalse(profile.profile.name.isEmpty)
+  }
+}


### PR DESCRIPTION
BraveCoreMain couldn't be deallocated properly without crashing so we were relying on the OS to clean up memory after the app was terminated. This change fixes the shutdown procedure so that we can properly tear down various Chromium services.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves
