### PR TITLE
[owners] Remove `brave-core-owners` factories rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -205,13 +205,6 @@ content_settings_registry.cc @brave/content-settings-reviewers
 # new content settings need review
 content_settings_types.mojom @brave/content-settings-reviewers
 
-# Keyed service factories need special attention for browser context handling
-# See docs/keyed_services.md
-*_service_factory.cc @brave/brave-core-owners
-*_service_factory.mm @brave/brave-core-owners
-*_service_factory_ios.mm @brave/brave-core-owners
-
-
 # These rules are last to take precedence over directory rules. Do not add any
 # new rules at the end of this file or below the comment above that indicates
 # the start of this list


### PR DESCRIPTION
This PR removes the ownership of factories from `brave-core-owners` as
this is now being verified by an AI assitant.
