### PR TITLE
Generate .brave_gclient with required vars on each sync.

### DIFF
--- a/.brave_gclient
+++ b/.brave_gclient
@@ -1,8 +1,0 @@
-solutions = [
-  {
-    "managed": False,
-    "name": ".",
-    # We do not use gclient to manage brave-core, so this not actually get used.
-    "url": "https://github.com/brave/brave-core.git"
-  }
-]

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ vendor/web-discovery-project
 vendor/depot_tools
 vendor/omaha/
 .DS_Store
-.brave_gclient_*
+.brave_gclient*
 .gclient_*
 .tags*
 .cipd

--- a/build/commands/lib/syncUtils.js
+++ b/build/commands/lib/syncUtils.js
@@ -63,10 +63,33 @@ function writeGclientConfig(
       // actually get used.
       url: 'https://github.com/brave/brave-core.git',
     })
+
+    const braveGclientConfig = {
+      solutions: [
+        {
+          managed: false,
+          name: '.',
+          url: 'https://github.com/brave/brave-core.git',
+        },
+      ],
+      cache_dir: config.gitCachePath,
+      target_os: targetOSList,
+      target_cpu: targetArchList,
+      ...config.gclientGlobalVars,
+    }
+
+    writeGclientConfigFile(
+      braveGclientConfig,
+      path.join(config.braveCoreDir, '.brave_gclient'),
+      '# Auto-updated on each sync.\n\n',
+    )
   }
 
   // Generate the gclient config file.
-  let out = `# Auto-updated on each sync.
+  writeGclientConfigFile(
+    gclientConfig,
+    config.gclientFile,
+    `# Auto-updated on each sync.
 #
 # Customize via brave/.env:
 #   - projects_chrome_custom_deps: Override chromium solution's custom_deps
@@ -88,7 +111,12 @@ function writeGclientConfig(
 #
 # Note: target_os and target_cpu persist unless set via CLI.
 
-`
+`,
+  )
+}
+
+function writeGclientConfigFile(gclientConfig, filePath, header) {
+  let out = header
   for (const [key, value] of Object.entries(gclientConfig)) {
     const singleLineValue = toGClientConfigItem(key, value, false)
     if (singleLineValue.length > 80) {
@@ -98,8 +126,8 @@ function writeGclientConfig(
     }
   }
 
-  if (util.writeFileIfModified(config.gclientFile, out)) {
-    Log.status(`${config.gclientFile} has been updated`)
+  if (util.writeFileIfModified(filePath, out)) {
+    Log.status(`${filePath} has been updated`)
   }
 }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
When running `npm run sync` without chromium sync, we run `gclient` with `.brave_gclient` file to scope DEPS and hooks only to brave-core part. The problem: `cache_dir` and `target_os/cpu` vars are not set in this file, which leads to git cache being unset and target-scoped hooks/deps ignoring the actual configuration.

This file needs to contain same global vars from the root `.gclient` to work correctly. 

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
