### PR TITLE
[Android] Fix Sync screen layout broken after rotation on tablets

### DIFF
--- a/android/java/brave-res/layout/brave_sync_layout.xml
+++ b/android/java/brave-res/layout/brave_sync_layout.xml
@@ -11,8 +11,6 @@
     android:orientation="vertical"
     android:layout_height="match_parent"
     android:layout_width="match_parent"
-    android:layout_gravity="center"
-    android:gravity="center"
     android:background="@color/brave_sync_bg_color" >
 
     <ScrollView android:id="@+id/view_sync_initial"

--- a/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
@@ -66,9 +66,11 @@ import org.chromium.chrome.browser.sync.SyncServiceFactory;
 import org.chromium.chrome.browser.sync.settings.BraveManageSyncSettings;
 import org.chromium.components.browser_ui.settings.SettingsNavigation;
 import org.chromium.components.browser_ui.settings.search.BaseSearchIndexProvider;
+import org.chromium.components.browser_ui.widget.displaystyle.UiConfig;
 import org.chromium.components.sync.SyncService;
 import org.chromium.ui.base.BraveClipboardHelper;
 import org.chromium.ui.base.DeviceFormFactor;
+import org.chromium.ui.base.ViewUtils;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -168,6 +170,60 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
             mCameraManager.handleConfigurationChange();
         }
         adjustImageButtons(newConfig.orientation);
+        correctWideDisplayLayoutAfterRotation();
+    }
+
+    /**
+     * On wide displays (tablets), SettingsActivity attaches a ViewResizer to this fragment's root
+     * view to center the content. Since cr150 the ViewResizer computes the centering padding from
+     * the root's measured width (crrev.com/c/7856821), which is stale during a landscape->portrait
+     * rotation. This leaves oversized horizontal padding on the root and the child views measured
+     * against the wrong width, collapsing the content to a narrow column.
+     *
+     * <p>We correct this after the rotation layout pass settles: apply the padding computed from
+     * screenWidthDp (already updated for the new orientation), force a re-layout, and rebuild the
+     * device list so the dynamically-added rows are re-measured against the correct width. This
+     * runs from a posted runnable (not from within a layout pass) so the forced re-layout is
+     * honored.
+     */
+    private void correctWideDisplayLayoutAfterRotation() {
+        // Post twice so this runs after the framework's rotation layout pass and the ViewResizer
+        // have finished, guaranteeing our padding is the final value and the forced re-layout is
+        // not swallowed by being called during a layout pass.
+        PostTask.postTask(
+                TaskTraits.UI_USER_VISIBLE,
+                () ->
+                        PostTask.postTask(
+                                TaskTraits.UI_USER_VISIBLE,
+                                this::applyWideDisplayLayoutCorrection));
+    }
+
+    private void applyWideDisplayLayoutCorrection() {
+        // PostTask does not track the fragment/view lifecycle (unlike View.post), so guard against
+        // the fragment being torn down between posting and execution.
+        if (getActivity() == null || getView() == null) {
+            return;
+        }
+        View root = getView().findViewById(R.id.brave_sync_layout);
+        if (root == null) {
+            return;
+        }
+        int screenWidthDp = getResources().getConfiguration().screenWidthDp;
+        int padding = 0;
+        if (screenWidthDp >= UiConfig.WIDE_DISPLAY_STYLE_MIN_WIDTH_DP) {
+            int minWidePadding =
+                    getResources().getDimensionPixelSize(R.dimen.settings_wide_display_min_padding);
+            int excessWidthDp = screenWidthDp - UiConfig.WIDE_DISPLAY_STYLE_MIN_WIDTH_DP;
+            int paddingPx =
+                    Math.round((excessWidthDp / 2.f) * getResources().getDisplayMetrics().density);
+            padding = Math.max(minWidePadding, paddingPx);
+        }
+        root.setPadding(padding, root.getPaddingTop(), padding, root.getPaddingBottom());
+        ViewUtils.requestLayout(root, "BraveSyncScreensPreference.correctWideDisplayLayout");
+        // Rebuild the device rows so they re-measure against the corrected content width.
+        if (mScrollViewSyncDone != null && View.VISIBLE == mScrollViewSyncDone.getVisibility()) {
+            onDevicesAvailable();
+        }
     }
 
     @Override
@@ -178,7 +234,6 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
         invalidateCodephrase();
 
         mInflater = inflater;
-        // Read which category we should be showing.
         return mInflater.inflate(R.layout.brave_sync_layout, container, false);
     }
 
@@ -259,8 +314,9 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
             insertPoint.removeAllViews();
             int index = 0;
             for (BraveSyncDevices.SyncDeviceInfo device : deviceInfos) {
-                View separator = (View) mInflater.inflate(R.layout.menu_separator, null);
-                View listItemView = (View) mInflater.inflate(R.layout.brave_sync_device, null);
+                View separator = mInflater.inflate(R.layout.menu_separator, insertPoint, false);
+                View listItemView =
+                        mInflater.inflate(R.layout.brave_sync_device, insertPoint, false);
                 if (null != listItemView && null != separator && null != insertPoint) {
                     ImageView imageView =
                             (ImageView) listItemView.findViewById(R.id.brave_sync_device_image);
@@ -311,7 +367,7 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
             if (index > 0) {
                 mBraveSyncTextDevicesTitle.setText(
                         getResources().getString(R.string.brave_sync_devices_title));
-                View separator = (View) mInflater.inflate(R.layout.menu_separator, null);
+                View separator = mInflater.inflate(R.layout.menu_separator, insertPoint, false);
                 if (null != insertPoint && null != separator) {
                     insertPoint.addView(separator, index++);
                 }
@@ -877,7 +933,7 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
                                         getResources()
                                                 .getString(
                                                         R.string
-                                                                .brave_sync_joining_deleted_account));
+                                                                .brave_sync_joining_deleted_account)); // presubmit: ignore-long-line
                                 allowNewQrScan();
                             }
                         });
@@ -1442,14 +1498,16 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
     }
 
     private void adjustWidth(View view, int orientation) {
+        LayoutParams params = view.getLayoutParams();
         if (orientation != Configuration.ORIENTATION_LANDSCAPE && DeviceFormFactor.isTablet()) {
-            DisplayMetrics metrics = new DisplayMetrics();
-            getActivity().getWindowManager().getDefaultDisplay().getMetrics(metrics);
-            LayoutParams params = view.getLayoutParams();
+            DisplayMetrics metrics = getResources().getDisplayMetrics();
             params.width = metrics.widthPixels * 3 / 5;
             params.height = metrics.heightPixels * 3 / 5;
-            view.setLayoutParams(params);
+        } else {
+            params.width = LayoutParams.MATCH_PARENT;
+            params.height = LayoutParams.MATCH_PARENT;
         }
+        view.setLayoutParams(params);
     }
 
     private void adjustImageButtons(int orientation) {


### PR DESCRIPTION
On tablets the Sync screen (`BraveSyncScreensPreference`) became collapsed into a narrow column after a landscape -> portrait rotation, and device list rows were not visible.

Root cause: on wide displays `SettingsActivity` attaches a `ViewResizer` to the fragment root to center content, computed via `ViewResizerUtil`. In `cr150`, Chromium change crrev.com/c/7856821 enabled the `UpdatePaddingForDisplayCalculation` feature (default-on) which, on non-automotive/non-XR devices where `DisplayUtil.isUiScaled()` is false (i.e. ordinary tablets), switches the wide-display padding computation from `screenWidthDp` to the root's measured width. Previously that measured-width branch was gated behind `isUiScaled()` and thus skipped on these devices, so `screenWidthDp` (correct for the new orientation) was used. During a landscape -> portrait rotation the measured width is momentarily stale (landscape-sized), so oversized horizontal padding is applied in portrait and the child views are measured against the wrong width, collapsing the content.

Fixes:
- `correctWideDisplayLayoutAfterRotation()`: after the rotation layout pass settles, recompute the centering padding from `screenWidthDp` (which is correct for the new orientation), force a re-layout, and rebuild the device rows so they re-measure against the corrected width. Posted twice via PostTask so it runs after the framework layout pass and `ViewResizer`, and so `requestLayout()` is not swallowed by running inside a layout pass.
- `adjustWidth()`: add the missing else branch that resets the start-new-chain view to `MATCH_PARENT` in landscape, so a fixed tablet-portrait width no longer persists across rotations. Also use `getResources().getDisplayMetrics()` instead of the deprecated `getDefaultDisplay().getMetrics()`.
- `fillDevices()`: inflate device rows and separators with their parent (attachToRoot=false) so the `layout_width="match_parent"` from XML is honored instead of being dropped.
- `brave_sync_layout.xml`: remove `gravity`/`layout_gravity="center"` from the root, which compounded the collapse by centering narrowed children.


<!-- Add brave-browser issue below that this PR will resolve -->

Resolves https://github.com/brave/brave-browser/issues/56861
Resolves https://github.com/brave/brave-browser/issues/56824

### Screenshots

&nbsp;|Initial portrait|Landscape|Back to Portrait
--|--|--|--
Tablet|<img width="801" height="1280" alt="image" src="https://github.com/user-attachments/assets/fc356aa3-8439-4702-b33c-16b6c2382109" />|<img width="1280" height="801" alt="image" src="https://github.com/user-attachments/assets/d1c1cc35-d4c0-4085-ad67-d365223a5560" />|<img width="801" height="1280" alt="image" src="https://github.com/user-attachments/assets/44788926-4d35-49bd-90d3-e0917d0733e1" />
Phone|<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/ad4b3040-c6c5-446a-8af0-8b334577d0b6" />|<img width="2400" height="1080" alt="image" src="https://github.com/user-attachments/assets/c6d7aea8-0854-487e-842b-18c99dc52908" />|<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/be2f715d-873d-4767-b265-8812594dde0a" />

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
