### PR TITLE
[Android] Fix variations not pulled on 1st launch after fresh install (uplift to 1.93.x)

### DIFF
--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-base-SplitChromeApplication.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-base-SplitChromeApplication.java.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/base/SplitChromeApplication.java b/chrome/android/java/src/org/chromium/chrome/browser/base/SplitChromeApplication.java
+index 46664df1ffdebd82c7c36ef41297aebe6510ca78..434f92ee6ae74995a7cd43d2f66c95970bca9a41 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/base/SplitChromeApplication.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/base/SplitChromeApplication.java
+@@ -243,7 +243,7 @@ public class SplitChromeApplication extends SplitCompatApplication {
+                     // fieldtrial_testing_config.json.
+                     ContextUtils.sDoFeatureListInitHookForTesting =
+                             InitializeFeatureList::initializeFeatureList;
+-                } else if (!BuildConfig.IS_CHROME_BRANDED
++                } else if (!true /* BuildConfig.IS_CHROME_BRANDED override for Brave */
+                         || !VariationsSeedFetcher.shouldFetchSeed()) {
+                     // For non-Chrome branded builds, we should initialize the feature list early to
+                     // apply the fieldtrial_testing_config.json. Otherwise, we should initialize the

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/base/SplitChromeApplication.java.yaml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/base/SplitChromeApplication.java.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Defer early feature list init on first run for non-Chrome-branded builds.
+
+      Since IS_CHROME_BRANDED = false for Brave, the upstream condition
+      `!IS_CHROME_BRANDED || !shouldFetchSeed()` always short-circuits to true,
+      causing the feature list to be initialized early without the variations seed
+      on first run. This prevents the native VariationsService from applying the
+      seed in the same launch, requiring a restart.
+
+      Replacing IS_CHROME_BRANDED with true makes the short-circuit always false,
+      so Brave behaves identically to Chrome-branded builds: early feature list
+      init is skipped on first run, letting the native VariationsService fetch and
+      apply the seed immediately.
+
+      See https://source.chromium.org/chromium/chromium/src/+/f00d1a3a65153510d612597de0dde2a4365ca130
+    pattern: 'BuildConfig.IS_CHROME_BRANDED'
+    replace: 'true /* BuildConfig.IS_CHROME_BRANDED override for Brave */'
+    count: 1


### PR DESCRIPTION
Uplift of #37728
Resolves https://github.com/brave/brave-browser/issues/56820

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.