### PR TITLE
[recipes][bootstrap] `package_node_modules.py` recipe

### DIFF
--- a/third_party/node/package_node_modules.py
+++ b/third_party/node/package_node_modules.py
@@ -9,15 +9,19 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import sys
 import tarfile
 from pathlib import Path
 
-# Import the shared hashing helper from the sibling node packager.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(
+    0,
+    str(Path(__file__).resolve().parents[2] / 'tools' / 'cr' / 'toolchains'))
 
 # pylint: disable=wrong-import-position
 from package_node import sha256_and_size
+from upload import S3Uploader, summarise
 
 # This directory: third_party/node.
 _NODE_DIR = Path(__file__).resolve().parent
@@ -56,6 +60,10 @@ def main() -> int:
         default=_NODE_DIR,
         help='Directory to write the tarball into (defaults to this '
         'directory).')
+    parser.add_argument(
+        '--upload',
+        action='store_true',
+        help=f'Upload the packaged tarball to our public bucket.')
     args = parser.parse_args()
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
@@ -64,14 +72,22 @@ def main() -> int:
     tarball = package(tarball_name, args.output_dir)
     if tarball is None:
         return 1
-
-    sha256, size = sha256_and_size(tarball)
     print(f'Packaged {tarball.name}')
 
-    # Echo the values needed to update the EXTRA_DEPS entry after upload.
-    print('\nObject details for install_extra_deps.py:')
-    print(f"  object_name: '{tarball.name}'")
-    print(f"  sha256sum:   '{sha256}'  ({size} bytes)")
+    if args.upload:
+        logging.basicConfig(level=logging.INFO, format='%(message)s')
+        result = S3Uploader(bucket='brave-build-deps-public').upload(
+            tarball, prefix='nodejs')
+        print(f'\nUpload summary:\n{summarise(result)}')
+        sha256, size = result.sha256, result.size_bytes
+    else:
+        sha256, size = sha256_and_size(tarball)
+
+        # Echo the values needed to update the EXTRA_DEPS entry (after upload).
+        print('\nObject details for install_extra_deps.py:')
+        print(f"  object_name: '{tarball.name}'")
+        print(f"  sha256sum:   '{sha256}'  ({size} bytes)")
+
     return 0
 
 

--- a/tools/cr/toolchains/upload.py
+++ b/tools/cr/toolchains/upload.py
@@ -108,6 +108,22 @@ class UploadResult:
     signature: ArtifactSignature | None
 
 
+# The fields of `UploadResult` that we want to be summarised.
+_PUBLIC_FIELDS = ('bucket', 'key', 'url', 'sha256', 'size_bytes', 'version_id',
+                  'etag')
+
+
+def summarise(result: UploadResult) -> str:
+    """Return a human-readable, publicly-safe summary of *result*.
+
+    A user friendly summary of the upload result, suitable for printing in CI.
+    """
+    width = max(len(name) for name in _PUBLIC_FIELDS) + 1
+    return '\n'.join(f'{name + ":":<{width}} {getattr(result, name)}'
+                     for name in _PUBLIC_FIELDS
+                     if getattr(result, name) is not None)
+
+
 def sha256_file(path: Path) -> str:
     """Return the hex SHA-256 of *path*.
 

--- a/tools/cr/toolchains/upload_test.py
+++ b/tools/cr/toolchains/upload_test.py
@@ -16,6 +16,8 @@ the digest-based KMS signing that must mirror `signing.createSignatureKms`.
 Layers:
 
 * `Sha256FileTest` runs the real (module-level) hasher over real on-disk files.
+* `SummariseTest` checks the public summary carries the location/integrity
+  fields and never the KMS signature envelope.
 * `KmsVerifyTest` covers the module-level download-side verify helper.
 * `SignTest` covers `S3Uploader.sign` argv and the base64-digest encoding.
 * `PutObjectTest` covers `S3Uploader._put_object` — the conditional-write and
@@ -146,6 +148,48 @@ class Sha256FileTest(unittest.TestCase):
         with _tempfile(data) as path:
             self.assertEqual(m.sha256_file(path),
                              hashlib.sha256(data).hexdigest())
+
+
+class SummariseTest(unittest.TestCase):
+    """`summarise` emits the public envelope and never the signing material."""
+
+    @staticmethod
+    def _result(**overrides):
+        base = dict(bucket='brave-build-deps-public',
+                    key='nodejs/node_modules.tar.gz',
+                    url='https://brave-build-deps-public.s3.brave.com/'
+                    'nodejs/node_modules.tar.gz',
+                    sha256='abc123',
+                    size_bytes=4574694,
+                    version_id='v-1',
+                    etag='"e-tag"',
+                    signature=m.ArtifactSignature(
+                        key_id='arn:aws:kms:us-west-2:123456789012:key/abcd',
+                        signature='c2lnbmF0dXJlLWJ5dGVz'))
+        base.update(overrides)
+        return m.UploadResult(**base)
+
+    def test_includes_public_fields(self):
+        summary = self._result()
+        rendered = m.summarise(summary)
+        for expected in (summary.bucket, summary.key, summary.url,
+                         summary.sha256, str(summary.size_bytes),
+                         summary.version_id, summary.etag):
+            self.assertIn(expected, rendered)
+
+    def test_omits_signature_envelope(self):
+        rendered = m.summarise(self._result())
+        self.assertNotIn('c2lnbmF0dXJlLWJ5dGVz', rendered)
+        self.assertNotIn('123456789012', rendered)
+        self.assertNotIn('key/abcd', rendered)
+        self.assertNotIn('signature', rendered.lower())
+
+    def test_skips_none_fields(self):
+        rendered = m.summarise(self._result(version_id=None, etag=None))
+        self.assertNotIn('version_id', rendered)
+        self.assertNotIn('etag', rendered)
+        # A required field is still rendered.
+        self.assertIn('sha256', rendered)
 
 
 class SignTest(unittest.TestCase):

--- a/tools/recipes/recipes/tools/node/package_node_modules.expected/basic.json
+++ b/tools/recipes/recipes/tools/node/package_node_modules.expected/basic.json
@@ -1,0 +1,67 @@
+[
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "2",
+      "--filter=blob:none",
+      "--sparse",
+      "--branch",
+      "master",
+      "git@github.com:brave/brave-core.git",
+      "[WORKSPACE]/chromium/src/brave"
+    ],
+    "name": "clone brave-core (shallow, sparse)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "sparse-checkout",
+      "add",
+      "third_party/node",
+      "tools/cr/toolchains"
+    ],
+    "name": "sparse-checkout add"
+  },
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "1",
+      "https://chromium.googlesource.com/chromium/tools/depot_tools",
+      "[WORKSPACE]/chromium/third_party/depot_tools"
+    ],
+    "name": "clone depot_tools"
+  },
+  {
+    "cmd": [
+      "gclient"
+    ],
+    "name": "verify gclient"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/chromium/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/chromium/src/brave/third_party/node/download_node_modules.py"
+    ],
+    "name": "download node_modules"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/chromium/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/chromium/src/brave/third_party/node/package_node_modules.py",
+      "--output-dir",
+      "[WORKSPACE]/out",
+      "--upload"
+    ],
+    "name": "package node_modules"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipes/tools/node/package_node_modules.expected/reuse_checkout.json
+++ b/tools/recipes/recipes/tools/node/package_node_modules.expected/reuse_checkout.json
@@ -1,0 +1,76 @@
+[
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "fetch",
+      "--depth",
+      "2",
+      "origin",
+      "master"
+    ],
+    "name": "fetch brave-core ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "checkout",
+      "--force",
+      "FETCH_HEAD"
+    ],
+    "name": "checkout brave-core ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "sparse-checkout",
+      "add",
+      "third_party/node",
+      "tools/cr/toolchains"
+    ],
+    "name": "sparse-checkout add"
+  },
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "1",
+      "https://chromium.googlesource.com/chromium/tools/depot_tools",
+      "[WORKSPACE]/chromium/third_party/depot_tools"
+    ],
+    "name": "clone depot_tools"
+  },
+  {
+    "cmd": [
+      "gclient"
+    ],
+    "name": "verify gclient"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/chromium/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/chromium/src/brave/third_party/node/download_node_modules.py"
+    ],
+    "name": "download node_modules"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/chromium/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/chromium/src/brave/third_party/node/package_node_modules.py",
+      "--output-dir",
+      "[WORKSPACE]/out",
+      "--upload"
+    ],
+    "name": "package node_modules"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipes/tools/node/package_node_modules.py
+++ b/tools/recipes/recipes/tools/node/package_node_modules.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Install and package third_party/node's node_modules into a tarball for the
+build-deps bucket.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import post_process
+
+if TYPE_CHECKING:
+    from engine import RecipeScriptApi
+
+DEPS = ['path', 'step', 'depot_tools', 'brave_core_shallow']
+
+
+def RunSteps(api: RecipeScriptApi, _: object) -> None:
+    brave_root = api.brave_core_shallow.deploy([
+        'third_party/node',
+        'tools/cr/toolchains',
+    ])
+
+    vpython3 = api.depot_tools.vpython3()
+    node_dir = brave_root / 'third_party/node'
+    api.step('download node_modules', [
+        vpython3,
+        node_dir / 'download_node_modules.py',
+    ])
+    api.step('package node_modules', [
+        vpython3,
+        node_dir / 'package_node_modules.py',
+        '--output-dir',
+        api.path.out,
+        '--upload',
+    ])
+
+
+def GenTests(api):
+    yield api.test(
+        'basic',
+        api.brave_core_shallow.deployed('third_party/node',
+                                        'tools/cr/toolchains'),
+        api.post_process(post_process.MustRun,
+                         'clone brave-core (shallow, sparse)'),
+        api.post_process(post_process.MustRun, 'download node_modules'),
+        api.post_process(post_process.MustRun, 'package node_modules'),
+        api.post_process(post_process.StatusSuccess),
+    )
+    # An existing brave-core checkout is fetched/updated rather than re-cloned.
+    yield api.test(
+        'reuse checkout',
+        api.brave_core_shallow.existing_checkout(),
+        api.brave_core_shallow.deployed('third_party/node',
+                                        'tools/cr/toolchains'),
+        api.post_process(post_process.MustRun, 'fetch brave-core ref'),
+        api.post_process(post_process.DoesNotRun,
+                         'clone brave-core (shallow, sparse)'),
+        api.post_process(post_process.MustRun, 'package node_modules'),
+        api.post_process(post_process.StatusSuccess),
+    )


### PR DESCRIPTION
This recipe runs the scripts to package and upload the node modules.
With this recipe, we pass `--upload` to uplaod directly into the bucket,
and changes have been made to the packaging script to permit that.

Bug: https://github.com/brave/brave-browser/issues/56529
Bug: https://github.com/brave/brave-browser/issues/56748
