### PR TITLE
[bootstrap] Package `pnpm` for syncing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ patches/**/*.patchinfo
 /third_party/macholib
 /third_party/libdmg-hfsplus/
 /third_party/node/node-*/
+/third_party/node/node_modules/
 /third_party/node/linux/
 /third_party/node/mac/
 /third_party/node/mac_arm64/

--- a/third_party/node/README.md
+++ b/third_party/node/README.md
@@ -1,0 +1,48 @@
+# third_party/node
+
+This directory provisions two separate things Brave's build depends on:
+
+1. **The Node.js runtime** — the `node` binary (and `npm`) used to run the
+   browser's build tooling.
+2. **npm-delivered build tools** — pinned CLI tools (currently `pnpm`) installed
+   from npm into `node_modules/`.
+
+Both are downloaded from upstream, repackaged into tarballs, uploaded to Brave's
+build-deps bucket, and pulled into each checkout during `gclient sync`. The
+tracked files here are the scripts and manifests that produce and pin those
+tarballs; the downloaded trees and generated tarballs are git-ignored (see the
+repo `.gitignore`).
+
+### Rolling Node
+
+```sh
+# 1. Bump NODE_VERSION in download_node.py, then:
+vpython3 download_node.py --clear
+vpython3 package_node.py
+```
+
+## npm-delivered build tools
+
+The tool set is pinned in [`package.json`](package.json), with
+[`package-lock.json`](package-lock.json) pinning the exact resolved versions and
+their integrity. Everything is installed into a single `node_modules/` tree.
+
+- [`download_node_modules.py`](download_node_modules.py) runs `npm install` from
+  `package.json` using whatever `node`/`npm` is on the system PATH, and
+  refreshes the lockfile.
+- [`package_node_modules.py`](package_node_modules.py) packs the `node_modules/`
+  contents into `node_modules.tar.gz` and prints the object details to record.
+
+Tools installed this way are run via their in-package entry point, e.g. pnpm:
+
+```sh
+node third_party/node/node_modules/pnpm/bin/pnpm.mjs --version
+```
+
+### Adding or rolling a tool
+
+```sh
+# 1. Pin (or bump) the tool in package.json, then:
+vpython3 download_node_modules.py   # installs it and refreshes package-lock.json
+vpython3 package_node_modules.py
+```

--- a/third_party/node/download_node.py
+++ b/third_party/node/download_node.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env vpython3
 # Copyright (c) 2026 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,

--- a/third_party/node/download_node_modules.py
+++ b/third_party/node/download_node_modules.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Install the pinned npm-delivered build tools into `node_modules`.
+
+The set of tools is declared in this directory's `package.json`. This runs
+`npm install` and refreshes the lockfile in the process. Add a tool by pinning
+it in `package.json`, run this, then `package_node_modules.py`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Import the pinned Node version from the sibling downloader.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# pylint: disable=wrong-import-position
+from download_node import NODE_VERSION
+
+# This directory: third_party/node. `package.json`/`package-lock.json` live here
+# and `npm install` deploys into its `node_modules/`.
+_NODE_DIR = Path(__file__).resolve().parent
+
+# The directory `npm install` populates.
+NODE_MODULES_DIR = _NODE_DIR / 'node_modules'
+
+
+def _executable(name: str) -> str:
+    """The system `name` binary, resolving its extension on Windows."""
+    path = shutil.which(name)
+    if path is None:
+        raise RuntimeError(
+            f'{name} not found on PATH; install Node/npm first.')
+    return path
+
+
+def _assert_node_version() -> None:
+    """Fail unless the system `node` matches the pinned `NODE_VERSION`.
+    """
+    version = subprocess.run([_executable('node'), '--version'],
+                             check=True,
+                             capture_output=True,
+                             text=True).stdout.strip()
+    if version != NODE_VERSION:
+        raise RuntimeError(
+            f'system node {version} does not match the pinned NODE_VERSION '
+            f'{NODE_VERSION}; select Node {NODE_VERSION} before installing.')
+
+
+def install() -> None:
+    """Wipe and repopulate `node_modules` from `package.json`.
+    """
+    _assert_node_version()
+    if NODE_MODULES_DIR.exists():
+        shutil.rmtree(NODE_MODULES_DIR)
+    subprocess.run(
+        [
+            _executable('npm'), 'install', '--no-bin-links', '--no-fund',
+            '--no-audit', '--ignore-scripts', '--omit=dev', '--omit=optional'
+        ],
+        check=True,
+        cwd=_NODE_DIR,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Install the pinned tools from package.json into '
+        'third_party/node/node_modules.')
+    parser.parse_args()
+
+    print('Installing node_modules from package.json via npm')
+    install()
+    print(f'Deployed -> {NODE_MODULES_DIR.relative_to(_NODE_DIR.parent)}')
+    print('\nDone. Run package_node_modules.py to package this for upload.')
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/third_party/node/package-lock.json
+++ b/third_party/node/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "brave-node-modules",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "brave-node-modules",
+      "version": "1.0.0",
+      "dependencies": {
+        "pnpm": "11.9.0"
+      }
+    },
+    "node_modules/pnpm": {
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-11.9.0.tgz",
+      "integrity": "sha512-vWgtXQP+Ul73yf1ngMaITR51asTJyf4AxTh4KCQxDc+Q493E9Tg18G3669UIXkGFXgvLs7YN4qxburieUDbwOw==",
+      "license": "MIT",
+      "bin": {
+        "pn": "bin/pnpm.mjs",
+        "pnpm": "bin/pnpm.mjs",
+        "pnpx": "bin/pnpx.mjs",
+        "pnx": "bin/pnpx.mjs"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    }
+  }
+}

--- a/third_party/node/package.json
+++ b/third_party/node/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "brave-node-modules",
+  "version": "1.0.0",
+  "author": "cdesouza@brave.com",
+  "private": true,
+  "dependencies": {
+    "pnpm": "11.9.0"
+  }
+}

--- a/third_party/node/package_node.py
+++ b/third_party/node/package_node.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env vpython3
 # Copyright (c) 2026 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import mmap
+import os
 import sys
 import tarfile
 from pathlib import Path
@@ -57,13 +59,14 @@ def package(tarball_name: str, deployed_dir: str,
 
 def sha256_and_size(path: Path) -> tuple[str, int]:
     """Return the (sha256, byte size) of `path`."""
-    digest = hashlib.sha256()
-    size = 0
     with path.open('rb') as file:
-        while chunk := file.read(1 << 16):
-            digest.update(chunk)
-            size += len(chunk)
-    return digest.hexdigest(), size
+        size = os.fstat(file.fileno()).st_size
+        # Our tarballs are never empty; a zero-length file means packaging
+        # produced nothing, and mmap cannot map it either.
+        if size == 0:
+            raise RuntimeError(f'refusing to hash empty file: {path}')
+        with mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ) as mapped:
+            return hashlib.sha256(mapped).hexdigest(), size
 
 
 def main() -> int:

--- a/third_party/node/package_node_modules.py
+++ b/third_party/node/package_node_modules.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Package the `node_modules` tree deployed by `download_node_modules.py`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tarfile
+from pathlib import Path
+
+# Import the shared hashing helper from the sibling node packager.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# pylint: disable=wrong-import-position
+from package_node import sha256_and_size
+
+# This directory: third_party/node.
+_NODE_DIR = Path(__file__).resolve().parent
+
+# The directory `download_node_modules.py` populates.
+NODE_MODULES_DIR = _NODE_DIR / 'node_modules'
+
+
+def package(tarball_name: str, output_dir: Path) -> Path | None:
+    """Pack the *contents* of `node_modules/` into `tarball_name`.
+
+    Returns the tarball path, or None when nothing has been deployed yet (run
+    `download_node_modules.py` first).
+    """
+    if not NODE_MODULES_DIR.is_dir():
+        print(f'Skipping {tarball_name}: {NODE_MODULES_DIR} does not exist '
+              f'(run download_node_modules.py first).')
+        return None
+
+    tarball = output_dir / tarball_name
+    # Archive the contents of node_modules/ (pnpm/, ...) at the archive root, so
+    # extracting the tarball repopulates the destination node_modules/ directly.
+    with tarfile.open(tarball, mode='w:gz') as tar:
+        for child in sorted(NODE_MODULES_DIR.iterdir()):
+            tar.add(child, arcname=child.name)
+    return tarball
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Package third_party/node/node_modules into a tarball for '
+        'upload.')
+    parser.add_argument(
+        '--output-dir',
+        type=Path,
+        default=_NODE_DIR,
+        help='Directory to write the tarball into (defaults to this '
+        'directory).')
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    tarball_name = 'node_modules.tar.gz'
+    tarball = package(tarball_name, args.output_dir)
+    if tarball is None:
+        return 1
+
+    sha256, size = sha256_and_size(tarball)
+    print(f'Packaged {tarball.name}')
+
+    # Echo the values needed to update the EXTRA_DEPS entry after upload.
+    print('\nObject details for install_extra_deps.py:')
+    print(f"  object_name: '{tarball.name}'")
+    print(f"  sha256sum:   '{sha256}'  ({size} bytes)")
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)


### PR DESCRIPTION
This PR adds the necessary scripts for packaging `pnpm` for syncing.
The tarball has not been given a unique name yet, and maybe we should
rely on AWS's version id to select the specific tarball in history we
want, but this is still to be decided in a follow up.

Bug: https://github.com/brave/brave-browser/issues/56529
