### PR TITLE
[AI Chat] Copy shared conversation link to clipboard as confidential

### DIFF
--- a/components/ai_chat/core/browser/BUILD.gn
+++ b/components/ai_chat/core/browser/BUILD.gn
@@ -5,6 +5,7 @@
 
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
 import("//brave/components/text_recognition/common/buildflags/buildflags.gni")
+import("//build/config/features.gni")
 import("//tools/json_schema_compiler/json_schema_api.gni")
 
 assert(enable_ai_chat)
@@ -153,6 +154,7 @@ static_library("browser") {
     "//third_party/re2",
     "//third_party/zlib/google:compression_utils",
     "//ui/base",
+    "//ui/base/clipboard",
     "//url",
   ]
 
@@ -242,6 +244,15 @@ source_set("unit_tests") {
       "ai_chat_database_unittest.cc",
       "sync/ai_chat_sync_conversions_unittest.cc",
     ]
+  }
+
+  if (use_blink) {
+    # The ShareConversation tests verify the clipboard copy with
+    # ui::TestClipboard, which the clipboard test support target only builds
+    # when use_blink is true. Kept in a separate file so gn check never scans
+    # its clipboard includes on non-blink builds (e.g. iOS).
+    sources += [ "ai_chat_service_share_conversation_unittest.cc" ]
+    deps += [ "//ui/base/clipboard:clipboard_test_support" ]
   }
 }
 

--- a/components/ai_chat/core/browser/ai_chat_service.cc
+++ b/components/ai_chat/core/browser/ai_chat_service.cc
@@ -25,7 +25,9 @@
 #include "base/functional/callback_helpers.h"
 #include "base/logging.h"
 #include "base/numerics/clamped_math.h"
+#include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
+#include "base/strings/utf_string_conversions.h"
 #include "base/task/task_traits.h"
 #include "base/task/thread_pool.h"
 #include "base/time/time.h"
@@ -56,6 +58,9 @@
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/struct_ptr.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "ui/base/clipboard/clipboard_buffer.h"
+#include "ui/base/clipboard/scoped_clipboard_writer.h"
+#include "url/gurl.h"
 #include "url/url_constants.h"
 
 namespace ai_chat {
@@ -94,6 +99,15 @@ std::vector<mojom::AssociatedContentPtr> CloneAssociatedContent(
     cloned_content.push_back(content->Clone());
   }
   return cloned_content;
+}
+
+// Writes |text| (UTF-8) to the system clipboard, marking the entry as
+// confidential so it is excluded from clipboard history and other
+// data-leak-prevention surfaces.
+void CopyTextToClipboardAsConfidential(std::string_view text) {
+  ui::ScopedClipboardWriter scw(ui::ClipboardBuffer::kCopyPaste);
+  scw.WriteText(base::UTF8ToUTF16(text));
+  scw.MarkAsConfidential();
 }
 
 }  // namespace
@@ -723,9 +737,43 @@ void AIChatService::ConversationExists(const std::string& conversation_uuid,
 }
 
 void AIChatService::ShareConversation(const std::string& encrypted_contents,
+                                      const std::string& key_fragment,
+                                      bool copy_to_clipboard,
                                       ShareConversationCallback callback) {
-  conversation_share_manager_->ShareConversation(encrypted_contents,
-                                                 std::move(callback));
+  // Only the ciphertext is handed to the share manager (which talks to the
+  // server). The decryption key fragment stays here and is combined with the
+  // returned viewer URL in OnShareConversationComplete, so it never reaches the
+  // network layer or the server.
+  conversation_share_manager_->ShareConversation(
+      encrypted_contents,
+      base::BindOnce(&AIChatService::OnShareConversationComplete,
+                     weak_ptr_factory_.GetWeakPtr(), key_fragment,
+                     copy_to_clipboard, std::move(callback)));
+}
+
+void AIChatService::OnShareConversationComplete(
+    std::string key_fragment,
+    bool copy_to_clipboard,
+    ShareConversationCallback callback,
+    const std::optional<GURL>& shared_conversation_viewer_url) {
+  if (!shared_conversation_viewer_url) {
+    std::move(callback).Run(std::nullopt);
+    return;
+  }
+
+  // Append the decryption key as a URL fragment to build the full shareable
+  // link. |key_fragment| is URL-safe base64, so it needs no further encoding.
+  GURL shared_conversation_url(base::StrCat(
+      {shared_conversation_viewer_url->spec(), "#", key_fragment}));
+  if (!shared_conversation_url.is_valid()) {
+    std::move(callback).Run(std::nullopt);
+    return;
+  }
+
+  if (copy_to_clipboard) {
+    CopyTextToClipboardAsConfidential(shared_conversation_url.spec());
+  }
+  std::move(callback).Run(std::move(shared_conversation_url));
 }
 
 void AIChatService::OnPremiumStatusReceived(GetPremiumStatusCallback callback,

--- a/components/ai_chat/core/browser/ai_chat_service.cc
+++ b/components/ai_chat/core/browser/ai_chat_service.cc
@@ -25,7 +25,6 @@
 #include "base/functional/callback_helpers.h"
 #include "base/logging.h"
 #include "base/numerics/clamped_math.h"
-#include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/task_traits.h"
@@ -752,7 +751,7 @@ void AIChatService::ShareConversation(const std::string& encrypted_contents,
 }
 
 void AIChatService::OnShareConversationComplete(
-    std::string key_fragment,
+    const std::string& key_fragment,
     bool copy_to_clipboard,
     ShareConversationCallback callback,
     const std::optional<GURL>& shared_conversation_viewer_url) {
@@ -761,10 +760,12 @@ void AIChatService::OnShareConversationComplete(
     return;
   }
 
-  // Append the decryption key as a URL fragment to build the full shareable
+  // Set the decryption key as the URL fragment to build the full shareable
   // link. |key_fragment| is URL-safe base64, so it needs no further encoding.
-  GURL shared_conversation_url(base::StrCat(
-      {shared_conversation_viewer_url->spec(), "#", key_fragment}));
+  GURL::Replacements replacements;
+  replacements.SetRefStr(key_fragment);
+  GURL shared_conversation_url =
+      shared_conversation_viewer_url->ReplaceComponents(replacements);
   if (!shared_conversation_url.is_valid()) {
     std::move(callback).Run(std::nullopt);
     return;

--- a/components/ai_chat/core/browser/ai_chat_service.h
+++ b/components/ai_chat/core/browser/ai_chat_service.h
@@ -202,6 +202,8 @@ class AIChatService : public KeyedService,
   void ConversationExists(const std::string& conversation_uuid,
                           ConversationExistsCallback callback) override;
   void ShareConversation(const std::string& encrypted_contents,
+                         const std::string& key_fragment,
+                         bool copy_to_clipboard,
                          ShareConversationCallback callback) override;
   void BindConversation(
       const std::string& uuid,
@@ -286,6 +288,15 @@ class AIChatService : public KeyedService,
       std::string conversation_uuid,
       base::OnceCallback<void(ConversationHandler*)> callback,
       mojom::ConversationArchivePtr data);
+
+  // Completes ShareConversation once the sharing server has returned the viewer
+  // URL: appends |key_fragment| to build the full shareable link, optionally
+  // copies it to the clipboard as confidential, and returns it via |callback|.
+  void OnShareConversationComplete(
+      std::string key_fragment,
+      bool copy_to_clipboard,
+      ShareConversationCallback callback,
+      const std::optional<GURL>& shared_conversation_viewer_url);
 
   void MaybeAssociateContent(
       ConversationHandler* conversation,

--- a/components/ai_chat/core/browser/ai_chat_service.h
+++ b/components/ai_chat/core/browser/ai_chat_service.h
@@ -293,7 +293,7 @@ class AIChatService : public KeyedService,
   // URL: appends |key_fragment| to build the full shareable link, optionally
   // copies it to the clipboard as confidential, and returns it via |callback|.
   void OnShareConversationComplete(
-      std::string key_fragment,
+      const std::string& key_fragment,
       bool copy_to_clipboard,
       ShareConversationCallback callback,
       const std::optional<GURL>& shared_conversation_viewer_url);

--- a/components/ai_chat/core/browser/ai_chat_service_share_conversation_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_service_share_conversation_unittest.cc
@@ -207,4 +207,34 @@ TEST_F(AIChatServiceShareConversationTest,
       "https://leo-ai.brave.app/sharing/test-share-id#url-safe-key-fragment");
 }
 
+TEST_F(AIChatServiceShareConversationTest,
+       DoesNotCopyToClipboardWhenNotRequested) {
+  auto fake_share_manager = std::make_unique<FakeConversationShareManager>();
+  fake_share_manager->viewer_url =
+      GURL("https://leo-ai.brave.app/sharing/test-share-id");
+  ai_chat_service_->SetConversationShareManagerForTesting(
+      std::move(fake_share_manager));
+
+  ui::TestClipboard* clipboard = ui::TestClipboard::CreateForCurrentThread();
+
+  base::test::TestFuture<const std::optional<GURL>&> future;
+  ai_chat_service_->ShareConversation(
+      "ciphertext-blob", "url-safe-key-fragment",
+      /*copy_to_clipboard=*/false, future.GetCallback());
+  std::optional<GURL> result = future.Get();
+
+  base::test::TestFuture<std::u16string> clipboard_future;
+  clipboard->ReadText(ui::ClipboardBuffer::kCopyPaste,
+                      /*data_dst=*/std::nullopt,
+                      clipboard_future.GetCallback());
+  std::u16string clipboard_text = clipboard_future.Get();
+
+  ui::Clipboard::DestroyClipboardForCurrentThread();
+
+  // The URL is still returned, but nothing is written to the clipboard when the
+  // caller does not request it.
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(clipboard_text.empty());
+}
+
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/ai_chat_service_share_conversation_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_service_share_conversation_unittest.cc
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// AIChatService::ShareConversation tests. These live in their own file (built
+// only when use_blink is true) because verifying the clipboard copy requires
+// ui::TestClipboard, which the clipboard test support target only builds when
+// use_blink is true (so it is unavailable on non-blink builds such as iOS). The
+// URL-building logic under test is platform-agnostic, so exercising it on the
+// blink-based platforms is sufficient.
+
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "base/check.h"
+#include "base/files/scoped_temp_dir.h"
+#include "base/functional/callback_helpers.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/strings/utf_string_conversions.h"
+#include "base/test/task_environment.h"
+#include "base/test/test_future.h"
+#include "brave/components/ai_chat/core/browser/ai_chat_credential_manager.h"
+#include "brave/components/ai_chat/core/browser/ai_chat_service.h"
+#include "brave/components/ai_chat/core/browser/conversation_share_manager.h"
+#include "brave/components/ai_chat/core/browser/model_service.h"
+#include "brave/components/ai_chat/core/browser/tab_tracker_service.h"
+#include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
+#include "brave/components/ai_chat/core/common/pref_names.h"
+#include "components/os_crypt/async/browser/os_crypt_async.h"
+#include "components/os_crypt/async/browser/test_utils.h"
+#include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "services/network/public/cpp/network_context_getter.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
+#include "services/network/test/test_url_loader_factory.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/base/clipboard/clipboard.h"
+#include "ui/base/clipboard/clipboard_buffer.h"
+#include "ui/base/clipboard/test/test_clipboard.h"
+#include "url/gurl.h"
+
+namespace ai_chat {
+
+namespace {
+
+class MockAIChatCredentialManager : public AIChatCredentialManager {
+ public:
+  using AIChatCredentialManager::AIChatCredentialManager;
+  MOCK_METHOD(void,
+              GetPremiumStatus,
+              (mojom::Service::GetPremiumStatusCallback callback),
+              (override));
+};
+
+// Returns a fixed viewer URL without any network access, so tests can exercise
+// AIChatService's post-upload handling (appending the key fragment and copying
+// to the clipboard) without hitting the sharing server.
+class FakeConversationShareManager : public ConversationShareManager {
+ public:
+  FakeConversationShareManager() : ConversationShareManager(nullptr) {}
+  ~FakeConversationShareManager() override = default;
+
+  void ShareConversation(const std::string& encrypted_contents,
+                         ShareConversationCallback callback) override {
+    last_encrypted_contents = encrypted_contents;
+    std::move(callback).Run(viewer_url);
+  }
+
+  // The URL the fake server "returns" (without the decryption key fragment).
+  std::optional<GURL> viewer_url;
+  // Captures what was uploaded, to assert the key fragment never reaches here.
+  std::string last_encrypted_contents;
+};
+
+}  // namespace
+
+class AIChatServiceShareConversationTest : public testing::Test {
+ public:
+  AIChatServiceShareConversationTest() = default;
+
+  void SetUp() override {
+    CHECK(temp_directory_.CreateUniqueTempDir());
+    prefs::RegisterProfilePrefs(prefs_.registry());
+    prefs::RegisterLocalStatePrefs(local_state_.registry());
+    ModelService::RegisterProfilePrefs(prefs_.registry());
+
+    // These tests exercise only ShareConversation, which is independent of
+    // conversation storage. Keep storage disabled so the service starts no
+    // async database work that would otherwise need draining at teardown.
+    prefs_.SetBoolean(prefs::kBraveChatStorageEnabled, false);
+
+    os_crypt_ = os_crypt_async::GetTestOSCryptAsyncForTesting(
+        /*is_sync_for_unittests=*/true);
+    shared_url_loader_factory_ =
+        base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
+            &url_loader_factory_);
+    model_service_ = std::make_unique<ModelService>(
+        &prefs_, os_crypt_.get(), network::NetworkContextGetter());
+    tab_tracker_service_ = std::make_unique<TabTrackerService>();
+
+    auto credential_manager =
+        std::make_unique<testing::NiceMock<MockAIChatCredentialManager>>(
+            base::NullCallback(), &local_state_);
+    ON_CALL(*credential_manager, GetPremiumStatus(testing::_))
+        .WillByDefault([](mojom::Service::GetPremiumStatusCallback callback) {
+          std::move(callback).Run(mojom::PremiumStatus::Active,
+                                  mojom::PremiumInfo::New());
+        });
+
+    ai_chat_service_ = std::make_unique<AIChatService>(
+        model_service_.get(), tab_tracker_service_.get(),
+        std::move(credential_manager), &prefs_, /*ai_chat_metrics=*/nullptr,
+        os_crypt_.get(), shared_url_loader_factory_, /*channel_string=*/"",
+        temp_directory_.GetPath());
+  }
+
+  void TearDown() override { ai_chat_service_.reset(); }
+
+ protected:
+  base::test::TaskEnvironment task_environment_;
+  base::ScopedTempDir temp_directory_;
+  sync_preferences::TestingPrefServiceSyncable prefs_;
+  sync_preferences::TestingPrefServiceSyncable local_state_;
+  std::unique_ptr<os_crypt_async::OSCryptAsync> os_crypt_;
+  network::TestURLLoaderFactory url_loader_factory_;
+  scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
+  std::unique_ptr<ModelService> model_service_;
+  std::unique_ptr<TabTrackerService> tab_tracker_service_;
+  std::unique_ptr<AIChatService> ai_chat_service_;
+};
+
+TEST_F(AIChatServiceShareConversationTest, ReturnsFullUrlWithKeyFragment) {
+  auto fake_share_manager = std::make_unique<FakeConversationShareManager>();
+  fake_share_manager->viewer_url =
+      GURL("https://leo-ai.brave.app/sharing/test-share-id");
+  auto* fake_share_manager_ptr = fake_share_manager.get();
+  ai_chat_service_->SetConversationShareManagerForTesting(
+      std::move(fake_share_manager));
+
+  base::test::TestFuture<const std::optional<GURL>&> future;
+  ai_chat_service_->ShareConversation(
+      "ciphertext-blob", "url-safe-key-fragment",
+      /*copy_to_clipboard=*/false, future.GetCallback());
+
+  const std::optional<GURL>& result = future.Get();
+  ASSERT_TRUE(result.has_value());
+  // The full shareable link is the server's viewer URL with the decryption key
+  // appended as a fragment.
+  EXPECT_EQ(
+      result->spec(),
+      "https://leo-ai.brave.app/sharing/test-share-id#url-safe-key-fragment");
+  // Only the ciphertext reaches the network-facing share manager; the key
+  // fragment stays in the browser process and is never uploaded.
+  EXPECT_EQ(fake_share_manager_ptr->last_encrypted_contents, "ciphertext-blob");
+}
+
+TEST_F(AIChatServiceShareConversationTest, ReturnsNulloptWhenSharingFails) {
+  auto fake_share_manager = std::make_unique<FakeConversationShareManager>();
+  // A null viewer URL simulates a failed upload (network error, bad response).
+  fake_share_manager->viewer_url = std::nullopt;
+  ai_chat_service_->SetConversationShareManagerForTesting(
+      std::move(fake_share_manager));
+
+  base::test::TestFuture<const std::optional<GURL>&> future;
+  ai_chat_service_->ShareConversation(
+      "ciphertext-blob", "url-safe-key-fragment",
+      /*copy_to_clipboard=*/true, future.GetCallback());
+
+  EXPECT_FALSE(future.Get().has_value());
+}
+
+TEST_F(AIChatServiceShareConversationTest,
+       CopiesFullLinkToClipboardWhenRequested) {
+  auto fake_share_manager = std::make_unique<FakeConversationShareManager>();
+  fake_share_manager->viewer_url =
+      GURL("https://leo-ai.brave.app/sharing/test-share-id");
+  ai_chat_service_->SetConversationShareManagerForTesting(
+      std::move(fake_share_manager));
+
+  ui::TestClipboard* clipboard = ui::TestClipboard::CreateForCurrentThread();
+
+  base::test::TestFuture<const std::optional<GURL>&> future;
+  ai_chat_service_->ShareConversation(
+      "ciphertext-blob", "url-safe-key-fragment",
+      /*copy_to_clipboard=*/true, future.GetCallback());
+  std::optional<GURL> result = future.Get();
+
+  base::test::TestFuture<std::u16string> clipboard_future;
+  clipboard->ReadText(ui::ClipboardBuffer::kCopyPaste,
+                      /*data_dst=*/std::nullopt,
+                      clipboard_future.GetCallback());
+  std::u16string clipboard_text = clipboard_future.Get();
+
+  ui::Clipboard::DestroyClipboardForCurrentThread();
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(
+      result->spec(),
+      "https://leo-ai.brave.app/sharing/test-share-id#url-safe-key-fragment");
+  // The browser process copied the full shareable link, not the bare viewer
+  // URL, so the recipient can decrypt the conversation.
+  EXPECT_EQ(
+      base::UTF16ToUTF8(clipboard_text),
+      "https://leo-ai.brave.app/sharing/test-share-id#url-safe-key-fragment");
+}
+
+}  // namespace ai_chat

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -172,10 +172,19 @@ interface Service {
   // Uploads client-encrypted conversation contents to the Brave sharing server
   // so the user can share a link to view them. |encrypted_contents| is the
   // base64-encoded blob (12-byte AES-GCM IV followed by the ciphertext)
-  // produced by the UI. The returned viewer URL does not contain the decryption
-  // key - the UI appends it as a URL fragment. Returns null if sharing failed.
-  ShareConversation(string encrypted_contents)
-      => (url.mojom.Url? shared_conversation_viewer);
+  // produced by the UI. |key_fragment| is the URL-safe-base64 decryption key
+  // which is never sent to the sharing server; it is appended to the server's
+  // viewer URL as a fragment to build the full shareable link. When
+  // |copy_to_clipboard| is true, that full link is written to the system
+  // clipboard marked as confidential (excluded from clipboard history and other
+  // data-leak-prevention surfaces) - this must happen in the browser process
+  // because the renderer cannot set clipboard confidentiality flags. Returns
+  // the full shareable URL (including the key fragment), or null if sharing
+  // failed.
+  ShareConversation(string encrypted_contents,
+                    string key_fragment,
+                    bool copy_to_clipboard)
+      => (url.mojom.Url? shared_conversation_url);
 
   // Bind ability to send events to the UI and receive current state
   BindObserver(pending_remote<ServiceObserver> ui) => (ServiceState state);

--- a/components/ai_chat/resources/page/api/mock_interfaces.ts
+++ b/components/ai_chat/resources/page/api/mock_interfaces.ts
@@ -169,8 +169,8 @@ export function createMockService(
     conversationExists: () => Promise.resolve({ exists: true }),
     shareConversation: () =>
       Promise.resolve({
-        sharedConversationViewer: {
-          url: 'https://leo-ai.brave.app/sharing/mock-share-id',
+        sharedConversationUrl: {
+          url: 'https://leo-ai.brave.app/sharing/mock-share-id#mock-key',
         },
       }),
     createSkill: () => {},

--- a/components/ai_chat/resources/page/components/header/index.tsx
+++ b/components/ai_chat/resources/page/components/header/index.tsx
@@ -78,14 +78,17 @@ export const ConversationHeader = React.forwardRef(function (
     // usable by whoever the user shares it with.
     const json = serializeConversationForSharing(conversationHistory)
     const { ciphertext, keyFragment } = await encryptForSharing(json)
-    const { sharedConversationViewer } =
-      await aiChatContext.api.service.shareConversation(ciphertext)
-    if (!sharedConversationViewer) {
-      // Sharing failed on the server; there is nothing to share.
-      return
-    }
-    const shareUrl = `${sharedConversationViewer.url}#${keyFragment}`
-    navigator.clipboard.writeText(shareUrl)
+    // The browser process combines the key fragment with the server's viewer
+    // URL and copies the resulting shareable link to the clipboard, marked as
+    // confidential (excluded from clipboard history and other
+    // data-leak-prevention surfaces) - something the renderer cannot do. The
+    // key fragment is not sent to the sharing server. Failure (a null result)
+    // is a no-op: nothing is copied, so there is nothing more to do here.
+    await aiChatContext.api.service.shareConversation(
+      ciphertext,
+      keyFragment,
+      /*copyToClipboard=*/ true,
+    )
   }
 
   const showTitle =


### PR DESCRIPTION
Move the "copy shared link" step out of the renderer and into the browser process so the clipboard entry can be marked confidential (excluded from clipboard history and other data-leak-prevention surfaces) - something the renderer's `navigator.clipboard` cannot do.

`ShareConversation` now takes the URL-safe-base64 key fragment and a `copy_to_clipboard` flag. `AIChatService` appends the fragment to the server's viewer URL to build the full shareable link, optionally writes it to the clipboard as confidential, and returns it. The fragment is combined only after the upload completes, so it never reaches the network-facing `ConversationShareManager` or the sharing server.

Because the copy happens in the shared Service, desktop, Android, and iOS all get it without per-platform WebUI handler code.

<!-- Add brave-browser issue below that this PR will resolve -->
- Series https://github.com/brave/brave-browser/issues/56444

As requested by @fmarier at https://github.com/brave/brave-core/pull/37744#discussion_r3555357724

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
