### PR TITLE
[ast-grep][plaster] Introducing `AstRewriter`

### DIFF
--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -16,8 +16,10 @@ import mmap
 from pathlib import Path, PurePath
 import json
 import os
+import platform
 import re
 import string
+import subprocess
 import sys
 import textwrap
 from types import MappingProxyType
@@ -1032,6 +1034,171 @@ class RewritersEval:
                     f'{self._source}: rewriter {op_id!r} result node '
                     f'{spec["result"]["node"]!r} does not match matcher '
                     f'{ref!r} node {matcher_node!r}')
+
+
+def _ast_grep_platform_dir() -> str:
+    """Host-OS token in ast-grep's per-platform dir name (`ast-grep-<os>`).
+
+    Mirrors `_platform_dir()` in third_party/ast-grep/build_ast_grep.py.
+    """
+    if sys.platform == 'darwin':
+        return 'mac_arm64' if platform.machine() == 'arm64' else 'mac'
+    if sys.platform == 'win32':
+        return 'win'
+    return 'linux'
+
+
+# Path to the ast-grep binary provisioned under brave/third_party/ast-grep.
+_AST_GREP_EXE = '.exe' if sys.platform == 'win32' else ''
+AST_GREP_BIN = (Path(__file__).resolve().parents[2] / 'third_party' /
+                'ast-grep' / f'ast-grep-{_ast_grep_platform_dir()}' / 'bin' /
+                f'ast-grep{_AST_GREP_EXE}')
+
+
+class AstGrepError(PlasterError):
+    """Raised when the ast-grep binary fails to run a rule."""
+
+
+@dataclass(frozen=True)
+class AstMatch:
+    """The byte range of a single ast-grep match within the scanned source.
+
+    `start` is the match's byte offset and `length` its size in bytes; `end`
+    is the exclusive offset one past it. The matched text is not stored -- read
+    it back from the source (`source[start:end]`) so the bytes have a single
+    source of truth, regardless of multi-byte content upstream.
+    """
+
+    start: int
+    length: int
+
+    @property
+    def end(self) -> int:
+        """Exclusive byte offset one past the match (`start + length`)."""
+        return self.start + self.length
+
+
+def _indent_yaml(text: str, spaces: int = 2) -> str:
+    """Indent every non-blank line of `text` by `spaces`, for nesting YAML."""
+    pad = ' ' * spaces
+    return '\n'.join(pad + line if line.strip() else line
+                     for line in text.splitlines())
+
+
+def run_ast_grep(*, language: str, rule_body: str,
+                 source: str) -> list[AstMatch]:
+    """Run an ast-grep rule against in-memory source and return its matches.
+
+    This function is the main entrypoint for the ast-grep binary invocation.
+
+    `rule_body` is an ast-grep YAML rule body (the part under `rule:`). Source
+    is fed over stdin with an explicit `--lang`. The reported offsets are into
+    `source`'s UTF-8 bytes, regardless of how stdin is encoded.
+    """
+    doc = (f'id: plaster\nlanguage: {language}\nrule:\n' +
+           _indent_yaml(rule_body))
+    # Route through terminal.run for consistent logging / infra keep-alive,
+    # like the rest of plaster's subprocess use. It runs with check=True, so a
+    # non-zero exit (e.g. a bad rule) raises CalledProcessError.
+    try:
+        result = terminal.run([
+            AST_GREP_BIN, 'scan', '--stdin', '--inline-rules', doc,
+            '--json=stream'
+        ],
+                              stdin=source)
+    except subprocess.CalledProcessError as e:
+        raise AstGrepError(f'ast-grep failed ({e.returncode}): '
+                           f'{(e.stderr or "").strip()}') from e
+
+    matches = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        obj = json.loads(line)
+        span = obj['range']['byteOffset']
+        matches.append(
+            AstMatch(start=span['start'], length=span['end'] - span['start']))
+    return matches
+
+
+class AstRewriter:
+    """Applies ast-grep rewriter ops to the contents of a single file.
+
+    Constructed with an already-parsed `RewritersEval` and the target file's
+    contents. `apply` runs one rewriter op (by id) over the current contents,
+    mutating them in place and returning how many places changed; call it
+    repeatedly to accumulate edits. Op-specific conveniences (which op id and
+    which adjacent tokens to consume) belong with the `Rewriter` classes that
+    drive this engine, not here.
+    """
+
+    def __init__(self, rewriters: RewritersEval, content: str):
+        self._rewriters = rewriters
+        self._content = content
+
+    @property
+    def content(self) -> str:
+        """The current file contents, reflecting every applied rewrite."""
+        return self._content
+
+    def apply(self,
+              op_id: str,
+              args: dict[str, str],
+              *,
+              consume_before: str = '',
+              consume_after: str = '') -> int:
+        """Run rewriter `op_id` with `args`, mutate content, return count.
+
+        Locates nodes via the op's matcher template, applies the op's `replace`
+        regex substitution (with `args` filled into the replacement template)
+        to each matched node, and splices the results back into the held
+        contents from the end so earlier byte offsets stay valid. Returns the
+        total number of substitutions made.
+
+        `consume_before` / `consume_after` are literals the op assumes
+        immediately precede / follow each matched node. They are folded into the
+        rewritten span used when the node kind stops short of an adjacent
+        token (e.g. the `:` after an access_specifier, or the space before a
+        `final` specifier). They are engine details, not part of the rewriters
+        spec.
+        """
+        rewriter = self._rewriters.rewriter(op_id)
+        matcher = self._rewriters.matcher(rewriter['matcher'])
+        language = self._rewriters.language_of(op_id)
+        rule_body = matcher['template'].format(**args)
+
+        matches = run_ast_grep(language=language,
+                               rule_body=rule_body,
+                               source=self._content)
+
+        pattern = rewriter['replace']['re_pattern']
+        replacement = rewriter['replace']['replace'].format(**args)
+        before = consume_before.encode('utf-8')
+        after = consume_after.encode('utf-8')
+
+        source = self._content.encode('utf-8')
+        edits = []
+        total = 0
+        for match in matches:
+            start = match.start - len(before)
+            end = match.end + len(after)
+            if (before and source[start:match.start]
+                    != before) or (after and source[match.end:end] != after):
+                # An assumed adjacent token isn't there; skip rather than
+                # corrupt. The caller's count check will flag the shortfall.
+                continue
+            text = source[match.start:match.end].decode('utf-8')
+            new_text, changes = re.subn(pattern, replacement, text)
+            if changes:
+                edits.append((start, end, new_text))
+                total += changes
+
+        # Match offsets are into the source's UTF-8 bytes, so splice on bytes.
+        # Apply from the end so each splice leaves earlier offsets unchanged.
+        for start, end, new_text in sorted(edits, reverse=True):
+            source = source[:start] + new_text.encode('utf-8') + source[end:]
+        self._content = source.decode('utf-8')
+        return total
 
 
 def get_plaster_files(filepaths: list[str] | None = None) -> list[PlasterFile]:

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1492,6 +1492,265 @@ class RewritersEvalTest(unittest.TestCase):
                 {'append': '!'}), 'Wrong keys')
 
 
+# ast-grep matcher templates used to build synthetic RewritersEval specs for
+# the engine tests below. The shipped rewriters.pyl is empty until the ops that
+# consume these land; these mirror the specs plaster will ship then, so the
+# engine can be exercised end-to-end against the real binary in the meantime.
+_METHOD_DECL_RULE = ('any:\n'
+                     '  - kind: field_declaration\n'
+                     '  - kind: declaration\n'
+                     'has:\n'
+                     '  kind: function_declarator\n'
+                     '  stopBy: end\n'
+                     '  has:\n'
+                     '    field: declarator\n'
+                     '    regex: ^{method_name}$\n'
+                     'inside:\n'
+                     '  kind: class_specifier\n'
+                     '  stopBy: end\n'
+                     '  has:\n'
+                     '    field: name\n'
+                     '    regex: ^{class_name}$\n')
+
+_PRIVATE_SECTION_RULE = ('kind: access_specifier\n'
+                         'regex: ^private$\n'
+                         'inside:\n'
+                         '  kind: class_specifier\n'
+                         '  stopBy: end\n'
+                         '  has:\n'
+                         '    field: name\n'
+                         '    regex: ^{class_name}$\n')
+
+_FINAL_RULE = ('kind: virtual_specifier\n'
+               'regex: ^final$\n'
+               'inside:\n'
+               '  kind: class_specifier\n'
+               '  has:\n'
+               '    field: name\n'
+               '    regex: ^{class_name}$\n')
+
+_SYNTHETIC_SPEC = {
+    'ast.matcher': {
+        'cxx.find_class_method_decl': {
+            'args': ['class_name', 'method_name'],
+            'template': _METHOD_DECL_RULE,
+            'result': {
+                'node': 'field_declaration'
+            },
+        },
+        'cxx.find_class_private_section': {
+            'args': ['class_name'],
+            'template': _PRIVATE_SECTION_RULE,
+            'result': {
+                'node': 'access_specifier'
+            },
+        },
+        'cxx.find_class_final': {
+            'args': ['class_name'],
+            'template': _FINAL_RULE,
+            'result': {
+                'node': 'virtual_specifier'
+            },
+        },
+    },
+    'ast.rewriter': {
+        'cxx.make_virtual': {
+            'matcher': 'cxx.find_class_method_decl',
+            'replace': {
+                're_pattern': '^',
+                'replace': 'virtual '
+            },
+            'result': {
+                'node': 'field_declaration'
+            },
+        },
+        'cxx.add_friend': {
+            'matcher': 'cxx.find_class_private_section',
+            'replace': {
+                're_pattern': '$',
+                'replace': ':\\n  friend {friend_type};'
+            },
+            'result': {
+                'node': 'access_specifier'
+            },
+        },
+        'cxx.remove_final': {
+            'matcher': 'cxx.find_class_final',
+            'replace': {
+                're_pattern': '^final$',
+                'replace': ''
+            },
+            'result': {
+                'node': 'virtual_specifier'
+            },
+        },
+    },
+}
+
+
+class RunAstGrepTest(unittest.TestCase):
+    """Integration tests for plaster.run_ast_grep (real ast-grep binary)."""
+
+    # A small C++ source. ASCII-only, so byte offsets equal character indices.
+    _SRC = 'class C {\n  void Foo();\n  void Bar();\n};\n'
+
+    def _find(self, method_name: str, source: str) -> list[plaster.AstMatch]:
+        body = _METHOD_DECL_RULE.format(class_name='C',
+                                        method_name=method_name)
+        return plaster.run_ast_grep(language='cpp',
+                                    rule_body=body,
+                                    source=source)
+
+    def test_finds_match_with_byte_offsets(self):
+        matches = self._find('Foo', self._SRC)
+        self.assertEqual(len(matches), 1)
+        # AstMatch is a byte range; the text is read back from the source.
+        raw = self._SRC.encode('utf-8')
+        m = matches[0]
+        self.assertEqual(raw[m.start:m.end], b'void Foo();')
+        self.assertEqual(m.length, len(b'void Foo();'))
+        self.assertEqual(m.end, m.start + m.length)
+
+    def test_no_match_returns_empty(self):
+        self.assertEqual(self._find('Nope', self._SRC), [])
+
+    def test_overloads_each_match(self):
+        source = 'class C {\n  void Foo();\n  void Foo(int x);\n};\n'
+        raw = source.encode('utf-8')
+        matches = self._find('Foo', source)
+        self.assertEqual([raw[m.start:m.end].decode() for m in matches],
+                         ['void Foo();', 'void Foo(int x);'])
+
+    def test_raises_on_bad_rule(self):
+        with self.assertRaises(plaster.AstGrepError):
+            plaster.run_ast_grep(language='cpp',
+                                 rule_body='kind: not_a_real_kind',
+                                 source='int x;\n')
+
+
+class AstRewriterTest(unittest.TestCase):
+    """Integration tests for plaster.AstRewriter (real ast-grep binary).
+
+    Driven with a synthetic RewritersEval built from `_SYNTHETIC_SPEC`, since
+    the shipped rewriters.pyl carries no ops yet.
+    """
+
+    _SRC = 'class C {\n  void Foo();\n  void Bar();\n};\n'
+
+    def _rewriter(self, source: str = _SRC) -> plaster.AstRewriter:
+        return plaster.AstRewriter(
+            plaster.RewritersEval(repr(_SYNTHETIC_SPEC)), source)
+
+    def test_make_virtual_single(self):
+        rewriter = self._rewriter()
+        count = rewriter.apply('cxx.make_virtual', {
+            'class_name': 'C',
+            'method_name': 'Foo'
+        })
+        self.assertEqual(count, 1)
+        self.assertEqual(
+            rewriter.content,
+            'class C {\n  virtual void Foo();\n  void Bar();\n};\n')
+
+    def test_make_virtual_destructor(self):
+        # Destructors parse as `declaration` with a `destructor_name`, not the
+        # `field_declaration`/`field_identifier` of a regular method.
+        rewriter = self._rewriter('class C {\n public:\n  ~C();\n};\n')
+        count = rewriter.apply('cxx.make_virtual', {
+            'class_name': 'C',
+            'method_name': '~C'
+        })
+        self.assertEqual(count, 1)
+        self.assertEqual(rewriter.content,
+                         'class C {\n public:\n  virtual ~C();\n};\n')
+
+    def test_make_virtual_overloads_count_each(self):
+        rewriter = self._rewriter(
+            'class C {\n  void Foo();\n  void Foo(int x);\n};\n')
+        count = rewriter.apply('cxx.make_virtual', {
+            'class_name': 'C',
+            'method_name': 'Foo'
+        })
+        self.assertEqual(count, 2)
+        # Splicing from the end keeps the earlier overload's offset valid.
+        self.assertEqual(
+            rewriter.content, 'class C {\n  virtual void Foo();\n'
+            '  virtual void Foo(int x);\n};\n')
+
+    def test_no_match_leaves_content_unchanged(self):
+        rewriter = self._rewriter()
+        self.assertEqual(
+            rewriter.apply('cxx.make_virtual', {
+                'class_name': 'C',
+                'method_name': 'Nope'
+            }), 0)
+        self.assertEqual(rewriter.content, self._SRC)
+
+    def test_content_accumulates_across_calls(self):
+        rewriter = self._rewriter()
+        rewriter.apply('cxx.make_virtual', {
+            'class_name': 'C',
+            'method_name': 'Foo'
+        })
+        rewriter.apply('cxx.make_virtual', {
+            'class_name': 'C',
+            'method_name': 'Bar'
+        })
+        self.assertEqual(
+            rewriter.content,
+            'class C {\n  virtual void Foo();\n  virtual void Bar();\n};\n')
+
+    def test_add_friend_inserts_after_private_colon(self):
+        rewriter = self._rewriter(
+            'class C {\n public:\n  void Foo();\n private:\n  int x_;\n};\n')
+        count = rewriter.apply('cxx.add_friend', {
+            'class_name': 'C',
+            'friend_type': 'class BraveC'
+        },
+                               consume_after=':')
+        self.assertEqual(count, 1)
+        # The friend lands as the first private line; the `:` is not duplicated.
+        self.assertEqual(
+            rewriter.content, 'class C {\n public:\n  void Foo();\n'
+            ' private:\n  friend class BraveC;\n  int x_;\n};\n')
+
+    def test_add_friend_no_private_section(self):
+        rewriter = self._rewriter('class C {\n public:\n  void Foo();\n};\n')
+        self.assertEqual(
+            rewriter.apply('cxx.add_friend', {
+                'class_name': 'C',
+                'friend_type': 'class BraveC'
+            },
+                           consume_after=':'), 0)
+        self.assertEqual(rewriter.content,
+                         'class C {\n public:\n  void Foo();\n};\n')
+
+    def test_remove_final_with_base(self):
+        # The class `final` is dropped (and the space before it); a method's
+        # trailing `final` is left untouched.
+        rewriter = self._rewriter(
+            'class C final : public Base {\n  void f() final;\n};\n')
+        self.assertEqual(
+            rewriter.apply('cxx.remove_final', {'class_name': 'C'},
+                           consume_before=' '), 1)
+        self.assertEqual(rewriter.content,
+                         'class C : public Base {\n  void f() final;\n};\n')
+
+    def test_remove_final_no_base(self):
+        rewriter = self._rewriter('class C final {\n};\n')
+        self.assertEqual(
+            rewriter.apply('cxx.remove_final', {'class_name': 'C'},
+                           consume_before=' '), 1)
+        self.assertEqual(rewriter.content, 'class C {\n};\n')
+
+    def test_remove_final_absent(self):
+        rewriter = self._rewriter('class C {\n};\n')
+        self.assertEqual(
+            rewriter.apply('cxx.remove_final', {'class_name': 'C'},
+                           consume_before=' '), 0)
+        self.assertEqual(rewriter.content, 'class C {\n};\n')
+
+
 class HelpTest(unittest.TestCase):
     """gn-style `plaster --help [topic]` overview, categories and topic docs.
 


### PR DESCRIPTION
This class is being introduced as the main driver for `ast-grep`. This
is the foundation work to get `ast-grep` being launched and used to
rewrite upstream files.

Follow up work will be submitted to wire the specific writers on top of
this class.

Bug: https://github.com/brave/brave-browser/issues/56760
