### PR TITLE
[iOS] Use main frame shield status for all frames when cosmetic filtering (uplift to 1.92.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CosmeticFiltersScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CosmeticFiltersScriptHandler.swift
@@ -46,7 +46,9 @@ class CosmeticFiltersScriptHandler: TabContentScript {
       let data = try JSONSerialization.data(withJSONObject: message.body)
       let dto = try JSONDecoder().decode(CosmeticFiltersDTO.self, from: data)
 
-      guard let frameURL = URLOrigin(wkSecurityOrigin: message.frameInfo.securityOrigin).url else {
+      guard let mainFrameURL = tab.currentPageData?.mainFrameURL,
+        let frameURL = URLOrigin(wkSecurityOrigin: message.frameInfo.securityOrigin).url
+      else {
         replyHandler(nil, nil)
         return
       }
@@ -54,7 +56,7 @@ class CosmeticFiltersScriptHandler: TabContentScript {
       Task { @MainActor in
         let cachedEngines = AdBlockGroupsManager.shared.cachedEngines(
           isAdBlockEnabled: tab.braveShieldsHelper?.shieldLevel(
-            for: frameURL,
+            for: mainFrameURL,
             considerAllShieldsOption: true
           ).isEnabled ?? true
         )


### PR DESCRIPTION
Uplift of #37642
Resolves https://github.com/brave/brave-browser/issues/56780

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.