### PR TITLE
Fix component updater re-registration after deferred unregistration (uplift to 1.93.x)

### DIFF
--- a/patches/components-component_updater-component_updater_service.cc.patch
+++ b/patches/components-component_updater-component_updater_service.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/components/component_updater/component_updater_service.cc b/components/component_updater/component_updater_service.cc
+index 1e6dc0e114a1f87b60688a264adad20c072795bc..b8210dce96d8013c9a8f8e06f9647b1c17b71ede 100644
+--- a/components/component_updater/component_updater_service.cc
++++ b/components/component_updater/component_updater_service.cc
+@@ -206,6 +206,9 @@ bool CrxUpdateService::RegisterComponent(
+     return false;
+   }
+ 
++  // Cancel any pending unregistration for this component.
++  std::erase(components_pending_unregistration_, component.app_id);
++
+   // Update the registration data if the component has been registered before.
+   auto it = components_.find(component.app_id);
+   if (it != components_.end()) {

--- a/patches/components-component_updater-component_updater_service_unittest.cc.patch
+++ b/patches/components-component_updater-component_updater_service_unittest.cc.patch
@@ -1,0 +1,123 @@
+diff --git a/components/component_updater/component_updater_service_unittest.cc b/components/component_updater/component_updater_service_unittest.cc
+index bf00ff7b8676e54cf0868b0e3035f0941e73a8e9..13a79f8be26c1434fb6413dce9db69accae8f8b9 100644
+--- a/components/component_updater/component_updater_service_unittest.cc
++++ b/components/component_updater/component_updater_service_unittest.cc
+@@ -178,6 +178,7 @@ class ComponentUpdaterTest : public testing::Test {
+ 
+  protected:
+   void RunThreads();
++  void TriggerUpdateComplete(const std::string& id);
+ 
+  private:
+   void RunUpdateTask(const UpdateScheduler::UserTask& user_task);
+@@ -253,6 +254,24 @@ void ComponentUpdaterTest::RunThreads() {
+   runloop_.Run();
+ }
+ 
++void ComponentUpdaterTest::TriggerUpdateComplete(const std::string& id) {
++  update_client::Callback update_callback;
++  EXPECT_CALL(update_client(), Update)
++      .WillOnce([&update_callback](const std::vector<std::string>&,
++                                   UpdateClient::CrxDataCallback,
++                                   UpdateClient::CrxStateChangeCallback, bool,
++                                   update_client::Callback callback) {
++        update_callback = std::move(callback);
++      });
++
++  OnDemandTester tester;
++  tester.OnDemand(&component_updater(), id,
++                  OnDemandUpdater::Priority::FOREGROUND);
++
++  ASSERT_TRUE(update_callback);
++  std::move(update_callback).Run(update_client::Error::NONE);
++}
++
+ void ComponentUpdaterTest::RunUpdateTask(
+     const UpdateScheduler::UserTask& user_task) {
+   task_environment_.GetMainThreadTaskRunner()->PostTask(
+@@ -590,4 +609,85 @@ TEST_F(ComponentUpdaterTest, CriticalComponentAlwaysUpdates) {
+   EXPECT_TRUE(registered.updates_enabled);
+ }
+ 
++TEST_F(ComponentUpdaterTest,
++       RegisterCancelsPendingUnregistrationBeforeUpdateCompletes) {
++  const std::string id = "abagagagagagagagagagagagagagagag";
++  scoped_refptr<MockInstaller> installer =
++      base::MakeRefCounted<MockInstaller>();
++  EXPECT_CALL(*installer, Uninstall()).Times(0);
++
++  ComponentRegistration component(
++      id, /*name=*/{}, base::ToVector(update_client::abag_hash),
++      base::Version("1.0"), /*fingerprint=*/{}, /*installer_attributes=*/{},
++      /*action_handler=*/nullptr, installer,
++      /*requires_network_encryption=*/false,
++      /*supports_group_policy_enable_component_updates=*/true,
++      /*allow_cached_copies=*/true,
++      /*allow_updates_on_metered_connection=*/true,
++      /*allow_updates=*/true);
++
++  EXPECT_TRUE(component_updater().RegisterComponent(component));
++
++  // Unregister during an in-progress update adds component ID to the pending
++  // unregistration list.
++  EXPECT_CALL(update_client(), IsUpdating(id)).WillOnce(Return(true));
++  EXPECT_TRUE(component_updater().UnregisterComponent(id));
++
++  // Re-register removes the component ID from the pending unregistration list
++  // so the component is not uninstalled after the update completes.
++  EXPECT_TRUE(component_updater().RegisterComponent(component));
++
++  // The update does not uninstall the component.
++  TriggerUpdateComplete(id);
++
++  CrxUpdateItem item;
++  EXPECT_TRUE(component_updater().GetComponentDetails(id, &item));
++  EXPECT_TRUE(item.component);
++}
++
++TEST_F(ComponentUpdaterTest,
++       RegisterCancelsPendingUnregistrationAfterUpdateCompletes) {
++  const std::string id = "abagagagagagagagagagagagagagagag";
++  scoped_refptr<MockInstaller> installer =
++      base::MakeRefCounted<MockInstaller>();
++  // The component is uninstalled after the first update completes when
++  // processing the pending unregistration list.
++  EXPECT_CALL(*installer, Uninstall()).WillOnce(Return(true));
++
++  ComponentRegistration component(
++      id, /*name=*/{}, base::ToVector(update_client::abag_hash),
++      base::Version("1.0"), /*fingerprint=*/{}, /*installer_attributes=*/{},
++      /*action_handler=*/nullptr, installer,
++      /*requires_network_encryption=*/false,
++      /*supports_group_policy_enable_component_updates=*/true,
++      /*allow_cached_copies=*/true,
++      /*allow_updates_on_metered_connection=*/true,
++      /*allow_updates=*/true);
++
++  EXPECT_TRUE(component_updater().RegisterComponent(component));
++
++  // Unregister during an in progress update adds component ID to the pending
++  // unregistration list.
++  EXPECT_CALL(update_client(), IsUpdating(id)).WillOnce(Return(true));
++  EXPECT_TRUE(component_updater().UnregisterComponent(id));
++
++  EXPECT_CALL(update_client(), IsUpdating(id)).WillOnce(Return(false));
++  // When the first update completes the component is uninstalled.
++  TriggerUpdateComplete(id);
++
++  CrxUpdateItem item;
++  EXPECT_FALSE(component_updater().GetComponentDetails(id, &item));
++  EXPECT_FALSE(item.component);
++
++  // Re-register removes the component ID from the pending unregistration list
++  // so the component is not uninstalled after the update completes.
++  EXPECT_TRUE(component_updater().RegisterComponent(component));
++
++  // The second update does not uninstall the component.
++  TriggerUpdateComplete(id);
++
++  EXPECT_TRUE(component_updater().GetComponentDetails(id, &item));
++  EXPECT_TRUE(item.component);
++}
++
+ }  // namespace component_updater


### PR DESCRIPTION
Uplift of #37568
Resolves https://github.com/brave/brave-browser/issues/56095
Resolves https://github.com/brave/brave-browser/issues/56379

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.