### PR TITLE
[CodeHealth][plaster] Pass `DeviceInfo` by-value

### DIFF
--- a/browser/sync/brave_sync_devices_android.cc
+++ b/browser/sync/brave_sync_devices_android.cc
@@ -73,15 +73,15 @@ base::ListValue BraveSyncDevicesAndroid::GetSyncDeviceList() {
   base::ListValue device_list;
 
   for (const auto& device : tracker->GetAllBraveDeviceInfo()) {
-    auto device_value = device->ToValue();
+    auto device_value = device.ToValue();
     bool is_current_device =
-        local_device_info && local_device_info->guid() == device->guid();
+        local_device_info && local_device_info->guid() == device.guid();
     device_value.Set("isCurrentDevice", is_current_device);
     // DeviceInfo::ToValue doesn't put guid
-    device_value.Set("guid", device->guid());
+    device_value.Set("guid", device.guid());
     device_value.Set(
         "supportsSelfDelete",
-        device->self_delete_support() == syncer::SelfDeleteSupport::kSupported);
+        device.self_delete_support() == syncer::SelfDeleteSupport::kSupported);
     device_list.Append(std::move(device_value));
   }
 

--- a/browser/ui/webui/settings/brave_sync_handler.cc
+++ b/browser/ui/webui/settings/brave_sync_handler.cc
@@ -413,14 +413,14 @@ base::ListValue BraveSyncHandler::GetSyncDeviceList() {
   base::ListValue device_list;
 
   for (const auto& device : tracker->GetAllBraveDeviceInfo()) {
-    auto device_value = device->ToValue();
+    auto device_value = device.ToValue();
     bool is_current_device =
-        local_device_info && local_device_info->guid() == device->guid();
+        local_device_info && local_device_info->guid() == device.guid();
     device_value.Set("isCurrentDevice", is_current_device);
-    device_value.Set("guid", device->guid());
+    device_value.Set("guid", device.guid());
     device_value.Set(
         "supportsSelfDelete",
-        !is_current_device && device->self_delete_support() ==
+        !is_current_device && device.self_delete_support() ==
                                   syncer::SelfDeleteSupport::kSupported);
 
     device_list.Append(std::move(device_value));

--- a/chromium_src/components/sync_device_info/device_info_sync_bridge.cc
+++ b/chromium_src/components/sync_device_info/device_info_sync_bridge.cc
@@ -86,14 +86,12 @@ void DeviceInfoSyncBridge::OnDeviceInfoDeleted(const std::string& client_id,
   }
 }
 
-std::vector<std::unique_ptr<DeviceInfo>>
-DeviceInfoSyncBridge::GetAllBraveDeviceInfo() const {
+std::vector<DeviceInfo> DeviceInfoSyncBridge::GetAllBraveDeviceInfo() const {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   TRACE_EVENT0("sync", "DeviceInfoSyncBridge::GetAllBraveDeviceInfo");
-  std::vector<std::unique_ptr<DeviceInfo>> list;
+  std::vector<DeviceInfo> list;
   for (const auto& data : all_data_) {
-    list.push_back(std::make_unique<DeviceInfo>(
-        SpecificsToModel(data.second.specifics())));
+    list.push_back(SpecificsToModel(data.second.specifics()));
   }
   return list;
 }
@@ -102,8 +100,7 @@ DeviceInfoSyncBridge::GetAllBraveDeviceInfo() const {
 // translation unit, and the clang plugin wont allow the definition in the
 // header. This function has to provide a dead definition, otherwise there are
 // certain types of breakages that require patching upstream code.
-std::vector<std::unique_ptr<DeviceInfo>>
-DeviceInfoTracker::GetAllBraveDeviceInfo() const {
+std::vector<DeviceInfo> DeviceInfoTracker::GetAllBraveDeviceInfo() const {
   NOTREACHED() << "This function must be overriden";
 }
 

--- a/chromium_src/components/sync_device_info/device_info_tracker.h
+++ b/chromium_src/components/sync_device_info/device_info_tracker.h
@@ -11,8 +11,7 @@
 #define ForcePulseForTest                                                      \
   DeleteDeviceInfo(const std::string& client_id, base::OnceClosure callback) { \
   }                                                                            \
-  virtual std::vector<std::unique_ptr<DeviceInfo>> GetAllBraveDeviceInfo()     \
-      const;                                                                   \
+  virtual std::vector<DeviceInfo> GetAllBraveDeviceInfo() const;               \
   virtual void ForcePulseForTest
 
 #include <components/sync_device_info/device_info_tracker.h>  // IWYU pragma: export

--- a/chromium_src/components/sync_device_info/fake_device_info_tracker.cc
+++ b/chromium_src/components/sync_device_info/fake_device_info_tracker.cc
@@ -10,9 +10,8 @@ namespace syncer {
 void FakeDeviceInfoTracker::DeleteDeviceInfo(const std::string& client_id,
                                              base::OnceClosure callback) {}
 
-std::vector<std::unique_ptr<DeviceInfo>>
-FakeDeviceInfoTracker::GetAllBraveDeviceInfo() const {
-  return std::vector<std::unique_ptr<DeviceInfo>>();
+std::vector<DeviceInfo> FakeDeviceInfoTracker::GetAllBraveDeviceInfo() const {
+  return std::vector<DeviceInfo>();
 }
 
 }  // namespace syncer

--- a/chromium_src/components/sync_device_info/fake_device_info_tracker.h
+++ b/chromium_src/components/sync_device_info/fake_device_info_tracker.h
@@ -11,8 +11,7 @@
 #define ForcePulseForTest                                                    \
   DeleteDeviceInfo(const std::string& client_id, base::OnceClosure callback) \
       override;                                                              \
-  std::vector<std::unique_ptr<DeviceInfo>> GetAllBraveDeviceInfo()           \
-      const override;                                                        \
+  std::vector<DeviceInfo> GetAllBraveDeviceInfo() const override;            \
   void ForcePulseForTest
 
 #include <components/sync_device_info/fake_device_info_tracker.h>  // IWYU pragma: export

--- a/ios/browser/api/sync/brave_sync_api.mm
+++ b/ios/browser/api/sync/brave_sync_api.mm
@@ -315,14 +315,14 @@ BraveSyncAPIWordsValidationStatus const
   base::ListValue device_list_value;
 
   for (const auto& device : device_list) {
-    auto device_value = device->ToValue();
+    auto device_value = device.ToValue();
     bool is_current_device =
-        local_device_info && local_device_info->guid() == device->guid();
+        local_device_info && local_device_info->guid() == device.guid();
     device_value.Set("isCurrentDevice", is_current_device);
-    device_value.Set("guid", device->guid());
+    device_value.Set("guid", device.guid());
     device_value.Set(
         "supportsSelfDelete",
-        device->self_delete_support() == syncer::SelfDeleteSupport::kSupported);
+        device.self_delete_support() == syncer::SelfDeleteSupport::kSupported);
     device_list_value.Append(base::Value(std::move(device_value)));
   }
 

--- a/ios/browser/api/sync/brave_sync_worker.cc
+++ b/ios/browser/api/sync/brave_sync_worker.cc
@@ -121,14 +121,13 @@ const syncer::DeviceInfo* BraveSyncWorker::GetLocalDeviceInfo() {
       ->GetLocalDeviceInfo();
 }
 
-std::vector<std::unique_ptr<syncer::DeviceInfo>>
-BraveSyncWorker::GetDeviceList() {
+std::vector<syncer::DeviceInfo> BraveSyncWorker::GetDeviceList() {
   DCHECK_CURRENTLY_ON(web::WebThread::UI);
   auto* device_info_service =
       DeviceInfoSyncServiceFactory::GetForProfile(profile_);
 
   if (!device_info_service) {
-    return std::vector<std::unique_ptr<syncer::DeviceInfo>>();
+    return std::vector<syncer::DeviceInfo>();
   }
 
   syncer::DeviceInfoTracker* tracker =

--- a/ios/browser/api/sync/brave_sync_worker.h
+++ b/ios/browser/api/sync/brave_sync_worker.h
@@ -93,7 +93,7 @@ class BraveSyncWorker : public syncer::SyncServiceObserver {
   std::string GetTimeLimitedWordsFromWords(const std::string& words);
   std::string GetHexSeedFromQrCodeJson(const std::string& json);
   const syncer::DeviceInfo* GetLocalDeviceInfo();
-  std::vector<std::unique_ptr<syncer::DeviceInfo>> GetDeviceList();
+  std::vector<syncer::DeviceInfo> GetDeviceList();
   bool CanSyncFeatureStart();
   bool IsSyncFeatureActive();
   bool IsInitialSyncFeatureSetupComplete();

--- a/patches/components-sync_device_info-device_info_sync_bridge.h.patch
+++ b/patches/components-sync_device_info-device_info_sync_bridge.h.patch
@@ -1,15 +1,14 @@
 diff --git a/components/sync_device_info/device_info_sync_bridge.h b/components/sync_device_info/device_info_sync_bridge.h
-index 6a9020e3d7a4fbe5788deb8d7a3e5c897115ed78..531d8c40b63545252ffecccf94df1c60698630a8 100644
+index 6a9020e3d7a4fbe5788deb8d7a3e5c897115ed78..4b6911f88ee65bbf235675476cfaadfebd93bb88 100644
 --- a/components/sync_device_info/device_info_sync_bridge.h
 +++ b/components/sync_device_info/device_info_sync_bridge.h
-@@ -61,6 +61,12 @@ class DeviceInfoSyncBridge : public DataTypeSyncBridge,
+@@ -61,6 +61,11 @@ class DeviceInfoSyncBridge : public DataTypeSyncBridge,
    DeviceInfoSyncBridge& operator=(const DeviceInfoSyncBridge&) = delete;
  
    ~DeviceInfoSyncBridge() override;
 +  void DeleteDeviceInfo(const std::string& client_id,
 +                        base::OnceClosure callback) override;
-+  std::vector<std::unique_ptr<DeviceInfo>> GetAllBraveDeviceInfo()
-+      const override;
++  std::vector<DeviceInfo> GetAllBraveDeviceInfo() const override;
 +  void OnDeviceInfoDeleted(const std::string& client_id, const int attempt,
 +                           base::OnceClosure callback);
  

--- a/rewrite/components/sync_device_info/device_info_sync_bridge.h.yaml
+++ b/rewrite/components/sync_device_info/device_info_sync_bridge.h.yaml
@@ -18,7 +18,6 @@ substitutions:
       \1\2
       \1void DeleteDeviceInfo(const std::string& client_id,
       \1                      base::OnceClosure callback) override;
-      \1std::vector<std::unique_ptr<DeviceInfo>> GetAllBraveDeviceInfo()
-      \1    const override;
+      \1std::vector<DeviceInfo> GetAllBraveDeviceInfo() const override;
       \1void OnDeviceInfoDeleted(const std::string& client_id, const int attempt,
       \1                         base::OnceClosure callback);


### PR DESCRIPTION
`DeviceInfo` has been migrated to `plaster`, and the great benefit we
have now is that `DeviceInfo` is not a subclass anymore, which means we
can now use its move constructor, rather than having to wrap every
instance of it in a `unique_ptr` to be able to move it.

This change corrects several places where `unique_ptr<DeviceInfo>` was
being used to pass it by-value.
