### PR TITLE
[ast-grep][plaster] Various `make_virtual` migrations

### DIFF
--- a/rewrite/chrome/browser/ui/page_action/page_action_controller.h.yaml
+++ b/rewrite/chrome/browser/ui/page_action/page_action_controller.h.yaml
@@ -19,8 +19,9 @@ substitutions:
   - description: |
       Make CreateModel virtual so the brave PageActionControllerImpl override can
       replace model construction with the brave PageActionModel.
-    pattern: 'std::unique_ptr<PageActionModelInterface> CreateModel('
-    replace: 'virtual std::unique_ptr<PageActionModelInterface> CreateModel('
+    make_virtual:
+      class_name: PageActionControllerImpl
+      method_name: CreateModel
 
   - description: |
       Friend the brave page_actions::PageActionControllerImpl so it can reach the

--- a/rewrite/chrome/browser/ui/views/frame/layout/browser_view_tabbed_layout_impl.h.yaml
+++ b/rewrite/chrome/browser/ui/views/frame/layout/browser_view_tabbed_layout_impl.h.yaml
@@ -9,8 +9,9 @@ substitutions:
 
       Brave overrides this hook to tuck the first tab against the
       caption-button cluster in compact horizontal tabs mode.
-    re_pattern: '(\s+)(int GetHorizontalTabStripLeadingMargin\()'
-    replace: '\1virtual \2'
+    make_virtual:
+      class_name: BrowserViewTabbedLayoutImpl
+      method_name: GetHorizontalTabStripLeadingMargin
 
   - description: |
       Make `CalculateSeparatorInfo` virtual.
@@ -21,8 +22,9 @@ substitutions:
       override's body lives in
       chromium_src/.../browser_view_tabbed_layout_impl.cc, which
       `#include`s the upstream .cc and therefore sees the full type.
-    re_pattern: '(\s+)(SeparatorInfo CalculateSeparatorInfo\(\) const;)'
-    replace: '\1virtual \2'
+    make_virtual:
+      class_name: BrowserViewTabbedLayoutImpl
+      method_name: CalculateSeparatorInfo
 
   - description: |
       Friend `BraveBrowserViewTabbedLayoutImpl` from the base class.

--- a/rewrite/chrome/browser/ui/views/frame/multi_contents_view.h.yaml
+++ b/rewrite/chrome/browser/ui/views/frame/multi_contents_view.h.yaml
@@ -19,25 +19,27 @@ substitutions:
 
       `BraveMultiContentsView` overrides this hook to return the
       web-panel container when a web panel is active.
-    re_pattern:
-      '(\s+)(ContentsContainerView\* GetActiveContentsContainerView\(\) const;)'
-    replace: '\1virtual \2'
+    make_virtual:
+      class_name: MultiContentsView
+      method_name: GetActiveContentsContainerView
 
   - description: |
       Make `GetContentsContainerViewFor` virtual.
 
       `BraveMultiContentsView` overrides this hook to return the
       web-panel container for the web-panel `WebContents`.
-    re_pattern: '(\s+)(ContentsContainerView\* GetContentsContainerViewFor\()'
-    replace: '\1virtual \2'
+    make_virtual:
+      class_name: MultiContentsView
+      method_name: GetContentsContainerViewFor
 
   - description: |
       Make `GetActiveContentsView` virtual.
 
       `BraveMultiContentsView` overrides this hook to return the
       web-panel's contents view when a web panel is active.
-    re_pattern: '(\s+)(ContentsWebView\* GetActiveContentsView\(\) const;)'
-    replace: '\1virtual \2'
+    make_virtual:
+      class_name: MultiContentsView
+      method_name: GetActiveContentsView
 
   - description: |
       Declare `ResetResizeArea` as a virtual no-op hook.
@@ -54,24 +56,27 @@ substitutions:
 
       `BraveMultiContentsView` overrides this hook to include the
       web-panel contents view when iterating visible contents.
-    re_pattern: '(\s+)(void ExecuteOnEachVisibleContentsView\()'
-    replace: '\1virtual \2'
+    make_virtual:
+      class_name: MultiContentsView
+      method_name: ExecuteOnEachVisibleContentsView
 
   - description: |
       Make `OnWebContentsFocused` virtual.
 
       `BraveMultiContentsView` overrides this hook to intercept focus on
       the web-panel contents.
-    re_pattern: '(\s+)(void OnWebContentsFocused\(views::WebView\*\);)'
-    replace: '\1virtual \2'
+    make_virtual:
+      class_name: MultiContentsView
+      method_name: OnWebContentsFocused
 
   - description: |
       Make `UpdateContentsBorderAndOverlay` virtual.
 
       `BraveMultiContentsView` overrides this hook to adjust the borders
       and overlays for the web-panel layout.
-    re_pattern: '(\s+)(void UpdateContentsBorderAndOverlay\(\);)'
-    replace: '\1virtual \2'
+    make_virtual:
+      class_name: MultiContentsView
+      method_name: UpdateContentsBorderAndOverlay
 
   - description: |
       Friend `BraveMultiContentsView` from the base class.

--- a/rewrite/chrome/browser/ui/views/tabs/dragging/dragging_tabs_session.h.yaml
+++ b/rewrite/chrome/browser/ui/views/tabs/dragging/dragging_tabs_session.h.yaml
@@ -10,6 +10,7 @@ substitutions:
     replace: 'class DraggingTabsSession {'
 
   - description:
-      'Remove final keyword from DraggingTabsSession to allow subclassing'
-    pattern: '~DraggingTabsSession();'
-    replace: 'virtual ~DraggingTabsSession();'
+      'Make the DraggingTabsSession destructor virtual to allow subclassing'
+    make_virtual:
+      class_name: DraggingTabsSession
+      method_name: '~DraggingTabsSession'

--- a/rewrite/components/permissions/permission_context_base.h.yaml
+++ b/rewrite/components/permissions/permission_context_base.h.yaml
@@ -25,8 +25,9 @@ substitutions:
 
   - description:
       'Make PermissionDecided virtual to allow Brave override in derived class'
-    pattern: 'void PermissionDecided('
-    replace: 'virtual void PermissionDecided('
+    make_virtual:
+      class_name: PermissionContextBase
+      method_name: PermissionDecided
 
   - description:
       'Add Brave PermissionContextBase as friend of

--- a/rewrite/components/tabs/public/tab_collection.h.yaml
+++ b/rewrite/components/tabs/public/tab_collection.h.yaml
@@ -5,5 +5,6 @@
 
 substitutions:
   - description: 'Add virtual keyword to OnReparented()'
-    re_pattern: '(void OnReparented\(TabCollection\* new_parent\);)'
-    replace: 'virtual \1'
+    make_virtual:
+      class_name: TabCollection
+      method_name: OnReparented


### PR DESCRIPTION
This PR contains several migrations of `make_virtual` cases. The only
case left owes to the fact that the class had a `#if defined(USE_AURA)`
macro interspersed with the inheritance list, which confused the parser.

Bug: https://github.com/brave/brave-browser/issues/56760
