### PR TITLE
[bootstrap] Fix Windows shim launcher path resolution

### DIFF
--- a/tools/cr/bootstrap/bootstrap_test.py
+++ b/tools/cr/bootstrap/bootstrap_test.py
@@ -722,5 +722,46 @@ class ArgumentForwardingTest(unittest.TestCase):
         self.assertNotIn('%', help_text)
 
 
+class BatShimLauncherResolutionTest(unittest.TestCase):
+    """Guards the Windows `.bat` shims against the `%~dp0`-is-cwd regression.
+
+    When a shim is invoked as a bare `node`/`npm` by another process (e.g. npm
+    running a package's lifecycle scripts), cmd can expand `%~dp0` to the
+    current directory, so a bare `python3 "%~dp0launcher.py"` pointed at the cwd
+    and failed with `can't open file '...\\launcher.py'`. Each `.bat` must fall
+    back to resolving its own name on `%PATH%` (`%~dp$PATH:0`) so `launcher.py`
+    is found beside the shim, not in the cwd.
+    """
+
+    _BAT_SHIMS = ('node.bat', 'npm.bat', 'brockit.bat', 'plaster.bat',
+                  'git-cr.bat')
+
+    def _read(self, name: str) -> str:
+        path = Path(launcher.__file__).resolve().parent / name
+        return path.read_text(encoding='utf-8')
+
+    def test_every_bat_shim_exists(self):
+        for name in self._BAT_SHIMS:
+            self.assertTrue(
+                (Path(launcher.__file__).resolve().parent / name).is_file(),
+                name)
+
+    def test_bat_shims_resolve_launcher_via_path_fallback(self):
+        for name in self._BAT_SHIMS:
+            text = self._read(name)
+            self.assertIn('launcher.py', text, name)
+            # Try `%~dp0` first, but fall back to a %PATH% search for our own
+            # name when launcher.py is not beside `%~dp0` (i.e. it was the cwd).
+            self.assertIn('if not exist "%_dir%launcher.py"', text, name)
+            self.assertIn('%~dp$PATH:0', text, name)
+
+    def test_bat_shims_do_not_run_launcher_straight_from_dp0(self):
+        # The fragile form this bug was about: python3 invoking `%~dp0launcher`
+        # directly, with no %PATH% fallback.
+        for name in self._BAT_SHIMS:
+            text = self._read(name)
+            self.assertNotIn('python3 "%~dp0launcher.py"', text, name)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tools/cr/bootstrap/brockit.bat
+++ b/tools/cr/bootstrap/brockit.bat
@@ -6,4 +6,11 @@
 ::
 :: Dispatches to tools/cr/brockit.py for the brave-core checkout the current
 :: directory is in. See launcher.py for the resolution logic.
-python3 "%~dp0launcher.py" brockit %*
+::
+:: `%~dp0` can expand to the current directory when the shim is invoked as a
+:: bare name by another process; if launcher.py is not there, resolve our own
+:: name on %PATH% (`%~dp$PATH:0`) to find it beside the shim.
+setlocal
+set "_dir=%~dp0"
+if not exist "%_dir%launcher.py" set "_dir=%~dp$PATH:0"
+python3 "%_dir%launcher.py" brockit %*

--- a/tools/cr/bootstrap/git-cr.bat
+++ b/tools/cr/bootstrap/git-cr.bat
@@ -9,4 +9,11 @@
 ::
 :: Named `git-cr` so that git resolves `git cr` to this shim via %PATH%, making
 :: the `git cr` subcommand work without registering a per-repository alias.
-python3 "%~dp0launcher.py" git-cr %*
+::
+:: `%~dp0` can expand to the current directory when the shim is invoked as a
+:: bare name by another process; if launcher.py is not there, resolve our own
+:: name on %PATH% (`%~dp$PATH:0`) to find it beside the shim.
+setlocal
+set "_dir=%~dp0"
+if not exist "%_dir%launcher.py" set "_dir=%~dp$PATH:0"
+python3 "%_dir%launcher.py" git-cr %*

--- a/tools/cr/bootstrap/node.bat
+++ b/tools/cr/bootstrap/node.bat
@@ -7,4 +7,12 @@
 :: Runs the node delivered into third_party/node for the brave-core checkout the
 :: current directory is in, falling back to the system node when there is none.
 :: See launcher.py for the resolution logic.
-python3 "%~dp0launcher.py" --allow-fallback node-win %*
+::
+:: `%~dp0` is normally this script's directory, but when the shim is invoked as
+:: a bare `node` by another process (e.g. npm running a package's scripts) cmd
+:: can expand it to the current directory instead. If launcher.py is not there,
+:: resolve our own name on %PATH% (`%~dp$PATH:0`) to find it beside the shim.
+setlocal
+set "_dir=%~dp0"
+if not exist "%_dir%launcher.py" set "_dir=%~dp$PATH:0"
+python3 "%_dir%launcher.py" --allow-fallback node-win %*

--- a/tools/cr/bootstrap/npm.bat
+++ b/tools/cr/bootstrap/npm.bat
@@ -7,4 +7,12 @@
 :: Runs the npm delivered into third_party/node for the brave-core checkout the
 :: current directory is in, falling back to the system npm when there is none.
 :: See launcher.py for the resolution logic.
-python3 "%~dp0launcher.py" --allow-fallback npm-win %*
+::
+:: `%~dp0` is normally this script's directory, but when the shim is invoked as
+:: a bare `npm` by another process (e.g. npm running a package's scripts) cmd
+:: can expand it to the current directory instead. If launcher.py is not there,
+:: resolve our own name on %PATH% (`%~dp$PATH:0`) to find it beside the shim.
+setlocal
+set "_dir=%~dp0"
+if not exist "%_dir%launcher.py" set "_dir=%~dp$PATH:0"
+python3 "%_dir%launcher.py" --allow-fallback npm-win %*

--- a/tools/cr/bootstrap/plaster.bat
+++ b/tools/cr/bootstrap/plaster.bat
@@ -6,4 +6,11 @@
 ::
 :: Dispatches to tools/cr/plaster.py for the brave-core checkout the current
 :: directory is in. See launcher.py for the resolution logic.
-python3 "%~dp0launcher.py" plaster %*
+::
+:: `%~dp0` can expand to the current directory when the shim is invoked as a
+:: bare name by another process; if launcher.py is not there, resolve our own
+:: name on %PATH% (`%~dp$PATH:0`) to find it beside the shim.
+setlocal
+set "_dir=%~dp0"
+if not exist "%_dir%launcher.py" set "_dir=%~dp$PATH:0"
+python3 "%_dir%launcher.py" plaster %*


### PR DESCRIPTION
The `node`/`npm` shims deliberately shadow `node`/`npm` on $PATH, so
`npm` re-invokes them to run a package's lifecycle scripts (web-
discovery's `patch-package` postinstall). In that nested, bare-name
invocation cmd expands `%~dp0` to the current directory rather than the
shim's own, so `python3 "%~dp0launcher.py"` pointed at the cwd and
`gclient runhooks` failed with:

```
python3: can't open file '...\vendor\web-discovery-project\launcher.py'
```

This fix hardens the resolution of `launcher.py` in the `.bat` shims:
try `%~dp0` first, and fall back to searching `$PATH` for the shim's
own name (`%~dp$PATH:0`) when `launcher.py` isn't beside `%~dp0`. This
covers both direct invocation and the bare-name nested case, while still
preferring the local dir.

Bug: https://github.com/brave/brave-browser/issues/56529
