### PR TITLE
Fix missing strings dependency for VPN panel WebUI

### DIFF
--- a/components/brave_vpn/resources/panel/BUILD.gn
+++ b/components/brave_vpn/resources/panel/BUILD.gn
@@ -21,6 +21,7 @@ transpile_web_ui("brave_vpn_panel_ui") {
   deps = [
     "//brave/components/brave_vpn/common/mojom:mojom_js",
     "//brave/components/brave_vpn/common/mojom:preprocess_mojo",
+    "//brave/components/resources:strings",
   ]
 }
 


### PR DESCRIPTION
## Summary

The VPN panel's `transpile_web_ui` target did not depend on the target that generates `gen/components/grit/brave_components_webui_strings`, so the build could race and transpile the panel before that module existed, causing the failure below. Adding `//brave/components/resources:strings` to the panel deps (matching every other panel that imports the generated strings) fixes the ordering.

## CI failure log

```
[2026-07-14T05:19:29.175Z] ERROR in /Users/jenkins/jenkins/workspace/brave-browser-build-macos-x64-beta/src/brave/components/brave_vpn/resources/panel/strings.ts
[2026-07-14T05:19:29.175Z] ./components/brave_vpn/resources/panel/strings.ts 8:27-79
[2026-07-14T05:19:29.175Z] [tsl] ERROR in /Users/jenkins/jenkins/workspace/brave-browser-build-macos-x64-beta/src/brave/components/brave_vpn/resources/panel/strings.ts(8,28)
[2026-07-14T05:19:29.175Z]       TS2307: Cannot find module 'gen/components/grit/brave_components_webui_strings' or its corresponding type declarations.
[2026-07-14T05:19:29.175Z] ts-loader-default_a2d3a140a869adfa
[2026-07-14T05:19:29.175Z]  @ ./components/brave_vpn/resources/panel/vpn_panel.tsx 10:0-19
[2026-07-14T05:19:29.175Z]
[2026-07-14T05:19:29.175Z] webpack 5.105.0 compiled with 1 error in 12393 ms
[2026-07-14T05:19:29.175Z]
[2026-07-14T05:19:29.175Z] stderr:
[2026-07-14T05:19:29.175Z] Traceback (most recent call last):
[2026-07-14T05:19:29.175Z]   File "/Users/jenkins/jenkins/workspace/brave-browser-build-macos-x64-beta/src/out/Release/../../brave/script/transpile-web-ui.py", line 251, in <module>
[2026-07-14T05:19:29.175Z]     sys.exit(main())
[2026-07-14T05:19:29.175Z]              ^^^^^^
[2026-07-14T05:19:29.175Z]   File "/Users/jenkins/jenkins/workspace/brave-browser-build-macos-x64-beta/src/out/Release/../../brave/script/transpile-web-ui.py", line 53, in main
[2026-07-14T05:19:29.175Z]     transpile_web_uis(transpile_options)
[2026-07-14T05:19:29.175Z]   File "/Users/jenkins/jenkins/workspace/brave-browser-build-macos-x64-beta/src/out/Release/../../brave/script/transpile-web-ui.py", line 164, in transpile_web_uis
[2026-07-14T05:19:29.175Z]     execute_stdout(args, env)
[2026-07-14T05:19:29.175Z]   File "/Users/jenkins/jenkins/workspace/brave-browser-build-macos-x64-beta/src/brave/script/lib/util.py", line 194, in execute_stdout
[2026-07-14T05:19:29.175Z]     execute(argv, env)
[2026-07-14T05:19:29.175Z]   File "/Users/jenkins/jenkins/workspace/brave-browser-build-macos-x64-beta/src/brave/script/lib/util.py", line 173, in execute
[2026-07-14T05:19:29.175Z]     raise RuntimeError('Command \'%s\' failed' % (argv_string),
[2026-07-14T05:19:29.175Z] RuntimeError: ("Command 'npm run web-ui -- --mode=production --env=webpack_aliases=chromeapp --env=brave_entries=brave_vpn_panel=/Users/jenkins/jenkins/workspace/brave-browser-build-macos-x64-beta/src/brave/components/brave_vpn/resources/panel/vpn_panel.tsx' failed", '')
[2026-07-14T05:19:29.176Z]
```

## Test plan

- [ ] Clean beta build on macOS x64 completes without the `TS2307` module-not-found error for `brave_components_webui_strings`.