### PR TITLE
[ads] Set dNTT background to black

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/SponsoredRichMediaWebView.java
+++ b/android/java/org/chromium/chrome/browser/ntp/SponsoredRichMediaWebView.java
@@ -6,6 +6,7 @@
 package org.chromium.chrome.browser.ntp;
 
 import android.app.Activity;
+import android.graphics.Color;
 import android.net.Uri;
 import android.view.View;
 import android.view.ViewGroup;
@@ -52,10 +53,12 @@ public class SponsoredRichMediaWebView {
                 windowAndroid,
                 WebContents.createDefaultInternalsHolder());
 
+        final ThinWebViewConstraints constraints = new ThinWebViewConstraints();
+        constraints.backgroundColor = Color.BLACK;
         mWebView =
                 ThinWebViewFactory.create(
                         activity,
-                        new ThinWebViewConstraints(),
+                        constraints,
                         windowAndroid.getIntentRequestTracker(),
                         /* enablePermissionRequests= */ false);
         mWebView.getView()

--- a/components/new_tab_takeover/new_tab_takeover.html
+++ b/components/new_tab_takeover/new_tab_takeover.html
@@ -6,6 +6,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="referrer" content="no-referrer">
   <title>New Tab Takeover</title>
+  <style>
+    body {
+      margin: 0;
+      background-color: #000;
+    }
+  </style>
   <script src="chrome://resources/js/load_time_data_deprecated.js"></script>
   <script src="/strings.js"></script>
   <script type="module" src="new_tab_takeover.bundle.js"></script>


### PR DESCRIPTION
This change reduces the flash seen during a long dNTT load when the white background changes to the new tab takeover content.

Screen recording of dNTT for light browser theme:
https://github.com/user-attachments/assets/43f108f8-4505-496d-863b-9e04e3c0dcb2

Screen recording of dNTT for dark browser theme:
https://github.com/user-attachments/assets/b9928ac6-4a9a-40f0-909d-7e73165a966e

## Test plan

Trigger dNTT in Android browser for both light and dark themes. Verify that black background is shown while dNTT is loading.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44508

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
