### PR TITLE
[Android] Fix Home screen widget settings-search result opening Search engines

### DIFF
--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -117,6 +117,10 @@
     *** initCommandLine(...);
 }
 
+-keep class org.chromium.chrome.browser.settings.MainSettings {
+    *** openSearchResult(...);
+}
+
 -keep class org.chromium.chrome.browser.ntp_customization.NtpCustomizationUtils {
     *** isInNarrowWindowOnLff(...);
     *** isNtpThemeCustomizationEnabled(...);

--- a/android/java/brave-res/xml/brave_main_preferences.xml
+++ b/android/java/brave-res/xml/brave_main_preferences.xml
@@ -102,7 +102,6 @@
         android:title="@string/brave_search_engines"/>
 
     <org.chromium.components.browser_ui.settings.ChromeBasePreference
-        android:fragment="org.chromium.chrome.browser.settings.BraveSearchEnginesPreferences"
         android:key="home_screen_widget"
         android:order="7"
         android:icon="@drawable/ic_widget_search2"

--- a/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
@@ -66,6 +66,7 @@ import org.chromium.components.browser_ui.site_settings.BraveSiteSettingsPrefere
 import org.chromium.components.browser_ui.site_settings.SiteSettings;
 import org.chromium.components.policy.PolicyService;
 import org.chromium.ui.base.DeviceFormFactor;
+import org.chromium.ui.modaldialog.ModalDialogManager;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -765,6 +766,26 @@ public abstract class BraveMainPreferencesBase extends BravePreferenceFragment
         }
         mFeaturePolicyService = null;
         mFeaturePolicyServiceObserver = null;
+    }
+
+    // Handles Settings-search results that have no android:fragment and therefore reach
+    // MainSettings.openSearchResult(). Bytecode redirects that call here (see
+    // BraveMainPreferenceBaseClassAdapter) so Brave-only keys can be handled before delegating the
+    // rest back to the upstream implementation.
+    public static boolean openSearchResult(
+            Context context,
+            Profile profile,
+            String key,
+            Bundle extras,
+            ModalDialogManager modalDialogManager) {
+        if (PREF_HOME_SCREEN_WIDGET.equals(key)) {
+            // The Home screen widget entry has no sub-screen to open; it triggers a system
+            // "pin widget" request. Keep the search state as is, like the other external-activity
+            // results handled upstream.
+            BraveSearchWidgetUtils.requestPinAppWidget();
+            return false;
+        }
+        return MainSettings.openSearchResult(context, profile, key, extras, modalDialogManager);
     }
 
     // Wraps MainSettings.SEARCH_INDEX_DATA_PROVIDER and additionally removes upstream preferences

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -573,6 +573,17 @@ public class BytecodeTest {
                         void.class,
                         String.class,
                         Supplier.class));
+        Assert.assertTrue(
+                methodExists(
+                        "org/chromium/chrome/browser/settings/MainSettings",
+                        "openSearchResult",
+                        MethodModifier.STATIC,
+                        boolean.class,
+                        Context.class,
+                        Profile.class,
+                        String.class,
+                        Bundle.class,
+                        ModalDialogManager.class));
 
         Assert.assertTrue(
                 methodExists(

--- a/build/android/bytecode/java/org/brave/bytecode/BraveMainPreferenceBaseClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveMainPreferenceBaseClassAdapter.java
@@ -16,7 +16,10 @@ public class BraveMainPreferenceBaseClassAdapter extends BraveClassVisitor {
 
     public BraveMainPreferenceBaseClassAdapter(ClassVisitor visitor) {
         super(visitor);
-        changeSuperName(sMainPreferencesClassName,
-                        sBraveMainPreferencesBaseClassName);
+        changeSuperName(sMainPreferencesClassName, sBraveMainPreferencesBaseClassName);
+        // Redirect the static MainSettings.openSearchResult() call site so Brave can handle
+        // Settings-search results that have no android:fragment (e.g. home_screen_widget).
+        changeMethodOwner(
+                sMainPreferencesClassName, "openSearchResult", sBraveMainPreferencesBaseClassName);
     }
 }


### PR DESCRIPTION
Searching Settings for `"Home screen widget"` and tapping the result opened the `"Search engines"` screen instead of triggering the add-widget flow.

The `home_screen_widget` entry in `brave_main_preferences.xml` carried a leftover  `android:fragment="...BraveSearchEnginesPreferences"`. In the live settings screen this is harmless because `BraveMainPreferencesBase` attaches an `OnPreferenceClickListener` that calls  `BraveSearchWidgetUtils.requestPinAppWidget()` and consumes the tap. From Settings search there is no such listener: the result is dispatched purely by the indexed android:fragment, so it opened Search engines.

Fix by removing the erroneous `android:fragment` so the result is dispatched by key to `MainSettings.openSearchResult()`, and handle the `home_screen_widget` key at `BraveMainPreference.openSearchResult` to trigger the system "pin widget" request. This mirrors how Chromium already handles action-style results such as `PREF_PASSWORDS`, `PREF_NOTIFICATIONS` and `PREF_DEFAULT_BROWSER`.

  ### Test Plan

  1. Open Brave Settings, tap search, type `Home screen widget`.
  2. Tap the result.
  3. Verify the system add-widget request appears (not the Search engines screen).

### Demo

https://github.com/user-attachments/assets/7bbf380c-2cfc-4237-8820-41f3bc7e25b7



<!-- Add brave-browser issue below that this PR will resolve -->
Fixed https://github.com/brave/brave-browser/issues/57140

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
