### PR TITLE
[iOS] Optimize `IOSHistoryNode` creation to avoid bridging until usage.

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -760,7 +760,7 @@ class TabManager: NSObject {
             options: HistorySearchOptions(
               maxCount: 0,
               hostOnly: false,
-              duplicateHandling: .keepAll,
+              duplicateHandling: .removeAll,
               begin: nil,
               end: nil
             )

--- a/ios/browser/api/history/brave_history_api+private.h
+++ b/ios/browser/api/history/brave_history_api+private.h
@@ -8,7 +8,11 @@
 
 #import <Foundation/Foundation.h>
 
+#include <string>
+
+#include "base/time/time.h"
 #include "brave/ios/browser/api/history/brave_history_api.h"
+#include "url/gurl.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -16,6 +20,14 @@ class ProfileIOS;
 
 @interface BraveHistoryAPI (Private)
 - (instancetype)initWithBrowserState:(ProfileIOS*)profile;
+@end
+
+@interface IOSHistoryNode (Private)
+// Builds a node directly from native types, avoiding a round-trip through
+// NSURL (which re-canonicalizes the URL and doubles per-node allocations).
+- (instancetype)initWithGURL:(const GURL&)url
+                       title:(const std::u16string&)title
+                   visitTime:(base::Time)visitTime;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/browser/api/history/brave_history_api.mm
+++ b/ios/browser/api/history/brave_history_api.mm
@@ -6,12 +6,14 @@
 #include "brave/ios/browser/api/history/brave_history_api.h"
 
 #include <optional>
+#include <vector>
 
 #include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "base/memory/raw_ptr.h"
 #include "base/strings/sys_string_conversions.h"
+#include "brave/ios/browser/api/history/brave_history_api+private.h"
 #include "brave/ios/browser/api/history/brave_history_observer.h"
 #include "brave/ios/browser/api/history/history_driver_ios.h"
 #include "brave/ios/browser/api/history/history_service_listener_ios.h"
@@ -111,7 +113,7 @@ DomainMetricTypeIOS const DomainMetricTypeIOSLast28DayMetric =
                       title:(NSString* _Nullable)title
                   dateAdded:(NSDate* _Nullable)dateAdded {
   if ((self = [super init])) {
-    [self setUrl:url];
+    gurl_ = net::GURLWithNSURL(url);
 
     if (title) {
       [self setTitle:title];
@@ -125,8 +127,15 @@ DomainMetricTypeIOS const DomainMetricTypeIOSLast28DayMetric =
   return self;
 }
 
-- (void)setUrl:(NSURL*)url {
-  gurl_ = net::GURLWithNSURL(url);
+- (instancetype)initWithGURL:(const GURL&)url
+                       title:(const std::u16string&)title
+                   visitTime:(base::Time)visitTime {
+  if ((self = [super init])) {
+    gurl_ = url;
+    title_ = title;
+    date_added_ = visitTime;
+  }
+  return self;
 }
 
 - (NSURL*)url {
@@ -373,10 +382,10 @@ DomainMetricTypeIOS const DomainMetricTypeIOSLast28DayMetric =
           NSMutableArray<IOSHistoryNode*>* historyNodes =
               [[NSMutableArray alloc] init];
           for (const auto& result : results) {
-            IOSHistoryNode* historyNode = [[IOSHistoryNode alloc]
-                initWithURL:net::NSURLWithGURL(result.url())
-                      title:base::SysUTF16ToNSString(result.title())
-                  dateAdded:result.visit_time().ToNSDate()];
+            IOSHistoryNode* historyNode =
+                [[IOSHistoryNode alloc] initWithGURL:result.url()
+                                               title:result.title()
+                                           visitTime:result.visit_time()];
             [historyNodes addObject:historyNode];
           }
 

--- a/ios/browser/api/history/history_service_listener_ios.mm
+++ b/ios/browser/api/history/history_service_listener_ios.mm
@@ -7,22 +7,14 @@
 
 #include "base/check.h"
 #include "base/memory/raw_ptr.h"
-#include "base/strings/sys_string_conversions.h"
-#include "brave/ios/browser/api/history/brave_history_api.h"
+#include "brave/ios/browser/api/history/brave_history_api+private.h"
 #include "brave/ios/browser/api/history/brave_history_observer.h"
 #include "components/history/core/browser/history_service.h"
 #include "components/history/core/browser/history_service_observer.h"
-#include "net/base/apple/url_conversions.h"
 
 #if !defined(__has_feature) || !__has_feature(objc_arc)
 #error "This file requires ARC support."
 #endif
-
-@interface IOSHistoryNode (Private)
-- (instancetype)initWithURL:(NSURL*)url
-                      title:(NSString* _Nullable)title
-                  dateAdded:(NSDate* _Nullable)dateAdded;
-@end
 
 namespace brave {
 namespace ios {
@@ -59,9 +51,9 @@ void HistoryServiceListenerIOS::OnURLVisited(
     history::HistoryService* history_service,
     const history::VisitedURLInfo& visited_url_info) {
   IOSHistoryNode* historyNode = [[IOSHistoryNode alloc]
-      initWithURL:net::NSURLWithGURL(visited_url_info.url_row.url())
-            title:base::SysUTF16ToNSString(visited_url_info.url_row.title())
-        dateAdded:visited_url_info.visit_row.visit_time.ToNSDate()];
+      initWithGURL:visited_url_info.url_row.url()
+             title:visited_url_info.url_row.title()
+         visitTime:visited_url_info.visit_row.visit_time];
 
   if ([observer_ respondsToSelector:@selector(historyNodeVisited:)]) {
     [observer_ historyNodeVisited:historyNode];
@@ -73,10 +65,10 @@ void HistoryServiceListenerIOS::OnURLsModified(
     const history::URLRows& changed_urls) {
   NSMutableArray<IOSHistoryNode*>* nodes = [[NSMutableArray alloc] init];
   for (const history::URLRow& row : changed_urls) {
-    IOSHistoryNode* node = [[IOSHistoryNode alloc]
-        initWithURL:net::NSURLWithGURL(row.url())
-              title:base::SysUTF16ToNSString(row.title())
-          dateAdded:row.last_visit().ToNSDate()];
+    IOSHistoryNode* node =
+        [[IOSHistoryNode alloc] initWithGURL:row.url()
+                                       title:row.title()
+                                   visitTime:row.last_visit()];
     [nodes addObject:node];
   }
 
@@ -95,10 +87,10 @@ void HistoryServiceListenerIOS::OnHistoryDeletions(
     isAllHistory = true;
   } else {
     for (const history::URLRow& row : deletion_info.deleted_rows()) {
-      IOSHistoryNode* node = [[IOSHistoryNode alloc]
-          initWithURL:net::NSURLWithGURL(row.url())
-                title:base::SysUTF16ToNSString(row.title())
-            dateAdded:row.last_visit().ToNSDate()];
+      IOSHistoryNode* node =
+          [[IOSHistoryNode alloc] initWithGURL:row.url()
+                                         title:row.title()
+                                     visitTime:row.last_visit()];
       [nodes addObject:node];
     }
   }


### PR DESCRIPTION
This is a speculative crash fix. This change also includes a micro-optimization to de-dupe queried history when obtaining urls to shred.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/57007
