### PR TITLE
[Bootstrap] update RunNodeRaw to find node shims

### DIFF
--- a/script/brave_node.py
+++ b/script/brave_node.py
@@ -21,7 +21,7 @@ def RunNodeRaw(cmd_parts):
     if sys.platform == 'win32':
         # On Windows, locate the shim file otherwise opening the subprocess
         # will fail.
-        node_executable = shutil.which('node') or 'node'
+        node_executable = shutil.which('node')
 
     cmd = [node_executable] + cmd_parts
     process = subprocess.Popen(cmd,

--- a/script/brave_node.py
+++ b/script/brave_node.py
@@ -17,10 +17,14 @@ def PathInNodeModules(*args):
 
 def RunNodeRaw(cmd_parts):
     cmd = ['node'] + cmd_parts
+    # On Windows, if we only locate node via the shim then running with
+    # `shell=False` will cause Python to not be able to find the shim, which
+    # will result in things such as `npm run presubmit` failing to run.
     process = subprocess.Popen(cmd,
                                cwd=os.getcwd(),
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE,
+                               shell=sys.platform == 'win32',
                                universal_newlines=True)
     stdout, stderr = process.communicate()
     return process.returncode, stdout, stderr

--- a/script/brave_node.py
+++ b/script/brave_node.py
@@ -7,6 +7,7 @@
 import subprocess
 import sys
 import os
+import shutil
 
 NODE_MODULES = os.path.join(os.path.dirname(__file__), '..', 'node_modules')
 
@@ -16,15 +17,17 @@ def PathInNodeModules(*args):
 
 
 def RunNodeRaw(cmd_parts):
-    cmd = ['node'] + cmd_parts
-    # On Windows, if we only locate node via the shim then running with
-    # `shell=False` will cause Python to not be able to find the shim, which
-    # will result in things such as `npm run presubmit` failing to run.
+    node_executable = 'node'
+    if sys.platform == 'win32':
+        # On Windows, locate the shim file otherwise opening the subprocess
+        # will fail.
+        node_executable = shutil.which('node') or 'node'
+
+    cmd = [node_executable] + cmd_parts
     process = subprocess.Popen(cmd,
                                cwd=os.getcwd(),
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE,
-                               shell=sys.platform == 'win32',
                                universal_newlines=True)
     stdout, stderr = process.communicate()
     return process.returncode, stdout, stderr


### PR DESCRIPTION
Update the call to `RunNodeRaw` to open the subprocess in the shell for
Windows subsystems as doing otherwise will cause the shim to be fail
to be located and commands like `npm run presubmit` will no longer
work.