### PR TITLE
feat(linux): add 'New Private Window with Tor' desktop action

### DIFF
--- a/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.html
+++ b/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.html
@@ -17,6 +17,7 @@
     --site-favicon-border-radius: 4px;
     --site-favicon-height: var(--favicon-size);
     --site-favicon-width: var(--favicon-size);
+    image-rendering: -webkit-optimize-contrast;
   }
 
   settings-private-search-engine-list-dialog {

--- a/browser/resources/settings/brave_search_engines_page/normal_search_engine_list_dialog.html
+++ b/browser/resources/settings/brave_search_engines_page/normal_search_engine_list_dialog.html
@@ -47,6 +47,7 @@
     --site-favicon-border-radius: 4px;
     --site-favicon-height: var(--icon-size);
     --site-favicon-width: var(--icon-size);
+    image-rendering: -webkit-optimize-contrast;
   }
 
   #setAsDefaultButton {

--- a/browser/resources/settings/brave_search_engines_page/private_search_engine_list_dialog.html
+++ b/browser/resources/settings/brave_search_engines_page/private_search_engine_list_dialog.html
@@ -47,6 +47,7 @@
     --site-favicon-border-radius: 4px;
     --site-favicon-height: var(--icon-size);
     --site-favicon-width: var(--icon-size);
+    image-rendering: -webkit-optimize-contrast;
   }
 
   #setAsDefaultButton {

--- a/patches/chrome-installer-linux-common-desktop.template-tor.patch
+++ b/patches/chrome-installer-linux-common-desktop.template-tor.patch
@@ -1,0 +1,18 @@
+diff --git a/chrome/installer/linux/common/desktop.template b/chrome/installer/linux/common/desktop.template
+index 9322d65c5be2eeb9d8c692a45ec0cdb64db7689c..b5435847db7883260857f87b2f1b3d0696d194f8 100644
+--- a/chrome/installer/linux/common/desktop.template
++++ b/chrome/installer/linux/common/desktop.template
+@@ -113,7 +113,7 @@ Type=Application
+ Categories=Network;WebBrowser;
+ MimeType=application/pdf;application/rdf+xml;application/rss+xml;application/xhtml+xml;application/xhtml_xml;application/xml;image/gif;image/jpeg;image/png;image/webp;text/html;text/xml;x-scheme-handler/http;x-scheme-handler/https;@@uri_scheme
+-Actions=new-window;new-private-window;
++Actions=new-window;new-private-window;new-tor-window;
+ @@extra_desktop_entries
+ 
+ [Desktop Action new-window]
+@@ -221,3 +221,6 @@ Name[zh_CN]=新建隐身窗口
+ Name[zh_TW]=新增無痕式視窗
+ Exec=/usr/bin/@@usr_bin_symlink_name --incognito
++[Desktop Action new-tor-window]
++Name=New Private Window with Tor
++Exec=/usr/bin/@@usr_bin_symlink_name --tor

--- a/patches/chrome-installer-linux-common-desktop.template.patch
+++ b/patches/chrome-installer-linux-common-desktop.template.patch
@@ -1,0 +1,22 @@
+diff --git a/chrome/installer/linux/common/desktop.template b/chrome/installer/linux/common/desktop.template
+index 0000000000000000000000000000000000000000..0000000000000000000000000000000000000000 100644
+--- a/chrome/installer/linux/common/desktop.template
++++ b/chrome/installer/linux/common/desktop.template
+@@ -171,7 +171,7 @@ Name[zh_TW]=開新視窗
+ Exec=/usr/bin/@@usr_bin_symlink_name
+ 
+ [Desktop Action new-private-window]
+-Name=New Incognito Window
++Name=New Private Window
+ Name[ar]=نافذة جديدة للتصفح المتخفي
+ Name[bg]=Нов прозорец „инкогнито“
+ Name[bn]=নতুন ছদ্মবেশী উইন্ডো
+@@ -180,7 +180,7 @@ Name[cs]=Nové anonymní okno
+ Name[da]=Nyt inkognitovindue
+ Name[de]=Neues Inkognito-Fenster
+ Name[el]=Νέο παράθυρο για ανώνυμη περιήγηση
+-Name[en_GB]=New Incognito window
++Name[en_GB]=New Private window
+ Name[es]=Nueva ventana de incógnito
+ Name[et]=Uus inkognito aken
+ Name[fa]=پنجره جدید حالت ناشناس


### PR DESCRIPTION
Adds a new [Desktop Action new-tor-window] entry to the Linux .desktop template so users can open a Tor window directly from the icon context menu. Uses the existing --tor command line switch.

Fixes brave/brave-browser#41606