### PR TITLE
Refactor PremiumSuggestion layout, styles, and strings

### DIFF
--- a/components/ai_chat/resources/untrusted_conversation_frame/components/premium_suggestion/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/premium_suggestion/index.tsx
@@ -7,7 +7,6 @@ import * as React from 'react'
 import Icon from '@brave/leo/react/icon'
 import Button from '@brave/leo/react/button'
 import Label from '@brave/leo/react/label'
-import classnames from '$web-common/classnames'
 import { getLocale, formatLocale } from '$web-common/locale'
 import { useUntrustedConversationContext } from '../../untrusted_conversation_context'
 import styles from './style.module.scss'
@@ -18,27 +17,10 @@ interface PremiumSuggestionProps {
   secondaryActionButton?: React.ReactNode
 }
 
-const featuresList = [
-  {
-    title: getLocale(S.CHAT_UI_PREMIUM_FEATURE_1),
-    desc: getLocale(S.CHAT_UI_PREMIUM_FEATURE_1_DESC),
-    icon: 'widget-generic',
-  },
-  {
-    title: getLocale(S.CHAT_UI_PREMIUM_FEATURE_2),
-    desc: getLocale(S.CHAT_UI_PREMIUM_FEATURE_2_DESC),
-    icon: 'idea',
-  },
-  {
-    title: getLocale(S.CHAT_UI_PREMIUM_FEATURE_3),
-    desc: getLocale(S.CHAT_UI_PREMIUM_FEATURE_3_DESC),
-    icon: 'edit-pencil',
-  },
-  {
-    title: getLocale(S.CHAT_UI_PREMIUM_FEATURE_4),
-    desc: getLocale(S.CHAT_UI_PREMIUM_FEATURE_4_DESC),
-    icon: 'message-bubble-comments',
-  },
+const sellingPoints = [
+  getLocale(S.CHAT_UI_PREMIUM_FEATURE_1),
+  getLocale(S.CHAT_UI_PREMIUM_FEATURE_2),
+  getLocale(S.CHAT_UI_PREMIUM_FEATURE_3),
 ]
 
 function PremiumSuggestion(props: PremiumSuggestionProps) {
@@ -62,70 +44,76 @@ function PremiumSuggestion(props: PremiumSuggestionProps) {
 
   return (
     <div className={styles.boxPremium}>
-      <div className={styles.header}>
-        <h4>{props.title}</h4>
-        <p>{props.description}</p>
-      </div>
-      <div className={styles.features}>
-        <ul>
-          {featuresList.map((entry, i) => {
-            return (
-              <li key={i}>
-                <div className={styles.icon}>
-                  <Icon name={entry.icon} />
+      <div className={styles.layout}>
+        <div className={styles.left}>
+          <div className={styles.header}>
+            <h4>{props.title}</h4>
+            {props.description && <p>{props.description}</p>}
+          </div>
+          <ul className={styles.sellingPoints}>
+            {sellingPoints.map((point, i) => {
+              return (
+                <li
+                  key={i}
+                  className={styles.sellingPoint}
+                >
+                  <Icon
+                    className={styles.checkIcon}
+                    name='check-normal'
+                  />
+                  <span>{point}</span>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+        <div className={styles.right}>
+          {!isMobile && (
+            <div className={styles.priceListWrapper}>
+              <div className={styles.planCard}>
+                <div className={styles.planDetails}>
+                  <div className={styles.planHeader}>
+                    <span className={styles.planName}>
+                      {getLocale(S.CHAT_UI_PREMIUM_ANNUAL_LABEL)}
+                    </span>
+                    <span className={styles.planPrice}>
+                      {pricingAnnualInfo}
+                    </span>
+                  </div>
                 </div>
-                <span>
-                  {entry.title}
-                  <p>{entry.desc}</p>
-                </span>
-              </li>
-            )
-          })}
-        </ul>
-      </div>
-      {!isMobile && (
-        <div className={styles.priceListWrapper}>
-          <div className={styles.priceList}>
-            <button
-              className={styles.priceButton}
-              tabIndex={-1}
-            >
-              <div className={styles.bestValueColumn}>
-                <span className={styles.priceButtonLabel}>
-                  {getLocale(S.CHAT_UI_ONE_YEAR_LABEL)}
-                </span>
-                <Label color='green'>
-                  {getLocale(S.CHAT_UI_BEST_VALUE_LABEL)}
+                <Label
+                  className={styles.saveLabel}
+                  mode='loud'
+                  color='primary'
+                >
+                  {getLocale(S.CHAT_UI_PREMIUM_SAVE_PERCENT_LABEL)}
                 </Label>
               </div>
-              <span className={styles.price}>{pricingAnnualInfo}</span>
-            </button>
-            <button
-              className={classnames(
-                styles.priceButton,
-                styles.priceButtonMonthly,
-              )}
-              tabIndex={-1}
+              <div className={styles.planCard}>
+                <div className={styles.planDetails}>
+                  <div className={styles.planHeader}>
+                    <span className={styles.planName}>
+                      {getLocale(S.CHAT_UI_MONTHLY_LABEL)}
+                    </span>
+                    <span className={styles.planPrice}>{pricingInfo}</span>
+                  </div>
+                </div>
+              </div>
+              <div className={styles.subscriptionPolicy}>
+                {getLocale(S.CHAT_UI_SUBSCRIPTION_POLICY_INFO)}
+              </div>
+            </div>
+          )}
+          <div className={styles.actions}>
+            <Button
+              onClick={() => context.uiHandler.goPremium()}
+              ref={buttonRef}
             >
-              <span className={styles.priceButtonLabel}>
-                {getLocale(S.CHAT_UI_MONTHLY_LABEL)}
-              </span>
-              <span className={styles.price}>{pricingInfo}</span>
-            </button>
-          </div>
-          <div className={styles.subscriptionPolicy}>
-            {getLocale(S.CHAT_UI_SUBSCRIPTION_POLICY_INFO)}
+              {getLocale(S.CHAT_UI_UPGRADE_BUTTON_LABEL)}
+            </Button>
+            {props.secondaryActionButton}
           </div>
         </div>
-      )}
-      <div className={styles.actions}>
-        <Button
-          onClick={() => context.uiHandler.goPremium()}
-          ref={buttonRef}
-        >
-          {getLocale(S.CHAT_UI_UPGRADE_BUTTON_LABEL)}
-        </Button>
-        {props.secondaryActionButton}
       </div>
     </div>
   )

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/premium_suggestion/style.module.scss
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/premium_suggestion/style.module.scss
@@ -1,19 +1,50 @@
 // Copyright (c) 2023 The Brave Authors. All rights reserved.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
-// you can obtain one at https://mozilla.org/MPL/2.0/.
+// You can obtain one at https://mozilla.org/MPL/2.0/.
 
 .boxPremium {
+  // Own containment so @container below can style descendants based on
+  // this card's width (an element cannot query its own size).
+  container-type: inline-size;
   width: 100%;
-  background: var(--leo-color-primary-10);
-  border-radius: 16px;
-  max-width: 600px;
-  margin: 0 auto;
+  padding: var(--leo-spacing-xl);
+  background: var(--leo-color-container-background);
+  border: 1px solid var(--leo-color-divider-subtle);
+  border-radius: var(--leo-radius-xl);
+  box-shadow: var(--leo-effect-elevation-01);
   color: var(--leo-color-text-primary);
+  box-sizing: border-box;
+}
+
+.layout {
+  display: flex;
+  flex-direction: column;
+  gap: var(--leo-spacing-xl);
+  width: 100%;
+}
+
+.left {
+  display: flex;
+  flex-direction: column;
+  gap: var(--leo-spacing-xl);
+  flex: 1;
+  min-width: 0;
+}
+
+.right {
+  display: flex;
+  flex-direction: column;
+  gap: var(--leo-spacing-2xl);
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .header {
-  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--leo-spacing-m);
+  padding: var(--leo-spacing-m) var(--leo-spacing-xl) 0;
 
   h4 {
     font: var(--leo-font-heading-h4);
@@ -22,125 +53,132 @@
 
   p {
     font: var(--leo-font-default-regular);
+    color: var(--leo-color-text-secondary);
     margin: 0;
   }
 }
 
-.features {
-  padding: 0 8px 8px 8px;
+.sellingPoints {
+  display: flex;
+  flex-direction: column;
+  gap: var(--leo-spacing-m);
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
 
-  ul {
-    --leo-icon-size: 20px;
-    display: flex;
-    flex-direction: column;
-    padding: 0;
-    margin: 0;
-    border: 1px solid var(--leo-color-primary-20);
-    border-radius: 8px;
-    overflow: hidden;
+.sellingPoint {
+  display: flex;
+  align-items: center;
+  gap: var(--leo-spacing-m);
+  min-width: 0;
+  padding: var(--leo-spacing-m) var(--leo-spacing-l);
+  background: var(--leo-color-page-background);
+  border-radius: var(--leo-radius-l);
+  font: var(--leo-font-default-regular);
+  color: var(--leo-color-text-secondary);
+
+  span {
+    flex: 1;
+    min-width: 0;
   }
+}
 
-  li {
-    font: var(--leo-font-default-semibold);
-    list-style-type: none;
-    padding: var(--leo-spacing-l);
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    border-bottom: 1px solid var(--leo-color-primary-20);
-
-    &:last-child {
-      border: 0;
-    }
-
-    p {
-      margin: 0;
-      font: var(--leo-font-small-regular);
-      color: var(--leo-color-text-secondary);
-    }
-  }
+.checkIcon {
+  --leo-icon-size: 20px;
+  --leo-icon-color: var(--leo-color-icon-interactive);
+  flex: 0 0 auto;
 }
 
 .priceListWrapper {
   display: flex;
   flex-direction: column;
-  border-bottom: 1px solid var(--leo-color-primary-20);
-  padding: 16px;
+  gap: var(--leo-spacing-m);
+  padding-top: var(--leo-spacing-l);
 }
 
-.priceList {
+.planCard {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: var(--leo-spacing-m);
+  gap: var(--leo-spacing-s);
+  width: 100%;
+  padding: var(--leo-spacing-xl);
+  background: var(--leo-color-container-background);
+  border: 1px solid var(--leo-color-divider-subtle);
+  border-radius: var(--leo-radius-l);
+  box-sizing: border-box;
+  color: var(--leo-color-text-secondary);
 }
 
-.price {
-  font: var(--leo-font-default-regular);
-  color: var(--leo-color-primary-50);
+.saveLabel {
+  position: absolute;
+  top: 0;
+  left: var(--leo-spacing-xl);
+  transform: translateY(-50%);
+}
+
+.planDetails {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.planHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--leo-spacing-s);
+  width: 100%;
+}
+
+.planName {
+  font: var(--leo-font-heading-h4);
+  flex: 0 0 auto;
+}
+
+.planPrice {
+  flex: 1;
   display: inline-flex;
   align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  font: var(--leo-font-default-regular);
+  text-align: right;
+  min-width: 0;
 
   data {
     font: var(--leo-font-heading-h2);
-    color: var(--leo-color-text-primary);
     margin: 0 5px;
   }
 }
 
-.icon {
-  width: 36px;
-  height: 36px;
-  border-radius: var(--leo-radius-m);
-  background: var(--leo-color-primary-20);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-
-  leo-icon {
-    color: var(--leo-color-primary-60);
-  }
-}
-
-.priceButton {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  border: 2px solid var(--leo-color-divider-interactive);
-  border-radius: 12px;
-  padding: var(--leo-spacing-xl);
-  background: var(--leo-color-blurple-5);
-}
-
-.priceButtonMonthly {
-  background: var(--leo-color-primary-10);
-}
-
-.priceButtonLabel {
-  font: var(--leo-font-heading-h4);
-  color: var(--leo-color-text-primary);
-}
-
 .subscriptionPolicy {
-  color: var(--leo-color-text-secondary);
+  color: var(--leo-color-text-tertiary);
   font: var(--leo-font-small-regular);
-  padding: var(--leo-spacing-l) 0 0 0;
-  text-align: center;
+  padding: 0 var(--leo-spacing-xl);
 }
 
 .actions {
-  display: inline-flex;
-  flex-direction: column;
-  gap: 10px;
-  width: 100%;
-  padding: 24px 16px 16px 16px;
-}
-
-.bestValueColumn {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: var(--leo-spacing-s);
+  gap: var(--leo-spacing-m);
+  width: 100%;
+
+  > * {
+    width: 100%;
+  }
+}
+
+@container (min-width: 560px) {
+  .layout {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: var(--leo-spacing-2xl);
+  }
+
+  .right {
+    width: 360px;
+    flex: 0 0 360px;
+    gap: var(--leo-spacing-xl);
+  }
 }

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -223,10 +223,10 @@
     You've reached the rate limit for Leo. Unlock a higher response rate by subscribing to Premium, or try again soon.
   </message>
   <message name="IDS_CHAT_UI_PREMIUM_FEATURE_1" desc="A premium feature: access to state-of-the-art LLMs" formatter_data="webui=AiChat">
-    Access state-of-the-art LLMs from Anthropic, OpenAI, Deepseek, &amp; more
+    Access state-of-the-art LLMs from Anthropic, OpenAI, DeepSeek, &amp; more
   </message>
   <message name="IDS_CHAT_UI_PREMIUM_FEATURE_2" desc="A premium feature: task-specific models" formatter_data="webui=AiChat">
-    Find task-specific models for coding, content generation, &amp; more
+    Find task-specific models for coding, content generation, and beyond
   </message>
   <message name="IDS_CHAT_UI_PREMIUM_FEATURE_3" desc="A premium feature: higher rate limits" formatter_data="webui=AiChat">
     Higher rate limits

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -229,7 +229,7 @@
     Find task-specific models for coding, content generation, and beyond
   </message>
   <message name="IDS_CHAT_UI_PREMIUM_FEATURE_3" desc="A premium feature: higher rate limits" formatter_data="webui=AiChat">
-    Higher rate limits
+    Higher rate limits for your conversations
   </message>
   <message name="IDS_CHAT_UI_PREMIUM_LABEL" translateable="false" desc="A label for Brave premium products" formatter_data="webui=AiChat">
      Leo Premium

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -222,17 +222,14 @@
   <message name="IDS_CHAT_UI_RATE_LIMIT_REACHED_DESC" desc="A description to unlock premium features" formatter_data="webui=AiChat">
     You've reached the rate limit for Leo. Unlock a higher response rate by subscribing to Premium, or try again soon.
   </message>
-  <message name="IDS_CHAT_UI_PREMIUM_FEATURE_1" desc="A premium feature" formatter_data="webui=AiChat">
-    Explore different AI models
+  <message name="IDS_CHAT_UI_PREMIUM_FEATURE_1" desc="A premium feature: access to state-of-the-art LLMs" formatter_data="webui=AiChat">
+    Access state-of-the-art LLMs from Anthropic, OpenAI, Deepseek, &amp; more
   </message>
-  <message name="IDS_CHAT_UI_PREMIUM_FEATURE_2" desc="A premium feature" formatter_data="webui=AiChat">
-    Unlock your creativity
+  <message name="IDS_CHAT_UI_PREMIUM_FEATURE_2" desc="A premium feature: task-specific models" formatter_data="webui=AiChat">
+    Find task-specific models for coding, content generation, &amp; more
   </message>
-  <message name="IDS_CHAT_UI_PREMIUM_FEATURE_3" desc="A premium feature" formatter_data="webui=AiChat">
-    Stay on topic
-  </message>
-  <message name="IDS_CHAT_UI_PREMIUM_FEATURE_4" desc="A premium feature" formatter_data="webui=AiChat">
-    Chat for longer
+  <message name="IDS_CHAT_UI_PREMIUM_FEATURE_3" desc="A premium feature: higher rate limits" formatter_data="webui=AiChat">
+    Higher rate limits
   </message>
   <message name="IDS_CHAT_UI_PREMIUM_LABEL" translateable="false" desc="A label for Brave premium products" formatter_data="webui=AiChat">
      Leo Premium
@@ -246,11 +243,11 @@
   <message name="IDS_CHAT_UI_MONTHLY_LABEL" desc="Monthly label for Premium modal" formatter_data="webui=AiChat">
     Monthly
   </message>
-  <message name="IDS_CHAT_UI_ONE_YEAR_LABEL" desc="One year label for Premium modal" formatter_data="webui=AiChat">
-    One year
+  <message name="IDS_CHAT_UI_PREMIUM_ANNUAL_LABEL" desc="Annual label for Premium plan card" formatter_data="webui=AiChat">
+    Annual
   </message>
-  <message name="IDS_CHAT_UI_BEST_VALUE_LABEL" desc="Best value label for Premium modal" formatter_data="webui=AiChat">
-    Best value
+  <message name="IDS_CHAT_UI_PREMIUM_SAVE_PERCENT_LABEL" desc="Discount label on the annual Premium plan card" formatter_data="webui=AiChat">
+    Save ~17%
   </message>
   <message name="IDS_CHAT_UI_DISMISS_BUTTON_LABEL" desc="A button label to dismiss dialog" formatter_data="webui=AiChat">
     Dismiss
@@ -260,18 +257,6 @@
   </message>
   <message name="IDS_CHAT_UI_UNLOCK_PREMIUM_TITLE" desc="A heading on prompt premium suggestion UI" formatter_data="webui=AiChat">
     Unleash Leo's full powers with Premium:
-  </message>
-  <message name="IDS_CHAT_UI_PREMIUM_FEATURE_1_DESC" desc="A premium feature that allows access to various models" formatter_data="webui=AiChat">
-    Priority access to powerful models with different skills.
-  </message>
-  <message name="IDS_CHAT_UI_PREMIUM_FEATURE_2_DESC" desc="A premium feature to various AI models" formatter_data="webui=AiChat">
-    Access models better suited for creative tasks and content generation.
-  </message>
-  <message name="IDS_CHAT_UI_PREMIUM_FEATURE_3_DESC" desc="A premium feature to stay scoped within a topic" formatter_data="webui=AiChat">
-    Get more accurate answers for more nuanced conversations.
-  </message>
-  <message name="IDS_CHAT_UI_PREMIUM_FEATURE_4_DESC" desc="A premium feature that allows higher rate limits" formatter_data="webui=AiChat">
-    Get higher rate limits for longer conversations.
   </message>
   <message name="IDS_CHAT_UI_PREMIUM_REFRESH_WARNING_DESCRIPTION" desc="Warning message when AI Chat Premium authentication is expired" formatter_data="webui=AiChat">
     Your Brave account session has expired. Please visit your account page to refresh, then come back to use premium features.


### PR DESCRIPTION
## Summary

Updates the in-conversation Leo Premium paywall (`PremiumSuggestion`) to the new Premium improvements design for both the side panel and full-page layouts.

### UI / layout
- Redesigned the paywall card: white container background, subtle border, elevation, Leo spacing/radius tokens
- Replaced the old 4-item title + description + custom-icon feature list with **3 selling-point pills**, each using a `check-normal` icon
- Plan cards updated:
  - **Annual** and **Monthly** share the same card style
  - Annual keeps a loud primary **“Save ~17%”** badge on the top edge
  - Label renamed from “One year” → **“Annual”**
  - Removed the old “Best value” green label and interactive/selected annual styling
- Split content into left (title + selling points) / right (plans + policy + CTAs)
- Responsive layout via CSS container query on the card (`@container (min-width: 560px)`):
  - **Panel / narrow**: single-column stack
  - **Full page / wide**: two-column layout (plans column fixed width)
- Kept mobile behavior: plan cards stay hidden on mobile; upgrade CTA still shown
- Kept existing actions wiring (`goPremium()`, Dismiss / Switch to free model / Maybe later)
- Optional `description` still supported (rate-limit paywall path)

### Pricing
- Still uses the existing hardcoded amounts via `formatLocale`:
  - Monthly: `USD $ 14.99 /month` (`CHAT_UI_PREMIUM_PRICING`)
  - Annual: `USD $ 149.99 /year` (`CHAT_UI_PREMIUM_ANNUAL_PRICING`)
- Plan cards remain purely visual (no plan selection; checkout URL unchanged)

### Strings (`ai_chat_ui_strings.grdp`)
- Updated selling points:
  - Access state-of-the-art LLMs from Anthropic, OpenAI, Deepseek, & more
  - Find task-specific models for coding, content generation, & more
  - Higher rate limits
- Added:
  - `IDS_CHAT_UI_PREMIUM_ANNUAL_LABEL` (“Annual”)
  - `IDS_CHAT_UI_PREMIUM_SAVE_PERCENT_LABEL` (“Save ~17%”)
- Removed unused:
  - `IDS_CHAT_UI_PREMIUM_FEATURE_4` (+ desc)
  - `IDS_CHAT_UI_PREMIUM_FEATURE_1_DESC` … `_3_DESC`
  - `IDS_CHAT_UI_ONE_YEAR_LABEL`
  - `IDS_CHAT_UI_BEST_VALUE_LABEL`

### Files
- `components/ai_chat/resources/untrusted_conversation_frame/components/premium_suggestion/index.tsx`
- `components/ai_chat/resources/untrusted_conversation_frame/components/premium_suggestion/style.module.scss`
- `components/resources/ai_chat_ui_strings.grdp`

- Resolves https://github.com/brave/brave-browser/issues/56049

# Previous

## Panel
<img width="1869" height="1297" alt="image" src="https://github.com/user-attachments/assets/3b36287f-52a8-4b4e-b3ef-5f0a647705bf" />

## Full page
<img width="1869" height="1297" alt="image" src="https://github.com/user-attachments/assets/34853b52-a6ec-462d-8ea2-8f3c238741a9" />

# New

<img width="1849" height="1386" alt="image" src="https://github.com/user-attachments/assets/ca5e684e-47d7-4b92-b853-1b88e9cd290c" />


## Test plan
- [ ] Side panel: paywall shows single-column layout with updated selling points, Annual/Monthly cards, Save ~17% badge, Try 7 days free + Dismiss
- [ ] Full page (wide): paywall switches to two-column layout
- [ ] Pricing shows `$14.99 /month` and `$149.99 /year`
- [ ] Upgrade opens existing Leo checkout
- [ ] Dismiss / Switch to free model / rate-limit “Maybe later” still work
- [ ] Mobile: plan cards hidden; selling points + upgrade CTA still shown