### PR TITLE
[iOS] Replace usages of update_symlink with iOS specific command

### DIFF
--- a/build/commands/lib/commandsUtils.ts
+++ b/build/commands/lib/commandsUtils.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { Argument } from 'commander'
+
+// Returns an Argument that parses the current build configuration
+export function createBuildConfigArgument() {
+  // Build config argument that's valid only if it's not an option.
+  return new Argument('[build_config]', 'build configuration').argParser(
+    (value) => {
+      if (value.startsWith('-')) {
+        return undefined
+      }
+      return value
+    },
+  )
+}

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -496,6 +496,34 @@ program
 
 program.command('docs').action(util.launchDocs)
 
+program
+  .command('ios_update_current_link')
+  .description(
+    'Updates the stable ios_current_link output directory symlink for upcoming Xcode builds',
+  )
+  .addOption(
+    new Option('--target_arch <target_arch>', 'target architecture').choices([
+      'arm64',
+      'x64',
+    ]),
+  )
+  .addOption(
+    new Option(
+      '--target_environment <target_environment>',
+      'target environment',
+    ).choices(['device', 'catalyst', 'simulator']),
+  )
+  .addArgument(createBuildConfigArgument())
+  .action((buildConfig, options) => {
+    config.buildConfig = buildConfig || config.defaultBuildConfig
+    config.targetOS = 'ios'
+    config.update(options)
+
+    const currentLink = path.join(config.srcDir, 'out', 'ios_current_link')
+    fs.removeSync(currentLink)
+    fs.symlinkSync(config.outputDir, currentLink, 'junction')
+  })
+
 registerListAffectedTestsCommand(program)
 registerGenerateCoverageReportCommand(program)
 

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -6,7 +6,7 @@
 // Check environment before doing anything.
 import '../lib/checkEnvironment.js'
 
-import { program, Argument, Option } from 'commander'
+import { program, Option } from 'commander'
 import path from 'node:path'
 import fs from 'fs-extra'
 import config from '../lib/config.ts'
@@ -27,6 +27,7 @@ import genGradle from '../lib/genGradle.js'
 import perfTests from '../lib/perfTests.ts'
 import registerListAffectedTestsCommand from './listAffectedTests.js'
 import registerGenerateCoverageReportCommand from './generateCoverageReport.js'
+import { createBuildConfigArgument } from '../lib/commandsUtils.ts'
 
 const collect = (value, accumulator) => {
   accumulator.push(value)
@@ -47,18 +48,6 @@ function parseInteger(string) {
 }
 
 const parsedArgs = program.parseOptions(process.argv)
-
-function createBuildConfigArgument() {
-  // Build config argument that's valid only if it's not an option.
-  return new Argument('[build_config]', 'build configuration').argParser(
-    (value) => {
-      if (value.startsWith('-')) {
-        return undefined
-      }
-      return value
-    },
-  )
-}
 
 // @ts-ignore
 program.version(process.env.npm_package_version)
@@ -495,34 +484,6 @@ program
   .action(genGradle.bind(null, parsedArgs.unknown))
 
 program.command('docs').action(util.launchDocs)
-
-program
-  .command('ios_update_current_link')
-  .description(
-    'Updates the stable ios_current_link output directory symlink for upcoming Xcode builds',
-  )
-  .addOption(
-    new Option('--target_arch <target_arch>', 'target architecture').choices([
-      'arm64',
-      'x64',
-    ]),
-  )
-  .addOption(
-    new Option(
-      '--target_environment <target_environment>',
-      'target environment',
-    ).choices(['device', 'catalyst', 'simulator']),
-  )
-  .addArgument(createBuildConfigArgument())
-  .action((buildConfig, options) => {
-    config.buildConfig = buildConfig || config.defaultBuildConfig
-    config.targetOS = 'ios'
-    config.update(options)
-
-    const currentLink = path.join(config.srcDir, 'out', 'ios_current_link')
-    fs.removeSync(currentLink)
-    fs.symlinkSync(config.outputDir, currentLink, 'junction')
-  })
 
 registerListAffectedTestsCommand(program)
 registerGenerateCoverageReportCommand(program)

--- a/build/commands/scripts/iosCommands.js
+++ b/build/commands/scripts/iosCommands.js
@@ -3,10 +3,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { program } from 'commander'
+import { program, Option } from 'commander'
+import fs from 'fs-extra'
 import path from 'node:path'
 import config from '../lib/config.ts'
 import util from '../lib/util.js'
+import { createBuildConfigArgument } from '../lib/commandsUtils.ts'
 
 const bootstrap = (options = {}) => {
   const utilConfig = config.defaultOptions
@@ -36,5 +38,33 @@ program
   .option('--open_xcodeproj', 'Open the Xcode project after bootstrapping')
   .option('--force', 'Always rewrite the symlink/directory entirely')
   .action(bootstrap)
+
+program
+  .command('ios_update_current_link')
+  .description(
+    'Updates the stable ios_current_link output directory symlink for upcoming Xcode builds',
+  )
+  .addOption(
+    new Option('--target_arch <target_arch>', 'target architecture').choices([
+      'arm64',
+      'x64',
+    ]),
+  )
+  .addOption(
+    new Option(
+      '--target_environment <target_environment>',
+      'target environment',
+    ).choices(['device', 'catalyst', 'simulator']),
+  )
+  .addArgument(createBuildConfigArgument())
+  .action((buildConfig, options) => {
+    config.buildConfig = buildConfig || config.defaultBuildConfig
+    config.targetOS = 'ios'
+    config.update(options)
+
+    const currentLink = path.join(config.srcDir, 'out', 'ios_current_link')
+    fs.removeSync(currentLink)
+    fs.symlinkSync(config.outputDir, currentLink, 'junction')
+  })
 
 program.parse(process.argv)

--- a/ios/brave-ios/scripts/scheme_preaction.py
+++ b/ios/brave-ios/scripts/scheme_preaction.py
@@ -18,7 +18,11 @@ this_dir = os.path.dirname(os.path.abspath(__file__))
 brave_root_dir = os.path.join(
     os.path.join(os.path.join(this_dir, os.pardir), os.pardir), os.pardir)
 src_dir = os.path.join(brave_root_dir, os.pardir)
+scripts_dir = os.path.join(brave_root_dir, 'build', 'commands', 'scripts')
 
+sys.path.append(os.path.join(src_dir, 'third_party', 'node'))
+
+import node
 
 def main():
     description = 'Runs actions before each build'
@@ -75,10 +79,11 @@ def BuildOutputDirectory(config, platform_name):
 def UpdateSymlink(config, target_arch, target_environment):
     """Updates the 'ios_current_link' symlink"""
     cmd_args = [
-        'npm', 'run', 'ios_update_current_link', '--', config, '--target_arch',
-        target_arch, '--target_environment', target_environment
+        os.path.join(scripts_dir, 'iosCommands.js'), 'ios_update_current_link',
+        config, '--target_arch', target_arch, '--target_environment',
+        target_environment
     ]
-    CallNpm(cmd_args)
+    node.RunNode(cmd_args)
 
 
 def BuildCore(config, target_arch, target_environment):

--- a/ios/brave-ios/scripts/scheme_preaction.py
+++ b/ios/brave-ios/scripts/scheme_preaction.py
@@ -75,10 +75,8 @@ def BuildOutputDirectory(config, platform_name):
 def UpdateSymlink(config, target_arch, target_environment):
     """Updates the 'ios_current_link' symlink"""
     cmd_args = [
-        'npm', 'run', 'update_symlink', '--', config, '--symlink_dir',
-        os.path.join(src_dir, 'out/ios_current_link'), '--target_os', 'ios',
-        '--target_arch', target_arch, '--target_environment',
-        target_environment
+        'npm', 'run', 'ios_update_current_link', '--', config, '--target_arch',
+        target_arch, '--target_environment', target_environment
     ]
     CallNpm(cmd_args)
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "gen_gradle": "node ./build/commands/scripts/commands.js gen_gradle",
     "ios_pack_js": "webpack --config ios/brave-ios/webpack.config.js",
     "ios_bootstrap": "node ./build/commands/scripts/iosCommands.js ios_bootstrap",
-    "ios_update_current_link": "node ./build/commands/scripts/iosCommands.js ios_update_current_link",
     "update_brave_tools_crates": "node ./build/commands/scripts/updateBraveToolsCrates.js",
     "update_wasm_resources": "node ./build/commands/scripts/updateWasmResources.js",
     "coverage_report": "node ./build/commands/scripts/commands.js coverage_report",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "gen_gradle": "node ./build/commands/scripts/commands.js gen_gradle",
     "ios_pack_js": "webpack --config ios/brave-ios/webpack.config.js",
     "ios_bootstrap": "node ./build/commands/scripts/iosCommands.js ios_bootstrap",
-    "ios_update_current_link": "node ./build/commands/scripts/commands.js ios_update_current_link",
+    "ios_update_current_link": "node ./build/commands/scripts/iosCommands.js ios_update_current_link",
     "update_brave_tools_crates": "node ./build/commands/scripts/updateBraveToolsCrates.js",
     "update_wasm_resources": "node ./build/commands/scripts/updateWasmResources.js",
     "coverage_report": "node ./build/commands/scripts/commands.js coverage_report",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "gen_gradle": "node ./build/commands/scripts/commands.js gen_gradle",
     "ios_pack_js": "webpack --config ios/brave-ios/webpack.config.js",
     "ios_bootstrap": "node ./build/commands/scripts/iosCommands.js ios_bootstrap",
+    "ios_update_current_link": "node ./build/commands/scripts/commands.js ios_update_current_link",
     "update_brave_tools_crates": "node ./build/commands/scripts/updateBraveToolsCrates.js",
     "update_wasm_resources": "node ./build/commands/scripts/updateWasmResources.js",
     "coverage_report": "node ./build/commands/scripts/commands.js coverage_report",


### PR DESCRIPTION
This replaces the usages of `npm run update_symlink` with a new iOS specific command `ios_update_current_link`.

