### PR TITLE
Document brave_chrome_browser_allow_circular_includes_from + cr150 audit TODO

### DIFF
--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -69,6 +69,17 @@ if (enable_playlist) {
   import("//brave/browser/playlist/sources.gni")
 }
 
+# Circular-include allowances for Brave sources injected into upstream's
+# `//chrome/browser:browser` target (see the `import("//brave/browser/
+# sources.gni")` line in `//chrome/browser/BUILD.gn`). Each entry permits a
+# Brave source compiled into `:browser` to include a header from one of the
+# listed `:impl`/circular targets, resolving a dependency cycle.
+#
+# TODO(https://github.com/brave/brave-browser/issues/56332): now that upstream
+# has split most of `chrome/browser` into a separate `:core` target, revisit
+# this componentization (inject into `:core` vs `:browser` where appropriate)
+# and audit every entry below to determine where each cycle actually lives,
+# dropping any allowance upstream's split now makes unnecessary.
 brave_chrome_browser_allow_circular_includes_from = []
 
 brave_chrome_browser_visibility = [


### PR DESCRIPTION
## Summary

Documents the `brave_chrome_browser_allow_circular_includes_from` list in
`browser/sources.gni` and records the pending `cr150` componentization audit as
a discoverable in-code TODO.

The added comment explains that entries in this list permit Brave sources
injected into upstream's `//chrome/browser:browser` target (via the
`import("//brave/browser/sources.gni")` line in `//chrome/browser/BUILD.gn`) to
include headers from the listed `:impl`/circular targets, resolving a
dependency cycle.

It then adds a `TODO` pointing at brave/brave-browser#56332 so the eventual
audit — revisiting whether sources belong in `:core` vs `:browser` after
upstream's core split, and pruning now-unnecessary circular-include allowances —
is anchored exactly where that work will happen.

## Scope

This is an intentionally small, **comment-only** first step toward
brave/brave-browser#56332. It makes no functional or build-graph changes:

- No target renames.
- No circular-include entries added or removed.
- No source/dep list changes.

The larger componentization refactor and per-entry cycle audit are deferred to
follow-up work, since each removal must be validated with a real build.

## Verification

- `npm run presubmit -- --base master`: `0 Presubmit Messages, 0 Presubmit
  Warnings, 0 Presubmit ERRORS`.
- Comment claims verified against the tree: Brave sources are injected into
  `static_library("browser")` in `chrome/browser/BUILD.gn`, and upstream's
  `source_set("core")` split is present.

Resolves (partially): brave/brave-browser#56332
