### PR TITLE
Disabled immersive tabbed mode on macOS

### DIFF
--- a/browser/ui/views/frame/brave_browser_view_browsertest.cc
+++ b/browser/ui/views/frame/brave_browser_view_browsertest.cc
@@ -882,6 +882,15 @@ IN_PROC_BROWSER_TEST_F(
 }
 
 #if BUILDFLAG(IS_MAC)
+IN_PROC_BROWSER_TEST_F(BraveBrowserViewTest, ImmersiveTabbedMode) {
+  // We disabled tabbed mode by default.
+  // See
+  // https://github.com/brave/brave-browser/issues/56914#issuecomment-4911022632
+  // for more details.
+  EXPECT_FALSE(WindowFeatureController::From(browser())
+                   ->UsesImmersiveFullscreenTabbedMode());
+}
+
 // Immersive fullscreen: (1) when vertical tabs are off at startup, immersive
 // is available and is disabled at runtime when vertical tabs are turned on;
 // (2) when vertical tabs were on at startup, immersive stays disabled for the

--- a/chromium_src/chrome/browser/ui/window_feature_controller/window_feature_controller.cc
+++ b/chromium_src/chrome/browser/ui/window_feature_controller/window_feature_controller.cc
@@ -45,6 +45,18 @@ bool WindowFeatureController::UsesImmersiveFullscreenTabbedMode() const {
     return false;
   }
 
+  // Can't use tabbed mode due to compact mode.
+  // In tabbed mode, tab strip is drawn over title bar.
+  // As macOS has its own titlebar min-height, it could not same with
+  // tab strip height in compact mode. As tab strip height is shorter
+  // than title bar min-height, we can't avoid gab between tab strip
+  // and toolbar as toolbar is drawn below the titlebar.
+  // Due to the limitations of immersive mode implementation, it's difficult
+  // to use tabbed mode selectively in runtime.
+  if (browser_type_ == BrowserWindowInterface::Type::TYPE_NORMAL) {
+    return false;
+  }
+
   return WindowFeatureController::
       UsesImmersiveFullscreenTabbedMode_ChromiumImpl();
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56914

macOS has its own titlebar min height in fullscreen. It seems 38px or 40px per macOS version.
In immersive tabbed mode, tab strip is drawn over the title bar.
As we can't make that title bar height same with compact mode's tab strip height,
visual gap was added between tab strip and toolbar.

Disabled immersive tabbed mode because tab strip height is much shorter than minimum
titlebar height in compact mode. It makes visible gap between tab strip and toolbar in fullscreen.
It's disabled always for normal tab regardless of compact mode because tabbed mode can't be
toggled during the runtime. See https://github.com/brave/brave-browser/issues/56914#issuecomment-4911022632 for more details.

In fullscreen, tab strip and toollbar will be located below the title bar after this change.

TEST=BraveBrowserViewTest.ImmersiveTabbedMode

https://github.com/user-attachments/assets/f834db6f-595a-44f9-98cc-e9bb1cc8265d


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
