### PR TITLE
[Reland] Register vertical tab region view as draggable area

### DIFF
--- a/browser/ui/views/frame/brave_non_client_hit_test_helper_browsertest.cc
+++ b/browser/ui/views/frame/brave_non_client_hit_test_helper_browsertest.cc
@@ -5,6 +5,10 @@
 
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/ui/browser_commands.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_container_view.h"
+#include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h"
+#include "chrome/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/views/frame/browser_frame_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/toolbar/reload_button.h"
@@ -12,6 +16,7 @@
 #include "chrome/test/base/in_process_browser_test.h"
 #include "content/public/test/browser_test.h"
 #include "ui/base/hit_test.h"
+#include "ui/views/view.h"
 
 using BraveNonClientHitTestHelperBrowserTest = InProcessBrowserTest;
 
@@ -46,4 +51,53 @@ IN_PROC_BROWSER_TEST_F(BraveNonClientHitTestHelperBrowserTest, Toolbar) {
   point = gfx::Point();
   views::View::ConvertPointToWidget(toolbar->reload_button(), &point);
   EXPECT_NE(HTCAPTION, frame_view->NonClientHitTest(point));
+}
+
+IN_PROC_BROWSER_TEST_F(BraveNonClientHitTestHelperBrowserTest,
+                       VerticalTabStripRegionView) {
+  brave::ToggleVerticalTabStrip(browser());
+
+  auto* browser_view = static_cast<BrowserView*>(browser()->window());
+  auto* frame_view = browser_view->browser_widget()->GetFrameView();
+  frame_view->DeprecatedLayoutImmediately();
+
+  auto* region_view = BraveBrowserView::From(browser_view)
+                          ->vertical_tab_strip_container_view()
+                          ->vertical_tab_strip_region_view();
+  ASSERT_TRUE(region_view);
+  ASSERT_TRUE(region_view->GetVisible());
+
+  // Hide all children so the region view's own surface is exposed.
+  for (views::View* child : region_view->GetChildrenInZOrder()) {
+    child->SetVisible(false);
+  }
+
+  gfx::Point point = region_view->GetLocalBounds().CenterPoint();
+  views::View::ConvertPointToWidget(region_view, &point);
+
+  // Dragging a window by the empty vertical tab strip region should work.
+  EXPECT_EQ(HTCAPTION, frame_view->NonClientHitTest(point));
+
+  // Restore children. A point covered by a direct child view should not be
+  // HTCAPTION so that users can interact with the child elements.
+  for (views::View* child : region_view->GetChildrenInZOrder()) {
+    child->SetVisible(true);
+  }
+
+  // The region view only occupies a small portion of the available height
+  // (e.g. one tab-height per tab), so the center of the full region view is
+  // typically empty space with no child underneath. Find a child with non-zero
+  // bounds and verify its center returns non-HTCAPTION. Children's bounds are
+  // preserved from the layout run before hiding, so no extra layout step is
+  // needed.
+  for (views::View* child : region_view->GetChildrenInZOrder()) {
+    if (child->bounds().IsEmpty()) {
+      continue;
+    }
+    // Child bounds are in region_view's local coordinate space.
+    gfx::Point child_center = child->bounds().CenterPoint();
+    views::View::ConvertPointToWidget(region_view, &child_center);
+    EXPECT_NE(HTCAPTION, frame_view->NonClientHitTest(child_center));
+    break;
+  }
 }

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -24,6 +24,7 @@
 #include "brave/browser/ui/tabs/public/switches.h"
 #include "brave/browser/ui/tabs/public/vertical_tab_controller.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/frame/tab_strip_placement_coordinator.h"
 #include "brave/browser/ui/views/tabs/brave_new_tab_button.h"
 #include "brave/browser/ui/views/tabs/brave_tab_search_button.h"
@@ -287,6 +288,13 @@ BraveVerticalTabStripRegionView::BraveVerticalTabStripRegionView(
       browser_(browser_view->browser()),
       original_region_view_(region_view),
       tab_style_(TabStyle::Get()) {
+  // Register this view to handle caption area hit test, so that users can drag
+  // the window by dragging the vertical tab strip region.
+  browser()
+      ->browser_window_features()
+      ->brave_non_client_hit_test_helper()
+      ->RegisterCaptionArea(this);
+
   // As we follow user's choice for vertical tab alignment,
   // we don't need to mirror this view.
   SetMirrored(false);

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1383,6 +1383,7 @@ test("brave_browser_tests") {
       "//brave/browser/ui/tabs:browser_tests",
       "//brave/browser/ui/tabs:tab_model",
       "//brave/browser/ui/views/frame:browser_tests",
+      "//brave/browser/ui/views/frame/vertical_tabs",
       "//brave/browser/ui/views/frame/vertical_tabs:browser_tests",
       "//brave/browser/ui/views/location_bar",
       "//brave/browser/ui/views/location_bar:browser_tests",


### PR DESCRIPTION
Now users can drag the window by dragging the vertical tab region view.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30011

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
