### PR TITLE
Fixed adding to reading list

### DIFF
--- a/patches/chrome-browser-ui-browser_commands.cc.patch
+++ b/patches/chrome-browser-ui-browser_commands.cc.patch
@@ -1,18 +1,8 @@
 diff --git a/chrome/browser/ui/browser_commands.cc b/chrome/browser/ui/browser_commands.cc
-index 98184befe73ccdb129221921717f24a60e1967bc..42e9db730a555c605f3447787dbd881c8c190365 100644
+index 98184befe73ccdb129221921717f24a60e1967bc..18e3c35a81174f2072acf1e2d5cb4e3b8843062c 100644
 --- a/chrome/browser/ui/browser_commands.cc
 +++ b/chrome/browser/ui/browser_commands.cc
-@@ -302,6 +302,9 @@ bool GetTabURLAndTitleToSave(content::WebContents* web_contents,
- }
- 
- ReadingListModel* GetReadingListModel(BrowserWindowInterface* browser) {
-+  if ((true)) {
-+    return nullptr;
-+  }
-   ReadingListModel* model =
-       ReadingListModelFactory::GetForBrowserContext(browser->GetProfile());
-   if (!model || !model->loaded()) {
-@@ -1007,7 +1010,7 @@ void Reload(BrowserWindowInterface* browser,
+@@ -1007,7 +1007,7 @@ void Reload(BrowserWindowInterface* browser,
    ReloadInternal(browser, disposition, false);
  }
  
@@ -21,7 +11,7 @@ index 98184befe73ccdb129221921717f24a60e1967bc..42e9db730a555c605f3447787dbd881c
                            WindowOpenDisposition disposition) {
    base::RecordAction(UserMetricsAction("ReloadBypassingCache"));
    ReloadInternal(browser, disposition, true);
-@@ -1285,6 +1288,7 @@ void CloseTab(BrowserWindowInterface* browser) {
+@@ -1285,6 +1285,7 @@ void CloseTab(BrowserWindowInterface* browser) {
    }
  
    ToastController* toast_controller = browser->GetFeatures().toast_controller();
@@ -29,7 +19,7 @@ index 98184befe73ccdb129221921717f24a60e1967bc..42e9db730a555c605f3447787dbd881c
    if (!toast_controller) {
      CloseSelectedTabAndRecordTabCountMetric(browser);
      return;
-@@ -1588,7 +1592,7 @@ void NewSplitTab(BrowserWindowInterface* browser,
+@@ -1588,7 +1589,7 @@ void NewSplitTab(BrowserWindowInterface* browser,
    // the regular NTP which renders special content when in Incognito.
    const GURL new_tab_url = browser->GetProfile()->IsIncognitoProfile()
                                 ? chrome::ChromeUINewTabURLAsGURL()

--- a/rewrite/chrome/browser/ui/browser_commands.cc.yaml
+++ b/rewrite/chrome/browser/ui/browser_commands.cc.yaml
@@ -11,17 +11,6 @@ substitutions:
     replace: \1_ChromiumImpl(
 
   - description:
-      Return nullptr in GetReadingListModel(). We don't want ReadingList panel
-      in the side panel.
-    re_pattern: (ReadingListModel\* GetReadingListModel\(.*?{)
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        if ((true)) {
-          return nullptr;
-        }
-
-  - description:
       Replace chrome::kChromeUISplitViewNewTabPageURL to kChromeUINewTabURL in
       NewSplitTab(). We don't want to have a separate NTP URL for split view.
     re_pattern: |-


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57114

Recently we replaced #define with patching with plaster in browser_commands.cc.
Before plaster patching, we had `GetReadingListModel()` replacement with #define.
As browser_commands.cc has all `GetReadingListModel()` definition and callers,
it was no-op so far. And we didn't need to that replacement as we're reusing upstream's readling list w/o any modification. As it's no-op, we didn't noticed this replacement was invalid.

Plaster pathcing made it visible. Deleted patching as we don't need.

No test added for this change because we're reusing upstream's readinglist w/o modification.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
