### PR TITLE
[iOS] Migrate default wallet preferences to wallet service preferences

### DIFF
--- a/ios/BUILD.gn
+++ b/ios/BUILD.gn
@@ -97,6 +97,7 @@ brave_core_public_headers = [
   "//brave/ios/browser/brave_news/brave_news_pref_names_bridge.h",
   "//brave/ios/browser/brave_vpn/brave_vpn_pref_names_bridge.h",
   "//brave/ios/browser/brave_wallet/brave_wallet_factory_wrappers.h",
+  "//brave/ios/browser/brave_wallet/wallet_pref_names_bridge.h",
   "//brave/ios/browser/skus/skus_sdk_factory_wrappers.h",
   "//brave/ios/browser/playlist/playlist_exclusions_bridge.h",
   "//brave/ios/browser/playlist/playlist_exclusions_factory.h",

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -503,6 +503,12 @@ public class BrowserViewController: UIViewController {
         tabManager.reloadSelectedTab()
       }
     }
+    prefsChangeRegistrar.addObserver(forPath: kDefaultEthereumWallet) { [weak self] _ in
+      self?.defaultWalletChanged(for: .eth)
+    }
+    prefsChangeRegistrar.addObserver(forPath: kDefaultSolanaWallet) { [weak self] _ in
+      self?.defaultWalletChanged(for: .sol)
+    }
 
     disconnectVPNIfDisabledByPolicy()
 
@@ -531,8 +537,6 @@ public class BrowserViewController: UIViewController {
     }
     Preferences.PrivacyReports.captureShieldsData.observe(from: self)
     Preferences.PrivacyReports.captureVPNAlerts.observe(from: self)
-    Preferences.Wallet.defaultEthWallet.observe(from: self)
-    Preferences.Wallet.defaultSolWallet.observe(from: self)
 
     if rewards.rewardsAPI != nil {
       // Ledger was started immediately due to user having ads enabled
@@ -2466,6 +2470,25 @@ extension BrowserViewController: WalletTabHelperDelegate {
     notificationsPresenter.removeNotification(with: WalletNotification.Constant.id)
   }
 
+  /// Responds to a change in the default wallet used to communicate with web3
+  /// for the given `coin`, cancelling any pending web3 requests and refreshing
+  /// the injected provider scripts.
+  private func defaultWalletChanged(for coin: BraveWallet.CoinType) {
+    tabManager.reset()
+    tabManager.reloadSelectedTab()
+    removeWalletNotificationAndClearOrigin()
+    WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests(for: [coin])
+    WalletProviderAccountCreationRequestManager.shared.cancelAllPendingRequests(coins: [coin])
+    let privateMode = privateBrowsingManager.isPrivateBrowsing
+    if let cryptoStore = CryptoStore.from(
+      ipfsApi: profileController.ipfsAPI,
+      privateMode: privateMode
+    ) {
+      cryptoStore.rejectAllPendingWebpageRequests()
+    }
+    updateURLBarWalletButton()
+  }
+
   /// Dismisses the wallet notification if it was shown for a different origin than the committed one (e.g. after redirect).
   func dismissWalletNotificationIfOriginDiffers(from committedOrigin: URLOrigin) {
     guard
@@ -2925,34 +2948,6 @@ extension BrowserViewController: PreferencesObserver {
       }
     case Preferences.PrivacyReports.captureVPNAlerts.key:
       PrivacyReportsManager.scheduleVPNAlertsTask()
-    case Preferences.Wallet.defaultEthWallet.key:
-      tabManager.reset()
-      tabManager.reloadSelectedTab()
-      removeWalletNotificationAndClearOrigin()
-      WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests(for: [.eth])
-      WalletProviderAccountCreationRequestManager.shared.cancelAllPendingRequests(coins: [.eth])
-      let privateMode = privateBrowsingManager.isPrivateBrowsing
-      if let cryptoStore = CryptoStore.from(
-        ipfsApi: profileController.ipfsAPI,
-        privateMode: privateMode
-      ) {
-        cryptoStore.rejectAllPendingWebpageRequests()
-      }
-      updateURLBarWalletButton()
-    case Preferences.Wallet.defaultSolWallet.key:
-      tabManager.reset()
-      tabManager.reloadSelectedTab()
-      removeWalletNotificationAndClearOrigin()
-      WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests(for: [.sol])
-      WalletProviderAccountCreationRequestManager.shared.cancelAllPendingRequests(coins: [.sol])
-      let privateMode = privateBrowsingManager.isPrivateBrowsing
-      if let cryptoStore = CryptoStore.from(
-        ipfsApi: profileController.ipfsAPI,
-        privateMode: privateMode
-      ) {
-        cryptoStore.rejectAllPendingWebpageRequests()
-      }
-      updateURLBarWalletButton()
     case Preferences.NewTabPage.backgroundMediaTypeRaw.key:
       recordAdsUsageType()
     case Preferences.Privacy.screenTimeEnabled.key:

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/WalletTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/WalletTabHelper.swift
@@ -316,7 +316,8 @@ extension WalletTabHelper: BraveWalletProviderDelegate {
 extension WalletTabHelper: BraveWalletEventsListener {
   func emitEthereumEvent(_ event: Web3ProviderEvent) {
     guard let tab, !tab.isPrivate,
-      Preferences.Wallet.defaultEthWallet.value == Preferences.Wallet.WalletType.brave.rawValue,
+      tab.profile.prefs.integer(forPath: kDefaultEthereumWallet)
+        != BraveWallet.DefaultWallet.none.rawValue,
       tab.isWebViewCreated
     else {
       return
@@ -369,7 +370,8 @@ extension WalletTabHelper: BraveWalletEventsListener {
   func updateEthereumProperties() async {
     guard let tab, !tab.isPrivate,
       let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: false),
-      Preferences.Wallet.defaultEthWallet.value == Preferences.Wallet.WalletType.brave.rawValue
+      tab.profile.prefs.integer(forPath: kDefaultEthereumWallet)
+        != BraveWallet.DefaultWallet.none.rawValue
     else {
       return
     }
@@ -471,7 +473,8 @@ extension WalletTabHelper: BraveWalletSolanaEventsListener {
 
   func emitSolanaEvent(_ event: Web3ProviderEvent) {
     guard let tab, tab.isWebViewCreated,
-      Preferences.Wallet.defaultSolWallet.value == Preferences.Wallet.WalletType.brave.rawValue
+      tab.profile.prefs.integer(forPath: kDefaultSolanaWallet)
+        != BraveWallet.DefaultWallet.none.rawValue
     else {
       return
     }
@@ -490,7 +493,8 @@ extension WalletTabHelper: BraveWalletSolanaEventsListener {
 
   @MainActor func updateSolanaProperties() async {
     guard let tab,
-      Preferences.Wallet.defaultSolWallet.value == Preferences.Wallet.WalletType.brave.rawValue,
+      tab.profile.prefs.integer(forPath: kDefaultSolanaWallet)
+        != BraveWallet.DefaultWallet.none.rawValue,
       tab.isWebViewCreated,
       let provider = walletSolProvider
     else {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/UserScriptManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/UserScriptManager.swift
@@ -366,9 +366,18 @@ class UserScriptManager {
       // TODO: Somehow refactor wallet and get rid of this
       // Inject WALLET specific scripts
 
+      // A default wallet other than `none` means the Brave Wallet provider
+      // should be injected to communicate with web3.
+      let prefs = tab.profile.prefs
+      let isEthProviderEnabled =
+        prefs.integer(forPath: kDefaultEthereumWallet) != BraveWallet.DefaultWallet.none.rawValue
+      let isSolProviderEnabled =
+        prefs.integer(forPath: kDefaultSolanaWallet) != BraveWallet.DefaultWallet.none.rawValue
+      let isCardanoProviderEnabled =
+        prefs.integer(forPath: kDefaultCardanoWallet) != BraveWallet.DefaultWallet.none.rawValue
+
       if !tab.isPrivate,
-        Preferences.Wallet.WalletType(rawValue: Preferences.Wallet.defaultEthWallet.value)
-          == .brave,
+        isEthProviderEnabled,
         let script = self.dynamicScripts[.ethereumProvider]
       {
 
@@ -382,8 +391,7 @@ class UserScriptManager {
 
       // Inject SolanaWeb3Script.js
       if !tab.isPrivate,
-        Preferences.Wallet.WalletType(rawValue: Preferences.Wallet.defaultSolWallet.value)
-          == .brave,
+        isSolProviderEnabled,
         let solanaWeb3Script = Preferences.UserScript.solanaProvider.value
           ? self.walletSolanaWeb3Script : nil
       {
@@ -391,8 +399,7 @@ class UserScriptManager {
       }
 
       if !tab.isPrivate,
-        Preferences.Wallet.WalletType(rawValue: Preferences.Wallet.defaultSolWallet.value)
-          == .brave,
+        isSolProviderEnabled,
         let script = self.dynamicScripts[.solanaProvider]
       {
 
@@ -414,8 +421,7 @@ class UserScriptManager {
       // Inject Cardano provider script
       if WalletConstants.isCardanoDAppSupportEnabled,
         !tab.isPrivate,
-        Preferences.Wallet.WalletType(rawValue: Preferences.Wallet.defaultCardanoWallet.value)
-          == .brave,
+        isCardanoProviderEnabled,
         let script = self.dynamicScripts[.cardanoProvider]
       {
         scriptController.addUserScript(script)

--- a/ios/brave-ios/Sources/Brave/Migration/Migration.swift
+++ b/ios/brave-ios/Sources/Brave/Migration/Migration.swift
@@ -136,10 +136,6 @@ public class BraveProfileMigrations {
   }
 
   private func migrateDefaultWalletPreferences() {
-    guard let walletService = BraveWallet.ServiceFactory.get(profile: profileController.profile)
-    else {
-      return
-    }
     // iOS only ever exposed `none` and `brave` (`WalletType`) as options, which
     // map onto the `DefaultWallet` values stored in the `PrefService`.
     func defaultWallet(from value: Int) -> BraveWallet.DefaultWallet {
@@ -147,13 +143,22 @@ public class BraveProfileMigrations {
         ? .none : .braveWallet
     }
     Preferences.DeprecatedPreferences.defaultEthWallet.migrate { value in
-      walletService.setDefaultEthereumWallet(defaultWallet: defaultWallet(from: value))
+      profileController.profile.prefs.set(
+        defaultWallet(from: value).rawValue,
+        forPath: kDefaultEthereumWallet
+      )
     }
     Preferences.DeprecatedPreferences.defaultSolWallet.migrate { value in
-      walletService.setDefaultSolanaWallet(defaultWallet: defaultWallet(from: value))
+      profileController.profile.prefs.set(
+        defaultWallet(from: value).rawValue,
+        forPath: kDefaultSolanaWallet
+      )
     }
     Preferences.DeprecatedPreferences.defaultCardanoWallet.migrate { value in
-      walletService.setDefaultCardanoWallet(defaultWallet: defaultWallet(from: value))
+      profileController.profile.prefs.set(
+        defaultWallet(from: value).rawValue,
+        forPath: kDefaultCardanoWallet
+      )
     }
   }
 }

--- a/ios/brave-ios/Sources/Brave/Migration/Migration.swift
+++ b/ios/brave-ios/Sources/Brave/Migration/Migration.swift
@@ -31,6 +31,7 @@ public class BraveProfileMigrations {
     migrateGPCPreference()
     migrateMediaBackgroundingPreference()
     migrateBlockAllCookiesPreference()
+    migrateDefaultWalletPreferences()
   }
 
   private func migrateDefaultUserAgentPreferences() {
@@ -131,6 +132,28 @@ public class BraveProfileMigrations {
   private func migrateBlockAllCookiesPreference() {
     Preferences.DeprecatedPreferences.blockAllCookies.migrate { value in
       profileController.profile.prefs.set(value, forPath: kBlockAllCookiesEnabled)
+    }
+  }
+
+  private func migrateDefaultWalletPreferences() {
+    guard let walletService = BraveWallet.ServiceFactory.get(profile: profileController.profile)
+    else {
+      return
+    }
+    // iOS only ever exposed `none` and `brave` (`WalletType`) as options, which
+    // map onto the `DefaultWallet` values stored in the `PrefService`.
+    func defaultWallet(from value: Int) -> BraveWallet.DefaultWallet {
+      value == Preferences.DeprecatedPreferences.DeprecatedWalletType.none.rawValue
+        ? .none : .braveWallet
+    }
+    Preferences.DeprecatedPreferences.defaultEthWallet.migrate { value in
+      walletService.setDefaultEthereumWallet(defaultWallet: defaultWallet(from: value))
+    }
+    Preferences.DeprecatedPreferences.defaultSolWallet.migrate { value in
+      walletService.setDefaultSolanaWallet(defaultWallet: defaultWallet(from: value))
+    }
+    Preferences.DeprecatedPreferences.defaultCardanoWallet.migrate { value in
+      walletService.setDefaultCardanoWallet(defaultWallet: defaultWallet(from: value))
     }
   }
 }
@@ -383,6 +406,32 @@ extension Preferences {
     static let blockAllCookies = Option<Bool>(
       key: "privacy.block-all-cookies",
       default: false
+    )
+
+    enum DeprecatedWalletType: Int, CaseIterable {
+      case none
+      case brave
+    }
+
+    /// The default wallet to use for Ethereum to communicate with web3.
+    /// Superseded by `kDefaultEthereumWallet` in the profile `PrefService`.
+    static let defaultEthWallet = Option<Int>(
+      key: "wallet.default-wallet",
+      default: DeprecatedWalletType.brave.rawValue
+    )
+
+    /// The default wallet to use for Solana to communicate with web3.
+    /// Superseded by `kDefaultSolanaWallet` in the profile `PrefService`.
+    static let defaultSolWallet = Option<Int>(
+      key: "wallet.default-sol-wallet",
+      default: DeprecatedWalletType.brave.rawValue
+    )
+
+    /// The default wallet to use for Cardano to communicate with web3.
+    /// Superseded by `kDefaultCardanoWallet` in the profile `PrefService`.
+    static let defaultCardanoWallet = Option<Int>(
+      key: "wallet.default-cardano-wallet",
+      default: DeprecatedWalletType.brave.rawValue
     )
   }
 

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -240,10 +240,16 @@ struct AccountActivityView: View {
           destination: {
             DappsSettings(
               coin: store.account.coin,
+              settingsStore: cryptoStore.settingsStore,
               siteConnectionStore: cryptoStore.settingsStore.manageSiteConnectionsStore(
                 keyringStore: keyringStore
               )
             )
+            .onAppear {
+              // Load the settings values (e.g. default wallet) since this
+              // `SettingsStore` is not otherwise set up outside of Web3 settings.
+              cryptoStore.settingsStore.setup()
+            }
           },
           label: {
             RowView(

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -76,6 +76,30 @@ public class SettingsStore: ObservableObject, WalletObserverStore {
     }
   }
 
+  /// The default wallet used to communicate with web3 for Ethereum
+  @Published var defaultEthWallet: BraveWallet.DefaultWallet = .braveWallet {
+    didSet {
+      guard oldValue != defaultEthWallet else { return }
+      walletService.setDefaultEthereumWallet(defaultWallet: defaultEthWallet)
+    }
+  }
+
+  /// The default wallet used to communicate with web3 for Solana
+  @Published var defaultSolWallet: BraveWallet.DefaultWallet = .braveWallet {
+    didSet {
+      guard oldValue != defaultSolWallet else { return }
+      walletService.setDefaultSolanaWallet(defaultWallet: defaultSolWallet)
+    }
+  }
+
+  /// The default wallet used to communicate with web3 for Cardano
+  @Published var defaultCardanoWallet: BraveWallet.DefaultWallet = .braveWallet {
+    didSet {
+      guard oldValue != defaultCardanoWallet else { return }
+      walletService.setDefaultCardanoWallet(defaultWallet: defaultCardanoWallet)
+    }
+  }
+
   private let keyringService: BraveWalletKeyringService
   private let walletService: BraveWalletBraveWalletService
   private let rpcService: BraveWalletJsonRpcService
@@ -123,6 +147,15 @@ public class SettingsStore: ObservableObject, WalletObserverStore {
     )
     self.walletServiceObserver = WalletServiceObserver(
       walletService: walletService,
+      _onDefaultEthereumWalletChanged: { [weak self] wallet in
+        self?.defaultEthWallet = wallet
+      },
+      _onDefaultSolanaWalletChanged: { [weak self] wallet in
+        self?.defaultSolWallet = wallet
+      },
+      _onDefaultCardanoWalletChanged: { [weak self] wallet in
+        self?.defaultCardanoWallet = wallet
+      },
       _onDefaultBaseCurrencyChanged: { [weak self] currency in
         self?.currencyCode = CurrencyCode(code: currency)
       }
@@ -144,6 +177,10 @@ public class SettingsStore: ObservableObject, WalletObserverStore {
 
       self.isNFTDiscoveryEnabled = await walletService.nftDiscoveryEnabled()
       self.isBiometricsUnlockEnabled = isPasswordStoredInKeychain && isBiometricsAvailable
+
+      self.defaultEthWallet = await walletService.defaultEthereumWallet()
+      self.defaultSolWallet = await walletService.defaultSolanaWallet()
+      self.defaultCardanoWallet = await walletService.defaultCardanoWallet()
     }
   }
 
@@ -155,6 +192,10 @@ public class SettingsStore: ObservableObject, WalletObserverStore {
       Domain.clearAllWalletPermissions(for: coin)
       Preferences.Wallet.reset(for: coin)
     }
+
+    defaultEthWallet = .braveWallet
+    defaultSolWallet = .braveWallet
+    defaultCardanoWallet = .braveWallet
 
     Preferences.Wallet.displayWeb3Notifications.reset()
     Preferences.Wallet.migrateCoreToWalletUserAssetCompleted.reset()

--- a/ios/brave-ios/Sources/BraveWallet/Settings/DappsSettings.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Settings/DappsSettings.swift
@@ -10,33 +10,69 @@ import SwiftUI
 
 struct DappsSettings: View {
   var coin: BraveWallet.CoinType
+  @ObservedObject var settingsStore: SettingsStore
   @ObservedObject var siteConnectionStore: ManageSiteConnectionsStore
-  @ObservedObject var defaultWallet: Preferences.Option<Int>
   @ObservedObject var allowProviderAccess: Preferences.Option<Bool>
   @State private var filterText: String = ""
   @State private var isShowingConfirmAlert: Bool = false
 
   init(
     coin: BraveWallet.CoinType,
+    settingsStore: SettingsStore,
     siteConnectionStore: ManageSiteConnectionsStore
   ) {
     self.coin = coin
+    self.settingsStore = settingsStore
     self.siteConnectionStore = siteConnectionStore
     switch coin {
     case .eth:
-      self.defaultWallet = Preferences.Wallet.defaultEthWallet
       self.allowProviderAccess = Preferences.Wallet.allowEthProviderAccess
     case .sol:
-      self.defaultWallet = Preferences.Wallet.defaultSolWallet
       self.allowProviderAccess = Preferences.Wallet.allowSolProviderAccess
     case .ada:
-      self.defaultWallet = Preferences.Wallet.defaultCardanoWallet
       self.allowProviderAccess = Preferences.Wallet.allowCardanoProviderAccess
     default:
       assertionFailure("Not supported coin type.")
-      self.defaultWallet = Preferences.Wallet.defaultEthWallet
       self.allowProviderAccess = Preferences.Wallet.allowEthProviderAccess
     }
+  }
+
+  private var defaultWallet: BraveWallet.DefaultWallet {
+    switch coin {
+    case .eth:
+      return settingsStore.defaultEthWallet
+    case .sol:
+      return settingsStore.defaultSolWallet
+    case .ada:
+      return settingsStore.defaultCardanoWallet
+    default:
+      return .braveWallet
+    }
+  }
+
+  /// Bridges the picker to the `DefaultWallet` value held by the `SettingsStore`.
+  /// iOS only exposes `none` and `brave` as options.
+  private var defaultWalletBinding: Binding<BraveWallet.DefaultWallet> {
+    Binding(
+      get: {
+        if defaultWallet == .braveWalletPreferExtension {
+          return .braveWallet
+        }
+        return defaultWallet
+      },
+      set: { newValue in
+        switch coin {
+        case .eth:
+          settingsStore.defaultEthWallet = newValue
+        case .sol:
+          settingsStore.defaultSolWallet = newValue
+        case .ada:
+          settingsStore.defaultCardanoWallet = newValue
+        default:
+          break
+        }
+      }
+    )
   }
 
   private var defaultWalletTitle: String {
@@ -75,29 +111,19 @@ struct DappsSettings: View {
         header: Text(Strings.Wallet.dappsSettingsGeneralSectionTitle)
           .foregroundColor(Color(braveSystemName: .textSecondary))
       ) {
-        Group {
-          HStack {
-            Text(defaultWalletTitle)
-              .foregroundColor(Color(braveSystemName: .textPrimary))
-            Spacer()
-            Menu {
-              Picker("", selection: $defaultWallet.value) {
-                ForEach(Preferences.Wallet.WalletType.allCases) { walletType in
-                  Text(walletType.name)
-                    .tag(walletType)
-                }
-              }
-              .pickerStyle(.inline)
-            } label: {
-              let wallet = Preferences.Wallet.WalletType(rawValue: defaultWallet.value) ?? .none
-              Text(wallet.name)
-                .foregroundColor(Color(braveSystemName: .textInteractive))
-            }
-          }
-          Toggle(allowProviderAccessTitle, isOn: $allowProviderAccess.value)
+        Picker(selection: defaultWalletBinding) {
+          Text(Strings.Wallet.walletTypeNone)
+            .tag(BraveWallet.DefaultWallet.none)
+          Text(Strings.Wallet.braveWallet)
+            .tag(BraveWallet.DefaultWallet.braveWallet)
+        } label: {
+          Text(defaultWalletTitle)
             .foregroundColor(Color(braveSystemName: .textPrimary))
-            .tint(Color(braveSystemName: .primitivePrimary40))
         }
+        .pickerStyle(.menu)
+        Toggle(allowProviderAccessTitle, isOn: $allowProviderAccess.value)
+          .foregroundColor(Color(braveSystemName: .textPrimary))
+          .tint(Color(braveSystemName: .primitivePrimary40))
       }
       Section(
         header: Text(Strings.Wallet.dappsSettingsConnectedSitesSectionTitle)

--- a/ios/brave-ios/Sources/BraveWallet/Settings/Web3SettingsView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Settings/Web3SettingsView.swift
@@ -209,6 +209,7 @@ private struct WalletSettingsView: View {
             destination:
               DappsSettings(
                 coin: coin,
+                settingsStore: settingsStore,
                 siteConnectionStore: settingsStore.manageSiteConnectionsStore(
                   keyringStore: keyringStore
                 )

--- a/ios/brave-ios/Sources/BraveWallet/WalletPreferences.swift
+++ b/ios/brave-ios/Sources/BraveWallet/WalletPreferences.swift
@@ -10,38 +10,6 @@ import struct Shared.Strings
 
 extension Preferences {
   public final class Wallet {
-    public enum WalletType: Int, Identifiable, CaseIterable {
-      case none
-      case brave
-
-      public var id: Int {
-        rawValue
-      }
-
-      public var name: String {
-        switch self {
-        case .none:
-          return Strings.Wallet.walletTypeNone
-        case .brave:
-          return Strings.Wallet.braveWallet
-        }
-      }
-    }
-    /// The default wallet to use for Ethereum to communicate with web3
-    public static let defaultEthWallet = Option<Int>(
-      key: "wallet.default-wallet",
-      default: WalletType.brave.rawValue
-    )
-    /// The default wallet to use for Solana to communicate with web3
-    public static let defaultSolWallet = Option<Int>(
-      key: "wallet.default-sol-wallet",
-      default: WalletType.brave.rawValue
-    )
-    /// The default wallet to use for Cardano to communicate with web3
-    public static let defaultCardanoWallet = Option<Int>(
-      key: "wallet.default-cardano-wallet",
-      default: WalletType.brave.rawValue
-    )
     /// Whether or not webpages can use the Ethereum Provider API to communicate with users Ethereum wallet
     public static let allowEthProviderAccess: Option<Bool> = .init(
       key: "wallet.allow-eth-provider-access",
@@ -113,13 +81,10 @@ extension Preferences {
     public static func reset(for coin: BraveWallet.CoinType) {
       switch coin {
       case .eth:
-        Preferences.Wallet.defaultEthWallet.reset()
         Preferences.Wallet.allowEthProviderAccess.reset()
       case .sol:
-        Preferences.Wallet.defaultSolWallet.reset()
         Preferences.Wallet.allowSolProviderAccess.reset()
       case .ada:
-        Preferences.Wallet.defaultCardanoWallet.reset()
         Preferences.Wallet.allowCardanoProviderAccess.reset()
       case .fil, .btc, .zec, .dot:
         // not supported

--- a/ios/brave-ios/Tests/BraveWalletTests/SettingsStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/SettingsStoreTests.swift
@@ -36,6 +36,12 @@ class SettingsStoreTests: XCTestCase {
     walletService._setDefaultBaseCurrency = { _ in }
     walletService._defaultBaseCurrency = { $0(CurrencyCode.usd.code) }  // default is USD
     walletService._nftDiscoveryEnabled = { _ in }
+    walletService._defaultEthereumWallet = { $0(.braveWallet) }
+    walletService._setDefaultEthereumWallet = { _ in }
+    walletService._defaultSolanaWallet = { $0(.braveWallet) }
+    walletService._setDefaultSolanaWallet = { _ in }
+    walletService._defaultCardanoWallet = { $0(.braveWallet) }
+    walletService._setDefaultCardanoWallet = { _ in }
 
     let rpcService = MockJsonRpcService()
     rpcService._ensResolveMethod = { $0(.ask) }
@@ -164,17 +170,12 @@ class SettingsStoreTests: XCTestCase {
       walletServiceResetCalled = true
     }
 
-    assert(
-      Preferences.Wallet.WalletType.none.rawValue
-        != Preferences.Wallet.defaultEthWallet.defaultValue,
-      "Test assumes default wallet for eth value is not `none`"
-    )
-    Preferences.Wallet.defaultEthWallet.value = Preferences.Wallet.WalletType.none.rawValue
-    XCTAssertEqual(
-      Preferences.Wallet.defaultEthWallet.value,
-      Preferences.Wallet.WalletType.none.rawValue,
-      "Failed to update default wallet for eth"
-    )
+    // Capture the default wallet values set on the wallet service during reset.
+    var defaultEthereumWallet: BraveWallet.DefaultWallet?
+    walletService._setDefaultEthereumWallet = { defaultEthereumWallet = $0 }
+    var defaultSolanaWallet: BraveWallet.DefaultWallet?
+    walletService._setDefaultSolanaWallet = { defaultSolanaWallet = $0 }
+
     Preferences.Wallet.allowEthProviderAccess.value = !Preferences.Wallet.allowEthProviderAccess
       .defaultValue
     XCTAssertEqual(
@@ -183,17 +184,6 @@ class SettingsStoreTests: XCTestCase {
       "Failed to update allow ethereum requests"
     )
 
-    assert(
-      Preferences.Wallet.WalletType.none.rawValue
-        != Preferences.Wallet.defaultSolWallet.defaultValue,
-      "Test assumes default wallet for sol value is not `none`"
-    )
-    Preferences.Wallet.defaultSolWallet.value = Preferences.Wallet.WalletType.none.rawValue
-    XCTAssertEqual(
-      Preferences.Wallet.defaultSolWallet.value,
-      Preferences.Wallet.WalletType.none.rawValue,
-      "Failed to update default wallet for sol"
-    )
     Preferences.Wallet.allowSolProviderAccess.value = !Preferences.Wallet.allowSolProviderAccess
       .defaultValue
     XCTAssertEqual(
@@ -221,6 +211,10 @@ class SettingsStoreTests: XCTestCase {
 
     sut.autoLockInterval = .minute
     sut.currencyCode = .cad
+    // Update the default wallets away from Brave Wallet so reset has to restore
+    // them.
+    sut.defaultEthWallet = .none
+    sut.defaultSolWallet = .none
 
     // reset internally in services, mock reset here.
     keyringServiceAutolockMinutes = 5
@@ -240,9 +234,9 @@ class SettingsStoreTests: XCTestCase {
       "WalletService reset() not called"
     )
     XCTAssertEqual(
-      Preferences.Wallet.defaultEthWallet.value,
-      Preferences.Wallet.defaultEthWallet.defaultValue,
-      "Default Wallet for eth was not reset to default"
+      defaultEthereumWallet,
+      .braveWallet,
+      "Default Wallet for eth was not reset to Brave Wallet"
     )
     XCTAssertEqual(
       Preferences.Wallet.allowEthProviderAccess.value,
@@ -250,9 +244,9 @@ class SettingsStoreTests: XCTestCase {
       "Allow ethereum requests was not reset to default"
     )
     XCTAssertEqual(
-      Preferences.Wallet.defaultSolWallet.value,
-      Preferences.Wallet.defaultSolWallet.defaultValue,
-      "Default Wallet for sol was not reset to default"
+      defaultSolanaWallet,
+      .braveWallet,
+      "Default Wallet for sol was not reset to Brave Wallet"
     )
     XCTAssertEqual(
       Preferences.Wallet.allowSolProviderAccess.value,

--- a/ios/browser/brave_wallet/BUILD.gn
+++ b/ios/browser/brave_wallet/BUILD.gn
@@ -15,6 +15,8 @@ source_set("brave_wallet") {
     "features.mm",
     "wallet_data_files_installer_delegate_impl.h",
     "wallet_data_files_installer_delegate_impl.mm",
+    "wallet_pref_names_bridge.h",
+    "wallet_pref_names_bridge.mm",
   ]
   deps = [
     "//base",

--- a/ios/browser/brave_wallet/wallet_pref_names_bridge.h
+++ b/ios/browser/brave_wallet/wallet_pref_names_bridge.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_BRAVE_WALLET_WALLET_PREF_NAMES_BRIDGE_H_
+#define BRAVE_IOS_BROWSER_BRAVE_WALLET_WALLET_PREF_NAMES_BRIDGE_H_
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+OBJC_EXPORT NSString* const kDefaultEthereumWallet;
+OBJC_EXPORT NSString* const kDefaultSolanaWallet;
+OBJC_EXPORT NSString* const kDefaultCardanoWallet;
+
+NS_ASSUME_NONNULL_END
+
+#endif  // BRAVE_IOS_BROWSER_BRAVE_WALLET_WALLET_PREF_NAMES_BRIDGE_H_

--- a/ios/browser/brave_wallet/wallet_pref_names_bridge.mm
+++ b/ios/browser/brave_wallet/wallet_pref_names_bridge.mm
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/brave_wallet/wallet_pref_names_bridge.h"
+
+#include "base/strings/sys_string_conversions.h"
+#include "brave/components/brave_wallet/browser/pref_names.h"
+
+NSString* const kDefaultEthereumWallet =
+    base::SysUTF8ToNSString(brave_wallet::kDefaultEthereumWallet);
+
+NSString* const kDefaultSolanaWallet =
+    base::SysUTF8ToNSString(brave_wallet::kDefaultSolanaWallet);
+
+NSString* const kDefaultCardanoWallet =
+    base::SysUTF8ToNSString(brave_wallet::kDefaultCardanoWallet);


### PR DESCRIPTION
This removes the custom `Preferences.Wallet.default{Eth/Sol/Cardano}Wallet` preferences and instead uses the preferences already registered in the component and migrates any user setting to that component preference.

Resolves https://github.com/brave/brave-browser/issues/57030

### Test
- Set the default ethereum wallet to none in an old build then upgrade, verify its still none
- Verify updating the preference refreshes the selected tab like normal
- Verify javascript providers are not injected when the preferences are none like normal 
