### PR TITLE
[CR 150] Fix vertical tab title alignment in horizontal tabs (#37479) (uplift to 1.92.x)

### DIFF
--- a/browser/ui/views/frame/brave_browser_frame_view_linux_browsertest.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_linux_browsertest.cc
@@ -282,9 +282,9 @@ IN_PROC_BROWSER_TEST_P(BraveBrowserFrameViewTabStripHeightTest,
 
   RunScheduledLayouts();
 
-  // Default: 32 (height) + 2*4 (spacing) + 1 (overlap) = 41
-  // Compact: 26 (height) + 2*2 (spacing) + 8 (overlap) = 38
-  const int expected_height = GetParam() ? 38 : 41;
+  // Default: 32 (height) + 2*4 (spacing) + 0 (overlap) = 40
+  // Compact: 26 (height) + 2*2 (spacing) + 0 (overlap) = 30
+  const int expected_height = GetParam() ? 30 : 40;
   EXPECT_EQ(expected_height, GetLayoutConstant(LayoutConstant::kTabStripHeight))
       << "kTabStripHeight constant is wrong for "
       << (GetParam() ? "compact" : "default") << " mode";

--- a/browser/ui/views/frame/brave_browser_frame_view_mac.mm
+++ b/browser/ui/views/frame/brave_browser_frame_view_mac.mm
@@ -104,8 +104,6 @@ int BraveBrowserFrameViewMac::GetTopInset(bool restored) const {
 BrowserFrameViewMac::BoundsAndMargins
 BraveBrowserFrameViewMac::GetCaptionButtonBounds() const {
   auto bounds_and_margins = BrowserFrameViewMac::GetCaptionButtonBounds();
-  bounds_and_margins.bounds.set_y(bounds_and_margins.bounds.y() +
-                                  tabs::GetHorizontalTabButtonYOffset());
   // Compact: zero the caption button vertical margins so the leading
   // exclusion collapses around the buttons themselves, letting the shorter
   // tab strip sit centred against the traffic lights.

--- a/browser/ui/views/frame/brave_browser_native_widget_mac.mm
+++ b/browser/ui/views/frame/brave_browser_native_widget_mac.mm
@@ -5,14 +5,11 @@
 
 #include "brave/browser/ui/views/frame/brave_browser_native_widget_mac.h"
 
-#include <algorithm>
-
 #include "base/feature_list.h"
 #include "brave/app/brave_command_ids.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/profiles/profile.h"
-#include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
@@ -49,15 +46,6 @@ void BraveBrowserNativeWidgetMac::GetWindowFrameTitlebarHeight(
 
   BrowserNativeWidgetMac::GetWindowFrameTitlebarHeight(override_titlebar_height,
                                                        titlebar_height);
-
-  // Compact: shrink the titlebar height AppKit sees so NSThemeFrame's
-  // auto-centred traffic lights shift up toward the shorter tab strip +
-  // toolbar row (AppKit moves the lights by half the delta).
-  if (*override_titlebar_height && tabs::UseCompactHorizontalTabs()) {
-    constexpr float kCompactTitlebarShrinkDip = 8.0f;
-    *titlebar_height =
-        std::max(0.0f, *titlebar_height - kCompactTitlebarShrinkDip);
-  }
 }
 
 void BraveBrowserNativeWidgetMac::ValidateUserInterfaceItem(

--- a/browser/ui/views/frame/brave_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/brave_tab_strip_region_view.cc
@@ -362,11 +362,6 @@ void BraveHorizontalTabStripRegionView::Layout(PassKey) {
             tab_strip_->bounds().right() +
             GetLayoutConstant(LayoutConstant::kTabStripPadding));
       }
-      // Adjust the vertical positioning in compact mode so that it remains
-      // centered.
-      if (tabs::UseCompactHorizontalTabs()) {
-        new_tab_button_->SetY(tabs::GetHorizontalTabButtonYOffset());
-      }
     }
 
     return;

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -485,14 +485,9 @@ void BraveTabContainer::PaintBoundingBoxForSplitTab(
 
   if (!is_vertical_tab) {
     // In order to make margin between the bounding box and tab strip.
-    // Need to compensate the amount of overlap because it's hidden by overlap
-    // at bottom.
     int vertical_margin = tab1->data().pinned ? 4 : 2;
-    bounding_rects.Inset(gfx::Insets::TLBR(
-        vertical_margin, tabs::kHorizontalTabInset,
-        vertical_margin +
-            GetLayoutConstant(LayoutConstant::kTabstripToolbarOverlap),
-        tabs::kHorizontalTabInset));
+    bounding_rects.Inset(
+        gfx::Insets::VH(vertical_margin, tabs::kHorizontalTabInset));
   }
 
   const float corner_radius =

--- a/browser/ui/views/tabs/brave_tab_style_views.inc.cc
+++ b/browser/ui/views/tabs/brave_tab_style_views.inc.cc
@@ -154,20 +154,11 @@ SkPath BraveVerticalTabStyle::GetPath(TabStyle::PathType path_type,
   if (!ShouldShowVerticalTabs()) {
     // Horizontal tabs should have a visual gap between them, even if their view
     // bounds are touching or slightly overlapping. Create a visual gap by
-    // insetting the bounds of the tab by the required gap plus overlap before
-    // drawing the rectangle.
+    // insetting the bounds of the tab by the required gap before drawing the
+    // rectangle.
     aligned_bounds.Inset(
         gfx::InsetsF::VH(tabs::GetHorizontalTabVerticalSpacing() * scale,
                          tabs::kHorizontalTabInset * scale));
-
-    // |aligned_bounds| is tab's bounds(). So, it includes insets also.
-    // Shrink height more if it's overlapped.
-    if (path_type != TabStyle::PathType::kHitTest) {
-      aligned_bounds.Inset(gfx::InsetsF::TLBR(
-          0, 0,
-          GetLayoutConstant(LayoutConstant::kTabstripToolbarOverlap) * scale,
-          0));
-    }
 
     // For hit testing, expand the rectangle so that the visual margins around
     // tabs can be used to select the tab. This will ensure that there is no
@@ -323,17 +314,7 @@ gfx::Insets BraveVerticalTabStyle::GetContentsInsets() const {
   }
 
   if (HorizontalTabsUpdateEnabled()) {
-    // Ignore any stroke widths when determining the horizontal contents insets.
-    // To make contents vertically align evenly regardless of overlap in non
-    // vertical tab, use it as bottom inset in a tab as it's hidden by
-    // overlapping.
-    return insets +
-           gfx::Insets::TLBR(
-               0, 0,
-               is_vertical_tabs
-                   ? 0
-                   : GetLayoutConstant(LayoutConstant::kTabstripToolbarOverlap),
-               0);
+    return insets;
   }
 
   auto result = TabStyleViewsImpl::GetContentsInsets();

--- a/chromium_src/chrome/browser/ui/layout_constants.cc
+++ b/chromium_src/chrome/browser/ui/layout_constants.cc
@@ -66,10 +66,14 @@ std::optional<int> GetBraveLayoutConstant(LayoutConstant constant) {
       return std::nullopt;
     }
     case LayoutConstant::kTabstripToolbarOverlap: {
-      if (!HorizontalTabsUpdateEnabled()) {
-        return std::nullopt;
+      // Upstream extends tabs 1px into the toolbar to hide a fractional-scale
+      // gap at the tab/toolbar seam. Brave's tabs are free-floating pills with
+      // a deliberate gap below them, so there is no seam and no need for an
+      // overlap.
+      if (HorizontalTabsUpdateEnabled()) {
+        return 0;
       }
-      return UseCompactHorizontalTabs() ? 8 : 1;
+      return std::nullopt;
     }
     case LayoutConstant::kLocationBarChildCornerRadius:
       return 4;
@@ -139,10 +143,6 @@ int GetHorizontalTabHeight() {
 
 int GetHorizontalTabVerticalSpacing() {
   return UseCompactHorizontalTabs() ? 2 : 4;
-}
-
-int GetHorizontalTabButtonYOffset() {
-  return UseCompactHorizontalTabs() ? -5 : -4;
 }
 
 int GetHorizontalTabStripHeight() {

--- a/chromium_src/chrome/browser/ui/layout_constants.h
+++ b/chromium_src/chrome/browser/ui/layout_constants.h
@@ -31,11 +31,6 @@ int GetHorizontalTabHeight();
 // be occupied by tab group underlines.
 int GetHorizontalTabVerticalSpacing();
 
-// Y-offset applied to buttons aligned with the horizontal tab strip (new tab
-// button, tab strip combo/search buttons, Mac caption buttons) so they sit
-// centered against the tab row.
-int GetHorizontalTabButtonYOffset();
-
 // The amount of space before the first tab view.
 inline constexpr int kHorizontalTabStripLeftMargin = 3;
 

--- a/chromium_src/chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.cc
@@ -18,24 +18,7 @@
 // `BraveNewTabButton::GetButtonSize` function.
 #define kButtonSize GetButtonSize()
 
-namespace {
-
-// Tab-strip-region-local override of `GetLayoutConstant`. Inside the upstream
-// `UpdateButtonBorders()` body, `kTabstripToolbarOverlap` is consumed as the
-// vertical inset used to center tab-strip control buttons (new tab, combo,
-// tab search). Routing just this translation unit's `GetLayoutConstant` calls
-// through the wrapper avoids patching upstream.
-int GetLayoutConstantForBraveHorizontalTabStripRegion(LayoutConstant constant) {
-  if (constant == LayoutConstant::kTabstripToolbarOverlap) {
-    return tabs::GetHorizontalTabButtonYOffset();
-  }
-  return GetLayoutConstant(constant);
-}
-
-}  // namespace
-
 #define BrowserTabStripController BraveBrowserTabStripController
-#define GetLayoutConstant GetLayoutConstantForBraveHorizontalTabStripRegion
 #define NewTabButton BraveNewTabButton
 #define TabHoverCardController BraveTabHoverCardController
 #define TabSearchButton BraveTabSearchButton
@@ -43,6 +26,5 @@ int GetLayoutConstantForBraveHorizontalTabStripRegion(LayoutConstant constant) {
 #undef TabSearchButton
 #undef TabHoverCardController
 #undef NewTabButton
-#undef GetLayoutConstant
 #undef BrowserTabStripController
 #undef kButtonSize


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56596
Uplift from https://github.com/brave/brave-core/pull/37479

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
