### PR TITLE
Extract open-tab semantic search util from tab_search page handler

### DIFF
--- a/browser/history_embeddings/BUILD.gn
+++ b/browser/history_embeddings/BUILD.gn
@@ -7,6 +7,29 @@ import("//brave/components/local_ai/buildflags/buildflags.gni")
 
 assert(enable_local_ai)
 
+# Resolves open-tab URLs to URLIDs via HistoryService and ranks them with
+# HistoryEmbeddingsSearch. Shared by the tab_search WebUI page handler and the
+# semantic tab search chat tool.
+source_set("open_tab_search") {
+  public = [ "open_tab_search.h" ]
+  sources = [ "open_tab_search.cc" ]
+
+  public_deps = [ "//base" ]
+
+  deps = [
+    "//chrome/browser/profiles",
+    "//chrome/browser/ui/browser_window",
+    "//chrome/browser/ui/tabs:tab_strip",
+    "//chrome/browser/ui/tabs:tabs_public",
+    "//components/history/core/browser",
+    "//components/history_embeddings/content",
+    "//components/history_embeddings/core",
+    "//components/tabs:public",
+    "//content/public/browser",
+    "//url",
+  ]
+}
+
 source_set("unit_tests") {
   testonly = true
   sources = [

--- a/browser/history_embeddings/BUILD.gn
+++ b/browser/history_embeddings/BUILD.gn
@@ -30,6 +30,34 @@ source_set("open_tab_search") {
   ]
 }
 
+source_set("browser_tests") {
+  testonly = true
+  sources = [ "open_tab_search_browsertest.cc" ]
+
+  defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+
+  deps = [
+    ":open_tab_search",
+    "//base",
+    "//brave/components/constants",
+    "//brave/components/history_embeddings:test_support",
+    "//chrome/browser/history",
+    "//chrome/browser/profiles",
+    "//chrome/browser/ui",
+    "//chrome/browser/ui/tabs:tabs_public",
+    "//chrome/test:test_support",
+    "//components/history/core/browser",
+    "//components/keyed_service/core",
+    "//content/public/browser",
+    "//content/test:test_support",
+    "//net:test_support",
+    "//testing/gmock",
+    "//testing/gtest",
+    "//ui/base",
+    "//url",
+  ]
+}
+
 source_set("unit_tests") {
   testonly = true
   sources = [

--- a/browser/history_embeddings/README.md
+++ b/browser/history_embeddings/README.md
@@ -100,6 +100,14 @@ as a `friend class` on the base so we can reach `observer_list_` and
   EmbeddingGemma files and hand them to `service_->BindPassageEmbedder()` once
   loaded.
 
+- **`open_tab_search.{h,cc}`** — Standalone util, unrelated to the embedder
+  above: it powers on-device "search my open tabs by content".
+  `SearchOpenTabsByContent` snapshots a profile's open HTTP(S) tabs, resolves
+  their URLs to URLIDs via `HistoryService`, then ranks them against a query
+  with `HistoryEmbeddingsSearch::Search`. Shared by the tab_search WebUI page
+  handler and the semantic tab search chat tool. Builds regardless of
+  `enable_local_ai` since it only wraps upstream Chromium APIs.
+
 ## Related Files
 
 - **`components/history_embeddings/content/brave_history_embeddings_service.h`**

--- a/browser/history_embeddings/open_tab_search.cc
+++ b/browser/history_embeddings/open_tab_search.cc
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/history_embeddings/open_tab_search.h"
+
+#include <numeric>
+#include <optional>
+#include <utility>
+
+#include "base/check_op.h"
+#include "base/containers/flat_map.h"
+#include "base/containers/map_util.h"
+#include "base/containers/to_vector.h"
+#include "base/functional/bind.h"
+#include "base/task/cancelable_task_tracker.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
+#include "chrome/browser/ui/browser_window/public/global_browser_collection.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "components/history/core/browser/history_service.h"
+#include "components/history/core/browser/history_types.h"
+#include "components/history_embeddings/content/history_embeddings_service.h"
+#include "components/history_embeddings/core/history_embeddings_search.h"
+#include "components/tabs/public/tab_interface.h"
+#include "content/public/browser/web_contents.h"
+#include "url/gurl.h"
+
+namespace history_embeddings {
+
+namespace {
+
+// Minimal descriptor of an open tab collected by `SnapshotOpenTabs`.
+struct OpenTabInfo {
+  int32_t tab_id = 0;
+  GURL url;
+};
+
+// Same predicate as `TabSearchPageHandler_ChromiumImpl::ShouldTrackBrowser`.
+// Uses `BrowserWindowInterface*` rather than `Browser*` because
+// `Browser`'s definition lives in `//chrome/browser/ui:ui`, which this
+// shared util cannot depend on (that target already depends on this util
+// via the chromium_src override, creating a cycle).
+bool ShouldTrackBrowser(Profile* profile, BrowserWindowInterface* browser) {
+  return browser->GetProfile() == profile &&
+         browser->GetType() == BrowserWindowInterface::TYPE_NORMAL;
+}
+
+// Walks `profile`'s browser windows and returns HTTP(S) tabs from
+// regular-type windows tracked by the tab_search feature.
+std::vector<OpenTabInfo> SnapshotOpenTabs(Profile* profile) {
+  std::vector<OpenTabInfo> tabs;
+  GlobalBrowserCollection::GetInstance()->ForEach(
+      [profile, &tabs](BrowserWindowInterface* browser_window) {
+        if (!ShouldTrackBrowser(profile, browser_window)) {
+          return true;
+        }
+        TabStripModel* tab_strip_model = browser_window->GetTabStripModel();
+        if (!tab_strip_model) {
+          return true;
+        }
+        std::vector<int> indices(tab_strip_model->count());
+        std::iota(indices.begin(), indices.end(), 0);
+        for (tabs::TabInterface* tab :
+             tab_strip_model->GetTabsAtIndices(indices)) {
+          if (!tab) {
+            continue;
+          }
+          content::WebContents* contents = tab->GetContents();
+          if (!contents) {
+            continue;
+          }
+          GURL url = contents->GetLastCommittedURL();
+          if (!url.SchemeIsHTTPOrHTTPS()) {
+            continue;
+          }
+          tabs.push_back({tab->GetHandle().raw_value(), std::move(url)});
+        }
+        return true;
+      });
+  return tabs;
+}
+
+// Emits the ranked tab_ids by joining the URLID→tab_id index against the
+// scored URL rows.
+void DispatchTabIdsForScoredUrls(
+    RankedTabIdsCallback& callback,
+    const base::flat_map<history::URLID, int32_t>& tab_id_by_url_id,
+    SearchResult result) {
+  std::vector<int32_t> tab_ids;
+  for (const auto& row : result.scored_url_rows) {
+    if (auto* tab_id =
+            base::FindOrNull(tab_id_by_url_id, row.scored_url.url_id)) {
+      tab_ids.push_back(*tab_id);
+    }
+  }
+  std::move(callback).Run(std::move(tab_ids));
+}
+
+void OnUrlIdsResolved(std::vector<OpenTabInfo> tabs,
+                      std::string query,
+                      HistoryEmbeddingsSearch* embeddings_search,
+                      RankedTabIdsCallback callback,
+                      std::optional<std::vector<history::URLID>> url_ids) {
+  // HistoryService returned no result (e.g. shutdown / cancellation).
+  if (!url_ids) {
+    std::move(callback).Run({});
+    return;
+  }
+  CHECK_EQ(tabs.size(), url_ids->size());
+  std::vector<history::URLID> url_id_filter;
+  base::flat_map<history::URLID, int32_t> tab_id_by_url_id;
+  url_id_filter.reserve(url_ids->size());
+  for (size_t i = 0; i < url_ids->size(); ++i) {
+    if ((*url_ids)[i] == 0) {
+      continue;
+    }
+    url_id_filter.push_back((*url_ids)[i]);
+    tab_id_by_url_id.emplace((*url_ids)[i], tabs[i].tab_id);
+  }
+  // None of the open tabs have a corresponding URLID in history yet, so the
+  // embeddings search would have nothing to score against.
+  if (url_id_filter.empty()) {
+    std::move(callback).Run({});
+    return;
+  }
+  const size_t count = url_id_filter.size();
+  embeddings_search->Search(
+      /*previous_search_result=*/nullptr, query,
+      /*time_range_start=*/std::nullopt, count,
+      /*skip_answering=*/true, std::move(url_id_filter),
+      base::BindRepeating(&DispatchTabIdsForScoredUrls,
+                          base::OwnedRef(std::move(callback)),
+                          std::move(tab_id_by_url_id)));
+}
+
+}  // namespace
+
+void SearchOpenTabsByContent(Profile* profile,
+                             history::HistoryService* history_service,
+                             HistoryEmbeddingsSearch* embeddings_search,
+                             std::string query,
+                             RankedTabIdsCallback callback,
+                             base::CancelableTaskTracker* task_tracker) {
+  std::vector<OpenTabInfo> tabs = SnapshotOpenTabs(profile);
+  // No tracked tabs to rank against — `SnapshotOpenTabs` only keeps
+  // tracked-browser HTTP(S) tabs, so non-normal windows, other profiles and
+  // incognito don't reach here.
+  if (tabs.empty()) {
+    std::move(callback).Run({});
+    return;
+  }
+  // Sequence the read-from-`tabs` (for URLs) before the move-of-`tabs` into
+  // the callback bind. Inlining the projection as a sibling argument leaves
+  // the order of evaluation unspecified and lets the move win on some
+  // toolchains.
+  const std::vector<GURL> urls = base::ToVector(tabs, &OpenTabInfo::url);
+  history_service->QueryUrlIds(
+      urls,
+      base::BindOnce(&OnUrlIdsResolved, std::move(tabs), std::move(query),
+                     embeddings_search, std::move(callback)),
+      task_tracker);
+}
+
+}  // namespace history_embeddings

--- a/browser/history_embeddings/open_tab_search.h
+++ b/browser/history_embeddings/open_tab_search.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_BROWSER_HISTORY_EMBEDDINGS_OPEN_TAB_SEARCH_H_
+#define BRAVE_BROWSER_HISTORY_EMBEDDINGS_OPEN_TAB_SEARCH_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "base/functional/callback_forward.h"
+
+namespace base {
+class CancelableTaskTracker;
+}  // namespace base
+
+namespace history {
+class HistoryService;
+}  // namespace history
+
+class Profile;
+
+namespace history_embeddings {
+
+class HistoryEmbeddingsSearch;
+
+// Callback signature that matches the mojom-generated
+// `TabSearchPageHandler::SearchTabsByContentCallback`: receives the tab_ids
+// of matched open tabs in ranked order (best first).
+using RankedTabIdsCallback =
+    base::OnceCallback<void(const std::vector<int32_t>&)>;
+
+// Snapshots `profile`'s open HTTP(S) tabs from regular-type windows tracked
+// by the tab_search feature, resolves their URLs to URLIDs via
+// `history_service`, ranks them against `query` with
+// `HistoryEmbeddingsSearch::Search` (`skip_answering=true`), and dispatches
+// the matched tab_ids (best first) to `callback`. Dispatches an empty list
+// when there are no such tabs or none of them match.
+void SearchOpenTabsByContent(Profile* profile,
+                             history::HistoryService* history_service,
+                             HistoryEmbeddingsSearch* embeddings_search,
+                             std::string query,
+                             RankedTabIdsCallback callback,
+                             base::CancelableTaskTracker* task_tracker);
+
+}  // namespace history_embeddings
+
+#endif  // BRAVE_BROWSER_HISTORY_EMBEDDINGS_OPEN_TAB_SEARCH_H_

--- a/browser/history_embeddings/open_tab_search_browsertest.cc
+++ b/browser/history_embeddings/open_tab_search_browsertest.cc
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/history_embeddings/open_tab_search.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "base/command_line.h"
+#include "base/files/file_path.h"
+#include "base/path_service.h"
+#include "base/strings/utf_string_conversions.h"
+#include "base/task/cancelable_task_tracker.h"
+#include "base/test/test_future.h"
+#include "base/time/time.h"
+#include "brave/components/constants/brave_paths.h"
+#include "brave/components/history_embeddings/test/fake_history_embeddings_search.h"
+#include "chrome/browser/history/history_service_factory.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "components/history/core/browser/history_service.h"
+#include "components/history/core/browser/history_types.h"
+#include "components/keyed_service/core/service_access_type.h"
+#include "components/tabs/public/tab_interface.h"
+#include "content/public/browser/navigation_controller.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/content_mock_cert_verifier.h"
+#include "net/dns/mock_host_resolver.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/base/page_transition_types.h"
+#include "url/gurl.h"
+
+namespace history_embeddings {
+
+class OpenTabSearchBrowserTest : public InProcessBrowserTest {
+ public:
+  OpenTabSearchBrowserTest()
+      : https_server_(net::EmbeddedTestServer::TYPE_HTTPS) {}
+
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+    base::FilePath test_data_dir =
+        base::PathService::CheckedGet(brave::DIR_TEST_DATA);
+    mock_cert_verifier_.mock_cert_verifier()->set_default_result(net::OK);
+    https_server_.ServeFilesFromDirectory(test_data_dir);
+    host_resolver()->AddRule("*", "127.0.0.1");
+    ASSERT_TRUE(https_server_.Start());
+  }
+
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    InProcessBrowserTest::SetUpCommandLine(command_line);
+    mock_cert_verifier_.SetUpCommandLine(command_line);
+  }
+
+  void SetUpInProcessBrowserTestFixture() override {
+    InProcessBrowserTest::SetUpInProcessBrowserTestFixture();
+    mock_cert_verifier_.SetUpInProcessBrowserTestFixture();
+  }
+
+  void TearDownInProcessBrowserTestFixture() override {
+    InProcessBrowserTest::TearDownInProcessBrowserTestFixture();
+    mock_cert_verifier_.TearDownInProcessBrowserTestFixture();
+  }
+
+  Profile* profile() { return browser()->profile(); }
+
+  GURL GetURL(const std::string& host, const std::string& path) {
+    return https_server_.GetURL(host, path);
+  }
+
+  void AppendTab(Browser* target, const GURL& url, const std::string& title) {
+    ui_test_utils::NavigateToURLWithDisposition(
+        target, url, WindowOpenDisposition::NEW_FOREGROUND_TAB,
+        ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
+    content::WebContents* contents =
+        target->tab_strip_model()->GetActiveWebContents();
+    contents->UpdateTitleForEntry(
+        contents->GetController().GetLastCommittedEntry(),
+        base::UTF8ToUTF16(title));
+  }
+
+  int TabIdAt(Browser* target, int index) {
+    return target->tab_strip_model()
+        ->GetTabAtIndex(index)
+        ->GetHandle()
+        .raw_value();
+  }
+
+  history::HistoryService* history_service() {
+    return HistoryServiceFactory::GetForProfile(
+        profile(), ServiceAccessType::EXPLICIT_ACCESS);
+  }
+
+  void AddToHistory(const GURL& url) {
+    history_service()->AddPage(
+        url, base::Time::Now(), /*context_id=*/0, /*nav_entry_id=*/0,
+        /*referrer=*/GURL(), history::RedirectList(), ui::PAGE_TRANSITION_LINK,
+        history::SOURCE_BROWSED, history::VisitResponseCodeCategory::kNot404,
+        /*did_replace_entry=*/false);
+  }
+
+  history::URLID QueryUrlId(const GURL& url) {
+    base::test::TestFuture<history::QueryURLResult> future;
+    history_service()->QueryURL(url, future.GetCallback(), &tracker_);
+    const history::QueryURLResult result = future.Take();
+    return result.success ? result.row.id() : 0;
+  }
+
+ protected:
+  base::CancelableTaskTracker tracker_;
+
+ private:
+  net::EmbeddedTestServer https_server_;
+  content::ContentMockCertVerifier mock_cert_verifier_;
+};
+
+// Results follow the scored-row order (best first), and open tabs whose URL
+// isn't among the scored rows are dropped.
+IN_PROC_BROWSER_TEST_F(OpenTabSearchBrowserTest, RanksAndDropsUnmatchedTabs) {
+  const GURL foo_url = GetURL("foo.com", "/empty.html");
+  const GURL bar_url = GetURL("bar.com", "/empty.html");
+  const GURL baz_url = GetURL("baz.com", "/empty.html");
+  AppendTab(browser(), foo_url, "Foo");
+  AppendTab(browser(), bar_url, "Bar");
+  AppendTab(browser(), baz_url, "Baz");
+
+  const int foo_tab_id = TabIdAt(browser(), 1);
+  const int bar_tab_id = TabIdAt(browser(), 2);
+
+  AddToHistory(foo_url);
+  AddToHistory(bar_url);
+  AddToHistory(baz_url);
+  const history::URLID foo_url_id = QueryUrlId(foo_url);
+  const history::URLID bar_url_id = QueryUrlId(bar_url);
+  const history::URLID baz_url_id = QueryUrlId(baz_url);
+  ASSERT_NE(foo_url_id, 0);
+  ASSERT_NE(bar_url_id, 0);
+  ASSERT_NE(baz_url_id, 0);
+
+  // Score bar above foo; leave baz unscored.
+  ai_chat::FakeHistoryEmbeddingsSearch fake;
+  fake.SetScoredRows({
+      ai_chat::FakeHistoryEmbeddingsSearch::MakeRow(
+          bar_url_id, bar_url, u"Bar", base::Time::Now(), /*score=*/0.9f),
+      ai_chat::FakeHistoryEmbeddingsSearch::MakeRow(
+          foo_url_id, foo_url, u"Foo", base::Time::Now(), /*score=*/0.7f),
+  });
+
+  base::test::TestFuture<const std::vector<int32_t>&> future;
+  SearchOpenTabsByContent(profile(), history_service(), &fake, "query",
+                          future.GetCallback(), &tracker_);
+  const std::vector<int32_t> tab_ids = future.Take();
+
+  // Every eligible open tab is offered to `Search()` for scoring...
+  EXPECT_TRUE(fake.last_skip_answering());
+  EXPECT_THAT(
+      fake.last_url_id_filter(),
+      testing::UnorderedElementsAre(foo_url_id, bar_url_id, baz_url_id));
+  // ...but only the scored ones come back, best first; baz is dropped.
+  EXPECT_THAT(tab_ids, testing::ElementsAre(bar_tab_id, foo_tab_id));
+}
+
+// Tabs from a different profile (here, incognito) never contribute, even when
+// their URL is present and scored in the searched profile's history.
+IN_PROC_BROWSER_TEST_F(OpenTabSearchBrowserTest, ExcludesOtherProfileTabs) {
+  const GURL foo_url = GetURL("foo.com", "/empty.html");
+  const GURL bar_url = GetURL("bar.com", "/empty.html");
+  AppendTab(browser(), foo_url, "Foo");
+  Browser* incognito = CreateIncognitoBrowser();
+  AppendTab(incognito, bar_url, "Bar (incognito)");
+
+  const int foo_tab_id = TabIdAt(browser(), 1);
+
+  // Both URLs are in the regular profile's history and both are scored, so the
+  // only reason bar can be excluded is the tracking filter dropping the
+  // incognito tab before its URL is ever resolved.
+  AddToHistory(foo_url);
+  AddToHistory(bar_url);
+  const history::URLID foo_url_id = QueryUrlId(foo_url);
+  const history::URLID bar_url_id = QueryUrlId(bar_url);
+  ASSERT_NE(foo_url_id, 0);
+  ASSERT_NE(bar_url_id, 0);
+
+  ai_chat::FakeHistoryEmbeddingsSearch fake;
+  fake.SetScoredRows({
+      ai_chat::FakeHistoryEmbeddingsSearch::MakeRow(
+          foo_url_id, foo_url, u"Foo", base::Time::Now(), /*score=*/0.9f),
+      ai_chat::FakeHistoryEmbeddingsSearch::MakeRow(
+          bar_url_id, bar_url, u"Bar", base::Time::Now(), /*score=*/0.8f),
+  });
+
+  base::test::TestFuture<const std::vector<int32_t>&> future;
+  SearchOpenTabsByContent(profile(), history_service(), &fake, "query",
+                          future.GetCallback(), &tracker_);
+  const std::vector<int32_t> tab_ids = future.Take();
+
+  // Only the regular-profile tab reaches the URL-id filter and the results.
+  EXPECT_THAT(fake.last_url_id_filter(), testing::ElementsAre(foo_url_id));
+  EXPECT_THAT(tab_ids, testing::ElementsAre(foo_tab_id));
+}
+
+}  // namespace history_embeddings

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -776,6 +776,15 @@ brave_chrome_browser_ui_allow_circular_includes_from = [ "//brave/browser/ui" ]
 brave_chrome_browser_ui_allow_circular_includes_from +=
     brave_ui_allow_circular_includes_from
 
+brave_chrome_browser_ui_deps =
+    [ "//brave/components/brave_wallet/common/buildflags" ]
+if (enable_brave_wallet) {
+  brave_chrome_browser_ui_deps += [
+    "//brave/browser/brave_wallet",
+    "//brave/browser/brave_wallet:tab_helper",
+  ]
+}
+
 brave_chrome_browser_allow_circular_includes_from += [
   "//brave/browser/brave_shields:brave_shields_impl",
   "//brave/browser/ui",

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -778,6 +778,10 @@ brave_chrome_browser_ui_allow_circular_includes_from +=
 
 brave_chrome_browser_ui_deps =
     [ "//brave/components/brave_wallet/common/buildflags" ]
+if (enable_local_ai) {
+  brave_chrome_browser_ui_deps +=
+      [ "//brave/browser/history_embeddings:open_tab_search" ]
+}
 if (enable_brave_wallet) {
   brave_chrome_browser_ui_deps += [
     "//brave/browser/brave_wallet",

--- a/browser/ui/webui/tab_search/tab_search_page_handler_browsertest.cc
+++ b/browser/ui/webui/tab_search/tab_search_page_handler_browsertest.cc
@@ -519,12 +519,10 @@ IN_PROC_BROWSER_TEST_F(TabSearchPageHandlerSearchTabsByContentBrowserTest,
   handler()->SearchTabsByContent("query", future.GetCallback());
   const std::vector<int32_t> tab_ids = future.Take();
 
-  EXPECT_EQ(fake.last_query(), "query");
-  EXPECT_TRUE(fake.last_skip_answering());
-  EXPECT_THAT(fake.last_url_id_filter(),
-              testing::UnorderedElementsAre(foo_url_id, bar_url_id));
-  // Result order matches the scored-row ordering returned by `Search()`.
-  EXPECT_THAT(tab_ids, testing::ElementsAre(bar_tab_id, foo_tab_id));
+  // The page handler forwards to `open_tab_search` and returns the matched
+  // open-tab ids; ranking order and the URL-id filter it builds are covered
+  // by open_tab_search's own browser test.
+  EXPECT_THAT(tab_ids, testing::UnorderedElementsAre(foo_tab_id, bar_tab_id));
 
   handler()->SetEmbeddingsSearchForTesting(nullptr);
 }

--- a/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_page_handler.cc
+++ b/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_page_handler.cc
@@ -6,7 +6,6 @@
 #include "chrome/browser/ui/webui/tab_search/tab_search_page_handler.h"
 
 #include <memory>
-#include <numeric>
 
 #include "base/check.h"
 #include "base/containers/flat_map.h"
@@ -51,69 +50,7 @@
 #endif  // BUILDFLAG(ENABLE_AI_CHAT)
 
 #if BUILDFLAG(ENABLE_LOCAL_AI)
-namespace {
-
-struct PendingTab {
-  int32_t tab_id;
-  GURL url;
-};
-
-// Maps the embeddings `Search()` result rows back to open-tab IDs via the
-// URL-id index established in `OnUrlIdsResolved()` and forwards the ranked
-// tab IDs to the SearchTabsByContent caller.
-void DispatchTabIdsForScoredUrls(
-    TabSearchPageHandler::SearchTabsByContentCallback& callback,
-    const base::flat_map<history::URLID, int32_t>& tab_id_by_url_id,
-    history_embeddings::SearchResult result) {
-  std::vector<int32_t> tab_ids;
-  for (const auto& row : result.scored_url_rows) {
-    if (auto* tab_id =
-            base::FindOrNull(tab_id_by_url_id, row.scored_url.url_id)) {
-      tab_ids.push_back(*tab_id);
-    }
-  }
-  std::move(callback).Run(std::move(tab_ids));
-}
-
-void OnUrlIdsResolved(
-    std::vector<PendingTab> tabs,
-    std::string query,
-    history_embeddings::HistoryEmbeddingsSearch* embeddings_search,
-    TabSearchPageHandler::SearchTabsByContentCallback callback,
-    std::optional<std::vector<history::URLID>> url_ids) {
-  // HistoryService returned no result (e.g. shutdown / cancellation).
-  if (!url_ids) {
-    std::move(callback).Run({});
-    return;
-  }
-  CHECK_EQ(tabs.size(), url_ids->size());
-  std::vector<history::URLID> url_id_filter;
-  base::flat_map<history::URLID, int32_t> tab_id_by_url_id;
-  url_id_filter.reserve(url_ids->size());
-  for (size_t i = 0; i < url_ids->size(); ++i) {
-    if ((*url_ids)[i] == 0) {
-      continue;
-    }
-    url_id_filter.push_back((*url_ids)[i]);
-    tab_id_by_url_id.emplace((*url_ids)[i], tabs[i].tab_id);
-  }
-  // None of the open tabs have a corresponding URLID in history yet, so the
-  // embeddings search would have nothing to score against.
-  if (url_id_filter.empty()) {
-    std::move(callback).Run({});
-    return;
-  }
-  const size_t count = url_id_filter.size();
-  embeddings_search->Search(
-      /*previous_search_result=*/nullptr, query,
-      /*time_range_start=*/std::nullopt, count,
-      /*skip_answering=*/true, std::move(url_id_filter),
-      base::BindRepeating(&DispatchTabIdsForScoredUrls,
-                          base::OwnedRef(std::move(callback)),
-                          std::move(tab_id_by_url_id)));
-}
-
-}  // namespace
+#include "brave/browser/history_embeddings/open_tab_search.h"
 #endif  // BUILDFLAG(ENABLE_LOCAL_AI)
 
 #define TabSearchPageHandler TabSearchPageHandler_ChromiumImpl
@@ -431,53 +368,8 @@ void TabSearchPageHandler::SearchTabsByContent(
     return;
   }
 
-  std::vector<PendingTab> tabs;
-  GlobalBrowserCollection::GetInstance()->ForEach(
-      [this, &tabs](BrowserWindowInterface* browser_window) {
-        Browser* browser = browser_window->GetBrowserForMigrationOnly();
-        if (!browser || !ShouldTrackBrowser(profile_, browser)) {
-          return true;
-        }
-        TabStripModel* tab_strip_model = browser->tab_strip_model();
-        if (!tab_strip_model) {
-          return true;
-        }
-        std::vector<int> indices(tab_strip_model->count());
-        std::iota(indices.begin(), indices.end(), 0);
-        for (tabs::TabInterface* tab :
-             tab_strip_model->GetTabsAtIndices(indices)) {
-          if (!tab) {
-            continue;
-          }
-          content::WebContents* contents = tab->GetContents();
-          if (!contents) {
-            continue;
-          }
-          GURL url = contents->GetLastCommittedURL();
-          if (!url.SchemeIsHTTPOrHTTPS()) {
-            continue;
-          }
-          tabs.push_back({tab->GetHandle().raw_value(), std::move(url)});
-        }
-        return true;
-      });
-
-  // No tracked tabs to rank against — the ForEach loop only keeps
-  // tracked-browser HTTP/HTTPS tabs, so non-normal windows, other profiles
-  // and incognito don't reach here.
-  if (tabs.empty()) {
-    std::move(callback).Run({});
-    return;
-  }
-
-  // Sequence the read-from-`tabs` (for URLs) before the move-of-`tabs` into the
-  // callback bind. Inlining the projection as a sibling argument leaves the
-  // order of evaluation unspecified and lets the move win on some toolchains.
-  const std::vector<GURL> urls = base::ToVector(tabs, &PendingTab::url);
-  history_service->QueryUrlIds(
-      urls,
-      base::BindOnce(&OnUrlIdsResolved, std::move(tabs), query,
-                     embeddings_search, std::move(callback)),
+  history_embeddings::SearchOpenTabsByContent(
+      profile, history_service, embeddings_search, query, std::move(callback),
       &query_url_task_tracker_);
 }
 #else   // !BUILDFLAG(ENABLE_LOCAL_AI)

--- a/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_page_handler_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_page_handler_unittest.cc
@@ -345,10 +345,10 @@ TEST_F(TabSearchPageHandlerTest, UndoFocusTabs) {
 #endif  // BUILDFLAG(ENABLE_AI_CHAT)
 
 #if BUILDFLAG(ENABLE_LOCAL_AI)
-// Exercises the early-return paths of `SearchTabsByContent` (empty query,
-// no tabs eligible for the open-tab URL-id filter). The happy path requires
-// a live `HistoryEmbeddingsService` and is covered by
-// `TabSearchPageHandlerBrowserTest.SearchTabsByContent`.
+// Exercises the page-handler's own empty-query guard for `SearchTabsByContent`.
+// The rest of the pipeline (tracking filter, URL-id resolution, ranking) lives
+// in `open_tab_search` and is covered by its browser test; the enabled happy
+// path is covered by `TabSearchPageHandlerBrowserTest.SearchTabsByContent`.
 class SearchTabsByContentEarlyReturnTest : public TabSearchPageHandlerTest {
  public:
   std::vector<int32_t> RunSearch(const std::string& query) {
@@ -364,14 +364,5 @@ class SearchTabsByContentEarlyReturnTest : public TabSearchPageHandlerTest {
 TEST_F(SearchTabsByContentEarlyReturnTest, EmptyQueryReturnsEmpty) {
   AddTabWithTitle(browser1(), GURL(kFooDotComUrl1), kFooDotComTitle1);
   EXPECT_TRUE(RunSearch("").empty());
-}
-
-TEST_F(SearchTabsByContentEarlyReturnTest, NoTrackedTabsReturnsEmpty) {
-  // Non-normal window, other profile, incognito profile — none of these
-  // should contribute to the open-tab URL-id filter.
-  AddTabWithTitle(browser5(), GURL(kFooDotComUrl1), kFooDotComTitle1);
-  AddTabWithTitle(browser4(), GURL(kFooDotComUrl2), kFooDotComTitle2);
-  AddTabWithTitle(browser3(), GURL(kBarDotComUrl1), kBarDotComTitle1);
-  EXPECT_TRUE(RunSearch("anything").empty());
 }
 #endif  // BUILDFLAG(ENABLE_LOCAL_AI)

--- a/components/brave_wallet/sources.gni
+++ b/components/brave_wallet/sources.gni
@@ -5,16 +5,6 @@
 
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
 
-# Deps for chrome/browser/ui
-brave_chrome_browser_ui_deps =
-    [ "//brave/components/brave_wallet/common/buildflags" ]
-if (enable_brave_wallet) {
-  brave_chrome_browser_ui_deps += [
-    "//brave/browser/brave_wallet",
-    "//brave/browser/brave_wallet:tab_helper",
-  ]
-}
-
 # Deps for chrome/browser/ui/hid
 brave_hid_deps = [ "//brave/components/brave_wallet/common/buildflags" ]
 if (enable_brave_wallet) {

--- a/patches/chrome-browser-ui-BUILD.gn.patch
+++ b/patches/chrome-browser-ui-BUILD.gn.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/browser/ui/BUILD.gn b/chrome/browser/ui/BUILD.gn
-index b669d4f3ee5f390b5b30ea4343b0cf082b72ac02..e51230a7c4d503ee4b0262923bb5383d213c79c3 100644
+index b669d4f3ee5f390b5b30ea4343b0cf082b72ac02..6fde08624e866c361d27b5d0fbdc80582be46ef1 100644
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
 @@ -921,6 +921,7 @@ static_library("ui") {
      # split out yet.
      "//chrome/browser/webauthn:impl",
    ]
-+  import("//brave/browser/sources.gni") import("//brave/components/brave_wallet/sources.gni") public_deps += [ "//brave/browser/ui" ] deps += brave_chrome_browser_ui_allow_circular_includes_from + brave_chrome_browser_ui_deps allow_circular_includes_from += brave_chrome_browser_ui_allow_circular_includes_from
++  import("//brave/browser/sources.gni") public_deps += [ "//brave/browser/ui" ] deps += brave_chrome_browser_ui_allow_circular_includes_from + brave_chrome_browser_ui_deps allow_circular_includes_from += brave_chrome_browser_ui_allow_circular_includes_from
  
    if (enable_vr && is_win) {
      deps += [ "//chrome/browser/vr:vr_base" ]

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1493,6 +1493,10 @@ test("brave_browser_tests") {
     deps += [ "//brave/browser/ntp_background:browser_tests" ]
   }
 
+  if (enable_local_ai) {
+    deps += [ "//brave/browser/history_embeddings:browser_tests" ]
+  }
+
   if (enable_ai_chat) {
     deps += [ "//brave/browser/ai_chat:browser_tests" ]
 


### PR DESCRIPTION
Behavior-preserving refactor. Extracts the open-tab gathering loop and the
URL→URLID→embeddings-search pipeline that were inline in
`TabSearchPageHandler::SearchTabsByContent` into a shared util,
`brave/browser/history_embeddings/open_tab_search.{h,cc}`, so a second
consumer can reuse it.

`SearchOpenTabsByContent(profile, …)` snapshots the profile's open HTTP(S)
tabs, resolves their URLs to URLIDs, runs `HistoryEmbeddingsSearch::Search`,
and dispatches the matched tab_ids via the mojom `SearchTabsByContentCallback`.
`OpenTabInfo` and the gathering loop stay internal to the util.

The loop reads `browser_window->GetTabStripModel()` directly (instead of
`GetBrowserForMigrationOnly()`) so the util avoids depending on
`//chrome/browser/ui:ui` and cycling through the chromium_src override;
behavior is identical.

`chrome/browser/ui:ui` links the override via `brave_chrome_browser_ui_deps`,
since `gn check` doesn't validate chromium_src override includes. A preceding
commit moves that variable from `brave_wallet/sources.gni` to
`browser/sources.gni` so any component can extend it.
