### PR TITLE
[bootstrap] Adding a default `.vpython3`

### DIFF
--- a/third_party/node/.vpython3
+++ b/third_party/node/.vpython3
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+python_version: "3.11"

--- a/tools/recipes/engine.py
+++ b/tools/recipes/engine.py
@@ -92,8 +92,13 @@ class _Engine:
         _ensure_on_sys_path()
         # Root directory the job runs in. Recipe paths (chromium/src, out, ...)
         # are derived from it by the `path` module. Defaults to the cwd.
-        self._workspace: Path = (Path(workspace).expanduser().resolve()
-                                 if workspace else Path.cwd())
+        if workspace:
+            self._workspace = Path(workspace).expanduser().resolve()
+            # Run from the workspace so every subprocess the recipes launch
+            # inherits it as their cwd.
+            os.chdir(self._workspace)
+        else:
+            self._workspace = Path.cwd()
         # brave-core ref the checkout modules clone. Defaults to `master`;
         # overridable (mainly for testing against a non-master ref).
         self._brave_core_ref: str = brave_core_ref

--- a/tools/recipes/unittests/engine_test.py
+++ b/tools/recipes/unittests/engine_test.py
@@ -12,6 +12,7 @@
 
 import os
 import sys
+import tempfile
 import types
 import unittest
 from dataclasses import dataclass
@@ -110,14 +111,22 @@ class RunRecipeTest(unittest.TestCase):
 class WorkspaceTest(unittest.TestCase):
     """The engine seeds its workspace; the `path` module derives job paths."""
 
+    def setUp(self):
+        # _Engine chdirs into an explicit workspace; restore cwd afterwards so
+        # it doesn't leak into other tests (some read Path.cwd()).
+        self._prev_cwd = Path.cwd()
+        self.addCleanup(os.chdir, self._prev_cwd)
+
     def test_workspace_seeded_into_path_module(self):
-        eng = engine._Engine(workspace='/tmp/ws')
-        path = eng._instantiate_module('path', [])
-        workspace = Path('/tmp/ws').resolve()
-        self.assertEqual(path.workspace, workspace)
-        self.assertEqual(path.chromium_src, workspace / 'chromium/src')
-        self.assertEqual(path.brave_core, workspace / 'chromium/src/brave')
-        self.assertEqual(path.out, workspace / 'out')
+        with tempfile.TemporaryDirectory() as tmp:
+            eng = engine._Engine(workspace=tmp)
+            path = eng._instantiate_module('path', [])
+            workspace = Path(tmp).resolve()
+            self.assertEqual(path.workspace, workspace)
+            self.assertEqual(path.chromium_src, workspace / 'chromium/src')
+            self.assertEqual(path.brave_core, workspace / 'chromium/src/brave')
+            self.assertEqual(path.out, workspace / 'out')
+            self.assertEqual(Path.cwd(), workspace)
 
     def test_workspace_defaults_to_cwd(self):
         path = engine._Engine()._instantiate_module('path', [])


### PR DESCRIPTION
This adds a default vpython to the root of `brave-core`. Chromium has
its own default `vpython`, however we don't have one in `brave-core`,
so when we clone `brave-core` on its own, our scripts have no baseline
`python` version to go by.

There will be follow up work to make sure python version bumps are
flagged during rebase.

Bug: https://github.com/brave/brave-browser/issues/5652