### PR TITLE
[plaster][ast-grep] Use `add_friend`

### DIFF
--- a/patches/chrome-browser-ui-page_action-page_action_pass_key.h.patch
+++ b/patches/chrome-browser-ui-page_action-page_action_pass_key.h.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/browser/ui/page_action/page_action_pass_key.h b/chrome/browser/ui/page_action/page_action_pass_key.h
-index 1c5c319b4050d21c313455242d0f9ac0a6a72a8c..700e56a8c6abee25e017acb1bde3116123535662 100644
+index 1c5c319b4050d21c313455242d0f9ac0a6a72a8c..d641e17a3ae1649c25690159b152c21ccf3f49d6 100644
 --- a/chrome/browser/ui/page_action/page_action_pass_key.h
 +++ b/chrome/browser/ui/page_action/page_action_pass_key.h
-@@ -29,6 +29,7 @@ class PageActionPassKey {
+@@ -27,6 +27,7 @@ class PageActionPassKey {
+   static PageActionPassKey PassKeyForTesting() { return PageActionPassKey(); }
+ 
   private:
++  friend class page_actions::chromium_impl::PageActionControllerImpl;
    friend class PageActionController;
    friend class PageActionControllerImpl;
-+  friend class page_actions::chromium_impl::PageActionControllerImpl;
    friend class PageActionView;
-   friend class ScopedPageActionActivity;
-   friend class PageActionModel;

--- a/rewrite/chrome/browser/ui/page_action/page_action_controller.h.yaml
+++ b/rewrite/chrome/browser/ui/page_action/page_action_controller.h.yaml
@@ -26,9 +26,6 @@ substitutions:
   - description: |
       Friend the brave page_actions::PageActionControllerImpl so it can reach the
       private members it relies on (FindPageActionModel, page_action_model_factory_).
-      The lazy match anchors on the first `private:` inside PageActionControllerImpl.
-    re_pattern: '(class PageActionControllerImpl.*?\bprivate:)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        friend class ::page_actions::PageActionControllerImpl;
+    add_friend:
+      class_name: PageActionControllerImpl
+      friend_type: class ::page_actions::PageActionControllerImpl

--- a/rewrite/chrome/browser/ui/page_action/page_action_model.h.yaml
+++ b/rewrite/chrome/browser/ui/page_action/page_action_model.h.yaml
@@ -67,8 +67,6 @@ substitutions:
   - description: |
       Friend the brave page_actions::PageActionModel so it can call NotifyChange and
       use the private Property enum from its base.
-    re_pattern: '(class PageActionModel\b.*?\bprivate:)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        friend class ::page_actions::PageActionModel;
+    add_friend:
+      class_name: PageActionModel
+      friend_type: class ::page_actions::PageActionModel

--- a/rewrite/chrome/browser/ui/page_action/page_action_pass_key.h.yaml
+++ b/rewrite/chrome/browser/ui/page_action/page_action_pass_key.h.yaml
@@ -3,15 +3,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# The friends in this file are being added next to the original declaration to
-# be intentionally fragile, and break whenever any of these classes stop being
-# a friend, so the privileged access can be review/removed when not needed
-# anymore.
-
 substitutions:
   - description:
       'Befriend page_actions::chromium_impl::PageActionControllerImpl'
-    pattern: 'friend class PageActionControllerImpl;'
-    replace: |-
-      friend class PageActionControllerImpl;
-        friend class page_actions::chromium_impl::PageActionControllerImpl;
+    add_friend:
+      class_name: PageActionPassKey
+      friend_type: class page_actions::chromium_impl::PageActionControllerImpl

--- a/rewrite/chrome/browser/ui/views/frame/layout/browser_view_tabbed_layout_impl.h.yaml
+++ b/rewrite/chrome/browser/ui/views/frame/layout/browser_view_tabbed_layout_impl.h.yaml
@@ -31,7 +31,6 @@ substitutions:
 
       The override needs access to the private nested `SeparatorInfo`
       type and to the (still private) virtuals above.
-    re_pattern: '(class BrowserViewTabbedLayoutImpl\b.*?\n private:\n)'
-    re_flags: [DOTALL]
-    replace: |
-      \1  friend class BraveBrowserViewTabbedLayoutImpl;
+    add_friend:
+      class_name: BrowserViewTabbedLayoutImpl
+      friend_type: class BraveBrowserViewTabbedLayoutImpl

--- a/rewrite/chrome/browser/ui/views/frame/multi_contents_view.h.yaml
+++ b/rewrite/chrome/browser/ui/views/frame/multi_contents_view.h.yaml
@@ -85,7 +85,6 @@ substitutions:
       (`ResetResizeArea`, `UpdateContentsBorderAndOverlay`,
       `OnWebContentsFocused`, `ExecuteOnEachVisibleContentsView`) and
       reads private members such as `contents_container_views_`.
-    re_pattern: '(class MultiContentsView\b.*?\n private:\n)'
-    re_flags: [DOTALL]
-    replace: |
-      \1  friend class BraveMultiContentsView;
+    add_friend:
+      class_name: MultiContentsView
+      friend_type: class BraveMultiContentsView

--- a/rewrite/components/permissions/permission_context_base.h.yaml
+++ b/rewrite/components/permissions/permission_context_base.h.yaml
@@ -32,5 +32,6 @@ substitutions:
   - description:
       'Add Brave PermissionContextBase as friend of
       chromium_impl::PermissionContextBase'
-    re_pattern: '(\bprivate:)'
-    replace: '\1\n  friend class ::permissions::PermissionContextBase;'
+    add_friend:
+      class_name: PermissionContextBase
+      friend_type: class ::permissions::PermissionContextBase


### PR DESCRIPTION
This PR migrates several places to use `add_friend` rather than a regex
to add a friend class.
