### PR TITLE
[recipes] `vpython3` provided on bootstrapping

### DIFF
--- a/tools/recipes/.vpython3
+++ b/tools/recipes/.vpython3
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# vpython VirtualEnv spec for the Brave recipes engine, modelled on
+# chrome-infra's recipes_py `.vpython3`.
+#
+# `engine_bootstrap.py` (and `engine.py`'s shebang) run the engine under
+# vpython3 with this spec, so the engine and the recipes it runs get a
+# hermetic interpreter with these wheels available -- notably protobuf, which
+# the engine will grow to depend on for typed properties.
+
+python_version: "3.11"
+
+wheel: <
+  name: "infra/python/wheels/protobuf-py3"
+  version: "version:6.32.1"
+>

--- a/tools/recipes/README.md
+++ b/tools/recipes/README.md
@@ -13,16 +13,12 @@ instantiates each _recipe module_, and runs the recipe's `RunSteps`.
 ## Usage
 
 ```sh
-python3 tools/recipes/engine.py toolchains/rust/package_rust \
+vpython3 tools/recipes/engine.py toolchains/rust/package_rust \
     --properties '{ "brave_subrevision": 2, "chromium_ref": "151.0.7917.1" }'
 ```
 
 The recipe name is a `/`-separated path under `recipes/`. `--properties` is a
-JSON object whose keys match the recipe's `PROPERTIES`. On-disk paths are not
-properties: recipes read them from the `path` module (`api.path.chromium_src`,
-`api.path.brave_core`, `api.path.out`), all derived from the job's workspace.
-Only the workspace is configurable, via `--workspace` (default: current
-directory).
+JSON object whose keys match the recipe's `PROPERTIES`.
 
 To run straight from a pipeline without a checkout, `engine_bootstrap.py`
 shallow-clones the engine from brave-core and forwards to `engine.py`:
@@ -33,6 +29,9 @@ curl -sL https://raw.githubusercontent.com/brave/brave-core/refs/heads/master/to
         --properties '{ "brave_subrevision": 2, "chromium_ref": "151.0.7917.1" }'
 ```
 
+The engine requires `vpython3` and the bootsrap will take care of these
+requirements.
+
 ## Testing
 
 Recipes and recipe modules are tested by _simulation_: a recipe declares
@@ -41,10 +40,10 @@ side effect mocked (no subprocess, no real filesystem or environment), and the
 recorded step stream is checked against a committed JSON _expectation_.
 
 ```sh
-python3 tools/recipes/engine.py test run      # compare against expectations
-python3 tools/recipes/engine.py test train    # (re)write expectations
-python3 tools/recipes/engine.py test list     # list all test case ids
-python3 tools/recipes/engine.py test run --filter package_rust
+vpython3 tools/recipes/engine.py test run      # compare against expectations
+vpython3 tools/recipes/engine.py test train    # (re)write expectations
+vpython3 tools/recipes/engine.py test list     # list all test case ids
+vpython3 tools/recipes/engine.py test run --filter package_rust
 ```
 
 Simulation is possible because the seam modules, such as `step`, `path`, `env`,

--- a/tools/recipes/engine.py
+++ b/tools/recipes/engine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env vpython3
 # Copyright (c) 2026 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,

--- a/tools/recipes/engine_bootstrap.py
+++ b/tools/recipes/engine_bootstrap.py
@@ -14,27 +14,21 @@ master/tools/recipes/engine_bootstrap.py \\
                            "brave_subrevision": 1,
                            "chromium_ref": "151.0.7917.1"}'
 
-That is equivalent to running, from a checkout:
+That is the bootstrapping equivalent to running, from a checkout:
 
     python3 tools/recipes/engine.py \\
         toolchains/rust/package_rust --properties ...
 
-It shallow-, sparse-clones brave-core's `tools/recipes/` tree into the recipe's
-`brave_core_dest` (default `brave_core`), then re-dispatches the original
-arguments to the checked-out `engine.py`. Because it clones into the *same*
-destination the `brave_core_shallow` recipe module uses, the recipe reuses this
-checkout (adding its own paths to it) instead of cloning brave-core a second
-time.
-
-This script is intentionally dependency-free (standard library only) so it can
-run via `curl ... | python3 -` on a bare machine.
+The bootstrap has to deploy a sparse checkout of brave-core's `tools/recipes/`
+to get the engine, and it has to deploy depot_tools if `vpython3` is not already
+on PATH, so it can run the engine.
 """
 
 from __future__ import annotations
 
 import argparse
-import json
 import logging
+import os
 from pathlib import Path
 import shutil
 import subprocess
@@ -45,12 +39,21 @@ import sys
 REPO_URL = 'git@github.com:brave/brave-core.git'
 BRAVE_CORE_REF = 'master'
 
-# Repo-relative path of the recipes engine tree, and the default checkout dir.
-# The default MUST match `recipes/toolchains/rust/package_rust.py`'s
-# `brave_core_dest` default (and the `brave_core_shallow` module) so the recipe
-# reuses this same checkout.
+# The relative path to the recipes engine in the bootstrapped checkout for it.
 RECIPES_PATH = 'tools/recipes'
-DEFAULT_BRAVE_CORE_DEST = 'brave_core'
+
+# The path relative to workspace where the shallow `brave-core` clone for the
+# bootstrap is deployed. This checkout is used exclusively for the engine.
+RECIPES_ENGINE_DEST = 'recipes_engine_bootstrap'
+
+# the vpython3 runtime.
+IS_WIN = sys.platform.startswith(('win', 'cygwin'))
+VPYTHON3 = 'vpython3' + ('.bat' if IS_WIN else '')
+VPYTHON_SPEC = '.vpython3'
+
+# The URL to clone depot_tools from if vpython3 is not found.
+DEPOT_TOOLS_URL = 'https://chromium.googlesource.com/chromium/tools/depot_tools'
+DEPOT_TOOLS_DEST = 'depot_tools_bootstrap'
 
 
 def _run(*cmd: str | Path, cwd: str | Path | None = None) -> None:
@@ -59,29 +62,11 @@ def _run(*cmd: str | Path, cwd: str | Path | None = None) -> None:
     subprocess.run([str(arg) for arg in cmd], cwd=cwd, check=True)
 
 
-def _brave_core_dest(properties_json: str) -> str:
-    """Read `brave_core_dest` from the --properties JSON, or the default.
-
-    The destination must agree with the recipe so both share one checkout. A
-    missing key or unparseable JSON falls back to the default; the engine
-    validates the properties for real once it runs.
-    """
-    try:
-        properties = json.loads(properties_json)
-    except json.JSONDecodeError:
-        return DEFAULT_BRAVE_CORE_DEST
-    if isinstance(properties, dict):
-        return properties.get('brave_core_dest') or DEFAULT_BRAVE_CORE_DEST
-    return DEFAULT_BRAVE_CORE_DEST
-
-
 def _deploy_recipes(dest: str | Path) -> Path:
     """Shallow-, sparse-clone brave-core's `tools/recipes/` into *dest*.
 
     *dest* is always wiped first so every run starts from a clean checkout --
-    no stale sparse state, and no partial clone left by a failed prior run. The
-    recipe then reuses this fresh checkout (the `brave_core_shallow` module
-    `sparse-checkout add`s its own paths, e.g. `tools/cr/toolchains`).
+    no stale sparse state, and no partial clone left by a failed prior run.
 
     Returns the path to the checked-out `engine.py`.
     """
@@ -99,31 +84,83 @@ def _deploy_recipes(dest: str | Path) -> Path:
     engine = dest / RECIPES_PATH / 'engine.py'
     if not engine.is_file():
         raise RuntimeError(f'engine not found after checkout: {engine}')
+    spec = engine.parent / VPYTHON_SPEC
+    if not spec.is_file():
+        raise RuntimeError(f'vpython spec not found after checkout: {spec}')
     return engine
+
+
+def _deploy_depot_tools(dest: str | Path) -> Path:
+    """Shallow-clone depot_tools into *dest* and return its directory.
+
+    An existing checkout that already has a `vpython3` is reused if found,
+    otherwise a fresh shallow clone is made.
+    """
+    dest = Path(dest).expanduser().resolve()
+    vpython3 = dest / VPYTHON3
+
+    if vpython3.is_file():
+        logging.info('Reusing existing depot_tools at %s', dest)
+        return dest
+
+    if dest.exists():
+        logging.info('Removing incomplete depot_tools at %s', dest)
+        shutil.rmtree(dest)
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    _run('git', 'clone', '--depth', '1', DEPOT_TOOLS_URL, dest)
+    if not vpython3.is_file():
+        raise RuntimeError(
+            f'vpython3 not found after depot_tools clone: {vpython3}')
+    return dest
+
+
+def _ensure_vpython3(depot_tools_dest: str | Path) -> str:
+    """Return a runnable `vpython3`, deploying depot_tools if none is found.
+
+    If no `vpython3` is found on PATH, a shallow clone of depot_tools is
+    and that clone is added to PATH.
+    """
+    if shutil.which(VPYTHON3):
+        return VPYTHON3
+
+    logging.info('%s not on PATH; deploying depot_tools', VPYTHON3)
+    depot_tools = _deploy_depot_tools(depot_tools_dest)
+    os.environ['PATH'] = os.pathsep.join(
+        [str(depot_tools), os.environ.get('PATH', '')])
+    return str(depot_tools / VPYTHON3)
 
 
 def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
 
-    # Peek at --properties to find the checkout destination, but forward the
-    # arguments to engine.py verbatim so the engine remains the source of truth
-    # for parsing and validation.
     parser = argparse.ArgumentParser(
         description='Bootstrap and run a Brave recipe from a shallow '
         'brave-core checkout.')
     parser.add_argument('recipe',
                         help='Recipe name (e.g. toolchains/rust/package_rust)')
-    parser.add_argument('--properties',
-                        default='{}',
-                        help='JSON object of recipe properties')
+    parser.add_argument(
+        '--workspace',
+        default=None,
+        help='Root directory the job runs in (forwarded to '
+        'engine.py); the bootstrap checkouts are deployed here')
     parser.add_argument('--verbose', action='store_true')
     args, _ = parser.parse_known_args(argv)
 
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
 
-    engine = _deploy_recipes(_brave_core_dest(args.properties))
+    # All boostrap checkouts are placed under workspace.
+    workspace = (Path(args.workspace).expanduser()
+                 if args.workspace else Path.cwd())
+    vpython3 = _ensure_vpython3(workspace / DEPOT_TOOLS_DEST)
+    engine = _deploy_recipes(workspace / RECIPES_ENGINE_DEST)
 
-    forwarded = [sys.executable, str(engine), *argv]
+    spec = engine.parent / VPYTHON_SPEC
+    forwarded = [
+        vpython3, '-vpython-spec',
+        str(spec), '-u',
+        str(engine), *argv
+    ]
     logging.info('Launching engine: %s', ' '.join(forwarded))
     return subprocess.run(forwarded, check=False).returncode
 

--- a/tools/recipes/unittests/engine_bootstrap_test.py
+++ b/tools/recipes/unittests/engine_bootstrap_test.py
@@ -6,7 +6,7 @@
 """Tests for the self-contained engine bootstrap."""
 
 # White-box tests: they exercise bootstrap internals (`_deploy_recipes`,
-# `_brave_core_dest`, `_run`), so protected-access is intentional.
+# `_deploy_depot_tools`, `_run`), so protected-access is intentional.
 # pylint: disable=protected-access
 
 import os
@@ -22,44 +22,63 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import engine_bootstrap as bootstrap  # pylint: disable=wrong-import-position
 
 
-class BraveCoreDestTest(unittest.TestCase):
-    """The checkout destination is read from --properties (or defaulted)."""
-
-    def test_default(self):
-        self.assertEqual(bootstrap._brave_core_dest('{}'), 'brave_core')
-
-    def test_explicit(self):
-        self.assertEqual(
-            bootstrap._brave_core_dest('{"brave_core_dest": "scratch/bc"}'),
-            'scratch/bc')
-
-    def test_unparseable_json_falls_back(self):
-        self.assertEqual(bootstrap._brave_core_dest('not json'), 'brave_core')
-
-    def test_non_object_json_falls_back(self):
-        self.assertEqual(bootstrap._brave_core_dest('[1, 2]'), 'brave_core')
-
-
 class MainForwardingTest(unittest.TestCase):
-    """main() deploys the engine and forwards argv to it verbatim."""
+    """main() deploys the engine and launches it under vpython3, forwarding
+    argv verbatim."""
 
-    def test_forwards_argv_verbatim(self):
-        argv = [
-            'toolchains/rust/package_rust', '--properties',
-            '{"brave_core_dest": "bc"}'
-        ]
-        engine_path = Path('bc/tools/recipes/engine.py')
+    def test_forwards_argv_under_vpython(self):
+        argv = ['toolchains/rust/package_rust', '--workspace', '/work']
+        engine_path = Path('/work/recipes_engine_bootstrap/tools/recipes/'
+                           'engine.py')
+        spec_path = engine_path.parent / bootstrap.VPYTHON_SPEC
         with mock.patch.object(bootstrap, '_deploy_recipes',
                                return_value=engine_path) as deploy, \
+             mock.patch.object(bootstrap.shutil, 'which',
+                               return_value='/path/to/vpython3'), \
              mock.patch.object(bootstrap.subprocess, 'run') as run:
             run.return_value = types.SimpleNamespace(returncode=0)
             rc = bootstrap.main(argv)
 
         self.assertEqual(rc, 0)
-        deploy.assert_called_once_with('bc')
+        # The engine checkout is deployed under --workspace, and vpython3 was
+        # on PATH, so the bare name is used (no depot_tools clone).
+        deploy.assert_called_once_with(
+            Path('/work') / bootstrap.RECIPES_ENGINE_DEST)
         forwarded = run.call_args[0][0]
-        self.assertEqual(forwarded[0], sys.executable)
-        self.assertEqual(forwarded[1:], [str(engine_path), *argv])
+        self.assertEqual(forwarded, [
+            bootstrap.VPYTHON3, '-vpython-spec',
+            str(spec_path), '-u',
+            str(engine_path), *argv
+        ])
+
+    def test_missing_vpython_clones_depot_tools(self):
+        """With no vpython3 on PATH, depot_tools is deployed under --workspace
+        and its vpython3 (absolute path) is used to launch the engine."""
+        engine_path = Path('/work/recipes_engine_bootstrap/tools/recipes/'
+                           'engine.py')
+        depot_tools = Path('/work/depot_tools_bootstrap')
+        with mock.patch.dict(os.environ, clear=False), \
+             mock.patch.object(bootstrap, '_deploy_recipes',
+                               return_value=engine_path), \
+             mock.patch.object(bootstrap, '_deploy_depot_tools',
+                               return_value=depot_tools) as deploy_dt, \
+             mock.patch.object(bootstrap.shutil, 'which', return_value=None), \
+             mock.patch.object(bootstrap.subprocess, 'run') as run:
+            run.return_value = types.SimpleNamespace(returncode=0)
+            rc = bootstrap.main(
+                ['toolchains/rust/package_rust', '--workspace', '/work'])
+            # The cloned depot_tools is prepended to PATH (asserted inside the
+            # patch.dict scope, which restores os.environ on exit) so the
+            # engine and any recipe's depot_tools module reuse it.
+            self.assertEqual(os.environ['PATH'].split(os.pathsep)[0],
+                             str(depot_tools))
+
+        self.assertEqual(rc, 0)
+        # The clone destination is resolved relative to --workspace.
+        deploy_dt.assert_called_once_with(
+            Path('/work') / bootstrap.DEPOT_TOOLS_DEST)
+        forwarded = run.call_args[0][0]
+        self.assertEqual(forwarded[0], str(depot_tools / bootstrap.VPYTHON3))
 
 
 class DeployRecipesTest(unittest.TestCase):
@@ -71,6 +90,9 @@ class DeployRecipesTest(unittest.TestCase):
             engine_file = dest / bootstrap.RECIPES_PATH / 'engine.py'
             engine_file.parent.mkdir(parents=True)
             engine_file.write_text('', encoding='utf-8', newline='')
+            # The spec is validated too, so it must exist alongside the engine.
+            (engine_file.parent / bootstrap.VPYTHON_SPEC).write_text(
+                '', encoding='utf-8', newline='')
             # rmtree is mocked, so the pre-created engine file survives the
             # is_file() check; _run is mocked so no real git runs.
             with mock.patch.object(bootstrap, '_run') as run, \
@@ -79,6 +101,39 @@ class DeployRecipesTest(unittest.TestCase):
         rmtree.assert_called_once_with(dest.resolve())
         self.assertTrue(run.called)
         self.assertEqual(result, engine_file.resolve())
+
+
+class DeployDepotToolsTest(unittest.TestCase):
+    """_deploy_depot_tools reuses a good checkout and clones when absent."""
+
+    def test_reuses_existing_vpython3(self):
+        with tempfile.TemporaryDirectory() as work:
+            dest = Path(work) / 'depot_tools'
+            dest.mkdir()
+            (dest / bootstrap.VPYTHON3).write_text('',
+                                                   encoding='utf-8',
+                                                   newline='')
+            with mock.patch.object(bootstrap, '_run') as run:
+                result = bootstrap._deploy_depot_tools(dest)
+        run.assert_not_called()
+        self.assertEqual(result, dest.resolve())
+
+    def test_clones_when_absent(self):
+        with tempfile.TemporaryDirectory() as work:
+            dest = Path(work) / 'depot_tools'
+
+            # _run is mocked, so simulate the clone producing a vpython3.
+            def fake_clone(*_cmd, cwd=None):  # pylint: disable=unused-argument
+                dest.mkdir(parents=True, exist_ok=True)
+                (dest / bootstrap.VPYTHON3).write_text('',
+                                                       encoding='utf-8',
+                                                       newline='')
+
+            with mock.patch.object(bootstrap, '_run',
+                                   side_effect=fake_clone) as run:
+                result = bootstrap._deploy_depot_tools(dest)
+        run.assert_called_once()
+        self.assertEqual(result, dest.resolve())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change adds support for `vpython3` to the boostrap mechanism. This
way we will be able to depend on protobuffers, and use it for the
properties of our recipes.

Bug: https://github.com/brave/brave-browser/issues/56748
