### PR TITLE
[Bootstrap] fix npm.cmd shim resolution

### DIFF
--- a/tools/cr/bootstrap/npm.cmd
+++ b/tools/cr/bootstrap/npm.cmd
@@ -1,0 +1,18 @@
+@echo off
+:: Copyright (c) 2026 The Brave Authors. All rights reserved.
+:: This Source Code Form is subject to the terms of the Mozilla Public
+:: License, v. 2.0. If a copy of the MPL was not distributed with this file,
+:: You can obtain one at https://mozilla.org/MPL/2.0/.
+::
+:: Runs the npm delivered into third_party/node for the brave-core checkout the
+:: current directory is in, falling back to the system npm when there is none.
+:: See launcher.py for the resolution logic.
+::
+:: `%~dp0` is normally this script's directory, but when the shim is invoked as
+:: a bare `npm` by another process (e.g. npm running a package's scripts) cmd
+:: can expand it to the current directory instead. If launcher.py is not there,
+:: resolve our own name on %PATH% (`%~dp$PATH:0`) to find it beside the shim.
+setlocal
+set "_dir=%~dp0"
+if not exist "%_dir%launcher.py" set "_dir=%~dp$PATH:0"
+python3 "%_dir%launcher.py" --allow-fallback npm-win %*


### PR DESCRIPTION
The `script/web_discovery_project.py` will invoke `npm` on Windows platforms by appending a `.cmd`:

```
NPM = 'npm'
if PLATFORM in ['win32', 'cygwin']:
    NPM += '.cmd'
```

This means that shim resolution fails and errors out with:

```
FileNotFoundError: [WinError 2] The system cannot find the file specified
Error: Command 'vpython3.bat script/web_discovery_project.py --install' returned non-zero exit status 1 in D:\brave-browser\src/brave
```

This fix adds the missing shim, using a verbatim copy of `npm.bat`.

Full log:
```
D:\brave-browser
> gclient runhooks
Updating depot_tools...
Running hooks:  91% (127/139) web_discovery_project_npm_deps
________ running 'vpython3.bat script/web_discovery_project.py --install' in 'D:\brave-browser\src/brave'
Traceback (most recent call last):
  File "D:\brave-browser\src\brave\script\web_discovery_project.py", line 48, in <module>
    sys.exit(main())
             ^^^^^^
  File "D:\brave-browser\src\brave\script\web_discovery_project.py", line 26, in main
    execute_stdout([NPM, 'install', '--no-save', '--yes'], env=env)
  File "D:\brave-browser\src\brave\script\lib\util.py", line 194, in execute_stdout
    execute(argv, env)
  File "D:\brave-browser\src\brave\script\lib\util.py", line 153, in execute
    process = subprocess.Popen(argv,
              ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\ChristianMazakas\AppData\Local\vpython-root.0\store\cpython+mi7dcjml3vvcqgcfj26qe857pk\contents\bin\Lib\subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "C:\Users\ChristianMazakas\AppData\Local\vpython-root.0\store\cpython+mi7dcjml3vvcqgcfj26qe857pk\contents\bin\Lib\subprocess.py", line 1538, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [WinError 2] The system cannot find the file specified
Error: Command 'vpython3.bat script/web_discovery_project.py --install' returned non-zero exit status 1 in D:\brave-browser\src/brave
Traceback (most recent call last):
  File "D:\brave-browser\src\brave\script\web_discovery_project.py", line 48, in <module>
    sys.exit(main())
             ^^^^^^
  File "D:\brave-browser\src\brave\script\web_discovery_project.py", line 26, in main
    execute_stdout([NPM, 'install', '--no-save', '--yes'], env=env)
  File "D:\brave-browser\src\brave\script\lib\util.py", line 194, in execute_stdout
    execute(argv, env)
  File "D:\brave-browser\src\brave\script\lib\util.py", line 153, in execute
    process = subprocess.Popen(argv,
              ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\ChristianMazakas\AppData\Local\vpython-root.0\store\cpython+mi7dcjml3vvcqgcfj26qe857pk\contents\bin\Lib\subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "C:\Users\ChristianMazakas\AppData\Local\vpython-root.0\store\cpython+mi7dcjml3vvcqgcfj26qe857pk\contents\bin\Lib\subprocess.py", line 1538, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [WinError 2] The system cannot find the file specified

```


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
