### PR TITLE
Fix PIP stopping on tablets during activity recreation

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -621,6 +621,18 @@ public abstract class BraveActivity extends ChromeActivity
     }
 
     @Override
+    public void onNightModeStateChanged() {
+        // A dark/light theme change recreates the activity, which while a Brave-managed YouTube PiP
+        // session is active destroys the activity backing the PiP window. Let the controller decide
+        // whether to defer it; it re-applies the change on PiP exit via
+        // applyDeferredNightModeRecreate().
+        if (getYouTubePictureInPictureController().maybeDeferNightModeRecreate()) {
+            return;
+        }
+        super.onNightModeStateChanged();
+    }
+
+    @Override
     public void onPictureInPictureModeChanged(boolean inPicture, Configuration newConfig) {
         super.onPictureInPictureModeChanged(inPicture, newConfig);
         BraveYouTubePictureInPictureController controller = getYouTubePictureInPictureController();
@@ -2390,6 +2402,17 @@ public abstract class BraveActivity extends ChromeActivity
      */
     public void onYouTubePictureInPictureNewTab() {
         getYouTubePictureInPictureController().onNewTabDuringPictureInPicture();
+    }
+
+    /**
+     * Applies a night-mode theme recreation from the controller while a YouTube PiP session
+     * was active. Exists as a shim because {@code super.onNightModeStateChanged()} is not reachable
+     * from the controller.
+     *
+     * @see BraveYouTubePictureInPictureController#maybeDeferNightModeRecreate
+     */
+    public void applyDeferredNightModeRecreate() {
+        super.onNightModeStateChanged();
     }
 
     /**

--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -2405,8 +2405,8 @@ public abstract class BraveActivity extends ChromeActivity
     }
 
     /**
-     * Applies a night-mode theme recreation from the controller while a YouTube PiP session
-     * was active. Exists as a shim because {@code super.onNightModeStateChanged()} is not reachable
+     * Applies a night-mode theme recreation from the controller while a YouTube PiP session was
+     * active. Exists as a shim because {@code super.onNightModeStateChanged()} is not reachable
      * from the controller.
      *
      * @see BraveYouTubePictureInPictureController#maybeDeferNightModeRecreate

--- a/android/java/org/chromium/chrome/browser/media/BraveYouTubePictureInPictureController.java
+++ b/android/java/org/chromium/chrome/browser/media/BraveYouTubePictureInPictureController.java
@@ -144,6 +144,13 @@ public class BraveYouTubePictureInPictureController {
      */
     private boolean mResumeMediaSessionOnPipEntry;
 
+    /**
+     * True when a dark/light theme change arrived while this session was active and its activity
+     * recreation was deferred by {@link #maybeDeferNightModeRecreate}. Consumed on PiP exit by
+     * {@link #maybeApplyDeferredNightModeRecreate} to apply the theme that was withheld.
+     */
+    private boolean mPendingNightModeRecreate;
+
     public BraveYouTubePictureInPictureController(BraveActivity activity) {
         mActivity = activity;
     }
@@ -260,6 +267,47 @@ public class BraveYouTubePictureInPictureController {
             return;
         }
         handleSessionExited();
+        maybeApplyDeferredNightModeRecreate();
+    }
+
+    /**
+     * Called from {@link BraveActivity#onNightModeStateChanged}. A dark/light theme change
+     * recreates the activity; doing so while this session is active destroys the activity backing
+     * the PiP window, after which Android drops PiP shortly after the recreated activity resumes
+     * full-screen and this controller tears the session down as a normal PiP exit. Defer the
+     * recreation while the session is active; it is re-applied on PiP exit by
+     * {@link #maybeApplyDeferredNightModeRecreate}.
+     *
+     * @return true if the recreation was deferred and the caller should skip it.
+     */
+    public boolean maybeDeferNightModeRecreate() {
+        if (!mActive) {
+            return false;
+        }
+        mPendingNightModeRecreate = true;
+        return true;
+    }
+
+    /**
+     * Applies a night-mode recreation deferred by {@link #maybeDeferNightModeRecreate}. Posted so
+     * the PiP-exit teardown settles first, then guarded against a finishing/destroyed activity or a
+     * re-entered PiP window before asking the activity to recreate. Left untouched on the
+     * screen-lock exit path so the withheld theme is applied only once the session ends for real.
+     */
+    private void maybeApplyDeferredNightModeRecreate() {
+        if (!mPendingNightModeRecreate) {
+            return;
+        }
+        mPendingNightModeRecreate = false;
+        PostTask.postTask(
+                TaskTraits.UI_DEFAULT,
+                () -> {
+                    if (mActivity.isActivityFinishingOrDestroyed()
+                            || mActivity.isInPictureInPictureMode()) {
+                        return;
+                    }
+                    mActivity.applyDeferredNightModeRecreate();
+                });
     }
 
     /**
@@ -880,6 +928,9 @@ public class BraveYouTubePictureInPictureController {
         mInterruptedByScreenLock = false;
         mWasPlayingBeforeScreenLock = false;
         mResumeMediaSessionOnPipEntry = false;
+        // Not applied via the normal PiP-exit path (new-tab teardown, enter failure, destroy);
+        // drop it so a withheld theme change cannot leak into a later session's exit.
+        mPendingNightModeRecreate = false;
         mWebContents = null;
         mTabId = Tab.INVALID_TAB_ID;
         stopObservingMediaSession();

--- a/android/java/org/chromium/chrome/browser/media/BraveYouTubePictureInPictureController.java
+++ b/android/java/org/chromium/chrome/browser/media/BraveYouTubePictureInPictureController.java
@@ -275,8 +275,8 @@ public class BraveYouTubePictureInPictureController {
      * recreates the activity; doing so while this session is active destroys the activity backing
      * the PiP window, after which Android drops PiP shortly after the recreated activity resumes
      * full-screen and this controller tears the session down as a normal PiP exit. Defer the
-     * recreation while the session is active; it is re-applied on PiP exit by
-     * {@link #maybeApplyDeferredNightModeRecreate}.
+     * recreation while the session is active; it is re-applied on PiP exit by {@link
+     * #maybeApplyDeferredNightModeRecreate}.
      *
      * @return true if the recreation was deferred and the caller should skip it.
      */

--- a/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
@@ -486,6 +486,15 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
         // to proactively update the shields button state here, otherwise shields
         // might sometimes show as disabled while it is actually enabled.
         updateBraveShieldsButtonState(getToolbarDataProvider().getTab());
+        // After an activity recreation that reparents the current tab (e.g. the theme switch
+        // applied on YouTube PiP exit), the page is preserved without any fresh navigation,
+        // page-load, tab-selection, or tab-shown callback, so nothing would re-evaluate the PiP
+        // icon and it would stay hidden until a manual reload. The tab model is (re)bound here on
+        // every activity start, so proactively evaluate the current tab's icon.
+        final Tab pipCurrentTab = getToolbarDataProvider().getTab();
+        if (pipCurrentTab != null) {
+            showYouTubePipIcon(pipCurrentTab);
+        }
         mTabModelSelectorTabObserver =
                 new TabModelSelectorTabObserver(selector) {
                     @Override

--- a/android/junit/src/org/chromium/chrome/browser/media/BraveYouTubePictureInPictureControllerTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/media/BraveYouTubePictureInPictureControllerTest.java
@@ -619,4 +619,60 @@ public class BraveYouTubePictureInPictureControllerTest {
         verify(mFullscreenManager, never()).exitPersistentFullscreenMode();
         verify(mBraveActivity, never()).exitOverviewModeForYouTubePictureInPicture();
     }
+
+    @Test
+    public void maybeDeferNightModeRecreate_inactive_returnsFalse() {
+        // With no active session there is nothing to protect, so the theme recreate proceeds
+        // normally (the caller runs super.onNightModeStateChanged()).
+        BraveYouTubePictureInPictureController controller =
+                new BraveYouTubePictureInPictureController(mBraveActivity);
+
+        assertFalse(controller.maybeDeferNightModeRecreate());
+    }
+
+    @Test
+    public void maybeDeferNightModeRecreate_reenteredPip_skipsApply() {
+        WebContents observableWebContents =
+                mock(
+                        WebContents.class,
+                        withSettings().extraInterfaces(WebContentsObserver.Observable.class));
+        BraveYouTubePictureInPictureController controller =
+                spy(new BraveYouTubePictureInPictureController(mBraveActivity));
+        doReturn(null).when(controller).getMediaSession(any());
+        controller.onSessionRequested(observableWebContents);
+        controller.maybeDeferNightModeRecreate();
+
+        // The activity is back in a PiP window by the time the posted recreate runs; it must be
+        // skipped so we never recreate the activity backing a live PiP window.
+        when(mBraveActivity.isInPictureInPictureMode()).thenReturn(true);
+
+        controller.onExitPictureInPictureMode();
+        ShadowLooper.idleMainLooper(
+                BraveYouTubePictureInPictureController.DISMISS_CHECK_DELAY_MS,
+                TimeUnit.MILLISECONDS);
+
+        verify(mBraveActivity, never()).applyDeferredNightModeRecreate();
+    }
+
+    @Test
+    public void maybeDeferNightModeRecreate_screenLockExit_notApplied() {
+        BraveYouTubePictureInPictureController controller =
+                spy(new BraveYouTubePictureInPictureController(mBraveActivity));
+        doReturn(null).when(controller).getMediaSession(any());
+        doReturn(false).when(controller).isBackgroundVideoPlaybackEnabled(any());
+        controller.onSessionRequested(mWebContents);
+        controller.maybeDeferNightModeRecreate();
+
+        // Locking the screen parks the session rather than ending it, so the withheld theme
+        // change must wait for a real exit instead of recreating behind the lock.
+        setKeyguardLocked();
+
+        controller.onExitPictureInPictureMode();
+        ShadowLooper.idleMainLooper(
+                BraveYouTubePictureInPictureController.DISMISS_CHECK_DELAY_MS,
+                TimeUnit.MILLISECONDS);
+
+        verify(mBraveActivity, never()).applyDeferredNightModeRecreate();
+        assertTrue(controller.isInterruptedByScreenLockForTesting());
+    }
 }


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/56782

Fixes an issue where PIP was stopping on tablets during activity recreation for theme switching.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
