### PR TITLE
Add setting to disable built-in password autofill

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -1618,6 +1618,12 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
       <message name="IDS_BRAVE_PASSWORD_MANAGER_UI_IMPORT_DESCRIPTION_SIGNEDOUT_USERS" desc="The description for the password import banner in Password Manager settings.">
         To import passwords to <ph name="BRAND">$1<ex>Brave Password Manager</ex></ph> on this device, select a CSV file
       </message>
+      <message name="IDS_BRAVE_PASSWORD_MANAGER_UI_FILL_LABEL" desc="Label for the toggle in Password Manager settings that enables or disables Brave's built-in password autofill.">
+        Autofill passwords using Brave
+      </message>
+      <message name="IDS_BRAVE_PASSWORD_MANAGER_UI_FILL_SUB_LABEL" desc="Sub-label explaining what the built-in password autofill toggle does. Shown beneath the toggle label.">
+        Turn this off to stop Brave from filling and saving passwords, for example when you use a third-party password manager
+      </message>
       <message name="IDS_LOCAL_AI_TASK_MANAGER_TITLE" desc="The label for the on-device AI background process in the Task Manager.">
         On-Device AI
       </message>

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -415,6 +415,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
       registry);
   // autofill
   registry->RegisterBooleanPref(kBraveAutofillPrivateWindows, true);
+  registry->RegisterBooleanPref(kBravePasswordManagerFillEnabled, true);
   // appearance
   registry->RegisterBooleanPref(kShowBookmarksButton, true);
   registry->RegisterBooleanPref(kShowSidePanelButton, true);

--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -135,6 +135,8 @@ const PrefsUtil::TypedPrefMap& BravePrefsUtil::GetAllowlistedKeys() {
   // autofill prefs
   (*s_brave_allowlist)[kBraveAutofillPrivateWindows] =
       settings_api::PrefType::kBoolean;
+  (*s_brave_allowlist)[kBravePasswordManagerFillEnabled] =
+      settings_api::PrefType::kBoolean;
 
   // appearance prefs
   (*s_brave_allowlist)[kShowBookmarksButton] = settings_api::PrefType::kBoolean;

--- a/browser/password_manager/BUILD.gn
+++ b/browser/password_manager/BUILD.gn
@@ -12,7 +12,9 @@ if (!is_android) {
 
     deps = [
       "//brave/browser",
+      "//brave/components/constants",
       "//chrome/browser",
+      "//chrome/browser/password_manager",
       "//chrome/browser/password_manager/factories",
       "//chrome/browser/ui",
       "//chrome/test:test_support",

--- a/browser/password_manager/password_manager_browsertest.cc
+++ b/browser/password_manager/password_manager_browsertest.cc
@@ -5,7 +5,10 @@
 
 #include "base/memory/scoped_refptr.h"
 #include "base/test/bind.h"
+#include "brave/components/constants/pref_names.h"
+#include "chrome/browser/password_manager/chrome_password_manager_client.h"
 #include "chrome/browser/password_manager/factories/profile_password_store_factory.h"
+#include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_commands.h"
 #include "chrome/common/webui_url_constants.h"
@@ -14,6 +17,7 @@
 #include "chrome/test/base/ui_test_utils.h"
 #include "components/password_manager/core/browser/password_form_manager_for_ui.h"
 #include "components/password_manager/core/browser/password_store/password_form_converters.h"
+#include "components/prefs/pref_service.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
 #include "url/gurl.h"
@@ -98,4 +102,34 @@ IN_PROC_BROWSER_TEST_F(PasswordManagerTest,
   )"));
 
   EXPECT_TRUE(console_observer.messages().empty());
+}
+
+// Verifies that the Brave "Autofill passwords using Brave" setting
+// (kBravePasswordManagerFillEnabled) gates password filling and saving. When
+// disabled, ChromePasswordManagerClient reports both filling and saving as
+// disabled, which suppresses the autofill dropdown and the save prompt so Brave
+// doesn't compete with a third-party password manager.
+// See https://github.com/brave/brave-browser/issues/19065.
+IN_PROC_BROWSER_TEST_F(PasswordManagerTest, FillEnabledPrefGatesFilling) {
+  const GURL url("https://example.com");
+  content::WebContents* contents =
+      chrome_test_utils::GetActiveWebContents(this);
+  auto* client = ChromePasswordManagerClient::FromWebContents(contents);
+  ASSERT_TRUE(client);
+
+  PrefService* prefs = browser()->profile()->GetPrefs();
+
+  // The pref defaults to true, preserving upstream behavior: filling is
+  // enabled.
+  ASSERT_TRUE(prefs->GetBoolean(kBravePasswordManagerFillEnabled));
+  EXPECT_TRUE(client->IsFillingEnabled(url));
+
+  // Turning the setting off disables both filling and saving.
+  prefs->SetBoolean(kBravePasswordManagerFillEnabled, false);
+  EXPECT_FALSE(client->IsFillingEnabled(url));
+  EXPECT_FALSE(client->IsSavingAndFillingEnabled(url));
+
+  // Turning it back on restores filling.
+  prefs->SetBoolean(kBravePasswordManagerFillEnabled, true);
+  EXPECT_TRUE(client->IsFillingEnabled(url));
 }

--- a/chromium_src/chrome/browser/password_manager/chrome_password_manager_client.cc
+++ b/chromium_src/chrome/browser/password_manager/chrome_password_manager_client.cc
@@ -3,13 +3,57 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+// Pull in the header override first so its declaration-splitting macros run and
+// are undefined before we define the definition-redirecting macros below. This
+// mirrors the pattern in brave/chromium_src/net/http/http_util.cc.
+#include "chrome/browser/password_manager/chrome_password_manager_client.h"
+
 #include "brave/components/constants/pref_names.h"
 #include "chrome/browser/profiles/profile.h"
+#include "components/prefs/pref_service.h"
+#include "content/public/browser/web_contents.h"
 
 #define IsGuestSession                                                   \
   IsGuestSession() ||                                                    \
       (!profile->GetPrefs()->GetBoolean(kBraveAutofillPrivateWindows) && \
        (IsOffTheRecord() || profile->IsTor())) ||                        \
       profile->IsGuestSession
+
+// Redirect the upstream bodies to the *_ChromiumImpl methods declared by the
+// accompanying header override, so Brave can gate them on the
+// kBravePasswordManagerFillEnabled pref below.
+#define IsSavingAndFillingEnabled IsSavingAndFillingEnabled_ChromiumImpl
+#define IsFillingEnabled IsFillingEnabled_ChromiumImpl
 #include <chrome/browser/password_manager/chrome_password_manager_client.cc>
+#undef IsFillingEnabled
+#undef IsSavingAndFillingEnabled
 #undef IsGuestSession
+
+namespace {
+
+// Returns true when Brave's built-in password autofill has been disabled by the
+// user via chrome://password-manager/settings. Disabling it suppresses both the
+// fill dropdown and the "offer to save password" prompt.
+bool IsBravePasswordFillingDisabled(content::WebContents* web_contents) {
+  const Profile* profile =
+      Profile::FromBrowserContext(web_contents->GetBrowserContext());
+  return profile &&
+         !profile->GetPrefs()->GetBoolean(kBravePasswordManagerFillEnabled);
+}
+
+}  // namespace
+
+bool ChromePasswordManagerClient::IsFillingEnabled(const GURL& url) const {
+  if (IsBravePasswordFillingDisabled(web_contents())) {
+    return false;
+  }
+  return IsFillingEnabled_ChromiumImpl(url);
+}
+
+bool ChromePasswordManagerClient::IsSavingAndFillingEnabled(
+    const GURL& url) const {
+  if (IsBravePasswordFillingDisabled(web_contents())) {
+    return false;
+  }
+  return IsSavingAndFillingEnabled_ChromiumImpl(url);
+}

--- a/chromium_src/chrome/browser/password_manager/chrome_password_manager_client.h
+++ b/chromium_src/chrome/browser/password_manager/chrome_password_manager_client.h
@@ -1,0 +1,34 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_PASSWORD_MANAGER_CHROME_PASSWORD_MANAGER_CLIENT_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_PASSWORD_MANAGER_CHROME_PASSWORD_MANAGER_CLIENT_H_
+
+// Include the base class header first (unmangled) so the macros below only
+// split the derived declarations in ChromePasswordManagerClient, not the
+// identically-named virtual methods on PasswordManagerClient.
+#include "components/password_manager/core/browser/password_manager_client.h"
+
+// Split each of these two virtual declarations into a non-virtual
+// _ChromiumImpl (the upstream body) plus the original virtual override. Brave's
+// overrides (defined in the accompanying .cc) gate password filling and saving
+// on the kBravePasswordManagerFillEnabled pref before delegating to the impls.
+// Both methods are entered by external translation units through the virtual
+// interface (IsFillingEnabled from PasswordManager::CreateFormManager,
+// IsSavingAndFillingEnabled from PasswordFormManager), so the gate is applied
+// on those user-facing paths.
+#define IsSavingAndFillingEnabled                                \
+  IsSavingAndFillingEnabled_ChromiumImpl(const GURL& url) const; \
+  bool IsSavingAndFillingEnabled
+#define IsFillingEnabled                                \
+  IsFillingEnabled_ChromiumImpl(const GURL& url) const; \
+  bool IsFillingEnabled
+
+#include <chrome/browser/password_manager/chrome_password_manager_client.h>  // IWYU pragma: export
+
+#undef IsFillingEnabled
+#undef IsSavingAndFillingEnabled
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_PASSWORD_MANAGER_CHROME_PASSWORD_MANAGER_CLIENT_H_

--- a/chromium_src/chrome/browser/resources/password_manager/settings_section.ts
+++ b/chromium_src/chrome/browser/resources/password_manager/settings_section.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// The web-component-missing-deps lint rule requires the class-definition file
+// (this override) to import every custom element referenced by the template
+// (settings_section.html), so mirror the upstream element imports here.
+import 'chrome://resources/cr_elements/cr_button/cr_button.js';
+import 'chrome://resources/cr_elements/cr_icon_button/cr_icon_button.js';
+import 'chrome://resources/cr_elements/cr_link_row/cr_link_row.js';
+import 'chrome://resources/cr_elements/cr_toast/cr_toast.js';
+import './dialogs/disconnect_cloud_authenticator_dialog.js';
+import './dialogs/remove_actor_login_permission_dialog.js';
+import './full_data_reset.js';
+import './passwords_exporter.js';
+import './passwords_importer.js';
+import './prefs/pref_toggle_button.js';
+import './site_favicon.js';
+import '/shared/settings/controls/extension_controlled_indicator.js';
+
+import {html, RegisterPolymerTemplateModifications} from '//resources/brave/polymer_overriding.js'
+import {loadTimeData} from '//resources/js/load_time_data.js'
+
+RegisterPolymerTemplateModifications({
+  'settings-section': (templateContent) => {
+    const passwordToggle = templateContent.querySelector('#passwordToggle')
+    if (!passwordToggle || !passwordToggle.parentNode) {
+      console.error(
+        `[Brave Password Manager Overrides] Could not find '#passwordToggle'`)
+      return
+    }
+    // Toggle that gates Brave's built-in password autofill/save via the
+    // brave.password_manager.fill_enabled pref. Turning it off suppresses both
+    // the fill dropdown and the "offer to save password" prompt, so users of a
+    // third-party password manager don't get two competing suggestions.
+    passwordToggle.parentNode.insertBefore(
+      html`
+        <pref-toggle-button id="braveFillToggle" class="hr"
+            label="${loadTimeData.getString('bravePasswordManagerFillLabel')}"
+            sub-label="${
+          loadTimeData.getString('bravePasswordManagerFillSubLabel')}"
+            pref="{{prefs.brave.password_manager.fill_enabled}}">
+        </pref-toggle-button>`,
+      passwordToggle.nextSibling)
+  }
+})
+
+export * from './settings_section-chromium.js'

--- a/chromium_src/chrome/browser/ui/webui/password_manager/password_manager_ui.cc
+++ b/chromium_src/chrome/browser/ui/webui/password_manager/password_manager_ui.cc
@@ -10,10 +10,14 @@
 #include "content/public/browser/web_ui_data_source.h"
 #include "ui/webui/webui_util.h"
 
-#define SetupWebUIDataSource(...)                             \
-  SetupWebUIDataSource(__VA_ARGS__);                          \
-  source->AddResourcePath("images/password_manager_logo.svg", \
-                          IDR_BRAVE_PASSWORD_MANAGER_LOGO)
+#define SetupWebUIDataSource(...)                                       \
+  SetupWebUIDataSource(__VA_ARGS__);                                    \
+  source->AddResourcePath("images/password_manager_logo.svg",           \
+                          IDR_BRAVE_PASSWORD_MANAGER_LOGO);             \
+  source->AddLocalizedString("bravePasswordManagerFillLabel",           \
+                             IDS_BRAVE_PASSWORD_MANAGER_UI_FILL_LABEL); \
+  source->AddLocalizedString("bravePasswordManagerFillSubLabel",        \
+                             IDS_BRAVE_PASSWORD_MANAGER_UI_FILL_SUB_LABEL)
 
 #undef IDS_PASSWORD_MANAGER_UI_EMPTY_STATE_SYNCING_USERS
 #define IDS_PASSWORD_MANAGER_UI_EMPTY_STATE_SYNCING_USERS \

--- a/components/constants/pref_names.h
+++ b/components/constants/pref_names.h
@@ -11,6 +11,8 @@
 
 inline constexpr char kBraveAutofillPrivateWindows[] =
     "brave.autofill_private_windows";
+inline constexpr char kBravePasswordManagerFillEnabled[] =
+    "brave.password_manager.fill_enabled";
 inline constexpr char kManagedBraveShieldsDisabledForUrls[] =
     "brave.managed_shields_disabled";
 inline constexpr char kManagedBraveShieldsEnabledForUrls[] =


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/19065

## Summary

Adds an "Autofill passwords using Brave" toggle to the Password Manager
settings (`brave://password-manager/settings`), directly under "Offer to save
passwords". It defaults to on, so existing behavior is unchanged.

When turned off, Brave's built-in password autofill is fully disabled:

- the password suggestion dropdown no longer appears,
- credentials are no longer auto-filled on page load, and
- the "Save password?" prompt is suppressed.

This lets people who use a third-party password manager (Bitwarden/Vaultwarden,
1Password, etc.) avoid having two sets of credential suggestions compete over
the same login field.

## Implementation

- New profile pref `kBravePasswordManagerFillEnabled`
  (`brave.password_manager.fill_enabled`, default `true`), registered in
  `brave_profile_prefs.cc` and allowlisted for `settingsPrivate` in
  `brave_prefs_util.cc`.
- A `chromium_src` override of `ChromePasswordManagerClient` gates
  `IsFillingEnabled()` and `IsSavingAndFillingEnabled()` on the pref. These are
  the two virtual entry points the fill path (`PasswordManager`) and save path
  (`PasswordFormManager`) go through, so a single gate covers the dropdown,
  auto-fill, and the save prompt.
- The toggle is injected into the `settings-section` Polymer template via a
  `chromium_src` WebUI override, following the existing `side_bar.ts` pattern.

## Note on scope (intentional)

Turning the toggle off also disables the save-password prompt, not just the
dropdown. This is by design: saving internally depends on filling being enabled,
and it's the behavior a user fully on a third-party manager wants. Saved
passwords remain viewable in `brave://password-manager`.

Manual QA:

1. Save a credential for a test site in Brave.
2. Open `brave://password-manager/settings` confirm the new "Autofill
   passwords using Brave" toggle appears under "Offer to save passwords" and
   is on by default.
3. Visit the test site's login page and focus the username/password field, 
   Brave's dropdown appears and the saved credential auto-fills.
4. Turn the toggle off, reload, focus the field no Brave dropdown, no
   auto-fill, and submitting new credentials produces no "Save password?"
   prompt.
5. Turn the toggle back on, reload, the dropdown and auto-fill return.
6. Restart Brave, the setting persists, and is per-profile.

<img width="586" height="522" alt="Screenshot From 2026-07-08 09-05-18-obfuscated" src="https://github.com/user-attachments/assets/7bcf9aca-467e-4916-8334-a041092ef1a4" />
<img width="1420" height="749" alt="Screenshot From 2026-07-08 09-05-40" src="https://github.com/user-attachments/assets/35486b1a-bb87-4715-8bcb-c62c60300c7f" />
<img width="691" height="498" alt="Screenshot From 2026-07-08 09-06-08-obfuscated" src="https://github.com/user-attachments/assets/1f6e6ebb-5548-4f66-90e9-e6f517859874" />

