### PR TITLE
[brockit] `merge` to check for WIPs and orphaned fixups

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -314,6 +314,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from typing import ClassVar
 
 from exceptions import (ActionNeededException, BadOutcomeException,
                         InvalidInputException)
@@ -1907,6 +1908,10 @@ class Merge(Task):
     diverged, so that the push to the remote is always a fast-forward.
     """
 
+    # A few of the tags we want to reject during merge.
+    _NEVER_MERGE_TAG_RE: ClassVar[re.Pattern[str]] = re.compile(
+        r'\[wip\]|\[do not[^\]]*\]', re.IGNORECASE)
+
     def status_message(self):
         return "Merging current branch into upstream..."
 
@@ -1962,7 +1967,6 @@ class Merge(Task):
             )
         remote, remote_branch = upstream.split('/', 1)
 
-        terminal.log_task(f'Fetching {remote_branch} from {remote}...')
         repository.brave.run_git('fetch', remote, remote_branch)
 
         head_before = repository.brave.run_git('rev-parse', 'HEAD')
@@ -1977,11 +1981,7 @@ class Merge(Task):
         if plans is not None:
             self._log_plan_diff(*plans)
             raise InvalidInputException(
-                f'{current_branch} is not ready to be merged: a '
-                '[bold cyan]brockit rebase --squash-minor-bumps[/] would still '
-                'collapse, drop, or reorder commits on this branch (see the '
-                'diff above). Run it first, then rerun '
-                '[italic]🚀Brockit![/] [bold cyan]merge[/].')
+                f'{current_branch} is not ready to be merged.')
 
         if dry_run:
             terminal.log_task(
@@ -2032,8 +2032,8 @@ class Merge(Task):
         This performs a no-op interactive rebase (`--onto <base> <base>
         <branch>`, where `<base>` is the merge-base with the upstream) to
         capture the plan git would run, and compares it against the same plan
-        after brockit's `--squash-minor-bumps` rewrite. Any differences indicate
-        that rebase is needed.
+        after brockit's `--squash-minor-bumps`. We also check for the presence
+        or WIPs and orphaned fixups, etc.
 
         Returns a `(current_plan, rewritten_plan)` pair of TODO lines when a
         change is detected, or `None` if the branch is ready to merge.
@@ -2060,17 +2060,25 @@ class Merge(Task):
             identity_entries = self._parse_plan(identity)
             squashed_entries = self._parse_plan(squashed)
 
+        # Dropping never-merge-tagged commits (`[wip]`, `[DO NOT ...]`) and
+        # orphaned fixups so that also fails validation.
+        squashed_entries = [
+            entry for entry in squashed_entries
+            if not self._NEVER_MERGE_TAG_RE.search(entry.out)
+            and not entry.is_orphan
+        ]
+
         # Comparing the `(command, hash)` sequence catches squashes/fixups (a
         # command other than `pick`), drops (a missing entry), and reordering
         # (pinned commits grouped to the top).
-        identity_seq = [(command, commit)
-                        for command, commit, _ in identity_entries]
-        squashed_seq = [(command, commit)
-                        for command, commit, _ in squashed_entries]
+        identity_seq = [(entry.command, entry.hash)
+                        for entry in identity_entries]
+        squashed_seq = [(entry.command, entry.hash)
+                        for entry in squashed_entries]
         if identity_seq == squashed_seq:
             return None
-        return ([out for _, _, out in identity_entries],
-                [out for _, _, out in squashed_entries])
+        return ([entry.out for entry in identity_entries],
+                [entry.out for entry in squashed_entries])
 
     @staticmethod
     def _log_plan_diff(current_plan: list[str],
@@ -2079,12 +2087,11 @@ class Merge(Task):
         plan and the plan a `--squash-minor-bumps` rebase would produce.
         """
         diff = '\n'.join(
-            difflib.unified_diff(
-                current_plan,
-                rewritten_plan,
-                fromfile='branch as-is',
-                tofile='after brockit rebase --squash-minor-bumps',
-                lineterm=''))
+            difflib.unified_diff(current_plan,
+                                 rewritten_plan,
+                                 fromfile='current',
+                                 tofile='expected',
+                                 lineterm=''))
         console.print(
             Padding(
                 Syntax(diff,
@@ -2136,17 +2143,16 @@ class Merge(Task):
                 'Failed to capture the rebase plan for the merge pre-check.')
 
     @staticmethod
-    def _parse_plan(todo_file: Path) -> list[tuple[str, str, str]]:
-        """Parses a captured TODO file into `(command, hash, out)` tuples.
+    def _parse_plan(todo_file: Path) -> list[rebase.EntryLine]:
+        """Parses a captured TODO file into `EntryLine`s.
 
-        Blank and comment lines are skipped. `out` preserves the original line
-        for display when reporting a detected plan change.
+        Blank and comment lines are skipped.
         """
-        entries: list[tuple[str, str, str]] = []
+        entries: list[rebase.EntryLine] = []
         for line in todo_file.read_bytes().decode('utf-8').splitlines():
             entry = rebase.EntryLine.parse(line)
             if entry is not None:
-                entries.append((entry.command, entry.hash, entry.out))
+                entries.append(entry)
         return entries
 
 

--- a/tools/cr/brockit_test.py
+++ b/tools/cr/brockit_test.py
@@ -1382,6 +1382,92 @@ class MergeTest(unittest.TestCase):
 
         self.assertEqual(self._remote_master(), master_before)
 
+    def test_merge_blocks_on_orphaned_fixup(self):
+        """An orphaned `fixup!` (no matching target) blocks the merge.
+
+        Git's autosquash leaves it as a `pick`, so only the orphan filter
+        catches it -- unlike an attached fixup, whose `fixup` command already
+        differs from the identity plan.
+        """
+        self._setup_upstream()
+        self.fake_chromium_src.commit_empty('[cr149] Feature A', self.brave)
+        self.fake_chromium_src.commit_empty(
+            'fixup! [cr149] A commit that is not on this branch', self.brave)
+        master_before = self._remote_master()
+
+        with self.assertRaises(brockit.InvalidInputException):
+            brockit.Merge().execute()
+
+        self.assertEqual(self._remote_master(), master_before)
+
+    def _assert_tag_blocks_merge(self, subject: str) -> None:
+        """Asserts a commit with `subject` blocks the merge without pushing."""
+        self._setup_upstream()
+        self.fake_chromium_src.commit_empty('[cr149] Feature A', self.brave)
+        self.fake_chromium_src.commit_empty(subject, self.brave)
+        master_before = self._remote_master()
+
+        with self.assertRaises(brockit.InvalidInputException):
+            brockit.Merge().execute()
+
+        self.assertEqual(self._remote_master(), master_before)
+
+    def test_merge_blocks_on_wip_commit_lowercase(self):
+        """A `[wip]` commit blocks the merge and is never pushed."""
+        self._assert_tag_blocks_merge('[wip] Not done yet')
+
+    def test_merge_blocks_on_wip_commit_uppercase(self):
+        """A `[WIP]` commit blocks the merge and is never pushed."""
+        self._assert_tag_blocks_merge('[WIP] Not done yet')
+
+    def test_merge_blocks_on_do_not_merge_tag(self):
+        """A `[DO NOT MERGE]` commit blocks the merge and is never pushed."""
+        self._assert_tag_blocks_merge('[DO NOT MERGE] keep this local')
+
+    def test_merge_blocks_on_do_not_tag_case_insensitive(self):
+        """`[DO NOT ...]` matching is case-insensitive and tag-agnostic."""
+        self._assert_tag_blocks_merge('[Do Not Land] experimental change')
+
+    def test_never_merge_tag_regex_only_matches_bracketed_tags(self):
+        """The tag regex matches only bracketed `[wip]` / `[DO NOT ...]` tags,
+        never a plain "WIP" / "do not" word elsewhere in the subject."""
+        regex = brockit.Merge._NEVER_MERGE_TAG_RE
+        matches = [
+            '[wip]',
+            '[WIP]',
+            '[Wip]',
+            '[DO NOT MERGE]',
+            '[do not land]',
+            '[Do Not Submit] foo',
+            'pick abc # [wip] subject # empty',
+        ]
+        for subject in matches:
+            with self.subTest(subject=subject):
+                self.assertIsNotNone(regex.search(subject))
+
+        non_matches = [
+            'Rework the WIP handling logic',
+            'wip cleanup without brackets',
+            'do not remove this comment',
+            'DO NOT panic',
+            '[cr149] WIP feature',
+            '[cr149] refactor: do not inline',
+        ]
+        for subject in non_matches:
+            with self.subTest(subject=subject):
+                self.assertIsNone(regex.search(subject))
+
+    def test_merge_allows_wip_word_outside_tag(self):
+        """A plain "WIP" word (no `[wip]` tag) does not block the merge."""
+        self._setup_upstream()
+        self.fake_chromium_src.commit_empty('[cr149] Rework WIP handling',
+                                            self.brave)
+        head = self._git('rev-parse', 'HEAD')
+
+        brockit.Merge().execute()
+
+        self.assertEqual(self._remote_master(), head)
+
     def test_merge_allows_canonical_branch(self):
         """A single, correctly-placed pinned commit is merge-ready."""
         self._setup_upstream()

--- a/tools/cr/rebase.py
+++ b/tools/cr/rebase.py
@@ -86,6 +86,9 @@ _CR_TAG_RE = re.compile(r'^(?:\[cr\d+\](?:\[[^\]]+\])*\s+)?')
 # regardless of how many autosquash levels deep the user has gone.
 _AUTOSQUASH_PREFIX_RE = re.compile(r'^(?:(?:fixup|amend|squash)!\s+)+')
 
+# Git-naitve subcommands that brockit treats as autosquash markers.
+_AUTOSQUASH_SUBCOMMANDS = frozenset({'fixup', 'amend', 'reword', 'squash'})
+
 # Chromium version shape: exactly four dot-separated numeric segments
 # (e.g. 149.0.7827.5).
 _CR_VERSION = r'\d+\.\d+\.\d+\.\d+'
@@ -390,6 +393,16 @@ class EntryLine:
     @property
     def is_drop(self) -> bool:
         return self._entry_type is EntryType.DROP
+
+    @property
+    def is_orphan(self) -> bool:
+        """ True when a autosquash marker is orphaned, False otherwise.
+
+        An autosquash marker is orphaned when git could not reattach it to a
+        target commit during the rebase, which leaves it still on a `pick`.
+        """
+        return (self._command == 'pick' and self._subcommand is not None
+                and self._subcommand[0] in _AUTOSQUASH_SUBCOMMANDS)
 
     @property
     def reassign_target_hash(self) -> str | None:

--- a/tools/cr/rebase_test.py
+++ b/tools/cr/rebase_test.py
@@ -85,6 +85,43 @@ class EntryLineParseTest(unittest.TestCase):
         self.assertEqual(entry_line.message, '[cr148] Feature B')
         self.assertEqual(entry_line.subcommand, ['reassign', 'bbb'])
 
+    def test_is_orphan_true_for_pick_autosquash_markers(self):
+        """A `pick` line still carrying an autosquash prefix is orphaned."""
+        orphans = [
+            'pick c8350895147 # fixup! [iOS] Dont inject Brave SKUs javascript '
+            'handlers in private tabs (#37860) # empty',
+            'pick aaa # amend! [cr149] Some subject',
+            'pick bbb # squash! [cr149] Some subject',
+            'pick ccc # reword! [cr149] Some subject',
+        ]
+        for line in orphans:
+            with self.subTest(line=line):
+                self.assertTrue(rebase.EntryLine.parse(line).is_orphan)
+
+    def test_is_orphan_false_for_attached_autosquash_markers(self):
+        """Once git reattaches the marker the command is no longer `pick`."""
+        attached = [
+            'fixup 19e7d36a927 # fixup! [cr151] immersive_mode_controller.h '
+            'moved to new directory',
+            'squash aaa # squash! [cr149] Some subject',
+            'fixup -C 2c334294014 # amend! [cr149] Permit cross-host',
+        ]
+        for line in attached:
+            with self.subTest(line=line):
+                self.assertFalse(rebase.EntryLine.parse(line).is_orphan)
+
+    def test_is_orphan_false_for_non_autosquash_lines(self):
+        """Plain picks and brockit `reassign!`/`drop!` markers aren't
+        orphans."""
+        non_orphans = [
+            'pick aaa # [cr148] Feature A',
+            'pick bbb # reassign!c080270dd7e! [cr149] Fix bookmark bar.',
+            'pick ccc # drop!c080270dd7e! [cr149] Fix bookmark bar.',
+        ]
+        for line in non_orphans:
+            with self.subTest(line=line):
+                self.assertFalse(rebase.EntryLine.parse(line).is_orphan)
+
     def test_parse_blank_line_returns_none(self):
         self.assertIsNone(rebase.EntryLine.parse('\n'))
         self.assertIsNone(rebase.EntryLine.parse('   \n'))


### PR DESCRIPTION
This change adds an additional check for WIP commits and orphaned
fixups, knocking them out of the rebased lists, so they result in a diff
and are shown to the user during the validation failure.

Fixed: https://github.com/brave/brave-browser/issues/57021
