### PR TITLE
[Android] Exclude background media playback from fresh NTP after idle

### DIFF
--- a/android/java/org/chromium/chrome/browser/tasks/BraveReturnToChromeUtil.java
+++ b/android/java/org/chromium/chrome/browser/tasks/BraveReturnToChromeUtil.java
@@ -13,6 +13,7 @@ import org.chromium.base.BravePreferenceKeys;
 import org.chromium.base.IntentUtils;
 import org.chromium.build.annotations.NullMarked;
 import org.chromium.build.annotations.Nullable;
+import org.chromium.chrome.R;
 import org.chromium.chrome.browser.ChromeInactivityTracker;
 import org.chromium.chrome.browser.ntp.BraveFreshNtpHelper;
 import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
@@ -20,6 +21,8 @@ import org.chromium.chrome.browser.tab.Tab;
 import org.chromium.chrome.browser.tabmodel.TabCreator;
 import org.chromium.chrome.browser.tabmodel.TabModel;
 import org.chromium.chrome.browser.tabmodel.TabModelSelector;
+import org.chromium.components.browser_ui.media.MediaNotificationController;
+import org.chromium.components.browser_ui.media.MediaNotificationManager;
 import org.chromium.url.GURL;
 
 @NullMarked
@@ -116,10 +119,26 @@ public final class BraveReturnToChromeUtil {
                 || inactivityTracker == null) {
             return false;
         }
-        // Check if app has been backgrounded for ≥ threshold
+        // Show the NTP only if the app has been backgrounded for ≥ threshold and no media is
+        // playing in the background — background playback means the user is not truly idle.
         long timeSinceLastBackgroundedMs = inactivityTracker.getTimeSinceLastBackgroundedMs();
 
-        return timeSinceLastBackgroundedMs >= inactivityThresholdMs;
+        return timeSinceLastBackgroundedMs >= inactivityThresholdMs && !isBackgroundMediaPlaying();
+    }
+
+    /**
+     * Returns whether media is actively playing in the background. Used to avoid replacing the
+     * user's current tab with a fresh NTP on return from idle while audio/video is playing, since
+     * background playback means the user is not truly idle.
+     */
+    // Reads MediaNotificationController.mMediaNotificationInfo, which is @VisibleForTesting.
+    @SuppressWarnings("VisibleForTests")
+    private static boolean isBackgroundMediaPlaying() {
+        MediaNotificationController controller =
+                MediaNotificationManager.getController(R.id.media_playback_notification);
+        return controller != null
+                && controller.mMediaNotificationInfo != null
+                && !controller.mMediaNotificationInfo.isPaused;
     }
 
     /**

--- a/android/junit/BUILD.gn
+++ b/android/junit/BUILD.gn
@@ -163,9 +163,14 @@ if (is_android) {
   }
 
   robolectric_library("brave_junit_tests_org.chromium.chrome.browser.tasks") {
+    resources_package = "org.chromium.chrome"
     sources = [ "src/org/chromium/chrome/browser/tasks/BraveReturnToChromeUtilUnitTest.java" ]
 
-    deps = [ "//chrome/android/junit:chrome_junit_tests_helper" ]
+    deps = [
+      "//chrome/android/junit:chrome_junit_tests_helper",
+      "//components/browser_ui/media/android:java",
+      "//services/media_session/public/cpp/android:media_session_java",
+    ]
   }
 
   robolectric_library("brave_junit_tests_org.chromium.chrome.browser.ui") {

--- a/android/junit/src/org/chromium/chrome/browser/tasks/BraveReturnToChromeUtilUnitTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/tasks/BraveReturnToChromeUtilUnitTest.java
@@ -7,12 +7,15 @@ package org.chromium.chrome.browser.tasks;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import android.content.Intent;
 import android.net.Uri;
 
 import androidx.test.filters.SmallTest;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,11 +24,21 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.robolectric.annotation.Config;
 
+import org.chromium.base.BraveFeatureList;
 import org.chromium.base.BravePreferenceKeys;
 import org.chromium.base.IntentUtils;
 import org.chromium.base.test.BaseRobolectricTestRunner;
+import org.chromium.base.test.util.Features.EnableFeatures;
+import org.chromium.chrome.R;
 import org.chromium.chrome.browser.ChromeInactivityTracker;
+import org.chromium.chrome.browser.app.flags.BraveCachedFlags;
+import org.chromium.chrome.browser.app.flags.ChromeCachedFlags;
 import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
+import org.chromium.components.browser_ui.media.MediaNotificationController;
+import org.chromium.components.browser_ui.media.MediaNotificationInfo;
+import org.chromium.components.browser_ui.media.MediaNotificationListener;
+import org.chromium.components.browser_ui.media.MediaNotificationManager;
+import org.chromium.services.media_session.MediaMetadata;
 
 /** Unit tests for {@link BraveReturnToChromeUtil} class. */
 @RunWith(BaseRobolectricTestRunner.class)
@@ -33,6 +46,13 @@ import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
 public class BraveReturnToChromeUtilUnitTest {
     @Rule public final MockitoRule mMockitoRule = MockitoJUnit.rule();
     @Mock private ChromeInactivityTracker mInactivityTracker;
+
+    @Before
+    public void setUp() {
+        // Force the ChromeCachedFlags superclass to initialize first so the BraveCachedFlags
+        // singleton is fully constructed before any of its static fields are accessed.
+        ChromeCachedFlags.getInstance();
+    }
 
     @Test
     @SmallTest
@@ -72,10 +92,95 @@ public class BraveReturnToChromeUtilUnitTest {
         assertTrue(IntentUtils.isMainIntentFromLauncher(intent));
     }
 
+    @Test
+    @SmallTest
+    @EnableFeatures(BraveFeatureList.BRAVE_FRESH_NTP_AFTER_IDLE_EXPERIMENT)
+    public void testShouldShowNtpAfterInactivityWhenNoMediaPlaying() {
+        setUpInactivityVariant();
+        MediaNotificationManager.clear(R.id.media_playback_notification);
+
+        assertTrue(
+                BraveReturnToChromeUtil.shouldShowNtpAsHomeSurfaceAtStartup(
+                        createMainIntentFromLauncher(),
+                        null,
+                        /* persistableBundle= */ null,
+                        mInactivityTracker));
+    }
+
+    @Test
+    @SmallTest
+    @EnableFeatures(BraveFeatureList.BRAVE_FRESH_NTP_AFTER_IDLE_EXPERIMENT)
+    public void testShouldNotShowNtpAfterInactivityWhenMediaPlaying() {
+        setUpInactivityVariant();
+        setMediaControllerPaused(false);
+
+        assertFalse(
+                BraveReturnToChromeUtil.shouldShowNtpAsHomeSurfaceAtStartup(
+                        createMainIntentFromLauncher(),
+                        null,
+                        /* persistableBundle= */ null,
+                        mInactivityTracker));
+
+        // Verify snackbar flag was NOT set while media is playing.
+        assertFalse(
+                ChromeSharedPreferences.getInstance()
+                        .readBoolean(BravePreferenceKeys.BRAVE_SHOW_RECENT_TABS_SNACKBAR, false));
+    }
+
+    @Test
+    @SmallTest
+    @EnableFeatures(BraveFeatureList.BRAVE_FRESH_NTP_AFTER_IDLE_EXPERIMENT)
+    public void testShouldShowNtpAfterInactivityWhenMediaPaused() {
+        setUpInactivityVariant();
+        // A paused media notification means the user is not actively listening, so the NTP
+        // should still be shown after inactivity.
+        setMediaControllerPaused(true);
+
+        assertTrue(
+                BraveReturnToChromeUtil.shouldShowNtpAsHomeSurfaceAtStartup(
+                        createMainIntentFromLauncher(),
+                        null,
+                        /* persistableBundle= */ null,
+                        mInactivityTracker));
+    }
+
     private Intent createMainIntentFromLauncher() {
         Intent intent = new Intent();
         intent.setAction(Intent.ACTION_MAIN);
         intent.addCategory(Intent.CATEGORY_LAUNCHER);
         return intent;
+    }
+
+    /**
+     * Configures variant B (1-hour threshold) with the "new tab after inactivity" opening screen
+     * option and a background duration that comfortably exceeds the threshold.
+     */
+    private void setUpInactivityVariant() {
+        BraveCachedFlags.sBraveFreshNtpAfterIdleExperimentVariant.setForTesting("B");
+        ChromeSharedPreferences.getInstance()
+                .writeInt(
+                        BravePreferenceKeys.BRAVE_NEW_TAB_PAGE_OPENING_SCREEN,
+                        BravePreferenceKeys.BRAVE_OPENING_SCREEN_OPTION_NEW_TAB_AFTER_INACTIVITY);
+        ChromeSharedPreferences.getInstance()
+                .writeBoolean(BravePreferenceKeys.BRAVE_SHOW_RECENT_TABS_SNACKBAR, false);
+        // Two hours, well beyond variant B's 1-hour threshold.
+        when(mInactivityTracker.getTimeSinceLastBackgroundedMs()).thenReturn(2 * 60 * 60 * 1000L);
+    }
+
+    /** Registers a media playback notification controller in the given paused state. */
+    private void setMediaControllerPaused(boolean isPaused) {
+        MediaNotificationInfo info =
+                new MediaNotificationInfo.Builder()
+                        .setMetadata(new MediaMetadata("title", "artist", "album"))
+                        .setOrigin("https://example.com")
+                        .setListener(mock(MediaNotificationListener.class))
+                        .setInstanceId(1)
+                        .setId(R.id.media_playback_notification)
+                        .setPaused(isPaused)
+                        .build();
+        MediaNotificationController controller = mock(MediaNotificationController.class);
+        controller.mMediaNotificationInfo = info;
+        MediaNotificationManager.setControllerForTesting(
+                R.id.media_playback_notification, controller);
     }
 }


### PR DESCRIPTION
When the fresh-NTP-after-idle experiment is enabled, returning to the app after the inactivity threshold would replace the user's current tab with a fresh NTP even while media was playing in the background. Background playback means the user is not truly idle, so skip showing the fresh NTP in that case.

The check is scoped to the inactivity-timer path and only evaluated once the background-time threshold is met; it reads the global media playback notification state via MediaNotificationManager.

Resolves: https://github.com/brave/brave-browser/issues/53922

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

STR:
1. Open Brave and make sure that Settings->Media->Background play is on
2. Make sure that you have enabled New Tab page after inactivity inside Settings->New Tab Page
3. Open youtube.com and start playing any video
4. Background Brave
5. Move device's clock ~2 hours 5 minutes ahead
6. Open Brave and make sure NTP didn't replace the current open tab.