### PR TITLE
[bootstrap] Pass arguments through in `launcher.py`

### DIFF
--- a/tools/cr/bootstrap/bootstrap_test.py
+++ b/tools/cr/bootstrap/bootstrap_test.py
@@ -392,5 +392,50 @@ class ResolveInvocationTest(unittest.TestCase):
             launcher.resolve_invocation('bogus', None, True)
 
 
+class ArgumentForwardingTest(unittest.TestCase):
+    """Exercises `launcher.build_parser` argv splitting.
+
+    The launcher must never swallow a tool's own arguments: it parses only its
+    leading options and the TOOL token, forwarding everything from TOOL onward
+    verbatim (regression coverage for `brockit gen-rust-toolchain --help`).
+    """
+
+    def _split(self, argv: list[str]) -> tuple[bool, str, list[str]]:
+        parsed = launcher.build_parser().parse_args(argv)
+        return parsed.allow_fallback, parsed.tool, parsed.tool_args
+
+    def test_forwards_help_to_tool(self):
+        # The bug: `--help` after TOOL was intercepted by the launcher instead
+        # of reaching the tool.
+        self.assertEqual(self._split(['gen-rust-toolchain', '--help']),
+                         (False, 'gen-rust-toolchain', ['--help']))
+        self.assertEqual(self._split(['brockit', '-h']),
+                         (False, 'brockit', ['-h']))
+
+    def test_forwards_tool_flags_verbatim(self):
+        self.assertEqual(self._split(['brockit', 'lift', '--to=1.2.3.4']),
+                         (False, 'brockit', ['lift', '--to=1.2.3.4']))
+
+    def test_leading_allow_fallback_is_consumed(self):
+        # Before TOOL, `--allow-fallback` is the launcher's own flag.
+        self.assertEqual(self._split(['--allow-fallback', 'node', 'build.js']),
+                         (True, 'node', ['build.js']))
+
+    def test_allow_fallback_after_tool_is_forwarded(self):
+        # After TOOL, the identical flag is the tool's — forwarded, not acted on.
+        self.assertEqual(self._split(['brockit', '--allow-fallback', 'foo']),
+                         (False, 'brockit', ['--allow-fallback', 'foo']))
+
+    def test_bare_tool_has_no_args(self):
+        self.assertEqual(self._split(['brockit']), (False, 'brockit', []))
+
+    def test_own_help_renders_without_crashing(self):
+        # argparse expands help strings through `% params`; a bare `%` (the
+        # `%PATH` typo) raised ValueError. The `%%` escape must survive it and
+        # render a literal `%PATH`.
+        help_text = launcher.build_parser().format_help()
+        self.assertIn('%PATH', help_text)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tools/cr/bootstrap/launcher.py
+++ b/tools/cr/bootstrap/launcher.py
@@ -184,8 +184,13 @@ def resolve_invocation(tool: str, checkout: Path | None,
     return invocation
 
 
-def main() -> int:
-    """Resolve the tool from argv and run it, or report why it cannot."""
+def build_parser() -> argparse.ArgumentParser:
+    """The launcher's own argument parser.
+
+    Only the launcher's leading options and the TOOL token are parsed here.
+    Everything from TOOL onward is captured verbatim by the REMAINDER
+    positional and forwarded to the tool.
+    """
     parser = argparse.ArgumentParser(
         prog='launcher.py',
         description='Run a brave tool shim against the checkout in the cwd.',
@@ -194,12 +199,26 @@ def main() -> int:
     parser.add_argument(
         '--allow-fallback',
         action='store_true',
-        help='Allows falling back to a binary in %PATH if outside a checkout.')
+        # The '%%' escapes the literal percent: argparse runs help strings
+        # through '% params' formatting, and a bare '%P' crashes it.
+        help='Allows falling back to a binary in %%PATH if outside a checkout.'
+    )
     parser.add_argument('tool',
                         metavar='TOOL',
                         help='shim to run (e.g. brockit, plaster, node, npm)')
-    parsed, tool_args = parser.parse_known_args()
+    parser.add_argument('tool_args',
+                        metavar='...',
+                        nargs=argparse.REMAINDER,
+                        help='arguments forwarded to TOOL verbatim')
+    return parser
+
+
+def main() -> int:
+    """Resolve the tool from argv and run it, or report why it cannot."""
+    parser = build_parser()
+    parsed = parser.parse_args()
     tool = parsed.tool
+    tool_args = parsed.tool_args
 
     checkout = _find_cwd_checkout()
     try:


### PR DESCRIPTION
This change corrects an issue with `launcher.py` eating arguments that
it assumed it was meant for it. With this change we assume all the
arguments after are meant to be passed through to the tool.

Bug: https://github.com/brave/brave-browser/issues/56529
