### PR TITLE
Add Restore purchase action to Brave Origin settings

### DIFF
--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -693,6 +693,9 @@
   <message name="IDS_SETTINGS_BRAVE_ORIGIN_ONBOARDING_BUY_NOW" desc="The label for the Buy now button in Brave Origin onboarding">
     Buy now
   </message>
+  <message name="IDS_SETTINGS_BRAVE_ORIGIN_ONBOARDING_RESTORE_PURCHASE" desc="The label for the button to restore a previous Brave Origin purchase">
+    Restore purchase
+  </message>
   <message name="IDS_SETTINGS_BRAVE_ORIGIN_ONBOARDING_LEARN_MORE" desc="The label for the Learn more link in Brave Origin onboarding">
     Learn more
   </message>

--- a/browser/resources/settings/brave_origin_page/brave_origin_onboarding.html
+++ b/browser/resources/settings/brave_origin_page/brave_origin_onboarding.html
@@ -14,6 +14,7 @@
   }
 
   #learnMoreLink,
+  #restorePurchaseButton,
   #proceedFreeButton {
     margin-inline-start: var(--leo-spacing-xl);
   }
@@ -37,6 +38,9 @@
   <div class="cr-row">
     <cr-button class="action-button" on-click="onBuyNowClick_">
       $i18n{braveOriginOnboardingBuyNow}
+    </cr-button>
+    <cr-button id="restorePurchaseButton" on-click="onRestorePurchaseClick_">
+      $i18n{braveOriginOnboardingRestorePurchase}
     </cr-button>
     <if expr="is_linux">
       <cr-button id="proceedFreeButton" on-click="onProceedFreeClick_">

--- a/browser/resources/settings/brave_origin_page/brave_origin_onboarding.ts
+++ b/browser/resources/settings/brave_origin_page/brave_origin_onboarding.ts
@@ -40,6 +40,13 @@ export class SettingsBraveOriginOnboardingElement extends
         'noopener');
   }
 
+  private onRestorePurchaseClick_() {
+    window.open(
+        loadTimeData.getString('braveOriginRestoreUrl'),
+        '_blank',
+        'noopener');
+  }
+
   private onLearnMoreClick_() {
     window.open(
         'https://support.brave.app/hc/en-us/articles/38561489788173',

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -326,6 +326,13 @@ void BraveSettingsUI::AddResources(content::WebUIDataSource* html_source,
            brave_domains::GetServicesDomain(
                "account", brave_domains::ServicesEnvironment::STAGING),
            "/?intent=checkout&product=origin&mtm_campaign=browser-settings"}));
+  html_source->AddString(
+      "braveOriginRestoreUrl",
+      base::StrCat(
+          {"https://",
+           brave_domains::GetServicesDomain(
+               "account", brave_domains::ServicesEnvironment::STAGING),
+           "/?intent=recover&product=origin&mtm_campaign=browser-settings"}));
   html_source->AddBoolean("isTreeTabsFlagEnabled",
                           base::FeatureList::IsEnabled(tabs::kBraveTreeTab));
   html_source->AddBoolean(

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -231,6 +231,8 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
        IDS_SETTINGS_BRAVE_ORIGIN_ONBOARDING_DESCRIPTION},
       {"braveOriginOnboardingBuyNow",
        IDS_SETTINGS_BRAVE_ORIGIN_ONBOARDING_BUY_NOW},
+      {"braveOriginOnboardingRestorePurchase",
+       IDS_SETTINGS_BRAVE_ORIGIN_ONBOARDING_RESTORE_PURCHASE},
       {"braveOriginOnboardingLearnMore",
        IDS_SETTINGS_BRAVE_ORIGIN_ONBOARDING_LEARN_MORE},
 #if BUILDFLAG(IS_LINUX)


### PR DESCRIPTION
## Summary

<img width="732" height="289" alt="Screenshot 2026-07-08 at 4 40 34 PM" src="https://github.com/user-attachments/assets/67c0ed1d-2f08-4e2c-a703-92635b9292aa" />


Adds a **Restore purchase** secondary button beside the existing **Buy now** button in Settings > Brave Origin, followed by the **Learn more** link in the same action row.

- **Buy now** continues to open the premium account site for Origin checkout (`intent=checkout&product=origin`).
- **Restore purchase** opens the same premium account site with the recovery intent (`intent=recover&product=origin`).

Resolves https://github.com/brave/brave-browser/issues/56929

## Test plan

- Navigate to `chrome://settings/origin` on a profile without Brave Origin enabled.
- Confirm the action row shows: `Buy now` (primary), `Restore purchase` (secondary), then the `Learn more` link.
- Click **Buy now** — verify it opens the account site with `intent=checkout&product=origin`.
- Click **Restore purchase** — verify it opens the account site with `intent=recover&product=origin`.
- Click **Learn more** — verify it opens the support article.