### PR TITLE
fix(brave_account): change email aliases Log out button to Sign out

### DIFF
--- a/components/brave_account/resources/brave_account_strings.grdp
+++ b/components/brave_account/resources/brave_account_strings.grdp
@@ -65,7 +65,7 @@
     Unable to change password
   </message>
   <message name="IDS_SETTINGS_BRAVE_ACCOUNT_LOG_OUT_BUTTON_LABEL" desc="Label for the button that signs the user out of their account when clicked" formatter_data="webui=BraveAccountSettings android_java">
-    Log out
+    Sign out
   </message>
 
   <!-- 'Entry' dialog: -->


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/56670

Updates the Brave Account email aliases settings page button label from `Log out` to `Sign out`, matching Brave's standard terminology.