### PR TITLE
fix(shields): add bottom padding to Save changes button in adblock editor

### DIFF
--- a/browser/resources/settings/default_brave_shields_page/components/brave_adblock_editor.html
+++ b/browser/resources/settings/default_brave_shields_page/components/brave_adblock_editor.html
@@ -59,7 +59,8 @@
   </div>
   <cr-button
     on-click="handleSave_"
-    disabled="[[!prefs.brave.ad_block.developer_mode.value]]">
+    disabled="[[!prefs.brave.ad_block.developer_mode.value]]"
+    style="margin-bottom: 16px;">
     $i18n{adblockSaveChangesButtonLabel}
   </cr-button>
 </div>


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/47782

Adds `margin-bottom: 16px` to the Save changes button in the custom filters editor so it no longer sits flush against the separator line below it when Developer mode is enabled.