### PR TITLE
[plaster] Make patches more deterministic

### DIFF
--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -30,6 +30,10 @@ PATCHES_PATH = repository.brave.root / 'patches'
 # The plaster file extension.
 PLASTER_EXTENSION = '.yaml'
 
+# A particular gitattributes file that is used to ensure we get deterministic
+# patch output across platforms and git versions.
+PLASTER_GITATTRIBUTES_PATH = Path(__file__).parent / 'plaster_gitattributes'
+
 
 @dataclass
 class PathChecksumPair:
@@ -307,14 +311,32 @@ class PatchinfoBuilder:
             dry_run:
               Indicates whether the actual write should not be performed.
         """
-        content = repository.chromium.run_git('diff',
-                                              '--src-prefix=a/',
-                                              '--dst-prefix=b/',
-                                              '--default-prefix',
-                                              '--full-index',
-                                              '--ignore-space-at-eol',
-                                              self.source,
-                                              no_trim=True)
+        # The hunk-header function context (the text git appends after
+        # `@@ ... @@`) is computed by the userdiff driver git selects for the
+        # source. That selection depends on the ambient environment (a
+        # per-user/global `core.attributesFile`, the system gitattributes, and
+        # git version built-ins), so the same source can yield different patch
+        # bytes on different machines even though the change is identical. This
+        # git diff peculiarity was causing `.mm` files to produce different
+        # patch files depending in which platform plaster was being run.
+        #
+        # We pin the attibutes when creating a diff (`plaster_gitattributes`),
+        # and ignore the system gitattributes (`GIT_ATTR_NOSYSTEM`), so the
+        # output is deterministic across platforms and git versions.
+        content = repository.chromium.run_git(
+            '-c',
+            f'core.attributesFile={PLASTER_GITATTRIBUTES_PATH}',
+            'diff',
+            '--src-prefix=a/',
+            '--dst-prefix=b/',
+            '--default-prefix',
+            '--full-index',
+            '--ignore-space-at-eol',
+            self.source,
+            no_trim=True,
+            env={
+                **os.environ, 'GIT_ATTR_NOSYSTEM': '1'
+            })
         return self.patch.save_if_changed(new_content=content, dry_run=dry_run)
 
     def save_patchinfo_if_changed(self):

--- a/tools/cr/plaster_gitattributes
+++ b/tools/cr/plaster_gitattributes
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Attributes used exclusively by plaster.py when generating patch files.
+#
+# `* diff` forces git's built-in default funcname driver for every path,
+# overriding any language-specific driver git might otherwise select (notably
+# the `objc` driver for `.mm` files was leading to discrepancies).
+#
+# This only ever applies to the single text source being plastered, so forcing
+# textual diff here carries no binary-file risk.
+* diff

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -988,6 +988,99 @@ class PlasterTest(unittest.TestCase):
         os.utime(patchinfo_path, (older, older))
         self.assertFalse(plaster_file.needs_apply())
 
+    # A source whose hunk-header function context differs depending on the
+    # userdiff driver git selects: the built-in `objc` driver's xfuncname regex
+    # skips the ObjC++ `Profile::~Profile()` member definition and anchors on
+    # the previous C-style free function, whereas the default/`cpp` driver
+    # reports the enclosing destructor. The change lands deep enough inside the
+    # destructor that the hunk's leading context does not reach its opening
+    # line, forcing git to search backwards for the function name.
+    _DRIVER_SENSITIVE_MM = ('// Copyright.\n'
+                            '#include "thing.h"\n'
+                            '\n'
+                            'void AssignTestingFactories(int a,\n'
+                            '                            int b) {\n'
+                            '  DoSomething();\n'
+                            '}\n'
+                            '\n'
+                            'Profile::~Profile() {\n'
+                            '  // Allows blocking in this scope for testing.\n'
+                            '  ScopedAllowBlocking allow;\n'
+                            '\n'
+                            '  // Notify before destroying anything.\n'
+                            '  NotifyDestroyed();\n'
+                            '\n'
+                            '  // Tear down the incognito profile first.\n'
+                            '  otr_.reset();\n'
+                            '\n'
+                            '  // Shut dependencies down backward.\n'
+                            '  MARKER_LINE;\n'
+                            '  more_cleanup();\n'
+                            '}\n')
+
+    def test_patch_generation_ignores_ambient_git_attributes(self):
+        """Generated patches do not depend on the developer's git attributes.
+
+        The hunk-header function context is produced by whichever userdiff
+        driver git selects for a source, and that selection depends on the
+        ambient environment (a per-user/global `core.attributesFile`, the
+        system gitattributes, git version built-ins). `.mm` files in particular
+        resolve to the `objc` driver on some setups (notably Apple Git), which
+        yields a different hunk header than the default driver and so makes the
+        committed patch bytes differ between machines. `save_patch_if_changed`
+        pins the diff to a dedicated attributes file and disables the system
+        gitattributes so the output is deterministic regardless of environment.
+        """
+        test_file = Path('chrome/browser/profile.mm')
+        self.fake_chromium_src.write_and_stage_file(
+            test_file, self._DRIVER_SENSITIVE_MM,
+            self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit('Add profile.mm',
+                                      self.fake_chromium_src.chromium)
+
+        # Simulate a machine whose ambient git configuration routes `.mm` files
+        # through the `objc` driver, e.g. via a per-user `core.attributesFile`.
+        ambient_attributes = (self.fake_chromium_src.base_path /
+                              'ambient_gitattributes')
+        ambient_attributes.write_text('*.mm diff=objc\n')
+        self.fake_chromium_src._run_git_command(
+            ['config', 'core.attributesFile',
+             str(ambient_attributes)], self.fake_chromium_src.chromium)
+
+        plaster_path = plaster.PLASTER_FILES_PATH / (str(test_file) + '.yaml')
+        plaster_path.parent.mkdir(parents=True, exist_ok=True)
+        plaster_path.write_text('substitutions:\n'
+                                '  - description: Touch the destructor body\n'
+                                "    pattern: 'MARKER_LINE;'\n"
+                                "    replace: 'MARKER_LINE_CHANGED;'\n")
+
+        plaster.PlasterFile(plaster_path).apply()
+
+        patch = plaster.PatchinfoBuilder(plaster_path).patch.path.read_text()
+        hunk_header = next(line for line in patch.splitlines()
+                           if line.startswith('@@'))
+
+        # Sanity check: the ambient `objc` mapping genuinely diverges from the
+        # default driver for this source, so the assertion below is meaningful.
+        # Otherwise a git without a diverging `objc` driver would make this test
+        # pass without exercising anything.
+        objc_diff = self.fake_chromium_src._run_git_command([
+            '-c', f'core.attributesFile={ambient_attributes}', 'diff',
+            str(test_file)
+        ], self.fake_chromium_src.chromium)
+        objc_header = next(line for line in objc_diff.splitlines()
+                           if line.startswith('@@'))
+        self.assertIn(
+            'AssignTestingFactories', objc_header,
+            'ambient objc mapping is expected to anchor the hunk '
+            'header on the free function; git behavior may have '
+            'changed')
+
+        # The generated patch must ignore the ambient `objc` mapping and use the
+        # default driver, which reports the enclosing destructor.
+        self.assertIn('Profile::~Profile()', hunk_header)
+        self.assertNotIn('AssignTestingFactories', hunk_header)
+
 
 class PatchinfoTest(unittest.TestCase):
     """Tests for Patchinfo and Patchinfo.parse."""


### PR DESCRIPTION
This PR fixes an issue where a patch generated in a linux machine looks
slightly different from a patch generated in a mac machine for an `.mm`
file. This occurs because git uses different drivers to build the header
of the hunk in some cases.

This change overrides all existing environmental factors when calling
`git diff`, making its output more deterministic irrespective of the
platform we are running plaster at.

Fixed: https://github.com/brave/brave-browser/issues/56927
