### PR TITLE
[plaster] Use `mmap` for hashing

### DIFF
--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -10,6 +10,7 @@ import argparse
 from dataclasses import dataclass, field
 import hashlib
 import logging
+import mmap
 from pathlib import Path, PurePath
 import json
 import os
@@ -55,13 +56,17 @@ class PathChecksumPair:
         self.checksum = self.calculate_file_checksum()
 
     def calculate_file_checksum(self) -> str | None:
-        """Calculate the SHA-256 checksum of the file's current content."""
+        """Calculate the SHA-256 checksum of the file's raw bytes.
+        """
         if not self.path.exists():
             return None
         checksum_generator = hashlib.sha256()
-        with self.path.open('r', encoding='utf-8') as file:
-            for chunk in iter(lambda: file.read(4096), ""):
-                checksum_generator.update(chunk.encode())
+        with self.path.open('rb') as file:
+            if os.fstat(file.fileno()).st_size == 0:
+                return checksum_generator.hexdigest()
+            with mmap.mmap(file.fileno(), 0,
+                           access=mmap.ACCESS_READ) as mapped:
+                checksum_generator.update(mapped)
         return checksum_generator.hexdigest()
 
     def save_if_changed(self, new_content: str, dry_run: bool = False) -> bool:

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -150,6 +150,35 @@ class PlasterTest(unittest.TestCase):
         self.assertEqual(temp_file.read_text(), 'bar')
         temp_file.unlink()
 
+    def test_checksum_hashes_raw_bytes_without_newline_normalization(self):
+        # The checksum must be over the file's raw bytes so it matches
+        # build/commands/lib/calculateFileChecksum.js, which apply_patches uses
+        # to validate .patchinfo entries. A text-mode read would fold CRLF into
+        # LF and diverge for files with Windows line endings.
+        temp_file = plaster.PLASTER_FILES_PATH / 'temp_crlf_checksum.txt'
+        content = b'line one\r\nline two\r\n'
+        temp_file.write_bytes(content)
+        try:
+            pair = plaster.PathChecksumPair(temp_file)
+            self.assertEqual(pair.checksum,
+                             hashlib.sha256(content).hexdigest())
+            # An LF-normalized digest (what a text-mode read produced) must not
+            # match, confirming the CRLF bytes are preserved.
+            self.assertNotEqual(
+                pair.checksum,
+                hashlib.sha256(content.replace(b'\r\n', b'\n')).hexdigest())
+        finally:
+            temp_file.unlink()
+
+    def test_checksum_of_empty_file(self):
+        temp_file = plaster.PLASTER_FILES_PATH / 'temp_empty_checksum.txt'
+        temp_file.write_bytes(b'')
+        try:
+            pair = plaster.PathChecksumPair(temp_file)
+            self.assertEqual(pair.checksum, hashlib.sha256(b'').hexdigest())
+        finally:
+            temp_file.unlink()
+
     def test_yaml_plaster_applies(self):
         """A .yaml plaster applies its substitutions and emits patch files."""
         test_file_chromium = Path(


### PR DESCRIPTION
This PR changes how we are hashing our `.patchinfo` data in `plaster`,
to use `mmap`. This also corrects the inconsistent line ending
normalation that was occurring in this hashing.

Bug: https://github.com/brave/brave-browser/issues/57027
