### PR TITLE
Replace Shields icon with Brave Origin icon in Origin standalone

### DIFF
--- a/browser/ui/views/brave_actions/BUILD.gn
+++ b/browser/ui/views/brave_actions/BUILD.gn
@@ -24,7 +24,9 @@ source_set("brave_actions") {
   deps = [
     "//brave/app:brave_generated_resources_grit",
     "//brave/browser/brave_shields",
+    "//brave/components/brave_origin/buildflags",
     "//brave/components/resources:strings_grit",
+    "//brave/components/vector_icons",
     "//chrome/browser/ui/extensions",
     "//chrome/browser/ui/tabs:tab_strip",
     "//chrome/browser/ui/views/bubble",

--- a/browser/ui/views/brave_actions/brave_shields_action_controller.cc
+++ b/browser/ui/views/brave_actions/brave_shields_action_controller.cc
@@ -48,6 +48,17 @@
 
 namespace {
 constexpr SkColor kBadgeBg = SkColorSetRGB(0x63, 0x64, 0x72);
+
+// Returns the color provider for |web_contents|, falling back to the native UI
+// color provider when there is no active web contents.
+const ui::ColorProvider* GetColorProviderForWebContents(
+    content::WebContents* web_contents) {
+  if (web_contents) {
+    return &web_contents->GetColorProvider();
+  }
+  return ui::ColorProviderManager::Get().GetColorProviderFor(
+      ui::NativeTheme::GetInstanceForNativeUi()->GetColorProviderKey(nullptr));
+}
 }  // namespace
 
 BraveShieldsActionController::BraveShieldsActionController(
@@ -123,13 +134,8 @@ gfx::ImageSkia BraveShieldsActionController::GetIconImage(
 #if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
   // In the Brave Origin standalone build the Shields icon is replaced with the
   // Brave Origin face icon, tinted to match the other location bar icons.
-  auto* web_contents = tab_strip_model_->GetActiveWebContents();
   const ui::ColorProvider* color_provider =
-      web_contents
-          ? &web_contents->GetColorProvider()
-          : ui::ColorProviderManager::Get().GetColorProviderFor(
-                ui::NativeTheme::GetInstanceForNativeUi()->GetColorProviderKey(
-                    nullptr));
+      GetColorProviderForWebContents(tab_strip_model_->GetActiveWebContents());
   return gfx::CreateVectorIcon(
       is_enabled ? kLeoBraveIconOnlyFaceIcon
                  : kLeoBraveIconOnlyFaceDisabledIcon,
@@ -154,13 +160,7 @@ BraveShieldsActionController::GetImageSource(
 
   auto get_color_provider_callback = base::BindRepeating(
       [](base::WeakPtr<content::WebContents> weak_web_contents) {
-        const auto* const color_provider =
-            weak_web_contents
-                ? &weak_web_contents->GetColorProvider()
-                : ui::ColorProviderManager::Get().GetColorProviderFor(
-                      ui::NativeTheme::GetInstanceForNativeUi()
-                          ->GetColorProviderKey(nullptr));
-        return color_provider;
+        return GetColorProviderForWebContents(weak_web_contents.get());
       },
       web_contents ? web_contents->GetWeakPtr()
                    : base::WeakPtr<content::WebContents>());

--- a/browser/ui/views/brave_actions/brave_shields_action_controller.cc
+++ b/browser/ui/views/brave_actions/brave_shields_action_controller.cc
@@ -12,11 +12,14 @@
 #include "base/memory/weak_ptr.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/browser/ui/views/brave_actions/brave_icon_with_badge_image_source.h"
+#include "brave/components/brave_origin/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/constants/url_constants.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
+#include "brave/components/vector_icons/vector_icons.h"
 #include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/color/chrome_color_id.h"
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/views/bubble/webui_bubble_manager.h"
@@ -33,6 +36,8 @@
 #include "ui/color/color_provider_manager.h"
 #include "ui/gfx/image/image_skia.h"
 #include "ui/gfx/image/image_skia_rep.h"
+#include "ui/gfx/paint_vector_icon.h"
+#include "ui/native_theme/native_theme.h"
 #include "ui/views/controls/button/label_button.h"
 #include "ui/views/view.h"
 #include "url/gurl.h"
@@ -114,16 +119,32 @@ void BraveShieldsActionController::RemoveObserverFromWebContents(
 
 gfx::ImageSkia BraveShieldsActionController::GetIconImage(
     bool is_enabled) const {
+  const int icon_size = IconDimensionForLayout();
+#if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  // In the Brave Origin standalone build the Shields icon is replaced with the
+  // Brave Origin face icon, tinted to match the other location bar icons.
+  auto* web_contents = tab_strip_model_->GetActiveWebContents();
+  const ui::ColorProvider* color_provider =
+      web_contents
+          ? &web_contents->GetColorProvider()
+          : ui::ColorProviderManager::Get().GetColorProviderFor(
+                ui::NativeTheme::GetInstanceForNativeUi()->GetColorProviderKey(
+                    nullptr));
+  return gfx::CreateVectorIcon(
+      is_enabled ? kLeoBraveIconOnlyFaceIcon
+                 : kLeoBraveIconOnlyFaceDisabledIcon,
+      icon_size, color_provider->GetColor(kColorOmniboxResultsIcon));
+#else
   ui::ResourceBundle& rb = ui::ResourceBundle::GetSharedInstance();
   gfx::ImageSkia image;
   const SkBitmap bitmap =
       rb.GetImageNamed(is_enabled ? IDR_BRAVE_SHIELDS_ICON_64
                                   : IDR_BRAVE_SHIELDS_ICON_64_DISABLED)
           .AsBitmap();
-  const int icon_size = IconDimensionForLayout();
   float scale = static_cast<float>(bitmap.width()) / icon_size;
   image.AddRepresentation(gfx::ImageSkiaRep(bitmap, scale));
   return image;
+#endif
 }
 
 std::unique_ptr<IconWithBadgeImageSource>

--- a/browser/ui/views/brave_actions/brave_shields_action_controller.cc
+++ b/browser/ui/views/brave_actions/brave_shields_action_controller.cc
@@ -150,7 +150,7 @@ gfx::ImageSkia BraveShieldsActionController::GetIconImage(
   float scale = static_cast<float>(bitmap.width()) / icon_size;
   image.AddRepresentation(gfx::ImageSkiaRep(bitmap, scale));
   return image;
-#endif
+#endif  // BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
 }
 
 std::unique_ptr<IconWithBadgeImageSource>

--- a/browser/ui/views/brave_actions/brave_shields_action_view.cc
+++ b/browser/ui/views/brave_actions/brave_shields_action_view.cc
@@ -132,6 +132,10 @@ void BraveShieldsActionView::OnThemeChanged() {
   views::InkDrop::Get(this)->SetVisibleOpacity(kOmniboxOpacitySelected);
   views::InkDrop::Get(this)->SetHighlightOpacity(kOmniboxOpacityHovered);
   ink_drop->SetBaseColor(color_provider->GetColor(kColorOmniboxText));
+
+  // Refresh the icon so any theme-dependent tint (e.g. the Brave Origin icon in
+  // branded builds) is re-rendered with the new colors.
+  Update();
 }
 
 BEGIN_METADATA(BraveShieldsActionView)

--- a/components/vector_icons/BUILD.gn
+++ b/components/vector_icons/BUILD.gn
@@ -25,6 +25,7 @@ aggregate_vector_icons("brave_components_vector_icons") {
     "leo_arrow_small_right.icon",
     "leo_brave_icon_monochrome.icon",
     "leo_brave_icon_only_face.icon",
+    "leo_brave_icon_only_face_disabled.icon",
     "leo_browser_add.icon",
     "leo_browser_bookmark_add.icon",
     "leo_browser_bookmark_normal.icon",


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/56950

In the Brave Origin standalone (branded) build, the Shields lion in the location bar is replaced with the Brave Origin face icon, tinted to match the other urlbar icons.

- Shields UP → `brave-icon-only-face` (`kLeoBraveIconOnlyFaceIcon`)
<img width="845" height="274" alt="Screenshot 2026-07-08 at 12 14 56 PM" src="https://github.com/user-attachments/assets/260456f4-796a-4205-9dce-ed000dd19b88" />


- Shields DOWN → `brave-icon-only-face-disabled` (`kLeoBraveIconOnlyFaceDisabledIcon`)
<img width="967" height="274" alt="Screenshot 2026-07-08 at 12 14 41 PM" src="https://github.com/user-attachments/assets/38822634-68c4-4700-a45a-3b51624b552b" />

- WebUI pages:
<img width="894" height="877" alt="Screenshot 2026-07-08 at 12 09 48 PM" src="https://github.com/user-attachments/assets/0da2af20-2ddd-4c5d-8fa1-a6a7e41cfa8a" />

- Color: `kColorOmniboxResultsIcon`

Non-branded builds are unchanged (still use the raster lion PNGs).

## Test plan
- With a Brave Origin branded build, confirm the location bar shows the Brave Origin face icon instead of the lion, in `icon/Default` color when on an https:// page
- Toggle Shields off and confirm the disabled variant is shown (cross through the icon).
- WebUI pages should show the cross through it.
- Switch between light/dark themes and confirm the icon re-tints.
- Confirm non-branded builds still show the original Shields lion.