### PR TITLE
[iOS] Fix Xcode build schemes that run ninja

### DIFF
--- a/ios/brave-ios/scripts/scheme_preaction.py
+++ b/ios/brave-ios/scripts/scheme_preaction.py
@@ -48,6 +48,11 @@ def main():
     target_environment = 'simulator' if (options.platform_name
                                          == 'iphonesimulator') else 'device'
 
+    # Ensure node is executed from the brave root directory, node.RunNode offers
+    # no option for passing in a custom working directory. This is required for
+    # paths in the webpack config to be parsed correctly.
+    os.chdir(brave_root_dir)
+
     if options.only_update_symlink:
         # If we're choosing to only update the symlink we should validate
         # that the resulting symlink will point to a valid folder

--- a/ios/brave-ios/scripts/xcode_scheme_preaction.sh
+++ b/ios/brave-ios/scripts/xcode_scheme_preaction.sh
@@ -10,7 +10,7 @@
 # $RUN_CLANG_STATIC_ANALYZER is NO for builds, YES for cleans
 if [[ $RUN_CLANG_STATIC_ANALYZER = "NO" ]]; then
   # Do not inject Xcode build configs into the GN build
-  env -i python3 \
+  env -i PATH="$PATH" python3 \
     "${PROJECT_DIR}/../scripts/scheme_preaction.py" \
     --platform_name "$PLATFORM_NAME" \
     "$@"


### PR DESCRIPTION
`PATH` must be set to something in order for `depot_tools` to be added to the path during `commands.js` execution and the working directory must be set correctly for webpack to parse the directories listed in the config correctly.
