### PR TITLE
Fix updates with Omaha 4 in macOS PKG installs

### DIFF
--- a/patches/chrome-updater-mac-privileged_helper-service.mm.patch
+++ b/patches/chrome-updater-mac-privileged_helper-service.mm.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/updater/mac/privileged_helper/service.mm b/chrome/updater/mac/privileged_helper/service.mm
+index bb17d2b9f91664e303037ccbcfaeb5c6747bf5b3..dc1784b40e5f856d7719aa20139f44fd7403fceb 100644
+--- a/chrome/updater/mac/privileged_helper/service.mm
++++ b/chrome/updater/mac/privileged_helper/service.mm
+@@ -116,7 +116,7 @@
+           .IdentifierIsOneOf({MAC_BROWSER_BUNDLE_IDENTIFIER_STRING,
+                               MAC_BROWSER_BUNDLE_IDENTIFIER_STRING ".beta",
+                               MAC_BROWSER_BUNDLE_IDENTIFIER_STRING ".dev",
+-                              MAC_BROWSER_BUNDLE_IDENTIFIER_STRING ".canary"})
++                              MAC_BROWSER_BUNDLE_IDENTIFIER_STRING ".nightly"})
+           .SignedWithSameIdentity()
+           .Build();
+   if (!requirement || !requirement->ValidateProcess(newConnection.auditToken)) {

--- a/rewrite/chrome/updater/mac/privileged_helper/service.mm.yaml
+++ b/rewrite/chrome/updater/mac/privileged_helper/service.mm.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Replace `.canary` with `.nightly` in the bundle identifier, in line with
+      our branding. This ensures that the browser (whose identifier is .nightly,
+      not .canary) can connect to the privileged helper.
+    regex:
+      pattern: 'MAC_BROWSER_BUNDLE_IDENTIFIER_STRING ".canary"'
+      replace: 'MAC_BROWSER_BUNDLE_IDENTIFIER_STRING ".nightly"'


### PR DESCRIPTION
Upstream's commit de06591e9e1e added extra verification in the updater's privileged helper that was broken under our "Canary" -> "Nightly" rebranding.

Resolves https://github.com/brave/brave-browser/issues/57057.

# Test plan

Please refer to the Steps to Reproduce from the issue description.