### PR TITLE
Hide top separator in macOS fullscreen with rounded corners

### DIFF
--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
@@ -97,6 +97,13 @@ class BraveBrowserViewTabbedLayoutImpl : public BrowserViewTabbedLayoutImpl {
   bool GetMultiContentsSeparatorForTesting() const;
   bool GetShadowBoxForTesting() const;
 
+  // Populates `layout_data_` with the given window state (and a zero side
+  // panel width) so `CalculateSeparatorInfo()` can be exercised without
+  // running a full layout pass. Implemented alongside CalculateSeparatorInfo()
+  // in the chromium_src shadow.
+  void SetWindowStateForTesting(
+      BrowserViewLayoutDelegate::WindowState window_state);
+
  private:
   void CalculateBraveVerticalTabStripLayout(
       ProposedLayout& layout,

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl_unittest.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl_unittest.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <optional>
 
+#include "build/build_config.h"
 #include "chrome/browser/ui/views/frame/layout/browser_view_layout_delegate.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -76,12 +77,19 @@ class FakeBrowserViewLayoutDelegate : public BrowserViewLayoutDelegate {
   bool IsFullscreen() const override { return false; }
 };
 
-// Only the two visibility hooks matter for the CalculateSeparatorInfo() "no
-// top UI" early return; gmock makes the test spell that out with EXPECT_CALL.
+// Mocks the CalculateSeparatorInfo() inputs exercised by the tests below:
+// IsToolbarVisible/IsBookmarkBarVisible drive the "no top UI" early return,
+// IsInfobarVisible and ShouldUseBraveWebViewRoundedCornersForContents drive
+// the mac fullscreen separator-suppression branch.
 class MockBrowserViewLayoutDelegate : public FakeBrowserViewLayoutDelegate {
  public:
   MOCK_METHOD(bool, IsToolbarVisible, (), (const, override));
   MOCK_METHOD(bool, IsBookmarkBarVisible, (), (const, override));
+  MOCK_METHOD(bool, IsInfobarVisible, (), (const, override));
+  MOCK_METHOD(bool,
+              ShouldUseBraveWebViewRoundedCornersForContents,
+              (),
+              (const, override));
 };
 
 }  // namespace
@@ -303,3 +311,99 @@ TEST(BraveBrowserViewTabbedLayoutImplTest,
   EXPECT_FALSE(layout->GetMultiContentsSeparatorForTesting());
   EXPECT_FALSE(layout->GetShadowBoxForTesting());
 }
+
+#if BUILDFLAG(IS_MAC)
+
+TEST(BraveBrowserViewTabbedLayoutImplTest,
+     CalculateSeparatorInfoMacFullscreenRoundedNoInfobarHidesSeparator) {
+  auto mock =
+      std::make_unique<testing::NiceMock<MockBrowserViewLayoutDelegate>>();
+  EXPECT_CALL(*mock, IsToolbarVisible())
+      .WillRepeatedly(::testing::Return(true));
+  EXPECT_CALL(*mock, IsInfobarVisible())
+      .WillRepeatedly(::testing::Return(false));
+  EXPECT_CALL(*mock, ShouldUseBraveWebViewRoundedCornersForContents())
+      .WillRepeatedly(::testing::Return(true));
+
+  BrowserViewLayoutViews views;
+  auto layout = std::make_unique<BraveBrowserViewTabbedLayoutImpl>(
+      std::move(mock), nullptr, std::move(views));
+  layout->SetWindowStateForTesting(
+      BrowserViewLayoutDelegate::WindowState::kFullscreenWithToolbar);
+
+  // Upstream would set top_container_separator=true here (no side panel, no
+  // split view, so `would_have_separator` wins). Brave's mac-only branch
+  // overrides that to false: the rounded contents corners already provide the
+  // visual divider, so the separator would double up with it.
+  EXPECT_FALSE(layout->GetTopContainerSeparatorForTesting());
+}
+
+TEST(BraveBrowserViewTabbedLayoutImplTest,
+     CalculateSeparatorInfoMacFullscreenNotRoundedKeepsSeparator) {
+  auto mock =
+      std::make_unique<testing::NiceMock<MockBrowserViewLayoutDelegate>>();
+  EXPECT_CALL(*mock, IsToolbarVisible())
+      .WillRepeatedly(::testing::Return(true));
+  EXPECT_CALL(*mock, IsInfobarVisible())
+      .WillRepeatedly(::testing::Return(false));
+  EXPECT_CALL(*mock, ShouldUseBraveWebViewRoundedCornersForContents())
+      .WillRepeatedly(::testing::Return(false));
+
+  BrowserViewLayoutViews views;
+  auto layout = std::make_unique<BraveBrowserViewTabbedLayoutImpl>(
+      std::move(mock), nullptr, std::move(views));
+  layout->SetWindowStateForTesting(
+      BrowserViewLayoutDelegate::WindowState::kFullscreenWithToolbar);
+
+  // Without rounded corners there's no shape to double up with, so the
+  // mac-only branch must not fire and the separator stays visible.
+  EXPECT_TRUE(layout->GetTopContainerSeparatorForTesting());
+}
+
+TEST(BraveBrowserViewTabbedLayoutImplTest,
+     CalculateSeparatorInfoMacFullscreenRoundedWithInfobarKeepsSeparator) {
+  auto mock =
+      std::make_unique<testing::NiceMock<MockBrowserViewLayoutDelegate>>();
+  EXPECT_CALL(*mock, IsToolbarVisible())
+      .WillRepeatedly(::testing::Return(true));
+  EXPECT_CALL(*mock, IsInfobarVisible())
+      .WillRepeatedly(::testing::Return(true));
+  EXPECT_CALL(*mock, ShouldUseBraveWebViewRoundedCornersForContents())
+      .WillRepeatedly(::testing::Return(true));
+
+  BrowserViewLayoutViews views;
+  auto layout = std::make_unique<BraveBrowserViewTabbedLayoutImpl>(
+      std::move(mock), nullptr, std::move(views));
+  layout->SetWindowStateForTesting(
+      BrowserViewLayoutDelegate::WindowState::kFullscreenWithToolbar);
+
+  // With an infobar showing, the separator is still needed to divide it from
+  // the toolbar above, so the mac-only branch must not suppress it.
+  EXPECT_TRUE(layout->GetTopContainerSeparatorForTesting());
+}
+
+TEST(BraveBrowserViewTabbedLayoutImplTest,
+     CalculateSeparatorInfoRegularFullscreenRoundedNotAffected) {
+  auto mock =
+      std::make_unique<testing::NiceMock<MockBrowserViewLayoutDelegate>>();
+  EXPECT_CALL(*mock, IsToolbarVisible())
+      .WillRepeatedly(::testing::Return(true));
+  EXPECT_CALL(*mock, IsInfobarVisible())
+      .WillRepeatedly(::testing::Return(false));
+  EXPECT_CALL(*mock, ShouldUseBraveWebViewRoundedCornersForContents())
+      .WillRepeatedly(::testing::Return(true));
+
+  BrowserViewLayoutViews views;
+  auto layout = std::make_unique<BraveBrowserViewTabbedLayoutImpl>(
+      std::move(mock), nullptr, std::move(views));
+  // Plain kFullscreen (toolbar auto-hidden), not kFullscreenWithToolbar.
+  layout->SetWindowStateForTesting(
+      BrowserViewLayoutDelegate::WindowState::kFullscreen);
+
+  // The mac-only branch is scoped to kFullscreenWithToolbar; plain kFullscreen
+  // must keep upstream's separator (true here, since IsToolbarVisible() is
+  // mocked true).
+  EXPECT_TRUE(layout->GetTopContainerSeparatorForTesting());
+}
+
+#endif  // BUILDFLAG(IS_MAC)

--- a/chromium_src/chrome/browser/ui/views/frame/layout/browser_view_tabbed_layout_impl.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/layout/browser_view_tabbed_layout_impl.cc
@@ -41,17 +41,25 @@ BraveBrowserViewTabbedLayoutImpl::CalculateSeparatorInfo() const {
   // its accompanying main-area padding) so it doesn't double up.
   info.shadow_box = false;
 
+  const bool rounded =
+      delegate().ShouldUseBraveWebViewRoundedCornersForContents();
+
   // When the upstream choice is "no top-container separator" (either nothing
   // at all, or only a multi-contents separator), Brave promotes that to a
   // full-width top-container separator unless the rounded-corners contents
   // view is in use - in which case the rounded shape provides the visual
   // divider and no separator is wanted.
   if (!info.top_container_separator) {
-    const bool rounded =
-        delegate().ShouldUseBraveWebViewRoundedCornersForContents();
     info.top_container_separator = !rounded;
     info.multi_contents_separator = false;
   }
+
+#if BUILDFLAG(IS_MAC)
+  if (layout_data_->window_state == WindowState::kFullscreenWithToolbar &&
+      rounded && !delegate().IsInfobarVisible()) {
+    info.top_container_separator = false;
+  }
+#endif
 
   return info;
 }
@@ -68,4 +76,10 @@ bool BraveBrowserViewTabbedLayoutImpl::GetMultiContentsSeparatorForTesting()
 
 bool BraveBrowserViewTabbedLayoutImpl::GetShadowBoxForTesting() const {
   return CalculateSeparatorInfo().shadow_box;
+}
+
+void BraveBrowserViewTabbedLayoutImpl::SetWindowStateForTesting(
+    BrowserViewLayoutDelegate::WindowState window_state) {
+  layout_data_ = std::make_unique<TransientLayoutData>(BrowserLayoutParams());
+  layout_data_->window_state = window_state;
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57091

We don't want to have top separator and rounded corners together in tabbed fullscreen mode.

TEST=BraveBrowserViewTabbedLayoutImplTest.*

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
