### PR TITLE
Extract BackgroundWebContents creation into browser/local_ai util

### DIFF
--- a/browser/history_embeddings/BUILD.gn
+++ b/browser/history_embeddings/BUILD.gn
@@ -79,14 +79,9 @@ source_set("history_embeddings") {
     "//brave/app:brave_generated_resources_grit",
     "//brave/browser/local_ai",
     "//brave/components/history_embeddings",
-    "//brave/components/local_ai/content",
     "//brave/components/local_ai/core",
-    "//chrome/browser:browser_process",
     "//chrome/browser:browser_public_dependencies",
     "//chrome/browser/profiles",
-    "//chrome/browser/task_manager",
     "//components/history_embeddings/core",
-    "//content/public/browser",
-    "//ui/base",
   ]
 }

--- a/browser/history_embeddings/BUILD.gn
+++ b/browser/history_embeddings/BUILD.gn
@@ -77,6 +77,7 @@ source_set("history_embeddings") {
   deps = [
     ":batch_passage_embedder",
     "//brave/app:brave_generated_resources_grit",
+    "//brave/browser/local_ai",
     "//brave/components/history_embeddings",
     "//brave/components/local_ai/content",
     "//brave/components/local_ai/core",

--- a/browser/history_embeddings/brave_passage_embeddings_service_controller.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service_controller.cc
@@ -17,18 +17,16 @@
 #include "base/task/task_traits.h"
 #include "base/task/thread_pool.h"
 #include "brave/browser/history_embeddings/brave_batch_passage_embedder.h"
-#include "brave/components/local_ai/content/background_web_contents_impl.h"
+#include "brave/browser/local_ai/background_web_contents_factory.h"
 #include "brave/components/local_ai/core/local_models_updater.h"
 #include "brave/components/local_ai/core/url_constants.h"
 #include "brave/grit/brave_generated_resources.h"
-#include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
-#include "chrome/browser/profiles/profile_manager.h"
-#include "chrome/browser/task_manager/web_contents_tags.h"
 #include "components/passage_embeddings/core/passage_embeddings_features.h"
 #include "components/passage_embeddings/core/passage_embeddings_types.h"
 #include "mojo/public/cpp/base/big_buffer.h"
 #include "mojo/public/cpp/bindings/callback_helpers.h"
+#include "url/gurl.h"
 
 namespace passage_embeddings {
 
@@ -46,41 +44,31 @@ mojom::PassagePriority ToMojom(PassagePriority priority) {
   }
 }
 
-void TagWebContentsForTaskManager(content::WebContents* web_contents) {
-  task_manager::WebContentsTags::CreateForToolContents(
-      web_contents, IDS_LOCAL_AI_TASK_MANAGER_TITLE);
-}
-
-void OnGuestProfileCreated(
-    base::WeakPtr<BraveBatchPassageEmbedder> weak_embedder,
+// Completion callback for local_ai::CreateBackgroundWebContents().
+//
+// Registers the OTR profile with the controller so we tear the service down
+// before the profile is destroyed on shutdown (otherwise the WebContents inside
+// the embedder would outlive its BrowserContext), then forwards the
+// BackgroundWebContents to the embedder.
+void OnBackgroundWebContentsCreated(
     BraveBatchPassageEmbedder::BackgroundWebContentsCreatedCallback callback,
-    Profile* guest_profile) {
-  CHECK(guest_profile);
-  if (!weak_embedder) {
-    return;
+    std::unique_ptr<local_ai::BackgroundWebContents> contents,
+    Profile* otr_profile) {
+  if (otr_profile) {
+    BravePassageEmbeddingsServiceController::Get()->ObserveGuestOTRProfile(
+        otr_profile);
   }
-  auto* otr = guest_profile->GetPrimaryOTRProfile(/*create_if_needed=*/true);
-  // Register the OTR profile with the controller so we tear the service
-  // down before the profile is destroyed on shutdown — otherwise the
-  // WebContents inside the embedder would outlive its BrowserContext.
-  BravePassageEmbeddingsServiceController::Get()->ObserveGuestOTRProfile(otr);
-  auto contents = std::make_unique<local_ai::BackgroundWebContentsImpl>(
-      otr, GURL(local_ai::kUntrustedLocalAIURL), weak_embedder.get(),
-      base::BindOnce(&TagWebContentsForTaskManager));
   std::move(callback).Run(std::move(contents));
 }
 
 void CreateBackgroundWebContents(
     local_ai::BackgroundWebContents::Delegate* delegate,
     BraveBatchPassageEmbedder::BackgroundWebContentsCreatedCallback callback) {
-  auto* embedder = static_cast<BraveBatchPassageEmbedder*>(delegate);
-  auto weak_embedder = embedder->GetWeakPtr();
-  auto* profile_manager = g_browser_process->profile_manager();
-  CHECK(profile_manager);
-  profile_manager->CreateProfileAsync(
-      ProfileManager::GetGuestProfilePath(),
-      base::BindOnce(&OnGuestProfileCreated, std::move(weak_embedder),
-                     std::move(callback)));
+  local_ai::CreateBackgroundWebContents(
+      GURL(local_ai::kUntrustedLocalAIURL), IDS_LOCAL_AI_TASK_MANAGER_TITLE,
+      /*sandbox_flags=*/std::nullopt,
+      static_cast<BraveBatchPassageEmbedder*>(delegate)->GetWeakPtr(),
+      base::BindOnce(&OnBackgroundWebContentsCreated, std::move(callback)));
 }
 
 // Reads a file directly into BigBuffer storage. For files >64KB

--- a/browser/local_ai/BUILD.gn
+++ b/browser/local_ai/BUILD.gn
@@ -7,36 +7,42 @@ import("//brave/components/local_ai/buildflags/buildflags.gni")
 
 assert(enable_local_ai)
 
-static_library("content") {
+source_set("local_ai") {
   sources = [
-    "background_web_contents_impl.cc",
-    "background_web_contents_impl.h",
+    "background_web_contents_factory.cc",
+    "background_web_contents_factory.h",
   ]
 
   public_deps = [
     "//base",
-    "//brave/components/restricted_web_contents_delegate",
+    "//brave/components/local_ai/core",
     "//services/network/public/mojom",
   ]
 
   deps = [
-    "//brave/components/local_ai/core",
+    "//brave/components/local_ai/content",
+    "//chrome/browser:browser_process",
+    "//chrome/browser/profiles",
+    "//chrome/browser/task_manager",
     "//content/public/browser",
-    "//services/network/public/cpp",
-    "//ui/base",
     "//url",
   ]
 }
 
 source_set("unit_tests") {
   testonly = true
-  sources = [ "background_web_contents_impl_unittest.cc" ]
+  sources = [ "background_web_contents_factory_unittest.cc" ]
 
   deps = [
-    ":content",
+    ":local_ai",
+    "//base",
     "//base/test:test_support",
+    "//brave/app:brave_generated_resources_grit",
+    "//brave/components/local_ai/core",
+    "//chrome/browser/profiles",
+    "//chrome/test:test_support",
+    "//content/public/browser",
     "//content/test:test_support",
-    "//testing/gmock",
     "//testing/gtest",
     "//url",
   ]

--- a/browser/local_ai/background_web_contents_factory.cc
+++ b/browser/local_ai/background_web_contents_factory.cc
@@ -1,0 +1,73 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/local_ai/background_web_contents_factory.h"
+
+#include <optional>
+#include <utility>
+
+#include "base/check.h"
+#include "base/functional/bind.h"
+#include "brave/components/local_ai/content/background_web_contents_impl.h"
+#include "chrome/browser/browser_process.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/profiles/profile_manager.h"
+#include "chrome/browser/task_manager/web_contents_tags.h"
+#include "content/public/browser/web_contents.h"
+#include "url/gurl.h"
+
+namespace local_ai {
+
+namespace {
+
+void TagWebContentsForTaskManager(int task_manager_title_id,
+                                  content::WebContents* web_contents) {
+  task_manager::WebContentsTags::CreateForToolContents(web_contents,
+                                                       task_manager_title_id);
+}
+
+// Reply for the guest-profile creation. Builds the worker's
+// BackgroundWebContentsImpl in the guest's primary OTR profile and hands both
+// back to the caller.
+void OnGuestProfileCreated(
+    GURL url,
+    int task_manager_title_id,
+    std::optional<network::mojom::WebSandboxFlags> sandbox_flags,
+    base::WeakPtr<BackgroundWebContents::Delegate> delegate,
+    BackgroundWebContentsCreatedCallback created,
+    Profile* guest_profile) {
+  if (!guest_profile || !delegate) {
+    std::move(created).Run(nullptr, nullptr);
+    return;
+  }
+  // Host the worker in the guest profile's primary OTR profile so the
+  // renderer's storage is ephemeral and, on shutdown, is destroyed before
+  // its parent.
+  Profile* otr_profile =
+      guest_profile->GetPrimaryOTRProfile(/*create_if_needed=*/true);
+  auto background_web_contents = std::make_unique<BackgroundWebContentsImpl>(
+      otr_profile, url, delegate.get(),
+      base::BindOnce(&TagWebContentsForTaskManager, task_manager_title_id),
+      sandbox_flags);
+  std::move(created).Run(std::move(background_web_contents), otr_profile);
+}
+
+}  // namespace
+
+void CreateBackgroundWebContents(
+    const GURL& url,
+    int task_manager_title_id,
+    std::optional<network::mojom::WebSandboxFlags> sandbox_flags,
+    base::WeakPtr<BackgroundWebContents::Delegate> delegate,
+    BackgroundWebContentsCreatedCallback created) {
+  auto* profile_manager = g_browser_process->profile_manager();
+  CHECK(profile_manager);
+  profile_manager->CreateProfileAsync(
+      ProfileManager::GetGuestProfilePath(),
+      base::BindOnce(&OnGuestProfileCreated, url, task_manager_title_id,
+                     sandbox_flags, std::move(delegate), std::move(created)));
+}
+
+}  // namespace local_ai

--- a/browser/local_ai/background_web_contents_factory.h
+++ b/browser/local_ai/background_web_contents_factory.h
@@ -1,0 +1,49 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_LOCAL_AI_BACKGROUND_WEB_CONTENTS_FACTORY_H_
+#define BRAVE_BROWSER_LOCAL_AI_BACKGROUND_WEB_CONTENTS_FACTORY_H_
+
+#include <memory>
+#include <optional>
+
+#include "base/functional/callback.h"
+#include "base/memory/weak_ptr.h"
+#include "brave/components/local_ai/core/background_web_contents.h"
+#include "services/network/public/mojom/web_sandbox_flags.mojom-shared.h"
+
+class GURL;
+class Profile;
+
+namespace local_ai {
+
+// Reply for CreateBackgroundWebContents(). Hands back the created worker
+// environment and the guest OTR profile it lives in (both null on failure).
+// The caller decides what to do with the profile (e.g. observe it for
+// destruction); the factory does not observe it.
+using BackgroundWebContentsCreatedCallback =
+    base::OnceCallback<void(std::unique_ptr<BackgroundWebContents>,
+                            Profile* otr_profile)>;
+
+// Creates the guest profile's primary OTR profile asynchronously, then builds
+// a BackgroundWebContentsImpl in it, navigated to `url` and tagged in the task
+// manager with `task_manager_title_id`. When `sandbox_flags` is nullopt the
+// worker uses the default background sandbox; pass a value to override (e.g.
+// kNone for a cross-origin-isolated worker that must be fully unsandboxed).
+//
+// `delegate` is held weakly: a caller destroyed during the async guest-profile
+// creation safely yields (nullptr, nullptr) instead of a use-after-free. This
+// covers both a NoDestructor singleton caller (whose weak ptr never
+// invalidates) and a caller owned by another object (whose weak ptr drops).
+void CreateBackgroundWebContents(
+    const GURL& url,
+    int task_manager_title_id,
+    std::optional<network::mojom::WebSandboxFlags> sandbox_flags,
+    base::WeakPtr<BackgroundWebContents::Delegate> delegate,
+    BackgroundWebContentsCreatedCallback created);
+
+}  // namespace local_ai
+
+#endif  // BRAVE_BROWSER_LOCAL_AI_BACKGROUND_WEB_CONTENTS_FACTORY_H_

--- a/browser/local_ai/background_web_contents_factory_unittest.cc
+++ b/browser/local_ai/background_web_contents_factory_unittest.cc
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/local_ai/background_web_contents_factory.h"
+
+#include <memory>
+#include <optional>
+
+#include "base/memory/weak_ptr.h"
+#include "base/test/test_future.h"
+#include "brave/components/local_ai/core/background_web_contents.h"
+#include "brave/grit/brave_generated_resources.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/profiles/profile_manager.h"
+#include "chrome/test/base/testing_browser_process.h"
+#include "chrome/test/base/testing_profile_manager.h"
+#include "content/public/test/browser_task_environment.h"
+#include "content/public/test/test_renderer_host.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace local_ai {
+
+namespace {
+
+// Minimal delegate whose weak pointer we can drop on demand to exercise the
+// "caller destroyed mid-async" guard.
+class StubDelegate : public BackgroundWebContents::Delegate {
+ public:
+  StubDelegate() = default;
+  ~StubDelegate() override = default;
+
+  // BackgroundWebContents::Delegate:
+  void OnBackgroundContentsDestroyed(
+      BackgroundWebContents::DestroyReason reason) override {}
+
+  base::WeakPtr<BackgroundWebContents::Delegate> GetWeakPtr() {
+    return weak_factory_.GetWeakPtr();
+  }
+
+  void InvalidateWeakPtrs() { weak_factory_.InvalidateWeakPtrs(); }
+
+ private:
+  base::WeakPtrFactory<BackgroundWebContents::Delegate> weak_factory_{this};
+};
+
+}  // namespace
+
+class BackgroundWebContentsFactoryTest : public testing::Test {
+ protected:
+  void SetUp() override { ASSERT_TRUE(profile_manager_.SetUp()); }
+
+  content::BrowserTaskEnvironment task_environment_;
+  content::RenderViewHostTestEnabler rvh_enabler_;
+  TestingProfileManager profile_manager_{TestingBrowserProcess::GetGlobal()};
+};
+
+TEST_F(BackgroundWebContentsFactoryTest, CreatesContentsInGuestOtrProfile) {
+  StubDelegate delegate;
+  base::test::TestFuture<std::unique_ptr<BackgroundWebContents>, Profile*>
+      future;
+  CreateBackgroundWebContents(GURL("chrome-untrusted://test/"),
+                              IDS_LOCAL_AI_TASK_MANAGER_TITLE,
+                              /*sandbox_flags=*/std::nullopt,
+                              delegate.GetWeakPtr(), future.GetCallback());
+
+  auto [contents, otr_profile] = future.Take();
+  EXPECT_TRUE(contents);
+  ASSERT_TRUE(otr_profile);
+  EXPECT_TRUE(otr_profile->IsOffTheRecord());
+  EXPECT_EQ(otr_profile->GetOriginalProfile()->GetPath(),
+            ProfileManager::GetGuestProfilePath());
+
+  // Destroy the worker before the profile manager tears down, so its
+  // WebContents does not outlive its BrowserContext.
+  contents.reset();
+}
+
+TEST_F(BackgroundWebContentsFactoryTest, DelegateDestroyedYieldsNull) {
+  StubDelegate delegate;
+  base::test::TestFuture<std::unique_ptr<BackgroundWebContents>, Profile*>
+      future;
+  CreateBackgroundWebContents(GURL("chrome-untrusted://test/"),
+                              IDS_LOCAL_AI_TASK_MANAGER_TITLE,
+                              /*sandbox_flags=*/std::nullopt,
+                              delegate.GetWeakPtr(), future.GetCallback());
+
+  // Simulate the caller being destroyed while the guest profile is still
+  // being created asynchronously. The reply must yield (nullptr, nullptr)
+  // instead of dereferencing the dead delegate.
+  delegate.InvalidateWeakPtrs();
+
+  auto [contents, otr_profile] = future.Take();
+  EXPECT_FALSE(contents);
+  EXPECT_FALSE(otr_profile);
+}
+
+}  // namespace local_ai

--- a/components/local_ai/content/BUILD.gn
+++ b/components/local_ai/content/BUILD.gn
@@ -35,6 +35,7 @@ source_set("unit_tests") {
   deps = [
     ":content",
     "//base/test:test_support",
+    "//content/public/browser",
     "//content/test:test_support",
     "//testing/gmock",
     "//testing/gtest",

--- a/components/local_ai/content/background_web_contents_impl.cc
+++ b/components/local_ai/content/background_web_contents_impl.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/local_ai/content/background_web_contents_impl.h"
 
+#include <optional>
 #include <utility>
 
 #include "base/logging.h"
@@ -21,19 +22,20 @@ BackgroundWebContentsImpl::BackgroundWebContentsImpl(
     content::BrowserContext* browser_context,
     const GURL& url,
     Delegate* delegate,
-    WebContentsCreatedCallback web_contents_created_callback)
+    WebContentsCreatedCallback web_contents_created_callback,
+    std::optional<network::mojom::WebSandboxFlags> sandbox_flags)
     : delegate_(delegate), expected_url_(url) {
   DCHECK(browser_context);
   DCHECK(delegate);
 
   content::WebContents::CreateParams create_params(browser_context);
   create_params.is_never_composited = true;
-  // Sandbox everything except scripts (needed for JS/WASM execution)
-  // and origin (needed for Mojo WebUI bridge).
+  // Sandbox everything except scripts (needed for JS/WASM execution) and
+  // origin (needed for the Mojo WebUI bridge) unless the caller overrides it.
   create_params.starting_sandbox_flags =
-      network::mojom::WebSandboxFlags::kAll &
-      ~network::mojom::WebSandboxFlags::kScripts &
-      ~network::mojom::WebSandboxFlags::kOrigin;
+      sandbox_flags.value_or(network::mojom::WebSandboxFlags::kAll &
+                             ~network::mojom::WebSandboxFlags::kScripts &
+                             ~network::mojom::WebSandboxFlags::kOrigin);
   web_contents_ = content::WebContents::Create(create_params);
   web_contents_->SetOwnerLocationForDebug(FROM_HERE);
 

--- a/components/local_ai/content/background_web_contents_impl.h
+++ b/components/local_ai/content/background_web_contents_impl.h
@@ -7,12 +7,14 @@
 #define BRAVE_COMPONENTS_LOCAL_AI_CONTENT_BACKGROUND_WEB_CONTENTS_IMPL_H_
 
 #include <memory>
+#include <optional>
 
 #include "base/functional/callback.h"
 #include "base/memory/raw_ptr.h"
 #include "brave/components/local_ai/core/background_web_contents.h"
 #include "brave/components/restricted_web_contents_delegate/restricted_web_contents_delegate.h"
 #include "content/public/browser/web_contents_observer.h"
+#include "services/network/public/mojom/web_sandbox_flags.mojom-shared.h"
 #include "url/gurl.h"
 
 namespace content {
@@ -38,12 +40,21 @@ class BackgroundWebContentsImpl : public BackgroundWebContents,
   // |web_contents_created_callback| is an optional callback invoked
   // immediately after the WebContents is created (e.g. for task manager
   // tagging). It runs before navigation begins.
+  //
+  // |sandbox_flags| is the starting sandbox of the hidden WebContents. When
+  // nullopt it defaults to "sandbox everything except scripts (needed for
+  // JS/WASM) and origin (needed for the Mojo WebUI bridge)". Pages that must
+  // be cross-origin isolated (COOP/COEP) need a relaxed value
+  // (WebSandboxFlags::kNone), since a sandboxed document can't become
+  // cross-origin isolated.
   BackgroundWebContentsImpl(
       content::BrowserContext* browser_context,
       const GURL& url,
       Delegate* delegate,
       WebContentsCreatedCallback web_contents_created_callback =
-          WebContentsCreatedCallback());
+          WebContentsCreatedCallback(),
+      std::optional<network::mojom::WebSandboxFlags> sandbox_flags =
+          std::nullopt);
   ~BackgroundWebContentsImpl() override;
 
   BackgroundWebContentsImpl(const BackgroundWebContentsImpl&) = delete;

--- a/components/local_ai/content/background_web_contents_impl_unittest.cc
+++ b/components/local_ai/content/background_web_contents_impl_unittest.cc
@@ -6,9 +6,14 @@
 #include "brave/components/local_ai/content/background_web_contents_impl.h"
 
 #include <memory>
+#include <optional>
 
+#include "base/functional/callback_helpers.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/web_contents.h"
 #include "content/public/test/navigation_simulator.h"
 #include "content/public/test/test_renderer_host.h"
+#include "services/network/public/mojom/web_sandbox_flags.mojom-shared.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "url/gurl.h"
@@ -31,10 +36,22 @@ class BackgroundWebContentsImplTest
     content::RenderViewHostTestHarness::TearDown();
   }
 
-  void CreateContents(const base::Location& location = FROM_HERE) {
+  void CreateContents(std::optional<network::mojom::WebSandboxFlags>
+                          sandbox_flags = std::nullopt,
+                      const base::Location& location = FROM_HERE) {
     SCOPED_TRACE(testing::Message() << location.ToString());
     background_contents_ = std::make_unique<BackgroundWebContentsImpl>(
-        browser_context(), GURL("chrome-untrusted://test/"), &delegate_);
+        browser_context(), GURL("chrome-untrusted://test/"), &delegate_,
+        base::NullCallback(), sandbox_flags);
+  }
+
+  // Commits the worker's navigation so its starting sandbox flags become the
+  // main frame's effective flags, then returns that frame.
+  content::RenderFrameHost* CommitAndGetMainFrame() {
+    content::WebContents* web_contents = background_contents_->web_contents();
+    content::NavigationSimulator::NavigateAndCommitFromBrowser(
+        web_contents, GURL("chrome-untrusted://test/"));
+    return web_contents->GetPrimaryMainFrame();
   }
 
   testing::NiceMock<MockDelegate> delegate_;
@@ -75,6 +92,28 @@ TEST_F(BackgroundWebContentsImplTest, DestructorDoesNotFireDelegateCallbacks) {
   CreateContents();
   // Destroying should not crash or fire delegate callbacks.
   background_contents_.reset();
+}
+
+TEST_F(BackgroundWebContentsImplTest, DefaultSandboxFlags) {
+  // With nullopt the worker keeps the default background sandbox: everything
+  // sandboxed except scripts (JS/WASM) and origin (Mojo WebUI bridge).
+  CreateContents(/*sandbox_flags=*/std::nullopt);
+  content::RenderFrameHost* rfh = CommitAndGetMainFrame();
+
+  EXPECT_TRUE(rfh->IsSandboxed(network::mojom::WebSandboxFlags::kPopups));
+  EXPECT_FALSE(rfh->IsSandboxed(network::mojom::WebSandboxFlags::kScripts));
+  EXPECT_FALSE(rfh->IsSandboxed(network::mojom::WebSandboxFlags::kOrigin));
+}
+
+TEST_F(BackgroundWebContentsImplTest, OverriddenSandboxFlags) {
+  // Passing kNone fully unsandboxes the worker, as required for a
+  // cross-origin-isolated (COOP/COEP) worker.
+  CreateContents(network::mojom::WebSandboxFlags::kNone);
+  content::RenderFrameHost* rfh = CommitAndGetMainFrame();
+
+  EXPECT_FALSE(rfh->IsSandboxed(network::mojom::WebSandboxFlags::kPopups));
+  EXPECT_FALSE(rfh->IsSandboxed(network::mojom::WebSandboxFlags::kScripts));
+  EXPECT_FALSE(rfh->IsSandboxed(network::mojom::WebSandboxFlags::kOrigin));
 }
 
 }  // namespace local_ai

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -398,7 +398,10 @@ test("brave_unit_tests") {
   }
 
   if (enable_local_ai) {
-    deps += [ "//brave/browser/history_embeddings:unit_tests" ]
+    deps += [
+      "//brave/browser/history_embeddings:unit_tests",
+      "//brave/browser/local_ai:unit_tests",
+    ]
   }
 
   if (enable_print_preview) {


### PR DESCRIPTION
Factor the guest-profile + BackgroundWebContentsImpl creation shared by local AI background workers into a browser/local_ai/background_web_contents_factory helper, and migrate the history embeddings passage-embedder controller onto it.

The helper takes a WeakPtr<BackgroundWebContents::Delegate> so it is safe for a caller owned by another object (the passage embedder), and returns the guest OTR profile so the caller keeps its own observation policy.

BackgroundWebContentsImpl also gains an optional sandbox_flags argument so a caller can relax the default sandbox. ORT-Web must be cross-origin isolated to support multithreading, and cross-origin isolation requires an unsandboxed document (WebSandboxFlags::kNone). The optional is threaded through the factory and resolved to the default inside BackgroundWebContentsImpl, so the default lives in exactly one place.

This is some groundwork for extracting code from what we have for history_embedding to share for https://github.com/brave/brave-browser/issues/56487.