### PR TITLE
Hide contents top padding when fullscreen with toolbar on macOS

### DIFF
--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
@@ -648,6 +648,15 @@ gfx::Insets BraveBrowserViewTabbedLayoutImpl::GetContentsMargins() const {
         return false;
       }
     }
+
+#if BUILDFLAG(IS_MAC)
+    // In this mode, top_container is in overlay widget but top_container is
+    // positioned above the browser view.
+    if (delegate().GetBrowserWindowState() ==
+        WindowState::kFullscreenWithToolbar) {
+      return false;
+    }
+#endif
     return true;
   };
 
@@ -656,6 +665,11 @@ gfx::Insets BraveBrowserViewTabbedLayoutImpl::GetContentsMargins() const {
   }
 
   return margins;
+}
+
+gfx::Insets BraveBrowserViewTabbedLayoutImpl::GetContentsMarginsForTesting()
+    const {
+  return GetContentsMargins();
 }
 
 bool BraveBrowserViewTabbedLayoutImpl::ShouldPushBookmarkBarForVerticalTabs()

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
@@ -97,6 +97,10 @@ class BraveBrowserViewTabbedLayoutImpl : public BrowserViewTabbedLayoutImpl {
   bool GetMultiContentsSeparatorForTesting() const;
   bool GetShadowBoxForTesting() const;
 
+  // Test-only accessor for GetContentsMargins(), which is private and
+  // non-virtual.
+  gfx::Insets GetContentsMarginsForTesting() const;
+
   // Populates `layout_data_` with the given window state (and a zero side
   // panel width) so `CalculateSeparatorInfo()` can be exercised without
   // running a full layout pass. Implemented alongside CalculateSeparatorInfo()

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl_unittest.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl_unittest.cc
@@ -9,6 +9,7 @@
 #include <optional>
 
 #include "build/build_config.h"
+#include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/views/frame/layout/browser_view_layout_delegate.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -77,10 +78,13 @@ class FakeBrowserViewLayoutDelegate : public BrowserViewLayoutDelegate {
   bool IsFullscreen() const override { return false; }
 };
 
-// Mocks the CalculateSeparatorInfo() inputs exercised by the tests below:
-// IsToolbarVisible/IsBookmarkBarVisible drive the "no top UI" early return,
-// IsInfobarVisible and ShouldUseBraveWebViewRoundedCornersForContents drive
-// the mac fullscreen separator-suppression branch.
+// Mocks the CalculateSeparatorInfo() and GetContentsMargins() inputs
+// exercised by the tests below: IsToolbarVisible/IsBookmarkBarVisible drive
+// the "no top UI" early return, IsInfobarVisible and
+// ShouldUseBraveWebViewRoundedCornersForContents drive the mac fullscreen
+// separator-suppression branch, and GetBrowserWindowState additionally drives
+// the mac fullscreen-with-toolbar top-padding-suppression branch in
+// GetContentsMargins().
 class MockBrowserViewLayoutDelegate : public FakeBrowserViewLayoutDelegate {
  public:
   MOCK_METHOD(bool, IsToolbarVisible, (), (const, override));
@@ -90,6 +94,7 @@ class MockBrowserViewLayoutDelegate : public FakeBrowserViewLayoutDelegate {
               ShouldUseBraveWebViewRoundedCornersForContents,
               (),
               (const, override));
+  MOCK_METHOD(WindowState, GetBrowserWindowState, (), (const, override));
 };
 
 }  // namespace
@@ -404,6 +409,57 @@ TEST(BraveBrowserViewTabbedLayoutImplTest,
   // must keep upstream's separator (true here, since IsToolbarVisible() is
   // mocked true).
   EXPECT_TRUE(layout->GetTopContainerSeparatorForTesting());
+}
+
+// On macOS, when the window is in kFullscreenWithToolbar state, the top
+// container lives in an overlay widget positioned above the contents, so
+// the rounded-corners contents view no longer needs a top margin.
+TEST(BraveBrowserViewTabbedLayoutImplTest,
+     GetContentsMarginsMacFullscreenWithToolbarHidesTopPadding) {
+  auto mock =
+      std::make_unique<testing::NiceMock<MockBrowserViewLayoutDelegate>>();
+  EXPECT_CALL(*mock, ShouldUseBraveWebViewRoundedCornersForContents())
+      .WillRepeatedly(::testing::Return(true));
+  EXPECT_CALL(*mock, IsInfobarVisible())
+      .WillRepeatedly(::testing::Return(false));
+  EXPECT_CALL(*mock, GetBrowserWindowState())
+      .WillRepeatedly(::testing::Return(
+          BrowserViewLayoutDelegate::WindowState::kFullscreenWithToolbar));
+
+  BrowserViewLayoutViews views;
+  auto layout = std::make_unique<BraveBrowserViewTabbedLayoutImpl>(
+      std::move(mock), nullptr, std::move(views));
+
+  // The top margin is suppressed, but the other sides still reserve room for
+  // the rounded-corners shadow.
+  gfx::Insets margins = layout->GetContentsMarginsForTesting();
+  EXPECT_EQ(0, margins.top());
+  EXPECT_EQ(kRoundedCornersContentsViewMargin, margins.left());
+  EXPECT_EQ(kRoundedCornersContentsViewMargin, margins.right());
+  EXPECT_EQ(kRoundedCornersContentsViewMargin, margins.bottom());
+}
+
+TEST(BraveBrowserViewTabbedLayoutImplTest,
+     GetContentsMarginsMacRegularFullscreenKeepsTopPadding) {
+  auto mock =
+      std::make_unique<testing::NiceMock<MockBrowserViewLayoutDelegate>>();
+  EXPECT_CALL(*mock, ShouldUseBraveWebViewRoundedCornersForContents())
+      .WillRepeatedly(::testing::Return(true));
+  EXPECT_CALL(*mock, IsInfobarVisible())
+      .WillRepeatedly(::testing::Return(false));
+  // Plain kFullscreen (toolbar auto-hidden), not kFullscreenWithToolbar.
+  EXPECT_CALL(*mock, GetBrowserWindowState())
+      .WillRepeatedly(::testing::Return(
+          BrowserViewLayoutDelegate::WindowState::kFullscreen));
+
+  BrowserViewLayoutViews views;
+  auto layout = std::make_unique<BraveBrowserViewTabbedLayoutImpl>(
+      std::move(mock), nullptr, std::move(views));
+
+  // The mac-only branch is scoped to kFullscreenWithToolbar; plain kFullscreen
+  // must keep the top margin.
+  gfx::Insets margins = layout->GetContentsMarginsForTesting();
+  EXPECT_EQ(kRoundedCornersContentsViewMargin, margins.top());
 }
 
 #endif  // BUILDFLAG(IS_MAC)


### PR DESCRIPTION
In fullscreen with toolbar mode, top container is positioned above the contents. so don't need top padding.

TEST=BraveBrowserViewTabbedLayoutImplTest.*

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57089

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
