### PR TITLE
[bootstrap] Self-update vendored `node`/`npm`

### DIFF
--- a/EXTRA_DEPS
+++ b/EXTRA_DEPS
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Bucket-hosted archives Brave installs during checkout, inspired by gclient's
+# `gcs` dependency and loaded by `tools/cr/extra_deps.py`. Keyed by the
+# checkout-relative destination path; each entry:
+#
+#   bucket      an https prefix `object_name` is appended to.
+#   condition   dep-level gate (host_os/host_cpu/...); resolved during sync.
+#   objects     one or more archives, each with `object_name` + `sha256sum`, an
+#               optional per-object `condition`, and optional `overlayed_on`:
+#                 * overlayed_on -- extracted on top of that upstream archive.
+#                 * omitted      -- owns its destination (wiped each install).
+#
+# A single-object entry may omit its per-object `condition` and gate on the
+# dep-level one alone. This is a pure literal (parsed as data, not executed),
+# and is repinned textually -- keep it in the format `tools/cr/toolchain.py`'s
+# renderer emits.
+
+extra_deps = {
+    'src/third_party/rust-toolchain': {
+        'bucket': 'https://brave-build-deps-public.s3.brave.com/rust-toolchain-aux/',
+        'condition': 'not rust_force_head_revision',
+        'objects': [
+            {
+                'object_name': 'linux-x64-rust-toolchain-4c4205163abcbd08948b3efab796c543ba1ea687-5-llvmorg-23-init-10931-g20b6ec66-1.tar.xz',
+                'sha256sum': '9e8664e93466c21a3ffedfe4d9e5996a7c967b64575cd2145ab39a6cc3f0ec7f',
+                'overlayed_on': 'Linux_x64/rust-toolchain-4c4205163abcbd08948b3efab796c543ba1ea687-5-llvmorg-23-init-10931-g20b6ec66.tar.xz',
+                'condition': 'host_os == "linux"',
+            },
+            {
+                'object_name': 'mac-arm64-rust-toolchain-4c4205163abcbd08948b3efab796c543ba1ea687-5-llvmorg-23-init-10931-g20b6ec66-1.tar.xz',
+                'sha256sum': 'ed9e927ebde21a8b6f991b598e18050988a295a5f49e4db35ff70ce25e9ffeea',
+                'overlayed_on': 'Mac_arm64/rust-toolchain-4c4205163abcbd08948b3efab796c543ba1ea687-5-llvmorg-23-init-10931-g20b6ec66.tar.xz',
+                'condition': 'host_os == "mac" and host_cpu == "arm64"',
+            },
+            {
+                'object_name': 'mac-rust-toolchain-4c4205163abcbd08948b3efab796c543ba1ea687-5-llvmorg-23-init-10931-g20b6ec66-1.tar.xz',
+                'sha256sum': '6cc780e5baa3f2500633e4ee56dd3116d70c375455052b871ee71e2b90ecad62',
+                'overlayed_on': 'Mac/rust-toolchain-4c4205163abcbd08948b3efab796c543ba1ea687-5-llvmorg-23-init-10931-g20b6ec66.tar.xz',
+                'condition': 'host_os == "mac" and host_cpu == "x64"',
+            },
+            {
+                'object_name': 'win-rust-toolchain-4c4205163abcbd08948b3efab796c543ba1ea687-5-llvmorg-23-init-10931-g20b6ec66-1.tar.xz',
+                'sha256sum': '869f725b2591892218bcfe70e926e41586ac6bb7921b97b48a2b8cd6468ae569',
+                'overlayed_on': 'Win/rust-toolchain-4c4205163abcbd08948b3efab796c543ba1ea687-5-llvmorg-23-init-10931-g20b6ec66.tar.xz',
+                'condition': 'host_os == "win"',
+            },
+        ],
+    },
+    'src/brave/third_party/node/node-linux-x64': {
+        'bucket': 'https://brave-build-deps-public.s3.brave.com/nodejs/',
+        'condition': 'host_os == "linux"',
+        'objects': [
+            {
+                'object_name': 'node-v24.18.0-linux-x64.tar.gz',
+                'sha256sum': '2e8e150bf8ca55cc7b1d89c9d71138d57a1b7900c5687b3fb1e03d5e6ba1231c',
+            },
+        ],
+    },
+    'src/brave/third_party/node/node-mac-x64': {
+        'bucket': 'https://brave-build-deps-public.s3.brave.com/nodejs/',
+        'condition': 'host_os == "mac" and host_cpu == "x64"',
+        'objects': [
+            {
+                'object_name': 'node-v24.18.0-mac-x64.tar.gz',
+                'sha256sum': 'c33ce3dfc0fb84dd6b54ebd6fdc5646ae4358e164f11a80af3abf09d40954871',
+            },
+        ],
+    },
+    'src/brave/third_party/node/node-mac-arm64': {
+        'bucket': 'https://brave-build-deps-public.s3.brave.com/nodejs/',
+        'condition': 'host_os == "mac" and host_cpu == "arm64"',
+        'objects': [
+            {
+                'object_name': 'node-v24.18.0-mac-arm64.tar.gz',
+                'sha256sum': '96c7a5b4c9d096084137333fa5a964514d593f859d0328a574f4509d4e3d6522',
+            },
+        ],
+    },
+    'src/brave/third_party/node/node-win-x64': {
+        'bucket': 'https://brave-build-deps-public.s3.brave.com/nodejs/',
+        'condition': 'host_os == "win"',
+        'objects': [
+            {
+                'object_name': 'node-v24.18.0-win-x64.tar.gz',
+                'sha256sum': 'c0a0e3b9fe5cadfedc4c6e82943a3c1201460716449c8e4cd188256751cca386',
+            },
+        ],
+    },
+    'src/brave/third_party/ast-grep/ast-grep-linux': {
+        'bucket': 'https://brave-build-deps-public.s3.brave.com/ast-grep/',
+        'condition': 'host_os == "linux"',
+        'objects': [
+            {
+                'object_name': 'ast-grep-0.44.0-linux-x64.tar.gz',
+                'sha256sum': 'e5a2d23541d7591fe4ec01190097ca8283a87f4039520271e7cee1ad9998ba5c',
+            },
+        ],
+    },
+    'src/brave/third_party/ast-grep/ast-grep-mac': {
+        'bucket': 'https://brave-build-deps-public.s3.brave.com/ast-grep/',
+        'condition': 'host_os == "mac" and host_cpu == "x64"',
+        'objects': [
+            {
+                'object_name': 'ast-grep-0.44.0-mac.tar.gz',
+                'sha256sum': 'ad3f3bcae7a91ce070fbe6b934dbfcf35ec9cf004f9c6d7ecb907165669844e2',
+            },
+        ],
+    },
+    'src/brave/third_party/ast-grep/ast-grep-mac_arm64': {
+        'bucket': 'https://brave-build-deps-public.s3.brave.com/ast-grep/',
+        'condition': 'host_os == "mac" and host_cpu == "arm64"',
+        'objects': [
+            {
+                'object_name': 'ast-grep-0.44.0-mac-arm64.tar.gz',
+                'sha256sum': '5bcb3568679ea6c636298c2b3e1edb44d54a8483f51d5e1ad0778609ef97bea3',
+            },
+        ],
+    },
+    'src/brave/third_party/ast-grep/ast-grep-win': {
+        'bucket': 'https://brave-build-deps-public.s3.brave.com/ast-grep/',
+        'condition': 'host_os == "win"',
+        'objects': [
+            {
+                'object_name': 'ast-grep-0.44.0-win.tar.gz',
+                'sha256sum': '1a074eaa2c4ba0e6df2b7a505c45ef26b2605a1360d43c8c2ae4d31624013845',
+            },
+        ],
+    },
+}

--- a/tools/cr/bootstrap/README.md
+++ b/tools/cr/bootstrap/README.md
@@ -58,3 +58,11 @@ node --version                    # runs third_party/node's node
 cd /tmp
 node --version                    # falls back to the system node
 ```
+
+## The chicken-and-egg `node` problem
+
+The shims for `node`/`npm` run cheap checks for the tarball installations, to
+determine if a new file needs to be downloaded. This is done through the
+`EXTRA_DEPS` mechanism itself, which makes this a lightweight sync check. For
+repos with no mechanism for self-updating, the path resolution degrades back to
+whatever is the system underlying binaries.

--- a/tools/cr/bootstrap/bootstrap_test.py
+++ b/tools/cr/bootstrap/bootstrap_test.py
@@ -7,9 +7,12 @@
 
 from __future__ import annotations
 
+import contextlib
+import io
 import os
 from pathlib import Path
 import platform
+import shutil
 import stat
 import tempfile
 import unittest
@@ -409,6 +412,271 @@ class ResolveInvocationTest(unittest.TestCase):
             launcher.resolve_invocation('bogus', None, False)
         with self.assertRaises(launcher.UnknownShimError):
             launcher.resolve_invocation('bogus', None, True)
+
+    def _make_installer(self, checkout: Path) -> None:
+        """Create an empty tarball_installer.py so the bootstrap is attempted."""
+        installer = checkout / 'tools' / 'cr' / 'tarball_installer.py'
+        installer.parent.mkdir(parents=True, exist_ok=True)
+        installer.write_text('', encoding='utf-8', newline='')
+
+    def test_bootstraps_missing_node_then_resolves(self):
+        # A missing node target with a known self_update_extra_dep_entry triggers a download
+        # (install_extra_deps.py), after which the vendored node resolves.
+        with tempfile.TemporaryDirectory() as tmp:
+            root, key = Path(tmp), self._key()
+            checkout = self._checkout(root)
+            self._make_installer(checkout)
+            dep = launcher.SHIM_TARGETS[
+                f'node-{key}'].self_update_extra_dep_entry
+
+            def _fake_download(_argv):
+                # Simulate the installer deploying the node target.
+                self._make_target(root, f'node-{key}')
+                return 0
+
+            with mock.patch.object(launcher.SelfUpdater,
+                                   '_load_extra_deps',
+                                   return_value=self._fake_extra_deps(
+                                       dep, deployed=False)):
+                with mock.patch.object(launcher.subprocess,
+                                       'call',
+                                       side_effect=_fake_download) as call:
+                    with contextlib.redirect_stderr(io.StringIO()):
+                        invocation = launcher.resolve_invocation(
+                            f'node-{key}', checkout, False)
+            call.assert_called_once()
+            self.assertEqual(
+                invocation,
+                [str(root / launcher.SHIM_TARGETS[f'node-{key}'].path)])
+
+    def test_missing_node_falls_back_when_download_deploys_nothing(self):
+        # The bootstrap is attempted but deploys no node; with fallback allowed
+        # the system node is used instead.
+        with tempfile.TemporaryDirectory() as tmp:
+            root, key = Path(tmp), self._key()
+            checkout = self._checkout(root)
+            self._make_installer(checkout)
+            dep = launcher.SHIM_TARGETS[
+                f'node-{key}'].self_update_extra_dep_entry
+            with mock.patch.object(launcher.SelfUpdater,
+                                   '_load_extra_deps',
+                                   return_value=self._fake_extra_deps(
+                                       dep, deployed=False)):
+                with mock.patch.object(launcher.subprocess,
+                                       'call',
+                                       return_value=1) as call:
+                    with mock.patch.object(launcher.shutil,
+                                           'which',
+                                           return_value='/usr/bin/node'):
+                        with contextlib.redirect_stderr(io.StringIO()):
+                            invocation = launcher.resolve_invocation(
+                                'node', checkout, True)
+            call.assert_called_once()
+            self.assertEqual(invocation, ['/usr/bin/node'])
+
+    def test_no_bootstrap_without_installer(self):
+        # With no install_extra_deps.py present the bootstrap is a no-op, and
+        # with no fallback the result is None.
+        with tempfile.TemporaryDirectory() as tmp:
+            root, key = Path(tmp), self._key()
+            with mock.patch.object(launcher.subprocess, 'call') as call:
+                self.assertIsNone(
+                    launcher.resolve_invocation(f'node-{key}',
+                                                self._checkout(root), False))
+            call.assert_not_called()
+
+    def test_no_bootstrap_when_checkout_lacks_extra_deps(self):
+        # An older/divergent checkout whose install_extra_deps.py predates
+        # `extra_deps.py` must NOT be handed this shim's baked-in key (its
+        # installer may use different EXTRA_DEPS keys): no bootstrap is tried,
+        # and with fallback allowed the system tool is used.
+        if launcher.host_platform_key() is None:
+            self.skipTest('no node shim on this host')
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            checkout = self._checkout(root)
+            self._make_installer(checkout)  # installer present, extra_deps not
+            with mock.patch.object(launcher.subprocess, 'call') as call:
+                with mock.patch.object(launcher.shutil,
+                                       'which',
+                                       return_value='/usr/bin/node'):
+                    invocation = launcher.resolve_invocation(
+                        'node', checkout, True)
+            call.assert_not_called()
+            self.assertEqual(invocation, ['/usr/bin/node'])
+
+    def test_vpython_tool_not_bootstrapped(self):
+        # Only node/npm carry an self_update_extra_dep_entry; a missing vpython tool is never
+        # bootstrapped (it ships in the repo, it is not downloaded).
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.object(launcher.subprocess, 'call') as call:
+                launcher.resolve_invocation('brockit',
+                                            self._checkout(Path(tmp)), False)
+            call.assert_not_called()
+
+    def _fake_extra_deps(self, dep: str, deployed: bool) -> mock.Mock:
+        """A stand-in `extra_deps` module reporting `deployed` for `dep`."""
+        module = mock.Mock()
+        module.EXTRA_DEPS = {dep: {'objects': [{}]}}
+        module.check_extra_deps_installed.return_value = deployed
+        return module
+
+    def test_stale_version_triggers_bootstrap_even_when_present(self):
+        # The node binary exists, but the sidecar/version check says it is not
+        # the pinned version -> bootstrap runs anyway (a bare is_file() would
+        # wrongly skip it).
+        with tempfile.TemporaryDirectory() as tmp:
+            root, key = Path(tmp), self._key()
+            checkout = self._checkout(root)
+            self._make_installer(checkout)
+            self._make_target(root, f'node-{key}')  # present but "stale"
+            dep = launcher.SHIM_TARGETS[
+                f'node-{key}'].self_update_extra_dep_entry
+            module = self._fake_extra_deps(dep, deployed=False)
+            with mock.patch.object(launcher.SelfUpdater,
+                                   '_load_extra_deps',
+                                   return_value=module):
+                with mock.patch.object(launcher.subprocess,
+                                       'call',
+                                       return_value=0) as call:
+                    with contextlib.redirect_stderr(io.StringIO()):
+                        invocation = launcher.resolve_invocation(
+                            f'node-{key}', checkout, False)
+            call.assert_called_once()
+            self.assertEqual(
+                invocation,
+                [str(root / launcher.SHIM_TARGETS[f'node-{key}'].path)])
+
+    def test_pinned_version_deployed_skips_bootstrap(self):
+        # The version check says the pinned node is deployed -> no bootstrap.
+        with tempfile.TemporaryDirectory() as tmp:
+            root, key = Path(tmp), self._key()
+            checkout = self._checkout(root)
+            self._make_installer(checkout)
+            self._make_target(root, f'node-{key}')
+            dep = launcher.SHIM_TARGETS[
+                f'node-{key}'].self_update_extra_dep_entry
+            module = self._fake_extra_deps(dep, deployed=True)
+            with mock.patch.object(launcher.SelfUpdater,
+                                   '_load_extra_deps',
+                                   return_value=module):
+                with mock.patch.object(launcher.subprocess, 'call') as call:
+                    invocation = launcher.resolve_invocation(
+                        f'node-{key}', checkout, False)
+            call.assert_not_called()
+            self.assertEqual(
+                invocation,
+                [str(root / launcher.SHIM_TARGETS[f'node-{key}'].path)])
+
+    def test_load_extra_deps_reads_checkout_module(self):
+        # `SelfUpdater._load_extra_deps` loads the module by path from the
+        # governing checkout (not the launcher's own), stdlib-only.
+        with tempfile.TemporaryDirectory() as tmp:
+            checkout = self._checkout(Path(tmp))
+            module_path = checkout / 'tools' / 'cr' / 'extra_deps.py'
+            module_path.parent.mkdir(parents=True, exist_ok=True)
+            module_path.write_text(
+                'EXTRA_DEPS = {"x": 1}\n'
+                'def check_extra_deps_installed(root, path):\n'
+                '    return True\n',
+                encoding='utf-8',
+                newline='')
+            module = launcher.SelfUpdater(checkout, 'src/x')._load_extra_deps()
+            self.assertIsNotNone(module)
+            self.assertEqual(module.EXTRA_DEPS, {'x': 1})
+
+    def test_load_extra_deps_missing_returns_none(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            updater = launcher.SelfUpdater(self._checkout(Path(tmp)), 'src/x')
+            self.assertIsNone(updater._load_extra_deps())
+
+    def test_needs_update_false_when_entry_absent_from_table(self):
+        # An entry the checkout's EXTRA_DEPS does not pin raises KeyError from
+        # check_extra_deps_installed; needs_update() swallows it and self-update
+        # is not attempted.
+        updater = launcher.SelfUpdater(Path('/ws/src/brave'), 'src/absent')
+        module = mock.Mock()
+        module.check_extra_deps_installed.side_effect = KeyError('src/absent')
+        with mock.patch.object(launcher.SelfUpdater,
+                               '_load_extra_deps',
+                               return_value=module):
+            self.assertFalse(updater.needs_update())
+
+
+class MultiRepoSelfUpdaterTest(unittest.TestCase):
+    """`SelfUpdater` resolves the `extra_deps` table, the sidecar tree, and the
+    installer in the *target* checkout it is given -- never in the checkout
+    `launcher.py` itself lives in. One installed shim serves many checkouts, so
+    it must always talk to the tree governing the current directory.
+    """
+
+    NODE = 'src/brave/third_party/node/node-linux-x64'
+
+    # `tools/cr` of the checkout launcher.py lives in (its "own" checkout).
+    _OWN_CR = Path(launcher.__file__).resolve().parents[1]
+
+    def _target_cr(self, root: Path) -> Path:
+        cr = root / 'src' / 'brave' / 'tools' / 'cr'
+        cr.mkdir(parents=True, exist_ok=True)
+        return cr
+
+    def test_load_extra_deps_reads_the_target_checkout(self):
+        # The target pins a made-up table; the loaded module must be that one,
+        # not the launcher's own (which pins the real node entries).
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (self._target_cr(root) / 'extra_deps.py').write_text(
+                'EXTRA_DEPS = {"src/only/in/target": 1}\n',
+                encoding='utf-8',
+                newline='')
+            checkout = root / 'src' / 'brave'
+            module = launcher.SelfUpdater(checkout, 'x')._load_extra_deps()
+            self.assertEqual(module.EXTRA_DEPS, {'src/only/in/target': 1})
+            self.assertNotIn(self.NODE, module.EXTRA_DEPS)
+
+    def test_deploy_runs_the_target_checkout_installer(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (self._target_cr(root) / 'tarball_installer.py').write_text(
+                '', encoding='utf-8', newline='')
+            checkout = root / 'src' / 'brave'
+            with mock.patch.object(launcher.subprocess, 'call',
+                                   return_value=0) as call:
+                launcher.SelfUpdater(checkout, 'src/dep').deploy()
+            argv = call.call_args.args[0]
+            self.assertEqual(
+                Path(argv[1]),
+                checkout / 'tools' / 'cr' / 'tarball_installer.py')
+            self.assertEqual(argv[2], 'src/dep')
+            # Emphatically not the launcher's own installer.
+            self.assertNotEqual(Path(argv[1]),
+                                self._OWN_CR / 'tarball_installer.py')
+
+    def test_needs_update_reads_the_target_sidecar_tree(self):
+        # Copy the real `extra_deps` into a target checkout with node NOT
+        # deployed: needs_update() is True even though the launcher's own
+        # checkout has node deployed -- so the sidecar lookup is rooted at the
+        # target's workspace root, not the launcher's.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            checkout = root / 'src' / 'brave'
+            # `extra_deps.py` loads the sibling `EXTRA_DEPS` data file, so the
+            # target checkout needs both.
+            shutil.copy(self._OWN_CR / 'extra_deps.py',
+                        self._target_cr(root) / 'extra_deps.py')
+            shutil.copy(self._OWN_CR.parent.parent / 'EXTRA_DEPS',
+                        checkout / 'EXTRA_DEPS')
+            updater = launcher.SelfUpdater(checkout, self.NODE)
+            self.assertTrue(updater.needs_update())
+
+            # Seed the target's sidecar for the pinned object -> now deployed.
+            module = updater._load_extra_deps()
+            obj = module.EXTRA_DEPS[self.NODE]['objects'][0]
+            dest = root / self.NODE
+            dest.mkdir(parents=True, exist_ok=True)
+            module.sidecar_path(dest, obj['object_name'],
+                                '_hash').write_text(obj['sha256sum'] + '\n')
+            self.assertFalse(updater.needs_update())
 
 
 class ArgumentForwardingTest(unittest.TestCase):

--- a/tools/cr/bootstrap/launcher.py
+++ b/tools/cr/bootstrap/launcher.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+import importlib.util
 import os
 from pathlib import Path
 import platform
@@ -44,6 +45,10 @@ class Shim:
     #   None      — `path` is itself the executable (node)
     runtime: str | None = None
 
+    # The `EXTRA_DEPS` entry to verify the freshness of the underlying target
+    # for a particular shim, so we can self-update at shim use.
+    self_update_extra_dep_entry: str | None = None
+
 
 # SHIM_TARGETS maps the shims we have with their desired targets. The keys are
 # the names of the shims. Platform-specific suffixes are used for shims that
@@ -52,23 +57,38 @@ SHIM_TARGETS: dict[str, Shim] = {
     'brockit': Shim('src/brave/tools/cr/brockit.py', 'vpython'),
     'plaster': Shim('src/brave/tools/cr/plaster.py', 'vpython'),
     'git-cr': Shim('src/brave/tools/cr/alias/cmd.py', 'vpython'),
-    'node-linux': Shim('src/brave/third_party/node/node-linux-x64/bin/node'),
-    'node-mac': Shim('src/brave/third_party/node/node-mac-x64/bin/node'),
+    'node-linux': Shim(
+        'src/brave/third_party/node/node-linux-x64/bin/node',
+        self_update_extra_dep_entry='src/brave/third_party/node/node-linux-x64'
+    ),
+    'node-mac': Shim(
+        'src/brave/third_party/node/node-mac-x64/bin/node',
+        self_update_extra_dep_entry='src/brave/third_party/node/node-mac-x64'),
     'node-mac_arm64': Shim(
-        'src/brave/third_party/node/node-mac-arm64/bin/node'),
-    'node-win': Shim('src/brave/third_party/node/node-win-x64/node.exe'),
+        'src/brave/third_party/node/node-mac-arm64/bin/node',
+        self_update_extra_dep_entry='src/brave/third_party/node/node-mac-arm64'
+    ),
+    'node-win': Shim(
+        'src/brave/third_party/node/node-win-x64/node.exe',
+        self_update_extra_dep_entry='src/brave/third_party/node/node-win-x64'),
     'npm-linux': Shim(
         'src/brave/third_party/node/node-linux-x64/lib/node_modules/npm/bin/npm-cli.js',
-        'node'),
+        'node',
+        self_update_extra_dep_entry='src/brave/third_party/node/node-linux-x64'
+    ),
     'npm-mac': Shim(
         'src/brave/third_party/node/node-mac-x64/lib/node_modules/npm/bin/npm-cli.js',
-        'node'),
+        'node',
+        self_update_extra_dep_entry='src/brave/third_party/node/node-mac-x64'),
     'npm-mac_arm64': Shim(
         'src/brave/third_party/node/node-mac-arm64/lib/node_modules/npm/bin/npm-cli.js',
-        'node'),
+        'node',
+        self_update_extra_dep_entry='src/brave/third_party/node/node-mac-arm64'
+    ),
     'npm-win': Shim(
         'src/brave/third_party/node/node-win-x64/node_modules/npm/bin/npm-cli.js',
-        'node'),
+        'node',
+        self_update_extra_dep_entry='src/brave/third_party/node/node-win-x64'),
 }
 
 
@@ -146,6 +166,82 @@ def _resolve_system_binary(tool: str,
     return shutil.which(tool, path=os.pathsep.join(entries))
 
 
+@dataclass(frozen=True)
+class SelfUpdater:
+    """Self-updates a shim's vendored `EXTRA_DEPS` target within a checkout.
+
+    Runs cheap checks to check if a certain shim target is deployed and fresh,
+    and if not, runs `tarball_installer.py` to fetch and deploy the pinned
+    version.
+
+    This class uses python files in the target checkout, loading and launching
+    them as needed.
+    """
+
+    # The `brave-core` checkout governing the current directory.
+    checkout: Path
+
+    # The single-object `EXTRA_DEPS` key this updater checks and deploys.
+    entry: str
+
+    def needs_update(self) -> bool:
+        """Whether `entry` is not deployed at the pinned version, per the
+        checkout's own `extra_deps`.
+
+        A cheap sidecar check. Returns False when the entry is up-to-date, when
+        the `extra_deps` module is missing, as that indicates we have an old
+        checkout of brave as a target.
+        """
+        module = self._load_extra_deps()
+        if module is None:
+            return False
+        try:
+            return not module.check_extra_deps_installed(
+                self.checkout.parent.parent, self.entry)
+        except (AttributeError, KeyError, ValueError, OSError):
+            return False
+
+    def deploy(self) -> None:
+        """Deploy the single-object `EXTRA_DEPS` `entry` into the checkout.
+
+        Runs `tarball_installer.py` with the same runtime the launcher is
+        using, assuming a bare, stdlib-only environment.
+        """
+        installer = self.checkout / 'tools' / 'cr' / 'tarball_installer.py'
+        if not installer.is_file():
+            return
+        try:
+            subprocess.call([sys.executable, str(installer), self.entry])
+        except OSError as error:
+            sys.stderr.write(
+                f'launcher.py: could not run tarball_installer.py: {error}\n')
+
+    def _load_extra_deps(self):
+        """Import the checkout's stdlib-only `extra_deps` module, or None.
+
+        This function loads `EXTRA_DEPS` and its module, so a check can be done
+        for the freshness of the install.
+        """
+        module_path = self.checkout / 'tools' / 'cr' / 'extra_deps.py'
+        if not module_path.is_file():
+            return None
+        spec = importlib.util.spec_from_file_location('brave_extra_deps',
+                                                      module_path)
+        if spec is None or spec.loader is None:
+            return None
+        module = importlib.util.module_from_spec(spec)
+        # Registered only for `exec` (definitions may consult `sys.modules`),
+        # then popped so no shared key lingers across checkouts.
+        sys.modules[spec.name] = module
+        try:
+            spec.loader.exec_module(module)
+        except (OSError, SyntaxError, ValueError):
+            return None
+        finally:
+            sys.modules.pop(spec.name, None)
+        return module
+
+
 def resolve_invocation(tool: str, checkout: Path | None,
                        allow_fallback: bool) -> list[str] | None:
     """The argv prefix to run `tool` from `checkout`.
@@ -159,6 +255,12 @@ def resolve_invocation(tool: str, checkout: Path | None,
     invocation = None
     if checkout is not None:
         target = checkout.parent.parent / shim.path
+        # Any target with `self_update_extra_dep_entry` is self-updatable.
+        entry = shim.self_update_extra_dep_entry
+        if entry is not None:
+            updater = SelfUpdater(checkout, entry)
+            if updater.needs_update():
+                updater.deploy()
         if target.is_file():
             if shim.runtime == 'vpython':
                 invocation = [

--- a/tools/cr/extra_deps.py
+++ b/tools/cr/extra_deps.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Loads the `EXTRA_DEPS` table and provides the cheap deployment check.
+
+`EXTRA_DEPS` itself lives in the sibling `src/brave/EXTRA_DEPS` data file (see
+its header for the entry schema); it is loaded here as data, never executed, so
+this module stays stdlib-only and importable under plain `python3`.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+# The extension we use for all sidecar files. Using stamp is deliberate to avoid
+# having gclient trying to read our sidecars.
+_STAMP = '.stamp'
+
+# Our EXTRA_DEPS file at the root of the repo.
+_EXTRA_DEPS_FILE = Path(__file__).resolve().parents[2] / 'EXTRA_DEPS'
+
+
+def _load_extra_deps() -> dict:
+    """Load the `extra_deps` literal from `_EXTRA_DEPS_FILE`.
+
+    The file is a pure declarative table: its `extra_deps = {...}` assignment is
+    read with `ast.literal_eval`, never executed.
+    """
+    source = _EXTRA_DEPS_FILE.read_text(encoding='utf-8')
+    for node in ast.parse(source).body:
+        if (isinstance(node, ast.Assign) and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)
+                and node.targets[0].id == 'extra_deps'):
+            return ast.literal_eval(node.value)
+    raise ValueError(f'No extra_deps assignment found in {_EXTRA_DEPS_FILE}')
+
+
+EXTRA_DEPS = _load_extra_deps()
+
+
+def sidecar_path(dest_dir: Path, object_name: str, suffix: str) -> Path:
+    """The `.{prefix}{suffix}.stamp` sidecar path in `dest_dir`.
+
+    `prefix` is the object name with every `/` and `.` mapped to `_`, matching
+    how gclient keys the sidecars it drops beside a `gcs` dep's extracted tree.
+    """
+    prefix = object_name.replace('/', '_').replace('.', '_')
+    return dest_dir / f'.{prefix}{suffix}{_STAMP}'
+
+
+def is_deployed(dest_dir: Path, object_name: str, sha256sum: str) -> bool:
+    """True when `dest_dir` holds `object_name` at `sha256sum`.
+
+    The cheapest possible check: it reads the `_hash` sidecar and compares, so
+    it reports whether the pinned version is deployed (not merely that files
+    exist).
+    """
+    hash_file = sidecar_path(dest_dir, object_name, '_hash')
+    if not hash_file.is_file():
+        return False
+    return hash_file.read_bytes().decode('utf-8').strip() == sha256sum
+
+
+def check_extra_deps_installed(root: Path, path: str) -> bool:
+    """Whether the entry `path` is already deployed under `root`.
+
+    `root` is the workspace root (the parent of `src`); `path` is the entry's
+    key in `EXTRA_DEPS`. Raises `KeyError` if `path` is not a known entry, and
+    `ValueError` for a multi-object entry -- picking one of its objects needs
+    host-condition resolution this check does not do.
+    """
+    objects = EXTRA_DEPS[path]['objects']
+    if len(objects) != 1:
+        raise ValueError(
+            f'{path}: check_extra_deps_installed supports single-object '
+            f'entries only, but this one has {len(objects)}')
+    obj = objects[0]
+    return is_deployed(root / path, obj['object_name'], obj['sha256sum'])

--- a/tools/cr/extra_deps_test.py
+++ b/tools/cr/extra_deps_test.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for the stdlib-only `extra_deps` module.
+
+Covers the sidecar helpers and the gclient-free `check_extra_deps_installed` check,
+plus a guard that the node entries stay cheaply checkable (single-object), as
+the bootstrap shims rely on.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+# `extra_deps` lives beside this test at the `tools/cr` root.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import extra_deps as m
+
+
+class SidecarTest(unittest.TestCase):
+    """Tests for `sidecar_path` and the `is_deployed` sidecar check."""
+
+    def test_sidecar_path_maps_dots_and_slashes(self):
+        """The sidecar prefix maps every `/` and `.` to `_` (matching gclient's
+        keying) and carries the `.stamp` tail."""
+        self.assertEqual(
+            m.sidecar_path(Path('/d'), 'Linux_x64/pkg.tar.gz', '_hash').name,
+            '.Linux_x64_pkg_tar_gz_hash.stamp')
+
+    def test_is_deployed_true_when_hash_matches(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp)
+            m.sidecar_path(dest, 'pkg.tar.gz', '_hash').write_text('abc\n')
+            self.assertTrue(m.is_deployed(dest, 'pkg.tar.gz', 'abc'))
+
+    def test_is_deployed_false_without_sidecar(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertFalse(m.is_deployed(Path(tmp), 'pkg.tar.gz', 'abc'))
+
+    def test_is_deployed_false_on_hash_mismatch(self):
+        """A sidecar recording a different sha (a rolled version) is stale."""
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp)
+            m.sidecar_path(dest, 'pkg.tar.gz', '_hash').write_text('old\n')
+            self.assertFalse(m.is_deployed(dest, 'pkg.tar.gz', 'new'))
+
+
+class CheapInstallStateTest(unittest.TestCase):
+    """Tests for the gclient-free `check_extra_deps_installed` sidecar check.
+
+    A temp dir stands in for the workspace root, so the sidecar lookup lands
+    there. No conditions are resolved: the check answers purely from the sidecar
+    under `root / path`.
+    """
+
+    PATH = 'src/brave/third_party/node/node-linux-x64'
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        # The workspace root (the parent of `src`).
+        self.root = Path(tmp.name)
+
+    def _spec(self,
+              *,
+              objects: list[dict] | None = None,
+              object_name: str = 'node.tar.gz',
+              sha256sum: str = 'abc') -> dict:
+        if objects is None:
+            objects = [{'object_name': object_name, 'sha256sum': sha256sum}]
+        return {'bucket': 'https://downloads.invalid/', 'objects': objects}
+
+    def _seed(self, spec: dict) -> None:
+        """Write the `_hash` sidecar so the entry reads as already deployed."""
+        obj = spec['objects'][0]
+        dest = self.root / self.PATH
+        dest.mkdir(parents=True, exist_ok=True)
+        m.sidecar_path(dest, obj['object_name'],
+                       '_hash').write_text(obj['sha256sum'] + '\n')
+
+    def _check(self, spec: dict) -> bool:
+        """`check_extra_deps_installed` looks the entry up in `EXTRA_DEPS`, so
+        patch the table to `spec` for `PATH`."""
+        with mock.patch.object(m, 'EXTRA_DEPS', {self.PATH: spec}):
+            return m.check_extra_deps_installed(self.root, self.PATH)
+
+    def test_installed_returns_true(self):
+        spec = self._spec()
+        self._seed(spec)
+        self.assertTrue(self._check(spec))
+
+    def test_missing_returns_false(self):
+        self.assertFalse(self._check(self._spec()))
+
+    def test_hash_mismatch_returns_false(self):
+        self._seed(self._spec(sha256sum='old'))
+        self.assertFalse(self._check(self._spec(sha256sum='new')))
+
+    def test_unknown_entry_raises(self):
+        with mock.patch.object(m, 'EXTRA_DEPS', {}):
+            with self.assertRaises(KeyError):
+                m.check_extra_deps_installed(self.root, self.PATH)
+
+    def test_multiple_objects_raises(self):
+        spec = self._spec(objects=[
+            {
+                'object_name': 'a.tar.gz',
+                'sha256sum': 'a',
+                'condition': 'host_os == "linux"'
+            },
+            {
+                'object_name': 'b.tar.gz',
+                'sha256sum': 'b',
+                'condition': 'host_os == "mac"'
+            },
+        ])
+        with self.assertRaisesRegex(ValueError, 'single-object'):
+            self._check(spec)
+
+
+class ExtraDepsTableTest(unittest.TestCase):
+    """Guards on the shared `EXTRA_DEPS` table itself."""
+
+    def test_node_entries_are_single_object(self):
+        """The bootstrap shims check node via `check_extra_deps_installed`, which only
+        supports single-object entries, so the node entries must stay so."""
+        node_entries = [path for path in m.EXTRA_DEPS if '/node/' in path]
+        self.assertTrue(node_entries)
+        for path in node_entries:
+            self.assertEqual(len(m.EXTRA_DEPS[path]['objects']), 1, path)
+
+    def test_all_buckets_are_https(self):
+        """Downloads must be over https; the installer refuses anything else."""
+        for path, spec in m.EXTRA_DEPS.items():
+            self.assertTrue(spec['bucket'].startswith('https://'), path)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/cr/install_extra_deps.py
+++ b/tools/cr/install_extra_deps.py
@@ -9,182 +9,39 @@ This is a small, general-purpose installer for archives Brave publishes to its
 own download bucket, similar to gclient's `gcs` dependency types. This mechanism
 was first written for the Rust/WASM toolchain, and to make the process of having
 it deployed more generic, and reusable for other cases.
-
-`EXTRA_DEPS` mirrors the shape of a gclient `gcs` dependency, keyed by the
-checkout-relative destination path. Each object lists an `object_name`, its
-`sha256sum`, an optional per-object `condition`, and optionally `overlayed_on`,
-which selects how it is installed:
-
-  * Overlay (with `overlayed_on`) -- extracted on top of the upstream archive it
-    names, which is validated against DEPS so we never overlay a rolled base.
-  * Owned (without `overlayed_on`) -- fully owns its destination, which is wiped
-    and re-extracted each install so no stale extraction lingers.
-
-An entry with a single object may omit its per-object `condition` and gate on
-the dep-level `condition` alone.
-
-`bucket` is just an HTTPS prefix `object_name` is appended to: one of Brave's
-buckets, or an upstream distribution (e.g. `nodejs.org/dist`) used as one.
-
-`condition` strings (both dep-level and per-object) are resolved with
-depot_tools by loading the checkout's `.gclient` config and the owning
-solution's DEPS, so every variable resolves exactly as it would during a real
-`gclient sync`.
 """
 
 from __future__ import annotations
 
 import argparse
 from collections.abc import Mapping
-from dataclasses import dataclass
-import json
 import logging
-import shutil
 import sys
-import tarfile
-import tempfile
-import zipfile
 from pathlib import Path
 
 # `src/` directory (this script lives at src/brave/tools/cr/).
 _SRC_DIR = Path(__file__).resolve().parents[3]
 
-# Importing script and depot_tools explicitly, so we can call this script from
-# the terminal without needing to set up the PYTHONPATH. `depot_tools` is
-# inserted at the front so its `third_party` package (which provides
-# `third_party.schema`, needed by gclient_eval) is not shadowed by the
-# `third_party` package in the vpython virtualenv.
-sys.path.append(str(Path(__file__).resolve().parents[2] / 'script'))
+# Importing depot_tools explicitly, so we can call this script from the terminal
+# without needing to set up the PYTHONPATH. `depot_tools` is inserted at the
+# front so its `third_party` package (which provides `third_party.schema`,
+# needed by gclient_eval) is not shadowed by the `third_party` package in the
+# vpython virtualenv.
 sys.path.insert(0, str(_SRC_DIR / 'third_party' / 'depot_tools'))
 
-import deps  # pylint: disable=wrong-import-position
 import gclient  # pylint: disable=wrong-import-position,import-error
 import gclient_eval  # pylint: disable=wrong-import-position,import-error
 import gclient_paths  # pylint: disable=wrong-import-position,import-error
 import gclient_utils  # pylint: disable=wrong-import-position,import-error
 
+from extra_deps import EXTRA_DEPS  # pylint: disable=wrong-import-position
+from tarball_installer import (  # pylint: disable=wrong-import-position
+    TarballInstaller)
+
 # This script's own logger, so we don't step on gclient's logger. It is also of
 # notice that most logs are DEBUG. No-op runs should not produce any output in
 # normal runs, to avoid cluttering the sync output.
 _LOG = logging.getLogger('install_extra_deps')
-
-# The extension we use for all sidecar files. Using stamp is deliberate to avoid
-# having gclient trying to read our sidecars.
-_STAMP = '.stamp'
-
-
-EXTRA_DEPS = {
-    'src/third_party/rust-toolchain': {
-        'bucket': 'https://brave-build-deps-public.s3.brave.com/rust-toolchain-aux/',
-        'condition': 'not rust_force_head_revision',
-        'objects': [
-            {
-                'object_name': 'linux-x64-rust-toolchain-4c4205163abcbd08948b3efab796c543ba1ea687-5-llvmorg-23-init-10931-g20b6ec66-1.tar.xz',
-                'sha256sum': '9e8664e93466c21a3ffedfe4d9e5996a7c967b64575cd2145ab39a6cc3f0ec7f',
-                'overlayed_on': 'Linux_x64/rust-toolchain-4c4205163abcbd08948b3efab796c543ba1ea687-5-llvmorg-23-init-10931-g20b6ec66.tar.xz',
-                'condition': 'host_os == "linux"',
-            },
-            {
-                'object_name': 'mac-arm64-rust-toolchain-4c4205163abcbd08948b3efab796c543ba1ea687-5-llvmorg-23-init-10931-g20b6ec66-1.tar.xz',
-                'sha256sum': 'ed9e927ebde21a8b6f991b598e18050988a295a5f49e4db35ff70ce25e9ffeea',
-                'overlayed_on': 'Mac_arm64/rust-toolchain-4c4205163abcbd08948b3efab796c543ba1ea687-5-llvmorg-23-init-10931-g20b6ec66.tar.xz',
-                'condition': 'host_os == "mac" and host_cpu == "arm64"',
-            },
-            {
-                'object_name': 'mac-rust-toolchain-4c4205163abcbd08948b3efab796c543ba1ea687-5-llvmorg-23-init-10931-g20b6ec66-1.tar.xz',
-                'sha256sum': '6cc780e5baa3f2500633e4ee56dd3116d70c375455052b871ee71e2b90ecad62',
-                'overlayed_on': 'Mac/rust-toolchain-4c4205163abcbd08948b3efab796c543ba1ea687-5-llvmorg-23-init-10931-g20b6ec66.tar.xz',
-                'condition': 'host_os == "mac" and host_cpu == "x64"',
-            },
-            {
-                'object_name': 'win-rust-toolchain-4c4205163abcbd08948b3efab796c543ba1ea687-5-llvmorg-23-init-10931-g20b6ec66-1.tar.xz',
-                'sha256sum': '869f725b2591892218bcfe70e926e41586ac6bb7921b97b48a2b8cd6468ae569',
-                'overlayed_on': 'Win/rust-toolchain-4c4205163abcbd08948b3efab796c543ba1ea687-5-llvmorg-23-init-10931-g20b6ec66.tar.xz',
-                'condition': 'host_os == "win"',
-            },
-        ],
-    },
-    'src/brave/third_party/node/node-linux-x64': {
-        'bucket': 'https://brave-build-deps-public.s3.brave.com/nodejs/',
-        'condition': 'host_os == "linux"',
-        'objects': [
-            {
-                'object_name': 'node-v24.18.0-linux-x64.tar.gz',
-                'sha256sum': '2e8e150bf8ca55cc7b1d89c9d71138d57a1b7900c5687b3fb1e03d5e6ba1231c',
-            },
-        ],
-    },
-    'src/brave/third_party/node/node-mac-x64': {
-        'bucket': 'https://brave-build-deps-public.s3.brave.com/nodejs/',
-        'condition': 'host_os == "mac" and host_cpu == "x64"',
-        'objects': [
-            {
-                'object_name': 'node-v24.18.0-mac-x64.tar.gz',
-                'sha256sum': 'c33ce3dfc0fb84dd6b54ebd6fdc5646ae4358e164f11a80af3abf09d40954871',
-            },
-        ],
-    },
-    'src/brave/third_party/node/node-mac-arm64': {
-        'bucket': 'https://brave-build-deps-public.s3.brave.com/nodejs/',
-        'condition': 'host_os == "mac" and host_cpu == "arm64"',
-        'objects': [
-            {
-                'object_name': 'node-v24.18.0-mac-arm64.tar.gz',
-                'sha256sum': '96c7a5b4c9d096084137333fa5a964514d593f859d0328a574f4509d4e3d6522',
-            },
-        ],
-    },
-    'src/brave/third_party/node/node-win-x64': {
-        'bucket': 'https://brave-build-deps-public.s3.brave.com/nodejs/',
-        'condition': 'host_os == "win"',
-        'objects': [
-            {
-                'object_name': 'node-v24.18.0-win-x64.tar.gz',
-                'sha256sum': 'c0a0e3b9fe5cadfedc4c6e82943a3c1201460716449c8e4cd188256751cca386',
-            },
-        ],
-    },
-    'src/brave/third_party/ast-grep/ast-grep-linux': {
-        'bucket': 'https://brave-build-deps-public.s3.brave.com/ast-grep/',
-        'condition': 'host_os == "linux"',
-        'objects': [
-            {
-                'object_name': 'ast-grep-0.44.0-linux-x64.tar.gz',
-                'sha256sum': 'e5a2d23541d7591fe4ec01190097ca8283a87f4039520271e7cee1ad9998ba5c',
-            },
-        ],
-    },
-    'src/brave/third_party/ast-grep/ast-grep-mac': {
-        'bucket': 'https://brave-build-deps-public.s3.brave.com/ast-grep/',
-        'condition': 'host_os == "mac" and host_cpu == "x64"',
-        'objects': [
-            {
-                'object_name': 'ast-grep-0.44.0-mac.tar.gz',
-                'sha256sum': 'ad3f3bcae7a91ce070fbe6b934dbfcf35ec9cf004f9c6d7ecb907165669844e2',
-            },
-        ],
-    },
-    'src/brave/third_party/ast-grep/ast-grep-mac_arm64': {
-        'bucket': 'https://brave-build-deps-public.s3.brave.com/ast-grep/',
-        'condition': 'host_os == "mac" and host_cpu == "arm64"',
-        'objects': [
-            {
-                'object_name': 'ast-grep-0.44.0-mac-arm64.tar.gz',
-                'sha256sum': '5bcb3568679ea6c636298c2b3e1edb44d54a8483f51d5e1ad0778609ef97bea3',
-            },
-        ],
-    },
-    'src/brave/third_party/ast-grep/ast-grep-win': {
-        'bucket': 'https://brave-build-deps-public.s3.brave.com/ast-grep/',
-        'condition': 'host_os == "win"',
-        'objects': [
-            {
-                'object_name': 'ast-grep-0.44.0-win.tar.gz',
-                'sha256sum': '1a074eaa2c4ba0e6df2b7a505c45ef26b2605a1360d43c8c2ae4d31624013845',
-            },
-        ],
-    },
-}
 
 
 def _select_object(objects: list[dict],
@@ -205,104 +62,6 @@ def _select_object(objects: list[dict],
         raise RuntimeError('Multiple objects match the resolved variables: ' +
                            ', '.join(obj['object_name'] for obj in matches))
     return matches[0]
-
-
-@dataclass(frozen=True)
-class TarballInstaller:
-    """Installs one resolved `EXTRA_DEPS` object into its destination.
-
-    Handles the mechanics for a single object: download, sha256 verification,
-    extraction (wiping the destination first when it owns it), and the
-    gclient-style sidecar bookkeeping used to detect an existing install.
-
-    gclient drops a set of dotfile "sidecars" next to each `gcs` dep's extracted
-    tree (see `GcsDependency` in gclient.py and `GcsRoot` in gclient_scm.py),
-    keyed by a prefix that is the object name with `/` and `.` replaced by `_`:
-
-      .{prefix}_hash                the object's sha256
-      .{prefix}_content_names       JSON list of the archive's members
-
-    We deploy the very same files so our install state mirrors gclient's, but
-    append `.stamp` so gclient's own globs (`.*_hash`, `.*_content_names`)
-    never read or clobber ours.
-    """
-
-    # The checkout directory the archive is extracted into.
-    dest_dir: Path
-    # The full URL the archive is downloaded from.
-    url: str
-    # The bucket object name; drives sidecar naming and diagnostics.
-    object_name: str
-    # The expected sha256 of the archive.
-    sha256sum: str
-    # True when the dep owns dest_dir (wiped before extract); False when it
-    # overlays an existing upstream tree (extracted on top).
-    owns_dest: bool
-
-    def is_installed(self) -> bool:
-        """True when the `_hash` sidecar already records `sha256sum`."""
-        return self._installed_hash() == self.sha256sum
-
-    def install(self) -> bool:
-        """Download and extract the object, writing the sidecars on success.
-
-        Returns False when the sidecar already records `sha256sum` and nothing
-        needed to be done.
-        """
-        if self.is_installed():
-            return False
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            archive_path = Path(tmp_dir) / self.object_name
-            with archive_path.open('wb') as archive_file:
-                deps.DownloadUrl(self.url, archive_file)
-            deps.VerifySHA256(str(archive_path), self.sha256sum, self.url)
-            if self.owns_dest and self.dest_dir.exists():
-                # Drop the previous extraction so nothing stale lingers;
-                # overlays deliberately keep the upstream tree they sit on.
-                shutil.rmtree(self.dest_dir)
-            member_names = self._extract(archive_path)
-        self._write_sidecars(member_names)
-        return True
-
-    def _extract(self, archive_path: Path) -> list[str]:
-        """Extract the archive (tar or zip) into `dest_dir`.
-
-        Returns the archive's member names, as gclient records them in its
-        `.*_content_names` sidecar (`ZipFile.namelist()` / `tar.getnames()`).
-        """
-        if zipfile.is_zipfile(archive_path):
-            with zipfile.ZipFile(archive_path) as archive:
-                names = archive.namelist()
-                archive.extractall(path=self.dest_dir)
-                return names
-        with tarfile.open(archive_path, mode='r:*') as tar:
-            names = tar.getnames()
-            tar.extractall(path=self.dest_dir, filter='data')
-            return names
-
-    def _sidecar(self, suffix: str) -> Path:
-        """The `.{prefix}{suffix}.stamp` sidecar path in `dest_dir`."""
-        prefix = self.object_name.replace('/', '_').replace('.', '_')
-        return self.dest_dir / f'.{prefix}{suffix}{_STAMP}'
-
-    def _installed_hash(self) -> str:
-        """The sha256 from the `_hash` sidecar, or '' when absent."""
-        hash_file = self._sidecar('_hash')
-        if hash_file.is_file():
-            return hash_file.read_bytes().decode('utf-8').strip()
-        return ''
-
-    def _write_sidecars(self, member_names: list[str]) -> None:
-        """Write the gclient-equivalent sidecar set, each with a `.stamp` tail.
-        """
-        contents = {
-            '_hash': self.sha256sum,
-            '_content_names': json.dumps(member_names),
-        }
-        for suffix, content in contents.items():
-            self._sidecar(suffix).write_text(f'{content}\n',
-                                             encoding='utf-8',
-                                             newline='')
 
 
 class ExtraDepsRunner:
@@ -345,14 +104,14 @@ class ExtraDepsRunner:
 
         Returns a dict with two keys:
 
-          * `vars` -- the exact dict gclient builds while processing that
+          * `vars`: the exact dict gclient builds while processing that
             solution's DEPS during a sync: the DEPS-declared `vars` overlaid
             with `.gclient` custom_vars, plus the built-in vars (`host_os`,
             `host_cpu`, `checkout_*`, ...). Letting depot_tools load and merge
             everything means this script never has to know which variables exist
             or how to compute their values. Conditions resolve the same way they
             would with `sync`.
-          * `deps` -- the raw `deps` mapping declared in the DEPS file, keyed by
+          * `deps`: the raw `deps` mapping declared in the DEPS file, keyed by
             checkout-relative path. Used to cross-check that an overlay still
             targets the upstream archive currently pinned in DEPS.
         """
@@ -433,23 +192,22 @@ class ExtraDepsRunner:
             _LOG.debug('No matching object for %s on this host', path)
             return
 
-        # An overlay must sit on the base it was built against: validate it
-        # still matches DEPS before touching the destination. No `overlayed_on`
-        # means the dep owns its destination, so there is no base to validate.
         overlayed_on = obj.get('overlayed_on')
-        if overlayed_on:
-            self._validate_overlay_target(path, overlayed_on)
-
         installer = TarballInstaller(dest_dir=_SRC_DIR.parent / path,
                                      url=spec['bucket'] + obj['object_name'],
                                      object_name=obj['object_name'],
                                      sha256sum=obj['sha256sum'],
                                      owns_dest=not overlayed_on)
-        if installer.install():
-            _LOG.info('Installed %s into %s', obj['object_name'],
-                      installer.dest_dir)
-        else:
-            _LOG.debug('%s already up to date (%s)', path, obj['object_name'])
+
+        # An overlay must sit on the base it was built against: validate it
+        # still matches DEPS before touching the destination. No `overlayed_on`
+        # means the dep owns its destination, so there is no base to validate.
+        if overlayed_on:
+            self._validate_overlay_target(path, overlayed_on)
+
+        # `install()` no-ops (returns False) when the sidecar already records
+        # this object's sha, so there is no separate deployment check here.
+        installer.install()
 
 
 def main() -> int:

--- a/tools/cr/install_extra_deps_test.py
+++ b/tools/cr/install_extra_deps_test.py
@@ -8,12 +8,7 @@
 The file is split into layers, from pure units to a full checkout integration:
 
 * `SelectObjectTest` covers the pure `_select_object` condition picker.
-
-* `TarballInstallerTest` drives a single `TarballInstaller` against real
-  on-disk archives (built in-memory). `deps.DownloadUrl` is faked so no network
-  is touched, but the real `deps.VerifySHA256` and the real tar/zip extraction
-  run, exercising download verification, the owned-vs-overlay wipe behaviour,
-  idempotency, and the gclient-equivalent sidecar bookkeeping.
+  (`TarballInstaller` itself is tested in `tarball_installer_test.py`.)
 
 * `ValidateOverlayTargetTest` and `InstallTest` exercise `ExtraDepsRunner`
   without the gclient machinery by pre-seeding its resolved-scope cache, so the
@@ -33,13 +28,11 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import io
-import json
 import logging
 import sys
 import tarfile
 import tempfile
 import unittest
-import zipfile
 from pathlib import Path
 from unittest import mock
 
@@ -48,6 +41,7 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import install_extra_deps as m
+import tarball_installer
 from test.fake_chromium_repo import FakeChromiumRepo
 
 
@@ -65,15 +59,6 @@ def _make_tar(members: list[tuple[str, bytes]],
             info = tarfile.TarInfo(name)
             info.size = len(content)
             tar.addfile(info, io.BytesIO(content))
-    return buf.getvalue()
-
-
-def _make_zip(members: list[tuple[str, bytes]]) -> bytes:
-    """Build a zip archive from `(name, content)` members."""
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, 'w') as archive:
-        for name, content in members:
-            archive.writestr(name, content)
     return buf.getvalue()
 
 
@@ -124,131 +109,6 @@ class SelectObjectTest(unittest.TestCase):
         objects = [{'object_name': 'node-linux-x64.tar.gz'}]
         picked = m._select_object(objects, {'host_os': 'mac'})
         self.assertEqual(picked['object_name'], 'node-linux-x64.tar.gz')
-
-
-class TarballInstallerTest(unittest.TestCase):
-    """Tests for `TarballInstaller` download/extract/sidecar mechanics."""
-
-    def setUp(self):
-        tmp = tempfile.TemporaryDirectory()
-        self.addCleanup(tmp.cleanup)
-        self.root = Path(tmp.name)
-        self.dest = self.root / 'dest'
-
-    def _installer(self,
-                   data: bytes,
-                   *,
-                   object_name: str = 'pkg.tar.gz',
-                   sha256sum: str | None = None,
-                   owns_dest: bool = True) -> m.TarballInstaller:
-        """A `TarballInstaller` for `data`, defaulting to its true sha256."""
-        return m.TarballInstaller(
-            dest_dir=self.dest,
-            url=f'https://downloads.invalid/{object_name}',
-            object_name=object_name,
-            sha256sum=_sha256(data) if sha256sum is None else sha256sum,
-            owns_dest=owns_dest)
-
-    def _faked_download(self, data: bytes) -> mock._patch:
-        """Patch `deps.DownloadUrl` to write `data` into the output file."""
-
-        def _write(_url, output_file):
-            output_file.write(data)
-
-        return mock.patch.object(m.deps, 'DownloadUrl', side_effect=_write)
-
-    def test_install_extracts_tarball_and_writes_sidecars(self):
-        """A fresh install extracts the tar members and records the sidecars."""
-        data = _make_tar([('bin/node', b'node'), ('README.md', b'hi')])
-        installer = self._installer(data)
-        with self._faked_download(data):
-            self.assertTrue(installer.install())
-        self.assertEqual((self.dest / 'bin/node').read_bytes(), b'node')
-        self.assertEqual((self.dest / 'README.md').read_bytes(), b'hi')
-        self.assertTrue(installer.is_installed())
-
-    def test_install_extracts_zip(self):
-        """Zip archives take the `ZipFile` branch and extract the same way."""
-        data = _make_zip([('node.exe', b'MZ'), ('LICENSE', b'mpl')])
-        installer = self._installer(data, object_name='node.zip')
-        with self._faked_download(data):
-            self.assertTrue(installer.install())
-        self.assertEqual((self.dest / 'node.exe').read_bytes(), b'MZ')
-        self.assertEqual((self.dest / 'LICENSE').read_bytes(), b'mpl')
-
-    def test_install_is_idempotent(self):
-        """A second install is a no-op: it returns False and re-downloads
-        nothing once the `_hash` sidecar already records the sha."""
-        data = _make_tar([('f', b'x')])
-        installer = self._installer(data)
-        with self._faked_download(data) as download:
-            self.assertTrue(installer.install())
-            self.assertFalse(installer.install())
-            download.assert_called_once()
-
-    def test_is_installed_is_false_without_sidecar(self):
-        """With no `_hash` sidecar present nothing is considered installed."""
-        self.assertFalse(
-            self._installer(_make_tar([('f', b'x')])).is_installed())
-
-    def test_owned_dest_is_wiped_before_extract(self):
-        """An owned dep wipes its destination first, so stale files are gone."""
-        self.dest.mkdir()
-        (self.dest / 'stale.txt').write_text('old')
-        data = _make_tar([('fresh.txt', b'new')])
-        installer = self._installer(data, owns_dest=True)
-        with self._faked_download(data):
-            installer.install()
-        self.assertFalse((self.dest / 'stale.txt').exists())
-        self.assertTrue((self.dest / 'fresh.txt').exists())
-
-    def test_overlay_keeps_existing_tree(self):
-        """An overlay (owns_dest=False) extracts on top, preserving the base."""
-        self.dest.mkdir()
-        (self.dest / 'base.txt').write_text('upstream')
-        data = _make_tar([('overlay.txt', b'brave')])
-        installer = self._installer(data, owns_dest=False)
-        with self._faked_download(data):
-            installer.install()
-        self.assertEqual((self.dest / 'base.txt').read_text(), 'upstream')
-        self.assertTrue((self.dest / 'overlay.txt').exists())
-
-    def test_sha256_mismatch_raises_and_installs_nothing(self):
-        """A hash mismatch surfaces from the real `VerifySHA256` and leaves the
-        destination untouched (no extraction, no sidecars)."""
-        data = _make_tar([('f', b'x')])
-        installer = self._installer(data, sha256sum='0' * 64)
-        with self._faked_download(data):
-            with self.assertRaises(ValueError):
-                installer.install()
-        self.assertFalse(self.dest.exists())
-        self.assertFalse(installer.is_installed())
-
-    def test_sidecar_contents(self):
-        """The written sidecars mirror gclient's set: the sha256 and the JSON
-        list of archive members, each `.stamp`."""
-        members = [('a', b'1'), ('b/c', b'2')]
-        data = _make_tar(members)
-        installer = self._installer(data, object_name='pkg.tar.gz')
-        with self._faked_download(data):
-            installer.install()
-        prefix = '.pkg_tar_gz'
-        hash_file = self.dest / f'{prefix}_hash.stamp'
-        names_file = self.dest / f'{prefix}_content_names.stamp'
-        self.assertTrue(hash_file.is_file())
-        self.assertEqual(hash_file.read_text().strip(), _sha256(data))
-        self.assertEqual(json.loads(names_file.read_text()), ['a', 'b/c'])
-        # The first-class-gcs migration toggle is deliberately not written.
-        self.assertFalse(
-            (self.dest / f'{prefix}_is_first_class_gcs.stamp').exists())
-
-    def test_sidecar_name_maps_dots_and_slashes(self):
-        """The sidecar prefix maps every `/` and `.` in the object name to `_`
-        (matching gclient's keying) and carries the `.stamp` tail."""
-        installer = self._installer(b'', object_name='Linux_x64/pkg.tar.gz')
-        self.assertEqual(
-            installer._sidecar('_hash').name,
-            '.Linux_x64_pkg_tar_gz_hash.stamp')
 
 
 class ValidateOverlayTargetTest(unittest.TestCase):
@@ -338,10 +198,13 @@ class InstallTest(unittest.TestCase):
 
     def _faked_download(self, data: bytes) -> mock._patch:
 
-        def _write(_url, output_file):
+        def _write(_self, _url, output_file):
             output_file.write(data)
 
-        return mock.patch.object(m.deps, 'DownloadUrl', side_effect=_write)
+        return mock.patch.object(tarball_installer.TarballInstaller,
+                                 '_download',
+                                 autospec=True,
+                                 side_effect=_write)
 
     def test_skips_when_dep_condition_is_false(self):
         """A false dep-level condition skips entirely; nothing downloads."""
@@ -476,10 +339,13 @@ class FromCheckoutIntegrationTest(unittest.TestCase):
 
     def _faked_download(self, data: bytes) -> mock._patch:
 
-        def _write(_url, output_file):
+        def _write(_self, _url, output_file):
             output_file.write(data)
 
-        return mock.patch.object(m.deps, 'DownloadUrl', side_effect=_write)
+        return mock.patch.object(tarball_installer.TarballInstaller,
+                                 '_download',
+                                 autospec=True,
+                                 side_effect=_write)
 
     def test_resolves_solution_vars_and_caches(self):
         """`from_checkout` loads the config and resolves the solution's vars,

--- a/tools/cr/tarball_installer.py
+++ b/tools/cr/tarball_installer.py
@@ -1,0 +1,239 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""`TarballInstaller`: fetch, verify, and extract one `EXTRA_DEPS` object.
+
+Stdlib-only: it downloads over HTTP, verifies the sha256, extracts the archive,
+and writes the sidecar files that record what is deployed. Also runnable as a
+CLI to deploy a single-object `EXTRA_DEPS` entry into the checkout.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from dataclasses import dataclass
+import hashlib
+import json
+import shutil
+import sys
+import tarfile
+import tempfile
+import time
+import zipfile
+from pathlib import Path
+from urllib.error import URLError
+from urllib.parse import urlsplit
+from urllib.request import urlopen
+
+from extra_deps import EXTRA_DEPS, is_deployed, sidecar_path
+
+# The workspace root (parent of `src`): this file is at
+# `<root>/src/brave/tools/cr/tarball_installer.py`.
+_WORKSPACE_ROOT = Path(__file__).resolve().parents[4]
+
+# Only single-object entries can be deployed here: picking an object out of a
+# multi-object entry needs host-condition resolution this installer does not do.
+_INSTALLABLE = sorted(path for path, spec in EXTRA_DEPS.items()
+                      if len(spec['objects']) == 1)
+
+
+@dataclass(frozen=True)
+class TarballInstaller:
+    """Installs one resolved `EXTRA_DEPS` object into its destination.
+
+    Handles the mechanics for a single object: sha256 verification, extraction
+    (wiping the destination first when it owns it), and writing the sidecar
+    files `extra_deps` reads back to tell a deployed tree from a stale one:
+
+      .{prefix}_hash                the object's sha256
+      .{prefix}_content_names       JSON list of the archive's members
+
+    where `prefix` is the object name with `/` and `.` mapped to `_`.
+    """
+
+    # The checkout directory the archive is extracted into.
+    dest_dir: Path
+    # The full URL the archive is downloaded from.
+    url: str
+    # The bucket object name; drives sidecar naming and diagnostics.
+    object_name: str
+    # The expected sha256 of the archive.
+    sha256sum: str
+    # True when the dep owns dest_dir (wiped before extract); False when it
+    # overlays an existing upstream tree (extracted on top).
+    owns_dest: bool
+
+    @classmethod
+    def for_dep(cls, root: Path, path: str, spec: dict) -> TarballInstaller:
+        """Build an installer for the single object of `spec` under `root`.
+
+        `root` is the workspace root (the parent of `src`) and `path` the
+        checkout-relative destination. Raises `ValueError` for a multi-object
+        entry: picking one of its objects needs host-condition resolution this
+        installer does not do.
+        """
+        objects = spec['objects']
+        if len(objects) != 1:
+            raise ValueError(
+                f'{path}: only single-object entries can be installed here, '
+                f'but this one has {len(objects)}')
+        obj = objects[0]
+        return cls(dest_dir=root / path,
+                   url=spec['bucket'] + obj['object_name'],
+                   object_name=obj['object_name'],
+                   sha256sum=obj['sha256sum'],
+                   owns_dest=not obj.get('overlayed_on'))
+
+    def is_installed(self) -> bool:
+        """True when the `_hash` sidecar already records `sha256sum`."""
+        return is_deployed(self.dest_dir, self.object_name, self.sha256sum)
+
+    def install(self,
+                download: Callable[[str, object], None] | None = None) -> bool:
+        """Fetch and extract the object, writing the sidecars on success.
+
+        `download(url, file_obj)` writes the archive bytes into `file_obj`;
+        it defaults to `_download` (a stdlib urllib fetch with live progress)
+        and can be overridden in tests to avoid the network. Returns False when
+        the sidecar already records `sha256sum` and nothing needed to be done.
+        """
+        if self.is_installed():
+            return False
+        download = download or self._download
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            archive_path = Path(tmp_dir) / self.object_name
+            with archive_path.open('wb') as archive_file:
+                download(self.url, archive_file)
+            self._verify(archive_path)
+            if self.owns_dest and self.dest_dir.exists():
+                # Drop the previous extraction so nothing stale lingers;
+                # overlays deliberately keep the upstream tree they sit on.
+                shutil.rmtree(self.dest_dir)
+            member_names = self._extract(archive_path)
+        self._write_sidecars(member_names)
+        return True
+
+    def _verify(self, archive_path: Path) -> None:
+        """Raise `ValueError` unless `archive_path` hashes to `sha256sum`."""
+        digest = hashlib.sha256()
+        # Not using mmap to make this script more tolerable to a larger range
+        # of Python versions, as this script is called by `launcher.py` without
+        # a guarantee of vpython being available.
+        with archive_path.open('rb') as archive_file:
+            for block in iter(lambda: archive_file.read(1 << 20), b''):
+                digest.update(block)
+        actual = digest.hexdigest()
+        if actual.lower() != self.sha256sum.lower():
+            raise ValueError(f'SHA-256 mismatch for {self.url}\n'
+                             f'  expected: {self.sha256sum.lower()}\n'
+                             f'  actual:   {actual}')
+
+    def _download(self, url: str, output_file) -> None:
+        """Fetch `url` into `output_file` with a live progress line.
+
+        A stdlib urllib fetch that retries (3 tries, doubling backoff, no retry
+        on 403/404), plus a carriage-return progress line on stderr in the
+        gsutil style `[<done>/<total>] <pct>%`. Refuses any non-`https` URL:
+        the sha256 check catches tampering, but the transport must be encrypted.
+        """
+        if urlsplit(url).scheme != 'https':
+            raise ValueError(f'refusing to fetch over a non-https URL: {url}')
+        num_retries = 3
+        retry_wait_s = 5  # Doubled at each retry.
+        while True:
+            try:
+                output_file.seek(0)
+                output_file.truncate()
+                with urlopen(url) as response:
+                    total = int(response.headers.get('Content-Length') or 0)
+                    done = 0
+                    last_pct = -1
+                    while chunk := response.read(64 * 1024):
+                        output_file.write(chunk)
+                        done += len(chunk)
+                        pct = int(done * 100 / total) if total else -1
+                        if pct != last_pct:
+                            last_pct = pct
+                            self._emit_progress(done, total)
+                    if total and done != total:
+                        raise URLError(f'only got {done} of {total} bytes')
+                    self._emit_progress(done, total, done_flag=True)
+                return
+            except URLError as error:
+                sys.stderr.write(f'\n{error}\n')
+                # `code` is an HTTPError-only attribute (a URLError subclass).
+                if num_retries == 0 or getattr(error, 'code',
+                                               None) in (403, 404):
+                    raise
+                num_retries -= 1
+                sys.stderr.write(f'Retrying in {retry_wait_s} s ...\n')
+                time.sleep(retry_wait_s)
+                retry_wait_s *= 2
+
+    def _emit_progress(self, done: int, total: int, done_flag=False) -> None:
+        """Rewrite the stderr progress line for `done`/`total` bytes."""
+        if total:
+            line = (f'{self._human(done)}/{self._human(total)}] '
+                    f'{int(done * 100 / total):>3}%')
+        else:
+            line = f'{self._human(done)}]'
+        tail = ' Done\n' if done_flag else ''
+        sys.stderr.write(f'\r{self.object_name} [{line}{tail}')
+        sys.stderr.flush()
+
+    @staticmethod
+    def _human(num: float) -> str:
+        """A base-1024 size string (`26.7 MiB`), matching gsutil's format."""
+        for unit in ('B', 'KiB', 'MiB', 'GiB', 'TiB'):
+            if num < 1024 or unit == 'TiB':
+                return f'{round(num, 1):g} {unit}'
+            num /= 1024
+        return f'{num:g} TiB'  # unreachable; keeps the type checker happy
+
+    def _extract(self, archive_path: Path) -> list[str]:
+        """Extract the archive (tar or zip) into `dest_dir`.
+
+        Returns the archive's member names (`ZipFile.namelist()` /
+        `tar.getnames()`), recorded in the `_content_names` sidecar.
+        """
+        if zipfile.is_zipfile(archive_path):
+            with zipfile.ZipFile(archive_path) as archive:
+                names = archive.namelist()
+                archive.extractall(path=self.dest_dir)
+                return names
+        with tarfile.open(archive_path, mode='r:*') as tar:
+            names = tar.getnames()
+            tar.extractall(path=self.dest_dir, filter='data')
+            return names
+
+    def _write_sidecars(self, member_names: list[str]) -> None:
+        """Write the sidecar set, each with a `.stamp` tail."""
+        contents = {
+            '_hash': self.sha256sum,
+            '_content_names': json.dumps(member_names),
+        }
+        for suffix, content in contents.items():
+            sidecar_path(self.dest_dir, self.object_name,
+                         suffix).write_text(f'{content}\n',
+                                            encoding='utf-8',
+                                            newline='')
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description='Deploy a single-object EXTRA_DEPS entry into this '
+        'checkout.')
+    parser.add_argument('dep',
+                        choices=_INSTALLABLE,
+                        metavar='DEP_PATH',
+                        help='The EXTRA_DEPS path key to deploy.')
+    args = parser.parse_args(argv)
+    TarballInstaller.for_dep(_WORKSPACE_ROOT, args.dep,
+                             EXTRA_DEPS[args.dep]).install()
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/cr/tarball_installer_test.py
+++ b/tools/cr/tarball_installer_test.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `TarballInstaller`.
+
+Drives a single installer against real on-disk archives (built in-memory) with
+the byte fetch injected, so no network is touched but the real sha verification,
+extraction, owned-vs-overlay wipe, idempotency, and sidecar bookkeeping run.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import json
+import sys
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest import mock
+
+# `tarball_installer` (and the `extra_deps` it imports) live at the tools/cr
+# root; add it so they resolve regardless of the working directory.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import tarball_installer as m
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _make_tar(members: list[tuple[str, bytes]], compression: str = 'gz'):
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode=f'w:{compression}') as tar:
+        for name, content in members:
+            info = tarfile.TarInfo(name)
+            info.size = len(content)
+            tar.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def _make_zip(members: list[tuple[str, bytes]]):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as archive:
+        for name, content in members:
+            archive.writestr(name, content)
+    return buf.getvalue()
+
+
+class TarballInstallerTest(unittest.TestCase):
+    """Tests for `TarballInstaller` fetch/extract/sidecar mechanics."""
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        self.dest = self.root / 'dest'
+
+    def _installer(self,
+                   data: bytes,
+                   *,
+                   object_name: str = 'pkg.tar.gz',
+                   sha256sum: str | None = None,
+                   owns_dest: bool = True) -> m.TarballInstaller:
+        """A `TarballInstaller` for `data`, defaulting to its true sha256."""
+        return m.TarballInstaller(
+            dest_dir=self.dest,
+            url=f'https://downloads.invalid/{object_name}',
+            object_name=object_name,
+            sha256sum=_sha256(data) if sha256sum is None else sha256sum,
+            owns_dest=owns_dest)
+
+    def _download(self, data: bytes):
+        """An injected fetch that writes `data` into the output file."""
+
+        def _write(_url, output_file):
+            output_file.write(data)
+
+        return _write
+
+    def test_install_extracts_tarball_and_writes_sidecars(self):
+        data = _make_tar([('bin/node', b'node'), ('README.md', b'hi')])
+        installer = self._installer(data)
+        self.assertTrue(installer.install(self._download(data)))
+        self.assertEqual((self.dest / 'bin/node').read_bytes(), b'node')
+        self.assertEqual((self.dest / 'README.md').read_bytes(), b'hi')
+        self.assertTrue(installer.is_installed())
+
+    def test_install_extracts_zip(self):
+        data = _make_zip([('node.exe', b'MZ'), ('LICENSE', b'mpl')])
+        installer = self._installer(data, object_name='node.zip')
+        self.assertTrue(installer.install(self._download(data)))
+        self.assertEqual((self.dest / 'node.exe').read_bytes(), b'MZ')
+        self.assertEqual((self.dest / 'LICENSE').read_bytes(), b'mpl')
+
+    def test_install_is_idempotent(self):
+        data = _make_tar([('f', b'x')])
+        installer = self._installer(data)
+        calls = []
+
+        def _counting(url, output_file):
+            calls.append(url)
+            output_file.write(data)
+
+        self.assertTrue(installer.install(_counting))
+        self.assertFalse(installer.install(_counting))
+        self.assertEqual(len(calls), 1)
+
+    def test_is_installed_is_false_without_sidecar(self):
+        self.assertFalse(
+            self._installer(_make_tar([('f', b'x')])).is_installed())
+
+    def test_owned_dest_is_wiped_before_extract(self):
+        self.dest.mkdir()
+        (self.dest / 'stale.txt').write_text('old')
+        data = _make_tar([('fresh.txt', b'new')])
+        self._installer(data, owns_dest=True).install(self._download(data))
+        self.assertFalse((self.dest / 'stale.txt').exists())
+        self.assertTrue((self.dest / 'fresh.txt').exists())
+
+    def test_overlay_keeps_existing_tree(self):
+        self.dest.mkdir()
+        (self.dest / 'base.txt').write_text('upstream')
+        data = _make_tar([('overlay.txt', b'brave')])
+        self._installer(data, owns_dest=False).install(self._download(data))
+        self.assertEqual((self.dest / 'base.txt').read_text(), 'upstream')
+        self.assertTrue((self.dest / 'overlay.txt').exists())
+
+    def test_sha256_mismatch_raises_and_installs_nothing(self):
+        data = _make_tar([('f', b'x')])
+        installer = self._installer(data, sha256sum='0' * 64)
+        with self.assertRaises(ValueError):
+            installer.install(self._download(data))
+        self.assertFalse(self.dest.exists())
+        self.assertFalse(installer.is_installed())
+
+    def test_download_refuses_non_https_url(self):
+        installer = self._installer(_make_tar([('f', b'x')]))
+        with self.assertRaisesRegex(ValueError, 'non-https'):
+            installer._download('http://downloads.invalid/pkg.tar.gz',
+                                io.BytesIO())
+
+    def test_sidecar_contents(self):
+        members = [('a', b'1'), ('b/c', b'2')]
+        data = _make_tar(members)
+        installer = self._installer(data, object_name='pkg.tar.gz')
+        installer.install(self._download(data))
+        prefix = '.pkg_tar_gz'
+        hash_file = self.dest / f'{prefix}_hash.stamp'
+        names_file = self.dest / f'{prefix}_content_names.stamp'
+        self.assertTrue(hash_file.is_file())
+        self.assertEqual(hash_file.read_text().strip(), _sha256(data))
+        self.assertEqual(json.loads(names_file.read_text()), ['a', 'b/c'])
+
+
+class ProgressTest(unittest.TestCase):
+    """Tests for the gsutil-style progress formatting."""
+
+    def test_human_uses_base_1024_units(self):
+        self.assertEqual(m.TarballInstaller._human(0), '0 B')
+        self.assertEqual(m.TarballInstaller._human(28001234), '26.7 MiB')
+        self.assertEqual(m.TarballInstaller._human(1024), '1 KiB')
+
+    def test_download_writes_bytes_and_reports_done(self):
+        """The real `_download` (no injected fetch) streams bytes and prints a
+        final `Done` line -- guards the built-in path the fakes bypass."""
+
+        class _FakeResponse:
+
+            def __init__(self, data):
+                self._buf = io.BytesIO(data)
+                self.headers = {'Content-Length': str(len(data))}
+
+            def read(self, size):
+                return self._buf.read(size)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                return False
+
+        data = b'payload' * 5000
+        out = io.BytesIO()
+        inst = m.TarballInstaller(dest_dir=Path('/x'),
+                                  url='https://downloads.invalid/pkg',
+                                  object_name='pkg.tar.gz',
+                                  sha256sum='a',
+                                  owns_dest=True)
+        err = io.StringIO()
+        with mock.patch.object(m, 'urlopen', return_value=_FakeResponse(data)):
+            with contextlib.redirect_stderr(err):
+                inst._download('https://downloads.invalid/pkg', out)
+        self.assertEqual(out.getvalue(), data)
+        self.assertTrue(err.getvalue().endswith('Done\n'))
+
+    def test_emit_progress_renders_live_line(self):
+        inst = m.TarballInstaller(dest_dir=Path('/x'),
+                                  url='u',
+                                  object_name='node.tar.gz',
+                                  sha256sum='a',
+                                  owns_dest=True)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            inst._emit_progress(26_700_000, 26_700_000, done_flag=True)
+        # Carriage-return prefixed, `[done/total] pct% Done`, matching gsutil.
+        self.assertEqual(err.getvalue(),
+                         '\rnode.tar.gz [25.5 MiB/25.5 MiB] 100% Done\n')
+
+
+class ForDepTest(unittest.TestCase):
+    """Tests for the `TarballInstaller.for_dep` single-object factory."""
+
+    def _spec(self, objects):
+        return {'bucket': 'https://downloads.invalid/', 'objects': objects}
+
+    def test_builds_single_object_installer(self):
+        inst = m.TarballInstaller.for_dep(
+            Path('/ws'), 'src/p',
+            self._spec([{
+                'object_name': 'x.tar.gz',
+                'sha256sum': 'abc'
+            }]))
+        self.assertEqual(inst.dest_dir, Path('/ws/src/p'))
+        self.assertEqual(inst.url, 'https://downloads.invalid/x.tar.gz')
+        self.assertEqual(inst.object_name, 'x.tar.gz')
+        self.assertEqual(inst.sha256sum, 'abc')
+        self.assertTrue(inst.owns_dest)
+
+    def test_overlay_object_does_not_own_dest(self):
+        inst = m.TarballInstaller.for_dep(
+            Path('/ws'), 'src/p',
+            self._spec([{
+                'object_name': 'x.tar.gz',
+                'sha256sum': 'abc',
+                'overlayed_on': 'base.tar.xz'
+            }]))
+        self.assertFalse(inst.owns_dest)
+
+    def test_multi_object_entry_raises(self):
+        spec = self._spec([
+            {
+                'object_name': 'a.tar.gz',
+                'sha256sum': '1'
+            },
+            {
+                'object_name': 'b.tar.gz',
+                'sha256sum': '2'
+            },
+        ])
+        with self.assertRaisesRegex(ValueError, 'single-object'):
+            m.TarballInstaller.for_dep(Path('/ws'), 'src/p', spec)
+
+
+class MainTest(unittest.TestCase):
+    """Tests for the `tarball_installer.py` CLI."""
+
+    def test_installs_the_requested_single_object_dep(self):
+        dep = 'src/brave/third_party/node/node-linux-x64'
+        with mock.patch.object(m.TarballInstaller,
+                               'install',
+                               autospec=True,
+                               return_value=True) as install:
+            self.assertEqual(m.main([dep]), 0)
+        install.assert_called_once()
+        installer = install.call_args.args[0]
+        self.assertEqual(installer.dest_dir, m._WORKSPACE_ROOT / dep)
+        self.assertEqual(installer.object_name,
+                         'node-v24.18.0-linux-x64.tar.gz')
+
+    def test_rejects_unknown_dep(self):
+        with contextlib.redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit):
+                m.main(['src/does/not/exist'])
+
+    def test_rejects_multi_object_dep(self):
+        # The rust toolchain has one object per host; argparse rejects it since
+        # only single-object entries are installable here.
+        with contextlib.redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit):
+                m.main(['src/third_party/rust-toolchain'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/cr/toolchain.py
+++ b/tools/cr/toolchain.py
@@ -118,7 +118,7 @@ TOOLCHAINS = {
                     'linux-x64-rust-toolchain-{revision}-1.tar.xz'),
         },
         'repin': {
-            'installer': 'tools/cr/install_extra_deps.py',
+            'installer': 'EXTRA_DEPS',
         },
         'advice': ('Run the jobs in https://ci.brave.com/view/toolchains/ to '
                    'generate a new Rust toolchain (or use '
@@ -481,7 +481,7 @@ class ToolchainAdvisory:
 
 
 class RustToolchain(Toolchain):
-    """The Rust/WASM toolchain, pinned in `install_extra_deps.py`."""
+    """The Rust/WASM toolchain, pinned in `EXTRA_DEPS`."""
 
     # A recovery is the first build for a revision, so it triggers (and probes,
     # via the `publish` URL) brave sub-revision 1.
@@ -522,18 +522,18 @@ class RustToolchain(Toolchain):
 
     @staticmethod
     def _load_extra_deps(source: str) -> tuple[ast.Assign, dict]:
-        """Return the `EXTRA_DEPS = {...}` assignment node and its dict value.
+        """Return the `extra_deps = {...}` assignment node and its dict value.
 
-        The value is read with `ast.literal_eval`, so the installer is parsed
-        as data rather than imported (importing it pulls in gclient).
+        The value is read with `ast.literal_eval`, so the file is parsed as
+        data rather than imported.
         """
         for node in ast.parse(source).body:
             if (isinstance(node, ast.Assign) and len(node.targets) == 1
                     and isinstance(node.targets[0], ast.Name)
-                    and node.targets[0].id == 'EXTRA_DEPS'):
+                    and node.targets[0].id == 'extra_deps'):
                 return node, ast.literal_eval(node.value)
         raise InvalidInputException(
-            'No EXTRA_DEPS assignment found in the Rust installer.')
+            'No extra_deps assignment found in the EXTRA_DEPS file.')
 
     @staticmethod
     def _upstream_stem(text: str) -> str:
@@ -606,9 +606,9 @@ class RustToolchain(Toolchain):
         node, extra_deps = self._load_extra_deps(source)
 
         # Replace the rust-toolchain entry (in place, preserving key order),
-        # then re-render the whole EXTRA_DEPS assignment.
+        # then re-render the whole extra_deps assignment.
         extra_deps.update(new_entry)
-        rendered = f'EXTRA_DEPS = {_render_py_literal(extra_deps)}\n'
+        rendered = f'extra_deps = {_render_py_literal(extra_deps)}\n'
         lines = source.splitlines(keepends=True)
         new_source = (''.join(lines[:node.lineno - 1]) + rendered +
                       ''.join(lines[node.end_lineno:]))
@@ -776,9 +776,9 @@ class WindowsToolchain(Toolchain):
 def _render_py_literal(value: object, indent: int = 0) -> str:
     """Render a str/bool/dict/list literal as multi-line Python source.
 
-    Matches the layout `install_extra_deps.py` already uses -- 4-space
-    indent steps, single-quoted strings, trailing commas -- so re-rendering
-    `EXTRA_DEPS` round-trips through yapf unchanged.
+    Used to re-render the `extra_deps` assignment when repinning. Matches the
+    committed `EXTRA_DEPS` file's layout (4-space indent steps, single-quoted
+    strings, trailing commas) so a repin is a minimal diff.
     """
     pad = ' ' * indent
     child = ' ' * (indent + 4)

--- a/tools/cr/toolchain_test.py
+++ b/tools/cr/toolchain_test.py
@@ -71,7 +71,7 @@ NEW_ENTRY = {
 SAMPLE_INSTALLER = """\
 # Installer module.
 
-EXTRA_DEPS = {
+extra_deps = {
     'src/other-dep': {
         'bucket': 'https://example.invalid/other/',
         'objects': [
@@ -179,7 +179,7 @@ class LoadExtraDepsTest(unittest.TestCase):
     def test_returns_node_and_value(self):
         node, value = toolchain.RustToolchain._load_extra_deps(
             SAMPLE_INSTALLER)
-        self.assertEqual(node.targets[0].id, 'EXTRA_DEPS')
+        self.assertEqual(node.targets[0].id, 'extra_deps')
         self.assertIn('src/third_party/rust-toolchain', value)
         self.assertIn('src/other-dep', value)
 
@@ -327,7 +327,7 @@ class _FakeRepoTest(unittest.TestCase):
 class RustRepinTest(_FakeRepoTest):
     """End-to-end `RustToolchain.repin` against a `FakeChromiumRepo`."""
 
-    INSTALLER = 'tools/cr/install_extra_deps.py'
+    INSTALLER = 'EXTRA_DEPS'
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
This PR solves the chicken-egg problem with `npm`/`node` shims and how
they are supposed to self-update. As we make these tools a dependency
of brave, expressed as an entry in `EXTRA_DEPS`, and handled by that
machinery, it is necessary to provide a lightweight self-update hook
for when these commands are pinned to a new version in a new branch
checkout. This change provides that by breaking `install_extra_deps.py`
apart, in order to permit us to check for the freshness of the `node`/
`npm` installs in a way that does not impose a huge cost per call.

The shims now deploy the pinned node on demand. When a checkout's
vendored node is missing, or stale, the shim downloads it before
resolving, so sync proceeds without a system node. The system-tool
fallback remains for when that download can't run. machinery is split
into three layers:

- `extra_deps.py`: the EXTRA_DEPS table plus a stdlib-only sidecar
  deployment check. No `depot_tools` needed, so `launcher.py` imports
  it directly under plain `python3` to decide if a dependency needs to
  be updated.
- `tarball_installer.py`: `TarballInstaller` this module provides a CLI
  that deploys a single-object, with no `gclient`, no condition
  resolution. This lightweight tool permits the shims to self-update
  for the platform in use.
- `install_extra_deps.py`: The traditional `gclient`-driven `DEPS`-hook
  installer that drives a `TarballInstaller` during sync.

The launcher only updates a dep the CWD checkout's own extra_deps.py
describes, so an older checkouts (whose keys differ) degrades to system
fallback instead of erroring.

Bug: https://github.com/brave/brave-browser/issues/56529
