### PR TITLE
Silence 'This extension was turned off message' for our 4 supported MV2 extensions. (uplift to 1.92.x)

### DIFF
--- a/chromium_src/chrome/browser/extensions/api/developer_private/extension_info_generator.cc
+++ b/chromium_src/chrome/browser/extensions/api/developer_private/extension_info_generator.cc
@@ -3,7 +3,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "chrome/common/extensions/api/developer_private.h"
+#include "extensions/common/constants.h"
+#include "extensions/common/extension_features.h"
 #include "extensions/common/manifest_handlers/incognito_info.h"
+
+namespace {
+
+void ProcessKnownMV2Extensions(
+    extensions::api::developer_private::ExtensionInfo& info) {
+  if (!extensions_mv2::features::IsExtensionReplacementEnabled()) {
+    return;
+  }
+  if (extensions_mv2::IsKnownWebStoreHostedExtension(info.id)) {
+    // Suppress mv2 messages for known extensions (which are being replaced with
+    // brave-hosted versions) on brave://extensions
+    info.is_affected_by_mv2_deprecation = false;
+    info.disable_reasons.unsupported_manifest_version = false;
+  }
+}
+
+}  // namespace
 
 #define BRAVE_CREATE_EXTENSION_INFO_HELPER \
   info.is_split_mode = IncognitoInfo::IsSplitMode(&extension);

--- a/patches/chrome-browser-extensions-api-developer_private-extension_info_generator.cc.patch
+++ b/patches/chrome-browser-extensions-api-developer_private-extension_info_generator.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/extensions/api/developer_private/extension_info_generator.cc b/chrome/browser/extensions/api/developer_private/extension_info_generator.cc
-index 71c472aa201adcd89bbbdb50984695345cd095b1..7d505e090b9d3256eba8050c08769d3f4cc629c0 100644
+index 71c472aa201adcd89bbbdb50984695345cd095b1..de5cd519ce0b8f21782db1fc9bd09055fa55c638 100644
 --- a/chrome/browser/extensions/api/developer_private/extension_info_generator.cc
 +++ b/chrome/browser/extensions/api/developer_private/extension_info_generator.cc
 @@ -716,6 +716,7 @@ void ExtensionInfoGenerator::FillExtensionInfo(const Extension& extension,
@@ -10,3 +10,11 @@ index 71c472aa201adcd89bbbdb50984695345cd095b1..7d505e090b9d3256eba8050c08769d3f
  
    // User Scripts toggle.
    info.user_scripts_access.is_enabled =
+@@ -871,6 +872,7 @@ void ExtensionInfoGenerator::FillExtensionInfo(const Extension& extension,
+   CHECK(mv2_experiment_manager);
+   info.is_affected_by_mv2_deprecation =
+       mv2_experiment_manager->IsExtensionAffected(extension);
++  ProcessKnownMV2Extensions(info);
+   if (info.web_store_url.length() > 0) {
+     info.recommendations_url =
+         extension_urls::GetNewWebstoreItemRecommendationsUrl(extension.id())


### PR DESCRIPTION
Uplift of #37753
Resolves https://github.com/brave/brave-browser/issues/56816

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.