### PR TITLE
Revert "[iOS] Shutdown Brave policy provider correctly (#37691)"

### DIFF
--- a/chromium_src/ios/chrome/browser/policy/model/profile_policy_connector.h
+++ b/chromium_src/ios/chrome/browser/policy/model/profile_policy_connector.h
@@ -18,13 +18,9 @@
   ProfilePolicyConnectorMock;                          \
   std::unique_ptr<policy::ConfigurationPolicyProvider> \
       brave_profile_policy_provider_
-#define Shutdown \
-  Shutdown();    \
-  void Shutdown_ChromiumImpl
 
 #include <ios/chrome/browser/policy/model/profile_policy_connector.h>  // IWYU pragma: export
 
-#undef Shutdown
 #undef ProfilePolicyConnectorMock
 #undef UseLocalTestPolicyProvider
 

--- a/chromium_src/ios/chrome/browser/policy/model/profile_policy_connector.mm
+++ b/chromium_src/ios/chrome/browser/policy/model/profile_policy_connector.mm
@@ -3,8 +3,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "ios/chrome/browser/policy/model/profile_policy_connector.h"
-
 #include "components/policy/core/common/configuration_policy_provider.h"
 
 namespace brave_policy {
@@ -19,19 +17,12 @@ CreateBraveProfilePolicyProvider();
       brave_policy::CreateBraveProfilePolicyProvider();              \
   policy_providers_.push_back(brave_profile_policy_provider_.get()); \
   brave_profile_policy_provider_->Init(schema_registry);
-#define Shutdown Shutdown_ChromiumImpl
 
 #include <ios/chrome/browser/policy/model/profile_policy_connector.mm>
-
-#undef Shutdown
-#undef BRAVE_PROFILE_POLICY_CONNECTOR_INIT
 
 raw_ptr<policy::ConfigurationPolicyProvider>
 ProfilePolicyConnector::GetBraveProfilePolicyProvider() {
   return brave_profile_policy_provider_.get();
 }
 
-void ProfilePolicyConnector::Shutdown() {
-  ProfilePolicyConnector::Shutdown_ChromiumImpl();
-  brave_profile_policy_provider_->Shutdown();
-}
+#undef BRAVE_PROFILE_POLICY_CONNECTOR_INIT


### PR DESCRIPTION
This `Shutdown` method is being removed upstream and was a no-op for Chromium so was never expected to be called. We'll have to find a different way to shutdown Brave's ProfilePolicyProvider on iOS in the future
