### PR TITLE
[iOS] Add nullptr check for policy connector in `TestProfileIOS` destructor

### DIFF
--- a/patches/ios-chrome-browser-shared-model-profile-test-test_profile_ios.mm.patch
+++ b/patches/ios-chrome-browser-shared-model-profile-test-test_profile_ios.mm.patch
@@ -1,0 +1,13 @@
+diff --git a/ios/chrome/browser/shared/model/profile/test/test_profile_ios.mm b/ios/chrome/browser/shared/model/profile/test/test_profile_ios.mm
+index 0151cd652d9adafbfa5edb3b1663174084990321..01be2224e819b2a4774648329297f1d161f93e5d 100644
+--- a/ios/chrome/browser/shared/model/profile/test/test_profile_ios.mm
++++ b/ios/chrome/browser/shared/model/profile/test/test_profile_ios.mm
+@@ -151,7 +151,7 @@ void AssignTestingFactories(
+   // depend on `policy_connector_` and `user_cloud_policy_manager_`, and (2)
+   // `policy_connector_` depends on `user_cloud_policy_manager_`. The
+   // dependencies have to be shut down backward.
+-  policy_connector_->Shutdown();
++  if (policy_connector_) policy_connector_->Shutdown();
+   if (user_cloud_policy_manager_) {
+     user_cloud_policy_manager_->Shutdown();
+   }

--- a/patches/ios-chrome-browser-shared-model-profile-test-test_profile_ios.mm.patch
+++ b/patches/ios-chrome-browser-shared-model-profile-test-test_profile_ios.mm.patch
@@ -2,7 +2,7 @@ diff --git a/ios/chrome/browser/shared/model/profile/test/test_profile_ios.mm b/
 index 0151cd652d9adafbfa5edb3b1663174084990321..01be2224e819b2a4774648329297f1d161f93e5d 100644
 --- a/ios/chrome/browser/shared/model/profile/test/test_profile_ios.mm
 +++ b/ios/chrome/browser/shared/model/profile/test/test_profile_ios.mm
-@@ -151,7 +151,7 @@ void AssignTestingFactories(
+@@ -151,7 +151,7 @@ TestProfileIOS::~TestProfileIOS() {
    // depend on `policy_connector_` and `user_cloud_policy_manager_`, and (2)
    // `policy_connector_` depends on `user_cloud_policy_manager_`. The
    // dependencies have to be shut down backward.

--- a/rewrite/ios/chrome/browser/shared/model/profile/test/test_profile_ios.mm.yaml
+++ b/rewrite/ios/chrome/browser/shared/model/profile/test/test_profile_ios.mm.yaml
@@ -1,0 +1,6 @@
+substitutions:
+  - description:
+      'Add nullptr check for policy_connector_ to prevent crash when using
+      IOSChromeTestWithWebState. '
+    pattern: 'policy_connector_->Shutdown();'
+    replace: 'if (policy_connector_) policy_connector_->Shutdown();'


### PR DESCRIPTION
This is a patch to address https://issues.chromium.org/issues/530884092. We will open cl for this upstream issue shortly.

This patch is needed to resolve Brave unit tests using `IOSChromeTestWithWebState ` crashing on tear down with `SEGV_ACCERR`.

Flaw:
`IOSChromeTestWithWebState` sets up `TestProfileIOS` with a nullptr for `ProfilePolicyConnector`, but the destructor does not check for nullptr before accessing. This does not crash upstream tests because [Shutdown()](https://source.chromium.org/chromium/chromium/src/+/main:ios/chrome/browser/policy/model/profile_policy_connector.mm;l=94;drc=c617105ac9b00d4956db839cd99019d0895e38ab) is empty (doesn't touch `this`). With our  `chromium_src` override in https://github.com/brave/brave-core/pull/37691, we have updated `Shutdown()` to be non-empty which resulted in a crash after our `IOSChromeTestWithWebState` tests executed. 

This crash was seen in Brave with https://github.com/brave/brave-core/pull/37025 unit tests. This was not caught in PR as the crash required https://github.com/brave/brave-core/pull/37691 (and #37025 was not rebased on top of this PR). Relevant test failures: https://github.com/brave/brave-browser/issues/56825, https://github.com/brave/brave-browser/issues/56826.

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
