### PR TITLE
[iOS] Fix colors in Brave Wallet enable biometrics unlock UI

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Onboarding/BiometricView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Onboarding/BiometricView.swift
@@ -53,11 +53,10 @@ struct BiometricView: View {
         VStack {
           ZStack {
             Circle()
+              .strokeBorder(Color(braveSystemName: .systemfeedbackInfoIcon).opacity(0.2))
               .background(
                 Circle()
-                  .foregroundColor(
-                    Color(braveSystemName: .systemfeedbackInfoBackground).opacity(0.5)
-                  )
+                  .foregroundColor(Color(braveSystemName: .systemfeedbackInfoBackground))
               )
               .frame(width: 240, height: 240)
             Rectangle()


### PR DESCRIPTION
Removing the strokeBorder in a previous PR caused the underlying Circle to render as black (the default), this re-adds the border but there is no "border" nala color here for this so we use the icon/text color with some opacity for the time being
