### PR TITLE
Fix vertical tab group editor placement

### DIFF
--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
@@ -46,6 +46,7 @@
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.h"
 #include "chrome/browser/ui/views/location_bar/location_bar_view.h"
+#include "chrome/browser/ui/views/tabs/groups/tab_group_editor_bubble_view.h"
 #include "chrome/browser/ui/views/tabs/new_tab_button.h"
 #include "chrome/browser/ui/views/tabs/tab/tab_context_menu_controller.h"
 #include "chrome/browser/ui/views/tabs/tab_search_button.h"
@@ -62,9 +63,12 @@
 #include "ui/events/event.h"
 #include "ui/gfx/animation/animation_test_api.h"
 #include "ui/gfx/geometry/skia_conversions.h"
+#include "ui/views/interaction/element_tracker_views.h"
 #include "ui/views/layout/flex_layout.h"
 #include "ui/views/layout/layout_manager.h"
 #include "ui/views/test/views_test_utils.h"
+#include "ui/views/test/widget_test.h"
+#include "ui/views/view_utils.h"
 
 #if BUILDFLAG(IS_WIN)
 #include "chrome/browser/ui/view_ids.h"
@@ -262,6 +266,25 @@ class VerticalTabStripBrowserTest : public InProcessBrowserTest {
   HorizontalTabStripRegionView* tab_strip_region_view() {
     return views::AsViewClass<HorizontalTabStripRegionView>(
         BrowserView::GetBrowserViewForBrowser(browser())->tab_strip_view());
+  }
+
+  TabGroupEditorBubbleView* OpenTabGroupEditorBubble(
+      tab_groups::TabGroupId group) {
+    browser()->tab_strip_model()->OpenTabGroupEditor(group);
+    const auto bubble_views =
+        views::ElementTrackerViews::GetInstance()
+            ->GetAllMatchingViewsInAnyContext(
+                TabGroupEditorBubbleView::kTabGroupEditorBubbleViewId);
+    if (bubble_views.empty()) {
+      return nullptr;
+    }
+
+    auto* bubble_view =
+        views::AsViewClass<TabGroupEditorBubbleView>(bubble_views[0]);
+    if (bubble_view) {
+      views::test::WidgetVisibleWaiter(bubble_view->GetWidget()).Wait();
+    }
+    return bubble_view;
   }
 
  private:
@@ -1874,6 +1897,53 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest,
   EXPECT_EQ(brave_tab_container->FindVisibleUnpinnedSlotViews()
                 .second->GetTabSlotViewType(),
             TabSlotView::ViewType::kTabGroupHeader);
+}
+
+IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest,
+                       GroupEditorBubbleAnchorsTowardWebContentsOnBothSides) {
+  browser_view()->Maximize();
+  ASSERT_TRUE(ui_test_utils::WaitForMaximized(browser()));
+  ToggleVerticalTabStrip();
+
+  const tab_groups::TabGroupId group = AddTabToNewGroup(browser(), 0);
+  auto* prefs = browser()->profile()->GetPrefs();
+  const gfx::Rect browser_bounds =
+      browser_view()->GetWidget()->GetWindowBoundsInScreen();
+
+  auto expect_bubble_inside_browser = [&](TabGroupEditorBubbleView* bubble,
+                                          bool opens_to_right) {
+    const gfx::Rect bubble_bounds =
+        bubble->GetWidget()->GetWindowBoundsInScreen();
+    EXPECT_TRUE(browser_bounds.Contains(bubble_bounds));
+
+    ASSERT_TRUE(bubble->GetAnchorView());
+    const gfx::Rect anchor_bounds =
+        bubble->GetAnchorView()->GetBoundsInScreen();
+    if (opens_to_right) {
+      EXPECT_GT(bubble_bounds.CenterPoint().x(),
+                anchor_bounds.CenterPoint().x());
+    } else {
+      EXPECT_LT(bubble_bounds.CenterPoint().x(),
+                anchor_bounds.CenterPoint().x());
+    }
+  };
+
+  TabGroupEditorBubbleView* left_bubble = OpenTabGroupEditorBubble(group);
+  ASSERT_TRUE(left_bubble);
+  EXPECT_EQ(views::BubbleBorder::Arrow::LEFT_TOP, left_bubble->arrow())
+      << "A left-side vertical tab group editor should open to the right";
+  expect_bubble_inside_browser(left_bubble, /*opens_to_right=*/true);
+  left_bubble->GetWidget()->CloseNow();
+
+  prefs->SetBoolean(brave_tabs::kVerticalTabsOnRight, true);
+  browser_non_client_frame_view()->DeprecatedLayoutImmediately();
+
+  TabGroupEditorBubbleView* right_bubble = OpenTabGroupEditorBubble(group);
+  ASSERT_TRUE(right_bubble);
+  EXPECT_EQ(views::BubbleBorder::Arrow::RIGHT_TOP, right_bubble->arrow())
+      << "A right-side vertical tab group editor should open to the left";
+  expect_bubble_inside_browser(right_bubble, /*opens_to_right=*/false);
+  right_bubble->GetWidget()->CloseNow();
 }
 
 // * Non-type argument of 'float' or 'double' for template is unsupported

--- a/browser/ui/views/tabs/brave_tab_group_header.cc
+++ b/browser/ui/views/tabs/brave_tab_group_header.cc
@@ -8,6 +8,7 @@
 #include <optional>
 
 #include "base/check.h"
+#include "base/i18n/rtl.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/components/vector_icons/vector_icons.h"
@@ -47,6 +48,35 @@ void BraveTabGroupHeader::AddedToWidget() {
     // the anchor widget.
     bubble_delegate->SetAnchorView(this);
   }
+}
+
+views::BubbleBorder::Arrow BraveTabGroupHeader::GetAnchorPosition() const {
+  const BrowserWindowInterface* browser =
+      tab_slot_controller_->GetBrowserWindowInterface();
+  if (!tabs::utils::ShouldShowBraveVerticalTabs(browser)) {
+    return TabGroupHeader::GetAnchorPosition();
+  }
+
+  const auto arrow = tabs::utils::IsVerticalTabOnRight(browser)
+                         ? views::BubbleBorder::Arrow::RIGHT_TOP
+                         : views::BubbleBorder::Arrow::LEFT_TOP;
+  // BubbleDialogDelegate mirrors arrows for RTL layouts. Vertical tab side
+  // preferences are physical, so compensate here to keep the bubble opening
+  // toward the web contents.
+  return base::i18n::IsRTL() ? views::BubbleBorder::horizontal_mirror(arrow)
+                             : arrow;
+}
+
+views::BubbleBorder::Arrow BraveTabGroupHeader::GetEditorBubbleArrow(
+    views::BubbleBorder::Arrow chromium_arrow) const {
+  auto arrow = GetAnchorPosition();
+  // Preserve Chromium's near-bottom fallback on Wayland, where automatic
+  // offscreen adjustment is unavailable.
+  if (chromium_arrow == views::BubbleBorder::Arrow::BOTTOM_LEFT ||
+      chromium_arrow == views::BubbleBorder::Arrow::BOTTOM_RIGHT) {
+    arrow = views::BubbleBorder::vertical_mirror(arrow);
+  }
+  return arrow;
 }
 
 void BraveTabGroupHeader::VisualsChanged() {

--- a/browser/ui/views/tabs/brave_tab_group_header.h
+++ b/browser/ui/views/tabs/brave_tab_group_header.h
@@ -24,8 +24,14 @@ class BraveTabGroupHeader : public TabGroupHeader {
   using TabGroupHeader::TabGroupHeader;
   ~BraveTabGroupHeader() override;
 
+  // Returns the inward editor arrow while preserving Chromium's vertical
+  // alignment choice.
+  views::BubbleBorder::Arrow GetEditorBubbleArrow(
+      views::BubbleBorder::Arrow chromium_arrow) const;
+
   // TabGroupHeader:
   void AddedToWidget() override;
+  views::BubbleBorder::Arrow GetAnchorPosition() const override;
   void VisualsChanged() override;
   int GetDesiredWidth() const override;
   void Layout(PassKey) override;

--- a/browser/ui/views/tabs/brave_tab_group_header_unittest.cc
+++ b/browser/ui/views/tabs/brave_tab_group_header_unittest.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/i18n/rtl.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "chrome/browser/ui/browser_window/test/mock_browser_window_interface.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
@@ -94,6 +95,58 @@ class BraveTabGroupHeaderTest : public ChromeViewsTestBase {
   tab_groups::TabGroupId id_ = tab_groups::TabGroupId::GenerateNew();
   std::unique_ptr<TabGroupViews> group_views_;
 };
+
+TEST_F(BraveTabGroupHeaderTest,
+       EditorBubbleAnchorsTowardContentForBothVerticalTabPositions) {
+  TestingProfile profile;
+  auto* header = static_cast<BraveTabGroupHeader*>(group_views_->header());
+
+  testing::NiceMock<MockBrowserWindowInterface> mock_browser_window;
+  EXPECT_CALL(mock_browser_window, GetProfile())
+      .WillRepeatedly(testing::Return(&profile));
+  EXPECT_CALL(testing::Const(mock_browser_window), GetProfile())
+      .WillRepeatedly(testing::Return(&profile));
+  EXPECT_CALL(mock_browser_window, GetType())
+      .WillRepeatedly(testing::Return(BrowserWindowInterface::TYPE_NORMAL));
+  EXPECT_CALL(*tab_slot_controller_, GetBrowserWindowInterface())
+      .WillRepeatedly(testing::Return(&mock_browser_window));
+
+  EXPECT_EQ(views::BubbleBorder::Arrow::TOP_LEFT, header->GetAnchorPosition())
+      << "Horizontal tab group editors should keep Chromium's anchor";
+
+  profile.GetPrefs()->SetBoolean(brave_tabs::kVerticalTabsEnabled, true);
+  EXPECT_EQ(views::BubbleBorder::Arrow::LEFT_TOP, header->GetAnchorPosition())
+      << "A left-side vertical tab group editor should open to the right";
+  EXPECT_EQ(
+      views::BubbleBorder::Arrow::LEFT_BOTTOM,
+      header->GetEditorBubbleArrow(views::BubbleBorder::Arrow::BOTTOM_LEFT))
+      << "A left-side editor should retain Wayland's bottom alignment";
+
+  profile.GetPrefs()->SetBoolean(brave_tabs::kVerticalTabsOnRight, true);
+  EXPECT_EQ(views::BubbleBorder::Arrow::RIGHT_TOP, header->GetAnchorPosition())
+      << "A right-side vertical tab group editor should open to the left";
+  EXPECT_EQ(
+      views::BubbleBorder::Arrow::RIGHT_BOTTOM,
+      header->GetEditorBubbleArrow(views::BubbleBorder::Arrow::BOTTOM_LEFT))
+      << "A right-side editor should retain Wayland's bottom alignment";
+
+  profile.GetPrefs()->SetBoolean(brave_tabs::kVerticalTabsOnRight, false);
+  base::i18n::ScopedRTLForTesting scoped_rtl(/*rtl=*/true);
+  EXPECT_EQ(views::BubbleBorder::Arrow::RIGHT_TOP, header->GetAnchorPosition())
+      << "Views should mirror a left-side RTL arrow back toward the content";
+  EXPECT_EQ(
+      views::BubbleBorder::Arrow::RIGHT_BOTTOM,
+      header->GetEditorBubbleArrow(views::BubbleBorder::Arrow::BOTTOM_RIGHT))
+      << "An RTL left-side editor should retain bottom alignment";
+
+  profile.GetPrefs()->SetBoolean(brave_tabs::kVerticalTabsOnRight, true);
+  EXPECT_EQ(views::BubbleBorder::Arrow::LEFT_TOP, header->GetAnchorPosition())
+      << "Views should mirror a right-side RTL arrow back toward the content";
+  EXPECT_EQ(
+      views::BubbleBorder::Arrow::LEFT_BOTTOM,
+      header->GetEditorBubbleArrow(views::BubbleBorder::Arrow::BOTTOM_RIGHT))
+      << "An RTL right-side editor should retain bottom alignment";
+}
 
 // Regression test: TabGroupHeader::VisualsChanged() sets |title_chip_|'s clip
 // path based on the (narrower) bounds computed for horizontal tabs, before

--- a/chromium_src/chrome/browser/ui/views/tabs/groups/tab_group_editor_bubble_view.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/groups/tab_group_editor_bubble_view.cc
@@ -6,10 +6,12 @@
 #include "chrome/browser/ui/views/tabs/groups/tab_group_editor_bubble_view.h"
 
 #include "base/check.h"
+#include "brave/browser/ui/views/tabs/brave_tab_group_header.h"
 #include "chrome/app/vector_icons/vector_icons.h"
 #include "chrome/browser/ui/views/data_sharing/data_sharing_bubble_controller.h"
 #include "chrome/browser/user_education/user_education_service.h"
 #include "ui/views/layout/flex_layout.h"
+#include "ui/views/view_utils.h"
 
 namespace {
 
@@ -31,11 +33,23 @@ void MaybeRemoveFooter(TabGroupEditorBubbleView* bubble_view,
   layout->SetInteriorMargin(margin);
 }
 
+TabGroupEditorBubbleView* SetEditorBubbleArrowForBraveTabGroupHeader(
+    TabGroupEditorBubbleView* bubble_view,
+    views::View* anchor_view) {
+  auto* group_header = views::AsViewClass<BraveTabGroupHeader>(anchor_view);
+  if (group_header) {
+    bubble_view->SetArrow(
+        group_header->GetEditorBubbleArrow(bubble_view->arrow()));
+  }
+  return bubble_view;
+}
+
 }  // namespace
 
-#define CreateBubble(bubble_view)                                           \
-  CreateBubble(bubble_view);                                                \
-  MaybeRemoveFooter(bubble_view, bubble_view->footer_.ExtractAsDangling()); \
+#define CreateBubble(bubble_view)                                            \
+  CreateBubble(                                                              \
+      SetEditorBubbleArrowForBraveTabGroupHeader(bubble_view, anchor_view)); \
+  MaybeRemoveFooter(bubble_view, bubble_view->footer_.ExtractAsDangling());  \
   bubble_view->footer_ = nullptr
 
 #define kUngroupRefreshOldIcon \


### PR DESCRIPTION
Resolves brave/brave-browser#52595

## Summary

- Anchor the tab-group editor toward web contents when Brave vertical tabs are on either side of the window.
- Preserve Chromium's horizontal-tab behavior and compensate for Views' RTL arrow mirroring.
- Preserve Chromium's near-bottom Wayland fallback while changing the bubble's horizontal direction.
- Add focused unit and browser regression coverage for horizontal, left, right, RTL, and in-window bounds states.

## Root cause

Chromium constructs `TabGroupEditorBubbleView` with a fixed `TOP_LEFT` arrow. Brave's vertical tab-group header inherited that placement, so a group editor opened outward from the tab strip and could extend beyond the browser window.

## Test plan

- `git diff --check upstream/master...HEAD` — passed.
- Chromium `150.0.7871.114` dependency sync, all Brave patches, and hooks — passed.
- `BraveTabGroupHeaderTest.EditorBubbleAnchorsTowardContentForBothVerticalTabPositions` — passed (1/1).
- `VerticalTabStripBrowserTest.GroupEditorBubbleAnchorsTowardWebContentsOnBothSides` — passed (1/1).
- Final `Brave Browser Development.app` component build — passed on macOS arm64.

## Manual verification

Verified the final build at `699f4dc87667b107943d940db58e84c05d1ad74e` on macOS arm64 with disposable profiles:

1. Enabled vertical tabs and placed the tab strip on the left.
2. Created a tab group and opened its editor.
3. Confirmed the editor opens to the right, toward web contents, and stays inside the browser window.
4. Repeated with the tab strip on the right.
5. Confirmed the editor opens to the left, toward web contents, and stays inside the browser window.

## Screenshots

### Vertical tabs on the left

<img width="1462" height="915" alt="image" src="https://github.com/user-attachments/assets/22fc6b2c-9a18-41da-980c-583646a1da28" />


### Vertical tabs on the right

<img width="1682" height="871" alt="image" src="https://github.com/user-attachments/assets/b7015c3b-fc09-4e97-88b3-fe66f46a13a7" />


## AI assistance

Codex assisted with issue investigation, implementation, tests, and review. The contributor reviewed and manually verified the final change and remains responsible for the submission.
