### PR TITLE
[AI Chat] Add movable side panel web view behind feature flag

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -633,6 +633,17 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
               ai_chat::features::kAIChatGlobalSidePanelEverywhere),            \
       },                                                                       \
       {                                                                        \
+          "brave-ai-chat-move-full-page-to-side-panel",                        \
+          "Brave AI Chat Move Full Page To Side Panel",                        \
+          "Moves the full-page AI Chat conversation into the side panel when " \
+          "an in-conversation link is clicked, and back to a tab when "        \
+          "opening "                                                           \
+          "full-page, preserving the live conversation state",                 \
+          kOsDesktop,                                                          \
+          FEATURE_VALUE_TYPE(                                                  \
+              ai_chat::features::kAIChatMoveFullPageToSidePanel),              \
+      },                                                                       \
+      {                                                                        \
           "brave-ai-chat-rich-search-widgets",                                 \
           "Brave AI Chat Rich Search Widgets",                                 \
           "Enables AI Chat Rich Search Widgets",                               \

--- a/browser/ai_chat/ai_chat_sidepanel_behavior_browsertest.cc
+++ b/browser/ai_chat/ai_chat_sidepanel_behavior_browsertest.cc
@@ -3,9 +3,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include <tuple>
+
 #include "base/test/scoped_feature_list.h"
 #include "base/test/test_future.h"
 #include "brave/browser/ai_chat/ai_chat_agent_profile_helper.h"
+#include "brave/browser/ui/webui/ai_chat/ai_chat_ui.h"
 #include "brave/components/ai_chat/core/browser/utils.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "chrome/browser/profiles/profile.h"
@@ -19,6 +22,8 @@
 #include "chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/browser/web_ui.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
 #include "printing/buildflags/buildflags.h"
@@ -30,22 +35,21 @@
 // Tests sidepanel behavior for AI Chat scenarios
 class AIChatGlobalSidePanelBrowserTest
     : public InProcessBrowserTest,
-      public testing::WithParamInterface<bool> {
+      public testing::WithParamInterface<std::tuple<bool, bool>> {
  public:
   AIChatGlobalSidePanelBrowserTest() {
     std::vector<base::test::FeatureRef> enabled_features = {
         ai_chat::features::kAIChatAgentProfile};
     std::vector<base::test::FeatureRef> disabled_features = {};
 
-    bool global_flag_enabled = GetParam();
-
-    if (global_flag_enabled) {
-      enabled_features.push_back(
-          ai_chat::features::kAIChatGlobalSidePanelEverywhere);
-    } else {
-      disabled_features.push_back(
-          ai_chat::features::kAIChatGlobalSidePanelEverywhere);
-    }
+    // The global side panel and the move-full-page-to-side-panel features are
+    // parameterized independently so the same assertions run against both the
+    // wrapper-based side panel view (move feature off) and the movable plain
+    // WebView (move feature on).
+    (IsGlobalFlagEnabled() ? enabled_features : disabled_features)
+        .push_back(ai_chat::features::kAIChatGlobalSidePanelEverywhere);
+    (IsMoveToSidePanelEnabled() ? enabled_features : disabled_features)
+        .push_back(ai_chat::features::kAIChatMoveFullPageToSidePanel);
 
     scoped_feature_list_.InitWithFeatures(enabled_features, disabled_features);
   }
@@ -58,7 +62,8 @@ class AIChatGlobalSidePanelBrowserTest
 
   ~AIChatGlobalSidePanelBrowserTest() override = default;
 
-  bool IsGlobalFlagEnabled() const { return GetParam(); }
+  bool IsGlobalFlagEnabled() const { return std::get<0>(GetParam()); }
+  bool IsMoveToSidePanelEnabled() const { return std::get<1>(GetParam()); }
 
  protected:
   void OpenSidePanelAndVerify(Browser* browser) {
@@ -196,12 +201,37 @@ IN_PROC_BROWSER_TEST_P(AIChatGlobalSidePanelBrowserTest,
   }
 }
 
+// The kChatUI side panel hosts and loads the AI Chat WebUI regardless of which
+// view backs it: the wrapper-based `AIChatSidePanelWebView` when the move
+// feature is off, or the movable plain `AIChatMovableSidePanelWebView` when it
+// is on. This verifies the conversation UI still opens and is reachable through
+// the standard side panel lookups for the movable view.
+IN_PROC_BROWSER_TEST_P(AIChatGlobalSidePanelBrowserTest,
+                       SidePanelHostsAndLoadsAIChatUI) {
+  auto* side_panel_coordinator = SidePanelCoordinator::From(browser());
+  ASSERT_TRUE(side_panel_coordinator);
+
+  side_panel_coordinator->Show(SidePanelEntry::Id::kChatUI);
+  EXPECT_TRUE(IsSidePanelOpen(browser()));
+
+  auto* side_panel_web_contents = side_panel_coordinator->GetWebContentsForTest(
+      SidePanelEntry::Id::kChatUI);
+  ASSERT_TRUE(side_panel_web_contents);
+  ASSERT_TRUE(content::WaitForLoadStop(side_panel_web_contents));
+
+  auto* web_ui = side_panel_web_contents->GetWebUI();
+  ASSERT_TRUE(web_ui);
+  EXPECT_TRUE(web_ui->GetController()->GetAs<AIChatUI>());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     ,
     AIChatGlobalSidePanelBrowserTest,
-    testing::Bool(),
+    testing::Combine(testing::Bool(), testing::Bool()),
     [](const testing::TestParamInfo<
         AIChatGlobalSidePanelBrowserTest::ParamType>& info) {
-      return absl::StrFormat("GlobalSidePanelFeature_%s",
-                             info.param ? "Enabled" : "NotEnabled");
+      return absl::StrFormat(
+          "GlobalSidePanel_%s_MoveToSidePanel_%s",
+          std::get<0>(info.param) ? "Enabled" : "NotEnabled",
+          std::get<1>(info.param) ? "Enabled" : "NotEnabled");
     });

--- a/browser/ui/views/side_panel/ai_chat/BUILD.gn
+++ b/browser/ui/views/side_panel/ai_chat/BUILD.gn
@@ -4,11 +4,14 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
+import("//extensions/buildflags/buildflags.gni")
 
 assert(enable_ai_chat)
 
 source_set("ai_chat") {
   sources = [
+    "ai_chat_movable_side_panel_web_view.cc",
+    "ai_chat_movable_side_panel_web_view.h",
     "ai_chat_side_panel_utils_views.cc",
     "ai_chat_side_panel_web_view.cc",
     "ai_chat_side_panel_web_view.h",
@@ -27,8 +30,16 @@ source_set("ai_chat") {
     "//chrome/browser/ui/side_panel",
     "//chrome/browser/ui/side_panel:side_panel_views_dependent",
     "//chrome/browser/ui/views/side_panel",
+    "//chrome/browser/ui/webui:webui_util",
+    "//components/web_modal",
+    "//content/public/browser",
+    "//extensions/buildflags",
     "//ui/base",
     "//ui/views",
     "//url",
   ]
+
+  if (enable_extensions_core) {
+    deps += [ "//extensions/browser" ]
+  }
 }

--- a/browser/ui/views/side_panel/ai_chat/BUILD.gn
+++ b/browser/ui/views/side_panel/ai_chat/BUILD.gn
@@ -17,6 +17,14 @@ source_set("ai_chat") {
     "ai_chat_side_panel_web_view.h",
   ]
 
+  # Header-visible dependencies: `ai_chat_movable_side_panel_web_view.h` derives
+  # from `views::WebView` (//ui/views) and
+  # `web_modal::WebContentsModalDialogManagerDelegate` (//components/web_modal).
+  public_deps = [
+    "//components/web_modal",
+    "//ui/views",
+  ]
+
   deps = [
     "//base",
     "//brave/browser/ai_chat",
@@ -24,6 +32,7 @@ source_set("ai_chat") {
     "//brave/components/ai_chat/core/common",
     "//brave/components/constants",
     "//brave/components/resources:strings_grit",
+    "//chrome/browser:file_select_helper",
     "//chrome/browser/profiles",
     "//chrome/browser/ui/browser_window",
     "//chrome/browser/ui/navigator",
@@ -31,11 +40,10 @@ source_set("ai_chat") {
     "//chrome/browser/ui/side_panel:side_panel_views_dependent",
     "//chrome/browser/ui/views/side_panel",
     "//chrome/browser/ui/webui:webui_util",
-    "//components/web_modal",
+    "//components/tabs:public",
     "//content/public/browser",
     "//extensions/buildflags",
     "//ui/base",
-    "//ui/views",
     "//url",
   ]
 

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.cc
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.cc
@@ -12,8 +12,8 @@
 #include "brave/components/ai_chat/core/common/ai_chat_urls.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/constants/webui_url_constants.h"
+#include "chrome/browser/file_select_helper.h"
 #include "chrome/browser/profiles/profile.h"
-#include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface_iterator.h"
@@ -22,9 +22,9 @@
 #include "chrome/browser/ui/side_panel/side_panel_entry_id.h"
 #include "chrome/browser/ui/side_panel/side_panel_entry_scope.h"
 #include "chrome/browser/ui/side_panel/side_panel_ui.h"
-#include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h"
 #include "chrome/browser/ui/webui/webui_embedding_context.h"
+#include "components/tabs/public/tab_interface.h"
 #include "components/web_modal/web_contents_modal_dialog_manager.h"
 #include "content/public/browser/file_select_listener.h"
 #include "content/public/browser/navigation_controller.h"
@@ -34,7 +34,6 @@
 #include "ui/base/page_transition_types.h"
 #include "ui/base/window_open_disposition.h"
 #include "ui/compositor/layer.h"
-#include "ui/views/widget/widget.h"
 #include "url/gurl.h"
 
 #if BUILDFLAG(ENABLE_EXTENSIONS_CORE)
@@ -158,26 +157,26 @@ content::WebContents* AIChatMovableSidePanelWebView::AddNewContents(
     const blink::mojom::WindowFeatures& window_features,
     bool user_gesture,
     bool* was_blocked) {
-  auto* browser_view = BrowserView::GetBrowserViewForNativeWindow(
-      GetWidget()->GetNativeWindow());
-  auto* browser = browser_view->browser();
+  BrowserWindowInterface* browser = webui::GetBrowserWindowInterface(source);
+  if (!browser) {
+    return nullptr;
+  }
 
   // If AI Chat is not open in the side panel, don't open the tab.
-  if (browser->browser_window_features()
-          ->side_panel_ui()
-          ->GetCurrentEntryId() != SidePanelEntryId::kChatUI) {
+  if (browser->GetFeatures().side_panel_ui()->GetCurrentEntryId() !=
+      SidePanelEntryId::kChatUI) {
     return nullptr;
   }
 
   // Rather than opening a new tab from the side panel we navigate the active
   // tab next to the sidepanel.
-  auto* active_tab = browser->tab_strip_model()->GetActiveWebContents();
+  tabs::TabInterface* active_tab = browser->GetActiveTabInterface();
   NavigateParams params(browser, target_url, ui::PAGE_TRANSITION_LINK);
 
   // If the global side panel is enabled, open the url in the current active
   // tab. Otherwise open in a new tab.
   if (ai_chat::features::IsAIChatGlobalSidePanelEverywhereEnabled()) {
-    params.source_contents = active_tab;
+    params.source_contents = active_tab ? active_tab->GetContents() : nullptr;
     params.disposition = WindowOpenDisposition::CURRENT_TAB;
   } else {
     // We open in a new foreground tab so we don't start a new conversation.
@@ -212,14 +211,8 @@ void AIChatMovableSidePanelWebView::RunFileChooser(
     content::RenderFrameHost* render_frame_host,
     scoped_refptr<content::FileSelectListener> listener,
     const blink::mojom::FileChooserParams& params) {
-  auto* browser_view = BrowserView::GetBrowserViewForNativeWindow(
-      GetWidget()->GetNativeWindow());
-  if (browser_view) {
-    static_cast<content::WebContentsDelegate*>(browser_view->browser())
-        ->RunFileChooser(render_frame_host, std::move(listener), params);
-  } else {
-    listener->FileSelectionCanceled();
-  }
+  FileSelectHelper::RunFileChooser(render_frame_host, std::move(listener),
+                                   params);
 }
 
 bool AIChatMovableSidePanelWebView::HandleKeyboardEvent(

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.cc
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.h"
 
+#include <memory>
 #include <utility>
 
 #include "base/check.h"
@@ -16,7 +17,6 @@
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
-#include "chrome/browser/ui/browser_window/public/browser_window_interface_iterator.h"
 #include "chrome/browser/ui/navigator/browser_navigator.h"
 #include "chrome/browser/ui/navigator/browser_navigator_params.h"
 #include "chrome/browser/ui/side_panel/side_panel_entry_id.h"
@@ -41,21 +41,6 @@
 #endif
 
 namespace {
-
-BrowserWindowInterface* FindNormalBrowser(
-    const content::BrowserContext* context) {
-  BrowserWindowInterface* normal_browser = nullptr;
-  ForEachCurrentBrowserWindowInterfaceOrderedByActivation(
-      [&](BrowserWindowInterface* browser) {
-        if (browser->GetType() == BrowserWindowInterface::TYPE_NORMAL &&
-            browser->GetProfile() == context) {
-          normal_browser = browser;
-          return false;  // stop iterating
-        }
-        return true;  // continue iterating
-      });
-  return normal_browser;
-}
 
 // Creates a fresh AI Chat `WebContents` for the side panel, wiring up the WebUI
 // embedding context from `scope` (mirrors `SidePanelWebUIView`) so links, modal
@@ -196,7 +181,7 @@ content::WebContents* AIChatMovableSidePanelWebView::OpenURLFromTab(
     const content::OpenURLParams& params,
     base::OnceCallback<void(content::NavigationHandle&)>
         navigation_handle_callback) {
-  auto* browser = FindNormalBrowser(source->GetBrowserContext());
+  BrowserWindowInterface* browser = webui::GetBrowserWindowInterface(source);
   if (browser &&
       (params.disposition == WindowOpenDisposition::NEW_FOREGROUND_TAB ||
        params.disposition == WindowOpenDisposition::NEW_BACKGROUND_TAB ||

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.cc
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.cc
@@ -1,0 +1,263 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.h"
+
+#include <utility>
+
+#include "base/check.h"
+#include "base/functional/callback.h"
+#include "brave/components/ai_chat/core/common/ai_chat_urls.h"
+#include "brave/components/ai_chat/core/common/features.h"
+#include "brave/components/constants/webui_url_constants.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_interface_iterator.h"
+#include "chrome/browser/ui/navigator/browser_navigator.h"
+#include "chrome/browser/ui/navigator/browser_navigator_params.h"
+#include "chrome/browser/ui/side_panel/side_panel_entry_id.h"
+#include "chrome/browser/ui/side_panel/side_panel_entry_scope.h"
+#include "chrome/browser/ui/side_panel/side_panel_ui.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h"
+#include "chrome/browser/ui/webui/webui_embedding_context.h"
+#include "components/web_modal/web_contents_modal_dialog_manager.h"
+#include "content/public/browser/file_select_listener.h"
+#include "content/public/browser/navigation_controller.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/browser/web_contents_delegate.h"
+#include "extensions/buildflags/buildflags.h"
+#include "ui/base/page_transition_types.h"
+#include "ui/base/window_open_disposition.h"
+#include "ui/compositor/layer.h"
+#include "ui/views/widget/widget.h"
+#include "url/gurl.h"
+
+#if BUILDFLAG(ENABLE_EXTENSIONS_CORE)
+#include "extensions/browser/view_type_utils.h"
+#endif
+
+namespace {
+
+BrowserWindowInterface* FindNormalBrowser(
+    const content::BrowserContext* context) {
+  BrowserWindowInterface* normal_browser = nullptr;
+  ForEachCurrentBrowserWindowInterfaceOrderedByActivation(
+      [&](BrowserWindowInterface* browser) {
+        if (browser->GetType() == BrowserWindowInterface::TYPE_NORMAL &&
+            browser->GetProfile() == context) {
+          normal_browser = browser;
+          return false;  // stop iterating
+        }
+        return true;  // continue iterating
+      });
+  return normal_browser;
+}
+
+// Creates a fresh AI Chat `WebContents` for the side panel, wiring up the WebUI
+// embedding context from `scope` (mirrors `SidePanelWebUIView`) so links, modal
+// dialogs and the hosting browser resolve correctly.
+std::unique_ptr<content::WebContents> CreateFreshAIChatContents(
+    Profile* profile,
+    bool is_tab_associated,
+    SidePanelEntryScope& scope) {
+  auto web_contents =
+      content::WebContents::Create(content::WebContents::CreateParams(profile));
+
+  if (scope.get_scope_type() == SidePanelEntryScope::ScopeType::kBrowser) {
+    webui::SetBrowserWindowInterface(web_contents.get(),
+                                     &scope.GetBrowserWindowInterface());
+  } else {
+    webui::SetTabInterface(web_contents.get(), &scope.GetTabInterface());
+  }
+
+  web_contents->GetController().LoadURLWithParams(
+      content::NavigationController::LoadURLParams(
+          is_tab_associated ? ai_chat::TabAssociatedConversationUrl()
+                            : GURL(kAIChatUIURL)));
+  return web_contents;
+}
+
+}  // namespace
+
+// static
+std::unique_ptr<views::View> AIChatMovableSidePanelWebView::CreateView(
+    Profile* profile,
+    bool is_tab_associated,
+    SidePanelEntryScope& scope) {
+  CHECK(profile);
+
+  auto web_view = std::make_unique<AIChatMovableSidePanelWebView>(profile);
+  web_view->AdoptWebContents(
+      CreateFreshAIChatContents(profile, is_tab_associated, scope));
+  return web_view;
+}
+
+AIChatMovableSidePanelWebView::AIChatMovableSidePanelWebView(Profile* profile)
+    : views::WebView(profile) {
+  // Use the shared side panel web view id so the hosted contents is
+  // discoverable by the same lookups the wrapper-based view supports (e.g.
+  // `SidePanelCoordinator::GetWebContentsForTest` and the webui_browser side
+  // panel), keeping parity with the flag-off `SidePanelWebUIView`.
+  SetID(SidePanelWebUIView::kSidePanelWebViewId);
+  // Paint to a non-opaque layer so the side panel's open/close content
+  // transition can composite this view smoothly.
+  SetPaintToLayer();
+  layer()->SetFillsBoundsOpaquely(false);
+}
+
+AIChatMovableSidePanelWebView::~AIChatMovableSidePanelWebView() {
+  SetWebContents(nullptr);
+}
+
+void AIChatMovableSidePanelWebView::AdoptWebContents(
+    std::unique_ptr<content::WebContents> web_contents) {
+  owned_web_contents_ = std::move(web_contents);
+  SetWebContents(owned_web_contents_.get());
+}
+
+void AIChatMovableSidePanelWebView::SetWebContents(
+    content::WebContents* web_contents) {
+  if (this->web_contents() == web_contents) {
+    return;
+  }
+
+  if (this->web_contents() && !this->web_contents()->IsBeingDestroyed()) {
+    this->web_contents()->WasHidden();
+  }
+  DetachWebContentsModalDialogManager(this->web_contents());
+
+  AttachWebContentsModalDialogManager(web_contents);
+  views::WebView::SetWebContents(web_contents);
+
+  if (web_contents) {
+    web_contents->WasShown();
+    // Set `this` as the delegate to handle new tabs, links, file chooser and
+    // media access requests.
+    web_contents->SetDelegate(this);
+#if BUILDFLAG(ENABLE_EXTENSIONS_CORE)
+    // Mark as a component view. This keeps the side-panel contents out of the
+    // extensions tab surface (e.g. chrome.tabs), and lets
+    // `ChromeSpeechRecognitionManagerDelegate::CheckRenderFrameType()` permit
+    // the Web Speech API that AI Chat uses for voice input.
+    extensions::SetViewType(web_contents,
+                            extensions::mojom::ViewType::kComponent);
+#endif
+  }
+}
+
+content::WebContents* AIChatMovableSidePanelWebView::AddNewContents(
+    content::WebContents* source,
+    std::unique_ptr<content::WebContents> new_contents,
+    const GURL& target_url,
+    WindowOpenDisposition disposition,
+    const blink::mojom::WindowFeatures& window_features,
+    bool user_gesture,
+    bool* was_blocked) {
+  auto* browser_view = BrowserView::GetBrowserViewForNativeWindow(
+      GetWidget()->GetNativeWindow());
+  auto* browser = browser_view->browser();
+
+  // If AI Chat is not open in the side panel, don't open the tab.
+  if (browser->browser_window_features()
+          ->side_panel_ui()
+          ->GetCurrentEntryId() != SidePanelEntryId::kChatUI) {
+    return nullptr;
+  }
+
+  // Rather than opening a new tab from the side panel we navigate the active
+  // tab next to the sidepanel.
+  auto* active_tab = browser->tab_strip_model()->GetActiveWebContents();
+  NavigateParams params(browser, target_url, ui::PAGE_TRANSITION_LINK);
+
+  // If the global side panel is enabled, open the url in the current active
+  // tab. Otherwise open in a new tab.
+  if (ai_chat::features::IsAIChatGlobalSidePanelEverywhereEnabled()) {
+    params.source_contents = active_tab;
+    params.disposition = WindowOpenDisposition::CURRENT_TAB;
+  } else {
+    // We open in a new foreground tab so we don't start a new conversation.
+    params.disposition = WindowOpenDisposition::NEW_FOREGROUND_TAB;
+  }
+
+  params.window_action = NavigateParams::WindowAction::kNoAction;
+  params.user_gesture = user_gesture;
+
+  Navigate(&params);
+
+  return params.navigated_or_inserted_contents;
+}
+
+content::WebContents* AIChatMovableSidePanelWebView::OpenURLFromTab(
+    content::WebContents* source,
+    const content::OpenURLParams& params,
+    base::OnceCallback<void(content::NavigationHandle&)>
+        navigation_handle_callback) {
+  auto* browser = FindNormalBrowser(source->GetBrowserContext());
+  if (browser &&
+      (params.disposition == WindowOpenDisposition::NEW_FOREGROUND_TAB ||
+       params.disposition == WindowOpenDisposition::NEW_BACKGROUND_TAB ||
+       params.disposition == WindowOpenDisposition::NEW_WINDOW ||
+       params.disposition == WindowOpenDisposition::OFF_THE_RECORD)) {
+    return browser->OpenURL(params, std::move(navigation_handle_callback));
+  }
+  return nullptr;
+}
+
+void AIChatMovableSidePanelWebView::RunFileChooser(
+    content::RenderFrameHost* render_frame_host,
+    scoped_refptr<content::FileSelectListener> listener,
+    const blink::mojom::FileChooserParams& params) {
+  auto* browser_view = BrowserView::GetBrowserViewForNativeWindow(
+      GetWidget()->GetNativeWindow());
+  if (browser_view) {
+    static_cast<content::WebContentsDelegate*>(browser_view->browser())
+        ->RunFileChooser(render_frame_host, std::move(listener), params);
+  } else {
+    listener->FileSelectionCanceled();
+  }
+}
+
+bool AIChatMovableSidePanelWebView::HandleKeyboardEvent(
+    content::WebContents* source,
+    const input::NativeWebKeyboardEvent& event) {
+  return unhandled_keyboard_event_handler_.HandleKeyboardEvent(
+      event, GetFocusManager());
+}
+
+web_modal::WebContentsModalDialogHost*
+AIChatMovableSidePanelWebView::GetWebContentsModalDialogHost(
+    content::WebContents* web_contents) {
+  BrowserWindowInterface* browser =
+      webui::GetBrowserWindowInterface(web_contents);
+  if (!browser) {
+    return nullptr;
+  }
+  return browser->GetWebContentsModalDialogHostForWindow();
+}
+
+void AIChatMovableSidePanelWebView::AttachWebContentsModalDialogManager(
+    content::WebContents* web_contents) {
+  if (!web_contents) {
+    return;
+  }
+  web_modal::WebContentsModalDialogManager::CreateForWebContents(web_contents);
+  web_modal::WebContentsModalDialogManager::FromWebContents(web_contents)
+      ->SetDelegate(this);
+}
+
+void AIChatMovableSidePanelWebView::DetachWebContentsModalDialogManager(
+    content::WebContents* web_contents) {
+  if (!web_contents) {
+    return;
+  }
+  auto* dialog_manager =
+      web_modal::WebContentsModalDialogManager::FromWebContents(web_contents);
+  if (dialog_manager) {
+    dialog_manager->SetDelegate(nullptr);
+  }
+}

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.h
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.h
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_AI_CHAT_AI_CHAT_MOVABLE_SIDE_PANEL_WEB_VIEW_H_
+#define BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_AI_CHAT_AI_CHAT_MOVABLE_SIDE_PANEL_WEB_VIEW_H_
+
+#include <memory>
+
+#include "components/web_modal/web_contents_modal_dialog_manager_delegate.h"
+#include "ui/views/controls/webview/unhandled_keyboard_event_handler.h"
+#include "ui/views/controls/webview/webview.h"
+
+namespace blink::mojom {
+class FileChooserParams;
+class WindowFeatures;
+}  // namespace blink::mojom
+
+namespace content {
+class FileSelectListener;
+class NavigationHandle;
+class RenderFrameHost;
+class WebContents;
+struct OpenURLParams;
+}  // namespace content
+
+namespace input {
+struct NativeWebKeyboardEvent;
+}  // namespace input
+
+namespace web_modal {
+class WebContentsModalDialogHost;
+}  // namespace web_modal
+
+class GURL;
+class Profile;
+class SidePanelEntryScope;
+
+// A side panel host for AI Chat used when the
+// `kAIChatMoveFullPageToSidePanel` feature is enabled. Unlike the WebUI-wrapper
+// based `AIChatSidePanelWebView`, this is a plain `views::WebView` that owns
+// its AI Chat `WebContents` directly (modeled on Chromium's Contextual Tasks
+// `ContextualTasksWebView`). Owning the contents allows the same live
+// `WebContents` to be moved between a browser tab and the side panel without
+// re-navigating.
+class AIChatMovableSidePanelWebView
+    : public views::WebView,
+      public web_modal::WebContentsModalDialogManagerDelegate {
+ public:
+  // Factory used by `AIChatSidePanelWebView::CreateView` when the feature is
+  // enabled. If `is_tab_associated` is true the panel tracks the active tab's
+  // conversation; otherwise it opens the standalone (global) conversation.
+  static std::unique_ptr<views::View> CreateView(Profile* profile,
+                                                 bool is_tab_associated,
+                                                 SidePanelEntryScope& scope);
+
+  explicit AIChatMovableSidePanelWebView(Profile* profile);
+  ~AIChatMovableSidePanelWebView() override;
+
+  AIChatMovableSidePanelWebView(const AIChatMovableSidePanelWebView&) = delete;
+  AIChatMovableSidePanelWebView& operator=(
+      const AIChatMovableSidePanelWebView&) = delete;
+
+  // Takes ownership of `web_contents` and displays it in this view.
+  void AdoptWebContents(std::unique_ptr<content::WebContents> web_contents);
+
+  // views::WebView:
+  void SetWebContents(content::WebContents* web_contents) override;
+
+  // content::WebContentsDelegate:
+  content::WebContents* AddNewContents(
+      content::WebContents* source,
+      std::unique_ptr<content::WebContents> new_contents,
+      const GURL& target_url,
+      WindowOpenDisposition disposition,
+      const blink::mojom::WindowFeatures& window_features,
+      bool user_gesture,
+      bool* was_blocked) override;
+  content::WebContents* OpenURLFromTab(
+      content::WebContents* source,
+      const content::OpenURLParams& params,
+      base::OnceCallback<void(content::NavigationHandle&)>
+          navigation_handle_callback) override;
+  void RunFileChooser(content::RenderFrameHost* render_frame_host,
+                      scoped_refptr<content::FileSelectListener> listener,
+                      const blink::mojom::FileChooserParams& params) override;
+  bool HandleKeyboardEvent(content::WebContents* source,
+                           const input::NativeWebKeyboardEvent& event) override;
+
+  // web_modal::WebContentsModalDialogManagerDelegate:
+  web_modal::WebContentsModalDialogHost* GetWebContentsModalDialogHost(
+      content::WebContents* web_contents) override;
+
+ private:
+  // Attach a modal dialog manager to `web_contents` so dialogs display
+  // correctly while it is hosted in the side panel.
+  void AttachWebContentsModalDialogManager(content::WebContents* web_contents);
+
+  // Detach the modal dialog manager from `web_contents` when it leaves the
+  // side panel.
+  void DetachWebContentsModalDialogManager(content::WebContents* web_contents);
+
+  // The AI Chat `WebContents` owned and displayed by this view.
+  std::unique_ptr<content::WebContents> owned_web_contents_;
+
+  // Handles keyboard events that come back unhandled from the renderer.
+  views::UnhandledKeyboardEventHandler unhandled_keyboard_event_handler_;
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_AI_CHAT_AI_CHAT_MOVABLE_SIDE_PANEL_WEB_VIEW_H_

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_web_view.cc
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_web_view.cc
@@ -6,7 +6,9 @@
 #include "brave/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_web_view.h"
 
 #include "base/check.h"
+#include "base/feature_list.h"
 #include "base/functional/bind.h"
+#include "brave/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.h"
 #include "brave/browser/ui/webui/ai_chat/ai_chat_ui.h"
 #include "brave/components/ai_chat/core/common/ai_chat_urls.h"
 #include "brave/components/ai_chat/core/common/features.h"
@@ -57,6 +59,17 @@ std::unique_ptr<views::View> AIChatSidePanelWebView::CreateView(
     bool is_tab_associated,
     SidePanelEntryScope& scope) {
   CHECK(profile);
+
+  // When enabled, serve AI Chat from a plain WebView that owns its WebContents,
+  // so the live conversation can be moved between a tab and the side panel. The
+  // WebUI-wrapper based view below remains the default and is a true no-op when
+  // the feature is off (it keeps top-chrome preload + content-readiness
+  // gating).
+  if (base::FeatureList::IsEnabled(
+          ai_chat::features::kAIChatMoveFullPageToSidePanel)) {
+    return AIChatMovableSidePanelWebView::CreateView(profile, is_tab_associated,
+                                                     scope);
+  }
 
   auto web_view = std::make_unique<AIChatSidePanelWebView>(
       scope, std::make_unique<WebUIContentsWrapperT<AIChatUI>>(

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_web_view.cc
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_web_view.cc
@@ -61,10 +61,9 @@ std::unique_ptr<views::View> AIChatSidePanelWebView::CreateView(
   CHECK(profile);
 
   // When enabled, serve AI Chat from a plain WebView that owns its WebContents,
-  // so the live conversation can be moved between a tab and the side panel. The
-  // WebUI-wrapper based view below remains the default and is a true no-op when
-  // the feature is off (it keeps top-chrome preload + content-readiness
-  // gating).
+  // so the live conversation can be moved between a tab and the side panel. If
+  // this feature flag becomes the default, we can remove this
+  // AIChatSidePanelWebView class, or rename the movable version to this name.
   if (base::FeatureList::IsEnabled(
           ai_chat::features::kAIChatMoveFullPageToSidePanel)) {
     return AIChatMovableSidePanelWebView::CreateView(profile, is_tab_associated,

--- a/components/ai_chat/core/common/features.cc
+++ b/components/ai_chat/core/common/features.cc
@@ -96,6 +96,8 @@ bool IsAIChatGlobalSidePanelEverywhereEnabled() {
       features::kAIChatGlobalSidePanelEverywhere);
 }
 
+BASE_FEATURE(kAIChatMoveFullPageToSidePanel, base::FEATURE_DISABLED_BY_DEFAULT);
+
 BASE_FEATURE(kCustomSiteDistillerScripts, base::FEATURE_ENABLED_BY_DEFAULT);
 
 bool IsCustomSiteDistillerScriptsEnabled() {

--- a/components/ai_chat/core/common/features.h
+++ b/components/ai_chat/core/common/features.h
@@ -96,6 +96,13 @@ BASE_DECLARE_FEATURE(kAIChatGlobalSidePanelEverywhere);
 COMPONENT_EXPORT(AI_CHAT_COMMON)
 bool IsAIChatGlobalSidePanelEverywhereEnabled();
 
+// Moves the full-page AI Chat conversation into the side panel when an
+// in-conversation link is clicked, and back into a tab when opening the
+// conversation full-page, transferring the live WebContents to preserve state.
+// Desktop only; disabled by default.
+COMPONENT_EXPORT(AI_CHAT_COMMON)
+BASE_DECLARE_FEATURE(kAIChatMoveFullPageToSidePanel);
+
 COMPONENT_EXPORT(AI_CHAT_COMMON)
 BASE_DECLARE_FEATURE(kCustomSiteDistillerScripts);
 COMPONENT_EXPORT(AI_CHAT_COMMON) bool IsCustomSiteDistillerScriptsEnabled();


### PR DESCRIPTION
This begins implementing a feature whereby the live WebContents for AI Chat can be moved between Side Panel and Tab. It mimics the Chromium ContextualTasks feature which lets the AI Mode search page (a wrapper of Google but hosted in a WebUI) do the same.

Introduces `kAIChatMoveFullPageToSidePanel` feature flag (disabled by default, desktop only) and a new plain `views::WebView` based side panel host, `AIChatMovableSidePanelWebView`, that owns its Leo `WebContents` directly (modeled on Chromium's Contextual Tasks `ContextualTasksWebView`).

This is the first step toward moving the live Leo conversation bidirectionally between a full tab and the side panel while preserving renderer/Mojo state. This change only wires up the flag and the alternate view at behavioral parity for a fresh open; the tab<->side-panel transfer, window controller and animation arrive in later changes.

- `AIChatSidePanelWebView::CreateView` branches on the flag: ON builds the new view, OFF keeps the existing `WebUIContentsWrapperT<AIChatUI>` path untouched, so flag-off is a true no-op and retains the top-chrome WebUI preload and content-readiness gating.
- The new view creates and owns a Leo WebContents, wires the WebUI embedding context from the `SidePanelEntryScope`, and ports the existing new-tab / link / file-chooser handling plus media access and keyboard handling.
- Adds a `brave://flags` entry (desktop only).

Series:
- https://github.com/brave/brave-browser/issues/57047

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
