### PR TITLE
[Android] Fix variations not pulled on 1st launch after fresh install

### DIFF
--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-base-SplitChromeApplication.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-base-SplitChromeApplication.java.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/base/SplitChromeApplication.java b/chrome/android/java/src/org/chromium/chrome/browser/base/SplitChromeApplication.java
+index 46664df1ffdebd82c7c36ef41297aebe6510ca78..434f92ee6ae74995a7cd43d2f66c95970bca9a41 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/base/SplitChromeApplication.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/base/SplitChromeApplication.java
+@@ -243,7 +243,7 @@ public class SplitChromeApplication extends SplitCompatApplication {
+                     // fieldtrial_testing_config.json.
+                     ContextUtils.sDoFeatureListInitHookForTesting =
+                             InitializeFeatureList::initializeFeatureList;
+-                } else if (!BuildConfig.IS_CHROME_BRANDED
++                } else if (!true /* BuildConfig.IS_CHROME_BRANDED override for Brave */
+                         || !VariationsSeedFetcher.shouldFetchSeed()) {
+                     // For non-Chrome branded builds, we should initialize the feature list early to
+                     // apply the fieldtrial_testing_config.json. Otherwise, we should initialize the

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/base/SplitChromeApplication.java.yaml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/base/SplitChromeApplication.java.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Defer early feature list init on first run for non-Chrome-branded builds.
+
+      Since IS_CHROME_BRANDED = false for Brave, the upstream condition
+      `!IS_CHROME_BRANDED || !shouldFetchSeed()` always short-circuits to true,
+      causing the feature list to be initialized early without the variations seed
+      on first run. This prevents the native VariationsService from applying the
+      seed in the same launch, requiring a restart.
+
+      Replacing IS_CHROME_BRANDED with true makes the short-circuit always false,
+      so Brave behaves identically to Chrome-branded builds: early feature list
+      init is skipped on first run, letting the native VariationsService fetch and
+      apply the seed immediately.
+
+      See https://source.chromium.org/chromium/chromium/src/+/f00d1a3a65153510d612597de0dde2a4365ca130
+    pattern: 'BuildConfig.IS_CHROME_BRANDED'
+    replace: 'true /* BuildConfig.IS_CHROME_BRANDED override for Brave */'
+    count: 1


### PR DESCRIPTION
On fresh installs (e.g. from Google Play), the variations seed was not applied on the first launch — a restart was required. This is a regression introduced in `cr150` by the Chromium commit f00d1a3a65153510d612597de0dde2a4365ca130, which enabled LoadNativeEarly by default.

With `LoadNativeEarly` enabled, `InitializeFeatureList.initializeFeatureList()` is now called early in `SplitChromeApplication.performBrowserProcessPreloading()`. The upstream guard condition is:
```java
  !BuildConfig.IS_CHROME_BRANDED || !VariationsSeedFetcher.shouldFetchSeed()
```
Since `IS_CHROME_BRANDED = false` for Brave, the first operand always short-circuits to true, causing the feature list to be initialized early on every run — including the first launch when no seed has been fetched yet. The feature list is then finalized without the seed, and the native `VariationsService` can no longer apply it in the same session.

Fix: drop the `IS_CHROME_BRANDED` short-circuit so that Brave behaves identically to Chrome-branded builds — deferring early feature list init on first run to let the native `VariationsService` fetch and apply the seed in the same launch.

Verified on `cr149`/`1.91.180` (no regression) and `cr150` (fix confirmed): fresh AAB install now pulls variations immediately without requiring a restart.



<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56820

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
