### PR TITLE
[iOS] Add Ethereum Provider JavaScriptFeature

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/WalletTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/WalletTabHelper.swift
@@ -10,7 +10,7 @@ import Foundation
 import Growth
 import Preferences
 import Shared
-import Web
+@_spi(ChromiumWebViewAccess) import Web
 import os.log
 
 extension TabDataValues {
@@ -64,6 +64,12 @@ class WalletTabHelper: NSObject, TabObserver {
   }
 
   // MARK: - TabObserver
+
+  func tabDidCreateWebView(_ tab: some TabState) {
+    if FeatureList.kUseProfileWebViewConfiguration.enabled {
+      BraveWebView.from(tab: tab)?.walletProviderDelegate = self
+    }
+  }
 
   func tabDidCommitNavigation(_ tab: some TabState) {
     clearSolanaConnectedAccounts()
@@ -294,7 +300,9 @@ extension WalletTabHelper: BraveWalletProviderDelegate {
   }
 
   func walletInteractionDetected() {
-    // No usage for iOS
+    if FeatureList.kUseProfileWebViewConfiguration.enabled {
+      isWalletIconVisible = true
+    }
   }
 
   func showWalletBackup() {

--- a/ios/browser/api/brave_wallet/BUILD.gn
+++ b/ios/browser/api/brave_wallet/BUILD.gn
@@ -21,15 +21,13 @@ source_set("brave_wallet") {
     "brave_wallet_api+private.h",
     "brave_wallet_api.h",
     "brave_wallet_api.mm",
-    "brave_wallet_provider_delegate_ios+private.h",
-    "brave_wallet_provider_delegate_ios.h",
-    "brave_wallet_provider_delegate_ios.mm",
     "brave_wallet_solana_utils.h",
     "brave_wallet_solana_utils.mm",
     "token_registry_utils.h",
     "token_registry_utils.mm",
   ]
   deps = [
+    ":provider_delegate",
     ":wallet_mojom_wrappers",
     "//base",
     "//brave/base/apple",
@@ -47,6 +45,28 @@ source_set("brave_wallet") {
     "//net",
     "//ui/base",
   ]
+}
+
+# The provider delegate bridge lives in its own target so it can be shared with
+# `//brave/ios/browser/brave_wallet` (which creates `EthereumProviderImpl`)
+# without forming a dependency cycle back into `:brave_wallet`.
+source_set("provider_delegate") {
+  configs += [ ":mojom_header_config" ]
+  sources = [
+    "brave_wallet_provider_delegate_ios+private.h",
+    "brave_wallet_provider_delegate_ios.h",
+    "brave_wallet_provider_delegate_ios.mm",
+  ]
+  deps = [
+    ":wallet_mojom_wrappers",
+    "//base",
+    "//brave/base/apple",
+    "//brave/components/brave_wallet/browser",
+    "//brave/components/brave_wallet/common",
+    "//brave/ios/browser/api/url",
+    "//net",
+  ]
+  public_configs = [ ":mojom_header_config" ]
 }
 
 ios_objc_mojom_wrappers("wallet_mojom_wrappers") {

--- a/ios/browser/api/web_view/BUILD.gn
+++ b/ios/browser/api/web_view/BUILD.gn
@@ -45,6 +45,7 @@ source_set("web_view") {
     "//brave/ios/browser/brave_search",
     "//brave/ios/browser/brave_shields",
     "//brave/ios/browser/brave_shields/request_blocking",
+    "//brave/ios/browser/brave_wallet",
     "//brave/ios/browser/favicon",
     "//brave/ios/browser/serp_metrics",
     "//brave/ios/browser/skus",

--- a/ios/browser/api/web_view/brave_web_view.h
+++ b/ios/browser/api/web_view/brave_web_view.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol ProtectionStatsTabHelperBridge;
 @protocol PrintHandler;
 @protocol RequestBlockingTabHelperBridge;
+@protocol BraveWalletProviderDelegate;
 
 typedef void (^ResetConfigurationCallback)(id<ProfileBridge>,
                                            WKWebViewConfiguration*);
@@ -166,10 +167,13 @@ CWV_EXPORT
 @end
 
 CWV_EXPORT
-@interface BraveWebView (WalletWebUI)
+@interface BraveWebView (Wallet)
 /// A bridge for handling Brave Wallet WebUI page actions
 @property(nonatomic, weak, nullable) id<WalletPageHandlerBridge>
     walletPageHandler;
+/// A bridge for handling wallet provider actions
+@property(nonatomic, weak, nullable) id<BraveWalletProviderDelegate>
+    walletProviderDelegate;
 @end
 
 CWV_EXPORT

--- a/ios/browser/api/web_view/brave_web_view.mm
+++ b/ios/browser/api/web_view/brave_web_view.mm
@@ -35,6 +35,7 @@
 #include "brave/ios/browser/brave_shields/protection_stats_tab_helper_bridge.h"
 #include "brave/ios/browser/brave_shields/request_blocking/request_blocking_tab_helper.h"
 #include "brave/ios/browser/brave_talk/brave_talk_tab_helper_bridge.h"
+#include "brave/ios/browser/brave_wallet/ethereum_provider_tab_helper.h"
 #include "brave/ios/browser/favicon/brave_ios_web_favicon_driver.h"
 #include "brave/ios/browser/serp_metrics/serp_metrics_tab_helper.h"
 #include "brave/ios/browser/ui/web_view/features.h"
@@ -285,6 +286,8 @@ class FaviconDriverObserver : public favicon::FaviconDriverObserver {
 @property(nonatomic, weak) id<PrintHandler> printHandler;
 @property(nonatomic, weak) id<RequestBlockingTabHelperBridge>
     requestBlockingTabHelperBridge;
+@property(nonatomic, weak) id<BraveWalletProviderDelegate>
+    walletProviderDelegate;
 @end
 
 @implementation BraveWebView {
@@ -427,6 +430,13 @@ class FaviconDriverObserver : public favicon::FaviconDriverObserver {
   brave_shields::ProtectionStatsTabHelper::CreateForWebState(self.webState);
   brave_shields::ProtectionStatsTabHelper::FromWebState(self.webState)
       ->SetBridge(self.protectionStatsHelper);
+
+  brave_wallet::EthereumProviderTabHelper::MaybeCreateForWebState(
+      self.webState);
+  if (auto* tabHelper = brave_wallet::EthereumProviderTabHelper::FromWebState(
+          self.webState)) {
+    tabHelper->SetBridge(self.walletProviderDelegate);
+  }
 
   LoginsTabHelper::MaybeCreateForWebState(self.webState, _loginsHelper);
 
@@ -671,6 +681,15 @@ class FaviconDriverObserver : public favicon::FaviconDriverObserver {
   brave_wallet::PageHandlerBridgeHolder::CreateForWebState(self.webState);
   brave_wallet::PageHandlerBridgeHolder::FromWebState(self.webState)
       ->SetBridge(bridge);
+}
+
+- (void)setWalletProviderDelegate:
+    (id<BraveWalletProviderDelegate>)walletProviderDelegate {
+  _walletProviderDelegate = walletProviderDelegate;
+  if (auto* tabHelper = brave_wallet::EthereumProviderTabHelper::FromWebState(
+          self.webState)) {
+    tabHelper->SetBridge(_walletProviderDelegate);
+  }
 }
 
 @end

--- a/ios/browser/brave_wallet/BUILD.gn
+++ b/ios/browser/brave_wallet/BUILD.gn
@@ -26,7 +26,6 @@ source_set("brave_wallet") {
   ]
   deps = [
     ":ethereum_provider_js",
-    "//base",
     "//brave/components/brave_wallet/browser",
     "//brave/components/brave_wallet/browser:constants",
     "//brave/components/brave_wallet/browser:pref_names",
@@ -37,7 +36,6 @@ source_set("brave_wallet") {
     "//brave/ios/browser/api/brave_wallet:provider_delegate",
     "//brave/ios/browser/api/brave_wallet:wallet_mojom_wrappers",
     "//brave/ios/browser/keyed_service",
-    "//brave/ios/web/js_messaging:message_handler_token",
     "//components/content_settings/core/browser",
     "//components/keyed_service/core",
     "//ios/chrome/browser/content_settings/model",
@@ -46,13 +44,18 @@ source_set("brave_wallet") {
     "//ios/chrome/browser/shared/model/profile:profile_keyed_service_factory",
     "//ios/components/webui:url_constants",
     "//ios/web/public",
-    "//ios/web/public/js_messaging",
     "//ios/web/public/security",
     "//ios/web/public/thread",
     "//ios/web/public/webui",
     "//ios/web/web_state/ui:wk_web_view_configuration_provider",
     "//mojo/public/cpp/bindings",
     "//services/network/public/cpp",
+  ]
+  public_deps = [
+    "//base",
+    "//brave/ios/web/js_messaging:message_handler_token",
+    "//components/prefs",
+    "//ios/web/public/js_messaging",
   ]
 }
 

--- a/ios/browser/brave_wallet/BUILD.gn
+++ b/ios/browser/brave_wallet/BUILD.gn
@@ -3,6 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import("//ios/web/public/js_messaging/optimize_ts.gni")
+
 source_set("brave_wallet") {
   sources = [
     "blockchain_images_source.h",
@@ -11,6 +13,10 @@ source_set("brave_wallet") {
     "brave_wallet_factory_wrappers.mm",
     "brave_wallet_service_factory.h",
     "brave_wallet_service_factory.mm",
+    "ethereum_provider_javascript_feature.h",
+    "ethereum_provider_javascript_feature.mm",
+    "ethereum_provider_tab_helper.h",
+    "ethereum_provider_tab_helper.mm",
     "features.h",
     "features.mm",
     "wallet_data_files_installer_delegate_impl.h",
@@ -19,6 +25,7 @@ source_set("brave_wallet") {
     "wallet_pref_names_bridge.mm",
   ]
   deps = [
+    ":ethereum_provider_js",
     "//base",
     "//brave/components/brave_wallet/browser",
     "//brave/components/brave_wallet/browser:constants",
@@ -26,17 +33,36 @@ source_set("brave_wallet") {
     "//brave/components/brave_wallet/common",
     "//brave/components/brave_wallet/common:common_constants",
     "//brave/components/brave_wallet/common:mojom",
+    "//brave/components/brave_wallet/resources:ethereum_provider_generated_resources",
+    "//brave/ios/browser/api/brave_wallet:provider_delegate",
     "//brave/ios/browser/api/brave_wallet:wallet_mojom_wrappers",
     "//brave/ios/browser/keyed_service",
+    "//brave/ios/web/js_messaging:message_handler_token",
+    "//components/content_settings/core/browser",
     "//components/keyed_service/core",
+    "//ios/chrome/browser/content_settings/model",
     "//ios/chrome/browser/shared/model/application_context",
     "//ios/chrome/browser/shared/model/profile",
     "//ios/chrome/browser/shared/model/profile:profile_keyed_service_factory",
+    "//ios/components/webui:url_constants",
     "//ios/web/public",
+    "//ios/web/public/js_messaging",
+    "//ios/web/public/security",
     "//ios/web/public/thread",
     "//ios/web/public/webui",
     "//ios/web/web_state/ui:wk_web_view_configuration_provider",
     "//mojo/public/cpp/bindings",
     "//services/network/public/cpp",
+  ]
+}
+
+optimize_ts("ethereum_provider_js") {
+  visibility = [ ":brave_wallet" ]
+
+  sources = [ "resources/ethereum_provider.ts" ]
+
+  deps = [
+    "//brave/ios/web/js_messaging:safe_builtins",
+    "//brave/ios/web/js_messaging:util_scripts",
   ]
 }

--- a/ios/browser/brave_wallet/BUILD.gn
+++ b/ios/browser/brave_wallet/BUILD.gn
@@ -13,6 +13,8 @@ source_set("brave_wallet") {
     "brave_wallet_factory_wrappers.mm",
     "brave_wallet_service_factory.h",
     "brave_wallet_service_factory.mm",
+    "brave_wallet_utils.h",
+    "brave_wallet_utils.mm",
     "ethereum_provider_javascript_feature.h",
     "ethereum_provider_javascript_feature.mm",
     "ethereum_provider_tab_helper.h",

--- a/ios/browser/brave_wallet/DEPS
+++ b/ios/browser/brave_wallet/DEPS
@@ -1,4 +1,5 @@
 include_rules = [
   "+brave/components/brave_wallet/browser",
   "+brave/components/brave_wallet/common",
+  "+brave/components/brave_wallet/resources",
 ]

--- a/ios/browser/brave_wallet/brave_wallet_utils.h
+++ b/ios/browser/brave_wallet/brave_wallet_utils.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_BRAVE_WALLET_BRAVE_WALLET_UTILS_H_
+#define BRAVE_IOS_BROWSER_BRAVE_WALLET_BRAVE_WALLET_UTILS_H_
+
+class PrefService;
+
+namespace brave_wallet {
+
+// Whether or not the default ethereum wallet is handled by Brave
+bool IsDefaultEthereumWalletBrave(PrefService* prefs);
+
+}  // namespace brave_wallet
+
+#endif  // BRAVE_IOS_BROWSER_BRAVE_WALLET_BRAVE_WALLET_UTILS_H_

--- a/ios/browser/brave_wallet/brave_wallet_utils.mm
+++ b/ios/browser/brave_wallet/brave_wallet_utils.mm
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/brave_wallet/brave_wallet_utils.h"
+
+#include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
+#include "components/prefs/pref_service.h"
+
+namespace brave_wallet {
+
+bool IsDefaultEthereumWalletBrave(PrefService* prefs) {
+  mojom::DefaultWallet eth_wallet = GetDefaultEthereumWallet(prefs);
+  // iOS does not have a separate extension so we consider Brave the default
+  // wallet for either state.
+  return eth_wallet == mojom::DefaultWallet::BraveWallet ||
+         eth_wallet == mojom::DefaultWallet::BraveWalletPreferExtension;
+}
+
+}  // namespace brave_wallet

--- a/ios/browser/brave_wallet/ethereum_provider_javascript_feature.h
+++ b/ios/browser/brave_wallet/ethereum_provider_javascript_feature.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_BRAVE_WALLET_ETHEREUM_PROVIDER_JAVASCRIPT_FEATURE_H_
+#define BRAVE_IOS_BROWSER_BRAVE_WALLET_ETHEREUM_PROVIDER_JAVASCRIPT_FEATURE_H_
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "base/memory/raw_ptr.h"
+#include "base/supports_user_data.h"
+#include "brave/ios/web/js_messaging/message_handler_token.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+
+namespace web {
+class BrowserState;
+class ScriptMessage;
+class WebState;
+}  // namespace web
+
+class ProfileIOS;
+
+namespace brave_wallet {
+
+// A JavaScriptFeature that injects the `window.ethereum`/`window.braveEthereum`
+// EIP-1193 provider into web pages so they can communicate with Brave Wallet.
+// The provider is only installed when Brave Wallet is allowed for the profile.
+class EthereumProviderJavaScriptFeature : public web::JavaScriptFeature,
+                                          public base::SupportsUserData::Data {
+ public:
+  ~EthereumProviderJavaScriptFeature() override;
+
+  static EthereumProviderJavaScriptFeature* FromBrowserState(
+      web::BrowserState* browser_state);
+
+  // web::JavaScriptFeature:
+  std::vector<web::JavaScriptFeature::FeatureScript> GetScripts()
+      const override;
+  bool GetFeatureRepliesToMessages() const override;
+  std::optional<std::string> GetScriptMessageHandlerName() const override;
+  void ScriptMessageReceivedWithReply(
+      web::WebState* web_state,
+      const web::ScriptMessage& message,
+      ScriptMessageReplyCallback callback) override;
+
+ private:
+  explicit EthereumProviderJavaScriptFeature(ProfileIOS* profile);
+
+  web::MessageHandlerToken token_;
+  raw_ptr<ProfileIOS> profile_;
+  std::string provider_bundle_js_;
+};
+
+}  // namespace brave_wallet
+
+#endif  // BRAVE_IOS_BROWSER_BRAVE_WALLET_ETHEREUM_PROVIDER_JAVASCRIPT_FEATURE_H_

--- a/ios/browser/brave_wallet/ethereum_provider_javascript_feature.h
+++ b/ios/browser/brave_wallet/ethereum_provider_javascript_feature.h
@@ -13,6 +13,7 @@
 #include "base/memory/raw_ptr.h"
 #include "base/supports_user_data.h"
 #include "brave/ios/web/js_messaging/message_handler_token.h"
+#include "components/prefs/pref_change_registrar.h"
 #include "ios/web/public/js_messaging/java_script_feature.h"
 
 namespace web {
@@ -49,9 +50,12 @@ class EthereumProviderJavaScriptFeature : public web::JavaScriptFeature,
  private:
   explicit EthereumProviderJavaScriptFeature(ProfileIOS* profile);
 
+  void OnDefaultEthereumWalletChanged();
+
   web::MessageHandlerToken token_;
   raw_ptr<ProfileIOS> profile_;
   std::string provider_bundle_js_;
+  PrefChangeRegistrar pref_change_registrar_;
 };
 
 }  // namespace brave_wallet

--- a/ios/browser/brave_wallet/ethereum_provider_javascript_feature.mm
+++ b/ios/browser/brave_wallet/ethereum_provider_javascript_feature.mm
@@ -214,14 +214,15 @@ void EthereumProviderJavaScriptFeature::ScriptMessageReceivedWithReply(
     const web::ScriptMessage& message,
     ScriptMessageReplyCallback callback) {
   const url::Origin security_origin = message.security_origin();
+  const web::NavigationItem* visible_item =
+      web_state->GetNavigationManager()->GetVisibleItem();
 
-  if (!message.is_main_frame() || security_origin.opaque()) {
+  if (!message.is_main_frame() || security_origin.opaque() || !visible_item) {
     std::move(callback).Run(nullptr, nil);
     return;
   }
 
-  const web::SSLStatus ssl =
-      web_state->GetNavigationManager()->GetVisibleItem()->GetSSL();
+  const web::SSLStatus ssl = visible_item->GetSSL();
   bool displayed_mixed_content =
       (ssl.content_status & web::SSLStatus::DISPLAYED_INSECURE_CONTENT) ? true
                                                                         : false;

--- a/ios/browser/brave_wallet/ethereum_provider_javascript_feature.mm
+++ b/ios/browser/brave_wallet/ethereum_provider_javascript_feature.mm
@@ -1,0 +1,341 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/brave_wallet/ethereum_provider_javascript_feature.h"
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "base/containers/fixed_flat_map.h"
+#include "base/containers/fixed_flat_set.h"
+#include "base/functional/bind.h"
+#include "base/json/json_reader.h"
+#include "base/json/json_writer.h"
+#include "base/memory/ptr_util.h"
+#include "base/memory/weak_ptr.h"
+#include "base/strings/sys_string_conversions.h"
+#include "base/values.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
+#include "brave/components/brave_wallet/resources/grit/brave_wallet_script_generated.h"
+#include "brave/ios/browser/brave_wallet/ethereum_provider_tab_helper.h"
+#include "brave/ios/web/js_messaging/message_handler_token.h"
+#include "ios/chrome/browser/shared/model/profile/profile_ios.h"
+#include "ios/web/public/browser_state.h"
+#include "ios/web/public/js_messaging/script_message.h"
+#include "ios/web/public/navigation/navigation_item.h"
+#include "ios/web/public/navigation/navigation_manager.h"
+#include "ios/web/public/security/ssl_status.h"
+#include "ios/web/public/web_state.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
+#include "ui/base/resource/resource_bundle.h"
+#include "url/gurl.h"
+#include "url/origin.h"
+
+namespace brave_wallet {
+
+namespace {
+
+constexpr char kEthereumProviderJavaScriptFeatureKeyName[] =
+    "ethereum_provider_java_script_feature";
+constexpr char kScriptName[] = "ethereum_provider";
+constexpr char kScriptHandlerName[] = "EthereumProviderMessageHandler";
+
+constexpr char kMethodKey[] = "method";
+constexpr char kArgsKey[] = "args";
+constexpr char kPayloadMethodKey[] = "method";
+constexpr char kPayloadParamsKey[] = "params";
+
+// The template for injecting the shared ethereum provider bundle which expects
+// a global $Object to exist. Expects `window.__gSafeBuiltins` to exist.
+// Note: New line preservation is important, the webpacked shared js includes a
+// sourceMappingURL comment at the end so it must be substituted on its own line
+constexpr char kJSProviderBundleScriptTemplate[] =
+    "(function ($Object){\n"
+    "  if (window.isSecureContext) {\n"
+    "    %s\n"
+    "  }\n"
+    "})(window.__gSafeBuiltins.$Object)";
+
+// Methods that `window.ethereum.send` may be called with as a single string
+// argument (with no params).
+constexpr auto kSupportedSingleArgMethods =
+    base::MakeFixedFlatSet<std::string_view>(
+        {"net_listening", "net_peerCount", "net_version", "eth_chainId",
+         "eth_syncing", "eth_coinbase", "eth_mining", "eth_hashrate",
+         "eth_accounts", "eth_newBlockFilter",
+         "eth_newPendingTransactionFilter"});
+
+// The `method` value posted by ethereum_provider.ts.
+enum class ProviderMethod {
+  kRequest,
+  kIsConnected,
+  kEnable,
+  kSend,
+  kSendAsync,
+  kIsUnlocked,
+};
+
+using ScriptMessageReplyCallback =
+    base::OnceCallback<void(const base::Value* reply, NSString* error)>;
+
+// Forwards an `EthereumProviderResponse` from the provider back to the page's
+// pending promise.
+void OnProviderResponse(base::WeakPtr<EthereumProviderTabHelper> tab_helper,
+                        ScriptMessageReplyCallback callback,
+                        mojom::EthereumProviderResponsePtr response) {
+  // Refresh the injected `chainId` / `networkVersion` / `selectedAddress`
+  // values on the page when the provider indicates they may have changed.
+  if (response->update_bind_js_properties && tab_helper) {
+    tab_helper->UpdateEthereumProperties();
+  }
+
+  if (response->reject) {
+    // The page rejects with the JSON-serialized error; ethereum_provider.ts
+    // strips the `Error: ` prefix and parses it.
+    std::string json;
+    base::JSONWriter::Write(response->formed_response, &json);
+    std::move(callback).Run(nullptr, base::SysUTF8ToNSString(json));
+    return;
+  }
+  std::move(callback).Run(&response->formed_response, nil);
+}
+
+std::optional<ProviderMethod> ParseMethod(std::string_view method) {
+  static constexpr auto kMethods =
+      base::MakeFixedFlatMap<std::string_view, ProviderMethod>({
+          {"request", ProviderMethod::kRequest},
+          {"isConnected", ProviderMethod::kIsConnected},
+          {"enable", ProviderMethod::kEnable},
+          {"send", ProviderMethod::kSend},
+          {"sendAsync", ProviderMethod::kSendAsync},
+          {"isUnlocked", ProviderMethod::kIsUnlocked},
+      });
+  auto it = kMethods.find(method);
+  if (it == kMethods.end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+std::string LoadDataResource(int id) {
+  auto& resource_bundle = ui::ResourceBundle::GetSharedInstance();
+  if (resource_bundle.IsGzipped(id)) {
+    return resource_bundle.LoadDataResourceString(id);
+  }
+  return std::string(resource_bundle.GetRawDataResource(id));
+}
+
+}  // namespace
+
+EthereumProviderJavaScriptFeature::EthereumProviderJavaScriptFeature(
+    ProfileIOS* profile)
+    : JavaScriptFeature(web::ContentWorld::kPageContentWorld,
+                        /*feature_scripts=*/{}),
+      profile_(profile),
+      provider_bundle_js_(LoadDataResource(
+          IDR_BRAVE_WALLET_SCRIPT_ETHEREUM_PROVIDER_SCRIPT_BUNDLE_JS)) {}
+
+EthereumProviderJavaScriptFeature::~EthereumProviderJavaScriptFeature() =
+    default;
+
+// static
+EthereumProviderJavaScriptFeature*
+EthereumProviderJavaScriptFeature::FromBrowserState(
+    web::BrowserState* browser_state) {
+  DCHECK(browser_state);
+  EthereumProviderJavaScriptFeature* feature =
+      static_cast<EthereumProviderJavaScriptFeature*>(
+          browser_state->GetUserData(
+              kEthereumProviderJavaScriptFeatureKeyName));
+  if (!feature) {
+    feature = new EthereumProviderJavaScriptFeature(
+        ProfileIOS::FromBrowserState(browser_state));
+    browser_state->SetUserData(kEthereumProviderJavaScriptFeatureKeyName,
+                               base::WrapUnique(feature));
+  }
+  return feature;
+}
+
+std::vector<web::JavaScriptFeature::FeatureScript>
+EthereumProviderJavaScriptFeature::GetScripts() const {
+  if (!IsAllowed(profile_->GetPrefs())) {
+    // Dont inject wallet scripts if wallet is not enabled for this profile
+    return {};
+  }
+  return {
+      FeatureScript::CreateWithFilename(
+          kScriptName, FeatureScript::InjectionTime::kDocumentStart,
+          FeatureScript::TargetFrames::kMainFrame,
+          FeatureScript::ReinjectionBehavior::kInjectOncePerWindow,
+          base::BindRepeating(
+              &web::MessageHandlerToken::GetPlaceholderReplacements,
+              base::Unretained(&token_))),
+      FeatureScript::CreateWithString(
+          absl::StrFormat(kJSProviderBundleScriptTemplate, provider_bundle_js_),
+          FeatureScript::InjectionTime::kDocumentStart,
+          FeatureScript::TargetFrames::kMainFrame)};
+}
+
+bool EthereumProviderJavaScriptFeature::GetFeatureRepliesToMessages() const {
+  return true;
+}
+
+std::optional<std::string>
+EthereumProviderJavaScriptFeature::GetScriptMessageHandlerName() const {
+  return kScriptHandlerName;
+}
+
+void EthereumProviderJavaScriptFeature::ScriptMessageReceivedWithReply(
+    web::WebState* web_state,
+    const web::ScriptMessage& message,
+    ScriptMessageReplyCallback callback) {
+  const url::Origin security_origin = message.security_origin();
+
+  if (!message.is_main_frame() || security_origin.opaque()) {
+    std::move(callback).Run(nullptr, nil);
+    return;
+  }
+
+  const web::SSLStatus ssl =
+      web_state->GetNavigationManager()->GetVisibleItem()->GetSSL();
+  bool displayed_mixed_content =
+      (ssl.content_status & web::SSLStatus::DISPLAYED_INSECURE_CONTENT) ? true
+                                                                        : false;
+
+  // Guard against a race where an old page's JS message is delivered after a
+  // navigation commit: the message origin must match the committed origin.
+  const GURL committed_url = web_state->GetLastCommittedURL();
+  if (!committed_url.is_valid() ||
+      !security_origin.IsSameOriginWith(committed_url) ||
+      displayed_mixed_content) {
+    std::move(callback).Run(nullptr, nil);
+    return;
+  }
+
+  std::optional<const base::Value*> validated_body =
+      token_.GetValidatedScriptMessageBody(message);
+  const base::DictValue* body =
+      validated_body ? (*validated_body)->GetIfDict() : nullptr;
+  if (!body) {
+    std::move(callback).Run(nullptr, nil);
+    return;
+  }
+
+  const std::string* method_string = body->FindString(kMethodKey);
+  const std::string* args = body->FindString(kArgsKey);
+  if (!method_string || !args) {
+    std::move(callback).Run(nullptr, nil);
+    return;
+  }
+
+  std::optional<ProviderMethod> method = ParseMethod(*method_string);
+  if (!method) {
+    std::move(callback).Run(nullptr, nil);
+    return;
+  }
+
+  EthereumProviderTabHelper* tab_helper =
+      EthereumProviderTabHelper::FromWebState(web_state);
+  mojom::EthereumProvider* provider =
+      tab_helper ? tab_helper->GetProvider() : nullptr;
+  if (!provider) {
+    std::move(callback).Run(nullptr, nil);
+    return;
+  }
+
+  switch (*method) {
+    case ProviderMethod::kRequest: {
+      std::optional<base::Value> request_payload =
+          base::JSONReader::Read(*args, base::JSON_PARSE_RFC);
+      if (!request_payload) {
+        std::move(callback).Run(nullptr, @"Invalid args");
+        return;
+      }
+      provider->Request(
+          std::move(*request_payload),
+          base::BindOnce(&OnProviderResponse, tab_helper->GetWeakPtr(),
+                         std::move(callback)));
+      return;
+    }
+    case ProviderMethod::kIsConnected:
+      // The page's `isConnected()` resolves locally
+      std::move(callback).Run(nullptr, nil);
+      return;
+    case ProviderMethod::kEnable:
+      provider->Enable(base::BindOnce(
+          &OnProviderResponse, tab_helper->GetWeakPtr(), std::move(callback)));
+      return;
+    case ProviderMethod::kSendAsync: {
+      std::optional<base::Value> request_payload =
+          base::JSONReader::Read(*args, base::JSON_PARSE_RFC);
+      if (!request_payload) {
+        std::move(callback).Run(nullptr, @"Invalid args");
+        return;
+      }
+      provider->SendAsync(
+          std::move(*request_payload),
+          base::BindOnce(&OnProviderResponse, tab_helper->GetWeakPtr(),
+                         std::move(callback)));
+      return;
+    }
+    case ProviderMethod::kSend: {
+      // `args` is a JSON string of `{ method: string, params: unknown }`.
+      std::optional<base::Value> parsed =
+          base::JSONReader::Read(*args, base::JSON_PARSE_RFC);
+      base::DictValue* payload = parsed ? parsed->GetIfDict() : nullptr;
+      const std::string* send_method =
+          payload ? payload->FindString(kPayloadMethodKey) : nullptr;
+      if (!send_method) {
+        std::move(callback).Run(nullptr, @"Invalid args");
+        return;
+      }
+      base::Value* params = payload->Find(kPayloadParamsKey);
+      const bool has_params = params && !params->is_none();
+
+      if (send_method->empty()) {
+        if (has_params) {
+          provider->SendAsync(
+              std::move(*params),
+              base::BindOnce(&OnProviderResponse, tab_helper->GetWeakPtr(),
+                             std::move(callback)));
+        } else {
+          // Empty method with no params is not valid.
+          std::move(callback).Run(nullptr, @"Invalid args");
+        }
+        return;
+      }
+
+      if (!kSupportedSingleArgMethods.contains(*send_method) && !has_params) {
+        // If it is not a single-arg supported method and there are no
+        // parameters then it is not a valid call.
+        std::move(callback).Run(nullptr, @"Invalid args");
+        return;
+      }
+
+      base::ListValue params_list;
+      if (base::ListValue* list = params ? params->GetIfList() : nullptr) {
+        params_list = std::move(*list);
+      }
+      provider->Send(
+          *send_method, std::move(params_list),
+          base::BindOnce(&OnProviderResponse, tab_helper->GetWeakPtr(),
+                         std::move(callback)));
+      return;
+    }
+    case ProviderMethod::kIsUnlocked:
+      provider->IsLocked(base::BindOnce(
+          [](ScriptMessageReplyCallback callback, bool is_locked) {
+            base::Value value(!is_locked);
+            std::move(callback).Run(&value, nil);
+          },
+          std::move(callback)));
+      return;
+  }
+}
+
+}  // namespace brave_wallet

--- a/ios/browser/brave_wallet/ethereum_provider_javascript_feature.mm
+++ b/ios/browser/brave_wallet/ethereum_provider_javascript_feature.mm
@@ -23,6 +23,7 @@
 #include "brave/components/brave_wallet/browser/pref_names.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/resources/grit/brave_wallet_script_generated.h"
+#include "brave/ios/browser/brave_wallet/brave_wallet_utils.h"
 #include "brave/ios/browser/brave_wallet/ethereum_provider_tab_helper.h"
 #include "brave/ios/web/js_messaging/message_handler_token.h"
 #include "ios/chrome/browser/shared/model/profile/profile_ios.h"
@@ -132,14 +133,6 @@ std::string LoadDataResource(int id) {
   return std::string(resource_bundle.GetRawDataResource(id));
 }
 
-bool IsDefaultWalletBrave(PrefService* prefs) {
-  mojom::DefaultWallet eth_wallet = GetDefaultEthereumWallet(prefs);
-  // iOS does not have a separate extension so we consider Brave the default
-  // wallet for either state.
-  return eth_wallet == mojom::DefaultWallet::BraveWallet ||
-         eth_wallet == mojom::DefaultWallet::BraveWalletPreferExtension;
-}
-
 }  // namespace
 
 EthereumProviderJavaScriptFeature::EthereumProviderJavaScriptFeature(
@@ -188,7 +181,7 @@ void EthereumProviderJavaScriptFeature::OnDefaultEthereumWalletChanged() {
 std::vector<web::JavaScriptFeature::FeatureScript>
 EthereumProviderJavaScriptFeature::GetScripts() const {
   PrefService* prefs = profile_->GetPrefs();
-  if (!IsAllowed(prefs) || !IsDefaultWalletBrave(prefs)) {
+  if (!IsAllowed(prefs) || !IsDefaultEthereumWalletBrave(prefs)) {
     // Dont inject wallet scripts if wallet is not enabled for this profile or
     // Brave is not set as the default ethereum wallet provider
     return {};

--- a/ios/browser/brave_wallet/ethereum_provider_javascript_feature.mm
+++ b/ios/browser/brave_wallet/ethereum_provider_javascript_feature.mm
@@ -20,6 +20,7 @@
 #include "base/strings/sys_string_conversions.h"
 #include "base/values.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
+#include "brave/components/brave_wallet/browser/pref_names.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/resources/grit/brave_wallet_script_generated.h"
 #include "brave/ios/browser/brave_wallet/ethereum_provider_tab_helper.h"
@@ -31,6 +32,7 @@
 #include "ios/web/public/navigation/navigation_manager.h"
 #include "ios/web/public/security/ssl_status.h"
 #include "ios/web/public/web_state.h"
+#include "ios/web/web_state/ui/wk_web_view_configuration_provider.h"
 #include "third_party/abseil-cpp/absl/strings/str_format.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "url/gurl.h"
@@ -130,6 +132,14 @@ std::string LoadDataResource(int id) {
   return std::string(resource_bundle.GetRawDataResource(id));
 }
 
+bool IsDefaultWalletBrave(PrefService* prefs) {
+  mojom::DefaultWallet eth_wallet = GetDefaultEthereumWallet(prefs);
+  // iOS does not have a separate extension so we consider Brave the default
+  // wallet for either state.
+  return eth_wallet == mojom::DefaultWallet::BraveWallet ||
+         eth_wallet == mojom::DefaultWallet::BraveWalletPreferExtension;
+}
+
 }  // namespace
 
 EthereumProviderJavaScriptFeature::EthereumProviderJavaScriptFeature(
@@ -138,7 +148,14 @@ EthereumProviderJavaScriptFeature::EthereumProviderJavaScriptFeature(
                         /*feature_scripts=*/{}),
       profile_(profile),
       provider_bundle_js_(LoadDataResource(
-          IDR_BRAVE_WALLET_SCRIPT_ETHEREUM_PROVIDER_SCRIPT_BUNDLE_JS)) {}
+          IDR_BRAVE_WALLET_SCRIPT_ETHEREUM_PROVIDER_SCRIPT_BUNDLE_JS)) {
+  pref_change_registrar_.Init(profile->GetPrefs());
+  pref_change_registrar_.Add(
+      kDefaultEthereumWallet,
+      base::BindRepeating(
+          &EthereumProviderJavaScriptFeature::OnDefaultEthereumWalletChanged,
+          base::Unretained(this)));
+}
 
 EthereumProviderJavaScriptFeature::~EthereumProviderJavaScriptFeature() =
     default;
@@ -161,10 +178,19 @@ EthereumProviderJavaScriptFeature::FromBrowserState(
   return feature;
 }
 
+void EthereumProviderJavaScriptFeature::OnDefaultEthereumWalletChanged() {
+  // Feature scripts must be explicitly updated after this pref changes.
+  web::WKWebViewConfigurationProvider& config_provider =
+      web::WKWebViewConfigurationProvider::FromBrowserState(profile_);
+  config_provider.UpdateScripts();
+}
+
 std::vector<web::JavaScriptFeature::FeatureScript>
 EthereumProviderJavaScriptFeature::GetScripts() const {
-  if (!IsAllowed(profile_->GetPrefs())) {
-    // Dont inject wallet scripts if wallet is not enabled for this profile
+  PrefService* prefs = profile_->GetPrefs();
+  if (!IsAllowed(prefs) || !IsDefaultWalletBrave(prefs)) {
+    // Dont inject wallet scripts if wallet is not enabled for this profile or
+    // Brave is not set as the default ethereum wallet provider
     return {};
   }
   return {

--- a/ios/browser/brave_wallet/ethereum_provider_tab_helper.h
+++ b/ios/browser/brave_wallet/ethereum_provider_tab_helper.h
@@ -93,6 +93,9 @@ class EthereumProviderTabHelper
   // web::WebStateObserver:
   void DidFinishNavigation(web::WebState* web_state,
                            web::NavigationContext* navigation_context) override;
+  void PageLoaded(
+      web::WebState* web_state,
+      web::PageLoadCompletionStatus load_completion_status) override;
   void WebStateDestroyed(web::WebState* web_state) override;
 
   raw_ptr<web::WebState> web_state_;

--- a/ios/browser/brave_wallet/ethereum_provider_tab_helper.h
+++ b/ios/browser/brave_wallet/ethereum_provider_tab_helper.h
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_BRAVE_WALLET_ETHEREUM_PROVIDER_TAB_HELPER_H_
+#define BRAVE_IOS_BROWSER_BRAVE_WALLET_ETHEREUM_PROVIDER_TAB_HELPER_H_
+
+#include <memory>
+#include <string>
+
+#include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
+#include "ios/web/public/web_state_observer.h"
+#include "ios/web/public/web_state_user_data.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+
+@protocol BraveWalletProviderDelegate;
+
+namespace web {
+class NavigationContext;
+class WebState;
+}  // namespace web
+
+class HostContentSettingsMap;
+
+namespace brave_wallet {
+
+namespace mojom {
+class EthereumProvider;
+}  // namespace mojom
+
+class BraveWalletService;
+class EthereumProviderImpl;
+
+// Owns the per-tab `EthereumProviderImpl` that backs the `window.ethereum`
+// provider injected by `EthereumProviderJavaScriptFeature`. The provider is
+// (re)created on every committed navigation so it is always scoped to the
+// current origin to align with desktop's per-frame binding.
+class EthereumProviderTabHelper
+    : public web::WebStateUserData<EthereumProviderTabHelper>,
+      public web::WebStateObserver,
+      public mojom::EventsListener {
+ public:
+  EthereumProviderTabHelper(const EthereumProviderTabHelper&) = delete;
+  EthereumProviderTabHelper& operator=(const EthereumProviderTabHelper&) =
+      delete;
+  ~EthereumProviderTabHelper() override;
+
+  // Creates the tab helper for `web_state` if a `BraveWalletService` is
+  // available for its profile.
+  static void MaybeCreateForWebState(web::WebState* web_state);
+
+  void SetBridge(id<BraveWalletProviderDelegate> bridge);
+
+  // Returns the provider for the tab's current committed origin, or nullptr if
+  // one could not be created (e.g. the wallet service is unavailable).
+  mojom::EthereumProvider* GetProvider();
+
+  // Refreshes the `chainId` / `networkVersion` / `selectedAddress` properties
+  // on the page's `window.ethereum` object by evaluating JavaScript in the main
+  // frame.
+  void UpdateEthereumProperties();
+
+  base::WeakPtr<EthereumProviderTabHelper> GetWeakPtr();
+
+  // mojom::EventsListener
+  void AccountsChangedEvent(const std::vector<std::string>& accounts) override;
+  void ChainChangedEvent(const std::string& chain_id) override;
+  void MessageEvent(const std::string& subscription_id,
+                    base::Value result) override;
+
+ private:
+  friend class web::WebStateUserData<EthereumProviderTabHelper>;
+
+  EthereumProviderTabHelper(web::WebState* web_state,
+                            BraveWalletService* brave_wallet_service,
+                            HostContentSettingsMap* host_content_settings_map);
+
+  // Recreates `provider_` scoped to the web state's current committed origin.
+  void CreateProvider();
+
+  // Assigns the `window.ethereum` properties once the current chain id is
+  // known.
+  void OnGetChainIdForProperties(const std::string& chain_id);
+
+  // Emits the `chainChanged` event and refreshes properties once the provider's
+  // current chain id is known, but only if it matches the changed chain.
+  void OnChainChangedGetChainId(const std::string& chain_id,
+                                const std::string& provider_chain_id);
+
+  // web::WebStateObserver:
+  void DidFinishNavigation(web::WebState* web_state,
+                           web::NavigationContext* navigation_context) override;
+  void WebStateDestroyed(web::WebState* web_state) override;
+
+  raw_ptr<web::WebState> web_state_;
+  raw_ptr<BraveWalletService> brave_wallet_service_;
+  raw_ptr<HostContentSettingsMap> host_content_settings_map_;
+  std::unique_ptr<EthereumProviderImpl> provider_;
+  __weak id<BraveWalletProviderDelegate> bridge_ = nil;
+  mojo::Receiver<mojom::EventsListener> events_receiver_{this};
+
+  base::WeakPtrFactory<EthereumProviderTabHelper> weak_ptr_factory_{this};
+};
+
+}  // namespace brave_wallet
+
+#endif  // BRAVE_IOS_BROWSER_BRAVE_WALLET_ETHEREUM_PROVIDER_TAB_HELPER_H_

--- a/ios/browser/brave_wallet/ethereum_provider_tab_helper.mm
+++ b/ios/browser/brave_wallet/ethereum_provider_tab_helper.mm
@@ -1,0 +1,287 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/brave_wallet/ethereum_provider_tab_helper.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "base/check.h"
+#include "base/functional/bind.h"
+#include "base/json/json_writer.h"
+#include "base/strings/strcat.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/strings/string_util.h"
+#include "base/strings/utf_string_conversions.h"
+#include "base/values.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
+#include "brave/components/brave_wallet/browser/ethereum_provider_impl.h"
+#include "brave/components/brave_wallet/common/web_ui_constants.h"
+#include "brave/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios+private.h"
+#include "brave/ios/browser/brave_wallet/brave_wallet_service_factory.h"
+#include "components/content_settings/core/browser/host_content_settings_map.h"
+#include "ios/chrome/browser/content_settings/model/host_content_settings_map_factory.h"
+#include "ios/chrome/browser/shared/model/profile/profile_ios.h"
+#include "ios/components/webui/web_ui_url_constants.h"
+#include "ios/web/public/js_messaging/content_world.h"
+#include "ios/web/public/js_messaging/web_frame.h"
+#include "ios/web/public/js_messaging/web_frames_manager.h"
+#include "ios/web/public/navigation/navigation_context.h"
+#include "ios/web/public/navigation/navigation_manager.h"
+#include "ios/web/public/web_state.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "url/gurl.h"
+#include "url/origin.h"
+
+namespace brave_wallet {
+
+namespace {
+
+void ExecuteJavaScript(web::WebState* web_state, const std::u16string& script) {
+  if (!web_state) {
+    return;
+  }
+  web::WebFramesManager* frames_manager =
+      web_state->GetPageWorldWebFramesManager();
+  if (!frames_manager) {
+    return;
+  }
+  web::WebFrame* main_frame = frames_manager->GetMainWebFrame();
+  if (!main_frame) {
+    return;
+  }
+  main_frame->ExecuteJavaScript(script);
+}
+
+// Dispatches an event to the page via `window.ethereum.emit(name, arguments)`.
+void EmitEthereumEvent(web::WebState* web_state,
+                       std::string_view event_name,
+                       std::optional<base::Value> arguments) {
+  std::string name_json;
+  base::JSONWriter::Write(base::Value(event_name), &name_json);
+
+  std::string script;
+  if (arguments) {
+    std::string arguments_json;
+    base::JSONWriter::Write(*arguments, &arguments_json);
+    script = base::StrCat(
+        {"window.ethereum.emit(", name_json, ", ", arguments_json, ")"});
+  } else {
+    script = base::StrCat({"window.ethereum.emit(", name_json, ")"});
+  }
+  ExecuteJavaScript(web_state, base::UTF8ToUTF16(script));
+}
+
+}  // namespace
+
+EthereumProviderTabHelper::EthereumProviderTabHelper(
+    web::WebState* web_state,
+    BraveWalletService* brave_wallet_service,
+    HostContentSettingsMap* host_content_settings_map)
+    : web_state_(web_state),
+      brave_wallet_service_(brave_wallet_service),
+      host_content_settings_map_(host_content_settings_map) {
+  CHECK(web_state_);
+  web_state_->AddObserver(this);
+}
+
+EthereumProviderTabHelper::~EthereumProviderTabHelper() {
+  if (web_state_) {
+    web_state_->RemoveObserver(this);
+  }
+}
+
+// static
+void EthereumProviderTabHelper::MaybeCreateForWebState(
+    web::WebState* web_state) {
+  CHECK(web_state);
+  ProfileIOS* profile =
+      ProfileIOS::FromBrowserState(web_state->GetBrowserState());
+  if (!brave_wallet::IsAllowed(profile->GetPrefs())) {
+    return;
+  }
+  BraveWalletService* brave_wallet_service =
+      BraveWalletServiceFactory::GetServiceForState(profile);
+  HostContentSettingsMap* settings_map =
+      ios::HostContentSettingsMapFactory::GetForProfile(profile);
+  if (!brave_wallet_service || !settings_map) {
+    return;
+  }
+  CreateForWebState(web_state, brave_wallet_service, settings_map);
+}
+
+void EthereumProviderTabHelper::SetBridge(
+    id<BraveWalletProviderDelegate> bridge) {
+  bridge_ = bridge;
+}
+
+mojom::EthereumProvider* EthereumProviderTabHelper::GetProvider() {
+  return provider_.get();
+}
+
+void EthereumProviderTabHelper::UpdateEthereumProperties() {
+  mojom::EthereumProvider* provider = GetProvider();
+  if (!provider) {
+    return;
+  }
+  provider->GetChainId(
+      base::BindOnce(&EthereumProviderTabHelper::OnGetChainIdForProperties,
+                     weak_ptr_factory_.GetWeakPtr()));
+}
+
+base::WeakPtr<EthereumProviderTabHelper>
+EthereumProviderTabHelper::GetWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
+}
+
+void EthereumProviderTabHelper::AccountsChangedEvent(
+    const std::vector<std::string>& accounts) {
+  // Only the first allowed account is exposed to the page
+  base::ListValue event_accounts;
+  if (!accounts.empty()) {
+    event_accounts.Append(accounts.front());
+  }
+  EmitEthereumEvent(web_state_, "accountsChanged",
+                    base::Value(std::move(event_accounts)));
+
+  UpdateEthereumProperties();
+}
+
+void EthereumProviderTabHelper::ChainChangedEvent(const std::string& chain_id) {
+  mojom::EthereumProvider* provider = GetProvider();
+  if (!provider) {
+    return;
+  }
+  // The chain change might not apply to this origin when a new default network
+  // is assigned so only emit once we've confirmed the provider's current chain
+  // id matches the changed chain.
+  provider->GetChainId(
+      base::BindOnce(&EthereumProviderTabHelper::OnChainChangedGetChainId,
+                     weak_ptr_factory_.GetWeakPtr(), chain_id));
+}
+
+void EthereumProviderTabHelper::OnChainChangedGetChainId(
+    const std::string& chain_id,
+    const std::string& provider_chain_id) {
+  if (provider_chain_id != chain_id) {
+    return;
+  }
+
+  EmitEthereumEvent(web_state_, "chainChanged", base::Value(chain_id));
+  UpdateEthereumProperties();
+
+  // Temporary fix for #5404: the dapp is not updated on chain change without a
+  // reload, so - like MetaMask - reload the tab on chain changes.
+  const GURL visible_url = web_state_->GetVisibleURL();
+  const bool is_wallet_webui_page = visible_url.scheme() == kChromeUIScheme &&
+                                    visible_url.host() == kWalletPageHost;
+  if (web_state_ && !is_wallet_webui_page) {
+    web_state_->GetNavigationManager()->Reload(web::ReloadType::NORMAL,
+                                               /*check_for_repost=*/false);
+  }
+}
+
+void EthereumProviderTabHelper::MessageEvent(const std::string& subscription_id,
+                                             base::Value result) {
+  base::DictValue data;
+  data.Set("subscription", subscription_id);
+  data.Set("result", std::move(result));
+
+  base::DictValue arguments;
+  arguments.Set("type", "eth_subscription");
+  arguments.Set("data", std::move(data));
+
+  EmitEthereumEvent(web_state_, "message", base::Value(std::move(arguments)));
+}
+
+void EthereumProviderTabHelper::OnGetChainIdForProperties(
+    const std::string& chain_id) {
+  if (!provider_) {
+    return;
+  }
+
+  // `chainId` is always assigned as a quoted hex string, e.g.
+  // `window.ethereum.chainId = "0x1"`.
+  ExecuteJavaScript(web_state_,
+                    base::UTF8ToUTF16(base::StrCat(
+                        {"window.ethereum.chainId = \"", chain_id, "\""})));
+
+  // `networkVersion` is the decimal form of the chain id, or the literal string
+  // "undefined" when it cannot be parsed.
+  std::string network_version = "undefined";
+  std::string_view hex = chain_id;
+  if (base::StartsWith(hex, "0x", base::CompareCase::INSENSITIVE_ASCII)) {
+    hex.remove_prefix(2);
+  }
+  if (uint32_t parsed = 0; base::HexStringToUInt(hex, &parsed)) {
+    network_version = base::NumberToString(parsed);
+  }
+  ExecuteJavaScript(
+      web_state_,
+      base::UTF8ToUTF16(base::StrCat(
+          {"window.ethereum.networkVersion = \"", network_version, "\""})));
+
+  // `selectedAddress` is the first allowed account (quoted), or bare
+  // `undefined` when the keyring is locked / there are no allowed accounts.
+  // `GetAllowedAccounts(false)` already returns nullopt when the keyring is
+  // locked.
+  std::string selected_address = "undefined";
+  std::optional<std::vector<std::string>> allowed_accounts =
+      provider_->GetAllowedAccounts(/*include_accounts_when_locked=*/false);
+  if (allowed_accounts && !allowed_accounts->empty()) {
+    selected_address = base::StrCat({"\"", allowed_accounts->front(), "\""});
+  }
+  ExecuteJavaScript(
+      web_state_,
+      base::UTF8ToUTF16(base::StrCat(
+          {"window.ethereum.selectedAddress = ", selected_address})));
+}
+
+void EthereumProviderTabHelper::CreateProvider() {
+  provider_.reset();
+  events_receiver_.reset();
+
+  if (!brave_wallet_service_ || !host_content_settings_map_) {
+    return;
+  }
+
+  ProfileIOS* profile =
+      ProfileIOS::FromBrowserState(web_state_->GetBrowserState());
+
+  provider_ = std::make_unique<EthereumProviderImpl>(
+      host_content_settings_map_, brave_wallet_service_,
+      std::make_unique<BraveWalletProviderDelegateBridge>(bridge_),
+      profile->GetPrefs(),
+      url::Origin::Create(web_state_->GetLastCommittedURL()));
+
+  // Register this tab helper as the provider's events listener so the provider
+  // can emit `chainChanged` / `accountsChanged` / `message` events to the page.
+  mojom::EthereumProvider* provider = provider_.get();
+  provider->Init(events_receiver_.BindNewPipeAndPassRemote());
+}
+
+void EthereumProviderTabHelper::DidFinishNavigation(
+    web::WebState* web_state,
+    web::NavigationContext* navigation_context) {
+  if (!navigation_context->HasCommitted()) {
+    return;
+  }
+
+  // Providers must be recreated when the origin changes to align with desktop
+  // (see `BraveContentBrowserClient::RegisterBrowserInterfaceBindersForFrame`).
+  CreateProvider();
+}
+
+void EthereumProviderTabHelper::WebStateDestroyed(web::WebState* web_state) {
+  provider_.reset();
+  web_state_->RemoveObserver(this);
+  web_state_ = nullptr;
+}
+
+}  // namespace brave_wallet

--- a/ios/browser/brave_wallet/ethereum_provider_tab_helper.mm
+++ b/ios/browser/brave_wallet/ethereum_provider_tab_helper.mm
@@ -278,6 +278,12 @@ void EthereumProviderTabHelper::DidFinishNavigation(
   CreateProvider();
 }
 
+void EthereumProviderTabHelper::PageLoaded(
+    web::WebState* web_state,
+    web::PageLoadCompletionStatus load_completion_status) {
+  EmitEthereumEvent(web_state, "connect", std::nullopt);
+}
+
 void EthereumProviderTabHelper::WebStateDestroyed(web::WebState* web_state) {
   provider_.reset();
   web_state_->RemoveObserver(this);

--- a/ios/browser/brave_wallet/ethereum_provider_tab_helper.mm
+++ b/ios/browser/brave_wallet/ethereum_provider_tab_helper.mm
@@ -25,6 +25,7 @@
 #include "brave/components/brave_wallet/common/web_ui_constants.h"
 #include "brave/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios+private.h"
 #include "brave/ios/browser/brave_wallet/brave_wallet_service_factory.h"
+#include "brave/ios/browser/brave_wallet/brave_wallet_utils.h"
 #include "components/content_settings/core/browser/host_content_settings_map.h"
 #include "ios/chrome/browser/content_settings/model/host_content_settings_map_factory.h"
 #include "ios/chrome/browser/shared/model/profile/profile_ios.h"
@@ -44,7 +45,10 @@ namespace brave_wallet {
 namespace {
 
 void ExecuteJavaScript(web::WebState* web_state, const std::u16string& script) {
-  if (!web_state) {
+  if (!web_state ||
+      !IsDefaultEthereumWalletBrave(
+          ProfileIOS::FromBrowserState(web_state->GetBrowserState())
+              ->GetPrefs())) {
     return;
   }
   web::WebFramesManager* frames_manager =
@@ -63,6 +67,12 @@ void ExecuteJavaScript(web::WebState* web_state, const std::u16string& script) {
 void EmitEthereumEvent(web::WebState* web_state,
                        std::string_view event_name,
                        std::optional<base::Value> arguments) {
+  if (!web_state ||
+      !IsDefaultEthereumWalletBrave(
+          ProfileIOS::FromBrowserState(web_state->GetBrowserState())
+              ->GetPrefs())) {
+    return;
+  }
   std::string name_json;
   base::JSONWriter::Write(base::Value(event_name), &name_json);
 

--- a/ios/browser/brave_wallet/ethereum_provider_tab_helper.mm
+++ b/ios/browser/brave_wallet/ethereum_provider_tab_helper.mm
@@ -257,12 +257,13 @@ void EthereumProviderTabHelper::CreateProvider() {
   provider_.reset();
   events_receiver_.reset();
 
-  if (!brave_wallet_service_ || !host_content_settings_map_) {
-    return;
-  }
-
   ProfileIOS* profile =
       ProfileIOS::FromBrowserState(web_state_->GetBrowserState());
+
+  if (!brave_wallet_service_ || !host_content_settings_map_ ||
+      !IsDefaultEthereumWalletBrave(profile->GetPrefs())) {
+    return;
+  }
 
   provider_ = std::make_unique<EthereumProviderImpl>(
       host_content_settings_map_, brave_wallet_service_,
@@ -279,7 +280,8 @@ void EthereumProviderTabHelper::CreateProvider() {
 void EthereumProviderTabHelper::DidFinishNavigation(
     web::WebState* web_state,
     web::NavigationContext* navigation_context) {
-  if (!navigation_context->HasCommitted()) {
+  if (!navigation_context->HasCommitted() ||
+      navigation_context->IsSameDocument()) {
     return;
   }
 
@@ -291,7 +293,9 @@ void EthereumProviderTabHelper::DidFinishNavigation(
 void EthereumProviderTabHelper::PageLoaded(
     web::WebState* web_state,
     web::PageLoadCompletionStatus load_completion_status) {
-  EmitEthereumEvent(web_state, "connect", std::nullopt);
+  if (load_completion_status == web::PageLoadCompletionStatus::SUCCESS) {
+    EmitEthereumEvent(web_state, "connect", std::nullopt);
+  }
 }
 
 void EthereumProviderTabHelper::WebStateDestroyed(web::WebState* web_state) {

--- a/ios/browser/brave_wallet/resources/ethereum_provider.ts
+++ b/ios/browser/brave_wallet/resources/ethereum_provider.ts
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { $Object } from '//brave/ios/web/js_messaging/resources/safe_builtins.js'
+import { sendTokenizedWebKitMessageWithReply } from '//brave/ios/web/js_messaging/resources/utils.js'
+
+type JsonRpcRequest = object
+type JsonRpcCallback = (err: Error | null, response?: any) => void
+
+if (window.isSecureContext) {
+  function post(method: string, payload: any): Promise<any> {
+    return new Promise(
+      (resolve: (value: any) => void, reject: (reason: any) => void) => {
+        sendTokenizedWebKitMessageWithReply('EthereumProviderMessageHandler', {
+          method: method,
+          args: JSON.stringify(payload),
+        }).then(resolve, (errorJSON: any) => {
+          /* remove `Error: ` prefix. errorJSON=`Error: {code: 1, errorMessage: "Internal error"}` */
+          const errorJSONString = new String(errorJSON)
+          const errorJSONStringSliced = errorJSONString.slice(
+            errorJSONString.indexOf('{'),
+          )
+          try {
+            reject(JSON.parse(errorJSONStringSliced))
+          } catch (e) {
+            reject(errorJSON)
+          }
+        })
+      },
+    )
+  }
+
+  const provider = { value: {} }
+  Object.defineProperty(window, 'ethereum', provider)
+  Object.defineProperty(window, 'braveEthereum', provider)
+  // When using `Object.defineProperties` & setting `writable: false` we cannot
+  // update properties using `ExecuteJavaScript` / `UpdateEthereumProperties`.
+  // `chainId`, `networkVersion`, `selectedAddress` differ from desktop (are
+  // writable) because need to update in `UpdateEthereumProperties`
+  Object.defineProperties((window as any).ethereum, {
+    chainId: {
+      value: undefined,
+      writable: true, // writable so `UpdateEthereumProperties()` can update.
+    },
+    networkVersion: {
+      value: undefined,
+      writable: true, // writable so `UpdateEthereumProperties()` can update.
+    },
+    selectedAddress: {
+      value: true,
+      writable: true, // writable so `UpdateEthereumProperties()` can update.
+    },
+    isBraveWallet: {
+      value: true,
+      writable: false,
+    },
+    isMetaMask: {
+      value: true,
+      writable: true, // https://github.com/brave/brave-browser/issues/22213
+    },
+    request: {
+      value: function (args: any): Promise<unknown> {
+        return post('request', args)
+      },
+      writable: false,
+    },
+    isConnected: {
+      value: function (): boolean {
+        return true
+      },
+      writable: false,
+    },
+    enable: {
+      value: function () {
+        return post('enable', {})
+      },
+      writable: false,
+    },
+    // ethereum.sendAsync(payload: JsonRpcRequest, callback: JsonRpcCallback): void;
+    sendAsync: {
+      value: function (payload: JsonRpcRequest, callback: JsonRpcCallback) {
+        post('sendAsync', payload)
+          .then((response) => {
+            callback(null, response)
+          })
+          .catch((response) => {
+            callback(response, null)
+          })
+      },
+      writable: false,
+    },
+    /*
+    Available overloads for send:
+      ethereum.send(payload: JsonRpcRequest, callback: JsonRpcCallback): void;
+      ethereum.send(method: string, params?: Array<unknown>): Promise<JsonRpcResponse>;
+    */
+    send: {
+      value: function (
+        methodOrPayload: string | JsonRpcRequest,
+        paramsOrCallback: Array<unknown> | JsonRpcCallback,
+      ): void | Promise<any> {
+        const payload = {
+          method: '',
+          params: {},
+        }
+        if (typeof methodOrPayload === 'string') {
+          payload.method = methodOrPayload
+          payload.params = paramsOrCallback
+          return post('send', payload)
+        } else {
+          payload.params = methodOrPayload
+          const callback = paramsOrCallback as JsonRpcCallback
+          if (paramsOrCallback != undefined) {
+            post('send', payload)
+              .then((response) => {
+                callback(null, response)
+              })
+              .catch((response) => {
+                callback(response, null)
+              })
+          } else {
+            // Unsupported usage of send
+            throw TypeError('Insufficient number of arguments.')
+          }
+        }
+      },
+      writable: true, // https://github.com/brave/brave-browser/issues/25078
+    },
+  })
+
+  let uuid = crypto.randomUUID()
+  if (uuid) {
+    const announceProvider = () => {
+      const info = {
+        walletId: 'com.brave.wallet',
+        rdns: 'com.brave.wallet',
+        uuid: uuid,
+        name: 'Brave Wallet',
+        icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAA0NSURBVHgB7VxtjB1VGX6n8YcChaJBtJTsbjFR22C/Kf7Q3i2hP+iPbiNVW7G7rfEjNmEXjU1MSO/dQiVShS4JiD/Y7m1iUUsoVZAEaPduMBFB221MK0Zwd2Otlia0Cy1/bHd8nznnzLwzd+7du5ucOXfrPMnsfH/s+5zzfp5zPZ9BOZxhFuVwipwAx8gJcIycAMfICXCMnADHyAlwjJwAx8gJcIycAMfICXCMnADHyAlwjJwAx8gJcIycAMfICXCMD1Ez4oPzRLvXE50dJZrweOFjl7lwdxlrL9q+RNF6Qm/L4xP6eXd2EO14lJoRzUnAwH1EJ4eIgmqppwXqK+Ff8tX+JS869l+Kk2IIuGye10d03Ryi7iI1G5qPgGd6iSoD8WOeXkgT4pnjniaJqq83G+b8npJaNxkJzWUDDrDwf12iUIK+J06aY6SE6om1J87JNZlzvjoGEp4pUzPBa5pRES+wmij3qG3d0EOEet2oIK1+LnnCDpjjeluqoOQzXzhGtGAxNQPc9ICzY2oxGB3WwtcSkipEwrQVTzZ1vXj6eNArPNF7Up65sZ3o1KjafY8N/qkxtXaA7HoAPJonthCNDCsvJ9DPvJq/iOgdPndhPCFv8VnSswkNbbI3UNRD5PUBvOh5ZnNem9o/NRJdc+11RGs6lJ2Y10pZIBsC0MJ7VxNdhOCNLhA6wehyieCrtMENPRzhBSU9nqptuK/6HaZXJN9t7IiBueYmJufpI5mQYF8FBcLnLn/xHMUFMIti6iOAUBtGpZiWKw2yMbqe8YiSasbcK4/Ld2v4ifea1/1rlGjTaqWaLMNuDxg9roUvWz6pbU+roOR29GnR/oT0/3n5MPv0rWxE5y9WwdabTPLrlXRjbexF6juI4qwJknA9esB+uz3BHgHQ+VA770DHCsGr14p9/Q93cqR6QyvR2HHVa2AXxobVZRAshH4zC/yOTqLPs56+Zk78faf5+jcqRAfLRH+oRNExAAGuLCjPZ14LB3n83L7eKI6Qbmzo3upzuPfpQWsk2CNg+xLVAwKk6P0QfGxDkZdS+nNGNAkfbyW6eg41hPe5x50YVkKrJbidHG3v7Yu+QSIWV/jKMP/8INmAPRuwokPsJA0gUahwV6yvLXygbbFaGhU+MJuvvb1Qv9X2MOkLFolAzqtuG8a+3NlBtmCvB0Dvb/lotachybiB1UGxwq27hZwAscDaZRwDvEtVXpER/k2tRK/+g2zBXg9Ai11YiNxJMmtBRmnQnfAB9JDdT1H4Xb4w2CZOuX0V2YRdN/QqDmyqDK/+5zbsUEbXNaDft3ZTKIowwafd42unoPqmAbte0Lb5eidhfFesI/qBMGpQV8iCXhxX92EJbuP7PtZG1MK6+jYW1K0NtEYY4DfZ+L/yHHtDQ0TndIoBgkSkiyALuj8QugbSEBvZY/vrMIWJOwBkzOZ7jp8jW7BHAFLKSD3EdKvR+4PKq5GA0E9UVEY0IGCWusfk/OGKfoSFuJLJ+86j6W5okd93goU/Pi7u86N3Q53AoN7dWd2y4ZquXaJ3vLg7ilgARt0C7KmgoX16wxd2gDfWdlcLH4A6KnQRPT5C9GPOVhY2K7JC8L0XuKW+VCZ6e7j6/j9VeOEWfwGtdUJdjzU8ou4SZ0CPKn8eLT9NrSBG2NqjtsPIWePlQ2QLdnpAqH5MykFHRBAyBDwVHGGBHx5gNVCJWvSz56p7wN+YlK8ujRJ2y7i1byuqAKxRQBV9Yb5SY9Jrhup6dcSKPbDTA8LUA1H0n3jKn58qVrO62MUtd1NR7UPw16QIYm5r9L5d/UT7BqcmfAACvrlFFHz0p1tMVdshAC396uvFAU3GyHGaNjaViG5k4dxSg0Somrl8/jN8vqOLpo1/jqq1iYKxhrtqyRuyQwBigFb2NEzLNx7Q2RFlZKeDM6Nq+Vyh9jXLCiqT+f40W+yenaq1eyIhh2TeynayBXtGeDnCd20IwzwvKQKmQ8LhslrfUkeNfXqxEv7haRjNPfxNfVrNBarHiz57zTqyBXsELFwldkyuRbesAyWiF/uoYaDlvzKgnvGJltrXGTvwRGlqvQDCf6wU7YcpbL22GA3bIwD5+qugN0XqOXRHednL2chKubFn/bJX1ZBhfOfX6QHLV6lnQw2VGyQ4aPklXfARKQgYYhxbsMRqNGw3FXGbUUMSwjtCoFbZV/8ZqAsMlpUw2hbVvxaGeLYWVnnP5L0gEH6v0PnmhBetZnQuqAWtNZmKTqSky92qAFMLz/fpSHYi3f1MYq5WURD+s3V6GMYHBcKneCFGlkmxb1H/A5Z7wLqU14i4AAvyPyhb1iIBtsRkJ/9SYaEyIW8n3FkI+89DRE/2qoAMmM1u8B01hAfhb9+iP8enWK7KE9+G7anGElOE/VER29p0bkc2NaJomIjOPiJuePhoeoYURviHTNK/R6NoGHmh+ayfx8+roSUy/7OUSdu1V+XykwhyPkujb/G0rg+/SagjCB/pC4uwPyoiqIx54oDkWwsfn4FREwd2pj/jxlaifhby14paDXkqL3SMhfP3Y2pMEZ6LVr/9EaKBwXThAw98j2Iq0PdEplwIH8fX2KuEGdgnoNUYTin4pC2YIKqqB6bgnhIbbu4lazopFuABG3s44caVq3t6JnmIn1AzfsJEeZoUX6WtLcO+CjKlyVQkiHj4mHJfG8EA6/unSirx1s0ez1e6G7vvtSE1NLHWAAEAJMD1HH6XbMN+DzBpidQGLuwCdH+jwge6WB19im3AFzsaFz6AVo3sZgDh8cQ+CemHVZQFshmcu6AQJbeSuXbz3081UzrMLfktNqhHh5RxbhRBxrNN53n0u33xLcH2LGsFmCSyIWCFCMhkcUaScdX11DDeYjf0fm0gUYD5bvvUSECZ0US78ls8PzLEV1QPCFSQMXym2xsPiNT+Gw0OfEJF7PvtygsKCOQ/p8eIvr1aVcQmA4ainDwe3eslgsQg/dyS2fyBbAiAHVhgWpTp9gkjCGNdL0GH809y/ugnW3TZkSK1huX0KNE3mZif9VJdYDTce+coPlbJFz3Ctx58SWQ3QQN2IDZExYtaYZig66lO0EHwSMZ9g0uFh/qi+xEPbGDje1cXZ0hbo2eDgDVtaoxoEsj99PdRNKpaBmHCJmSk/4O3ZjZB42SFqNROIuqhwP+XA2TNlxQ61aAujAtFHQAtNhghTSo18fUi0aJC/Pm/5esODRC9PhRFxJ9s5ZLmOqVOkH54jb8h1ggS0bj5NoyEu6ImaBh0saH9YFzvpPnh8rhunUaYUGEbi/UrYgBGSD/eq/x9c6+flgKhamcsSD8vViMoMkK2c8QCV1Pr2QByndDJAISCnvDgEaKHBicXPrCioFIRD/XrdIRMtJk/syg+A5OiazKIfiWyJWC5zAsJnRtrneIYsqkPsDBvLdCUsb6L7cmIKqiYZ4dGe6La/hhYHAmdhmwJWJjwrf1kT5CE8LE/cm33V700bTx4n8p+Vj1bvDLZ8ywXYJLIloCwTAkk/O80pQwfHRO3H9uqxxo1CJQkN6+uUZaU79XvMbBcfkxDtgQAQZEmTeBJ+FHUfGSA6F7O4Z8Zo0mBYKyrXc0ZM8+Jrc22cEXNknHrB7InYFUnxRJgnoiOZaRsYAKkM6zPt3EPOlgnWPsFn9varoKy8GaTakgSLlxQYw++1ElZw81PFcTcUSDpJgo9jVIBZjwGa0+ln1EX2Lwjuh0lyZ+yvv9NWU/U1teZ+cWmJ6W9y8Qf8H7wEwYZI/seAKxF0SRFB6e1UCM8X6iMcpGTceuJ/jOqknBIxj0/kDCsaXGGn+hxFKUftkxWyLEDdz/WUTWLMvgcivcAP5ojbEY9h62bVF0YPeP8+fh8AHnNZT+egU3rCXd3Ee3uJxdwRwDG+2AecVCwT3g/Bjhs1IhJRYSqJSnsFMGHEzRIpBv0DH3zms8uUoX3jL0fAzcqCMAkjeIRPQlDR6dV6kiSIbwVL0W1pBnwAEmPayI6hZy/Q+ED7ggAQAImbGCidmpawghLBlEexSpYsfukeknATwR59z/iXPjB1zTNDzZhfhiGKoa/I6RVR6h6/GobUKVu0o4TxfI+yHJi1nvGOZ9acNsDJJB0w7zhQi1fvF7wluZJJT0qX80PQ6azSYQPNE8PkMAMy2C25Jj4kaZ6BpdSDLI4h6zo7r2ZFloaRXMSAMBLAgkoyNQScOii6vWElxA+73dyq7+36FzX10LzEmCAPND+nWp8qPz90Lp2wFdlyh/tzbS+Ox00PwEAhL+fe8NL+1i4EwljnBITbOpWU1RnN2erl5gZBBi8PEC0b6dKtqUJH62+2K+qYjMEM4sAAPmfMveGFwfiPeHL3Oq/NTNavcTMI8Dg988R/a6sCjx3seu6tEAzETOXgCsEzROI/Z8iJ8AxcgIcIyfAMXICHCMnwDFyAhwjJ8AxcgIcIyfAMXICHCMnwDFyAhwjJ8AxcgIc43+t6oqSdy4VYgAAAABJRU5ErkJggg==',
+      }
+      let provider = (window as any).braveEthereum
+      const event = $Object.freeze(
+        new CustomEvent('eip6963:announceProvider', {
+          detail: $Object.freeze({ info, provider }),
+        }),
+      )
+      window.dispatchEvent(event)
+    }
+    window.addEventListener('eip6963:requestProvider', () => {
+      announceProvider()
+    })
+
+    announceProvider()
+  }
+}

--- a/ios/browser/brave_wallet/resources/ethereum_provider.ts
+++ b/ios/browser/brave_wallet/resources/ethereum_provider.ts
@@ -49,7 +49,7 @@ if (window.isSecureContext) {
       writable: true, // writable so `UpdateEthereumProperties()` can update.
     },
     selectedAddress: {
-      value: true,
+      value: undefined,
       writable: true, // writable so `UpdateEthereumProperties()` can update.
     },
     isBraveWallet: {

--- a/ios/browser/web/BUILD.gn
+++ b/ios/browser/web/BUILD.gn
@@ -20,6 +20,7 @@ source_set("web") {
     "//brave/components/brave_component_updater/browser:public",
     "//brave/components/brave_talk/buildflags",
     "//brave/components/brave_user_agent/browser",
+    "//brave/components/brave_wallet/common/buildflags",
     "//brave/components/constants",
     "//brave/components/playlist/core/common/buildflags",
     "//brave/components/query_filter/browser",
@@ -70,7 +71,10 @@ source_set("web") {
     deps += [ "//brave/ios/browser/brave_talk" ]
   }
   if (enable_brave_wallet) {
-    deps += [ "//brave/components/brave_wallet/browser" ]
+    deps += [
+      "//brave/components/brave_wallet/browser",
+      "//brave/ios/browser/brave_wallet",
+    ]
   }
   if (enable_playlist) {
     deps += [

--- a/ios/browser/web/brave_web_client.mm
+++ b/ios/browser/web/brave_web_client.mm
@@ -14,6 +14,7 @@
 #include "base/notimplemented.h"
 #include "base/strings/sys_string_conversions.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
+#include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/constants/url_constants.h"
 #include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/ios/browser/ai_chat/ai_chat_distiller_javascript_feature.h"
@@ -73,6 +74,10 @@
 
 #if BUILDFLAG(ENABLE_PLAYLIST)
 #include "brave/components/playlist/core/common/features.h"
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_WALLET)
+#include "brave/ios/browser/brave_wallet/ethereum_provider_javascript_feature.h"
 #endif
 
 BraveWebClient::BraveWebClient() {}
@@ -184,6 +189,12 @@ std::vector<web::JavaScriptFeature*> BraveWebClient::GetJavaScriptFeatures(
             brave::features::kUseChromiumWebViewsAutofill)) {
       features.push_back(LoginsJavaScriptFeature::GetInstance());
     }
+
+#if BUILDFLAG(ENABLE_BRAVE_WALLET)
+    features.push_back(
+        brave_wallet::EthereumProviderJavaScriptFeature::FromBrowserState(
+            browser_state));
+#endif
 
     // Some privacy related features need to be injected in a specific order
     // as they may override similar JavaScript APIs


### PR DESCRIPTION
This allows connecting to ethereum dapps possible when the `UseProfileWebViewConfiguration` feature flag is enabled. This port is based on the `WalletEthereumProviderScript.js` script

Resolves https://github.com/brave/brave-browser/issues/56990

### Test
- Enable the `UseProfileWebViewConfiguration` feature flag
- Create an ethereum wallet
- Visit a site that can connect to that wallet such as `myetherwallet` and connect to Brave
- Verify the wallet icon appears correctly in the URL bar and that the flow for connecting the wallet to the dapp works as usual
- Enable Brave Origin and re-launch the app and verify that when Wallet is disabled by Origin the dapps cannot connect to the Brave wallet