### PR TITLE
[iOS] Add checks to avoid invalid geometry during tab tray animation

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridTransition.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridTransition.swift
@@ -30,6 +30,7 @@ extension TabGridHostingController: BasicAnimationControllerDelegate {
   func animatePresentation(context: any UIViewControllerContextTransitioning) {
     let finalFrame = context.finalFrame(for: self)
     guard let fromView = context.view(forKey: .from),
+      fromView.bounds.width != 0, fromView.bounds.height != 0,
       let selectedTab = tabManager.selectedTab
     else {
       view.frame = finalFrame
@@ -51,7 +52,7 @@ extension TabGridHostingController: BasicAnimationControllerDelegate {
 
     guard let destinationIndexPath = containerView.dataSource.indexPath(for: selectedTab.id),
       let destinationCell = containerView.collectionView.cellForItem(at: destinationIndexPath),
-      destinationCell.bounds.size != .zero,
+      destinationCell.bounds.width != 0, destinationCell.bounds.height != 0,
       let destinationCellSnapshot = destinationCell.snapshotView(afterScreenUpdates: true)
     else {
       let fallbackAnimation = UIViewPropertyAnimator(duration: 0.3, curve: .linear)
@@ -131,7 +132,11 @@ extension TabGridHostingController: BasicAnimationControllerDelegate {
       return
     }
 
-    let finalFrame = context.finalFrame(for: toVC)
+    var finalFrame = context.finalFrame(for: toVC)
+    // Fall back to the container's bounds if UIKit hands us an empty or invalid frame
+    if finalFrame.isEmpty || finalFrame.width.isZero || finalFrame.height.isZero {
+      finalFrame = context.containerView.bounds
+    }
     let dimmingView = UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
     dimmingView.backgroundColor = .clear
     dimmingView.frame = finalFrame
@@ -150,7 +155,9 @@ extension TabGridHostingController: BasicAnimationControllerDelegate {
       let sourceIndexPath = containerView.dataSource.indexPath(for: selectedTab.id),
       let sourceAttributes = containerView.collectionView.layoutAttributesForItem(
         at: sourceIndexPath
-      )
+      ),
+      sourceAttributes.bounds.width != 0, sourceAttributes.bounds.height != 0,
+      toView.bounds.width != 0, toView.bounds.height != 0
     else {
       let fallbackAnimation = UIViewPropertyAnimator(duration: 0.3, curve: .linear)
       toView.alpha = 0


### PR DESCRIPTION
This is a speculative crash fix where the dismissing the tab tray could result in the web view being assigned invalid geometry which would throw an exception inside WebKit by adding additional geometry checks during the custom transition to avoid dividing by 0.

Resolves https://github.com/brave/brave-browser/issues/57111
