### PR TITLE
[iOS] Update iOS bootstrap and pre-action scripts to use node directly

### DIFF
--- a/ios/brave-ios/scripts/scheme_preaction.py
+++ b/ios/brave-ios/scripts/scheme_preaction.py
@@ -9,7 +9,6 @@ Actions to run before every build in the brave-ios Xcode project
 
 import argparse
 import os
-import subprocess
 import platform
 import sys
 import inspect
@@ -63,7 +62,7 @@ def main():
             raise Exception(err)
     else:
         BuildCore(options.configuration, target_arch, target_environment)
-        CallNpm(['npm', 'run', 'ios_pack_js'])
+        PackJavaScript()
     UpdateSymlink(options.configuration, target_arch, target_environment)
 
 
@@ -86,21 +85,23 @@ def UpdateSymlink(config, target_arch, target_environment):
     node.RunNode(cmd_args)
 
 
+def PackJavaScript():
+    """Bundles the iOS user script JavaScript resources via webpack"""
+    webpack_cli = os.path.join(brave_root_dir, 'node_modules', 'webpack-cli',
+                               'bin', 'cli.js')
+    webpack_config = os.path.join(brave_root_dir, 'ios', 'brave-ios',
+                                  'webpack.config.js')
+    node.RunNode([webpack_cli, '--config', webpack_config])
+
+
 def BuildCore(config, target_arch, target_environment):
     """Generates and builds the BraveCore.framework"""
     cmd_args = [
-        'npm', 'run', 'build', '--', config, '--target_os', 'ios',
-        '--target_arch', target_arch, '--target_environment',
-        target_environment
+        os.path.join(scripts_dir, 'commands.js'), 'build', config,
+        '--target_os', 'ios', '--target_arch', target_arch,
+        '--target_environment', target_environment
     ]
-    CallNpm(cmd_args)
-
-
-def CallNpm(cmd):
-    retcode = subprocess.call(cmd, cwd=brave_root_dir, stderr=subprocess.STDOUT)
-    if retcode:
-        raise subprocess.CalledProcessError(retcode, cmd)
-
+    node.RunNode(cmd_args)
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/ios/brave-ios/scripts/xcode_scheme_preaction.sh
+++ b/ios/brave-ios/scripts/xcode_scheme_preaction.sh
@@ -9,29 +9,8 @@
 # $ACTION is empty for Xcode builds unfortunately
 # $RUN_CLANG_STATIC_ANALYZER is NO for builds, YES for cleans
 if [[ $RUN_CLANG_STATIC_ANALYZER = "NO" ]]; then
-  if ! command -v npm &> /dev/null; then
-    # Fixup PATH for users who didn't install node directly or use nvm
-    if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
-      . "$HOME/.nvm/nvm.sh"
-    else
-        BREW='brew'
-        if [[ $(uname -p) == 'arm' ]]; then
-            # On Apple Silicon (M1, M2, M3) Brew is not part
-            # of the PATH.
-            BREW='/opt/homebrew/bin/brew'
-        fi
-      if [[ -x "$(command -v $BREW)" ]]; then
-        if [[ -s "$($BREW --prefix nvm)/nvm.sh" ]]; then
-          . "$($BREW --prefix nvm)/nvm.sh"
-        else
-          # Fixup PATH for brew users
-          eval "$($BREW shellenv)"
-        fi
-      fi
-    fi
-  fi
   # Do not inject Xcode build configs into the GN build
-  env -i PATH="$PATH" python3 \
+  env -i python3 \
     "${PROJECT_DIR}/../scripts/scheme_preaction.py" \
     --platform_name "$PLATFORM_NAME" \
     "$@"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "perf_tests": "node ./build/commands/scripts/commands.js run_perf_tests",
     "gen_env": "node ./build/commands/scripts/genEnv.js",
     "gen_gradle": "node ./build/commands/scripts/commands.js gen_gradle",
-    "ios_pack_js": "webpack --config ios/brave-ios/webpack.config.js",
     "ios_bootstrap": "node ./build/commands/scripts/iosCommands.js ios_bootstrap",
     "update_brave_tools_crates": "node ./build/commands/scripts/updateBraveToolsCrates.js",
     "update_wasm_resources": "node ./build/commands/scripts/updateWasmResources.js",

--- a/script/ios_bootstrap.py
+++ b/script/ios_bootstrap.py
@@ -11,11 +11,12 @@ import shutil
 import sys
 
 from distutils.dir_util import copy_tree
-from brave_chromium_utils import wspath
+from brave_chromium_utils import wspath, sys_path
 from lib.config import PLATFORM, enable_verbose_mode, is_verbose_mode
-from lib.util import execute_stdout
 from pathlib import Path
 
+with sys_path("//third_party/node"):
+    import node
 
 def main():
     if PLATFORM != 'darwin':
@@ -42,10 +43,18 @@ def parse_args():
     return parser.parse_args()
 
 
+def pack_javascript():
+    """Bundles the iOS user script JavaScript resources via webpack"""
+    webpack_cli = wspath("//brave/node_modules/webpack-cli/bin/cli.js")
+    webpack_config = wspath("//brave/ios/brave-ios/webpack.config.js")
+    stdout = node.RunNode([webpack_cli, '--config', webpack_config])
+    if is_verbose_mode():
+        print(stdout)
+
 def create_required_spm_resources(force=False):
     # Runs webpack on the JS files that are generated in iOS. This is so that
     # Package.swift/SPM resolves with the resources available
-    execute_stdout(['npm', 'run', 'ios_pack_js'])
+    pack_javascript()
     # Creates the expected out/ios_current_link directory and places placeholder
     # xcframeworks inside to ensure Package.swift/SPM validates the manifest
     # correctly.


### PR DESCRIPTION
This swaps out the `npm run` calls with direct `node` calls which also cleans up `npm` pathing requirements in the Xcode pre-action scripts. This also removes `ios_pack_js` from package.json as theres no reason to ever execute this manually
