### PR TITLE
[ast-grep][plaster] Adding `rewriters.pyl`

### DIFF
--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import abc
 import argparse
+import ast
 from dataclasses import dataclass, field
 import hashlib
 import logging
@@ -16,6 +17,7 @@ from pathlib import Path, PurePath
 import json
 import os
 import re
+import string
 import sys
 import textwrap
 from types import MappingProxyType
@@ -26,6 +28,16 @@ import yaml
 
 from terminal import IncendiaryErrorHandler, console, is_verbose, terminal
 import repository
+
+# A round-about import for https://github.com/keleshev/schema, vendored under
+# depot_tools. It could be helpful to deploy this under our own third_party in
+# the future.
+sys.path.insert(
+    0,
+    str(
+        Path(__file__).resolve().parents[3] / 'third_party' / 'depot_tools' /
+        'third_party'))
+import schema  # pylint: disable=wrong-import-position,import-error
 
 # The path to the directory containing plaster files in brave-core.
 PLASTER_FILES_PATH = repository.brave.root / 'rewrite'
@@ -39,6 +51,10 @@ PLASTER_EXTENSION = '.yaml'
 # A particular gitattributes file that is used to ensure we get deterministic
 # patch output across platforms and git versions.
 PLASTER_GITATTRIBUTES_PATH = Path(__file__).parent / 'plaster_gitattributes'
+
+# The declarative ast-grep rewriters spec, loaded and validated by
+# `RewritersEval`.
+REWRITERS_FILE = Path(__file__).parent / 'rewriters.pyl'
 
 
 @dataclass
@@ -815,6 +831,207 @@ class PlasterApplyError(PlasterError):
         super().__init__(
             'There were errors attempting to apply the patches:\n' +
             '\n'.join(errors))
+
+
+class RewritersSchemaError(PlasterError):
+    """Raised when `rewriters.pyl` does not conform to the expected schema."""
+
+
+# Namespace mapping for ast-grep rewriter types. This list will grow as more
+# rewriters are added for other languages.
+_LANGUAGE_BY_PREFIX = MappingProxyType({'cxx': 'cpp'})
+
+
+def _is_regex(pattern: str) -> bool:
+    """schema predicate: True if `pattern` compiles as a regular expression."""
+    try:
+        re.compile(pattern)
+        return True
+    except re.error:
+        return False
+
+
+def _is_op_id(op_id: str) -> bool:
+    """schema predicate: True if `op_id` is `<known-lang>.<name>`."""
+    prefix, _, name = op_id.partition('.')
+    return bool(name) and prefix in _LANGUAGE_BY_PREFIX
+
+
+def _template_args_match(spec: dict) -> dict:
+    """schema validator: a matcher's template uses exactly its declared args.
+
+    Returns the spec unchanged on success or raises schema.SchemaError if the
+    template references a placeholder that is not a declared arg, or declares
+    an arg the template never uses, catching any typos.
+    """
+    placeholders = {
+        name
+        for _, name, _, _ in string.Formatter().parse(spec['template']) if name
+    }
+    declared = set(spec['args'])
+    undeclared = sorted(placeholders - declared)
+    if undeclared:
+        raise schema.SchemaError(
+            f'template uses undeclared placeholder(s): {", ".join(undeclared)}'
+        )
+    unused = sorted(declared - placeholders)
+    if unused:
+        raise schema.SchemaError(
+            f'declared arg(s) never used in template: {", ".join(unused)}')
+    return spec
+
+
+# Reusable leaf schemas.
+_NON_EMPTY_STR = schema.And(str, len, error='must be a non-empty string')
+_REGEX_STR = schema.And(str,
+                        _is_regex,
+                        error='must be a valid regular expression')
+_OP_ID = schema.And(str,
+                    _is_op_id,
+                    error='op id must be "<lang>.<name>" with a known '
+                    'language prefix')
+
+# The "result" block shared by matcher and rewriter ops.
+_RESULT_SCHEMA = {
+    'node': _NON_EMPTY_STR,
+}
+
+# A matcher op: a templated ast-grep query plus its result shape.
+_MATCHER_SCHEMA = schema.And(
+    {
+        'args': [str],
+        'template': _NON_EMPTY_STR,
+        'result': _RESULT_SCHEMA,
+    }, _template_args_match)
+
+# A rewriter op: locates nodes through a matcher op and edits each via a regex
+# substitution.
+_REWRITER_SCHEMA = {
+    'matcher': _NON_EMPTY_STR,
+    'replace': {
+        're_pattern': _REGEX_STR,
+        'replace': str,
+    },
+    'result': _RESULT_SCHEMA,
+}
+
+# Top-level schema for rewriters.pyl.
+_REWRITERS_SCHEMA = schema.Schema({
+    schema.Optional('ast.matcher'): {
+        schema.Optional(_OP_ID): _MATCHER_SCHEMA
+    },
+    schema.Optional('ast.rewriter'): {
+        schema.Optional(_OP_ID): _REWRITER_SCHEMA
+    },
+})
+
+
+class RewritersEval:
+    """Loads and schema-validates `rewriters.pyl`.
+
+    The main function of this class is to make sure the file is valid, and to
+    provide access to the loaded content. Note the distinction from the
+    `Rewriter` op classes above: `Rewriter`/`Regex` are the `substitutions:`
+    transforms, while this loads the declarative ast-grep matcher/rewriter
+    *specs* those transforms will drive.
+    """
+
+    # Process-wide singleton, loaded once from REWRITERS_FILE by load().
+    _instance: RewritersEval | None = None
+
+    def __init__(self, content: str, *, source: str = str(REWRITERS_FILE)):
+        """Parse and validate `content` (the text of a rewriters.pyl file).
+
+        Raises RewritersSchemaError if the content is not a valid literal or
+        does not satisfy the schema. `source` is only used in error messages.
+        """
+        self._source = source
+        data = self._parse(content, source)
+        try:
+            data = _REWRITERS_SCHEMA.validate(data)
+        except schema.SchemaError as e:
+            raise RewritersSchemaError(f'{source}: {e}') from e
+        self._matchers = data.get('ast.matcher', {})
+        self._rewriters = data.get('ast.rewriter', {})
+        self._check_cross_references()
+
+    @classmethod
+    def load(cls) -> RewritersEval:
+        """Return the process-wide RewritersEval, reading rewriters.pyl once."""
+        if cls._instance is None:
+            cls._instance = cls(REWRITERS_FILE.read_bytes().decode('utf-8'),
+                                source=str(REWRITERS_FILE))
+        return cls._instance
+
+    # -- access -------------------------------------------------------------
+
+    @property
+    def matchers(self) -> MappingProxyType[str, dict]:
+        """Read-only mapping of matcher op id -> validated matcher spec."""
+        return MappingProxyType(self._matchers)
+
+    @property
+    def rewriters(self) -> MappingProxyType[str, dict]:
+        """Read-only mapping of rewriter op id -> validated rewriter spec."""
+        return MappingProxyType(self._rewriters)
+
+    def matcher(self, op_id: str) -> dict:
+        """Return the matcher spec for `op_id`, or raise if it is unknown."""
+        try:
+            return self._matchers[op_id]
+        except KeyError:
+            raise RewritersSchemaError(
+                f'unknown matcher op: {op_id!r}') from None
+
+    def rewriter(self, op_id: str) -> dict:
+        """Return the rewriter spec for `op_id`, or raise if it is unknown."""
+        try:
+            return self._rewriters[op_id]
+        except KeyError:
+            raise RewritersSchemaError(
+                f'unknown rewriter op: {op_id!r}') from None
+
+    @classmethod
+    def language_of(cls, op_id: str) -> str:
+        """Return the ast-grep language id derived from `op_id`'s prefix."""
+        prefix = op_id.split('.', 1)[0]
+        try:
+            return _LANGUAGE_BY_PREFIX[prefix]
+        except KeyError:
+            raise RewritersSchemaError(
+                f'op {op_id!r} has unknown language prefix {prefix!r}; '
+                f'known prefixes: {sorted(_LANGUAGE_BY_PREFIX)}') from None
+
+    # -- validation ---------------------------------------------------------
+
+    @staticmethod
+    def _parse(content: str, source: str) -> object:
+        """Evaluate `content` as a Python literal (shape is checked later)."""
+        try:
+            return ast.literal_eval(content)
+        except (ValueError, SyntaxError, TypeError) as e:
+            raise RewritersSchemaError(
+                f'{source}: not a valid Python literal: {e}') from e
+
+    def _check_cross_references(self) -> None:
+        """Validate rules that span records, which schema cannot express.
+
+        Each rewriter must reference a matcher that exists, and must declare the
+        same result node as that matcher (it replaces the node the matcher
+        locates, so the two must agree).
+        """
+        for op_id, spec in self._rewriters.items():
+            ref = spec['matcher']
+            if ref not in self._matchers:
+                raise RewritersSchemaError(
+                    f'{self._source}: rewriter {op_id!r} references unknown '
+                    f'matcher {ref!r}')
+            matcher_node = self._matchers[ref]['result']['node']
+            if spec['result']['node'] != matcher_node:
+                raise RewritersSchemaError(
+                    f'{self._source}: rewriter {op_id!r} result node '
+                    f'{spec["result"]["node"]!r} does not match matcher '
+                    f'{ref!r} node {matcher_node!r}')
 
 
 def get_plaster_files(filepaths: list[str] | None = None) -> list[PlasterFile]:

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1279,6 +1279,219 @@ class RewriterRegistryTest(unittest.TestCase):
             self.assertTrue(cls.help_text(), f'{name} is missing help text')
 
 
+class RewritersEvalTest(unittest.TestCase):
+    """Schema evaluation and access tests for plaster.RewritersEval."""
+
+    def setUp(self):
+        # load() memoises a process-wide instance; clear it so tests that
+        # exercise the singleton start from a clean slate.
+        plaster.RewritersEval._instance = None
+        self.addCleanup(setattr, plaster.RewritersEval, '_instance', None)
+
+    @staticmethod
+    def _valid_spec() -> dict:
+        """A minimal, schema-valid rewriters spec as a Python dict."""
+        return {
+            'ast.matcher': {
+                'cxx.find_class_method_decl': {
+                    'args': ['class_name', 'method_name'],
+                    'template': ('kind: field_declaration\n'
+                                 'has:\n'
+                                 '  regex: ^{method_name}$\n'
+                                 'inside:\n'
+                                 '  regex: ^{class_name}$\n'),
+                    'result': {
+                        'node': 'field_declaration',
+                    },
+                },
+            },
+            'ast.rewriter': {
+                'cxx.make_virtual': {
+                    'matcher': 'cxx.find_class_method_decl',
+                    'replace': {
+                        're_pattern': '^',
+                        'replace': 'virtual '
+                    },
+                    'result': {
+                        'node': 'field_declaration',
+                    },
+                },
+            },
+        }
+
+    def _eval_valid(self) -> plaster.RewritersEval:
+        return plaster.RewritersEval(repr(self._valid_spec()))
+
+    def _assert_invalid(self, mutate, expected_substr=None):
+        """Apply `mutate` to a valid spec and assert it fails validation."""
+        spec = self._valid_spec()
+        mutate(spec)
+        with self.assertRaises(plaster.RewritersSchemaError) as cm:
+            plaster.RewritersEval(repr(spec))
+        if expected_substr is not None:
+            self.assertIn(expected_substr, str(cm.exception))
+
+    # -- the real on-disk spec ---------------------------------------------
+
+    def test_load_real_rewriters_file(self):
+        """The shipped rewriters.pyl validates and loads.
+
+        It ships empty for now (ops are added when they are wired in), so this
+        just asserts a clean load and empty, read-only op mappings.
+        """
+        rewriters = plaster.RewritersEval.load()
+        self.assertEqual(dict(rewriters.matchers), {})
+        self.assertEqual(dict(rewriters.rewriters), {})
+
+    def test_load_is_a_singleton(self):
+        """load() reads the file once and returns the same instance."""
+        first = plaster.RewritersEval.load()
+        second = plaster.RewritersEval.load()
+        self.assertIs(first, second)
+
+    # -- access -------------------------------------------------------------
+
+    def test_accessors_return_specs(self):
+        rewriters = self._eval_valid()
+        self.assertEqual(
+            rewriters.matcher('cxx.find_class_method_decl')['args'],
+            ['class_name', 'method_name'])
+        self.assertEqual(
+            rewriters.rewriter('cxx.make_virtual')['matcher'],
+            'cxx.find_class_method_decl')
+
+    def test_unknown_op_access_raises(self):
+        rewriters = self._eval_valid()
+        with self.assertRaises(plaster.RewritersSchemaError):
+            rewriters.matcher('cxx.nope')
+        with self.assertRaises(plaster.RewritersSchemaError):
+            rewriters.rewriter('cxx.nope')
+
+    def test_language_of(self):
+        self.assertEqual(
+            plaster.RewritersEval.language_of('cxx.find_class_method_decl'),
+            'cpp')
+        with self.assertRaises(plaster.RewritersSchemaError):
+            plaster.RewritersEval.language_of('py.find_class_method_decl')
+
+    def test_exposed_mappings_are_read_only(self):
+        rewriters = self._eval_valid()
+        with self.assertRaises(TypeError):
+            rewriters.matchers['x'] = {}
+        with self.assertRaises(TypeError):
+            rewriters.rewriters['x'] = {}
+
+    def test_valid_spec_round_trips(self):
+        rewriters = self._eval_valid()
+        self.assertEqual(list(rewriters.matchers),
+                         ['cxx.find_class_method_decl'])
+        self.assertEqual(list(rewriters.rewriters), ['cxx.make_virtual'])
+
+    # -- top-level / parsing failures --------------------------------------
+
+    def test_not_a_literal(self):
+        with self.assertRaises(plaster.RewritersSchemaError):
+            plaster.RewritersEval('this is not a literal (((')
+
+    def test_top_level_not_a_dict(self):
+        with self.assertRaises(plaster.RewritersSchemaError):
+            plaster.RewritersEval('[1, 2, 3]')
+
+    def test_present_but_empty_groups_are_valid(self):
+        # A group may be present with no ops yet (as the shipped file is).
+        rewriters = plaster.RewritersEval(
+            "{'ast.matcher': {}, 'ast.rewriter': {}}")
+        self.assertEqual(dict(rewriters.matchers), {})
+        self.assertEqual(dict(rewriters.rewriters), {})
+
+    def test_unknown_category(self):
+        # schema rejects keys outside the top-level matcher/rewriter set.
+        self._assert_invalid(lambda s: s.update({'mangler': {}}), 'Wrong keys')
+
+    def test_category_not_a_mapping(self):
+        self._assert_invalid(lambda s: s.__setitem__('ast.matcher', []),
+                             "should be instance of 'dict'")
+
+    # -- op id --------------------------------------------------------------
+
+    def test_op_id_without_prefix(self):
+        # An id that does not match the _OP_ID key schema is an unexpected key.
+        def mutate(s):
+            s['ast.matcher']['nodothere'] = s['ast.matcher'].pop(
+                'cxx.find_class_method_decl')
+
+        self._assert_invalid(mutate, 'Wrong keys')
+
+    def test_op_id_unknown_prefix(self):
+
+        def mutate(s):
+            s['ast.matcher']['py.find_class_method_decl'] = s[
+                'ast.matcher'].pop('cxx.find_class_method_decl')
+
+        self._assert_invalid(mutate, 'Wrong keys')
+
+    # -- matcher schema ------------------------------------------------------
+
+    def test_matcher_missing_required_key(self):
+        self._assert_invalid(
+            lambda s: s['ast.matcher']['cxx.find_class_method_decl'].pop(
+                'template'), 'Missing keys')
+
+    def test_matcher_unknown_key(self):
+        self._assert_invalid(
+            lambda s: s['ast.matcher']['cxx.find_class_method_decl'].update(
+                {'language': 'cpp'}), 'Wrong keys')
+
+    def test_matcher_args_not_list_of_strings(self):
+        self._assert_invalid(
+            lambda s: s['ast.matcher']['cxx.find_class_method_decl'].
+            __setitem__('args', 'class_name'), "should be instance of 'list'")
+
+    def test_matcher_undeclared_placeholder(self):
+        self._assert_invalid(
+            lambda s: s['ast.matcher']
+            ['cxx.find_class_method_decl'].__setitem__(
+                'template', 'regex: ^{class_name}$ ^{method_name}$ ^{bogus}$'),
+            'undeclared placeholder')
+
+    def test_matcher_unused_arg(self):
+        self._assert_invalid(
+            lambda s: s['ast.matcher']['cxx.find_class_method_decl']['args'].
+            append('unused'), 'never used')
+
+    def test_matcher_bad_result(self):
+        self._assert_invalid(
+            lambda s: s['ast.matcher']['cxx.find_class_method_decl']['result'].
+            pop('node'), 'Missing keys')
+
+    # -- rewriter schema ----------------------------------------------------
+
+    def test_rewriter_unknown_matcher_reference(self):
+        self._assert_invalid(
+            lambda s: s['ast.rewriter']['cxx.make_virtual'].__setitem__(
+                'matcher', 'cxx.ghost'), 'unknown matcher')
+
+    def test_rewriter_replace_missing_key(self):
+        self._assert_invalid(
+            lambda s: s['ast.rewriter']['cxx.make_virtual']['replace'].pop(
+                're_pattern'), 'Missing keys')
+
+    def test_rewriter_invalid_replace_regex(self):
+        self._assert_invalid(
+            lambda s: s['ast.rewriter']['cxx.make_virtual']['replace'].
+            __setitem__('re_pattern', '(unclosed'), 'valid regular expression')
+
+    def test_rewriter_result_node_mismatch(self):
+        self._assert_invalid(
+            lambda s: s['ast.rewriter']['cxx.make_virtual']['result'].
+            __setitem__('node', 'declaration'), 'does not match matcher')
+
+    def test_rewriter_unknown_key(self):
+        self._assert_invalid(
+            lambda s: s['ast.rewriter']['cxx.make_virtual'].update(
+                {'append': '!'}), 'Wrong keys')
+
+
 class HelpTest(unittest.TestCase):
     """gn-style `plaster --help [topic]` overview, categories and topic docs.
 

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -1,0 +1,32 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# rewriters.pyl — ast-grep op specs for plaster. Data only: a Python literal
+# (ast.literal_eval), so no imports, calls, or names.
+#
+# Two op categories, each keyed by an op id "<lang>.<name>" ("cxx" -> cpp,
+# resolved in code):
+#
+#   "ast.matcher" — a structural query:
+#       args:     arg names the caller supplies; each is a {placeholder}.
+#       template: ast-grep rule body (the part under `rule:`); {arg}s filled.
+#       result:   { node: <tree-sitter kind> } each match is.
+#
+#   "ast.rewriter" — edits each node a matcher finds:
+#       matcher:  id of the "ast.matcher" op locating the node(s).
+#       replace:  { re_pattern, replace }, re.sub'd over each match's source;
+#                 `replace` is {arg}-formatted first (literal braces: {{ }}).
+#       result:   { node: <kind> } being replaced.
+#
+# An op yields every match in source order; the caller (plaster) decides how
+# many it expects. Arg values are injected verbatim into the rule's `regex:`
+# fields, so the caller escapes any regex metacharacters.
+
+{
+    "ast.matcher": {
+    },
+    "ast.rewriter": {
+    },
+}


### PR DESCRIPTION
This PR introduces `tools/cr/rewriters.pyl` with some schema to attempt
to provide the basic machinery for all types of macros and ast-based
macros that we may use in the future.

This change introduces a basic schema that is being geared toward the
use of `ast-grep`. This is obviously fluid and changing, but the
current PR provides the basic shape for the use of this file.

Bug: https://github.com/brave/brave-browser/issues/56760
