### PR TITLE
Environment variable cleanup: use default GN args (uplift of 1.91.x)

### DIFF
--- a/brave_domains/buildflags.gni
+++ b/brave_domains/buildflags.gni
@@ -7,7 +7,7 @@ import("//brave/build/config.gni")
 import("//build/config/ui.gni")
 
 declare_args() {
-  brave_services_production_domain = ""
-  brave_services_staging_domain = ""
-  brave_services_dev_domain = ""
+  brave_services_production_domain = "brave.com"
+  brave_services_staging_domain = "bravesoftware.com"
+  brave_services_dev_domain = "brave.software"
 }

--- a/browser/brave_stats/buildflags.gni
+++ b/browser/brave_stats/buildflags.gni
@@ -6,7 +6,7 @@
 import("//brave/components/brave_origin/buildflags/buildflags.gni")
 
 declare_args() {
-  brave_stats_updater_url = ""
+  brave_stats_updater_url = "https://usage-ping.brave.com"
 
   enable_brave_stats_updater = !is_brave_origin_branded
 }

--- a/build/commands/lib/buildArgs.ts
+++ b/build/commands/lib/buildArgs.ts
@@ -11,31 +11,22 @@ import path from 'node:path'
 
 const FORWARD_ENV_CONFIG_VARS_TO_GN_ARGS = [
   'brave_android_developer_options_code',
-  'brave_google_api_endpoint',
   'brave_google_api_key',
   'brave_safebrowsing_api_key',
-  'brave_services_dev_domain',
   'brave_services_key_id',
-  'brave_services_production_domain',
-  'brave_services_staging_domain',
   'brave_stats_api_key',
-  'brave_stats_updater_url',
   'brave_sync_endpoint',
-  'brave_variations_server_url',
   'concurrent_links',
   'dcheck_always_on',
   'enable_updater',
   'google_default_client_id',
   'google_default_client_secret',
   'msan_track_origins',
-  'safebrowsing_api_endpoint',
   'service_key_aichat',
   'service_key_stt',
   'sparkle_dsa_private_key_file',
   'sparkle_eddsa_private_key',
   'sparkle_eddsa_public_key',
-  'updater_dev_endpoint',
-  'updater_prod_endpoint',
   'use_prebuilt_omaha4',
   'webcompat_report_api_endpoint',
   'use_clang_coverage',
@@ -332,11 +323,8 @@ export function getBuildArgs(config: Config) {
 
     args.brave_ios_developer_options_code = config.braveIOSDeveloperOptionsCode
 
-    delete args.safebrowsing_api_endpoint
     delete args.enable_hangout_services_extension
-    delete args.brave_google_api_endpoint
     delete args.brave_google_api_key
-    delete args.brave_stats_updater_url
     delete args.use_blink_v8_binding_new_idl_interface
     delete args.v8_enable_verify_heap
     delete args.service_key_stt

--- a/components/geolocation/BUILD.gn
+++ b/components/geolocation/BUILD.gn
@@ -7,8 +7,7 @@ import("//build/buildflag_header.gni")
 
 declare_args() {
   brave_google_api_key = "AIzaSyAREPLACEWITHYOUROWNGOOGLEAPIKEY2Q"
-  brave_google_api_endpoint =
-      "https://www.googleapis.com/geolocation/v1/geolocate?key="
+  brave_google_api_endpoint = "https://location.brave.com/v1/geolocate?key="
 }
 
 buildflag_header("geolocation") {

--- a/components/safebrowsing/BUILD.gn
+++ b/components/safebrowsing/BUILD.gn
@@ -7,7 +7,7 @@ import("//build/buildflag_header.gni")
 import("//build/config/features.gni")
 
 declare_args() {
-  safebrowsing_api_endpoint = ""
+  safebrowsing_api_endpoint = "safebrowsing.brave.com"
 }
 
 buildflag_header("buildflags") {

--- a/components/update_client/BUILD.gn
+++ b/components/update_client/BUILD.gn
@@ -6,8 +6,8 @@
 import("//build/buildflag_header.gni")
 
 declare_args() {
-  updater_dev_endpoint = ""
-  updater_prod_endpoint = ""
+  updater_dev_endpoint = "https://go-updater-dev.bravesoftware.com/extensions"
+  updater_prod_endpoint = "https://go-updater.brave.com/extensions"
 }
 
 if (is_official_build) {

--- a/components/variations/buildflags.gni
+++ b/components/variations/buildflags.gni
@@ -4,7 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 declare_args() {
-  brave_variations_server_url = ""
+  brave_variations_server_url = "https://variations.brave.com/seed"
 }
 
 if (is_official_build) {


### PR DESCRIPTION
Squashed uplift of the following PRs:
- #36226 add default values for brave services domains
- #37454 [Rewards] Add default public rewards GN args
- #37324 Put updater endpoints as default GN args
- #37672 Remove brave_services_*_domain from .env
- #37752 Use default for more brave gn args
