### PR TITLE
[Workspaces] Fix widget ownership issues which caused a problem on Windows

### DIFF
--- a/patches/components-eye_dropper-eye_dropper_view.cc.patch
+++ b/patches/components-eye_dropper-eye_dropper_view.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/components/eye_dropper/eye_dropper_view.cc b/components/eye_dropper/eye_dropper_view.cc
+index d96981103dd8339ee07093f854c5537089233ec5..1bff11db91509bad8fc6ad39ba7d86271bc55870 100644
+--- a/components/eye_dropper/eye_dropper_view.cc
++++ b/components/eye_dropper/eye_dropper_view.cc
+@@ -406,7 +406,6 @@ EyeDropperView::~EyeDropperView() {
+   pre_dispatch_handler_.reset();
+   if (widget_) {
+     widget_->RemoveObserver(this);
+-    widget_->CloseNow();
+     widget_.reset();
+   }
+   delegate_.reset();

--- a/patches/ui-views-widget-desktop_aura-desktop_window_tree_host_win.cc.patch
+++ b/patches/ui-views-widget-desktop_aura-desktop_window_tree_host_win.cc.patch
@@ -1,0 +1,23 @@
+diff --git a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
+index 999fcd474717aab5f9f8e1b23e99dbaf6d748329..f6aeff09045a2a94d18c33981e28a13f376c005d 100644
+--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
++++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
+@@ -130,7 +130,8 @@ DesktopWindowTreeHostWin::DesktopWindowTreeHostWin(
+       drag_drop_client_(nullptr),
+       should_animate_window_close_(false),
+       pending_close_(false),
+-      has_non_client_view_(false) {}
++      has_non_client_view_(false),
++      is_modal_(native_widget_delegate_->IsModal()) {}
+ 
+ DesktopWindowTreeHostWin::~DesktopWindowTreeHostWin() {
+   ClearBackgroundPaintBrush();
+@@ -950,7 +951,7 @@ bool DesktopWindowTreeHostWin::WidgetSizeIsClientSize() const {
+ }
+ 
+ bool DesktopWindowTreeHostWin::IsModal() const {
+-  return native_widget_delegate_ ? native_widget_delegate_->IsModal() : false;
++  return is_modal_;
+ }
+ 
+ int DesktopWindowTreeHostWin::GetInitialShowState() const {

--- a/patches/ui-views-widget-desktop_aura-desktop_window_tree_host_win.h.patch
+++ b/patches/ui-views-widget-desktop_aura-desktop_window_tree_host_win.h.patch
@@ -1,0 +1,17 @@
+diff --git a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.h b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.h
+index 9ba64dc1b546b3a4e48e13949a555c227e02327c..cfeb1627eabec16cd5f65ccc91297d9cb76113f2 100644
+--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.h
++++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.h
+@@ -374,6 +374,12 @@ class VIEWS_EXPORT DesktopWindowTreeHostWin
+   // whenever the cursor visibility state changes.
+   static bool is_cursor_visible_;
+ 
++   // Modality of the window should be immutable, so we can cache it here for
++  // later interrogation. This ensures that any owner window is properly enabled
++  // when a modal window is destroyed/hidden, regardless of whether or not the
++  // native_widget_delegate_ is still present.
++  const bool is_modal_;
++
+   // Captures system key events when keyboard lock is requested.
+   std::unique_ptr<ui::KeyboardHook> keyboard_hook_;
+ 


### PR DESCRIPTION
This PR fixes a bug where saving a workspace on Windows causes the window to get stuck (acts modal; can't be interacted with or closed)

This is a cherry-pick from upstream:
https://chromium-review.googlesource.com/c/chromium/src/+/8007736

Which landed here:
https://chromiumdash.appspot.com/commit/be8cd95719f58fefd3a6b646b6016aec24ce679a

Shout out to @sangwoo108 for finding the root cause. I found the recent upstream commit when looking to report / upstream the fix 😄 Upstream reported with https://issues.chromium.org/u/1/issues/40232479#comment24

Fixes https://github.com/brave/brave-browser/issues/57038

