### PR TITLE
chore(ci): Add `ai_chat_shared_conversation_lib` CI feature

### DIFF
--- a/build/.ci_features
+++ b/build/.ci_features
@@ -11,3 +11,5 @@ cache_dir
 
 # Supports passing extra GN args to the build via .env file.
 env_gn_args
+
+ai_chat_shared_conversation_lib


### PR DESCRIPTION
Complementary to #37315

In order to simplify CI config and avoid `package.json` parsing, let's add a new CI feature flag to follow the existing convention.