### PR TITLE
[bootstrap] Fix `argparser` `%` crash

### DIFF
--- a/tools/cr/bootstrap/bootstrap_test.py
+++ b/tools/cr/bootstrap/bootstrap_test.py
@@ -717,11 +717,9 @@ class ArgumentForwardingTest(unittest.TestCase):
         self.assertEqual(self._split(['brockit']), (False, 'brockit', []))
 
     def test_own_help_renders_without_crashing(self):
-        # argparse expands help strings through `% params`; a bare `%` (the
-        # `%PATH` typo) raised ValueError. The `%%` escape must survive it and
-        # render a literal `%PATH`.
         help_text = launcher.build_parser().format_help()
-        self.assertIn('%PATH', help_text)
+        self.assertIn('$PATH', help_text)
+        self.assertNotIn('%', help_text)
 
 
 if __name__ == '__main__':

--- a/tools/cr/bootstrap/launcher.py
+++ b/tools/cr/bootstrap/launcher.py
@@ -298,10 +298,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         '--allow-fallback',
         action='store_true',
-        # The '%%' escapes the literal percent: argparse runs help strings
-        # through '% params' formatting, and a bare '%P' crashes it.
-        help='Allows falling back to a binary in %%PATH if outside a checkout.'
-    )
+        help='Allow falling back to a binary on $PATH if outside a checkout.')
     parser.add_argument('tool',
                         metavar='TOOL',
                         help='shim to run (e.g. brockit, plaster, node, npm)')


### PR DESCRIPTION
This issue is still recurring, and this fix attempts to side-step it
entirely by not using `%` in help.

Bug: https://github.com/brave/brave-browser/issues/56529
