### PR TITLE
[Android] Fix Server region VPN screen layout broken after rotation on tablets

### DIFF
--- a/android/java/org/chromium/chrome/browser/vpn/activities/BraveVpnParentActivity.java
+++ b/android/java/org/chromium/chrome/browser/vpn/activities/BraveVpnParentActivity.java
@@ -8,6 +8,7 @@
 package org.chromium.chrome.browser.vpn.activities;
 
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.os.Handler;
 import android.util.Pair;
 
@@ -22,6 +23,8 @@ import com.wireguard.crypto.KeyPair;
 import org.chromium.base.Log;
 import org.chromium.base.ThreadUtils;
 import org.chromium.base.supplier.OneshotSupplier;
+import org.chromium.base.task.PostTask;
+import org.chromium.base.task.TaskTraits;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.BraveLandscapeHelper;
 import org.chromium.chrome.browser.billing.InAppPurchaseWrapper;
@@ -96,6 +99,28 @@ public abstract class BraveVpnParentActivity extends AsyncInitializationActivity
         if (hasFocus && shouldApplyLandscapeWindowSizing()) {
             BraveLandscapeHelper.applyLandscapeWindowSizing(this);
         }
+    }
+
+    @Override
+    public void performOnConfigurationChanged(Configuration newConfig) {
+        super.performOnConfigurationChanged(newConfig);
+        if (!shouldApplyLandscapeWindowSizing()) {
+            return;
+        }
+        // Activities such as VpnServerSelectionActivity and VpnServerActivity declare
+        // configChanges in the manifest, so an orientation change does not recreate them and does
+        // not trigger onWindowFocusChanged. Without this, the landscape side padding applied by
+        // BraveLandscapeHelper persists after rotating landscape->portrait, squeezing the content
+        // into a narrow column. Re-apply the sizing for the new orientation. Post it so it runs
+        // after the framework's rotation layout pass, when the display metrics for the new
+        // orientation are final.
+        PostTask.postTask(
+                TaskTraits.UI_USER_VISIBLE,
+                () -> {
+                    if (!isActivityFinishingOrDestroyed()) {
+                        BraveLandscapeHelper.applyLandscapeWindowSizing(this);
+                    }
+                });
     }
 
     // Subclasses that ship a dedicated `layout-land` resource should return

--- a/android/java/org/chromium/chrome/browser/vpn/activities/BraveVpnParentActivity.java
+++ b/android/java/org/chromium/chrome/browser/vpn/activities/BraveVpnParentActivity.java
@@ -23,8 +23,6 @@ import com.wireguard.crypto.KeyPair;
 import org.chromium.base.Log;
 import org.chromium.base.ThreadUtils;
 import org.chromium.base.supplier.OneshotSupplier;
-import org.chromium.base.task.PostTask;
-import org.chromium.base.task.TaskTraits;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.BraveLandscapeHelper;
 import org.chromium.chrome.browser.billing.InAppPurchaseWrapper;
@@ -104,23 +102,15 @@ public abstract class BraveVpnParentActivity extends AsyncInitializationActivity
     @Override
     public void performOnConfigurationChanged(Configuration newConfig) {
         super.performOnConfigurationChanged(newConfig);
-        if (!shouldApplyLandscapeWindowSizing()) {
-            return;
-        }
         // Activities such as VpnServerSelectionActivity and VpnServerActivity declare
         // configChanges in the manifest, so an orientation change does not recreate them and does
         // not trigger onWindowFocusChanged. Without this, the landscape side padding applied by
         // BraveLandscapeHelper persists after rotating landscape->portrait, squeezing the content
-        // into a narrow column. Re-apply the sizing for the new orientation. Post it so it runs
-        // after the framework's rotation layout pass, when the display metrics for the new
-        // orientation are final.
-        PostTask.postTask(
-                TaskTraits.UI_USER_VISIBLE,
-                () -> {
-                    if (!isActivityFinishingOrDestroyed()) {
-                        BraveLandscapeHelper.applyLandscapeWindowSizing(this);
-                    }
-                });
+        // into a narrow column. Re-apply the sizing for the new orientation; the display metrics
+        // are already updated for it by the time performOnConfigurationChanged runs.
+        if (shouldApplyLandscapeWindowSizing()) {
+            BraveLandscapeHelper.applyLandscapeWindowSizing(this);
+        }
     }
 
     // Subclasses that ship a dedicated `layout-land` resource should return


### PR DESCRIPTION
This PR re-applies window sizing on the orientation change.


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56965

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
