### PR TITLE
Fix flaky InstallShTest

### DIFF
--- a/patches/chrome-updater-mac-.install.sh.patch
+++ b/patches/chrome-updater-mac-.install.sh.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/updater/mac/.install.sh b/chrome/updater/mac/.install.sh
-index 3b1874d09fca0cf88e361927dfea7c4273790030..ed5b6f20de83978d426fe180eb9c5c491cfe0d68 100755
+index 3b1874d09fca0cf88e361927dfea7c4273790030..c98a50dab0f753aff3a604b43d1659b9eb78abd0 100755
 --- a/chrome/updater/mac/.install.sh
 +++ b/chrome/updater/mac/.install.sh
 @@ -322,7 +322,7 @@ main() {
@@ -20,49 +20,11 @@ index 3b1874d09fca0cf88e361927dfea7c4273790030..ed5b6f20de83978d426fe180eb9c5c49
    note "update_app = ${update_app}"
  
    # Make sure that it's an absolute path.
-@@ -455,15 +455,88 @@ main() {
-   # directory unusable even for an instant.
-   if [[ -n "${update_versioned_dir}" ]]; then
-     note "rsyncing versioned directory"
--    if ! rsync ${RSYNC_FLAGS} --delete-before "${update_versioned_dir}/" \
--                                              "${new_versioned_dir}"; then
-+    rsync ${RSYNC_FLAGS} --delete-before "${update_versioned_dir}/" \
-+                                              "${new_versioned_dir}" &
-+    local rsync_pid=$!
-+    # Enforce the timeout with an external process that SIGKILLs rsync if
-+    # it runs too long. The killer is a single perl process - not a
-+    # `( sleep; kill ) &` subshell - so that killing it below leaves no
-+    # orphaned `sleep` behind holding our stdout/stderr (and, under test,
-+    # the harness') pipe open, which would stall the parent's read-to-EOF
-+    # and hang the install. Its stdio is redirected for the same reason.
-+    #
-+    # Instead of the kill approach chosen here, it is tempting to use a
-+    # perl `alarm` wrapper that invokes rsync with a self-imposed timeout.
-+    # However, this is unreliable: it depends on SIGALRM's default action,
-+    # which is somehow suppressed in the invocation from
-+    # install_from_archive.mm. SIGKILL does not have this problem.
-+    perl -e 'sleep shift; kill "KILL", shift' "${RSYNC_TIMEOUT:-600}" "${rsync_pid}" > /dev/null 2>&1 &
-+    local killer_pid=$!
-+    local rsync_status=0
-+    wait "${rsync_pid}" || rsync_status=$?
-+    # rsync finished; stop and reap the killer so it cannot fire later.
-+    kill "${killer_pid}" 2> /dev/null || true
-+    wait "${killer_pid}" 2> /dev/null || true
-+    if [[ ${rsync_status} -ne 0 ]]; then
-+      # Restore PIPESTATUS[0] for the err line below. The leading `!`
-+      # keeps `set -e` from terminating the script.
-+      ! (exit "${rsync_status}")
-       err "rsync of versioned directory failed, status ${PIPESTATUS[0]}"
- 
-       # If the rsync of a new-layout versioned directory failed, remove it.
+@@ -463,7 +463,52 @@ main() {
        # The incomplete version would break code signature validation.
        note "cleaning up new_versioned_dir"
        rm -rf "${new_versioned_dir}"
 -      exit 12
-+      if [[ ${rsync_status} -eq 137 ]]; then
-+      # rsync was SIGKILL'd by the watchdog, i.e. it timed out.
-+        exit 80
-+      fi
 +      # Try various remedies; Report in exit code what would have worked.
 +      local mkdir_stderr
 +      if ! mkdir_stderr="$(mkdir -p "${new_versioned_dir}" 2>&1 1>/dev/null)"

--- a/rewrite/chrome/updater/mac/.install.sh.yaml
+++ b/rewrite/chrome/updater/mac/.install.sh.yaml
@@ -29,45 +29,6 @@ substitutions:
       "--perms --recursive --times"; else echo "--no-perms --executability
       --chmod=u=rwX,go=rX --recursive"; fi)"'
 
-  # install_from_archive.mm executes .install.sh with a timeout of 15 minutes.
-  # The versioned-dir rsync normally takes only a few seconds. But there were
-  # several cases where it took 16 minutes. (It seems likely that there was some
-  # interference; either the computer went to sleep or the OS was blocking on a
-  # prompt.) This case bricked the browser because install_from_archive.mm then
-  # interrupted the later rsyncing of the app directory mid-execution.
-  # The following substitution runs rsync under its own, lower timeout. This
-  # gives the script a chance to put the browser back into a usable state when
-  # the parent timeout would have likely been exceeded.
-  - description: 'Cap versioned-dir rsync at 10 minutes, capture status'
-    re_pattern: 'if ! rsync (.*? "\$\{update_versioned_dir\}/" .*?); then'
-    re_flags: [DOTALL]
-    replace: |-
-      rsync \1 &
-          local rsync_pid=$!
-          # Enforce the timeout with an external process that SIGKILLs rsync if
-          # it runs too long. The killer is a single perl process - not a
-          # `( sleep; kill ) &` subshell - so that killing it below leaves no
-          # orphaned `sleep` behind holding our stdout/stderr (and, under test,
-          # the harness') pipe open, which would stall the parent's read-to-EOF
-          # and hang the install. Its stdio is redirected for the same reason.
-          #
-          # Instead of the kill approach chosen here, it is tempting to use a
-          # perl `alarm` wrapper that invokes rsync with a self-imposed timeout.
-          # However, this is unreliable: it depends on SIGALRM's default action,
-          # which is somehow suppressed in the invocation from
-          # install_from_archive.mm. SIGKILL does not have this problem.
-          perl -e 'sleep shift; kill "KILL", shift' "${RSYNC_TIMEOUT:-600}" "${rsync_pid}" > /dev/null 2>&1 &
-          local killer_pid=$!
-          local rsync_status=0
-          wait "${rsync_pid}" || rsync_status=$?
-          # rsync finished; stop and reap the killer so it cannot fire later.
-          kill "${killer_pid}" 2> /dev/null || true
-          wait "${killer_pid}" 2> /dev/null || true
-          if [[ ${rsync_status} -ne 0 ]]; then
-            # Restore PIPESTATUS[0] for the err line below. The leading `!`
-            # keeps `set -e` from terminating the script.
-            ! (exit "${rsync_status}")
-
   - description: |-
       Try various fixes for exit code 12 failures.
 
@@ -81,11 +42,7 @@ substitutions:
       case they add new ones beyond the current maximum 16.
     pattern: 'exit 12'
     replace: |-
-      if [[ ${rsync_status} -eq 137 ]]; then
-            # rsync was SIGKILL'd by the watchdog, i.e. it timed out.
-              exit 80
-            fi
-            # Try various remedies; Report in exit code what would have worked.
+      # Try various remedies; Report in exit code what would have worked.
             local mkdir_stderr
             if ! mkdir_stderr="$(mkdir -p "${new_versioned_dir}" 2>&1 1>/dev/null)"
             then

--- a/updater/install_sh_mac_test.py
+++ b/updater/install_sh_mac_test.py
@@ -14,7 +14,6 @@ from stat import S_IXUSR
 from subprocess import run, DEVNULL, Popen, PIPE, STDOUT
 from tempfile import TemporaryDirectory
 from threading import Thread
-from time import sleep
 
 import plistlib
 import re
@@ -203,19 +202,6 @@ class InstallShPatchTest(unittest.TestCase):
                                          'mkdir': mock_mkdir
                                      },
                                      expected_exit_code=expected_exit_code)
-
-    def test_rsync_timeout(self):
-
-        def rsync(_):
-            sleep(2)
-            return 0, ""
-
-        app_dir = join(self.temp_dir.name, f"{PRODUCT_NAME}.app")
-        self._make_app(app_dir, CURRENT_VERSION)
-        self._run_install_sh(app_dir,
-                             commands={'rsync': rsync},
-                             expected_exit_code=80,
-                             env={"RSYNC_TIMEOUT": "1"})
 
     def _prepare_dmg_dir(self):
         dmg_dir = join(self.temp_dir.name, "dmg")


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/56442.

The test sometimes output only:

```
    [ RUN      ] InstallShTest.RunTestScript
    [  FAILED  ] InstallShTest.RunTestScript
```

This PR partially removes code that was added in PRs #36914 and #37143. The code was ineffectual: It aimed to replace extracode1 update errors -9 (which can indicate a bricked browser) by the more graceful extracode1 80. But in telemetry we still see -9 and no 80. This means that the "code 80" fix had no effect. Furthermore, upstream is working on a [fix](https://issuetracker.google.com/issues/523387688) for the -9 error that we hope to also receive soon.

The code that is being removed here launched a background process in .install.sh that I hypothesize was the reason why InstallShTest was flaky. Specifically: The `perl ... &` call inherited the write end of a pipe that the test harness reads until EOF. When the process outlived .install.sh, that EOF never came and the test hung until the launcher killed it - which is why we only saw the two lines above.

# Test plan

Please check that browser updates with Omaha 4 still work.