### PR TITLE
[Brave News]: Don't discover localhost feeds on a page for the Brave News button

### DIFF
--- a/browser/brave_news/brave_news_tab_helper.cc
+++ b/browser/brave_news/brave_news_tab_helper.cc
@@ -29,6 +29,7 @@
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "content/public/browser/web_contents_user_data.h"
+#include "net/base/url_util.h"
 #include "url/gurl.h"
 
 BraveNewsTabHelper::FeedDetails::FeedDetails() = default;
@@ -75,6 +76,12 @@ const std::vector<GURL> BraveNewsTabHelper::GetAvailableFeedUrls() {
 
   for (const auto& rss_feed : rss_page_feeds_) {
     if (seen_feeds.contains(rss_feed.feed_url)) {
+      continue;
+    }
+
+    // Don't include localhost feeds as it would allows sites to trigger
+    // requests to localhost.
+    if (net::IsLocalhost(rss_feed.feed_url)) {
       continue;
     }
 

--- a/browser/brave_news/brave_news_tab_helper_browsertest.cc
+++ b/browser/brave_news/brave_news_tab_helper_browsertest.cc
@@ -185,7 +185,8 @@ IN_PROC_BROWSER_TEST_F(BraveNewsTabHelperTest, NonExistingFeedsAreRemoved) {
   OptIn();
 
   ASSERT_TRUE(https_server()->Start());
-  GURL rss_page_url = https_server()->GetURL("/page_with_bad_rss.html");
+  GURL rss_page_url =
+      https_server()->GetURL("example.com", "/page_with_bad_rss.html");
 
   auto* tab_helper = BraveNewsTabHelper::FromWebContents(contents());
 
@@ -200,7 +201,8 @@ IN_PROC_BROWSER_TEST_F(BraveNewsTabHelperTest, NonExistingFeedsAreRemoved) {
 
     ASSERT_EQ(1u, result.size());
     feed_url = result[0];
-    EXPECT_EQ(https_server()->GetURL("/rss_feed_which_does_not_exist.xml"),
+    EXPECT_EQ(https_server()->GetURL("example.com",
+                                     "/rss_feed_which_does_not_exist.xml"),
               feed_url);
   }
 
@@ -220,7 +222,8 @@ IN_PROC_BROWSER_TEST_F(BraveNewsTabHelperTest, FeedsAreFoundWhenTheyExist) {
   OptIn();
 
   ASSERT_TRUE(https_server()->Start());
-  GURL rss_page_url = https_server()->GetURL("/page_with_rss.html");
+  GURL rss_page_url =
+      https_server()->GetURL("example.com", "/page_with_rss.html");
 
   auto* tab_helper = BraveNewsTabHelper::FromWebContents(contents());
 
@@ -235,7 +238,8 @@ IN_PROC_BROWSER_TEST_F(BraveNewsTabHelperTest, FeedsAreFoundWhenTheyExist) {
 
     ASSERT_EQ(1u, result.size());
     feed_url = result[0];
-    EXPECT_EQ(https_server()->GetURL("/page_with_rss.xml"), feed_url);
+    EXPECT_EQ(https_server()->GetURL("example.com", "/page_with_rss.xml"),
+              feed_url);
   }
 
   // At first, we should not have loaded the title (and fallback to the feed


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56884

**Note:** Users can still directly add a localhost feed by pasting one into the feed box

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
