### PR TITLE
[plaster][ast-grep] Migrate all substitutions to `regex:`

### DIFF
--- a/rewrite/.rustfmt.toml.yaml
+++ b/rewrite/.rustfmt.toml.yaml
@@ -9,15 +9,17 @@ substitutions:
 
       Append Brave-specific paths to the end of the upstream `ignore` list so
       rustfmt leaves our vendored crates alone.
-    re_pattern: '(ignore = \[.+?",\n)\]'
-    re_flags: [DOTALL]
-    replace: |-
-      \1  "brave/third_party/",
-        "brave/tools/crates/vendor/",
-        "brave/third_party/wasm/vendor/",
-      ]
+    regex:
+      re_pattern: '(ignore = \[.+?",\n)\]'
+      re_flags: [DOTALL]
+      replace: |-
+        \1  "brave/third_party/",
+          "brave/tools/crates/vendor/",
+          "brave/third_party/wasm/vendor/",
+        ]
   - description: |
       Do not format submodules.
-    re_pattern: '\Z'
-    replace: |
-      skip_children = true  # Do not format submodules.
+    regex:
+      re_pattern: '\Z'
+      replace: |
+        skip_children = true  # Do not format submodules.

--- a/rewrite/DEPS.yaml
+++ b/rewrite/DEPS.yaml
@@ -10,8 +10,9 @@ substitutions:
       Brave has its own script to download the hermetic toolchain,
       brave/build/mac/download_hermetic_xcode.py, so it is okay to disable the
       upstream hook as it causes confusing output to be printed to the user.
-    re_pattern: |-
-      ('name': 'mac_toolchain',.+?'condition':\s*)'checkout_mac or checkout_ios'
-    re_flags: [DOTALL]
-    replace: |-
-      \1'False'
+    regex:
+      re_pattern: |-
+        ('name': 'mac_toolchain',.+?'condition':\s*)'checkout_mac or checkout_ios'
+      re_flags: [DOTALL]
+      replace: |-
+        \1'False'

--- a/rewrite/base/trace_event/builtin_categories.h.yaml
+++ b/rewrite/base/trace_event/builtin_categories.h.yaml
@@ -11,10 +11,11 @@ substitutions:
       * For small features use the existing 'brave' category.
       * For new big subsystems with a lot of traces create a separate category
         named 'brave.<feature_name>'.
-    re_pattern: '(PERFETTO_DEFINE_CATEGORIES_IN_NAMESPACE_WITH_ATTRS\(.+?BASE_EXPORT,\n)'
-    re_flags: [DOTALL]
-    replace: |
-      \1    perfetto::Category("brave"),
-          perfetto::Category("brave.adblock"),
-          perfetto::Category("brave.ads"),
-          perfetto::Category("brave.news"),
+    regex:
+      re_pattern: '(PERFETTO_DEFINE_CATEGORIES_IN_NAMESPACE_WITH_ATTRS\(.+?BASE_EXPORT,\n)'
+      re_flags: [DOTALL]
+      replace: |
+        \1    perfetto::Category("brave"),
+            perfetto::Category("brave.adblock"),
+            perfetto::Category("brave.ads"),
+            perfetto::Category("brave.news"),

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java.yaml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java.yaml
@@ -5,18 +5,20 @@
 
 substitutions:
   - description: 'Add import for UrlConstants.'
-    pattern: 'import org.chromium.chrome.R;'
-    replace: |-
-      import org.chromium.chrome.R;
-      import org.chromium.components.embedder_support.util.UrlConstants;
+    regex:
+      pattern: 'import org.chromium.chrome.R;'
+      replace: |-
+        import org.chromium.chrome.R;
+        import org.chromium.components.embedder_support.util.UrlConstants;
 
   - description: |
       Make it possible to add chrome://leo-ai to the Home Screen on Android.
       This patch updates the `shouldShowHomescreenMenuItem` function to whitelist
       chrome://leo-ai.
-    re_pattern: '(isAddToHomeIntentSupported\(\)\s+)&& (!isNativePage)$'
-    re_flags: [MULTILINE]
-    replace:
-      '\1&& (\2 || (url != null &&
-      UrlConstants.CHROME_SCHEME.equals(url.getScheme()) &&
-      url.getHost().equals("leo-ai")))'
+    regex:
+      re_pattern: '(isAddToHomeIntentSupported\(\)\s+)&& (!isNativePage)$'
+      re_flags: [MULTILINE]
+      replace:
+        '\1&& (\2 || (url != null &&
+        UrlConstants.CHROME_SCHEME.equals(url.getScheme()) &&
+        url.getHost().equals("leo-ai")))'

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/base/SplitChromeApplication.java.yaml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/base/SplitChromeApplication.java.yaml
@@ -19,6 +19,7 @@ substitutions:
       apply the seed immediately.
 
       See https://source.chromium.org/chromium/chromium/src/+/f00d1a3a65153510d612597de0dde2a4365ca130
-    pattern: 'BuildConfig.IS_CHROME_BRANDED'
-    replace: 'true /* BuildConfig.IS_CHROME_BRANDED override for Brave */'
+    regex:
+      pattern: 'BuildConfig.IS_CHROME_BRANDED'
+      replace: 'true /* BuildConfig.IS_CHROME_BRANDED override for Brave */'
     count: 1

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuItem.java.yaml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuItem.java.yaml
@@ -5,11 +5,12 @@
 
 substitutions:
   - description: 'Register COPY_CLEAN_LINK at the end of the @IntDef list'
-    re_pattern: '(@IntDef\(\{.+?),?(\n\s*\}\))'
-    re_flags: [DOTALL]
-    replace: |-
-      \1,
-              Item.COPY_CLEAN_LINK,\2
+    regex:
+      re_pattern: '(@IntDef\(\{.+?),?(\n\s*\}\))'
+      re_flags: [DOTALL]
+      replace: |-
+        \1,
+                Item.COPY_CLEAN_LINK,\2
 
   - description: |
       Define COPY_CLEAN_LINK at the end of @interface Item
@@ -27,20 +28,24 @@ substitutions:
 
       Notice that the value for `COPY_CLEAN_LINK` is being whatever was the value for
       `NUM_ENTRIES`, which allows us to take over the end of the list.
-    re_pattern: '(@interface Item \{.+;\n)(.+?\n)(\s+)int NUM_ENTRIES = (\d+);'
-    re_flags: [DOTALL]
-    replace: |-
-      \1\3int COPY_CLEAN_LINK = \4;
-      \2\3int NUM_ENTRIES = COPY_CLEAN_LINK + 1;
+    regex:
+      re_pattern:
+        '(@interface Item \{.+;\n)(.+?\n)(\s+)int NUM_ENTRIES = (\d+);'
+      re_flags: [DOTALL]
+      replace: |-
+        \1\3int COPY_CLEAN_LINK = \4;
+        \2\3int NUM_ENTRIES = COPY_CLEAN_LINK + 1;
 
   - description: 'Append COPY_CLEAN_LINK at the end of the MENU_IDS array'
-    re_pattern: '(int\[\] MENU_IDS = \{[^}]+\n)([^}]+\};)'
-    replace: |-
-      \1        R.id.contextmenu_copy_clean_link, // Item.COPY_CLEAN_LINK
-      \2
+    regex:
+      re_pattern: '(int\[\] MENU_IDS = \{[^}]+\n)([^}]+\};)'
+      replace: |-
+        \1        R.id.contextmenu_copy_clean_link, // Item.COPY_CLEAN_LINK
+        \2
 
   - description: 'Append COPY_CLEAN_LINK at the end of the STRING_IDS array'
-    re_pattern: '(int\[\] STRING_IDS = \{[^}]+\n)([^}]+\};)'
-    replace: |-
-      \1        R.string.contextmenu_copy_clean_link, // Item.COPY_CLEAN_LINK
-      \2
+    regex:
+      re_pattern: '(int\[\] STRING_IDS = \{[^}]+\n)([^}]+\};)'
+      replace: |-
+        \1        R.string.contextmenu_copy_clean_link, // Item.COPY_CLEAN_LINK
+        \2

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuPopulator.java.yaml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuPopulator.java.yaml
@@ -6,25 +6,28 @@
 substitutions:
   - description:
       'Register COPY_CLEAN_LINK at the end of the Action @IntDef list'
-    re_pattern: '(@IntDef\(\{[^}]*Action\..+?),?(\n\s*\}\))'
-    re_flags: [DOTALL]
-    replace: |-
-      \1,
-                  Action.COPY_CLEAN_LINK,\2
+    regex:
+      re_pattern: '(@IntDef\(\{[^}]*Action\..+?),?(\n\s*\}\))'
+      re_flags: [DOTALL]
+      replace: |-
+        \1,
+                    Action.COPY_CLEAN_LINK,\2
 
   - description: |
       Define COPY_CLEAN_LINK at the end of @interface Action
 
       Notice that the value for `COPY_CLEAN_LINK` is being whatever was the value for
       `NUM_ENTRIES`, which allows us to take over the end of the list.
-    re_pattern: '(@interface Action \{.+?;\n)(\s+)int NUM_ENTRIES = (\d+);'
-    re_flags: [DOTALL]
-    replace: |-
-      \1\2int COPY_CLEAN_LINK = \3;
-      \2int NUM_ENTRIES = COPY_CLEAN_LINK + 1;
+    regex:
+      re_pattern: '(@interface Action \{.+?;\n)(\s+)int NUM_ENTRIES = (\d+);'
+      re_flags: [DOTALL]
+      replace: |-
+        \1\2int COPY_CLEAN_LINK = \3;
+        \2int NUM_ENTRIES = COPY_CLEAN_LINK + 1;
 
   - description: 'Append the COPY_CLEAN_LINK list item after COPY_LINK_ADDRESS'
-    pattern: 'linkGroup.add(createListItem(Item.COPY_LINK_ADDRESS));'
-    replace: |-
-      linkGroup.add(createListItem(Item.COPY_LINK_ADDRESS));
-                      linkGroup.add(createListItem(Item.COPY_CLEAN_LINK));
+    regex:
+      pattern: 'linkGroup.add(createListItem(Item.COPY_LINK_ADDRESS));'
+      replace: |-
+        linkGroup.add(createListItem(Item.COPY_LINK_ADDRESS));
+                        linkGroup.add(createListItem(Item.COPY_CLEAN_LINK));

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/FullscreenHtmlApiHandlerBase.java.yaml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/FullscreenHtmlApiHandlerBase.java.yaml
@@ -12,14 +12,15 @@ substitutions:
       Brave-managed YouTube Picture-in-Picture session is active.
       maybeSkipExitFullscreenOnTabHidden also records whether the tab was hidden
       by a tab switch before deciding whether to skip.
-    re_pattern: '(public void onHidden\(.*\)\s+\{)'
-    replace: |-
-      \1
-                              if (BraveFullscreenHtmlApiHandlerBase.class.cast(
-                                              FullscreenHtmlApiHandlerBase.this)
-                                      .maybeSkipExitFullscreenOnTabHidden(mActivity, reason)) {
-                                  return;
-                              }
+    regex:
+      re_pattern: '(public void onHidden\(.*\)\s+\{)'
+      replace: |-
+        \1
+                                if (BraveFullscreenHtmlApiHandlerBase.class.cast(
+                                                FullscreenHtmlApiHandlerBase.this)
+                                        .maybeSkipExitFullscreenOnTabHidden(mActivity, reason)) {
+                                    return;
+                                }
 
   - description: |-
       Preserve fullscreen across transient activity stops while YouTube PiP is active.
@@ -31,13 +32,14 @@ substitutions:
       browser and DOM fullscreen state intact across transient activity stops
       (e.g. screen-off or PiP window occlusion) so there is no flicker when the
       user returns. The DESTROYED branch is intentionally left untouched.
-    re_pattern:
-      '(public void onActivityStateChange\(Activity activity, int
-      newState\)\s+\{\n\s+if \(newState == ActivityState\.STOPPED &&
-      mExitFullscreenOnStop\)\s+\{)'
-    replace: |-
-      \1
-                  if (BraveFullscreenHtmlApiHandlerBase.class.cast(FullscreenHtmlApiHandlerBase.this)
-                              .shouldPreservePersistentFullscreenForPictureInPicture(activity)) {
-                      return;
-                  }
+    regex:
+      re_pattern:
+        '(public void onActivityStateChange\(Activity activity, int
+        newState\)\s+\{\n\s+if \(newState == ActivityState\.STOPPED &&
+        mExitFullscreenOnStop\)\s+\{)'
+      replace: |-
+        \1
+                    if (BraveFullscreenHtmlApiHandlerBase.class.cast(FullscreenHtmlApiHandlerBase.this)
+                                .shouldPreservePersistentFullscreenForPictureInPicture(activity)) {
+                        return;
+                    }

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/media/FullscreenVideoPictureInPictureController.java.yaml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/media/FullscreenVideoPictureInPictureController.java.yaml
@@ -19,13 +19,15 @@ substitutions:
       statement. The return value (rather than a bare return) is required because a
       bare return before the try would make it an unreachable statement, which Java
       rejects at compile time.
-    re_pattern: '(public void attemptPictureInPicture\(\) \{[\s\S]*?)\btry\s*\{'
-    replace: |-
-      \1if (BraveFullscreenVideoPictureInPictureController.class.cast(this)
-                      .braveAttemptPictureInPicture(mActivity, webContents, builder, bounds)) {
-                  return;
-              }
-              try {
+    regex:
+      re_pattern:
+        '(public void attemptPictureInPicture\(\) \{[\s\S]*?)\btry\s*\{'
+      replace: |-
+        \1if (BraveFullscreenVideoPictureInPictureController.class.cast(this)
+                        .braveAttemptPictureInPicture(mActivity, webContents, builder, bounds)) {
+                    return;
+                }
+                try {
 
   - description: |-
       Let Brave intercept YouTube PiP dismiss signals.
@@ -35,16 +37,17 @@ substitutions:
       translating the upstream MetricsEndReason enum into individual boolean
       flags so Brave does not depend on the enum directly. Returns early when
       Brave handles it.
-    re_pattern: '(\s+private void dismissActivityIfNeeded\(.*\) \{)'
-    replace: |-
-      \1
-              if (BraveFullscreenVideoPictureInPictureController.class.cast(this)
-                      .maybeHandleDismissActivityForYouTubePictureInPicture(
-                              activity,
-                              reason == MetricsEndReason.START,
-                              reason == MetricsEndReason.RESUME,
-                              reason == MetricsEndReason.LEFT_FULLSCREEN,
-                              reason == MetricsEndReason.WEB_CONTENTS_LEFT_FULLSCREEN,
-                              reason == MetricsEndReason.NEW_TAB)) {
-                  return;
-              }
+    regex:
+      re_pattern: '(\s+private void dismissActivityIfNeeded\(.*\) \{)'
+      replace: |-
+        \1
+                if (BraveFullscreenVideoPictureInPictureController.class.cast(this)
+                        .maybeHandleDismissActivityForYouTubePictureInPicture(
+                                activity,
+                                reason == MetricsEndReason.START,
+                                reason == MetricsEndReason.RESUME,
+                                reason == MetricsEndReason.LEFT_FULLSCREEN,
+                                reason == MetricsEndReason.WEB_CONTENTS_LEFT_FULLSCREEN,
+                                reason == MetricsEndReason.NEW_TAB)) {
+                    return;
+                }

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/multiwindow/MultiInstanceOrchestratorImpl.java.yaml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/multiwindow/MultiInstanceOrchestratorImpl.java.yaml
@@ -6,15 +6,17 @@
 substitutions:
   - description:
       'Remove final to allow BraveMultiInstanceOrchestratorImpl to extend it.'
-    pattern: '/* package */ final class MultiInstanceOrchestratorImpl'
-    replace: '/* package */ class MultiInstanceOrchestratorImpl'
+    regex:
+      pattern: '/* package */ final class MultiInstanceOrchestratorImpl'
+      replace: '/* package */ class MultiInstanceOrchestratorImpl'
 
   - description:
       'Make constructor package-private to allow
       BraveMultiInstanceOrchestratorImpl to call super().'
-    pattern:
-      'private MultiInstanceOrchestratorImpl(TabReparentingDelegate
-      tabReparentingDelegate)'
-    replace:
-      'MultiInstanceOrchestratorImpl(TabReparentingDelegate
-      tabReparentingDelegate)'
+    regex:
+      pattern:
+        'private MultiInstanceOrchestratorImpl(TabReparentingDelegate
+        tabReparentingDelegate)'
+      replace:
+        'MultiInstanceOrchestratorImpl(TabReparentingDelegate
+        tabReparentingDelegate)'

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/ntp/NewTabPage.java.yaml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/ntp/NewTabPage.java.yaml
@@ -19,7 +19,8 @@ substitutions:
 
       The match is generic enough so the name of the arguments are not as
       important.
-    re_pattern:
-      '(public static boolean isInSingleUrlBarMode\(boolean (\w+)\) \{\s+return
-      )!\2;'
-    replace: '\1false;'
+    regex:
+      re_pattern:
+        '(public static boolean isInSingleUrlBarMode\(boolean (\w+)\)
+        \{\s+return )!\2;'
+      replace: '\1false;'

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/settings/search/SearchIndexProviderRegistry.java.yaml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/settings/search/SearchIndexProviderRegistry.java.yaml
@@ -7,87 +7,96 @@ substitutions:
   - description:
       'Remove unused MainSettings import (replaced inline with FQN
       BraveMainPreferencesBase)'
-    re_pattern:
-      'import org\.chromium\.chrome\.browser\.settings\.MainSettings;\n'
-    replace: ''
+    regex:
+      re_pattern:
+        'import org\.chromium\.chrome\.browser\.settings\.MainSettings;\n'
+      replace: ''
 
   - description:
       'Use BraveMainPreferencesBase search index provider instead of
       MainSettings'
-    pattern: 'MainSettings.SEARCH_INDEX_DATA_PROVIDER'
-    replace: 'org.chromium.chrome.browser.settings.BraveMainPreferencesBase.SEARCH_INDEX_DATA_PROVIDER'
+    regex:
+      pattern: 'MainSettings.SEARCH_INDEX_DATA_PROVIDER'
+      replace: 'org.chromium.chrome.browser.settings.BraveMainPreferencesBase.SEARCH_INDEX_DATA_PROVIDER'
 
   - description:
       'Remove AppearanceSettingsFragment import (Brave uses
       AppearancePreferences instead)'
-    re_pattern:
-      'import
-      org\.chromium\.chrome\.browser\.appearance\.settings\.AppearanceSettingsFragment;\n'
-    replace: ''
+    regex:
+      re_pattern:
+        'import
+        org\.chromium\.chrome\.browser\.appearance\.settings\.AppearanceSettingsFragment;\n'
+      replace: ''
 
   - description:
       'Remove AppearanceSettingsFragment provider (Brave uses
       AppearancePreferences instead)'
-    re_pattern: '\n\s+AppearanceSettingsFragment\.SEARCH_INDEX_DATA_PROVIDER,'
-    replace: ''
+    regex:
+      re_pattern: '\n\s+AppearanceSettingsFragment\.SEARCH_INDEX_DATA_PROVIDER,'
+      replace: ''
 
   - description:
       'Remove LanguageSettings import (Brave uses BraveLanguageSettings instead)'
-    re_pattern:
-      'import
-      org\.chromium\.chrome\.browser\.language\.settings\.LanguageSettings;\n'
-    replace: ''
+    regex:
+      re_pattern:
+        'import
+        org\.chromium\.chrome\.browser\.language\.settings\.LanguageSettings;\n'
+      replace: ''
 
   - description:
       'Remove LanguageSettings provider (Brave uses BraveLanguageSettings
       instead)'
-    re_pattern: '\n\s+LanguageSettings\.SEARCH_INDEX_DATA_PROVIDER,'
-    replace: ''
+    regex:
+      re_pattern: '\n\s+LanguageSettings\.SEARCH_INDEX_DATA_PROVIDER,'
+      replace: ''
 
   - description:
       'Remove PrivacySettings import (Brave uses BravePrivacySettings instead)'
-    re_pattern:
-      'import
-      org\.chromium\.chrome\.browser\.privacy\.settings\.PrivacySettings;\n'
-    replace: ''
+    regex:
+      re_pattern:
+        'import
+        org\.chromium\.chrome\.browser\.privacy\.settings\.PrivacySettings;\n'
+      replace: ''
 
   - description:
       'Remove PrivacySettings provider (Brave uses BravePrivacySettings instead)'
-    re_pattern: '\n\s+PrivacySettings\.SEARCH_INDEX_DATA_PROVIDER,'
-    replace: ''
+    regex:
+      re_pattern: '\n\s+PrivacySettings\.SEARCH_INDEX_DATA_PROVIDER,'
+      replace: ''
 
   - description:
       'Append Brave settings search index providers at the end of ALL_PROVIDERS
       (using FQN to avoid adding imports)'
-    re_pattern:
-      '(public static final List<SearchIndexProvider> ALL_PROVIDERS
-      =\s+List\.of\([\s\S]*\.SEARCH_INDEX_DATA_PROVIDER)\);'
-    replace: |-
-      \1,
-                          org.chromium.chrome.browser.accessibility.BraveAccessibilitySettings.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.components.browser_ui.site_settings.BraveSiteSettingsPreferencesBase.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.password_manager.settings.PasswordSettings.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.playlist.settings.BravePlaylistPreferences.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.privacy.settings.BravePrivacySettings.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.settings.BraveLeoDefaultModelPreferences.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.settings.BraveLeoPreferences.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.settings.BraveLicensePreferences.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.settings.BraveOriginPreferences.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.settings.BraveSearchEnginesPreferences.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.settings.BraveSyncScreensPreference.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.settings.BraveWalletNetworksPreferenceFragment.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.settings.BraveWalletPreferences.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.settings.BraveWebrtcPolicyPreferencesFragment.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.settings.developer.BraveQAPreferences.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.site_settings.BraveWalletEthereumConnectedSites.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.site_settings.BraveWalletSolanaConnectedSites.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.vpn.settings.BraveVpnPreferences.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.brave.browser.customize_menu.settings.BraveCustomizeMenuPreferenceFragment.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.password_entry_edit.BlockedCredentialFragmentView.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.password_entry_edit.CredentialEditFragmentView.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.password_entry_edit.FederatedCredentialFragmentView.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.brave.browser.quick_search_engines.settings.QuickSearchEnginesFragment.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.brave.browser.custom_search_engines.settings.AddCustomSearchEnginePreferenceFragment.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.settings.AppearancePreferences.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.language.settings.BraveLanguageSettings.SEARCH_INDEX_DATA_PROVIDER,
-                          org.chromium.chrome.browser.sync.settings.BraveManageSyncSettings.SEARCH_INDEX_DATA_PROVIDER);
+    regex:
+      re_pattern:
+        '(public static final List<SearchIndexProvider> ALL_PROVIDERS
+        =\s+List\.of\([\s\S]*\.SEARCH_INDEX_DATA_PROVIDER)\);'
+      replace: |-
+        \1,
+                            org.chromium.chrome.browser.accessibility.BraveAccessibilitySettings.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.components.browser_ui.site_settings.BraveSiteSettingsPreferencesBase.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.password_manager.settings.PasswordSettings.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.playlist.settings.BravePlaylistPreferences.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.privacy.settings.BravePrivacySettings.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.settings.BraveLeoDefaultModelPreferences.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.settings.BraveLeoPreferences.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.settings.BraveLicensePreferences.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.settings.BraveOriginPreferences.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.settings.BraveSearchEnginesPreferences.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.settings.BraveSyncScreensPreference.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.settings.BraveWalletNetworksPreferenceFragment.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.settings.BraveWalletPreferences.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.settings.BraveWebrtcPolicyPreferencesFragment.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.settings.developer.BraveQAPreferences.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.site_settings.BraveWalletEthereumConnectedSites.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.site_settings.BraveWalletSolanaConnectedSites.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.vpn.settings.BraveVpnPreferences.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.brave.browser.customize_menu.settings.BraveCustomizeMenuPreferenceFragment.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.password_entry_edit.BlockedCredentialFragmentView.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.password_entry_edit.CredentialEditFragmentView.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.password_entry_edit.FederatedCredentialFragmentView.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.brave.browser.quick_search_engines.settings.QuickSearchEnginesFragment.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.brave.browser.custom_search_engines.settings.AddCustomSearchEnginePreferenceFragment.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.settings.AppearancePreferences.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.language.settings.BraveLanguageSettings.SEARCH_INDEX_DATA_PROVIDER,
+                            org.chromium.chrome.browser.sync.settings.BraveManageSyncSettings.SEARCH_INDEX_DATA_PROVIDER);

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/suggestions/SuggestionsConfig.java.yaml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/suggestions/SuggestionsConfig.java.yaml
@@ -9,5 +9,6 @@ substitutions:
 
       We want 15 items for our NTP top site tiles on Android:
       4 rows x 4 element -1 for plus button.
-    re_pattern: '(MAX_TILE_COUNT\s+=\s+)8;'
-    replace: '\g<1>15;  // We want 15 tiles for Brave NTP'
+    regex:
+      re_pattern: '(MAX_TILE_COUNT\s+=\s+)8;'
+      replace: '\g<1>15;  // We want 15 tiles for Brave NTP'

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/ManageSyncSettings.java.yaml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/ManageSyncSettings.java.yaml
@@ -7,22 +7,24 @@ substitutions:
   - description: |-
       Make mSyncTypeSwitchPreferencesMap protected so BraveManageSyncSettings
       can register the AI Chat toggle. Replaces the bytecode visibility tweak.
-    re_pattern:
-      'private (Map<Integer, ChromeSwitchPreference>
-      mSyncTypeSwitchPreferencesMap)'
-    replace: 'protected \1'
+    regex:
+      re_pattern:
+        'private (Map<Integer, ChromeSwitchPreference>
+        mSyncTypeSwitchPreferencesMap)'
+      replace: 'protected \1'
 
   - description: |-
       Skip the isUsingExplicitPassphrase() block in onPreferenceChange()
 
       It suppresses the "addresses not encrypted" warning, which is not
       applicable to Brave's sync model.
-    re_pattern: |-
-      (onPreferenceChange\(Preference preference, Object newValue\) \{)\n( *)(if \(mSyncService\.isUsingExplicitPassphrase\(\))
-    replace: |-
-      \1
-      \2if (false)  // Suppress the "addresses not encrypted" warning (not applicable to Brave's sync model).
-      \2\3
+    regex:
+      re_pattern: |-
+        (onPreferenceChange\(Preference preference, Object newValue\) \{)\n( *)(if \(mSyncService\.isUsingExplicitPassphrase\(\))
+      replace: |-
+        \1
+        \2if (false)  // Suppress the "addresses not encrypted" warning (not applicable to Brave's sync model).
+        \2\3
 
   - description: |-
       Use an empty AccountInfo for primaryAccount in updateSyncPreferences
@@ -30,7 +32,8 @@ substitutions:
       This forces the signed-in account name passed to
       onGoogleActivityControlsClicked to be empty, keeping Brave's Google
       account details out of the activity controls flow.
-    re_pattern:
-      'primaryAccount = getIdentityManager\(\)\.getPrimaryAccountInfo\(\)'
-    replace: |-
-      primaryAccount = new AccountInfo.Builder("", new org.chromium.google_apis.gaia.GaiaId("")).build()
+    regex:
+      re_pattern:
+        'primaryAccount = getIdentityManager\(\)\.getPrimaryAccountInfo\(\)'
+      replace: |-
+        primaryAccount = new AccountInfo.Builder("", new org.chromium.google_apis.gaia.GaiaId("")).build()

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/webapps/AppInstallMenuHandler.java.yaml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/webapps/AppInstallMenuHandler.java.yaml
@@ -5,15 +5,18 @@
 
 substitutions:
   - description: 'Add import for UrlConstants.'
-    pattern: 'import org.chromium.chrome.R;'
-    replace: |-
-      import org.chromium.chrome.R;
-      import org.chromium.components.embedder_support.util.UrlConstants;
+    regex:
+      pattern: 'import org.chromium.chrome.R;'
+      replace: |-
+        import org.chromium.chrome.R;
+        import org.chromium.components.embedder_support.util.UrlConstants;
 
   - description: |
       Always make chrome:// schemes install rather than creating a shortcut (shortcuts can't handle chrome: urls).
-    re_pattern: '(doUniversalInstall(\s|.)+?if \()(controller == null\))'
-    re_flags: [MULTILINE]
-    replace:
-      '\1(currentTab.getUrl() != null &&
-      UrlConstants.CHROME_SCHEME.equals(currentTab.getUrl().getScheme())) || \3'
+    regex:
+      re_pattern: '(doUniversalInstall(\s|.)+?if \()(controller == null\))'
+      re_flags: [MULTILINE]
+      replace:
+        '\1(currentTab.getUrl() != null &&
+        UrlConstants.CHROME_SCHEME.equals(currentTab.getUrl().getScheme())) ||
+        \3'

--- a/rewrite/chrome/app/BUILD.gn.yaml
+++ b/rewrite/chrome/app/BUILD.gn.yaml
@@ -8,19 +8,21 @@ substitutions:
   # block, and adds our line just as the last line before the block closes.
   - description:
       "Adding brave_generated_resources_grit to Chromium's resources."
-    re_pattern: '(grit_strings\("generated_resources"\) {[\s\S]*?)(^})'
-    re_flags: [MULTILINE]
-    replace: '\1  deps = [ "//brave/app:brave_generated_resources_grit" ]\n\2'
+    regex:
+      re_pattern: '(grit_strings\("generated_resources"\) {[\s\S]*?)(^})'
+      re_flags: [MULTILINE]
+      replace: '\1  deps = [ "//brave/app:brave_generated_resources_grit" ]\n\2'
 
   # Define IS_BRAVE_ORIGIN_BRANDED for chrome_dll_resources when building with
   # is_brave_origin_branded=true so chrome_dll.rc picks the brave_origin icons.
   # This is what gets loaded for the per-window HICON via WM_SETICON, which is
   # what Windows shows in the alt+tab task switcher.
   - description: 'Add IS_BRAVE_ORIGIN_BRANDED define to chrome_dll_resources.'
-    re_pattern:
-      '(source_set\("chrome_dll_resources"\)
-      {[\s\S]*?"//printing/buildflags",\n    \])'
-    re_flags: [MULTILINE]
-    replace:
-      '\1\n    import("//brave/components/brave_origin/buildflags/buildflags.gni")
-      if (is_brave_origin_branded) { defines = [ "IS_BRAVE_ORIGIN_BRANDED" ] }'
+    regex:
+      re_pattern:
+        '(source_set\("chrome_dll_resources"\)
+        {[\s\S]*?"//printing/buildflags",\n    \])'
+      re_flags: [MULTILINE]
+      replace:
+        '\1\n    import("//brave/components/brave_origin/buildflags/buildflags.gni")
+        if (is_brave_origin_branded) { defines = [ "IS_BRAVE_ORIGIN_BRANDED" ] }'

--- a/rewrite/chrome/browser/actor/ui/handoff_button_controller.cc.yaml
+++ b/rewrite/chrome/browser/actor/ui/handoff_button_controller.cc.yaml
@@ -11,26 +11,28 @@ substitutions:
       unconditional Brave sweep gradient. Anchors on the `colors` declaration
       and the `pos` array name (not their values) so upstream tweaks to the
       stop positions don't break the match.
-    re_pattern:
-      'std::vector<SkColor> colors;.+?const SkScalar pos\[\] = \{[^}]+\};'
-    re_flags: ['DOTALL']
-    replace: |-
-      std::vector<SkColor> colors = {
-                SkColorSetARGB(255, 250, 114, 80),
-                SkColorSetARGB(255, 255, 24, 147),
-                SkColorSetARGB(255, 167, 138, 255),
-            };
-            const SkScalar pos[] = {0.0f, 0.5f, 1.0f};
+    regex:
+      re_pattern:
+        'std::vector<SkColor> colors;.+?const SkScalar pos\[\] = \{[^}]+\};'
+      re_flags: ['DOTALL']
+      replace: |-
+        std::vector<SkColor> colors = {
+                  SkColorSetARGB(255, 250, 114, 80),
+                  SkColorSetARGB(255, 255, 24, 147),
+                  SkColorSetARGB(255, 167, 138, 255),
+              };
+              const SkScalar pos[] = {0.0f, 0.5f, 1.0f};
 
   - description: |-
       Tighten handoff button content padding.
 
       Anchors on the `kHandoffButtonContentPadding` declaration so upstream
       tweaks to its default insets don't break the match.
-    re_pattern: 'kHandoffButtonContentPadding =\s+gfx::Insets::TLBR\([^)]*\)'
-    replace: |-
-      kHandoffButtonContentPadding =
-          gfx::Insets::TLBR(4, 6, 4, 10)
+    regex:
+      re_pattern: 'kHandoffButtonContentPadding =\s+gfx::Insets::TLBR\([^)]*\)'
+      replace: |-
+        kHandoffButtonContentPadding =
+            gfx::Insets::TLBR(4, 6, 4, 10)
 
   - description: |-
       Nudge the handoff button down when the location bar is visible.
@@ -42,10 +44,11 @@ substitutions:
       `is_tab_strip_visible`. This keeps the substitution scoped to one
       specific function and one specific statement, so unrelated returns of
       the same shape elsewhere in the file can't be mis-targeted.
-    re_pattern:
-      '(gfx::Rect
-      HandoffButtonController::GetHandoffButtonBounds\(\)[\s\S]+?)return
-      gfx::Rect\(\{x, y\}, preferred_size\);'
-    replace:
-      '\1return gfx::Rect({x, y + (is_tab_strip_visible ?
-      kHandoffButtonPreferredHeight / 3 : 0)}, preferred_size);'
+    regex:
+      re_pattern:
+        '(gfx::Rect
+        HandoffButtonController::GetHandoffButtonBounds\(\)[\s\S]+?)return
+        gfx::Rect\(\{x, y\}, preferred_size\);'
+      replace:
+        '\1return gfx::Rect({x, y + (is_tab_strip_visible ?
+        kHandoffButtonPreferredHeight / 3 : 0)}, preferred_size);'

--- a/rewrite/chrome/browser/android/backup/chrome_backup_agent.cc.yaml
+++ b/rewrite/chrome/browser/android/backup/chrome_backup_agent.cc.yaml
@@ -8,9 +8,10 @@ substitutions:
       Account for Brave's extra UserSelectableType in the kLastType
       static_assert. Add one to the upstream count rather than matching its
       value, so the assert is undisturbed when upstream adds or removes types.
-    re_pattern:
-      'static_assert\((\d+) ==
-      static_cast<int>\(syncer::UserSelectableType::kLastType\),'
-    replace:
-      'static_assert(\1 + 1 ==
-      static_cast<int>(syncer::UserSelectableType::kLastType),'
+    regex:
+      re_pattern:
+        'static_assert\((\d+) ==
+        static_cast<int>\(syncer::UserSelectableType::kLastType\),'
+      replace:
+        'static_assert(\1 + 1 ==
+        static_cast<int>(syncer::UserSelectableType::kLastType),'

--- a/rewrite/chrome/browser/enterprise/connectors/device_trust/key_management/browser/metrics_utils.cc.yaml
+++ b/rewrite/chrome/browser/enterprise/connectors/device_trust/key_management/browser/metrics_utils.cc.yaml
@@ -5,8 +5,9 @@
 
 substitutions:
   - description: 'Add ECDSA_SHA384 to the EC key case in `AlgorithmToType`.'
-    re_pattern: '(AlgorithmToType\([^)]*\).*?)(\n\s*return DTKeyType::kEc;)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case crypto::SignatureVerifier::ECDSA_SHA384:\2
+    regex:
+      re_pattern: '(AlgorithmToType\([^)]*\).*?)(\n\s*return DTKeyType::kEc;)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case crypto::SignatureVerifier::ECDSA_SHA384:\2

--- a/rewrite/chrome/browser/enterprise/connectors/device_trust/key_management/core/network/key_upload_request.cc.yaml
+++ b/rewrite/chrome/browser/enterprise/connectors/device_trust/key_management/core/network/key_upload_request.cc.yaml
@@ -5,8 +5,9 @@
 
 substitutions:
   - description: 'Add ECDSA_SHA384 to the EC_KEY case in `AlgorithmToType`'
-    re_pattern: '(AlgorithmToType\([^)]*\).*?)(\n\s*return BPKUR::EC_KEY;)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case crypto::SignatureVerifier::ECDSA_SHA384:\2
+    regex:
+      re_pattern: '(AlgorithmToType\([^)]*\).*?)(\n\s*return BPKUR::EC_KEY;)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case crypto::SignatureVerifier::ECDSA_SHA384:\2

--- a/rewrite/chrome/browser/extensions/BUILD.gn.yaml
+++ b/rewrite/chrome/browser/extensions/BUILD.gn.yaml
@@ -9,12 +9,14 @@ substitutions:
       `source_set("extensions")`.
 
       Inserted at the top of the file.
-    re_pattern: '(# found in the LICENSE file\.\n\n)'
-    replace: |
-      \1import("//brave/browser/extensions/resources.gni")
+    regex:
+      re_pattern: '(# found in the LICENSE file\.\n\n)'
+      replace: |
+        \1import("//brave/browser/extensions/resources.gni")
 
   - description: |
       Append Brave deps to `source_set("extensions")`.
-    re_pattern: '(source_set\("extensions"\).*?\bdeps\s*=\s*\[.*?\])'
-    re_flags: [DOTALL]
-    replace: '\1\n  deps += brave_extensions_resources'
+    regex:
+      re_pattern: '(source_set\("extensions"\).*?\bdeps\s*=\s*\[.*?\])'
+      re_flags: [DOTALL]
+      replace: '\1\n  deps += brave_extensions_resources'

--- a/rewrite/chrome/browser/global_features.cc.yaml
+++ b/rewrite/chrome/browser/global_features.cc.yaml
@@ -5,9 +5,11 @@
 
 substitutions:
   - description: 'Replacing GlobalFeatures with BraveGlobalFeatures'
-    pattern: 'new GlobalFeatures()'
-    replace: 'CreateBraveGlobalFeatures()'
+    regex:
+      pattern: 'new GlobalFeatures()'
+      replace: 'CreateBraveGlobalFeatures()'
 
   - description: 'Forward declare CreateBraveGlobalFeatures'
-    re_pattern: '(namespace {)'
-    replace: 'GlobalFeatures* CreateBraveGlobalFeatures();\n\1'
+    regex:
+      re_pattern: '(namespace {)'
+      replace: 'GlobalFeatures* CreateBraveGlobalFeatures();\n\1'

--- a/rewrite/chrome/browser/history_embeddings/history_embeddings_utils.cc.yaml
+++ b/rewrite/chrome/browser/history_embeddings/history_embeddings_utils.cc.yaml
@@ -14,10 +14,12 @@ substitutions:
   - description:
       'Swap IDS_HISTORY_EMBEDDINGS_DISCLAIMER_LOGGING_OFF to the Brave-owned
       string.'
-    re_pattern: '\bIDS_HISTORY_EMBEDDINGS_DISCLAIMER_LOGGING_OFF\b'
-    replace: 'IDS_BRAVE_HISTORY_EMBEDDINGS_DISCLAIMER'
+    regex:
+      re_pattern: '\bIDS_HISTORY_EMBEDDINGS_DISCLAIMER_LOGGING_OFF\b'
+      replace: 'IDS_BRAVE_HISTORY_EMBEDDINGS_DISCLAIMER'
 
   - description:
       'Swap IDS_HISTORY_EMBEDDINGS_DISCLAIMER to the Brave-owned string.'
-    re_pattern: '\bIDS_HISTORY_EMBEDDINGS_DISCLAIMER\b'
-    replace: 'IDS_BRAVE_HISTORY_EMBEDDINGS_DISCLAIMER'
+    regex:
+      re_pattern: '\bIDS_HISTORY_EMBEDDINGS_DISCLAIMER\b'
+      replace: 'IDS_BRAVE_HISTORY_EMBEDDINGS_DISCLAIMER'

--- a/rewrite/chrome/browser/lifetime/BUILD.gn.yaml
+++ b/rewrite/chrome/browser/lifetime/BUILD.gn.yaml
@@ -6,7 +6,8 @@
 substitutions:
   - description:
       'Add deps needed by Brave overrides in the lifetime:impl target'
-    re_pattern:
-      '(\n    sources \+= \[\n      "application_lifetime_desktop\.cc")'
-    replace: |-
-      \n    import("//brave/chromium_src/chrome/browser/lifetime/sources.gni") deps += brave_chrome_browser_lifetime_impl_deps\1
+    regex:
+      re_pattern:
+        '(\n    sources \+= \[\n      "application_lifetime_desktop\.cc")'
+      replace: |-
+        \n    import("//brave/chromium_src/chrome/browser/lifetime/sources.gni") deps += brave_chrome_browser_lifetime_impl_deps\1

--- a/rewrite/chrome/browser/resources/history/app.html.ts.yaml
+++ b/rewrite/chrome/browser/resources/history/app.html.ts.yaml
@@ -9,5 +9,6 @@
 
 substitutions:
   - description: 'Remove the disclaimer Learn more link from the history page.'
-    re_pattern: '\s*<a id="historyEmbeddingsDisclaimerLink"[\s\S]+?</a>'
-    replace: ''
+    regex:
+      re_pattern: '\s*<a id="historyEmbeddingsDisclaimerLink"[\s\S]+?</a>'
+      replace: ''

--- a/rewrite/chrome/browser/resources/history/history_embeddings_promo.html.ts.yaml
+++ b/rewrite/chrome/browser/resources/history/history_embeddings_promo.html.ts.yaml
@@ -12,6 +12,7 @@ substitutions:
   - description:
       'Remove the Manage-history-search-setting link from the history embeddings
       promo.'
-    re_pattern:
-      '\s*<a href="\$i18n\{historyEmbeddingsSettingsUrl\}"[\s\S]+?</a>'
-    replace: ''
+    regex:
+      re_pattern:
+        '\s*<a href="\$i18n\{historyEmbeddingsSettingsUrl\}"[\s\S]+?</a>'
+      replace: ''

--- a/rewrite/chrome/browser/resources/settings_shared/people_page/sync_browser_proxy.ts.yaml
+++ b/rewrite/chrome/browser/resources/settings_shared/people_page/sync_browser_proxy.ts.yaml
@@ -9,34 +9,37 @@ substitutions:
 
       Brave adds an AI Chat sync data type, so its managed/registered/synced
       flags must be part of SyncPrefs alongside the other data types.
-    re_pattern:
-      '(export interface SyncPrefs \{.*?\n)( *)(wifiConfigurationsSynced:
-      boolean;)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1\2\3
-      \2aiChatManaged: boolean;
-      \2aiChatRegistered: boolean;
-      \2aiChatSynced: boolean;
+    regex:
+      re_pattern:
+        '(export interface SyncPrefs \{.*?\n)( *)(wifiConfigurationsSynced:
+        boolean;)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1\2\3
+        \2aiChatManaged: boolean;
+        \2aiChatRegistered: boolean;
+        \2aiChatSynced: boolean;
 
   - description: |-
       Add aiChatSynced to the syncPrefsIndividualDataTypes list.
 
       This list names the per-type prefs cached when "Sync All" is on, so the
       AI Chat type must be present to be cached and restored correctly.
-    re_pattern: '(syncPrefsIndividualDataTypes: string\[\] = \[.*?)(\n\];)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        'aiChatSynced',\2
+    regex:
+      re_pattern: '(syncPrefsIndividualDataTypes: string\[\] = \[.*?)(\n\];)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          'aiChatSynced',\2
 
   - description: |-
       Append AI_CHAT to the UserSelectableType enum.
 
       Mirrors the C++ UserSelectableType, which is kept in sync via the
       LINT.IfChange annotation; AI_CHAT = 14 follows COOKIES = 13.
-    re_pattern: '(export enum UserSelectableType \{.*?[A-Z0-9_]+ = \d+)(\n\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1,
-        AI_CHAT = 14\2
+    regex:
+      re_pattern: '(export enum UserSelectableType \{.*?[A-Z0-9_]+ = \d+)(\n\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1,
+          AI_CHAT = 14\2

--- a/rewrite/chrome/browser/resources/side_panel/history_clusters/app.html.ts.yaml
+++ b/rewrite/chrome/browser/resources/side_panel/history_clusters/app.html.ts.yaml
@@ -10,5 +10,6 @@
 substitutions:
   - description:
       'Remove the disclaimer Learn more link from the history side panel.'
-    re_pattern: '\s*<a id="historyEmbeddingsDisclaimerLink"[\s\S]+?</a>'
-    replace: ''
+    regex:
+      re_pattern: '\s*<a id="historyEmbeddingsDisclaimerLink"[\s\S]+?</a>'
+      replace: ''

--- a/rewrite/chrome/browser/sessions/session_restore.cc.yaml
+++ b/rewrite/chrome/browser/sessions/session_restore.cc.yaml
@@ -5,8 +5,9 @@
 
 substitutions:
   - description: 'Modify navigation params before Navigate call for startup tab'
-    re_pattern: |-
-      (.+)(Navigate\(&params\);)
-    replace: |-
-      \1BraveModifyStartupTabNavigationParams(startup_tab, browser, params);
-      \1\2
+    regex:
+      re_pattern: |-
+        (.+)(Navigate\(&params\);)
+      replace: |-
+        \1BraveModifyStartupTabNavigationParams(startup_tab, browser, params);
+        \1\2

--- a/rewrite/chrome/browser/sessions/session_service_base.cc.yaml
+++ b/rewrite/chrome/browser/sessions/session_service_base.cc.yaml
@@ -7,8 +7,9 @@ substitutions:
   - description:
       Call BuildCommandsForTreeTab at in
       SessionTabBase::BuildCommandsForBrowser().
-    re_pattern: |-
-      (void SessionServiceBase::BuildCommandsForBrowser\([\s\S]*?\) {)
-    replace: |-
-      \1
-        BuildCommandsForTreeTab(browser->tab_strip_model(), command_storage_manager());
+    regex:
+      re_pattern: |-
+        (void SessionServiceBase::BuildCommandsForBrowser\([\s\S]*?\) {)
+      replace: |-
+        \1
+          BuildCommandsForTreeTab(browser->tab_strip_model(), command_storage_manager());

--- a/rewrite/chrome/browser/sharing_hub/sharing_hub_model.cc.yaml
+++ b/rewrite/chrome/browser/sharing_hub/sharing_hub_model.cc.yaml
@@ -10,5 +10,6 @@ substitutions:
       The helper, defined in the chromium_src wrapper for this source, adds a
       "Copy Clean Link" entry to the first-party action list when applicable and
       returns the original label ID so the upstream `emplace_back` keeps working.
-    pattern: 'IDS_SHARING_HUB_COPY_LINK_LABEL'
-    replace: 'MaybeAddCopyCleanLinkItem(context_, &first_party_action_list_)'
+    regex:
+      pattern: 'IDS_SHARING_HUB_COPY_LINK_LABEL'
+      replace: 'MaybeAddCopyCleanLinkItem(context_, &first_party_action_list_)'

--- a/rewrite/chrome/browser/ssl/ask_before_http_dialog_controller.cc.yaml
+++ b/rewrite/chrome/browser/ssl/ask_before_http_dialog_controller.cc.yaml
@@ -5,6 +5,8 @@
 
 substitutions:
   - description: 'Point Learn More link to the Brave support article.'
-    re_pattern: '(kLearnMoreLink[^=]*=\s*)(?:"[^"]*"\s*)+;'
+    regex:
+      re_pattern: '(kLearnMoreLink[^=]*=\s*)(?:"[^"]*"\s*)+;'
+      replace: '\1"https://support.brave.app/hc/en-us/articles/15513090104717";'
+
     count: 1
-    replace: '\1"https://support.brave.app/hc/en-us/articles/15513090104717";'

--- a/rewrite/chrome/browser/sync/sync_service_factory_unittest.cc.yaml
+++ b/rewrite/chrome/browser/sync/sync_service_factory_unittest.cc.yaml
@@ -8,5 +8,6 @@ substitutions:
       Account for Brave's extra data type in the GetNumDataTypes static_assert.
       Add one to the upstream count rather than matching its value, so the
       assert is undisturbed when upstream adds or removes data types.
-    re_pattern: 'static_assert\((\d+) == syncer::GetNumDataTypes\(\),'
-    replace: 'static_assert(\1 + 1 == syncer::GetNumDataTypes(),'
+    regex:
+      re_pattern: 'static_assert\((\d+) == syncer::GetNumDataTypes\(\),'
+      replace: 'static_assert(\1 + 1 == syncer::GetNumDataTypes(),'

--- a/rewrite/chrome/browser/sync/test/integration/sync_test.cc.yaml
+++ b/rewrite/chrome/browser/sync/test/integration/sync_test.cc.yaml
@@ -8,5 +8,6 @@ substitutions:
       Account for Brave's extra data type in the GetNumDataTypes static_assert.
       Add one to the upstream count rather than matching its value, so the
       assert is undisturbed when upstream adds or removes data types.
-    re_pattern: 'static_assert\((\d+) == syncer::GetNumDataTypes\(\),'
-    replace: 'static_assert(\1 + 1 == syncer::GetNumDataTypes(),'
+    regex:
+      re_pattern: 'static_assert\((\d+) == syncer::GetNumDataTypes\(\),'
+      replace: 'static_assert(\1 + 1 == syncer::GetNumDataTypes(),'

--- a/rewrite/chrome/browser/tab_group_sync/BUILD.gn.yaml
+++ b/rewrite/chrome/browser/tab_group_sync/BUILD.gn.yaml
@@ -6,11 +6,12 @@
 substitutions:
   - description: |-
       Add Brave sources to the tab group sync library.
-    re_pattern: |-
-      (android_library\("java"\).*?)\n  \}
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          import("//brave/browser/tab_group_sync/android/sources.gni")
-          sources += brave_browser_tab_group_sync_java_sources
-        }
+    regex:
+      re_pattern: |-
+        (android_library\("java"\).*?)\n  \}
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            import("//brave/browser/tab_group_sync/android/sources.gni")
+            sources += brave_browser_tab_group_sync_java_sources
+          }

--- a/rewrite/chrome/browser/tab_group_sync/android/java/src/org/chromium/chrome/browser/tab_group_sync/TabGroupSyncControllerImpl.java.yaml
+++ b/rewrite/chrome/browser/tab_group_sync/android/java/src/org/chromium/chrome/browser/tab_group_sync/TabGroupSyncControllerImpl.java.yaml
@@ -7,7 +7,8 @@ substitutions:
   - description: |-
       Use Brave's observer, which does not auto-open synced tab groups while the
       "Enable tab groups" master switch is off.
-    re_pattern: |-
-      new (TabGroupSyncRemoteObserver\()
-    replace: |-
-      new Brave\1
+    regex:
+      re_pattern: |-
+        new (TabGroupSyncRemoteObserver\()
+      replace: |-
+        new Brave\1

--- a/rewrite/chrome/browser/tab_group_sync/android/java/src/org/chromium/chrome/browser/tab_group_sync/TabGroupSyncRemoteObserver.java.yaml
+++ b/rewrite/chrome/browser/tab_group_sync/android/java/src/org/chromium/chrome/browser/tab_group_sync/TabGroupSyncRemoteObserver.java.yaml
@@ -6,7 +6,8 @@
 substitutions:
   - description: |-
       Allow BraveTabGroupSyncRemoteObserver to subclass this observer.
-    re_pattern: |-
-      public final (class TabGroupSyncRemoteObserver)
-    replace: |-
-      public \1
+    regex:
+      re_pattern: |-
+        public final (class TabGroupSyncRemoteObserver)
+      replace: |-
+        public \1

--- a/rewrite/chrome/browser/ui/accelerator_table.cc.yaml
+++ b/rewrite/chrome/browser/ui/accelerator_table.cc.yaml
@@ -7,5 +7,7 @@ substitutions:
   - description: |-
       Rename GetAcceleratorList() to GetAcceleratorList_ChromiumImpl() so that
       we can have our own implementation of GetAcceleratorList().
-    re_pattern: '(std::vector<AcceleratorMapping>\ GetAcceleratorList)(\(\)\ {)'
-    replace: '\1_ChromiumImpl\2'
+    regex:
+      re_pattern:
+        '(std::vector<AcceleratorMapping>\ GetAcceleratorList)(\(\)\ {)'
+      replace: '\1_ChromiumImpl\2'

--- a/rewrite/chrome/browser/ui/actions/chrome_action_id.h.yaml
+++ b/rewrite/chrome/browser/ui/actions/chrome_action_id.h.yaml
@@ -6,14 +6,16 @@
 substitutions:
   - description: |
       Register Brave's side panel action ids.
-    re_pattern: '(#define SIDE_PANEL_ACTION_IDS \\\n)'
-    replace: |
-      \1  E(kActionSidePanelShowPlaylist) \
-        E(kActionSidePanelShowChatUI) \
-        E(kActionSidePanelShowBraveNews) \
+    regex:
+      re_pattern: '(#define SIDE_PANEL_ACTION_IDS \\\n)'
+      replace: |
+        \1  E(kActionSidePanelShowPlaylist) \
+          E(kActionSidePanelShowChatUI) \
+          E(kActionSidePanelShowBraveNews) \
   - description: |
       Register Brave's toolbar action ids.
-    re_pattern: '(#define TOOLBAR_PINNABLE_ACTION_IDS \\\n)'
-    replace: |
-      \1  E(kActionShowPartitionedStorage) \
-        E(kActionShowPsstIcon) \
+    regex:
+      re_pattern: '(#define TOOLBAR_PINNABLE_ACTION_IDS \\\n)'
+      replace: |
+        \1  E(kActionShowPartitionedStorage) \
+          E(kActionShowPsstIcon) \

--- a/rewrite/chrome/browser/ui/android/omnibox/java/res/layout/location_status.xml.yaml
+++ b/rewrite/chrome/browser/ui/android/omnibox/java/res/layout/location_status.xml.yaml
@@ -8,6 +8,8 @@
 
 substitutions:
   - description: 'Use BraveStatusView in place of upstream StatusView'
-    pattern: 'org.chromium.chrome.browser.omnibox.status.StatusView'
+    regex:
+      pattern: 'org.chromium.chrome.browser.omnibox.status.StatusView'
+      replace: 'org.chromium.chrome.browser.omnibox.status.BraveStatusView'
+
     count: 2
-    replace: 'org.chromium.chrome.browser.omnibox.status.BraveStatusView'

--- a/rewrite/chrome/browser/ui/browser_commands.cc.yaml
+++ b/rewrite/chrome/browser/ui/browser_commands.cc.yaml
@@ -7,20 +7,23 @@ substitutions:
   - description:
       Rename ReloadBypassingCache to ReloadBypassingCache_ChromiumImpl to avoid
       conflict with Brave implementation
-    re_pattern: (void ReloadBypassingCache)\(
-    replace: \1_ChromiumImpl(
+    regex:
+      re_pattern: (void ReloadBypassingCache)\(
+      replace: \1_ChromiumImpl(
 
   - description:
       Replace chrome::kChromeUISplitViewNewTabPageURL to kChromeUINewTabURL in
       NewSplitTab(). We don't want to have a separate NTP URL for split view.
-    re_pattern: |-
-      (void NewSplitTab\(.*?)(chrome::kChromeUISplitViewNewTabPageURL)(.*?^})
-    re_flags: [DOTALL, MULTILINE]
-    replace: \1chrome::kChromeUINewTabURL\3
+    regex:
+      re_pattern: |-
+        (void NewSplitTab\(.*?)(chrome::kChromeUISplitViewNewTabPageURL)(.*?^})
+      re_flags: [DOTALL, MULTILINE]
+      replace: \1chrome::kChromeUINewTabURL\3
 
   - description:
       Nullify toast controller in CloseTab() not to show toast when closing a
       pinned tab
-    re_pattern: (void CloseTab\(.*?toast_controller\(\);)
-    re_flags: [DOTALL]
-    replace: \1\n  toast_controller = nullptr;
+    regex:
+      re_pattern: (void CloseTab\(.*?toast_controller\(\);)
+      re_flags: [DOTALL]
+      replace: \1\n  toast_controller = nullptr;

--- a/rewrite/chrome/browser/ui/browser_live_tab_context.cc.yaml
+++ b/rewrite/chrome/browser/ui/browser_live_tab_context.cc.yaml
@@ -7,8 +7,9 @@ substitutions:
   - description:
       Call MaybePopulateTreeTabExtraData() from
       BrowserLiveTabContext::GetExtraDataForTab()
-    re_pattern: |-
-      (std::map<std::string, std::string> BrowserLiveTabContext::GetExtraDataForTab\(.*std::map<std::string, std::string> extra_data;)
-    re_flags: [DOTALL]
-    replace: |-
-      \1\n  MaybePopulateTreeTabExtraData(*browser_, index, extra_data);
+    regex:
+      re_pattern: |-
+        (std::map<std::string, std::string> BrowserLiveTabContext::GetExtraDataForTab\(.*std::map<std::string, std::string> extra_data;)
+      re_flags: [DOTALL]
+      replace: |-
+        \1\n  MaybePopulateTreeTabExtraData(*browser_, index, extra_data);

--- a/rewrite/chrome/browser/ui/browser_tabrestore.cc.yaml
+++ b/rewrite/chrome/browser/ui/browser_tabrestore.cc.yaml
@@ -5,32 +5,35 @@
 
 substitutions:
   - description: 'Pass containers storage partition config when restoring tabs'
-    re_pattern: 'tab_util::GetSiteInstanceForNewTab\(([\s\S]*?)\)\)'
-    replace: |-
-      tab_util::GetSiteInstanceForNewTab(
-                \1
-      #if BUILDFLAG(ENABLE_CONTAINERS)
-                ,
-                containers::GetStoragePartitionConfigToRestore(
-                    browser->profile(), navigations, selected_navigation)
-      #endif  // BUILDFLAG(ENABLE_CONTAINERS)
-        ))
+    regex:
+      re_pattern: 'tab_util::GetSiteInstanceForNewTab\(([\s\S]*?)\)\)'
+      replace: |-
+        tab_util::GetSiteInstanceForNewTab(
+                  \1
+        #if BUILDFLAG(ENABLE_CONTAINERS)
+                  ,
+                  containers::GetStoragePartitionConfigToRestore(
+                      browser->profile(), navigations, selected_navigation)
+        #endif  // BUILDFLAG(ENABLE_CONTAINERS)
+          ))
 
   - description: |-
       Try restoration of tree tab hierarchy when restoring a tab after calling 
       AddRestoredTabImpl()
-    re_pattern: 'return (AddRestoredTabImpl\(.*?\);)'
-    re_flags: [DOTALL]
-    replace: |-
-      content::WebContents* restored_contents = \1
-        return MaybeRestoreTabTreeHierarchy(browser, restored_contents, extra_data);
+    regex:
+      re_pattern: 'return (AddRestoredTabImpl\(.*?\);)'
+      re_flags: [DOTALL]
+      replace: |-
+        content::WebContents* restored_contents = \1
+          return MaybeRestoreTabTreeHierarchy(browser, restored_contents, extra_data);
 
   - description: |-
       Try restoration of tree tab hierarchy when restoring a tab in
       ReplaceRestoredTab() right before returning the new contents
-    re_pattern:
-      '(WebContents\*\ ReplaceRestoredTab\(.*?)(return\ raw_web_contents;)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1MaybeRestoreTabTreeHierarchy(browser, raw_web_contents, extra_data);
-        \2
+    regex:
+      re_pattern:
+        '(WebContents\*\ ReplaceRestoredTab\(.*?)(return\ raw_web_contents;)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1MaybeRestoreTabTreeHierarchy(browser, raw_web_contents, extra_data);
+          \2

--- a/rewrite/chrome/browser/ui/browser_window/internal/browser_window_features.cc.yaml
+++ b/rewrite/chrome/browser/ui/browser_window/internal/browser_window_features.cc.yaml
@@ -12,6 +12,7 @@ substitutions:
       without walking `BrowserList`. The non-greedy regex captures the full
       argument list (no matter how many arguments upstream chooses to pass) and
       appends `*browser` immediately before the closing `);`.
-    re_pattern: '(CreateInstance<WindowFeatureController>\(.*?)(\);)'
-    re_flags: [DOTALL]
-    replace: '\1, *browser\2'
+    regex:
+      re_pattern: '(CreateInstance<WindowFeatureController>\(.*?)(\);)'
+      re_flags: [DOTALL]
+      replace: '\1, *browser\2'

--- a/rewrite/chrome/browser/ui/download/download_bubble_info_utils.cc.yaml
+++ b/rewrite/chrome/browser/ui/download/download_bubble_info_utils.cc.yaml
@@ -10,8 +10,9 @@ substitutions:
       DELETE_LOCAL_FILE is a Brave-only extension of DownloadCommands::Command, and
       the matching "Delete" quick action is shown alongside the upstream
       OPEN_WHEN_COMPLETE entry whenever the download can be opened.
-    re_pattern: '(QuickActionsForDownload\([^)]*\)\s*\{[\s\S]*?Command::OPEN_WHEN_COMPLETE,[\s\S]*?\);)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          AddDeleteLocalFileQuickAction(actions);
+    regex:
+      re_pattern: '(QuickActionsForDownload\([^)]*\)\s*\{[\s\S]*?Command::OPEN_WHEN_COMPLETE,[\s\S]*?\);)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            AddDeleteLocalFileQuickAction(actions);

--- a/rewrite/chrome/browser/ui/page_action/action_ids.h.yaml
+++ b/rewrite/chrome/browser/ui/page_action/action_ids.h.yaml
@@ -7,8 +7,9 @@ substitutions:
   - description:
       'Add kActionShowPartitionedStorage and kActionShowPsstIcon as the second
       entry of kActionIds'
-    re_pattern:
-      '(kActionIds = std::to_array<actions::ActionId>\(\{\n[ \t]*\w+,\n)'
-    replace: |
-      \1    kActionShowPartitionedStorage,
-          kActionShowPsstIcon,
+    regex:
+      re_pattern:
+        '(kActionIds = std::to_array<actions::ActionId>\(\{\n[ \t]*\w+,\n)'
+      replace: |
+        \1    kActionShowPartitionedStorage,
+            kActionShowPsstIcon,

--- a/rewrite/chrome/browser/ui/page_action/page_action_controller.cc.yaml
+++ b/rewrite/chrome/browser/ui/page_action/page_action_controller.cc.yaml
@@ -10,21 +10,24 @@ substitutions:
       The constructor is the first PageActionControllerImpl content in the TU; the
       ScopedPageActionActivity definitions and the file-local `using PassKey` above
       the constructor stay in page_actions::.
-    re_pattern: '(PageActionControllerImpl::PageActionControllerImpl\()'
-    replace: |-
-      namespace chromium_impl {
-      \1
+    regex:
+      re_pattern: '(PageActionControllerImpl::PageActionControllerImpl\()'
+      replace: |-
+        namespace chromium_impl {
+        \1
 
   - description: |
       Closes the detail namespace `chromium_impl::` in the translation unit.
 
       operator<< free function. operator<< must remain in page_actions:: so ADL on
       page_actions::SuggestionChipConfig still finds it.
-    re_pattern:
-      '(std::ostream& operator<<\(std::ostream& os, const SuggestionChipConfig)'
-    replace: |-
-      }  // namespace chromium_impl
-      \1
+    regex:
+      re_pattern:
+        '(std::ostream& operator<<\(std::ostream& os, const
+        SuggestionChipConfig)'
+      replace: |-
+        }  // namespace chromium_impl
+        \1
 
   - description: |2
        Instantiates `page_actions::PageActionModel`
@@ -33,5 +36,6 @@ substitutions:
       be instantiated on its own, as it is made an abstract class by another plaster.
       This substitution corrects the resolution, so we instantiate
       `page_actions::PageActionModel` with the parent namespace.
-    re_pattern: '\bPageActionModel\b'
-    replace: '::page_actions::PageActionModel'
+    regex:
+      re_pattern: '\bPageActionModel\b'
+      replace: '::page_actions::PageActionModel'

--- a/rewrite/chrome/browser/ui/page_action/page_action_controller.h.yaml
+++ b/rewrite/chrome/browser/ui/page_action/page_action_controller.h.yaml
@@ -10,11 +10,12 @@ substitutions:
       The abstract PageActionController base, ScopedPageActionActivity and other
       free declarations are intentionally left in page_actions::; only the concrete
       impl class is wrapped, so we can shadow it with our own implementation.
-    re_pattern: '(class PageActionControllerImpl[\s\S]*?\n\};)'
-    replace: |
-      namespace chromium_impl {
-      \1
-      }  // namespace chromium_impl
+    regex:
+      re_pattern: '(class PageActionControllerImpl[\s\S]*?\n\};)'
+      replace: |
+        namespace chromium_impl {
+        \1
+        }  // namespace chromium_impl
 
   - description: |
       Make CreateModel virtual so the brave PageActionControllerImpl override can

--- a/rewrite/chrome/browser/ui/page_action/page_action_model.cc.yaml
+++ b/rewrite/chrome/browser/ui/page_action/page_action_model.cc.yaml
@@ -9,14 +9,16 @@ substitutions:
 
       The constructor is the first PageActionModel content in the TU; the file-local
       anonymous namespace above it stays in page_actions::.
-    re_pattern: '(PageActionModel::PageActionModel\()'
-    replace: |-
-      namespace chromium_impl {
-      \1
+    regex:
+      re_pattern: '(PageActionModel::PageActionModel\()'
+      replace: |-
+        namespace chromium_impl {
+        \1
 
   - description: |
       Closes the detail namespace `chromium_impl::` in the translation unit.
-    re_pattern: '(\}\s*//\s*namespace page_actions)'
-    replace: |-
-      }  // namespace chromium_impl
-      \1
+    regex:
+      re_pattern: '(\}\s*//\s*namespace page_actions)'
+      replace: |-
+        }  // namespace chromium_impl
+        \1

--- a/rewrite/chrome/browser/ui/page_action/page_action_model.h.yaml
+++ b/rewrite/chrome/browser/ui/page_action/page_action_model.h.yaml
@@ -12,28 +12,29 @@ substitutions:
       PartitionedStoragePageActionController via PageActionControllerImpl. As there's
       also FakePageActionModel, we can't cast to the brave PageActionModel in
       PageActionControllerImpl, so we need a default empty implementation here.
-    re_pattern: '(class PageActionModelInterface \{.*?)(\n\};)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        virtual void SetOverrideChipColors(
-            PageActionPassKey,
-            std::optional<SkColor> override_background_color,
-            std::optional<SkColor> override_foreground_color) = 0;
-        virtual void SetAlwaysShowLabel(PageActionPassKey,
-                                        bool always_show) = 0;
-        virtual void SetOverrideHeight(PageActionPassKey,
-                                       std::optional<int> height) = 0;
-        virtual void SetOverrideTriggerableEvent(PageActionPassKey,
-                                                 std::optional<int> event_flags) = 0;
-        virtual void SetOverrideBorder(PageActionPassKey,
-                                       std::optional<gfx::Insets> border) = 0;
-        virtual std::optional<SkColor> GetOverrideBackgroundColor() const = 0;
-        virtual std::optional<SkColor> GetOverrideForegroundColor() const = 0;
-        virtual bool GetAlwaysShowLabel() const = 0;
-        virtual std::optional<int> GetOverrideHeight() const = 0;
-        virtual std::optional<int> GetOverrideTriggerableEvent() const = 0;
-        virtual std::optional<gfx::Insets> GetOverrideBorder() const = 0;\2
+    regex:
+      re_pattern: '(class PageActionModelInterface \{.*?)(\n\};)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          virtual void SetOverrideChipColors(
+              PageActionPassKey,
+              std::optional<SkColor> override_background_color,
+              std::optional<SkColor> override_foreground_color) = 0;
+          virtual void SetAlwaysShowLabel(PageActionPassKey,
+                                          bool always_show) = 0;
+          virtual void SetOverrideHeight(PageActionPassKey,
+                                         std::optional<int> height) = 0;
+          virtual void SetOverrideTriggerableEvent(PageActionPassKey,
+                                                   std::optional<int> event_flags) = 0;
+          virtual void SetOverrideBorder(PageActionPassKey,
+                                         std::optional<gfx::Insets> border) = 0;
+          virtual std::optional<SkColor> GetOverrideBackgroundColor() const = 0;
+          virtual std::optional<SkColor> GetOverrideForegroundColor() const = 0;
+          virtual bool GetAlwaysShowLabel() const = 0;
+          virtual std::optional<int> GetOverrideHeight() const = 0;
+          virtual std::optional<int> GetOverrideTriggerableEvent() const = 0;
+          virtual std::optional<gfx::Insets> GetOverrideBorder() const = 0;\2
 
   - description: |
       Adding Property types for NotifyChange for the new set methods added above.
@@ -41,15 +42,16 @@ substitutions:
       Keys are appended at the end of the PageActionModel::Property enum, and
       kMaxValue is re-pointed to the last Brave-added entry so PropertySet's EnumSet
       range covers them.
-    re_pattern: '(enum class Property \{.+?,\n)\s+kMaxValue = \w+,'
-    re_flags: [DOTALL]
-    replace: |-
-      \1    kAlwaysShowLabel,
-          kOverrideChipColors,
-          kOverrideHeight,
-          kOverrideTriggerableEvent,
-          kOverrideBorder,
-          kMaxValue = kOverrideBorder,
+    regex:
+      re_pattern: '(enum class Property \{.+?,\n)\s+kMaxValue = \w+,'
+      re_flags: [DOTALL]
+      replace: |-
+        \1    kAlwaysShowLabel,
+            kOverrideChipColors,
+            kOverrideHeight,
+            kOverrideTriggerableEvent,
+            kOverrideBorder,
+            kMaxValue = kOverrideBorder,
 
   - description: |
       Wrap PageActionModel in a chromium_impl namespace.
@@ -57,12 +59,13 @@ substitutions:
       This makes our implementation of `PageActionModel` a full shadow, guaranteeing
       that only `PageActionModel` from Brave can be instantiated by Chromium code, as
       this class is now left as an abstract class.
-    re_pattern: '(class PageActionModel\b.*?\n\};)'
-    re_flags: [DOTALL]
-    replace: |-
-      namespace chromium_impl {
-      \1
-      }  // namespace chromium_impl
+    regex:
+      re_pattern: '(class PageActionModel\b.*?\n\};)'
+      re_flags: [DOTALL]
+      replace: |-
+        namespace chromium_impl {
+        \1
+        }  // namespace chromium_impl
 
   - description: |
       Friend the brave page_actions::PageActionModel so it can call NotifyChange and

--- a/rewrite/chrome/browser/ui/page_action/page_action_properties_provider.cc.yaml
+++ b/rewrite/chrome/browser/ui/page_action/page_action_properties_provider.cc.yaml
@@ -7,20 +7,21 @@ substitutions:
   - description:
       'Insert kActionShowPartitionedStorage and kActionShowPsstIcon before
       kActionVirtualCardEnroll'
-    pattern: 'kActionVirtualCardEnroll,'
-    replace: |-
-      kActionShowPartitionedStorage,
-              {
-                  .histogram_name = "PartitionedStorage",
-                  .type = brave::kPartitionedStorageActionIconType,
-              },
-          },
-          {
-              kActionShowPsstIcon,
-              {
-                 .histogram_name = "PsstIcon",
-                 .type = brave::kPsstIconActionIconType,
-              },
-          },
-          {
-              kActionVirtualCardEnroll,
+    regex:
+      pattern: 'kActionVirtualCardEnroll,'
+      replace: |-
+        kActionShowPartitionedStorage,
+                {
+                    .histogram_name = "PartitionedStorage",
+                    .type = brave::kPartitionedStorageActionIconType,
+                },
+            },
+            {
+                kActionShowPsstIcon,
+                {
+                   .histogram_name = "PsstIcon",
+                   .type = brave::kPsstIconActionIconType,
+                },
+            },
+            {
+                kActionVirtualCardEnroll,

--- a/rewrite/chrome/browser/ui/side_panel/side_panel_entry.h.yaml
+++ b/rewrite/chrome/browser/ui/side_panel/side_panel_entry.h.yaml
@@ -7,5 +7,6 @@ substitutions:
   - description: |
       Increase the default (and minimum) side panel content width to better fit
       Brave's side panel.
-    pattern: 'static constexpr int kSidePanelDefaultContentWidth = 360;'
-    replace: 'static constexpr int kSidePanelDefaultContentWidth = 400;'
+    regex:
+      pattern: 'static constexpr int kSidePanelDefaultContentWidth = 360;'
+      replace: 'static constexpr int kSidePanelDefaultContentWidth = 400;'

--- a/rewrite/chrome/browser/ui/startup/startup_browser_creator_impl.cc.yaml
+++ b/rewrite/chrome/browser/ui/startup/startup_browser_creator_impl.cc.yaml
@@ -6,8 +6,9 @@
 substitutions:
   - description: 'Modify navigation params before Navigate call for startup tab'
     count: 2
-    re_pattern: |-
-      (.+)(Navigate\(&params\);)
-    replace: |-
-      \1BraveModifyStartupTabNavigationParams(tab, browser, params);
-      \1\2
+    regex:
+      re_pattern: |-
+        (.+)(Navigate\(&params\);)
+      replace: |-
+        \1BraveModifyStartupTabNavigationParams(tab, browser, params);
+        \1\2

--- a/rewrite/chrome/browser/ui/startup/startup_tab.h.yaml
+++ b/rewrite/chrome/browser/ui/startup/startup_tab.h.yaml
@@ -5,16 +5,17 @@
 
 substitutions:
   - description: 'Append Brave members at the end of struct StartupTab'
-    re_pattern: '(struct StartupTab \{.*?)(\n\};)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
+    regex:
+      re_pattern: '(struct StartupTab \{.*?)(\n\};)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
 
-      #if BUILDFLAG(ENABLE_CONTAINERS)
-        containers::ContainerSpecifier container;
-      #endif
+        #if BUILDFLAG(ENABLE_CONTAINERS)
+          containers::ContainerSpecifier container;
+        #endif
 
-        StartupTab(const StartupTab&);
-        StartupTab& operator=(const StartupTab&);
-        StartupTab(StartupTab&&) noexcept;
-        StartupTab& operator=(StartupTab&&) noexcept;\2
+          StartupTab(const StartupTab&);
+          StartupTab& operator=(const StartupTab&);
+          StartupTab(StartupTab&&) noexcept;
+          StartupTab& operator=(StartupTab&&) noexcept;\2

--- a/rewrite/chrome/browser/ui/tabs/pinned_tab_codec.cc.yaml
+++ b/rewrite/chrome/browser/ui/tabs/pinned_tab_codec.cc.yaml
@@ -5,15 +5,17 @@
 
 substitutions:
   - description: 'Add handler to modify encoded pinned tab'
-    re_pattern: |-
-      (.+)(serialized_tabs.Append\(EncodeTab.*)
-    replace: |-
-      \1\2
-      \1BraveModifyEncodedPinnedTab(web_contents, serialized_tabs.back());
+    regex:
+      re_pattern: |-
+        (.+)(serialized_tabs.Append\(EncodeTab.*)
+      replace: |-
+        \1\2
+        \1BraveModifyEncodedPinnedTab(web_contents, serialized_tabs.back());
 
   - description: 'Add handler to modify decoded pinned tab'
-    re_pattern: |-
-      (.+)(results.push_back\(tab.value.*)
-    replace: |-
-      \1BraveModifyDecodedPinnedTab(serialized_tab, tab.value());
-      \1\2
+    regex:
+      re_pattern: |-
+        (.+)(results.push_back\(tab.value.*)
+      replace: |-
+        \1BraveModifyDecodedPinnedTab(serialized_tab, tab.value());
+        \1\2

--- a/rewrite/chrome/browser/ui/tabs/split_tab_menu_model.cc.yaml
+++ b/rewrite/chrome/browser/ui/tabs/split_tab_menu_model.cc.yaml
@@ -6,31 +6,35 @@
 substitutions:
   - description: |
       Handle Brave's kToggleLinkState command in the metrics suffix switch.
-    re_pattern: '(GetMetricsSuffixForCommand\(.+?switch \(command_id\) \{\n)'
-    re_flags: [DOTALL]
-    replace: |
-      \1    case SplitTabMenuModel::CommandId::kToggleLinkState:
-            return "ToggleLinkState";
+    regex:
+      re_pattern: '(GetMetricsSuffixForCommand\(.+?switch \(command_id\) \{\n)'
+      re_flags: [DOTALL]
+      replace: |
+        \1    case SplitTabMenuModel::CommandId::kToggleLinkState:
+              return "ToggleLinkState";
   - description: |
       Handle Brave's kToggleLinkState command in the execute switch.
-    re_pattern: '(ExecuteCommand\(.+?switch \(split_command_id\) \{\n)'
-    re_flags: [DOTALL]
-    replace: |
-      \1    case CommandId::kToggleLinkState: {
-            split_tab_data->set_linked(!split_tab_data->linked());
-            break;
-          }
+    regex:
+      re_pattern: '(ExecuteCommand\(.+?switch \(split_command_id\) \{\n)'
+      re_flags: [DOTALL]
+      replace: |
+        \1    case CommandId::kToggleLinkState: {
+              split_tab_data->set_linked(!split_tab_data->linked());
+              break;
+            }
   - description: |
       Rename the file-local GetCommandIdEnum definition to _ChromiumImpl.
 
       This allows us to expose this internal linkage function as
       `SplitTabMenuModel::GetCommandIdEnum`.
-    re_pattern: 'GetCommandIdEnum(\([^;]+?\) \{)'
-    replace: 'GetCommandIdEnum_ChromiumImpl\1'
+    regex:
+      re_pattern: 'GetCommandIdEnum(\([^;]+?\) \{)'
+      replace: 'GetCommandIdEnum_ChromiumImpl\1'
   - description: |
       Rename the file-local GetCommandIdInt definition to _ChromiumImpl.
 
       This allows us to expose this internal linkage function as
       `SplitTabMenuModel::GetCommandIdInt`.
-    re_pattern: 'GetCommandIdInt(\([^;]+?\) \{)'
-    replace: 'GetCommandIdInt_ChromiumImpl\1'
+    regex:
+      re_pattern: 'GetCommandIdInt(\([^;]+?\) \{)'
+      replace: 'GetCommandIdInt_ChromiumImpl\1'

--- a/rewrite/chrome/browser/ui/tabs/tab_style.cc.yaml
+++ b/rewrite/chrome/browser/ui/tabs/tab_style.cc.yaml
@@ -5,5 +5,6 @@
 
 substitutions:
   - description: 'Replacing TabStyle with BraveTabStyle'
-    pattern: 'static_cast<TabStyle*>(new TabStyle())'
-    replace: 'static_cast<TabStyle*>(new BraveTabStyle())'
+    regex:
+      pattern: 'static_cast<TabStyle*>(new TabStyle())'
+      replace: 'static_cast<TabStyle*>(new BraveTabStyle())'

--- a/rewrite/chrome/browser/ui/toasts/toast_controller_unittest.cc.yaml
+++ b/rewrite/chrome/browser/ui/toasts/toast_controller_unittest.cc.yaml
@@ -11,12 +11,15 @@
 substitutions:
   - description:
       'Redirect upstream kLinkCopied tests to a non-suppressed toast.'
-    pattern: 'ToastId::kLinkCopied'
-    count: 0
-    replace: 'ToastId::kLinkToHighlightCopied'
+    regex:
+      pattern: 'ToastId::kLinkCopied'
+      replace: 'ToastId::kLinkToHighlightCopied'
 
+    count: 0
   - description:
       'Redirect upstream kImageCopied tests to a non-suppressed toast.'
-    pattern: 'ToastId::kImageCopied'
+    regex:
+      pattern: 'ToastId::kImageCopied'
+      replace: 'ToastId::kClearBrowsingData'
+
     count: 0
-    replace: 'ToastId::kClearBrowsingData'

--- a/rewrite/chrome/browser/ui/views/bookmarks/bookmark_bubble_view.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/bookmarks/bookmark_bubble_view.cc.yaml
@@ -9,6 +9,7 @@ substitutions:
 
       Brave's star action lives on the left of the location bar, so the bubble
       must anchor from there instead of upstream's top-right default.
-    re_pattern: '(bookmark_bubble_ = bubble.get\(\);\n)'
-    replace: |
-      \1  bubble->SetArrow(views::BubbleBorder::TOP_LEFT);
+    regex:
+      re_pattern: '(bookmark_bubble_ = bubble.get\(\);\n)'
+      replace: |
+        \1  bubble->SetArrow(views::BubbleBorder::TOP_LEFT);

--- a/rewrite/chrome/browser/ui/views/bubble/webui_bubble_manager.h.yaml
+++ b/rewrite/chrome/browser/ui/views/bubble/webui_bubble_manager.h.yaml
@@ -10,8 +10,9 @@ substitutions:
       Brave subclasses WebUIBubbleManagerImpl and needs to reach
       CreateWebUIBubbleDialog and GetContentsWrapper, so wrap both overrides in
       a `protected:` section.
-    re_pattern:
-      '(\n)(  [^\n]*CreateWebUIBubbleDialog\([^;{]*override;\n[^\n]*GetContentsWrapper\(\)[^\n]*override;\n)'
-    replace: |
-      \1 protected:
-      \2 private:
+    regex:
+      re_pattern:
+        '(\n)(  [^\n]*CreateWebUIBubbleDialog\([^;{]*override;\n[^\n]*GetContentsWrapper\(\)[^\n]*override;\n)'
+      replace: |
+        \1 protected:
+        \2 private:

--- a/rewrite/chrome/browser/ui/views/download/bubble/download_toolbar_ui_controller.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/download/bubble/download_toolbar_ui_controller.cc.yaml
@@ -10,8 +10,9 @@ substitutions:
       This replacement adds a `UpdateIcon_BraveImpl` call after the upstream image
       update to apply Brave's icon color and replace the icon when an insecure file
       is downloaded.
-    re_pattern: '(badge_background_color\);)'
-    re_flags: [MULTILINE]
-    replace: |-
-      \1
-        UpdateIcon_BraveImpl(browser_view_, *new_icon, state_, active_, action_item_);
+    regex:
+      re_pattern: '(badge_background_color\);)'
+      re_flags: [MULTILINE]
+      replace: |-
+        \1
+          UpdateIcon_BraveImpl(browser_view_, *new_icon, state_, active_, action_item_);

--- a/rewrite/chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.cc.yaml
@@ -5,19 +5,22 @@
 
 substitutions:
   - description: 'Replace TabStrip construction with BraveTabStrip'
-    pattern: 'std::make_unique<TabStrip>'
-    replace: 'std::make_unique<BraveTabStrip>'
+    regex:
+      pattern: 'std::make_unique<TabStrip>'
+      replace: 'std::make_unique<BraveTabStrip>'
 
   - description: |
       Use BraveBrowserTabStripController in place of BrowserTabStripController
-    pattern: 'BrowserTabStripController'
-    replace: 'BraveBrowserTabStripController'
+    regex:
+      pattern: 'BrowserTabStripController'
+      replace: 'BraveBrowserTabStripController'
     count: 3
 
   - description: |
       Construct BraveNewTabButton instead of NewTabButton
-    pattern: 'std::make_unique<NewTabButton>'
-    replace: 'std::make_unique<BraveNewTabButton>'
+    regex:
+      pattern: 'std::make_unique<NewTabButton>'
+      replace: 'std::make_unique<BraveNewTabButton>'
 
   - description: |
       Read the new tab button size from BraveNewTabButton::GetButtonSize()
@@ -25,15 +28,18 @@ substitutions:
       The Brave new tab button size varies with the tabs update feature flag,
       so it must be read from the static `BraveNewTabButton::GetButtonSize()`
       helper.
-    pattern: 'NewTabButton::kButtonSize'
-    replace: 'BraveNewTabButton::GetButtonSize()'
+    regex:
+      pattern: 'NewTabButton::kButtonSize'
+      replace: 'BraveNewTabButton::GetButtonSize()'
 
   - description: |
       Declare the hover card controller as BraveTabHoverCardController
-    pattern: 'std::unique_ptr<TabHoverCardController>'
-    replace: 'std::unique_ptr<BraveTabHoverCardController>'
+    regex:
+      pattern: 'std::unique_ptr<TabHoverCardController>'
+      replace: 'std::unique_ptr<BraveTabHoverCardController>'
 
   - description: |
       Construct BraveTabHoverCardController
-    pattern: 'std::make_unique<TabHoverCardController>'
-    replace: 'std::make_unique<BraveTabHoverCardController>'
+    regex:
+      pattern: 'std::make_unique<TabHoverCardController>'
+      replace: 'std::make_unique<BraveTabHoverCardController>'

--- a/rewrite/chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.h.yaml
+++ b/rewrite/chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.h.yaml
@@ -9,28 +9,31 @@ substitutions:
 
       Brave derives BraveHorizontalTabStripRegionView from this view, so the
       upstream `final` specifier has to be dropped.
-    pattern: 'class HorizontalTabStripRegionView final'
-    replace: 'class HorizontalTabStripRegionView'
+    regex:
+      pattern: 'class HorizontalTabStripRegionView final'
+      replace: 'class HorizontalTabStripRegionView'
 
   - description: |
       Expose new_tab_button() to Brave
-    re_pattern: '(  ~HorizontalTabStripRegionView\(\) override;)'
-    replace: |-
-      \1
-        views::Button* new_tab_button() { return new_tab_button_; }
+    regex:
+      re_pattern: '(  ~HorizontalTabStripRegionView\(\) override;)'
+      replace: |-
+        \1
+          views::Button* new_tab_button() { return new_tab_button_; }
 
   - description: |
       Friend the Brave tab strip classes and vertical tab strip test
 
       Grants the Brave tab strip subclasses and the vertical tab strip browser
       test access to private members.
-    re_pattern: '( private:)'
-    replace: |-
-      \1
-        friend class BraveVerticalTabStripRegionView;
-        friend class BraveTabStrip;
-        friend class BraveHorizontalTabStripRegionView;
-        FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest, MinHeight);
+    regex:
+      re_pattern: '( private:)'
+      replace: |-
+        \1
+          friend class BraveVerticalTabStripRegionView;
+          friend class BraveTabStrip;
+          friend class BraveHorizontalTabStripRegionView;
+          FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest, MinHeight);
 
   - description: |
       Make UpdateTabStripMargin overridable

--- a/rewrite/chrome/browser/ui/views/frame/layout/browser_view_tabbed_layout_impl.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/frame/layout/browser_view_tabbed_layout_impl.cc.yaml
@@ -10,5 +10,6 @@ substitutions:
       With Brave vertical tabs, the leading exclusion is owned by the
       vertical tab strip itself rather than by the horizontal layout, so
       the top container should not also reserve space for it.
-    re_pattern: '(bool needs_exclusion = )true;'
-    replace: '\1!delegate().ShouldShowVerticalTabs();'
+    regex:
+      re_pattern: '(bool needs_exclusion = )true;'
+      replace: '\1!delegate().ShouldShowVerticalTabs();'

--- a/rewrite/chrome/browser/ui/views/frame/multi_contents_view.h.yaml
+++ b/rewrite/chrome/browser/ui/views/frame/multi_contents_view.h.yaml
@@ -11,8 +11,9 @@ substitutions:
       instead. The constant is referenced both inside and outside
       `MultiContentsView`, so adjusting it here is preferable to zeroing
       the inset fields in the constructor.
-    re_pattern: 'kSplitViewContentInset = 8;'
-    replace: 'kSplitViewContentInset = 0;'
+    regex:
+      re_pattern: 'kSplitViewContentInset = 8;'
+      replace: 'kSplitViewContentInset = 0;'
 
   - description: |
       Make `GetActiveContentsContainerView` virtual.
@@ -46,10 +47,11 @@ substitutions:
 
       `BraveMultiContentsView` overrides this to reset the resize area
       when the web-panel layout changes.
-    re_pattern: '( +)(void SetBackgroundRadii\([^)]*\);)'
-    replace: |-
-      \1\2
-      \1virtual void ResetResizeArea() {}
+    regex:
+      re_pattern: '( +)(void SetBackgroundRadii\([^)]*\);)'
+      replace: |-
+        \1\2
+        \1virtual void ResetResizeArea() {}
 
   - description: |
       Make `ExecuteOnEachVisibleContentsView` virtual.

--- a/rewrite/chrome/browser/ui/views/location_bar/icon_label_bubble_view.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/location_bar/icon_label_bubble_view.cc.yaml
@@ -7,26 +7,29 @@ substitutions:
   - description:
       'Use preferred size instead of minimum size when ShouldAlwaysShowLabel is
       true in CalculateProposedLayout()'
-    re_pattern:
-      'if (\(ShouldShowLabel\(\) && label\(\)->GetElideBehavior\(\) !=
-      gfx::NO_ELIDE\)) {'
-    replace: 'if (\1 || ShouldAlwaysShowLabel()) {'
+    regex:
+      re_pattern:
+        'if (\(ShouldShowLabel\(\) && label\(\)->GetElideBehavior\(\) !=
+        gfx::NO_ELIDE\)) {'
+      replace: 'if (\1 || ShouldAlwaysShowLabel()) {'
 
   - description:
       'Force should_use_label_bounds to true when ShouldAlwaysShowLabel is true
       in CalculateProposedLayout()'
-    re_pattern: 'const bool should_use_label_bounds =([\s\S]*?);'
-    replace: |-
-      bool should_use_label_bounds =\1;
-        should_use_label_bounds = should_use_label_bounds || ShouldAlwaysShowLabel();
+    regex:
+      re_pattern: 'const bool should_use_label_bounds =([\s\S]*?);'
+      replace: |-
+        bool should_use_label_bounds =\1;
+          should_use_label_bounds = should_use_label_bounds || ShouldAlwaysShowLabel();
 
   - description:
       'Use rounded corners from layout constants in GetHighlightPath()'
-    re_pattern:
-      'const SkRect rect = RectToSkRect\(highlight_bounds\);[\s\S]*?return
-      SkPath::RRect\(SkRRect::MakeRectRadii\(rect, sk_radii\)\);'
-    replace: |-
-      const int layout_radius =
-            GetLayoutConstant(LayoutConstant::kLocationBarChildCornerRadius);
-        return SkPath::RRect(gfx::RectToSkRect(highlight_bounds), layout_radius,
-                             layout_radius);
+    regex:
+      re_pattern:
+        'const SkRect rect = RectToSkRect\(highlight_bounds\);[\s\S]*?return
+        SkPath::RRect\(SkRRect::MakeRectRadii\(rect, sk_radii\)\);'
+      replace: |-
+        const int layout_radius =
+              GetLayoutConstant(LayoutConstant::kLocationBarChildCornerRadius);
+          return SkPath::RRect(gfx::RectToSkRect(highlight_bounds), layout_radius,
+                               layout_radius);

--- a/rewrite/chrome/browser/ui/views/location_bar/star_view.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/location_bar/star_view.cc.yaml
@@ -10,17 +10,19 @@ substitutions:
       Brave keeps the bookmark star hidden, so its bubble is never shown; the
       early return skips observing the bubble widget (and its CHECK) for a view
       that should never become active.
-    re_pattern: '(StarView::OnBubbleWidgetChanged\(.+?\) \{\n)'
-    re_flags: [DOTALL]
-    replace: |
-      \1  return;
+    regex:
+      re_pattern: '(StarView::OnBubbleWidgetChanged\(.+?\) \{\n)'
+      re_flags: [DOTALL]
+      replace: |
+        \1  return;
 
   - description: |
       Makes sure the view is never shown by calling SetVisible(false).
 
       Brave removes the bookmark star page action from the location bar, so
       `enabled` is forced false regardless of the bookmark prefs.
-    re_pattern: '(StarView::UpdateImpl\(\) \{\n  bool enabled =)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1 false &&
+    regex:
+      re_pattern: '(StarView::UpdateImpl\(\) \{\n  bool enabled =)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1 false &&

--- a/rewrite/chrome/browser/ui/views/overlay/playback_image_button.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/overlay/playback_image_button.cc.yaml
@@ -9,13 +9,16 @@
 
 substitutions:
   - description: 'Use Leo play icon for the picture-in-picture play button.'
-    pattern: 'vector_icons::kPlayArrowOldIcon'
-    replace: 'kLeoPlayFilledIcon'
+    regex:
+      pattern: 'vector_icons::kPlayArrowOldIcon'
+      replace: 'kLeoPlayFilledIcon'
 
   - description: 'Use Leo pause icon for the picture-in-picture pause button.'
-    pattern: 'vector_icons::kPauseOldIcon'
-    replace: 'kLeoPauseFilledIcon'
+    regex:
+      pattern: 'vector_icons::kPauseOldIcon'
+      replace: 'kLeoPauseFilledIcon'
 
   - description: 'Use Leo reload icon for the picture-in-picture replay button.'
-    pattern: 'vector_icons::kReplayOldIcon'
-    replace: 'kLeoReloadIcon'
+    regex:
+      pattern: 'vector_icons::kReplayOldIcon'
+      replace: 'kLeoReloadIcon'

--- a/rewrite/chrome/browser/ui/views/page_action/page_action_view.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/page_action/page_action_view.cc.yaml
@@ -10,8 +10,9 @@ substitutions:
       Upstream only animates the chip in when it is acting as a suggestion
       chip. Brave has page actions whose label must remain visible regardless,
       so we widen the condition to also cover `model.GetAlwaysShowLabel()`.
-    re_pattern: 'else if \((model.ShouldShowSuggestionChip\(\))\)'
-    replace: 'else if (\1 || model.GetAlwaysShowLabel())'
+    regex:
+      re_pattern: 'else if \((model.ShouldShowSuggestionChip\(\))\)'
+      replace: 'else if (\1 || model.GetAlwaysShowLabel())'
 
   - description: |
       Let Brave adjust the border insets before UpdateBorder() applies them.
@@ -20,11 +21,12 @@ substitutions:
       SetBorder(). Inserting a MaybeOverrideBorder() hook just before that call
       gives Brave a chance to tweak the insets without duplicating the whole
       method.
-    re_pattern: '(void PageActionView::UpdateBorder\(\).*?)(SetBorder\()'
-    re_flags: [DOTALL]
-    replace: |-
-      \1MaybeOverrideBorder(observation_.GetSource(), border_insets);
-        \2
+    regex:
+      re_pattern: '(void PageActionView::UpdateBorder\(\).*?)(SetBorder\()'
+      re_flags: [DOTALL]
+      replace: |-
+        \1MaybeOverrideBorder(observation_.GetSource(), border_insets);
+          \2
 
   - description: |
       Propagate the click event flags through the page action invocation.
@@ -33,9 +35,10 @@ substitutions:
       modifier flags, so Brave action handlers cannot tell e.g. a plain click
       from a ctrl/shift click. We attach them via `kBravePageActionEventFlagKey`
       on the builder in NotifyClick() right before `.Build()`.
-    re_pattern: '(void PageActionView::NotifyClick\(.*?\n)(\s*\.Build\(\)\);)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1          .SetProperty(kBravePageActionEventFlagKey,
-                             event.IsMouseEvent() ? event.flags() : ui::EF_NONE)
-      \2
+    regex:
+      re_pattern: '(void PageActionView::NotifyClick\(.*?\n)(\s*\.Build\(\)\);)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1          .SetProperty(kBravePageActionEventFlagKey,
+                               event.IsMouseEvent() ? event.flags() : ui::EF_NONE)
+        \2

--- a/rewrite/chrome/browser/ui/views/page_info/page_info_view_factory.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/page_info/page_info_view_factory.cc.yaml
@@ -19,10 +19,11 @@ substitutions:
       following `switch (permission.type)` to single out the fallback
       switch (the function also has an earlier switch on the same
       variable).
-    re_pattern:
-      '(icon = &gfx::VectorIcon::EmptyIcon\(\);\s+switch \(permission\.type\)
-      \{\n)'
-    replace: |
-      \1    case ContentSettingsType::AUTOPLAY:
-            icon = &kAutoplayStatusIcon;
-            break;
+    regex:
+      re_pattern:
+        '(icon = &gfx::VectorIcon::EmptyIcon\(\);\s+switch \(permission\.type\)
+        \{\n)'
+      replace: |
+        \1    case ContentSettingsType::AUTOPLAY:
+              icon = &kAutoplayStatusIcon;
+              break;

--- a/rewrite/chrome/browser/ui/views/profiles/avatar_toolbar_button.h.yaml
+++ b/rewrite/chrome/browser/ui/views/profiles/avatar_toolbar_button.h.yaml
@@ -9,6 +9,7 @@ substitutions:
 
       Brave subclasses AvatarToolbarButton, so it needs friend access to the
       private members.
-    re_pattern: '( private:\n)'
-    replace: |
-      \1  friend class BraveAvatarToolbarButton;
+    regex:
+      re_pattern: '( private:\n)'
+      replace: |
+        \1  friend class BraveAvatarToolbarButton;

--- a/rewrite/chrome/browser/ui/views/side_panel/side_panel.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/side_panel/side_panel.cc.yaml
@@ -14,7 +14,8 @@ substitutions:
       PopulateSidePanel), avoiding the timing issue where
       coordinator->GetCurrentEntryId() still returns the previous entry when
       OnChildViewAdded fires.
-    re_pattern: '(  gfx::RoundedCornersF GetRoundedCorners\(\) \{)'
-    replace: |-
-      \1
-          return brave::GetPanelContentsRoundedCorners(browser_view_);
+    regex:
+      re_pattern: '(  gfx::RoundedCornersF GetRoundedCorners\(\) \{)'
+      replace: |-
+        \1
+            return brave::GetPanelContentsRoundedCorners(browser_view_);

--- a/rewrite/chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h.yaml
+++ b/rewrite/chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h.yaml
@@ -5,9 +5,10 @@
 
 substitutions:
   - description: Add more overrides to SidePanelWebUIView
-    re_pattern:
-      '(bool HandleKeyboardEvent\(content::WebContents\* source,\s+const
-      input::NativeWebKeyboardEvent& event\) override;)'
-    replace: |-
-      \1
-        bool HandleContextMenu(content::RenderFrameHost& render_frame_host, const content::ContextMenuParams& params) override;
+    regex:
+      re_pattern:
+        '(bool HandleKeyboardEvent\(content::WebContents\* source,\s+const
+        input::NativeWebKeyboardEvent& event\) override;)'
+      replace: |-
+        \1
+          bool HandleContextMenu(content::RenderFrameHost& render_frame_host, const content::ContextMenuParams& params) override;

--- a/rewrite/chrome/browser/ui/views/tab_search_bubble_host.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/tab_search_bubble_host.cc.yaml
@@ -9,5 +9,6 @@ substitutions:
       so the tab search bubble uses TOP_LEFT only for Brave vertical tabs and
       upstream vertical tabstrip; horizontal tab strip uses TOP_RIGHT so the
       bubble opens to the left of the trailing-edge combo button.'
-    pattern: 'position == tabs::TabSearchPosition::kLeadingHorizontalTabstrip'
-    replace: 'use_brave_vertical_tab_'
+    regex:
+      pattern: 'position == tabs::TabSearchPosition::kLeadingHorizontalTabstrip'
+      replace: 'use_brave_vertical_tab_'

--- a/rewrite/chrome/browser/ui/views/tabs/common/tab_strip_view.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/tabs/common/tab_strip_view.cc.yaml
@@ -10,10 +10,11 @@ substitutions:
       Tree nodes are not rendered in the vertical tab strip view tree (see the
       sibling CreateViewForNode() switch, which marks TREE_NODE NOTREACHED), so
       a moved tree node needs no scroll handling.
-    re_pattern:
-      '(OnChildMoved\([^)]*\)\s*\{.*?switch \(moved_node->type\(\)\) \{)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-            case TabCollectionNode::Type::TREE_NODE:
-              break;
+    regex:
+      re_pattern:
+        '(OnChildMoved\([^)]*\)\s*\{.*?switch \(moved_node->type\(\)\) \{)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+              case TabCollectionNode::Type::TREE_NODE:
+                break;

--- a/rewrite/chrome/browser/ui/views/tabs/dragging/dragging_tabs_session.h.yaml
+++ b/rewrite/chrome/browser/ui/views/tabs/dragging/dragging_tabs_session.h.yaml
@@ -6,8 +6,9 @@
 substitutions:
   - description:
       'Remove final keyword from DraggingTabsSession to allow subclassing'
-    pattern: 'class DraggingTabsSession final {'
-    replace: 'class DraggingTabsSession {'
+    regex:
+      pattern: 'class DraggingTabsSession final {'
+      replace: 'class DraggingTabsSession {'
 
   - description:
       'Make the DraggingTabsSession destructor virtual to allow subclassing'

--- a/rewrite/chrome/browser/ui/views/tabs/dragging/tab_drag_controller.h.yaml
+++ b/rewrite/chrome/browser/ui/views/tabs/dragging/tab_drag_controller.h.yaml
@@ -5,5 +5,6 @@
 
 substitutions:
   - description: 'Add virtual keyword to Init()'
-    pattern: '[[nodiscard]] Liveness Init('
-    replace: '[[nodiscard]] virtual Liveness Init('
+    regex:
+      pattern: '[[nodiscard]] Liveness Init('
+      replace: '[[nodiscard]] virtual Liveness Init('

--- a/rewrite/chrome/browser/ui/views/tabs/tab.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/tabs/tab.cc.yaml
@@ -6,17 +6,20 @@
 substitutions:
   - description:
       'Check if tab can be closed via middle mouse button click based on prefs'
-    pattern: 'if (event.IsOnlyMiddleMouseButton())'
-    replace:
-      'if (event.IsOnlyMiddleMouseButton() &&
-      controller_->CanCloseTabViaMiddleButtonClick())'
+    regex:
+      pattern: 'if (event.IsOnlyMiddleMouseButton())'
+      replace:
+        'if (event.IsOnlyMiddleMouseButton() &&
+        controller_->CanCloseTabViaMiddleButtonClick())'
 
   - description: 'Add BRAVE_UI_VIEWS_TABS_TAB_LAYOUT_ADJUST_ICON_POSITION'
-    re_pattern:
-      '(gfx::Rect favicon_bounds\(start, contents_rect\.y\(\), 0, 0\);\s+if
-      \(showing_icon_\) \{\n)'
-    replace: '\1    BRAVE_UI_VIEWS_TABS_TAB_LAYOUT_ADJUST_ICON_POSITION\n'
+    regex:
+      re_pattern:
+        '(gfx::Rect favicon_bounds\(start, contents_rect\.y\(\), 0, 0\);\s+if
+        \(showing_icon_\) \{\n)'
+      replace: '\1    BRAVE_UI_VIEWS_TABS_TAB_LAYOUT_ADJUST_ICON_POSITION\n'
 
   - description: 'Add BRAVE_UI_VIEWS_TABS_TAB_ALERT_INDICATOR_POSITION'
-    re_pattern: '(if\s*\(showing_alert_indicator_\)\s*\{\n\s*title_right\s*=\s*alert_indicator_button_->x\(\)\s*-\s*after_title_padding;)'
-    replace: '\1\n      BRAVE_UI_VIEWS_TABS_TAB_ALERT_INDICATOR_POSITION'
+    regex:
+      re_pattern: '(if\s*\(showing_alert_indicator_\)\s*\{\n\s*title_right\s*=\s*alert_indicator_button_->x\(\)\s*-\s*after_title_padding;)'
+      replace: '\1\n      BRAVE_UI_VIEWS_TABS_TAB_ALERT_INDICATOR_POSITION'

--- a/rewrite/chrome/browser/ui/views/tabs/tab.h.yaml
+++ b/rewrite/chrome/browser/ui/views/tabs/tab.h.yaml
@@ -5,6 +5,8 @@
 
 substitutions:
   - description: 'Adding header for BraveAutocompleteSchemeClassifier'
-    re_pattern: 'bool showing_close_button_ = false;'
-    replace:
-      'ControllableCloseButtonState showing_close_button_{*controller_, *this};'
+    regex:
+      re_pattern: 'bool showing_close_button_ = false;'
+      replace:
+        'ControllableCloseButtonState showing_close_button_{*controller_,
+        *this};'

--- a/rewrite/chrome/browser/ui/views/tabs/tab_container_impl.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/tabs/tab_container_impl.cc.yaml
@@ -12,6 +12,7 @@ substitutions:
       to patch it in. The decision itself lives in `GetBraveDragHandleExtension`
       in the chromium_src shadow of this file.
     # Match every use of the constant, but not its declaration (`... = 6;`).
-    re_pattern: '\bkDragHandleExtension\b(?!\s*=)'
-    replace: 'GetBraveDragHandleExtension(kDragHandleExtension)'
+    regex:
+      re_pattern: '\bkDragHandleExtension\b(?!\s*=)'
+      replace: 'GetBraveDragHandleExtension(kDragHandleExtension)'
     count: 0 # Any current or future use of the constant wants the Brave value.

--- a/rewrite/chrome/browser/ui/views/tabs/tab_strip.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/tabs/tab_strip.cc.yaml
@@ -6,26 +6,31 @@
 substitutions:
   - description:
       'Insert Brave-specific macro in CalculateBoundsForDraggedViews()'
-    re_pattern:
-      '(std::vector<gfx::Rect> CalculateBoundsForDraggedViews\(\s*const
-      std::vector<TabSlotView\*>& views\) override {)'
-    replace:
-      '\1\n    BRAVE_TAB_DRAG_CONTEXT_IMPL_CALCULATE_BOUNDS_FOR_DRAGGED_VIEWS'
+    regex:
+      re_pattern:
+        '(std::vector<gfx::Rect> CalculateBoundsForDraggedViews\(\s*const
+        std::vector<TabSlotView\*>& views\) override {)'
+      replace:
+        '\1\n    BRAVE_TAB_DRAG_CONTEXT_IMPL_CALCULATE_BOUNDS_FOR_DRAGGED_VIEWS'
 
   - description: 'Insert Brave-specific macro in CalculateInsertionIndex()'
-    re_pattern:
-      '(int CalculateInsertionIndex\(const gfx::Rect&
-      dragged_bounds,[\s\S]*continue;\n\s*}\n)(\n\s*// If there)'
-    replace: '\1\n      BRAVE_TAB_DRAG_CONTEXT_IMPL_CALCULATE_INSERTION_INDEX\2'
+    regex:
+      re_pattern:
+        '(int CalculateInsertionIndex\(const gfx::Rect&
+        dragged_bounds,[\s\S]*continue;\n\s*}\n)(\n\s*// If there)'
+      replace:
+        '\1\n      BRAVE_TAB_DRAG_CONTEXT_IMPL_CALCULATE_INSERTION_INDEX\2'
 
   - description:
       'allow to expand tab groups only when tabstrip is editable inside
       SetSelection()'
-    re_pattern:
-      '(TabStrip::SetSelection\(const ui::ListSelectionModel& new_selection\)
-      {[\s\S]*if \()(IsGroupCollapsed\(new_group\))'
-    replace: '\1\2 && IsTabStripEditable()'
+    regex:
+      re_pattern:
+        '(TabStrip::SetSelection\(const ui::ListSelectionModel& new_selection\)
+        {[\s\S]*if \()(IsGroupCollapsed\(new_group\))'
+      replace: '\1\2 && IsTabStripEditable()'
 
   - description: 'Use BraveTabDragController instead of TabDragController'
-    pattern: 'std::make_unique<TabDragController>()'
-    replace: 'std::make_unique<BraveTabDragController>()'
+    regex:
+      pattern: 'std::make_unique<TabDragController>()'
+      replace: 'std::make_unique<BraveTabDragController>()'

--- a/rewrite/chrome/browser/ui/views/tabs/tab_style_views.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/tabs/tab_style_views.cc.yaml
@@ -10,9 +10,10 @@ substitutions:
       Brave subclasses TabStyleViewsImpl (in
       chromium_src/chrome/browser/ui/views/tabs/tab_style_views.cc), so its
       members must be reachable from the derived class.
-    re_pattern: '(class TabStyleViewsImpl\b.*?)\n private:'
-    re_flags: [DOTALL]
-    replace: '\1\n protected:'
+    regex:
+      re_pattern: '(class TabStyleViewsImpl\b.*?)\n private:'
+      re_flags: [DOTALL]
+      replace: '\1\n protected:'
 
   - description: |-
       Virtualise GetSeparatorBounds for BraveVerticalTabStyle.
@@ -54,28 +55,32 @@ substitutions:
   - description: |-
       Square off the extension corner in TabStyleViewsImpl::GetPath, so Brave
       tabs don't carry upstream's rounded extension.
-    re_pattern:
-      '(  float left_extension_corner_radius = extension_corner_radius;)'
-    replace: '  extension_corner_radius = 0;\n\1'
+    regex:
+      re_pattern:
+        '(  float left_extension_corner_radius = extension_corner_radius;)'
+      replace: '  extension_corner_radius = 0;\n\1'
 
   - description: |-
       Fully round the tab separators in TabStyleViewsImpl::PaintSeparators
 
       This patch computes a radius of half the separator width.
-    re_pattern:
-      '(void TabStyleViewsImpl::PaintSeparators\(.*?\n)(  cc::PaintFlags flags;)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1  // Even if |separator_radius| becomes 1 native pixel the 'roundedness'
-        // will be approximated with color, although extremely subtle and
-        // likely only on screens >= 2x (i.e. separator width is 2+px)!
-        const int separator_radius = separator_bounds.leading.width() / 2;
-      \2
+    regex:
+      re_pattern:
+        '(void TabStyleViewsImpl::PaintSeparators\(.*?\n)(  cc::PaintFlags
+        flags;)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1  // Even if |separator_radius| becomes 1 native pixel the 'roundedness'
+          // will be approximated with color, although extremely subtle and
+          // likely only on screens >= 2x (i.e. separator width is 2+px)!
+          const int separator_radius = separator_bounds.leading.width() / 2;
+        \2
 
   - description: |-
       Use the fully-rounded separator radius for both separator draws.
-    re_pattern: 'tab_style\(\)->GetSeparatorCornerRadius\(\) \* scale'
-    replace: 'separator_radius'
+    regex:
+      re_pattern: 'tab_style\(\)->GetSeparatorCornerRadius\(\) \* scale'
+      replace: 'separator_radius'
     count: 2
 
   - description: |-
@@ -86,11 +91,12 @@ substitutions:
       declaration isn't enough for `make_unique`, so we disable the whole
       upstream factory and re-define it in `chromium_src` where the full type is
       visible.
-    re_pattern:
-      '(// static\nstd::unique_ptr<TabStyleViews>
-      TabStyleViews::CreateForTab\(Tab\* tab\) \{.*?\n\})'
-    re_flags: [DOTALL]
-    replace: |-
-      #if 0  // TabStyleViews::CreateForTab declared in the chromium_src.
-      \1
-      #endif
+    regex:
+      re_pattern:
+        '(// static\nstd::unique_ptr<TabStyleViews>
+        TabStyleViews::CreateForTab\(Tab\* tab\) \{.*?\n\})'
+      re_flags: [DOTALL]
+      replace: |-
+        #if 0  // TabStyleViews::CreateForTab declared in the chromium_src.
+        \1
+        #endif

--- a/rewrite/chrome/browser/ui/views/toolbar/toolbar_view.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/toolbar/toolbar_view.cc.yaml
@@ -10,16 +10,18 @@ substitutions:
       Brave subclasses AvatarToolbarButton; swap the concrete type created in
       the non-WebUI avatar button branch. The Brave header is supplied by the
       chromium_src override.
-    re_pattern: 'std::make_unique<AvatarToolbarButton>'
-    replace: 'std::make_unique<BraveAvatarToolbarButton>'
+    regex:
+      re_pattern: 'std::make_unique<AvatarToolbarButton>'
+      replace: 'std::make_unique<BraveAvatarToolbarButton>'
 
   - description: |
       Use Brave's browser app menu button in ToolbarView::Init().
 
       Brave subclasses BrowserAppMenuButton; swap the concrete type created for
       the app menu. The Brave header is supplied by the chromium_src override.
-    re_pattern: 'std::make_unique<BrowserAppMenuButton>'
-    replace: 'std::make_unique<BraveBrowserAppMenuButton>'
+    regex:
+      re_pattern: 'std::make_unique<BrowserAppMenuButton>'
+      replace: 'std::make_unique<BraveBrowserAppMenuButton>'
 
   - description: |
       Declare the location bar as Brave's LocationBarView type.
@@ -28,8 +30,9 @@ substitutions:
       chromium_src override, which maps to BraveLocationBarView only when
       extensions are enabled. This is why the swap cannot be a plaster on the
       type name directly - the substitution must be gated on a build flag.
-    re_pattern: 'std::unique_ptr<LocationBarView>'
-    replace: 'std::unique_ptr<LocationBarViewAlias>'
+    regex:
+      re_pattern: 'std::unique_ptr<LocationBarView>'
+      replace: 'std::unique_ptr<LocationBarViewAlias>'
 
   - description: |
       Construct the location bar as Brave's LocationBarView type.
@@ -37,5 +40,6 @@ substitutions:
       Pairs with the std::unique_ptr declaration above. The concrete class comes
       from the LocationBarViewAlias defined in the chromium_src override, which
       resolves to BraveLocationBarView only when extensions are enabled.
-    re_pattern: 'std::make_unique<LocationBarView>'
-    replace: 'std::make_unique<LocationBarViewAlias>'
+    regex:
+      re_pattern: 'std::make_unique<LocationBarView>'
+      replace: 'std::make_unique<LocationBarViewAlias>'

--- a/rewrite/chrome/browser/ui/views/toolbar/toolbar_view.h.yaml
+++ b/rewrite/chrome/browser/ui/views/toolbar/toolbar_view.h.yaml
@@ -28,11 +28,12 @@ substitutions:
       `app_menu_button_` has been made private in `ToolbarView`, as upstream is
       abstracting it away due to the WebUI work, so we expose an accessor for
       the concrete type that Brave still uses.
-    re_pattern: '(~ToolbarView\(\) override;)'
-    replace: |-
-      \1
+    regex:
+      re_pattern: '(~ToolbarView\(\) override;)'
+      replace: |-
+        \1
 
-        BrowserAppMenuButton* app_menu_button() const { return app_menu_button_; }
+          BrowserAppMenuButton* app_menu_button() const { return app_menu_button_; }
 
   - description: |
       Make ToolbarView::ShowBookmarkBubble() virtual.
@@ -59,9 +60,10 @@ substitutions:
       BraveToolbarView and the listed browser tests need access to ToolbarView's
       otherwise-private members. Anchored at the private: access specifier so the
       friend declarations land in private scope.
-    re_pattern: '( private:)'
-    replace: |-
-      \1
-        friend class BraveToolbarView;
-        FRIEND_TEST_ALL_PREFIXES(BraveToolbarViewTest, SplitTabsToolbarButtonTest);
-        FRIEND_TEST_ALL_PREFIXES(BraveToolbarViewTest, ToolbarCornerRadiusTest);
+    regex:
+      re_pattern: '( private:)'
+      replace: |-
+        \1
+          friend class BraveToolbarView;
+          FRIEND_TEST_ALL_PREFIXES(BraveToolbarViewTest, SplitTabsToolbarButtonTest);
+          FRIEND_TEST_ALL_PREFIXES(BraveToolbarViewTest, ToolbarCornerRadiusTest);

--- a/rewrite/chrome/browser/ui/web_modal/browser_window_modal_dialog_delegate.h.yaml
+++ b/rewrite/chrome/browser/ui/web_modal/browser_window_modal_dialog_delegate.h.yaml
@@ -5,7 +5,8 @@
 
 substitutions:
   - description: "IsWebContentsVisible override for inactive split tabs'"
-    re_pattern: '(  // ChromeWebModalDialogManagerDelegate:\n)'
-    replace:
-      '\1  bool IsWebContentsVisible(content::WebContents* web_contents)
-      override;\n'
+    regex:
+      re_pattern: '(  // ChromeWebModalDialogManagerDelegate:\n)'
+      replace:
+        '\1  bool IsWebContentsVisible(content::WebContents* web_contents)
+        override;\n'

--- a/rewrite/chrome/browser/ui/webui/BUILD.gn.yaml
+++ b/rewrite/chrome/browser/ui/webui/BUILD.gn.yaml
@@ -5,13 +5,14 @@
 
 substitutions:
   - description: Brave additions to `source_set("configs")`.
-    re_pattern: '(source_set\("configs"\).*?)\n\}'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        import("//brave/browser/ui/webui/sources.gni")
-        deps += brave_browser_ui_webui_configs_deps
-      }
+    regex:
+      re_pattern: '(source_set\("configs"\).*?)\n\}'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          import("//brave/browser/ui/webui/sources.gni")
+          deps += brave_browser_ui_webui_configs_deps
+        }
   - description: |
       Define `favicon_source` on regular Android too.
 
@@ -20,7 +21,8 @@ substitutions:
       (wallet, AI chat, rewards, etc.) need FaviconSource on Android; the
       chromium_src override of favicon_source.cc maps the default favicon
       resources so the source compiles there.
-    re_pattern: 'if \(([^)]+)\) \{\n  source_set\("favicon_source"\)'
-    replace: |-
-      if (\1 || is_android) {
-        source_set("favicon_source")
+    regex:
+      re_pattern: 'if \(([^)]+)\) \{\n  source_set\("favicon_source"\)'
+      replace: |-
+        if (\1 || is_android) {
+          source_set("favicon_source")

--- a/rewrite/chrome/browser/ui/webui/bookmarks/bookmarks_ui.cc.yaml
+++ b/rewrite/chrome/browser/ui/webui/bookmarks/bookmarks_ui.cc.yaml
@@ -5,5 +5,6 @@
 
 substitutions:
   - description: 'Swap `emptyList` with the a Brave ID.'
-    pattern: 'IDS_BOOKMARK_MANAGER_EMPTY_LIST'
-    replace: 'IDS_BRAVE_BOOKMARK_MANAGER_EMPTY_LIST'
+    regex:
+      pattern: 'IDS_BOOKMARK_MANAGER_EMPTY_LIST'
+      replace: 'IDS_BRAVE_BOOKMARK_MANAGER_EMPTY_LIST'

--- a/rewrite/chrome/browser/ui/webui/certificate_manager/certificate_manager_ui.cc.yaml
+++ b/rewrite/chrome/browser/ui/webui/certificate_manager/certificate_manager_ui.cc.yaml
@@ -5,6 +5,8 @@
 
 substitutions:
   - description: 'Point Learn More link to the Brave support article.'
-    re_pattern: '(kCRSLearnMoreLink[^=]*=\s*)(?:"[^"]*"\s*)+;'
+    regex:
+      re_pattern: '(kCRSLearnMoreLink[^=]*=\s*)(?:"[^"]*"\s*)+;'
+      replace: '\1"https://github.com/brave/brave-browser/wiki/TLS-Policy#root-store";'
+
     count: 1
-    replace: '\1"https://github.com/brave/brave-browser/wiki/TLS-Policy#root-store";'

--- a/rewrite/chrome/browser/ui/webui/cr_components/searchbox/searchbox_handler.cc.yaml
+++ b/rewrite/chrome/browser/ui/webui/cr_components/searchbox/searchbox_handler.cc.yaml
@@ -10,28 +10,30 @@ substitutions:
       This regex looks for the NOTREACHED at the end of the function, making sure it
       is in fact the last NOTREACHED, and inserts our code just after, meaning, at the
       end of the function.
-    re_pattern:
-      '(SearchboxHandler::AutocompleteIconToResourceName\(.*?\) const
-      \{.*?)(NOTREACHED\b.*?;)(?=(?:(?!NOTREACHED).)*?\n\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1if (icon.name == kLeoWindowTabNewIcon.name) {
-          return kLeoWindowTabNewIconResourceName;
-        } else if (icon.name == kLeoMessageBubbleAskIcon.name) {
-          return kLeoMessageBubbleAskIconResourceName;
-        }
-        // This function is used for the WebUI Omnibox which isn't enabled in Brave,
-        // so its okay to disable the NOTREACHED() check here and use the default icon
-        // instead.
-        if ((true)) return "";
-        \2
+    regex:
+      re_pattern:
+        '(SearchboxHandler::AutocompleteIconToResourceName\(.*?\) const
+        \{.*?)(NOTREACHED\b.*?;)(?=(?:(?!NOTREACHED).)*?\n\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1if (icon.name == kLeoWindowTabNewIcon.name) {
+            return kLeoWindowTabNewIconResourceName;
+          } else if (icon.name == kLeoMessageBubbleAskIcon.name) {
+            return kLeoMessageBubbleAskIconResourceName;
+          }
+          // This function is used for the WebUI Omnibox which isn't enabled in Brave,
+          // so its okay to disable the NOTREACHED() check here and use the default icon
+          // instead.
+          if ((true)) return "";
+          \2
 
   - description: |
       Force keyword mode in the NTP realbox.
 
       We tweak a few AutocompleteInput settings because unlike Chromium we only
       want keyword search results.
-    re_pattern: 'autocomplete_input\.set_in_keyword_mode\(false\);\s*autocomplete_input\.set_allow_exact_keyword_match\(false\);'
-    replace: |-
-      autocomplete_input.set_in_keyword_mode(true);
-        autocomplete_input.set_allow_exact_keyword_match(true);
+    regex:
+      re_pattern: 'autocomplete_input\.set_in_keyword_mode\(false\);\s*autocomplete_input\.set_allow_exact_keyword_match\(false\);'
+      replace: |-
+        autocomplete_input.set_in_keyword_mode(true);
+          autocomplete_input.set_allow_exact_keyword_match(true);

--- a/rewrite/chrome/browser/ui/webui/cr_components/searchbox/searchbox_omnibox_client.cc.yaml
+++ b/rewrite/chrome/browser/ui/webui/cr_components/searchbox/searchbox_omnibox_client.cc.yaml
@@ -12,6 +12,7 @@ substitutions:
       in the chromium_src shadow), which appends the source marker for Brave
       Search keyword matches. Anchored on `OnAutocompleteAccept` so the
       identically-shaped `OpenURL()` call in `OpenUrl()` is left untouched.
-    re_pattern: '(SearchboxOmniboxClient::OnAutocompleteAccept\(.*?web_contents_->OpenURL\(\s*)(content::OpenURLParams\((?:[^()]|\([^()]*\))*\))'
-    re_flags: [DOTALL]
-    replace: '\1MaybeOverrideURLParams(\2, match, GetTemplateURLService())'
+    regex:
+      re_pattern: '(SearchboxOmniboxClient::OnAutocompleteAccept\(.*?web_contents_->OpenURL\(\s*)(content::OpenURLParams\((?:[^()]|\([^()]*\))*\))'
+      re_flags: [DOTALL]
+      replace: '\1MaybeOverrideURLParams(\2, match, GetTemplateURLService())'

--- a/rewrite/chrome/browser/ui/webui/extensions/extensions_ui.cc.yaml
+++ b/rewrite/chrome/browser/ui/webui/extensions/extensions_ui.cc.yaml
@@ -6,18 +6,21 @@
 substitutions:
   - description: |
       Add Brave's extensions resources to the WebUI data source.
-    re_pattern:
-      '(content::WebUIDataSource\*
-      CreateAndAddExtensionsSource\([^{]*\{.+?\n)(  return source;)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1  BraveAddExtensionsResources(source, profile);
-      \2
+    regex:
+      re_pattern:
+        '(content::WebUIDataSource\*
+        CreateAndAddExtensionsSource\([^{]*\{.+?\n)(  return source;)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1  BraveAddExtensionsResources(source, profile);
+        \2
   - description: |
       Use Brave's Chrome Web Store item string.
-    pattern: 'IDS_EXTENSIONS_ITEM_CHROME_WEB_STORE'
-    replace: 'IDS_EXTENSIONS_BRAVE_ITEM_CHROME_WEB_STORE'
+    regex:
+      pattern: 'IDS_EXTENSIONS_ITEM_CHROME_WEB_STORE'
+      replace: 'IDS_EXTENSIONS_BRAVE_ITEM_CHROME_WEB_STORE'
   - description: |
       Use Brave's webstore item-source string.
-    pattern: 'IDS_EXTENSIONS_ITEM_SOURCE_WEBSTORE'
-    replace: 'IDS_EXTENSIONS_BRAVE_ITEM_SOURCE_WEBSTORE'
+    regex:
+      pattern: 'IDS_EXTENSIONS_ITEM_SOURCE_WEBSTORE'
+      replace: 'IDS_EXTENSIONS_BRAVE_ITEM_SOURCE_WEBSTORE'

--- a/rewrite/chrome/browser/ui/webui/help/BUILD.gn.yaml
+++ b/rewrite/chrome/browser/ui/webui/help/BUILD.gn.yaml
@@ -9,11 +9,13 @@ substitutions:
 
       Brave is official but not `is_chrome_branded`, and still needs the real
       Windows updater rather than the `version_updater_basic.cc` no-op.
-    re_pattern: '(if \(is_win\) \{\s+if \()is_chrome_branded(\) \{)'
-    replace: '\1is_official_build\2'
+    regex:
+      re_pattern: '(if \(is_win\) \{\s+if \()is_chrome_branded(\) \{)'
+      replace: '\1is_official_build\2'
   - description: |
       Add dependency on group that brings in deps introduced by includes in
       `brave/chromium_src/chrome/browser/ui/webui/help/version_updater.h`
-    re_pattern: '("version_updater\.h".*?  deps.*?\])'
-    re_flags: [DOTALL]
-    replace: '\1\n  deps += [ "//brave/browser/ui/webui/help" ]'
+    regex:
+      re_pattern: '("version_updater\.h".*?  deps.*?\])'
+      re_flags: [DOTALL]
+      replace: '\1\n  deps += [ "//brave/browser/ui/webui/help" ]'

--- a/rewrite/chrome/browser/ui/webui/settings/site_settings_helper.cc.yaml
+++ b/rewrite/chrome/browser/ui/webui/settings/site_settings_helper.cc.yaml
@@ -9,31 +9,34 @@ substitutions:
 
       This rename is done so our own version of `HasRegisteredGroupName` can be used
       wrap the Chromium function inside it.
-    re_pattern: 'bool HasRegisteredGroupName(\([^)]*\)\s*\{)'
-    re_flags: [DOTALL]
-    replace: 'bool HasRegisteredGroupName_ChromiumImpl\1'
+    regex:
+      re_pattern: 'bool HasRegisteredGroupName(\([^)]*\)\s*\{)'
+      re_flags: [DOTALL]
+      replace: 'bool HasRegisteredGroupName_ChromiumImpl\1'
 
   - description: |
       Rename to `GetVisiblePermissionCategories_ChromiumImpl`
 
       Renaming the upstream function to be shadowed by ours, so we can wrap the
       upstream function insdie and add our own content settings types.
-    re_pattern:
-      'std::vector<ContentSettingsType>
-      GetVisiblePermissionCategories(\([^)]*\)\s*\{)'
-    re_flags: [DOTALL]
-    replace:
-      'std::vector<ContentSettingsType>
-      GetVisiblePermissionCategories_ChromiumImpl\1'
+    regex:
+      re_pattern:
+        'std::vector<ContentSettingsType>
+        GetVisiblePermissionCategories(\([^)]*\)\s*\{)'
+      re_flags: [DOTALL]
+      replace:
+        'std::vector<ContentSettingsType>
+        GetVisiblePermissionCategories_ChromiumImpl\1'
 
   - description:
       'Map `SiteSettingSource::kRemoteList` to "remote-list" in
       `SiteSettingSourceToString`'
-    pattern: 'case SiteSettingSource::kNumSources:'
-    replace: |-
-      case SiteSettingSource::kRemoteList:
-            return "remote-list";
-          case SiteSettingSource::kNumSources:
+    regex:
+      pattern: 'case SiteSettingSource::kNumSources:'
+      replace: |-
+        case SiteSettingSource::kRemoteList:
+              return "remote-list";
+            case SiteSettingSource::kNumSources:
 
   - description: |
       Append Brave entries to kContentSettingsTypeGroupNames
@@ -42,99 +45,104 @@ substitutions:
       trailing comma (without capturing it), so we can always emit our own comma
       ahead of the Brave entries whether upstream's last entry has a trailing comma or
       not.
-    re_pattern: '(kContentSettingsTypeGroupNames\s*=.*?\}),?(\n\}\);)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1,
-          {ContentSettingsType::BRAVE_ADS, nullptr},
-          {ContentSettingsType::BRAVE_COSMETIC_FILTERING, nullptr},
-          {ContentSettingsType::BRAVE_TRACKERS, nullptr},
-          {ContentSettingsType::BRAVE_HTTP_UPGRADABLE_RESOURCES, nullptr},
-          {ContentSettingsType::BRAVE_FINGERPRINTING_V2, nullptr},
-          {ContentSettingsType::BRAVE_SHIELDS, brave_shields::kBraveShields},
-          {ContentSettingsType::BRAVE_REFERRERS, nullptr},
-          {ContentSettingsType::BRAVE_COOKIES, nullptr},
-          {ContentSettingsType::BRAVE_SPEEDREADER, nullptr},
-      #if BUILDFLAG(ENABLE_BRAVE_WALLET)
-          {ContentSettingsType::BRAVE_ETHEREUM, "ethereum"},
-          {ContentSettingsType::BRAVE_SOLANA, "solana"},
-          {ContentSettingsType::BRAVE_CARDANO, "cardano"},
-      #else
-          {ContentSettingsType::BRAVE_ETHEREUM, nullptr},
-          {ContentSettingsType::BRAVE_SOLANA, nullptr},
-          {ContentSettingsType::BRAVE_CARDANO, nullptr},
-      #endif
-          {ContentSettingsType::BRAVE_GOOGLE_SIGN_IN, "googleSignIn"},
-          {ContentSettingsType::BRAVE_HTTPS_UPGRADE, nullptr},
-          {ContentSettingsType::BRAVE_REMEMBER_1P_STORAGE, nullptr},
-          {ContentSettingsType::BRAVE_OPEN_AI_CHAT, "braveOpenAIChat"},
-          {ContentSettingsType::BRAVE_AUTO_SHRED, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_NONE, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_AUDIO, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_CANVAS, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_DEVICE_MEMORY, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_EVENT_SOURCE_POOL, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_FONT, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_HARDWARE_CONCURRENCY, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_KEYBOARD, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_LANGUAGE, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_MEDIA_DEVICES, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_PLUGINS, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_SCREEN, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_SPEECH_SYNTHESIS, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_USB_DEVICE_SERIAL_NUMBER, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_USER_AGENT, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL2, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_WEBGPU, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_WEB_SOCKETS_POOL, nullptr},
-          {ContentSettingsType::BRAVE_WEBCOMPAT_ALL, nullptr},
-          {ContentSettingsType::BRAVE_SHIELDS_METADATA, nullptr},
-          {ContentSettingsType::BRAVE_PSST, nullptr},\2
+    regex:
+      re_pattern: '(kContentSettingsTypeGroupNames\s*=.*?\}),?(\n\}\);)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1,
+            {ContentSettingsType::BRAVE_ADS, nullptr},
+            {ContentSettingsType::BRAVE_COSMETIC_FILTERING, nullptr},
+            {ContentSettingsType::BRAVE_TRACKERS, nullptr},
+            {ContentSettingsType::BRAVE_HTTP_UPGRADABLE_RESOURCES, nullptr},
+            {ContentSettingsType::BRAVE_FINGERPRINTING_V2, nullptr},
+            {ContentSettingsType::BRAVE_SHIELDS, brave_shields::kBraveShields},
+            {ContentSettingsType::BRAVE_REFERRERS, nullptr},
+            {ContentSettingsType::BRAVE_COOKIES, nullptr},
+            {ContentSettingsType::BRAVE_SPEEDREADER, nullptr},
+        #if BUILDFLAG(ENABLE_BRAVE_WALLET)
+            {ContentSettingsType::BRAVE_ETHEREUM, "ethereum"},
+            {ContentSettingsType::BRAVE_SOLANA, "solana"},
+            {ContentSettingsType::BRAVE_CARDANO, "cardano"},
+        #else
+            {ContentSettingsType::BRAVE_ETHEREUM, nullptr},
+            {ContentSettingsType::BRAVE_SOLANA, nullptr},
+            {ContentSettingsType::BRAVE_CARDANO, nullptr},
+        #endif
+            {ContentSettingsType::BRAVE_GOOGLE_SIGN_IN, "googleSignIn"},
+            {ContentSettingsType::BRAVE_HTTPS_UPGRADE, nullptr},
+            {ContentSettingsType::BRAVE_REMEMBER_1P_STORAGE, nullptr},
+            {ContentSettingsType::BRAVE_OPEN_AI_CHAT, "braveOpenAIChat"},
+            {ContentSettingsType::BRAVE_AUTO_SHRED, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_NONE, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_AUDIO, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_CANVAS, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_DEVICE_MEMORY, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_EVENT_SOURCE_POOL, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_FONT, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_HARDWARE_CONCURRENCY, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_KEYBOARD, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_LANGUAGE, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_MEDIA_DEVICES, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_PLUGINS, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_SCREEN, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_SPEECH_SYNTHESIS, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_USB_DEVICE_SERIAL_NUMBER, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_USER_AGENT, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL2, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_WEBGPU, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_WEB_SOCKETS_POOL, nullptr},
+            {ContentSettingsType::BRAVE_WEBCOMPAT_ALL, nullptr},
+            {ContentSettingsType::BRAVE_SHIELDS_METADATA, nullptr},
+            {ContentSettingsType::BRAVE_PSST, nullptr},\2
 
   - description:
       'Map "autoplay" group name to AUTOPLAY in
       `ContentSettingsTypeFromGroupName`'
-    re_pattern: '(ContentSettingsTypeFromGroupName\([^)]*\)\s*\{)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        if (name == "autoplay") {
-          return ContentSettingsType::AUTOPLAY;
-        }
+    regex:
+      re_pattern: '(ContentSettingsTypeFromGroupName\([^)]*\)\s*\{)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          if (name == "autoplay") {
+            return ContentSettingsType::AUTOPLAY;
+          }
 
   - description:
       'Map AUTOPLAY back to "autoplay" in `ContentSettingsTypeToGroupName`'
-    re_pattern: '(ContentSettingsTypeToGroupName\([^)]*\)\s*\{)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        if (type == ContentSettingsType::AUTOPLAY) {
-          return "autoplay";
-        }
+    regex:
+      re_pattern: '(ContentSettingsTypeToGroupName\([^)]*\)\s*\{)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          if (type == ContentSettingsType::AUTOPLAY) {
+            return "autoplay";
+          }
 
   - description: |
       kRemoteListProvider case in `ProviderTypeToSiteSettingsSource`
 
       This adds the case entry as first in the list.
-    re_pattern: '(ProviderTypeToSiteSettingsSource.*?switch.*?\{)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case ProviderType::kRemoteListProvider:
-            return SiteSettingSource::kRemoteList;
+    regex:
+      re_pattern: '(ProviderTypeToSiteSettingsSource.*?switch.*?\{)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case ProviderType::kRemoteListProvider:
+              return SiteSettingSource::kRemoteList;
 
   - description: |
       \
       kRemoteListProvider case in `ProviderToDefaultSettingSourceString`
 
       This adds the case entry as first in the switch list.
-    re_pattern: '(ProviderToDefaultSettingSourceString.*?switch.*?\{)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case ProviderType::kRemoteListProvider:
-            return "remote_list";
+    regex:
+      re_pattern: '(ProviderToDefaultSettingSourceString.*?switch.*?\{)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case ProviderType::kRemoteListProvider:
+              return "remote_list";
 
   - description: |
       Rename to `GetExceptionForPage_ChromiumImpl`
@@ -142,6 +150,7 @@ substitutions:
       Renaming the upstream function so the chromium_src shadow can provide its own
       `GetExceptionForPage` that wraps it and decorates the returned dict with
       Brave-specific cookie-type annotations.
-    re_pattern: 'base::DictValue GetExceptionForPage(\([^)]*\)\s*\{)'
-    re_flags: [DOTALL]
-    replace: 'base::DictValue GetExceptionForPage_ChromiumImpl\1'
+    regex:
+      re_pattern: 'base::DictValue GetExceptionForPage(\([^)]*\)\s*\{)'
+      re_flags: [DOTALL]
+      replace: 'base::DictValue GetExceptionForPage_ChromiumImpl\1'

--- a/rewrite/chrome/browser/ui/webui/settings/site_settings_helper.h.yaml
+++ b/rewrite/chrome/browser/ui/webui/settings/site_settings_helper.h.yaml
@@ -6,9 +6,11 @@
 substitutions:
   - description:
       'Insert Brave `SiteSettingSource` entries before kNumSources sentinel'
-    re_pattern: '(enum class SiteSettingSource\s*\{.*?)(\n\s*kNumSources,)'
-    re_flags: [DOTALL]
+    regex:
+      re_pattern: '(enum class SiteSettingSource\s*\{.*?)(\n\s*kNumSources,)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          kRemoteList,\2
+
     count: 1
-    replace: |-
-      \1
-        kRemoteList,\2

--- a/rewrite/chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler.cc.yaml
+++ b/rewrite/chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler.cc.yaml
@@ -9,11 +9,12 @@ substitutions:
 
       As ObserveBraveActions() is dependant on pref_registrar_, we should anchor
       the invocation to the pref_registrar_.Init().
-    re_pattern: (CustomizeToolbarHandler::CustomizeToolbarHandler.*?)(^})
-    re_flags: [DOTALL, MULTILINE]
-    replace: |-
-      \1  ObserveBraveActions(&client_, pref_change_registrar_);
-      \2
+    regex:
+      re_pattern: (CustomizeToolbarHandler::CustomizeToolbarHandler.*?)(^})
+      re_flags: [DOTALL, MULTILINE]
+      replace: |-
+        \1  ObserveBraveActions(&client_, pref_change_registrar_);
+        \2
 
   - description: |
       Modify categories in ListCategories() with list_modifiers.h at the end of
@@ -21,14 +22,15 @@ substitutions:
 
       Captures the callback invoked at the end of ListCategories() and wraps it
       with our modifiers.
-    re_pattern: |-
-      (void CustomizeToolbarHandler::ListCategories\(.*?)(std::move\(callback\)\.Run\(std::move\(categories\)\);)(\n^})
-    re_flags: [DOTALL, MULTILINE]
-    replace: |-
-      \1base::BindOnce(&customize_chrome::AppendBraveSpecificCategories,
-                 web_contents_.get())
-            .Then(std::move(callback))
-            .Run(std::move(categories));\3
+    regex:
+      re_pattern: |-
+        (void CustomizeToolbarHandler::ListCategories\(.*?)(std::move\(callback\)\.Run\(std::move\(categories\)\);)(\n^})
+      re_flags: [DOTALL, MULTILINE]
+      replace: |-
+        \1base::BindOnce(&customize_chrome::AppendBraveSpecificCategories,
+                   web_contents_.get())
+              .Then(std::move(callback))
+              .Run(std::move(categories));\3
 
   - description: |
       Modify actions in ListActions() with list_modifiers.h at the end of the
@@ -37,15 +39,16 @@ substitutions:
       Captures the callback invoked at the end of ListActions() and wraps it
       with our modifiers.
 
-    re_pattern: |-
-      (void CustomizeToolbarHandler::ListActions\(.*?)(std::move\(callback\)\.Run\(std::move\(actions\)\);)(\n^})
-    re_flags: [DOTALL, MULTILINE]
-    replace: |-
-      \1base::BindOnce(&customize_chrome::FilterUnsupportedChromiumActions)
-            .Then(base::BindOnce(&customize_chrome::ApplyBraveSpecificModifications,
-                                 web_contents_.get()))
-            .Then(std::move(callback))
-            .Run(std::move(actions));\3
+    regex:
+      re_pattern: |-
+        (void CustomizeToolbarHandler::ListActions\(.*?)(std::move\(callback\)\.Run\(std::move\(actions\)\);)(\n^})
+      re_flags: [DOTALL, MULTILINE]
+      replace: |-
+        \1base::BindOnce(&customize_chrome::FilterUnsupportedChromiumActions)
+              .Then(base::BindOnce(&customize_chrome::ApplyBraveSpecificModifications,
+                                   web_contents_.get()))
+              .Then(std::move(callback))
+              .Run(std::move(actions));\3
 
   - description: |
       Handle Brave-specific action pinning/unpinning in PinAction().
@@ -54,14 +57,15 @@ substitutions:
       and adds code to pin brave specific actions before calling the original
       PinAction code.
 
-    re_pattern: |-
-      (void CustomizeToolbarHandler::PinAction\(.*?{)
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        if (PinBraveAction(action_id, prefs(), pin)) {
-          return;
-        }
+    regex:
+      re_pattern: |-
+        (void CustomizeToolbarHandler::PinAction\(.*?{)
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          if (PinBraveAction(action_id, prefs(), pin)) {
+            return;
+          }
 
   - description: |
       Replace the resource ID for the "Your Chrome" category with "Brave Menu"
@@ -69,30 +73,33 @@ substitutions:
 
       IDS_NTP_CUSTOMIZE_TOOLBAR_CATEGORY_YOUR_CHROME will be replaced with
       IDS_CUSTOMIZE_TOOLBAR_CATEGORY_TOOLBAR.
-    pattern: IDS_NTP_CUSTOMIZE_TOOLBAR_CATEGORY_YOUR_CHROME
-    replace: IDS_CUSTOMIZE_TOOLBAR_CATEGORY_TOOLBAR
+    regex:
+      pattern: IDS_NTP_CUSTOMIZE_TOOLBAR_CATEGORY_YOUR_CHROME
+      replace: IDS_CUSTOMIZE_TOOLBAR_CATEGORY_TOOLBAR
 
   - description: |
       Check if Brave specific actions are customized in GetIsCustomized().
 
       Inserts a call to IsBraveActionCustomized() before upstream logic.
 
-    re_pattern: (void CustomizeToolbarHandler::GetIsCustomized\(.*?{)
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        if (IsBraveActionCustomized(web_contents_.get())) {
-          std::move(callback).Run(true);
-          return;
-        }
+    regex:
+      re_pattern: (void CustomizeToolbarHandler::GetIsCustomized\(.*?{)
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          if (IsBraveActionCustomized(web_contents_.get())) {
+            std::move(callback).Run(true);
+            return;
+          }
 
   - description: |
       Reset Brave specific actions to default in ResetToDefault().
 
       Inserts a call to ResetBraveActionsToDefault() before upstream logic.
 
-    re_pattern: (void CustomizeToolbarHandler::ResetToDefault\(.*?{)
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        ResetBraveActionsToDefault(web_contents_.get());
+    regex:
+      re_pattern: (void CustomizeToolbarHandler::ResetToDefault\(.*?{)
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          ResetBraveActionsToDefault(web_contents_.get());

--- a/rewrite/chrome/browser/ui/webui/unexportable_keys_internals/unexportable_keys_internals_handler.cc.yaml
+++ b/rewrite/chrome/browser/ui/webui/unexportable_keys_internals/unexportable_keys_internals_handler.cc.yaml
@@ -8,9 +8,10 @@ substitutions:
       Add `ECDSA_SHA384` to `GetAlgorithmName`.
 
       Returns the literal string "ECDSA_SHA384" for display in the internals WebUI.
-    re_pattern: '(GetAlgorithmName\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case crypto::SignatureVerifier::SignatureAlgorithm::ECDSA_SHA384:
-            return "ECDSA_SHA384";\2
+    regex:
+      re_pattern: '(GetAlgorithmName\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case crypto::SignatureVerifier::SignatureAlgorithm::ECDSA_SHA384:
+              return "ECDSA_SHA384";\2

--- a/rewrite/chrome/browser/ui/window_feature_controller/window_feature_controller.cc.yaml
+++ b/rewrite/chrome/browser/ui/window_feature_controller/window_feature_controller.cc.yaml
@@ -8,26 +8,30 @@ substitutions:
       Add `browser` to the ctor.
 
       This `browser_` field is required for `NormalBrowserSupportsWindowFeature`.
-    re_pattern: '(WindowFeatureController::WindowFeatureController\(.*?)(\)\n\s+:)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1,
-          BrowserWindowInterface& browser\2
+    regex:
+      re_pattern: '(WindowFeatureController::WindowFeatureController\(.*?)(\)\n\s+:)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1,
+            BrowserWindowInterface& browser\2
 
   - description: |
       Initialise `browser_` in the constructor
 
       This `browser_` field is required for `NormalBrowserSupportsWindowFeature`.
-    re_pattern: '(WindowFeatureController::WindowFeatureController\(.*?)( \{\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1,
-            browser_(browser)\2
+    regex:
+      re_pattern:
+        '(WindowFeatureController::WindowFeatureController\(.*?)( \{\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1,
+              browser_(browser)\2
 
   - description: |
       Make `NormalBrowserSupportsWindowFeature` an internal method
 
       This is done so we can provide our own `NormalBrowserSupportsWindowFeature` with
       specific handling for Windows.
-    pattern: 'WindowFeatureController::NormalBrowserSupportsWindowFeature('
-    replace: 'WindowFeatureController::NormalBrowserSupportsWindowFeature_ChromiumImpl('
+    regex:
+      pattern: 'WindowFeatureController::NormalBrowserSupportsWindowFeature('
+      replace: 'WindowFeatureController::NormalBrowserSupportsWindowFeature_ChromiumImpl('

--- a/rewrite/chrome/browser/ui/window_feature_controller/window_feature_controller.h.yaml
+++ b/rewrite/chrome/browser/ui/window_feature_controller/window_feature_controller.h.yaml
@@ -8,29 +8,32 @@ substitutions:
       Add `browser` to the ctor arg list
 
       This `browser_` field is required for `NormalBrowserSupportsWindowFeature`.
-    re_pattern: '(WindowFeatureController\((?=[^)]*ui::UnownedUserDataHost).*?)(\);)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1,
-            BrowserWindowInterface& browser\2
+    regex:
+      re_pattern: '(WindowFeatureController\((?=[^)]*ui::UnownedUserDataHost).*?)(\);)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1,
+              BrowserWindowInterface& browser\2
 
   - description: |
       Add `browser_` as the last member of WindowFeatureController
 
       This `browser_` field is required for `NormalBrowserSupportsWindowFeature`.
-    re_pattern: '(class WindowFeatureController \{.*)(\n\};)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        const raw_ref<BrowserWindowInterface> browser_;\2
+    regex:
+      re_pattern: '(class WindowFeatureController \{.*)(\n\};)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          const raw_ref<BrowserWindowInterface> browser_;\2
 
   - description: |
       Mirror NormalBrowserSupportsWindowFeature as `_ChromiumImpl`
 
       This sibling function is required for the customisation of
       NormalBrowserSupportsWindowFeature.
-    re_pattern:
-      '(bool )(NormalBrowserSupportsWindowFeature)(\([\s\S]*?\) const;)'
-    replace: |-
-      \1\2\3
-        \1\2_ChromiumImpl\3
+    regex:
+      re_pattern:
+        '(bool )(NormalBrowserSupportsWindowFeature)(\([\s\S]*?\) const;)'
+      replace: |-
+        \1\2\3
+          \1\2_ChromiumImpl\3

--- a/rewrite/chrome/browser/ui/window_feature_controller/window_feature_controller_unittest.cc.yaml
+++ b/rewrite/chrome/browser/ui/window_feature_controller/window_feature_controller_unittest.cc.yaml
@@ -9,6 +9,7 @@ substitutions:
 
       `WindowFeatureController` now takes the owning `BrowserWindowInterface&` as
       its last constructor argument. This requires a fix for the tests in question.
-    re_pattern: '(make_unique<WindowFeatureController>\(.*?)(\);)'
-    re_flags: [DOTALL]
-    replace: '\1, mock_browser_window_interface_\2'
+    regex:
+      re_pattern: '(make_unique<WindowFeatureController>\(.*?)(\);)'
+      re_flags: [DOTALL]
+      replace: '\1, mock_browser_window_interface_\2'

--- a/rewrite/chrome/common/extensions/BUILD.gn.yaml
+++ b/rewrite/chrome/common/extensions/BUILD.gn.yaml
@@ -9,30 +9,35 @@ substitutions:
       `source_set("extensions")` target.
 
       Anchored on the license header, so always on top.
-    re_pattern: '(# found in the LICENSE file\.\n\n)'
-    replace: |
-      \1import("//brave/common/extensions/sources.gni")
+    regex:
+      re_pattern: '(# found in the LICENSE file\.\n\n)'
+      replace: |
+        \1import("//brave/common/extensions/sources.gni")
 
   - description: |
       Append Brave public headers to `source_set("extensions")`.
-    re_pattern: '(source_set\("extensions"\).*?\bpublic\s*=\s*\[.*?\])'
-    re_flags: [DOTALL]
-    replace: '\1\n  public += brave_chrome_common_extensions_public'
+    regex:
+      re_pattern: '(source_set\("extensions"\).*?\bpublic\s*=\s*\[.*?\])'
+      re_flags: [DOTALL]
+      replace: '\1\n  public += brave_chrome_common_extensions_public'
 
   - description: |
       Append Brave sources to `source_set("extensions")`.
-    re_pattern: '(source_set\("extensions"\).*?\bsources\s*=\s*\[.*?\])'
-    re_flags: [DOTALL]
-    replace: '\1\n  sources += brave_chrome_common_extensions_sources'
+    regex:
+      re_pattern: '(source_set\("extensions"\).*?\bsources\s*=\s*\[.*?\])'
+      re_flags: [DOTALL]
+      replace: '\1\n  sources += brave_chrome_common_extensions_sources'
 
   - description: |
       Append Brave public_deps to `source_set("extensions")`.
-    re_pattern: '(source_set\("extensions"\).*?\bpublic_deps\s*=\s*\[.*?\])'
-    re_flags: [DOTALL]
-    replace: '\1\n  public_deps += brave_chrome_common_extensions_public_deps'
+    regex:
+      re_pattern: '(source_set\("extensions"\).*?\bpublic_deps\s*=\s*\[.*?\])'
+      re_flags: [DOTALL]
+      replace: '\1\n  public_deps += brave_chrome_common_extensions_public_deps'
 
   - description: |
       Append Brave deps to `source_set("extensions")`.
-    re_pattern: '(source_set\("extensions"\).*?\bdeps\s*=\s*\[.*?\])'
-    re_flags: [DOTALL]
-    replace: '\1\n  deps += brave_chrome_common_extensions_deps'
+    regex:
+      re_pattern: '(source_set\("extensions"\).*?\bdeps\s*=\s*\[.*?\])'
+      re_flags: [DOTALL]
+      replace: '\1\n  deps += brave_chrome_common_extensions_deps'

--- a/rewrite/chrome/common/extensions/chrome_extensions_client.cc.yaml
+++ b/rewrite/chrome/common/extensions/chrome_extensions_client.cc.yaml
@@ -6,9 +6,10 @@
 substitutions:
   - description: |
       Register Brave's extensions API provider.
-    re_pattern:
-      '(ChromeExtensionsClient::ChromeExtensionsClient\(\) \{.+?\n)(\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1  AddAPIProvider(std::make_unique<BraveExtensionsAPIProvider>());
-      \2
+    regex:
+      re_pattern:
+        '(ChromeExtensionsClient::ChromeExtensionsClient\(\) \{.+?\n)(\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1  AddAPIProvider(std::make_unique<BraveExtensionsAPIProvider>());
+        \2

--- a/rewrite/chrome/test/data/webui/settings/sync_test_util.ts.yaml
+++ b/rewrite/chrome/test/data/webui/settings/sync_test_util.ts.yaml
@@ -9,12 +9,13 @@ substitutions:
 
       Brave extends SyncPrefs with AI Chat fields, so this fixture must populate
       them to remain a complete SyncPrefs for the settings sync tests.
-    re_pattern:
-      '(getSyncAllPrefs\(\): SyncPrefs \{.*?\n)( *)(wifiConfigurationsSynced:
-      true,)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1\2\3
-      \2aiChatManaged: false,
-      \2aiChatRegistered: true,
-      \2aiChatSynced: true,
+    regex:
+      re_pattern:
+        '(getSyncAllPrefs\(\): SyncPrefs \{.*?\n)( *)(wifiConfigurationsSynced:
+        true,)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1\2\3
+        \2aiChatManaged: false,
+        \2aiChatRegistered: true,
+        \2aiChatSynced: true,

--- a/rewrite/chrome/updater/mac/.install.sh.yaml
+++ b/rewrite/chrome/updater/mac/.install.sh.yaml
@@ -15,19 +15,22 @@ substitutions:
   # Brave.app from the DMG, when it should read Brave Browser.app. The
   # substitution below fixes this.
   - description: 'Use PRODUCT_NAME instead of APP_DIR for update app path'
-    pattern: '${update_dmg_mount_point}/${APP_DIR}'
-    replace: '${update_dmg_mount_point}/${PRODUCT_NAME}.app'
+    regex:
+      pattern: '${update_dmg_mount_point}/${APP_DIR}'
+      replace: '${update_dmg_mount_point}/${PRODUCT_NAME}.app'
 
   # There are two installs scripts for updates in upstream: keystone_install.sh
   # and .install.sh. Chrome uses the former but it has legacy code related to
   # Keystone. The more modern alternative is .install.sh. But it lacks a fix
   # from Chromium CL 5866112. This substitution applies it.
   - description: 'Omit perms, link and dir times when non-root'
-    pattern: 'RSYNC_FLAGS="--ignore-times --links --perms --recursive --times"'
-    replace:
-      'RSYNC_FLAGS="--ignore-times --links $(if [[ ${EUID} -eq 0 ]]; then echo
-      "--perms --recursive --times"; else echo "--no-perms --executability
-      --chmod=u=rwX,go=rX --recursive"; fi)"'
+    regex:
+      pattern:
+        'RSYNC_FLAGS="--ignore-times --links --perms --recursive --times"'
+      replace:
+        'RSYNC_FLAGS="--ignore-times --links $(if [[ ${EUID} -eq 0 ]]; then echo
+        "--perms --recursive --times"; else echo "--no-perms --executability
+        --chmod=u=rwX,go=rX --recursive"; fi)"'
 
   - description: |-
       Try various fixes for exit code 12 failures.
@@ -40,51 +43,52 @@ substitutions:
 
       We start our custom codes at 70 in order to not clash with upstream's, even in
       case they add new ones beyond the current maximum 16.
-    pattern: 'exit 12'
-    replace: |-
-      # Try various remedies; Report in exit code what would have worked.
-            local mkdir_stderr
-            if ! mkdir_stderr="$(mkdir -p "${new_versioned_dir}" 2>&1 1>/dev/null)"
-            then
-              # If `mkdir` fails, then other remedies won't work either; Exit with a
-              # code that tells us the cause.
-              case "${mkdir_stderr}" in
-                *"Read-only file system"*)
-                  exit 70 ;;
-                *"No space left on device"*|*"Disc quota exceeded"*)
-                  exit 71 ;;
-                *"Operation not permitted"*)
-                  exit 72 ;;
-                *"Permission denied"*)
-                  exit 73 ;;
-                *"File exists"*|*"Not a directory"*)
-                  exit 74 ;;
-                *)
-                  exit 75 ;;
-              esac
-            fi
-            # `mkdir` succeeded. Retry the original rsync. If it succeeds, then clean
-            # up and return an exit code that tells us that this fix is worth keeping.
-            if rsync ${RSYNC_FLAGS} --delete-before "${update_versioned_dir}/" \
-                                                    "${new_versioned_dir}"; then
+    regex:
+      pattern: 'exit 12'
+      replace: |-
+        # Try various remedies; Report in exit code what would have worked.
+              local mkdir_stderr
+              if ! mkdir_stderr="$(mkdir -p "${new_versioned_dir}" 2>&1 1>/dev/null)"
+              then
+                # If `mkdir` fails, then other remedies won't work either; Exit with a
+                # code that tells us the cause.
+                case "${mkdir_stderr}" in
+                  *"Read-only file system"*)
+                    exit 70 ;;
+                  *"No space left on device"*|*"Disc quota exceeded"*)
+                    exit 71 ;;
+                  *"Operation not permitted"*)
+                    exit 72 ;;
+                  *"Permission denied"*)
+                    exit 73 ;;
+                  *"File exists"*|*"Not a directory"*)
+                    exit 74 ;;
+                  *)
+                    exit 75 ;;
+                esac
+              fi
+              # `mkdir` succeeded. Retry the original rsync. If it succeeds, then clean
+              # up and return an exit code that tells us that this fix is worth keeping.
+              if rsync ${RSYNC_FLAGS} --delete-before "${update_versioned_dir}/" \
+                                                      "${new_versioned_dir}"; then
+                rm -rf "${new_versioned_dir}"
+                exit 76
+              fi
+              # Another potential remedy is to rsync into the parent directory. As
+              # before, if this succeeds, clean up and return a unique exit code that
+              # tells us that this workaround is worth keeping.
+              if rsync ${RSYNC_FLAGS} --delete-before "${update_versioned_dir}" \
+                                                      "${installed_versions_dir}"; then
+                rm -rf "${new_versioned_dir}"
+                exit 77
+              fi
+              # Try the same rsync-into-parent, but from a clean slate.
               rm -rf "${new_versioned_dir}"
-              exit 76
-            fi
-            # Another potential remedy is to rsync into the parent directory. As
-            # before, if this succeeds, clean up and return a unique exit code that
-            # tells us that this workaround is worth keeping.
-            if rsync ${RSYNC_FLAGS} --delete-before "${update_versioned_dir}" \
-                                                    "${installed_versions_dir}"; then
+              if rsync ${RSYNC_FLAGS} --delete-before "${update_versioned_dir}" \
+                                                      "${installed_versions_dir}"; then
+                rm -rf "${new_versioned_dir}"
+                exit 78
+              fi
+              # None of the attempted remedies worked.
               rm -rf "${new_versioned_dir}"
-              exit 77
-            fi
-            # Try the same rsync-into-parent, but from a clean slate.
-            rm -rf "${new_versioned_dir}"
-            if rsync ${RSYNC_FLAGS} --delete-before "${update_versioned_dir}" \
-                                                    "${installed_versions_dir}"; then
-              rm -rf "${new_versioned_dir}"
-              exit 78
-            fi
-            # None of the attempted remedies worked.
-            rm -rf "${new_versioned_dir}"
-            exit 79
+              exit 79

--- a/rewrite/chrome/utility/BUILD.gn.yaml
+++ b/rewrite/chrome/utility/BUILD.gn.yaml
@@ -5,9 +5,10 @@
 
 substitutions:
   - description: 'Add brave/utility sources'
-    re_pattern: '(static_library\("utility"\) {[\s\S]*?)(^})'
-    re_flags: [MULTILINE]
-    replace:
-      '\1  import("//brave/utility/sources.gni") sources +=
-      brave_utility_sources deps += brave_utility_deps public_deps +=
-      brave_utility_public_deps\n\2'
+    regex:
+      re_pattern: '(static_library\("utility"\) {[\s\S]*?)(^})'
+      re_flags: [MULTILINE]
+      replace:
+        '\1  import("//brave/utility/sources.gni") sources +=
+        brave_utility_sources deps += brave_utility_deps public_deps +=
+        brave_utility_public_deps\n\2'

--- a/rewrite/components/browser_ui/settings/android/java/src/org/chromium/components/browser_ui/settings/SettingsUtils.java.yaml
+++ b/rewrite/components/browser_ui/settings/android/java/src/org/chromium/components/browser_ui/settings/SettingsUtils.java.yaml
@@ -10,5 +10,6 @@ substitutions:
   - description:
       'Make addVisiblePreferences package-private to call it at
       BraveSettingsUtils.getVisiblePreferences override'
-    pattern: 'private static void addVisiblePreferences('
-    replace: 'static void addVisiblePreferences('
+    regex:
+      pattern: 'private static void addVisiblePreferences('
+      replace: 'static void addVisiblePreferences('

--- a/rewrite/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsCategory.java.yaml
+++ b/rewrite/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsCategory.java.yaml
@@ -6,12 +6,13 @@
 substitutions:
   - description:
       'Register AUTOPLAY and BRAVE_GOOGLE_SIGN_IN in the @IntDef list'
-    re_pattern: '(@IntDef\(\{.+,)(.+?\}\))'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-              Type.AUTOPLAY,
-              Type.BRAVE_GOOGLE_SIGN_IN,\2
+    regex:
+      re_pattern: '(@IntDef\(\{.+,)(.+?\}\))'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+                Type.AUTOPLAY,
+                Type.BRAVE_GOOGLE_SIGN_IN,\2
 
   - description: |
       Define AUTOPLAY and BRAVE_GOOGLE_SIGN_IN at the end of Type
@@ -23,9 +24,11 @@ substitutions:
 
       The prior value of `NUM_ENTRIES` is replaced to cascade over the keys we are
       inserting.
-    re_pattern: '(@interface Type \{.+;\n)(.+?\n)(\s+)int NUM_ENTRIES = (\d+);'
-    re_flags: [DOTALL]
-    replace: |-
-      \1\3int AUTOPLAY = \4;
-      \3int BRAVE_GOOGLE_SIGN_IN = AUTOPLAY + 1;
-      \2\3int NUM_ENTRIES = BRAVE_GOOGLE_SIGN_IN + 1;
+    regex:
+      re_pattern:
+        '(@interface Type \{.+;\n)(.+?\n)(\s+)int NUM_ENTRIES = (\d+);'
+      re_flags: [DOTALL]
+      replace: |-
+        \1\3int AUTOPLAY = \4;
+        \3int BRAVE_GOOGLE_SIGN_IN = AUTOPLAY + 1;
+        \2\3int NUM_ENTRIES = BRAVE_GOOGLE_SIGN_IN + 1;

--- a/rewrite/components/browsing_data/core/browsing_data_policies_utils.cc.yaml
+++ b/rewrite/components/browsing_data/core/browsing_data_policies_utils.cc.yaml
@@ -8,9 +8,10 @@ substitutions:
       Account for Brave's extra UserSelectableType in the kLastType
       static_assert. Add one to the upstream count rather than matching its
       value, so the assert is undisturbed when upstream adds or removes types.
-    re_pattern:
-      'static_assert\(static_cast<int>\(syncer::UserSelectableType::kLastType\)
-      == (\d+),'
-    replace:
-      'static_assert(static_cast<int>(syncer::UserSelectableType::kLastType) ==
-      \1 + 1,'
+    regex:
+      re_pattern:
+        'static_assert\(static_cast<int>\(syncer::UserSelectableType::kLastType\)
+        == (\d+),'
+      replace:
+        'static_assert(static_cast<int>(syncer::UserSelectableType::kLastType)
+        == \1 + 1,'

--- a/rewrite/components/browsing_data/core/browsing_data_policies_utils_unittest.cc.yaml
+++ b/rewrite/components/browsing_data/core/browsing_data_policies_utils_unittest.cc.yaml
@@ -8,6 +8,7 @@ substitutions:
       Add the kAIChat selectable type at the end of the always_enabled_sync_types
       set in the AllSyncTypesChecked test. Anchored on the container rather than
       a sibling key, so it is undisturbed when upstream adds or removes keys.
-    re_pattern: '(always_enabled_sync_types\s*=\s*\{.*?)(\};)'
-    re_flags: [DOTALL]
-    replace: '\1, syncer::UserSelectableType::kAIChat\2'
+    regex:
+      re_pattern: '(always_enabled_sync_types\s*=\s*\{.*?)(\};)'
+      re_flags: [DOTALL]
+      replace: '\1, syncer::UserSelectableType::kAIChat\2'

--- a/rewrite/components/cached_flags/android/java/src/org/chromium/components/cached_flags/CachedFlag.java.yaml
+++ b/rewrite/components/cached_flags/android/java/src/org/chromium/components/cached_flags/CachedFlag.java.yaml
@@ -8,5 +8,6 @@ substitutions:
       Make mDefaultValue protected and non-final so BraveCachedFlag can override
       it from the subclass constructor via maybeOverrideDefaultValue(),
       replacing the fragile bytecode deleteField/makeProtectedField approach.
-    pattern: 'private final boolean mDefaultValue;'
-    replace: 'protected boolean mDefaultValue;'
+    regex:
+      pattern: 'private final boolean mDefaultValue;'
+      replace: 'protected boolean mDefaultValue;'

--- a/rewrite/components/content_settings/core/browser/content_settings_policy_provider.cc.yaml
+++ b/rewrite/components/content_settings/core/browser/content_settings_policy_provider.cc.yaml
@@ -9,38 +9,42 @@ substitutions:
 
       Adds the Brave Shields enabled/disabled managed prefs to the
       kPrefsForManagedContentSettingsMap array.
-    re_pattern: '(kPrefsForManagedContentSettingsMap\[\] = \{\n)'
-    replace: |
-      \1        {kManagedBraveShieldsDisabledForUrls,
-               ContentSettingsType::BRAVE_SHIELDS, CONTENT_SETTING_BLOCK},
-              {kManagedBraveShieldsEnabledForUrls,
-               ContentSettingsType::BRAVE_SHIELDS, CONTENT_SETTING_ALLOW},
+    regex:
+      re_pattern: '(kPrefsForManagedContentSettingsMap\[\] = \{\n)'
+      replace: |
+        \1        {kManagedBraveShieldsDisabledForUrls,
+                 ContentSettingsType::BRAVE_SHIELDS, CONTENT_SETTING_BLOCK},
+                {kManagedBraveShieldsEnabledForUrls,
+                 ContentSettingsType::BRAVE_SHIELDS, CONTENT_SETTING_ALLOW},
   - description: |
       Register Brave Shields managed prefs.
-    re_pattern: '(kManagedPrefs\[\] = \{\n)'
-    replace: |
-      \1    kManagedBraveShieldsDisabledForUrls,
-          kManagedBraveShieldsEnabledForUrls,
+    regex:
+      re_pattern: '(kManagedPrefs\[\] = \{\n)'
+      replace: |
+        \1    kManagedBraveShieldsDisabledForUrls,
+            kManagedBraveShieldsEnabledForUrls,
   - description: |
       Register Brave's managed default prefs.
-    re_pattern: '(kManagedDefaultPrefs\[\] = \{\n)'
-    replace: |
-      \1    kManagedDefaultBraveFingerprintingV2,
-          prefs::kManagedDefaultBraveHttpsUpgrade,
-          prefs::kManagedDefaultBraveReferrersSetting,
-          prefs::kManagedDefaultBraveRemember1PStorageSetting,
-          prefs::kManagedDefaultBraveAdblockSetting,
+    regex:
+      re_pattern: '(kManagedDefaultPrefs\[\] = \{\n)'
+      replace: |
+        \1    kManagedDefaultBraveFingerprintingV2,
+            prefs::kManagedDefaultBraveHttpsUpgrade,
+            prefs::kManagedDefaultBraveReferrersSetting,
+            prefs::kManagedDefaultBraveRemember1PStorageSetting,
+            prefs::kManagedDefaultBraveAdblockSetting,
   - description: |
       Register Brave's managed default content settings mappings.
-    re_pattern: '(kPrefsForManagedDefault\[\] = \{\n)'
-    replace: |
-      \1        {ContentSettingsType::BRAVE_FINGERPRINTING_V2,
-               kManagedDefaultBraveFingerprintingV2},
-              {ContentSettingsType::BRAVE_HTTPS_UPGRADE,
-               prefs::kManagedDefaultBraveHttpsUpgrade},
-              {ContentSettingsType::BRAVE_REFERRERS,
-               prefs::kManagedDefaultBraveReferrersSetting},
-              {ContentSettingsType::BRAVE_REMEMBER_1P_STORAGE,
-               prefs::kManagedDefaultBraveRemember1PStorageSetting},
-              {ContentSettingsType::BRAVE_ADS,
-               prefs::kManagedDefaultBraveAdblockSetting},
+    regex:
+      re_pattern: '(kPrefsForManagedDefault\[\] = \{\n)'
+      replace: |
+        \1        {ContentSettingsType::BRAVE_FINGERPRINTING_V2,
+                 kManagedDefaultBraveFingerprintingV2},
+                {ContentSettingsType::BRAVE_HTTPS_UPGRADE,
+                 prefs::kManagedDefaultBraveHttpsUpgrade},
+                {ContentSettingsType::BRAVE_REFERRERS,
+                 prefs::kManagedDefaultBraveReferrersSetting},
+                {ContentSettingsType::BRAVE_REMEMBER_1P_STORAGE,
+                 prefs::kManagedDefaultBraveRemember1PStorageSetting},
+                {ContentSettingsType::BRAVE_ADS,
+                 prefs::kManagedDefaultBraveAdblockSetting},

--- a/rewrite/components/enterprise/client_certificates/core/key_upload_client.cc.yaml
+++ b/rewrite/components/enterprise/client_certificates/core/key_upload_client.cc.yaml
@@ -9,8 +9,9 @@ substitutions:
 
       It is necessary to add `ECDSA_SHA384` to any types that get passed as a
       signature algorithm.
-    re_pattern: '(AlgorithmToType\([^)]*\).*?)(\n\s*return BPKUR::EC_KEY;)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case crypto::SignatureVerifier::ECDSA_SHA384:\2
+    regex:
+      re_pattern: '(AlgorithmToType\([^)]*\).*?)(\n\s*return BPKUR::EC_KEY;)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case crypto::SignatureVerifier::ECDSA_SHA384:\2

--- a/rewrite/components/enterprise/connectors/core/connectors_internals_utils.cc.yaml
+++ b/rewrite/components/enterprise/connectors/core/connectors_internals_utils.cc.yaml
@@ -9,10 +9,11 @@ substitutions:
 
       It is necessary to add `ECDSA_SHA384` to any types that get passed as a
       signature algorithm.
-    re_pattern:
-      '(AlgorithmToType\([^)]*\).*?)(\n\s*return
-      connectors_internals::mojom::KeyType::EC;)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case crypto::SignatureVerifier::ECDSA_SHA384:\2
+    regex:
+      re_pattern:
+        '(AlgorithmToType\([^)]*\).*?)(\n\s*return
+        connectors_internals::mojom::KeyType::EC;)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case crypto::SignatureVerifier::ECDSA_SHA384:\2

--- a/rewrite/components/history/core/browser/top_sites_constants.h.yaml
+++ b/rewrite/components/history/core/browser/top_sites_constants.h.yaml
@@ -9,13 +9,14 @@ substitutions:
 
       kTopSitesNumber should be 12 for Desktop and 15 (4 rows x 4 element -1
       for plus button) items for Android
-    re_pattern: '(static constexpr size_t kTopSitesNumber = )10;'
-    replace: |
-      \1
-      // Brave replacement: 12 for Desktop and 15 (4 rows x 4 element -1 for
-      // plus button) items for Android
-      #if BUILDFLAG(IS_ANDROID)
-        15;
-      #else
-        12;
-      #endif  // BUILDFLAG(IS_ANDROID)
+    regex:
+      re_pattern: '(static constexpr size_t kTopSitesNumber = )10;'
+      replace: |
+        \1
+        // Brave replacement: 12 for Desktop and 15 (4 rows x 4 element -1 for
+        // plus button) items for Android
+        #if BUILDFLAG(IS_ANDROID)
+          15;
+        #else
+          12;
+        #endif  // BUILDFLAG(IS_ANDROID)

--- a/rewrite/components/infobars/core/infobar_delegate.h.yaml
+++ b/rewrite/components/infobars/core/infobar_delegate.h.yaml
@@ -11,19 +11,20 @@ substitutions:
       adding a new identifier, also add the corresponding entry to:
         brave/android/java/org/chromium/chrome/browser/infobar/BraveInfoBarIdentifier.java
       When the list grows too large, switch to `java_cpp_enum.py` to generate it.
-    re_pattern: '(enum InfoBarIdentifier\s*\{.*?)(\s*\};)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          BRAVE_CONFIRM_P3A_INFOBAR_DELEGATE = 500,
-          // WAYBACK_MACHINE_INFOBAR_DELEGATE = 502
-          // SYNC_V2_MIGRATE_INFOBAR_DELEGATE = 503
-          // ANDROID_SYSTEM_SYNC_DISABLED_INFOBAR = 504
-          SYNC_CANNOT_RUN_INFOBAR = 505,
-          WEB_DISCOVERY_INFOBAR_DELEGATE = 506,
-          BRAVE_SYNC_ACCOUNT_DELETED_INFOBAR = 507,
-          BRAVE_REQUEST_OTR_INFOBAR_DELEGATE = 508,
-          // DEV_CHANNEL_DEPRECATION_INFOBAR_DELEGATE = 509
-          SEARCH_RESULT_AD_CLICKED_INFOBAR_DELEGATE = 510,
-          NEW_TAB_TAKEOVER_INFOBAR_DELEGATE = 511,
-          BRAVE_PSST_INFOBAR_DELEGATE = 512,\2
+    regex:
+      re_pattern: '(enum InfoBarIdentifier\s*\{.*?)(\s*\};)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            BRAVE_CONFIRM_P3A_INFOBAR_DELEGATE = 500,
+            // WAYBACK_MACHINE_INFOBAR_DELEGATE = 502
+            // SYNC_V2_MIGRATE_INFOBAR_DELEGATE = 503
+            // ANDROID_SYSTEM_SYNC_DISABLED_INFOBAR = 504
+            SYNC_CANNOT_RUN_INFOBAR = 505,
+            WEB_DISCOVERY_INFOBAR_DELEGATE = 506,
+            BRAVE_SYNC_ACCOUNT_DELETED_INFOBAR = 507,
+            BRAVE_REQUEST_OTR_INFOBAR_DELEGATE = 508,
+            // DEV_CHANNEL_DEPRECATION_INFOBAR_DELEGATE = 509
+            SEARCH_RESULT_AD_CLICKED_INFOBAR_DELEGATE = 510,
+            NEW_TAB_TAKEOVER_INFOBAR_DELEGATE = 511,
+            BRAVE_PSST_INFOBAR_DELEGATE = 512,\2

--- a/rewrite/components/omnibox/browser/BUILD.gn.yaml
+++ b/rewrite/components/omnibox/browser/BUILD.gn.yaml
@@ -9,19 +9,21 @@ substitutions:
 
       These bindings are used by `brave_new_tab_ui`. This plaster always adds
       the line at the beginning of the target.
-    re_pattern: '(mojom\("mojo_bindings"\)\s*\{)'
-    re_flags: [DOTALL]
-    replace: '\1\n  generate_legacy_js_bindings = true'
+    regex:
+      re_pattern: '(mojom\("mojo_bindings"\)\s*\{)'
+      re_flags: [DOTALL]
+      replace: '\1\n  generate_legacy_js_bindings = true'
 
   - description: |
       Brave additions to `static_library("browser")`.
 
       The Brave sources and deps are grouped together at the end of the target.
-    re_pattern: '(static_library\("browser"\).*?)\n\}'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        sources += brave_components_omnibox_browser_sources
-        public_deps += brave_components_omnibox_browser_public_deps
-        deps += brave_components_omnibox_browser_deps
-      }
+    regex:
+      re_pattern: '(static_library\("browser"\).*?)\n\}'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          sources += brave_components_omnibox_browser_sources
+          public_deps += brave_components_omnibox_browser_public_deps
+          deps += brave_components_omnibox_browser_deps
+        }

--- a/rewrite/components/omnibox/browser/featured_search_provider.cc.yaml
+++ b/rewrite/components/omnibox/browser/featured_search_provider.cc.yaml
@@ -14,8 +14,9 @@ substitutions:
   - description:
       'Swap IDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH_LINK_TEXT to an empty
       string so the "Learn more" link view renders at zero width.'
-    re_pattern: '\bIDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH_LINK_TEXT\b'
-    replace: 'IDS_BRAVE_EMPTY_STRING'
+    regex:
+      re_pattern: '\bIDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH_LINK_TEXT\b'
+      replace: 'IDS_BRAVE_EMPTY_STRING'
 
   - description: |
       Swap IDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH to the
@@ -25,5 +26,7 @@ substitutions:
       space (the link text was swapped to IDS_BRAVE_EMPTY_STRING above) that
       fails AutocompleteMatch::SanitizeString in
       AutocompleteResult::AppendMatches.
-    re_pattern: 'IDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH(\))\s*\+\s*u" "'
-    replace: 'IDS_BRAVE_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH\1'
+    regex:
+      re_pattern:
+        'IDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH(\))\s*\+\s*u" "'
+      replace: 'IDS_BRAVE_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH\1'

--- a/rewrite/components/omnibox/browser/omnibox_popup_selection.cc.yaml
+++ b/rewrite/components/omnibox/browser/omnibox_popup_selection.cc.yaml
@@ -19,5 +19,6 @@ substitutions:
       labels so we don't depend on the exact form of the upstream return
       expression. This keeps the plaster resilient if Chromium tweaks the
       condition (e.g. swaps the match type check or refactors the body).
-    re_pattern: '(case FOCUSED_BUTTON_THUMBS_DOWN:\n)(\s+)return'
-    replace: '\1\2if ((true)) return false;\n\2return'
+    regex:
+      re_pattern: '(case FOCUSED_BUTTON_THUMBS_DOWN:\n)(\s+)return'
+      replace: '\1\2if ((true)) return false;\n\2return'

--- a/rewrite/components/omnibox/browser/omnibox_popup_selection_unittest.cc.yaml
+++ b/rewrite/components/omnibox/browser/omnibox_popup_selection_unittest.cc.yaml
@@ -20,10 +20,12 @@ substitutions:
       followed by an `EXPECT_EQ(next.state, ...THUMBS_UP|THUMBS_DOWN);`, so
       it tolerates whitespace/line-wrap changes and is unaffected by edits
       to the surrounding `next = ...` assignments.
-    re_pattern:
-      'EXPECT_EQ\(next\.line, 2u\);\s+EXPECT_EQ\(next\.state,
-      LineState::FOCUSED_BUTTON_THUMBS_(?:UP|DOWN)\);'
+    regex:
+      re_pattern:
+        'EXPECT_EQ\(next\.line, 2u\);\s+EXPECT_EQ\(next\.state,
+        LineState::FOCUSED_BUTTON_THUMBS_(?:UP|DOWN)\);'
+      replace: |-
+        EXPECT_EQ(next.line, 0u);
+          EXPECT_EQ(next.state, LineState::NORMAL);
+
     count: 2
-    replace: |-
-      EXPECT_EQ(next.line, 0u);
-        EXPECT_EQ(next.state, LineState::NORMAL);

--- a/rewrite/components/page_info/page_info.cc.yaml
+++ b/rewrite/components/page_info/page_info.cc.yaml
@@ -10,11 +10,12 @@ substitutions:
       If `delegate_->BraveShouldShowPermission(info.type)` says the
       permission should be hidden, return `false` before the upstream
       logic runs.
-    re_pattern: '(bool PageInfo::ShouldShowPermission\([^)]*\) const \{\n)'
-    replace: |
-      \1  if (!delegate_->BraveShouldShowPermission(info.type)) {
-          return false;
-        }
+    regex:
+      re_pattern: '(bool PageInfo::ShouldShowPermission\([^)]*\) const \{\n)'
+      replace: |
+        \1  if (!delegate_->BraveShouldShowPermission(info.type)) {
+            return false;
+          }
 
   - description: |
       Short-circuit `PageInfo::GetTwoSitePermissionRequesters`
@@ -23,10 +24,11 @@ substitutions:
       This is for`STORAGE_ACCESS we dont surface Storage Access requester pairs
       in page info, so return an empty set before the upstream lookup walks
       `PageSpecificContentSettings` / `HostContentSettings Map`.
-    re_pattern:
-      '(std::set<net::SchemefulSite>
-      PageInfo::GetTwoSitePermissionRequesters\([^)]*\) \{\n)'
-    replace: |
-      \1  if (type == ContentSettingsType::STORAGE_ACCESS) {
-          return {};
-        }
+    regex:
+      re_pattern:
+        '(std::set<net::SchemefulSite>
+        PageInfo::GetTwoSitePermissionRequesters\([^)]*\) \{\n)'
+      replace: |
+        \1  if (type == ContentSettingsType::STORAGE_ACCESS) {
+            return {};
+          }

--- a/rewrite/components/permissions/permission_context_base.cc.yaml
+++ b/rewrite/components/permissions/permission_context_base.cc.yaml
@@ -6,11 +6,14 @@
 substitutions:
   - description:
       'Moving `PermissionContextBase` into `chromium_impl` as in the header.'
-    pattern: 'namespace permissions'
-    count: 2
-    replace: 'namespace permissions::chromium_impl'
+    regex:
+      pattern: 'namespace permissions'
+      replace: 'namespace permissions::chromium_impl'
 
-  - description: 'Calls BraveCanBypassEmbeddingOriginCheck for wallet handling'
-    pattern: 'CanBypassEmbeddingOriginCheck('
     count: 2
-    replace: 'BraveCanBypassEmbeddingOriginCheck(content_settings_type_, '
+  - description: 'Calls BraveCanBypassEmbeddingOriginCheck for wallet handling'
+    regex:
+      pattern: 'CanBypassEmbeddingOriginCheck('
+      replace: 'BraveCanBypassEmbeddingOriginCheck(content_settings_type_, '
+
+    count: 2

--- a/rewrite/components/permissions/permission_context_base.h.yaml
+++ b/rewrite/components/permissions/permission_context_base.h.yaml
@@ -15,13 +15,14 @@ substitutions:
       The namespace introduced here only wraps the class definition, so it searches
       for the class declaration first, to avoid wrapping the forward declarations
       or the Observer class that appear earlier in the same namespace block.
-    re_pattern:
-      '(class PermissionContextBase[\s\S]*?)(\n\}\s*// namespace permissions)'
-    re_flags: [MULTILINE]
-    replace: |-
-      namespace chromium_impl {
-      \1
-      }  // namespace chromium_impl\2
+    regex:
+      re_pattern:
+        '(class PermissionContextBase[\s\S]*?)(\n\}\s*// namespace permissions)'
+      re_flags: [MULTILINE]
+      replace: |-
+        namespace chromium_impl {
+        \1
+        }  // namespace chromium_impl\2
 
   - description:
       'Make PermissionDecided virtual to allow Brave override in derived class'

--- a/rewrite/components/permissions/request_type.cc.yaml
+++ b/rewrite/components/permissions/request_type.cc.yaml
@@ -11,98 +11,104 @@
 
 substitutions:
   - description: 'Brave mappings for `ContentSettingsType` -> `RequestType`'
-    re_pattern: '(ContentSettingsTypeToRequestTypeIfExists\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*default:)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-      #if BUILDFLAG(ENABLE_BRAVE_WALLET)
-          case ContentSettingsType::BRAVE_ETHEREUM:
-            return RequestType::kBraveEthereum;
-          case ContentSettingsType::BRAVE_SOLANA:
-            return RequestType::kBraveSolana;
-          case ContentSettingsType::BRAVE_CARDANO:
-            return RequestType::kBraveCardano;
-      #endif
-          case ContentSettingsType::BRAVE_GOOGLE_SIGN_IN:
-            return RequestType::kBraveGoogleSignInPermission;
-          case ContentSettingsType::BRAVE_OPEN_AI_CHAT:
-            return RequestType::kBraveOpenAIChat;
-          case ContentSettingsType::DEFAULT:
-            return RequestType::kWidevine;\2
+    regex:
+      re_pattern: '(ContentSettingsTypeToRequestTypeIfExists\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*default:)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+        #if BUILDFLAG(ENABLE_BRAVE_WALLET)
+            case ContentSettingsType::BRAVE_ETHEREUM:
+              return RequestType::kBraveEthereum;
+            case ContentSettingsType::BRAVE_SOLANA:
+              return RequestType::kBraveSolana;
+            case ContentSettingsType::BRAVE_CARDANO:
+              return RequestType::kBraveCardano;
+        #endif
+            case ContentSettingsType::BRAVE_GOOGLE_SIGN_IN:
+              return RequestType::kBraveGoogleSignInPermission;
+            case ContentSettingsType::BRAVE_OPEN_AI_CHAT:
+              return RequestType::kBraveOpenAIChat;
+            case ContentSettingsType::DEFAULT:
+              return RequestType::kWidevine;\2
 
   - description: 'Add Brave permission types to `GetIconIdAndroid`'
-    re_pattern: '(GetIconIdAndroid\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case RequestType::kWidevine:
-          case RequestType::kBraveEthereum:
-          case RequestType::kBraveSolana:
-          case RequestType::kBraveCardano:
-          case RequestType::kBraveGoogleSignInPermission:
-          case RequestType::kBraveOpenAIChat:
-            return IDR_ANDROID_INFOBAR_PERMISSION_COOKIE;\2
+    regex:
+      re_pattern: '(GetIconIdAndroid\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case RequestType::kWidevine:
+            case RequestType::kBraveEthereum:
+            case RequestType::kBraveSolana:
+            case RequestType::kBraveCardano:
+            case RequestType::kBraveGoogleSignInPermission:
+            case RequestType::kBraveOpenAIChat:
+              return IDR_ANDROID_INFOBAR_PERMISSION_COOKIE;\2
 
   - description: 'Add Brave permission types to `GetIconIdDesktop`'
-    re_pattern: '(GetIconIdDesktop\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case RequestType::kWidevine:
-          case RequestType::kBraveEthereum:
-          case RequestType::kBraveSolana:
-          case RequestType::kBraveCardano:
-          case RequestType::kBraveGoogleSignInPermission:
-          case RequestType::kBraveOpenAIChat:
-            return vector_icons::kExtensionOldIcon;\2
+    regex:
+      re_pattern: '(GetIconIdDesktop\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case RequestType::kWidevine:
+            case RequestType::kBraveEthereum:
+            case RequestType::kBraveSolana:
+            case RequestType::kBraveCardano:
+            case RequestType::kBraveGoogleSignInPermission:
+            case RequestType::kBraveOpenAIChat:
+              return vector_icons::kExtensionOldIcon;\2
 
   - description: 'Brave mappings for `RequestType` -> `ContentSettingsType`'
-    re_pattern:
-      '(RequestTypeToContentSettingsType\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*//
-      Not associated with a ContentSettingsType\..*?)(\n\s*return std::nullopt;)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case RequestType::kBraveGoogleSignInPermission:
-            return ContentSettingsType::BRAVE_GOOGLE_SIGN_IN;
-      #if BUILDFLAG(ENABLE_BRAVE_WALLET)
-          case RequestType::kBraveEthereum:
-            return ContentSettingsType::BRAVE_ETHEREUM;
-          case RequestType::kBraveSolana:
-            return ContentSettingsType::BRAVE_SOLANA;
-          case RequestType::kBraveCardano:
-            return ContentSettingsType::BRAVE_CARDANO;
-      #endif
-          case RequestType::kBraveOpenAIChat:
-            return ContentSettingsType::BRAVE_OPEN_AI_CHAT;\2
-          case RequestType::kWidevine:
-      #if !BUILDFLAG(ENABLE_BRAVE_WALLET)
-          case RequestType::kBraveEthereum:
-          case RequestType::kBraveSolana:
-          case RequestType::kBraveCardano:
-      #endif\3
+    regex:
+      re_pattern:
+        '(RequestTypeToContentSettingsType\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*//
+        Not associated with a ContentSettingsType\..*?)(\n\s*return
+        std::nullopt;)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case RequestType::kBraveGoogleSignInPermission:
+              return ContentSettingsType::BRAVE_GOOGLE_SIGN_IN;
+        #if BUILDFLAG(ENABLE_BRAVE_WALLET)
+            case RequestType::kBraveEthereum:
+              return ContentSettingsType::BRAVE_ETHEREUM;
+            case RequestType::kBraveSolana:
+              return ContentSettingsType::BRAVE_SOLANA;
+            case RequestType::kBraveCardano:
+              return ContentSettingsType::BRAVE_CARDANO;
+        #endif
+            case RequestType::kBraveOpenAIChat:
+              return ContentSettingsType::BRAVE_OPEN_AI_CHAT;\2
+            case RequestType::kWidevine:
+        #if !BUILDFLAG(ENABLE_BRAVE_WALLET)
+            case RequestType::kBraveEthereum:
+            case RequestType::kBraveSolana:
+            case RequestType::kBraveCardano:
+        #endif\3
 
   - description: 'Brave mappings for `RequestType` to permission key'
-    re_pattern: '(PermissionKeyForRequestType\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case permissions::RequestType::kWidevine:
-            return "widevine";
-      #if BUILDFLAG(ENABLE_BRAVE_WALLET)
-          case permissions::RequestType::kBraveEthereum:
-            return "brave_ethereum";
-          case permissions::RequestType::kBraveSolana:
-            return "brave_solana";
-          case permissions::RequestType::kBraveCardano:
-            return "brave_cardano";
-      #else
-          case permissions::RequestType::kBraveEthereum:
-          case permissions::RequestType::kBraveSolana:
-          case permissions::RequestType::kBraveCardano:
-            NOTREACHED();
-      #endif
-          case permissions::RequestType::kBraveGoogleSignInPermission:
-            return "brave_google_sign_in";
-          case permissions::RequestType::kBraveOpenAIChat:
-            return "brave_ai_chat";\2
+    regex:
+      re_pattern: '(PermissionKeyForRequestType\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case permissions::RequestType::kWidevine:
+              return "widevine";
+        #if BUILDFLAG(ENABLE_BRAVE_WALLET)
+            case permissions::RequestType::kBraveEthereum:
+              return "brave_ethereum";
+            case permissions::RequestType::kBraveSolana:
+              return "brave_solana";
+            case permissions::RequestType::kBraveCardano:
+              return "brave_cardano";
+        #else
+            case permissions::RequestType::kBraveEthereum:
+            case permissions::RequestType::kBraveSolana:
+            case permissions::RequestType::kBraveCardano:
+              NOTREACHED();
+        #endif
+            case permissions::RequestType::kBraveGoogleSignInPermission:
+              return "brave_google_sign_in";
+            case permissions::RequestType::kBraveOpenAIChat:
+              return "brave_ai_chat";\2

--- a/rewrite/components/permissions/request_type.h.yaml
+++ b/rewrite/components/permissions/request_type.h.yaml
@@ -9,16 +9,17 @@ substitutions:
 
       This plaster is generic enough to guarantee that our entries are always last,
       and that they also become the new kMaxValue.
-    re_pattern: '(enum class RequestType \{.+?,)(\s+)kMaxValue = \w+'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        kWidevine,
-        kBraveEthereum,
-        kBraveSolana,
-        kBraveOpenAIChat,
-        kBraveGoogleSignInPermission,
-        kBraveCardano,
-        kBraveMinValue = kWidevine,
-        kBraveMaxValue = kBraveCardano,
-        kMaxValue = kBraveCardano
+    regex:
+      re_pattern: '(enum class RequestType \{.+?,)(\s+)kMaxValue = \w+'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          kWidevine,
+          kBraveEthereum,
+          kBraveSolana,
+          kBraveOpenAIChat,
+          kBraveGoogleSignInPermission,
+          kBraveCardano,
+          kBraveMinValue = kWidevine,
+          kBraveMaxValue = kBraveCardano,
+          kMaxValue = kBraveCardano

--- a/rewrite/components/sessions/content/content_serialized_navigation_builder.cc.yaml
+++ b/rewrite/components/sessions/content/content_serialized_navigation_builder.cc.yaml
@@ -14,20 +14,22 @@ substitutions:
   - description:
       'Restore storage partition key from SerializedNavigationEntry for
       containers'
-    re_pattern:
-      '(ContentSerializedNavigationBuilder::ToNavigationEntry\b.*?\n)([
-      \t]*return entry;.*?\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1  MaybeRestoreStoragePartitionKey(navigation, entry.get());
-      \2
+    regex:
+      re_pattern:
+        '(ContentSerializedNavigationBuilder::ToNavigationEntry\b.*?\n)([
+        \t]*return entry;.*?\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1  MaybeRestoreStoragePartitionKey(navigation, entry.get());
+        \2
 
   - description:
       'Set virtual URL prefix and storage partition key for containers'
-    re_pattern:
-      '(ContentSerializedNavigationBuilder::FromNavigationEntry\b.*?\n)([
-      \t]*return navigation;.*?\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1  MaybeSaveStoragePartitionKey(entry, &navigation);
-      \2
+    regex:
+      re_pattern:
+        '(ContentSerializedNavigationBuilder::FromNavigationEntry\b.*?\n)([
+        \t]*return navigation;.*?\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1  MaybeSaveStoragePartitionKey(entry, &navigation);
+        \2

--- a/rewrite/components/sessions/core/serialized_navigation_entry.cc.yaml
+++ b/rewrite/components/sessions/core/serialized_navigation_entry.cc.yaml
@@ -6,6 +6,7 @@
 substitutions:
   - description:
       'Prefix virtual URL when writing SerializedNavigationEntry to Pickle'
-    re_pattern: '(WriteStringToPickle\([\s\S]*,\s*)(?:virtual_url_\.spec\(\))'
-    re_flags: [MULTILINE]
-    replace: '\1maybe_prefixed_virtual_url_spec()'
+    regex:
+      re_pattern: '(WriteStringToPickle\([\s\S]*,\s*)(?:virtual_url_\.spec\(\))'
+      re_flags: [MULTILINE]
+      replace: '\1maybe_prefixed_virtual_url_spec()'

--- a/rewrite/components/signin/public/base/session_binding_utils.cc.yaml
+++ b/rewrite/components/signin/public/base/session_binding_utils.cc.yaml
@@ -8,9 +8,10 @@ substitutions:
       Add `ECDSA_SHA384` to `SignatureAlgorithmToString`.
 
       Returns "SHA384" to identify the hash algorithm used for ECDSA_SHA384 keys.
-    re_pattern: '(SignatureAlgorithmToString\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case crypto::SignatureVerifier::ECDSA_SHA384:
-            return "SHA384";\2
+    regex:
+      re_pattern: '(SignatureAlgorithmToString\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case crypto::SignatureVerifier::ECDSA_SHA384:
+              return "SHA384";\2

--- a/rewrite/components/sync/base/data_type.cc.yaml
+++ b/rewrite/components/sync/base/data_type.cc.yaml
@@ -7,52 +7,56 @@ substitutions:
   - description: |-
       Append the AI_CHAT_CONVERSATION row at the end of kDataTypeInfoTable. The
       table is keyed by .type at runtime, so the position is not significant.
-    re_pattern: '(kDataTypeInfoTable = \{\{.*?)(\n[ \t]*\}\};)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-              {
-                  .type = AI_CHAT_CONVERSATION,
-                  .specifics_field_number =
-                      sync_pb::EntitySpecifics::kAiChatConversationFieldNumber,
-                  .debug_string = "AI Chat Conversation",
-                  .histogram_suffix = "AI_CHAT_CONVERSATION",
-                  .stable_lowercase_string = "ai_chat_conversation",
-                  .encryption_policy = EncryptionPolicy::kEncryptedIfCustomPassphraseSet,
-                  .priority = DataTypePriority::kRegular,
-                  .communication_direction = CommunicationDirection::kRegularTwoWay,
-                  .apply_updates_batch_policy = ApplyUpdatesBatchPolicy::kStandard,
-                  .unsynced_data_check_on_signout_policy =
-                      UnsyncedDataCheckOnSignoutPolicy::kNone,
-                  .cross_user_sharing_policy = CrossUserSharingPolicy::kNone,
-              },\2
+    regex:
+      re_pattern: '(kDataTypeInfoTable = \{\{.*?)(\n[ \t]*\}\};)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+                {
+                    .type = AI_CHAT_CONVERSATION,
+                    .specifics_field_number =
+                        sync_pb::EntitySpecifics::kAiChatConversationFieldNumber,
+                    .debug_string = "AI Chat Conversation",
+                    .histogram_suffix = "AI_CHAT_CONVERSATION",
+                    .stable_lowercase_string = "ai_chat_conversation",
+                    .encryption_policy = EncryptionPolicy::kEncryptedIfCustomPassphraseSet,
+                    .priority = DataTypePriority::kRegular,
+                    .communication_direction = CommunicationDirection::kRegularTwoWay,
+                    .apply_updates_batch_policy = ApplyUpdatesBatchPolicy::kStandard,
+                    .unsynced_data_check_on_signout_policy =
+                        UnsyncedDataCheckOnSignoutPolicy::kNone,
+                    .cross_user_sharing_policy = CrossUserSharingPolicy::kNone,
+                },\2
 
   - description: |-
       Account for Brave's extra data type in the GetNumDataTypes static_assert.
       Add one to the upstream count rather than matching its value, so the
       assert is undisturbed when upstream adds or removes data types.
-    re_pattern: 'static_assert\(GetNumDataTypes\(\) == (\d+),'
-    replace: 'static_assert(GetNumDataTypes() == \1 + 1,'
+    regex:
+      re_pattern: 'static_assert\(GetNumDataTypes\(\) == (\d+),'
+      replace: 'static_assert(GetNumDataTypes() == \1 + 1,'
 
   - description: |-
       Provide the default specifics field for AI_CHAT_CONVERSATION at the end of
       the switch in AddDefaultFieldValue.
-    re_pattern: '(AddDefaultFieldValue\(.*?switch[^{]*\{.*?)(\n[ \t]*\}\n\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case AI_CHAT_CONVERSATION:
-            specifics->mutable_ai_chat_conversation();
-            break;\2
+    regex:
+      re_pattern: '(AddDefaultFieldValue\(.*?switch[^{]*\{.*?)(\n[ \t]*\}\n\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case AI_CHAT_CONVERSATION:
+              specifics->mutable_ai_chat_conversation();
+              break;\2
 
   - description: |-
       Map AI_CHAT_CONVERSATION to its histogram value at the end of the switch in
       DataTypeHistogramValue.
-    re_pattern:
-      '(DataTypeHistogramValue\(DataType data_type\).*?switch[^{]*\{.*?)(\n[
-      \t]*\}\n[ \t]*NOTREACHED\(\);)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case AI_CHAT_CONVERSATION:
-            return DataTypeForHistograms::kAIChatConversation;\2
+    regex:
+      re_pattern:
+        '(DataTypeHistogramValue\(DataType data_type\).*?switch[^{]*\{.*?)(\n[
+        \t]*\}\n[ \t]*NOTREACHED\(\);)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case AI_CHAT_CONVERSATION:
+              return DataTypeForHistograms::kAIChatConversation;\2

--- a/rewrite/components/sync/base/data_type.h.yaml
+++ b/rewrite/components/sync/base/data_type.h.yaml
@@ -8,12 +8,14 @@ substitutions:
       Append AI_CHAT_CONVERSATION as the last user DataType and make it the new
       LAST_USER_DATA_TYPE. Anchored on LAST_USER_DATA_TYPE value-agnostically so
       it does not depend on which type is currently last.
-    re_pattern: '(\n[ \t]*)LAST_USER_DATA_TYPE = \w+,'
-    replace:
-      '\1AI_CHAT_CONVERSATION,\1LAST_USER_DATA_TYPE = AI_CHAT_CONVERSATION,'
+    regex:
+      re_pattern: '(\n[ \t]*)LAST_USER_DATA_TYPE = \w+,'
+      replace:
+        '\1AI_CHAT_CONVERSATION,\1LAST_USER_DATA_TYPE = AI_CHAT_CONVERSATION,'
 
   - description: |-
       Append the AI Chat histogram value and make it the new kMaxValue. Anchored
       on kMaxValue value-agnostically.
-    re_pattern: '(\n[ \t]*)kMaxValue = \w+,'
-    replace: '\1kAIChatConversation = 81,\1kMaxValue = kAIChatConversation,'
+    regex:
+      re_pattern: '(\n[ \t]*)kMaxValue = \w+,'
+      replace: '\1kAIChatConversation = 81,\1kMaxValue = kAIChatConversation,'

--- a/rewrite/components/sync/base/user_selectable_type.cc.yaml
+++ b/rewrite/components/sync/base/user_selectable_type.cc.yaml
@@ -8,28 +8,31 @@ substitutions:
       Account for Brave's extra data type in the GetNumDataTypes static_assert.
       Add one to the upstream count rather than matching its value, so the
       assert is undisturbed when upstream adds or removes data types.
-    re_pattern: 'static_assert\((\d+) == syncer::GetNumDataTypes\(\),'
-    replace: 'static_assert(\1 + 1 == syncer::GetNumDataTypes(),'
+    regex:
+      re_pattern: 'static_assert\((\d+) == syncer::GetNumDataTypes\(\),'
+      replace: 'static_assert(\1 + 1 == syncer::GetNumDataTypes(),'
 
   - description: |-
       Return the UserSelectableTypeInfo for kAIChat at the end of the switch in
       GetUserSelectableTypeInfo.
-    re_pattern:
-      '(UserSelectableTypeInfo
-      GetUserSelectableTypeInfo\(.*?switch[^{]*\{.*?)(\n[ \t]*\}\n[
-      \t]*NOTREACHED\(\);)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case UserSelectableType::kAIChat:
-            return {kAIChatTypeName, AI_CHAT_CONVERSATION, {AI_CHAT_CONVERSATION}};\2
+    regex:
+      re_pattern:
+        '(UserSelectableTypeInfo
+        GetUserSelectableTypeInfo\(.*?switch[^{]*\{.*?)(\n[ \t]*\}\n[
+        \t]*NOTREACHED\(\);)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case UserSelectableType::kAIChat:
+              return {kAIChatTypeName, AI_CHAT_CONVERSATION, {AI_CHAT_CONVERSATION}};\2
 
   - description: |-
       Add the kAIChat string mapping at the end of the lookup map in
       GetUserSelectableTypeFromString.
-    re_pattern:
-      '(std::optional<UserSelectableType>
-      GetUserSelectableTypeFromString\(.*?base::MakeFixedFlatMap<.*?>\(\{.*?)(\n[
-      \t]*\}\);)'
-    re_flags: [DOTALL]
-    replace: '\1\n          {kAIChatTypeName, UserSelectableType::kAIChat},\2'
+    regex:
+      re_pattern:
+        '(std::optional<UserSelectableType>
+        GetUserSelectableTypeFromString\(.*?base::MakeFixedFlatMap<.*?>\(\{.*?)(\n[
+        \t]*\}\);)'
+      re_flags: [DOTALL]
+      replace: '\1\n          {kAIChatTypeName, UserSelectableType::kAIChat},\2'

--- a/rewrite/components/sync/base/user_selectable_type.h.yaml
+++ b/rewrite/components/sync/base/user_selectable_type.h.yaml
@@ -8,9 +8,10 @@ substitutions:
       Append kAIChat to the UserSelectableType enum as the new kLastType.
       Anchored on the enum and the existing kLastType, value-agnostically, so it
       does not depend on which key happens to be last upstream.
-    re_pattern: '(enum class UserSelectableType \{.+?,)(\s+)kLastType = \w+'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        kAIChat,
-        kLastType = kAIChat
+    regex:
+      re_pattern: '(enum class UserSelectableType \{.+?,)(\s+)kLastType = \w+'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          kAIChat,
+          kLastType = kAIChat

--- a/rewrite/components/sync/engine/cycle/data_type_tracker.cc.yaml
+++ b/rewrite/components/sync/engine/cycle/data_type_tracker.cc.yaml
@@ -8,15 +8,17 @@ substitutions:
       Group AI_CHAT_CONVERSATION with the medium-nudge-delay data types in
       GetDefaultLocalChangeNudgeDelay. Anchored on the function and the return
       outcome, so it does not depend on any sibling case key.
-    re_pattern:
-      '(GetDefaultLocalChangeNudgeDelay\(.*?)(\n[ \t]*return
-      kMediumLocalChangeNudgeDelay;)'
-    re_flags: [DOTALL]
-    replace: '\1\n    case AI_CHAT_CONVERSATION:\2'
+    regex:
+      re_pattern:
+        '(GetDefaultLocalChangeNudgeDelay\(.*?)(\n[ \t]*return
+        kMediumLocalChangeNudgeDelay;)'
+      re_flags: [DOTALL]
+      replace: '\1\n    case AI_CHAT_CONVERSATION:\2'
 
   - description: |-
       Group AI_CHAT_CONVERSATION with the data types that cannot get commits
       from extensions in CanGetCommitsFromExtensions.
-    re_pattern: '(CanGetCommitsFromExtensions\(.*?)(\n[ \t]*return false;)'
-    re_flags: [DOTALL]
-    replace: '\1\n    case AI_CHAT_CONVERSATION:\2'
+    regex:
+      re_pattern: '(CanGetCommitsFromExtensions\(.*?)(\n[ \t]*return false;)'
+      re_flags: [DOTALL]
+      replace: '\1\n    case AI_CHAT_CONVERSATION:\2'

--- a/rewrite/components/sync/model/model_error.h.yaml
+++ b/rewrite/components/sync/model/model_error.h.yaml
@@ -8,8 +8,9 @@ substitutions:
       Append the AI Chat model error as the new kMaxValue. Anchored on the enum
       and the existing kMaxValue, value-agnostically. The new value and kMaxValue
       share a line so the upstream java_cpp_enum parser still emits kMaxValue.
-    re_pattern: '(enum class Type \{.+?,)(\s+)kMaxValue = \w+'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          kAIChatFailedToLoadMetadata = 193, kMaxValue = kAIChatFailedToLoadMetadata
+    regex:
+      re_pattern: '(enum class Type \{.+?,)(\s+)kMaxValue = \w+'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            kAIChatFailedToLoadMetadata = 193, kMaxValue = kAIChatFailedToLoadMetadata

--- a/rewrite/components/sync/protocol/device_info_specifics.proto.yaml
+++ b/rewrite/components/sync/protocol/device_info_specifics.proto.yaml
@@ -6,16 +6,18 @@
 substitutions:
   - description: |
       Import Brave's device info specifics.
-    re_pattern: '(import "components/sync/protocol/sync_enums.proto";\n)'
-    replace: |
-      \1import "brave/components/sync/protocol/brave_device_info_specifics.proto";
+    regex:
+      re_pattern: '(import "components/sync/protocol/sync_enums.proto";\n)'
+      replace: |
+        \1import "brave/components/sync/protocol/brave_device_info_specifics.proto";
   - description: |
       Add Brave's fields as the last entry of DeviceInfoSpecifics.
 
       Anchored on the message and its closing brace (at column 0, so the nested
       oneof's indented brace is skipped) so the field is always appended last.
-    re_pattern: '(message DeviceInfoSpecifics \{.+?\n)(\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1  optional BraveSpecificFields brave_fields = 1000;
-      \2
+    regex:
+      re_pattern: '(message DeviceInfoSpecifics \{.+?\n)(\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1  optional BraveSpecificFields brave_fields = 1000;
+        \2

--- a/rewrite/components/sync/protocol/entity_specifics.proto.yaml
+++ b/rewrite/components/sync/protocol/entity_specifics.proto.yaml
@@ -5,17 +5,19 @@
 
 substitutions:
   - description: 'Import the Brave AI Chat specifics proto.'
-    re_pattern: 'import "components/sync/protocol/ai_thread_specifics.proto";'
-    replace: |-
-      import "brave/components/sync/protocol/ai_chat_specifics.proto";
-      import "components/sync/protocol/ai_thread_specifics.proto";
+    regex:
+      re_pattern: 'import "components/sync/protocol/ai_thread_specifics.proto";'
+      replace: |-
+        import "brave/components/sync/protocol/ai_chat_specifics.proto";
+        import "components/sync/protocol/ai_thread_specifics.proto";
 
   - description: |-
       Add the AI Chat conversation field to EntitySpecifics, before the trailing
       "keep this comment as the last entry" marker so it does not depend on any
       sibling field.
-    re_pattern:
-      '(\n([ \t]*))(// When adding a new type, follow the docs below and keep
-      this comment)'
-    replace:
-      '\1AIChatConversationSpecifics ai_chat_conversation = 10000001;\1\3'
+    regex:
+      re_pattern:
+        '(\n([ \t]*))(// When adding a new type, follow the docs below and keep
+        this comment)'
+      replace:
+        '\1AIChatConversationSpecifics ai_chat_conversation = 10000001;\1\3'

--- a/rewrite/components/sync/protocol/proto_value_conversions_unittest.cc.yaml
+++ b/rewrite/components/sync/protocol/proto_value_conversions_unittest.cc.yaml
@@ -8,14 +8,16 @@ substitutions:
       Account for Brave's extra data type in the GetNumDataTypes static_assert.
       Add one to the upstream count rather than matching its value, so the
       assert is undisturbed when upstream adds or removes data types.
-    re_pattern: 'static_assert\((\d+) == syncer::GetNumDataTypes\(\),'
-    replace: 'static_assert(\1 + 1 == syncer::GetNumDataTypes(),'
+    regex:
+      re_pattern: 'static_assert\((\d+) == syncer::GetNumDataTypes\(\),'
+      replace: 'static_assert(\1 + 1 == syncer::GetNumDataTypes(),'
 
   - description: |-
       Add the AI Chat conversation specifics-to-value test after the last
       existing DEFINE_SPECIFICS_TO_VALUE_TEST, so it does not depend on any
       particular upstream entry.
-    re_pattern: '(DEFINE_SPECIFICS_TO_VALUE_TEST\([^)]*\))(?![\s\S]*DEFINE_SPECIFICS_TO_VALUE_TEST\()'
-    replace: |-
-      \1
-      DEFINE_SPECIFICS_TO_VALUE_TEST(ai_chat_conversation)
+    regex:
+      re_pattern: '(DEFINE_SPECIFICS_TO_VALUE_TEST\([^)]*\))(?![\s\S]*DEFINE_SPECIFICS_TO_VALUE_TEST\()'
+      replace: |-
+        \1
+        DEFINE_SPECIFICS_TO_VALUE_TEST(ai_chat_conversation)

--- a/rewrite/components/sync/protocol/proto_visitors.h.yaml
+++ b/rewrite/components/sync/protocol/proto_visitors.h.yaml
@@ -5,24 +5,28 @@
 
 substitutions:
   - description: 'Visit Brave-specific DeviceInfoSpecifics fields.'
-    re_pattern: '(\n[ \t]*)VISIT\(feature_fields\);'
-    replace: '\1VISIT(feature_fields);\1BRAVE_VISIT_DEVICE_INFO_SPECIFICS_BRAVE_FIELDS'
+    regex:
+      re_pattern: '(\n[ \t]*)VISIT\(feature_fields\);'
+      replace: '\1VISIT(feature_fields);\1BRAVE_VISIT_DEVICE_INFO_SPECIFICS_BRAVE_FIELDS'
 
   - description: |-
       Inject Brave-specific VISIT_PROTO_FIELDS definitions ahead of the
       SharingSpecificFields visitor.
-    re_pattern: 'VISIT_PROTO_FIELDS\(const\s+sync_pb::SharingSpecificFields&\s*proto\)\s*\{'
-    replace: |-
-      BRAVE_VISIT_PROTO_FIELDS_BRAVE_SPECIFIC_FIELD
-      VISIT_PROTO_FIELDS(const sync_pb::SharingSpecificFields& proto) {
+    regex:
+      re_pattern: 'VISIT_PROTO_FIELDS\(const\s+sync_pb::SharingSpecificFields&\s*proto\)\s*\{'
+      replace: |-
+        BRAVE_VISIT_PROTO_FIELDS_BRAVE_SPECIFIC_FIELD
+        VISIT_PROTO_FIELDS(const sync_pb::SharingSpecificFields& proto) {
 
   - description: |-
       Account for Brave's extra data type in the GetNumDataTypes static_assert.
       Add one to the upstream count rather than matching its value, so the
       assert is undisturbed when upstream adds or removes data types.
-    re_pattern: 'static_assert\((\d+) == GetNumDataTypes\(\),'
-    replace: 'static_assert(\1 + 1 == GetNumDataTypes(),'
+    regex:
+      re_pattern: 'static_assert\((\d+) == GetNumDataTypes\(\),'
+      replace: 'static_assert(\1 + 1 == GetNumDataTypes(),'
 
   - description: 'Visit the AI Chat conversation field in EntitySpecifics.'
-    re_pattern: '(\n[ \t]*)VISIT\(gemini_thread\);'
-    replace: '\1VISIT(gemini_thread);\1VISIT(ai_chat_conversation);'
+    regex:
+      re_pattern: '(\n[ \t]*)VISIT\(gemini_thread\);'
+      replace: '\1VISIT(gemini_thread);\1VISIT(ai_chat_conversation);'

--- a/rewrite/components/sync/service/sync_prefs.cc.yaml
+++ b/rewrite/components/sync/service/sync_prefs.cc.yaml
@@ -7,35 +7,38 @@ substitutions:
   - description: |-
       Return the kSyncAIChat pref for the kAIChat type, at the end of the switch
       in GetPrefNameForType.
-    re_pattern:
-      '(SyncPrefs::GetPrefNameForType\(UserSelectableType type\) \{.*?switch
-      \(type\) \{.*?)(\n[ \t]*\}\n[ \t]*NOTREACHED\(\);)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case UserSelectableType::kAIChat:
-            return prefs::internal::kSyncAIChat;\2
+    regex:
+      re_pattern:
+        '(SyncPrefs::GetPrefNameForType\(UserSelectableType type\) \{.*?switch
+        \(type\) \{.*?)(\n[ \t]*\}\n[ \t]*NOTREACHED\(\);)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case UserSelectableType::kAIChat:
+              return prefs::internal::kSyncAIChat;\2
 
   - description: |-
       Mark kAIChat as supported in transport mode, at the end of the switch in
       IsTypeSupportedInTransportMode.
-    re_pattern:
-      '(SyncPrefs::IsTypeSupportedInTransportMode\(.*?switch \(type\) \{.*?)(\n[
-      \t]*\}\n[ \t]*NOTREACHED\(\);)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case UserSelectableType::kAIChat:
-            return true;\2
+    regex:
+      re_pattern:
+        '(SyncPrefs::IsTypeSupportedInTransportMode\(.*?switch \(type\)
+        \{.*?)(\n[ \t]*\}\n[ \t]*NOTREACHED\(\);)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case UserSelectableType::kAIChat:
+              return true;\2
 
   - description: |-
       Mark kAIChat as selected by default in transport mode, at the end of the
       switch in IsTypeSelectedByDefaultInTransportMode.
-    re_pattern:
-      '(SyncPrefs::IsTypeSelectedByDefaultInTransportMode\(.*?switch \(type\)
-      \{.*?)(\n[ \t]*\}\n[ \t]*NOTREACHED\(\);)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case UserSelectableType::kAIChat:
-            return true;\2
+    regex:
+      re_pattern:
+        '(SyncPrefs::IsTypeSelectedByDefaultInTransportMode\(.*?switch \(type\)
+        \{.*?)(\n[ \t]*\}\n[ \t]*NOTREACHED\(\);)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case UserSelectableType::kAIChat:
+              return true;\2

--- a/rewrite/components/sync/service/sync_user_settings_impl.cc.yaml
+++ b/rewrite/components/sync/service/sync_user_settings_impl.cc.yaml
@@ -7,8 +7,9 @@ substitutions:
   - description: |-
       Call BraveAdjustPreferredDataTypes for unconditional and
       local-sync-only type exclusions.
-    re_pattern: '(SyncUserSettingsImpl::GetPreferredDataTypes[\s\S]+?)(\s+return\s+types;\s*\})'
-    re_flags: ['MULTILINE']
-    replace: |-
-      \1
-        BraveAdjustPreferredDataTypes(&types, prefs_->IsLocalSyncEnabled());\2
+    regex:
+      re_pattern: '(SyncUserSettingsImpl::GetPreferredDataTypes[\s\S]+?)(\s+return\s+types;\s*\})'
+      re_flags: ['MULTILINE']
+      replace: |-
+        \1
+          BraveAdjustPreferredDataTypes(&types, prefs_->IsLocalSyncEnabled());\2

--- a/rewrite/components/sync_device_info/device_info.cc.yaml
+++ b/rewrite/components/sync_device_info/device_info.cc.yaml
@@ -9,18 +9,20 @@ substitutions:
 
       This regex always adds the argument as the last one in the argument list. This
       is used to initialise `self_delete_support_`.
-    re_pattern: '(DeviceInfo::DeviceInfo\(.*?)(\)\n\s+:)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1,
-          SelfDeleteSupport self_delete_support\2
+    regex:
+      re_pattern: '(DeviceInfo::DeviceInfo\(.*?)(\)\n\s+:)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1,
+            SelfDeleteSupport self_delete_support\2
 
   - description: |
       Initialize `self_delete_support_` in the constructor
 
       This always initialises `self_delete_support_` as the last field.
-    re_pattern: '(DeviceInfo::DeviceInfo\(.*?)( \{\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1,
-            self_delete_support_(self_delete_support)\2
+    regex:
+      re_pattern: '(DeviceInfo::DeviceInfo\(.*?)( \{\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1,
+              self_delete_support_(self_delete_support)\2

--- a/rewrite/components/sync_device_info/device_info.h.yaml
+++ b/rewrite/components/sync_device_info/device_info.h.yaml
@@ -13,12 +13,13 @@ substitutions:
       This regex matches with the constructor declaration, by checking that there is
       a `std::string` somewhere in the list, and adds `self_delete_support` as the
       last argument in the list.
-    re_pattern: '(DeviceInfo\((?=[^)]*std::string).*?)(\);)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1,
-                   SelfDeleteSupport self_delete_support =
-                       SelfDeleteSupport::kNotSupported\2
+    regex:
+      re_pattern: '(DeviceInfo\((?=[^)]*std::string).*?)(\);)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1,
+                     SelfDeleteSupport self_delete_support =
+                         SelfDeleteSupport::kNotSupported\2
 
   - description: |
       Declare a move constructor for DeviceInfo
@@ -28,11 +29,12 @@ substitutions:
       constructor so that Brave-specific call sites can wrap the value-returning
       upstream `SpecificsToModel` into `std::make_unique<DeviceInfo>(...)`,
       removing the need to duplicate the upstream argument list.
-    re_pattern: '(DeviceInfo& operator=\(const DeviceInfo&\) = delete;)'
-    replace: |-
-      \1
+    regex:
+      re_pattern: '(DeviceInfo& operator=\(const DeviceInfo&\) = delete;)'
+      replace: |-
+        \1
 
-        DeviceInfo(DeviceInfo&&);
+          DeviceInfo(DeviceInfo&&);
 
   - description: |
       Add Brave-specific methods to DeviceInfo public interface
@@ -40,30 +42,32 @@ substitutions:
       Adding brave-specific methods to this type's interface. This methods used to
       exist in Chromium, but they were dropped at some point, and then reinstated on
       Brave.
-    re_pattern: '(~DeviceInfo\(\);)'
-    replace: |-
-      \1
-        SelfDeleteSupport self_delete_support() const {
-          return self_delete_support_;
-        }
-        void set_self_delete_support(SelfDeleteSupport self_delete_support) {
-          self_delete_support_ = self_delete_support;
-        }
-        // Gets the OS in string form.
-        std::string GetOSString() const;
-        // Gets the device type in string form.
-        std::string GetDeviceTypeString() const;
-        // Converts the DeviceInfo values to a JS friendly DictionaryValue,
-        // which extension APIs can expose to third party apps.
-        base::DictValue ToValue() const;
+    regex:
+      re_pattern: '(~DeviceInfo\(\);)'
+      replace: |-
+        \1
+          SelfDeleteSupport self_delete_support() const {
+            return self_delete_support_;
+          }
+          void set_self_delete_support(SelfDeleteSupport self_delete_support) {
+            self_delete_support_ = self_delete_support;
+          }
+          // Gets the OS in string form.
+          std::string GetOSString() const;
+          // Gets the device type in string form.
+          std::string GetDeviceTypeString() const;
+          // Converts the DeviceInfo values to a JS friendly DictionaryValue,
+          // which extension APIs can expose to third party apps.
+          base::DictValue ToValue() const;
 
   - description: |
       Add self_delete_support_ as last member of DeviceInfo
 
       This replacement adds `self_delete_support_` as the last member of
       `DeviceInfo`.
-    re_pattern: '(class DeviceInfo \{.*)(\n\};)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        SelfDeleteSupport self_delete_support_;\2
+    regex:
+      re_pattern: '(class DeviceInfo \{.*)(\n\};)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          SelfDeleteSupport self_delete_support_;\2

--- a/rewrite/components/sync_device_info/device_info_sync_bridge.cc.yaml
+++ b/rewrite/components/sync_device_info/device_info_sync_bridge.cc.yaml
@@ -9,20 +9,23 @@ substitutions:
 
       This plaster adds our own custom `DeviceInfo` values at the end of the
       arg list instantiating it.
-    re_pattern:
-      '(DeviceInfo SpecificsToModel\([^)]*\)\s*\{.+?return DeviceInfo\(.+?)(\);)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1,
-            SpecificsToSelfDeleteSupport(specifics)\2
+    regex:
+      re_pattern:
+        '(DeviceInfo SpecificsToModel\([^)]*\)\s*\{.+?return
+        DeviceInfo\(.+?)(\);)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1,
+              SpecificsToSelfDeleteSupport(specifics)\2
 
   - description: |
       Rename upstream `MakeLocalDeviceSpecifics` to `_ChromiumImpl`.
 
       We rename this function, so we can wrap its calls, and insert our own
       handling of `set_is_self_delete_supported`.
-    re_pattern: '(DeviceInfoSpecifics> )MakeLocalDeviceSpecifics(\()'
-    replace: '\1MakeLocalDeviceSpecifics_ChromiumImpl\2'
+    regex:
+      re_pattern: '(DeviceInfoSpecifics> )MakeLocalDeviceSpecifics(\()'
+      replace: '\1MakeLocalDeviceSpecifics_ChromiumImpl\2'
 
   - description: |
       `RefreshLocalDeviceInfoIfNeeded` early-return on `all_data_`.
@@ -35,21 +38,22 @@ substitutions:
 
       The `DCHECK_CALLED_ON_VALID_SEQUENCE` is required for the thread-safety
       analysis to allow reading `sequence_checker_`-guarded `all_data_`.
-    re_pattern:
-      '(void DeviceInfoSyncBridge::RefreshLocalDeviceInfoIfNeeded\(\)\s*\{)'
-    replace: |
-      \1
-        DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-        // After initiating leave the sync chain `DeleteSpecifics` cleans
-        // `all_data_` map.
-        // It is possible that user close sync settings page or change the data type
-        // before the confirmation `DeviceInfoSyncBridge::OnDeviceInfoDeleted()`
-        // comes - this leaded to access to the invalid iterator and crash.
-        if (const DeviceInfo* current_info =
-                local_device_info_provider_->GetLocalDeviceInfo();
-            current_info && !all_data_.contains(current_info->guid())) {
-          return;
-        }
+    regex:
+      re_pattern:
+        '(void DeviceInfoSyncBridge::RefreshLocalDeviceInfoIfNeeded\(\)\s*\{)'
+      replace: |
+        \1
+          DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+          // After initiating leave the sync chain `DeleteSpecifics` cleans
+          // `all_data_` map.
+          // It is possible that user close sync settings page or change the data type
+          // before the confirmation `DeviceInfoSyncBridge::OnDeviceInfoDeleted()`
+          // comes - this leaded to access to the invalid iterator and crash.
+          if (const DeviceInfo* current_info =
+                  local_device_info_provider_->GetLocalDeviceInfo();
+              current_info && !all_data_.contains(current_info->guid())) {
+            return;
+          }
 
   - description: |
       Disable the local-device re-upload block in `ApplyIncrementalSyncChanges`.
@@ -58,14 +62,15 @@ substitutions:
       local device record should be re-uploaded to server. We disable it
       because it breaks the ability to remove other device in sync chain for
       Brave
-    re_pattern:
-      '(    // Reupload local device if it was deleted from the
-      server\.\n.+?has_tombstone_for_local_device = true;.+?\})'
-    re_flags: [DOTALL]
-    replace: |-
-      #if 0  // Brave: re-upload defeats removing other devices in the sync chain
-      \1
-      #endif
+    regex:
+      re_pattern:
+        '(    // Reupload local device if it was deleted from the
+        server\.\n.+?has_tombstone_for_local_device = true;.+?\})'
+      re_flags: [DOTALL]
+      replace: |-
+        #if 0  // Brave: re-upload defeats removing other devices in the sync chain
+        \1
+        #endif
 
   - description: |
       Allow `ACTION_DELETE` changes for recent local cache guids.
@@ -73,10 +78,11 @@ substitutions:
       Upstream unconditionally skips remote changes whose guid is or was the
       local device. Brave needs the `ACTION_DELETE` path to still run on those
       guids so that leaving the sync chain can complete.
-    re_pattern:
-      '(if \(device_info_prefs_->IsRecentLocalCacheGuid\(guid\)\)
-      \{\s+)continue;'
-    replace: '\1if (change->type() != EntityChange::ACTION_DELETE) continue;'
+    regex:
+      re_pattern:
+        '(if \(device_info_prefs_->IsRecentLocalCacheGuid\(guid\)\)
+        \{\s+)continue;'
+      replace: '\1if (change->type() != EntityChange::ACTION_DELETE) continue;'
 
   - description: |
       Clear the metadata progress token after a forced device-list reset.
@@ -84,15 +90,16 @@ substitutions:
       Guarded by `IsResetDevicesProgressTokenDone` so it only runs once per
       reset. Clearing the token forces the next sync to re-fetch the full
       device list rather than resuming from a stale incremental cursor.
-    re_pattern:
-      '(void DeviceInfoSyncBridge::OnReadAllMetadata\(.+?return;\n  \}\n)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        if (!device_info_prefs_->IsResetDevicesProgressTokenDone()) {
-          metadata_batch->ClearProgressToken();
-          device_info_prefs_->SetResetDevicesProgressTokenDone();
-        }
+    regex:
+      re_pattern:
+        '(void DeviceInfoSyncBridge::OnReadAllMetadata\(.+?return;\n  \}\n)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          if (!device_info_prefs_->IsResetDevicesProgressTokenDone()) {
+            metadata_batch->ClearProgressToken();
+            device_info_prefs_->SetResetDevicesProgressTokenDone();
+          }
 
   - description: |
       Stop expiring old device-info entries.
@@ -101,5 +108,6 @@ substitutions:
       them and let the user remove them manually. Early-returning on the
       first line of `ExpireOldEntries` is the simplest way to disable
       upstream's time-based expiry without restructuring the function.
-    re_pattern: '(void DeviceInfoSyncBridge::ExpireOldEntries\(\) \{)'
-    replace: '\1\n  return;'
+    regex:
+      re_pattern: '(void DeviceInfoSyncBridge::ExpireOldEntries\(\) \{)'
+      replace: '\1\n  return;'

--- a/rewrite/components/sync_device_info/device_info_sync_bridge.h.yaml
+++ b/rewrite/components/sync_device_info/device_info_sync_bridge.h.yaml
@@ -13,11 +13,12 @@ substitutions:
       overrides of `DeviceInfoTracker`; `OnDeviceInfoDeleted` is the delayed
       continuation that `DeleteDeviceInfo` posts to re-check whether the
       deletion was ack'd by the sync server.
-    re_pattern: '( +)(~DeviceInfoSyncBridge\(\) override;)'
-    replace: |-
-      \1\2
-      \1void DeleteDeviceInfo(const std::string& client_id,
-      \1                      base::OnceClosure callback) override;
-      \1std::vector<DeviceInfo> GetAllBraveDeviceInfo() const override;
-      \1void OnDeviceInfoDeleted(const std::string& client_id, const int attempt,
-      \1                         base::OnceClosure callback);
+    regex:
+      re_pattern: '( +)(~DeviceInfoSyncBridge\(\) override;)'
+      replace: |-
+        \1\2
+        \1void DeleteDeviceInfo(const std::string& client_id,
+        \1                      base::OnceClosure callback) override;
+        \1std::vector<DeviceInfo> GetAllBraveDeviceInfo() const override;
+        \1void OnDeviceInfoDeleted(const std::string& client_id, const int attempt,
+        \1                         base::OnceClosure callback);

--- a/rewrite/components/sync_sessions/synced_session.cc.yaml
+++ b/rewrite/components/sync_sessions/synced_session.cc.yaml
@@ -6,6 +6,7 @@
 substitutions:
   - description:
       'Prefix virtual URL on converting SerializedNavigationEntry to SyncData'
-    re_pattern: '(sync_data\.set_virtual_url[\s\S]*?\s+navigation\.)(?:virtual_url\(\)\.spec\(\))'
-    re_flags: [MULTILINE]
-    replace: '\1maybe_prefixed_virtual_url_spec()'
+    regex:
+      re_pattern: '(sync_data\.set_virtual_url[\s\S]*?\s+navigation\.)(?:virtual_url\(\)\.spec\(\))'
+      re_flags: [MULTILINE]
+      replace: '\1maybe_prefixed_virtual_url_spec()'

--- a/rewrite/components/version_info/version_info_with_user_agent.h.yaml
+++ b/rewrite/components/version_info/version_info_with_user_agent.h.yaml
@@ -7,5 +7,6 @@ substitutions:
   - description: |
       Report Brave's Chromium version in the User-Agent product string by
       swapping Chromium's PRODUCT_VERSION for our BRAVE_CHROMIUM_VERSION.
-    re_pattern: '\bPRODUCT_VERSION\b'
-    replace: 'BRAVE_CHROMIUM_VERSION'
+    regex:
+      re_pattern: '\bPRODUCT_VERSION\b'
+      replace: 'BRAVE_CHROMIUM_VERSION'

--- a/rewrite/content/browser/renderer_host/navigation_request.cc.yaml
+++ b/rewrite/content/browser/renderer_host/navigation_request.cc.yaml
@@ -14,13 +14,14 @@ substitutions:
       insertion point. The injected call relies on the `browser_context`
       local defined earlier in the same function, and on `GetTopDocumentGURL`
       from the chromium_src shadow file's anonymous namespace.
-    re_pattern:
-      '(common_params_->referrer->url = GURL\(redirect_info\.new_referrer\);)'
-    replace: |-
-      \1
-        GetContentClient()->browser()->MaybeHideReferrer(
-            browser_context, common_params_->url,
-            GetTopDocumentGURL(frame_tree_node_), &common_params_->referrer);
+    regex:
+      re_pattern:
+        '(common_params_->referrer->url = GURL\(redirect_info\.new_referrer\);)'
+      replace: |-
+        \1
+          GetContentClient()->browser()->MaybeHideReferrer(
+              browser_context, common_params_->url,
+              GetTopDocumentGURL(frame_tree_node_), &common_params_->referrer);
 
   - description: |
       Call `MaybeHideReferrer` from
@@ -32,12 +33,13 @@ substitutions:
       to the closing brace of the merge block — without depending on the
       block's indentation. `GetTopDocumentGURL` comes from the chromium_src
       shadow file's anonymous namespace.
-    re_pattern:
-      '(NavigationRequest::OnStartChecksComplete\b.*?begin_params_->headers =
-      headers\.ToString\(\);\s*\}\n+)'
-    re_flags: [DOTALL]
-    replace: |
-      \1  GetContentClient()->browser()->MaybeHideReferrer(
-            frame_tree_node_->navigator().controller().GetBrowserContext(),
-            common_params_->url, GetTopDocumentGURL(frame_tree_node_),
-            &common_params_->referrer);
+    regex:
+      re_pattern:
+        '(NavigationRequest::OnStartChecksComplete\b.*?begin_params_->headers =
+        headers\.ToString\(\);\s*\}\n+)'
+      re_flags: [DOTALL]
+      replace: |
+        \1  GetContentClient()->browser()->MaybeHideReferrer(
+              frame_tree_node_->navigator().controller().GetBrowserContext(),
+              common_params_->url, GetTopDocumentGURL(frame_tree_node_),
+              &common_params_->referrer);

--- a/rewrite/content/browser/webui/web_ui_data_source_impl.cc.yaml
+++ b/rewrite/content/browser/webui/web_ui_data_source_impl.cc.yaml
@@ -9,7 +9,8 @@ substitutions:
 
       Note: This needs to be done here, so that when upstream overrides the
       CSP it still gets our policies.
-    re_pattern: '((csp_overrides_\.insert_or_assign\(directive), value(\);))'
-    re_flags: [DOTALL]
-    replace: |-
-      \2, GetBraveTrustedTypesValue(directive, value)\3
+    regex:
+      re_pattern: '((csp_overrides_\.insert_or_assign\(directive), value(\);))'
+      re_flags: [DOTALL]
+      replace: |-
+        \2, GetBraveTrustedTypesValue(directive, value)\3

--- a/rewrite/content/browser/webui/web_ui_data_source_unittest.cc.yaml
+++ b/rewrite/content/browser/webui/web_ui_data_source_unittest.cc.yaml
@@ -12,5 +12,6 @@ substitutions:
       SetCspValues test exercises that override path with
       "trusted-types test;" and expects the stored value back verbatim;
       update the expectation to match the augmented value.
-    re_pattern: 'EXPECT_EQ\("trusted-types test;",'
-    replace: 'EXPECT_EQ("trusted-types test svelte-trusted-html default;",'
+    regex:
+      re_pattern: 'EXPECT_EQ\("trusted-types test;",'
+      replace: 'EXPECT_EQ("trusted-types test svelte-trusted-html default;",'

--- a/rewrite/crypto/signature_verifier.cc.yaml
+++ b/rewrite/crypto/signature_verifier.cc.yaml
@@ -8,11 +8,12 @@ substitutions:
       Add `ECDSA_SHA384` handling to `VerifyInit`.
 
       Sets EVP_PKEY_EC with SHA-384 digest, mirroring the ECDSA_SHA256 case.
-    re_pattern: '(VerifyInit\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case ECDSA_SHA384:
-            pkey_type = EVP_PKEY_EC;
-            digest = EVP_sha384();
-            break;\2
+    regex:
+      re_pattern: '(VerifyInit\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case ECDSA_SHA384:
+              pkey_type = EVP_PKEY_EC;
+              digest = EVP_sha384();
+              break;\2

--- a/rewrite/crypto/signature_verifier.h.yaml
+++ b/rewrite/crypto/signature_verifier.h.yaml
@@ -10,8 +10,9 @@ substitutions:
       It is necessary to add `ECDSA_SHA384` so that all downstream switch statements
       can handle it. The negative lookahead prevents a duplicate if upstream adds the
       value independently.
-    re_pattern: '(enum SignatureAlgorithm\s*\{.*?)(\n\s*\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          ECDSA_SHA384,\2
+    regex:
+      re_pattern: '(enum SignatureAlgorithm\s*\{.*?)(\n\s*\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            ECDSA_SHA384,\2

--- a/rewrite/crypto/unexportable_key_metrics.cc.yaml
+++ b/rewrite/crypto/unexportable_key_metrics.cc.yaml
@@ -8,39 +8,43 @@ substitutions:
       Add `ECDSA_SHA384` to the `kAllAlgorithms` test array.
 
       Ensures ECDSA_SHA384 is exercised alongside ECDSA_SHA256 in TPM metrics.
-    re_pattern: '(kAllAlgorithms\[\]\s*=\s*\{.*?)(\n\s*\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          SignatureVerifier::SignatureAlgorithm::ECDSA_SHA384,\2
+    regex:
+      re_pattern: '(kAllAlgorithms\[\]\s*=\s*\{.*?)(\n\s*\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            SignatureVerifier::SignatureAlgorithm::ECDSA_SHA384,\2
 
   - description: |
       Add `ECDSA_SHA384` fallthrough in `MeasureVirtualTpmOperations`.
 
       Treats ECDSA_SHA384 as ECDSA for virtual TPM support classification.
-    re_pattern: '(MeasureVirtualTpmOperations\([^)]*\).*?)(\n\s*supported_virtual_algo)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-            case SignatureVerifier::SignatureAlgorithm::ECDSA_SHA384:\2
+    regex:
+      re_pattern: '(MeasureVirtualTpmOperations\([^)]*\).*?)(\n\s*supported_virtual_algo)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+              case SignatureVerifier::SignatureAlgorithm::ECDSA_SHA384:\2
 
   - description: |
       Add `ECDSA_SHA384` fallthrough in `MeasureTpmOperationsInternal`.
 
       Treats ECDSA_SHA384 as ECDSA for hardware TPM support classification.
-    re_pattern: '(MeasureTpmOperationsInternal\([^)]*\).*?)(\n\s*supported_algo)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-            case SignatureVerifier::SignatureAlgorithm::ECDSA_SHA384:\2
+    regex:
+      re_pattern: '(MeasureTpmOperationsInternal\([^)]*\).*?)(\n\s*supported_algo)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+              case SignatureVerifier::SignatureAlgorithm::ECDSA_SHA384:\2
 
   - description: |
       Add `ECDSA_SHA384` to `AlgorithmToString`.
 
       ECDSA_SHA384 keys are reported under the same "ECDSA" histogram bucket.
-    re_pattern: '(AlgorithmToString\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case SignatureVerifier::SignatureAlgorithm::ECDSA_SHA384:
-            return "ECDSA";\2
+    regex:
+      re_pattern: '(AlgorithmToString\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case SignatureVerifier::SignatureAlgorithm::ECDSA_SHA384:
+              return "ECDSA";\2

--- a/rewrite/crypto/unexportable_key_software_unsecure.cc.yaml
+++ b/rewrite/crypto/unexportable_key_software_unsecure.cc.yaml
@@ -13,9 +13,11 @@ substitutions:
       (`SelectAlgorithm`, `GenerateSigningKeySlowly` and
       `GenerateAttestationKeySlowly`), grouping it with `RSA_PSS_SHA256` which
       already takes that path.
-    re_pattern: '(switch\s*\(algo\).*?)(\n\s*continue;\s*// Not supported)'
-    re_flags: [DOTALL]
+    regex:
+      re_pattern: '(switch\s*\(algo\).*?)(\n\s*continue;\s*// Not supported)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+                case SignatureVerifier::SignatureAlgorithm::ECDSA_SHA384:\2
+
     count: 3
-    replace: |-
-      \1
-              case SignatureVerifier::SignatureAlgorithm::ECDSA_SHA384:\2

--- a/rewrite/extensions/common/manifest_handlers/manifest_url_handlers.cc.yaml
+++ b/rewrite/extensions/common/manifest_handlers/manifest_url_handlers.cc.yaml
@@ -6,11 +6,13 @@
 substitutions:
   - description:
       'Return empty GURL for known Brave hosted extensions in GetWebStoreURL'
-    re_pattern: '(GetWebStoreURL\([^)]*\)\s*\{)'
-    re_flags: [DOTALL]
+    regex:
+      re_pattern: '(GetWebStoreURL\([^)]*\)\s*\{)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          if (extensions_mv2::IsKnownBraveHostedExtension(extension->id())) {
+            return GURL::EmptyGURL();
+          }
+
     count: 1
-    replace: |-
-      \1
-        if (extensions_mv2::IsKnownBraveHostedExtension(extension->id())) {
-          return GURL::EmptyGURL();
-        }

--- a/rewrite/ios/chrome/browser/settings/manage_sync/coordinator/manage_sync_settings_mediator.mm.yaml
+++ b/rewrite/ios/chrome/browser/settings/manage_sync/coordinator/manage_sync_settings_mediator.mm.yaml
@@ -8,8 +8,9 @@ substitutions:
       Group the kAIChat UserSelectableType with the unhandled cases in
       tableViewItemWithDataType:. Anchored on the method and the NOTREACHED()
       outcome rather than a sibling case key.
-    re_pattern:
-      '(tableViewItemWithDataType:.*?switch \(dataType\) \{.*?)(\n[
-      \t]*NOTREACHED\(\);)'
-    re_flags: [DOTALL]
-    replace: '\1\n    case syncer::UserSelectableType::kAIChat:\2'
+    regex:
+      re_pattern:
+        '(tableViewItemWithDataType:.*?switch \(dataType\) \{.*?)(\n[
+        \t]*NOTREACHED\(\);)'
+      re_flags: [DOTALL]
+      replace: '\1\n    case syncer::UserSelectableType::kAIChat:\2'

--- a/rewrite/ios/chrome/browser/sync/model/sync_service_factory_unittest.mm.yaml
+++ b/rewrite/ios/chrome/browser/sync/model/sync_service_factory_unittest.mm.yaml
@@ -8,5 +8,6 @@ substitutions:
       Account for Brave's extra data type in the GetNumDataTypes static_assert.
       Add one to the upstream count rather than matching its value, so the
       assert is undisturbed when upstream adds or removes data types.
-    re_pattern: 'static_assert\((\d+) == syncer::GetNumDataTypes\(\),'
-    replace: 'static_assert(\1 + 1 == syncer::GetNumDataTypes(),'
+    regex:
+      re_pattern: 'static_assert\((\d+) == syncer::GetNumDataTypes\(\),'
+      replace: 'static_assert(\1 + 1 == syncer::GetNumDataTypes(),'

--- a/rewrite/ios/web/js_messaging/origin_filter.mm.yaml
+++ b/rewrite/ios/web/js_messaging/origin_filter.mm.yaml
@@ -9,35 +9,36 @@ substitutions:
 
       We add a number of cases to OriginFilter that now need to be handled
       exhaustively in GetOriginList
-    re_pattern: '(GetOriginList\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case web::OriginFilter::kYouTube:
-            return @[
-              @"https://youtube.com",
-              @"https://www.youtube.com",
-              @"https://m.youtube.com",
-            ];
-          case web::OriginFilter::kBraveSearch:
-            return @[
-              @"https://safesearch.brave.com",
-              @"https://safesearch.brave.software",
-              @"https://safesearch.bravesoftware.com",
-              @"https://search-dev-local.brave.com",
-              @"https://search.brave.com",
-              @"https://search.brave.software",
-              @"https://search.bravesoftware.com",
-            ];
-          case web::OriginFilter::kBraveTalk:
-            return @[
-              @"https://talk.brave.com",
-              @"https://talk.bravesoftware.com",
-              @"https://talk.brave.software",
-            ];
-          case web::OriginFilter::kBraveAccount:
-            return @[
-              @"https://account.brave.com",
-              @"https://account.bravesoftware.com",
-              @"https://account.brave.software",
-            ];\2
+    regex:
+      re_pattern: '(GetOriginList\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case web::OriginFilter::kYouTube:
+              return @[
+                @"https://youtube.com",
+                @"https://www.youtube.com",
+                @"https://m.youtube.com",
+              ];
+            case web::OriginFilter::kBraveSearch:
+              return @[
+                @"https://safesearch.brave.com",
+                @"https://safesearch.brave.software",
+                @"https://safesearch.bravesoftware.com",
+                @"https://search-dev-local.brave.com",
+                @"https://search.brave.com",
+                @"https://search.brave.software",
+                @"https://search.bravesoftware.com",
+              ];
+            case web::OriginFilter::kBraveTalk:
+              return @[
+                @"https://talk.brave.com",
+                @"https://talk.bravesoftware.com",
+                @"https://talk.brave.software",
+              ];
+            case web::OriginFilter::kBraveAccount:
+              return @[
+                @"https://account.brave.com",
+                @"https://account.bravesoftware.com",
+                @"https://account.brave.software",
+              ];\2

--- a/rewrite/ios/web/public/js_messaging/origin_filter.h.yaml
+++ b/rewrite/ios/web/public/js_messaging/origin_filter.h.yaml
@@ -9,11 +9,12 @@ substitutions:
 
       This enum doesn't contain a kMaxValue and only has a single case that
       contains an explicit value (kPublic)
-    re_pattern: '(enum class OriginFilter \{\s+kPublic = 0,)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        kYouTube,
-        kBraveSearch,
-        kBraveTalk,
-        kBraveAccount,
+    regex:
+      re_pattern: '(enum class OriginFilter \{\s+kPublic = 0,)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          kYouTube,
+          kBraveSearch,
+          kBraveTalk,
+          kBraveAccount,

--- a/rewrite/ios/web/web_state/ui/crw_web_controller.mm.yaml
+++ b/rewrite/ios/web/web_state/ui/crw_web_controller.mm.yaml
@@ -5,8 +5,10 @@
 
 substitutions:
   - description: Replace CRWWKNavigationHandler with BraveCRWWKNavigationHandler
-    pattern: 'CRWWKNavigationHandler alloc'
-    replace: 'BraveCRWWKNavigationHandler alloc'
+    regex:
+      pattern: 'CRWWKNavigationHandler alloc'
+      replace: 'BraveCRWWKNavigationHandler alloc'
   - description: Replace CRWWKUIHandler with BraveCRWWKUIHandler
-    pattern: 'CRWWKUIHandler alloc'
-    replace: 'BraveCRWWKUIHandler alloc'
+    regex:
+      pattern: 'CRWWKUIHandler alloc'
+      replace: 'BraveCRWWKUIHandler alloc'

--- a/rewrite/net/cookies/cookie_monster.cc.yaml
+++ b/rewrite/net/cookies/cookie_monster.cc.yaml
@@ -5,15 +5,17 @@
 
 substitutions:
   - description: 'Moving `CookieMonster` into `chromium_impl` as in the header.'
-    pattern: 'namespace net'
-    count: 2
-    replace: 'namespace net::chromium_impl'
+    regex:
+      pattern: 'namespace net'
+      replace: 'namespace net::chromium_impl'
 
+    count: 2
   - description: |
       Tweaking `MaybeRunDeleteCallback` to use the original class.
 
       Sadly this function alone sits outside in an unnamed namespace in the global
       scope, which make its use of `net::CookieMonster` to select the Brave
       implementation, however this is a simple case.
-    pattern: 'base::WeakPtr<net::CookieMonster> cookie_monster'
-    replace: 'base::WeakPtr<net::chromium_impl::CookieMonster> cookie_monster'
+    regex:
+      pattern: 'base::WeakPtr<net::CookieMonster> cookie_monster'
+      replace: 'base::WeakPtr<net::chromium_impl::CookieMonster> cookie_monster'

--- a/rewrite/net/cookies/cookie_monster.h.yaml
+++ b/rewrite/net/cookies/cookie_monster.h.yaml
@@ -14,9 +14,10 @@ substitutions:
       The namespace introduced here only wraps the classes in the header, so it
       searches for the class declaration first, to avoid wrapping the forward
       declarations.
-    re_pattern: '(class NET_EXPORT CookieMonster.*?)(\n\}\s*// namespace net)'
-    re_flags: [DOTALL]
-    replace: |-
-      namespace chromium_impl {
-      \1
-      }  // namespace chromium_impl\2
+    regex:
+      re_pattern: '(class NET_EXPORT CookieMonster.*?)(\n\}\s*// namespace net)'
+      re_flags: [DOTALL]
+      replace: |-
+        namespace chromium_impl {
+        \1
+        }  // namespace chromium_impl\2

--- a/rewrite/net/cookies/cookie_monster_change_dispatcher.cc.yaml
+++ b/rewrite/net/cookies/cookie_monster_change_dispatcher.cc.yaml
@@ -5,5 +5,6 @@
 
 substitutions:
   - description: 'Using `chromium_impl::CookieMonster` as in the header.'
-    re_pattern: '\bCookieMonster\b'
-    replace: 'chromium_impl::CookieMonster'
+    regex:
+      re_pattern: '\bCookieMonster\b'
+      replace: 'chromium_impl::CookieMonster'

--- a/rewrite/net/cookies/cookie_monster_change_dispatcher.h.yaml
+++ b/rewrite/net/cookies/cookie_monster_change_dispatcher.h.yaml
@@ -9,10 +9,11 @@ substitutions:
 
       `CookieMonsterChangeDispatcher` has to use `chromium_impl::CookieMonster`
       because it gets used by the Chromium implementation of `CookieMonster`.
-    re_pattern: '\bCookieMonster\b'
-    count: 4
-    replace: 'chromium_impl::CookieMonster'
+    regex:
+      re_pattern: '\bCookieMonster\b'
+      replace: 'chromium_impl::CookieMonster'
 
+    count: 4
   - description: |
       Fixing foward decl for chromium_impl::CookieMonster.
 
@@ -20,8 +21,9 @@ substitutions:
       including the one that was foward-declaring `CookieMonster`, this results in
       broken C++ syntax that has to be corrected, to open a namespace and then
       forward-declare inside it.
-    pattern: 'class chromium_impl::CookieMonster;'
-    replace: |-
-      namespace chromium_impl {
-      class CookieMonster;
-      }
+    regex:
+      pattern: 'class chromium_impl::CookieMonster;'
+      replace: |-
+        namespace chromium_impl {
+        class CookieMonster;
+        }

--- a/rewrite/net/cookies/cookie_monster_unittest.cc.yaml
+++ b/rewrite/net/cookies/cookie_monster_unittest.cc.yaml
@@ -10,6 +10,8 @@ substitutions:
       This is necessary because these tests require access to private members of
       `CookieMonster` brokered through `FRIEND_TEST_ALL_PREFIXES`, and this macro
       does has to match the namespace used.
-    pattern: 'namespace net'
+    regex:
+      pattern: 'namespace net'
+      replace: 'namespace net::chromium_impl'
+
     count: 2
-    replace: 'namespace net::chromium_impl'

--- a/rewrite/net/device_bound_sessions/session_binding_utils.cc.yaml
+++ b/rewrite/net/device_bound_sessions/session_binding_utils.cc.yaml
@@ -8,9 +8,10 @@ substitutions:
       Add `ECDSA_SHA384` to `SignatureAlgorithmToString`.
 
       Returns "SHA384" to identify the hash algorithm used for ECDSA_SHA384 keys.
-    re_pattern: '(SignatureAlgorithmToString\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-          case crypto::SignatureVerifier::ECDSA_SHA384:
-            return "SHA384";\2
+    regex:
+      re_pattern: '(SignatureAlgorithmToString\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+            case crypto::SignatureVerifier::ECDSA_SHA384:
+              return "SHA384";\2

--- a/rewrite/third_party/blink/renderer/core/dom/document.cc.yaml
+++ b/rewrite/third_party/blink/renderer/core/dom/document.cc.yaml
@@ -5,5 +5,6 @@
 
 substitutions:
   - description: 'Convert brave scheme to chrome'
-    re_pattern: '(\s+)(url_cache_.Put\(base_url_override, url, result\);)'
-    replace: '\1result = RewriteBraveToChrome(result);\1\2'
+    regex:
+      re_pattern: '(\s+)(url_cache_.Put\(base_url_override, url, result\);)'
+      replace: '\1result = RewriteBraveToChrome(result);\1\2'

--- a/rewrite/third_party/blink/renderer/core/dom/events/event_dispatcher.cc.yaml
+++ b/rewrite/third_party/blink/renderer/core/dom/events/event_dispatcher.cc.yaml
@@ -7,8 +7,9 @@ substitutions:
   - description:
       'Adding ShouldBypassDefaultPreventedForContextMenu() in context menu
       handling'
-    re_pattern:
-      'if \((!event_->defaultPrevented\(\)) && !event_->DefaultHandled\(\) &&'
-    replace:
-      'if ((\1 || ShouldBypassDefaultPreventedForContextMenu(event_)) &&
-      !event_->DefaultHandled() &&'
+    regex:
+      re_pattern:
+        'if \((!event_->defaultPrevented\(\)) && !event_->DefaultHandled\(\) &&'
+      replace:
+        'if ((\1 || ShouldBypassDefaultPreventedForContextMenu(event_)) &&
+        !event_->DefaultHandled() &&'

--- a/rewrite/third_party/blink/renderer/core/html/canvas/html_canvas_element.h.yaml
+++ b/rewrite/third_party/blink/renderer/core/html/canvas/html_canvas_element.h.yaml
@@ -9,17 +9,19 @@ substitutions:
 
       Brave exposes toDataURL variants that take an explicit ScriptState so it
       can be called off the main flow; declared right after the destructor.
-    re_pattern: '(  ~HTMLCanvasElement\(\) override;\n)'
-    replace: |
-      \1  String toDataURL(ScriptState* script_state, const String& mime_type,
-                         const ScriptValue& quality_argument,
-                         ExceptionState& exception_state) const;
-        String toDataURL(ScriptState* script_state, const String& mime_type,
-                         ExceptionState& exception_state) const {
-          return toDataURL(script_state, mime_type, ScriptValue(), exception_state);
-        }
+    regex:
+      re_pattern: '(  ~HTMLCanvasElement\(\) override;\n)'
+      replace: |
+        \1  String toDataURL(ScriptState* script_state, const String& mime_type,
+                           const ScriptValue& quality_argument,
+                           ExceptionState& exception_state) const;
+          String toDataURL(ScriptState* script_state, const String& mime_type,
+                           ExceptionState& exception_state) const {
+            return toDataURL(script_state, mime_type, ScriptValue(), exception_state);
+          }
   - description: |
       Hold the execution context used by Brave's farbling.
-    re_pattern: '( private:\n)'
-    replace: |
-      \1  mutable UntracedMember<ExecutionContext> scoped_execution_context_;
+    regex:
+      re_pattern: '( private:\n)'
+      replace: |
+        \1  mutable UntracedMember<ExecutionContext> scoped_execution_context_;

--- a/rewrite/third_party/blink/renderer/modules/BUILD.gn.yaml
+++ b/rewrite/third_party/blink/renderer/modules/BUILD.gn.yaml
@@ -6,9 +6,10 @@
 substitutions:
   - description: |
       Extend the file-scope modules visibility with brave entries.
-    re_pattern: '(^visibility = \[.*?\])'
-    re_flags: [DOTALL, MULTILINE]
-    replace: '\1\nvisibility += brave_blink_renderer_modules_visibility'
+    regex:
+      re_pattern: '(^visibility = \[.*?\])'
+      re_flags: [DOTALL, MULTILINE]
+      replace: '\1\nvisibility += brave_blink_renderer_modules_visibility'
 
   - description: |
       brave_blink_sub_modules add to `component("modules")`.
@@ -20,8 +21,9 @@ substitutions:
       Without this, brave sub modules never become public_deps of
       `component("modules")` and their symbols fail to link into
       libblink_modules.so.
-    re_pattern: '(component\("modules"\) \{.*?sub_modules = \[.*?\])'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        sub_modules += brave_blink_sub_modules
+    regex:
+      re_pattern: '(component\("modules"\) \{.*?sub_modules = \[.*?\])'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          sub_modules += brave_blink_sub_modules

--- a/rewrite/third_party/expat/BUILD.gn.yaml
+++ b/rewrite/third_party/expat/BUILD.gn.yaml
@@ -5,10 +5,11 @@
 
 substitutions:
   - description: 'Grant //brave/ios/browser/svg visibility into expat on iOS.'
-    re_pattern: '(expat_visibility = \[.*?\])'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-      if (is_ios) {
-        expat_visibility += ["//brave/ios/browser/svg:*" ]
-      }
+    regex:
+      re_pattern: '(expat_visibility = \[.*?\])'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+        if (is_ios) {
+          expat_visibility += ["//brave/ios/browser/svg:*" ]
+        }

--- a/rewrite/third_party/rust/aho_corasick/v1/BUILD.gn.yaml
+++ b/rewrite/third_party/rust/aho_corasick/v1/BUILD.gn.yaml
@@ -5,5 +5,6 @@
 
 substitutions:
   - description: 'Allow aho_corasick to be used outside of test targets'
-    pattern: 'testonly = true'
-    replace: 'testonly = false'
+    regex:
+      pattern: 'testonly = true'
+      replace: 'testonly = false'

--- a/rewrite/third_party/rust/regex_automata/v0_4/BUILD.gn.yaml
+++ b/rewrite/third_party/rust/regex_automata/v0_4/BUILD.gn.yaml
@@ -5,5 +5,6 @@
 
 substitutions:
   - description: 'Allow regex_automata to be used outside of test targets'
-    pattern: 'testonly = true'
-    replace: 'testonly = false'
+    regex:
+      pattern: 'testonly = true'
+      replace: 'testonly = false'

--- a/rewrite/tools/grit/grit/gather/policy_json.py.yaml
+++ b/rewrite/tools/grit/grit/gather/policy_json.py.yaml
@@ -11,6 +11,7 @@ substitutions:
       upstream has finished defining its own symbols, so it must be the very
       last statement in the file. Anchoring on end-of-file keeps the match
       independent of whatever upstream's final statement happens to be.
-    re_pattern: '\Z'
-    replace: |
-      from brave_chromium_utils import inline_chromium_src_override; inline_chromium_src_override(globals(), locals())
+    regex:
+      re_pattern: '\Z'
+      replace: |
+        from brave_chromium_utils import inline_chromium_src_override; inline_chromium_src_override(globals(), locals())

--- a/rewrite/tools/perf/core/perfetto_binary_roller/binary_deps.json.yaml
+++ b/rewrite/tools/perf/core/perfetto_binary_roller/binary_deps.json.yaml
@@ -11,9 +11,10 @@ substitutions:
       https://issues.chromium.org/issues/512709653. Matching the whole `"win"`
       block keeps the substitution working even when upstream bumps the hash
       or remote path.
-    re_pattern: '"win": \{[^}]*\}'
-    replace: |-
-      "win": {
-                  "hash": "bbfdca9a518712ec83e4cec27407d02e1843e5b5",
-                  "full_remote_path": "chromium-telemetry/perfetto_binaries/trace_processor_shell/win/e2b82363b4c2a1912a6e33c9c6ae8a6561a35b93/trace_processor_shell.exe"
-              }
+    regex:
+      re_pattern: '"win": \{[^}]*\}'
+      replace: |-
+        "win": {
+                    "hash": "bbfdca9a518712ec83e4cec27407d02e1843e5b5",
+                    "full_remote_path": "chromium-telemetry/perfetto_binaries/trace_processor_shell/win/e2b82363b4c2a1912a6e33c9c6ae8a6561a35b93/trace_processor_shell.exe"
+                }

--- a/rewrite/ui/color/BUILD.gn.yaml
+++ b/rewrite/ui/color/BUILD.gn.yaml
@@ -9,25 +9,27 @@ substitutions:
 
       The `sources.gni` import and the Brave deps are grouped together at the
       end of the target.
-    re_pattern: '(component\("color"\).*?)\n\}'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        import("//brave/ui/color/sources.gni")
-        sources += brave_ui_color_sources
-        public_deps += brave_ui_color_public_deps
-      }
+    regex:
+      re_pattern: '(component\("color"\).*?)\n\}'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          import("//brave/ui/color/sources.gni")
+          sources += brave_ui_color_sources
+          public_deps += brave_ui_color_public_deps
+        }
 
   - description: |
       Brave additions to `component("mixers")`.
 
       The `sources.gni` import and the Brave deps are grouped together at the
       end of the target.
-    re_pattern: '(component\("mixers"\).*?)\n\}'
-    re_flags: [DOTALL]
-    replace: |-
-      \1
-        import("//brave/ui/color/sources.gni")
-        sources += brave_ui_color_mixer_sources
-        public_deps += brave_ui_color_mixer_public_deps
-      }
+    regex:
+      re_pattern: '(component\("mixers"\).*?)\n\}'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          import("//brave/ui/color/sources.gni")
+          sources += brave_ui_color_mixer_sources
+          public_deps += brave_ui_color_mixer_public_deps
+        }

--- a/rewrite/ui/views/controls/menu/menu_item_view.cc.yaml
+++ b/rewrite/ui/views/controls/menu/menu_item_view.cc.yaml
@@ -10,6 +10,7 @@ substitutions:
       Brave's vector icons default to a larger size than upstream Chromium's, so
       upstream's two-arg `FromVectorIcon` call ends up too big for the menu arrow.
       Pass the explicit 16 px size that upstream implicitly relies on.
-    re_pattern: '(ui::ImageModel::FromVectorIcon\(.*?kSubmenuArrowChromeRefreshOldIcon,.*?)\)'
-    re_flags: [DOTALL]
-    replace: '\1, 16)'
+    regex:
+      re_pattern: '(ui::ImageModel::FromVectorIcon\(.*?kSubmenuArrowChromeRefreshOldIcon,.*?)\)'
+      re_flags: [DOTALL]
+      replace: '\1, 16)'

--- a/rewrite/ui/webui/resources/cr_components/history_embeddings/history_embeddings.html.ts.yaml
+++ b/rewrite/ui/webui/resources/cr_components/history_embeddings/history_embeddings.html.ts.yaml
@@ -7,6 +7,8 @@ substitutions:
   - description:
       'Hide thumbs up/down feedback buttons to avoid exposing a feedback
       mechanism; nothing leaves the device.'
-    re_pattern: '\s*<cr-feedback-buttons[\s\S]+?</cr-feedback-buttons>'
+    regex:
+      re_pattern: '\s*<cr-feedback-buttons[\s\S]+?</cr-feedback-buttons>'
+      replace: ''
+
     count: 0
-    replace: ''

--- a/rewrite/ui/webui/resources/tools/build_webui.gni.yaml
+++ b/rewrite/ui/webui/resources/tools/build_webui.gni.yaml
@@ -11,9 +11,10 @@ substitutions:
       Anchored on the license header so the insertion does not depend
       on any particular upstream import surviving — only on the BSD
       header block that every Chromium source file starts with.
-    re_pattern: '(# found in the LICENSE file\.\n\n)'
-    replace: |
-      \1import("//brave/resources/brave_grit.gni")
+    regex:
+      re_pattern: '(# found in the LICENSE file\.\n\n)'
+      replace: |
+        \1import("//brave/resources/brave_grit.gni")
 
   - description: |
       Let `build_webui` callers exclude specific TypeScript files from
@@ -30,17 +31,18 @@ substitutions:
       deeper and therefore can't satisfy the backreference. The
       replacement strings reuse `\1` too, so the inserted hooks pick
       up the same indent.
-    re_pattern:
-      '( *)(preprocess_if_expr\("preprocess_ts_files"\) \{.*?)(\n\1\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1\2
-      \1  if (defined(invoker.exclude_ts_preprocess_files)) {
-      \1    in_files -= invoker.exclude_ts_preprocess_files
-      \1  }
-      \1  if (defined(invoker.preprocess_deps)) {
-      \1    public_deps = invoker.preprocess_deps
-      \1  }\3
+    regex:
+      re_pattern:
+        '( *)(preprocess_if_expr\("preprocess_ts_files"\) \{.*?)(\n\1\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1\2
+        \1  if (defined(invoker.exclude_ts_preprocess_files)) {
+        \1    in_files -= invoker.exclude_ts_preprocess_files
+        \1  }
+        \1  if (defined(invoker.preprocess_deps)) {
+        \1    public_deps = invoker.preprocess_deps
+        \1  }\3
 
   - description: |
       Same pair of hooks for the HTML/CSS preprocess target: exclude
@@ -50,17 +52,18 @@ substitutions:
       sits one level deeper than the target's own close. The
       backreference pairs the close with the opener so they can't be
       confused.
-    re_pattern:
-      '( *)(preprocess_if_expr\("preprocess_html_css_files"\) \{.*?)(\n\1\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1\2
-      \1  if (defined(invoker.exclude_html_css_preprocess_files)) {
-      \1    in_files -= invoker.exclude_html_css_preprocess_files
-      \1  }
-      \1  if (defined(invoker.preprocess_deps)) {
-      \1    public_deps = invoker.preprocess_deps
-      \1  }\3
+    regex:
+      re_pattern:
+        '( *)(preprocess_if_expr\("preprocess_html_css_files"\) \{.*?)(\n\1\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1\2
+        \1  if (defined(invoker.exclude_html_css_preprocess_files)) {
+        \1    in_files -= invoker.exclude_html_css_preprocess_files
+        \1  }
+        \1  if (defined(invoker.preprocess_deps)) {
+        \1    public_deps = invoker.preprocess_deps
+        \1  }\3
 
   - description: |
       Default the ESLint `enable_web_component_missing_deps` check to
@@ -70,8 +73,9 @@ substitutions:
       visible to the upstream missing-deps check, so keeping it on by
       default would break the build. Callers can still opt in via
       `invoker.eslint_enable_web_component_missing_deps`.
-    re_pattern: 'enable_web_component_missing_deps = true'
-    replace: 'enable_web_component_missing_deps = false'
+    regex:
+      re_pattern: 'enable_web_component_missing_deps = true'
+      replace: 'enable_web_component_missing_deps = false'
 
   - description: |
       Append `//brave/ui/webui/resources` to `no_explicit_any_exceptions`
@@ -84,10 +88,11 @@ substitutions:
       are. The `[^\]]*` body keeps the match from running past the
       list's own `]` (greedy `.*` would otherwise reach the `grit_flags`
       list further down).
-    re_pattern: '(no_explicit_any_exceptions = \[[^\]]*\])'
-    replace: |-
-      \1
-            no_explicit_any_exceptions += [ "//brave/ui/webui/resources" ]
+    regex:
+      re_pattern: '(no_explicit_any_exceptions = \[[^\]]*\])'
+      replace: |-
+        \1
+              no_explicit_any_exceptions += [ "//brave/ui/webui/resources" ]
 
   - description: |
       Route the `grit("resources")` template call through Brave's
@@ -95,7 +100,8 @@ substitutions:
       `use_brave_grit` can substitute Brave-specific grit handling.
       The `brave_grit.gni` import that defines this wrapper is added
       to the top of the file by the first substitution in this plaster.
-    re_pattern: '(    )(grit\("resources"\) \{)'
-    replace: |-
-      \1forward_variables_from(invoker, [ "use_brave_grit" ])
-      \1brave_or_default_grit("resources") {
+    regex:
+      re_pattern: '(    )(grit\("resources"\) \{)'
+      replace: |-
+        \1forward_variables_from(invoker, [ "use_brave_grit" ])
+        \1brave_or_default_grit("resources") {


### PR DESCRIPTION
This is a mechanical change to migrate all substitutions doing a regex
rewrite to use the `regex:` key. This change was done with the following
script:

```python
from __future__ import annotations

import argparse
import re
import sys
from dataclasses import dataclass
from pathlib import Path

import plaster

_REWRITER_KEYS = frozenset(plaster._REWRITERS.keys())

_FIELD_KEYS = frozenset(plaster.Regex._FIELD_KEYS)

_ENVELOPE_KEYS = frozenset(('description', 'count'))

_INDENT_STEP = 2

_ITEM_RE = re.compile(r'^(?P<list_indent>\s*)-(?P<sep>\s+)(?P<rest>\S.*)$')

@dataclass
class _KeySpan:
    """A top-level item key and the line range [start, end) it owns."""
    name: str
    start: int
    end: int
    # True for the key that shares the `- ` line (cannot be moved trivially).
    on_dash_line: bool

def _rewriter_field_values(sub: plaster.Substitution) -> tuple:
    """A comparable snapshot of a substitution's meaning."""
    rw = sub.rewriter
    if isinstance(rw, plaster.Regex):
        rw_snapshot: object = ('regex', rw._re_pattern, rw._replace,
                               rw._re_flags)
    else:
        # Non-regex (AST) rewriters are never migrated; a shallow marker is
        # enough to confirm they were left untouched.
        rw_snapshot = (type(rw).__name__, repr(rw.__dict__))
    return (sub.description, sub.expected_count, rw_snapshot)

def _key_name(line: str, indent: int) -> str | None:
    """Return the mapping key on `line` at exactly `indent` spaces, else None.

    Deeper-indented lines (block-scalar bodies, wrapped scalars) return None,
    so `foo:` appearing inside a `replace:` body is not mistaken for a key.
    """
    match = re.match(r'^(?P<indent>\s*)(?P<key>[A-Za-z_][A-Za-z0-9_]*):'
                     r'(?:\s|$)', line)
    if not match or len(match.group('indent')) != indent:
        return None
    return match.group('key')

def _item_bounds(lines: list[str], start: int, list_indent: int) -> int:
    """Return the exclusive end line of the item beginning at `start`.

    An item runs until the next sibling `- ` item or a line that dedents to
    the list indent or shallower (the next top-level key / end of block).
    """
    for i in range(start + 1, len(lines)):
        line = lines[i]
        if not line.strip():
            continue
        indent = len(line) - len(line.lstrip(' '))
        if indent <= list_indent:
            return i
    return len(lines)

def _collect_key_spans(lines: list[str], start: int, end: int,
                       key_indent: int, first_key: str) -> list[_KeySpan]:
    """List the top-level key spans of the item in [start, end)."""
    spans: list[_KeySpan] = []
    # The first key shares the `- ` line at `start`.
    spans.append(_KeySpan(first_key, start, end, on_dash_line=True))
    for i in range(start + 1, end):
        name = _key_name(lines[i], key_indent)
        if name is not None:
            spans[-1].end = i
            spans.append(_KeySpan(name, i, end, on_dash_line=False))
    return spans

def _reindent(lines: list[str], span: _KeySpan) -> list[str]:
    """Return the span's lines indented one step deeper (blanks untouched)."""
    out = []
    for line in lines[span.start:span.end]:
        out.append(line if not line.strip() else ' ' * _INDENT_STEP + line)
    return out

def _migrate_item(lines: list[str], start: int, end: int, list_indent: int,
                  first_key: str, sep_len: int) -> list[str] | None:
    """Rewrite one item's lines, or None if it needs no migration.

    Returns the replacement lines for [start, end). Only bare-form regex
    items are changed; keyed items and pure-envelope items return None.
    """
    key_indent = list_indent + 1 + sep_len
    spans = _collect_key_spans(lines, start, end, key_indent, first_key)
    names = {span.name for span in spans}

    if names & _REWRITER_KEYS:
        return None  # Already keyed (or an AST rewriter).
    field_spans = [s for s in spans if s.name in _FIELD_KEYS]
    if not field_spans:
        return None  # Nothing to migrate.

    # A bare field on the `- ` line would need the dash rewritten; none exist
    # in-tree today, so flag it loudly rather than silently mishandle it.
    if any(s.on_dash_line for s in field_spans):
        raise NotImplementedError(
            f'bare regex field on the "- " line at line {start + 1}; '
            f'migrate this item by hand')

    field_start = min(s.start for s in field_spans)
    regex_block = [' ' * key_indent + 'regex:']
    for span in field_spans:
        regex_block.extend(_reindent(lines, span))

    out: list[str] = []
    for span in spans:
        if span in field_spans:
            if span.start == field_start:
                out.extend(regex_block)  # Drop the whole block in place.
            continue  # Other field spans are folded into the block above.
        out.extend(lines[span.start:span.end])
    return out

def _migrate_text(text: str) -> str:
    """Return `text` with every bare-form item rewritten to `regex:`."""
    lines = text.split('\n')
    # Splitting a trailing-newline file yields a trailing '' element; keep it
    # so the file terminator round-trips.
    out: list[str] = []
    i = 0
    while i < len(lines):
        match = _ITEM_RE.match(lines[i])
        if not match:
            out.append(lines[i])
            i += 1
            continue
        list_indent = len(match.group('list_indent'))
        sep_len = len(match.group('sep'))
        first_key = _key_name(
            ' ' * (list_indent + 1 + sep_len) + match.group('rest'),
            list_indent + 1 + sep_len)
        end = _item_bounds(lines, i, list_indent)
        replacement = None
        if first_key is not None:
            replacement = _migrate_item(lines, i, end, list_indent, first_key,
                                        sep_len)
        out.extend(replacement if replacement is not None
                   else lines[i:end])
        i = end
    return '\n'.join(out)

def _assert_equivalent(path: Path, old: str, new: str) -> None:
    """Confirm the rewrite preserves the parsed substitutions exactly."""
    before = [_rewriter_field_values(s) for s in
              plaster.Substitution.from_yaml(old)]
    after = [_rewriter_field_values(s) for s in
             plaster.Substitution.from_yaml(new)]
    if before != after:
        raise RuntimeError(
            f'migration changed the meaning of {path}:\n'
            f'  before: {before}\n  after:  {after}')

def main() -> int:
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument('--write', action='store_true',
                        help='rewrite files in place (default: dry run)')
    parser.add_argument('--rewrite-dir', type=Path,
                        default=Path(__file__).resolve().parents[2] /
                        'rewrite',
                        help='root of the plaster files (default: src/brave/'
                        'rewrite)')
    args = parser.parse_args()

    if not args.rewrite_dir.is_dir():
        parser.error(f'rewrite dir not found: {args.rewrite_dir}')

    changed = 0
    for path in sorted(args.rewrite_dir.rglob('*.yaml')):
        old = path.read_text(encoding='utf-8')
        try:
            new = _migrate_text(old)
        except NotImplementedError as err:
            print(f'SKIP  {path}: {err}', file=sys.stderr)
            continue
        if new == old:
            continue
        try:
            _assert_equivalent(path, old, new)
        except (RuntimeError, ValueError) as err:
            print(f'FAIL  {path}: {err}', file=sys.stderr)
            return 1
        changed += 1
        if args.write:
            path.write_text(new, encoding='utf-8')
            print(f'wrote {path.relative_to(args.rewrite_dir)}')
        else:
            print(f'would migrate {path.relative_to(args.rewrite_dir)}')

    verb = 'migrated' if args.write else 'to migrate'
    print(f'\n{changed} file(s) {verb}.')
    if not args.write and changed:
        print('Re-run with --write to apply, then `npm run format`.')
    return 0

if __name__ == '__main__':
    sys.exit(main())
```

Bug: https://github.com/brave/brave-browser/issues/56760
