### PR TITLE
[Wallet] Fix wallet autolock crashing when running with --test-type cmd line

### DIFF
--- a/browser/brave_wallet/asset_discovery_manager_unittest.cc
+++ b/browser/brave_wallet/asset_discovery_manager_unittest.cc
@@ -14,7 +14,6 @@
 #include "brave/components/api_request_helper/api_request_helper.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_service.h"
-#include "brave/components/brave_wallet/browser/brave_wallet_service_delegate.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_service_observer_base.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
@@ -109,8 +108,7 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
     profile_ = builder.Build();
     wallet_service_ = std::make_unique<BraveWalletService>(
         url_loader_factory_.GetSafeWeakWrapper(),
-        BraveWalletServiceDelegate::Create(profile_.get()), GetPrefs(),
-        GetLocalState());
+        TestBraveWalletServiceDelegate::Create(), GetPrefs(), GetLocalState());
     network_manager_ = wallet_service_->network_manager();
     json_rpc_service_ = wallet_service_->json_rpc_service();
     keyring_service_ = wallet_service_->keyring_service();

--- a/browser/brave_wallet/asset_discovery_task_unittest.cc
+++ b/browser/brave_wallet/asset_discovery_task_unittest.cc
@@ -21,13 +21,13 @@
 #include "brave/components/brave_wallet/browser/blockchain_registry.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_service.h"
-#include "brave/components/brave_wallet/browser/brave_wallet_service_delegate.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_service_observer_base.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"
 #include "brave/components/brave_wallet/browser/pref_names.h"
 #include "brave/components/brave_wallet/browser/simple_hash_client.h"
+#include "brave/components/brave_wallet/browser/test_utils.h"
 #include "brave/components/brave_wallet/browser/tx_service.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/common_utils.h"
@@ -190,8 +190,7 @@ class AssetDiscoveryTaskUnitTest : public testing::Test {
     profile_ = builder.Build();
     wallet_service_ = std::make_unique<BraveWalletService>(
         url_loader_factory_.GetSafeWeakWrapper(),
-        BraveWalletServiceDelegate::Create(profile_.get()), GetPrefs(),
-        GetLocalState());
+        TestBraveWalletServiceDelegate::Create(), GetPrefs(), GetLocalState());
     json_rpc_service_ = wallet_service_->json_rpc_service();
     keyring_service_ = wallet_service_->keyring_service();
     tx_service_ = wallet_service_->tx_service();

--- a/browser/brave_wallet/brave_wallet_service_delegate_base.cc
+++ b/browser/brave_wallet/brave_wallet_service_delegate_base.cc
@@ -6,7 +6,6 @@
 #include "brave/browser/brave_wallet/brave_wallet_service_delegate_base.h"
 
 #include "base/auto_reset.h"
-#include "base/check_is_test.h"
 #include "base/command_line.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/browser/permission_utils.h"
@@ -14,10 +13,9 @@
 #include "chrome/browser/profiles/profile.h"
 #include "components/permissions/permission_util.h"
 #include "content/public/browser/browser_context.h"
-#include "content/public/common/content_switches.h"
 
 namespace {
-bool g_enable_autolock_commandline_check = true;
+bool g_enable_wallet_autolock = true;
 }
 
 namespace brave_wallet {
@@ -99,22 +97,13 @@ bool BraveWalletServiceDelegateBase::IsPrivateWindow() {
 }
 
 bool BraveWalletServiceDelegateBase::IsAutolockEnabled() {
-  if (g_enable_autolock_commandline_check) {
-    if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-            switches::kTestType)) {
-      CHECK_IS_TEST();
-      // We don't want autolock happening in most of the tests.
-      return false;
-    }
-  }
-
-  return true;
+  return g_enable_wallet_autolock;
 }
 
 // static
 base::AutoReset<bool>
-BraveWalletServiceDelegateBase::GetScopedEnableAutolockForTesting() {
-  return {&g_enable_autolock_commandline_check, false};
+BraveWalletServiceDelegateBase::GetScopedDisableAutolockForTesting() {
+  return {&g_enable_wallet_autolock, false};
 }
 
 }  // namespace brave_wallet

--- a/browser/brave_wallet/brave_wallet_service_delegate_base.h
+++ b/browser/brave_wallet/brave_wallet_service_delegate_base.h
@@ -35,8 +35,8 @@ class BraveWalletServiceDelegateBase : public BraveWalletServiceDelegate {
   ~BraveWalletServiceDelegateBase() override;
 
   // Delegates created in scope of returned object will have wallet autolock
-  // enabled. Autolock is disabled in tests by default.
-  static base::AutoReset<bool> GetScopedEnableAutolockForTesting();
+  // disabled.
+  static base::AutoReset<bool> GetScopedDisableAutolockForTesting();
 
   bool HasPermission(mojom::CoinType coin,
                      const url::Origin& origin,

--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -305,7 +305,7 @@ class TestBraveWalletServiceObserver
       observer_receiver_{this};
 };
 
-class MockBraveWalletServiceDelegate : public BraveWalletServiceDelegate {
+class MockBraveWalletServiceDelegate : public TestBraveWalletServiceDelegate {
  public:
   MockBraveWalletServiceDelegate() = default;
   ~MockBraveWalletServiceDelegate() override = default;
@@ -317,9 +317,6 @@ class MockBraveWalletServiceDelegate : public BraveWalletServiceDelegate {
                const std::string& tx_id,
                const GURL& tx_url),
               (override));
-  MOCK_METHOD(base::FilePath, GetWalletBaseDirectory, (), (override));
-  bool IsPrivateWindow() override { return false; }
-  bool IsAutolockEnabled() override { return false; }
 };
 
 class BraveWalletServiceUnitTest : public testing::Test {
@@ -358,6 +355,8 @@ class BraveWalletServiceUnitTest : public testing::Test {
         std::make_unique<sync_preferences::TestingPrefServiceSyncable>();
     RegisterUserProfilePrefs(prefs->registry());
     builder.SetPrefService(std::move(prefs));
+    auto scoped_disable_autolock =
+        BraveWalletServiceDelegateBase::GetScopedDisableAutolockForTesting();
     builder.AddTestingFactory(
         brave_wallet::BraveWalletServiceFactory::GetInstance(),
         base::BindRepeating(
@@ -2905,21 +2904,20 @@ TEST_F(BraveWalletServiceUnitTest, DisplayTxNotification) {
 }
 
 TEST_F(BraveWalletServiceUnitTest, AutolockIsDisabledInTests) {
-  // Wallet autolock is turned off in tests by default.
+  // Wallet autolock was turned off for `service_`.
   EXPECT_FALSE(service_->keyring_service()->IsLockedSync());
   task_environment_.FastForwardBy(base::Minutes(20));
   EXPECT_FALSE(service_->keyring_service()->IsLockedSync());
 
-  auto scoped_enable_autolock =
-      BraveWalletServiceDelegateBase::GetScopedEnableAutolockForTesting();
-
+  // Setup wallet service with autolock enabled.
+  auto delegate = std::make_unique<TestBraveWalletServiceDelegate>();
+  delegate->set_enable_autolock(true);
   auto another_wallet_service = std::make_unique<BraveWalletService>(
-      url_loader_factory_.GetSafeWeakWrapper(),
-      BraveWalletServiceDelegate::Create(profile_.get()), profile_->GetPrefs(),
-      &local_state_);
+      url_loader_factory_.GetSafeWeakWrapper(), std::move(delegate),
+      profile_->GetPrefs(), &local_state_);
   SetupWallet(another_wallet_service->keyring_service());
 
-  // Wallet is locked after some period which matches production behavior.
+  // Wallet is locked after some period.
   EXPECT_FALSE(another_wallet_service->keyring_service()->IsLockedSync());
   task_environment_.FastForwardBy(base::Minutes(20));
   EXPECT_TRUE(another_wallet_service->keyring_service()->IsLockedSync());

--- a/browser/brave_wallet/eth_allowance_manager_unittest.cc
+++ b/browser/brave_wallet/eth_allowance_manager_unittest.cc
@@ -218,8 +218,7 @@ class EthAllowanceManagerUnitTest : public testing::Test {
     profile_ = builder.Build();
     wallet_service_ = std::make_unique<BraveWalletService>(
         url_loader_factory_.GetSafeWeakWrapper(),
-        BraveWalletServiceDelegate::Create(profile_.get()), GetPrefs(),
-        GetLocalState());
+        TestBraveWalletServiceDelegate::Create(), GetPrefs(), GetLocalState());
     json_rpc_service_ = wallet_service_->json_rpc_service();
     keyring_service_ = wallet_service_->keyring_service();
     bitcoin_test_rpc_server_ = std::make_unique<BitcoinTestRpcServer>();

--- a/browser/brave_wallet/ethereum_provider_impl_unittest.cc
+++ b/browser/brave_wallet/ethereum_provider_impl_unittest.cc
@@ -204,6 +204,8 @@ class EthereumProviderImplUnitTest : public testing::Test {
     BraveWalletServiceDelegateImpl::SetActiveWebContentsForTesting(
         web_contents_.get());
     permissions::PermissionRequestManager::CreateForWebContents(web_contents());
+    auto scoped_disable_autolock =
+        BraveWalletServiceDelegateBase::GetScopedDisableAutolockForTesting();
     brave_wallet_service_ = std::make_unique<BraveWalletService>(
         url_loader_factory_.GetSafeWeakWrapper(),
         BraveWalletServiceDelegate::Create(browser_context()), prefs(),

--- a/browser/brave_wallet/solana_provider_impl_unittest.cc
+++ b/browser/brave_wallet/solana_provider_impl_unittest.cc
@@ -125,8 +125,8 @@ class SolanaProviderImplUnitTest : public testing::Test {
 
     brave_wallet_service_ = std::make_unique<BraveWalletService>(
         url_loader_factory_.GetSafeWeakWrapper(),
-        BraveWalletServiceDelegate::Create(browser_context()),
-        profile_.GetPrefs(), &local_state_);
+        TestBraveWalletServiceDelegate::Create(), profile_.GetPrefs(),
+        &local_state_);
     json_rpc_service_ = brave_wallet_service_->json_rpc_service();
     json_rpc_service_->SetAPIRequestHelperForTesting(
         url_loader_factory_.GetSafeWeakWrapper());

--- a/browser/net/decentralized_dns_network_delegate_helper_unittest.cc
+++ b/browser/net/decentralized_dns_network_delegate_helper_unittest.cc
@@ -23,6 +23,7 @@
 #include "brave/components/brave_wallet/browser/json_rpc_service_test_utils.h"
 #include "brave/components/brave_wallet/browser/network_manager.h"
 #include "brave/components/brave_wallet/browser/pref_names.h"
+#include "brave/components/brave_wallet/browser/test_utils.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/eth_abi_utils.h"
 #include "brave/components/brave_wallet/common/hex_utils.h"
@@ -90,7 +91,7 @@ class DecentralizedDnsNetworkDelegateHelperTest : public testing::Test {
                                        -> std::unique_ptr<KeyedService> {
           return std::make_unique<brave_wallet::BraveWalletService>(
               test_url_loader_factory_.GetSafeWeakWrapper(),
-              brave_wallet::BraveWalletServiceDelegate::Create(context),
+              brave_wallet::TestBraveWalletServiceDelegate::Create(),
               user_prefs::UserPrefs::Get(context),
               g_browser_process->local_state());
         }));

--- a/browser/ui/webui/settings/BUILD.gn
+++ b/browser/ui/webui/settings/BUILD.gn
@@ -56,6 +56,7 @@ source_set("unit_tests") {
         "//brave/components/brave_wallet/browser",
         "//brave/components/brave_wallet/browser:constants",
         "//brave/components/brave_wallet/browser:pref_names",
+        "//brave/components/brave_wallet/browser:test_support",
         "//brave/components/brave_wallet/browser:utils",
         "//brave/components/brave_wallet/common:test_support",
         "//components/user_prefs",

--- a/browser/ui/webui/settings/brave_wallet_handler_unittest.cc
+++ b/browser/ui/webui/settings/brave_wallet_handler_unittest.cc
@@ -26,6 +26,7 @@
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
 #include "brave/components/brave_wallet/browser/network_manager.h"
 #include "brave/components/brave_wallet/browser/pref_names.h"
+#include "brave/components/brave_wallet/browser/test_utils.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/common_utils.h"
 #include "brave/components/brave_wallet/common/test_utils.h"
@@ -80,7 +81,7 @@ class TestBraveWalletHandler : public BraveWalletHandler {
                                        -> std::unique_ptr<KeyedService> {
           return std::make_unique<brave_wallet::BraveWalletService>(
               url_loader_factory_.GetSafeWeakWrapper(),
-              brave_wallet::BraveWalletServiceDelegate::Create(context),
+              brave_wallet::TestBraveWalletServiceDelegate::Create(),
               user_prefs::UserPrefs::Get(context),
               g_browser_process->local_state());
         }));

--- a/chromium_src/chrome/test/base/DEPS
+++ b/chromium_src/chrome/test/base/DEPS
@@ -5,5 +5,6 @@ include_rules = [
   "+brave/app",
   "+brave/utility",
   "+brave/components/brave_shields/core/browser",
+  "+brave/components/brave_wallet/common",
   "+brave/test/base",
 ]

--- a/chromium_src/chrome/test/base/chrome_test_suite.h
+++ b/chromium_src/chrome/test/base/chrome_test_suite.h
@@ -7,6 +7,11 @@
 #define BRAVE_CHROMIUM_SRC_CHROME_TEST_BASE_CHROME_TEST_SUITE_H_
 
 #include "brave/components/brave_shields/core/browser/brave_shields_test_utils.h"
+#include "brave/components/brave_wallet/common/buildflags/buildflags.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_WALLET)
+#include "brave/browser/brave_wallet/brave_wallet_service_delegate_base.h"
+#endif
 
 #define ChromeTestSuite ChromeTestSuite_ChromiumImpl
 #include <chrome/test/base/chrome_test_suite.h>  // IWYU pragma: export
@@ -25,6 +30,13 @@ class ChromeTestSuite : public ChromeTestSuite_ChromiumImpl {
   // Use stable farbling both in Brave and Chromium tests.
   brave_shields::ScopedStableFarblingTokensForTesting
       scoped_stable_farbling_tokens_{1, base::Token()};
+#if BUILDFLAG(ENABLE_BRAVE_WALLET)
+  // We don't want to lock wallet by timeout in tests. It may cause intermittent
+  // CI failures.
+  base::AutoReset<bool> scoped_disable_wallet_autolock_{
+      brave_wallet::BraveWalletServiceDelegateBase::
+          GetScopedDisableAutolockForTesting()};
+#endif
 };
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_TEST_BASE_CHROME_TEST_SUITE_H_

--- a/chromium_src/chrome/test/sources.gni
+++ b/chromium_src/chrome/test/sources.gni
@@ -5,6 +5,7 @@
 
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
+import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
 import("//brave/components/tor/buildflags/buildflags.gni")
 
 brave_chromium_src_chrome_test_test_support_sources = [
@@ -34,4 +35,9 @@ if (enable_brave_vpn_v1) {
 
 if (enable_tor) {
   brave_chromium_src_chrome_test_test_support_deps += [ "//brave/browser/tor" ]
+}
+
+if (enable_brave_wallet) {
+  brave_chromium_src_chrome_test_test_support_deps +=
+      [ "//brave/browser/brave_wallet" ]
 }

--- a/chromium_src/chrome/test/sources.gni
+++ b/chromium_src/chrome/test/sources.gni
@@ -20,6 +20,7 @@ brave_chromium_src_chrome_test_test_support_deps = [
   "//brave/components/brave_shields/core/browser",
   "//brave/components/brave_shields/core/browser:test_support",
   "//brave/components/brave_vpn/common/buildflags",
+  "//brave/components/brave_wallet/common/buildflags",
   "//brave/components/tor/buildflags",
 ]
 

--- a/components/brave_wallet/browser/keyring_service.cc
+++ b/components/brave_wallet/browser/keyring_service.cc
@@ -66,7 +66,6 @@
 #include "brave/components/brave_wallet/common/fil_address.h"
 #include "brave/components/brave_wallet/common/hex_utils.h"
 #include "brave/components/brave_wallet/common/solana_utils.h"
-#include "brave/components/brave_wallet/common/switches.h"
 #include "components/grit/brave_components_strings.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "components/prefs/pref_service.h"
@@ -2723,8 +2722,7 @@ void KeyringService::StopAutoLockTimer() {
 
 void KeyringService::ResetAutoLockTimer() {
   // Autolock is disabled in most of the tests.
-  if (!is_autolock_enabled_.value_or(false)) {
-    CHECK_IS_TEST();
+  if (!is_autolock_enabled_) {
     return;
   }
 
@@ -3867,7 +3865,6 @@ void KeyringService::MaybeFixAccountSelection() {
 }
 
 void KeyringService::SetAutolockEnabled(bool enabled) {
-  CHECK(!is_autolock_enabled_.has_value());
   is_autolock_enabled_ = enabled;
 }
 

--- a/components/brave_wallet/browser/keyring_service.h
+++ b/components/brave_wallet/browser/keyring_service.h
@@ -529,7 +529,7 @@ class KeyringService : public mojom::KeyringService {
   raw_ptr<BraveWalletServiceDelegate> delegate_ = nullptr;
   bool request_unlock_pending_ = false;
 
-  std::optional<bool> is_autolock_enabled_;
+  bool is_autolock_enabled_ = false;
 
   base::RepeatingClosure wallet_reset_cb_;
   mojo::RemoteSet<mojom::KeyringServiceObserver> observers_;

--- a/components/brave_wallet/browser/keyring_service_unittest.cc
+++ b/components/brave_wallet/browser/keyring_service_unittest.cc
@@ -90,7 +90,7 @@ namespace {
 constexpr char kPasswordBrave[] = "brave";
 constexpr char kPasswordBrave123[] = "brave123";
 
-class MockBraveWalletServiceDelegate : public BraveWalletServiceDelegate {
+class MockBraveWalletServiceDelegate : public TestBraveWalletServiceDelegate {
  public:
   MockBraveWalletServiceDelegate() = default;
   ~MockBraveWalletServiceDelegate() override = default;
@@ -99,9 +99,6 @@ class MockBraveWalletServiceDelegate : public BraveWalletServiceDelegate {
               ResetPermissionsForAccount,
               (mojom::CoinType coin, const std::string& account),
               (override));
-  MOCK_METHOD(base::FilePath, GetWalletBaseDirectory, (), (override));
-  bool IsPrivateWindow() override { return false; }
-  bool IsAutolockEnabled() override { return false; }
 };
 
 struct ImportData {

--- a/components/brave_wallet/browser/test_utils.cc
+++ b/components/brave_wallet/browser/test_utils.cc
@@ -455,7 +455,7 @@ bool TestBraveWalletServiceDelegate::IsPrivateWindow() {
 }
 
 bool TestBraveWalletServiceDelegate::IsAutolockEnabled() {
-  return false;  // Don't need autolock to trigger in tests.
+  return enable_autolock_;
 }
 
 // static

--- a/components/brave_wallet/browser/test_utils.h
+++ b/components/brave_wallet/browser/test_utils.h
@@ -155,10 +155,14 @@ class TestBraveWalletServiceDelegate : public BraveWalletServiceDelegate {
   bool IsPrivateWindow() override;
   bool IsAutolockEnabled() override;
 
+  void set_enable_autolock(bool enable) { enable_autolock_ = enable; }
+
   static std::unique_ptr<BraveWalletServiceDelegate> Create();
 
  private:
   base::ScopedTempDir temp_dir_;
+  // Don't need autolock to trigger in tests.
+  bool enable_autolock_ = false;
 };
 
 void WaitForTxStorageInitialized(TxStorage* delegate);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/56904

# Test plan
Browser should not crash whent started with cmd line having `--test-type` 

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
