### PR TITLE
[plaster] Fix `count=0` oversight

### DIFF
--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -102,8 +102,13 @@ substitutions:
     re_pattern: '' # regex pattern
     replace: ''
     re_flags: [] # traditional Python `re` flag names, e.g. [DOTALL]
-    count: 1 # 1 is the default; 0 means no count, not advised.
+    count: 1 # 1 is the default; 0 means "one or more matches".
 ```
+
+> [!NOTE]
+>
+> The default value for `count` is `1` so `count=1` can be omitted, whilst
+> `count=0` mean "at least one or more matches".
 
 Use YAML's `|` / `|-` block scalars when you need multi-line `replace` or
 `description` values — `|` keeps a trailing newline, `|-` strips it.

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -375,8 +375,8 @@ class Substitution:
     # Replacement string passed to `re.subn`.
     replace: str
 
-    # Expected number of substitutions. `0` means "replace all matches"
-    # and disables the count check.
+    # Expected number of substitutions. `0` means "one or more matches";
+    # zero matches is still a failure.
     expected_count: int = 1
 
     # Combined bitmask of `re` flags built from the `re_flags` plaster
@@ -615,9 +615,14 @@ class PlasterFile:
                     # expected.
                     count=0)
 
-                # count == 0 means "replace all matches" and bypasses count
-                # validation.
-                if substitution.expected_count not in (0, num_changes):
+                # count == 0 means "one or more matches", but zero matches still
+                # result in a failure.
+                if substitution.expected_count == 0:
+                    if num_changes == 0:
+                        errors.append(
+                            'Expected at least one match but found none in '
+                            f'{self.path}')
+                elif num_changes != substitution.expected_count:
                     errors.append(
                         f'Unexpected number of matches ({num_changes} vs '
                         f'{substitution.expected_count}) in {self.path}')

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -783,9 +783,9 @@ class PlasterTest(unittest.TestCase):
 
     def test_count_zero_replaces_all(self):
         """
-        Test that count=0 replaces all matches and bypasses count validation.
-        Note: All substitutions now behave as count=0 since count=0 is
-        always passed to subn.
+        Test that count=0 replaces all matches (requiring at least one).
+        count=0 rewrites every match but still fails if nothing matched; here
+        there are three matches, so it succeeds.
         """
         test_file_chromium = Path(
             'chrome/common/extensions/api/test_count_zero_all.idl')
@@ -811,7 +811,8 @@ class PlasterTest(unittest.TestCase):
               count: 0
         ''')
 
-        # Should succeed because count=0 means replace all and bypass validation
+        # Should succeed: count=0 replaces all matches, and there is at least
+        # one match here.
         plaster_file = plaster.PlasterFile(plaster_path)
         plaster_file.apply()
 
@@ -819,6 +820,39 @@ class PlasterTest(unittest.TestCase):
                   test_file_chromium).read_text()
         self.assertEqual(result,
                          'Brave content with Brave and more Brave text.')
+
+    def test_count_zero_no_match_fails(self):
+        """
+        Test that count=0 fails when there are no matches.
+
+        count=0 means "one or more matches"; a pattern that matches nothing
+        must fail rather than silently leave the source untouched.
+        """
+        test_file_chromium = Path(
+            'chrome/common/extensions/api/test_count_zero_no_match.idl')
+
+        # Write and commit a file that lacks the pattern entirely.
+        self.fake_chromium_src.write_and_stage_file(
+            test_file_chromium, 'A Chromium thing.',
+            self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit('Add test_count_zero_no_match.idl',
+                                      self.fake_chromium_src.chromium)
+
+        plaster_path = plaster.PLASTER_FILES_PATH / (str(test_file_chromium) +
+                                                     '.yaml')
+        plaster_path.parent.mkdir(parents=True, exist_ok=True)
+        plaster_path.write_text('''
+          substitutions:
+            - description: replace a pattern that is absent
+              re_pattern: 'DoesNotAppear'
+              replace: 'X'
+              count: 0
+        ''')
+
+        plaster_file = plaster.PlasterFile(plaster_path)
+        with self.assertRaises(plaster.PlasterApplyError) as ctx:
+            plaster_file.apply()
+        self.assertIn('at least one match', str(ctx.exception))
 
     def test_count_explicit_values_work(self):
         """Test that explicit count values work correctly for validation.


### PR DESCRIPTION
The use of `count=0` was always meant to be "at least one or more",
however it has been all this time been implmented as "no count
validation". This fix corrects this oversight.

This is being done in preparation for the `ast-grep` changes.

Bug: https://github.com/brave/brave-browser/issues/56760
