### PR TITLE
[bootstrap][git-cr] Adding `git-cr` shims

### DIFF
--- a/tools/cr/alias/README.md
+++ b/tools/cr/alias/README.md
@@ -1,24 +1,35 @@
-# `git cr` alias for Chromium rebasing tooling
+# `git cr` for Chromium rebasing tooling
 
-This alias is maintained by the Chromium Rebase team to simplify many of the
-rebase tasks. This directory provides the `git cr` git alias and the supporting
-commit-msg hook used when committing to `brave-core`.
+The `git cr` command is maintained by the Chromium Rebase team to simplify many
+of the rebase tasks. This directory provides the `git cr` implementation and the
+supporting commit-msg hook used when committing to `brave-core`.
 
 ## Quick start
 
-From the `brave-core` repository root, install this alias with:
+The recommended way to get `git cr` is the bootstrap shims, which put a `git-cr`
+executable on your `$PATH`:
 
 ```sh
-python3 tools/cr/alias/cmd.py setup-alias
+vpython3 tools/cr/bootstrap/bootstrap.py install
 git cr install-hook
 ```
 
-- `setup-alias` writes a `cr` entry to `.git/config`. After this, `git cr` works
-  in this repository.
+See [`../bootstrap/README.md`](../bootstrap/README.md) for details. Open a new
+shell for the `$PATH` change to take effect.
+
 - `install-hook` installs `commit-msg.py` as the repository's `commit-msg` hook.
-  This is necessary to use `git cr commit`
+  This is necessary to use `git cr commit`.
 
 Once installed, run `git cr` to see the available commands.
+
+### Alternative: a per-repository alias
+
+If you would rather not modify your `$PATH`, register a `git cr` alias in the
+current repository's `.git/config` instead:
+
+```sh
+vpython3 tools/cr/alias/cmd.py setup-alias
+```
 
 ## Subcommands
 

--- a/tools/cr/alias/cmd.py
+++ b/tools/cr/alias/cmd.py
@@ -15,12 +15,17 @@ Subcommands:
                     tools/cr/alias/commit-msg.py.
   - setup-alias     Register the `git cr` alias in the local .git/config.
 
-Installing the alias
---------------------
+Getting `git cr`
+----------------
+  The recommended way is the bootstrap shims, which put a `git-cr` executable
+  on $PATH so git resolves the `git cr` subcommand to it in every checkout:
+    vpython3 tools/cr/bootstrap/bootstrap.py install
+
+Installing the alias (alternative)
+----------------------------------
+  If you would rather not modify $PATH, register a per-repository alias.
   From inside the brave-core repository, run once:
     vpython3 tools/cr/alias/cmd.py setup-alias
-  This writes a 'cr' entry to .git/config so that 'git cr' works immediately
-  in the current repository without modifying any shell config files.
 
 Installing the hook
 -------------------

--- a/tools/cr/alias/cmd_test.py
+++ b/tools/cr/alias/cmd_test.py
@@ -47,6 +47,22 @@ _GIT_ENV_OVERRIDES: dict[str, str] = {
 # ---------------------------------------------------------------------------
 
 
+def _path_without_git_cr_shim() -> str:
+    """`$PATH` with every directory holding a `git-cr` executable removed.
+
+    git resolves `git cr` to a `git-cr` on `$PATH` *before* consulting the
+    `.git/config` alias, so a bootstrap shim installed on the developer's
+    machine would shadow the alias this test is exercising. Dropping those
+    directories keeps `git` itself resolvable while isolating the alias path.
+    """
+    entries = os.environ.get('PATH', '').split(os.pathsep)
+    kept = [
+        entry for entry in entries if entry and not any(
+            (Path(entry) / name).exists() for name in ('git-cr', 'git-cr.bat'))
+    ]
+    return os.pathsep.join(kept)
+
+
 def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
     """Run a git command in cwd; raise on failure."""
     return subprocess.run(
@@ -334,7 +350,11 @@ class TestSetupAlias(unittest.TestCase):
             check=False,
             env={
                 **os.environ,
-                **_GIT_ENV_OVERRIDES
+                **_GIT_ENV_OVERRIDES,
+                # Isolate the alias under test from any bootstrap `git-cr`
+                # shim installed on this machine, which git would otherwise
+                # prefer over the .git/config alias.
+                'PATH': _path_without_git_cr_shim(),
             },
         )
         self.assertEqual(result.returncode, 0, msg=f'stderr: {result.stderr}')

--- a/tools/cr/bootstrap/README.md
+++ b/tools/cr/bootstrap/README.md
@@ -1,13 +1,7 @@
 # `tools/cr/bootstrap`
 
-Provides shims for `plaster`, `brockit`, `node` and `npm`, selecting them
-relative to the Brave repository in the current directory.
-
-`plaster` / `brockit` dispatch to the matching `tools/cr` script. `node` / `npm`
-are a prototype front-end for the node delivered into `third_party/node` by
-`gclient sync` (see [Node delivery](#node-delivery) below): inside a checkout
-that has a downloaded node they run _that_ node, and everywhere else they fall
-back transparently to the system `node` / `npm`.
+This path incubates a boostrap module, to provide shims as ergonomics for tools
+we use to build Brave.
 
 ## Install
 
@@ -51,11 +45,12 @@ checkout than the one that was installed.
 cd ~/browser/src/brave/components # anywhere inside a checkout
 plaster check                     # runs that checkout's plaster.py
 brockit lift --to=1.2.3.4         # runs that checkout's brockit.py
+git cr commit -m "…"              # runs that checkout's alias/cmd.py
 ```
 
-`plaster` / `brockit` are resolved relative to `brave-core`, so calling them
-from a directory that is not inside `brave-core` will fail. `node` / `npm`
-instead fall back to the system tool in that case (see below).
+`plaster` / `brockit` / `git cr` are resolved relative to `brave-core`, so
+calling them from a directory that is not inside `brave-core` will fail. `node`
+/ `npm` instead fall back to the system tool in that case (see below).
 
 ```sh
 cd ~/browser/src/brave

--- a/tools/cr/bootstrap/bootstrap_test.py
+++ b/tools/cr/bootstrap/bootstrap_test.py
@@ -301,6 +301,13 @@ class FindShimTargetTest(unittest.TestCase):
         self.assertEqual(launcher.find_shim_target('brockit'),
                          launcher.SHIM_TARGETS['brockit'])
 
+    def test_git_cr_token_resolves_to_cmd(self):
+        # git resolves `git cr` to the `git-cr` shim, which passes `git-cr`
+        # verbatim; it must map to the git_cr command entry point.
+        target = launcher.find_shim_target('git-cr')
+        self.assertEqual(target, launcher.SHIM_TARGETS['git-cr'])
+        self.assertTrue(target.path.endswith('alias/cmd.py'))
+
     def test_bare_family_gets_host_suffix(self):
         # A POSIX shim passes the bare family; the launcher appends the host.
         key = launcher.host_platform_key()
@@ -366,6 +373,18 @@ class ResolveInvocationTest(unittest.TestCase):
             # brockit is launched as: <vpython3> <brockit.py>.
             self.assertEqual(len(invocation), 2)
             self.assertTrue(invocation[1].endswith('brockit.py'))
+
+    def test_git_cr_runs_through_vpython3(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_target(root, 'git-cr')
+            invocation = launcher.resolve_invocation('git-cr',
+                                                     self._checkout(root),
+                                                     False)
+            self.assertIsNotNone(invocation)
+            # git-cr is launched as: <vpython3> <cmd.py>.
+            self.assertEqual(len(invocation), 2)
+            self.assertTrue(invocation[1].endswith('cmd.py'))
 
     def test_falls_back_to_system_when_allowed(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/cr/bootstrap/git-cr
+++ b/tools/cr/bootstrap/git-cr
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Dispatches to tools/cr/alias/cmd.py for the brave-core checkout the current
+# directory is in. See launcher.py for the resolution logic.
+#
+# Named `git-cr` so that git resolves `git cr` to this shim via $PATH, making
+# the `git cr` subcommand work without registering a per-repository alias.
+exec python3 "$(dirname "$0")/launcher.py" git-cr "$@"

--- a/tools/cr/bootstrap/git-cr.bat
+++ b/tools/cr/bootstrap/git-cr.bat
@@ -1,0 +1,12 @@
+@echo off
+:: Copyright (c) 2026 The Brave Authors. All rights reserved.
+:: This Source Code Form is subject to the terms of the Mozilla Public
+:: License, v. 2.0. If a copy of the MPL was not distributed with this file,
+:: You can obtain one at https://mozilla.org/MPL/2.0/.
+::
+:: Dispatches to tools/cr/alias/cmd.py for the brave-core checkout the current
+:: directory is in. See launcher.py for the resolution logic.
+::
+:: Named `git-cr` so that git resolves `git cr` to this shim via %PATH%, making
+:: the `git cr` subcommand work without registering a per-repository alias.
+python3 "%~dp0launcher.py" git-cr %*

--- a/tools/cr/bootstrap/launcher.py
+++ b/tools/cr/bootstrap/launcher.py
@@ -51,6 +51,7 @@ class Shim:
 SHIM_TARGETS: dict[str, Shim] = {
     'brockit': Shim('src/brave/tools/cr/brockit.py', 'vpython'),
     'plaster': Shim('src/brave/tools/cr/plaster.py', 'vpython'),
+    'git-cr': Shim('src/brave/tools/cr/alias/cmd.py', 'vpython'),
     'node-linux': Shim(
         'src/brave/third_party/node/linux/node-v24.17.0-linux-x64/bin/node'),
     'node-mac': Shim(


### PR DESCRIPTION
This change adds shims for `git-cr`, which dispenses with the
per-repository installation we currently support.

Bug: https://github.com/brave/brave-browser/issues/56529
