### PR TITLE
[iOS] Update sync preference on sync service state update

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -365,10 +365,6 @@ public class BrowserViewController: UIViewController {
       }
     )
 
-    // Update the preference based on the underlying Chromium prefs
-    // Remove this when the pref is deleted: https://github.com/brave/brave-browser/issues/47487
-    Preferences.Chromium.syncEnabled.value = profileController.syncAPI.isInSyncGroup
-
     // Observer watching state change in sync chain
     syncServiceStateListener = profileController.syncAPI.addServiceStateObserver { [weak self] in
       guard let self = self else { return }
@@ -377,6 +373,10 @@ public class BrowserViewController: UIViewController {
         // from another device - Clean local sync chain
         if self.profileController.syncAPI.shouldLeaveSyncGroup {
           self.profileController.syncAPI.leaveSyncGroup()
+        } else {
+          // Update the preference based on the underlying Chromium prefs
+          // Remove this when the pref is deleted: https://github.com/brave/brave-browser/issues/47487
+          Preferences.Chromium.syncEnabled.value = profileController.syncAPI.isInSyncGroup
         }
       }
     }


### PR DESCRIPTION
The sync service is not ready immediately anymore due to the migration to `OSCryptAsync` so we need to update this preference in the sync state listener instead.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/57046
