### PR TITLE
fix(ai_chat): add dismiss button to Leo premium disconnected warning

### DIFF
--- a/components/ai_chat/resources/untrusted_conversation_frame/components/alerts/warning_premium_disconnected.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/alerts/warning_premium_disconnected.tsx
@@ -12,6 +12,11 @@ import styles from './alerts.module.scss'
 
 export default function WarningPremiumDisconnected() {
   const context = useUntrustedConversationContext()
+  const [dismissed, setDismissed] = React.useState(false)
+
+  if (dismissed) {
+    return null
+  }
 
   return (
     <div className={styles.alert}>
@@ -23,6 +28,13 @@ export default function WarningPremiumDisconnected() {
           onClick={() => context.uiHandler.refreshPremiumSession()}
         >
           {getLocale(S.CHAT_UI_PREMIUM_REFRESH_WARNING_ACTION)}
+        </Button>
+        <Button
+          slot='actions'
+          kind='plain-faint'
+          onClick={() => setDismissed(true)}
+        >
+          {getLocale(S.CHAT_UI_DISMISS_BUTTON_LABEL)}
         </Button>
       </Alert>
     </div>


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/34575

Adds a dismiss button to the Leo premium disconnected warning banner so users can close the message without immediately refreshing their Brave account session.