### PR TITLE
[VPN 2.0] Implement main loop and graceful shutdown handler in Agent

### DIFF
--- a/components/brave_vpn/app/v2/agent/BUILD.gn
+++ b/components/brave_vpn/app/v2/agent/BUILD.gn
@@ -19,15 +19,23 @@ source_set("core") {
   sources = [
     "agent_app.cc",
     "agent_app.h",
+    "shutdown_handlers.cc",
+    "shutdown_handlers.h",
     "single_instance.h",
   ]
 
   if (is_win) {
-    sources += [ "win/single_instance_win.cc" ]
+    sources += [
+      "win/shutdown_handlers_win.cc",
+      "win/single_instance_win.cc",
+    ]
   }
 
-  if (is_mac) {
-    sources += [ "posix/single_instance_posix.cc" ]
+  if (is_posix) {
+    sources += [
+      "posix/shutdown_handlers_posix.cc",
+      "posix/single_instance_posix.cc",
+    ]
   }
 
   public_deps = [ "//base" ]
@@ -133,7 +141,11 @@ if (is_mac) {
 
 source_set("unit_tests") {
   testonly = true
-  sources = [ "single_instance_unittest.cc" ]
+  sources = [
+    "agent_app_unittest.cc",
+    "shutdown_handlers_unittest.cc",
+    "single_instance_unittest.cc",
+  ]
 
   deps = [
     ":core",

--- a/components/brave_vpn/app/v2/agent/agent_app.cc
+++ b/components/brave_vpn/app/v2/agent/agent_app.cc
@@ -5,17 +5,68 @@
 
 #include "brave/components/brave_vpn/app/v2/agent/agent_app.h"
 
+#include <memory>
+#include <utility>
+
+#include "base/check.h"
+#include "base/functional/bind.h"
+#include "base/location.h"
 #include "base/logging.h"
+#include "base/message_loop/message_pump_type.h"
+#include "base/run_loop.h"
+#include "base/task/single_thread_task_executor.h"
+#include "base/task/single_thread_task_runner.h"
+#include "brave/components/brave_vpn/app/v2/agent/shutdown_handlers.h"
 
 namespace brave_vpn::v2 {
 
-AgentApp::AgentApp() = default;
+AgentApp::AgentApp()
+    : shutdown_handlers_(std::make_unique<ShutdownHandlers>(
+          base::BindRepeating(&AgentApp::Shutdown, base::Unretained(this)))) {}
 
 AgentApp::~AgentApp() = default;
 
 int AgentApp::Run() {
   VLOG(1) << "Hello from the Brave VPN Agent!";
+
+  base::SingleThreadTaskExecutor main_task_executor(
+      base::MessagePumpType::DEFAULT);
+  main_runner_ = base::SingleThreadTaskRunner::GetCurrentDefault();
+
+  base::RunLoop run_loop;
+  quit_closure_ = run_loop.QuitClosure();
+
+  // Once installed, the handlers may invoke Shutdown() from a background thread
+  // at any moment, which requires |main_runner_| and |quit_closure_| to already
+  // be in place.
+  if (!shutdown_handlers_->Install()) {
+    VLOG(1) << "Shutdown handlers not installed";
+  }
+  run_loop.Run();
+
+  shutdown_handlers_->SignalShutdownComplete();
   return 0;
+}
+
+void AgentApp::Shutdown() {
+  CHECK(main_runner_) << "Shutdown() called before Run()";
+  if (main_runner_->RunsTasksInCurrentSequence()) {
+    ExecuteShutdown();
+  } else {
+    main_runner_->PostTask(FROM_HERE, base::BindOnce(&AgentApp::ExecuteShutdown,
+                                                     base::Unretained(this)));
+  }
+}
+
+void AgentApp::ExecuteShutdown() {
+  if (is_shutting_down_) {
+    return;
+  }
+  is_shutting_down_ = true;
+  VLOG(1) << "Shutting down Brave VPN Agent";
+  if (quit_closure_) {
+    std::move(quit_closure_).Run();
+  }
 }
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/agent_app.cc
+++ b/components/brave_vpn/app/v2/agent/agent_app.cc
@@ -20,9 +20,12 @@
 
 namespace brave_vpn::v2 {
 
+// Unretained is safe: the shutdown handlers may invoke this callback from a
+// background thread, but only while the process (and hence |this|, which
+// lives for main()'s duration) is alive.
 AgentApp::AgentApp()
     : shutdown_handlers_(std::make_unique<ShutdownHandlers>(
-          base::BindRepeating(&AgentApp::Shutdown, base::Unretained(this)))) {}
+          base::BindOnce(&AgentApp::Shutdown, base::Unretained(this)))) {}
 
 AgentApp::~AgentApp() = default;
 
@@ -59,12 +62,8 @@ void AgentApp::Shutdown() {
 }
 
 void AgentApp::ExecuteShutdown() {
-  if (is_shutting_down_) {
-    return;
-  }
-  is_shutting_down_ = true;
-  VLOG(1) << "Shutting down Brave VPN Agent";
   if (quit_closure_) {
+    VLOG(1) << "Shutting down Brave VPN Agent";
     std::move(quit_closure_).Run();
   }
 }

--- a/components/brave_vpn/app/v2/agent/agent_app.h
+++ b/components/brave_vpn/app/v2/agent/agent_app.h
@@ -6,11 +6,21 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_AGENT_APP_H_
 #define BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_AGENT_APP_H_
 
+#include <memory>
+
+#include "base/functional/callback.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/task/single_thread_task_runner.h"
+
 namespace brave_vpn::v2 {
 
-// The AgentApp class encapsulates the main application logic for the Brave VPN
-// agent process. It provides a stub method for running the main event loop.
+class ShutdownHandlers;
 
+// The AgentApp class encapsulates the main application logic for the Brave VPN
+// agent process. It owns the main thread's task executor and run loop, and
+// funnels external termination requests (POSIX signals, Windows console control
+// events, and eventually Mojo Shutdown()/disconnect) into a single graceful
+// shutdown path.
 class AgentApp final {
  public:
   AgentApp();
@@ -20,8 +30,23 @@ class AgentApp final {
   AgentApp& operator=(const AgentApp&) = delete;
 
   // Runs the main event loop of the application. The return value is the exit
-  // code of the application.
+  // code of the application. Must be called exactly once, on the main thread.
   int Run();
+
+  // Requests a graceful shutdown. Idempotent and safe to call from any thread
+  // once Run() has started.
+  void Shutdown();
+
+ private:
+  // Runs exclusively on the main thread to perform cleanup and quit the run
+  // loop.
+  void ExecuteShutdown();
+
+  scoped_refptr<base::SingleThreadTaskRunner> main_runner_;
+  std::unique_ptr<ShutdownHandlers> shutdown_handlers_;
+  base::OnceClosure quit_closure_;
+
+  bool is_shutting_down_ = false;
 };
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/agent_app.h
+++ b/components/brave_vpn/app/v2/agent/agent_app.h
@@ -45,8 +45,6 @@ class AgentApp final {
   scoped_refptr<base::SingleThreadTaskRunner> main_runner_;
   std::unique_ptr<ShutdownHandlers> shutdown_handlers_;
   base::OnceClosure quit_closure_;
-
-  bool is_shutting_down_ = false;
 };
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/agent_app_unittest.cc
+++ b/components/brave_vpn/app/v2/agent/agent_app_unittest.cc
@@ -1,0 +1,219 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/agent_app.h"
+
+#include <string>
+
+#include "base/check.h"
+#include "base/check_op.h"
+#include "base/command_line.h"
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
+#include "base/functional/bind.h"
+#include "base/location.h"
+#include "base/process/process.h"
+#include "base/run_loop.h"
+#include "base/synchronization/waitable_event.h"
+#include "base/task/single_thread_task_executor.h"
+#include "base/test/bind.h"
+#include "base/test/gtest_util.h"
+#include "base/test/multiprocess_test.h"
+#include "base/test/test_timeouts.h"
+#include "base/threading/platform_thread.h"
+#include "base/threading/thread.h"
+#include "base/time/time.h"
+#include "brave/components/brave_vpn/app/v2/agent/shutdown_handlers.h"
+#include "build/build_config.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "testing/multiprocess_func_list.h"
+
+#if BUILDFLAG(IS_POSIX)
+#include <signal.h>
+#endif  // BUILDFLAG(IS_POSIX)
+
+namespace brave_vpn::v2 {
+
+TEST(AgentAppDeathTest, ShutdownBeforeRunChecks) {
+  AgentApp app;
+  EXPECT_CHECK_DEATH(app.Shutdown());
+}
+
+// The functional signal tests exercise the real OS signal path end-to-end
+// (sigaction -> self-pipe -> detector thread -> Shutdown -> RunLoop quit), so
+// they must run against a separate child process: delivering signals to the
+// test binary itself would mutate its process-global dispositions and race
+// the test launcher's own signal handling.
+//
+// The Windows console-event analog is deliberately not implemented, as it
+// requires the child to own a console, which may not be the case in test
+// environments.
+#if BUILDFLAG(IS_POSIX)
+
+namespace {
+
+// Switch used to hand a per-test temp dir to the child for handshaking.
+constexpr char kSignalDirSwitch[] = "agent-app-signal-dir";
+
+// Marker file the child creates once it is ready to receive signals.
+constexpr base::FilePath::CharType kReadySignal[] =
+    FILE_PATH_LITERAL("child_ready");
+
+bool SignalEvent(const base::FilePath& path) {
+  return base::WriteFile(path, "");
+}
+
+// Polls for |path| to appear, up to the standard action timeout.
+bool WaitForEvent(const base::FilePath& path) {
+  const base::TimeTicks deadline =
+      base::TimeTicks::Now() + TestTimeouts::action_timeout();
+  while (base::TimeTicks::Now() < deadline) {
+    if (base::PathExists(path)) {
+      return true;
+    }
+    base::PlatformThread::Sleep(base::Milliseconds(10));
+  }
+  return false;
+}
+
+base::FilePath SignalDirFromCommandLine() {
+  const base::FilePath dir =
+      base::CommandLine::ForCurrentProcess()->GetSwitchValuePath(
+          kSignalDirSwitch);
+  CHECK(!dir.empty());
+  return dir;
+}
+
+}  // namespace
+
+// Child entry point: Run() sets up the task runner and quit closure and then
+// ShutdownHandlers::Install() registers SIGINT, SIGTERM, and SIGHUP, in that
+// order. Once SIGHUP's disposition is no longer SIG_DFL, everything the signal
+// path depends on is provably in place, so a watcher thread polls for that and
+// only then tells the parent it is safe to send the signal under test.
+MULTIPROCESS_TEST_MAIN(AgentAppRunChild) {
+  const base::FilePath dir = SignalDirFromCommandLine();
+
+  base::Thread readiness("readiness_watcher");
+  CHECK(readiness.Start());
+  readiness.task_runner()->PostTask(
+      FROM_HERE, base::BindLambdaForTesting([dir] {
+        struct sigaction current = {};
+        do {
+          base::PlatformThread::Sleep(base::Milliseconds(1));
+          CHECK_EQ(0, sigaction(SIGHUP, nullptr, &current));
+        } while (current.sa_handler == SIG_DFL);
+        CHECK(SignalEvent(dir.Append(kReadySignal)));
+      }));
+
+  AgentApp app;
+  return app.Run();
+}
+
+// Child whose shutdown callback never completes, simulating a hung graceful
+// shutdown. Uses ShutdownHandlers directly (not AgentApp, whose shutdown cannot
+// hang), so readiness can simply be signaled after Install() returns.
+MULTIPROCESS_TEST_MAIN(HungShutdownChild) {
+  const base::FilePath dir = SignalDirFromCommandLine();
+
+  base::SingleThreadTaskExecutor executor;
+  base::RunLoop run_loop;
+
+  base::WaitableEvent never_signaled;
+  ShutdownHandlers handlers(
+      base::BindRepeating([](base::WaitableEvent* event) { event->Wait(); },
+                          base::Unretained(&never_signaled)));
+  CHECK(handlers.Install());
+  CHECK(SignalEvent(dir.Append(kReadySignal)));
+
+  run_loop.Run();  // Never quits; the test ends this process with a signal.
+  return 0;
+}
+
+struct SignalParam {
+  int signal;
+  const char* name;
+};
+
+class AgentAppSignalTest : public base::MultiProcessTest,
+                           public testing::WithParamInterface<SignalParam> {
+ protected:
+  void SetUp() override {
+    base::MultiProcessTest::SetUp();
+    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
+  }
+
+  // Inject the per-test signal directory into every spawned child.
+  base::CommandLine MakeCmdLine(const std::string& procname) override {
+    base::CommandLine command_line =
+        base::MultiProcessTest::MakeCmdLine(procname);
+    command_line.AppendSwitchPath(kSignalDirSwitch, temp_dir_.GetPath());
+    return command_line;
+  }
+
+  base::FilePath ready_signal() const {
+    return temp_dir_.GetPath().Append(kReadySignal);
+  }
+
+  int signal() const { return GetParam().signal; }
+
+  base::ScopedTempDir temp_dir_;
+};
+
+INSTANTIATE_TEST_SUITE_P(,
+                         AgentAppSignalTest,
+                         testing::Values(SignalParam{SIGINT, "SIGINT"},
+                                         SignalParam{SIGTERM, "SIGTERM"},
+                                         SignalParam{SIGHUP, "SIGHUP"}),
+                         [](const testing::TestParamInfo<SignalParam>& info) {
+                           return std::string(info.param.name);
+                         });
+
+// Each handled signal must drive the full graceful path and produce a clean
+// exit code.
+TEST_P(AgentAppSignalTest, SignalTriggersGracefulExit) {
+  base::Process child = SpawnChild("AgentAppRunChild");
+  ASSERT_TRUE(child.IsValid());
+  ASSERT_TRUE(WaitForEvent(ready_signal()));
+
+  ASSERT_EQ(0, kill(child.Handle(), signal()));
+
+  int exit_code = -1;
+  ASSERT_TRUE(
+      child.WaitForExitWithTimeout(TestTimeouts::action_timeout(), &exit_code));
+  EXPECT_EQ(0, exit_code);
+}
+
+// If the graceful shutdown hangs, the first signal must leave the process
+// running (handler consumed, callback stuck), and a second signal must kill it
+// via the restored default disposition.
+TEST_P(AgentAppSignalTest, SecondSignalKillsHungShutdown) {
+  base::Process child = SpawnChild("HungShutdownChild");
+  ASSERT_TRUE(child.IsValid());
+  ASSERT_TRUE(WaitForEvent(ready_signal()));
+
+  ASSERT_EQ(0, kill(child.Handle(), signal()));
+
+  // The child must survive the first signal: its shutdown callback blocks
+  // forever, so this negative wait is deterministic, not timing-dependent.
+  int exit_code = -1;
+  EXPECT_FALSE(
+      child.WaitForExitWithTimeout(base::Milliseconds(250), &exit_code));
+
+  // The handler restored SIG_DFL for this signal before writing to the pipe, so
+  // the second signal takes the default disposition and terminates the process
+  // even though the graceful path is stuck.
+  ASSERT_EQ(0, kill(child.Handle(), signal()));
+  ASSERT_TRUE(
+      child.WaitForExitWithTimeout(TestTimeouts::action_timeout(), &exit_code));
+  // Terminated by the signal's default disposition, so anything but a clean
+  // exit; base reports a non-zero code for signal deaths.
+  EXPECT_NE(0, exit_code);
+}
+
+#endif  // BUILDFLAG(IS_POSIX)
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/agent_app_unittest.cc
+++ b/components/brave_vpn/app/v2/agent/agent_app_unittest.cc
@@ -124,8 +124,8 @@ MULTIPROCESS_TEST_MAIN(HungShutdownChild) {
 
   base::WaitableEvent never_signaled;
   ShutdownHandlers handlers(
-      base::BindRepeating([](base::WaitableEvent* event) { event->Wait(); },
-                          base::Unretained(&never_signaled)));
+      base::BindOnce([](base::WaitableEvent* event) { event->Wait(); },
+                     base::Unretained(&never_signaled)));
   CHECK(handlers.Install());
   CHECK(SignalEvent(dir.Append(kReadySignal)));
 

--- a/components/brave_vpn/app/v2/agent/main.cc
+++ b/components/brave_vpn/app/v2/agent/main.cc
@@ -3,11 +3,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include <string>
+
 #include "base/at_exit.h"
 #include "base/command_line.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
 #include "base/logging.h"
+#include "base/process/launch.h"
 #include "base/process/memory.h"
 #include "brave/components/brave_vpn/app/v2/agent/agent_app.h"
 #include "brave/components/brave_vpn/app/v2/agent/single_instance.h"
@@ -63,6 +66,11 @@ int main(int argc, char* argv[]) {
                             brave_vpn::v2::switches::kVpnAppUserDataDir));
   if (crashpad_handler_status.has_value()) {
     return crashpad_handler_status.value();
+  }
+
+  // Attach a console to the process if requested.
+  if (command_line.HasSwitch(brave_vpn::v2::switches::kVpnAppConsole)) {
+    base::RouteStdioToConsole(/*create_console_if_not_found=*/true);
   }
 #endif  // BUILDFLAG(IS_WIN)
 

--- a/components/brave_vpn/app/v2/agent/posix/shutdown_handlers_posix.cc
+++ b/components/brave_vpn/app/v2/agent/posix/shutdown_handlers_posix.cc
@@ -1,0 +1,131 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Modeled on chrome/browser/shutdown_signal_handlers_posix.cc: the signal
+// handler only performs async-signal-safe work (it writes one byte to a
+// self-pipe); a dedicated detector thread blocks on the read end and invokes
+// the shutdown callback from a normal thread context.
+
+#include "brave/components/brave_vpn/app/v2/agent/shutdown_handlers.h"
+
+#include <signal.h>
+#include <unistd.h>
+
+#include <utility>
+
+#include "base/check.h"
+#include "base/check_op.h"
+#include "base/debug/leak_annotations.h"
+#include "base/functional/callback.h"
+#include "base/posix/eintr_wrapper.h"
+#include "base/threading/platform_thread.h"
+
+namespace brave_vpn::v2 {
+namespace {
+// The self-pipe. The write end is used from the signal handler, so it must be
+// fully set up before the handlers are installed.
+int g_shutdown_pipe_read_fd = -1;
+int g_shutdown_pipe_write_fd = -1;
+
+// Blocks on the read end of the self-pipe on a dedicated background thread and
+// runs the shutdown callback when the signal handler writes to it. Created
+// non-joinable and deletes itself when done, Chromium-style.
+class ShutdownDetector : public base::PlatformThread::Delegate {
+ public:
+  ShutdownDetector(int shutdown_fd, base::RepeatingClosure shutdown_callback)
+      : shutdown_fd_(shutdown_fd),
+        shutdown_callback_(std::move(shutdown_callback)) {
+    CHECK_NE(shutdown_fd_, -1);
+    CHECK(shutdown_callback_);
+  }
+
+  ShutdownDetector(const ShutdownDetector&) = delete;
+  ShutdownDetector& operator=(const ShutdownDetector&) = delete;
+
+  void ThreadMain() override {
+    base::PlatformThread::SetName("VpnShutdownDetector");
+
+    char signaled{0};
+    const ssize_t bytes_read =
+        HANDLE_EINTR(read(shutdown_fd_, &signaled, sizeof(signaled)));
+    if (bytes_read == static_cast<ssize_t>(sizeof(signaled))) {
+      shutdown_callback_.Run();
+    }
+    // bytes_read == 0 means the write end was closed without a signal being
+    // delivered; just let the thread exit.
+    delete this;
+  }
+
+ private:
+  const int shutdown_fd_;
+  const base::RepeatingClosure shutdown_callback_;
+};
+
+void GracefulShutdownHandler(int sig) {
+  // Reinstall the default handler.  We had one shot at graceful shutdown.
+  struct sigaction action = {};
+  action.sa_handler = SIG_DFL;
+  RAW_CHECK(sigaction(sig, &action, nullptr) == 0);
+
+  RAW_CHECK(g_shutdown_pipe_write_fd != -1);
+  RAW_CHECK(g_shutdown_pipe_read_fd != -1);
+
+  const char signaled{1};
+  const ssize_t rv = HANDLE_EINTR(
+      write(g_shutdown_pipe_write_fd, &signaled, sizeof(signaled)));
+  RAW_CHECK(rv == static_cast<ssize_t>(sizeof(signaled)));
+}
+
+}  // namespace
+
+bool ShutdownHandlers::Install() {
+  CHECK(!installed_);
+  installed_ = true;
+
+  int pipefd[2];
+  PCHECK(pipe(pipefd) == 0);
+  g_shutdown_pipe_read_fd = pipefd[0];
+  g_shutdown_pipe_write_fd = pipefd[1];
+
+  // Deletes itself once the pipe is signaled or closed.
+  auto* detector =
+      new ShutdownDetector(g_shutdown_pipe_read_fd, shutdown_callback_);
+  // PlatformThread does not delete its delegate.
+  ANNOTATE_LEAKING_OBJECT_PTR(detector);
+  CHECK(base::PlatformThread::CreateNonJoinable(0, detector));
+
+  struct sigaction action = {};
+  action.sa_handler = &GracefulShutdownHandler;
+  sigemptyset(&action.sa_mask);
+
+  // Order of signal installation is arbitrary, but if changed, make sure unit
+  // tests are updated to match, since they currently rely on the last
+  // registered signal being SIGHUP.
+  CHECK_EQ(0, sigaction(SIGINT, &action, nullptr));
+  CHECK_EQ(0, sigaction(SIGTERM, &action, nullptr));
+  CHECK_EQ(0, sigaction(SIGHUP, &action, nullptr));
+  return true;
+}
+
+void ShutdownHandlers::SignalShutdownComplete() {
+  // No-op on POSIX: the signal handler never blocks awaiting shutdown.
+}
+
+void ShutdownHandlers::Uninstall() {
+  struct sigaction action = {};
+  action.sa_handler = SIG_DFL;
+  sigemptyset(&action.sa_mask);
+  CHECK_EQ(0, sigaction(SIGINT, &action, nullptr));
+  CHECK_EQ(0, sigaction(SIGTERM, &action, nullptr));
+  CHECK_EQ(0, sigaction(SIGHUP, &action, nullptr));
+
+  // The pipe fds and the detector thread are intentionally leaked: a signal
+  // delivered concurrently with this teardown may still be writing to the
+  // pipe, and the detector thread may be blocked in read(). Both are
+  // reclaimed by the OS at process exit, which mirrors Chromium, where the
+  // equivalent handlers are never uninstalled at all.
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/posix/shutdown_handlers_posix.cc
+++ b/components/brave_vpn/app/v2/agent/posix/shutdown_handlers_posix.cc
@@ -26,6 +26,9 @@ namespace brave_vpn::v2 {
 namespace {
 // The self-pipe. The write end is used from the signal handler, so it must be
 // fully set up before the handlers are installed.
+// Unlike chrome/browser/shutdown_signal_handlers_posix.cc, we keep no
+// g_pipe_pid guard: the agent never forks, so the handler cannot run in a child
+// that shares this pipe.
 int g_shutdown_pipe_read_fd = -1;
 int g_shutdown_pipe_write_fd = -1;
 
@@ -34,7 +37,7 @@ int g_shutdown_pipe_write_fd = -1;
 // non-joinable and deletes itself when done, Chromium-style.
 class ShutdownDetector : public base::PlatformThread::Delegate {
  public:
-  ShutdownDetector(int shutdown_fd, base::RepeatingClosure shutdown_callback)
+  ShutdownDetector(int shutdown_fd, base::OnceClosure shutdown_callback)
       : shutdown_fd_(shutdown_fd),
         shutdown_callback_(std::move(shutdown_callback)) {
     CHECK_NE(shutdown_fd_, -1);
@@ -47,24 +50,25 @@ class ShutdownDetector : public base::PlatformThread::Delegate {
   void ThreadMain() override {
     base::PlatformThread::SetName("VpnShutdownDetector");
 
-    char signaled{0};
-    const ssize_t bytes_read =
-        HANDLE_EINTR(read(shutdown_fd_, &signaled, sizeof(signaled)));
-    if (bytes_read == static_cast<ssize_t>(sizeof(signaled))) {
-      shutdown_callback_.Run();
+    // The wakeup_byte value is irrelevant; a successful read means "shut down".
+    if (char wakeup_byte{}; HANDLE_EINTR(read(shutdown_fd_, &wakeup_byte,
+                                              sizeof(wakeup_byte))) > 0) {
+      std::move(shutdown_callback_).Run();
     }
-    // bytes_read == 0 means the write end was closed without a signal being
-    // delivered; just let the thread exit.
     delete this;
   }
 
  private:
   const int shutdown_fd_;
-  const base::RepeatingClosure shutdown_callback_;
+  base::OnceClosure shutdown_callback_;
 };
 
 void GracefulShutdownHandler(int sig) {
-  // Reinstall the default handler.  We had one shot at graceful shutdown.
+  // Reinstall the default handler. We had one shot at graceful shutdown.
+  // Note this restores only the signal that fired, so the "second signal
+  // force-kills a hung shutdown" behavior is per-signal (e.g. SIGINT then
+  // SIGTERM will not force-kill). Windows makes it process-wide via
+  // g_shutdown_requested.
   struct sigaction action = {};
   action.sa_handler = SIG_DFL;
   RAW_CHECK(sigaction(sig, &action, nullptr) == 0);
@@ -72,10 +76,10 @@ void GracefulShutdownHandler(int sig) {
   RAW_CHECK(g_shutdown_pipe_write_fd != -1);
   RAW_CHECK(g_shutdown_pipe_read_fd != -1);
 
-  const char signaled{1};
+  const char wakeup_byte{};
   const ssize_t rv = HANDLE_EINTR(
-      write(g_shutdown_pipe_write_fd, &signaled, sizeof(signaled)));
-  RAW_CHECK(rv == static_cast<ssize_t>(sizeof(signaled)));
+      write(g_shutdown_pipe_write_fd, &wakeup_byte, sizeof(wakeup_byte)));
+  RAW_CHECK(rv == static_cast<ssize_t>(sizeof(wakeup_byte)));
 }
 
 }  // namespace
@@ -90,8 +94,8 @@ bool ShutdownHandlers::Install() {
   g_shutdown_pipe_write_fd = pipefd[1];
 
   // Deletes itself once the pipe is signaled or closed.
-  auto* detector =
-      new ShutdownDetector(g_shutdown_pipe_read_fd, shutdown_callback_);
+  auto* detector = new ShutdownDetector(g_shutdown_pipe_read_fd,
+                                        std::move(shutdown_callback_));
   // PlatformThread does not delete its delegate.
   ANNOTATE_LEAKING_OBJECT_PTR(detector);
   CHECK(base::PlatformThread::CreateNonJoinable(0, detector));

--- a/components/brave_vpn/app/v2/agent/shutdown_handlers.cc
+++ b/components/brave_vpn/app/v2/agent/shutdown_handlers.cc
@@ -1,0 +1,25 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/shutdown_handlers.h"
+
+#include <utility>
+
+#include "base/check.h"
+
+namespace brave_vpn::v2 {
+
+ShutdownHandlers::ShutdownHandlers(ShutdownCallback shutdown_callback)
+    : shutdown_callback_(std::move(shutdown_callback)) {
+  CHECK(shutdown_callback_);
+}
+
+ShutdownHandlers::~ShutdownHandlers() {
+  if (installed_) {
+    Uninstall();
+  }
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/shutdown_handlers.h
+++ b/components/brave_vpn/app/v2/agent/shutdown_handlers.h
@@ -1,0 +1,63 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_SHUTDOWN_HANDLERS_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_SHUTDOWN_HANDLERS_H_
+
+#include "base/functional/callback.h"
+
+namespace brave_vpn::v2 {
+
+// Installs platform-specific handlers that translate external termination
+// requests (SIGINT/SIGTERM/SIGHUP on POSIX, console control events on Windows)
+// into an invocation of a shutdown callback.
+//
+// Threading contract:
+//   * Install() must be called on the main thread, after the main task runner
+//   and the RunLoop quit closure have been set up, because the callback may
+//   fire as soon as the handlers are installed.
+//   * |shutdown_callback| may be invoked from an arbitrary background thread.
+//   It is supposed to be cheap, thread-safe and idempotent: posts the real
+//   shutdown work to the main thread.
+//   * Following the Chromium convention, the first signal requests a graceful
+//   shutdown; a second one falls through to the OS default disposition and
+//   terminates the process immediately.
+//
+// The handlers are expected to stay installed for the lifetime of the process.
+// The destructor restores the OS defaults but intentionally leaks the small
+// amount of state shared with the (possibly still running) handler threads.
+class ShutdownHandlers final {
+ public:
+  using ShutdownCallback = base::RepeatingClosure;
+
+  explicit ShutdownHandlers(ShutdownCallback shutdown_callback);
+  ~ShutdownHandlers();
+
+  ShutdownHandlers(const ShutdownHandlers&) = delete;
+  ShutdownHandlers& operator=(const ShutdownHandlers&) = delete;
+
+  // Installs the platform-specific handlers. Must be called on the main thread,
+  // and must not be called again after it succeeds. Returns true if the
+  // handlers were installed, false if the platform does not support them (e.g.
+  // no console on Windows).
+  bool Install();
+
+  // Must be called on the main thread after the run loop has quit and shutdown
+  // work is complete. On Windows this releases a console control handler thread
+  // that blocks on CTRL_CLOSE/LOGOFF/SHUTDOWN events to keep the OS from
+  // terminating the process before cleanup finishes. No-op on POSIX.
+  void SignalShutdownComplete();
+
+ private:
+  // Platform-specific teardown; called from the destructor if installed.
+  void Uninstall();
+
+  const ShutdownCallback shutdown_callback_;
+  bool installed_ = false;
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_SHUTDOWN_HANDLERS_H_

--- a/components/brave_vpn/app/v2/agent/shutdown_handlers.h
+++ b/components/brave_vpn/app/v2/agent/shutdown_handlers.h
@@ -18,9 +18,9 @@ namespace brave_vpn::v2 {
 //   * Install() must be called on the main thread, after the main task runner
 //   and the RunLoop quit closure have been set up, because the callback may
 //   fire as soon as the handlers are installed.
-//   * |shutdown_callback| may be invoked from an arbitrary background thread.
-//   It is supposed to be cheap, thread-safe and idempotent: posts the real
-//   shutdown work to the main thread.
+//   * |shutdown_callback| may be invoked at most once from an arbitrary
+//   background thread. It is supposed to be cheap and thread-safe: posts the
+//   real shutdown work to the main thread.
 //   * Following the Chromium convention, the first signal requests a graceful
 //   shutdown; a second one falls through to the OS default disposition and
 //   terminates the process immediately.
@@ -30,7 +30,7 @@ namespace brave_vpn::v2 {
 // amount of state shared with the (possibly still running) handler threads.
 class ShutdownHandlers final {
  public:
-  using ShutdownCallback = base::RepeatingClosure;
+  using ShutdownCallback = base::OnceClosure;
 
   explicit ShutdownHandlers(ShutdownCallback shutdown_callback);
   ~ShutdownHandlers();
@@ -39,7 +39,8 @@ class ShutdownHandlers final {
   ShutdownHandlers& operator=(const ShutdownHandlers&) = delete;
 
   // Installs the platform-specific handlers. Must be called on the main thread,
-  // and must not be called again after it succeeds. Returns true if the
+  // and must not be called again after it succeeds; may be called again after
+  // it returns false, which leaves no state behind. Returns true if the
   // handlers were installed, false if the platform does not support them (e.g.
   // no console on Windows).
   bool Install();
@@ -54,7 +55,7 @@ class ShutdownHandlers final {
   // Platform-specific teardown; called from the destructor if installed.
   void Uninstall();
 
-  const ShutdownCallback shutdown_callback_;
+  ShutdownCallback shutdown_callback_;
   bool installed_ = false;
 };
 

--- a/components/brave_vpn/app/v2/agent/shutdown_handlers_unittest.cc
+++ b/components/brave_vpn/app/v2/agent/shutdown_handlers_unittest.cc
@@ -1,0 +1,71 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/shutdown_handlers.h"
+
+#include "base/check.h"
+#include "base/functional/callback.h"
+#include "base/functional/callback_helpers.h"
+#include "base/test/gtest_util.h"
+#include "build/build_config.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+#if BUILDFLAG(IS_WIN)
+#include <windows.h>
+#endif
+
+namespace brave_vpn::v2 {
+
+// These tests deliberately never perform a *successful* Install() in the
+// parent test process: installation mutates process-global state (POSIX
+// signal dispositions, the Windows console control handler chain) that would
+// leak into every other test in the binary. Successful installs happen only
+// inside death-test children, which are separate processes.
+
+TEST(ShutdownHandlersDeathTest, NullCallbackChecks) {
+  EXPECT_CHECK_DEATH({
+    [[maybe_unused]] ShutdownHandlers handlers{base::RepeatingClosure()};
+  });
+}
+
+TEST(ShutdownHandlersDeathTest, InstallTwiceAfterSuccessChecks) {
+#if BUILDFLAG(IS_WIN)
+  if (!::GetConsoleWindow()) {
+    GTEST_SKIP() << "Install() is a no-op without an attached console, so the "
+                    "second call cannot trip the CHECK.";
+  }
+#endif
+  // Both Install() calls run inside the death-test child process; the CHECK
+  // inside the statement guards test validity (the death must come from the
+  // *second* install, not from a failed first one).
+  EXPECT_CHECK_DEATH({
+    ShutdownHandlers handlers(base::DoNothing());
+    CHECK(handlers.Install());
+    handlers.Install();
+  });
+}
+
+TEST(ShutdownHandlersTest, SignalShutdownCompleteWithoutInstallIsSafe) {
+  ShutdownHandlers handlers(base::DoNothing());
+  handlers.SignalShutdownComplete();
+}
+
+#if BUILDFLAG(IS_WIN)
+TEST(ShutdownHandlersTest, InstallWithoutConsoleReturnsFalseAndIsRetriable) {
+  if (::GetConsoleWindow()) {
+    GTEST_SKIP() << "Test runner has a console attached; the consoleless path "
+                    "cannot be exercised in this process.";
+  }
+  ShutdownHandlers handlers(base::DoNothing());
+  EXPECT_FALSE(handlers.Install());
+  // A false return leaves no state behind, so calling Install() again is
+  // allowed by contract and must not CHECK.
+  EXPECT_FALSE(handlers.Install());
+  // And the rest of the API stays safe to call.
+  handlers.SignalShutdownComplete();
+}
+#endif  // BUILDFLAG(IS_WIN)
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/shutdown_handlers_unittest.cc
+++ b/components/brave_vpn/app/v2/agent/shutdown_handlers_unittest.cc
@@ -25,9 +25,7 @@ namespace brave_vpn::v2 {
 // inside death-test children, which are separate processes.
 
 TEST(ShutdownHandlersDeathTest, NullCallbackChecks) {
-  EXPECT_CHECK_DEATH({
-    [[maybe_unused]] ShutdownHandlers handlers{base::RepeatingClosure()};
-  });
+  EXPECT_CHECK_DEATH({ ShutdownHandlers{base::OnceClosure()}; });
 }
 
 TEST(ShutdownHandlersDeathTest, InstallTwiceAfterSuccessChecks) {

--- a/components/brave_vpn/app/v2/agent/win/shutdown_handlers_win.cc
+++ b/components/brave_vpn/app/v2/agent/win/shutdown_handlers_win.cc
@@ -1,0 +1,101 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/shutdown_handlers.h"
+
+#include <windows.h>
+
+#include <atomic>
+
+#include "base/check.h"
+#include "base/debug/leak_annotations.h"
+#include "base/functional/callback.h"
+#include "base/synchronization/waitable_event.h"
+#include "base/time/time.h"
+
+namespace brave_vpn::v2 {
+namespace {
+// State shared with the console control handler, which the OS runs on a thread
+// it injects into this process. Heap-allocated and intentionally leaked so that
+// an in-flight handler can never observe destroyed objects.
+base::RepeatingClosure* g_shutdown_callback = nullptr;
+base::WaitableEvent* g_shutdown_complete_event = nullptr;
+
+// The first event requests a graceful shutdown; subsequent events fall through
+// to the default handler, which terminates the process. This mirrors the POSIX
+// "second signal kills immediately" convention.
+std::atomic<bool> g_shutdown_requested{false};
+
+// How long the handler may hold off process termination on
+// CTRL_CLOSE/LOGOFF/SHUTDOWN events. The OS grants roughly five seconds before
+// terminating the process regardless, so stay under that.
+constexpr base::TimeDelta kShutdownCompleteTimeout = base::Seconds(4);
+
+BOOL WINAPI ConsoleCtrlHandler(DWORD ctrl_type) {
+  switch (ctrl_type) {
+    case CTRL_C_EVENT:
+    case CTRL_BREAK_EVENT:
+      if (g_shutdown_requested.exchange(true)) {
+        // Second Ctrl+C: let the default handler terminate the process, in case
+        // the graceful shutdown has hung.
+        return FALSE;
+      }
+      g_shutdown_callback->Run();
+      // TRUE suppresses the default handler, which would terminate the process
+      // immediately and skip our cleanup.
+      return TRUE;
+    case CTRL_CLOSE_EVENT:
+    case CTRL_LOGOFF_EVENT:
+    case CTRL_SHUTDOWN_EVENT:
+      // For these events Windows terminates the process as soon as this handler
+      // returns, regardless of the return value. Request shutdown, then block
+      // here until the main thread reports completion (or the OS deadline
+      // approaches), so the graceful path has time to run.
+      if (!g_shutdown_requested.exchange(true)) {
+        g_shutdown_callback->Run();
+      }
+      g_shutdown_complete_event->TimedWait(kShutdownCompleteTimeout);
+      return TRUE;
+    default:
+      return FALSE;
+  }
+}
+
+}  // namespace
+
+bool ShutdownHandlers::Install() {
+  CHECK(!installed_);
+  if (!::GetConsoleWindow()) {
+    // If the process has no console, the OS will not send any console events.
+    return false;
+  }
+  installed_ = true;
+
+  // Set up the shared state before registering the handler so the handler can
+  // never observe null globals.
+  g_shutdown_callback = new base::RepeatingClosure(shutdown_callback_);
+  g_shutdown_complete_event =
+      new base::WaitableEvent(base::WaitableEvent::ResetPolicy::MANUAL,
+                              base::WaitableEvent::InitialState::NOT_SIGNALED);
+  ANNOTATE_LEAKING_OBJECT_PTR(g_shutdown_callback);
+  ANNOTATE_LEAKING_OBJECT_PTR(g_shutdown_complete_event);
+  CHECK(::SetConsoleCtrlHandler(&ConsoleCtrlHandler, /*Add=*/TRUE));
+  return true;
+}
+
+void ShutdownHandlers::SignalShutdownComplete() {
+  if (g_shutdown_complete_event) {
+    g_shutdown_complete_event->Signal();
+  }
+}
+
+void ShutdownHandlers::Uninstall() {
+  ::SetConsoleCtrlHandler(&ConsoleCtrlHandler, /*Add=*/FALSE);
+  // `g_shutdown_callback` and `g_shutdown_complete_event` are intentionally
+  // leaked: a handler dispatched just before removal may still be using
+  // them.
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/win/shutdown_handlers_win.cc
+++ b/components/brave_vpn/app/v2/agent/win/shutdown_handlers_win.cc
@@ -8,6 +8,7 @@
 #include <windows.h>
 
 #include <atomic>
+#include <utility>
 
 #include "base/check.h"
 #include "base/debug/leak_annotations.h"
@@ -20,12 +21,26 @@ namespace {
 // State shared with the console control handler, which the OS runs on a thread
 // it injects into this process. Heap-allocated and intentionally leaked so that
 // an in-flight handler can never observe destroyed objects.
-base::RepeatingClosure* g_shutdown_callback = nullptr;
+
+// Set once in Install() before SetConsoleCtrlHandler(), so handler threads
+// always see the fully-published pointer. Never rewritten afterward, so a
+// non-atomic pointer is race-free. Pointee is run at most once, guaranteed by
+// g_shutdown_requested.
+base::OnceClosure* g_shutdown_callback = nullptr;
+
+// Same as g_shutdown_callback: written once before SetConsoleCtrlHandler(),
+// never after, so the plain pointer needs no atomic. Pointee is a
+// WaitableEvent, which is internally thread-safe, so the main-thread Signal()
+// vs. handler-thread Wait() handshake is not a data race.
 base::WaitableEvent* g_shutdown_complete_event = nullptr;
 
 // The first event requests a graceful shutdown; subsequent events fall through
 // to the default handler, which terminates the process. This mirrors the POSIX
 // "second signal kills immediately" convention.
+// Sequential consistency (the default) is intentional: while a weaker ordering
+// would be correct today, one might later start relying on that flag to publish
+// other state, and it'll turn into a silent race. The stronger ordering costs
+// nothing on this cold path.
 std::atomic<bool> g_shutdown_requested{false};
 
 // How long the handler may hold off process termination on
@@ -42,7 +57,7 @@ BOOL WINAPI ConsoleCtrlHandler(DWORD ctrl_type) {
         // the graceful shutdown has hung.
         return FALSE;
       }
-      g_shutdown_callback->Run();
+      std::move(*g_shutdown_callback).Run();
       // TRUE suppresses the default handler, which would terminate the process
       // immediately and skip our cleanup.
       return TRUE;
@@ -54,7 +69,7 @@ BOOL WINAPI ConsoleCtrlHandler(DWORD ctrl_type) {
       // here until the main thread reports completion (or the OS deadline
       // approaches), so the graceful path has time to run.
       if (!g_shutdown_requested.exchange(true)) {
-        g_shutdown_callback->Run();
+        std::move(*g_shutdown_callback).Run();
       }
       g_shutdown_complete_event->TimedWait(kShutdownCompleteTimeout);
       return TRUE;
@@ -75,7 +90,7 @@ bool ShutdownHandlers::Install() {
 
   // Set up the shared state before registering the handler so the handler can
   // never observe null globals.
-  g_shutdown_callback = new base::RepeatingClosure(shutdown_callback_);
+  g_shutdown_callback = new base::OnceClosure(std::move(shutdown_callback_));
   g_shutdown_complete_event =
       new base::WaitableEvent(base::WaitableEvent::ResetPolicy::MANUAL,
                               base::WaitableEvent::InitialState::NOT_SIGNALED);

--- a/components/brave_vpn/app/v2/shared/switches.h
+++ b/components/brave_vpn/app/v2/shared/switches.h
@@ -9,6 +9,7 @@
 namespace brave_vpn::v2::switches {
 
 inline constexpr char kVpnAppLogFile[] = "log-file";
+inline constexpr char kVpnAppConsole[] = "console";
 inline constexpr char kVpnAppProcessType[] = "type";
 inline constexpr char kVpnAppUserDataDir[] = "user-data-dir";
 inline constexpr char kVpnAppChannelName[] = "channel-name";


### PR DESCRIPTION
Adds a task executor and a run loop to the VPN agent app. Funnels external termination requests into a single graceful shutdown path that quits agent app's run loop, modeled on the existing Chromium's chrome/browser/shutdown_signal_handlers_posix.cc:

- POSIX: handle SIGINT/SIGTERM/SIGHUP via an async-signal-safe self-pipe; a detached detector thread invokes the shutdown callback. The handler restores SIG_DFL first, so a second signal terminates immediately if the graceful path hangs.
- Windows: handle console control events via SetConsoleCtrlHandler when a console is attached (dev/testing; enabled with the console switch via base::RouteStdioToConsole). CTRL_CLOSE/LOGOFF/SHUTDOWN block on a completion event, since the OS terminates the process once the handler returns.

Handler-shared state is process-lifetime and intentionally leaked (annotated for LSan). Production termination will be driven by Mojo Shutdown()/disconnect in another PR.

Tests: contract death tests for ShutdownHandlers, plus multiprocess tests exercising the real signal path per signal, including the second-signal kill of a hung shutdown.

Resolves https://github.com/brave/brave-browser/issues/56960

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
