### PR TITLE
[recipes] Adding AWS upload support code

### DIFF
--- a/tools/cr/toolchains/upload.py
+++ b/tools/cr/toolchains/upload.py
@@ -1,0 +1,351 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Upload a file to an S3 bucket with an integrity + authenticity envelope.
+
+An `S3Uploader` is bound to one bucket (served at
+`https://<bucket>.s3.brave.com`) and returns, per upload, the file's `sha256`,
+`size_bytes`, a KMS `signature` over the digest, and the S3 `version_id`.
+Uploads are write-once by default (`If-None-Match: *`) with a server-side
+SHA256 checksum, so a misbehaving caller can neither overwrite an object nor
+publish corrupted bytes.
+
+Signing may require assuming a cross-account role. Its ARN is supplied at
+runtime (`sign_role_arn`, defaulting from the `KMS_SIGN_ROLE_ARN` env var) so no
+account id or role name is baked into this public file; when unset, `sign()`
+uses the ambient credentials directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import dataclasses
+import hashlib
+import json
+import logging
+import mmap
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+# KMS signing parameters. The caller's ambient credentials must be able to
+# `kms:Sign` with it.
+DEFAULT_KMS_KEY = 'alias/gpg/checksums_pre_release_v2'
+
+# The KMS signing algorithm.
+KMS_ALGORITHM = 'RSASSA_PSS_SHA_256'
+
+# AWS region the S3 and KMS calls target.
+DEFAULT_REGION = 'us-west-2'
+
+# Env var the CLI reads the signing role ARN from, so the account id / role name
+# stay in the (private) caller's environment rather than in this public file.
+SIGN_ROLE_ARN_ENV = 'KMS_SIGN_ROLE_ARN'
+
+# Public URL template for our buckets: every one is served at
+# `https://<bucket>.s3.brave.com`. Used to compose the result's `url`.
+PUBLIC_URL_TEMPLATE = 'https://{bucket}.s3.brave.com'
+
+
+def _check_output(*command, env: dict[str, str] | None = None) -> str:
+    """Run *command*, logging the invocation, and return its captured stdout.
+
+    stderr is inherited so the `aws` CLI's own diagnostics stream to the log on
+    failure. *env* overrides the child environment when given (used to pass
+    assumed-role credentials to a single call); the parent env is inherited when
+    it is None.
+
+    Raises:
+        subprocess.CalledProcessError: if the command exits non-zero.
+    """
+    logging.info(' >>>> %s', ' '.join(str(a) for a in command))
+    return subprocess.run(command,
+                          check=True,
+                          text=True,
+                          stdout=subprocess.PIPE,
+                          env=env).stdout
+
+
+@dataclasses.dataclass(frozen=True)
+class ArtifactSignature:
+    """A KMS signature over a file's SHA-256 digest."""
+
+    # KMS key the signature was produced with (alias or ARN).
+    key_id: str
+
+    # Base64-encoded signature bytes, as returned by `aws kms sign`. Always
+    # produced with `KMS_ALGORITHM` over the file's SHA-256 digest.
+    signature: str
+
+
+@dataclasses.dataclass(frozen=True)
+class UploadResult:
+    """The authenticity + integrity envelope for an uploaded object."""
+
+    # Bucket and key the object was written to.
+    bucket: str
+    key: str
+
+    # Public URL the object is served at
+    # (`https://<bucket>.s3.brave.com/<key>`).
+    url: str
+
+    # Integrity: hex SHA-256 and byte size of the uploaded bytes.
+    sha256: str
+    size_bytes: int
+
+    # S3 object version id (present when bucket versioning is enabled), so a
+    # consumer can pin an exact revision even of a mutable object.
+    version_id: str | None
+
+    # S3 ETag of the stored object.
+    etag: str | None
+
+    # KMS signature, or None when the upload was made with `sign=False`.
+    signature: ArtifactSignature | None
+
+
+def sha256_file(path: Path) -> str:
+    """Return the hex SHA-256 of *path*.
+
+    The file is memory-mapped and hashed in a single `update`, leaving the OS
+    to page bytes in and out of the page cache on demand rather than us
+    buffering them in Python.
+    """
+    digest = hashlib.sha256()
+    with path.open('rb') as file:
+        if os.fstat(file.fileno()).st_size == 0:
+            return digest.hexdigest()
+        with mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ) as mapped:
+            digest.update(mapped)
+    return digest.hexdigest()
+
+
+def kms_verify(sha256_hex: str,
+               signature: ArtifactSignature,
+               region: str = DEFAULT_REGION) -> None:
+    """Verify a KMS *signature* over a SHA-256 digest, raising on failure.
+
+    The download-side counterpart to `S3Uploader.sign`: a consumer verifying a
+    downloaded file needs no bucket, so this is a free function rather than an
+    `S3Uploader` method.
+
+    Raises:
+        subprocess.CalledProcessError: if the signature does not verify.
+    """
+    digest = bytes.fromhex(sha256_hex)
+    message_b64 = base64.b64encode(digest).decode('ascii')
+    _check_output('aws', 'kms', 'verify', '--region', region, '--key-id',
+                  signature.key_id, '--signing-algorithm', KMS_ALGORITHM,
+                  '--message-type', 'DIGEST', '--message', message_b64,
+                  '--signature', signature.signature, '--output', 'json')
+
+
+class S3Uploader:
+    """Uploads files to one S3 bucket with a signed, verifiable envelope.
+
+    Binds the destination bucket and the AWS region + KMS key shared across
+    uploads. Each call `upload()` supplies the file and its key. Uses the
+    `aws` CLI with ambient credentials (see the module docstring).
+    """
+
+    def __init__(self,
+                 bucket: str,
+                 region: str = DEFAULT_REGION,
+                 kms_key: str = DEFAULT_KMS_KEY,
+                 sign_role_arn: str | None = None):
+        """Bind the uploader to *bucket* and its signing parameters.
+
+        Args:
+            bucket: Destination S3 bucket.
+            region: AWS region for the S3 and KMS calls.
+            kms_key: KMS key alias/ARN to sign with.
+            sign_role_arn: Role ARN to assume before signing. Supplied at
+                runtime so this public file carries no account id/role name;
+                when None, `sign()` uses the ambient credentials directly.
+        """
+        self._bucket = bucket
+        self._region = region
+        self._kms_key = kms_key
+        self._sign_role_arn = sign_role_arn
+
+    def _assume_role_env(self) -> dict[str, str] | None:
+        """Return an env with `sign_role_arn`'s temp creds, or None if unset.
+
+        The KMS key's policy trusts a dedicated signing role rather than the
+        caller's identity, so signing must run under assumed-role credentials.
+        Assuming the role here (only for the sign call) leaves the ambient
+        credentials, which the bucket policy grants `PutObject`, in place for
+        the upload.
+        """
+        if not self._sign_role_arn:
+            return None
+        credentials = json.loads(
+            _check_output('aws', 'sts', 'assume-role', '--region',
+                          self._region, '--role-arn', self._sign_role_arn,
+                          '--role-session-name', 'brave-upload-sign',
+                          '--output', 'json'))['Credentials']
+        return {
+            **os.environ,
+            'AWS_ACCESS_KEY_ID': credentials['AccessKeyId'],
+            'AWS_SECRET_ACCESS_KEY': credentials['SecretAccessKey'],
+            'AWS_SESSION_TOKEN': credentials['SessionToken'],
+        }
+
+    def sign(self, sha256_hex: str) -> ArtifactSignature:
+        """Sign a SHA-256 digest with this uploader's KMS key.
+
+        The digest is signed directly (`--message-type DIGEST`), with the raw
+        32-byte digest passed base64-encoded as the message. When
+        `sign_role_arn` is set the sign call runs under that assumed role (see
+        `_assume_role_env`), otherwise it uses the ambient credentials.
+        """
+        digest = bytes.fromhex(sha256_hex)
+        if len(digest) != 32:
+            raise ValueError(
+                f'Expected a 32-byte SHA-256 digest, got {len(digest)} bytes.')
+        message_b64 = base64.b64encode(digest).decode('ascii')
+        response = json.loads(
+            _check_output('aws',
+                          'kms',
+                          'sign',
+                          '--region',
+                          self._region,
+                          '--key-id',
+                          self._kms_key,
+                          '--signing-algorithm',
+                          KMS_ALGORITHM,
+                          '--message-type',
+                          'DIGEST',
+                          '--message',
+                          message_b64,
+                          '--output',
+                          'json',
+                          env=self._assume_role_env()))
+        return ArtifactSignature(key_id=self._kms_key,
+                                 signature=response['Signature'])
+
+    def _put_object(self, path: Path, key: str,
+                    immutable: bool) -> tuple[str | None, str | None]:
+        """PUT *path* to `s3://<bucket>/<key>` and return `(version_id, etag)`.
+
+        With *immutable* set, an `If-None-Match: *` precondition makes S3 reject
+        the write if the key already exists, so an object is never overwritten
+        in place. `--checksum-algorithm SHA256` has S3 validate the bytes.
+        """
+        command = [
+            'aws', 's3api', 'put-object', '--region', self._region, '--bucket',
+            self._bucket, '--key', key, '--body',
+            str(path), '--checksum-algorithm', 'SHA256', '--output', 'json'
+        ]
+        if immutable:
+            # Conditional write: fails with PreconditionFailed if the key
+            # already exists.
+            command += ['--if-none-match', '*']
+        response = json.loads(_check_output(*command))
+        return response.get('VersionId'), response.get('ETag')
+
+    def upload(self,
+               path: Path,
+               key: str | None = None,
+               prefix: str | None = None,
+               immutable: bool = True,
+               sign: bool = True) -> UploadResult:
+        """Upload *path* and return its integrity + authenticity envelope.
+
+        Args:
+            path: The local file to upload.
+            key: Explicit destination key. When omitted, the key is the file's
+                name, optionally under *prefix* (`<prefix>/<filename>`).
+            prefix: Key prefix used when *key* is not given. Ignored otherwise.
+            immutable: Enforce write-once via `If-None-Match: *` (default). Pass
+                False for objects meant to be replaced.
+            sign: Produce a KMS signature over the file's digest (default).
+
+        Returns:
+            An `UploadResult` describing what was published.
+
+        Raises:
+            FileNotFoundError: if *path* does not exist.
+            subprocess.CalledProcessError: if an `aws` call fails — notably a
+                PreconditionFailed when *immutable* and the key already exists.
+        """
+        if not path.is_file():
+            raise FileNotFoundError(f'File to upload not found: {path}')
+
+        if key is not None:
+            resolved_key = key
+        elif prefix:
+            resolved_key = f'{prefix.rstrip("/")}/{path.name}'
+        else:
+            resolved_key = path.name
+
+        sha256_hex = sha256_file(path)
+        size_bytes = path.stat().st_size
+
+        logging.info('Uploading %s (%d bytes, sha256=%s) to s3://%s/%s%s',
+                     path, size_bytes, sha256_hex, self._bucket, resolved_key,
+                     ' [immutable]' if immutable else '')
+
+        # Sign before the upload so a KMS/permissions failure aborts without
+        # leaving an unsigned object behind.
+        signature = self.sign(sha256_hex) if sign else None
+
+        version_id, etag = self._put_object(path, resolved_key, immutable)
+
+        host = PUBLIC_URL_TEMPLATE.format(bucket=self._bucket)
+        url = f'{host}/{resolved_key}'
+        return UploadResult(bucket=self._bucket,
+                            key=resolved_key,
+                            url=url,
+                            sha256=sha256_hex,
+                            size_bytes=size_bytes,
+                            version_id=version_id,
+                            etag=etag,
+                            signature=signature)
+
+
+def main() -> int:
+    """CLI wrapper: upload one file and print its `UploadResult` as JSON."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument('file', help='Local file to upload.')
+    parser.add_argument('--bucket', required=True, help='Destination bucket.')
+    parser.add_argument('--key', help='Explicit destination key.')
+    parser.add_argument('--prefix',
+                        help='Key prefix used when --key is not given.')
+    parser.add_argument('--mutable',
+                        action='store_true',
+                        help='Allow overwriting an existing object (no '
+                        'If-None-Match).')
+    parser.add_argument('--no-sign',
+                        action='store_true',
+                        help='Skip KMS signing.')
+    parser.add_argument('--kms-key', default=DEFAULT_KMS_KEY)
+    parser.add_argument('--region', default=DEFAULT_REGION)
+    parser.add_argument('--sign-role-arn',
+                        default=os.environ.get(SIGN_ROLE_ARN_ENV),
+                        help='Role ARN to assume before signing (defaults to '
+                        f'${SIGN_ROLE_ARN_ENV}).')
+    parser.add_argument('--verbose', action='store_true')
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+
+    uploader = S3Uploader(bucket=args.bucket,
+                          region=args.region,
+                          kms_key=args.kms_key,
+                          sign_role_arn=args.sign_role_arn)
+    result = uploader.upload(Path(args.file).expanduser().resolve(),
+                             key=args.key,
+                             prefix=args.prefix,
+                             immutable=not args.mutable,
+                             sign=not args.no_sign)
+    print(json.dumps(dataclasses.asdict(result), indent=2))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/cr/toolchains/upload_test.py
+++ b/tools/cr/toolchains/upload_test.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `upload`.
+
+The module's only side effects are `aws` CLI invocations funnelled through
+`_check_output`, so every test that touches AWS patches `subprocess.run` with a
+dispatcher (`_FakeAws`) that recognises the `kms sign`, `kms verify`, and `s3api
+put-object` calls, records the exact argv, and returns canned JSON. The command
+strings are then asserted against, which is where the behaviour that matters
+lives: the `If-None-Match: *` immutability guard, the server-side checksum, and
+the digest-based KMS signing that must mirror `signing.createSignatureKms`.
+
+Layers:
+
+* `Sha256FileTest` runs the real (module-level) hasher over real on-disk files.
+* `KmsVerifyTest` covers the module-level download-side verify helper.
+* `SignTest` covers `S3Uploader.sign` argv and the base64-digest encoding.
+* `PutObjectTest` covers `S3Uploader._put_object` — the conditional-write and
+  checksum flags plus the version-id/etag parsing.
+* `UploadTest` drives `S3Uploader.upload` end to end (sign-before-put ordering,
+  key/prefix/url resolution, flag propagation, error paths).
+* `MainTest` covers the CLI dispatch, `S3Uploader` construction, and flag
+  mapping.
+"""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import dataclasses
+import hashlib
+import io
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import upload as m
+
+
+class _FakeAws:
+    """Dispatcher standing in for `subprocess.run`, faking the `aws` CLI.
+
+    Records every command it is handed (as a list) on `self.commands`, and
+    returns a `CompletedProcess` whose stdout is the JSON the matching real
+    `aws` subcommand would emit. Unknown commands raise, so a test can never
+    accidentally pass against an unexercised code path.
+    """
+
+    def __init__(self,
+                 signature: str = 'ZmFrZS1zaWc=',
+                 version_id: str | None = 'v-1',
+                 etag: str | None = '"deadbeef"'):
+        self.commands: list[list[str]] = []
+        self.envs: list[dict[str, str] | None] = []
+        self._signature = signature
+        self._version_id = version_id
+        self._etag = etag
+
+    def __call__(self, command, **kwargs) -> subprocess.CompletedProcess:
+        command = list(command)
+        self.commands.append(command)
+        self.envs.append(kwargs.get('env'))
+        return subprocess.CompletedProcess(command,
+                                           0,
+                                           stdout=self._stdout(command))
+
+    def _stdout(self, command: list[str]) -> str:
+        if 'sts' in command and 'assume-role' in command:
+            return json.dumps({
+                'Credentials': {
+                    'AccessKeyId': 'AKIA_TEMP',
+                    'SecretAccessKey': 'temp-secret',
+                    'SessionToken': 'temp-token',
+                }
+            })
+        if 'kms' in command and 'sign' in command:
+            algorithm = command[command.index('--signing-algorithm') + 1]
+            return json.dumps({
+                'KeyId': 'arn:aws:kms:...:key/abc',
+                'Signature': self._signature,
+                'SigningAlgorithm': algorithm,
+            })
+        if 'kms' in command and 'verify' in command:
+            return json.dumps({'SignatureValid': True})
+        if 'put-object' in command:
+            body: dict[str, object] = {}
+            if self._version_id is not None:
+                body['VersionId'] = self._version_id
+            if self._etag is not None:
+                body['ETag'] = self._etag
+            return json.dumps(body)
+        raise AssertionError(f'unexpected aws command: {command}')
+
+    def command_with(self, needle: str) -> list[str]:
+        """Return the single recorded command containing *needle*."""
+        matches = [c for c in self.commands if needle in c]
+        assert len(
+            matches) == 1, f'{needle}: expected 1 command, got {matches}'
+        return matches[0]
+
+    def env_for(self, needle: str) -> dict[str, str] | None:
+        """Return the env the single command containing *needle* ran with."""
+        command = self.command_with(needle)
+        return self.envs[self.commands.index(command)]
+
+
+def _flag(command: list[str], flag: str) -> str:
+    """Return the value following *flag* in *command*."""
+    return command[command.index(flag) + 1]
+
+
+@contextlib.contextmanager
+def _tempfile(data: bytes = b'toolchain-bytes'):
+    """Yield a real file on disk holding *data*."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / 'linux-x64-rust-toolchain-abc-1.tar.xz'
+        path.write_bytes(data)
+        yield path
+
+
+class Sha256FileTest(unittest.TestCase):
+
+    def test_matches_hashlib(self):
+        data = b'the quick brown fox' * 1000
+        with _tempfile(data) as path:
+            self.assertEqual(m.sha256_file(path),
+                             hashlib.sha256(data).hexdigest())
+
+    def test_empty_file(self):
+        with _tempfile(b'') as path:
+            self.assertEqual(m.sha256_file(path),
+                             hashlib.sha256(b'').hexdigest())
+
+    def test_large_file(self):
+        # A multi-MiB file exercises the memory-mapped path beyond a page.
+        data = b'x' * (4 * 1024 * 1024 + 7)
+        with _tempfile(data) as path:
+            self.assertEqual(m.sha256_file(path),
+                             hashlib.sha256(data).hexdigest())
+
+
+class SignTest(unittest.TestCase):
+
+    def test_signs_digest_as_base64_message(self):
+        fake = _FakeAws(signature='c2lnMQ==')
+        sha256_hex = hashlib.sha256(b'abc').hexdigest()
+        with mock.patch.object(m.subprocess, 'run', fake):
+            sig = m.S3Uploader('bucket').sign(sha256_hex)
+
+        command = fake.command_with('sign')
+        # Message must be the base64 of the raw 32-byte digest, not the hex.
+        expected_message = base64.b64encode(bytes.fromhex(sha256_hex)).decode()
+        self.assertEqual(_flag(command, '--message'), expected_message)
+        self.assertEqual(_flag(command, '--message-type'), 'DIGEST')
+        self.assertEqual(_flag(command, '--key-id'), m.DEFAULT_KMS_KEY)
+        self.assertEqual(_flag(command, '--signing-algorithm'),
+                         m.KMS_ALGORITHM)
+        self.assertEqual(_flag(command, '--region'), m.DEFAULT_REGION)
+
+        self.assertEqual(sig.signature, 'c2lnMQ==')
+        self.assertEqual(sig.key_id, m.DEFAULT_KMS_KEY)
+
+    def test_signing_algorithm_is_fixed(self):
+        # The algorithm is not configurable: it is always KMS_ALGORITHM, whose
+        # SHA-256 hash matches the digest produced by sha256_file.
+        fake = _FakeAws()
+        sha256_hex = hashlib.sha256(b'abc').hexdigest()
+        with mock.patch.object(m.subprocess, 'run', fake):
+            m.S3Uploader('bucket').sign(sha256_hex)
+        command = fake.command_with('sign')
+        self.assertEqual(_flag(command, '--signing-algorithm'),
+                         'RSASSA_PSS_SHA_256')
+
+    def test_honours_uploader_config(self):
+        fake = _FakeAws()
+        sha256_hex = hashlib.sha256(b'abc').hexdigest()
+        uploader = m.S3Uploader('bucket',
+                                region='eu-west-1',
+                                kms_key='alias/gpg/other')
+        with mock.patch.object(m.subprocess, 'run', fake):
+            sig = uploader.sign(sha256_hex)
+        command = fake.command_with('sign')
+        self.assertEqual(_flag(command, '--key-id'), 'alias/gpg/other')
+        self.assertEqual(_flag(command, '--region'), 'eu-west-1')
+        self.assertEqual(sig.key_id, 'alias/gpg/other')
+
+    def test_no_role_uses_ambient_credentials(self):
+        # Without a sign_role_arn, sign() must not assume a role and must run
+        # the kms sign with the ambient env (env=None).
+        fake = _FakeAws()
+        sha256_hex = hashlib.sha256(b'abc').hexdigest()
+        with mock.patch.object(m.subprocess, 'run', fake):
+            m.S3Uploader('bucket').sign(sha256_hex)
+        self.assertTrue(all('assume-role' not in c for c in fake.commands))
+        self.assertIsNone(fake.env_for('sign'))
+
+    def test_assumes_role_when_configured(self):
+        # With a sign_role_arn, sign() assumes it and runs kms sign under the
+        # returned temporary credentials.
+        fake = _FakeAws()
+        sha256_hex = hashlib.sha256(b'abc').hexdigest()
+        arn = 'arn:aws:iam::123456789012:role/signing-role-x-production'
+        with mock.patch.object(m.subprocess, 'run', fake):
+            m.S3Uploader('bucket', sign_role_arn=arn).sign(sha256_hex)
+        self.assertEqual(_flag(fake.command_with('assume-role'), '--role-arn'),
+                         arn)
+        env = fake.env_for('sign')
+        self.assertEqual(env['AWS_ACCESS_KEY_ID'], 'AKIA_TEMP')
+        self.assertEqual(env['AWS_SECRET_ACCESS_KEY'], 'temp-secret')
+        self.assertEqual(env['AWS_SESSION_TOKEN'], 'temp-token')
+
+    def test_rejects_non_digest_length(self):
+        # A non-SHA-256 hex string must never be signed as if it were a digest.
+        with mock.patch.object(m.subprocess, 'run') as run:
+            with self.assertRaises(ValueError):
+                m.S3Uploader('bucket').sign('abcd')
+            run.assert_not_called()
+
+    def test_propagates_kms_failure(self):
+        sha256_hex = hashlib.sha256(b'abc').hexdigest()
+        err = subprocess.CalledProcessError(255, 'aws')
+        with mock.patch.object(m.subprocess, 'run', side_effect=err):
+            with self.assertRaises(subprocess.CalledProcessError):
+                m.S3Uploader('bucket').sign(sha256_hex)
+
+
+class KmsVerifyTest(unittest.TestCase):
+
+    def test_builds_verify_command(self):
+        fake = _FakeAws()
+        sha256_hex = hashlib.sha256(b'abc').hexdigest()
+        sig = m.ArtifactSignature(key_id='alias/gpg/k', signature='c2ln')
+        with mock.patch.object(m.subprocess, 'run', fake):
+            m.kms_verify(sha256_hex, sig)
+        command = fake.command_with('verify')
+        expected_message = base64.b64encode(bytes.fromhex(sha256_hex)).decode()
+        self.assertEqual(_flag(command, '--message'), expected_message)
+        self.assertEqual(_flag(command, '--signature'), 'c2ln')
+        self.assertEqual(_flag(command, '--key-id'), 'alias/gpg/k')
+        self.assertEqual(_flag(command, '--signing-algorithm'),
+                         'RSASSA_PSS_SHA_256')
+
+    def test_raises_on_bad_signature(self):
+        sig = m.ArtifactSignature('k', 'c2ln')
+        err = subprocess.CalledProcessError(1, 'aws')
+        with mock.patch.object(m.subprocess, 'run', side_effect=err):
+            with self.assertRaises(subprocess.CalledProcessError):
+                m.kms_verify(hashlib.sha256(b'abc').hexdigest(), sig)
+
+
+class PutObjectTest(unittest.TestCase):
+
+    def _put(self, fake, immutable):
+        with _tempfile() as path:
+            with mock.patch.object(m.subprocess, 'run', fake):
+                return m.S3Uploader('bucket')._put_object(path,
+                                                          'prefix/obj',
+                                                          immutable=immutable)
+
+    def test_immutable_adds_if_none_match(self):
+        fake = _FakeAws()
+        self._put(fake, immutable=True)
+        command = fake.command_with('put-object')
+        self.assertEqual(_flag(command, '--if-none-match'), '*')
+        # Server-side integrity is always requested.
+        self.assertEqual(_flag(command, '--checksum-algorithm'), 'SHA256')
+
+    def test_mutable_omits_if_none_match(self):
+        fake = _FakeAws()
+        self._put(fake, immutable=False)
+        command = fake.command_with('put-object')
+        self.assertNotIn('--if-none-match', command)
+        self.assertEqual(_flag(command, '--checksum-algorithm'), 'SHA256')
+
+    def test_returns_version_and_etag(self):
+        fake = _FakeAws(version_id='v-42', etag='"abc"')
+        self.assertEqual(self._put(fake, immutable=True), ('v-42', '"abc"'))
+
+    def test_missing_version_and_etag_are_none(self):
+        fake = _FakeAws(version_id=None, etag=None)
+        self.assertEqual(self._put(fake, immutable=True), (None, None))
+
+
+class UploadTest(unittest.TestCase):
+
+    def test_end_to_end(self):
+        data = b'archive-payload'
+        fake = _FakeAws(signature='c2lnQVo=', version_id='v-9', etag='"e"')
+        with _tempfile(data) as path:
+            with mock.patch.object(m.subprocess, 'run', fake):
+                result = m.S3Uploader('my-bucket').upload(path)
+
+        self.assertEqual(result.bucket, 'my-bucket')
+        self.assertEqual(result.key, path.name)
+        self.assertEqual(result.url,
+                         f'https://my-bucket.s3.brave.com/{path.name}')
+        self.assertEqual(result.sha256, hashlib.sha256(data).hexdigest())
+        self.assertEqual(result.size_bytes, len(data))
+        self.assertEqual(result.version_id, 'v-9')
+        self.assertEqual(result.etag, '"e"')
+        self.assertEqual(result.signature.signature, 'c2lnQVo=')
+        self.assertEqual(_flag(fake.command_with('put-object'), '--bucket'),
+                         'my-bucket')
+        # Default is a write-once upload.
+        self.assertEqual(
+            _flag(fake.command_with('put-object'), '--if-none-match'), '*')
+
+    def test_signs_the_uploaded_bytes_digest(self):
+        data = b'payload-to-sign'
+        fake = _FakeAws()
+        with _tempfile(data) as path:
+            with mock.patch.object(m.subprocess, 'run', fake):
+                m.S3Uploader('b').upload(path)
+        signed = _flag(fake.command_with('sign'), '--message')
+        expected = base64.b64encode(hashlib.sha256(data).digest()).decode()
+        self.assertEqual(signed, expected)
+
+    def test_key_defaults_to_filename(self):
+        fake = _FakeAws()
+        with _tempfile() as path:
+            with mock.patch.object(m.subprocess, 'run', fake):
+                result = m.S3Uploader('b').upload(path)
+        self.assertEqual(result.key, path.name)
+
+    def test_prefix_composes_key(self):
+        fake = _FakeAws()
+        with _tempfile() as path:
+            with mock.patch.object(m.subprocess, 'run', fake):
+                # Trailing slash on the prefix must not double up.
+                result = m.S3Uploader('b').upload(path, prefix='some/dir/')
+        self.assertEqual(result.key, f'some/dir/{path.name}')
+        self.assertEqual(_flag(fake.command_with('put-object'), '--key'),
+                         f'some/dir/{path.name}')
+
+    def test_explicit_key_overrides_prefix(self):
+        fake = _FakeAws()
+        with _tempfile() as path:
+            with mock.patch.object(m.subprocess, 'run', fake):
+                result = m.S3Uploader('b').upload(path,
+                                                  key='custom/name.bin',
+                                                  prefix='ignored')
+        self.assertEqual(result.key, 'custom/name.bin')
+        self.assertEqual(_flag(fake.command_with('put-object'), '--key'),
+                         'custom/name.bin')
+
+    def test_url_derived_from_bucket(self):
+        fake = _FakeAws()
+        with _tempfile() as path:
+            with mock.patch.object(m.subprocess, 'run', fake):
+                result = m.S3Uploader('some-bucket').upload(path, prefix='p')
+        self.assertEqual(result.url,
+                         f'https://some-bucket.s3.brave.com/p/{path.name}')
+
+    def test_mutable_upload(self):
+        fake = _FakeAws()
+        with _tempfile() as path:
+            with mock.patch.object(m.subprocess, 'run', fake):
+                m.S3Uploader('b').upload(path, immutable=False)
+        self.assertNotIn('--if-none-match', fake.command_with('put-object'))
+
+    def test_no_sign_skips_kms(self):
+        fake = _FakeAws()
+        with _tempfile() as path:
+            with mock.patch.object(m.subprocess, 'run', fake):
+                result = m.S3Uploader('b').upload(path, sign=False)
+        self.assertIsNone(result.signature)
+        self.assertTrue(all('kms' not in c for c in fake.commands))
+
+    def test_put_object_keeps_ambient_creds_under_signing_role(self):
+        # The signing role has no PutObject; only the sign call may run under
+        # it, so put-object must keep the ambient credentials (env=None).
+        fake = _FakeAws()
+        arn = 'arn:aws:iam::123456789012:role/signing-role-x-production'
+        with _tempfile() as path:
+            with mock.patch.object(m.subprocess, 'run', fake):
+                m.S3Uploader('b', sign_role_arn=arn).upload(path)
+        self.assertIsNotNone(fake.env_for('sign'))
+        self.assertIsNone(fake.env_for('put-object'))
+
+    def test_missing_file_raises_before_any_aws_call(self):
+        with mock.patch.object(m.subprocess, 'run') as run:
+            with self.assertRaises(FileNotFoundError):
+                m.S3Uploader('b').upload(Path('/does/not/exist.bin'))
+            run.assert_not_called()
+
+    def test_sign_failure_aborts_before_put(self):
+        # A KMS failure must not leave an unsigned object behind.
+        def run(command, **_kwargs):
+            command = list(command)
+            if 'sign' in command:
+                raise subprocess.CalledProcessError(255, 'aws')
+            raise AssertionError(
+                'put-object must not run after a sign failure')
+
+        with _tempfile() as path:
+            with mock.patch.object(m.subprocess, 'run', side_effect=run):
+                with self.assertRaises(subprocess.CalledProcessError):
+                    m.S3Uploader('b').upload(path)
+
+    def test_precondition_failure_propagates(self):
+        # An immutable re-upload (existing key) surfaces as CalledProcessError.
+        def run(command, **_kwargs):
+            command = list(command)
+            if 'sign' in command:
+                return subprocess.CompletedProcess(command,
+                                                   0,
+                                                   stdout=json.dumps({
+                                                       'Signature': 's',
+                                                       'SigningAlgorithm': 'a'
+                                                   }))
+            raise subprocess.CalledProcessError(1,
+                                                'aws',
+                                                stderr='PreconditionFailed')
+
+        with _tempfile() as path:
+            with mock.patch.object(m.subprocess, 'run', side_effect=run):
+                with self.assertRaises(subprocess.CalledProcessError):
+                    m.S3Uploader('b').upload(path)
+
+
+class MainTest(unittest.TestCase):
+
+    def _run(self, argv):
+        out = io.StringIO()
+        with mock.patch.object(sys, 'argv', ['upload.py', *argv]):
+            with mock.patch.object(m, 'S3Uploader') as cls:
+                cls.return_value.upload.return_value = m.UploadResult(
+                    bucket='b',
+                    key='p/o',
+                    url='https://h/p/o',
+                    sha256='d',
+                    size_bytes=1,
+                    version_id='v',
+                    etag='"e"',
+                    signature=None)
+                with contextlib.redirect_stdout(out):
+                    code = m.main()
+        return code, cls, out.getvalue()
+
+    def test_defaults(self):
+        code, cls, out = self._run(['/tmp/a.bin', '--bucket', 'my-bucket'])
+        self.assertEqual(code, 0)
+        # Uploader is constructed with the bucket + default KMS config.
+        _, ctor = cls.call_args
+        self.assertEqual(ctor['bucket'], 'my-bucket')
+        self.assertEqual(ctor['kms_key'], m.DEFAULT_KMS_KEY)
+        self.assertEqual(ctor['region'], m.DEFAULT_REGION)
+        # And driven with the write-once + sign defaults.
+        _, kwargs = cls.return_value.upload.call_args
+        self.assertTrue(kwargs['immutable'])
+        self.assertTrue(kwargs['sign'])
+        # Result is emitted as JSON.
+        self.assertEqual(json.loads(out)['url'], 'https://h/p/o')
+
+    def test_bucket_is_required(self):
+        with mock.patch.object(sys, 'argv', ['upload.py', '/tmp/a.bin']):
+            with mock.patch.object(m, 'S3Uploader'):
+                with self.assertRaises(SystemExit):
+                    m.main()
+
+    def test_mutable_and_no_sign_flags(self):
+        _, cls, _ = self._run(
+            ['/tmp/a.bin', '--bucket', 'b', '--mutable', '--no-sign'])
+        _, kwargs = cls.return_value.upload.call_args
+        self.assertFalse(kwargs['immutable'])
+        self.assertFalse(kwargs['sign'])
+
+    def test_sign_role_arn_from_flag(self):
+        _, cls, _ = self._run(
+            ['/tmp/a.bin', '--bucket', 'b', '--sign-role-arn', 'arn:flag'])
+        _, ctor = cls.call_args
+        self.assertEqual(ctor['sign_role_arn'], 'arn:flag')
+
+    def test_sign_role_arn_defaults_from_env(self):
+        with mock.patch.dict(m.os.environ,
+                             {m.SIGN_ROLE_ARN_ENV: 'arn:from-env'}):
+            _, cls, _ = self._run(['/tmp/a.bin', '--bucket', 'b'])
+        _, ctor = cls.call_args
+        self.assertEqual(ctor['sign_role_arn'], 'arn:from-env')
+
+    def test_key_prefix_and_kms_overrides(self):
+        _, cls, _ = self._run([
+            '/tmp/a.bin', '--bucket', 'b', '--key', 'k/o', '--prefix', 'p',
+            '--kms-key', 'alias/gpg/x', '--region', 'eu-west-1'
+        ])
+        # KMS/region overrides land on the constructor...
+        _, ctor = cls.call_args
+        self.assertEqual(ctor['kms_key'], 'alias/gpg/x')
+        self.assertEqual(ctor['region'], 'eu-west-1')
+        # ...while key/prefix are per-upload.
+        _, kwargs = cls.return_value.upload.call_args
+        self.assertEqual(kwargs['key'], 'k/o')
+        self.assertEqual(kwargs['prefix'], 'p')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is a basic support infrastructure to permit us to upload to the
bucket. `S3Uploader` can imported directly in various scripts,
(toolchains, ast-grep, etc), and should be usable in the node, although
we may have follow up work to improve the coordination between the
pipeline code and the client code.

Bug: https://github.com/brave/brave-browser/issues/56748
