### PR TITLE
[iOS] Dismiss deep link presented Origin Paywall when a URL is opened

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Origin.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Origin.swift
@@ -85,6 +85,7 @@ extension BrowserViewController {
                 isPrivate: privateBrowsingManager.isPrivateBrowsing,
                 isPrivileged: url.scheme == InternalURL.scheme
               )
+              dismiss(animated: true)
               return .handled
             }
           )


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/57137
