### PR TITLE
[iOS] Ensure Brave policy provider is created before shutting it down

### DIFF
--- a/chromium_src/ios/chrome/browser/policy/model/profile_policy_connector.mm
+++ b/chromium_src/ios/chrome/browser/policy/model/profile_policy_connector.mm
@@ -33,5 +33,7 @@ ProfilePolicyConnector::GetBraveProfilePolicyProvider() {
 
 void ProfilePolicyConnector::Shutdown() {
   ProfilePolicyConnector::Shutdown_ChromiumImpl();
-  brave_profile_policy_provider_->Shutdown();
+  if (brave_profile_policy_provider_) {
+    brave_profile_policy_provider_->Shutdown();
+  }
 }


### PR DESCRIPTION
This adds a nullptr check on `brave_profile_policy_provider_` since the value itself is only created on `Init`, not in the constructor so its theoretically possible for the provider to be nullptr if shutdown is called without an accompanying `Init`
