### PR TITLE
Keep vertical tab strip scroll position when toggling expanded state

### DIFF
--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
@@ -1708,6 +1708,48 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, ScrollOffset) {
             brave_tab_container->GetMaxScrollOffset());
 }
 
+IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest,
+                       ScrollOffsetKeptWhenTogglingExpandedState) {
+  // https://github.com/brave/brave-browser/issues/52270
+  ToggleVerticalTabStrip();
+
+  auto* brave_tab_container = views::AsViewClass<BraveTabContainer>(
+      views::AsViewClass<BraveTabStrip>(
+          browser_view()->horizontal_tab_strip_for_testing())
+          ->GetTabContainerForTesting());
+  ASSERT_TRUE(brave_tab_container);
+
+  // Add tabs until the tab strip overflows enough to scroll by a few tabs.
+  while (brave_tab_container->GetMaxScrollOffsetForTesting() <
+         2 * tabs::kVerticalTabHeight) {
+    AppendTab(browser());
+    browser_view()->horizontal_tab_strip_for_testing()->StopAnimating();
+    InvalidateAndRunLayoutForVerticalTabStrip();
+  }
+
+  // Scroll to the middle of the tab strip.
+  const int scroll_offset =
+      brave_tab_container->GetMaxScrollOffsetForTesting() / 2;
+  ASSERT_GT(scroll_offset, 0);
+  brave_tab_container->SetScrollOffsetForTesting(scroll_offset);
+  ASSERT_EQ(scroll_offset, brave_tab_container->GetScrollOffsetForTesting());
+
+  // Collapsing the tab strip shouldn't reset the scroll offset. Note that
+  // collapsing only changes the tab strip width, so the max scroll offset
+  // stays the same and no clamping should happen.
+  auto* prefs = browser()->profile()->GetPrefs();
+  prefs->SetBoolean(brave_tabs::kVerticalTabsCollapsed, true);
+  browser_view()->horizontal_tab_strip_for_testing()->StopAnimating();
+  InvalidateAndRunLayoutForVerticalTabStrip();
+  EXPECT_EQ(scroll_offset, brave_tab_container->GetScrollOffsetForTesting());
+
+  // Expanding the tab strip shouldn't reset the scroll offset either.
+  prefs->SetBoolean(brave_tabs::kVerticalTabsCollapsed, false);
+  browser_view()->horizontal_tab_strip_for_testing()->StopAnimating();
+  InvalidateAndRunLayoutForVerticalTabStrip();
+  EXPECT_EQ(scroll_offset, brave_tab_container->GetScrollOffsetForTesting());
+}
+
 IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, ClipPathOnScrollOffset) {
   // https://github.com/brave/brave-browser/issues/51734
   ToggleVerticalTabStrip();

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -117,14 +117,6 @@ BraveTabContainer::BraveTabContainer(
       brave_tabs::kVerticalTabsEnabled, prefs,
       base::BindRepeating(&BraveTabContainer::UpdateLayoutOrientation,
                           base::Unretained(this)));
-  vertical_tabs_floating_mode_enabled_.Init(
-      brave_tabs::kVerticalTabsFloatingEnabled, prefs,
-      base::BindRepeating(&BraveTabContainer::UpdateLayoutOrientation,
-                          base::Unretained(this)));
-  vertical_tabs_collapsed_.Init(
-      brave_tabs::kVerticalTabsCollapsed, prefs,
-      base::BindRepeating(&BraveTabContainer::UpdateLayoutOrientation,
-                          base::Unretained(this)));
   if (base::FeatureList::IsEnabled(tabs::kBraveTreeTab)) {
     tree_tabs_enabled_.Init(
         brave_tabs::kTreeTabsEnabled, prefs,

--- a/browser/ui/views/tabs/brave_tab_container.h
+++ b/browser/ui/views/tabs/brave_tab_container.h
@@ -311,8 +311,6 @@ class BraveTabContainer : public TabContainerImpl,
   raw_ptr<views::ScrollBar> scroll_bar_;
 
   BooleanPrefMember show_vertical_tabs_;
-  BooleanPrefMember vertical_tabs_floating_mode_enabled_;
-  BooleanPrefMember vertical_tabs_collapsed_;
   BooleanPrefMember tree_tabs_enabled_;
   BooleanPrefMember should_show_scroll_bar_;
   BooleanPrefMember scrollable_horizontal_tab_strip_;


### PR DESCRIPTION
Expanding or collapsing the vertical tab strip scrolled the tab list
back to the top, losing the user's scroll position.

`BraveTabContainer::UpdateLayoutOrientation()` unconditionally reset
`scroll_offset_` whenever vertical tabs were enabled. Since this method
is also invoked when the collapsed state or the floating mode pref
changes (not only when the orientation actually changes), every
expand/collapse toggle reset the scroll offset.

Fix by resetting the offset only when the layout orientation actually
changes (horizontal ↔ vertical). For all other calls the current offset
is kept; the existing `ClampScrollOffset()` logic keeps it within the
valid range if the viewport size changes.

Test plan:

1. Enable vertical tabs
2. Open enough tabs so the vertical tab strip becomes scrollable
3. Scroll the tab list down
4. Collapse the vertical tab strip, then expand it again
5. Observe that the scroll position is preserved instead of jumping back to the top

TEST=VerticalTabStripBrowserTest.ScrollOffsetKeptWhenTogglingExpandedState

Resolves https://github.com/brave/brave-browser/issues/52270

## Manual test evidence

Tested manually on Windows 11 x64 (local Component build).

### Before (scroll position resets to top):


https://github.com/user-attachments/assets/9214a5f5-b21d-43a9-959d-9836eb1f5cd5



### After (scroll position is preserved):


https://github.com/user-attachments/assets/86ec55c0-e265-46cb-85eb-3c80cb4cd17f

