### PR TITLE
[FocusMode] Update toolbar padding based on overlay active state

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -1505,6 +1505,13 @@ void BraveBrowserView::UpdateFocusModeState() {
     focus_mode_title_bar_view_->SetTab(
         enabled ? browser()->tab_strip_model()->GetActiveTab() : nullptr);
   }
+
+  // The toolbar is given extra horizontal padding in vertical tabs mode when
+  // it is not hosted in the top overlay. Since the overlay's active state may
+  // have changed, trigger an update of the horizontal padding.
+  if (auto* toolbar_view = views::AsViewClass<BraveToolbarView>(toolbar())) {
+    toolbar_view->UpdateHorizontalPadding();
+  }
 }
 
 bool BraveBrowserView::ShouldDisableFocusModeForActiveTab() const {

--- a/browser/ui/views/frame/focus_mode_top_overlay_browsertest.cc
+++ b/browser/ui/views/frame/focus_mode_top_overlay_browsertest.cc
@@ -10,12 +10,16 @@
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/ui/focus_mode/focus_mode_controller.h"
 #include "brave/browser/ui/focus_mode/focus_mode_features.h"
+#include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
+#include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_commands.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/frame/browser_widget.h"
 #include "chrome/browser/ui/views/frame/top_container_view.h"
 #include "chrome/browser/ui/views/location_bar/location_bar_view.h"
 #include "chrome/browser/ui/views/tabs/tab_strip.h"
@@ -23,14 +27,17 @@
 #include "chrome/test/base/chrome_test_utils.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
+#include "components/prefs/pref_service.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
 #include "content/public/test/test_navigation_observer.h"
 #include "net/dns/mock_host_resolver.h"
 #include "net/test/embedded_test_server/embedded_test_server.h"
+#include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/scoped_animation_duration_scale_mode.h"
+#include "ui/views/border.h"
 #include "ui/views/focus/focus_manager.h"
 #include "ui/views/view.h"
 #include "url/gurl.h"
@@ -261,6 +268,55 @@ IN_PROC_BROWSER_TEST_F(FocusModeTopOverlayBrowserTest,
   ASSERT_TRUE(active_web_contents()->GetLastCommittedURL().SchemeIsBlob());
   EXPECT_TRUE(WaitForOverlayActive(false));
   EXPECT_EQ(top_container->parent(), browser_view());
+}
+
+IN_PROC_BROWSER_TEST_F(FocusModeTopOverlayBrowserTest,
+                       ToolbarBorderTracksOverlayActivation) {
+  // The caption-button border only applies with vertical tabs enabled and the
+  // window title hidden.
+  auto* prefs = browser()->profile()->GetPrefs();
+  prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled, true);
+  prefs->SetBoolean(brave_tabs::kVerticalTabsShowTitleOnWindow, false);
+
+  auto* overlay = browser_view()->focus_mode_top_overlay();
+  ASSERT_TRUE(overlay);
+  auto* toolbar = browser_view()->toolbar();
+  ASSERT_TRUE(toolbar);
+
+  // Reads the toolbar's border insets, treating a null border (left when the
+  // insets would be zero) as empty. This keeps the assertions meaningful even
+  // where the frame reports zero-width caption exclusions.
+  auto border_insets = [toolbar]() {
+    const auto* border = toolbar->GetBorder();
+    return border ? border->GetInsets() : gfx::Insets();
+  };
+
+  focus_mode_controller()->SetEnabled(true);
+
+  // Secure page: the overlay hosts the top container, which upstream lays out
+  // with caption exclusions applied, so no border is set here.
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(), https_server_.GetURL("/empty.html")));
+  ASSERT_TRUE(WaitForOverlayActive(true));
+  EXPECT_FALSE(toolbar->GetBorder());
+
+  // Suppressed (insecure page): the top container returns to the browser view
+  // and shares its row with the caption buttons, so the border is applied.
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(),
+      embedded_test_server()->GetURL("insecure.test", "/empty.html")));
+  ASSERT_TRUE(WaitForOverlayActive(false));
+  const auto [expected_left, expected_right] =
+      tabs::utils::GetLeadingTrailingCaptionButtonWidth(
+          browser_view()->browser_widget());
+  EXPECT_EQ(border_insets().left(), expected_left);
+  EXPECT_EQ(border_insets().right(), expected_right);
+
+  // Returning to a secure page re-activates the overlay and clears the border.
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(), https_server_.GetURL("/empty.html")));
+  ASSERT_TRUE(WaitForOverlayActive(true));
+  EXPECT_FALSE(toolbar->GetBorder());
 }
 
 IN_PROC_BROWSER_TEST_F(FocusModeTopOverlayBrowserTest,

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -16,10 +16,10 @@
 #include "base/i18n/rtl.h"
 #include "brave/app/brave_command_ids.h"
 #include "brave/app/vector_icons/vector_icons.h"
-#include "brave/browser/ui/focus_mode/focus_mode_utils.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
+#include "brave/browser/ui/views/frame/focus_mode_top_overlay.h"
 #include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_container_view.h"
 #include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h"
 #include "brave/browser/ui/views/location_bar/brave_location_bar_view.h"
@@ -231,10 +231,6 @@ void BraveToolbarView::Init() {
   if (IsAvatarButtonHideable(profile)) {
     profile_observer_.Observe(
         &g_browser_process->profile_manager()->GetProfileAttributesStorage());
-  }
-
-  if (auto* controller = browser_->GetFeatures().focus_mode_controller()) {
-    focus_mode_observation_.Observe(controller);
   }
 
   // track changes in bookmarks enabled setting
@@ -503,10 +499,6 @@ void BraveToolbarView::OnProfileWasRemoved(const base::FilePath& profile_path,
   Update(nullptr);
 }
 
-void BraveToolbarView::OnFocusModeToggled(bool enabled) {
-  UpdateHorizontalPadding();
-}
-
 void BraveToolbarView::LoadImages() {
   ToolbarView::LoadImages();
   if (bookmark_) {
@@ -553,9 +545,15 @@ void BraveToolbarView::UpdateHorizontalPadding() {
     return;
   }
 
+  // In vertical tabs mode the toolbar rises into the row occupied by the OS
+  // caption buttons, so a border insets the toolbar's contents by the caption
+  // button widths. The border is not needed when the vertical tabs title bar is
+  // shown, or when the top container is hosted in the Focus Mode top overlay.
+  // In the latter case, upstream's "top container reparented" layout branch
+  // takes care of the insets.
   if (!tabs::utils::ShouldShowBraveVerticalTabs(browser()) ||
       tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser()) ||
-      IsFocusModeEnabled(browser())) {
+      IsFocusModeOverlayActive()) {
     SetBorder(nullptr);
     return;
   }
@@ -794,6 +792,15 @@ void BraveToolbarView::UpdateComboButtonState() {
   }
 
   combo_button_->SetVisible(tabs::utils::ShouldShowBraveVerticalTabs(browser_));
+}
+
+bool BraveToolbarView::IsFocusModeOverlayActive() const {
+  auto* brave_browser_view = BraveBrowserView::From(browser_view_);
+  if (!brave_browser_view) {
+    return false;
+  }
+  auto* overlay = brave_browser_view->focus_mode_top_overlay();
+  return overlay && overlay->active();
 }
 
 BEGIN_METADATA(BraveToolbarView)

--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -9,7 +9,6 @@
 #include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/scoped_observation.h"
-#include "brave/browser/ui/focus_mode/focus_mode_controller.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "chrome/browser/profiles/profile_attributes_storage.h"
@@ -33,8 +32,7 @@ class ToolbarButton;
 class WalletButton;
 
 class BraveToolbarView : public ToolbarView,
-                         public ProfileAttributesStorage::Observer,
-                         public FocusModeController::Observer {
+                         public ProfileAttributesStorage::Observer {
   METADATA_HEADER(BraveToolbarView, ToolbarView)
  public:
   class LayoutGuard;
@@ -86,14 +84,12 @@ class BraveToolbarView : public ToolbarView,
   void OnVerticalTabTogglePressed();
   void OnCompactModePrefChanged();
   void UpdateComboButtonState();
+  bool IsFocusModeOverlayActive() const;
 
   // ProfileAttributesStorage::Observer:
   void OnProfileAdded(const base::FilePath& profile_path) override;
   void OnProfileWasRemoved(const base::FilePath& profile_path,
                            const std::u16string& profile_name) override;
-
-  // FocusModeController::Observer:
-  void OnFocusModeToggled(bool enabled) override;
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
   void UpdateAIChatButtonVisibility();
@@ -150,8 +146,6 @@ class BraveToolbarView : public ToolbarView,
   base::ScopedObservation<ProfileAttributesStorage,
                           ProfileAttributesStorage::Observer>
       profile_observer_{this};
-  base::ScopedObservation<FocusModeController, FocusModeController::Observer>
-      focus_mode_observation_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_TOOLBAR_VIEW_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Subtask of https://github.com/brave/brave-browser/issues/54369

Since the Focus Mode top overlay can be deactivated for some pages, the toolbar padding should depend on the overlay's `active` state, rather than the Focus Mode enabled state.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
