### PR TITLE
[iOS] Clamp download percentages in download toast

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/DownloadToast.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/DownloadToast.swift
@@ -120,12 +120,16 @@ class DownloadToast: Toast {
 
   func updatePercent() {
     DispatchQueue.main.async {
-      guard let combinedTotalBytesExpected = self.combinedTotalBytesExpected else {
+      guard let combinedTotalBytesExpected = self.combinedTotalBytesExpected,
+        combinedTotalBytesExpected > 0
+      else {
         self.percent = 0.0
         return
       }
 
-      self.percent = CGFloat(self.combinedBytesDownloaded) / CGFloat(combinedTotalBytesExpected)
+      let percent =
+        CGFloat(self.combinedBytesDownloaded) / CGFloat(combinedTotalBytesExpected)
+      self.percent = min(max(percent, 0.0), 1.0)
     }
   }
 


### PR DESCRIPTION
This is a speculative crash fix, where a non-finite percent was being assigned if `combinedTotalBytesExpected` was somehow 0 which would cause the value to be used for the progress width constraint.

Resolves https://github.com/brave/brave-browser/issues/57109
