### PR TITLE
[ast-grep][plaster] Adding `make_virtual`

### DIFF
--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -141,13 +141,19 @@ YAML).
 
 ### Rewriters
 
-The keyed rewrite (`regex:` above) is a **rewriter**. `regex` is the default and
-most flexible one, and more will be added over time. To discover the available
-rewriters use `plaster --help`:
+The keyed rewrite (`regex:` above) is a **rewriter**. There is on-going work to
+introduce more rewriters. These are the ones we have supported for now.
+
+| Rewriter       | Kind | Description                                      |
+| -------------- | ---- | ------------------------------------------------ |
+| `regex`        | text | A Python `re.subn` substitution (the default).   |
+| `make_virtual` | AST  | Prepends `virtual ` to a C++ method declaration. |
+
+Use `plaster --help` to discover rewriters and read their full docs:
 
 ```sh
-tools/cr/plaster.py --help         # overview of commands and rewriters
-tools/cr/plaster.py --help regex   # full docs for a specific rewriter
+tools/cr/plaster.py --help                # overview of commands and rewriters
+tools/cr/plaster.py --help make_virtual   # full docs for a specific rewriter
 ```
 
 ### Applying a plaster

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -694,10 +694,84 @@ class Regex(Rewriter):
         return re_flags
 
 
+class MakeVirtual(Rewriter):
+    """Make a C++ method declaration `virtual`, via the ast-grep rewriters.
+
+    Resolves to the rewriters spec's `cxx.make_virtual` rewriter (the only
+    language for now); a future generic ast-op subtype would pull its op id and
+    arg names from `RewritersEval` instead of hard-coding them here.
+    """
+
+    NAME: Final = 'make_virtual'
+    SUMMARY: Final = 'Prepend `virtual ` to a class method declaration.'
+    # Authored in Markdown; `Help` renders it with rich.
+    HELP: Final = r"""
+        Prepends `virtual ` to a C++ method declaration.
+
+        Fields:
+
+        - `class_name` — the class declaring the method.
+        - `method_name` — the method's name. Quote a destructor
+          (`'~Foo'`), since a leading `~` is YAML null.
+
+        Each overload sharing the name is one change, so an overloaded method
+        needs a matching `count`.
+
+        Example:
+
+        ```yaml
+        substitutions:
+          - description: Make the destructor virtual for subclassing.
+            make_virtual:
+              class_name: DraggingTabsSession
+              method_name: '~DraggingTabsSession'
+        ```
+    """
+
+    # The arguments the `make_virtual:` op body must supply.
+    _ARG_KEYS = frozenset(('class_name', 'method_name'))
+
+    def __init__(self, *, class_name: str, method_name: str):
+        self._class_name = class_name
+        self._method_name = method_name
+
+    def apply(self, contents: str) -> tuple[str, int]:
+        rewriter = AstRewriter(RewritersEval.load(), contents)
+        count = rewriter.apply('cxx.make_virtual', {
+            'class_name': self._class_name,
+            'method_name': self._method_name,
+        })
+        return rewriter.content, count
+
+    @classmethod
+    def parse(cls, body: object, *, description: str) -> MakeVirtual:
+        """Build from a `make_virtual:` body: `class_name` and `method_name`."""
+        if not isinstance(body, dict):
+            raise ValueError(
+                f'"make_virtual" must be a mapping (in "{description}")')
+        unknown = sorted(set(body) - cls._ARG_KEYS)
+        if unknown:
+            raise ValueError(
+                f'Unrecognised make_virtual arg(s): '
+                f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
+        missing = sorted(cls._ARG_KEYS - set(body))
+        if missing:
+            raise ValueError(f'make_virtual requires arg(s): '
+                             f'{", ".join(missing)} (in "{description}")')
+        if not isinstance(body['class_name'], str):
+            raise ValueError('make_virtual `class_name` must be a string '
+                             f'(in "{description}")')
+        if not isinstance(body['method_name'], str):
+            raise ValueError('make_virtual `method_name` must be a string '
+                             f'(in "{description}")')
+        return cls(class_name=body['class_name'],
+                   method_name=body['method_name'])
+
+
 # A set with all the rewriters available in plaster.
 _REWRITERS: MappingProxyType[str, type[Rewriter]] = MappingProxyType(
     {rewriter.NAME: rewriter
-     for rewriter in (Regex, )})
+     for rewriter in (Regex, MakeVirtual)})
 
 
 @dataclass

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1149,10 +1149,10 @@ class PlasterTest(unittest.TestCase):
 
 
 class RewriterFormsTest(unittest.TestCase):
-    """End-to-end tests for the substitution envelope and the `regex` rewriter.
+    """End-to-end tests for the substitution envelope and its rewriters.
 
     Rewriters apply through `PlasterFile` against a fake Chromium repo, just
-    like real usage. Only the `regex` rewriter exists for now; further
+    like real usage; `make_virtual` runs the real ast-grep binary. Further
     rewriters attach to the same envelope later.
     """
 
@@ -1208,7 +1208,77 @@ class RewriterFormsTest(unittest.TestCase):
             "    replace: 'Brave'\n")
         self.assertEqual(result, 'A Brave thing.')
 
+    # -- make_virtual op (real ast-grep binary) -----------------------------
+
+    def test_make_virtual_op(self):
+        result = self._apply(
+            'virt.h', 'class C {\n  void Foo();\n};\n', 'substitutions:\n'
+            '  - description: make Foo virtual\n'
+            '    make_virtual:\n'
+            '      class_name: C\n'
+            '      method_name: Foo\n')
+        self.assertEqual(result, 'class C {\n  virtual void Foo();\n};\n')
+
+    def test_make_virtual_destructor_quoted(self):
+        result = self._apply(
+            'dtor.h', 'class C {\n public:\n  ~C();\n};\n', 'substitutions:\n'
+            '  - description: make the destructor virtual\n'
+            '    make_virtual:\n'
+            '      class_name: C\n'
+            "      method_name: '~C'\n")
+        self.assertEqual(result, 'class C {\n public:\n  virtual ~C();\n};\n')
+
+    def test_make_virtual_overloads_need_count(self):
+        result = self._apply(
+            'ovl.h', 'class C {\n  void Foo();\n  void Foo(int x);\n};\n',
+            'substitutions:\n'
+            '  - description: make both overloads virtual\n'
+            '    count: 2\n'
+            '    make_virtual:\n'
+            '      class_name: C\n'
+            '      method_name: Foo\n')
+        self.assertEqual(
+            result, 'class C {\n  virtual void Foo();\n'
+            '  virtual void Foo(int x);\n};\n')
+
+    def test_make_virtual_count_mismatch_fails(self):
+        # Two overloads match, but the default count is 1.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'ovl2.h', 'class C {\n  void Foo();\n  void Foo(int x);\n};\n',
+                'substitutions:\n'
+                '  - description: forgot the count\n'
+                '    make_virtual:\n'
+                '      class_name: C\n'
+                '      method_name: Foo\n')
+
+    def test_make_virtual_unknown_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: typo arg\n'
+            '    make_virtual:\n'
+            '      class_name: C\n'
+            '      method_nam: Foo\n', 'Unrecognised make_virtual arg')
+
+    def test_make_virtual_missing_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: missing arg\n'
+            '    make_virtual:\n'
+            '      class_name: C\n', 'make_virtual requires arg')
+
     # -- validation ---------------------------------------------------------
+
+    def test_two_op_keys_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: two ops\n'
+            '    regex:\n'
+            "      re_pattern: 'x'\n"
+            "      replace: 'y'\n"
+            '    make_virtual:\n'
+            '      class_name: C\n'
+            '      method_name: Foo\n', 'Only one rewriter')
 
     def test_cannot_mix_op_and_bare_regex(self):
         self._expect_value_error(
@@ -1241,13 +1311,12 @@ class RewriterFormsTest(unittest.TestCase):
             self._apply(
                 'unknown_rw.h', 'class C {};\n', 'substitutions:\n'
                 '  - description: not a real rewriter\n'
-                '    make_virtual:\n'
-                '      class_name: C\n'
-                '      method_name: Foo\n')
+                '    make_final:\n'
+                '      class_name: C\n')
         message = str(ctx.exception)
         self.assertIn('Unknown rewriter', message)
-        self.assertIn("'make_virtual'", message)
-        self.assertIn('regex', message)
+        self.assertIn("'make_final'", message)
+        self.assertIn('make_virtual', message)
 
     def test_stray_scalar_key_is_unrecognised(self):
         # A non-mapping stray key is a bare-field typo, not a rewriter attempt,
@@ -1334,14 +1403,10 @@ class RewritersEvalTest(unittest.TestCase):
     # -- the real on-disk spec ---------------------------------------------
 
     def test_load_real_rewriters_file(self):
-        """The shipped rewriters.pyl validates and loads.
-
-        It ships empty for now (ops are added when they are wired in), so this
-        just asserts a clean load and empty, read-only op mappings.
-        """
+        """The shipped rewriters.pyl validates and exposes its ops."""
         rewriters = plaster.RewritersEval.load()
-        self.assertEqual(dict(rewriters.matchers), {})
-        self.assertEqual(dict(rewriters.rewriters), {})
+        self.assertIn('cxx.find_class_method_decl', rewriters.matchers)
+        self.assertIn('cxx.make_virtual', rewriters.rewriters)
 
     def test_load_is_a_singleton(self):
         """load() reads the file once and returns the same instance."""

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -26,7 +26,50 @@
 
 {
     "ast.matcher": {
+
+        # The full declaration of `class_name::method_name`, including a
+        # multi-line signature and its trailing semicolon. The name is matched
+        # by text, so methods (field_identifier), destructors (destructor_name,
+        # e.g. "~Foo") and constructors (identifier) are all found. Overloads
+        # sharing the name each produce their own match. The result node is a
+        # field_declaration for methods and a declaration for con/destructors.
+        "cxx.find_class_method_decl": {
+            "args": ["class_name", "method_name"],
+            "template": """\
+any:
+  - kind: field_declaration
+  - kind: declaration
+has:
+  kind: function_declarator
+  stopBy: end
+  has:
+    field: declarator
+    regex: ^{method_name}$
+inside:
+  kind: class_specifier
+  stopBy: end
+  has:
+    field: name
+    regex: ^{class_name}$
+""",
+            "result": {
+                "node": "field_declaration",
+            },
+        },
     },
     "ast.rewriter": {
+
+        # The whole method declaration (multi-line signature and trailing
+        # semicolon included) with `virtual ` prepended.
+        "cxx.make_virtual": {
+            "matcher": "cxx.find_class_method_decl",
+            "replace": {
+                "re_pattern": "^",
+                "replace": "virtual ",
+            },
+            "result": {
+                "node": "field_declaration",
+            },
+        },
     },
 }


### PR DESCRIPTION
This change adds a `make_virtual` rewriter, that can be used to add the
`virtual` keyword to particular functions in a class.

Bug: https://github.com/brave/brave-browser/issues/56760
