### PR TITLE
Don't crash on --test-type in production builds

### DIFF
--- a/browser/brave_wallet/brave_wallet_service_delegate_base.cc
+++ b/browser/brave_wallet/brave_wallet_service_delegate_base.cc
@@ -6,7 +6,6 @@
 #include "brave/browser/brave_wallet/brave_wallet_service_delegate_base.h"
 
 #include "base/auto_reset.h"
-#include "base/check_is_test.h"
 #include "base/command_line.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/browser/permission_utils.h"
@@ -102,7 +101,6 @@ bool BraveWalletServiceDelegateBase::IsAutolockEnabled() {
   if (g_enable_autolock_commandline_check) {
     if (base::CommandLine::ForCurrentProcess()->HasSwitch(
             switches::kTestType)) {
-      CHECK_IS_TEST();
       // We don't want autolock happening in most of the tests.
       return false;
     }


### PR DESCRIPTION
## Description

`CHECK_IS_TEST()` in `BraveWalletServiceDelegateBase::IsAutolockEnabled()` (added in #36270) is fatal in official builds, so any production launch with `--test-type` — a switch reachable from ordinary user command lines, used by web-app wrapper tools (Coherence X and similar) to suppress the bad-flags infobar — aborts with SIGTRAP on `CrBrowserMain` during KeyringService initialization. This shipped in 1.92.x and instantly broke every wrapper-created Brave app on auto-update.

This change removes the `CHECK_IS_TEST()` and keeps the early `return false;`, restoring launchability while preserving the intended disable-autolock-in-tests behavior. The now-unused `base/check_is_test.h` include is removed as well.

Verified empirically against 1.92.134 official builds (macOS x86_64 + arm64): with `--test-type` the browser SIGTRAPs at startup; the identical launch without the switch (or on 1.91.x and earlier) works. Not built locally (no Chromium build environment) — relying on CI.

Resolves brave/brave-browser#56904

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews)
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally — **note: not built locally; one-line CHECK removal, relying on CI**
- [ ] Run `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` — **not run locally, see above**

## Reviewer Checklist:

- [x] A security review [is not needed, or a link to one is included](https://github.com/brave/brave-browser/wiki/Security-reviews)
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://github.com/brave/brave-core/blob/master/docs/style.md)

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest planned release version
- [ ] All relevant documentation has been updated

## Test Plan:

1. Official/release build of Brave.
2. Launch with `--test-type --user-data-dir=/tmp/brave-test`.
3. Before this change: browser process aborts with SIGTRAP (`CHECK_IS_TEST` failure) within ~2s. After: browser launches normally and wallet autolock is disabled for that session (pre-existing intended behavior of the switch branch).
