### PR TITLE
[Android] Add dynamic colors preference

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -450,7 +450,6 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/upgrade/BravePackageReplacedBroadcastReceiver.java",
   "../../brave/android/java/org/chromium/chrome/browser/upgrade/NotificationIntent.java",
   "../../brave/android/java/org/chromium/chrome/browser/util/BraveDbUtil.java",
-  "../../brave/android/java/org/chromium/chrome/browser/util/BraveDynamicColors.java",
   "../../brave/android/java/org/chromium/chrome/browser/util/BraveTouchUtils.java",
   "../../brave/android/java/org/chromium/chrome/browser/util/ConfigurationUtils.java",
   "../../brave/android/java/org/chromium/chrome/browser/util/ImageUtils.java",

--- a/android/java/brave-res/xml/brave_appearance_preferences.xml
+++ b/android/java/brave-res/xml/brave_appearance_preferences.xml
@@ -9,6 +9,13 @@
         android:key="navigation_section"
         android:title="@string/appearance_navigation_section_title" />
 
+    <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
+        android:key="brave_android_dynamic_colors_enabled"
+        android:icon="@drawable/ic_themes"
+        android:title="@string/brave_android_dynamic_colors_title"
+        android:summary="@string/brave_android_dynamic_colors_summary"
+        app:isPreferenceVisible="false" />
+
     <org.chromium.components.browser_ui.settings.ChromeBasePreference
         android:fragment="org.chromium.brave.browser.customize_menu.settings.BraveCustomizeMenuPreferenceFragment"
         android:key="brave_customize_menu"
@@ -47,7 +54,8 @@
         android:icon="@drawable/ic_share"
         android:title="@string/brave_sharing_hub_title"
         android:summaryOn="@string/text_on"
-        android:summaryOff="@string/text_off" />
+        android:summaryOff="@string/text_off"
+        app:isPreferenceVisible="false" />
 
     <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
         android:key="show_brave_rewards_icon"

--- a/android/java/org/chromium/base/BravePreferenceKeys.java
+++ b/android/java/org/chromium/base/BravePreferenceKeys.java
@@ -11,6 +11,8 @@ import org.chromium.build.annotations.NullMarked;
 public final class BravePreferenceKeys {
     public static final String BRAVE_BOTTOM_TOOLBAR_ENABLED_KEY =
             "brave_bottom_toolbar_enabled_key";
+    public static final String BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED =
+            "brave_android_dynamic_colors_enabled";
     public static final String BRAVE_BOTTOM_TOOLBAR_SET_KEY = "brave_bottom_toolbar_enabled";
     public static final String BRAVE_IS_MENU_FROM_BOTTOM = "brave_is_menu_from_bottom";
     public static final String BRAVE_USE_CUSTOM_TABS = "use_custom_tabs";

--- a/android/java/org/chromium/chrome/browser/app/flags/BraveCachedFlags.java
+++ b/android/java/org/chromium/chrome/browser/app/flags/BraveCachedFlags.java
@@ -37,9 +37,7 @@ public class BraveCachedFlags extends ChromeCachedFlags {
 
     // List of cached flags for Brave features - safe to access before native is ready
     private static final List<CachedFlag> sBraveFlagsCached =
-            List.of(
-                    BraveDynamicColors.sDynamicColorsEnabled,
-                    sBraveFreshNtpAfterIdleExperimentEnabled);
+            List.of(BraveDynamicColors.getCachedFlag(), sBraveFreshNtpAfterIdleExperimentEnabled);
     // List of cached feature params for Brave features - safe to access before native is ready
     private static final List<CachedFeatureParam<?>> sBraveFeatureParamsCached =
             List.of(sBraveFreshNtpAfterIdleExperimentVariant);

--- a/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
@@ -42,6 +42,7 @@ import org.chromium.chrome.browser.toolbar.adaptive.BraveAdaptiveToolbarPrefs;
 import org.chromium.chrome.browser.toolbar.adaptive.settings.BraveRadioButtonGroupAdaptiveToolbarPreference;
 import org.chromium.chrome.browser.toolbar.bottom.BottomToolbarConfiguration;
 import org.chromium.chrome.browser.toolbar.settings.AddressBarSettingsFragment;
+import org.chromium.chrome.browser.util.BraveDynamicColors;
 import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
 import org.chromium.components.browser_ui.settings.SettingsUtils;
 import org.chromium.components.browser_ui.settings.search.PreferenceParser;
@@ -102,6 +103,13 @@ public class AppearancePreferences extends AppearanceSettingsFragment
         setPreferenceVisibleIfPresent(
                 PREF_BRAVE_DISABLE_SHARING_HUB, shouldShowSharingHubPreference());
 
+        if (BraveDynamicColors.isDynamicColorsAvailable()) {
+            setPreferenceVisibleIfPresent(
+                    BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, true);
+        } else {
+            removePreferenceIfPresent(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED);
+        }
+
         if (BraveTabUiFeatureUtilities.isBraveAndroidTabGroupsSettingsFeatureEnabled()) {
             removePreferenceIfPresent(PREF_BRAVE_ENABLE_TAB_GROUPS);
             removePreferenceIfPresent(PREF_SHOW_UNDO_WHEN_TABS_CLOSED);
@@ -155,6 +163,14 @@ public class AppearancePreferences extends AppearanceSettingsFragment
                 findPreference(BravePreferenceKeys.BRAVE_BOTTOM_TOOLBAR_ENABLED_KEY);
         if (enableBottomToolbar != null) {
             enableBottomToolbar.setOnPreferenceChangeListener(this);
+        }
+
+        ChromeSwitchPreference dynamicColorsPref =
+                (ChromeSwitchPreference)
+                        findPreference(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED);
+        if (dynamicColorsPref != null) {
+            dynamicColorsPref.setChecked(BraveDynamicColors.isDynamicColorsUserEnabled());
+            dynamicColorsPref.setOnPreferenceChangeListener(this);
         }
 
         Preference sharingHub = findPreference(PREF_BRAVE_DISABLE_SHARING_HUB);
@@ -283,6 +299,9 @@ public class AppearancePreferences extends AppearanceSettingsFragment
             BraveFeatureUtil.enableFeature(
                     BraveFeatureList.ENABLE_FORCE_DARK, (boolean) newValue, true);
             shouldRelaunch = true;
+        } else if (BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED.equals(key)) {
+            ChromeSharedPreferences.getInstance().writeBoolean(key, (boolean) newValue);
+            shouldRelaunch = true;
         } else if (PREF_BRAVE_DISABLE_SHARING_HUB.equals(key)) {
             setSharingHubEnabled((boolean) newValue);
         } else if (PREF_BRAVE_ENABLE_TAB_GROUPS.equals(key)) {
@@ -381,19 +400,20 @@ public class AppearancePreferences extends AppearanceSettingsFragment
     private void applyOrdering() {
         setPreferenceOrder(PREF_NAVIGATION_SECTION, 0);
         setPreferenceOrder(AppearanceSettingsFragment.PREF_UI_THEME, 1);
-        setPreferenceOrder(PREF_BRAVE_CUSTOMIZE_MENU, 2);
-        setPreferenceOrder(AppearanceSettingsFragment.PREF_TOOLBAR_SHORTCUT, 3);
-        setPreferenceOrder(PREF_ADDRESS_BAR, 4);
-        setPreferenceOrder(BravePreferenceKeys.BRAVE_BOTTOM_TOOLBAR_ENABLED_KEY, 5);
-        setPreferenceOrder(PREF_ENABLE_MULTI_WINDOWS, 6);
-        setPreferenceOrder(PREF_GENERAL_SECTION, 7);
-        setPreferenceOrder(PREF_BRAVE_NIGHT_MODE_ENABLED, 8);
-        setPreferenceOrder(PREF_BRAVE_DISABLE_SHARING_HUB, 9);
-        setPreferenceOrder(PREF_SHOW_BRAVE_REWARDS_ICON, 10);
-        setPreferenceOrder(PREF_ADS_SWITCH, 11);
-        setPreferenceOrder(AppearanceSettingsFragment.PREF_BOOKMARK_BAR, 12);
-        setPreferenceOrder(PREF_BRAVE_ENABLE_TAB_GROUPS, 13);
-        setPreferenceOrder(PREF_SHOW_UNDO_WHEN_TABS_CLOSED, 14);
+        setPreferenceOrder(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, 2);
+        setPreferenceOrder(PREF_BRAVE_CUSTOMIZE_MENU, 3);
+        setPreferenceOrder(AppearanceSettingsFragment.PREF_TOOLBAR_SHORTCUT, 4);
+        setPreferenceOrder(PREF_ADDRESS_BAR, 5);
+        setPreferenceOrder(BravePreferenceKeys.BRAVE_BOTTOM_TOOLBAR_ENABLED_KEY, 6);
+        setPreferenceOrder(PREF_ENABLE_MULTI_WINDOWS, 7);
+        setPreferenceOrder(PREF_GENERAL_SECTION, 8);
+        setPreferenceOrder(PREF_BRAVE_NIGHT_MODE_ENABLED, 9);
+        setPreferenceOrder(PREF_BRAVE_DISABLE_SHARING_HUB, 10);
+        setPreferenceOrder(PREF_SHOW_BRAVE_REWARDS_ICON, 11);
+        setPreferenceOrder(PREF_ADS_SWITCH, 12);
+        setPreferenceOrder(AppearanceSettingsFragment.PREF_BOOKMARK_BAR, 13);
+        setPreferenceOrder(PREF_BRAVE_ENABLE_TAB_GROUPS, 14);
+        setPreferenceOrder(PREF_SHOW_UNDO_WHEN_TABS_CLOSED, 15);
     }
 
     private void setPreferenceOrder(String key, int order) {
@@ -484,6 +504,11 @@ public class AppearancePreferences extends AppearanceSettingsFragment
 
                     if (!shouldShowSharingHubPreference()) {
                         indexData.removeEntryForKey(frag, PREF_BRAVE_DISABLE_SHARING_HUB);
+                    }
+
+                    if (!BraveDynamicColors.isDynamicColorsAvailable()) {
+                        indexData.removeEntryForKey(
+                                frag, BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED);
                     }
 
                     if (BraveTabUiFeatureUtilities

--- a/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
@@ -169,7 +169,7 @@ public class AppearancePreferences extends AppearanceSettingsFragment
                 (ChromeSwitchPreference)
                         findPreference(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED);
         if (dynamicColorsPref != null) {
-            dynamicColorsPref.setChecked(BraveDynamicColors.isDynamicColorsUserEnabled());
+            dynamicColorsPref.setChecked(BraveDynamicColors.isDynamicColorsEnabled());
             dynamicColorsPref.setOnPreferenceChangeListener(this);
         }
 

--- a/android/java/org/chromium/chrome/browser/tabbed_mode/BraveTabbedNavigationBarColorControllerBase.java
+++ b/android/java/org/chromium/chrome/browser/tabbed_mode/BraveTabbedNavigationBarColorControllerBase.java
@@ -50,7 +50,7 @@ class BraveTabbedNavigationBarColorControllerBase {
     public int getNavigationBarColor(boolean forceDarkNavigationBar) {
         // Adjust navigation bar color to match the bottom toolbar color when it is visible,
         // unless dynamic colors are enabled (in which case we let upstream handle it).
-        if (!BraveDynamicColors.sDynamicColorsEnabled.isEnabled()) {
+        if (!BraveDynamicColors.isDynamicColorsEnabled()) {
             if (BottomToolbarConfiguration.isBraveBottomControlsEnabled()
                     && BraveMenuButtonCoordinator.isMenuFromBottom()
                     && mContext != null

--- a/android/java/org/chromium/chrome/browser/ui/system/BraveStatusBarColorController.java
+++ b/android/java/org/chromium/chrome/browser/ui/system/BraveStatusBarColorController.java
@@ -57,8 +57,7 @@ public class BraveStatusBarColorController extends StatusBarColorController {
 
         // Dark theme doesn't have the regression, apply adjustment to light one only.
         // Skip when dynamic colors are enabled — the themed surface color should be used instead.
-        if (!ColorUtils.inNightMode(activity)
-                && !BraveDynamicColors.sDynamicColorsEnabled.isEnabled()) {
+        if (!ColorUtils.inNightMode(activity) && !BraveDynamicColors.isDynamicColorsEnabled()) {
             mBackgroundColorForNtp = Color.WHITE;
         }
     }

--- a/android/java/org/chromium/chrome/browser/util/BUILD.gn
+++ b/android/java/org/chromium/chrome/browser/util/BUILD.gn
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//build/config/android/rules.gni")
+
+android_library("java") {
+  sources = [ "BraveDynamicColors.java" ]
+
+  deps = [
+    "//base:base_java",
+    "//chrome/browser/flags:java",
+    "//chrome/browser/preferences:java",
+    "//components/cached_flags:java",
+    "//third_party/android_deps:material_design_java",
+  ]
+}

--- a/android/java/org/chromium/chrome/browser/util/BraveDynamicColors.java
+++ b/android/java/org/chromium/chrome/browser/util/BraveDynamicColors.java
@@ -17,29 +17,58 @@ import org.chromium.chrome.browser.flags.ChromeFeatureMap;
 import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
 import org.chromium.components.cached_flags.CachedFlag;
 
-public class BraveDynamicColors {
-    // Declared here (not in BraveCachedFlags) to avoid circular class-initialization:
-    // BraveCachedFlags extends ChromeCachedFlags whose <clinit> creates a BraveCachedFlags
-    // instance before BraveCachedFlags static fields are ready. Accessing this field early
-    // only triggers BraveDynamicColors class-init, which has no such circular dependency.
-    public static final CachedFlag sDynamicColorsEnabled =
-            new CachedFlag(
-                    ChromeFeatureMap.getInstance(),
-                    BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS,
-                    false);
-
-    public static boolean isDynamicColorsAvailable() {
-        return sDynamicColorsEnabled.isEnabled() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S;
+public final class BraveDynamicColors {
+    private static final class LazyHolder {
+        // BraveCachedFlags extends ChromeCachedFlags. ChromeCachedFlags.<clinit> creates a
+        // singleton whose constructor is bytecode-redirected to BraveCachedFlags. This can run
+        // before BraveCachedFlags static fields are ready, so this CachedFlag must not live
+        // directly in BraveCachedFlags. It is obtained from this separately initialized holder.
+        private static final CachedFlag sDynamicColorsFlag =
+                new CachedFlag(
+                        ChromeFeatureMap.getInstance(),
+                        BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS,
+                        true);
     }
 
-    public static boolean isDynamicColorsUserEnabled() {
+    private BraveDynamicColors() {}
+
+    /**
+     * Returns the lazily initialized feature flag used for cached-flag registration and
+     * early-startup reads.
+     */
+    public static CachedFlag getCachedFlag() {
+        return LazyHolder.sDynamicColorsFlag;
+    }
+
+    /**
+     * Returns whether dynamic colors are available for this app session.
+     *
+     * <p>Availability requires the cached feature flag to be enabled and Android 12 or later. It
+     * does not include the user's preference; {@link #isDynamicColorsEnabled()} is the preferred
+     * method for runtime behavior checks.
+     */
+    public static boolean isDynamicColorsAvailable() {
+        return getCachedFlag().isEnabled() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S;
+    }
+
+    /**
+     * Returns whether dynamic colors should be used at runtime.
+     *
+     * <p>This requires dynamic colors to be available and the user preference to be enabled. The
+     * preference defaults to enabled when it has not been set.
+     */
+    public static boolean isDynamicColorsEnabled() {
+        return isDynamicColorsAvailable() && isDynamicColorsUserEnabled();
+    }
+
+    /** Returns the persisted user preference, which defaults to enabled when unset. */
+    private static boolean isDynamicColorsUserEnabled() {
         return ChromeSharedPreferences.getInstance()
                 .readBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, true);
     }
 
     public static void applyToActivityIfAvailable(Activity activity) {
-        if (!sDynamicColorsEnabled.isEnabled()) {
-            // We disable dynamic colors as it causes styling issues with Brave theme.
+        if (!isDynamicColorsEnabled()) {
             return;
         }
 
@@ -48,8 +77,7 @@ public class BraveDynamicColors {
 
     public static void applyToActivityIfAvailable(
             Activity activity, DynamicColorsOptions dynamicColorsOptions) {
-        if (!sDynamicColorsEnabled.isEnabled()) {
-            // We disable dynamic colors as it causes styling issues with Brave theme.
+        if (!isDynamicColorsEnabled()) {
             return;
         }
 

--- a/android/java/org/chromium/chrome/browser/util/BraveDynamicColors.java
+++ b/android/java/org/chromium/chrome/browser/util/BraveDynamicColors.java
@@ -6,12 +6,15 @@
 package org.chromium.chrome.browser.util;
 
 import android.app.Activity;
+import android.os.Build;
 
 import com.google.android.material.color.DynamicColors;
 import com.google.android.material.color.DynamicColorsOptions;
 
 import org.chromium.base.BraveFeatureList;
+import org.chromium.base.BravePreferenceKeys;
 import org.chromium.chrome.browser.flags.ChromeFeatureMap;
+import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
 import org.chromium.components.cached_flags.CachedFlag;
 
 public class BraveDynamicColors {
@@ -24,6 +27,15 @@ public class BraveDynamicColors {
                     ChromeFeatureMap.getInstance(),
                     BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS,
                     false);
+
+    public static boolean isDynamicColorsAvailable() {
+        return sDynamicColorsEnabled.isEnabled() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S;
+    }
+
+    public static boolean isDynamicColorsUserEnabled() {
+        return ChromeSharedPreferences.getInstance()
+                .readBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, true);
+    }
 
     public static void applyToActivityIfAvailable(Activity activity) {
         if (!sDynamicColorsEnabled.isEnabled()) {

--- a/android/javatests/org/chromium/chrome/browser/settings/BraveAppearancePreferencesTest.java
+++ b/android/javatests/org/chromium/chrome/browser/settings/BraveAppearancePreferencesTest.java
@@ -5,8 +5,10 @@
 
 package org.chromium.chrome.browser.settings;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import android.os.Build;
 import android.os.Looper;
 
 import androidx.annotation.Nullable;
@@ -25,6 +27,7 @@ import org.chromium.base.test.util.DoNotBatch;
 import org.chromium.base.test.util.Features.DisableFeatures;
 import org.chromium.base.test.util.Features.EnableFeatures;
 import org.chromium.chrome.browser.appearance.settings.AppearanceSettingsFragment;
+import org.chromium.chrome.browser.flags.ChromeFeatureList;
 import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
 
 /** Test for {@link AppearancePreferences}. */
@@ -61,6 +64,7 @@ public class BraveAppearancePreferencesTest {
         final String[] sortedPrefKeys = {
             AppearancePreferences.PREF_NAVIGATION_SECTION,
             AppearanceSettingsFragment.PREF_UI_THEME,
+            BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED,
             AppearancePreferences.PREF_BRAVE_CUSTOMIZE_MENU,
             AppearanceSettingsFragment.PREF_TOOLBAR_SHORTCUT,
             AppearancePreferences.PREF_ADDRESS_BAR,
@@ -89,6 +93,36 @@ public class BraveAppearancePreferencesTest {
                     pref.getOrder() > prevPref.getOrder());
             prevPref = pref;
         }
+    }
+
+    @Test
+    @SmallTest
+    @DisableFeatures(BraveFeatureList.BRAVE_ANDROID_TAB_GROUPS_SETTINGS)
+    public void testDynamicColorsPreferenceCount() {
+        startSettings();
+
+        int dynamicColorsPreferenceCount = 0;
+        for (int index = 0;
+                index < mAppearancePreferences.getPreferenceScreen().getPreferenceCount();
+                index++) {
+            Preference preference =
+                    mAppearancePreferences.getPreferenceScreen().getPreference(index);
+            if (BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED.equals(
+                    preference.getKey())) {
+                dynamicColorsPreferenceCount++;
+            }
+        }
+
+        // Dynamic colors are only available when the feature is enabled on Android 12 or later.
+        int expectedDynamicColorsPreferenceCount =
+                ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
+                                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                        ? 1
+                        : 0;
+        assertEquals(
+                "Unexpected number of Dynamic Colors preferences in Appearance settings.",
+                expectedDynamicColorsPreferenceCount,
+                dynamicColorsPreferenceCount);
     }
 
     @Test

--- a/android/junit/BUILD.gn
+++ b/android/junit/BUILD.gn
@@ -179,6 +179,16 @@ if (is_android) {
     deps = [ "//chrome/android/junit:chrome_junit_tests_helper" ]
   }
 
+  robolectric_library("brave_junit_tests_org.chromium.chrome.browser.util") {
+    sources =
+        [ "src/org/chromium/chrome/browser/util/BraveDynamicColorsTest.java" ]
+
+    deps = [
+      "//brave/android/java/org/chromium/chrome/browser/util:java",
+      "//chrome/android/junit:chrome_junit_tests_helper",
+    ]
+  }
+
   robolectric_library(
       "brave_junit_tests_org.chromium.chrome.browser.autofill") {
     sources = [

--- a/android/junit/src/org/chromium/chrome/browser/tabbed_mode/BraveTabbedNavigationBarColorControllerBaseTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/tabbed_mode/BraveTabbedNavigationBarColorControllerBaseTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;
+import android.os.Build;
 import android.view.ContextThemeWrapper;
 
 import androidx.test.core.app.ApplicationProvider;
@@ -107,6 +108,8 @@ public class BraveTabbedNavigationBarColorControllerBaseTest {
                 .removeKey(BravePreferenceKeys.BRAVE_BOTTOM_TOOLBAR_SET_KEY);
         ChromeSharedPreferences.getInstance()
                 .removeKey(BravePreferenceKeys.BRAVE_BOTTOM_TOOLBAR_ENABLED_KEY);
+        ChromeSharedPreferences.getInstance()
+                .removeKey(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED);
         ChromeSharedPreferences.getInstance().removeKey(ChromePreferenceKeys.TOOLBAR_TOP_ANCHORED);
     }
 
@@ -128,12 +131,34 @@ public class BraveTabbedNavigationBarColorControllerBaseTest {
 
     @Test
     @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
+    @Config(sdk = Build.VERSION_CODES.S)
     public void testGetNavigationBarColor_dynamicColorsEnabled_delegatesToUpstream() {
         // When dynamic colors is enabled, the Brave-specific block is skipped and the
         // upstream TabbedNavigationBarColorController logic runs, returning the semantic
         // bottom system nav color rather than Brave's hardcoded colors.
         assertEquals(
                 SemanticColorUtils.getBottomSystemNavColor(mContext),
+                mBase.getNavigationBarColor(false));
+    }
+
+    @Test
+    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
+    public void testGetNavigationBarColor_dynamicColorsBelowAndroidS_usesBraveColor() {
+        when(mTabModelSelector.isIncognitoSelected()).thenReturn(false);
+        assertEquals(
+                mContext.getColor(R.color.default_bg_color_baseline),
+                mBase.getNavigationBarColor(false));
+    }
+
+    @Test
+    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
+    @Config(sdk = Build.VERSION_CODES.S)
+    public void testGetNavigationBarColor_dynamicColorsUserDisabled_usesBraveColor() {
+        ChromeSharedPreferences.getInstance()
+                .writeBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, false);
+        when(mTabModelSelector.isIncognitoSelected()).thenReturn(false);
+        assertEquals(
+                mContext.getColor(R.color.default_bg_color_baseline),
                 mBase.getNavigationBarColor(false));
     }
 

--- a/android/junit/src/org/chromium/chrome/browser/ui/system/BraveStatusBarColorControllerUnitTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/ui/system/BraveStatusBarColorControllerUnitTest.java
@@ -6,14 +6,17 @@
 package org.chromium.chrome.browser.ui.system;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 import android.app.Activity;
 import android.graphics.Color;
+import android.os.Build;
 
 import androidx.annotation.ColorInt;
-import androidx.core.content.ContextCompat;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -21,8 +24,10 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.robolectric.annotation.Config;
 
 import org.chromium.base.BraveFeatureList;
+import org.chromium.base.BravePreferenceKeys;
 import org.chromium.base.supplier.MonotonicObservableSupplier;
 import org.chromium.base.supplier.ObservableSuppliers;
 import org.chromium.base.supplier.SettableNonNullObservableSupplier;
@@ -34,6 +39,7 @@ import org.chromium.chrome.browser.ActivityTabProvider;
 import org.chromium.chrome.browser.browser_controls.BrowserControlsStateProvider;
 import org.chromium.chrome.browser.layouts.LayoutManager;
 import org.chromium.chrome.browser.lifecycle.ActivityLifecycleDispatcher;
+import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
 import org.chromium.chrome.browser.theme.TopUiThemeColorProvider;
 import org.chromium.chrome.browser.ui.system.StatusBarColorController.StatusBarColorProvider;
 import org.chromium.components.browser_ui.desktop_windowing.DesktopWindowStateManager;
@@ -43,6 +49,9 @@ import org.chromium.ui.edge_to_edge.EdgeToEdgeSystemBarColorHelper;
 /** Unit tests for {@link BraveStatusBarColorController}. */
 @RunWith(BaseRobolectricTestRunner.class)
 public class BraveStatusBarColorControllerUnitTest {
+    private static final @ColorInt int TEST_UPSTREAM_NTP_BACKGROUND_COLOR =
+            Color.rgb(0x12, 0x34, 0x56);
+
     @Rule public final MockitoRule mMockitoRule = MockitoJUnit.rule();
 
     @Rule
@@ -69,37 +78,61 @@ public class BraveStatusBarColorControllerUnitTest {
         mActivityScenarioRule.getScenario().onActivity(activity -> mActivity = activity);
     }
 
+    @After
+    public void tearDown() {
+        ChromeSharedPreferences.getInstance()
+                .removeKey(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED);
+    }
+
     @Test
     @DisableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
+    @Config(sdk = Build.VERSION_CODES.S)
     public void testBackgroundColorForNtp_dynamicColorsDisabled_returnsWhite() {
-        // Existing Brave behavior in light mode: force the NTP status-bar background to white
-        // to mask the upstream regression.
-        BraveStatusBarColorController controller = newController();
+        BraveStatusBarColorController controller =
+                newControllerWithUpstreamNtpBackground(TEST_UPSTREAM_NTP_BACKGROUND_COLOR);
         assertEquals(Color.WHITE, controller.getBackgroundColorForNtpForTesting());
     }
 
     @Test
     @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
+    @Config(sdk = Build.VERSION_CODES.S)
     public void testBackgroundColorForNtp_dynamicColorsEnabled_returnsUpstreamDefault() {
-        // With dynamic colors enabled the Brave override is skipped so the themed surface
-        // color (set by upstream's constructor) is preserved.
-        // home_surface_background_color resolves ?attr/colorSurface. In Robolectric the
-        // Material3 dynamic token chain isn't available, so colorSurface falls back to
-        // white - the same value Brave's override would set. The assertEquals below still
-        // documents that we preserve the upstream default; the companion test
-        // testBackgroundColorForNtp_dynamicColorsDisabled_returnsWhite provides the
-        // regression-catching coverage (if the guard is dropped, that test still asserts
-        // Color.WHITE is set, which is a deliberate Brave choice, not upstream's default).
-        @ColorInt
-        int upstreamDefault =
-                ContextCompat.getColor(mActivity, R.color.home_surface_background_color);
-        BraveStatusBarColorController controller = newController();
-        assertEquals(upstreamDefault, controller.getBackgroundColorForNtpForTesting());
+        BraveStatusBarColorController controller =
+                newControllerWithUpstreamNtpBackground(TEST_UPSTREAM_NTP_BACKGROUND_COLOR);
+        assertEquals(
+                TEST_UPSTREAM_NTP_BACKGROUND_COLOR,
+                controller.getBackgroundColorForNtpForTesting());
     }
 
-    private BraveStatusBarColorController newController() {
+    @Test
+    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
+    @Config(sdk = Build.VERSION_CODES.R)
+    public void testBackgroundColorForNtp_dynamicColorsBelowAndroidS_returnsWhite() {
+        BraveStatusBarColorController controller =
+                newControllerWithUpstreamNtpBackground(TEST_UPSTREAM_NTP_BACKGROUND_COLOR);
+        assertEquals(Color.WHITE, controller.getBackgroundColorForNtpForTesting());
+    }
+
+    @Test
+    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
+    @Config(sdk = Build.VERSION_CODES.S)
+    public void testBackgroundColorForNtp_dynamicColorsUserDisabled_returnsWhite() {
+        ChromeSharedPreferences.getInstance()
+                .writeBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, false);
+        BraveStatusBarColorController controller =
+                newControllerWithUpstreamNtpBackground(TEST_UPSTREAM_NTP_BACKGROUND_COLOR);
+        assertEquals(Color.WHITE, controller.getBackgroundColorForNtpForTesting());
+    }
+
+    private BraveStatusBarColorController newControllerWithUpstreamNtpBackground(
+            @ColorInt int upstreamNtpBackground) {
+        Activity activity = spy(mActivity);
+        doReturn(upstreamNtpBackground)
+                .when(activity)
+                .getColor(R.color.home_surface_background_color);
+
         return new BraveStatusBarColorController(
-                mActivity,
+                activity,
                 /* isTablet= */ false,
                 mStatusBarColorProvider,
                 mLayoutManagerSupplier,

--- a/android/junit/src/org/chromium/chrome/browser/util/BraveDynamicColorsTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/util/BraveDynamicColorsTest.java
@@ -1,0 +1,87 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.os.Build;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import org.chromium.base.BraveFeatureList;
+import org.chromium.base.BravePreferenceKeys;
+import org.chromium.base.test.BaseRobolectricTestRunner;
+import org.chromium.base.test.util.Features.DisableFeatures;
+import org.chromium.base.test.util.Features.EnableFeatures;
+import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
+
+/** Unit tests for {@link BraveDynamicColors}. */
+@RunWith(BaseRobolectricTestRunner.class)
+@Config(manifest = Config.NONE, sdk = Build.VERSION_CODES.S)
+public class BraveDynamicColorsTest {
+    @After
+    public void tearDown() {
+        ChromeSharedPreferences.getInstance()
+                .removeKey(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED);
+    }
+
+    @Test
+    public void testGetCachedFlag_defaultsToEnabled() {
+        assertTrue(BraveDynamicColors.getCachedFlag().getDefaultValue());
+    }
+
+    @Test
+    @DisableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
+    public void testIsDynamicColorsAvailable_featureDisabled_returnsFalse() {
+        assertFalse(BraveDynamicColors.isDynamicColorsAvailable());
+    }
+
+    @Test
+    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
+    @Config(sdk = Build.VERSION_CODES.R)
+    public void testIsDynamicColorsAvailable_belowAndroidS_returnsFalse() {
+        assertFalse(BraveDynamicColors.isDynamicColorsAvailable());
+    }
+
+    @Test
+    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
+    public void testIsDynamicColorsAvailable_androidSAndFeatureEnabled_returnsTrue() {
+        assertTrue(BraveDynamicColors.isDynamicColorsAvailable());
+    }
+
+    @Test
+    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
+    public void testIsDynamicColorsEnabled_userPreferenceUnset_returnsTrue() {
+        assertTrue(BraveDynamicColors.isDynamicColorsEnabled());
+    }
+
+    @Test
+    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
+    public void testIsDynamicColorsEnabled_userPreferenceDisabled_returnsFalse() {
+        ChromeSharedPreferences.getInstance()
+                .writeBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, false);
+
+        assertTrue(BraveDynamicColors.isDynamicColorsAvailable());
+        assertFalse(BraveDynamicColors.isDynamicColorsEnabled());
+    }
+
+    @Test
+    @DisableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
+    public void testIsDynamicColorsEnabled_featureDisabled_returnsFalse() {
+        assertFalse(BraveDynamicColors.isDynamicColorsEnabled());
+    }
+
+    @Test
+    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
+    @Config(sdk = Build.VERSION_CODES.R)
+    public void testIsDynamicColorsEnabled_belowAndroidS_returnsFalse() {
+        assertFalse(BraveDynamicColors.isDynamicColorsEnabled());
+    }
+}

--- a/android/nala/icons.gni
+++ b/android/nala/icons.gni
@@ -163,6 +163,7 @@ nala_icons = [
   "ic_social_brave_outline_favicon_fullheight.xml",
   "ic_social_brave_release_favicon_fullheight_color.xml",
   "ic_theme_dark.xml",
+  "ic_themes.xml",
   "ic_trash.xml",
   "ic_tune.xml",
   "ic_widget_generic.xml",

--- a/browser/download/internal/android/BUILD.gn
+++ b/browser/download/internal/android/BUILD.gn
@@ -13,6 +13,7 @@ android_library("java") {
 
   deps = [
     "//base:base_java",
+    "//brave/android/java/org/chromium/chrome/browser/util:java",
     "//build/android:build_java",
     "//chrome/browser/download/internal/android:java",
     "//chrome/browser/download/internal/android:java_resources",

--- a/browser/download/internal/android/java/src/org/chromium/chrome/browser/download/home/search/BraveSearchBarCoordinator.java
+++ b/browser/download/internal/android/java/src/org/chromium/chrome/browser/download/home/search/BraveSearchBarCoordinator.java
@@ -7,11 +7,10 @@ package org.chromium.chrome.browser.download.home.search;
 
 import android.content.Context;
 
-import org.chromium.base.BraveFeatureList;
 import org.chromium.base.Callback;
 import org.chromium.build.annotations.NullMarked;
 import org.chromium.chrome.browser.download.internal.R;
-import org.chromium.chrome.browser.flags.ChromeFeatureList;
+import org.chromium.chrome.browser.util.BraveDynamicColors;
 
 @NullMarked
 public class BraveSearchBarCoordinator extends SearchBarCoordinator {
@@ -19,9 +18,9 @@ public class BraveSearchBarCoordinator extends SearchBarCoordinator {
             Context context, Callback<String> queryCallback, boolean autoFocusSearchBox) {
         super(context, queryCallback, autoFocusSearchBox);
 
-        // When Dynamic colors flag is disabled (default) we replace here icon with one
-        // without color_primary reference toi avoid orange tint on light theme
-        if (!ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)) {
+        // When dynamic colors are disabled, use a background without color_primary to avoid
+        // orange tint on light theme.
+        if (!BraveDynamicColors.isDynamicColorsEnabled()) {
             getView().setBackgroundResource(R.drawable.no_dynamic_download_search_bar_background);
         }
     }

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -1689,6 +1689,12 @@ Are you sure you want to do this?
       <message name="IDS_NIGHT_MODE_SUMMARY" desc="Summary for Night Mode, which forces web content into dark mode.">
         Force dark mode for web content
       </message>
+      <message name="IDS_BRAVE_ANDROID_DYNAMIC_COLORS_TITLE" desc="Title for the Android Appearance preference that enables dynamic colors.">
+        Dynamic colors
+      </message>
+      <message name="IDS_BRAVE_ANDROID_DYNAMIC_COLORS_SUMMARY" desc="Summary for the Android Appearance preference that enables dynamic colors.">
+        Change the color palette to match user settings and wallpaper colors
+      </message>
       <message name="IDS_ACCESSIBILITY_TOOLBAR_BTN_SEARCH_ACCELERATOR" desc="Content description for the search accelerator button">
         Search
       </message>

--- a/build/android/config.gni
+++ b/build/android/config.gni
@@ -24,6 +24,7 @@ brave_chrome_java_deps = [
   "//brave/android:qrreader_java",
   "//brave/android/java/org/chromium/chrome/browser/accessibility:java",
   "//brave/android/java/org/chromium/chrome/browser/search_engines:java",
+  "//brave/android/java/org/chromium/chrome/browser/util:java",
   "//brave/brave_domains/android:java",
   "//brave/browser/android/preferences:pref_names_java",
   "//brave/browser/autofill/android:java",

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1767,6 +1767,7 @@ if (is_android) {
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.tasks",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.toolbar",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.ui",
+      "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.util",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.vpn",
       "//brave/browser/customize_menu/android:junit",
       "//brave/browser/first_run/android:junit",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55968.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### Screenshots

Android 12+, `#brave-android-dynamic-colors` enabled, `"Dynamic Colors"` preference `off`:
<img width="400" height="920" alt="Screenshot_2026-07-10 at 15 45 57" src="https://github.com/user-attachments/assets/49d9b2b7-d29c-401b-b129-9a49d3b043c7" />

Android 12+, `#brave-android-dynamic-colors` enabled, `"Dynamic Colors"` preference `on`:
<img width="400" height="920" alt="Screenshot_2026-07-10 at 15 46 23" src="https://github.com/user-attachments/assets/9b009f7c-8d68-480a-98d7-2e1d7cb61736" />

Android 12+, `#brave-android-dynamic-colors` disabled:
<img width="400" height="920" alt="Screenshot_2026-07-10 at 15 47 36" src="https://github.com/user-attachments/assets/d61f0a9c-3bc5-4070-87b8-010c258ca3dc" />

<= Android 11, `#brave-android-dynamic-colors` enabled:
<img width="400" height="920" alt="Screenshot_2026-07-10 at 15 56 58" src="https://github.com/user-attachments/assets/9cc5ddd0-9a7f-409a-ba2e-cb459ad2de2f" />


### Notes
Part of the https://github.com/brave/brave-browser/issues/55968 ticket specifies:
> Let's enable the `#brave-android-dynamic-colors` by default to users

I have not done this portion of the ticket, given there's still outstanding work to be done for the dynamic colors features,  specifically:
* https://github.com/brave/brave-browser/issues/57054
* https://github.com/brave/brave-browser/issues/55610


