### PR TITLE
Treat sandboxed .onion pages as .onion for insecure forms

### DIFF
--- a/browser/brave_content_browser_client_browsertest.cc
+++ b/browser/brave_content_browser_client_browsertest.cc
@@ -335,6 +335,27 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, MixedContentForOnion) {
     ASSERT_TRUE(content::ExecJs(contents, kFetchScript));
     ASSERT_TRUE(console_observer.Wait());
   }
+  {
+    // Regression test: an .onion page sandboxed via `Content-Security-Policy:
+    // sandbox` has an opaque origin whose precursor is the .onion origin. It
+    // must still be treated as secure, so insecure http subresources are
+    // blocked as mixed content instead of being allowed through.
+    const GURL sandboxed_onion_url =
+        embedded_test_server()->GetURL("test.onion", "/onion_sandboxed.html");
+    ASSERT_TRUE(ui_test_utils::NavigateToURL(tor_browser, sandboxed_onion_url));
+
+    content::WebContentsConsoleObserver console_observer(contents);
+    console_observer.SetPattern(
+        "Mixed Content: The page at 'http://test.onion*/onion_sandboxed.html' "
+        "was loaded over HTTPS, but requested an insecure resource "
+        "'http://example.com*'. This request has been blocked; the content "
+        "must be served over HTTPS.");
+    const GURL resource_url =
+        embedded_test_server()->GetURL("example.com", "/logo-referrer.png");
+    const std::string kFetchScript = fetch(resource_url.spec());
+    ASSERT_FALSE(content::ExecJs(contents, kFetchScript));
+    ASSERT_TRUE(console_observer.Wait());
+  }
 }
 #endif
 

--- a/chromium_src/content/browser/renderer_host/mixed_content_checker.cc
+++ b/chromium_src/content/browser/renderer_host/mixed_content_checker.cc
@@ -21,8 +21,7 @@ bool MixedContentChecker::DoesOriginSchemeRestrictMixedContent(
   const url::SchemeHostPort& tuple = origin.GetTupleOrPrecursorTupleIfOpaque();
   if (tuple.host().ends_with(".onion") &&
       (tuple.scheme() == url::kHttpsScheme ||
-       tuple.scheme() == url::kHttpScheme ||
-       tuple.scheme() == url::kWsScheme ||
+       tuple.scheme() == url::kHttpScheme || tuple.scheme() == url::kWsScheme ||
        tuple.scheme() == url::kWssScheme)) {
     return true;
   }

--- a/chromium_src/content/browser/renderer_host/mixed_content_checker.cc
+++ b/chromium_src/content/browser/renderer_host/mixed_content_checker.cc
@@ -12,11 +12,18 @@ namespace content {
 // static
 bool MixedContentChecker::DoesOriginSchemeRestrictMixedContent(
     const url::Origin& origin) {
-  if (origin.host().ends_with(".onion") &&
-      (origin.scheme() == url::kHttpsScheme ||
-       origin.scheme() == url::kHttpScheme ||
-       origin.scheme() == url::kWsScheme ||
-       origin.scheme() == url::kWssScheme)) {
+  // Use the precursor tuple so that opaque origins (e.g. an .onion page
+  // sandboxed via `Content-Security-Policy: sandbox`) are still recognized as
+  // .onion, mirroring how upstream's DoesOriginSchemeRestrictMixedContent uses
+  // GetTupleOrPrecursorTupleIfOpaque(). Reading origin.host()/scheme() directly
+  // returns empty strings for opaque origins, which would let mixed content
+  // through.
+  const url::SchemeHostPort& tuple = origin.GetTupleOrPrecursorTupleIfOpaque();
+  if (tuple.host().ends_with(".onion") &&
+      (tuple.scheme() == url::kHttpsScheme ||
+       tuple.scheme() == url::kHttpScheme ||
+       tuple.scheme() == url::kWsScheme ||
+       tuple.scheme() == url::kWssScheme)) {
     return true;
   }
   return ::content::DoesOriginSchemeRestrictMixedContent(origin);

--- a/chromium_src/net/base/url_util.cc
+++ b/chromium_src/net/base/url_util.cc
@@ -37,7 +37,13 @@ bool IsOnion(const GURL& url) {
 }
 
 bool IsOnion(const url::Origin& origin) {
-  return origin.DomainIs(kOnionDomain);
+  // Recognize opaque origins (e.g. an .onion page sandboxed via
+  // `Content-Security-Policy: sandbox`) via their precursor tuple, since
+  // url::Origin::DomainIs() returns false for opaque origins. Without this,
+  // sandboxed .onion pages are not treated as .onion, so insecure form
+  // submissions and mixed autofill are not caught.
+  return origin.DomainIs(kOnionDomain) ||
+         IsOnion(origin.GetTupleOrPrecursorTupleIfOpaque().GetURL());
 }
 
 bool IsLocalhostOrOnion(const GURL& url) {

--- a/chromium_src/net/base/url_util_unittest.cc
+++ b/chromium_src/net/base/url_util_unittest.cc
@@ -14,6 +14,17 @@ TEST(UrlUtilTest, IsOnionOrigin) {
   EXPECT_TRUE(IsOnion(url::Origin::Create(GURL("https://foo.bar.onion/"))));
   EXPECT_FALSE(IsOnion(url::Origin::Create(GURL("https://foo.onion.com/"))));
   EXPECT_FALSE(IsOnion(url::Origin::Create(GURL("https://foo.com/b.onion"))));
+
+  // Opaque origins (e.g. a page sandboxed via `Content-Security-Policy:
+  // sandbox`) must be recognized as .onion via their precursor tuple.
+  EXPECT_TRUE(IsOnion(url::Origin::Create(GURL("https://foo.onion/"))
+                          .DeriveNewOpaqueOrigin()));
+  EXPECT_TRUE(IsOnion(url::Origin::Create(GURL("http://foo.bar.onion/"))
+                          .DeriveNewOpaqueOrigin()));
+  EXPECT_FALSE(IsOnion(url::Origin::Create(GURL("https://foo.com/"))
+                           .DeriveNewOpaqueOrigin()));
+  // A fully opaque origin with no precursor tuple is not .onion.
+  EXPECT_FALSE(IsOnion(url::Origin()));
 }
 
 TEST(UrlUtilTest, IsOnionUrlSchemes) {

--- a/chromium_src/net/base/url_util_unittest.cc
+++ b/chromium_src/net/base/url_util_unittest.cc
@@ -17,12 +17,12 @@ TEST(UrlUtilTest, IsOnionOrigin) {
 
   // Opaque origins (e.g. a page sandboxed via `Content-Security-Policy:
   // sandbox`) must be recognized as .onion via their precursor tuple.
-  EXPECT_TRUE(IsOnion(url::Origin::Create(GURL("https://foo.onion/"))
-                          .DeriveNewOpaqueOrigin()));
+  EXPECT_TRUE(IsOnion(
+      url::Origin::Create(GURL("https://foo.onion/")).DeriveNewOpaqueOrigin()));
   EXPECT_TRUE(IsOnion(url::Origin::Create(GURL("http://foo.bar.onion/"))
                           .DeriveNewOpaqueOrigin()));
-  EXPECT_FALSE(IsOnion(url::Origin::Create(GURL("https://foo.com/"))
-                           .DeriveNewOpaqueOrigin()));
+  EXPECT_FALSE(IsOnion(
+      url::Origin::Create(GURL("https://foo.com/")).DeriveNewOpaqueOrigin()));
   // A fully opaque origin with no precursor tuple is not .onion.
   EXPECT_FALSE(IsOnion(url::Origin()));
 }

--- a/chromium_src/third_party/blink/renderer/core/loader/mixed_content_checker.cc
+++ b/chromium_src/third_party/blink/renderer/core/loader/mixed_content_checker.cc
@@ -68,7 +68,7 @@ std::optional<bool> MixedContentChecker::IsMixedContentForOnion(
     const KURL& resource_url) {
   // Use the precursor origin so that opaque origins (e.g. an .onion page
   // sandboxed via `Content-Security-Policy: sandbox`) are still recognized as
-  // .onion. This matches how the frame-context check above and upstream's
+  // .onion. This matches how the frame-context check and upstream's
   // IsMixedContent() use GetOriginOrPrecursorOriginIfOpaque(). Reading the
   // opaque origin's Host()/Protocol() directly returns empty strings, which
   // would let mixed content (e.g. insecure form submissions) through.

--- a/chromium_src/third_party/blink/renderer/core/loader/mixed_content_checker.cc
+++ b/chromium_src/third_party/blink/renderer/core/loader/mixed_content_checker.cc
@@ -66,7 +66,13 @@ namespace blink {
 std::optional<bool> MixedContentChecker::IsMixedContentForOnion(
     const SecurityOrigin* security_origin,
     const KURL& resource_url) {
-  if (!IsOnion(*security_origin)) {
+  // Use the precursor origin so that opaque origins (e.g. an .onion page
+  // sandboxed via `Content-Security-Policy: sandbox`) are still recognized as
+  // .onion. This matches how the frame-context check above and upstream's
+  // IsMixedContent() use GetOriginOrPrecursorOriginIfOpaque(). Reading the
+  // opaque origin's Host()/Protocol() directly returns empty strings, which
+  // would let mixed content (e.g. insecure form submissions) through.
+  if (!IsOnion(*security_origin->GetOriginOrPrecursorOriginIfOpaque())) {
     return std::nullopt;
   }
   if (IsOnion(resource_url)) {

--- a/chromium_src/third_party/blink/renderer/platform/loader/fetch/https_state.cc
+++ b/chromium_src/third_party/blink/renderer/platform/loader/fetch/https_state.cc
@@ -17,8 +17,16 @@ namespace blink {
 
 HttpsState CalculateHttpsState(const SecurityOrigin* security_origin,
                                std::optional<HttpsState> parent_https_state) {
-  if (security_origin && (security_origin->Protocol() == "http" &&
-                          security_origin->Host().ends_with(".onion"))) {
+  // Use the precursor origin so that opaque origins (e.g. an .onion page
+  // sandboxed via `Content-Security-Policy: sandbox`) are still recognized as
+  // .onion. Reading the opaque origin's Protocol()/Host() directly returns
+  // empty strings, which would leave the page as kNone and let insecure
+  // (mixed) content through instead of treating .onion as https.
+  const SecurityOrigin* tuple_origin =
+      security_origin ? security_origin->GetOriginOrPrecursorOriginIfOpaque()
+                      : nullptr;
+  if (tuple_origin && (tuple_origin->Protocol() == "http" &&
+                       tuple_origin->Host().ends_with(".onion"))) {
     // MixedContentChecker::ShouldAutoupgrade upgrades resource only on the
     // kModern pages. Return it for .onion as for https.
     return HttpsState::kModern;

--- a/test/data/onion_sandboxed.html
+++ b/test/data/onion_sandboxed.html
@@ -1,0 +1,6 @@
+<html>
+<head><title>OK</title></head>
+
+<body>
+</body>
+</html>

--- a/test/data/onion_sandboxed.html.mock-http-headers
+++ b/test/data/onion_sandboxed.html.mock-http-headers
@@ -1,0 +1,3 @@
+HTTP/1.1 200 OK
+Content-Type: text/html
+Content-Security-Policy: sandbox allow-scripts


### PR DESCRIPTION

fix https://github.com/brave/internal/issues/1780
follow-up to https://github.com/brave/brave-core/pull/28224

An http .onion page sandboxed with `Content-Security-Policy: sandbox` has an opaque origin whose scheme()/host() (and Blink Protocol()/Host()) are empty, so Brave's .onion checks failed to recognize it. As a result, mixed content and insecure form submissions from such pages were not blocked, even though non-sandboxed .onion pages are treated as secure (https-like).

Recover the underlying tuple via GetTupleOrPrecursorTupleIfOpaque() / GetOriginOrPrecursorOriginIfOpaque() (matching how upstream handles opaque origins) in every .onion check that reads the origin directly:

- content MixedContentChecker::DoesOriginSchemeRestrictMixedContent
- blink MixedContentChecker::IsMixedContentForOnion (insecure form/subresource console warning + blocking)
- blink CalculateHttpsState (autoupgrade / secure-context treatment)
- net::IsOnion(url::Origin) — url::Origin::DomainIs() returns false for opaque origins; this fixes the insecure-form clickthrough interstitial (InsecureFormNavigationThrottle -> IsInsecureFormActionOnSecureSource) and autofill's IsFormMixedContent, the two callers of that overload.

Add regression coverage: a sandboxed .onion case in the MixedContentForOnion browser test (served with a `sandbox` CSP header) and opaque-origin cases in net's IsOnion unit test.


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
