### PR TITLE
fix(settings): prevent blurry search engine icons in CR150

### DIFF
--- a/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.html
+++ b/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.html
@@ -17,6 +17,7 @@
     --site-favicon-border-radius: 4px;
     --site-favicon-height: var(--favicon-size);
     --site-favicon-width: var(--favicon-size);
+    image-rendering: -webkit-optimize-contrast;
   }
 
   settings-private-search-engine-list-dialog {

--- a/browser/resources/settings/brave_search_engines_page/normal_search_engine_list_dialog.html
+++ b/browser/resources/settings/brave_search_engines_page/normal_search_engine_list_dialog.html
@@ -47,6 +47,7 @@
     --site-favicon-border-radius: 4px;
     --site-favicon-height: var(--icon-size);
     --site-favicon-width: var(--icon-size);
+    image-rendering: -webkit-optimize-contrast;
   }
 
   #setAsDefaultButton {

--- a/browser/resources/settings/brave_search_engines_page/private_search_engine_list_dialog.html
+++ b/browser/resources/settings/brave_search_engines_page/private_search_engine_list_dialog.html
@@ -47,6 +47,7 @@
     --site-favicon-border-radius: 4px;
     --site-favicon-height: var(--icon-size);
     --site-favicon-width: var(--icon-size);
+    image-rendering: -webkit-optimize-contrast;
   }
 
   #setAsDefaultButton {


### PR DESCRIPTION
Apply image-rendering: -webkit-optimize-contrast to settings-search-engine-icon in Brave's search engine settings pages. The Brave favicon (64x60) was being scaled down and rendered blurry in CR150 on brave://settings/search and brave://settings/searchEngines.

Fixes brave/brave-browser#56564