### PR TITLE
[Android] Change Sharing Hub setting

### DIFF
--- a/android/java/brave-res/xml/brave_appearance_preferences.xml
+++ b/android/java/brave-res/xml/brave_appearance_preferences.xml
@@ -38,6 +38,7 @@
 
     <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
         android:key="brave_disable_sharing_hub"
+        android:icon="@drawable/ic_share"
         android:title="@string/sharing_hub_title"
         android:summaryOn="@string/text_on"
         android:summaryOff="@string/text_off" />

--- a/android/java/brave-res/xml/brave_appearance_preferences.xml
+++ b/android/java/brave-res/xml/brave_appearance_preferences.xml
@@ -39,7 +39,7 @@
     <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
         android:key="brave_disable_sharing_hub"
         android:icon="@drawable/ic_share"
-        android:title="@string/sharing_hub_title"
+        android:title="@string/brave_sharing_hub_title"
         android:summaryOn="@string/text_on"
         android:summaryOff="@string/text_off"
         app:isPreferenceVisible="false" />

--- a/android/java/brave-res/xml/brave_appearance_preferences.xml
+++ b/android/java/brave-res/xml/brave_appearance_preferences.xml
@@ -41,7 +41,8 @@
         android:icon="@drawable/ic_share"
         android:title="@string/sharing_hub_title"
         android:summaryOn="@string/text_on"
-        android:summaryOff="@string/text_off" />
+        android:summaryOff="@string/text_off"
+        app:isPreferenceVisible="false" />
 
     <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
         android:key="brave_enable_tab_groups"

--- a/android/java/brave-res/xml/brave_appearance_preferences.xml
+++ b/android/java/brave-res/xml/brave_appearance_preferences.xml
@@ -38,7 +38,7 @@
 
     <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
         android:key="brave_disable_sharing_hub"
-        android:title="@string/disable_sharing_hub"
+        android:title="@string/sharing_hub_title"
         android:summaryOn="@string/text_on"
         android:summaryOff="@string/text_off" />
 

--- a/android/java/org/chromium/base/BravePreferenceKeys.java
+++ b/android/java/org/chromium/base/BravePreferenceKeys.java
@@ -40,6 +40,8 @@ public final class BravePreferenceKeys {
             "org.chromium.chrome.browser.Brave_Tab_Groups_Feature_Enabled";
     public static final String BRAVE_TAB_GROUPS_BAR_ENABLED =
             "org.chromium.chrome.browser.Brave_Tab_Groups_Bar_Enabled";
+    // Note: the user-facing preference is labelled "Sharing Hub", but this stored value is
+    // inverted. Be sure to invert it when reading/writing.
     public static final String BRAVE_DISABLE_SHARING_HUB =
             "org.chromium.chrome.browser.Brave_Disable_Sharing_Hub";
     public static final String BRAVE_NEWS_CHANGE_SOURCE = "brave_news_change_source";

--- a/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
@@ -6,6 +6,7 @@
 package org.chromium.chrome.browser.settings;
 
 import android.content.Context;
+import android.os.Build;
 import android.os.Bundle;
 
 import androidx.preference.Preference;
@@ -95,6 +96,9 @@ public class AppearancePreferences extends AppearanceSettingsFragment
         if (!ToolbarPositionController.isToolbarPositionCustomizationEnabled(getContext(), false)) {
             removePreferenceIfPresent(PREF_ADDRESS_BAR);
         }
+
+        setPreferenceVisibleIfPresent(
+                PREF_BRAVE_DISABLE_SHARING_HUB, shouldShowSharingHubPreference());
 
         if (BraveTabUiFeatureUtilities.isBraveAndroidTabGroupsSettingsFeatureEnabled()) {
             removePreferenceIfPresent(PREF_BRAVE_ENABLE_TAB_GROUPS);
@@ -347,6 +351,10 @@ public class AppearancePreferences extends AppearanceSettingsFragment
                 .writeBoolean(BravePreferenceKeys.BRAVE_DISABLE_SHARING_HUB, !enabled);
     }
 
+    private static boolean shouldShowSharingHubPreference() {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
+    }
+
     private void updatePreferenceIcon(String preferenceString, int drawable) {
         Preference preference = findPreference(preferenceString);
         if (preference != null) {
@@ -478,6 +486,10 @@ public class AppearancePreferences extends AppearanceSettingsFragment
                     if (BraveRewardsPolicy.isDisabledByPolicy(profile)) {
                         indexData.removeEntryForKey(frag, PREF_SHOW_BRAVE_REWARDS_ICON);
                         indexData.removeEntryForKey(frag, PREF_ADS_SWITCH);
+                    }
+
+                    if (!shouldShowSharingHubPreference()) {
+                        indexData.removeEntryForKey(frag, PREF_BRAVE_DISABLE_SHARING_HUB);
                     }
 
                     if (BraveTabUiFeatureUtilities

--- a/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
@@ -151,16 +151,11 @@ public class AppearancePreferences extends AppearanceSettingsFragment
             enableBottomToolbar.setOnPreferenceChangeListener(this);
         }
 
-        Preference disableSharingHub = findPreference(PREF_BRAVE_DISABLE_SHARING_HUB);
-        if (disableSharingHub != null) {
-            disableSharingHub.setOnPreferenceChangeListener(this);
-            if (disableSharingHub instanceof ChromeSwitchPreference) {
-                ((ChromeSwitchPreference) disableSharingHub)
-                        .setChecked(
-                                ChromeSharedPreferences.getInstance()
-                                        .readBoolean(
-                                                BravePreferenceKeys.BRAVE_DISABLE_SHARING_HUB,
-                                                false));
+        Preference sharingHub = findPreference(PREF_BRAVE_DISABLE_SHARING_HUB);
+        if (sharingHub != null) {
+            sharingHub.setOnPreferenceChangeListener(this);
+            if (sharingHub instanceof ChromeSwitchPreference) {
+                ((ChromeSwitchPreference) sharingHub).setChecked(isSharingHubEnabled());
             }
         }
 
@@ -286,9 +281,7 @@ public class AppearancePreferences extends AppearanceSettingsFragment
                     BraveFeatureList.ENABLE_FORCE_DARK, (boolean) newValue, true);
             shouldRelaunch = true;
         } else if (PREF_BRAVE_DISABLE_SHARING_HUB.equals(key)) {
-            ChromeSharedPreferences.getInstance()
-                    .writeBoolean(
-                            BravePreferenceKeys.BRAVE_DISABLE_SHARING_HUB, (boolean) newValue);
+            setSharingHubEnabled((boolean) newValue);
         } else if (PREF_BRAVE_ENABLE_TAB_GROUPS.equals(key)) {
             ChromeSharedPreferences.getInstance()
                     .writeBoolean(BravePreferenceKeys.BRAVE_TAB_GROUPS_ENABLED, (boolean) newValue);
@@ -341,6 +334,17 @@ public class AppearancePreferences extends AppearanceSettingsFragment
     /** Sets the user preference for whether the brave ads in background is enabled. */
     public void setPrefAdsInBackgroundEnabled(boolean enabled) {
         ChromeSharedPreferences.getInstance().writeBoolean(PREF_ADS_SWITCH, enabled);
+    }
+
+    private static boolean isSharingHubEnabled() {
+        return !ChromeSharedPreferences.getInstance()
+                .readBoolean(BravePreferenceKeys.BRAVE_DISABLE_SHARING_HUB, false);
+    }
+
+    private static void setSharingHubEnabled(boolean enabled) {
+        // The persisted pref predates the positive "Sharing Hub" UI label, so we invert the value.
+        ChromeSharedPreferences.getInstance()
+                .writeBoolean(BravePreferenceKeys.BRAVE_DISABLE_SHARING_HUB, !enabled);
     }
 
     private void updatePreferenceIcon(String preferenceString, int drawable) {

--- a/android/nala/icons.gni
+++ b/android/nala/icons.gni
@@ -154,6 +154,7 @@ nala_icons = [
   "ic_product_translate.xml",
   "ic_product_vpn.xml",
   "ic_search.xml",
+  "ic_share.xml",
   "ic_shred_data.xml",
   "ic_shield_done.xml",
   "ic_smartphone_laptop.xml",

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -2367,8 +2367,8 @@ If you don't accept this request, VPN will not reconnect and your internet conne
     <message name="IDS_GAS_LIMIT" desc="Brave crypto wallet gas limit edit box">
       Gas Limit
     </message>
-    <message name="IDS_DISABLE_SHARING_HUB" desc="Menu item for disabling sharing hub.">
-      Disable Sharing Hub
+    <message name="IDS_SHARING_HUB_TITLE" desc="Title for preference that enables or disables the Chromium sharing hub.">
+      Sharing Hub
     </message>
     <message name="IDS_WALLET_ACCOUNTS_UPDATE" desc="Brave wallet accounts update text">
       Update

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -2367,7 +2367,7 @@ If you don't accept this request, VPN will not reconnect and your internet conne
     <message name="IDS_GAS_LIMIT" desc="Brave crypto wallet gas limit edit box">
       Gas Limit
     </message>
-    <message name="IDS_SHARING_HUB_TITLE" desc="Title for a preference shown on Android 13 and earlier. The preference controls whether Brave uses the upstream in-app sharing hub or the Android system share sheet when users share content.">
+    <message name="IDS_BRAVE_SHARING_HUB_TITLE" desc="Title for a preference shown on Android 13 and earlier. The preference controls whether Brave uses the upstream in-app sharing hub or the Android system share sheet when users share content.">
       Sharing Hub
     </message>
     <message name="IDS_WALLET_ACCOUNTS_UPDATE" desc="Brave wallet accounts update text">

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -2367,7 +2367,7 @@ If you don't accept this request, VPN will not reconnect and your internet conne
     <message name="IDS_GAS_LIMIT" desc="Brave crypto wallet gas limit edit box">
       Gas Limit
     </message>
-    <message name="IDS_SHARING_HUB_TITLE" desc="Title for preference that enables or disables the Chromium sharing hub.">
+    <message name="IDS_SHARING_HUB_TITLE" desc="Title for a preference shown on Android 13 and earlier. The preference controls whether Brave uses the upstream in-app sharing hub or the Android system share sheet when users share content.">
       Sharing Hub
     </message>
     <message name="IDS_WALLET_ACCOUNTS_UPDATE" desc="Brave wallet accounts update text">


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56857.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

Screenshot of the refactored setting: 
<img width="638" height="1470" alt="Screenshot_2026-07-03 at 13 44 11" src="https://github.com/user-attachments/assets/224efb42-3781-4668-b385-67a2dda86482" />

Note that, per the task description, this preference no longer displays on Android 14+ / API 34+.

Demo video:

https://github.com/user-attachments/assets/27deff9d-2465-474d-9ea8-a56893c0c7c6



Observe that:
1. 0-13 seconds: an app version running `master`. Observe "Disable sharing hub" is `true`
2. 18-27 seconds: the code from this branch is loaded
3. 27 seconds: Observe the setting is labelled "Sharing Hub", and it's value is `false`

Note for @brave/string-reviewers-team - this PR removes the `IDS_DISABLE_SHARING_HUB` string and replaces it with `IDS_SHARING_HUB_TITLE`. If there's a process for removing strings I've missed, please let me know.

