### PR TITLE
[iOS] Add origin opaque check to protection stats JS feature

### DIFF
--- a/ios/browser/brave_shields/protection_stats_javascript_feature.mm
+++ b/ios/browser/brave_shields/protection_stats_javascript_feature.mm
@@ -54,7 +54,8 @@ void ProtectionStatsJavaScriptFeature::ScriptMessageReceived(
     const web::ScriptMessage& message) {
   const base::ListValue* body =
       message.body() ? message.body()->GetIfList() : nullptr;
-  if (!body) {
+  url::Origin security_origin = message.security_origin();
+  if (!body || security_origin.opaque()) {
     return;
   }
 
@@ -81,8 +82,7 @@ void ProtectionStatsJavaScriptFeature::ScriptMessageReceived(
     return;
   }
 
-  tab_helper->HandleBlockedResources(resources,
-                                     message.security_origin().GetURL());
+  tab_helper->HandleBlockedResources(resources, security_origin.GetURL());
 }
 
 }  // namespace brave_shields


### PR DESCRIPTION
This fixes a crash that occurred when the security origin is opaque and the resulting `NSURL` is nil
