### PR TITLE
[FocusMode] Add focus mode check to ShouldShowWindowTitleForVerticalTabs

### DIFF
--- a/browser/ui/browser_window/internal/browser_window_features.cc
+++ b/browser/ui/browser_window/internal/browser_window_features.cc
@@ -181,7 +181,7 @@ void BrowserWindowFeatures::InitPostBrowserViewConstruction(
 
   vertical_tab_controller_ = std::make_unique<VerticalTabController>(
       browser_view->browser()->GetType(),
-      browser_view->GetProfile()->GetPrefs());
+      browser_view->GetProfile()->GetPrefs(), focus_mode_controller_.get());
 
   if (base::FeatureList::IsEnabled(features::kWorkspaces) &&
       browser_->GetType() == BrowserWindowInterface::Type::TYPE_NORMAL) {

--- a/browser/ui/tabs/BUILD.gn
+++ b/browser/ui/tabs/BUILD.gn
@@ -39,6 +39,7 @@ if (!is_android) {
 
     deps = [
       ":tabs_public",
+      "//brave/browser/ui/focus_mode",
       "//brave/browser/ui/side_panel",
       "//brave/browser/ui/views/page_action",
       "//chrome/browser/content_settings:content_settings_factory",

--- a/browser/ui/tabs/public/vertical_tab_controller.h
+++ b/browser/ui/tabs/public/vertical_tab_controller.h
@@ -6,8 +6,10 @@
 #ifndef BRAVE_BROWSER_UI_TABS_PUBLIC_VERTICAL_TAB_CONTROLLER_H_
 #define BRAVE_BROWSER_UI_TABS_PUBLIC_VERTICAL_TAB_CONTROLLER_H_
 
+#include "base/memory/raw_ptr.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 
+class FocusModeController;
 class PrefService;
 
 class VerticalTabController {
@@ -18,7 +20,9 @@ class VerticalTabController {
   static const VerticalTabController* FromBrowser(
       const BrowserWindowInterface* browser);
 
-  VerticalTabController(BrowserWindowInterface::Type type, PrefService* prefs);
+  VerticalTabController(BrowserWindowInterface::Type type,
+                        PrefService* prefs,
+                        FocusModeController* focus_mode_controller);
   VerticalTabController(const VerticalTabController&) = delete;
   VerticalTabController& operator=(const VerticalTabController&) = delete;
   ~VerticalTabController();
@@ -48,6 +52,7 @@ class VerticalTabController {
  private:
   BrowserWindowInterface::Type type_;
   raw_ptr<PrefService> prefs_;
+  raw_ptr<FocusModeController> focus_mode_controller_;
 };
 
 #endif  // BRAVE_BROWSER_UI_TABS_PUBLIC_VERTICAL_TAB_CONTROLLER_H_

--- a/browser/ui/tabs/test/BUILD.gn
+++ b/browser/ui/tabs/test/BUILD.gn
@@ -66,6 +66,7 @@ source_set("unit_tests") {
       "vertical_tab_controller_unittest.cc",
     ]
     deps += [
+      "//brave/browser/ui/focus_mode",
       "//brave/browser/ui/tabs:tabs_public",
       "//brave/components/tabs",
       "//chrome/browser/ui/tabs:test_support",

--- a/browser/ui/tabs/test/vertical_tab_controller_unittest.cc
+++ b/browser/ui/tabs/test/vertical_tab_controller_unittest.cc
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "base/test/scoped_feature_list.h"
+#include "brave/browser/ui/focus_mode/focus_mode_controller.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 #include "chrome/browser/ui/tabs/features.h"
@@ -23,8 +24,10 @@ class VerticalTabControllerUnitTest : public testing::Test {
 
  protected:
   std::unique_ptr<VerticalTabController> MakeController(
-      BrowserWindowInterface::Type type = BrowserWindowInterface::TYPE_NORMAL) {
-    return std::make_unique<VerticalTabController>(type, &pref_service_);
+      BrowserWindowInterface::Type type = BrowserWindowInterface::TYPE_NORMAL,
+      FocusModeController* focus_mode_controller = nullptr) {
+    return std::make_unique<VerticalTabController>(type, &pref_service_,
+                                                   focus_mode_controller);
   }
 
   TestingPrefServiceSimple pref_service_;
@@ -71,6 +74,22 @@ TEST_F(VerticalTabControllerUnitTest,
   pref_service_.SetBoolean(brave_tabs::kVerticalTabsShowTitleOnWindow, true);
   auto controller = MakeController();
   EXPECT_FALSE(controller->ShouldShowWindowTitleForVerticalTabs());
+}
+
+TEST_F(VerticalTabControllerUnitTest, ShouldShowWindowTitleFalseInFocusMode) {
+  pref_service_.SetBoolean(brave_tabs::kVerticalTabsEnabled, true);
+  pref_service_.SetBoolean(brave_tabs::kVerticalTabsShowTitleOnWindow, true);
+
+  FocusModeController focus_mode_controller;
+  auto controller = MakeController(BrowserWindowInterface::TYPE_NORMAL,
+                                   &focus_mode_controller);
+  EXPECT_TRUE(controller->ShouldShowWindowTitleForVerticalTabs());
+
+  focus_mode_controller.SetEnabled(true);
+  EXPECT_FALSE(controller->ShouldShowWindowTitleForVerticalTabs());
+
+  focus_mode_controller.SetEnabled(false);
+  EXPECT_TRUE(controller->ShouldShowWindowTitleForVerticalTabs());
 }
 
 TEST_F(VerticalTabControllerUnitTest, IsFloatingVerticalTabsEnabledDefault) {

--- a/browser/ui/tabs/vertical_tab_controller.cc
+++ b/browser/ui/tabs/vertical_tab_controller.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/ui/tabs/public/vertical_tab_controller.h"
 
 #include "base/command_line.h"
+#include "brave/browser/ui/focus_mode/focus_mode_controller.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/tabs/public/switches.h"
 #include "build/build_config.h"
@@ -31,9 +32,13 @@ const VerticalTabController* VerticalTabController::FromBrowser(
   return browser->GetFeatures().vertical_tab_controller();
 }
 
-VerticalTabController::VerticalTabController(BrowserWindowInterface::Type type,
-                                             PrefService* prefs)
-    : type_(type), prefs_(prefs) {}
+VerticalTabController::VerticalTabController(
+    BrowserWindowInterface::Type type,
+    PrefService* prefs,
+    FocusModeController* focus_mode_controller)
+    : type_(type),
+      prefs_(prefs),
+      focus_mode_controller_(focus_mode_controller) {}
 
 VerticalTabController::~VerticalTabController() = default;
 
@@ -62,6 +67,10 @@ bool VerticalTabController::ShouldShowBraveVerticalTabs() const {
 
 bool VerticalTabController::ShouldShowWindowTitleForVerticalTabs() const {
   if (!ShouldShowBraveVerticalTabs()) {
+    return false;
+  }
+
+  if (focus_mode_controller_ && focus_mode_controller_->IsEnabled()) {
     return false;
   }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Subtask of https://github.com/brave/brave-browser/issues/54369

`ShouldShowWindowTitleForVerticalTabs ` was made focus-mode aware in https://github.com/brave/brave-core/pull/37703, but this change was not propagated to the new `VerticalTabController`.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
