### PR TITLE
Fix suppressed ScannerUseDelimiter warning in BraveLicensePreferences.java

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveLicensePreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveLicensePreferences.java
@@ -18,6 +18,7 @@ import org.chromium.components.browser_ui.settings.search.BaseSearchIndexProvide
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 
 /**
@@ -32,7 +33,6 @@ public class BraveLicensePreferences extends BravePreferenceFragment {
     private final SettableMonotonicObservableSupplier<String> mPageTitle =
             ObservableSuppliers.createMonotonic();
 
-    @SuppressWarnings("ScannerUseDelimiter")
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String s) {
         // These strings are not used in Brave, but we get them from automated string translation
@@ -48,10 +48,10 @@ public class BraveLicensePreferences extends BravePreferenceFragment {
                 (BraveLicensePreference) findPreference(PREF_BRAVE_LICENSE_TEXT);
         try {
             InputStream in = getActivity().getAssets().open(ASSET_BRAVE_LICENSE);
-            Scanner scanner = new Scanner(in).useDelimiter("\\A");
-            String summary = scanner.hasNext() ? scanner.next() : "";
-            in.close();
-            licenseText.setSummary(BraveRewardsHelper.spannedFromHtmlString(summary));
+            try (Scanner scanner = new Scanner(in, StandardCharsets.UTF_8).useDelimiter("\\A")) {
+                String summary = scanner.hasNext() ? scanner.next() : "";
+                licenseText.setSummary(BraveRewardsHelper.spannedFromHtmlString(summary));
+            }
         } catch (IOException e) {
             Log.e(TAG, "Could not load license text: " + e);
         }


### PR DESCRIPTION
## Description

Fixes the suppressed `ScannerUseDelimiter` lint warning in `BraveLicensePreferences.java`, as tracked in https://github.com/brave/brave-browser/issues/53024.

## Changes

The `@SuppressWarnings("ScannerUseDelimiter")` annotation was used to silence an Android lint warning triggered when creating a `Scanner` from an `InputStream` without specifying an explicit character set. The proper fix is to pass the charset explicitly.

**Before:**
```java
@SuppressWarnings("ScannerUseDelimiter")
@Override
public void onCreatePreferences(...) {
    ...
    Scanner scanner = new Scanner(in).useDelimiter("\\A");
    String summary = scanner.hasNext() ? scanner.next() : "";
    in.close();
    ...
}
```

**After:**
```java
@Override
public void onCreatePreferences(...) {
    ...
    try (Scanner scanner = new Scanner(in, StandardCharsets.UTF_8).useDelimiter("\\A")) {
        String summary = scanner.hasNext() ? scanner.next() : "";
        licenseText.setSummary(BraveRewardsHelper.spannedFromHtmlString(summary));
    }
    ...
}
```

## What changed

1. **Removed** `@SuppressWarnings("ScannerUseDelimiter")` annotation — the warning is now properly resolved rather than suppressed.
2. **Added** `StandardCharsets.UTF_8` as an explicit charset argument to the `Scanner` constructor — this is the root fix that eliminates the lint warning.
3. **Added** `import java.nio.charset.StandardCharsets;`
4. **Wrapped** `Scanner` in a try-with-resources block — this is a bonus improvement that ensures the `Scanner` (and its underlying stream) is properly closed even if an exception occurs, eliminating a potential resource leak.

## Testing

- The `LICENSE.html` asset is read and displayed correctly using the `StandardCharsets.UTF_8` charset (consistent with the encoding of the HTML file).
- No functional behavior change — this is a code quality fix only.