### PR TITLE
[iOS] Display SSL status in QuickView toolbar

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
@@ -6,6 +6,7 @@
 import BraveCore
 import BraveShields
 import BraveUI
+import CertificateUtilities
 import Data
 import Preferences
 import Shared
@@ -139,6 +140,8 @@ class QuickViewController: UIViewController {
             }
           )
         )
+      case .sslStatus:
+        self?.presentSSLStatusView()
       case .playlist, .translate:
         break
       }
@@ -222,6 +225,65 @@ class QuickViewController: UIViewController {
       from: toolbarHostingController.rootView.shieldBackgroundView.uiView,
       on: self
     )
+  }
+
+  private func presentSSLStatusView() {
+    guard let tab = currentTab else { return }
+    let hasCertificate = tab.serverTrust != nil
+    let pageSecurityView = PageSecurityView(
+      displayURL: toolbarViewModel.url.absoluteDisplayString,
+      secureState: tab.visibleSecureContentState,
+      hasCertificate: hasCertificate,
+      presentCertificateViewer: { [weak self] in
+        self?.dismiss(animated: true)
+        self?.displayPageCertificateInfo()
+      }
+    )
+    let popoverController = PopoverController(content: pageSecurityView)
+    popoverController.present(
+      from: toolbarHostingController.rootView.sslStatusBackgroundView.uiView,
+      on: self
+    )
+  }
+
+  private func displayPageCertificateInfo() {
+    guard let tab = currentTab, let trust = tab.serverTrust else { return }
+    let host = tab.visibleURL?.host
+
+    Task.detached {
+      let serverCertificates: [SecCertificate] =
+        SecTrustCopyCertificateChain(trust) as? [SecCertificate] ?? []
+
+      if let serverCertificate = serverCertificates.first,
+        let certificate = BraveCertificateModel(certificate: serverCertificate)
+      {
+
+        var errorDescription: String?
+
+        do {
+          try await BraveCertificateUtils.evaluateTrust(trust, for: host)
+        } catch {
+          errorDescription = error.localizedDescription
+          if let range = errorDescription?.range(of: "“\(certificate.subjectName.commonName)” ")
+            ?? errorDescription?.range(of: "\"\(certificate.subjectName.commonName)\" ")
+          {
+            errorDescription =
+              errorDescription?.replacingCharacters(in: range, with: "").capitalizeFirstLetter
+          }
+        }
+
+        await MainActor.run { [errorDescription] in
+          tab.dismissFindInteraction()
+          let certificateViewController = CertificateViewController(
+            certificate: certificate,
+            evaluationError: errorDescription
+          )
+          certificateViewController.modalPresentationStyle = .pageSheet
+          certificateViewController.sheetPresentationController?.detents = [.medium(), .large()]
+          self.present(certificateViewController, animated: true)
+        }
+      }
+    }
   }
 
   private func showSubmitReportView(for url: URL) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewToolbar.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewToolbar.swift
@@ -119,6 +119,7 @@ struct QuickViewToolbarView: View {
       Image(braveSystemName: "leo.info.filled")
         .foregroundColor(Color(braveSystemName: .iconDefault))
         .font(.caption2)
+        .accessibilityLabel(Text(Strings.PageSecurityView.pageUnknownStatusTitle))
     case .invalidCertificate:
       Image(braveSystemName: "leo.warning.triangle-filled")
         .foregroundColor(Color(braveSystemName: .systemfeedbackErrorIcon))

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewToolbar.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewToolbar.swift
@@ -15,6 +15,7 @@ struct QuickViewToolbarView: View {
   /// An invisible `UIView` background lives in SwiftUI for UIKit API to reference later
   var shieldBackgroundView: InvisibleUIView = .init()
   var shareBackgroundView: InvisibleUIView = .init()
+  var sslStatusBackgroundView: InvisibleUIView = .init()
 
   var body: some View {
     VStack(spacing: 0) {
@@ -100,7 +101,6 @@ struct QuickViewToolbarView: View {
       .font(.subheadline)
       .foregroundStyle(Color(braveSystemName: .textTertiary))
       .lineLimit(1)
-      .frame(maxWidth: .infinity)
       .accessibilityLabel(viewModel.url.host ?? viewModel.url.absoluteString)
   }
 
@@ -111,13 +111,64 @@ struct QuickViewToolbarView: View {
     }
   }
 
+  @ViewBuilder private var warningIcon: some View {
+    switch viewModel.secureContentState {
+    case .secure, .localhost:
+      EmptyView()
+    case .unknown:
+      Image(braveSystemName: "leo.info.filled")
+        .foregroundColor(Color(braveSystemName: .iconDefault))
+        .font(.caption2)
+    case .invalidCertificate:
+      Image(braveSystemName: "leo.warning.triangle-filled")
+        .foregroundColor(Color(braveSystemName: .systemfeedbackErrorIcon))
+        .font(.footnote)
+    case .missingSSL, .mixedContent:
+      Image(braveSystemName: "leo.warning.triangle-filled")
+        .foregroundColor(Color(braveSystemName: .textTertiary))
+        .font(.footnote)
+    }
+  }
+
+  @ViewBuilder private var warningTitle: some View {
+    switch viewModel.secureContentState {
+    case .secure, .localhost, .unknown:
+      EmptyView()
+    case .invalidCertificate:
+      Text(Strings.tabToolbarNotSecureTitle)
+        .foregroundColor(Color(braveSystemName: .systemfeedbackErrorText))
+        .font(.footnote)
+    case .missingSSL, .mixedContent:
+      Text(Strings.tabToolbarNotSecureTitle)
+        .foregroundColor(Color(braveSystemName: .textTertiary))
+        .font(.footnote)
+    }
+  }
+
+  private var sslStatusButton: some View {
+    Button {
+      viewModel.onActionButton?(.sslStatus)
+    } label: {
+      HStack(spacing: 4) {
+        warningIcon
+        warningTitle
+      }
+    }
+  }
+
   private var topRow: some View {
     HStack(alignment: .top, spacing: 8) {
       shieldButton
         .background(shieldBackgroundView)
 
       VStack(spacing: 12) {
-        addressView
+        HStack(spacing: 8) {
+          if viewModel.secureContentState.shouldDisplayWarning {
+            sslStatusButton
+              .background(sslStatusBackgroundView)
+          }
+          addressView
+        }
         progressBar
           .padding(.horizontal, 16)
           .hidden(isHidden: !viewModel.isLoading)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewToolbarModel.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewToolbarModel.swift
@@ -18,11 +18,13 @@ enum QuickViewActionButton {
   case forward
   case share
   case openTab
+  case sslStatus
 }
 
 @Observable
 class QuickViewToolbarModel {
   var url: URL
+  var secureContentState: SecureContentState = .unknown
   var secondaryTopButton: QuickViewActionButton? {
     if readerModeState != .unavailable { return .readerMode }
     return nil
@@ -49,6 +51,7 @@ class QuickViewToolbarModel {
 extension QuickViewToolbarModel: TabObserver {
   func tabDidUpdateURL(_ tab: some TabState) {
     self.url = tab.visibleURL?.displayURL ?? tab.visibleURL ?? url
+    secureContentState = tab.visibleSecureContentState
   }
 
   func tabDidStartLoading(_ tab: some TabState) {
@@ -72,5 +75,9 @@ extension QuickViewToolbarModel: TabObserver {
 
   func tabWillBeDestroyed(_ tab: some TabState) {
     tab.removeObserver(self)
+  }
+
+  func tabDidChangeVisibleSecurityState(_ tab: some TabState) {
+    secureContentState = tab.visibleSecureContentState
   }
 }


### PR DESCRIPTION
Shows the SSL security indicator in the QuickView toolbar when the page has a non-secure or problematic connection state, matching the behaviour of BVC's collapsed URL bar. Tapping the indicator presents the page security popover with the option to view full certificate details.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56505

Test:

1. Enable quickview feature flag
2. Open badssl.com in QuickView
3. Tap Expired
4. Verify SSL status indicator shows it's not secure
5. tap on the indicator 
6. verify SSL status popover shows up
7. tap on View Certificate
8. verify full screen certificate view is presented 
9. repeat the steps to test other bad ssl from badssl.com home page. 

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
