### PR TITLE
[VPN 2.0] Add PurchasedStateManager stub to BraveVpnService v2

### DIFF
--- a/components/brave_vpn/browser/v2/BUILD.gn
+++ b/components/brave_vpn/browser/v2/BUILD.gn
@@ -11,6 +11,8 @@ static_library("browser") {
   sources = [
     "brave_vpn_service_impl.cc",
     "brave_vpn_service_impl.h",
+    "purchased_state_manager.cc",
+    "purchased_state_manager.h",
   ]
 
   if (is_android) {
@@ -29,5 +31,25 @@ static_library("browser") {
     "//base",
     "//brave/components/brave_vpn/common",
     "//components/prefs",
+  ]
+}
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [
+    "brave_vpn_service_impl_unittest.cc",
+    "purchased_state_manager_unittest.cc",
+  ]
+
+  deps = [
+    ":browser",
+    "//base",
+    "//base/test:test_support",
+    "//brave/components/brave_vpn/common",
+    "//brave/components/skus/common",
+    "//components/prefs:test_support",
+    "//components/sync_preferences:test_support",
+    "//testing/gtest",
   ]
 }

--- a/components/brave_vpn/browser/v2/DEPS
+++ b/components/brave_vpn/browser/v2/DEPS
@@ -5,6 +5,7 @@ include_rules = [
   "+brave/components/brave_vpn/browser/brave_vpn_service.h",
   "+brave/components/brave_vpn/common/brave_vpn_constants.h",
   "+brave/components/brave_vpn/common/brave_vpn_utils.h",
+  "+brave/components/brave_vpn/common/features.h",
   "+brave/components/brave_vpn/common/pref_names.h",
   "+brave/components/brave_vpn/common/buildflags",
   "+brave/components/brave_vpn/common/mojom",

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl.cc
@@ -5,24 +5,29 @@
 
 #include "brave/components/brave_vpn/browser/v2/brave_vpn_service_impl.h"
 
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "base/check.h"
 #include "base/check_deref.h"
+#include "base/functional/bind.h"
 #include "base/notimplemented.h"
 #include "base/types/to_address.h"
+#include "brave/components/brave_vpn/browser/v2/purchased_state_manager.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
-#include "brave/components/brave_vpn/common/pref_names.h"
-#include "brave/components/skus/browser/skus_utils.h"
-#include "components/prefs/pref_service.h"
 
-namespace brave_vpn {
-namespace v2 {
+namespace brave_vpn::v2 {
 
 BraveVpnServiceImpl::BraveVpnServiceImpl(PrefService* local_prefs,
                                          PrefService* profile_prefs)
-    : local_prefs_(CHECK_DEREF(local_prefs)),
-      profile_prefs_(CHECK_DEREF(profile_prefs)),
-      connection_state_(mojom::ConnectionState::DISCONNECTED),
-      purchased_state_(mojom::PurchasedState::NOT_PURCHASED) {
+    : profile_prefs_(CHECK_DEREF(profile_prefs)),
+      connection_state_(mojom::ConnectionState::DISCONNECTED) {
   DCHECK(IsBraveVPNFeatureEnabled());
+  purchased_state_manager_ = std::make_unique<PurchasedStateManager>(
+      local_prefs,
+      base::BindRepeating(&BraveVpnServiceImpl::OnPurchasedStateChanged,
+                          base::Unretained(this)));
 }
 
 BraveVpnServiceImpl::~BraveVpnServiceImpl() = default;
@@ -32,27 +37,39 @@ bool BraveVpnServiceImpl::IsBraveVPNEnabled() const {
 }
 
 bool BraveVpnServiceImpl::IsPurchased() const {
-  NOTIMPLEMENTED();
-  return purchased_state_ == mojom::PurchasedState::PURCHASED;
+  if (!purchased_state_manager_) {
+    return false;
+  }
+  return purchased_state_manager_->IsPurchased();
 }
 
 void BraveVpnServiceImpl::ReloadPurchasedState() {
-  NOTIMPLEMENTED();
+  if (purchased_state_manager_) {
+    purchased_state_manager_->Reload();
+  }
 }
 
 std::string BraveVpnServiceImpl::GetCurrentEnvironment() const {
-  return local_prefs_->GetString(prefs::kBraveVPNEnvironment);
+  if (!purchased_state_manager_) {
+    return {};
+  }
+  return purchased_state_manager_->GetCurrentEnvironment();
 }
 
 void BraveVpnServiceImpl::GetPurchasedState(
     GetPurchasedStateCallback callback) {
-  NOTIMPLEMENTED();
-  std::move(callback).Run(
-      mojom::PurchasedInfo::New(purchased_state_, std::nullopt));
+  if (purchased_state_manager_) {
+    std::move(callback).Run(purchased_state_manager_->GetInfo().Clone());
+    return;
+  }
+  std::move(callback).Run(mojom::PurchasedInfo::New(
+      mojom::PurchasedState::NOT_PURCHASED, std::nullopt));
 }
 
 void BraveVpnServiceImpl::LoadPurchasedState(const std::string& domain) {
-  NOTIMPLEMENTED();
+  if (purchased_state_manager_) {
+    purchased_state_manager_->Load(domain);
+  }
 }
 
 void BraveVpnServiceImpl::GetAllRegions(GetAllRegionsCallback callback) {
@@ -61,8 +78,20 @@ void BraveVpnServiceImpl::GetAllRegions(GetAllRegionsCallback callback) {
 }
 
 void BraveVpnServiceImpl::Shutdown() {
+  purchased_state_manager_.reset();
   BraveVpnService::Shutdown();
 }
 
-}  // namespace v2
-}  // namespace brave_vpn
+void BraveVpnServiceImpl::OnPurchasedStateChanged(
+    mojom::PurchasedState state,
+    std::optional<std::string> description) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  NotifyPurchasedStateChanged(state, description);
+
+  // TODO: If purchased state changed to PURCHASED on desktop, we can attempt to
+  // install VPN apps, connect to the agent, etc. We also need to make sure
+  // agent gets connected and fetches the region data - BEFORE we actually send
+  // a notification to the UI.
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl.h
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_BRAVE_VPN_SERVICE_IMPL_H_
 #define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_BRAVE_VPN_SERVICE_IMPL_H_
 
+#include <memory>
+#include <optional>
 #include <string>
 
 #include "base/memory/raw_ref.h"
@@ -14,13 +16,13 @@
 
 class PrefService;
 
-namespace brave_vpn {
-namespace v2 {
+namespace brave_vpn::v2 {
+
+class PurchasedStateManager;
 
 class BraveVpnServiceImpl : public BraveVpnService {
  public:
-  explicit BraveVpnServiceImpl(PrefService* local_prefs,
-                               PrefService* profile_prefs);
+  BraveVpnServiceImpl(PrefService* local_prefs, PrefService* profile_prefs);
   ~BraveVpnServiceImpl() override;
 
   BraveVpnServiceImpl(const BraveVpnServiceImpl&) = delete;
@@ -109,6 +111,8 @@ class BraveVpnServiceImpl : public BraveVpnService {
 #endif  // BUILDFLAG(IS_ANDROID)
 
  private:
+  friend class BraveVpnServiceImplTest;
+
   // KeyedService overrides:
   void Shutdown() override;
 
@@ -119,14 +123,14 @@ class BraveVpnServiceImpl : public BraveVpnService {
                                    mojom::PurchasedState state) override;
 #endif  // !BUILDFLAG(IS_ANDROID)
 
- private:
-  const raw_ref<PrefService> local_prefs_;
+  void OnPurchasedStateChanged(mojom::PurchasedState state,
+                               std::optional<std::string> description);
+
   const raw_ref<PrefService> profile_prefs_;
+  std::unique_ptr<PurchasedStateManager> purchased_state_manager_;
   [[maybe_unused]] mojom::ConnectionState connection_state_;
-  mojom::PurchasedState purchased_state_;
 };
 
-}  // namespace v2
-}  // namespace brave_vpn
+}  // namespace brave_vpn::v2
 
 #endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_BRAVE_VPN_SERVICE_IMPL_H_

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl_android.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl_android.cc
@@ -7,8 +7,7 @@
 
 #include "base/notimplemented.h"
 
-namespace brave_vpn {
-namespace v2 {
+namespace brave_vpn::v2 {
 
 void BraveVpnServiceImpl::GetPurchaseToken(GetPurchaseTokenCallback callback) {
   NOTIMPLEMENTED();
@@ -92,5 +91,4 @@ void BraveVpnServiceImpl::RecordAndroidBackgroundP3A(
   NOTIMPLEMENTED();
 }
 
-}  // namespace v2
-}  // namespace brave_vpn
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl_desktop.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl_desktop.cc
@@ -3,13 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include <utility>
+
 #include "base/notimplemented.h"
 #include "brave/components/brave_vpn/browser/v2/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/v2/purchased_state_manager.h"
 #include "brave/components/brave_vpn/common/brave_vpn_constants.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 
-namespace brave_vpn {
-namespace v2 {
+namespace brave_vpn::v2 {
 
 bool BraveVpnServiceImpl::IsConnected() const {
   NOTIMPLEMENTED();
@@ -115,9 +117,7 @@ void BraveVpnServiceImpl::SetConnectionStateForTesting(  // IN-TEST
 void BraveVpnServiceImpl::SetPurchasedStateForTesting(  // IN-TEST
     const std::string& env,
     mojom::PurchasedState state) {
-  purchased_state_ = state;
-  NotifyPurchasedStateChanged(state, std::nullopt);
+  purchased_state_manager_->SetPurchasedState(env, state);
 }
 
-}  // namespace v2
-}  // namespace brave_vpn
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl_unittest.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl_unittest.cc
@@ -1,0 +1,96 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/brave_vpn_service_impl.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "base/test/scoped_feature_list.h"
+#include "base/test/task_environment.h"
+#include "base/test/test_future.h"
+#include "brave/components/brave_vpn/common/brave_vpn_utils.h"
+#include "brave/components/brave_vpn/common/features.h"
+#include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"
+#include "brave/components/brave_vpn/common/pref_names.h"
+#include "brave/components/skus/browser/skus_utils.h"
+#include "brave/components/skus/common/features.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/testing_pref_service.h"
+#include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn::v2 {
+namespace {
+constexpr char kTestDomain[] = "vpn.brave.com";
+constexpr char kTestEnvironment[] = "unittest-env";
+}  // namespace
+
+class BraveVpnServiceImplTest : public testing::Test {
+ public:
+  BraveVpnServiceImplTest() {
+    scoped_feature_list_.InitWithFeatures(
+        {skus::features::kSkusFeature, features::kBraveVPN}, {});
+  }
+
+  void SetUp() override {
+    brave_vpn::RegisterLocalStatePrefs(local_pref_service_.registry());
+    brave_vpn::RegisterProfilePrefs(profile_pref_service_.registry());
+  }
+
+  void CreateService() {
+    service_ = std::make_unique<BraveVpnServiceImpl>(&local_pref_service_,
+                                                     &profile_pref_service_);
+  }
+
+  void ShutdownService() { service_->Shutdown(); }
+
+ protected:
+  base::test::TaskEnvironment task_environment_;
+  base::test::ScopedFeatureList scoped_feature_list_;
+  TestingPrefServiceSimple local_pref_service_;
+  sync_preferences::TestingPrefServiceSyncable profile_pref_service_;
+  std::unique_ptr<BraveVpnServiceImpl> service_;
+};
+
+TEST_F(BraveVpnServiceImplTest, ConstructorCreatesWorkingManager) {
+  CreateService();
+
+  // The stub manager's contract: unresolved reads as not-purchased.
+  EXPECT_FALSE(service_->IsPurchased());
+  EXPECT_EQ(service_->GetCurrentEnvironment(), skus::GetDefaultEnvironment());
+}
+
+TEST_F(BraveVpnServiceImplTest, EnvironmentComesFromLocalPrefs) {
+  CreateService();
+  local_pref_service_.SetString(prefs::kBraveVPNEnvironment, kTestEnvironment);
+  EXPECT_EQ(service_->GetCurrentEnvironment(), kTestEnvironment);
+}
+
+// Every entry point that delegates to the manager must return a safe default
+// (not crash) after KeyedService::Shutdown destroys it. This is the test that
+// guards the null-checks in the service; a newly added delegating method that
+// forgets its guard should extend this test.
+TEST_F(BraveVpnServiceImplTest, SafeDefaultsAfterShutdown) {
+  CreateService();
+  ShutdownService();
+
+  EXPECT_FALSE(service_->IsPurchased());
+  EXPECT_TRUE(service_->GetCurrentEnvironment().empty());
+
+  // Must not crash.
+  service_->ReloadPurchasedState();
+  service_->LoadPurchasedState(kTestDomain);
+
+  base::test::TestFuture<mojom::PurchasedInfoPtr> future;
+  service_->GetPurchasedState(future.GetCallback());
+  const mojom::PurchasedInfoPtr& info = future.Get();
+  ASSERT_TRUE(info);
+  EXPECT_EQ(info->state, mojom::PurchasedState::NOT_PURCHASED);
+  EXPECT_EQ(info->description, std::nullopt);
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/purchased_state_manager.cc
+++ b/components/brave_vpn/browser/v2/purchased_state_manager.cc
@@ -1,0 +1,60 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/purchased_state_manager.h"
+
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "base/check.h"
+#include "base/check_deref.h"
+#include "base/notimplemented.h"
+#include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"
+#include "brave/components/brave_vpn/common/pref_names.h"
+#include "brave/components/skus/browser/skus_utils.h"
+#include "components/prefs/pref_service.h"
+
+namespace brave_vpn::v2 {
+
+PurchasedStateManager::PurchasedStateManager(
+    PrefService* local_prefs,
+    PurchasedStateChangedCallback callback)
+    : local_prefs_(CHECK_DEREF(local_prefs)),
+      purchased_state_changed_callback_(std::move(callback)) {
+  CHECK(purchased_state_changed_callback_);
+}
+
+PurchasedStateManager::~PurchasedStateManager() = default;
+
+void PurchasedStateManager::Reload() {
+  Load(skus::GetDomain(skus::GetVpnProductPrefix(), GetCurrentEnvironment()));
+}
+
+void PurchasedStateManager::Load(const std::string& domain) {
+  NOTIMPLEMENTED();
+}
+
+mojom::PurchasedInfo PurchasedStateManager::GetInfo() const {
+  return purchased_state_.value_or(
+      mojom::PurchasedInfo(mojom::PurchasedState::NOT_PURCHASED, std::nullopt));
+}
+
+bool PurchasedStateManager::IsPurchased() const {
+  return GetInfo().state == mojom::PurchasedState::PURCHASED;
+}
+
+std::string PurchasedStateManager::GetCurrentEnvironment() const {
+  return local_prefs_->GetString(prefs::kBraveVPNEnvironment);
+}
+
+void PurchasedStateManager::SetPurchasedState(
+    const std::string& env,
+    mojom::PurchasedState state,
+    std::optional<std::string> description) {
+  NOTIMPLEMENTED();
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/purchased_state_manager.h
+++ b/components/brave_vpn/browser/v2/purchased_state_manager.h
@@ -1,0 +1,54 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_PURCHASED_STATE_MANAGER_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_PURCHASED_STATE_MANAGER_H_
+
+#include <optional>
+#include <string>
+
+#include "base/functional/callback.h"
+#include "base/memory/raw_ref.h"
+#include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"
+
+class PrefService;
+
+namespace brave_vpn::v2 {
+
+// PurchasedStateManager owns the purchased-state value and the current
+// environment, and runs the credential chain that produces that state.
+// For now, it is a stub.
+class PurchasedStateManager final {
+ public:
+  using PurchasedStateChangedCallback =
+      base::RepeatingCallback<void(mojom::PurchasedState,
+                                   std::optional<std::string>)>;
+
+  PurchasedStateManager(PrefService* local_prefs,
+                        PurchasedStateChangedCallback callback);
+  ~PurchasedStateManager();
+
+  PurchasedStateManager(const PurchasedStateManager&) = delete;
+  PurchasedStateManager& operator=(const PurchasedStateManager&) = delete;
+
+  void Reload();
+  void Load(const std::string& domain);
+  mojom::PurchasedInfo GetInfo() const;
+  bool IsPurchased() const;
+  std::string GetCurrentEnvironment() const;
+
+  void SetPurchasedState(const std::string& env,
+                         mojom::PurchasedState state,
+                         std::optional<std::string> description = std::nullopt);
+
+ private:
+  const raw_ref<PrefService> local_prefs_;
+  PurchasedStateChangedCallback purchased_state_changed_callback_;
+  std::optional<mojom::PurchasedInfo> purchased_state_;
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_PURCHASED_STATE_MANAGER_H_

--- a/components/brave_vpn/browser/v2/purchased_state_manager_unittest.cc
+++ b/components/brave_vpn/browser/v2/purchased_state_manager_unittest.cc
@@ -1,0 +1,58 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/purchased_state_manager.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "base/functional/callback_helpers.h"
+#include "brave/components/brave_vpn/common/brave_vpn_utils.h"
+#include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"
+#include "brave/components/brave_vpn/common/pref_names.h"
+#include "brave/components/skus/browser/skus_utils.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/testing_pref_service.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn::v2 {
+namespace {
+constexpr char kTestEnvironment[] = "unittest-env";
+}  // namespace
+
+class PurchasedStateManagerTest : public testing::Test {
+ public:
+  PurchasedStateManagerTest() {
+    brave_vpn::RegisterLocalStatePrefs(local_pref_service_.registry());
+  }
+
+  void CreateManager() {
+    manager_ = std::make_unique<PurchasedStateManager>(&local_pref_service_,
+                                                       base::DoNothing());
+  }
+
+ protected:
+  TestingPrefServiceSimple local_pref_service_;
+  std::unique_ptr<PurchasedStateManager> manager_;
+};
+
+TEST_F(PurchasedStateManagerTest, UnresolvedStateReadsAsNotPurchased) {
+  CreateManager();
+
+  const mojom::PurchasedInfo info = manager_->GetInfo();
+  EXPECT_EQ(info.state, mojom::PurchasedState::NOT_PURCHASED);
+  EXPECT_EQ(info.description, std::nullopt);
+  EXPECT_FALSE(manager_->IsPurchased());
+}
+
+TEST_F(PurchasedStateManagerTest, EnvironmentIsReadFromPrefs) {
+  CreateManager();
+  EXPECT_EQ(manager_->GetCurrentEnvironment(), skus::GetDefaultEnvironment());
+  local_pref_service_.SetString(prefs::kBraveVPNEnvironment, kTestEnvironment);
+  EXPECT_EQ(manager_->GetCurrentEnvironment(), kTestEnvironment);
+}
+
+}  // namespace brave_vpn::v2

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -449,6 +449,10 @@ test("brave_unit_tests") {
       ]
     }
   }
+  if (enable_brave_vpn_v2) {
+    deps += [ "//brave/components/brave_vpn/browser/v2:unit_tests" ]
+  }
+
   if (toolkit_views) {
     deps += [ "//chrome/browser/ui/views" ]
   }


### PR DESCRIPTION
Introduces the purchased-state skeleton for the VPN v2 service:

- PurchasedStateManager: stub that owns the purchased state and the current environment (read from local state). All behavior (Load/Reload/SetPurchasedState) is NOTIMPLEMENTED; the unresolved state reads as NOT_PURCHASED.
- BraveVpnServiceImpl: delegates purchased-state queries to the manager and returns safe defaults after KeyedService::Shutdown.

Unit tests cover the stub contracts: NOT_PURCHASED default, environment sourced from prefs, and safe defaults after Shutdown.

Implements part of https://github.com/brave/brave-browser/issues/56692

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
