### PR TITLE
[iOS] Disable ShouldCancelRequestsForUserAgentChange logic on iOS27+

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabPolicyDecider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabPolicyDecider.swift
@@ -477,7 +477,10 @@ extension BrowserViewController {
     // Only redirect for main frames
     guard let requestURL = request.url, isMainFrame else { return nil }
 
-    if FeatureList.kShouldCancelRequestsForUserAgentChange.enabled,
+    // WebKit bug resolved on iOS 27+
+    // https://bugs.webkit.org/show_bug.cgi?id=313542
+    if #unavailable(iOS 27.0),
+      FeatureList.kShouldCancelRequestsForUserAgentChange.enabled,
       let headerUserAgent = request.allHTTPHeaderFields?["User-Agent"],
       case let userAgentForType = userAgent(
         for: request,


### PR DESCRIPTION
- Disables `kShouldCancelRequestsForUserAgentChange` feature flag logic on iOS 27+ which includes the fix from https://bugs.webkit.org/show_bug.cgi?id=313542
    - Flag was added with https://github.com/brave/brave-browser/issues/54479

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### Testplan

On iOS 27:
1. Enter `https://test-website-a.pages.dev/server-redirect/go` in omnibox
2. Verify `Brave` is not listed in user-agent value fields
3. Enable `should-cancel-requests-for-user-agent-change` feature flag and relaunch
4. Enter `https://test-website-a.pages.dev/server-redirect/go` in omnibox
5. Verify `Brave` is not listed in user-agent value fields

On iOS 26
1. Enable `should-cancel-requests-for-user-agent-change` feature flag and relaunch
2. Enter `https://test-website-a.pages.dev/server-redirect/go` in omnibox
3. Verify `Brave` is not listed in user-agent value fields