### PR TITLE
Disabled Extensions manifest V2 deprecation.

### DIFF
--- a/chromium_src/extensions/browser/mv2_deprecation_impact_checker.cc
+++ b/chromium_src/extensions/browser/mv2_deprecation_impact_checker.cc
@@ -37,8 +37,12 @@ std::string BuildBraveMV2ExceptionList() {
   extensions_features::kExtensionManifestV2ExceptionListParam
 
 // We want to extend support for all MV2 extensions until August 31, 2026.
-// This forces IsExtensionAffected(...) to return false.
-#define IsComponentLocation(...) IsComponentLocation(__VA_ARGS__) || true
+// This forces IsExtensionAffected(...) to return false for all extensions
+// excluding those that have a Brave-hosted version.
+// Tracking: https://github.com/brave/brave-browser/issues/57050
+#define IsComponentLocation(...)      \
+  IsComponentLocation(__VA_ARGS__) || \
+      !extensions_mv2::IsKnownWebStoreHostedExtension(extension_id)
 
 #include <extensions/browser/mv2_deprecation_impact_checker.cc>
 

--- a/chromium_src/extensions/browser/mv2_deprecation_impact_checker.cc
+++ b/chromium_src/extensions/browser/mv2_deprecation_impact_checker.cc
@@ -12,6 +12,7 @@
 #include "extensions/common/extension_features.h"
 #include "extensions/common/extension_id.h"
 #include "extensions/common/hashed_extension_id.h"
+#include "extensions/common/manifest.h"
 
 namespace {
 
@@ -35,6 +36,11 @@ std::string BuildBraveMV2ExceptionList() {
       BuildBraveMV2ExceptionList();                    \
   extensions_features::kExtensionManifestV2ExceptionListParam
 
+// We want to extend support for all MV2 extensions until August 31, 2026.
+// This forces IsExtensionAffected(...) to return false.
+#define IsComponentLocation(...) IsComponentLocation(__VA_ARGS__) || true
+
 #include <extensions/browser/mv2_deprecation_impact_checker.cc>
 
 #undef kExtensionManifestV2ExceptionListParam
+#undef IsComponentLocation

--- a/test/filters/unit_tests.filter
+++ b/test/filters/unit_tests.filter
@@ -733,6 +733,15 @@
 -TabStripPrefsTest.MigrateTabSearchPref_ExperimentEnabled_Pinned
 -TabStripPrefsTest.MigrateTabSearchPref_ExperimentEnabled_Unpinned
 
+# These tests are related to MV2 extension deprecation, which is disabled until 
+# MV2 extensions are removed from the Web Store.
+-ManifestV2ExperimentManagerDisableWithReEnableAndPolicyUnitTest.*
+-ExtensionInstallStatusTestWithMV2Deprecation.*
+-ManifestV2ExperimentManagerUnsupportedUnitTest.*
+-MV2DeprecationImpactCheckerUnitTest.*
+-ManifestV2ExperimentManagerDisableWithReEnableUnitTest.*
+-MV2DeprecationImpactCheckerUnitTestWithAllowlist.*
+
 # Tests below this point have not been diagnosed or had issues created yet.
 -AboutFlagsHistogramTest.*
 -AboutFlagsTest.EveryFlagHasMetadata


### PR DESCRIPTION
Do not deprecate Manifest V2 extensions while they are still available on the Web Store (as of August 31, 2026).

Resolves https://github.com/brave/brave-browser/issues/57155

Test:

0. Open brave://extensions and switch to developer mode.
1. Install any mv2 extension, e.g. [AdNauseam](https://github.com/dhowe/AdNauseam/wiki/Install-AdNauseam-on-Chromium-browsers#install-adnauseam)
2. Check the extension is installed
3. Relaunch the browser, check the extension is still enabled

4. https://github.com/brave/brave-core/pull/37500 known mv2 extensions should be replaced with brave-hosted versions