### PR TITLE
[Refactoring] Move GetFarblingToken related tests

### DIFF
--- a/components/brave_shields/core/browser/brave_shields_settings_service_unittest.cc
+++ b/components/brave_shields/core/browser/brave_shields_settings_service_unittest.cc
@@ -699,3 +699,188 @@ TEST_F(BraveShieldsSettingsServiceTest, FingerprintingAllowed) {
   EXPECT_FALSE(brave_shields_settings()->MakePseudoRandomGeneratorForURL(
       url, {}, &prng));
 }
+
+// Farbling token related tests.
+
+// Unsupported schemes (chrome://, about:blank, data:, invalid URL) must return
+// the zero token because shields are not active there.
+TEST_F(BraveShieldsSettingsServiceTest,
+       FarblingToken_UnsupportedScheme_ReturnsZeroToken) {
+  const base::Token zero;
+  EXPECT_EQ(zero, brave_shields_settings()->GetFarblingToken(
+                      GURL("chrome://settings"), {}));
+  EXPECT_EQ(zero, brave_shields_settings()->GetFarblingToken(
+                      GURL("about:blank"), {}));
+  EXPECT_EQ(zero, brave_shields_settings()->GetFarblingToken(
+                      GURL("data:text/html,<h1>hello</h1>"), {}));
+  EXPECT_EQ(zero, brave_shields_settings()->GetFarblingToken(
+                      GURL("file:///etc/hosts"), {}));
+  EXPECT_EQ(zero, brave_shields_settings()->GetFarblingToken(GURL(), {}));
+}
+
+// HTTP and HTTPS URLs must produce a non-zero token.
+TEST_F(BraveShieldsSettingsServiceTest,
+       FarblingToken_HttpAndHttps_ReturnNonZeroToken) {
+  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
+  EXPECT_FALSE(brave_shields_settings()
+                   ->GetFarblingToken(GURL("http://example.com"), {})
+                   .is_zero());
+  EXPECT_FALSE(brave_shields_settings()
+                   ->GetFarblingToken(GURL("https://example.com"), {})
+                   .is_zero());
+}
+
+// Two URLs with the same origin but different paths must share the same token,
+// because the path is stripped when deriving the effective URL.
+TEST_F(BraveShieldsSettingsServiceTest,
+       FarblingToken_SameOrigin_DifferentPaths_SameToken) {
+  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
+  const auto t1 = brave_shields_settings()->GetFarblingToken(
+      GURL("https://example.com/page1"), {});
+  const auto t2 = brave_shields_settings()->GetFarblingToken(
+      GURL("https://example.com/page2?q=1#anchor"), {});
+  EXPECT_EQ(t1, t2);
+}
+
+// A blob URL whose inner origin is https://example.com must yield the same
+// token as a plain https://example.com URL, because both resolve to the same
+// effective origin (https://example.com/).
+TEST_F(BraveShieldsSettingsServiceTest,
+       FarblingToken_BlobUrl_SameTokenAsOriginUrl) {
+  // Use a random seed (0 = random) to exercise the storage path: the first
+  // caller writes a random token keyed under https://example.com/; the second
+  // caller reads it back regardless of whether it used the blob or plain URL.
+  const auto blob_token = brave_shields_settings()->GetFarblingToken(
+      url::Origin::Create(
+          GURL("blob:https://example.com/550e8400-e29b-41d4-a716-446655440000"))
+          .GetURL(),
+      {});
+  const auto https_token = brave_shields_settings()->GetFarblingToken(
+      GURL("https://example.com/some/path"), {});
+  EXPECT_EQ(blob_token, https_token);
+}
+
+// A blob URL whose inner origin is a subdomain must resolve to the same token
+// as a plain HTTPS URL for that subdomain (the subdomain itself shares a token
+// with the root via schemeful-site scoping — see
+// FarblingToken_SubdomainAndRoot_ShareToken).
+TEST_F(BraveShieldsSettingsServiceTest,
+       FarblingToken_BlobSubdomainUrl_SameTokenAsSubdomainUrl) {
+  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
+  const auto sub_token = brave_shields_settings()->GetFarblingToken(
+      GURL("https://sub.example.com"), {});
+  const auto blob_sub_token = brave_shields_settings()->GetFarblingToken(
+      url::Origin::Create(GURL("blob:https://sub.example.com/some-uuid"))
+          .GetURL(),
+      {});
+  EXPECT_EQ(sub_token, blob_sub_token);
+}
+
+// A blob URL for a subdomain must share the token of the root domain.
+// BRAVE_SHIELDS_METADATA is registered with
+// REQUESTING_SCHEMEFUL_SITE_ONLY_SCOPE, so the content setting is keyed by the
+// schemeful site (eTLD+1 + scheme). https://example.com and
+// https://sub.example.com resolve to the same schemeful site, so they always
+// share one token.
+TEST_F(BraveShieldsSettingsServiceTest,
+       FarblingToken_BlobSubdomainUrl_SameTokenAsRootDomain) {
+  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
+  const auto root_token = brave_shields_settings()->GetFarblingToken(
+      GURL("https://example.com"), {});
+  const auto blob_sub_token = brave_shields_settings()->GetFarblingToken(
+      url::Origin::Create(GURL("blob:https://sub.example.com/some-uuid"))
+          .GetURL(),
+      {});
+  EXPECT_EQ(root_token, blob_sub_token);
+}
+
+// Two completely different origins must get different tokens.
+TEST_F(BraveShieldsSettingsServiceTest,
+       FarblingToken_DifferentOrigins_DifferentTokens) {
+  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
+  const auto t1 = brave_shields_settings()->GetFarblingToken(
+      GURL("https://example.com"), {});
+  const auto t2 =
+      brave_shields_settings()->GetFarblingToken(GURL("https://other.com"), {});
+  EXPECT_NE(t1, t2);
+}
+
+// A subdomain and its root domain share the same token as they map to same
+// schemeful site (eTLD+1 + scheme).
+TEST_F(BraveShieldsSettingsServiceTest,
+       FarblingToken_SubdomainAndRoot_ShareToken) {
+  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
+  const auto root = brave_shields_settings()->GetFarblingToken(
+      GURL("https://example.com"), {});
+  const auto sub = brave_shields_settings()->GetFarblingToken(
+      GURL("https://sub.example.com"), {});
+  EXPECT_EQ(root, sub);
+}
+
+// Calling GetFarblingToken twice for the same URL must return the same token.
+// This verifies that the token is persisted in HostContentSettingsMap and not
+// regenerated on every call.
+TEST_F(BraveShieldsSettingsServiceTest,
+       FarblingToken_IsStableAcrossMultipleCalls) {
+  const auto t1 = brave_shields_settings()->GetFarblingToken(
+      GURL("https://example.com"), {});
+  const auto t2 = brave_shields_settings()->GetFarblingToken(
+      GURL("https://example.com"), {});
+  EXPECT_EQ(t1, t2);
+  EXPECT_FALSE(t1.is_zero());
+}
+
+// Providing additional_entropy must produce a token different from the base
+// token for the same URL.
+TEST_F(BraveShieldsSettingsServiceTest,
+       FarblingToken_AdditionalEntropy_ChangesToken) {
+  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
+  const auto base_token = brave_shields_settings()->GetFarblingToken(
+      GURL("https://example.com"), {});
+  constexpr std::array<uint8_t, 4> entropy = {0x01, 0x02, 0x03, 0x04};
+  const auto derived_token = brave_shields_settings()->GetFarblingToken(
+      GURL("https://example.com"), entropy);
+  EXPECT_NE(base_token, derived_token);
+}
+
+// Two calls with the same URL and the same additional_entropy must produce the
+// same derived token (the XOR derivation is deterministic given a stable base).
+TEST_F(BraveShieldsSettingsServiceTest,
+       FarblingToken_SameEntropy_ProducesSameDerivedToken) {
+  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
+  constexpr std::array<uint8_t, 4> entropy = {0x05, 0x06, 0x07, 0x08};
+  const auto t1 = brave_shields_settings()->GetFarblingToken(
+      GURL("https://example.com"), entropy);
+  const auto t2 = brave_shields_settings()->GetFarblingToken(
+      GURL("https://example.com"), entropy);
+  EXPECT_EQ(t1, t2);
+}
+
+// Two calls with the same URL but different additional_entropy values must
+// produce different derived tokens.
+TEST_F(BraveShieldsSettingsServiceTest,
+       FarblingToken_DifferentEntropy_ProducesDifferentDerivedTokens) {
+  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
+  constexpr std::array<uint8_t, 4> entropy_a = {0xAA, 0xBB, 0xCC, 0xDD};
+  constexpr std::array<uint8_t, 4> entropy_b = {0x11, 0x22, 0x33, 0x44};
+  const auto t1 = brave_shields_settings()->GetFarblingToken(
+      GURL("https://example.com"), entropy_a);
+  const auto t2 = brave_shields_settings()->GetFarblingToken(
+      GURL("https://example.com"), entropy_b);
+  EXPECT_NE(t1, t2);
+}
+
+// The base token (no entropy) is unaffected by what another origin's derived
+// token looks like: each origin owns its own stored base token.
+TEST_F(BraveShieldsSettingsServiceTest,
+       FarblingToken_PerOrigin_TokensAreIndependent) {
+  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
+  constexpr std::array<uint8_t, 4> entropy = {0x01, 0x02, 0x03, 0x04};
+  const auto derived_a = brave_shields_settings()->GetFarblingToken(
+      GURL("https://a.com"), entropy);
+  const auto derived_b = brave_shields_settings()->GetFarblingToken(
+      GURL("https://b.com"), entropy);
+  // Different origins → different base tokens → different derived tokens even
+  // with identical entropy.
+  EXPECT_NE(derived_a, derived_b);
+}

--- a/components/brave_shields/core/test/brave_shields_utils_unittest.cc
+++ b/components/brave_shields/core/test/brave_shields_utils_unittest.cc
@@ -5,17 +5,14 @@
 
 #include "brave/components/brave_shields/core/browser/brave_shields_utils.h"
 
-#include <array>
 #include <memory>
 #include <utility>
 
 #include "base/files/scoped_temp_dir.h"
 #include "base/test/scoped_feature_list.h"
-#include "base/token.h"
 #include "brave/browser/profiles/brave_profile_manager.h"
 #include "brave/components/brave_shields/core/browser/brave_shields_p3a.h"
 #include "brave/components/brave_shields/core/browser/brave_shields_settings_service.h"
-#include "brave/components/brave_shields/core/browser/brave_shields_test_utils.h"
 #include "brave/components/brave_shields/core/common/brave_shield_utils.h"
 #include "brave/components/brave_shields/core/common/features.h"
 #include "brave/components/constants/pref_names.h"
@@ -38,8 +35,6 @@
 #include "content/public/test/test_utils.h"
 #include "net/base/features.h"
 #include "testing/gtest/include/gtest/gtest.h"
-#include "url/gurl.h"
-#include "url/origin.h"
 
 using brave_shields::ControlType;
 using brave_shields::ControlTypeFromString;
@@ -1095,182 +1090,4 @@ TEST_F(BraveShieldsUtilTest, GetDomainBlockingType_ControlTypes) {
 TEST_F(BraveShieldsUtilTest, GetDomainBlockingType) {
   ExpectDomainBlockingType(GURL("https://brave.com"),
                            DomainBlockingType::k1PES);
-}
-
-// Farbling token related tests.
-// TODO(https://github.com/brave/brave-browser/issues/56839): Move these tests
-// to brave_shields_settings_service_unittest.cc
-
-// Unsupported schemes (chrome://, about:blank, data:, invalid URL) must return
-// the zero token because shields are not active there.
-TEST_F(BraveShieldsUtilTest, FarblingToken_UnsupportedScheme_ReturnsZeroToken) {
-  const base::Token zero;
-  EXPECT_EQ(zero,
-            shields_service()->GetFarblingToken(GURL("chrome://settings"), {}));
-  EXPECT_EQ(zero, shields_service()->GetFarblingToken(GURL("about:blank"), {}));
-  EXPECT_EQ(zero, shields_service()->GetFarblingToken(
-                      GURL("data:text/html,<h1>hello</h1>"), {}));
-  EXPECT_EQ(zero,
-            shields_service()->GetFarblingToken(GURL("file:///etc/hosts"), {}));
-  EXPECT_EQ(zero, shields_service()->GetFarblingToken(GURL(), {}));
-}
-
-// HTTP and HTTPS URLs must produce a non-zero token.
-TEST_F(BraveShieldsUtilTest, FarblingToken_HttpAndHttps_ReturnNonZeroToken) {
-  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
-  EXPECT_FALSE(shields_service()
-                   ->GetFarblingToken(GURL("http://example.com"), {})
-                   .is_zero());
-  EXPECT_FALSE(shields_service()
-                   ->GetFarblingToken(GURL("https://example.com"), {})
-                   .is_zero());
-}
-
-// Two URLs with the same origin but different paths must share the same token,
-// because the path is stripped when deriving the effective URL.
-TEST_F(BraveShieldsUtilTest,
-       FarblingToken_SameOrigin_DifferentPaths_SameToken) {
-  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
-  const auto t1 = shields_service()->GetFarblingToken(
-      GURL("https://example.com/page1"), {});
-  const auto t2 = shields_service()->GetFarblingToken(
-      GURL("https://example.com/page2?q=1#anchor"), {});
-  EXPECT_EQ(t1, t2);
-}
-
-// A blob URL whose inner origin is https://example.com must yield the same
-// token as a plain https://example.com URL, because both resolve to the same
-// effective origin (https://example.com/).
-TEST_F(BraveShieldsUtilTest, FarblingToken_BlobUrl_SameTokenAsOriginUrl) {
-  // Use a random seed (0 = random) to exercise the storage path: the first
-  // caller writes a random token keyed under https://example.com/; the second
-  // caller reads it back regardless of whether it used the blob or plain URL.
-  const auto blob_token = shields_service()->GetFarblingToken(
-      url::Origin::Create(
-          GURL("blob:https://example.com/550e8400-e29b-41d4-a716-446655440000"))
-          .GetURL(),
-      {});
-  const auto https_token = shields_service()->GetFarblingToken(
-      GURL("https://example.com/some/path"), {});
-  EXPECT_EQ(blob_token, https_token);
-}
-
-// A blob URL whose inner origin is a subdomain must resolve to the same token
-// as a plain HTTPS URL for that subdomain (the subdomain itself shares a token
-// with the root via schemeful-site scoping — see
-// FarblingToken_SubdomainAndRoot_ShareToken).
-TEST_F(BraveShieldsUtilTest,
-       FarblingToken_BlobSubdomainUrl_SameTokenAsSubdomainUrl) {
-  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
-  const auto sub_token =
-      shields_service()->GetFarblingToken(GURL("https://sub.example.com"), {});
-  const auto blob_sub_token = shields_service()->GetFarblingToken(
-      url::Origin::Create(GURL("blob:https://sub.example.com/some-uuid"))
-          .GetURL(),
-      {});
-  EXPECT_EQ(sub_token, blob_sub_token);
-}
-
-// A blob URL for a subdomain must share the token of the root domain.
-// BRAVE_SHIELDS_METADATA is registered with
-// REQUESTING_SCHEMEFUL_SITE_ONLY_SCOPE, so the content setting is keyed by the
-// schemeful site (eTLD+1 + scheme). https://example.com and
-// https://sub.example.com resolve to the same schemeful site, so they always
-// share one token.
-TEST_F(BraveShieldsUtilTest,
-       FarblingToken_BlobSubdomainUrl_SameTokenAsRootDomain) {
-  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
-  const auto root_token =
-      shields_service()->GetFarblingToken(GURL("https://example.com"), {});
-  const auto blob_sub_token = shields_service()->GetFarblingToken(
-      url::Origin::Create(GURL("blob:https://sub.example.com/some-uuid"))
-          .GetURL(),
-      {});
-  EXPECT_EQ(root_token, blob_sub_token);
-}
-
-// Two completely different origins must get different tokens.
-TEST_F(BraveShieldsUtilTest, FarblingToken_DifferentOrigins_DifferentTokens) {
-  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
-  const auto t1 =
-      shields_service()->GetFarblingToken(GURL("https://example.com"), {});
-  const auto t2 =
-      shields_service()->GetFarblingToken(GURL("https://other.com"), {});
-  EXPECT_NE(t1, t2);
-}
-
-// A subdomain and its root domain share the same token as they map to same
-// schemeful site (eTLD+1 + scheme).
-TEST_F(BraveShieldsUtilTest, FarblingToken_SubdomainAndRoot_ShareToken) {
-  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
-  const auto root =
-      shields_service()->GetFarblingToken(GURL("https://example.com"), {});
-  const auto sub =
-      shields_service()->GetFarblingToken(GURL("https://sub.example.com"), {});
-  EXPECT_EQ(root, sub);
-}
-
-// Calling GetFarblingToken twice for the same URL must return the same token.
-// This verifies that the token is persisted in HostContentSettingsMap and not
-// regenerated on every call.
-TEST_F(BraveShieldsUtilTest, FarblingToken_IsStableAcrossMultipleCalls) {
-  const auto t1 =
-      shields_service()->GetFarblingToken(GURL("https://example.com"), {});
-  const auto t2 =
-      shields_service()->GetFarblingToken(GURL("https://example.com"), {});
-  EXPECT_EQ(t1, t2);
-  EXPECT_FALSE(t1.is_zero());
-}
-
-// Providing additional_entropy must produce a token different from the base
-// token for the same URL.
-TEST_F(BraveShieldsUtilTest, FarblingToken_AdditionalEntropy_ChangesToken) {
-  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
-  const auto base_token =
-      shields_service()->GetFarblingToken(GURL("https://example.com"), {});
-  constexpr std::array<uint8_t, 4> entropy = {0x01, 0x02, 0x03, 0x04};
-  const auto derived_token =
-      shields_service()->GetFarblingToken(GURL("https://example.com"), entropy);
-  EXPECT_NE(base_token, derived_token);
-}
-
-// Two calls with the same URL and the same additional_entropy must produce the
-// same derived token (the XOR derivation is deterministic given a stable base).
-TEST_F(BraveShieldsUtilTest,
-       FarblingToken_SameEntropy_ProducesSameDerivedToken) {
-  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
-  constexpr std::array<uint8_t, 4> entropy = {0x05, 0x06, 0x07, 0x08};
-  const auto t1 =
-      shields_service()->GetFarblingToken(GURL("https://example.com"), entropy);
-  const auto t2 =
-      shields_service()->GetFarblingToken(GURL("https://example.com"), entropy);
-  EXPECT_EQ(t1, t2);
-}
-
-// Two calls with the same URL but different additional_entropy values must
-// produce different derived tokens.
-TEST_F(BraveShieldsUtilTest,
-       FarblingToken_DifferentEntropy_ProducesDifferentDerivedTokens) {
-  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
-  constexpr std::array<uint8_t, 4> entropy_a = {0xAA, 0xBB, 0xCC, 0xDD};
-  constexpr std::array<uint8_t, 4> entropy_b = {0x11, 0x22, 0x33, 0x44};
-  const auto t1 = shields_service()->GetFarblingToken(
-      GURL("https://example.com"), entropy_a);
-  const auto t2 = shields_service()->GetFarblingToken(
-      GURL("https://example.com"), entropy_b);
-  EXPECT_NE(t1, t2);
-}
-
-// The base token (no entropy) is unaffected by what another origin's derived
-// token looks like: each origin owns its own stored base token.
-TEST_F(BraveShieldsUtilTest, FarblingToken_PerOrigin_TokensAreIndependent) {
-  brave_shields::ScopedStableFarblingTokensForTesting scoped_seed(1);
-  constexpr std::array<uint8_t, 4> entropy = {0x01, 0x02, 0x03, 0x04};
-  const auto derived_a =
-      shields_service()->GetFarblingToken(GURL("https://a.com"), entropy);
-  const auto derived_b =
-      shields_service()->GetFarblingToken(GURL("https://b.com"), entropy);
-  // Different origins → different base tokens → different derived tokens even
-  // with identical entropy.
-  EXPECT_NE(derived_a, derived_b);
 }


### PR DESCRIPTION
This is a purely **mechanical** change, which moves bunch for tests from one file to other.  It's follow-up on the prior move of `GetFarblingToken` out from brave_shields_utils to brave_shields_setting_service at https://github.com/brave/brave-core/pull/37937. 

This is needed as these tests are testing `GetFarblingToken` functionality which doesn't belong to brave_shields_utils anymore.

Related https://github.com/brave/brave-browser/issues/56839

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
