### PR TITLE
Account for outline thickness on side panel edges

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -2023,9 +2023,11 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
       EXPECT_EQ(1, side_panel->GetInsets().left())
           << "rounded: 1px gap on the content-facing side, reserved for the "
              "outline (the content view otherwise owns its margin)";
-      EXPECT_EQ(kRoundedCornersContentsViewMargin,
+      EXPECT_EQ(kRoundedCornersContentsViewMargin +
+                    kRoundedCornersContentsOutlineThickness,
                 side_panel->GetInsets().right())
-          << "rounded: outer-side gap for visual separation from window chrome";
+          << "rounded: outer-side gap matches main content (margin + outline "
+             "thickness)";
     } else {
       EXPECT_EQ(1, side_panel->GetInsets().left())
           << "plain: 1px separator on the content-facing side";
@@ -2105,8 +2107,11 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, PanelBorderInsetsFollowAlignment) {
       EXPECT_EQ(1, content_side)
           << "rounded: 1px gap on the content-facing side, reserved for the "
              "outline (the content view otherwise owns its margin)";
-      EXPECT_EQ(kRoundedCornersContentsViewMargin, outer_side)
-          << "rounded: outer-side gap for visual separation from window chrome";
+      EXPECT_EQ(kRoundedCornersContentsViewMargin +
+                    kRoundedCornersContentsOutlineThickness,
+                outer_side)
+          << "rounded: outer-side gap matches main content (margin + outline "
+             "thickness)";
     } else {
       EXPECT_EQ(1, content_side)
           << "plain: 1px separator on the content-facing side";
@@ -2457,9 +2462,11 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, PanelRoundedOutline) {
         << "rounded corners: 1px top gap reserved for the outline";
     EXPECT_EQ(kOutlineThickness, insets.left())
         << "rounded corners: 1px content-facing gap reserved for the outline";
-    EXPECT_EQ(kRoundedCornersContentsViewMargin, insets.right())
-        << "rounded corners: outer-side gap for visual separation from window "
-           "chrome";
+    EXPECT_EQ(kRoundedCornersContentsViewMargin +
+                  kRoundedCornersContentsOutlineThickness,
+              insets.right())
+        << "rounded corners: outer-side gap matches main content (margin + "
+           "outline thickness)";
   }
 
   // Disabling rounded corners drops the extra top/inner gap again.

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
@@ -175,14 +175,8 @@ void SidePanel::UpdateBorder() {
   // outer-side gap for visual separation from the window chrome.
   const bool is_sidebar_leading = (IsRightAligned() == base::i18n::IsRTL());
   if (rounded_border_enabled_) {
-    // The window-facing edges (bottom and outer side) must line up with the
-    // main content area. There, the web contents sits at the margin plus the
-    // outline thickness from the window edge: the margin positions the outline
-    // (the contents container's outer edge) and CreateContentsOutlineBorder()
-    // insets the contents a further outline-thickness inside it. This panel
-    // instead applies the inset directly to its contents, so it must add the
-    // outline thickness here too -- otherwise the panel would sit 1px closer to
-    // the window edge than the main content.
+    // Include outline thickness on window-facing edges to align with main
+    // content.
     constexpr int kWindowEdgeMargin = kRoundedCornersContentsViewMargin +
                                       kRoundedCornersContentsOutlineThickness;
 

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
@@ -175,18 +175,29 @@ void SidePanel::UpdateBorder() {
   // outer-side gap for visual separation from the window chrome.
   const bool is_sidebar_leading = (IsRightAligned() == base::i18n::IsRTL());
   if (rounded_border_enabled_) {
+    // The window-facing edges (bottom and outer side) must line up with the
+    // main content area. There, the web contents sits at the margin plus the
+    // outline thickness from the window edge: the margin positions the outline
+    // (the contents container's outer edge) and CreateContentsOutlineBorder()
+    // insets the contents a further outline-thickness inside it. This panel
+    // instead applies the inset directly to its contents, so it must add the
+    // outline thickness here too -- otherwise the panel would sit 1px closer to
+    // the window edge than the main content.
+    constexpr int kWindowEdgeMargin = kRoundedCornersContentsViewMargin +
+                                      kRoundedCornersContentsOutlineThickness;
+
     // Reserve an extra |kRoundedCornersContentsOutlineThickness| on the top and
     // inner-side edges -- where the header/content would otherwise be flush
     // with the panel edge
     // -- so the outline painted below this has room to show on all four
     // sides.
     insets.set_top(insets.top() + kRoundedCornersContentsOutlineThickness);
-    insets.set_bottom(kRoundedCornersContentsViewMargin);
+    insets.set_bottom(kWindowEdgeMargin);
     if (is_sidebar_leading) {
-      insets.set_left(kRoundedCornersContentsViewMargin);
+      insets.set_left(kWindowEdgeMargin);
       insets.set_right(kRoundedCornersContentsOutlineThickness);
     } else {
-      insets.set_right(kRoundedCornersContentsViewMargin);
+      insets.set_right(kWindowEdgeMargin);
       insets.set_left(kRoundedCornersContentsOutlineThickness);
     }
 


### PR DESCRIPTION
## Summary

Fix a 1px misalignment between side panels (AI Chat, bookmarks, reading list, etc.) and the main content area when **Show rounded corners on main content areas** is enabled.

Introduce `kWindowEdgeMargin` (`kRoundedCornersContentsViewMargin` + `kRoundedCornersContentsOutlineThickness`) and apply it to the panel's bottom and window-facing side insets in `SidePanel::UpdateBorder()`.

### Why this is needed

On the main content area, the 4px margin positions the outline and `CreateContentsOutlineBorder()` insets the web contents a further 1px inside it — so web contents sit **5px** from the window edge and the outline sits **4px** from the window edge.

The side panel previously applied only the 4px margin directly as a content inset and painted the outline 1px outward into that margin, so the panel sat **1px closer** to the window edge than the main content.

### What changed

- Bottom and outer-side insets now use `kWindowEdgeMargin` (5px) instead of `kRoundedCornersContentsViewMargin` (4px).
- Top and inner-side insets are unchanged (they abut the toolbar / main contents, not the window edge).
- Added a comment explaining the asymmetry between the main-content and side-panel outline paths.

**File:** `chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc`

## Issue status

| Area | Before | After (this PR) | Notes |
| --- | --- | --- | --- |
| Main content window | 4px outline gap, 3px visible empty space | unchanged | Intended behavior |
| Side panel | 3px outline gap, 2px visible empty space | 4px / 3px — matches main content | **Fixed in this PR** |
| Split view | ~5px bottom gap | unchanged | Follow-up: compensate for the 2px active-pane border inset |

## Problem

### Side panel
<img width="1906" height="1500" alt="image" src="https://github.com/user-attachments/assets/895a7120-e2d5-47d5-a32d-8f1ac07f8ad1" />

### Split view
<img width="3024" height="2266" alt="image" src="https://github.com/user-attachments/assets/c7c6a14c-11dd-412c-a1bc-7c5589358cdf" />

## Fixes

### Side panel
<img width="1654" height="790" alt="image" src="https://github.com/user-attachments/assets/75be35b0-4f20-4d13-b1fd-1b5a087be54d" />


## Test plan

- [ ] Enable **Show rounded corners on main content areas**
- [ ] Open a side panel (AI Chat, bookmarks, or reading list)
- [ ] Confirm the panel's bottom and outer-side gaps match the main content area (outline at 4px, visible empty space at 3px from the window edge)
- [ ] Confirm the panel still lines up vertically with the main contents container
- [ ] Verify RTL: panel on the left side still aligns correctly on the window-facing edge
- [ ] Split view: confirm bottom gap is still larger than main content (known follow-up)

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->