### PR TITLE
[recipes] Add scoped context module for step cwd/env

### DIFF
--- a/tools/recipes/engine_env.py
+++ b/tools/recipes/engine_env.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Environment merging for step execution.
+
+This module is kept as a standalone module so the production step runner can
+compose a child environment without importing the engine. Given a base
+environment plus the `context` module's whole-variable overrides and path
+prefix/suffix additions, it produces the environment a step's subprocess runs
+with.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from itertools import chain
+
+
+def merge_envs(
+    original: Mapping[str, str],
+    overrides: Mapping[str, str | None],
+    prefixes: Mapping[str, Sequence[str]],
+    suffixes: Mapping[str, Sequence[str]],
+    pathsep: str,
+) -> dict[str, str]:
+    """Merge *overrides*/*prefixes*/*suffixes* onto the *original* environment.
+
+    Entries in *overrides* overwrite the corresponding variable, while a value
+    of `None` removes it. Values may contain `%(KEY)s`, substituted from
+    *original* (so a variable like `PATH` can be amended rather than
+    overwritten). *prefixes* and *suffixes* prepend / append their lists to the
+    named variable, joined with *pathsep*. When a key has both an affix and an
+    override, the override value is folded in as the last prefix component.
+    """
+    result = dict(original)
+    if not any((prefixes, suffixes, overrides)):
+        return result
+
+    # Backing for `%(KEY)s` substitution: unknown keys resolve to '' rather than
+    # raising, matching the upstream behaviour.
+    subst: Mapping[str, str] = defaultdict(str, **dict(original))
+
+    merged: set[str] = set()
+    for key in set(suffixes).union(prefixes):
+        pfxs = tuple(prefixes.get(key, ()))
+        sfxs = tuple(suffixes.get(key, ()))
+        if not (pfxs or sfxs):
+            continue
+
+        # If the same key is also overridden, fold it in here (and skip it in
+        # the override pass below).
+        merged.add(key)
+        if key in overrides:
+            val = overrides[key]
+            if val is not None:
+                val = str(val) % subst
+        else:
+            # Not overridden: append the original value iff it is non-empty.
+            val = original.get(key, '')
+        if val:
+            pfxs += (val, )
+        result[key] = pathsep.join(str(v) for v in chain(pfxs, sfxs))
+
+    for key, val in overrides.items():
+        if key in merged:
+            continue
+        if val is None:
+            result.pop(key, None)
+        else:
+            result[key] = str(val) % subst
+
+    return result

--- a/tools/recipes/engine_env_test.py
+++ b/tools/recipes/engine_env_test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `engine_env.merge_envs` (the env composition ported from
+recipe_engine). Covers prefix/suffix joining, override folding, `%(VAR)s`
+substitution, and variable removal."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import engine_env as m
+
+
+class MergeEnvsTest(unittest.TestCase):
+
+    def test_no_modifications_returns_copy(self):
+        original = {'A': '1'}
+        result = m.merge_envs(original, {}, {}, {}, ':')
+        self.assertEqual(result, {'A': '1'})
+        self.assertIsNot(result, original)
+
+    def test_prefix_prepends_to_existing_value(self):
+        result = m.merge_envs({'PATH': '/bin'}, {}, {'PATH': ['/opt']}, {},
+                              ':')
+        self.assertEqual(result['PATH'], '/opt:/bin')
+
+    def test_prefix_when_variable_absent(self):
+        # No existing value: only the prefix, no dangling separator.
+        result = m.merge_envs({}, {}, {'PATH': ['/opt']}, {}, ':')
+        self.assertEqual(result['PATH'], '/opt')
+
+    def test_suffix_appends(self):
+        result = m.merge_envs({'PATH': '/bin'}, {}, {}, {'PATH': ['/z']}, ':')
+        self.assertEqual(result['PATH'], '/bin:/z')
+
+    def test_prefix_and_suffix_bracket_the_value(self):
+        result = m.merge_envs({'PATH': '/bin'}, {}, {'PATH': ['/a']},
+                              {'PATH': ['/z']}, ':')
+        self.assertEqual(result['PATH'], '/a:/bin:/z')
+
+    def test_override_folds_into_prefix(self):
+        # When a key has both an override and a prefix, the override value is
+        # folded in as the last prefix component (replacing the original value).
+        result = m.merge_envs({'PATH': '/bin'}, {'PATH': '/custom'},
+                              {'PATH': ['/a']}, {}, ':')
+        self.assertEqual(result['PATH'], '/a:/custom')
+
+    def test_override_substitution_amends_existing(self):
+        result = m.merge_envs({'PATH': '/bin'}, {'PATH': '%(PATH)s:/x'}, {},
+                              {}, ':')
+        self.assertEqual(result['PATH'], '/bin:/x')
+
+    def test_unknown_substitution_is_empty(self):
+        result = m.merge_envs({}, {'X': '%(MISSING)s-y'}, {}, {}, ':')
+        self.assertEqual(result['X'], '-y')
+
+    def test_override_none_removes_variable(self):
+        result = m.merge_envs({'A': '1', 'B': '2'}, {'A': None}, {}, {}, ':')
+        self.assertNotIn('A', result)
+        self.assertEqual(result['B'], '2')
+
+    def test_pathsep_is_honoured(self):
+        result = m.merge_envs({'PATH': 'C:\\bin'}, {}, {'PATH': ['C:\\opt']},
+                              {}, ';')
+        self.assertEqual(result['PATH'], 'C:\\opt;C:\\bin')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/recipes/recipe_modules/context/__init__.py
+++ b/tools/recipes/recipe_modules/context/__init__.py
@@ -2,6 +2,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Core `step` module: run a subprocess as a named build step."""
+"""`context` module: scoped ambient step settings (cwd + environment)."""
 
-DEPS = ['context']
+DEPS = []

--- a/tools/recipes/recipe_modules/context/api.py
+++ b/tools/recipes/recipe_modules/context/api.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""The `context` module: scoped adjustments to how steps run.
+
+This module manipulates a few pieces of 'ambient' data that affect the steps run
+within a `with` block:
+
+  * `cwd`: the working directory steps run in.
+  * `env`: whole-variable environment overrides.
+  * `env_prefixes` / `env_suffixes`: path-like values prepended / appended to
+    a variable (e.g. `PATH`), joined with the OS path separator by the step
+    runner.
+
+Everything is scoped with Python's `with`: there is no open-ended mutation the
+way `os.environ` / `os.chdir` (or `env.prepend_path`) allow. Values are pushed
+on entry and restored on exit, so a change never surprises a later step, and
+nested contexts compose (prefixes accumulate, inner values shadow outer ones):
+
+    with api.context(env_prefixes={'PATH': [node_bin]}):
+        # This step sees `node_bin` prepended to PATH.
+        api.step('node --version', [node, '--version'])
+"""
+
+from __future__ import annotations
+
+import collections
+from collections.abc import Mapping, Sequence
+import contextlib
+from pathlib import Path
+from typing import Any
+
+from recipe_api import RecipeApi
+
+
+def _check_type(name: str, var: object,
+                expect: type | tuple[type, ...]) -> None:
+    if not isinstance(var, expect):
+        expected = getattr(expect, '__name__', str(expect))
+        raise TypeError(
+            f'{name} is not {expected}: {var!r} ({type(var).__name__})')
+
+
+class ContextApi(RecipeApi):
+    """Scoped ambient settings (cwd + environment) applied to steps.
+
+    The single per-run instance holds the current scope. `__call__` pushes new
+    values for the duration of a `with` block and restores them afterwards. The
+    `step` module reads the accessors below when building each step.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Current scope. Replaced wholesale (never mutated in place) by
+        # `__call__`, so an outer scope's dicts are never disturbed.
+        self._cwd: Path | None = None
+        self._env: dict[str, str | None] = {}
+        self._env_prefixes: dict[str, tuple[str, ...]] = {}
+        self._env_suffixes: dict[str, tuple[str, ...]] = {}
+
+    @contextlib.contextmanager
+    def __call__(
+        self,
+        cwd: str | Path | None = None,
+        env_prefixes: Mapping[str, Sequence[str | Path]] | None = None,
+        env_suffixes: Mapping[str, Sequence[str | Path]] | None = None,
+        env: Mapping[str, str | None] | None = None,
+    ):
+        """Adjust cwd/env for the steps run within the `with` block.
+
+        Args:
+            cwd: Working directory for steps in this scope.
+            env_prefixes: Per-variable lists prepended to the variable (joined
+                with the OS path separator) -- typically `{'PATH': [dir, ...]}`.
+            env_suffixes: As `env_prefixes`, but appended.
+            env: Whole-variable overrides. A value may contain `%(VAR)s`,
+                substituted from the startup environment when the step runs;
+                `None` removes the variable.
+        """
+        # member name -> value to restore on exit (mirrors upstream's
+        # `deferred_assignments`), so the `finally` unwinds exactly what changed.
+        deferred: dict[str, Any] = {}
+
+        def _push(member: str, new: Any) -> None:
+            deferred[member] = getattr(self, member)
+            setattr(self, member, new)
+
+        def _add(member: str, to_add: Mapping | None, adder) -> None:
+            if to_add:
+                _check_type(member, to_add, Mapping)
+                new = dict(getattr(self, member))
+                for key, val in to_add.items():
+                    adder(key, val, new)
+                _push(member, new)
+
+        def _as_prefixes(key: str, val: Sequence, new: dict) -> None:
+            if val:
+                new[key] = tuple(str(v) for v in val) + new.get(key, ())
+
+        def _as_suffixes(key: str, val: Sequence, new: dict) -> None:
+            if val:
+                new[key] = new.get(key, ()) + tuple(str(v) for v in val)
+
+        def _as_env(key: str, val: str | None, new: dict) -> None:
+            if val is not None:
+                val = str(val)
+                try:
+                    # Add a bogus `%(foo)s` to force %-dictionary mode, then
+                    # format with a defaultdict: every `%(KEY)s` lookup
+                    # succeeds, but a stray sequential `%s` raises -- so an
+                    # accidental non-`%(VAR)s` format is rejected here.
+                    ('%(foo)s' + val) % collections.defaultdict(str)
+                except Exception as exc:
+                    raise ValueError(
+                        'invalid %-format in env value, only %(VAR)s allowed: '
+                        f'{val!r}') from exc
+            new[key] = val
+
+        try:
+            if cwd is not None:
+                _check_type('cwd', cwd, (str, Path))
+                _push('_cwd', Path(cwd))
+            _add('_env_prefixes', env_prefixes, _as_prefixes)
+            _add('_env_suffixes', env_suffixes, _as_suffixes)
+            _add('_env', env, _as_env)
+            yield
+        finally:
+            for member, val in deferred.items():
+                setattr(self, member, val)
+
+    @property
+    def cwd(self) -> Path | None:
+        """The cwd steps run in, or `None` to inherit the engine's cwd."""
+        return self._cwd
+
+    @property
+    def env(self) -> dict[str, str | None]:
+        """Whole-variable environment overrides currently in effect."""
+        return dict(self._env)
+
+    @property
+    def env_prefixes(self) -> dict[str, tuple[str, ...]]:
+        """Per-variable path prefixes currently in effect."""
+        return dict(self._env_prefixes)
+
+    @property
+    def env_suffixes(self) -> dict[str, tuple[str, ...]]:
+        """Per-variable path suffixes currently in effect."""
+        return dict(self._env_suffixes)

--- a/tools/recipes/recipe_modules/context/examples/__init__.py
+++ b/tools/recipes/recipe_modules/context/examples/__init__.py
@@ -2,6 +2,4 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Core `step` module: run a subprocess as a named build step."""
-
-DEPS = ['context']
+"""Example recipes exercising the `context` module."""

--- a/tools/recipes/recipe_modules/context/examples/full.expected/basic.json
+++ b/tools/recipes/recipe_modules/context/examples/full.expected/basic.json
@@ -1,0 +1,45 @@
+[
+  {
+    "cmd": [
+      "node",
+      "--version"
+    ],
+    "env": {
+      "CI": "brave"
+    },
+    "env_prefixes": {
+      "PATH": [
+        "[WORKSPACE]/node/bin"
+      ]
+    },
+    "name": "inside context"
+  },
+  {
+    "cmd": [
+      "node",
+      "build.js"
+    ],
+    "cwd": "[WORKSPACE]/out",
+    "env": {
+      "CI": "brave"
+    },
+    "env_prefixes": {
+      "PATH": [
+        "/opt/extra",
+        "[WORKSPACE]/node/bin"
+      ]
+    },
+    "name": "nested context"
+  },
+  {
+    "cmd": [
+      "node",
+      "--version"
+    ],
+    "name": "outside context"
+  },
+  {
+    "name": "$result",
+    "status": "SUCCESS"
+  }
+]

--- a/tools/recipes/recipe_modules/context/examples/full.py
+++ b/tools/recipes/recipe_modules/context/examples/full.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipe exercising the `context` module's scoping."""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['context', 'path', 'step']
+
+
+def RunSteps(api):
+    node_bin = api.path.workspace / 'node' / 'bin'
+
+    # Prepend a dir to PATH and override a var for steps in this scope.
+    with api.context(env_prefixes={'PATH': [node_bin]}, env={'CI': 'brave'}):
+        api.step('inside context', ['node', '--version'])
+
+        # Nested contexts compose: a second PATH prefix stacks in front, and
+        # cwd applies only within the inner block.
+        with api.context(env_prefixes={'PATH': ['/opt/extra']},
+                         cwd=api.path.out):
+            api.step('nested context', ['node', 'build.js'])
+
+    # Back outside every `with`: the ambient environment is restored.
+    api.step('outside context', ['node', '--version'])
+
+
+def GenTests(api):
+    yield api.test(
+        'basic',
+        # The PATH prefix and env override are recorded on the scoped step.
+        api.post_process(post_process.MustRun, 'inside context'),
+        api.post_process(post_process.MustRun, 'nested context'),
+        api.post_process(post_process.MustRun, 'outside context'),
+        api.post_process(post_process.StatusSuccess),
+    )

--- a/tools/recipes/recipe_modules/step/api.py
+++ b/tools/recipes/recipe_modules/step/api.py
@@ -25,6 +25,11 @@ class StepApi(RecipeApi):
     Windows command resolution); under test the engine seeds a
     `SimulationStepRunner` that records the step and returns canned data, so no
     subprocess runs.
+
+    Each step's cwd and environment are drawn from the ambient `context` module
+    (`with api.context(...)`): the step inherits `context.cwd` and applies
+    `context.env` / `env_prefixes` / `env_suffixes`. Explicit `cwd` / `env`
+    arguments, when given, layer on top of that ambient state.
     """
 
     def __init__(self) -> None:
@@ -58,8 +63,10 @@ class StepApi(RecipeApi):
             name: Human-readable step name, logged before the command runs.
             cmd: The program and its arguments as a sequence; each element is
                 stringified (so `Path` objects are fine).
-            cwd: Optional working directory for the subprocess.
-            env: Optional environment mapping; inherits the parent when `None`.
+            cwd: Working directory override for the subprocess; defaults to
+                `context.cwd` (and, when neither is set, the engine's cwd).
+            env: Whole-variable environment overrides layered on top of
+                `context.env` (the explicit value wins per key).
             check: Raise `CalledProcessError` on non-zero exit when True.
             capture_output: Capture stdout/stderr (as text) instead of
                 inheriting the parent's streams.
@@ -71,11 +78,19 @@ class StepApi(RecipeApi):
             subprocess.CalledProcessError: If `check` and the process fails.
             RuntimeError: On Windows, if the command cannot be resolved.
         """
+        # Draw cwd/env from the ambient context, letting explicit arguments
+        # override. The env overrides and the path prefix/suffix affixes are
+        # carried separately so the runner can compose them (production) or
+        # record them (simulation), mirroring recipe_engine's split.
+        context = self.m.context
+        env_overrides = {**context.env, **(env or {})}
         step = {
             'name': name,
             'cmd': [str(arg) for arg in cmd],
-            'cwd': cwd,
-            'env': env,
+            'cwd': cwd if cwd is not None else context.cwd,
+            'env': env_overrides or None,
+            'env_prefixes': context.env_prefixes,
+            'env_suffixes': context.env_suffixes,
         }
         logging.info('[step] %s\n >>>> %s', name, ' '.join(step['cmd']))
         return self._runner().run(step,

--- a/tools/recipes/simulation.py
+++ b/tools/recipes/simulation.py
@@ -31,6 +31,7 @@ from pathlib import Path, PurePosixPath
 import subprocess
 from typing import Any
 
+from engine_env import merge_envs
 import post_process as pp
 from recipe_test_api import StepTestData, TestData
 
@@ -96,7 +97,8 @@ class SubprocessStepRunner:
 
     def run(self, step: dict, *, check: bool,
             capture_output: bool) -> subprocess.CompletedProcess:
-        import platform  # Local import: only the prod path needs it.
+        import os  # Local imports: only the prod path needs these.
+        import platform
         import shutil
 
         cmd = [str(arg) for arg in step['cmd']]
@@ -107,9 +109,20 @@ class SubprocessStepRunner:
             if resolved is None:
                 raise RuntimeError(f'Command not found: {cmd[0]}')
             cmd[0] = resolved
+
+        # Compose the child environment from the context module's overrides and
+        # path affixes over the real environment; when nothing was set, inherit
+        # the parent environment unchanged (env=None).
+        overrides = step.get('env')
+        prefixes = step.get('env_prefixes')
+        suffixes = step.get('env_suffixes')
+        env = None
+        if overrides or prefixes or suffixes:
+            env = merge_envs(os.environ, overrides or {}, prefixes or {},
+                             suffixes or {}, os.pathsep)
         return subprocess.run(cmd,
                               cwd=step.get('cwd'),
-                              env=step.get('env'),
+                              env=env,
                               check=check,
                               capture_output=capture_output,
                               text=True)
@@ -140,7 +153,18 @@ class SimulationStepRunner:
         if step.get('cwd'):
             record['cwd'] = str(step['cwd'])
         if step.get('env'):
-            record['env'] = {k: str(v) for k, v in step['env'].items()}
+            # A `None` value means "remove this variable"; preserve it (rather
+            # than stringifying to 'None') so it renders as null.
+            record['env'] = {
+                k: (None if v is None else str(v))
+                for k, v in step['env'].items()
+            }
+        for affix in ('env_prefixes', 'env_suffixes'):
+            if step.get(affix):
+                record[affix] = {
+                    k: [str(v) for v in values]
+                    for k, values in step[affix].items()
+                }
         if data.retcode:
             record['retcode'] = data.retcode
         self.recorded_steps.append(record)
@@ -233,9 +257,15 @@ def build_steps(runner: SimulationStepRunner, status: str, reason: str | None,
             entry['cwd'] = stabilize(step['cwd'], context)
         if 'env' in step:
             entry['env'] = {
-                k: stabilize(v, context)
+                k: (None if v is None else stabilize(v, context))
                 for k, v in step['env'].items()
             }
+        for affix in ('env_prefixes', 'env_suffixes'):
+            if affix in step:
+                entry[affix] = {
+                    k: [stabilize(v, context) for v in values]
+                    for k, values in step[affix].items()
+                }
         if 'retcode' in step:
             entry['retcode'] = step['retcode']
         steps[step['name']] = entry


### PR DESCRIPTION
With this module recipes can adjust how a step runs for the duration of a
`with` block:

```
with api.context(env_prefixes={'PATH': [node_bin]}):
    api.step('node --version', [node, '--version'])
```

Bug: https://github.com/brave/brave-browser/issues/56748
