### PR TITLE
[Polkadot] [Wallet] deduplicate transaction status tracking tasks

### DIFF
--- a/components/brave_wallet/browser/polkadot/polkadot_tx_manager.cc
+++ b/components/brave_wallet/browser/polkadot/polkadot_tx_manager.cc
@@ -323,6 +323,11 @@ void PolkadotTxManager::UpdatePendingTransactions(
 
     new_pending_chain_ids.insert(polkadot_tx->chain_id());
 
+    auto tx_meta_id = polkadot_tx->id();
+    if (polkadot_transaction_status_tasks_.contains(tx_meta_id)) {
+      continue;
+    }
+
     auto task_ptr = PolkadotTransactionStatusTask::Create(
         *polkadot_wallet_service_, keyring_service(),
         polkadot_tx->from()->Clone(), polkadot_tx->chain_id(),
@@ -334,10 +339,11 @@ void PolkadotTxManager::UpdatePendingTransactions(
     }
 
     auto* task = task_ptr.get();
-    polkadot_transaction_status_tasks_.insert(std::move(task_ptr));
+    polkadot_transaction_status_tasks_.emplace(std::move(tx_meta_id),
+                                               std::move(task_ptr));
 
     task->Start(base::BindOnce(&PolkadotTxManager::OnTransactionStatusResolved,
-                               weak_ptr_factory_.GetWeakPtr(), task,
+                               weak_ptr_factory_.GetWeakPtr(),
                                std::move(polkadot_tx)));
   }
 
@@ -345,13 +351,12 @@ void PolkadotTxManager::UpdatePendingTransactions(
 }
 
 void PolkadotTxManager::OnTransactionStatusResolved(
-    PolkadotTransactionStatusTask* task,
     std::unique_ptr<PolkadotTxMeta> polkadot_tx,
     base::expected<
         std::pair<PolkadotTransactionStatus, std::optional<uint128_t>>,
         std::string> result) {
   CHECK(polkadot_tx->tx());
-  polkadot_transaction_status_tasks_.erase(task);
+  polkadot_transaction_status_tasks_.erase(polkadot_tx->id());
 
   if (!result.has_value()) {
     return;

--- a/components/brave_wallet/browser/polkadot/polkadot_tx_manager.h
+++ b/components/brave_wallet/browser/polkadot/polkadot_tx_manager.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_POLKADOT_POLKADOT_TX_MANAGER_H_
 #define BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_POLKADOT_POLKADOT_TX_MANAGER_H_
 
+#include <memory>
 #include <optional>
 #include <string>
 
@@ -16,7 +17,7 @@
 #include "brave/components/brave_wallet/browser/polkadot/polkadot_tx_meta.h"
 #include "brave/components/brave_wallet/browser/tx_manager.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
-#include "third_party/abseil-cpp/absl/container/flat_hash_set.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 
 namespace brave_wallet {
 
@@ -94,7 +95,6 @@ class PolkadotTxManager : public TxManager,
                      std::string> tx_hash_metadata_pair);
 
   void OnTransactionStatusResolved(
-      PolkadotTransactionStatusTask* task,
       std::unique_ptr<PolkadotTxMeta> polkadot_tx,
       base::expected<
           std::pair<PolkadotTransactionStatus, std::optional<uint128_t>>,
@@ -108,7 +108,8 @@ class PolkadotTxManager : public TxManager,
 
   raw_ref<PolkadotWalletService> polkadot_wallet_service_;
   raw_ref<NetworkManager> network_manager_;
-  absl::flat_hash_set<std::unique_ptr<PolkadotTransactionStatusTask>>
+  absl::flat_hash_map<std::string,
+                      std::unique_ptr<PolkadotTransactionStatusTask>>
       polkadot_transaction_status_tasks_;
 
   base::WeakPtrFactory<PolkadotTxManager> weak_ptr_factory_{this};

--- a/components/brave_wallet/browser/polkadot/polkadot_tx_manager_unittest.cc
+++ b/components/brave_wallet/browser/polkadot/polkadot_tx_manager_unittest.cc
@@ -279,6 +279,15 @@ class PolkadotTxManagerUnitTest : public testing::Test {
               kExpectedExtrinsic);
   }
 
+  size_t GetStatusTaskCount() {
+    return GetPolkadotTxManager()->polkadot_transaction_status_tasks_.size();
+  }
+
+  bool HasStatusTaskFor(const std::string& tx_meta_id) {
+    return GetPolkadotTxManager()->polkadot_transaction_status_tasks_.contains(
+        tx_meta_id);
+  }
+
  protected:
   base::test::TaskEnvironment task_environment_;
 
@@ -1122,6 +1131,37 @@ TEST_F(PolkadotTxManagerUnitTest, UpdatePendingTransactions_BlockTracker) {
 
   GetPolkadotTxManager()->UpdatePendingTransactions(mojom::kPolkadotMainnet);
   EXPECT_TRUE(GetPolkadotBlockTracker()->IsRunning(mojom::kPolkadotTestnet));
+}
+
+TEST_F(PolkadotTxManagerUnitTest,
+       UpdatePendingTransactions_DedupesStatusTasks) {
+  // Calling UpdatePendingTransactions() shouldn't spawn more than one task for
+  // a given transaction.
+
+  SetUpMockRpcForFoundExtrinsic(polkadot_mock_rpc_.get(), true, false);
+  polkadot_mock_rpc_->AddReqResPairs();
+  polkadot_mock_rpc_->FinalizeSetup();
+
+  std::string chain_id = mojom::kPolkadotTestnet;
+
+  auto tx_meta_id = SetUpUnapprovedTx(chain_id);
+
+  base::test::TestFuture<bool, mojom::ProviderErrorUnionPtr, const std::string&>
+      approved_future;
+  GetPolkadotTxManager()->ApproveTransaction(tx_meta_id,
+                                             approved_future.GetCallback());
+  auto [success, error, msg] = approved_future.Take();
+  ASSERT_TRUE(success);
+
+  ExpectSubmittedTxState(tx_meta_id);
+  ASSERT_EQ(GetStatusTaskCount(), 1u);
+  ASSERT_TRUE(HasStatusTaskFor(tx_meta_id));
+
+  for (int i = 0; i < 5; ++i) {
+    GetPolkadotTxManager()->UpdatePendingTransactions(chain_id);
+    EXPECT_EQ(GetStatusTaskCount(), 1u);
+    EXPECT_TRUE(HasStatusTaskFor(tx_meta_id));
+  }
 }
 
 }  // namespace brave_wallet


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/57008

Update `PolkadotTxManager::UpdatePendingTransactions()` to de-deduplicate transaction status tracking based on the `tx_meta->id()`. We update the code to use a hash map instead of a hash set and add a small regression test.

# Test Plan

Submit multiple different send transactions on a flaky network such as AssetHub Westend. Most will likely be dropped and there should only be one notification popup per transaction. For the most reliable testing, submit ~3 AssetHub Westend transactions and ~2 AssetHub Paseo transactions.

Brave permits extrinsics to be included in a 64 block window from their signing block. Chains seem to mint blocks on a 3s to 6s basis meaning it can take around 5 minutes for a dropped transaction to be confirmed.

Westend runs very few validators so many extrinsics that are small and don't pay any tip are likely to be ejected from the mempool in comparison to Paseo which is the official testnet and as such has much more resources put into it, so transactions drop at a much less frequent rate.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
