### PR TITLE
[recipes] simulation-test machinery for recipes and modules

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -43,6 +43,9 @@ snapcraft.yaml
 # Ignored minified javascript
 components/brave_wallet/resources/solana_web3_script.js
 
+# Ignore JSON gen tests files for the recipes engine.
+/tools/recipes/**/*.expected/*.json
+
 # Ignore browser/resources sub folders that still need to be formatted
 /browser/resources/settings/
 

--- a/tools/recipes/PRESUBMIT.py
+++ b/tools/recipes/PRESUBMIT.py
@@ -2,18 +2,17 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Presubmit script for changes affecting tools/recipes/
-
-See http://dev.chromium.org/developers/how-tos/depottools/presubmit-scripts
-for more details about the presubmit API built into depot_tools.
-"""
 
 import os
 
 PRESUBMIT_VERSION = '2.0.0'
 
+# Recipe simulation tests that should be run by the recipes engine
+_RECIPE_SIM_TEST_RE = r'recipes_test\.py$'
 
-def CheckTests(input_api, output_api):
+
+def CheckUnitTests(input_api, output_api):
+    """Run the machinery/unit tests (every *_test.py except the sim suite)."""
     script_dir = input_api.PresubmitLocalPath()
     tests = []
     for root, dirs, files in os.walk(script_dir):
@@ -24,5 +23,16 @@ def CheckTests(input_api, output_api):
                     input_api,
                     output_api,
                     root,
-                    files_to_check=[r'.+_test\.py$']))
+                    files_to_check=[r'.+_test\.py$'],
+                    files_to_skip=[_RECIPE_SIM_TEST_RE]))
     return input_api.RunTests(tests)
+
+
+def CheckRecipeSimulationTests(input_api, output_api):
+    """Run the recipe simulation suite on its own, sequentially."""
+    tests = input_api.canned_checks.GetUnitTestsInDirectory(
+        input_api,
+        output_api,
+        input_api.os_path.join(input_api.PresubmitLocalPath(), 'unittests'),
+        files_to_check=[_RECIPE_SIM_TEST_RE])
+    return input_api.RunTests(tests, parallel=False)

--- a/tools/recipes/README.md
+++ b/tools/recipes/README.md
@@ -32,3 +32,74 @@ curl -sL https://raw.githubusercontent.com/brave/brave-core/refs/heads/master/to
     | python3 - toolchains/rust/package_rust \
         --properties '{ "brave_subrevision": 2, "chromium_ref": "151.0.7917.1" }'
 ```
+
+## Testing
+
+Recipes and recipe modules are tested by _simulation_: a recipe declares
+`GenTests(api)` yielding one case per run, the engine runs `RunSteps` with every
+side effect mocked (no subprocess, no real filesystem or environment), and the
+recorded step stream is checked against a committed JSON _expectation_.
+
+```sh
+python3 tools/recipes/engine.py test run      # compare against expectations
+python3 tools/recipes/engine.py test train    # (re)write expectations
+python3 tools/recipes/engine.py test list     # list all test case ids
+python3 tools/recipes/engine.py test run --filter package_rust
+```
+
+Simulation is possible because the seam modules, such as `step`, `path`, `env`,
+`platform`, are the only ones that touch the outside world, and in test mode
+they read/mutate the case's simulated state instead. A recipe or module that
+does I/O must go through them (e.g. `api.path.exists(...)`,
+`api.env.which(...)`) rather than `os`/`pathlib`/`shutil` directly.
+
+A test case is built from fragments merged by `api.test`:
+
+```python
+import post_process
+
+def GenTests(api):
+    yield api.test(
+        'linux',
+        api.chromium_checkout.with_git_cache(),                 # seed preconditions
+        api.brave_core_shallow.deployed('tools/cr/toolchains'),
+        api.properties(brave_subrevision=1, chromium_ref='151.0.7917.1'),
+        api.post_process(post_process.MustRun, 'fetch chromium'),
+        api.post_process(post_process.StatusSuccess),
+    )
+```
+
+Fragment builders live on the root api (`api.test`, `api.properties`,
+`api.step_data`, `api.post_process`) and on each DEPS module's `TEST_API`
+(`api.platform.name('mac')`, `api.path.files(...)`, `api.env.set(...)`, and
+module-specific precondition helpers).
+
+`post_process` checks run against the recorded steps after simulation, each
+registered with `api.post_process(<check>, <args...>)`. A failing check fails
+the test; a check may also filter the written expectation. The available checks:
+
+| Check                 | Arguments             | Passes when                                                             |
+| --------------------- | --------------------- | ----------------------------------------------------------------------- |
+| `MustRun`             | `step_name`           | a step with that exact name ran                                         |
+| `DoesNotRun`          | `step_name`           | no step with that name ran                                              |
+| `MustRunRE`           | `pattern`             | some step name matches the regex                                        |
+| `DoesNotRunRE`        | `pattern`             | no step name matches the regex                                          |
+| `StepCommandContains` | `step_name, args`     | the step ran and its command contains `args` as an in-order subsequence |
+| `StepCommandRE`       | `step_name, patterns` | the step ran and `patterns[i]` matches `cmd[i]` for each `i`            |
+| `StepSuccess`         | `step_name`           | the step ran with retcode `0`                                           |
+| `StepFailure`         | `step_name`           | the step ran with a non-zero retcode                                    |
+| `StatusSuccess`       | _(none)_              | the overall run status is `SUCCESS`                                     |
+| `StatusFailure`       | _(none)_              | the overall run status is `FAILURE` (a checked step failed)             |
+| `StatusException`     | _(none)_              | the overall run status is `EXCEPTION` (the recipe raised)               |
+| `DropExpectation`     | _(none)_              | always; suppresses writing this test's expectation file                 |
+
+`DropExpectation` is filter-only (it writes/keeps no golden), and should be
+considered for cases where there are too many permutations.
+
+Modules are tested via small example recipes under
+`recipe_modules/<module>/examples/`, run through this same machinery.
+Expectation files sit next to each recipe in a `<recipe>.expected/` directory
+and are committed. The `unittests/` suite
+(`python3 -m unittest discover -s tools/recipes/unittests -p '*_test.py'`)
+covers the machinery itself and, via `recipes_test.py`, fails presubmit if any
+expectation is stale.

--- a/tools/recipes/engine.py
+++ b/tools/recipes/engine.py
@@ -10,12 +10,12 @@ detection), instantiates each recipe module's `RecipeApi`, wires dependencies
 onto each module's `.m` injection site, and finally calls the recipe's
 `RunSteps(api, properties)`.
 
-This is intentionally minimal -- a starting point modelled on chrome-infra's
-recipes_py that we will grow incrementally. Notable simplifications vs upstream:
+This is intentionally minimal for now as a starting point modelled on
+chrome-infra's recipes_py that we will grow incrementally. Notable
+simplifications vs upstream:
 
   * Single repo only; module names are bare directory names under
     `recipe_modules/` (no `repo/module` qualification).
-  * No TEST_API / GenTests, no expectations, no warnings framework.
   * Properties are a plain object, not a protobuf message.
 
 Run a recipe directly (recipe names are `/`-separated paths under recipes/).
@@ -88,11 +88,21 @@ class _Engine:
 
     def __init__(self,
                  workspace: str | Path | None = None,
-                 brave_core_ref: str = 'master') -> None:
+                 brave_core_ref: str = 'master',
+                 test: object | None = None) -> None:
         _ensure_on_sys_path()
+        # Simulation context, or None in production. When set, the engine runs
+        # in test mode: it seeds this onto every module (so the seam modules
+        # simulate I/O) and does not touch the real cwd.
+        self._test = test
         # Root directory the job runs in. Recipe paths (chromium/src, out, ...)
-        # are derived from it by the `path` module. Defaults to the cwd.
-        if workspace:
+        # are derived from it by the `path` module.
+        if self._test is not None:
+            # Fixed synthetic workspace so module-derived paths are
+            # deterministic; never chdir'd into (nothing runs on disk).
+            from simulation import SIM_WORKSPACE
+            self._workspace = Path(str(SIM_WORKSPACE))
+        elif workspace:
             self._workspace = Path(workspace).expanduser().resolve()
             # Run from the workspace so every subprocess the recipes launch
             # inherits it as their cwd.
@@ -129,6 +139,12 @@ class _Engine:
         # A module can reach itself via `self.m.<own_name>`, as in recipes_py.
         setattr(inst.m, name, inst)
 
+        # Seed the simulation context (test mode only) after DEPS are wired but
+        # before initialise(), so a module's initialise() can already use the
+        # seam modules (e.g. depot_tools reading api.platform.is_win).
+        if self._test is not None:
+            setattr(inst, '_test', self._test)
+
         inst.initialise()
         self._cache[name] = inst
         return inst
@@ -136,12 +152,19 @@ class _Engine:
     def run_recipe(self,
                    recipe_name: str,
                    properties: dict[str, object] | None = None) -> object:
-        # Recipe names are `/`-separated paths under recipes/ (e.g.
-        # `toolchains/rust/package_rust`), mirroring recipes_py; map them to the
-        # dotted module path importlib expects.
-        module_path = recipe_name.replace('/', '.')
-        recipe = importlib.import_module(f'{RECIPES_PKG}.{module_path}')
+        return self.run_loaded_recipe(_import_recipe(recipe_name), recipe_name,
+                                      properties)
 
+    def run_loaded_recipe(
+            self,
+            recipe: types.ModuleType,
+            recipe_name: str,
+            properties: dict[str, object] | None = None) -> object:
+        """Run an already-imported *recipe* module's `RunSteps`.
+
+        Splits the import from the run so the test runner can import a recipe
+        once (from either `recipes/` or a module's `examples/`) and drive it.
+        """
         api = RecipeScriptApi()
         for dep_name in getattr(recipe, 'DEPS', []):
             setattr(api, dep_name, self._instantiate_module(dep_name, []))
@@ -150,13 +173,41 @@ class _Engine:
         if run_steps is None:
             raise RuntimeError(f"recipe '{recipe_name}' is missing RunSteps")
 
+        # In test mode, source `from_environ` properties from the simulated
+        # environment so expectations don't depend on the host's env vars.
+        environ = self._test.env if self._test is not None else os.environ
         props_obj = _build_properties(getattr(recipe, 'PROPERTIES', None),
-                                      properties or {})
+                                      properties or {}, environ)
         return run_steps(api, props_obj)
 
 
+def _module_names() -> set[str]:
+    """Names of the recipe modules under `recipe_modules/`."""
+    modules_dir = RECIPES_ROOT / MODULES_PKG
+    return {
+        entry.name
+        for entry in modules_dir.iterdir()
+        if entry.is_dir() and (entry / '__init__.py').exists()
+    }
+
+
+def _import_recipe(recipe_name: str) -> types.ModuleType:
+    """Import a recipe by its `/`-separated id.
+
+    Ids whose first segment is a recipe module (e.g. `step/examples/full`) load
+    from `recipe_modules/`; all others load from `recipes/` (e.g.
+    `toolchains/rust/package_rust`).
+    """
+    _ensure_on_sys_path()
+    module_path = recipe_name.replace('/', '.')
+    first = recipe_name.split('/', 1)[0]
+    pkg = MODULES_PKG if first in _module_names() else RECIPES_PKG
+    return importlib.import_module(f'{pkg}.{module_path}')
+
+
 def _build_properties(properties_def: type | None,
-                      properties: dict[str, object]) -> object:
+                      properties: dict[str, object],
+                      environ: object | None = None) -> object:
     """Build the properties object passed as `RunSteps`' second argument.
 
     If the recipe declares `PROPERTIES` (any callable, e.g. a dataclass), it is
@@ -166,7 +217,8 @@ def _build_properties(properties_def: type | None,
     """
     if properties_def is None:
         return types.SimpleNamespace(**properties)
-    values = apply_environ(properties_def, properties, os.environ)
+    values = apply_environ(properties_def, properties,
+                           os.environ if environ is None else environ)
     return properties_def(**values)
 
 
@@ -180,6 +232,16 @@ def run_recipe(recipe_name: str,
 
 
 def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else list(argv)
+    # `engine.py test run|train|list [...]` dispatches to the simulation-test
+    # runner; everything else runs a recipe (the original CLI, unchanged).
+    if argv and argv[0] == 'test':
+        # Imported via importlib (not a plain `import`) so there is no static
+        # engine -> recipe_test_runner import edge: the runner imports engine,
+        # and this keeps that dependency one-directional (no import cycle).
+        runner = importlib.import_module('recipe_test_runner')
+        return runner.main(argv[1:])
+
     parser = argparse.ArgumentParser(description='Run a Brave recipe.')
     parser.add_argument(
         'recipe',

--- a/tools/recipes/post_process.py
+++ b/tools/recipes/post_process.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Post-process checks for recipe simulation tests.
+
+A minimal mirror of `recipe_engine.post_process`. A recipe's `GenTests` attaches
+checks with `api.post_process(func, *args)`; after simulation the test runner
+calls each `func(check, steps, *args)`, where:
+
+  * `check` is a `Checker`. Call it as `check(cond)` or `check(hint, cond)`.
+    Failures are collected (not raised), so every check in a hook runs.
+  * `steps` is an ordered `dict` mapping step name -> step dict
+    (`{'name', 'cmd', 'cwd'?, 'env'?, 'retcode'}`), plus the terminal
+    `'$result'` entry (`{'name': '$result', 'status': ...}`).
+
+A check function returns `None` to only assert, or a (subset) `dict` to *filter*
+the recorded steps for the written expectation. Returning an empty dict drops
+the expectation file entirely (see `DropExpectation`).
+
+Simplifications vs upstream: no AST-introspected failure rendering (checks carry
+a caller-supplied hint), and the returned-dict filter is used verbatim rather
+than subset-verified.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# The '$result' pseudo-step name holding the overall run status.
+RESULT_STEP = '$result'
+
+# A step dict, or the $result dict.
+Step = dict
+Steps = dict  # OrderedDict-like {name: Step}
+
+# Sentinel distinguishing `check(cond)` from `check(hint, cond)`.
+_MISSING = object()
+
+
+class Checker:
+    """Collects check failures for a single post-process hook.
+
+    Calling the checker records (but does not raise) failures, so a hook reports
+    every failed assertion in one pass. `failures` is a list of human-readable
+    strings, each prefixed with the `api.post_process(...)` call site.
+    """
+
+    def __init__(self, context: str) -> None:
+        self._context = context
+        self.failures: list[str] = []
+
+    def __call__(self, arg1: Any, arg2: Any = _MISSING) -> bool:
+        """`check(cond)` or `check(hint, cond)`; returns `bool(cond)`."""
+        if arg2 is _MISSING:
+            hint, cond = None, arg1
+        else:
+            hint, cond = arg1, arg2
+        if not cond:
+            message = f'{self._context}: check failed'
+            if hint:
+                message += f': {hint}'
+            self.failures.append(message)
+        return bool(cond)
+
+
+def _run_steps(steps: Steps) -> Steps:
+    """Return only the executed steps (drops the `$result` pseudo-step)."""
+    return {name: step for name, step in steps.items() if name != RESULT_STEP}
+
+
+# -- Presence -----------------------------------------------------------------
+
+
+def MustRun(check: Checker, steps: Steps, step_name: str) -> None:
+    check(f'step {step_name!r} must run', step_name in _run_steps(steps))
+
+
+def DoesNotRun(check: Checker, steps: Steps, step_name: str) -> None:
+    check(f'step {step_name!r} must not run', step_name
+          not in _run_steps(steps))
+
+
+def MustRunRE(check: Checker, steps: Steps, pattern: str) -> None:
+    regex = re.compile(pattern)
+    check(f'a step matching {pattern!r} must run',
+          any(regex.search(name) for name in _run_steps(steps)))
+
+
+def DoesNotRunRE(check: Checker, steps: Steps, pattern: str) -> None:
+    regex = re.compile(pattern)
+    check(f'no step may match {pattern!r}',
+          not any(regex.search(name) for name in _run_steps(steps)))
+
+
+# -- Command inspection -------------------------------------------------------
+
+
+def _is_subsequence(sub: list, seq: list) -> bool:
+    """Whether *sub* appears in *seq* in order (not always contiguously)."""
+    it = iter(seq)
+    return all(item in it for item in sub)
+
+
+def StepCommandContains(check: Checker, steps: Steps, step_name: str,
+                        args: list[str]) -> None:
+    step = _run_steps(steps).get(step_name)
+    if not check(f'step {step_name!r} must run', step is not None):
+        return
+    check(f'{step_name!r} command must contain {args!r} in order',
+          _is_subsequence([str(a) for a in args], step['cmd']))
+
+
+def StepCommandRE(check: Checker, steps: Steps, step_name: str,
+                  patterns: list[str]) -> None:
+    step = _run_steps(steps).get(step_name)
+    if not check(f'step {step_name!r} must run', step is not None):
+        return
+    cmd = step['cmd']
+    for i, pattern in enumerate(patterns):
+        matched = i < len(cmd) and re.search(pattern, cmd[i]) is not None
+        check(f'{step_name!r} cmd[{i}] must match {pattern!r}', matched)
+
+
+# -- Per-step status ----------------------------------------------------------
+
+
+def StepSuccess(check: Checker, steps: Steps, step_name: str) -> None:
+    step = _run_steps(steps).get(step_name)
+    if not check(f'step {step_name!r} must run', step is not None):
+        return
+    check(f'step {step_name!r} must succeed', step.get('retcode', 0) == 0)
+
+
+def StepFailure(check: Checker, steps: Steps, step_name: str) -> None:
+    step = _run_steps(steps).get(step_name)
+    if not check(f'step {step_name!r} must run', step is not None):
+        return
+    check(f'step {step_name!r} must fail', step.get('retcode', 0) != 0)
+
+
+# -- Overall result -----------------------------------------------------------
+
+
+def _status(steps: Steps) -> str | None:
+    result = steps.get(RESULT_STEP)
+    return result.get('status') if result else None
+
+
+def StatusSuccess(check: Checker, steps: Steps) -> None:
+    check(f'overall status must be SUCCESS (was {_status(steps)})',
+          _status(steps) == 'SUCCESS')
+
+
+def StatusFailure(check: Checker, steps: Steps) -> None:
+    check(f'overall status must be FAILURE (was {_status(steps)})',
+          _status(steps) == 'FAILURE')
+
+
+def StatusException(check: Checker, steps: Steps) -> None:
+    check(f'overall status must be EXCEPTION (was {_status(steps)})',
+          _status(steps) == 'EXCEPTION')
+
+
+# -- Expectation control ------------------------------------------------------
+
+
+def DropExpectation(_check: Checker, _steps: Steps) -> Steps:
+    """Suppress writing this test's expectation file.
+
+    Returning an empty mapping signals the runner to write (and, in train mode,
+    remove any stale) expectation file. Handy for tests that assert only via
+    other post-process checks and don't need a golden file.
+    """
+    return {}

--- a/tools/recipes/recipe_api.py
+++ b/tools/recipes/recipe_api.py
@@ -7,8 +7,8 @@
 Deliberately tiny mirror of `recipe_engine.recipe_api.RecipeApi` from
 chrome-infra's recipes_py. Every recipe module exposes exactly one `RecipeApi`
 subclass (in its `api.py`). After constructing it, the engine attaches the
-module's resolved `DEPS` onto `self.m` -- the "module injection site" -- so a
-module reaches each dependency as `self.m.<dep_name>` (and itself as
+module's resolved `DEPS` onto `self.m`, which is the "module injection site",
+so a module reaches each dependency as `self.m.<dep_name>` (and itself as
 `self.m.<own_name>`).
 """
 
@@ -46,6 +46,11 @@ class RecipeApi:
         # brave-core ref the checkout modules clone, seeded by the engine.
         # `brave_core_shallow` uses it; defaults to `master` until overridden.
         self._brave_core_ref: str = 'master'
+        # Simulation context, seeded by the engine only in test mode. `None`
+        # means production: the seam modules (`path`, `env`, `platform`, `step`)
+        # touch the real machine. When set, they read/mutate this instead. Its
+        # presence (`self._test is not None`) is the sole test-mode flag.
+        self._test = None
 
     def initialise(self) -> None:
         """Hook run once after DEPS are injected. Override for setup."""

--- a/tools/recipes/recipe_modules/brave_core_shallow/api.py
+++ b/tools/recipes/recipe_modules/brave_core_shallow/api.py
@@ -87,9 +87,9 @@ class BraveCoreShallowApi(RecipeApi):
         # Fall back to the engine-provided ref when the caller doesn't specify.
         ref = ref if ref is not None else self._brave_core_ref
 
-        dest = Path(dest).expanduser().resolve()
+        dest = self.m.path.abs(dest)
 
-        if (dest / '.git').is_dir():
+        if self.m.path.is_dir(dest / '.git'):
             # Reuse the existing checkout, but bring it to *ref* -- it may have
             # been cloned (here or by a prior run) at a different ref that lacks
             # the requested paths, so fetch and hard-checkout rather than trust
@@ -106,7 +106,7 @@ class BraveCoreShallowApi(RecipeApi):
                 ['git', '-C',
                  str(dest), 'checkout', '--force', 'FETCH_HEAD'])
         else:
-            dest.parent.mkdir(parents=True, exist_ok=True)
+            self.m.path.mkdir(dest.parent)
             clone_cmd = [
                 'git', 'clone', '--depth',
                 str(depth), '--filter=blob:none', '--sparse', '--branch', ref,
@@ -124,7 +124,7 @@ class BraveCoreShallowApi(RecipeApi):
              str(dest), 'sparse-checkout', 'add', *rel_paths])
 
         for rel in rel_paths:
-            if not (dest / rel).exists():
+            if not self.m.path.exists(dest / rel):
                 raise RuntimeError(
                     f'brave-core path not found after sparse checkout: {rel!r} '
                     f'(looked under {dest})')

--- a/tools/recipes/recipe_modules/brave_core_shallow/examples/__init__.py
+++ b/tools/recipes/recipe_modules/brave_core_shallow/examples/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipes exercising the `brave_core_shallow` module."""

--- a/tools/recipes/recipe_modules/brave_core_shallow/examples/full.expected/clone.json
+++ b/tools/recipes/recipe_modules/brave_core_shallow/examples/full.expected/clone.json
@@ -1,0 +1,32 @@
+[
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "2",
+      "--filter=blob:none",
+      "--sparse",
+      "--branch",
+      "master",
+      "git@github.com:brave/brave-core.git",
+      "[WORKSPACE]/chromium/src/brave"
+    ],
+    "name": "clone brave-core (shallow, sparse)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "sparse-checkout",
+      "add",
+      "third_party/node"
+    ],
+    "name": "sparse-checkout add"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipe_modules/brave_core_shallow/examples/full.expected/reuse.json
+++ b/tools/recipes/recipe_modules/brave_core_shallow/examples/full.expected/reuse.json
@@ -1,0 +1,41 @@
+[
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "fetch",
+      "--depth",
+      "2",
+      "origin",
+      "master"
+    ],
+    "name": "fetch brave-core ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "checkout",
+      "--force",
+      "FETCH_HEAD"
+    ],
+    "name": "checkout brave-core ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "sparse-checkout",
+      "add",
+      "third_party/node"
+    ],
+    "name": "sparse-checkout add"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipe_modules/brave_core_shallow/examples/full.py
+++ b/tools/recipes/recipe_modules/brave_core_shallow/examples/full.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipe exercising the `brave_core_shallow` module."""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['brave_core_shallow', 'path', 'step']
+
+
+def RunSteps(api, _properties):
+    api.brave_core_shallow.deploy('third_party/node')
+
+
+def GenTests(api):
+    # Fresh clone: `.git` absent, so it clones and sparse-checks-out; the
+    # requested path is seeded so the post-checkout existence check passes.
+    yield api.test(
+        'clone',
+        api.path.files('chromium/src/brave/third_party/node'),
+        api.post_process(post_process.MustRun,
+                         'clone brave-core (shallow, sparse)'),
+        api.post_process(post_process.MustRun, 'sparse-checkout add'),
+        api.post_process(post_process.StatusSuccess),
+    )
+    # Existing checkout: `.git` present, so it fetches/checks-out the ref
+    # instead of cloning.
+    yield api.test(
+        'reuse',
+        api.path.dirs('chromium/src/brave/.git'),
+        api.path.files('chromium/src/brave/third_party/node'),
+        api.post_process(post_process.MustRun, 'fetch brave-core ref'),
+        api.post_process(post_process.MustRun, 'checkout brave-core ref'),
+        api.post_process(post_process.DoesNotRun,
+                         'clone brave-core (shallow, sparse)'),
+        api.post_process(post_process.StatusSuccess),
+    )
+    # Requested path missing after checkout -> the module raises.
+    yield api.test(
+        'missing path',
+        api.post_process(post_process.StatusException),
+        api.post_process(post_process.DropExpectation),
+        status='EXCEPTION',
+    )

--- a/tools/recipes/recipe_modules/brave_core_shallow/test_api.py
+++ b/tools/recipes/recipe_modules/brave_core_shallow/test_api.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Test API for `brave_core_shallow`: set up its checkout preconditions.
+
+Exposes the module's simulated preconditions as helpers so a *recipe* that
+merely depends on `brave_core_shallow` can arrange them without itself depending
+on `path`, mirroring how recipes_py modules provide their own test seams.
+"""
+
+from __future__ import annotations
+
+from recipe_test_api import RecipeTestApi, TestData
+
+# Where the module checks brave-core out (matches `api.path.brave_core`).
+_BRAVE_CORE = 'chromium/src/brave'
+
+
+class BraveCoreShallowTestApi(RecipeTestApi):
+    """Seed the simulated state `brave_core_shallow.deploy` inspects."""
+
+    def deployed(self, *paths: str) -> TestData:
+        """Mark repo-relative *paths* present after the sparse checkout.
+
+        `deploy` verifies each requested path exists once checked out; seed them
+        so a happy-path test passes (omit to exercise the missing-path error).
+        """
+        return self.m.path.files(*[f'{_BRAVE_CORE}/{p}' for p in paths])
+
+    def existing_checkout(self) -> TestData:
+        """Simulate an existing checkout (a `.git` dir), so it fetches, not
+        clones."""
+        return self.m.path.dirs(f'{_BRAVE_CORE}/.git')

--- a/tools/recipes/recipe_modules/chromium_checkout/__init__.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/__init__.py
@@ -4,4 +4,4 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """`chromium_checkout` module: clone / sync / validate a Chromium src/ tree."""
 
-DEPS = ['path', 'step', 'depot_tools']
+DEPS = ['path', 'step', 'depot_tools', 'env', 'platform']

--- a/tools/recipes/recipe_modules/chromium_checkout/api.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/api.py
@@ -7,11 +7,9 @@
 from __future__ import annotations
 
 import logging
-import os
 from pathlib import Path
 import re
 import subprocess
-import sys
 
 from recipe_api import RecipeApi
 
@@ -56,7 +54,7 @@ class ChromiumCheckoutApi(RecipeApi):
         """
         if chromium_src is None:
             chromium_src = self.m.path.chromium_src
-        chromium_src = Path(chromium_src).expanduser().resolve()
+        chromium_src = self.m.path.abs(chromium_src)
 
         if git_cache is not None:
             self.set_git_cache(git_cache or None)
@@ -91,13 +89,13 @@ class ChromiumCheckoutApi(RecipeApi):
             RuntimeError: If `GIT_CACHE_PATH` is unset or not a directory. Set
                 it in the environment or via `set_git_cache()` beforehand.
         """
-        git_cache_path = os.environ.get('GIT_CACHE_PATH')
+        git_cache_path = self.m.env.get('GIT_CACHE_PATH')
         if not git_cache_path:
             raise RuntimeError(
                 'GIT_CACHE_PATH is not set; a shared git cache is required. '
                 'Set it in the environment or via set_git_cache() before '
                 'running the checkout.')
-        if not Path(git_cache_path).is_dir():
+        if not self.m.path.is_dir(git_cache_path):
             raise RuntimeError(
                 f'GIT_CACHE_PATH is not a valid directory: {git_cache_path}')
         logging.info('Using GIT_CACHE_PATH=%s', git_cache_path)
@@ -123,22 +121,22 @@ class ChromiumCheckoutApi(RecipeApi):
             RuntimeError: If `GIT_CACHE_PATH` is already set, or the resolved
                 directory does not exist.
         """
-        if 'GIT_CACHE_PATH' in os.environ:
+        if 'GIT_CACHE_PATH' in self.m.env:
             raise RuntimeError('GIT_CACHE_PATH is already set in the '
                                'environment.')
 
         if path:
-            git_cache_path = Path(path).expanduser()
+            git_cache_path = self.m.path.abs(path)
         else:
-            home_var = 'USERPROFILE' if sys.platform == 'win32' else 'HOME'
-            home = os.environ.get(home_var, str(Path.home()))
+            home_var = 'USERPROFILE' if self.m.platform.is_win else 'HOME'
+            home = self.m.env.get(home_var) or self.m.path.home()
             git_cache_path = Path(home) / 'cache'
 
-        if not git_cache_path.is_dir():
+        if not self.m.path.is_dir(git_cache_path):
             raise RuntimeError(
                 f'GIT_CACHE_PATH is not a valid directory: {git_cache_path}')
 
-        os.environ['GIT_CACHE_PATH'] = str(git_cache_path)
+        self.m.env.set('GIT_CACHE_PATH', str(git_cache_path))
         logging.info('Set GIT_CACHE_PATH=%s', git_cache_path)
         return git_cache_path
 
@@ -146,7 +144,7 @@ class ChromiumCheckoutApi(RecipeApi):
         """Return whether *chromium_src* points to a valid Chromium repo."""
         chromium_src = Path(chromium_src)
         # `chrome/VERSION` is an unmistakable trait of a proper checkout.
-        if not (chromium_src / CHROME_VERSION_FILE).exists():
+        if not self.m.path.exists(chromium_src / CHROME_VERSION_FILE):
             return False
 
         logging.info('Checking for valid Chromium repo at %s', chromium_src)
@@ -163,7 +161,7 @@ class ChromiumCheckoutApi(RecipeApi):
     def clone(self, chromium_src: str | Path) -> None:
         """Clone a fresh Chromium checkout at *chromium_src* via `fetch`."""
         chromium_src = Path(chromium_src)
-        chromium_src.parent.mkdir(parents=True, exist_ok=True)
+        self.m.path.mkdir(chromium_src.parent)
         self.m.step('fetch chromium', ['fetch', '--nohooks', 'chromium'],
                     cwd=chromium_src.parent)
 
@@ -171,11 +169,11 @@ class ChromiumCheckoutApi(RecipeApi):
         """Check out *ref* in *chromium_src* and resync dependencies."""
         chromium_src = Path(chromium_src)
         logging.info('Checking out Chromium ref %s', ref)
-        if (sys.platform == 'win32'
-                and 'DEPOT_TOOLS_WIN_TOOLCHAIN' not in os.environ):
+        if (self.m.platform.is_win
+                and 'DEPOT_TOOLS_WIN_TOOLCHAIN' not in self.m.env):
             # Build hermetically without a local VS install.
-            os.environ['DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL'] = (
-                WIN_HERMETIC_TOOLCHAIN_BASE_URL)
+            self.m.env.set('DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL',
+                           WIN_HERMETIC_TOOLCHAIN_BASE_URL)
 
         if re.fullmatch(r'\d+\.\d+\.\d+\.\d+', ref):
             # Chromium release tag (e.g. `150.0.7850.1`): fetch it as a tag so

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/__init__.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipes exercising the `chromium_checkout` module."""

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/existing_branch.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/existing_branch.json
@@ -1,0 +1,64 @@
+[
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "1",
+      "https://chromium.googlesource.com/chromium/tools/depot_tools",
+      "[WORKSPACE]/chromium/third_party/depot_tools"
+    ],
+    "name": "clone depot_tools"
+  },
+  {
+    "cmd": [
+      "gclient"
+    ],
+    "name": "verify gclient"
+  },
+  {
+    "cmd": [
+      "git",
+      "log",
+      "-1",
+      "--oneline",
+      "chrome/VERSION"
+    ],
+    "cwd": "[WORKSPACE]/chromium/src",
+    "name": "check chrome/VERSION"
+  },
+  {
+    "cmd": [
+      "git",
+      "fetch",
+      "origin",
+      "main"
+    ],
+    "cwd": "[WORKSPACE]/chromium/src",
+    "name": "fetch ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "checkout",
+      "--force",
+      "FETCH_HEAD"
+    ],
+    "cwd": "[WORKSPACE]/chromium/src",
+    "name": "checkout FETCH_HEAD"
+  },
+  {
+    "cmd": [
+      "gclient",
+      "sync",
+      "--force",
+      "-D"
+    ],
+    "cwd": "[WORKSPACE]/chromium/src",
+    "name": "gclient sync"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/fresh_tag.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/fresh_tag.json
@@ -1,0 +1,63 @@
+[
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "1",
+      "https://chromium.googlesource.com/chromium/tools/depot_tools",
+      "[WORKSPACE]/chromium/third_party/depot_tools"
+    ],
+    "name": "clone depot_tools"
+  },
+  {
+    "cmd": [
+      "gclient"
+    ],
+    "name": "verify gclient"
+  },
+  {
+    "cmd": [
+      "fetch",
+      "--nohooks",
+      "chromium"
+    ],
+    "cwd": "[WORKSPACE]/chromium",
+    "name": "fetch chromium"
+  },
+  {
+    "cmd": [
+      "git",
+      "fetch",
+      "--no-tags",
+      "origin",
+      "refs/tags/151.0.7917.1:refs/tags/151.0.7917.1"
+    ],
+    "cwd": "[WORKSPACE]/chromium/src",
+    "name": "fetch tag"
+  },
+  {
+    "cmd": [
+      "git",
+      "checkout",
+      "--force",
+      "FETCH_HEAD"
+    ],
+    "cwd": "[WORKSPACE]/chromium/src",
+    "name": "checkout FETCH_HEAD"
+  },
+  {
+    "cmd": [
+      "gclient",
+      "sync",
+      "--force",
+      "-D"
+    ],
+    "cwd": "[WORKSPACE]/chromium/src",
+    "name": "gclient sync"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipe exercising the `chromium_checkout` module."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import post_process
+
+DEPS = ['chromium_checkout']
+
+
+@dataclass(frozen=True)
+class InputProperties:
+    chromium_ref: str = 'main'
+
+
+PROPERTIES = InputProperties
+
+
+def RunSteps(api, properties):
+    api.chromium_checkout.ensure_checkout(ref=properties.chromium_ref)
+
+
+def GenTests(api):
+    # No existing checkout -> clone, then check out a release tag.
+    yield api.test(
+        'fresh tag',
+        api.chromium_checkout.with_git_cache(),
+        api.properties(chromium_ref='151.0.7917.1'),
+        api.post_process(post_process.MustRun, 'fetch chromium'),
+        api.post_process(post_process.MustRun, 'fetch tag'),
+        api.post_process(post_process.MustRun, 'gclient sync'),
+        api.post_process(post_process.StatusSuccess),
+    )
+    # Existing checkout (chrome/VERSION present) + a branch ref -> no clone,
+    # `fetch ref` rather than `fetch tag`.
+    yield api.test(
+        'existing branch',
+        api.chromium_checkout.with_git_cache(),
+        api.chromium_checkout.existing_checkout(),
+        api.properties(chromium_ref='main'),
+        api.post_process(post_process.MustRun, 'check chrome/VERSION'),
+        api.post_process(post_process.DoesNotRun, 'fetch chromium'),
+        api.post_process(post_process.MustRun, 'fetch ref'),
+        api.post_process(post_process.StatusSuccess),
+    )
+    # No git cache configured -> validate_git_cache raises.
+    yield api.test(
+        'missing git cache',
+        api.properties(chromium_ref='main'),
+        api.post_process(post_process.StatusException),
+        api.post_process(post_process.DropExpectation),
+        status='EXCEPTION',
+    )

--- a/tools/recipes/recipe_modules/chromium_checkout/test_api.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/test_api.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Test API for `chromium_checkout`: set up its checkout preconditions.
+
+`ensure_checkout` requires a valid `GIT_CACHE_PATH` and probes for an existing
+checkout; these helpers seed those (via the `env`/`path` seams this module
+depends on) so a recipe depending on `chromium_checkout` can arrange them
+without depending on `env`/`path` directly.
+"""
+
+from __future__ import annotations
+
+from recipe_test_api import RecipeTestApi, TestData
+
+# Default simulated git cache directory.
+_GIT_CACHE = '/b/cache'
+
+
+class ChromiumCheckoutTestApi(RecipeTestApi):
+    """Seed the simulated state `chromium_checkout.ensure_checkout` requires."""
+
+    def with_git_cache(self, path: str = _GIT_CACHE) -> TestData:
+        """Set `GIT_CACHE_PATH` and mark it a real directory (required)."""
+        return self.m.env.set('GIT_CACHE_PATH', path) + self.m.path.dirs(path)
+
+    def existing_checkout(self) -> TestData:
+        """Simulate a valid existing checkout (`chrome/VERSION` present)."""
+        return self.m.path.files('chromium/src/chrome/VERSION')

--- a/tools/recipes/recipe_modules/depot_tools/__init__.py
+++ b/tools/recipes/recipe_modules/depot_tools/__init__.py
@@ -4,4 +4,4 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """`depot_tools` module: ensure a usable depot_tools install is on PATH."""
 
-DEPS = ['path', 'step']
+DEPS = ['path', 'step', 'env', 'platform']

--- a/tools/recipes/recipe_modules/depot_tools/api.py
+++ b/tools/recipes/recipe_modules/depot_tools/api.py
@@ -7,18 +7,12 @@
 from __future__ import annotations
 
 import logging
-import os
 from pathlib import Path
-import shutil
-import sys
 
 from recipe_api import RecipeApi
 
 # the urls we clone from
 DEPOT_TOOLS_URL = 'https://chromium.googlesource.com/chromium/tools/depot_tools'
-
-# vpython3 entry point.
-VPYTHON3 = 'vpython3.bat' if sys.platform == 'win32' else 'vpython3'
 
 # the relative path for depot_tools in the chromium checkout.
 DEPOT_TOOLS_PATH = Path('third_party') / 'depot_tools'
@@ -35,6 +29,14 @@ class DepotToolsApi(RecipeApi):
         # Resolved path to depot_tools, or None if no `depot_tools` has been
         # deployed yet.
         self._depot_tools_path: Path | None = None
+        # vpython3 entry point; resolved from the platform in initialise().
+        self._vpython3 = 'vpython3'
+
+    def initialise(self) -> None:
+        # `.bat` on Windows; resolved via the platform seam so a test can
+        # simulate either host (and so this isn't fixed at import time).
+        self._vpython3 = ('vpython3.bat'
+                          if self.m.platform.is_win else 'vpython3')
 
     def ensure_on_path(self) -> None:
         """Deploy depot_tools and put it on PATH. Successive calls are no-ops.
@@ -42,31 +44,31 @@ class DepotToolsApi(RecipeApi):
         if self._depot_tools_path is not None:
             return  # Already deployed this run.
 
-        if shutil.which('gclient') is not None:
+        resolved = self.m.env.which('gclient')
+        if resolved is not None:
             logging.debug('depot_tools already on PATH, skipping clone')
             # Using whatever depot_tools is already on PATH.
-            self._depot_tools_path = Path(shutil.which('gclient')).parent
+            self._depot_tools_path = Path(resolved).parent
             return
 
         # Checking for a standalone depot_tools under what would be a supposed
         # Chromium checkout.
-        depot_tools_path = (self.m.path.chromium_src.parent /
-                            DEPOT_TOOLS_PATH).resolve()
-        if (depot_tools_path / 'gclient').is_file():
+        depot_tools_path = self.m.path.abs(self.m.path.chromium_src.parent /
+                                           DEPOT_TOOLS_PATH)
+        if self.m.path.is_file(depot_tools_path / 'gclient'):
             # If Chromium has already been deployed, we just use whatever
             # is in place.
             logging.info('depot_tools already present at %s, adding to PATH.',
                          depot_tools_path)
         else:
             logging.info('Installing depot_tools under %s', depot_tools_path)
-            depot_tools_path.parent.mkdir(parents=True, exist_ok=True)
+            self.m.path.mkdir(depot_tools_path.parent)
             self.m.step('clone depot_tools', [
                 'git', 'clone', '--depth', '1', DEPOT_TOOLS_URL,
                 str(depot_tools_path)
             ])
 
-        os.environ['PATH'] = os.pathsep.join(
-            [str(depot_tools_path), os.environ['PATH']])
+        self.m.env.prepend_path(depot_tools_path)
         # Run once so depot_tools bootstraps itself (downloads its own deps).
         self.m.step('verify gclient', ['gclient'])
         self._depot_tools_path = depot_tools_path
@@ -82,4 +84,4 @@ class DepotToolsApi(RecipeApi):
         """
         self.ensure_on_path()
         assert self._depot_tools_path is not None
-        return self._depot_tools_path / VPYTHON3
+        return self._depot_tools_path / self._vpython3

--- a/tools/recipes/recipe_modules/depot_tools/examples/__init__.py
+++ b/tools/recipes/recipe_modules/depot_tools/examples/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipes exercising the `depot_tools` module."""

--- a/tools/recipes/recipe_modules/depot_tools/examples/full.expected/already_on_path.json
+++ b/tools/recipes/recipe_modules/depot_tools/examples/full.expected/already_on_path.json
@@ -1,0 +1,13 @@
+[
+  {
+    "cmd": [
+      "/existing/depot_tools/vpython3",
+      "--version"
+    ],
+    "name": "use vpython3"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipe_modules/depot_tools/examples/full.expected/clone.json
+++ b/tools/recipes/recipe_modules/depot_tools/examples/full.expected/clone.json
@@ -1,0 +1,30 @@
+[
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "1",
+      "https://chromium.googlesource.com/chromium/tools/depot_tools",
+      "[WORKSPACE]/chromium/third_party/depot_tools"
+    ],
+    "name": "clone depot_tools"
+  },
+  {
+    "cmd": [
+      "gclient"
+    ],
+    "name": "verify gclient"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/chromium/third_party/depot_tools/vpython3",
+      "--version"
+    ],
+    "name": "use vpython3"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipe_modules/depot_tools/examples/full.expected/windows.json
+++ b/tools/recipes/recipe_modules/depot_tools/examples/full.expected/windows.json
@@ -1,0 +1,30 @@
+[
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "1",
+      "https://chromium.googlesource.com/chromium/tools/depot_tools",
+      "[WORKSPACE]/chromium/third_party/depot_tools"
+    ],
+    "name": "clone depot_tools"
+  },
+  {
+    "cmd": [
+      "gclient"
+    ],
+    "name": "verify gclient"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/chromium/third_party/depot_tools/vpython3.bat",
+      "--version"
+    ],
+    "name": "use vpython3"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipe_modules/depot_tools/examples/full.py
+++ b/tools/recipes/recipe_modules/depot_tools/examples/full.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipe exercising the `depot_tools` module."""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['depot_tools', 'env', 'platform', 'step']
+
+
+def RunSteps(api, _properties):
+    vpython3 = api.depot_tools.vpython3()
+    api.step('use vpython3', [vpython3, '--version'])
+
+
+def GenTests(api):
+    yield api.test(
+        'clone',
+        api.platform.name('linux'),
+        api.post_process(post_process.MustRun, 'clone depot_tools'),
+        api.post_process(post_process.MustRun, 'verify gclient'),
+        api.post_process(post_process.StepCommandRE, 'use vpython3',
+                         [r'vpython3$', r'--version']),
+        api.post_process(post_process.StatusSuccess),
+    )
+    yield api.test(
+        'already on path',
+        api.env.on_path('gclient', '/existing/depot_tools/gclient'),
+        api.post_process(post_process.DoesNotRun, 'clone depot_tools'),
+        api.post_process(post_process.StatusSuccess),
+    )
+    yield api.test(
+        'windows',
+        api.platform.name('win'),
+        api.post_process(post_process.StepCommandRE, 'use vpython3',
+                         [r'vpython3\.bat$', r'--version']),
+        api.post_process(post_process.StatusSuccess),
+    )

--- a/tools/recipes/recipe_modules/env/__init__.py
+++ b/tools/recipes/recipe_modules/env/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""`env` module: mockable access to environment variables and PATH lookup."""
+
+DEPS = []

--- a/tools/recipes/recipe_modules/env/api.py
+++ b/tools/recipes/recipe_modules/env/api.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""The `env` module API: mockable environment access.
+
+Modules read/write process environment variables and resolve executables
+through this seam instead of touching `os.environ`/`shutil.which` directly, so
+recipes run deterministically under simulation. In production it is a thin
+wrapper over the real environment; in test mode it reads and mutates the
+simulated environment on the run's `TestContext`.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+from recipe_api import RecipeApi
+
+
+class _RealEnv:
+    """Production backend: the real process environment and PATH lookup."""
+
+    def get(self, key: str, default: str | None) -> str | None:
+        return os.environ.get(key, default)
+
+    def set(self, key: str, value: str) -> None:
+        os.environ[key] = value
+
+    def contains(self, key: str) -> bool:
+        return key in os.environ
+
+    def which(self, cmd: str) -> str | None:
+        return shutil.which(cmd)
+
+    def prepend_path(self, entry: str) -> None:
+        current = os.environ.get('PATH', '')
+        os.environ['PATH'] = (os.pathsep.join([entry, current])
+                              if current else entry)
+
+
+class _SimEnv:
+    """Test backend: the simulated environment on the run's TestContext."""
+
+    def __init__(self, test) -> None:
+        self._test = test
+
+    def get(self, key: str, default: str | None) -> str | None:
+        return self._test.env.get(key, default)
+
+    def set(self, key: str, value: str) -> None:
+        self._test.env[key] = value
+
+    def contains(self, key: str) -> bool:
+        return key in self._test.env
+
+    def which(self, cmd: str) -> str | None:
+        return self._test.which_map.get(cmd)
+
+    def prepend_path(self, entry: str) -> None:
+        current = self._test.env.get('PATH', '')
+        self._test.env['PATH'] = (os.pathsep.join([entry, current])
+                                  if current else entry)
+
+
+class EnvApi(RecipeApi):
+    """Get/set environment variables, test membership, and resolve commands.
+
+    The real-vs-simulated choice is made once in `initialise()` by picking a
+    backend; the methods below just delegate, so there is no per-call test-mode
+    branching (the same shape as the `step` module's runner selection).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Default to the real environment; swapped for a simulated backend in
+        # test mode by initialise() (once the engine has seeded `_test`).
+        self._backend = _RealEnv()
+
+    def initialise(self) -> None:
+        if self._test is not None:
+            self._backend = _SimEnv(self._test)
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        """Return env var *key*, or *default* when unset."""
+        return self._backend.get(key, default)
+
+    def set(self, key: str, value: str) -> None:
+        """Set env var *key* to *value* for subsequent steps."""
+        self._backend.set(key, value)
+
+    def __contains__(self, key: str) -> bool:
+        """Whether env var *key* is set."""
+        return self._backend.contains(key)
+
+    def which(self, cmd: str) -> str | None:
+        """Resolve *cmd* on PATH, returning its absolute path or `None`."""
+        return self._backend.which(cmd)
+
+    def prepend_path(self, entry: str | os.PathLike) -> None:
+        """Prepend *entry* to `PATH` so later steps find binaries there."""
+        self._backend.prepend_path(str(entry))

--- a/tools/recipes/recipe_modules/env/examples/__init__.py
+++ b/tools/recipes/recipe_modules/env/examples/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipes exercising the `env` module."""

--- a/tools/recipes/recipe_modules/env/examples/full.expected/basic.json
+++ b/tools/recipes/recipe_modules/env/examples/full.expected/basic.json
@@ -1,0 +1,20 @@
+[
+  {
+    "cmd": [
+      "echo",
+      "/depot_tools/gclient"
+    ],
+    "name": "resolved gclient"
+  },
+  {
+    "cmd": [
+      "echo",
+      "on"
+    ],
+    "name": "flag set"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipe_modules/env/examples/full.expected/gclient_absent.json
+++ b/tools/recipes/recipe_modules/env/examples/full.expected/gclient_absent.json
@@ -1,0 +1,13 @@
+[
+  {
+    "cmd": [
+      "echo",
+      "on"
+    ],
+    "name": "flag set"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipe_modules/env/examples/full.py
+++ b/tools/recipes/recipe_modules/env/examples/full.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipe exercising the `env` module's seams."""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['env', 'step']
+
+
+def RunSteps(api, _properties):
+    gclient = api.env.which('gclient')
+    if gclient:
+        api.step('resolved gclient', ['echo', gclient])
+    api.env.set('BRAVE_FLAG', 'on')
+    if 'BRAVE_FLAG' in api.env:
+        api.step('flag set', ['echo', api.env.get('BRAVE_FLAG')])
+    api.env.prepend_path('/opt/tools')
+
+
+def GenTests(api):
+    yield api.test(
+        'basic',
+        api.env.on_path('gclient', '/depot_tools/gclient'),
+        api.post_process(post_process.MustRun, 'resolved gclient'),
+        api.post_process(post_process.StepCommandContains, 'resolved gclient',
+                         ['/depot_tools/gclient']),
+        api.post_process(post_process.MustRun, 'flag set'),
+        api.post_process(post_process.StepCommandContains, 'flag set', ['on']),
+        api.post_process(post_process.StatusSuccess),
+    )
+    yield api.test(
+        'gclient absent',
+        api.post_process(post_process.DoesNotRun, 'resolved gclient'),
+        api.post_process(post_process.MustRun, 'flag set'),
+        api.post_process(post_process.StatusSuccess),
+    )

--- a/tools/recipes/recipe_modules/env/test_api.py
+++ b/tools/recipes/recipe_modules/env/test_api.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Test API for the `env` module: seed environment vars and `which` results."""
+
+from __future__ import annotations
+
+from recipe_test_api import RecipeTestApi, TestData
+
+
+class EnvTestApi(RecipeTestApi):
+    """Seed the simulated environment a recipe sees."""
+
+    def set(self, key: str, value: str) -> TestData:
+        """Set env var *key* before the recipe runs."""
+        return self._mod_data(vars={key: value})
+
+    def on_path(self, cmd: str, resolved: str) -> TestData:
+        """Make `api.env.which(cmd)` resolve to *resolved* during the run."""
+        return self._mod_data(which={cmd: resolved})

--- a/tools/recipes/recipe_modules/path/api.py
+++ b/tools/recipes/recipe_modules/path/api.py
@@ -6,9 +6,69 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from recipe_api import RecipeApi
+
+
+class _RealFs:
+    """Production backend: the real filesystem."""
+
+    def exists(self, path: str | Path) -> bool:
+        return Path(path).exists()
+
+    def is_dir(self, path: str | Path) -> bool:
+        return Path(path).is_dir()
+
+    def is_file(self, path: str | Path) -> bool:
+        return Path(path).is_file()
+
+    def mkdir(self, path: str | Path, *, parents: bool,
+              exist_ok: bool) -> None:
+        Path(path).mkdir(parents=parents, exist_ok=exist_ok)
+
+    def abs(self, path: str | Path) -> Path:
+        return Path(path).expanduser().resolve()
+
+    def home(self) -> Path:
+        return Path.home()
+
+
+class _SimFs:
+    """Test backend: the simulated filesystem on the run's TestContext.
+
+    `abs` normalizes lexically (expanding `~` to the simulated home) rather than
+    resolving against the real cwd/filesystem, so paths stay deterministic.
+    """
+
+    def __init__(self, test) -> None:
+        self._test = test
+
+    def exists(self, path: str | Path) -> bool:
+        return self._test.fs.exists(path)
+
+    def is_dir(self, path: str | Path) -> bool:
+        return self._test.fs.is_dir(path)
+
+    def is_file(self, path: str | Path) -> bool:
+        return self._test.fs.is_file(path)
+
+    def mkdir(self, path: str | Path, *, parents: bool,
+              exist_ok: bool) -> None:
+        # The simulated fs has no real directory tree: `add_dir` is idempotent
+        # and implies parents, so these flags don't apply here.
+        del parents, exist_ok
+        self._test.fs.add_dir(path)
+
+    def abs(self, path: str | Path) -> Path:
+        text = str(path)
+        if text.startswith('~'):
+            text = str(self._test.home) + text[1:]
+        return Path(os.path.normpath(text))
+
+    def home(self) -> Path:
+        return self._test.home
 
 
 class PathApi(RecipeApi):
@@ -40,3 +100,51 @@ class PathApi(RecipeApi):
     def out(self) -> Path:
         """Build output directory: `<workspace>/out`."""
         return self._workspace / 'out'
+
+    # Filesystem seams. The real-vs-simulated choice is made once in
+    # `initialise()` by picking a backend. The methods below just delegate, so
+    # in test mode recipes probe (and `mkdir` mutates) the simulated filesystem
+    # without any real disk access, and with no per-call test-mode branching.
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Default to the real filesystem; swapped for a simulated backend in
+        # test mode by initialise() (once the engine has seeded `_test`).
+        self._fs = _RealFs()
+
+    def initialise(self) -> None:
+        if self._test is not None:
+            self._fs = _SimFs(self._test)
+
+    def exists(self, path: str | Path) -> bool:
+        """Whether *path* exists (a file or a directory)."""
+        return self._fs.exists(path)
+
+    def is_dir(self, path: str | Path) -> bool:
+        """Whether *path* exists and is a directory."""
+        return self._fs.is_dir(path)
+
+    def is_file(self, path: str | Path) -> bool:
+        """Whether *path* exists and is a regular file."""
+        return self._fs.is_file(path)
+
+    def mkdir(self,
+              path: str | Path,
+              *,
+              parents: bool = True,
+              exist_ok: bool = True) -> None:
+        """Create directory *path* (creating parents by default)."""
+        self._fs.mkdir(path, parents=parents, exist_ok=exist_ok)
+
+    def abs(self, path: str | Path) -> Path:
+        """Return an absolute, `~`-expanded, normalized `Path`.
+
+        Replaces `Path(p).expanduser().resolve()`. In test mode `~` expands to
+        the simulated home and the path is normalized lexically, never
+        resolved against the real cwd or filesystem (so it stays deterministic).
+        """
+        return self._fs.abs(path)
+
+    def home(self) -> Path:
+        """The user's home directory (simulated in test mode)."""
+        return self._fs.home()

--- a/tools/recipes/recipe_modules/path/examples/__init__.py
+++ b/tools/recipes/recipe_modules/path/examples/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipes exercising the `path` module."""

--- a/tools/recipes/recipe_modules/path/examples/full.expected/absent.json
+++ b/tools/recipes/recipe_modules/path/examples/full.expected/absent.json
@@ -1,0 +1,13 @@
+[
+  {
+    "cmd": [
+      "echo",
+      "[WORKSPACE]/out"
+    ],
+    "name": "out ready"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipe_modules/path/examples/full.expected/seeded.json
+++ b/tools/recipes/recipe_modules/path/examples/full.expected/seeded.json
@@ -1,0 +1,20 @@
+[
+  {
+    "cmd": [
+      "echo",
+      "present"
+    ],
+    "name": "found version"
+  },
+  {
+    "cmd": [
+      "echo",
+      "[WORKSPACE]/out"
+    ],
+    "name": "out ready"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipe_modules/path/examples/full.py
+++ b/tools/recipes/recipe_modules/path/examples/full.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipe exercising the `path` module's filesystem seams."""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['path', 'step']
+
+
+def RunSteps(api, _properties):
+    # Probe a seeded file, then create and re-probe a directory: the created
+    # directory must "exist" for the rest of the run.
+    if api.path.exists(api.path.chromium_src / 'chrome/VERSION'):
+        api.step('found version', ['echo', 'present'])
+    api.path.mkdir(api.path.out)
+    if api.path.is_dir(api.path.out):
+        api.step('out ready', ['echo', str(api.path.out)])
+
+
+def GenTests(api):
+    yield api.test(
+        'seeded',
+        api.path.files('chromium/src/chrome/VERSION'),
+        api.post_process(post_process.MustRun, 'found version'),
+        api.post_process(post_process.MustRun, 'out ready'),
+        api.post_process(post_process.StepCommandContains, 'out ready',
+                         ['[WORKSPACE]/out']),
+        api.post_process(post_process.StatusSuccess),
+    )
+    yield api.test(
+        'absent',
+        api.post_process(post_process.DoesNotRun, 'found version'),
+        api.post_process(post_process.MustRun, 'out ready'),
+        api.post_process(post_process.StatusSuccess),
+    )

--- a/tools/recipes/recipe_modules/path/test_api.py
+++ b/tools/recipes/recipe_modules/path/test_api.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Test API for the `path` module: seed the simulated filesystem."""
+
+from __future__ import annotations
+
+from recipe_test_api import RecipeTestApi, TestData
+
+
+class PathTestApi(RecipeTestApi):
+    """Seed which paths "exist" during simulation.
+
+    Paths may be absolute or workspace-relative (relative ones are resolved
+    under the simulated workspace, matching `api.path.chromium_src` etc.). Use
+    `files(...)` for regular files and `dirs(...)` for directories; a directory
+    is also implicitly present if it is an ancestor of any seeded path.
+    """
+
+    def files(self, *paths: str) -> TestData:
+        return self._mod_data(files=list(paths))
+
+    def dirs(self, *paths: str) -> TestData:
+        return self._mod_data(dirs=list(paths))

--- a/tools/recipes/recipe_modules/platform/__init__.py
+++ b/tools/recipes/recipe_modules/platform/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""`platform` module: mockable host OS identification."""
+
+DEPS = []

--- a/tools/recipes/recipe_modules/platform/api.py
+++ b/tools/recipes/recipe_modules/platform/api.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""The `platform` module API: mockable host OS identification.
+
+Modules branch on `api.platform.is_win` (etc.) instead of `sys.platform` /
+`platform.system()` directly, so a `GenTests` case can simulate any OS with
+`api.platform.name('mac')`. In production the name is derived from the real
+host; in test mode it comes from the run's `TestContext`.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from recipe_api import RecipeApi
+
+# Canonical short platform names, matching recipes_py.
+_VALID = ('linux', 'mac', 'win')
+
+
+def _host_name() -> str:
+    if sys.platform == 'win32':
+        return 'win'
+    if sys.platform == 'darwin':
+        return 'mac'
+    return 'linux'
+
+
+class PlatformApi(RecipeApi):
+    """The host platform as a short name plus convenience predicates."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Default to the real host; refined in initialise() once the engine has
+        # seeded `_test`. Accessors below just read `self._name`. No per-call
+        # test-mode branching (mirrors recipes_py's PlatformApi).
+        self._name = _host_name()
+
+    def initialise(self) -> None:
+        if self._test is not None:
+            self._name = self._test.platform
+        assert self._name in _VALID, (
+            f'unknown simulated platform {self._name!r}; use one of {_VALID}')
+
+    @property
+    def name(self) -> str:
+        """`'linux'`, `'mac'`, or `'win'`."""
+        return self._name
+
+    @property
+    def is_win(self) -> bool:
+        return self.name == 'win'
+
+    @property
+    def is_mac(self) -> bool:
+        return self.name == 'mac'
+
+    @property
+    def is_linux(self) -> bool:
+        return self.name == 'linux'

--- a/tools/recipes/recipe_modules/platform/examples/__init__.py
+++ b/tools/recipes/recipe_modules/platform/examples/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipes exercising the `platform` module."""

--- a/tools/recipes/recipe_modules/platform/examples/full.expected/linux.json
+++ b/tools/recipes/recipe_modules/platform/examples/full.expected/linux.json
@@ -1,0 +1,13 @@
+[
+  {
+    "cmd": [
+      "echo",
+      "linux"
+    ],
+    "name": "report platform"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipe_modules/platform/examples/full.expected/win.json
+++ b/tools/recipes/recipe_modules/platform/examples/full.expected/win.json
@@ -1,0 +1,20 @@
+[
+  {
+    "cmd": [
+      "echo",
+      "win"
+    ],
+    "name": "report platform"
+  },
+  {
+    "cmd": [
+      "echo",
+      "win"
+    ],
+    "name": "windows only"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipe_modules/platform/examples/full.py
+++ b/tools/recipes/recipe_modules/platform/examples/full.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipe exercising the `platform` module's seams."""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['platform', 'step']
+
+
+def RunSteps(api, _properties):
+    api.step('report platform', ['echo', api.platform.name])
+    if api.platform.is_win:
+        api.step('windows only', ['echo', 'win'])
+
+
+def GenTests(api):
+    yield api.test(
+        'linux',
+        api.platform.name('linux'),
+        api.post_process(post_process.StepCommandContains, 'report platform',
+                         ['linux']),
+        api.post_process(post_process.DoesNotRun, 'windows only'),
+        api.post_process(post_process.StatusSuccess),
+    )
+    yield api.test(
+        'win',
+        api.platform.name('win'),
+        api.post_process(post_process.StepCommandContains, 'report platform',
+                         ['win']),
+        api.post_process(post_process.MustRun, 'windows only'),
+        api.post_process(post_process.StatusSuccess),
+    )

--- a/tools/recipes/recipe_modules/platform/test_api.py
+++ b/tools/recipes/recipe_modules/platform/test_api.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Test API for the `platform` module: choose the simulated host OS."""
+
+from __future__ import annotations
+
+from recipe_test_api import RecipeTestApi, TestData
+
+
+class PlatformTestApi(RecipeTestApi):
+    """Select the platform a `GenTests` case simulates."""
+
+    def name(self, name: str) -> TestData:
+        """Simulate host platform *name* (`'linux'`, `'mac'`, or `'win'`)."""
+        return self._mod_data(name=name)

--- a/tools/recipes/recipe_modules/step/api.py
+++ b/tools/recipes/recipe_modules/step/api.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 import logging
 from pathlib import Path
-import platform
-import shutil
 import subprocess
 
 from recipe_api import RecipeApi
@@ -21,10 +19,29 @@ class StepApi(RecipeApi):
 
     The instance is callable, so recipes and modules invoke it as
     `api.step(name, cmd, ...)`, mirroring `recipe_engine/step`. This is the one
-    place that actually shells out; everything else describes work in terms of
-    steps. Consolidates the logging and Windows command resolution that
-    `build_rust_toolchain.py::_check_call` did inline.
+    place work actually happens; everything else describes work in terms of
+    steps. The API only *describes* a step (name + command + cwd/env) and hands
+    it to a step runner: in production a `SubprocessStepRunner` shells out (with
+    Windows command resolution); under test the engine seeds a
+    `SimulationStepRunner` that records the step and returns canned data, so no
+    subprocess runs.
     """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Lazily-created production runner (unused in test mode, where the
+        # engine seeds `self._test.step_runner`).
+        self._prod_runner = None
+
+    def _runner(self):
+        if self._test is not None:
+            return self._test.step_runner
+        if self._prod_runner is None:
+            # Imported lazily so `step` stays dependency-free at import time and
+            # simulation code isn't loaded on the production path until needed.
+            from simulation import SubprocessStepRunner
+            self._prod_runner = SubprocessStepRunner()
+        return self._prod_runner
 
     def __call__(
             self,
@@ -54,20 +71,13 @@ class StepApi(RecipeApi):
             subprocess.CalledProcessError: If `check` and the process fails.
             RuntimeError: On Windows, if the command cannot be resolved.
         """
-        cmd = [str(arg) for arg in cmd]
-        logging.info('[step] %s\n >>>> %s', name, ' '.join(cmd))
-
-        if platform.system() == 'Windows':
-            # Resolve to an absolute path to avoid bat-file name mismatches
-            # (e.g. `gclient` vs `gclient.bat`) without using `shell=True`.
-            resolved = shutil.which(cmd[0])
-            if resolved is None:
-                raise RuntimeError(f'Command not found: {cmd[0]}')
-            cmd[0] = resolved
-
-        return subprocess.run(cmd,
-                              cwd=cwd,
-                              env=env,
-                              check=check,
-                              capture_output=capture_output,
-                              text=True)
+        step = {
+            'name': name,
+            'cmd': [str(arg) for arg in cmd],
+            'cwd': cwd,
+            'env': env,
+        }
+        logging.info('[step] %s\n >>>> %s', name, ' '.join(step['cmd']))
+        return self._runner().run(step,
+                                  check=check,
+                                  capture_output=capture_output)

--- a/tools/recipes/recipe_modules/step/examples/__init__.py
+++ b/tools/recipes/recipe_modules/step/examples/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipes exercising the `step` module."""

--- a/tools/recipes/recipe_modules/step/examples/full.expected/all_pass.json
+++ b/tools/recipes/recipe_modules/step/examples/full.expected/all_pass.json
@@ -1,0 +1,26 @@
+[
+  {
+    "cmd": [
+      "echo",
+      "hello"
+    ],
+    "name": "first"
+  },
+  {
+    "cmd": [
+      "do-thing"
+    ],
+    "name": "might fail"
+  },
+  {
+    "cmd": [
+      "echo",
+      "done"
+    ],
+    "name": "after"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipe_modules/step/examples/full.expected/step_fails.json
+++ b/tools/recipes/recipe_modules/step/examples/full.expected/step_fails.json
@@ -1,0 +1,20 @@
+[
+  {
+    "cmd": [
+      "echo",
+      "hello"
+    ],
+    "name": "first"
+  },
+  {
+    "cmd": [
+      "do-thing"
+    ],
+    "name": "might fail",
+    "retcode": 1
+  },
+  {
+    "name": "$result",
+    "status": "FAILURE"
+  }
+]

--- a/tools/recipes/recipe_modules/step/examples/full.py
+++ b/tools/recipes/recipe_modules/step/examples/full.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipe exercising the `step` module (success and failure)."""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['step']
+
+
+def RunSteps(api, _properties):
+    api.step('first', ['echo', 'hello'])
+    # A checked step that fails aborts the recipe: 'after' won't run.
+    api.step('might fail', ['do-thing'])
+    api.step('after', ['echo', 'done'])
+
+
+def GenTests(api):
+    yield api.test(
+        'all pass',
+        api.post_process(post_process.MustRun, 'first'),
+        api.post_process(post_process.MustRun, 'after'),
+        api.post_process(post_process.StepSuccess, 'might fail'),
+        api.post_process(post_process.StatusSuccess),
+    )
+    yield api.test(
+        'step fails',
+        api.step_data('might fail', retcode=1),
+        api.post_process(post_process.MustRun, 'might fail'),
+        api.post_process(post_process.StepFailure, 'might fail'),
+        api.post_process(post_process.DoesNotRun, 'after'),
+        api.post_process(post_process.StatusFailure),
+        status='FAILURE',
+    )

--- a/tools/recipes/recipe_modules/step/test_api.py
+++ b/tools/recipes/recipe_modules/step/test_api.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Test API for the `step` module: seed a step's simulated result.
+
+`api.step_data(...)` on the root api is the usual entry point; this exposes the
+same thing as `api.step.data(...)` for symmetry with recipes_py, so a step's
+retcode/output can be seeded next to other `api.step.*` fragments.
+"""
+
+from __future__ import annotations
+
+from recipe_test_api import RecipeTestApi, TestData
+
+
+class StepTestApi(RecipeTestApi):
+    """Seed the simulated result (retcode / captured output) of a step."""
+
+    def data(self,
+             name: str,
+             retcode: int = 0,
+             stdout: str | None = None,
+             stderr: str | None = None) -> TestData:
+        return self.step_data(name,
+                              retcode=retcode,
+                              stdout=stdout,
+                              stderr=stderr)

--- a/tools/recipes/recipe_properties.py
+++ b/tools/recipes/recipe_properties.py
@@ -20,8 +20,9 @@ properties. `int` and `bool` fields are coerced from their string form.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import dataclasses
-from typing import Any, Mapping
+from typing import Any
 
 # Metadata key under which a field stores the env var it may be sourced from.
 _FROM_ENVIRON = 'from_environ'

--- a/tools/recipes/recipe_test_api.py
+++ b/tools/recipes/recipe_test_api.py
@@ -1,0 +1,251 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Test-side API for Brave recipes.
+
+A recipe declares `def GenTests(api): ...` and yields one `TestData` per
+simulated run. `api` is the root `RecipeTestApi`. Each of the recipe's `DEPS`
+modules contributes its own `TEST_API` (from the module's `test_api.py`),
+injected as `api.<module>`, so a recipe writes, e.g.:
+
+    def GenTests(api):
+        yield api.test(
+            'linux',
+            api.platform.name('linux'),
+            api.properties(chromium_ref='151.0.7917.1'),
+            api.step_data('fetch chromium', retcode=0),
+            api.post_process(post_process.MustRun, 'fetch chromium'),
+            api.post_process(post_process.StatusSuccess),
+        )
+
+Each `api.*` call returns a `TestData` *fragment*; `api.test(name, *fragments)`
+folds them together (via `TestData.__add__`) into the case the engine runs.
+
+Notable simplifications vs upstream: plain dicts instead of protobuf messages,
+no output placeholders, and a simple `check(cond, hint)` collector rather than
+the AST-introspecting `Checker`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import inspect
+from typing import Any, NamedTuple
+
+from recipe_api import ModuleInjectionSite
+
+
+class StepTestData:
+    """Simulated result for a single step: retcode and captured output.
+
+    Seeded in `GenTests` via `api.step_data(name, ...)`. During simulation the
+    `step` module returns a `CompletedProcess` built from this, and raises
+    `CalledProcessError` when the step is `check`ed and `retcode` is non-zero.
+    """
+
+    def __init__(self,
+                 retcode: int | None = None,
+                 stdout: str | None = None,
+                 stderr: str | None = None) -> None:
+        # `retcode` is kept optional internally so merging can tell "unset" from
+        # an explicit 0; `.retcode` exposes the effective value (0 when unset).
+        self._retcode = retcode
+        self.stdout = stdout
+        self.stderr = stderr
+
+    @property
+    def retcode(self) -> int:
+        return self._retcode or 0
+
+    def __add__(self, other: StepTestData) -> StepTestData:
+        """Merge two fragments.
+
+        A non-zero retcode from either side wins (0 is the unset default, so a
+        later success fragment doesn't clobber an earlier failure); captured
+        output is last-set-wins.
+        """
+        return StepTestData(
+            retcode=other._retcode or self._retcode,
+            stdout=other.stdout if other.stdout is not None else self.stdout,
+            stderr=other.stderr if other.stderr is not None else self.stderr,
+        )
+
+
+class PostprocessHook(NamedTuple):
+    """A `post_process` callback plus where it was registered (for messages)."""
+    func: Callable[..., Any]
+    args: tuple
+    kwargs: dict
+    context: str  # "<file>:<lineno>" of the api.post_process(...) call.
+
+
+class TestData:
+    """One simulated recipe run (or a fragment merged into one).
+
+    Fragments returned by the `api.*` builders each populate one aspect
+    (properties, a step's data, a module's seed values, a post-process hook, the
+    expected overall status). `api.test` sums them into the final case.
+    """
+
+    def __init__(self, name: str = '') -> None:
+        self.name = name
+        # Recipe PROPERTIES payload (keys match the recipe's PROPERTIES fields).
+        self.properties: dict[str, Any] = {}
+        # Per-step simulated results, keyed by step name.
+        self.step_data: dict[str, StepTestData] = {}
+        # Per-module seed values consumed to build the run's TestContext
+        # (e.g. mod_data['platform'] = {'name': 'mac'}).
+        self.mod_data: dict[str, dict[str, Any]] = {}
+        # post_process checks run against the recorded steps after simulation.
+        self.post_process_hooks: list[PostprocessHook] = []
+        # Expected overall status ('SUCCESS' | 'FAILURE' | 'EXCEPTION'); None
+        # means "don't assert" (a mismatch during a run is still reported).
+        self.expected_status: str | None = None
+        # brave-core ref the engine seeds (mirrors --brave-core-ref).
+        self.brave_core_ref: str = 'master'
+        # Absolute path of the expectation JSON; filled in by the test runner.
+        self.expect_file: str | None = None
+
+    def __add__(self, other: TestData) -> TestData:
+        """Associatively merge *other* into a copy of *self*.
+
+        Dicts update, lists concatenate, and last-set-wins for scalar fields --
+        so fragment order in `api.test(...)` reads left-to-right.
+        """
+        merged = TestData(self.name or other.name)
+        merged.properties = {**self.properties, **other.properties}
+        merged.mod_data = _merge_mod_data(self.mod_data, other.mod_data)
+        merged.step_data = dict(self.step_data)
+        for step_name, data in other.step_data.items():
+            existing = merged.step_data.get(step_name)
+            merged.step_data[step_name] = (existing +
+                                           data if existing else data)
+        merged.post_process_hooks = (self.post_process_hooks +
+                                     other.post_process_hooks)
+        merged.expected_status = (other.expected_status
+                                  if other.expected_status is not None else
+                                  self.expected_status)
+        merged.brave_core_ref = (other.brave_core_ref if other.brave_core_ref
+                                 != 'master' else self.brave_core_ref)
+        return merged
+
+
+def _merge_mod_data(a: dict[str, dict], b: dict[str, dict]) -> dict[str, dict]:
+    """Merge per-module seed dicts: lists concatenate, dicts update, else last.
+
+    List concatenation lets repeated fragments accumulate (two
+    `api.path.files(...)` calls extend one seeded file list rather than the
+    second clobbering the first); dict update lets `api.env.set(...)` calls pile
+    up into one env mapping.
+    """
+    out: dict[str, dict] = {}
+    for module in {**a, **b}:
+        left, right = a.get(module, {}), b.get(module, {})
+        merged = dict(left)
+        for key, value in right.items():
+            current = merged.get(key)
+            if isinstance(value, list) and isinstance(current, list):
+                merged[key] = current + value
+            elif isinstance(value, dict) and isinstance(current, dict):
+                merged[key] = {**current, **value}
+            else:
+                merged[key] = value
+        out[module] = merged
+    return out
+
+
+class RecipeTestApi:
+    """Root test API (passed to `GenTests`) and base for module `TEST_API`s.
+
+    Constructed with `module=None` for the root, where `self.m is self`, so
+    `api.<module>` reaches an injected module test API and `api.test(...)` are
+    called directly. A module's `TEST_API` is constructed with its module
+    name. The engine wires that module's DEPS onto `self.m`, matching how the
+    production engine wires `RecipeApi.m`.
+    """
+
+    def __init__(self, module: str | None = None) -> None:
+        self._module = module
+        self.m: ModuleInjectionSite | RecipeTestApi = (
+            self if module is None else ModuleInjectionSite())
+
+    def __getattr__(self, name: str):
+        # DEPS module test APIs are injected by the runner (onto the root api,
+        # or onto `self.m`); a missing one means it was not declared in DEPS.
+        # (Also tells static analysis that these attributes are dynamic, so
+        # accessing an injected dep is not flagged as no-member.)
+        raise AttributeError(
+            f'{name!r} is not an injected module test API (add it to DEPS?)')
+
+    # -- Fragment builders available on the root api (and inherited by modules).
+
+    @staticmethod
+    def test(name: str,
+             *test_data: TestData,
+             status: str | None = None) -> TestData:
+        """Fold *test_data* fragments into a single named test case."""
+        base = TestData(name)
+        if status is not None:
+            base.expected_status = status
+        for fragment in test_data:
+            base = base + fragment
+        return base
+
+    @staticmethod
+    def properties(**kwargs: Any) -> TestData:
+        """A fragment supplying the recipe's PROPERTIES payload."""
+        data = TestData()
+        data.properties = dict(kwargs)
+        return data
+
+    @staticmethod
+    def step_data(name: str,
+                  retcode: int = 0,
+                  stdout: str | None = None,
+                  stderr: str | None = None) -> TestData:
+        """A fragment seeding the simulated result of the step named *name*."""
+        data = TestData()
+        data.step_data[name] = StepTestData(retcode=retcode,
+                                            stdout=stdout,
+                                            stderr=stderr)
+        return data
+
+    @staticmethod
+    def brave_core_ref(ref: str) -> TestData:
+        """A fragment overriding the engine-seeded brave-core ref."""
+        data = TestData()
+        data.brave_core_ref = ref
+        return data
+
+    @staticmethod
+    def post_process(func: Callable[..., Any], *args: Any,
+                     **kwargs: Any) -> TestData:
+        """A fragment registering a post-process check (see `post_process`)."""
+        frame = inspect.currentframe()
+        caller = frame.f_back if frame is not None else None
+        context = (f'{caller.f_code.co_filename}:{caller.f_lineno}'
+                   if caller is not None else '<unknown>')
+        data = TestData()
+        data.post_process_hooks.append(
+            PostprocessHook(func, args, kwargs, context))
+        return data
+
+    @staticmethod
+    def empty_test_data() -> TestData:
+        """An empty fragment (useful as a merge identity in conditionals)."""
+        return TestData()
+
+    # -- Helper for module TEST_APIs to seed their own module's values.
+
+    def _mod_data(self, **values: Any) -> TestData:
+        """A fragment seeding this module's entry in `TestData.mod_data`.
+
+        Only valid on a module `TEST_API` (which knows its module name); the
+        root api has no module of its own.
+        """
+        assert self._module is not None, (
+            '_mod_data is only available on a module TEST_API')
+        data = TestData()
+        data.mod_data[self._module] = dict(values)
+        return data

--- a/tools/recipes/recipe_test_runner.py
+++ b/tools/recipes/recipe_test_runner.py
@@ -1,0 +1,338 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Simulation-test runner for Brave recipes (`engine.py test run|train`).
+
+Discovers every testable recipe -- those under `recipes/` and the module
+example/test recipes under `recipe_modules/<mod>/{examples,tests}/` that define
+both `RunSteps` and `GenTests` -- then, for each `TestData` a recipe's
+`GenTests` yields:
+
+  1. builds a `TestContext` from the case's seed values,
+  2. runs the recipe under a fresh engine in test mode (no real I/O),
+  3. records the ordered step stream and the run's `$result` status,
+  4. applies the case's `post_process` checks,
+  5. compares the result against the checked-in expectation JSON (`run`) or
+     writes it (`train`).
+
+Modules are tested the recipes_py way: via small example recipes that exercise
+them, run through this very machinery.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import importlib
+import json
+import logging
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+import engine
+import simulation
+from recipe_test_api import RecipeTestApi, TestData
+
+# -- TEST_API discovery & injection (mirrors engine's DEPS resolution) --------
+
+
+def _find_test_api_class(module, name: str) -> type[RecipeTestApi]:
+    """Return the single `RecipeTestApi` subclass in *module*, if any."""
+    classes = [
+        value for value in vars(module).values()
+        if isinstance(value, type) and issubclass(value, RecipeTestApi)
+        and value is not RecipeTestApi and value.__module__ == module.__name__
+    ]
+    if len(classes) > 1:
+        raise RuntimeError(
+            f"recipe module '{name}' defines {len(classes)} RecipeTestApi "
+            f'subclasses in test_api.py; expected at most one')
+    return classes[0] if classes else RecipeTestApi
+
+
+def _instantiate_test_module(name: str, chain: list[str],
+                             cache: dict[str, RecipeTestApi]) -> RecipeTestApi:
+    """Instantiate a module's TEST_API, wiring its DEPS onto `.m` (cached)."""
+    if name in cache:
+        return cache[name]
+    if name in chain:
+        cycle = ' -> '.join(chain + [name])
+        raise RuntimeError(f'cyclical DEPS detected: {cycle}')
+
+    package = importlib.import_module(f'{engine.MODULES_PKG}.{name}')
+    deps = list(getattr(package, 'DEPS', []))
+
+    test_api_path = (engine.RECIPES_ROOT / engine.MODULES_PKG / name /
+                     'test_api.py')
+    if test_api_path.exists():
+        test_module = importlib.import_module(
+            f'{engine.MODULES_PKG}.{name}.test_api')
+        api_class = _find_test_api_class(test_module, name)
+    else:
+        # Modules without a test_api.py contribute the base api (no helpers).
+        api_class = RecipeTestApi
+
+    inst = api_class(module=name)
+    for dep_name in deps:
+        setattr(inst.m, dep_name,
+                _instantiate_test_module(dep_name, chain + [name], cache))
+    setattr(inst.m, name, inst)
+    cache[name] = inst
+    return inst
+
+
+def _build_root_test_api(deps: list[str]) -> RecipeTestApi:
+    """Build the `api` passed to `GenTests`, with each DEP injected by name."""
+    root = RecipeTestApi(module=None)
+    cache: dict[str, RecipeTestApi] = {}
+    for dep_name in deps:
+        setattr(root, dep_name, _instantiate_test_module(dep_name, [], cache))
+    return root
+
+
+# -- Recipe discovery ---------------------------------------------------------
+
+
+def _iter_recipe_ids() -> list[str]:
+    """Every candidate recipe id, from `recipes/` and module examples/tests."""
+    root = engine.RECIPES_ROOT
+    ids: list[str] = []
+
+    recipes_root = root / engine.RECIPES_PKG
+    for path in sorted(recipes_root.rglob('*.py')):
+        if path.name == '__init__.py':
+            continue
+        ids.append(path.relative_to(recipes_root).with_suffix('').as_posix())
+
+    modules_root = root / engine.MODULES_PKG
+    for module in sorted(engine._module_names()):  # pylint: disable=protected-access
+        for sub in ('examples', 'tests'):
+            directory = modules_root / module / sub
+            if not directory.is_dir():
+                continue
+            for path in sorted(directory.rglob('*.py')):
+                if path.name == '__init__.py':
+                    continue
+                ids.append(
+                    path.relative_to(modules_root).with_suffix('').as_posix())
+    return ids
+
+
+def _testable_recipes() -> list[tuple[str, object]]:
+    """(id, module) for every recipe defining both RunSteps and GenTests."""
+    recipes = []
+    for recipe_id in _iter_recipe_ids():
+        recipe = engine._import_recipe(recipe_id)  # pylint: disable=protected-access
+        if hasattr(recipe, 'RunSteps') and hasattr(recipe, 'GenTests'):
+            recipes.append((recipe_id, recipe))
+    return recipes
+
+
+def _expect_dir(recipe) -> Path:
+    recipe_file = Path(recipe.__file__)
+    return recipe_file.parent / f'{recipe_file.stem}.expected'
+
+
+def _expect_file(recipe, test_name: str) -> Path:
+    safe = re.sub(r'[^A-Za-z0-9._-]', '_', test_name)
+    return _expect_dir(recipe) / f'{safe}.json'
+
+
+def _dump(steps: dict[str, dict]) -> str:
+    return json.dumps(list(steps.values()), indent=2, sort_keys=True) + '\n'
+
+
+def _read_expectation(path: Path) -> str:
+    """Read an expectation file as UTF-8 with no newline translation.
+
+    Expectations are compared byte-for-byte and must be identical on every
+    platform, so we avoid `read_text`'s locale-encoding and universal-newline
+    defaults (see tools/cr/python_dos_and_donts.md).
+    """
+    return path.read_bytes().decode('utf-8')
+
+
+def _write_expectation(path: Path, text: str) -> None:
+    """Write an expectation file as UTF-8 with no newline translation."""
+    path.write_text(text, encoding='utf-8', newline='')
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(engine.RECIPES_ROOT))
+    except ValueError:
+        return str(path)
+
+
+# -- Running ------------------------------------------------------------------
+
+
+class _Results:
+    """Accumulates per-case verdicts for the final report."""
+
+    def __init__(self) -> None:
+        self.passed = 0
+        self.written = 0
+        self.removed = 0
+        self.failures: list[tuple[str, list[str]]] = []
+
+    def record(self, case_id: str, failures: list[str]) -> None:
+        if failures:
+            self.failures.append((case_id, failures))
+        else:
+            self.passed += 1
+
+
+def _simulate(
+        recipe, recipe_id: str,
+        test_data: TestData) -> tuple[dict[str, dict], simulation.TestContext]:
+    """Run one recipe case in a fresh test-mode engine; return (steps, ctx)."""
+    ctx = simulation.TestContext.from_test_data(test_data)
+    # A fresh engine per case: module instances are cached per engine, so
+    # reusing one would leak state (deployed depot_tools, set env vars, ...).
+    eng = engine._Engine(  # pylint: disable=protected-access
+        brave_core_ref=test_data.brave_core_ref,
+        test=ctx)
+    status, reason = 'SUCCESS', None
+    try:
+        eng.run_loaded_recipe(recipe, recipe_id, test_data.properties)
+    except subprocess.CalledProcessError:
+        # A checked step returned non-zero: the recipe failed as designed.
+        status = 'FAILURE'
+    except Exception as exc:  # pylint: disable=broad-except
+        # Any other exception is an infra/logic error (bad input, missing dep).
+        status, reason = 'EXCEPTION', str(exc)
+    steps = simulation.build_steps(ctx.step_runner, status, reason, ctx)
+    return steps, ctx
+
+
+def _run_case(recipe, recipe_id: str, test_data: TestData, train: bool,
+              results: _Results, seen: set[Path]) -> None:
+    steps, _ = _simulate(recipe, recipe_id, test_data)
+    filtered, failures = simulation.apply_post_process(
+        test_data.post_process_hooks, steps)
+
+    status = steps[simulation.pp.RESULT_STEP]['status']
+    if (test_data.expected_status is not None
+            and test_data.expected_status != status):
+        reason = steps[simulation.pp.RESULT_STEP].get('reason')
+        failures.append(f'expected overall status '
+                        f'{test_data.expected_status!r}, got {status!r}' +
+                        (f' ({reason})' if reason else ''))
+
+    expect_file = _expect_file(recipe, test_data.name)
+    seen.add(expect_file)
+
+    if filtered is None:  # DropExpectation.
+        if expect_file.exists():
+            if train:
+                expect_file.unlink()
+                results.removed += 1
+            else:
+                failures.append(
+                    f'{_rel(expect_file)} exists but the test drops its '
+                    f'expectation; delete it or run `test train`')
+    else:
+        payload = _dump(filtered)
+        if train:
+            expect_file.parent.mkdir(parents=True, exist_ok=True)
+            if (not expect_file.exists()
+                    or _read_expectation(expect_file) != payload):
+                _write_expectation(expect_file, payload)
+                results.written += 1
+        elif not expect_file.exists():
+            failures.append(f'missing expectation {_rel(expect_file)} '
+                            f'(run `engine.py test train`)')
+        else:
+            current = _read_expectation(expect_file)
+            if current != payload:
+                diff = difflib.unified_diff(
+                    current.splitlines(),
+                    payload.splitlines(),
+                    fromfile=f'{_rel(expect_file)} (expected)',
+                    tofile='actual',
+                    lineterm='')
+                failures.append('expectation mismatch:\n' + '\n'.join(diff))
+
+    results.record(f'{recipe_id}.{test_data.name}', failures)
+
+
+def run_tests(train: bool = False,
+              filter_: str | None = None,
+              list_only: bool = False) -> int:
+    """Run (or train, or list) all recipe simulation tests; return an exit code.
+    """
+    engine._ensure_on_sys_path()  # pylint: disable=protected-access
+    results = _Results()
+
+    for recipe_id, recipe in _testable_recipes():
+        root_api = _build_root_test_api(list(getattr(recipe, 'DEPS', [])))
+        seen: set[Path] = set()
+        for test_data in recipe.GenTests(root_api):
+            case_id = f'{recipe_id}.{test_data.name}'
+            if filter_ and filter_ not in case_id:
+                continue
+            if list_only:
+                print(case_id)
+                continue
+            _run_case(recipe, recipe_id, test_data, train, results, seen)
+
+        # Train mode prunes stale expectation files (only on a full, unfiltered
+        # run, so a filtered train never deletes another case's golden).
+        if train and not list_only and not filter_:
+            expect_dir = _expect_dir(recipe)
+            if expect_dir.is_dir():
+                for stale in sorted(expect_dir.glob('*.json')):
+                    if stale not in seen:
+                        stale.unlink()
+                        results.removed += 1
+
+    if list_only:
+        return 0
+    return _report(results, train)
+
+
+def _report(results: _Results, train: bool) -> int:
+    for case_id, failures in results.failures:
+        print(f'FAIL {case_id}')
+        for failure in failures:
+            for line in failure.splitlines():
+                print(f'    {line}')
+    summary = [f'{results.passed} passed', f'{len(results.failures)} failed']
+    if train:
+        summary.append(f'{results.written} written')
+        summary.append(f'{results.removed} removed')
+    print(f'\nrecipe tests: {", ".join(summary)}')
+    return 1 if results.failures else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog='engine.py test',
+        description='Run Brave recipe simulation tests.')
+    parser.add_argument('subcommand',
+                        choices=['run', 'train', 'list'],
+                        help='run: compare against expectations; train: write '
+                        'expectations; list: print test case ids')
+    parser.add_argument('--filter',
+                        default=None,
+                        help='only cases whose "<recipe>.<test>" id contains '
+                        'this substring')
+    parser.add_argument('--verbose',
+                        action='store_true',
+                        help='enable step/debug logging (noisy)')
+    args = parser.parse_args(argv)
+
+    # Keep step logging quiet by default so test output is just the report.
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.WARNING)
+    return run_tests(train=args.subcommand == 'train',
+                     filter_=args.filter,
+                     list_only=args.subcommand == 'list')
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
@@ -1,0 +1,104 @@
+[
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "1",
+      "https://chromium.googlesource.com/chromium/tools/depot_tools",
+      "[WORKSPACE]/chromium/third_party/depot_tools"
+    ],
+    "name": "clone depot_tools"
+  },
+  {
+    "cmd": [
+      "gclient"
+    ],
+    "name": "verify gclient"
+  },
+  {
+    "cmd": [
+      "fetch",
+      "--nohooks",
+      "chromium"
+    ],
+    "cwd": "[WORKSPACE]/chromium",
+    "name": "fetch chromium"
+  },
+  {
+    "cmd": [
+      "git",
+      "fetch",
+      "--no-tags",
+      "origin",
+      "refs/tags/151.0.7917.1:refs/tags/151.0.7917.1"
+    ],
+    "cwd": "[WORKSPACE]/chromium/src",
+    "name": "fetch tag"
+  },
+  {
+    "cmd": [
+      "git",
+      "checkout",
+      "--force",
+      "FETCH_HEAD"
+    ],
+    "cwd": "[WORKSPACE]/chromium/src",
+    "name": "checkout FETCH_HEAD"
+  },
+  {
+    "cmd": [
+      "gclient",
+      "sync",
+      "--force",
+      "-D"
+    ],
+    "cwd": "[WORKSPACE]/chromium/src",
+    "name": "gclient sync"
+  },
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "2",
+      "--filter=blob:none",
+      "--sparse",
+      "--branch",
+      "master",
+      "git@github.com:brave/brave-core.git",
+      "[WORKSPACE]/chromium/src/brave"
+    ],
+    "name": "clone brave-core (shallow, sparse)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "sparse-checkout",
+      "add",
+      "tools/cr/toolchains"
+    ],
+    "name": "sparse-checkout add"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/chromium/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/chromium/src/brave/tools/cr/toolchains/build_rust_toolchain.py",
+      "--out-dir",
+      "[WORKSPACE]/out",
+      "--chromium-src",
+      "[WORKSPACE]/chromium/src",
+      "--brave-subrevision",
+      "1",
+      "--clear",
+      "--no-full-toolchain"
+    ],
+    "name": "build rust toolchain"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipes/toolchains/rust/package_rust.py
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+import post_process
 from recipe_properties import Property
 
 if TYPE_CHECKING:
@@ -46,3 +47,29 @@ def RunSteps(api: RecipeScriptApi, properties: InputProperties) -> None:
         '--clear',
         '--no-full-toolchain',
     ])
+
+
+def GenTests(api):
+    # Happy path: checkout (with a seeded git cache), deploy the build scripts,
+    # then build. `with_git_cache`/`deployed` seed chromium_checkout's and
+    # brave_core_shallow's preconditions.
+    yield api.test(
+        'linux',
+        api.chromium_checkout.with_git_cache(),
+        api.brave_core_shallow.deployed('tools/cr/toolchains'),
+        api.properties(brave_subrevision=1, chromium_ref='151.0.7917.1'),
+        api.post_process(post_process.MustRun, 'fetch chromium'),
+        api.post_process(post_process.MustRun, 'fetch tag'),
+        api.post_process(post_process.MustRun, 'build rust toolchain'),
+        api.post_process(post_process.StepCommandContains,
+                         'build rust toolchain', ['--brave-subrevision', '1']),
+        api.post_process(post_process.StatusSuccess),
+    )
+    # Without a git cache, the checkout refuses to run.
+    yield api.test(
+        'no git cache',
+        api.properties(brave_subrevision=1, chromium_ref='151.0.7917.1'),
+        api.post_process(post_process.StatusException),
+        api.post_process(post_process.DropExpectation),
+        status='EXCEPTION',
+    )

--- a/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/linux.json
+++ b/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/linux.json
@@ -1,0 +1,99 @@
+[
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "1",
+      "https://chromium.googlesource.com/chromium/tools/depot_tools",
+      "[WORKSPACE]/chromium/third_party/depot_tools"
+    ],
+    "name": "clone depot_tools"
+  },
+  {
+    "cmd": [
+      "gclient"
+    ],
+    "name": "verify gclient"
+  },
+  {
+    "cmd": [
+      "fetch",
+      "--nohooks",
+      "chromium"
+    ],
+    "cwd": "[WORKSPACE]/chromium",
+    "name": "fetch chromium"
+  },
+  {
+    "cmd": [
+      "git",
+      "fetch",
+      "--no-tags",
+      "origin",
+      "refs/tags/151.0.7917.1:refs/tags/151.0.7917.1"
+    ],
+    "cwd": "[WORKSPACE]/chromium/src",
+    "name": "fetch tag"
+  },
+  {
+    "cmd": [
+      "git",
+      "checkout",
+      "--force",
+      "FETCH_HEAD"
+    ],
+    "cwd": "[WORKSPACE]/chromium/src",
+    "name": "checkout FETCH_HEAD"
+  },
+  {
+    "cmd": [
+      "gclient",
+      "sync",
+      "--force",
+      "-D"
+    ],
+    "cwd": "[WORKSPACE]/chromium/src",
+    "name": "gclient sync"
+  },
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "2",
+      "--filter=blob:none",
+      "--sparse",
+      "--branch",
+      "master",
+      "git@github.com:brave/brave-core.git",
+      "[WORKSPACE]/chromium/src/brave"
+    ],
+    "name": "clone brave-core (shallow, sparse)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "sparse-checkout",
+      "add",
+      "third_party/ast-grep"
+    ],
+    "name": "sparse-checkout add"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/chromium/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/chromium/src/brave/third_party/ast-grep/package_ast_grep.py",
+      "--clean",
+      "--out-dir",
+      "[WORKSPACE]/out"
+    ],
+    "name": "package ast-grep"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipes/tools/ast_grep/package_ast_grep.py
+++ b/tools/recipes/recipes/tools/ast_grep/package_ast_grep.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+import post_process
 from recipe_properties import Property
 
 if TYPE_CHECKING:
@@ -41,3 +42,15 @@ def RunSteps(api: RecipeScriptApi, properties: InputProperties) -> None:
         '--out-dir',
         api.path.out,
     ])
+
+
+def GenTests(api):
+    yield api.test(
+        'linux',
+        api.chromium_checkout.with_git_cache(),
+        api.brave_core_shallow.deployed('third_party/ast-grep'),
+        api.properties(chromium_ref='151.0.7917.1'),
+        api.post_process(post_process.MustRun, 'fetch chromium'),
+        api.post_process(post_process.MustRun, 'package ast-grep'),
+        api.post_process(post_process.StatusSuccess),
+    )

--- a/tools/recipes/recipes/tools/node/package_node.expected/basic.json
+++ b/tools/recipes/recipes/tools/node/package_node.expected/basic.json
@@ -1,0 +1,66 @@
+[
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "2",
+      "--filter=blob:none",
+      "--sparse",
+      "--branch",
+      "master",
+      "git@github.com:brave/brave-core.git",
+      "[WORKSPACE]/chromium/src/brave"
+    ],
+    "name": "clone brave-core (shallow, sparse)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "sparse-checkout",
+      "add",
+      "third_party/node"
+    ],
+    "name": "sparse-checkout add"
+  },
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "1",
+      "https://chromium.googlesource.com/chromium/tools/depot_tools",
+      "[WORKSPACE]/chromium/third_party/depot_tools"
+    ],
+    "name": "clone depot_tools"
+  },
+  {
+    "cmd": [
+      "gclient"
+    ],
+    "name": "verify gclient"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/chromium/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/chromium/src/brave/third_party/node/download_node.py",
+      "--clear"
+    ],
+    "name": "download node"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/chromium/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/chromium/src/brave/third_party/node/package_node.py",
+      "--output-dir",
+      "[WORKSPACE]/out"
+    ],
+    "name": "package node"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipes/tools/node/package_node.expected/reuse_checkout.json
+++ b/tools/recipes/recipes/tools/node/package_node.expected/reuse_checkout.json
@@ -1,0 +1,75 @@
+[
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "fetch",
+      "--depth",
+      "2",
+      "origin",
+      "master"
+    ],
+    "name": "fetch brave-core ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "checkout",
+      "--force",
+      "FETCH_HEAD"
+    ],
+    "name": "checkout brave-core ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "sparse-checkout",
+      "add",
+      "third_party/node"
+    ],
+    "name": "sparse-checkout add"
+  },
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "1",
+      "https://chromium.googlesource.com/chromium/tools/depot_tools",
+      "[WORKSPACE]/chromium/third_party/depot_tools"
+    ],
+    "name": "clone depot_tools"
+  },
+  {
+    "cmd": [
+      "gclient"
+    ],
+    "name": "verify gclient"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/chromium/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/chromium/src/brave/third_party/node/download_node.py",
+      "--clear"
+    ],
+    "name": "download node"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/chromium/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/chromium/src/brave/third_party/node/package_node.py",
+      "--output-dir",
+      "[WORKSPACE]/out"
+    ],
+    "name": "package node"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipes/tools/node/package_node.py
+++ b/tools/recipes/recipes/tools/node/package_node.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import post_process
+
 if TYPE_CHECKING:
     from engine import RecipeScriptApi
 
@@ -33,3 +35,28 @@ def RunSteps(api: RecipeScriptApi, _: object) -> None:
         '--output-dir',
         api.path.out,
     ])
+
+
+def GenTests(api):
+    # brave-core is deployed (sparse), then node is downloaded and packaged.
+    # `deployed(...)` seeds the sparse path so the existence check passes.
+    yield api.test(
+        'basic',
+        api.brave_core_shallow.deployed('third_party/node'),
+        api.post_process(post_process.MustRun,
+                         'clone brave-core (shallow, sparse)'),
+        api.post_process(post_process.MustRun, 'download node'),
+        api.post_process(post_process.MustRun, 'package node'),
+        api.post_process(post_process.StatusSuccess),
+    )
+    # An existing brave-core checkout is fetched/updated rather than re-cloned.
+    yield api.test(
+        'reuse checkout',
+        api.brave_core_shallow.existing_checkout(),
+        api.brave_core_shallow.deployed('third_party/node'),
+        api.post_process(post_process.MustRun, 'fetch brave-core ref'),
+        api.post_process(post_process.DoesNotRun,
+                         'clone brave-core (shallow, sparse)'),
+        api.post_process(post_process.MustRun, 'package node'),
+        api.post_process(post_process.StatusSuccess),
+    )

--- a/tools/recipes/simulation.py
+++ b/tools/recipes/simulation.py
@@ -1,0 +1,268 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Simulation runtime for recipe tests.
+
+Holds everything needed to run a recipe with zero real side effects:
+
+  * `TestContext`: run-global simulated state (env, filesystem, `which`
+    resolution, platform, home) plus the step runner. Built from a `TestData`
+    via `TestContext.from_test_data`. The engine seeds one onto each module (as
+    `RecipeApi._test`); the seam modules (`path`, `env`, `platform`, `step`)
+    read/mutate it instead of the real machine.
+  * `SubprocessStepRunner` / `SimulationStepRunner`: the two `step`
+    back-ends. Production shells out (with the Windows resolution that used to
+    live in `StepApi`); simulation records an ordered step list and returns
+    canned results.
+  * expectation helpers: `stabilize` (machine paths -> `[WORKSPACE]`/`[HOME]`
+    tokens), `serialize_steps`, and `apply_post_process`.
+
+Deliberately never imports `engine` (the engine imports this), so there is no
+cycle: the test runner in `engine.py` drives a recipe, then hands the recorded
+steps here for post-processing and serialization.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+import copy
+from pathlib import Path, PurePosixPath
+import subprocess
+from typing import Any
+
+import post_process as pp
+from recipe_test_api import StepTestData, TestData
+
+# Fixed synthetic locations used in test mode. They are never touched on disk;
+# they exist only so module-derived paths are deterministic, and are rewritten
+# to tokens in expectations so goldens are machine-independent.
+SIM_WORKSPACE = PurePosixPath('/b/s')
+SIM_HOME = PurePosixPath('/b/home')
+
+WORKSPACE_TOKEN = '[WORKSPACE]'
+HOME_TOKEN = '[HOME]'
+
+
+def _norm(path: str | Path) -> str:
+    """Normalize a path to a stable string key for the simulated filesystem."""
+    return str(PurePosixPath(str(path)))
+
+
+class SimFS:
+    """A tiny simulated filesystem: sets of files and directories.
+
+    Seeded from `api.path.files(...)` / `api.path.dirs(...)` and mutated by
+    `api.path.mkdir(...)` during a run. A directory also "exists" implicitly if
+    it is an ancestor of any seeded/created path, so parents of seeded files
+    don't each need to be declared.
+    """
+
+    def __init__(
+        self,
+        files: Iterable[str | Path] = (),
+        dirs: Iterable[str | Path] = ()
+    ) -> None:
+        self._files: set[str] = {_norm(f) for f in files}
+        self._dirs: set[str] = {_norm(d) for d in dirs}
+
+    def _has_descendant(self, path: str) -> bool:
+        prefix = path.rstrip('/') + '/'
+        return any(p.startswith(prefix) for p in (self._files | self._dirs))
+
+    def is_file(self, path: str | Path) -> bool:
+        return _norm(path) in self._files
+
+    def is_dir(self, path: str | Path) -> bool:
+        path = _norm(path)
+        return path in self._dirs or self._has_descendant(path)
+
+    def exists(self, path: str | Path) -> bool:
+        return self.is_file(path) or self.is_dir(path)
+
+    def add_file(self, path: str | Path) -> None:
+        self._files.add(_norm(path))
+
+    def add_dir(self, path: str | Path) -> None:
+        self._dirs.add(_norm(path))
+
+
+class SubprocessStepRunner:
+    """Production step back-end: run the command as a real subprocess.
+
+    Consolidates the Windows command resolution that used to live inline in
+    `StepApi.__call__`, so the API layer no longer touches the OS directly.
+    """
+
+    def run(self, step: dict, *, check: bool,
+            capture_output: bool) -> subprocess.CompletedProcess:
+        import platform  # Local import: only the prod path needs it.
+        import shutil
+
+        cmd = [str(arg) for arg in step['cmd']]
+        if platform.system() == 'Windows':
+            # Resolve to an absolute path to avoid bat-file name mismatches
+            # (e.g. `gclient` vs `gclient.bat`) without using `shell=True`.
+            resolved = shutil.which(cmd[0])
+            if resolved is None:
+                raise RuntimeError(f'Command not found: {cmd[0]}')
+            cmd[0] = resolved
+        return subprocess.run(cmd,
+                              cwd=step.get('cwd'),
+                              env=step.get('env'),
+                              check=check,
+                              capture_output=capture_output,
+                              text=True)
+
+
+class SimulationStepRunner:
+    """Simulation step back-end: record the step, return canned data.
+
+    No subprocess ever runs. Each `run` appends a step dict to `recorded_steps`
+    (the ordered stream the expectation is built from) and returns a
+    `CompletedProcess` seeded from the step's `StepTestData`. When the step is
+    `check`ed and its seeded retcode is non-zero, it raises the genuine
+    `subprocess.CalledProcessError` so module `except CalledProcessError` arms
+    and the recipe's failure path behave exactly as in production.
+    """
+
+    def __init__(self,
+                 step_data: dict[str, StepTestData] | None = None) -> None:
+        self._step_data = step_data or {}
+        self.recorded_steps: list[dict] = []
+
+    def run(self, step: dict, *, check: bool,
+            capture_output: bool) -> subprocess.CompletedProcess:
+        data = self._step_data.get(step['name'], StepTestData())
+        cmd = [str(arg) for arg in step['cmd']]
+
+        record: dict[str, Any] = {'name': step['name'], 'cmd': cmd}
+        if step.get('cwd'):
+            record['cwd'] = str(step['cwd'])
+        if step.get('env'):
+            record['env'] = {k: str(v) for k, v in step['env'].items()}
+        if data.retcode:
+            record['retcode'] = data.retcode
+        self.recorded_steps.append(record)
+
+        # Mirror subprocess: captured output is only available when the caller
+        # asked to capture it; otherwise the child inherited the parent streams
+        # and `stdout`/`stderr` come back as None.
+        stdout = data.stdout if capture_output else None
+        stderr = data.stderr if capture_output else None
+
+        if check and data.retcode != 0:
+            raise subprocess.CalledProcessError(data.retcode,
+                                                cmd,
+                                                output=stdout,
+                                                stderr=stderr)
+        return subprocess.CompletedProcess(cmd,
+                                           data.retcode,
+                                           stdout=stdout,
+                                           stderr=stderr)
+
+
+class TestContext:
+    """Run-global simulated state, seeded onto every module in test mode."""
+
+    def __init__(self,
+                 *,
+                 platform: str = 'linux',
+                 env: dict[str, str] | None = None,
+                 files: Iterable[str | Path] = (),
+                 dirs: Iterable[str | Path] = (),
+                 which_map: dict[str, str] | None = None,
+                 home: str | Path = SIM_HOME,
+                 step_data: dict[str, StepTestData] | None = None) -> None:
+        self.platform = platform
+        self.env = dict(env or {})
+        self.fs = SimFS(files, dirs)
+        self.which_map = dict(which_map or {})
+        self.home = Path(str(home))
+        self.step_runner = SimulationStepRunner(step_data)
+
+    @classmethod
+    def from_test_data(cls, test_data: TestData) -> TestContext:
+        """Build a context from the seed values a `GenTests` case supplied."""
+        mod = test_data.mod_data
+        platform = mod.get('platform', {}).get('name', 'linux')
+        env_seed = mod.get('env', {})
+        path_seed = mod.get('path', {})
+        return cls(
+            platform=platform,
+            env=dict(env_seed.get('vars', {})),
+            which_map=dict(env_seed.get('which', {})),
+            files=[_resolve_seed(p) for p in path_seed.get('files', [])],
+            dirs=[_resolve_seed(p) for p in path_seed.get('dirs', [])],
+            step_data=test_data.step_data,
+        )
+
+
+def _resolve_seed(path: str) -> str:
+    """Resolve a seeded path: absolute as-is, relative under the workspace."""
+    pure = PurePosixPath(path)
+    return str(pure if pure.is_absolute() else SIM_WORKSPACE / pure)
+
+
+def stabilize(value: str, context: TestContext | None = None) -> str:
+    """Rewrite machine-specific path prefixes to stable tokens."""
+    value = value.replace(str(SIM_WORKSPACE), WORKSPACE_TOKEN)
+    home = str(context.home) if context is not None else str(SIM_HOME)
+    return value.replace(home, HOME_TOKEN)
+
+
+def build_steps(runner: SimulationStepRunner, status: str, reason: str | None,
+                context: TestContext) -> dict[str, dict]:
+    """Assemble the ordered `{name: step}` map (+ `$result`) for post-process.
+
+    Paths are stabilized here so post-process checks and the written
+    expectation see the same tokenized commands.
+    """
+    steps: dict[str, dict] = {}
+    for step in runner.recorded_steps:
+        entry: dict[str, Any] = {
+            'name': step['name'],
+            'cmd': [stabilize(arg, context) for arg in step['cmd']],
+        }
+        if 'cwd' in step:
+            entry['cwd'] = stabilize(step['cwd'], context)
+        if 'env' in step:
+            entry['env'] = {
+                k: stabilize(v, context)
+                for k, v in step['env'].items()
+            }
+        if 'retcode' in step:
+            entry['retcode'] = step['retcode']
+        steps[step['name']] = entry
+
+    result: dict[str, Any] = {'name': pp.RESULT_STEP, 'status': status}
+    if reason is not None:
+        result['reason'] = reason
+    steps[pp.RESULT_STEP] = result
+    return steps
+
+
+def apply_post_process(
+        hooks, steps: dict[str,
+                           dict]) -> tuple[dict[str, dict] | None, list[str]]:
+    """Run post-process hooks; return (filtered steps or None, failures).
+
+    Each hook gets its own `Checker` and a deep copy of the current steps. A
+    hook that returns a mapping replaces the steps for later hooks and for the
+    written expectation; an empty mapping drops the expectation (returns None).
+    """
+    failures: list[str] = []
+    for hook in hooks:
+        check = pp.Checker(hook.context)
+        working = copy.deepcopy(steps)
+        try:
+            result = hook.func(check, working, *hook.args, **hook.kwargs)
+        except Exception as exc:  # pylint: disable=broad-except
+            failures.append(f'{hook.context}: hook raised {exc!r}')
+            continue
+        failures.extend(check.failures)
+        if result is not None:
+            if not result:
+                return None, failures  # DropExpectation.
+            steps = result
+    return steps, failures

--- a/tools/recipes/unittests/post_process_test.py
+++ b/tools/recipes/unittests/post_process_test.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for the post_process check library."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# pylint: disable=wrong-import-position
+import post_process as pp
+
+
+def _steps(status='SUCCESS'):
+    return {
+        'compile': {
+            'name': 'compile',
+            'cmd': ['ninja', '-C', 'out'],
+            'retcode': 0
+        },
+        'test': {
+            'name': 'test',
+            'cmd': ['run_tests'],
+            'retcode': 1
+        },
+        '$result': {
+            'name': '$result',
+            'status': status
+        },
+    }
+
+
+def _run(func, steps, *args):
+    """Run a check hook, returning (failure_count, return_value)."""
+    check = pp.Checker('ctx')
+    result = func(check, steps, *args)
+    return len(check.failures), result
+
+
+class CheckerTest(unittest.TestCase):
+
+    def test_collects_without_raising(self):
+        check = pp.Checker('ctx')
+        check(True)
+        check('hint', False)
+        self.assertEqual(len(check.failures), 1)
+        self.assertIn('hint', check.failures[0])
+
+
+class PresenceTest(unittest.TestCase):
+
+    def test_must_run(self):
+        self.assertEqual(_run(pp.MustRun, _steps(), 'compile')[0], 0)
+        self.assertEqual(_run(pp.MustRun, _steps(), 'missing')[0], 1)
+
+    def test_does_not_run(self):
+        self.assertEqual(_run(pp.DoesNotRun, _steps(), 'missing')[0], 0)
+        self.assertEqual(_run(pp.DoesNotRun, _steps(), 'compile')[0], 1)
+
+    def test_run_re(self):
+        self.assertEqual(_run(pp.MustRunRE, _steps(), r'^comp')[0], 0)
+        self.assertEqual(_run(pp.DoesNotRunRE, _steps(), r'^zzz')[0], 0)
+
+    def test_result_is_not_a_run_step(self):
+        # The $result pseudo-step must not satisfy MustRun.
+        self.assertEqual(_run(pp.MustRun, _steps(), '$result')[0], 1)
+
+
+class CommandTest(unittest.TestCase):
+
+    def test_command_contains_subsequence(self):
+        self.assertEqual(
+            _run(pp.StepCommandContains, _steps(), 'compile',
+                 ['ninja', 'out'])[0], 0)
+        self.assertEqual(
+            _run(pp.StepCommandContains, _steps(), 'compile',
+                 ['out', 'ninja'])[0], 1)  # wrong order
+
+    def test_command_re(self):
+        self.assertEqual(
+            _run(pp.StepCommandRE, _steps(), 'compile',
+                 [r'ninja', r'-C', r'out'])[0], 0)
+
+
+class StatusTest(unittest.TestCase):
+
+    def test_step_success_and_failure(self):
+        self.assertEqual(_run(pp.StepSuccess, _steps(), 'compile')[0], 0)
+        self.assertEqual(_run(pp.StepFailure, _steps(), 'test')[0], 0)
+        self.assertEqual(_run(pp.StepSuccess, _steps(), 'test')[0], 1)
+
+    def test_overall_status(self):
+        self.assertEqual(_run(pp.StatusSuccess, _steps('SUCCESS'))[0], 0)
+        self.assertEqual(_run(pp.StatusFailure, _steps('FAILURE'))[0], 0)
+        self.assertEqual(_run(pp.StatusException, _steps('SUCCESS'))[0], 1)
+
+
+class DropExpectationTest(unittest.TestCase):
+
+    def test_returns_empty_mapping(self):
+        _, result = _run(pp.DropExpectation, _steps())
+        self.assertEqual(result, {})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/recipes/unittests/recipe_test_api_test.py
+++ b/tools/recipes/unittests/recipe_test_api_test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for TestData/StepTestData merging and the RecipeTestApi builders."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# pylint: disable=wrong-import-position
+from recipe_test_api import RecipeTestApi, StepTestData, TestData
+
+
+class StepTestDataTest(unittest.TestCase):
+    """StepTestData merges with explicitly-set fields on the right winning."""
+
+    def test_retcode_and_output_override(self):
+        base = StepTestData(retcode=0, stdout='a')
+        override = StepTestData(retcode=2)
+        merged = base + override
+        self.assertEqual(merged.retcode, 2)
+        self.assertEqual(merged.stdout, 'a')  # not overridden -> kept
+
+    def test_unset_retcode_defaults_to_zero(self):
+        self.assertEqual(StepTestData().retcode, 0)
+
+
+class TestDataMergeTest(unittest.TestCase):
+    """TestData.__add__ is an associative merge of the fragment aspects."""
+
+    def test_properties_and_status_merge(self):
+        merged = (RecipeTestApi.properties(a=1) +
+                  RecipeTestApi.properties(b=2))
+        self.assertEqual(merged.properties, {'a': 1, 'b': 2})
+
+    def test_mod_data_lists_concatenate(self):
+        api = _module_api('path')
+        merged = api.files('one') + api.files('two')
+        self.assertEqual(merged.mod_data['path']['files'], ['one', 'two'])
+
+    def test_mod_data_dicts_merge(self):
+        api = _module_api('env')
+        merged = api.set('A', '1') + api.set('B', '2')
+        self.assertEqual(merged.mod_data['env']['vars'], {'A': '1', 'B': '2'})
+
+    def test_step_data_merges_per_step(self):
+        merged = (RecipeTestApi.step_data('s', retcode=1) +
+                  RecipeTestApi.step_data('s', stdout='out'))
+        self.assertEqual(merged.step_data['s'].retcode, 1)
+        self.assertEqual(merged.step_data['s'].stdout, 'out')
+
+    def test_hooks_concatenate(self):
+        merged = (RecipeTestApi.post_process(lambda c, s: None) +
+                  RecipeTestApi.post_process(lambda c, s: None))
+        self.assertEqual(len(merged.post_process_hooks), 2)
+
+
+class RecipeTestApiTest(unittest.TestCase):
+    """The root api folds fragments and records call sites for hooks."""
+
+    def test_test_folds_fragments_and_status(self):
+        td = RecipeTestApi.test('case',
+                                RecipeTestApi.properties(x=1),
+                                status='FAILURE')
+        self.assertEqual(td.name, 'case')
+        self.assertEqual(td.properties, {'x': 1})
+        self.assertEqual(td.expected_status, 'FAILURE')
+
+    def test_post_process_records_context(self):
+        td = RecipeTestApi.post_process(lambda c, s: None)
+        hook = td.post_process_hooks[0]
+        self.assertIn('recipe_test_api_test.py:', hook.context)
+
+    def test_root_is_its_own_injection_site(self):
+        root = RecipeTestApi(module=None)
+        self.assertIs(root.m, root)
+
+    def test_mod_data_requires_a_module(self):
+        with self.assertRaises(AssertionError):
+            RecipeTestApi(module=None)._mod_data(x=1)  # pylint: disable=protected-access
+
+
+def _module_api(name):
+    """A module test api instance (as the runner would build it)."""
+    from importlib import import_module
+    module = import_module(f'recipe_modules.{name}.test_api')
+    for value in vars(module).values():
+        if (isinstance(value, type) and issubclass(value, RecipeTestApi)
+                and value is not RecipeTestApi
+                and value.__module__ == module.__name__):
+            return value(module=name)
+    raise AssertionError(f'no test api in {name}')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/recipes/unittests/recipe_test_runner_test.py
+++ b/tools/recipes/unittests/recipe_test_runner_test.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for the test runner's TEST_API discovery/DI and recipe discovery."""
+
+# White-box tests exercising runner internals; protected access is intentional.
+# pylint: disable=protected-access
+
+import os
+import sys
+import types
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# pylint: disable=wrong-import-position
+import recipe_test_runner as runner
+from recipe_test_api import RecipeTestApi
+
+
+class FindTestApiClassTest(unittest.TestCase):
+
+    def test_defaults_to_base_when_absent(self):
+        module = types.ModuleType('fake')
+        self.assertIs(runner._find_test_api_class(module, 'fake'),
+                      RecipeTestApi)
+
+    def test_finds_the_single_subclass(self):
+        module = types.ModuleType('fake')
+
+        class MyTestApi(RecipeTestApi):
+            pass
+
+        MyTestApi.__module__ = 'fake'
+        module.MyTestApi = MyTestApi
+        self.assertIs(runner._find_test_api_class(module, 'fake'), MyTestApi)
+
+
+class TestApiInjectionTest(unittest.TestCase):
+
+    def test_deps_are_wired_onto_m(self):
+        cache = {}
+        cc = runner._instantiate_test_module('chromium_checkout', [], cache)
+        # chromium_checkout's DEPS test apis are reachable via .m.
+        self.assertTrue(hasattr(cc.m, 'env'))
+        self.assertTrue(hasattr(cc.m, 'path'))
+        # Cached instances are shared.
+        self.assertIs(runner._instantiate_test_module('path', [], cache),
+                      cc.m.path)
+
+    def test_root_api_exposes_dep_helpers(self):
+        root = runner._build_root_test_api(['platform', 'step'])
+        # api.platform.name(...) and api.step.data(...) resolve to the module
+        # test apis, mirroring the recipes_py example.
+        self.assertEqual(
+            root.platform.name('mac').mod_data['platform']['name'], 'mac')
+        self.assertIn('s', root.step.data('s', retcode=2).step_data)
+
+
+class DiscoveryTest(unittest.TestCase):
+
+    def test_iter_recipe_ids_includes_recipes_and_examples(self):
+        ids = runner._iter_recipe_ids()
+        self.assertIn('toolchains/rust/package_rust', ids)
+        self.assertIn('platform/examples/full', ids)
+
+    def test_testable_recipes_have_gentests(self):
+        recipes = dict(runner._testable_recipes())
+        self.assertIn('tools/node/package_node', recipes)
+        for recipe in recipes.values():
+            self.assertTrue(hasattr(recipe, 'GenTests'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/recipes/unittests/recipes_test.py
+++ b/tools/recipes/unittests/recipes_test.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Presubmit gate: every recipe's expectations must be current.
+
+Runs the full recipe simulation suite in compare mode (equivalent to
+`engine.py test run`) and fails if any expectation is stale or missing, so a
+recipe/module change that alters the step stream can't land without retraining
+(`engine.py test train`). The finer-grained machinery tests live alongside this
+file (`*_test.py`); this one asserts the goldens themselves.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import recipe_test_runner  # pylint: disable=wrong-import-position
+
+
+class RecipeExpectationsTest(unittest.TestCase):
+
+    def test_all_expectations_are_current(self):
+        exit_code = recipe_test_runner.run_tests(train=False)
+        self.assertEqual(
+            exit_code, 0,
+            'recipe expectations are stale or a check failed; run '
+            '`python3 tools/recipes/engine.py test train` and review the diff')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/recipes/unittests/simulation_test.py
+++ b/tools/recipes/unittests/simulation_test.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for the simulation runtime: SimFS, step runner, and expectations."""
+
+import os
+import subprocess
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# pylint: disable=wrong-import-position
+import post_process as pp
+import simulation
+from recipe_test_api import RecipeTestApi, StepTestData, TestData
+
+
+class SimFSTest(unittest.TestCase):
+
+    def test_file_and_ancestor_semantics(self):
+        fs = simulation.SimFS(files=['/b/s/chromium/src/chrome/VERSION'])
+        self.assertTrue(fs.is_file('/b/s/chromium/src/chrome/VERSION'))
+        self.assertTrue(fs.exists('/b/s/chromium/src/chrome/VERSION'))
+        # Ancestors of a seeded file are directories that exist.
+        self.assertTrue(fs.is_dir('/b/s/chromium/src'))
+        # The file itself is not a directory.
+        self.assertFalse(fs.is_dir('/b/s/chromium/src/chrome/VERSION'))
+        self.assertFalse(fs.exists('/b/s/nope'))
+
+    def test_mkdir_mutates(self):
+        fs = simulation.SimFS()
+        self.assertFalse(fs.is_dir('/b/s/out'))
+        fs.add_dir('/b/s/out')
+        self.assertTrue(fs.is_dir('/b/s/out'))
+
+
+class SimulationStepRunnerTest(unittest.TestCase):
+
+    def test_records_and_returns_completed_process(self):
+        runner = simulation.SimulationStepRunner()
+        result = runner.run({
+            'name': 'go',
+            'cmd': ['echo', 'hi']
+        },
+                            check=True,
+                            capture_output=False)
+        self.assertIsInstance(result, subprocess.CompletedProcess)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(runner.recorded_steps[0]['name'], 'go')
+
+    def test_checked_failure_raises_and_records_retcode(self):
+        runner = simulation.SimulationStepRunner(
+            {'go': StepTestData(retcode=1)})
+        with self.assertRaises(subprocess.CalledProcessError):
+            runner.run({
+                'name': 'go',
+                'cmd': ['false']
+            },
+                       check=True,
+                       capture_output=False)
+        # The failing step is still recorded (before the raise).
+        self.assertEqual(runner.recorded_steps[0]['retcode'], 1)
+
+    def test_unchecked_failure_does_not_raise(self):
+        runner = simulation.SimulationStepRunner(
+            {'go': StepTestData(retcode=1)})
+        result = runner.run({
+            'name': 'go',
+            'cmd': ['false']
+        },
+                            check=False,
+                            capture_output=False)
+        self.assertEqual(result.returncode, 1)
+
+
+class TestContextTest(unittest.TestCase):
+
+    def test_from_test_data_reads_mod_data(self):
+        td = (RecipeTestApi.empty_test_data())
+        td.mod_data = {
+            'platform': {
+                'name': 'mac'
+            },
+            'env': {
+                'vars': {
+                    'K': 'V'
+                },
+                'which': {
+                    'gclient': '/g'
+                }
+            },
+            'path': {
+                'files': ['chromium/src/chrome/VERSION'],
+                'dirs': []
+            },
+        }
+        ctx = simulation.TestContext.from_test_data(td)
+        self.assertEqual(ctx.platform, 'mac')
+        self.assertEqual(ctx.env['K'], 'V')
+        self.assertEqual(ctx.which_map['gclient'], '/g')
+        # Relative seed resolves under the simulated workspace.
+        self.assertTrue(ctx.fs.is_file('/b/s/chromium/src/chrome/VERSION'))
+
+
+class ExpectationTest(unittest.TestCase):
+
+    def test_stabilize_tokens(self):
+        ctx = simulation.TestContext()
+        self.assertEqual(simulation.stabilize('/b/s/out/x', ctx),
+                         '[WORKSPACE]/out/x')
+        self.assertEqual(simulation.stabilize('/b/home/.cache', ctx),
+                         '[HOME]/.cache')
+
+    def test_build_steps_appends_result(self):
+        runner = simulation.SimulationStepRunner()
+        runner.run({
+            'name': 'a',
+            'cmd': ['/b/s/out/tool']
+        },
+                   check=True,
+                   capture_output=False)
+        steps = simulation.build_steps(runner, 'EXCEPTION', 'boom',
+                                       simulation.TestContext())
+        self.assertEqual(steps['a']['cmd'], ['[WORKSPACE]/out/tool'])
+        self.assertEqual(steps[pp.RESULT_STEP], {
+            'name': '$result',
+            'status': 'EXCEPTION',
+            'reason': 'boom',
+        })
+
+    def test_apply_post_process_filter_and_drop(self):
+        steps = {
+            'a': {
+                'name': 'a'
+            },
+            '$result': {
+                'name': '$result',
+                'status': 'SUCCESS'
+            }
+        }
+        # A filtering hook narrows the steps for the written expectation.
+        keep_a = RecipeTestApi.post_process(lambda c, s: {'a': s['a']})
+        filtered, failures = simulation.apply_post_process(
+            keep_a.post_process_hooks, steps)
+        self.assertEqual(list(filtered), ['a'])
+        self.assertEqual(failures, [])
+        # DropExpectation -> None.
+        drop = RecipeTestApi.post_process(pp.DropExpectation)
+        filtered, _ = simulation.apply_post_process(drop.post_process_hooks,
+                                                    steps)
+        self.assertIsNone(filtered)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is a straight port of the upstream's infra superproject machinery
for and in particular of `recipes_py`'s GenTests/expectation testing.

Core machinery:
  * `recipe_test_api.py`: `RecipeTestApi` (the `api` passed to
    `GenTests`), `TestData`/`StepTestData` with associative merge, and
    fragment builders (test, properties, `step_data`, `post_process`).
  * `simulation.py`: TestContext (run-global simulated `env/fs/which/`
    platform), `SubprocessStepRunner` (production) and
    `SimulationStepRunner` (records steps, returns canned results,
    raises real CalledProcessError), path-token stabilization, and
    post_process application.
  * `post_process.py`: `MustRun`/`DoesNotRun`/`*RE`,
    `StepCommand{Contains,RE}`, `Step{Success,Failure}`,
    `Status{Success,Failure,Exception}`,
    `DropExpectation`, plus a failure-collecting Checker.
  * `recipe_test_runner.py`: `TEST_API` discovery/DI, recipe + example
    discovery, and the `engine.py test run|train|list [--filter]`
    subcommand.

To make simulation deterministic, `step` is no longer the only I/O
seam: we have added `env` (`get`/`set`/`which`/`prepend_path`) and
`platform` (`name`/`is_win`/...) modules and extend `path` (`exists`/
`is_dir`/`is_file`/`mkdir`/`abs`/`home`), routed the ambient I/O in
`step`, `depot_tools`, `chromium_checkout`, and `brave_core_shallow`
through these seams instead of `os`/`shutil`/`pathlib`/`sys` directly.
Every seam is a no-op wrapper over the real machine in production and
reads/mutates the `TestContext` under test. Everything is wired in the
test context into the engine without touching the production code path.

Added `GenTests` + committed expectations for all recipes
(`package_rust`, `package_node`, `package_ast_grep`) and example
recipes exercising each module, plus unit tests for the machinery.
`unittests/recipes_test.py` gates presubmit on expectation freshness.

Finally, the generated `*.expected/` goldens have been excluded from
Prettier (.prettierignore) as they are generated by training.

Tests can now be run with:

```
python3 tools/recipes/engine.py test run|train
```

Bug: https://github.com/brave/brave-browser/issues/56748
