### PR TITLE
[plaster][ast-grep] Adding `add_friend` and `drop_final`

### DIFF
--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -144,10 +144,12 @@ YAML).
 The keyed rewrite (`regex:` above) is a **rewriter**. There is on-going work to
 introduce more rewriters. These are the ones we have supported for now.
 
-| Rewriter       | Kind | Description                                      |
-| -------------- | ---- | ------------------------------------------------ |
-| `regex`        | text | A Python `re.subn` substitution (the default).   |
-| `make_virtual` | AST  | Prepends `virtual ` to a C++ method declaration. |
+| Rewriter       | Kind | Description                                       |
+| -------------- | ---- | ------------------------------------------------- |
+| `regex`        | text | A Python `re.subn` substitution (the default).    |
+| `make_virtual` | AST  | Prepends `virtual ` to a C++ method declaration.  |
+| `add_friend`   | AST  | Adds a `friend` declaration to a private section. |
+| `drop_final`   | AST  | Removes `final` from a C++ class declaration.     |
 
 Use `plaster --help` to discover rewriters and read their full docs:
 

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -694,16 +694,67 @@ class Regex(Rewriter):
         return re_flags
 
 
-class MakeVirtual(Rewriter):
-    """Make a C++ method declaration `virtual`, via the ast-grep rewriters.
+class _AstGrepRewriter(Rewriter):
+    """Base for rewriters backed by an ast-grep op declared in `rewriters.pyl`.
 
-    Resolves to the rewriters spec's `cxx.make_virtual` rewriter (the only
-    language for now); a future generic ast-op subtype would pull its op id and
-    arg names from `RewritersEval` instead of hard-coding them here.
+    A concrete subclass sets the usual `NAME`/`SUMMARY`/`HELP` metadata plus the
+    `OP_ID` it resolves to, the string arguments its body accepts (`_ARG_KEYS`),
+    and any adjacent tokens the op consumes (`_CONSUME_BEFORE`/`_CONSUME_AFTER`,
+    engine details -- see `AstRewriter.apply`). `parse` validates the body as a
+    mapping of exactly those string args and `apply` runs the op, so subclasses
+    are pure declarations.
     """
 
+    # The `rewriters.pyl` op id this resolves to (e.g. `cxx.make_virtual`).
+    OP_ID: ClassVar[str] = ''
+
+    # The string argument names the op body must supply.
+    _ARG_KEYS: ClassVar[frozenset[str]] = frozenset()
+
+    # Literals the op assumes sit immediately before / after each matched node.
+    _CONSUME_BEFORE: ClassVar[str] = ''
+    _CONSUME_AFTER: ClassVar[str] = ''
+
+    def __init__(self, args: dict[str, str]):
+        self._args = args
+
+    def apply(self, contents: str) -> tuple[str, int]:
+        rewriter = AstRewriter(RewritersEval.load(), contents)
+        count = rewriter.apply(self.OP_ID,
+                               self._args,
+                               consume_before=self._CONSUME_BEFORE,
+                               consume_after=self._CONSUME_AFTER)
+        return rewriter.content, count
+
+    @classmethod
+    def parse(cls, body: object, *, description: str) -> _AstGrepRewriter:
+        """Validate a `<NAME>:` body of string args and build the rewriter."""
+        if not isinstance(body, dict):
+            raise ValueError(
+                f'"{cls.NAME}" must be a mapping (in "{description}")')
+        unknown = sorted(set(body) - cls._ARG_KEYS)
+        if unknown:
+            raise ValueError(
+                f'Unrecognised {cls.NAME} arg(s): '
+                f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
+        missing = sorted(cls._ARG_KEYS - set(body))
+        if missing:
+            raise ValueError(f'{cls.NAME} requires arg(s): '
+                             f'{", ".join(missing)} (in "{description}")')
+        for key in sorted(cls._ARG_KEYS):
+            if not isinstance(body[key], str):
+                raise ValueError(f'{cls.NAME} `{key}` must be a string '
+                                 f'(in "{description}")')
+        return cls({key: body[key] for key in cls._ARG_KEYS})
+
+
+class MakeVirtual(_AstGrepRewriter):
+    """Make a C++ method declaration `virtual`, via the ast-grep rewriters."""
+
     NAME: Final = 'make_virtual'
+    OP_ID: Final = 'cxx.make_virtual'
     SUMMARY: Final = 'Prepend `virtual ` to a class method declaration.'
+    _ARG_KEYS: Final = frozenset(('class_name', 'method_name'))
     # Authored in Markdown; `Help` renders it with rich.
     HELP: Final = r"""
         Prepends `virtual ` to a C++ method declaration.
@@ -728,50 +779,78 @@ class MakeVirtual(Rewriter):
         ```
     """
 
-    # The arguments the `make_virtual:` op body must supply.
-    _ARG_KEYS = frozenset(('class_name', 'method_name'))
 
-    def __init__(self, *, class_name: str, method_name: str):
-        self._class_name = class_name
-        self._method_name = method_name
+class AddFriend(_AstGrepRewriter):
+    """Add a `friend` declaration to a C++ class's private section, via the
+    ast-grep rewriters."""
 
-    def apply(self, contents: str) -> tuple[str, int]:
-        rewriter = AstRewriter(RewritersEval.load(), contents)
-        count = rewriter.apply('cxx.make_virtual', {
-            'class_name': self._class_name,
-            'method_name': self._method_name,
-        })
-        return rewriter.content, count
+    NAME: Final = 'add_friend'
+    OP_ID: Final = 'cxx.add_friend'
+    SUMMARY: Final = 'Add a `friend` declaration to a class private section.'
+    _ARG_KEYS: Final = frozenset(('class_name', 'friend_type'))
+    # The matcher stops at the `private` keyword; the op re-emits the `:` that
+    # follows, so consume the original one.
+    _CONSUME_AFTER: Final = ':'
+    # Authored in Markdown; `Help` renders it with rich.
+    HELP: Final = r"""
+        Inserts a `friend` declaration as the first line of a class's private
+        section. The class must have a `private:` section.
 
-    @classmethod
-    def parse(cls, body: object, *, description: str) -> MakeVirtual:
-        """Build from a `make_virtual:` body: `class_name` and `method_name`."""
-        if not isinstance(body, dict):
-            raise ValueError(
-                f'"make_virtual" must be a mapping (in "{description}")')
-        unknown = sorted(set(body) - cls._ARG_KEYS)
-        if unknown:
-            raise ValueError(
-                f'Unrecognised make_virtual arg(s): '
-                f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
-        missing = sorted(cls._ARG_KEYS - set(body))
-        if missing:
-            raise ValueError(f'make_virtual requires arg(s): '
-                             f'{", ".join(missing)} (in "{description}")')
-        if not isinstance(body['class_name'], str):
-            raise ValueError('make_virtual `class_name` must be a string '
-                             f'(in "{description}")')
-        if not isinstance(body['method_name'], str):
-            raise ValueError('make_virtual `method_name` must be a string '
-                             f'(in "{description}")')
-        return cls(class_name=body['class_name'],
-                   method_name=body['method_name'])
+        Fields:
+
+        - `class_name` — the class to befriend from.
+        - `friend_type` — the friend's declaration body, e.g. `class BraveFoo`
+          becomes `friend class BraveFoo;`.
+
+        Example:
+
+        ```yaml
+        substitutions:
+          - description: Let the Brave subclass reach private members.
+            add_friend:
+              class_name: MultiContentsView
+              friend_type: class BraveMultiContentsView
+        ```
+    """
+
+
+class DropFinal(_AstGrepRewriter):
+    """Remove the `final` specifier from a C++ class declaration, via the
+    ast-grep rewriters, so the class can be subclassed."""
+
+    NAME: Final = 'drop_final'
+    OP_ID: Final = 'cxx.drop_final'
+    SUMMARY: Final = 'Remove the `final` specifier from a class declaration.'
+    _ARG_KEYS: Final = frozenset(('class_name', ))
+    # The matcher stops at the `final` keyword; consume the space before it so
+    # dropping `final` leaves no doubled space.
+    _CONSUME_BEFORE: Final = ' '
+    # Authored in Markdown; `Help` renders it with rich.
+    HELP: Final = r"""
+        Removes the `final` specifier from a C++ class declaration, so the class
+        can be subclassed. Only the class-head `final` is removed; a method's
+        trailing `final` is left untouched.
+
+        Fields:
+
+        - `class_name` — the class to drop `final` from.
+
+        Example:
+
+        ```yaml
+        substitutions:
+          - description: Drop `final` so Brave can subclass.
+            drop_final:
+              class_name: DraggingTabsSession
+        ```
+    """
 
 
 # A set with all the rewriters available in plaster.
-_REWRITERS: MappingProxyType[str, type[Rewriter]] = MappingProxyType(
-    {rewriter.NAME: rewriter
-     for rewriter in (Regex, MakeVirtual)})
+_REWRITERS: MappingProxyType[str, type[Rewriter]] = MappingProxyType({
+    rewriter.NAME: rewriter
+    for rewriter in (Regex, MakeVirtual, AddFriend, DropFinal)
+})
 
 
 @dataclass

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1267,6 +1267,64 @@ class RewriterFormsTest(unittest.TestCase):
             '    make_virtual:\n'
             '      class_name: C\n', 'make_virtual requires arg')
 
+    # -- add_friend op (real ast-grep binary) -------------------------------
+
+    def test_add_friend_op(self):
+        result = self._apply(
+            'friend.h',
+            'class C {\n public:\n  void Foo();\n private:\n  int x_;\n};\n',
+            'substitutions:\n'
+            '  - description: friend the Brave subclass\n'
+            '    add_friend:\n'
+            '      class_name: C\n'
+            '      friend_type: class BraveC\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            ' private:\n  friend class BraveC;\n  int x_;\n};\n')
+
+    def test_add_friend_no_private_section_fails(self):
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'nofriend.h', 'class C {\n public:\n  void Foo();\n};\n',
+                'substitutions:\n'
+                '  - description: no private section to insert into\n'
+                '    add_friend:\n'
+                '      class_name: C\n'
+                '      friend_type: class BraveC\n')
+
+    def test_add_friend_unknown_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: typo arg\n'
+            '    add_friend:\n'
+            '      class_name: C\n'
+            '      freind: class BraveC\n', 'Unrecognised add_friend arg')
+
+    # -- drop_final op (real ast-grep binary) -----------------------------
+
+    def test_drop_final_op(self):
+        result = self._apply(
+            'final.h', 'class C final : public Base {\n};\n',
+            'substitutions:\n'
+            '  - description: drop final so Brave can subclass\n'
+            '    drop_final:\n'
+            '      class_name: C\n')
+        self.assertEqual(result, 'class C : public Base {\n};\n')
+
+    def test_drop_final_absent_fails(self):
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'nofinal.h', 'class C {\n};\n', 'substitutions:\n'
+                '  - description: nothing to remove\n'
+                '    drop_final:\n'
+                '      class_name: C\n')
+
+    def test_drop_final_missing_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: missing arg\n'
+            '    drop_final: {}\n', 'drop_final requires arg')
+
     # -- validation ---------------------------------------------------------
 
     def test_two_op_keys_rejected(self):
@@ -1406,7 +1464,8 @@ class RewritersEvalTest(unittest.TestCase):
         """The shipped rewriters.pyl validates and exposes its ops."""
         rewriters = plaster.RewritersEval.load()
         self.assertIn('cxx.find_class_method_decl', rewriters.matchers)
-        self.assertIn('cxx.make_virtual', rewriters.rewriters)
+        for op in ('cxx.make_virtual', 'cxx.add_friend', 'cxx.drop_final'):
+            self.assertIn(op, rewriters.rewriters)
 
     def test_load_is_a_singleton(self):
         """load() reads the file once and returns the same instance."""
@@ -1639,7 +1698,7 @@ _SYNTHETIC_SPEC = {
                 'node': 'access_specifier'
             },
         },
-        'cxx.remove_final': {
+        'cxx.drop_final': {
             'matcher': 'cxx.find_class_final',
             'replace': {
                 're_pattern': '^final$',
@@ -1790,28 +1849,28 @@ class AstRewriterTest(unittest.TestCase):
         self.assertEqual(rewriter.content,
                          'class C {\n public:\n  void Foo();\n};\n')
 
-    def test_remove_final_with_base(self):
+    def test_drop_final_with_base(self):
         # The class `final` is dropped (and the space before it); a method's
         # trailing `final` is left untouched.
         rewriter = self._rewriter(
             'class C final : public Base {\n  void f() final;\n};\n')
         self.assertEqual(
-            rewriter.apply('cxx.remove_final', {'class_name': 'C'},
+            rewriter.apply('cxx.drop_final', {'class_name': 'C'},
                            consume_before=' '), 1)
         self.assertEqual(rewriter.content,
                          'class C : public Base {\n  void f() final;\n};\n')
 
-    def test_remove_final_no_base(self):
+    def test_drop_final_no_base(self):
         rewriter = self._rewriter('class C final {\n};\n')
         self.assertEqual(
-            rewriter.apply('cxx.remove_final', {'class_name': 'C'},
+            rewriter.apply('cxx.drop_final', {'class_name': 'C'},
                            consume_before=' '), 1)
         self.assertEqual(rewriter.content, 'class C {\n};\n')
 
-    def test_remove_final_absent(self):
+    def test_drop_final_absent(self):
         rewriter = self._rewriter('class C {\n};\n')
         self.assertEqual(
-            rewriter.apply('cxx.remove_final', {'class_name': 'C'},
+            rewriter.apply('cxx.drop_final', {'class_name': 'C'},
                            consume_before=' '), 0)
         self.assertEqual(rewriter.content, 'class C {\n};\n')
 

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -56,6 +56,46 @@ inside:
                 "node": "field_declaration",
             },
         },
+
+        # The `private` access specifier opening `class_name`'s private section.
+        # The node is the `private` keyword; the `:` that follows is a separate
+        # token immediately after it.
+        "cxx.find_class_private_section": {
+            "args": ["class_name"],
+            "template": """\
+kind: access_specifier
+regex: ^private$
+inside:
+  kind: class_specifier
+  stopBy: end
+  has:
+    field: name
+    regex: ^{class_name}$
+""",
+            "result": {
+                "node": "access_specifier",
+            },
+        },
+
+        # The `final` specifier on `class_name`'s declaration (the
+        # virtual_specifier node holding the `final` keyword). Only the
+        # class-head `final` matches; a method's trailing `final` is nested
+        # under its declaration, not directly inside the class.
+        "cxx.find_class_final": {
+            "args": ["class_name"],
+            "template": """\
+kind: virtual_specifier
+regex: ^final$
+inside:
+  kind: class_specifier
+  has:
+    field: name
+    regex: ^{class_name}$
+""",
+            "result": {
+                "node": "virtual_specifier",
+            },
+        },
     },
     "ast.rewriter": {
 
@@ -69,6 +109,33 @@ inside:
             },
             "result": {
                 "node": "field_declaration",
+            },
+        },
+
+        # The class's `private:` section with a `friend` declaration inserted as
+        # its first line.
+        "cxx.add_friend": {
+            "matcher": "cxx.find_class_private_section",
+            "replace": {
+                "re_pattern": "$",
+                "replace": ":\\n  friend {friend_type};",
+            },
+            "result": {
+                "node": "access_specifier",
+            },
+        },
+
+        # `class_name`'s declaration with its `final` specifier removed, so the
+        # class can be subclassed. The drop_final engine also consumes the
+        # leading space before `final` so no doubled space is left behind.
+        "cxx.drop_final": {
+            "matcher": "cxx.find_class_final",
+            "replace": {
+                "re_pattern": "^final$",
+                "replace": "",
+            },
+            "result": {
+                "node": "virtual_specifier",
             },
         },
     },


### PR DESCRIPTION
This PR adds two new `ast-grep`-based ops, namely, `add_friend` and
`drop_final`.

Fix: https://github.com/brave/brave-browser/issues/56760
