### PR TITLE
Add default_model_key and hide default model intro

### DIFF
--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -2120,6 +2120,7 @@ ConversationHandler::GetStateForConversationEntries() {
   entries_state->is_leo_model = is_leo_model;
   entries_state->all_models = std::move(models_copy);
   entries_state->current_model_key = model.key;
+  entries_state->default_model_key = model_service_->GetDefaultModelKey();
   entries_state->total_tokens = metadata_->total_tokens;
   entries_state->trimmed_tokens = metadata_->trimmed_tokens;
   entries_state->content_used_percentage =

--- a/components/ai_chat/core/common/mojom/common.mojom
+++ b/components/ai_chat/core/common/mojom/common.mojom
@@ -699,6 +699,8 @@ struct ConversationEntriesState {
   bool is_leo_model;
   array<Model> all_models;
   string current_model_key;
+  // The user's default model key, used to detect a non-default selection.
+  string default_model_key;
   // How much of the content has been used by the AI engine, percentage,or null
   // if no content is associated.
   uint32? content_used_percentage;

--- a/components/ai_chat/resources/untrusted_conversation_frame/api/mock_interfaces.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/api/mock_interfaces.ts
@@ -29,6 +29,7 @@ export const defaultConversationEntriesState: Mojom.ConversationEntriesState = {
   isLeoModel: true,
   allModels: [],
   currentModelKey: '',
+  defaultModelKey: '',
   contentUsedPercentage: undefined,
   visualContentUsedPercentage: undefined,
   trimmedTokens: BigInt(0),

--- a/components/ai_chat/resources/untrusted_conversation_frame/api/untrusted_conversation_api.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/api/untrusted_conversation_api.ts
@@ -120,6 +120,7 @@ export default function createUntrustedConversationApi(
         isLeoModel: true,
         allModels: [],
         currentModelKey: '',
+        defaultModelKey: '',
         contentUsedPercentage: undefined,
         visualContentUsedPercentage: undefined,
         trimmedTokens: BigInt(0),

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/index.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/index.test.tsx
@@ -8,16 +8,17 @@ import { act, render, waitFor } from '@testing-library/react'
 import MockContext, {
   MockContextRef,
 } from '../../mock_untrusted_conversation_context'
+import { createConversationTurnWithDefaults } from '../../../common/test_data_utils'
 import Conversation from '.'
 
 jest.mock('../conversation_entries', () => ({
   __esModule: true,
-  default: () => null,
+  default: () => <div data-testid='conversation-entries' />,
 }))
 
 jest.mock('../model_intro', () => ({
   __esModule: true,
-  default: () => null,
+  default: () => <div data-testid='model-intro' />,
 }))
 
 jest.mock('./useScrollToBottom', () => ({
@@ -31,6 +32,37 @@ const withSuggestionsState = {
   serviceState: { hasAcceptedAgreement: true },
   conversationEntriesState: { suggestedQuestions: ['Test question'] },
 }
+
+describe('Conversation ModelIntro placement', () => {
+  it('renders before conversation entries when the conversation has not started', () => {
+    const { getByTestId } = render(
+      <MockContext>
+        <Conversation />
+      </MockContext>,
+    )
+
+    const modelIntro = getByTestId('model-intro')
+    const conversationEntries = getByTestId('conversation-entries')
+    expect(
+      modelIntro.compareDocumentPosition(conversationEntries)
+        & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+  })
+
+  it('does not render at the conversation level when the conversation has started', () => {
+    const { queryByTestId } = render(
+      <MockContext
+        initialState={{
+          conversationHistory: [createConversationTurnWithDefaults({})],
+        }}
+      >
+        <Conversation />
+      </MockContext>,
+    )
+
+    expect(queryByTestId('model-intro')).not.toBeInTheDocument()
+  })
+})
 
 describe('Conversation --notices-height CSS variable', () => {
   let resizeObserverCallbacks: ResizeObserverCallback[]

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/index.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/index.test.tsx
@@ -5,6 +5,7 @@
 
 import * as React from 'react'
 import { act, render, waitFor } from '@testing-library/react'
+import * as Mojom from '../../../common/mojom'
 import MockContext, {
   MockContextRef,
 } from '../../mock_untrusted_conversation_context'
@@ -18,7 +19,12 @@ jest.mock('../conversation_entries', () => ({
 
 jest.mock('../model_intro', () => ({
   __esModule: true,
-  default: () => <div data-testid='model-intro' />,
+  default: ({ modelKey }: { modelKey: string }) => (
+    <div
+      data-testid='model-intro'
+      data-model-key={modelKey}
+    />
+  ),
 }))
 
 jest.mock('./useScrollToBottom', () => ({
@@ -34,33 +40,86 @@ const withSuggestionsState = {
 }
 
 describe('Conversation ModelIntro placement', () => {
-  it('renders before conversation entries when the conversation has not started', () => {
+  it('renders top markers before conversation entries', async () => {
+    const mockRef = React.createRef<MockContextRef>()
     const { getByTestId } = render(
-      <MockContext>
-        <Conversation />
-      </MockContext>,
-    )
-
-    const modelIntro = getByTestId('model-intro')
-    const conversationEntries = getByTestId('conversation-entries')
-    expect(
-      modelIntro.compareDocumentPosition(conversationEntries)
-        & Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy()
-  })
-
-  it('does not render at the conversation level when the conversation has started', () => {
-    const { queryByTestId } = render(
       <MockContext
+        ref={mockRef}
         initialState={{
-          conversationHistory: [createConversationTurnWithDefaults({})],
+          conversationEntriesState: {
+            currentModelKey: 'default-model',
+            defaultModelKey: 'default-model',
+          },
         }}
       >
         <Conversation />
       </MockContext>,
     )
 
-    expect(queryByTestId('model-intro')).not.toBeInTheDocument()
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'test-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(getByTestId('model-intro')).toBeInTheDocument()
+    })
+
+    const modelIntro = getByTestId('model-intro')
+    const conversationEntries = getByTestId('conversation-entries')
+    expect(modelIntro).toHaveAttribute('data-model-key', 'test-model')
+    expect(
+      modelIntro.compareDocumentPosition(conversationEntries)
+        & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+  })
+
+  it('keeps top markers after the conversation starts', async () => {
+    const mockRef = React.createRef<MockContextRef>()
+    const { getAllByTestId } = render(
+      <MockContext
+        ref={mockRef}
+        initialState={{
+          conversationEntriesState: {
+            currentModelKey: 'default-model',
+            defaultModelKey: 'default-model',
+          },
+        }}
+      >
+        <Conversation />
+      </MockContext>,
+    )
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'test-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(getAllByTestId('model-intro')).toHaveLength(1)
+    })
+
+    await act(async () => {
+      mockRef.current!.api.getConversationHistory.update([
+        createConversationTurnWithDefaults({
+          uuid: 'turn-1',
+          characterType: Mojom.CharacterType.HUMAN,
+          text: 'Hello',
+        }),
+      ])
+    })
+
+    await waitFor(() => {
+      expect(getAllByTestId('model-intro')).toHaveLength(1)
+    })
+    expect(getAllByTestId('model-intro')[0]).toHaveAttribute(
+      'data-model-key',
+      'test-model',
+    )
   })
 })
 

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/index.tsx
@@ -29,6 +29,7 @@ import PremiumSuggestion from '../premium_suggestion'
 import WarningPremiumDisconnected from '../alerts/warning_premium_disconnected'
 import LongConversationInfo from '../alerts/long_conversation_info'
 import styles from './style.module.scss'
+import { useModelIntroMarkers } from './useModelIntroMarkers'
 import { useScrollToBottom } from './useScrollToBottom'
 
 export interface ConversationProps {
@@ -147,6 +148,8 @@ function Conversation(props: ConversationProps) {
   // Total and trimmed tokens for long conversation info
   const shouldShowLongConversationInfo = state.trimmedTokens > BigInt(0)
 
+  const modelIntroMarkers = useModelIntroMarkers()
+
   // Scroll tracking
   const { scrollToBottomContinuously, hasScrollableContent } =
     useScrollToBottom(scrollElementRef, contentRef)
@@ -204,7 +207,7 @@ function Conversation(props: ConversationProps) {
         className={styles.conversationContent}
         ref={contentRef}
       >
-        {context.modelIntroMarkers
+        {modelIntroMarkers
           .filter((marker) => marker.afterPairIndex === null)
           .map((marker) => (
             <ModelIntro
@@ -219,7 +222,10 @@ function Conversation(props: ConversationProps) {
           </div>
         )}
 
-        <ConversationEntries scrollToBottom={scrollToBottom} />
+        <ConversationEntries
+          modelIntroMarkers={modelIntroMarkers}
+          scrollToBottom={scrollToBottom}
+        />
 
         <div ref={noticesRef}>
           {showSuggestions && (

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/index.tsx
@@ -61,7 +61,6 @@ function Conversation(props: ConversationProps) {
   const isPremiumUserDisconnected = premiumStatus.data.isPremiumUserDisconnected
 
   const showTemporaryChatInfo = state.isTemporary
-  const hasConversationStarted = context.conversationHistory.length > 0
 
   const apiHasError = state.currentError !== Mojom.APIError.None
 
@@ -205,7 +204,14 @@ function Conversation(props: ConversationProps) {
         className={styles.conversationContent}
         ref={contentRef}
       >
-        {!hasConversationStarted && <ModelIntro />}
+        {context.modelIntroMarkers
+          .filter((marker) => marker.afterPairIndex === null)
+          .map((marker) => (
+            <ModelIntro
+              key={marker.id}
+              modelKey={marker.modelKey}
+            />
+          ))}
 
         {showTemporaryChatInfo && (
           <div className={styles.promptContainer}>

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/index.tsx
@@ -61,6 +61,7 @@ function Conversation(props: ConversationProps) {
   const isPremiumUserDisconnected = premiumStatus.data.isPremiumUserDisconnected
 
   const showTemporaryChatInfo = state.isTemporary
+  const hasConversationStarted = context.conversationHistory.length > 0
 
   const apiHasError = state.currentError !== Mojom.APIError.None
 
@@ -204,7 +205,7 @@ function Conversation(props: ConversationProps) {
         className={styles.conversationContent}
         ref={contentRef}
       >
-        <ModelIntro />
+        {!hasConversationStarted && <ModelIntro />}
 
         {showTemporaryChatInfo && (
           <div className={styles.promptContainer}>

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.test.tsx
@@ -95,12 +95,14 @@ describe('useModelIntroMarkers', () => {
       })
     })
 
+    // Wait for the modelKey itself — length stays 1 across the replace, so
+    // asserting only on length can pass before the pending marker is updated.
     await waitFor(() => {
       expect(result.current).toHaveLength(1)
-    })
-    expect(result.current[0]).toMatchObject({
-      modelKey: 'second-model',
-      afterPairIndex: null,
+      expect(result.current[0]).toMatchObject({
+        modelKey: 'second-model',
+        afterPairIndex: null,
+      })
     })
   })
 
@@ -145,12 +147,14 @@ describe('useModelIntroMarkers', () => {
       })
     })
 
+    // Wait for the modelKey itself — length stays 1 across the replace, so
+    // asserting only on length can pass before the pending marker is updated.
     await waitFor(() => {
       expect(result.current).toHaveLength(1)
-    })
-    expect(result.current[0]).toMatchObject({
-      modelKey: 'second-model',
-      afterPairIndex: 0,
+      expect(result.current[0]).toMatchObject({
+        modelKey: 'second-model',
+        afterPairIndex: 0,
+      })
     })
   })
 

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.test.tsx
@@ -65,7 +65,46 @@ describe('useModelIntroMarkers', () => {
     })
   })
 
-  it('creates inline markers for each non-default model change during a conversation', async () => {
+  it('replaces the top marker when changing models again before sending', async () => {
+    const { result, mockRef } = renderModelIntroMarkersHook({
+      conversationEntriesState: {
+        currentModelKey: 'default-model',
+        defaultModelKey: 'default-model',
+      },
+    })
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'first-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1)
+    })
+    expect(result.current[0]).toMatchObject({
+      modelKey: 'first-model',
+      afterPairIndex: null,
+    })
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'second-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1)
+    })
+    expect(result.current[0]).toMatchObject({
+      modelKey: 'second-model',
+      afterPairIndex: null,
+    })
+  })
+
+  it('replaces the pending inline marker when changing models before the next prompt', async () => {
     const conversationHistory = [
       createConversationTurnWithDefaults({
         uuid: 'turn-1',
@@ -107,6 +146,69 @@ describe('useModelIntroMarkers', () => {
     })
 
     await waitFor(() => {
+      expect(result.current).toHaveLength(1)
+    })
+    expect(result.current[0]).toMatchObject({
+      modelKey: 'second-model',
+      afterPairIndex: 0,
+    })
+  })
+
+  it('keeps earlier markers and adds a new one after another prompt is sent', async () => {
+    const firstTurn = createConversationTurnWithDefaults({
+      uuid: 'turn-1',
+      characterType: Mojom.CharacterType.ASSISTANT,
+      text: 'First reply',
+    })
+    const { result, mockRef } = renderModelIntroMarkersHook(
+      {
+        conversationEntriesState: {
+          currentModelKey: 'default-model',
+          defaultModelKey: 'default-model',
+        },
+        conversationHistory: [firstTurn],
+      },
+      [firstTurn],
+    )
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'first-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1)
+    })
+
+    const secondTurn = createConversationTurnWithDefaults({
+      uuid: 'turn-2',
+      characterType: Mojom.CharacterType.HUMAN,
+      text: 'Follow-up',
+    })
+    const thirdTurn = createConversationTurnWithDefaults({
+      uuid: 'turn-3',
+      characterType: Mojom.CharacterType.ASSISTANT,
+      text: 'Second reply',
+    })
+
+    await act(async () => {
+      mockRef.current!.api.getConversationHistory.update([
+        firstTurn,
+        secondTurn,
+        thirdTurn,
+      ])
+    })
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'second-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
       expect(result.current).toHaveLength(2)
     })
     expect(result.current[0]).toMatchObject({
@@ -115,7 +217,7 @@ describe('useModelIntroMarkers', () => {
     })
     expect(result.current[1]).toMatchObject({
       modelKey: 'second-model',
-      afterPairIndex: 0,
+      afterPairIndex: 1,
     })
   })
 

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.test.tsx
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import * as Mojom from '../../../common/mojom'
+import { createConversationTurnWithDefaults } from '../../../common/test_data_utils'
+import MockContext, { MockContextRef } from '../../mock_untrusted_conversation_context'
+import { useModelIntroMarkers } from './useModelIntroMarkers'
+
+describe('useModelIntroMarkers', () => {
+  function renderModelIntroMarkersHook(
+    initialState?: React.ComponentProps<typeof MockContext>['initialState'],
+    conversationHistory?: Mojom.ConversationTurn[],
+  ) {
+    const mockRef = React.createRef<MockContextRef>()
+    const history = conversationHistory ?? initialState?.conversationHistory
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <MockContext
+        ref={mockRef}
+        conversationHandler={
+          history
+            ? {
+                getConversationHistory() {
+                  return Promise.resolve({ conversationHistory: history })
+                },
+              }
+            : undefined
+        }
+        initialState={initialState}
+      >
+        {children}
+      </MockContext>
+    )
+
+    const result = renderHook(() => useModelIntroMarkers(), { wrapper })
+    return { ...result, mockRef }
+  }
+
+  it('creates a top marker when switching to a non-default model before messages', async () => {
+    const { result, mockRef } = renderModelIntroMarkersHook({
+      conversationEntriesState: {
+        currentModelKey: 'default-model',
+        defaultModelKey: 'default-model',
+      },
+    })
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'test-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1)
+    })
+    expect(result.current[0]).toMatchObject({
+      modelKey: 'test-model',
+      afterPairIndex: null,
+    })
+  })
+
+  it('creates inline markers for each non-default model change during a conversation', async () => {
+    const conversationHistory = [
+      createConversationTurnWithDefaults({
+        uuid: 'turn-1',
+        characterType: Mojom.CharacterType.ASSISTANT,
+        text: 'Latest reply',
+      }),
+    ]
+    const { result, mockRef } = renderModelIntroMarkersHook(
+      {
+        conversationEntriesState: {
+          currentModelKey: 'default-model',
+          defaultModelKey: 'default-model',
+        },
+        conversationHistory,
+      },
+      conversationHistory,
+    )
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'first-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1)
+    })
+    expect(result.current[0]).toMatchObject({
+      modelKey: 'first-model',
+      afterPairIndex: 0,
+    })
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'second-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(2)
+    })
+    expect(result.current[0]).toMatchObject({
+      modelKey: 'first-model',
+      afterPairIndex: 0,
+    })
+    expect(result.current[1]).toMatchObject({
+      modelKey: 'second-model',
+      afterPairIndex: 0,
+    })
+  })
+
+  it('does not create a marker when switching back to the default model', async () => {
+    const { result, mockRef } = renderModelIntroMarkersHook({
+      conversationEntriesState: {
+        currentModelKey: 'default-model',
+        defaultModelKey: 'default-model',
+      },
+    })
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'test-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1)
+    })
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'default-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0].modelKey).toBe('test-model')
+  })
+
+  it('keeps top markers after the conversation starts', async () => {
+    const { result, mockRef } = renderModelIntroMarkersHook({
+      conversationEntriesState: {
+        currentModelKey: 'default-model',
+        defaultModelKey: 'default-model',
+      },
+    })
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'test-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1)
+    })
+
+    await act(async () => {
+      mockRef.current!.api.getConversationHistory.update([
+        createConversationTurnWithDefaults({
+          uuid: 'turn-1',
+          characterType: Mojom.CharacterType.HUMAN,
+          text: 'Hello',
+        }),
+      ])
+    })
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1)
+    })
+    expect(result.current[0]).toMatchObject({
+      modelKey: 'test-model',
+      afterPairIndex: null,
+    })
+  })
+})

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.test.tsx
@@ -7,7 +7,9 @@ import * as React from 'react'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import * as Mojom from '../../../common/mojom'
 import { createConversationTurnWithDefaults } from '../../../common/test_data_utils'
-import MockContext, { MockContextRef } from '../../mock_untrusted_conversation_context'
+import MockContext, {
+  MockContextRef,
+} from '../../mock_untrusted_conversation_context'
 import { useModelIntroMarkers } from './useModelIntroMarkers'
 
 describe('useModelIntroMarkers', () => {

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.test.tsx
@@ -225,7 +225,7 @@ describe('useModelIntroMarkers', () => {
     })
   })
 
-  it('does not create a marker when switching back to the default model', async () => {
+  it('removes the pending marker when switching back to the baseline model before sending', async () => {
     const { result, mockRef } = renderModelIntroMarkersHook({
       conversationEntriesState: {
         currentModelKey: 'default-model',
@@ -251,8 +251,206 @@ describe('useModelIntroMarkers', () => {
       })
     })
 
-    expect(result.current).toHaveLength(1)
-    expect(result.current[0].modelKey).toBe('test-model')
+    await waitFor(() => {
+      expect(result.current).toHaveLength(0)
+    })
+  })
+
+  it('removes the pending inline marker when switching back to the baseline model before sending', async () => {
+    const conversationHistory = [
+      createConversationTurnWithDefaults({
+        uuid: 'turn-1',
+        characterType: Mojom.CharacterType.ASSISTANT,
+        text: 'Latest reply',
+      }),
+    ]
+    const { result, mockRef } = renderModelIntroMarkersHook(
+      {
+        conversationEntriesState: {
+          currentModelKey: 'default-model',
+          defaultModelKey: 'default-model',
+        },
+        conversationHistory,
+      },
+      conversationHistory,
+    )
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'test-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1)
+    })
+    expect(result.current[0]).toMatchObject({
+      modelKey: 'test-model',
+      afterPairIndex: 0,
+    })
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'default-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(0)
+    })
+  })
+
+  it('creates a marker when switching to the default model from a specific model', async () => {
+    const conversationHistory = [
+      createConversationTurnWithDefaults({
+        uuid: 'turn-1',
+        characterType: Mojom.CharacterType.ASSISTANT,
+        text: 'Latest reply',
+      }),
+    ]
+    const { result, mockRef } = renderModelIntroMarkersHook(
+      {
+        conversationEntriesState: {
+          currentModelKey: 'test-model',
+          defaultModelKey: 'default-model',
+        },
+        conversationHistory,
+      },
+      conversationHistory,
+    )
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'default-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1)
+    })
+    expect(result.current[0]).toMatchObject({
+      modelKey: 'default-model',
+      afterPairIndex: 0,
+    })
+  })
+
+  it('keeps committed markers and adds one when switching models after sending', async () => {
+    const firstTurn = createConversationTurnWithDefaults({
+      uuid: 'turn-1',
+      characterType: Mojom.CharacterType.ASSISTANT,
+      text: 'First reply',
+    })
+    const { result, mockRef } = renderModelIntroMarkersHook(
+      {
+        conversationEntriesState: {
+          currentModelKey: 'default-model',
+          defaultModelKey: 'default-model',
+        },
+        conversationHistory: [firstTurn],
+      },
+      [firstTurn],
+    )
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'test-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1)
+    })
+    expect(result.current[0]).toMatchObject({
+      modelKey: 'test-model',
+      afterPairIndex: 0,
+    })
+
+    // Sending a prompt commits the marker at afterPairIndex 0 and advances
+    // the baseline to test-model, so switching to default creates a new pill.
+    const secondTurn = createConversationTurnWithDefaults({
+      uuid: 'turn-2',
+      characterType: Mojom.CharacterType.HUMAN,
+      text: 'Follow-up',
+    })
+    const thirdTurn = createConversationTurnWithDefaults({
+      uuid: 'turn-3',
+      characterType: Mojom.CharacterType.ASSISTANT,
+      text: 'Second reply',
+    })
+
+    await act(async () => {
+      mockRef.current!.api.getConversationHistory.update([
+        firstTurn,
+        secondTurn,
+        thirdTurn,
+      ])
+    })
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'default-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(2)
+    })
+    expect(result.current[0]).toMatchObject({
+      modelKey: 'test-model',
+      afterPairIndex: 0,
+    })
+    expect(result.current[1]).toMatchObject({
+      modelKey: 'default-model',
+      afterPairIndex: 1,
+    })
+  })
+
+  it('removes a pending default-model marker when switching back to the prior specific model', async () => {
+    const conversationHistory = [
+      createConversationTurnWithDefaults({
+        uuid: 'turn-1',
+        characterType: Mojom.CharacterType.ASSISTANT,
+        text: 'Latest reply',
+      }),
+    ]
+    const { result, mockRef } = renderModelIntroMarkersHook(
+      {
+        conversationEntriesState: {
+          currentModelKey: 'test-model',
+          defaultModelKey: 'default-model',
+        },
+        conversationHistory,
+      },
+      conversationHistory,
+    )
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'default-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1)
+    })
+    expect(result.current[0].modelKey).toBe('default-model')
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'test-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(0)
+    })
   })
 
   it('keeps top markers after the conversation starts', async () => {

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.ts
@@ -101,7 +101,7 @@ export function useModelIntroMarkers(): ModelIntroMarker[] {
     }
   }, [conversationHistory.length, conversationHistory[0]?.uuid])
 
-  // Append a marker when the user selects a non-default model.
+  // Create or replace a marker when the user selects a non-default model.
   React.useEffect(() => {
     const { currentModelKey, defaultModelKey } = state
 

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.ts
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { useUntrustedConversationContext } from '../../untrusted_conversation_context'
+import { getPairedConversationGroups } from '../conversation_entries/conversation_entries_utils'
+
+/**
+ * A sticky ModelIntro pill anchored to the point in the conversation where
+ * the user selected a non-default model. Markers are session-only.
+ *
+ * - `afterPairIndex === null`: render at the top of Conversation (before
+ *   any entries), typically when the model was changed before the first
+ *   message.
+ * - `afterPairIndex === N`: render inside ConversationEntries after entry
+ *   pair N.
+ */
+export type ModelIntroMarker = {
+  id: string
+  modelKey: string
+  afterPairIndex: number | null
+}
+
+let modelIntroMarkerCounter = 0
+
+function createModelIntroMarker(
+  modelKey: string,
+  afterPairIndex: number | null,
+): ModelIntroMarker {
+  modelIntroMarkerCounter += 1
+  return {
+    id: `model-intro-${modelIntroMarkerCounter}`,
+    modelKey,
+    afterPairIndex,
+  }
+}
+
+/**
+ * Tracks append-only ModelIntro markers for the active conversation session.
+ * Only used by Conversation (and passed down to ConversationEntries).
+ */
+export function useModelIntroMarkers(): ModelIntroMarker[] {
+  const context = useUntrustedConversationContext()
+  const state = context.api.useState().data
+  const conversationHistory = context.api.useGetConversationHistoryData()
+
+  const [modelIntroMarkers, setModelIntroMarkers] = React.useState<
+    ModelIntroMarker[]
+  >([])
+
+  // Last observed currentModelKey. Used to distinguish the initial mount
+  // (and post-reset baseline) from a real model change that should create a
+  // marker. Avoids showing a pill for whatever model happens to be selected
+  // when the conversation first loads.
+  const prevModelKeyRef = React.useRef<string | undefined>(undefined)
+
+  // Identity of the conversation currently showing markers. The untrusted
+  // frame does not receive a conversation-level uuid on every history turn,
+  // so we use the first turn's uuid as a stable stand-in. When it changes,
+  // the user switched conversations and session markers must be cleared.
+  const conversationIdentityRef = React.useRef<string | null>(null)
+
+  // Reset markers when the conversation session ends or switches.
+  React.useEffect(() => {
+    // Empty history means a brand-new / cleared conversation: drop any
+    // leftover markers and reset tracking so the next model selection can
+    // create a fresh top-of-conversation marker.
+    if (conversationHistory.length === 0) {
+      setModelIntroMarkers([])
+      conversationIdentityRef.current = null
+      prevModelKeyRef.current = undefined
+      return
+    }
+
+    const firstUuid = conversationHistory[0]?.uuid
+    if (!firstUuid) {
+      return
+    }
+
+    // First turn arrived for this session — record identity without clearing
+    // markers so a top-of-conversation pill created before the first message
+    // stays visible once the conversation starts.
+    if (conversationIdentityRef.current === null) {
+      conversationIdentityRef.current = firstUuid
+      return
+    }
+
+    // Different first-turn uuid means a different conversation was loaded.
+    // Clear session markers and allow the next model change to create new
+    // ones from a clean baseline.
+    if (conversationIdentityRef.current !== firstUuid) {
+      conversationIdentityRef.current = firstUuid
+      setModelIntroMarkers([])
+      prevModelKeyRef.current = undefined
+    }
+  }, [conversationHistory.length, conversationHistory[0]?.uuid])
+
+  // Append a marker when the user selects a non-default model.
+  React.useEffect(() => {
+    const { currentModelKey, defaultModelKey } = state
+
+    // Establish a baseline on mount / after a reset; do not create a marker
+    // for the model that is already selected.
+    if (prevModelKeyRef.current === undefined) {
+      prevModelKeyRef.current = currentModelKey
+      return
+    }
+
+    if (prevModelKeyRef.current === currentModelKey) {
+      return
+    }
+
+    prevModelKeyRef.current = currentModelKey
+
+    // Switching back to the default model should not add a new pill;
+    // existing historical markers remain.
+    if (currentModelKey === defaultModelKey) {
+      return
+    }
+
+    setModelIntroMarkers((previousMarkers) => {
+      // Ignore duplicate consecutive selections of the same non-default model.
+      const lastMarker = previousMarkers.at(-1)
+      if (lastMarker?.modelKey === currentModelKey) {
+        return previousMarkers
+      }
+
+      // Anchor to the latest entry pair, or to the top when there are no turns
+      // yet (model changed before the conversation started).
+      const pairedGroups = getPairedConversationGroups(conversationHistory)
+      const afterPairIndex =
+        conversationHistory.length === 0 ? null : pairedGroups.length - 1
+
+      return [
+        ...previousMarkers,
+        createModelIntroMarker(currentModelKey, afterPairIndex),
+      ]
+    })
+  }, [conversationHistory.length, state.currentModelKey, state.defaultModelKey])
+
+  return modelIntroMarkers
+}

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.ts
@@ -38,8 +38,12 @@ function createModelIntroMarker(
 }
 
 /**
- * Tracks append-only ModelIntro markers for the active conversation session.
+ * Tracks ModelIntro markers for the active conversation session.
  * Only used by Conversation (and passed down to ConversationEntries).
+ *
+ * Markers are sticky once the user sends a prompt after selecting a model.
+ * Repeated model changes at the same conversation position (before sending)
+ * replace the pending marker instead of stacking.
  */
 export function useModelIntroMarkers(): ModelIntroMarker[] {
   const context = useUntrustedConversationContext()
@@ -132,11 +136,15 @@ export function useModelIntroMarkers(): ModelIntroMarker[] {
       const pairedGroups = getPairedConversationGroups(conversationHistory)
       const afterPairIndex =
         conversationHistory.length === 0 ? null : pairedGroups.length - 1
+      const nextMarker = createModelIntroMarker(currentModelKey, afterPairIndex)
 
-      return [
-        ...previousMarkers,
-        createModelIntroMarker(currentModelKey, afterPairIndex),
-      ]
+      // User changed the model again before sending a prompt — replace the
+      // pending marker at this position instead of stacking another pill.
+      if (lastMarker && lastMarker.afterPairIndex === afterPairIndex) {
+        return [...previousMarkers.slice(0, -1), nextMarker]
+      }
+
+      return [...previousMarkers, nextMarker]
     })
   }, [conversationHistory.length, state.currentModelKey, state.defaultModelKey])
 

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.ts
@@ -120,9 +120,10 @@ export function useModelIntroMarkers(): ModelIntroMarker[] {
   React.useEffect(() => {
     const { currentModelKey } = state
 
-    // Establish a baseline on mount / after a reset; do not create a marker
-    // for the model that is already selected.
-    if (prevModelKeyRef.current === undefined) {
+    // Establish a baseline on mount / after a reset / while the API is still
+    // hydrating an empty currentModelKey. Do not create a marker for the
+    // model that is already selected once state settles.
+    if (!prevModelKeyRef.current) {
       prevModelKeyRef.current = currentModelKey
       baselineModelKeyRef.current = currentModelKey
       prevHistoryLengthRef.current = conversationHistory.length

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/useModelIntroMarkers.ts
@@ -9,7 +9,7 @@ import { getPairedConversationGroups } from '../conversation_entries/conversatio
 
 /**
  * A sticky ModelIntro pill anchored to the point in the conversation where
- * the user selected a non-default model. Markers are session-only.
+ * the user selected a different model. Markers are session-only.
  *
  * - `afterPairIndex === null`: render at the top of Conversation (before
  *   any entries), typically when the model was changed before the first
@@ -43,7 +43,10 @@ function createModelIntroMarker(
  *
  * Markers are sticky once the user sends a prompt after selecting a model.
  * Repeated model changes at the same conversation position (before sending)
- * replace the pending marker instead of stacking.
+ * replace the pending marker instead of stacking. Switching back to the
+ * baseline model for that position (the model in use when the position was
+ * established) removes the pending marker — including when that baseline is
+ * Automatic / the default.
  */
 export function useModelIntroMarkers(): ModelIntroMarker[] {
   const context = useUntrustedConversationContext()
@@ -60,6 +63,14 @@ export function useModelIntroMarkers(): ModelIntroMarker[] {
   // when the conversation first loads.
   const prevModelKeyRef = React.useRef<string | undefined>(undefined)
 
+  // Model in effect for the current pending position. Selecting a different
+  // model creates/replaces a marker; selecting this model again removes it.
+  const baselineModelKeyRef = React.useRef<string | undefined>(undefined)
+
+  // Used to detect newly sent turns so the baseline can advance with the
+  // conversation position.
+  const prevHistoryLengthRef = React.useRef(0)
+
   // Identity of the conversation currently showing markers. The untrusted
   // frame does not receive a conversation-level uuid on every history turn,
   // so we use the first turn's uuid as a stable stand-in. When it changes,
@@ -75,6 +86,8 @@ export function useModelIntroMarkers(): ModelIntroMarker[] {
       setModelIntroMarkers([])
       conversationIdentityRef.current = null
       prevModelKeyRef.current = undefined
+      baselineModelKeyRef.current = undefined
+      prevHistoryLengthRef.current = 0
       return
     }
 
@@ -98,18 +111,33 @@ export function useModelIntroMarkers(): ModelIntroMarker[] {
       conversationIdentityRef.current = firstUuid
       setModelIntroMarkers([])
       prevModelKeyRef.current = undefined
+      baselineModelKeyRef.current = undefined
+      prevHistoryLengthRef.current = 0
     }
   }, [conversationHistory.length, conversationHistory[0]?.uuid])
 
-  // Create or replace a marker when the user selects a non-default model.
+  // Create, replace, or clear a marker when the user changes models.
   React.useEffect(() => {
-    const { currentModelKey, defaultModelKey } = state
+    const { currentModelKey } = state
 
     // Establish a baseline on mount / after a reset; do not create a marker
     // for the model that is already selected.
     if (prevModelKeyRef.current === undefined) {
       prevModelKeyRef.current = currentModelKey
+      baselineModelKeyRef.current = currentModelKey
+      prevHistoryLengthRef.current = conversationHistory.length
       return
+    }
+
+    const historyGrew =
+      conversationHistory.length !== prevHistoryLengthRef.current
+    prevHistoryLengthRef.current = conversationHistory.length
+
+    // New turns commit the previous selection. Advance the baseline using the
+    // model that was selected when those turns were produced (before any
+    // simultaneous model change in this effect run).
+    if (historyGrew) {
+      baselineModelKeyRef.current = prevModelKeyRef.current
     }
 
     if (prevModelKeyRef.current === currentModelKey) {
@@ -118,24 +146,33 @@ export function useModelIntroMarkers(): ModelIntroMarker[] {
 
     prevModelKeyRef.current = currentModelKey
 
-    // Switching back to the default model should not add a new pill;
-    // existing historical markers remain.
-    if (currentModelKey === defaultModelKey) {
+    // Anchor to the latest entry pair, or to the top when there are no turns
+    // yet (model changed before the conversation started).
+    const pairedGroups = getPairedConversationGroups(conversationHistory)
+    const afterPairIndex =
+      conversationHistory.length === 0 ? null : pairedGroups.length - 1
+
+    // Reverting to the baseline model for this position drops the pending
+    // marker (e.g. Automatic → Qwen → Automatic). Historical markers from
+    // earlier turns remain.
+    if (currentModelKey === baselineModelKeyRef.current) {
+      setModelIntroMarkers((previousMarkers) => {
+        const lastMarker = previousMarkers.at(-1)
+        if (lastMarker && lastMarker.afterPairIndex === afterPairIndex) {
+          return previousMarkers.slice(0, -1)
+        }
+        return previousMarkers
+      })
       return
     }
 
     setModelIntroMarkers((previousMarkers) => {
-      // Ignore duplicate consecutive selections of the same non-default model.
+      // Ignore duplicate consecutive selections of the same model.
       const lastMarker = previousMarkers.at(-1)
       if (lastMarker?.modelKey === currentModelKey) {
         return previousMarkers
       }
 
-      // Anchor to the latest entry pair, or to the top when there are no turns
-      // yet (model changed before the conversation started).
-      const pairedGroups = getPairedConversationGroups(conversationHistory)
-      const afterPairIndex =
-        conversationHistory.length === 0 ? null : pairedGroups.length - 1
       const nextMarker = createModelIntroMarker(currentModelKey, afterPairIndex)
 
       // User changed the model again before sending a prompt — replace the
@@ -146,7 +183,7 @@ export function useModelIntroMarkers(): ModelIntroMarker[] {
 
       return [...previousMarkers, nextMarker]
     })
-  }, [conversationHistory.length, state.currentModelKey, state.defaultModelKey])
+  }, [conversationHistory.length, state.currentModelKey])
 
   return modelIntroMarkers
 }

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/conversation_entries_utils.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/conversation_entries_utils.ts
@@ -52,6 +52,40 @@ export function groupConversationEntries(
 }
 
 /**
+ * Pairs a human turn with the following (potentially grouped) assistant turn.
+ * Free-hanging human or assistant turns form their own pair.
+ */
+export function getPairedConversationGroups(
+  allEntries: Mojom.ConversationTurn[],
+): Mojom.ConversationTurn[][][] {
+  const groupedEntries = groupConversationEntries(allEntries)
+  const result: Mojom.ConversationTurn[][][] = []
+
+  for (let i = 0; i < groupedEntries.length; i++) {
+    const entry = groupedEntries[i][0]
+
+    if (entry.characterType !== Mojom.CharacterType.HUMAN) {
+      result.push([groupedEntries[i]])
+      continue
+    }
+
+    const nextEntry = groupedEntries[i + 1]?.[0]
+    if (
+      !nextEntry
+      || nextEntry.characterType !== Mojom.CharacterType.ASSISTANT
+    ) {
+      result.push([groupedEntries[i]])
+      continue
+    }
+
+    result.push([groupedEntries[i], groupedEntries[i + 1]])
+    i++
+  }
+
+  return result
+}
+
+/**
  * A task is an assistant response group with at least {@link TASK_TOOL_COUNT}
  * task tool use events.
  * @param group Group of assistant conversation entries from

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.test.tsx
@@ -55,15 +55,6 @@ describe('ConversationEntries ModelIntro placement', () => {
   it('renders inline markers after the anchored entry pair', () => {
     const { container, getByTestId } = render(
       <MockContext
-        overrides={{
-          modelIntroMarkers: [
-            {
-              id: 'marker-1',
-              modelKey: 'test-model',
-              afterPairIndex: 0,
-            },
-          ],
-        }}
         initialState={{
           conversationHistory: [
             createConversationTurnWithDefaults({
@@ -73,7 +64,15 @@ describe('ConversationEntries ModelIntro placement', () => {
           ],
         }}
       >
-        <ConversationEntries />
+        <ConversationEntries
+          modelIntroMarkers={[
+            {
+              id: 'marker-1',
+              modelKey: 'test-model',
+              afterPairIndex: 0,
+            },
+          ]}
+        />
       </MockContext>,
     )
 
@@ -91,70 +90,6 @@ describe('ConversationEntries ModelIntro placement', () => {
       assistantTurn!.compareDocumentPosition(modelIntro)
         & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy()
-  })
-
-  it('creates a new inline marker when the model changes during a conversation', async () => {
-    const mockRef = React.createRef<MockContextRef>()
-    const conversationHistory = [
-      createConversationTurnWithDefaults({
-        uuid: 'turn-1',
-        characterType: Mojom.CharacterType.ASSISTANT,
-        text: 'Latest reply',
-      }),
-    ]
-    const { getAllByTestId } = render(
-      <MockContext
-        ref={mockRef}
-        conversationHandler={{
-          getConversationHistory() {
-            return Promise.resolve({ conversationHistory })
-          },
-        }}
-        initialState={{
-          conversationEntriesState: {
-            currentModelKey: 'default-model',
-            defaultModelKey: 'default-model',
-          },
-          conversationHistory,
-        }}
-      >
-        <ConversationEntries scrollToBottom={jest.fn()} />
-      </MockContext>,
-    )
-
-    await act(async () => {
-      mockRef.current!.api.state.update({
-        currentModelKey: 'first-model',
-        defaultModelKey: 'default-model',
-      })
-    })
-
-    await waitFor(() => {
-      expect(getAllByTestId('model-intro')).toHaveLength(1)
-    })
-    expect(getAllByTestId('model-intro')[0]).toHaveAttribute(
-      'data-model-key',
-      'first-model',
-    )
-
-    await act(async () => {
-      mockRef.current!.api.state.update({
-        currentModelKey: 'second-model',
-        defaultModelKey: 'default-model',
-      })
-    })
-
-    await waitFor(() => {
-      expect(getAllByTestId('model-intro')).toHaveLength(2)
-    })
-    expect(getAllByTestId('model-intro')[0]).toHaveAttribute(
-      'data-model-key',
-      'first-model',
-    )
-    expect(getAllByTestId('model-intro')[1]).toHaveAttribute(
-      'data-model-key',
-      'second-model',
-    )
   })
 })
 

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.test.tsx
@@ -39,6 +39,46 @@ jest.mock('../assistant_task/assistant_task', () => ({
   default: () => <div data-testid='assistant-task' />,
 }))
 
+jest.mock('../model_intro', () => ({
+  __esModule: true,
+  default: () => <div data-testid='model-intro' />,
+}))
+
+import styles from './style.module.scss'
+
+describe('ConversationEntries ModelIntro placement', () => {
+  it('renders after the latest reply inside the last entry pair', () => {
+    const { container, getByTestId } = render(
+      <MockContext
+        initialState={{
+          conversationHistory: [
+            createConversationTurnWithDefaults({
+              characterType: Mojom.CharacterType.ASSISTANT,
+              text: 'Latest reply',
+            }),
+          ],
+        }}
+      >
+        <ConversationEntries />
+      </MockContext>,
+    )
+
+    const modelIntro = getByTestId('model-intro')
+    const entryPairs = container.querySelectorAll(`.${styles.entryPair}`)
+    const lastEntryPair = entryPairs[entryPairs.length - 1]
+    expect(lastEntryPair).toContainElement(modelIntro)
+
+    const assistantTurn = lastEntryPair.querySelector(
+      '[data-testid="assistant-turn"]',
+    )
+    expect(assistantTurn).toBeTruthy()
+    expect(
+      assistantTurn!.compareDocumentPosition(modelIntro)
+        & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+  })
+})
+
 describe('ConversationEntries allowedLinks per response', () => {
   const assistantTurn1 = {
     characterType: Mojom.CharacterType.ASSISTANT,

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.test.tsx
@@ -18,6 +18,7 @@ import MockContext, {
 import { UntrustedConversationContext } from '../../untrusted_conversation_context'
 import type { AssistantResponseProps } from '../assistant_response'
 import ConversationEntries, { highlightRichText } from '.'
+import styles from './style.module.scss'
 
 const assistantResponseMock = jest.fn((props: AssistantResponseProps) => (
   <div />
@@ -48,8 +49,6 @@ jest.mock('../model_intro', () => ({
     />
   ),
 }))
-
-import styles from './style.module.scss'
 
 describe('ConversationEntries ModelIntro placement', () => {
   it('renders inline markers after the anchored entry pair', () => {

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.test.tsx
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import * as React from 'react'
 import * as Mojom from '../../../common/mojom'
@@ -41,15 +41,29 @@ jest.mock('../assistant_task/assistant_task', () => ({
 
 jest.mock('../model_intro', () => ({
   __esModule: true,
-  default: () => <div data-testid='model-intro' />,
+  default: ({ modelKey }: { modelKey: string }) => (
+    <div
+      data-testid='model-intro'
+      data-model-key={modelKey}
+    />
+  ),
 }))
 
 import styles from './style.module.scss'
 
 describe('ConversationEntries ModelIntro placement', () => {
-  it('renders after the latest reply inside the last entry pair', () => {
+  it('renders inline markers after the anchored entry pair', () => {
     const { container, getByTestId } = render(
       <MockContext
+        overrides={{
+          modelIntroMarkers: [
+            {
+              id: 'marker-1',
+              modelKey: 'test-model',
+              afterPairIndex: 0,
+            },
+          ],
+        }}
         initialState={{
           conversationHistory: [
             createConversationTurnWithDefaults({
@@ -65,10 +79,11 @@ describe('ConversationEntries ModelIntro placement', () => {
 
     const modelIntro = getByTestId('model-intro')
     const entryPairs = container.querySelectorAll(`.${styles.entryPair}`)
-    const lastEntryPair = entryPairs[entryPairs.length - 1]
-    expect(lastEntryPair).toContainElement(modelIntro)
+    const anchoredEntryPair = entryPairs[0]
+    expect(anchoredEntryPair).toContainElement(modelIntro)
+    expect(modelIntro).toHaveAttribute('data-model-key', 'test-model')
 
-    const assistantTurn = lastEntryPair.querySelector(
+    const assistantTurn = anchoredEntryPair.querySelector(
       '[data-testid="assistant-turn"]',
     )
     expect(assistantTurn).toBeTruthy()
@@ -76,6 +91,70 @@ describe('ConversationEntries ModelIntro placement', () => {
       assistantTurn!.compareDocumentPosition(modelIntro)
         & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy()
+  })
+
+  it('creates a new inline marker when the model changes during a conversation', async () => {
+    const mockRef = React.createRef<MockContextRef>()
+    const conversationHistory = [
+      createConversationTurnWithDefaults({
+        uuid: 'turn-1',
+        characterType: Mojom.CharacterType.ASSISTANT,
+        text: 'Latest reply',
+      }),
+    ]
+    const { getAllByTestId } = render(
+      <MockContext
+        ref={mockRef}
+        conversationHandler={{
+          getConversationHistory() {
+            return Promise.resolve({ conversationHistory })
+          },
+        }}
+        initialState={{
+          conversationEntriesState: {
+            currentModelKey: 'default-model',
+            defaultModelKey: 'default-model',
+          },
+          conversationHistory,
+        }}
+      >
+        <ConversationEntries scrollToBottom={jest.fn()} />
+      </MockContext>,
+    )
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'first-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(getAllByTestId('model-intro')).toHaveLength(1)
+    })
+    expect(getAllByTestId('model-intro')[0]).toHaveAttribute(
+      'data-model-key',
+      'first-model',
+    )
+
+    await act(async () => {
+      mockRef.current!.api.state.update({
+        currentModelKey: 'second-model',
+        defaultModelKey: 'default-model',
+      })
+    })
+
+    await waitFor(() => {
+      expect(getAllByTestId('model-intro')).toHaveLength(2)
+    })
+    expect(getAllByTestId('model-intro')[0]).toHaveAttribute(
+      'data-model-key',
+      'first-model',
+    )
+    expect(getAllByTestId('model-intro')[1]).toHaveAttribute(
+      'data-model-key',
+      'second-model',
+    )
   })
 })
 

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
@@ -32,7 +32,7 @@ import {
   getGroupAllowedLinks,
   getReasoningText,
   getToolArtifacts,
-  groupConversationEntries,
+  getPairedConversationGroups,
   isAssistantGroupTask,
 } from './conversation_entries_utils'
 import useConversationEventClipboardCopyHandler from './use_conversation_event_clipboard_copy_handler'
@@ -176,42 +176,10 @@ const makeEditContent = (
  */
 function usePairedConversationGroups() {
   const conversationContext = useUntrustedConversationContext()
-  const groupedEntries = React.useMemo<Mojom.ConversationTurn[][]>(
-    () => groupConversationEntries(conversationContext.conversationHistory),
+  return React.useMemo(
+    () => getPairedConversationGroups(conversationContext.conversationHistory),
     [conversationContext.conversationHistory],
   )
-
-  // This pairs a human turn with the following (potentially grouped) assistant turn.
-  const pairedEntries = React.useMemo(() => {
-    const result: Mojom.ConversationTurn[][][] = []
-    for (let i = 0; i < groupedEntries.length; i++) {
-      const entry = groupedEntries[i][0]
-
-      // Free hanging assistant turn - just leave it be.
-      if (entry.characterType !== Mojom.CharacterType.HUMAN) {
-        result.push([groupedEntries[i]])
-        continue
-      }
-
-      const nextEntry = groupedEntries[i + 1]?.[0]
-      // Free hanging or last human turn - just leave it be.
-      if (
-        !nextEntry
-        || nextEntry.characterType !== Mojom.CharacterType.ASSISTANT
-      ) {
-        result.push([groupedEntries[i]])
-        continue
-      }
-
-      // Pair the human turn with the grouped assistant turns.
-      result.push([groupedEntries[i], groupedEntries[i + 1]])
-      // we've already processed the next entry, so skip it.
-      i++
-    }
-    return result
-  }, [groupedEntries])
-
-  return pairedEntries
 }
 
 function ConversationEntries(props: { scrollToBottom: () => void }) {
@@ -583,7 +551,14 @@ function ConversationEntries(props: { scrollToBottom: () => void }) {
               </React.Fragment>
             ))}
           </ProgressBubbleContextProvider>
-          {pairIndex === entryPairs.length - 1 && <ModelIntro />}
+          {conversationContext.modelIntroMarkers
+            .filter((marker) => marker.afterPairIndex === pairIndex)
+            .map((marker) => (
+              <ModelIntro
+                key={marker.id}
+                modelKey={marker.modelKey}
+              />
+            ))}
         </div>
       ))}
     </div>

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
@@ -41,6 +41,7 @@ import AssistantTask from '../assistant_task/assistant_task'
 import ProgressBubble, {
   ProgressBubbleContextProvider,
 } from '../progress_bubble/progress_bubble'
+import ModelIntro from '../model_intro'
 
 const escape = (text: string): string => (RegExp as any).escape(text)
 
@@ -582,6 +583,7 @@ function ConversationEntries(props: { scrollToBottom: () => void }) {
               </React.Fragment>
             ))}
           </ProgressBubbleContextProvider>
+          {pairIndex === entryPairs.length - 1 && <ModelIntro />}
         </div>
       ))}
     </div>

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
@@ -17,6 +17,7 @@ import {
   stringifyContent,
 } from '../../../page/components/input_box/editable_content'
 import { useUntrustedConversationContext } from '../../untrusted_conversation_context'
+import type { ModelIntroMarker } from '../conversation/useModelIntroMarkers'
 import AssistantReasoning from '../assistant_reasoning'
 import ContextActionsAssistant from '../context_actions_assistant'
 import ContextMenuHuman from '../context_menu_human'
@@ -182,7 +183,11 @@ function usePairedConversationGroups() {
   )
 }
 
-function ConversationEntries(props: { scrollToBottom: () => void }) {
+function ConversationEntries(props: {
+  modelIntroMarkers?: ModelIntroMarker[]
+  scrollToBottom?: () => void
+}) {
+  const { modelIntroMarkers = [], scrollToBottom } = props
   const conversationContext = useUntrustedConversationContext()
 
   const [hoverMenuButtonId, setHoverMenuButtonId] = React.useState<number>()
@@ -529,7 +534,7 @@ function ConversationEntries(props: { scrollToBottom: () => void }) {
           className={styles.entryPair}
           ref={
             pairIndex === entryPairs.length - 1 && hasGenerated.current
-              ? props.scrollToBottom
+              ? scrollToBottom
               : undefined
           }
         >
@@ -551,7 +556,7 @@ function ConversationEntries(props: { scrollToBottom: () => void }) {
               </React.Fragment>
             ))}
           </ProgressBubbleContextProvider>
-          {conversationContext.modelIntroMarkers
+          {modelIntroMarkers
             .filter((marker) => marker.afterPairIndex === pairIndex)
             .map((marker) => (
               <ModelIntro

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/index.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/index.test.tsx
@@ -38,21 +38,17 @@ describe('ModelIntro', () => {
     },
   }
 
-  const defaultModelKey = 'default-model'
-
-  it('should render model intro when current model differs from default', () => {
+  it('should render model intro for the provided model key', () => {
     const { container } = render(
       <MockContext
         initialState={{
           conversationEntriesState: {
             allModels: [currentModel],
-            currentModelKey: currentModel.key,
-            defaultModelKey,
             isLeoModel: true,
           },
         }}
       >
-        <ModelIntro />
+        <ModelIntro modelKey={currentModel.key} />
       </MockContext>,
     )
     expect(container).toBeInTheDocument()
@@ -71,19 +67,17 @@ describe('ModelIntro', () => {
     expect(tooltip).toBeInTheDocument()
   })
 
-  it('should not render when current model matches default', () => {
+  it('should not render when the model key is unknown', () => {
     const { container } = render(
       <MockContext
         initialState={{
           conversationEntriesState: {
             allModels: [currentModel],
-            currentModelKey: currentModel.key,
-            defaultModelKey: currentModel.key,
             isLeoModel: true,
           },
         }}
       >
-        <ModelIntro />
+        <ModelIntro modelKey='missing-model' />
       </MockContext>,
     )
 
@@ -97,13 +91,11 @@ describe('ModelIntro', () => {
         initialState={{
           conversationEntriesState: {
             allModels: [currentModel],
-            currentModelKey: currentModel.key,
-            defaultModelKey,
             isLeoModel: true,
           },
         }}
       >
-        <ModelIntro />
+        <ModelIntro modelKey={currentModel.key} />
       </MockContext>,
     )
     const tooltip = container.querySelector<HTMLDivElement>('leo-tooltip')

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/index.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/index.test.tsx
@@ -10,6 +10,7 @@ import * as Mojom from '../../../common/mojom'
 import MockContext from '../../mock_untrusted_conversation_context'
 import { clearAllDataForTesting } from '$web-common/api'
 import ModelIntro from '.'
+import styles from './style.module.scss'
 
 describe('ModelIntro', () => {
   beforeEach(() => {
@@ -56,9 +57,15 @@ describe('ModelIntro', () => {
     )
     expect(container).toBeInTheDocument()
 
-    const modelText = container.querySelector<HTMLHeadingElement>('h3')
+    const modelText = container.querySelector<HTMLSpanElement>(
+      `.${styles.name}`,
+    )
     expect(modelText).toBeInTheDocument()
     expect(modelText).toHaveTextContent('Test Model')
+
+    const modelIntroIcon = container.querySelector<HTMLDivElement>('leo-icon')
+    expect(modelIntroIcon).toBeInTheDocument()
+    expect(modelIntroIcon).toHaveAttribute('name', 'product-brave-leo')
 
     const tooltip = container.querySelector<HTMLDivElement>('leo-tooltip')
     expect(tooltip).toBeInTheDocument()
@@ -80,7 +87,7 @@ describe('ModelIntro', () => {
       </MockContext>,
     )
 
-    expect(container.querySelector('h3')).not.toBeInTheDocument()
+    expect(container.querySelector(`.${styles.name}`)).not.toBeInTheDocument()
     expect(container.querySelector('leo-tooltip')).not.toBeInTheDocument()
   })
 

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/index.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/index.test.tsx
@@ -37,13 +37,16 @@ describe('ModelIntro', () => {
     },
   }
 
-  it('should render model intro', () => {
+  const defaultModelKey = 'default-model'
+
+  it('should render model intro when current model differs from default', () => {
     const { container } = render(
       <MockContext
         initialState={{
           conversationEntriesState: {
             allModels: [currentModel],
             currentModelKey: currentModel.key,
+            defaultModelKey,
             isLeoModel: true,
           },
         }}
@@ -53,19 +56,32 @@ describe('ModelIntro', () => {
     )
     expect(container).toBeInTheDocument()
 
-    // Test that the model text is rendered
     const modelText = container.querySelector<HTMLHeadingElement>('h3')
     expect(modelText).toBeInTheDocument()
     expect(modelText).toHaveTextContent('Test Model')
 
-    // Test that the model intro icon is rendered
-    const modelIntroIcon = container.querySelector<HTMLDivElement>('leo-icon')
-    expect(modelIntroIcon).toBeInTheDocument()
-    expect(modelIntroIcon).toHaveAttribute('name', 'product-brave-leo')
-
-    // Test that the tooltip is rendered
     const tooltip = container.querySelector<HTMLDivElement>('leo-tooltip')
     expect(tooltip).toBeInTheDocument()
+  })
+
+  it('should not render when current model matches default', () => {
+    const { container } = render(
+      <MockContext
+        initialState={{
+          conversationEntriesState: {
+            allModels: [currentModel],
+            currentModelKey: currentModel.key,
+            defaultModelKey: currentModel.key,
+            isLeoModel: true,
+          },
+        }}
+      >
+        <ModelIntro />
+      </MockContext>,
+    )
+
+    expect(container.querySelector('h3')).not.toBeInTheDocument()
+    expect(container.querySelector('leo-tooltip')).not.toBeInTheDocument()
   })
 
   it('should render model intro tooltip', () => {
@@ -75,6 +91,7 @@ describe('ModelIntro', () => {
           conversationEntriesState: {
             allModels: [currentModel],
             currentModelKey: currentModel.key,
+            defaultModelKey,
             isLeoModel: true,
           },
         }}
@@ -85,12 +102,10 @@ describe('ModelIntro', () => {
     const tooltip = container.querySelector<HTMLDivElement>('leo-tooltip')
     expect(tooltip).toBeInTheDocument()
 
-    // Test that the tooltip content is rendered
     const tooltipContent =
       tooltip?.querySelector<HTMLDivElement>('[slot="content"]')
     expect(tooltipContent).toBeInTheDocument()
 
-    // Test that the tooltip content has the correct message
     const tooltipContentText = tooltipContent?.textContent
     expect(tooltipContentText).toBe(S.CHAT_UI_INTRO_MESSAGE_TEST_MODEL)
   })

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/index.tsx
@@ -7,18 +7,10 @@ import * as React from 'react'
 import Icon from '@brave/leo/react/icon'
 import Tooltip from '@brave/leo/react/tooltip'
 import Button from '@brave/leo/react/button'
-import { getLocale, formatLocale } from '$web-common/locale'
+import { formatLocale } from '$web-common/locale'
 import * as Mojom from '../../../common/mojom'
 import { useUntrustedConversationContext } from '../../untrusted_conversation_context'
 import styles from './style.module.scss'
-import { getKeysForMojomEnum } from '$web-common/mojomUtils'
-
-function getCategoryName(category: Mojom.ModelCategory) {
-  // To avoid problems when order of enum values change, we base the key
-  // on the enum name rather than the number value, e.g. "CHAT" vs 0
-  const categoryKey = getKeysForMojomEnum(Mojom.ModelCategory)[category]
-  return getLocale('CHAT_UI_MODEL_CATEGORY_' + categoryKey)
-}
 
 function getIntroMessageKey(model: Mojom.Model) {
   return `CHAT_UI_INTRO_MESSAGE_${model.key.toUpperCase().replaceAll('-', '_')}`
@@ -34,7 +26,7 @@ export default function ModelIntro() {
   // </if>
 
   const model = state.allModels.find((m) => m.key === state.currentModelKey)
-  if (!model) {
+  if (!model || state.currentModelKey === state.defaultModelKey) {
     return <></>
   }
 
@@ -42,15 +34,7 @@ export default function ModelIntro() {
 
   return (
     <div className={styles.modelInfo}>
-      <div className={styles.modelIcon}>
-        <Icon name='product-brave-leo' />
-      </div>
       <div className={styles.meta}>
-        <h4 className={styles.category}>
-          {isLeoModel
-            ? getCategoryName(model.options.leoModelOptions!.category)
-            : model.displayName}
-        </h4>
         <h3 className={styles.name}>
           {isLeoModel
             ? model.displayName

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/index.tsx
@@ -9,6 +9,7 @@ import Tooltip from '@brave/leo/react/tooltip'
 import Button from '@brave/leo/react/button'
 import { formatLocale } from '$web-common/locale'
 import * as Mojom from '../../../common/mojom'
+import { getModelIcon } from '../../../common/constants'
 import { useUntrustedConversationContext } from '../../untrusted_conversation_context'
 import styles from './style.module.scss'
 
@@ -31,54 +32,59 @@ export default function ModelIntro() {
   }
 
   const isLeoModel = state.isLeoModel
+  const modelName = isLeoModel
+    ? model.displayName
+    : model.options.customModelOptions?.modelRequestName
 
   return (
     <div className={styles.modelInfo}>
-      <div className={styles.meta}>
-        <h3 className={styles.name}>
-          {isLeoModel
-            ? model.displayName
-            : model.options.customModelOptions?.modelRequestName}
-          {isLeoModel && (
-            <Tooltip
-              mode='default'
-              className={styles.tooltip}
-              offset={4}
-              // <if expr="is_ios">
-              visible={isTooltipVisible}
-              // </if>
-            >
-              <div
-                slot='content'
-                className={styles.tooltipContent}
-              >
-                {formatLocale(getIntroMessageKey(model), {
-                  $1: (content) => {
-                    return (
-                      <button
-                        key={content}
-                        onClick={() => context.uiHandler.openModelSupportUrl()}
-                      >
-                        {content}
-                      </button>
-                    )
-                  },
-                })}
-              </div>
-              <Button
-                fab
-                kind='plain-faint'
-                className={styles.tooltipButton}
-                // <if expr="is_ios">
-                onClick={() => setIsTooltipVisible((prev) => !prev)}
-                // </if>
-              >
-                <Icon name='info-outline' />
-              </Button>
-            </Tooltip>
-          )}
-        </h3>
+      <div className={styles.modelRow}>
+        <div
+          className={styles.modelIcon}
+          data-key={model.key}
+        >
+          <Icon name={getModelIcon(model)} />
+        </div>
+        <span className={styles.name}>{modelName}</span>
       </div>
+      {isLeoModel && (
+        <Tooltip
+          mode='default'
+          className={styles.tooltip}
+          offset={4}
+          // <if expr="is_ios">
+          visible={isTooltipVisible}
+          // </if>
+        >
+          <div
+            slot='content'
+            className={styles.tooltipContent}
+          >
+            {formatLocale(getIntroMessageKey(model), {
+              $1: (content) => {
+                return (
+                  <button
+                    key={content}
+                    onClick={() => context.uiHandler.openModelSupportUrl()}
+                  >
+                    {content}
+                  </button>
+                )
+              },
+            })}
+          </div>
+          <Button
+            fab
+            kind='plain-faint'
+            className={styles.tooltipButton}
+            // <if expr="is_ios">
+            onClick={() => setIsTooltipVisible((prev) => !prev)}
+            // </if>
+          >
+            <Icon name='info-outline' />
+          </Button>
+        </Tooltip>
+      )}
     </div>
   )
 }

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/index.tsx
@@ -51,45 +51,45 @@ export default function ModelIntro(props: ModelIntroProps) {
           <Icon name={getModelIcon(model)} />
         </div>
         <span className={styles.name}>{modelName}</span>
-      </div>
-      {isLeoModel && (
-        <Tooltip
-          mode='default'
-          className={styles.tooltip}
-          offset={4}
-          // <if expr="is_ios">
-          visible={isTooltipVisible}
-          // </if>
-        >
-          <div
-            slot='content'
-            className={styles.tooltipContent}
-          >
-            {formatLocale(getIntroMessageKey(model), {
-              $1: (content) => {
-                return (
-                  <button
-                    key={content}
-                    onClick={() => context.uiHandler.openModelSupportUrl()}
-                  >
-                    {content}
-                  </button>
-                )
-              },
-            })}
-          </div>
-          <Button
-            fab
-            kind='plain-faint'
-            className={styles.tooltipButton}
+        {isLeoModel && (
+          <Tooltip
+            mode='default'
+            className={styles.tooltip}
+            offset={4}
             // <if expr="is_ios">
-            onClick={() => setIsTooltipVisible((prev) => !prev)}
+            visible={isTooltipVisible}
             // </if>
           >
-            <Icon name='info-outline' />
-          </Button>
-        </Tooltip>
-      )}
+            <div
+              slot='content'
+              className={styles.tooltipContent}
+            >
+              {formatLocale(getIntroMessageKey(model), {
+                $1: (content) => {
+                  return (
+                    <button
+                      key={content}
+                      onClick={() => context.uiHandler.openModelSupportUrl()}
+                    >
+                      {content}
+                    </button>
+                  )
+                },
+              })}
+            </div>
+            <Button
+              fab
+              kind='plain-faint'
+              className={styles.tooltipButton}
+              // <if expr="is_ios">
+              onClick={() => setIsTooltipVisible((prev) => !prev)}
+              // </if>
+            >
+              <Icon name='info-outline' />
+            </Button>
+          </Tooltip>
+        )}
+      </div>
     </div>
   )
 }

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/index.tsx
@@ -17,7 +17,12 @@ function getIntroMessageKey(model: Mojom.Model) {
   return `CHAT_UI_INTRO_MESSAGE_${model.key.toUpperCase().replaceAll('-', '_')}`
 }
 
-export default function ModelIntro() {
+interface ModelIntroProps {
+  modelKey: string
+}
+
+export default function ModelIntro(props: ModelIntroProps) {
+  const { modelKey } = props
   const context = useUntrustedConversationContext()
   const state = context.api.useState().data
 
@@ -26,12 +31,12 @@ export default function ModelIntro() {
   const [isTooltipVisible, setIsTooltipVisible] = React.useState(false)
   // </if>
 
-  const model = state.allModels.find((m) => m.key === state.currentModelKey)
-  if (!model || state.currentModelKey === state.defaultModelKey) {
+  const model = state.allModels.find((m) => m.key === modelKey)
+  if (!model) {
     return <></>
   }
 
-  const isLeoModel = state.isLeoModel
+  const isLeoModel = !!model.options.leoModelOptions
   const modelName = isLeoModel
     ? model.displayName
     : model.options.customModelOptions?.modelRequestName

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/style.module.scss
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/style.module.scss
@@ -1,34 +1,66 @@
 .modelInfo {
-  margin-top: var(--leo-spacing-2xl);
+  margin-top: var(--leo-spacing-l);
   display: flex;
-  flex-direction: column;
-  gap: var(--leo-spacing-m);
-  align-items: start;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--leo-spacing-l);
+  background: var(--leo-color-page-background);
+  border: 1px solid var(--leo-color-divider-subtle);
+  border-radius: var(--leo-radius-l);
 }
 
-.meta {
-  .name {
-    margin: 0;
-    font: var(--leo-font-small-regular);
-    color: var(--leo-color-text-tertiary);
-    display: flex;
-    align-items: center;
-    gap: 4px;
+.modelRow {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--leo-spacing-m);
+  min-width: 0;
+}
+
+.modelIcon {
+  --leo-icon-size: 20px;
+  --leo-icon-color: var(--leo-color-icon-default);
+  border-radius: var(--leo-radius-m);
+  border: 1px solid var(--leo-color-divider-subtle);
+  background: var(--leo-color-container-background);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+
+  &[data-key='chat-automatic'] {
+    --leo-icon-color: white;
+    background: var(--leo-gradient-icons-active);
+    border: none;
   }
+}
+
+.name {
+  margin: 0;
+  font: var(--leo-font-default-semibold);
+  color: var(--leo-color-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .tooltipButton {
   --leo-button-padding: 0;
+  flex-shrink: 0;
 
   leo-icon {
-    --leo-icon-size: 14px;
-    --leo-icon-color: var(--leo-color-text-tertiary);
+    --leo-icon-size: 20px;
+    --leo-icon-color: var(--leo-color-icon-secondary);
   }
 }
 
 .tooltip {
   --leo-tooltip-padding: var(--leo-spacing-xl);
-  height: 14px;
+  height: 20px;
 }
 
 .tooltipContent {

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/style.module.scss
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/style.module.scss
@@ -6,26 +6,7 @@
   align-items: start;
 }
 
-.modelIcon {
-  --leo-icon-color: white;
-  --leo-icon-width: 18px;
-  width: 32px;
-  height: 32px;
-  background: var(--leo-gradient-icons-active);
-  padding: 9px;
-  border-radius: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 .meta {
-  .category {
-    margin: 0;
-    font: var(--leo-font-heading-h4);
-    color: var(--leo-color-text-primary);
-  }
-
   .name {
     margin: 0;
     font: var(--leo-font-small-regular);

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/style.module.scss
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/model_intro/style.module.scss
@@ -3,12 +3,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: space-between;
   width: 100%;
-  padding: var(--leo-spacing-l);
-  background: var(--leo-color-page-background);
-  border: 1px solid var(--leo-color-divider-subtle);
-  border-radius: var(--leo-radius-l);
 }
 
 .modelRow {
@@ -53,14 +48,14 @@
   flex-shrink: 0;
 
   leo-icon {
-    --leo-icon-size: 20px;
+    --leo-icon-size: 16px;
     --leo-icon-color: var(--leo-color-icon-secondary);
   }
 }
 
 .tooltip {
   --leo-tooltip-padding: var(--leo-spacing-xl);
-  height: 20px;
+  height: 16px;
 }
 
 .tooltipContent {

--- a/components/ai_chat/resources/untrusted_conversation_frame/untrusted_conversation_context.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/untrusted_conversation_context.ts
@@ -123,11 +123,7 @@ export function useProvideUntrustedConversationContext(
         createModelIntroMarker(currentModelKey, afterPairIndex),
       ]
     })
-  }, [
-    conversationHistory.length,
-    state.currentModelKey,
-    state.defaultModelKey,
-  ])
+  }, [conversationHistory.length, state.currentModelKey, state.defaultModelKey])
 
   return {
     api,

--- a/components/ai_chat/resources/untrusted_conversation_frame/untrusted_conversation_context.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/untrusted_conversation_context.ts
@@ -7,6 +7,7 @@ import * as React from 'react'
 import generateReactContext from '$web-common/api/react_api'
 import { UntrustedConversationAPI } from './api/untrusted_conversation_api'
 import { loadTimeData } from '$web-common/loadTimeData'
+import { getPairedConversationGroups } from './components/conversation_entries/conversation_entries_utils'
 
 // Props required to provide the context
 export interface UntrustedConversationContextProps {
@@ -14,8 +15,28 @@ export interface UntrustedConversationContextProps {
   isReadOnly?: boolean
 }
 
+export type ModelIntroMarker = {
+  id: string
+  modelKey: string
+  afterPairIndex: number | null
+}
+
 const IS_MOBILE = loadTimeData.getBoolean('isMobile')
 const IS_HISTORY_FEATURE_ENABLED = loadTimeData.getBoolean('isHistoryEnabled')
+
+let modelIntroMarkerCounter = 0
+
+function createModelIntroMarker(
+  modelKey: string,
+  afterPairIndex: number | null,
+): ModelIntroMarker {
+  modelIntroMarkerCounter += 1
+  return {
+    id: `model-intro-${modelIntroMarkerCounter}`,
+    modelKey,
+    afterPairIndex,
+  }
+}
 
 /**
  * Provides the untrusted conversation context with API hooks
@@ -29,6 +50,12 @@ export function useProvideUntrustedConversationContext(
     showPremiumSuggestionForRegenerate,
     setShowPremiumSuggestionForRegenerate,
   ] = React.useState(false)
+  const [modelIntroMarkers, setModelIntroMarkers] = React.useState<
+    ModelIntroMarker[]
+  >([])
+
+  const prevModelKeyRef = React.useRef<string | undefined>(undefined)
+  const conversationIdentityRef = React.useRef<string | null>(null)
 
   // Use API hooks for state
   const state = api.useState().data
@@ -38,6 +65,70 @@ export function useProvideUntrustedConversationContext(
   const associatedContent = api.useCurrentAssociatedContentChanged().data?.[0]
   const contentTaskTabId = api.useCurrentContentTaskStarted().data?.[0]
 
+  React.useEffect(() => {
+    if (conversationHistory.length === 0) {
+      setModelIntroMarkers([])
+      conversationIdentityRef.current = null
+      prevModelKeyRef.current = undefined
+      return
+    }
+
+    const firstUuid = conversationHistory[0]?.uuid
+    if (!firstUuid) {
+      return
+    }
+
+    if (conversationIdentityRef.current === null) {
+      conversationIdentityRef.current = firstUuid
+      return
+    }
+
+    if (conversationIdentityRef.current !== firstUuid) {
+      conversationIdentityRef.current = firstUuid
+      setModelIntroMarkers([])
+      prevModelKeyRef.current = undefined
+    }
+  }, [conversationHistory.length, conversationHistory[0]?.uuid])
+
+  React.useEffect(() => {
+    const { currentModelKey, defaultModelKey } = state
+
+    if (prevModelKeyRef.current === undefined) {
+      prevModelKeyRef.current = currentModelKey
+      return
+    }
+
+    if (prevModelKeyRef.current === currentModelKey) {
+      return
+    }
+
+    prevModelKeyRef.current = currentModelKey
+
+    if (currentModelKey === defaultModelKey) {
+      return
+    }
+
+    setModelIntroMarkers((previousMarkers) => {
+      const lastMarker = previousMarkers.at(-1)
+      if (lastMarker?.modelKey === currentModelKey) {
+        return previousMarkers
+      }
+
+      const pairedGroups = getPairedConversationGroups(conversationHistory)
+      const afterPairIndex =
+        conversationHistory.length === 0 ? null : pairedGroups.length - 1
+
+      return [
+        ...previousMarkers,
+        createModelIntroMarker(currentModelKey, afterPairIndex),
+      ]
+    })
+  }, [
+    conversationHistory.length,
+    state.currentModelKey,
+    state.defaultModelKey,
+  ])
+
   return {
     api,
 
@@ -45,6 +136,8 @@ export function useProvideUntrustedConversationContext(
 
     showPremiumSuggestionForRegenerate,
     setShowPremiumSuggestionForRegenerate,
+
+    modelIntroMarkers,
 
     // Expose state properties directly for backwards compatibility
     // These are marked as deprecated - components should use api.useState() instead

--- a/components/ai_chat/resources/untrusted_conversation_frame/untrusted_conversation_context.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/untrusted_conversation_context.ts
@@ -7,7 +7,6 @@ import * as React from 'react'
 import generateReactContext from '$web-common/api/react_api'
 import { UntrustedConversationAPI } from './api/untrusted_conversation_api'
 import { loadTimeData } from '$web-common/loadTimeData'
-import { getPairedConversationGroups } from './components/conversation_entries/conversation_entries_utils'
 
 // Props required to provide the context
 export interface UntrustedConversationContextProps {
@@ -15,28 +14,8 @@ export interface UntrustedConversationContextProps {
   isReadOnly?: boolean
 }
 
-export type ModelIntroMarker = {
-  id: string
-  modelKey: string
-  afterPairIndex: number | null
-}
-
 const IS_MOBILE = loadTimeData.getBoolean('isMobile')
 const IS_HISTORY_FEATURE_ENABLED = loadTimeData.getBoolean('isHistoryEnabled')
-
-let modelIntroMarkerCounter = 0
-
-function createModelIntroMarker(
-  modelKey: string,
-  afterPairIndex: number | null,
-): ModelIntroMarker {
-  modelIntroMarkerCounter += 1
-  return {
-    id: `model-intro-${modelIntroMarkerCounter}`,
-    modelKey,
-    afterPairIndex,
-  }
-}
 
 /**
  * Provides the untrusted conversation context with API hooks
@@ -50,12 +29,6 @@ export function useProvideUntrustedConversationContext(
     showPremiumSuggestionForRegenerate,
     setShowPremiumSuggestionForRegenerate,
   ] = React.useState(false)
-  const [modelIntroMarkers, setModelIntroMarkers] = React.useState<
-    ModelIntroMarker[]
-  >([])
-
-  const prevModelKeyRef = React.useRef<string | undefined>(undefined)
-  const conversationIdentityRef = React.useRef<string | null>(null)
 
   // Use API hooks for state
   const state = api.useState().data
@@ -65,66 +38,6 @@ export function useProvideUntrustedConversationContext(
   const associatedContent = api.useCurrentAssociatedContentChanged().data?.[0]
   const contentTaskTabId = api.useCurrentContentTaskStarted().data?.[0]
 
-  React.useEffect(() => {
-    if (conversationHistory.length === 0) {
-      setModelIntroMarkers([])
-      conversationIdentityRef.current = null
-      prevModelKeyRef.current = undefined
-      return
-    }
-
-    const firstUuid = conversationHistory[0]?.uuid
-    if (!firstUuid) {
-      return
-    }
-
-    if (conversationIdentityRef.current === null) {
-      conversationIdentityRef.current = firstUuid
-      return
-    }
-
-    if (conversationIdentityRef.current !== firstUuid) {
-      conversationIdentityRef.current = firstUuid
-      setModelIntroMarkers([])
-      prevModelKeyRef.current = undefined
-    }
-  }, [conversationHistory.length, conversationHistory[0]?.uuid])
-
-  React.useEffect(() => {
-    const { currentModelKey, defaultModelKey } = state
-
-    if (prevModelKeyRef.current === undefined) {
-      prevModelKeyRef.current = currentModelKey
-      return
-    }
-
-    if (prevModelKeyRef.current === currentModelKey) {
-      return
-    }
-
-    prevModelKeyRef.current = currentModelKey
-
-    if (currentModelKey === defaultModelKey) {
-      return
-    }
-
-    setModelIntroMarkers((previousMarkers) => {
-      const lastMarker = previousMarkers.at(-1)
-      if (lastMarker?.modelKey === currentModelKey) {
-        return previousMarkers
-      }
-
-      const pairedGroups = getPairedConversationGroups(conversationHistory)
-      const afterPairIndex =
-        conversationHistory.length === 0 ? null : pairedGroups.length - 1
-
-      return [
-        ...previousMarkers,
-        createModelIntroMarker(currentModelKey, afterPairIndex),
-      ]
-    })
-  }, [conversationHistory.length, state.currentModelKey, state.defaultModelKey])
-
   return {
     api,
 
@@ -132,8 +45,6 @@ export function useProvideUntrustedConversationContext(
 
     showPremiumSuggestionForRegenerate,
     setShowPremiumSuggestionForRegenerate,
-
-    modelIntroMarkers,
 
     // Expose state properties directly for backwards compatibility
     // These are marked as deprecated - components should use api.useState() instead


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/40435

## Summary

This PR simplifies Leo's **ModelIntro** block, restyles it to match the Figma "Model name - in chat" design, and renders it as **sticky historical markers** anchored to the point in the conversation where each model change occurred.

Previously, every new conversation showed a Leo icon, a category title (e.g. "Chat"), and the model name with an info tooltip. That added visual noise when the user had not changed models. A later iteration also repositioned a single live intro block when the first message was sent, which made the pill visibly jump.

Now, each model change from the **baseline** model at the current conversation position creates a pill that **stays where it was inserted** for the rest of the session. That includes switching **to Automatic / the default model** after starting on a specific model. Changing models again at the same position (before sending a prompt) **replaces** the pending marker. Switching **back to the baseline** model before sending **removes** the pending marker so a pill is not shown for a model that will not be used.

## What changed

### Backend: expose the user's default model to the untrusted frame

The untrusted conversation frame only receives `ConversationEntriesState`, which previously had `current_model_key` but not the user's default. This PR also plumbs `default_model_key` through for the untrusted frame:

- Added `default_model_key` to `ConversationEntriesState` in `common.mojom`
- Populated it in `ConversationHandler::GetStateForConversationEntries()` via `model_service_->GetDefaultModelKey()`
- Updated untrusted API initial state and mocks to include `defaultModelKey`

Marker creation itself is driven by **session baseline tracking** in the React hook (not by comparing against `defaultModelKey`).

### Frontend: sticky model intro markers via `useModelIntroMarkers`

Instead of one live `ModelIntro` that repositions based on conversation state, marker creation lives in a dedicated `useModelIntroMarkers` hook (extracted out of the conversation context for clearer ownership and unit testing).

```ts
type ModelIntroMarker = {
  id: string
  modelKey: string
  afterPairIndex: number | null // null = top, before entries
}
```

`Conversation` calls the hook and:

- Renders top markers (`afterPairIndex === null`) itself
- Passes the full marker list down to `ConversationEntries` as a prop for inline placement

On mount (and after a session reset), the hook records a **baseline** model for the current conversation position — the model already selected — and does **not** create a marker for it.

When `currentModelKey` changes:

- If the new model equals the **baseline** for this position → remove the pending marker at this `afterPairIndex` (revert; no unused-model pill)
- Otherwise → create or replace a marker for the newly selected model (including Automatic / default)

The anchor is computed from conversation history using shared `getPairedConversationGroups()`:

- **Before the first message** (`conversationHistory.length === 0`): `afterPairIndex = null` → rendered at the top of `Conversation`, above entries
- **During a conversation**: `afterPairIndex = lastPairIndex` → rendered inside `ConversationEntries` after that entry pair

**Pending marker replace:** if the user changes models again at the same `afterPairIndex` before sending a prompt, the last marker at that position is replaced rather than appending another pill.

**Baseline advance:** after a prompt is sent (history grows), the baseline advances to the model that produced those turns. A later model change — including switching to Automatic — creates a **new** marker at the new position while earlier markers stay in place.

Session lifecycle handled by the hook:

- Markers reset when history is cleared or a different conversation is loaded (tracked via the first turn's uuid)
- Top-of-conversation markers created before the first message are preserved once the conversation starts
- Markers are session-only (not persisted in C++ metadata)

### Frontend: `ModelIntro` refactor

- Accepts a required `modelKey` prop and renders a frozen model snapshot from `allModels`

Removed from the old design:

- The Leo product icon
- The "Chat" category heading (`CHAT_UI_MODEL_CATEGORY_*`)

### Frontend: Figma-aligned layout and Nala tokens

When shown, the intro is a full-width pill bar:

- **Container:** `--leo-color-page-background`, `--leo-color-divider-subtle` border, `--leo-radius-l`, `--leo-spacing-l` padding
- **Left:** model brand icon (via existing `getModelIcon`) in a 32×32 tile with `--leo-color-container-background` / `--leo-radius-m`, matching the model selector pattern
- **Center:** model display name using `--leo-font-default-semibold` and `--leo-color-text-secondary`
- **Right:** info tooltip button nested inside the model row (16px icon, `--leo-color-icon-secondary`)

The info tooltip content and behavior are unchanged for Leo models.

### Shared conversation grouping utility

Extracted `getPairedConversationGroups()` into `conversation_entries_utils.ts` so both entry rendering and marker anchoring use the same pairing logic.

### Tests

Updated and added coverage for:

- `ModelIntro` unit tests: render via explicit `modelKey` prop; hide when model is missing
- `useModelIntroMarkers` unit tests:
  - Marker creation when switching away from the baseline model
  - Skip duplicates / initial mount
  - Top vs inline anchoring
  - Preserve top markers after first message
  - Reset on conversation switch / clear
  - **Replace** pending top / inline markers when changing models again before send
  - **Remove** pending markers when switching back to the baseline model before send
  - **Create** a marker when switching to Automatic / default from a specific model
  - Keep earlier markers and add a new one after another prompt is sent (including switching to default after send)
  - Stabilize replace assertions by waiting on `modelKey` (not only list length, which stays `1` across a replace)
- `Conversation` tests: top markers stay rendered after conversation starts; no live repositioning; markers passed into entries
- `ConversationEntries` tests: inline markers render after the anchored entry pair; import order fixed for lint (`import/first`)

## How it works

```
useModelIntroMarkers()
  baseline = model in effect at current conversation position
  On mount / session reset: record baseline; no marker
  On history growth: advance baseline to the model that produced the new turns
  On currentModelKey change:
    if currentModelKey === baseline
      → remove pending marker at this afterPairIndex
    else
      if last marker has same afterPairIndex → replace it
      else append ModelIntroMarker { modelKey, afterPairIndex }
        ↓
Conversation
  afterPairIndex === null → render ModelIntro at top
  pass markers → ConversationEntries
        ↓
ConversationEntries
  afterPairIndex === N → render ModelIntro after entry pair N
```

Examples:

- Automatic → Qwen → Automatic (before send) → pending Qwen pill is removed
- Qwen conversation → Automatic → Automatic pill is shown
- Qwen → Automatic → Qwen (before send) → pending Automatic pill is removed
- Switch model, send prompt, switch again → earlier pill stays; new pill at the new position

## Demo - Default model is set to automatic

https://github.com/user-attachments/assets/4406fd34-9f6b-47fe-9ca6-b3e6f1ad2172

## Demo - Default model is set to a specific model

https://github.com/user-attachments/assets/672eda5d-321e-428a-a604-68dbeed9423d

## Demo - User changed model on an ongoing conversation

https://github.com/user-attachments/assets/ad79df8a-31e0-4160-bb1e-c7132c555159

## Demo - User changed model before the conversation starts and after a reply

https://github.com/user-attachments/assets/08e1fa76-7431-4468-aa56-75191b262902

## Test plan

- [ ] Open Leo AI and start a **new conversation** — no ModelIntro pill should appear for the model already selected on load
- [ ] Before sending a message, switch to a **different model** (e.g. Claude, Llama) — one pill appears at the **top** with the correct brand icon, model name, and info icon
- [ ] Before sending, switch to another model again — the top pill is **replaced** (still one pill), showing the latest model
- [ ] Switch **back to the original model** before sending — the pending pill is **removed**
- [ ] Hover/click the info icon — tooltip shows the model-specific intro message with the support link
- [ ] Send the first message — the pill **stays at the top**; conversation continues below it
- [ ] Start (or continue) a conversation on a **specific model**, then switch to **Automatic** — an Automatic pill appears at the current position
- [ ] From that Automatic pill, switch back to the specific model before sending — the pending Automatic pill is **removed**
- [ ] In an ongoing conversation, switch models and send a prompt — a pill appears below the latest reply; earlier pills stay put
- [ ] After sending, switch to another model (including Automatic) — a **new** pill appears at the new position; earlier pills remain
- [ ] Before sending the next prompt, switch models again — the pending inline pill is **replaced**; earlier pills stay put
- [ ] Switch to a different conversation / clear history — markers reset (session-only, expected)
- [ ] Reload the conversation — markers are gone (session-only, expected)
- [ ] Verify appearance in **light and dark** themes
- [ ] Run unit tests: `npm run test-unit -- --testPathPatterns="model_intro/index.test|conversation/index.test|conversation_entries/index.test|useModelIntroMarkers.test"`

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->