### PR TITLE
feat: Include additional key in aichat SKU request

### DIFF
--- a/components/ai_chat/core/browser/ai_chat_credential_manager.cc
+++ b/components/ai_chat/core/browser/ai_chat_credential_manager.cc
@@ -152,6 +152,15 @@ void AIChatCredentialManager::OnCredentialSummary(
     return;
   }
 
+  // Persist the order id separately from the rest of the summary so it can
+  // be attached to premium requests even when a cached credential is reused
+  // without re-fetching the credential summary.
+  if (const auto* order_dict = records->FindDict("order")) {
+    if (const std::string* order_id = order_dict->FindString("id")) {
+      prefs_service_->SetString(prefs::kBraveChatPremiumOrderId, *order_id);
+    }
+  }
+
   premium_info->remaining_credential_count +=
       records->FindInt("remaining_credential_count").value_or(0);
   const std::string* next_active_at = records->FindString("next_active_at");
@@ -226,6 +235,7 @@ void AIChatCredentialManager::FetchPremiumCredential(
 
   // Use credential from the cache if it existed.
   if (found_valid_credential) {
+    valid_credential.order_id = GetCachedOrderId();
     std::move(callback).Run(valid_credential);
     return;
   }
@@ -306,6 +316,7 @@ void AIChatCredentialManager::OnPrepareCredentialsPresentation(
   CredentialCacheEntry entry;
   entry.credential = credential;
   entry.expires_at = time;
+  entry.order_id = GetCachedOrderId();
   std::move(callback).Run(entry);
 }
 
@@ -379,6 +390,18 @@ void AIChatCredentialManager::RefreshOrder(
   skus_service_->RefreshOrder(leo_sku_domain, order_id, std::move(callback));
 }
 #endif
+
+std::optional<std::string> AIChatCredentialManager::GetCachedOrderId() const {
+  if (!prefs_service_) {
+    return std::nullopt;
+  }
+  const std::string& order_id =
+      prefs_service_->GetString(prefs::kBraveChatPremiumOrderId);
+  if (order_id.empty()) {
+    return std::nullopt;
+  }
+  return order_id;
+}
 
 bool AIChatCredentialManager::EnsureMojoConnected() {
   // Bind if not bound yet

--- a/components/ai_chat/core/browser/ai_chat_credential_manager.h
+++ b/components/ai_chat/core/browser/ai_chat_credential_manager.h
@@ -32,6 +32,7 @@ namespace ai_chat {
 struct CredentialCacheEntry {
   std::string credential;
   base::Time expires_at;
+  std::optional<std::string> order_id;
 };
 
 // Interfaces with the SKUs SDK to provide APIs to check and fetch Leo
@@ -73,6 +74,8 @@ class AIChatCredentialManager {
   bool EnsureMojoConnected();
 
   void OnMojoConnectionError();
+
+  std::optional<std::string> GetCachedOrderId() const;
 
   void OnCredentialSummary(mojom::Service::GetPremiumStatusCallback callback,
                            const std::string& domain,

--- a/components/ai_chat/core/browser/ai_chat_credential_manager_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_credential_manager_unittest.cc
@@ -426,4 +426,58 @@ TEST_F(AIChatCredentialManagerUnitTest, FetchPremiumCredential) {
   EXPECT_EQ(cached_creds_list4.size(), 0u);
 }
 
+TEST_F(AIChatCredentialManagerUnitTest, GetPremiumStatusPersistsOrderId) {
+  EXPECT_TRUE(prefs()->GetString(prefs::kBraveChatPremiumOrderId).empty());
+
+  base::Time start_time = base::Time::Now();
+  base::Time::Exploded exploded;
+  start_time.UTCExplode(&exploded);
+  exploded.millisecond = 0;  // Trim off milliseconds because they are not
+                             // included in the skusState.
+  ASSERT_TRUE(base::Time::FromUTCExploded(exploded, &start_time));
+  SetSkusState(formatSkusStateValue(start_time));
+
+  base::RunLoop run_loop;
+  ai_chat_credential_manager_->GetPremiumStatus(base::BindLambdaForTesting(
+      [&](mojom::PremiumStatus status, mojom::PremiumInfoPtr info) {
+        EXPECT_EQ(status, mojom::PremiumStatus::Active);
+        run_loop.Quit();
+      }));
+  run_loop.Run();
+
+  EXPECT_EQ(prefs()->GetString(prefs::kBraveChatPremiumOrderId),
+           "e24787ab-7bc3-46b9-bc05-65befb361111");
+}
+
+TEST_F(AIChatCredentialManagerUnitTest,
+      FetchPremiumCredentialAttachesKnownOrderId) {
+  CredentialCacheEntry entry;
+  entry.credential = "credential";
+  entry.expires_at = base::Time::Now() + base::Hours(1);
+
+  ai_chat_credential_manager_->PutCredentialInCache(entry);
+  base::RunLoop run_loop1;
+  ai_chat_credential_manager_->FetchPremiumCredential(
+      base::BindLambdaForTesting(
+          [&](std::optional<CredentialCacheEntry> credential) {
+            ASSERT_TRUE(credential);
+            EXPECT_FALSE(credential->order_id.has_value());
+            run_loop1.Quit();
+          }));
+  run_loop1.Run();
+
+  prefs()->SetString(prefs::kBraveChatPremiumOrderId, "test-order-id");
+  ai_chat_credential_manager_->PutCredentialInCache(entry);
+  base::RunLoop run_loop2;
+  ai_chat_credential_manager_->FetchPremiumCredential(
+      base::BindLambdaForTesting(
+          [&](std::optional<CredentialCacheEntry> credential) {
+            ASSERT_TRUE(credential);
+            ASSERT_TRUE(credential->order_id.has_value());
+            EXPECT_EQ(*credential->order_id, "test-order-id");
+            run_loop2.Quit();
+          }));
+  run_loop2.Run();
+}
+
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/engine/conversation_api_client_unittest.cc
+++ b/components/ai_chat/core/browser/engine/conversation_api_client_unittest.cc
@@ -723,6 +723,80 @@ TEST_F(ConversationAPIClientUnitTest, PerformRequest_PremiumHeaders) {
   testing::Mock::VerifyAndClearExpectations(credential_manager_.get());
 }
 
+TEST_F(ConversationAPIClientUnitTest, PerformRequest_PremiumHeadersWithOrderId) {
+  // When the fetched premium credential carries a known order id, it should
+  // be appended to the Cookie header as a second "id" pair.
+  std::string expected_credential = "test-premium-credential";
+  std::string expected_order_id = "test-order-id";
+  auto [messages, expected_messages_json] =
+      GetMockMessagesAndExpectedMessagesJson();
+  std::string expected_system_language = "en_KY";
+  const brave_l10n::test::ScopedDefaultLocale scoped_default_locale(
+      expected_system_language);
+
+  MockAPIRequestHelper* mock_request_helper =
+      client_->GetMockAPIRequestHelper();
+  testing::StrictMock<MockCallbacks> mock_callbacks;
+  base::RunLoop run_loop;
+
+  // Intercept credential fetch and provide premium credentials with a known
+  // order id.
+  credential_ = CredentialCacheEntry{expected_credential,
+                                     base::Time::Now() + base::Hours(1),
+                                     expected_order_id};
+
+  EXPECT_CALL(*mock_request_helper, RequestSSE(_, _, _, _, _, _, _, _))
+      .WillOnce([&](const std::string& method, const GURL& url,
+                    const std::string& body, const std::string& content_type,
+                    DataReceivedCallback data_received_callback,
+                    ResultCallback result_callback,
+                    const base::flat_map<std::string, std::string>& headers,
+                    const api_request_helper::APIRequestOptions& options) {
+        // Verify premium Cookie header includes both the credential and the
+        // order id.
+        EXPECT_TRUE(headers.contains("Cookie"));
+        const auto& cookie = headers.at("Cookie");
+        EXPECT_EQ(cookie, "__Secure-sku#brave-leo-premium=" +
+                              expected_credential + "; id=" +
+                              expected_order_id);
+
+        // Simulate completion
+        auto completion_dict = base::test::ParseJsonDict(R"({
+          "model": "chat-claude-sonnet",
+          "choices": [{
+            "message": {"content": "premium response"}
+          }]
+        })");
+        std::move(result_callback)
+            .Run(api_request_helper::APIRequestResult(
+                200, base::Value(std::move(completion_dict)), {}, net::OK,
+                GURL()));
+
+        run_loop.Quit();
+        return Ticket();
+      });
+
+  EXPECT_CALL(mock_callbacks, OnCompleted(_))
+      .WillOnce([&](EngineConsumer::GenerationResult result) {
+        ASSERT_TRUE(result.has_value());
+      });
+
+  // Begin request
+  client_->PerformRequest(
+      std::move(messages), std::nullopt,
+      /* oai_tool_definitions */ std::nullopt, /* preferred_tool_name */
+      {mojom::ConversationCapability::CHAT},
+      base::BindRepeating(&MockCallbacks::OnDataReceived,
+                          base::Unretained(&mock_callbacks)),
+      base::BindOnce(&MockCallbacks::OnCompleted,
+                     base::Unretained(&mock_callbacks)));
+
+  run_loop.Run();
+  testing::Mock::VerifyAndClearExpectations(client_.get());
+  testing::Mock::VerifyAndClearExpectations(mock_request_helper);
+  testing::Mock::VerifyAndClearExpectations(credential_manager_.get());
+}
+
 TEST_F(ConversationAPIClientUnitTest, PerformRequest_NonPremium) {
   // Performs the same test as Premium, verifying that nothing else changes
   // apart from request headers (and request url).

--- a/components/ai_chat/core/browser/utils.cc
+++ b/components/ai_chat/core/browser/utils.cc
@@ -254,8 +254,12 @@ base::flat_map<std::string, std::string> GetBraveHeaders(
     std::optional<CredentialCacheEntry> credential) {
   base::flat_map<std::string, std::string> headers;
   if (credential) {
-    headers.emplace("Cookie", base::StrCat({"__Secure-sku#brave-leo-premium=",
-                                            credential->credential}));
+    std::string cookie = base::StrCat(
+        {"__Secure-sku#brave-leo-premium=", credential->credential});
+    if (credential->order_id && !credential->order_id->empty()) {
+      base::StrAppend(&cookie, {"; id=", *credential->order_id});
+    }
+    headers.emplace("Cookie", std::move(cookie));
   }
   headers.emplace("x-brave-key", BUILDFLAG(BRAVE_SERVICES_KEY));
   return headers;

--- a/components/ai_chat/core/browser/utils.h
+++ b/components/ai_chat/core/browser/utils.h
@@ -54,7 +54,8 @@ EngineConsumer::GenerationDataCallback BindParseRewriteReceivedData(
 GURL GetEndpointUrl(bool premium, const std::string& path);
 
 // Builds the standard Brave AI Chat relay request headers: the Leo premium SKU
-// Cookie header (when |credential| is provided) and the x-brave-key header.
+// Cookie header (when |credential| is provided, including the order id as an
+// "id" cookie pair when known) and the x-brave-key header.
 base::flat_map<std::string, std::string> GetBraveHeaders(
     std::optional<CredentialCacheEntry> credential);
 

--- a/components/ai_chat/core/browser/utils_unittest.cc
+++ b/components/ai_chat/core/browser/utils_unittest.cc
@@ -5,8 +5,11 @@
 
 #include "brave/components/ai_chat/core/browser/utils.h"
 
+#include <optional>
 #include <string_view>
 
+#include "base/time/time.h"
+#include "brave/components/ai_chat/core/browser/ai_chat_credential_manager.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "url/gurl.h"
 
@@ -27,6 +30,49 @@ TEST_F(AIChatUtilsUnitTest, IsBraveSearchSERP) {
   EXPECT_FALSE(IsBraveSearchSERP(GURL("http://search.brave.com/search?q=foo")));
   // Wrong host.
   EXPECT_FALSE(IsBraveSearchSERP(GURL("https://brave.com/search?q=foo")));
+}
+
+TEST_F(AIChatUtilsUnitTest, GetBraveHeadersNoCredential) {
+  auto headers = GetBraveHeaders(std::nullopt);
+  EXPECT_FALSE(headers.contains("Cookie"));
+  EXPECT_TRUE(headers.contains("x-brave-key"));
+}
+
+TEST_F(AIChatUtilsUnitTest, GetBraveHeadersWithCredentialNoOrderId) {
+  CredentialCacheEntry credential;
+  credential.credential = "test-credential";
+  credential.expires_at = base::Time::Now() + base::Hours(1);
+
+  auto headers = GetBraveHeaders(credential);
+  ASSERT_TRUE(headers.contains("Cookie"));
+  EXPECT_EQ(headers.at("Cookie"),
+           "__Secure-sku#brave-leo-premium=test-credential");
+  EXPECT_TRUE(headers.contains("x-brave-key"));
+}
+
+TEST_F(AIChatUtilsUnitTest, GetBraveHeadersWithCredentialAndOrderId) {
+  CredentialCacheEntry credential;
+  credential.credential = "test-credential";
+  credential.expires_at = base::Time::Now() + base::Hours(1);
+  credential.order_id = "test-order-id";
+
+  auto headers = GetBraveHeaders(credential);
+  ASSERT_TRUE(headers.contains("Cookie"));
+  EXPECT_EQ(
+      headers.at("Cookie"),
+      "__Secure-sku#brave-leo-premium=test-credential; id=test-order-id");
+}
+
+TEST_F(AIChatUtilsUnitTest, GetBraveHeadersWithEmptyOrderIdOmitsIdPair) {
+  CredentialCacheEntry credential;
+  credential.credential = "test-credential";
+  credential.expires_at = base::Time::Now() + base::Hours(1);
+  credential.order_id = "";
+
+  auto headers = GetBraveHeaders(credential);
+  ASSERT_TRUE(headers.contains("Cookie"));
+  EXPECT_EQ(headers.at("Cookie"),
+           "__Secure-sku#brave-leo-premium=test-credential");
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/common/pref_names.cc
+++ b/components/ai_chat/core/common/pref_names.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/ai_chat/core/common/pref_names.h"
 
+#include <string>
 #include <string_view>
 
 #include "base/time/time.h"
@@ -63,6 +64,8 @@ void RegisterProfilePrefsForMigration(PrefRegistrySimple* registry) {
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
   // Added 11/2023
   registry->RegisterDictionaryPref(kBraveChatPremiumCredentialCache);
+  // Added 07/2026
+  registry->RegisterStringPref(kBraveChatPremiumOrderId, std::string());
 }
 
 }  // namespace ai_chat::prefs

--- a/components/ai_chat/core/common/pref_names.h
+++ b/components/ai_chat/core/common/pref_names.h
@@ -43,6 +43,8 @@ inline constexpr char kBraveChatP3ASkillsUsedStorage[] =
 // SKU SDK but were not used because the chat server was unavailable.
 inline constexpr char kBraveChatPremiumCredentialCache[] =
     "brave.ai_chat.premium_credential_cache";
+inline constexpr char kBraveChatPremiumOrderId[] =
+    "brave.ai_chat.premium_order_id";
 // Per-model OHTTP key config cache. Dict keyed by model name.
 inline constexpr char kAIChatObliviousHttpKeyConfigs[] =
     "brave.ai_chat.oblivious_http_key_configs";


### PR DESCRIPTION
- Includes an additional key id in the premium cookie header sent to aichat

Example of new header value:
```
__Secure-sku#brave-leo-premium=<credential base64>;id=<order_id base64>
```

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
