### PR TITLE
[bootstrap] Remove `node` bootstrap syncing for now.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -205,16 +205,6 @@ hooks = [
                'src/third_party/rust-toolchain']
   },
   {
-    'name': 'download_node',
-    'pattern': '.',
-    'action': ['vpython3',
-               'tools/cr/install_extra_deps.py',
-               'src/brave/third_party/node/linux',
-               'src/brave/third_party/node/mac',
-               'src/brave/third_party/node/mac_arm64',
-               'src/brave/third_party/node/win']
-  },
-  {
     'name': 'download_ast_grep',
     'pattern': '.',
     'action': ['vpython3',


### PR DESCRIPTION
This is being done whilst we some question regarding packaging and
publishing still need to be defined.

https://github.com/brave/brave-browser/issues/56529
