### PR TITLE
NTP background not receiving clicks in empty areas around content

### DIFF
--- a/browser/resources/brave_new_tab_page_refresh/components/app.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/app.style.ts
@@ -125,23 +125,6 @@ export const style = scoped.css`
     }
   }
 
-  .allow-background-pointer-events {
-    /* This element will allow pointer events to target the background. */
-    pointer-events: none;
-
-    /* But children will not (unless they explicitly allow it). */
-    > :not(.allow-background-pointer-events) {
-      pointer-events: auto;
-    }
-
-    /* And not when a popover is open. When a popover is open and the background
-       contains an interactive iframe, pointer events on a background iframe
-       will not "light-dismiss" the popover. */
-    :scope:has(:popover-open) & {
-      pointer-events: auto;
-    }
-  }
-
   main {
     container-type: inline-size;
     view-timeline-name: --ntp-main-view-timeline;
@@ -275,6 +258,23 @@ export const style = scoped.css`
 `
 
 style.passthrough.css`
+  .allow-background-pointer-events {
+    /* This element will allow pointer events to target the background. */
+    pointer-events: none;
+
+    /* But children will not (unless they explicitly allow it). */
+    > :not(.allow-background-pointer-events) {
+      pointer-events: auto;
+    }
+
+    /* And not when a popover is open. When a popover is open and the background
+       contains an interactive iframe, pointer events on a background iframe
+       will not "light-dismiss" the popover. */
+    :scope:has(:popover-open) & {
+      pointer-events: auto;
+    }
+  }
+
   & {
     font: ${font.default.regular};
     color: ${color.text.primary};

--- a/browser/resources/brave_new_tab_page_refresh/components/app.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/app.tsx
@@ -64,10 +64,10 @@ export function App() {
         >
           <Icon name='settings' />
         </button>
-        <div className='topsites-container'>
+        <div className='topsites-container allow-background-pointer-events'>
           <TopSites />
         </div>
-        <div className='searchbox-container'>
+        <div className='searchbox-container allow-background-pointer-events'>
           {searchLayoutReady && (
             <Search showSearchSettings={() => setSettingsView('search')} />
           )}
@@ -80,10 +80,10 @@ export function App() {
         >
           <BackgroundClickRegion />
         </div>
-        <div className='caption-container'>
+        <div className='caption-container allow-background-pointer-events'>
           <BackgroundCaption />
         </div>
-        <div className='widget-container'>
+        <div className='widget-container allow-background-pointer-events'>
           {widgetLayoutReady && (
             <>
               {threeColumnWidth ? (

--- a/browser/resources/brave_new_tab_page_refresh/components/query_box/query_box.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/query_box/query_box.tsx
@@ -90,7 +90,10 @@ export function QueryBox(props: Props) {
   }
 
   return (
-    <div data-css-scope={style.scope}>
+    <div
+      className='allow-background-pointer-events'
+      data-css-scope={style.scope}
+    >
       <div className='query-container'>
         <div className='input-container'>
           <MaybeAIChatContext shouldRenderContext={showChatInput}>

--- a/browser/resources/brave_new_tab_page_refresh/components/search/search_box.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/search/search_box.tsx
@@ -55,7 +55,7 @@ export function SearchBox(props: Props) {
 
   return (
     <div
-      className={classNames({ expanded })}
+      className={classNames({ expanded }, 'allow-background-pointer-events')}
       data-css-scope={style.scope}
     >
       <Popover

--- a/browser/resources/brave_new_tab_page_refresh/components/top_sites/top_sites.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/top_sites/top_sites.style.ts
@@ -29,8 +29,9 @@ export const style = scoped.css`
   .top-sites {
     display: flex;
     align-items: flex-start;
-    justify-content: center;
     gap: 8px;
+    width: fit-content;
+    margin: 0 auto;
   }
 
   .top-site-tiles-mask {
@@ -164,6 +165,7 @@ export const style = scoped.css`
     opacity: 0;
     border-radius: 12px;
     visibility: hidden;
+    pointer-events: none;
 
     transition: opacity var(--self-transition-duration);
 
@@ -222,6 +224,7 @@ export const style = scoped.css`
     .menu-button {
       opacity: 1;
       visibility: visible;
+      pointer-events: auto;
     }
   }
 `

--- a/browser/resources/brave_new_tab_page_refresh/components/top_sites/top_sites.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/top_sites/top_sites.tsx
@@ -82,11 +82,12 @@ export function TopSites() {
   return (
     <div
       ref={rootRef}
+      className='allow-background-pointer-events'
       data-css-scope={style.scope}
     >
       <div className='top-site-context-menu-anchor' />
       <div className='top-sites'>
-        <div className='left-spacer' />
+        <div className='left-spacer allow-background-pointer-events' />
         <TopSitesGrid
           expanded={expanded}
           canAddSite={showAddButton}


### PR DESCRIPTION
Several full-width wrapper containers on the new tab page intercept pointer events across their entire bounding box even though their visible content does not fill the full width. This prevents users from clicking on rich NTP background content in the empty areas around the search input, top sites, widgets, and background caption.

The fix makes empty areas around the NTP search box, top sites row, and other containers pass pointer events through to the background. Test with chrome://flags/#brave-ai-chat-show-input-on-new-tab-page both disabled and enabled: clicking empty space beside and around those components should reach the background, while the components themselves (search input, tiles, kebab menu, settings gear, clock, widgets) remain fully interactive. Also verify that open popovers (e.g. top sites context menu) still block background clicks as expected.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56864

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
