### PR TITLE
Restore correct playing state for YouTube playlist

### DIFF
--- a/android/javatests/org/chromium/components/browser_ui/media/BraveMediaSessionHelperTest.java
+++ b/android/javatests/org/chromium/components/browser_ui/media/BraveMediaSessionHelperTest.java
@@ -21,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import org.chromium.base.CommandLine;
 import org.chromium.base.test.util.Batch;
 import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
 import org.chromium.content_public.browser.WebContents;
@@ -36,6 +37,11 @@ import java.lang.ref.WeakReference;
 @Batch(Batch.PER_CLASS)
 @RunWith(ChromeJUnit4ClassRunner.class)
 public class BraveMediaSessionHelperTest {
+    // Java-side mirror of switches::kDisableBackgroundMediaSuspend, set at startup when the
+    // background video playback feature and preference are both enabled.
+    private static final String DISABLE_BACKGROUND_MEDIA_SUSPEND =
+            "disable-background-media-suspend";
+
     @Rule public MockitoRule mMockitoRule = MockitoJUnit.rule();
 
     @Mock private WebContents mWebContents;
@@ -52,6 +58,7 @@ public class BraveMediaSessionHelperTest {
     @After
     public void tearDown() {
         BraveMediaSessionHelper.setYouTubePictureInPictureWebContents(null);
+        CommandLine.getInstance().removeSwitch(DISABLE_BACKGROUND_MEDIA_SUSPEND);
     }
 
     @Test
@@ -139,5 +146,62 @@ public class BraveMediaSessionHelperTest {
         BraveMediaSessionHelper.setYouTubePictureInPictureWebContents(mOtherWebContents);
 
         assertFalse(mHelper.isYouTubePictureInPicture(mWebContents));
+    }
+
+    @Test
+    @SmallTest
+    public void shouldForcePlayingState_trueForYouTubeWithBackgroundPlayback() {
+        mockUrl("https://m.youtube.com/watch?v=dQw4w9WgXcQ");
+        CommandLine.getInstance().appendSwitch(DISABLE_BACKGROUND_MEDIA_SUSPEND);
+
+        assertTrue(mHelper.shouldForcePlayingState(mWebContents));
+    }
+
+    @Test
+    @SmallTest
+    public void shouldForcePlayingState_falseForYouTubeWithoutBackgroundPlayback() {
+        mockUrl("https://m.youtube.com/watch?v=dQw4w9WgXcQ");
+
+        assertFalse(mHelper.shouldForcePlayingState(mWebContents));
+    }
+
+    @Test
+    @SmallTest
+    public void shouldForcePlayingState_trueForBraveTalk() {
+        mockUrl("https://talk.brave.com/room");
+
+        assertTrue(mHelper.shouldForcePlayingState(mWebContents));
+    }
+
+    @Test
+    @SmallTest
+    public void shouldForcePlayingState_falseForPipSessionWithoutBackgroundPlayback() {
+        mockUrl("https://m.youtube.com/watch?v=dQw4w9WgXcQ");
+        when(mWebContents.getTopLevelNativeWindow()).thenReturn(mWindowAndroid);
+        when(mWindowAndroid.getActivity()).thenReturn(new WeakReference<>(mActivity));
+        when(mActivity.isInPictureInPictureMode()).thenReturn(true);
+        BraveMediaSessionHelper.setYouTubePictureInPictureWebContents(mWebContents);
+
+        // The pause suppression still applies, so the media controls stay alive, but the real
+        // paused state is preserved for the PiP pause-on-lock flow.
+        assertTrue(mHelper.shouldSuppressMediaPause(mWebContents));
+        assertFalse(mHelper.shouldForcePlayingState(mWebContents));
+    }
+
+    @Test
+    @SmallTest
+    public void shouldSuppressMediaPause_trueForYouTubeWithBackgroundPlayback() {
+        mockUrl("https://m.youtube.com/watch?v=dQw4w9WgXcQ");
+        CommandLine.getInstance().appendSwitch(DISABLE_BACKGROUND_MEDIA_SUSPEND);
+
+        assertTrue(mHelper.shouldSuppressMediaPause(mWebContents));
+    }
+
+    @Test
+    @SmallTest
+    public void shouldSuppressMediaPause_falseForYouTubeWithoutBackgroundPlaybackOrPip() {
+        mockUrl("https://m.youtube.com/watch?v=dQw4w9WgXcQ");
+
+        assertFalse(mHelper.shouldSuppressMediaPause(mWebContents));
     }
 }

--- a/components/browser_ui/media/android/java/src/org/chromium/components/browser_ui/media/BraveMediaSessionHelper.java
+++ b/components/browser_ui/media/android/java/src/org/chromium/components/browser_ui/media/BraveMediaSessionHelper.java
@@ -101,22 +101,17 @@ public class BraveMediaSessionHelper implements MediaImageCallback {
         return false;
     }
 
-    private boolean shouldSuppressMediaNotificationActions() {
-        WebContents webContents =
-                (WebContents)
-                        BraveReflectionUtil.getField(
-                                MediaSessionHelper.class, "mWebContents", this);
-
-        return isBraveTalk(webContents);
+    private @Nullable WebContents getMediaSessionWebContents() {
+        return (WebContents)
+                BraveReflectionUtil.getField(MediaSessionHelper.class, "mWebContents", this);
     }
 
-    private boolean shouldSuppressMediaPause() {
-        // Compute the YouTube classification once and pass it to the
-        // YT-specific predicates instead of having each one re-parse the URL.
-        WebContents webContents =
-                (WebContents)
-                        BraveReflectionUtil.getField(
-                                MediaSessionHelper.class, "mWebContents", this);
+    private boolean shouldSuppressMediaNotificationActions() {
+        return isBraveTalk(getMediaSessionWebContents());
+    }
+
+    @VisibleForTesting
+    boolean shouldSuppressMediaPause(@Nullable WebContents webContents) {
         if (isBraveTalk(webContents)) {
             return true;
         }
@@ -125,6 +120,19 @@ public class BraveMediaSessionHelper implements MediaImageCallback {
             return false;
         }
         return isBackgroundVideo() || isYouTubePictureInPicture(webContents);
+    }
+
+    // While the screen is locked, the media session transiently reports itself as not
+    // controllable and paused when the current track ends. If that paused state reaches the
+    // upstream helper, the media notification leaves its playback state and YouTube never
+    // advances to the next track (brave-browser#53077), so Brave Talk and background playback
+    // must report the session as still playing. An active Brave PiP session with background
+    // playback disabled is deliberately excluded: its pause-on-lock flow relies on the real
+    // paused state so SystemUI shows the correct action after unlock.
+    @VisibleForTesting
+    boolean shouldForcePlayingState(@Nullable WebContents webContents) {
+        return isBraveTalk(webContents)
+                || (isBackgroundPlaybackHost(webContents) && isBackgroundVideo());
     }
 
     @VisibleForTesting
@@ -230,11 +238,19 @@ public class BraveMediaSessionHelper implements MediaImageCallback {
             public void mediaSessionStateChanged(boolean isControllable, boolean isPaused) {
                 // Keep the Android media controls alive for Brave Talk, background YouTube audio,
                 // and the active Brave-managed YouTube PiP session when the page transiently
-                // reports itself as not controllable. Preserve the real paused state so SystemUI
-                // shows the correct action and forwards the right command after wake/restore
-                // transitions.
-                if (!isControllable && shouldSuppressMediaPause()) {
-                    isControllable = true;
+                // reports itself as not controllable. For Brave Talk and background playback the
+                // session is also reported as playing so the next track can start while the
+                // screen is locked (see shouldForcePlayingState); the PiP-only case preserves
+                // the real paused state so SystemUI shows the correct action and forwards the
+                // right command after wake/restore transitions.
+                if (!isControllable) {
+                    WebContents webContents = getMediaSessionWebContents();
+                    if (shouldSuppressMediaPause(webContents)) {
+                        isControllable = true;
+                        if (shouldForcePlayingState(webContents)) {
+                            isPaused = false;
+                        }
+                    }
                 }
                 mediaSessionObserver.mediaSessionStateChanged(isControllable, isPaused);
             }


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/57087

Restores the playing state, but scoped so it does not undo what https://github.com/brave/brave-core/pull/34272 fixed:

- New predicate `shouldForcePlayingState()`: true for Brave Talk and for background playback hosts when the disable-background-media-suspend switch is set (background video playback enabled). This is exactly the pre [#36838](https://github.com/brave/brave-core/pull/36838) set of cases.
- In `mediaSessionStateChanged`, a not controllable transition still becomes controllable for all suppressed cases, but `isPaused` is forced to false only when `shouldForcePlayingState()` holds. The PiP only case (background playback disabled, active Brave PiP session) keeps the real paused state, so the pause-on-lock flow and its SystemUI play action from [#36838](https://github.com/brave/brave-core/pull/36838) are untouched.
- One deliberate ordering choice: with background playback enabled and a PiP window surviving the lock, the forcing branch wins, so next-track autoplay works in that variant too, matching the pre [#36838](https://github.com/brave/brave-core/pull/36838) behavior.
- Minor cleanup: `shouldSuppressMediaPause` now takes the WebContents as a parameter, fetched once via a new `getMediaSessionWebContents()` helper, instead of doing reflection internally.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
