### PR TITLE
Don't show icon in title bar

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -324,6 +324,14 @@ bool BraveBrowserView::ShouldUseBraveWebViewRoundedCornersForContents(
 BraveBrowserView::BraveBrowserView(Browser* browser) : BrowserView(browser) {
   CHECK(multi_contents_view_);
 
+  // Upstream doesn't set icon because kFeatureTitleBar is not supported by
+  // default via WindowFeatureController::SupportsWindowfeatures. In brave, we
+  // support kFeatureTitleBar so it's set to true when browser is launched with
+  // vertical tab mode. Set to false as we don't want to icon in title bar.
+  if (browser_->is_type_normal()) {
+    SetShowIcon(false);
+  }
+
   tab_strip_placement_ = std::make_unique<TabStripPlacementCoordinator>(
       base::PassKey<BraveBrowserView>(), browser,
       horizontal_tab_strip_region_view_);

--- a/browser/ui/views/frame/brave_browser_view_browsertest.cc
+++ b/browser/ui/views/frame/brave_browser_view_browsertest.cc
@@ -295,6 +295,30 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserViewTest, TopSeparatorWithPanelTest) {
                   ->GetVisible());
 }
 
+// Regression test: BraveBrowserView's constructor unconditionally hides the
+// window icon for normal browser windows (SetShowIcon(false)), because brave
+// supports Browser::WindowFeature::kFeatureTitleBar (unlike upstream), which
+// would otherwise make ShouldShowWindowIcon() return true whenever vertical
+// tabs are enabled. The PRE_ test persists the pref so the following test's
+// browser() is actually launched with vertical tabs already on.
+IN_PROC_BROWSER_TEST_F(BraveBrowserViewTest,
+                       PRE_ShouldNotShowWindowIconWithVerticalTabTest) {
+  ASSERT_FALSE(VerticalTabController::FromBrowser(browser())
+                   ->ShouldShowBraveVerticalTabs());
+  EXPECT_FALSE(browser_view()->ShouldShowWindowIcon());
+
+  browser()->profile()->GetPrefs()->SetBoolean(brave_tabs::kVerticalTabsEnabled,
+                                               true);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveBrowserViewTest,
+                       ShouldNotShowWindowIconWithVerticalTabTest) {
+  // Browser is launched with vertical tab mode already on.
+  ASSERT_TRUE(VerticalTabController::FromBrowser(browser())
+                  ->ShouldShowBraveVerticalTabs());
+  EXPECT_FALSE(browser_view()->ShouldShowWindowIcon());
+}
+
 class BraveBrowserViewWithRoundedCornersTest
     : public BraveBrowserViewTest,
       public testing::WithParamInterface<bool> {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57123

Always hide title bar icon in normal window.
Upstream doesn't set icon for normal window because kFeatureTitleBar is not supported by
default via WindowFeatureController::SupportsWindowfeatures. In brave, we
support kFeatureTitleBar when vertical tab is enabled so it's set to true when browser is launched
with vertical tab mode. Set to false as we don't want to icon in title bar.

TEST=BraveBrowserViewTest.ShouldNotShowWindowIconWithVerticalTabTest

<img width="933" height="270" alt="image" src="https://github.com/user-attachments/assets/5532459e-35b1-4f47-94c6-4b1d31247fe7" />


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
