### PR TITLE
[Android] Fix Server region VPN screen layout broken after rotation on tablets (uplift to 1.93.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/vpn/activities/BraveVpnParentActivity.java
+++ b/android/java/org/chromium/chrome/browser/vpn/activities/BraveVpnParentActivity.java
@@ -8,6 +8,7 @@
 package org.chromium.chrome.browser.vpn.activities;
 
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.os.Handler;
 import android.util.Pair;
 
@@ -94,6 +95,20 @@ public abstract class BraveVpnParentActivity extends AsyncInitializationActivity
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
         if (hasFocus && shouldApplyLandscapeWindowSizing()) {
+            BraveLandscapeHelper.applyLandscapeWindowSizing(this);
+        }
+    }
+
+    @Override
+    public void performOnConfigurationChanged(Configuration newConfig) {
+        super.performOnConfigurationChanged(newConfig);
+        // Activities such as VpnServerSelectionActivity and VpnServerActivity declare
+        // configChanges in the manifest, so an orientation change does not recreate them and does
+        // not trigger onWindowFocusChanged. Without this, the landscape side padding applied by
+        // BraveLandscapeHelper persists after rotating landscape->portrait, squeezing the content
+        // into a narrow column. Re-apply the sizing for the new orientation; the display metrics
+        // are already updated for it by the time performOnConfigurationChanged runs.
+        if (shouldApplyLandscapeWindowSizing()) {
             BraveLandscapeHelper.applyLandscapeWindowSizing(this);
         }
     }


### PR DESCRIPTION
Uplift of #37858
Resolves https://github.com/brave/brave-browser/issues/56965

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.