### PR TITLE
Extract ReadFileToBigBuffer into local_ai core utils

### DIFF
--- a/browser/history_embeddings/brave_passage_embeddings_service_controller.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service_controller.cc
@@ -9,8 +9,6 @@
 #include <utility>
 
 #include "base/check.h"
-#include "base/containers/span.h"
-#include "base/files/file.h"
 #include "base/files/file_path.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
@@ -20,6 +18,7 @@
 #include "brave/components/local_ai/content/background_web_contents_impl.h"
 #include "brave/components/local_ai/core/local_models_updater.h"
 #include "brave/components/local_ai/core/url_constants.h"
+#include "brave/components/local_ai/core/utils.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
@@ -83,51 +82,29 @@ void CreateBackgroundWebContents(
                      std::move(callback)));
 }
 
-// Reads a file directly into BigBuffer storage. For files >64KB
-// BigBuffer uses shared memory.
-std::optional<mojo_base::BigBuffer> ReadFileToBigBuffer(
-    const base::FilePath& path) {
-  base::File file(path, base::File::FLAG_OPEN | base::File::FLAG_READ);
-  if (!file.IsValid()) {
-    DVLOG(0) << "Failed to open: " << path;
-    return std::nullopt;
-  }
-  int64_t size = file.GetLength();
-  if (size <= 0) {
-    DVLOG(0) << "Empty or unreadable: " << path;
-    return std::nullopt;
-  }
-  mojo_base::BigBuffer buffer(static_cast<size_t>(size));
-  if (!file.ReadAndCheck(0, base::span<uint8_t>(buffer))) {
-    DVLOG(0) << "Failed to read: " << path;
-    return std::nullopt;
-  }
-  return buffer;
-}
-
 local_ai::mojom::ModelFilesPtr LoadLocalModelFilesFromDisk(
     const base::FilePath& weights_path,
     const base::FilePath& weights_dense1_path,
     const base::FilePath& weights_dense2_path,
     const base::FilePath& tokenizer_path,
     const base::FilePath& config_path) {
-  auto weights = ReadFileToBigBuffer(weights_path);
+  auto weights = local_ai::ReadFileToBigBuffer(weights_path);
   if (!weights) {
     return nullptr;
   }
-  auto weights_dense1 = ReadFileToBigBuffer(weights_dense1_path);
+  auto weights_dense1 = local_ai::ReadFileToBigBuffer(weights_dense1_path);
   if (!weights_dense1) {
     return nullptr;
   }
-  auto weights_dense2 = ReadFileToBigBuffer(weights_dense2_path);
+  auto weights_dense2 = local_ai::ReadFileToBigBuffer(weights_dense2_path);
   if (!weights_dense2) {
     return nullptr;
   }
-  auto tokenizer = ReadFileToBigBuffer(tokenizer_path);
+  auto tokenizer = local_ai::ReadFileToBigBuffer(tokenizer_path);
   if (!tokenizer) {
     return nullptr;
   }
-  auto config = ReadFileToBigBuffer(config_path);
+  auto config = local_ai::ReadFileToBigBuffer(config_path);
   if (!config) {
     return nullptr;
   }

--- a/components/local_ai/core/BUILD.gn
+++ b/components/local_ai/core/BUILD.gn
@@ -43,6 +43,7 @@ static_library("core") {
     "on_device_speech_models_state.h",
     "pref_names.h",
     "url_constants.h",
+    "utils.h",
   ]
 
   sources = [
@@ -55,12 +56,15 @@ static_library("core") {
     "on_device_speech_models_state.h",
     "pref_names.cc",
     "pref_names.h",
+    "utils.cc",
+    "utils.h",
   ]
 
   public_deps = [
     ":features",
     ":mojom",
     "//base",
+    "//mojo/public/cpp/base",
   ]
 
   deps = [
@@ -72,7 +76,6 @@ static_library("core") {
     "//components/prefs",
     "//components/update_client",
     "//crypto",
-    "//mojo/public/cpp/base",
     "//mojo/public/cpp/bindings",
   ]
 }

--- a/components/local_ai/core/DEPS
+++ b/components/local_ai/core/DEPS
@@ -6,5 +6,6 @@ include_rules = [
   "+components/prefs",
   "+components/update_client",
   "+crypto",
+  "+mojo/public/cpp/base",
   "+mojo/public/cpp/bindings",
 ]

--- a/components/local_ai/core/utils.cc
+++ b/components/local_ai/core/utils.cc
@@ -1,0 +1,35 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/local_ai/core/utils.h"
+
+#include "base/containers/span.h"
+#include "base/files/file.h"
+#include "base/files/file_path.h"
+#include "base/logging.h"
+
+namespace local_ai {
+
+std::optional<mojo_base::BigBuffer> ReadFileToBigBuffer(
+    const base::FilePath& path) {
+  base::File file(path, base::File::FLAG_OPEN | base::File::FLAG_READ);
+  if (!file.IsValid()) {
+    DVLOG(0) << "Failed to open: " << path;
+    return std::nullopt;
+  }
+  int64_t size = file.GetLength();
+  if (size <= 0) {
+    DVLOG(0) << "Empty or unreadable: " << path;
+    return std::nullopt;
+  }
+  mojo_base::BigBuffer buffer(static_cast<size_t>(size));
+  if (!file.ReadAndCheck(0, base::span<uint8_t>(buffer))) {
+    DVLOG(0) << "Failed to read: " << path;
+    return std::nullopt;
+  }
+  return buffer;
+}
+
+}  // namespace local_ai

--- a/components/local_ai/core/utils.h
+++ b/components/local_ai/core/utils.h
@@ -1,0 +1,27 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_LOCAL_AI_CORE_UTILS_H_
+#define BRAVE_COMPONENTS_LOCAL_AI_CORE_UTILS_H_
+
+#include <optional>
+
+#include "mojo/public/cpp/base/big_buffer.h"
+
+namespace base {
+class FilePath;
+}  // namespace base
+
+namespace local_ai {
+
+// Reads a file directly into BigBuffer storage. For files >64KB BigBuffer
+// uses shared memory. Returns std::nullopt if the file can't be opened, is
+// empty, or can't be fully read. Must run on a sequence that allows blocking.
+std::optional<mojo_base::BigBuffer> ReadFileToBigBuffer(
+    const base::FilePath& path);
+
+}  // namespace local_ai
+
+#endif  // BRAVE_COMPONENTS_LOCAL_AI_CORE_UTILS_H_


### PR DESCRIPTION
Moves the file-into-BigBuffer reader out of the passage embeddings controller into a shared local_ai::ReadFileToBigBuffer so the speech controller can reuse it..

This is some groundwork for extracting code from what we have for history_embedding to share for https://github.com/brave/brave-browser/issues/56487.