### PR TITLE
Leo AI - Refactor feedback form to use Dialog component and design updates

### DIFF
--- a/components/ai_chat/resources/page/components/feedback_form/feedback_form.stories.tsx
+++ b/components/ai_chat/resources/page/components/feedback_form/feedback_form.stories.tsx
@@ -7,15 +7,16 @@ import * as React from 'react'
 import { Meta } from '@storybook/react'
 import { MockContext } from '../../state/mock_context'
 import FeedbackForm from './'
-import styles from '../../stories/style.module.scss'
 
 export const _FeedbackForm = {
   render: () => {
     return (
-      <MockContext>
-        <div className={styles.container}>
-          <FeedbackForm />
-        </div>
+      <MockContext
+        conversationOverrides={{
+          isFeedbackFormVisible: true,
+        }}
+      >
+        <FeedbackForm />
       </MockContext>
     )
   },

--- a/components/ai_chat/resources/page/components/feedback_form/index.tsx
+++ b/components/ai_chat/resources/page/components/feedback_form/index.tsx
@@ -4,9 +4,9 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react'
-import DropDown from '@brave/leo/react/dropdown'
 import Button from '@brave/leo/react/button'
 import Checkbox from '@brave/leo/react/checkbox'
+import Dialog from '@brave/leo/react/dialog'
 import { getLocale, formatLocale } from '$web-common/locale'
 import { useAIChat } from '../../state/ai_chat_context'
 import { useConversation } from '../../state/conversation_context'
@@ -28,7 +28,6 @@ const getHostName = (url: string) => {
 }
 
 function FeedbackForm() {
-  const ref = React.useRef<HTMLDivElement>(null)
   const [category, setCategory] = React.useState('')
   const [feedbackText, setFeedbackText] = React.useState('')
   const aiChatContext = useAIChat()
@@ -45,10 +44,6 @@ function FeedbackForm() {
     )
   }
 
-  const handleSelectOnChange = ({ value }: { value: string }) => {
-    setCategory(value)
-  }
-
   const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setFeedbackText(e.target.value)
   }
@@ -57,100 +52,106 @@ function FeedbackForm() {
     setShouldSendUrl(checked)
   }
 
+  // Reset form state when the dialog closes so the next open is clean.
   React.useEffect(() => {
-    ref.current?.scrollIntoView()
-  }, [])
-
-  // TODO(petemill): allow submission and show error on Dropdown if nothing
-  // is selected when user attempts to Submit.
+    if (!conversationContext.isFeedbackFormVisible) {
+      setCategory('')
+      setFeedbackText('')
+      setShouldSendUrl(true)
+    }
+  }, [conversationContext.isFeedbackFormVisible])
 
   return (
-    <div
-      ref={ref}
-      className={styles.form}
+    <Dialog
+      isOpen={conversationContext.isFeedbackFormVisible}
+      showClose
+      onClose={conversationContext.handleFeedbackFormCancel}
+      className={styles.dialog}
     >
-      <h4>{getLocale(S.CHAT_UI_PROVIDE_FEEDBACK_TITLE)}</h4>
-      <form>
-        <fieldset>
-          <DropDown
-            positionStrategy='fixed'
-            className={styles.dropdown}
-            placeholder={getLocale(S.CHAT_UI_SELECT_FEEDBACK_TOPIC)}
-            onChange={handleSelectOnChange}
-            required={true}
-            value={CATEGORY_OPTIONS.get(category)}
-          >
-            <div slot='label'>
-              {getLocale(S.CHAT_UI_FEEDBACK_CATEGORY_LABEL)}
-            </div>
-            {[...CATEGORY_OPTIONS.keys()].map((key) => {
-              return (
-                <leo-option
-                  key={key}
-                  value={key}
-                >
-                  {CATEGORY_OPTIONS.get(key)}
-                </leo-option>
-              )
-            })}
-          </DropDown>
-        </fieldset>
-        <fieldset>
-          <label>
-            {getLocale(S.CHAT_UI_FEEDBACK_DESCRIPTION_LABEL)}
-            <textarea
-              onChange={handleInputChange}
-              placeholder={getLocale(S.CHAT_UI_FEEDBACK_DESCRIPTION_LABEL)}
-            />
-          </label>
-        </fieldset>
+      <div
+        slot='title'
+        className={styles.dialogTitle}
+      >
+        {getLocale(S.CHAT_UI_PROVIDE_FEEDBACK_TITLE)}
+      </div>
+      <div className={styles.body}>
+        <div className={styles.categorySection}>
+          <div className={styles.categoryLabel}>
+            {getLocale(S.CHAT_UI_FEEDBACK_CATEGORY_LABEL)}
+          </div>
+          <div className={styles.reasons}>
+            {[...CATEGORY_OPTIONS.keys()].map((key) => (
+              <Button
+                key={key}
+                kind={category === key ? 'filled' : 'outline'}
+                onClick={() => setCategory(key)}
+              >
+                {CATEGORY_OPTIONS.get(key)}
+              </Button>
+            ))}
+          </div>
+        </div>
+        <label className={styles.detailsLabel}>
+          {getLocale(S.CHAT_UI_FEEDBACK_DESCRIPTION_LABEL)}
+          <textarea
+            value={feedbackText}
+            onChange={handleInputChange}
+            placeholder={getLocale(S.CHAT_UI_FEEDBACK_DESCRIPTION_LABEL)}
+          />
+        </label>
         {conversationContext.associatedContentInfo.length > 0 && (
-          <fieldset>
-            <Checkbox
-              checked={shouldSendUrl}
-              onChange={handleCheckboxChange}
-            >
-              <label>
-                {formatLocale(S.CHAT_UI_SEND_SITE_HOSTNAME_LABEL, {
-                  $1: conversationContext.associatedContentInfo
-                    .map((c) => getHostName(c.url.url))
-                    .join(', '),
-                })}
-              </label>
-            </Checkbox>
-          </fieldset>
+          <Checkbox
+            checked={shouldSendUrl}
+            onChange={handleCheckboxChange}
+          >
+            <span>
+              {formatLocale(S.CHAT_UI_SEND_SITE_HOSTNAME_LABEL, {
+                $1: conversationContext.associatedContentInfo
+                  .map((c) => getHostName(c.url.url))
+                  .join(', '),
+              })}
+            </span>
+          </Checkbox>
         )}
         {!aiChatContext.isPremiumUser && (
           <div className={styles.premiumNote}>
             {formatLocale(S.CHAT_UI_FEEDBACK_PREMIUM_NOTE, {
               $1: (linkText) => (
-                <Button
-                  kind='plain'
-                  size='medium'
-                  onClick={aiChatContext.goPremium}
+                <a
+                  href='#'
+                  className={styles.learnMoreLink}
+                  onClick={(e) => {
+                    e.preventDefault()
+                    aiChatContext.goPremium()
+                  }}
                 >
                   {linkText}
-                </Button>
+                </a>
               ),
             })}
           </div>
         )}
-        <fieldset className={styles.actions}>
+        <div className={styles.footer}>
           <Button
-            onClick={conversationContext.handleFeedbackFormCancel}
+            className={styles.footerButton}
             kind='plain-faint'
+            size='medium'
+            onClick={conversationContext.handleFeedbackFormCancel}
           >
             {getLocale(S.CHAT_UI_CANCEL_BUTTON_LABEL)}
           </Button>
           <Button
+            className={styles.footerButton}
+            kind='filled'
+            size='medium'
             isDisabled={!canSubmit}
             onClick={handleSubmit}
           >
             {getLocale(S.CHAT_UI_SUBMIT_BUTTON_LABEL)}
           </Button>
-        </fieldset>
-      </form>
-    </div>
+        </div>
+      </div>
+    </Dialog>
   )
 }
 

--- a/components/ai_chat/resources/page/components/feedback_form/style.module.scss
+++ b/components/ai_chat/resources/page/components/feedback_form/style.module.scss
@@ -3,35 +3,62 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
-.form {
-  --leo-control-font: var(--leo-font-default-regular);
+.dialog {
+  --leo-dialog-padding: var(--leo-spacing-2xl);
+  --leo-dialog-width: 520px;
+  --leo-dialog-backdrop-background: var(--leo-color-dialogs-scrim-background);
+}
 
-  max-width: 500px;
-  font: var(--leo-control-font);
-  background: var(--leo-color-blue-10);
-  border-radius: 8px;
-  display: inline-block;
+.dialogTitle {
+  font: var(--leo-font-heading-h3);
+  font-size: 20px;
+}
 
-  h4 {
-    padding: 24px 16px;
-    font: var(--leo-font-heading-h4);
-    margin: 0;
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--leo-spacing-2xl);
+}
+
+.categorySection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--leo-spacing-m);
+}
+
+.categoryLabel {
+  font: var(--leo-font-small-semibold);
+  color: var(--leo-color-text-primary);
+  padding-inline: var(--leo-spacing-s);
+}
+
+.reasons {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--leo-spacing-m);
+
+  leo-button {
+    width: 100%;
   }
+}
 
-  fieldset {
-    border: 0;
-    padding: 0 16px;
-    margin-bottom: 16px;
-  }
+.detailsLabel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--leo-spacing-s);
+  font: var(--leo-font-small-semibold);
+  color: var(--leo-color-text-primary);
 
   textarea {
     display: block;
     width: 100%;
-    padding: 10px 16px;
+    padding: 11px 16px;
     resize: none;
-    background-color: transparent;
-    border: 1px solid var(--leo-color-divider-strong);
-    border-radius: 8px;
+    background-color: var(--leo-color-container-background);
+    border: 1px solid var(--leo-color-divider-subtle);
+    border-radius: var(--leo-radius-l);
+    font: var(--leo-font-default-regular);
+    color: var(--leo-color-text-primary);
 
     &:focus-within {
       outline: none;
@@ -45,24 +72,37 @@
   }
 }
 
-.dropdown {
-  width: 100%;
+.premiumNote {
+  font: var(--leo-font-default-regular);
+  color: var(--leo-color-systemfeedback-info-text);
+  padding: 16px;
+  border-radius: var(--leo-radius-l);
+  background: var(--leo-color-systemfeedback-info-background);
 }
 
-.actions {
-  display: flex;
-  justify-content: end;
-  gap: 16px;
+.learnMoreLink {
+  cursor: pointer;
+  background: none;
+  border: none;
+  margin: 0;
+  padding: 0;
+  text-decoration: underline;
+  color: inherit;
 
-  leo-button {
-    flex: 0 1 auto;
+  &:hover {
+    color: var(--leo-color-text-interactive);
   }
 }
 
-.premiumNote {
-  font: var(--leo-font-default-regular);
-  margin: 0 16px 16px 16px;
-  padding: 16px;
-  border-radius: 8px;
-  background: var(--leo-color-blue-20);
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--leo-spacing-m);
+  margin-top: var(--leo-spacing-m);
+}
+
+.footerButton {
+  flex: 0 0 auto;
+  width: auto;
+  max-width: max-content;
 }

--- a/components/ai_chat/resources/page/components/main/index.tsx
+++ b/components/ai_chat/resources/page/components/main/index.tsx
@@ -184,7 +184,7 @@ function Main() {
         setIsConversationsListOpen={setIsConversationsListOpen}
       />
       <AlertCenter
-        position='top-left'
+        position='top-center'
         className={styles.alertCenter}
       />
       {!aiChatContext.hasAcceptedAgreement && !hasConversationStarted ? (
@@ -198,16 +198,6 @@ function Main() {
         </div>
       ) : (
         <>
-          {conversationContext.isFeedbackFormVisible && (
-            <Dialog
-              isOpen
-              onClose={conversationContext.handleFeedbackFormCancel}
-              className={styles.attachmentsDialog}
-            >
-              <FeedbackForm />
-            </Dialog>
-          )}
-
           <aiChatContext.conversationEntriesComponent
             className={styles.conversationContainer}
           />
@@ -249,6 +239,7 @@ function Main() {
       <DeleteConversationModal />
       <OpenExternalLinkModal />
       <RateMessagePrivacyModal />
+      <FeedbackForm />
       {aiChatContext.skillDialog && <SkillModal />}
     </main>
   )

--- a/components/ai_chat/resources/page/components/main/style.module.scss
+++ b/components/ai_chat/resources/page/components/main/style.module.scss
@@ -133,12 +133,14 @@
 }
 
 .alertCenter {
-  --leo-alert-center-width: calc(100% - 32px);
-  /* remove scrollbar space */
-  position: absolute;
-  left: 0;
+  /* Nala AlertCenter default max is 540px; keep panel padding on narrow layouts */
+  --leo-alert-center-width: min(540px, calc(100% - 32px));
+  --leo-alert-center-position: absolute;
   z-index: 5;
-  width: 100%;
+
+  leo-button {
+    flex-grow: 0;
+  }
 }
 
 .toggleContainer {

--- a/components/ai_chat/resources/page/components/rate_message_privacy_modal/index.tsx
+++ b/components/ai_chat/resources/page/components/rate_message_privacy_modal/index.tsx
@@ -70,13 +70,9 @@ export default function RateMessagePrivacyModal() {
             ),
           })}
         </span>
-      </div>
-      <div
-        slot='actions'
-        className={styles.actionsRow}
-      >
-        <div className={styles.buttonsWrapper}>
+        <div className={styles.footer}>
           <Button
+            className={styles.footerButton}
             kind='plain-faint'
             size='medium'
             onClick={() =>
@@ -86,6 +82,7 @@ export default function RateMessagePrivacyModal() {
             {getLocale(S.CHAT_UI_CANCEL_BUTTON_LABEL)}
           </Button>
           <Button
+            className={styles.footerButton}
             kind='filled'
             size='medium'
             onClick={onClickSend}

--- a/components/ai_chat/resources/page/components/rate_message_privacy_modal/style.module.scss
+++ b/components/ai_chat/resources/page/components/rate_message_privacy_modal/style.module.scss
@@ -19,13 +19,18 @@
   color: var(--leo-color-text-secondary);
 }
 
-.actionsRow {
+.footer {
+  display: flex;
   justify-content: flex-end;
+  align-items: center;
+  gap: var(--leo-spacing-m);
+  width: 100%;
 }
 
-.buttonsWrapper {
-  display: flex;
-  gap: var(--leo-spacing-m);
+.footerButton {
+  flex: 0 0 auto !important;
+  width: auto !important;
+  max-width: max-content;
 }
 
 .learnMoreLink {

--- a/components/ai_chat/resources/page/state/useSendFeedback.ts
+++ b/components/ai_chat/resources/page/state/useSendFeedback.ts
@@ -102,6 +102,7 @@ export default function useSendFeedback(
           {
             type: 'info',
             content: getLocale(S.CHAT_UI_ANSWER_DISLIKED),
+            isInlineActions: true,
             actions: [
               {
                 text: getLocale(S.CHAT_UI_ADD_FEEDBACK_BUTTON_LABEL),


### PR DESCRIPTION
## Summary

Redesigns Leo AI response feedback UI to match Figma, and cleans up related rating/toast layouts.

- Resolves https://github.com/brave/brave-browser/issues/46077

### Feedback form (`FeedbackForm`)
- Converts the form into a Leo `Dialog` (owns open/close via `isFeedbackFormVisible`)
- Replaces the category dropdown with a 2×2 grid of selectable outline/filled pill buttons
- Restyles layout to match Figma (title slot, body sections, textarea, premium note)
- Turns the premium upsell “Learn more” into an underlined text link (still calls `goPremium`)
- Keeps existing locale strings and the “Send site hostname” checkbox
- Moves Cancel / Submit into a right-aligned footer with content-width buttons (avoids Dialog `actions` slot full-width stretch in the side panel)
- Resets form state when the dialog closes
- Mounts `<FeedbackForm />` alongside other modals in `Main` (no longer wrapped in a nested Dialog)

### Rating privacy modal (`RateMessagePrivacyModal`)
- Moves Cancel / Send out of Dialog `actions` slot into a right-aligned footer
- Forces content-width buttons so they no longer span full width

### Liked / disliked alerts (`AlertCenter` + `useSendFeedback`)
- Centers alerts horizontally (`position='top-center'`)
- Caps alert width using Nala’s 540px max: `min(540px, calc(100% - 32px))`
- Sets `isInlineActions: true` on the disliked alert so “Add feedback” is content-width instead of full-width

### Storybook
- Updates the FeedbackForm story to open via `isFeedbackFormVisible: true`

# Before
## Panel
<img width="1631" height="1122" alt="image" src="https://github.com/user-attachments/assets/f3871c69-1fb7-4ecd-b576-d1950de44a03" />

<img width="1631" height="1122" alt="image" src="https://github.com/user-attachments/assets/cea54cf1-2071-420c-a81f-8a658686c72f" />

<img width="1631" height="1122" alt="image" src="https://github.com/user-attachments/assets/738b32c7-a063-47bc-aeec-ad2a31458c0d" />

<img width="1631" height="1122" alt="image" src="https://github.com/user-attachments/assets/2693f451-d74a-457f-bbea-90620543be63" />

## Full page
<img width="1631" height="1122" alt="image" src="https://github.com/user-attachments/assets/d97c6677-4114-49f3-87bd-9d7522747265" />

<img width="1631" height="1122" alt="image" src="https://github.com/user-attachments/assets/11f84c14-f8ab-4a5e-a40b-d8a1c7f2ca8b" />

<img width="1631" height="1122" alt="image" src="https://github.com/user-attachments/assets/d8434699-ab62-45e3-989b-7f488f722bbb" />

<img width="1631" height="1122" alt="image" src="https://github.com/user-attachments/assets/b1b8147a-e332-4b20-a819-ef797284b5b7" />

<img width="1631" height="1122" alt="image" src="https://github.com/user-attachments/assets/1b9bf75f-deeb-428a-9868-9e6169370435" />

# After
## Panel
<img width="1414" height="1084" alt="image" src="https://github.com/user-attachments/assets/f25760a8-4e80-4ce7-b678-281b62360a10" />

<img width="1414" height="1084" alt="image" src="https://github.com/user-attachments/assets/08f926b9-fc5c-4a87-a238-8605e894587e" />

<img width="1414" height="1084" alt="image" src="https://github.com/user-attachments/assets/9bf5d5c7-f65b-42f8-9a77-73551695c644" />

<img width="1414" height="1084" alt="image" src="https://github.com/user-attachments/assets/33875f7a-48ec-474b-959f-f971b19e55b7" />

## Full page
<img width="1414" height="1084" alt="image" src="https://github.com/user-attachments/assets/381a6bf0-f47a-4226-b19f-f619f3de7805" />

<img width="1414" height="1084" alt="image" src="https://github.com/user-attachments/assets/ad9b9250-d873-4e87-ba7f-62b8ce59a8a0" />

<img width="1414" height="1084" alt="image" src="https://github.com/user-attachments/assets/32f0a029-e659-4578-8f0b-37eb585ec18e" />

<img width="1414" height="1084" alt="image" src="https://github.com/user-attachments/assets/1dee453c-5615-4976-8559-815cb71df444" />

<img width="1414" height="1084" alt="image" src="https://github.com/user-attachments/assets/ce1b3955-d4b3-4edb-9471-b9459058b362" />
