### PR TITLE
Do not silently deny undelegated permissions in contained tabs.

### DIFF
--- a/browser/containers/BUILD.gn
+++ b/browser/containers/BUILD.gn
@@ -52,6 +52,8 @@ source_set("browser_tests") {
     "//chrome/browser/browsing_data:constants",
     "//chrome/browser/ui/zoom",
     "//chrome/test:test_support",
+    "//components/permissions",
+    "//components/permissions:test_support",
     "//content/public/browser",
     "//content/test:test_support",
     "//third_party/blink/public:blink_headers",
@@ -63,7 +65,10 @@ source_set("browser_tests") {
 source_set("unit_tests") {
   testonly = true
 
-  sources = [ "containers_service_delegate_unittest.cc" ]
+  sources = [
+    "containers_service_delegate_unittest.cc",
+    "permission_util_containers_unittest.cc",
+  ]
 
   deps = [
     ":containers",
@@ -74,7 +79,9 @@ source_set("unit_tests") {
     "//brave/components/containers/core/mojom",
     "//chrome/browser",
     "//chrome/test:test_support",
+    "//components/permissions",
     "//components/sessions:test_support",
+    "//content/test:test_support",
     "//testing/gmock",
     "//testing/gtest",
   ]

--- a/browser/containers/containers_browsertest.cc
+++ b/browser/containers/containers_browsertest.cc
@@ -46,6 +46,9 @@
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
 #include "components/content_settings/core/browser/host_content_settings_map.h"
+#include "components/permissions/permission_request_manager.h"
+#include "components/permissions/request_type.h"
+#include "components/permissions/test/mock_permission_prompt_factory.h"
 #include "components/sessions/core/tab_restore_service.h"
 #include "components/tabs/public/tab_interface.h"
 #include "content/public/browser/browsing_data_remover.h"
@@ -2478,6 +2481,37 @@ IN_PROC_BROWSER_TEST_F(ContainersBrowserTest,
   ASSERT_TRUE(cookies.is_ok());
   EXPECT_NE(std::string::npos,
             cookies.ExtractString().find("pinned_cookie=pinned_value"));
+}
+
+IN_PROC_BROWSER_TEST_F(ContainersBrowserTest,
+                       NotificationPermissionNotSilentlyDeniedInContainerTab) {
+  const GURL url = https_server_.GetURL("a.test", "/simple.html");
+  content::WebContents* web_contents =
+      OpenUrlInContainerTab(url, kTestContainerId);
+  ASSERT_TRUE(web_contents);
+
+  content::RenderFrameHost* main_frame = web_contents->GetPrimaryMainFrame();
+  ASSERT_TRUE(main_frame);
+
+  EXPECT_TRUE(containers::IsContainersStoragePartition(
+      main_frame->GetStoragePartition()->GetConfig()));
+
+  // Partition guard used to map this to DENIED ("denied"); expect ASK
+  // ("default").
+  EXPECT_EQ("default", content::EvalJs(main_frame, "Notification.permission"));
+
+  permissions::PermissionRequestManager* manager =
+      permissions::PermissionRequestManager::FromWebContents(web_contents);
+  ASSERT_TRUE(manager);
+  auto prompt_factory =
+      std::make_unique<permissions::MockPermissionPromptFactory>(manager);
+  prompt_factory->set_response_type(
+      permissions::PermissionRequestManager::ACCEPT_ALL);
+
+  EXPECT_EQ("granted",
+            content::EvalJs(main_frame, "Notification.requestPermission()"));
+  EXPECT_TRUE(prompt_factory->RequestTypeSeen(
+      permissions::RequestType::kNotifications));
 }
 
 class ContainersCommandLineContainerBrowserTest : public ContainersBrowserTest {

--- a/browser/containers/permission_util_containers_unittest.cc
+++ b/browser/containers/permission_util_containers_unittest.cc
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/containers/content/browser/storage_partition_utils.h"
+#include "brave/components/containers/core/common/features.h"
+#include "chrome/test/base/testing_profile.h"
+#include "components/content_settings/core/common/content_settings_types.h"
+#include "components/permissions/permission_util.h"
+#include "content/public/test/browser_task_environment.h"
+#include "content/public/test/mock_render_process_host.h"
+#include "content/test/storage_partition_test_helpers.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace containers {
+
+class PermissionUtilContainersTest : public testing::Test {
+ public:
+  PermissionUtilContainersTest() {
+    scoped_feature_list_.InitAndEnableFeature(features::kContainers);
+  }
+  ~PermissionUtilContainersTest() override = default;
+
+ protected:
+  content::BrowserTaskEnvironment task_environment_;
+  TestingProfile profile_;
+  base::test::ScopedFeatureList scoped_feature_list_;
+};
+
+TEST_F(PermissionUtilContainersTest,
+       IsPermissionBlockedInPartition_NotBlockedInContainersPartition) {
+  const GURL requesting_origin("https://example.com");
+  const auto containers_config =
+      content::CreateStoragePartitionConfigForTesting(
+          /*in_memory=*/false, kContainersStoragePartitionDomain,
+          "test-container");
+  content::MockRenderProcessHost containers_process(
+      &profile_, containers_config, /*is_for_guests_only=*/false);
+
+  EXPECT_FALSE(permissions::PermissionUtil::IsPermissionBlockedInPartition(
+      ContentSettingsType::NOTIFICATIONS, requesting_origin,
+      &containers_process));
+}
+
+TEST_F(PermissionUtilContainersTest,
+       IsPermissionBlockedInPartition_BlockedInMismatchedDefaultPartition) {
+  const GURL requesting_origin("https://example.com");
+  const auto default_config = content::CreateStoragePartitionConfigForTesting(
+      /*in_memory=*/false, "test_partition", "other");
+  content::MockRenderProcessHost mismatched_process(
+      &profile_, default_config, /*is_for_guests_only=*/false);
+
+  EXPECT_TRUE(permissions::PermissionUtil::IsPermissionBlockedInPartition(
+      ContentSettingsType::NOTIFICATIONS, requesting_origin,
+      &mismatched_process));
+}
+
+}  // namespace containers

--- a/chromium_src/components/permissions/DEPS
+++ b/chromium_src/components/permissions/DEPS
@@ -1,6 +1,9 @@
 include_rules = [
   "+brave/components/brave_wallet/browser/permission_utils.h",
   "+brave/components/brave_wallet/common/buildflags",
+  "+brave/components/containers/buildflags",
+  "+brave/components/containers/content/browser",
+  "+brave/components/containers/core/common",
   "+brave/components/permissions",
   "+components/grit/brave_components_strings.h",
   "+components/resources/android",

--- a/chromium_src/components/permissions/permission_util.cc
+++ b/chromium_src/components/permissions/permission_util.cc
@@ -6,8 +6,16 @@
 #include "components/permissions/permission_util.h"
 
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
+#include "brave/components/containers/buildflags/buildflags.h"
 #include "components/permissions/permission_uma_util.h"
+#include "content/public/browser/render_process_host.h"
+#include "content/public/browser/storage_partition.h"
 #include "third_party/blink/public/common/permissions/permission_utils.h"
+
+#if BUILDFLAG(ENABLE_CONTAINERS)
+#include "brave/components/containers/content/browser/storage_partition_utils.h"
+#include "brave/components/containers/core/common/features.h"
+#endif
 
 #define PermissionUtil PermissionUtil_ChromiumImpl
 
@@ -197,6 +205,24 @@ GURL PermissionUtil::GetCanonicalOrigin(ContentSettingsType permission,
 
   return PermissionUtil_ChromiumImpl::GetCanonicalOrigin(
       permission, requesting_origin, embedding_origin);
+}
+
+// static
+bool PermissionUtil::IsPermissionBlockedInPartition(
+    ContentSettingsType permission,
+    const GURL& requesting_origin,
+    content::RenderProcessHost* render_process_host) {
+#if BUILDFLAG(ENABLE_CONTAINERS)
+  if (base::FeatureList::IsEnabled(containers::features::kContainers)) {
+    const auto& config =
+        render_process_host->GetStoragePartition()->GetConfig();
+    if (containers::IsContainersStoragePartition(config)) {
+      return false;
+    }
+  }
+#endif
+  return PermissionUtil_ChromiumImpl::IsPermissionBlockedInPartition(
+      permission, requesting_origin, render_process_host);
 }
 
 }  // namespace permissions

--- a/chromium_src/components/permissions/permission_util.h
+++ b/chromium_src/components/permissions/permission_util.h
@@ -25,6 +25,11 @@ class PermissionUtil : public PermissionUtil_ChromiumImpl {
   static GURL GetCanonicalOrigin(ContentSettingsType permission,
                                  const GURL& requesting_origin,
                                  const GURL& embedding_origin);
+
+  static bool IsPermissionBlockedInPartition(
+      ContentSettingsType permission,
+      const GURL& requesting_origin,
+      content::RenderProcessHost* render_process_host);
 };
 
 }  // namespace permissions

--- a/components/permissions/sources.gni
+++ b/components/permissions/sources.gni
@@ -4,6 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
+import("//brave/components/containers/buildflags/buildflags.gni")
 import("//third_party/widevine/cdm/widevine.gni")
 
 brave_components_permissions_sources = [
@@ -62,6 +63,13 @@ if (enable_brave_wallet) {
   brave_components_permissions_deps += [
     "//brave/components/brave_wallet/browser:permission_utils",
     "//brave/components/brave_wallet/common:mojom",
+  ]
+}
+
+if (enable_containers) {
+  brave_components_permissions_deps += [
+    "//brave/components/containers/content/browser",
+    "//brave/components/containers/core/common",
   ]
 }
 

--- a/components/permissions/sources.gni
+++ b/components/permissions/sources.gni
@@ -47,6 +47,7 @@ brave_components_permissions_deps = [
   "//brave/brave_domains",
   "//brave/components/brave_wallet/common/buildflags",
   "//brave/components/constants",
+  "//brave/components/containers/buildflags",
   "//brave/components/resources:strings_grit",
   "//components/content_settings/core/browser",
   "//components/content_settings/core/common",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Exempt Containers storage partitions from the block so notification (and other undelegated) permission prompts work normally. Permissions remain profile-scoped (shared across containers), same as today.

Containers force websites into a custom StoragePartition. Chromium's `IsPermissionBlockedInPartition` check compares that partition to the origin's default "home" partition and silently DENIES undelegated
permissions (e.g. notifications) when they differ. That was intended for inherited/iframe partition mismatches, not for Containers, where the non-default partition is intentional and tab-scoped.

Resolves https://github.com/brave/brave-browser/issues/56943

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
