### PR TITLE
Leo - Model selector - Learn more link for NearAI model. Fix for clickable area

### DIFF
--- a/components/ai_chat/resources/page/components/model_menu_item/model_menu_item_style.module.scss
+++ b/components/ai_chat/resources/page/components/model_menu_item/model_menu_item_style.module.scss
@@ -69,6 +69,7 @@
 }
 
 .learnMoreLink {
+  align-self: start;
   font: var(--leo-font-small-regular);
   text-decoration: underline;
   color: var(--leo-color-text-tertiary);

--- a/components/ai_chat/resources/page/stories/components_panel.tsx
+++ b/components/ai_chat/resources/page/stories/components_panel.tsx
@@ -170,6 +170,33 @@ const MODELS: Mojom.Model[] = [
       },
     },
   },
+  {
+    key: 'chat-near-glm-5',
+    displayName: 'GLM-5',
+    visionSupport: false,
+    audioSupport: false,
+    videoSupport: false,
+    supportsTools: false,
+    supportedCapabilities: [
+      Mojom.ConversationCapability.CHAT,
+      Mojom.ConversationCapability.DEEP_RESEARCH,
+    ],
+    isSuggestedModel: true,
+    isNearModel: true,
+    supportsPrivateInference: false,
+    options: {
+      leoModelOptions: {
+        name: 'near-glm-5',
+        displayMaker: 'Z.ai',
+        description: '',
+        category: Mojom.ModelCategory.CHAT,
+        access: Mojom.ModelAccess.BASIC_AND_PREMIUM,
+        maxAssociatedContentLength: 128000,
+        longConversationWarningCharacterLimit: 128000,
+      },
+      customModelOptions: undefined,
+    },
+  },
 ]
 
 const SAMPLE_QUESTIONS = [


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/55546


Add GLM-5 model configuration to the supported models list with chat and deep research capabilities. Also fix the alignment of the 'Learn More' link in model menu items by adding `align-self: start` to prevent vertical centering issues.

## Before - Entire row was clickable as "learn more"

https://github.com/user-attachments/assets/043e8f0c-7305-4151-9034-54e6941a9c7f

## After - Only the "lear more" text is clickable


https://github.com/user-attachments/assets/2b879299-c241-4ed2-a919-fce140ee14c8



<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
