### PR TITLE
[AI Chat] Share Conversation Dialog

### DIFF
--- a/components/ai_chat/resources/page/components/header/index.tsx
+++ b/components/ai_chat/resources/page/components/header/index.tsx
@@ -8,8 +8,6 @@ import Icon from '@brave/leo/react/icon'
 import Button from '@brave/leo/react/button'
 import Label from '@brave/leo/react/label'
 import { Conversation } from '../../../common/mojom'
-import { serializeConversationForSharing } from '../../../common/conversation_serialization'
-import { encryptForSharing } from '../../../common/conversation_share_encryption'
 import useCanStartNewConversation from '../../hooks/useCanStartNewConversation'
 import FeatureButtonMenu, {
   Props as FeatureButtonMenuProps,
@@ -19,6 +17,10 @@ import { useAIChat, useIsSmall } from '../../state/ai_chat_context'
 import { useConversation } from '../../state/conversation_context'
 import { getLocale } from '$web-common/locale'
 import { useActiveChat } from '../../state/active_chat_context'
+
+type Props = FeatureButtonMenuProps & {
+  startSharingConversation: () => void
+}
 
 const Logo = ({ isPremium }: { isPremium: boolean }) => (
   <div className={styles.logo}>
@@ -42,11 +44,11 @@ const newChatButtonLabel = getLocale(S.CHAT_UI_NEW_CONVERSATION_BUTTON_LABEL)
 const closeButtonLabel = getLocale(S.CHAT_UI_LABEL_CLOSE)
 const openFullPageButtonLabel = getLocale(S.CHAT_UI_OPEN_LABEL)
 const shareConversationButtonLabel = getLocale(
-  S.CHAT_UI_SHARE_CONVERSATION_BUTTON_LABEL,
+  S.CHAT_UI_SHARE_CONVERSATION_LABEL,
 )
 
 export const ConversationHeader = React.forwardRef(function (
-  props: FeatureButtonMenuProps,
+  props: Props,
   ref: React.Ref<HTMLDivElement>,
 ) {
   const aiChatContext = useAIChat()
@@ -70,26 +72,6 @@ export const ConversationHeader = React.forwardRef(function (
     aiChatContext.isConversationShareEnabled
     && conversationHistory.length > 0
     && !conversationState.isRequestInProgress
-
-  const handleShareConversation = async () => {
-    // Encrypt the conversation in the client so the sharing server only ever
-    // sees ciphertext. The decryption key stays on the client and is appended
-    // to the returned viewer URL as a fragment, so the shared link is only
-    // usable by whoever the user shares it with.
-    const json = serializeConversationForSharing(conversationHistory)
-    const { ciphertext, keyFragment } = await encryptForSharing(json)
-    // The browser process combines the key fragment with the server's viewer
-    // URL and copies the resulting shareable link to the clipboard, marked as
-    // confidential (excluded from clipboard history and other
-    // data-leak-prevention surfaces) - something the renderer cannot do. The
-    // key fragment is not sent to the sharing server. Failure (a null result)
-    // is a no-op: nothing is copied, so there is nothing more to do here.
-    await aiChatContext.api.service.shareConversation(
-      ciphertext,
-      keyFragment,
-      /*copyToClipboard=*/ true,
-    )
-  }
 
   const showTitle =
     (!isMainConversation || aiChatContext.isStandalone) && !isMobile
@@ -180,7 +162,7 @@ export const ConversationHeader = React.forwardRef(function (
                 kind='plain-faint'
                 aria-label={shareConversationButtonLabel}
                 title={shareConversationButtonLabel}
-                onClick={handleShareConversation}
+                onClick={props.startSharingConversation}
               >
                 <Icon name='share' />
               </Button>

--- a/components/ai_chat/resources/page/components/main/index.tsx
+++ b/components/ai_chat/resources/page/components/main/index.tsx
@@ -24,6 +24,7 @@ import RateMessagePrivacyModal from '../rate_message_privacy_modal'
 import SkillModal from '../skill_modal/skill_modal'
 import PrivacyMessage from '../privacy_message'
 import FeedbackForm from '../feedback_form'
+import ShareConversationModal from '../share_conversation_modal'
 import ToolsMenu, {
   ExtendedActionEntry,
   getIsSkill,
@@ -41,6 +42,7 @@ function Main() {
   const conversationContext = useConversation()
   const [isConversationListOpen, setIsConversationsListOpen] =
     React.useState(false)
+  const [isShareDialogOpen, setIsShareDialogOpen] = React.useState(false)
   const { isDragActive, isDragOver } = conversationContext
 
   const showAttachments = !!conversationContext.attachmentsDialog
@@ -182,6 +184,7 @@ function Main() {
       <ConversationHeader
         ref={headerElement}
         setIsConversationsListOpen={setIsConversationsListOpen}
+        startSharingConversation={() => setIsShareDialogOpen(true)}
       />
       <AlertCenter
         position='top-center'
@@ -202,6 +205,12 @@ function Main() {
             className={styles.conversationContainer}
           />
         </>
+      )}
+      {aiChatContext.isConversationShareEnabled && (
+        <ShareConversationModal
+          isOpen={isShareDialogOpen}
+          onClose={() => setIsShareDialogOpen(false)}
+        />
       )}
       {showAttachments && (
         <Dialog

--- a/components/ai_chat/resources/page/components/share_conversation_modal/index.tsx
+++ b/components/ai_chat/resources/page/components/share_conversation_modal/index.tsx
@@ -1,4 +1,4 @@
-/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/components/ai_chat/resources/page/components/share_conversation_modal/index.tsx
+++ b/components/ai_chat/resources/page/components/share_conversation_modal/index.tsx
@@ -1,0 +1,130 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+import Button from '@brave/leo/react/button'
+import Dialog from '@brave/leo/react/dialog'
+import Icon from '@brave/leo/react/icon'
+import { getLocale } from '$web-common/locale'
+import { serializeConversationForSharing } from '../../../common/conversation_serialization'
+import { encryptForSharing } from '../../../common/conversation_share_encryption'
+import { useAIChat } from '../../state/ai_chat_context'
+import { useConversation } from '../../state/conversation_context'
+import styles from './style.module.scss'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export default function ShareConversationModal(props: Props) {
+  const aiChatContext = useAIChat()
+  const conversationContext = useConversation()
+
+  const [isGenerating, setIsGenerating] = React.useState(false)
+  const [isCopied, setIsCopied] = React.useState(false)
+
+  const conversationUuid =
+    conversationContext.api.useGetStateData().conversationUuid
+  const allConversations = aiChatContext.api.useGetConversationsData()
+
+  const conversationTitle = React.useMemo(() => {
+    const conversation = allConversations.find(
+      (c) => c.uuid === conversationUuid,
+    )
+    return conversation?.title || ''
+  }, [allConversations, conversationUuid])
+
+  // Reset back to the initial "Generate link" state each time the dialog is
+  // (re)opened, so a subsequent share doesn't start from the "copied" state.
+  React.useEffect(() => {
+    if (props.isOpen) {
+      setIsGenerating(false)
+      setIsCopied(false)
+    }
+  }, [props.isOpen])
+
+  const handleGenerateLink = async () => {
+    // Do not generate multiple times
+    if (isGenerating || isCopied) {
+      return
+    }
+
+    setIsGenerating(true)
+    try {
+      // Encrypt the conversation in the client so the sharing server only ever
+      // sees ciphertext. The decryption key stays on the client and is appended
+      // to the returned viewer URL as a fragment, so the shared link is only
+      // usable by whoever the user shares it with.
+      const json = serializeConversationForSharing(
+        conversationContext.api.getConversationHistory.current(),
+      )
+      const { ciphertext, keyFragment } = await encryptForSharing(json)
+      // The browser process combines the key fragment with the server's viewer
+      // URL and copies the resulting shareable link to the clipboard, marked as
+      // confidential (excluded from clipboard history and other
+      // data-leak-prevention surfaces) - something the renderer cannot do. The
+      // key fragment is not sent to the sharing server.
+      const { sharedConversationUrl } =
+        await aiChatContext.api.service.shareConversation(
+          ciphertext,
+          keyFragment,
+          /*copyToClipboard=*/ true,
+        )
+      // A null result means sharing failed and nothing was copied, so leave the
+      // button in its initial state to allow retrying.
+      if (sharedConversationUrl) {
+        setIsCopied(true)
+      }
+    } finally {
+      setIsGenerating(false)
+    }
+  }
+
+  return (
+    <Dialog
+      isOpen={props.isOpen}
+      showClose
+      onClose={props.onClose}
+      className={styles.dialog}
+    >
+      <div
+        slot='title'
+        className={styles.title}
+      >
+        {getLocale(S.CHAT_UI_SHARE_CONVERSATION_LABEL)}
+      </div>
+      <div className={styles.body}>
+        {conversationTitle && (
+          <div className={styles.conversationName}>{conversationTitle}</div>
+        )}
+        <div className={styles.description}>
+          {getLocale(S.CHAT_UI_SHARE_CONVERSATION_DIALOG_DESCRIPTION)}
+        </div>
+      </div>
+      <div slot='actions'>
+        <Button
+          kind='filled'
+          size='medium'
+          isLoading={isGenerating}
+          className={isCopied ? styles.buttonCopied : styles.button}
+          onClick={handleGenerateLink}
+        >
+          <Icon
+            slot='icon-before'
+            name={isCopied ? 'check-circle-outline' : 'link-normal'}
+          />
+          {isCopied
+            ? getLocale(
+                S.CHAT_UI_SHARE_CONVERSATION_DIALOG_LINK_COPIED_BUTTON_LABEL,
+              )
+            : getLocale(
+                S.CHAT_UI_SHARE_CONVERSATION_DIALOG_GENERATE_LINK_BUTTON_LABEL,
+              )}
+        </Button>
+      </div>
+    </Dialog>
+  )
+}

--- a/components/ai_chat/resources/page/components/share_conversation_modal/style.module.scss
+++ b/components/ai_chat/resources/page/components/share_conversation_modal/style.module.scss
@@ -1,0 +1,50 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at https://mozilla.org/MPL/2.0/.
+
+.dialog {
+  --leo-dialog-padding: var(--leo-spacing-2xl);
+}
+
+.title {
+  font: var(--leo-font-heading-h3);
+  color: var(--leo-color-text-primary);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--leo-spacing-xl);
+}
+
+.conversationName {
+  width: 100%;
+  padding: var(--leo-spacing-xl);
+  border-radius: var(--leo-radius-xl);
+  border: 1px solid var(--leo-color-divider-subtle);
+  font: var(--leo-font-heading-h4);
+  color: var(--leo-color-text-primary);
+  word-break: break-word;
+}
+
+.description {
+  font: var(--leo-font-default-regular);
+  color: var(--leo-color-text-primary);
+}
+
+.button,
+.buttonCopied {
+  width: 100%;
+}
+
+.buttonCopied {
+  // Recolor the filled button to the success color. We override the base
+  // --leo-color-button-background token rather than --leo-button-color because
+  // setting --leo-button-color forces the button text to white, which is wrong
+  // for the light-green success background in dark mode. Overriding the base
+  // token keeps the button's paired success text/icon color instead.
+  // TODO(https://github.com/brave/leo/issues/1422): Fix in Nala
+  --leo-color-button-background: var(--leo-color-button-success-background);
+  --leo-color-schemes-on-primary: var(--leo-color-button-success-text);
+}

--- a/components/ai_chat/resources/page/components/share_conversation_modal/style.module.scss
+++ b/components/ai_chat/resources/page/components/share_conversation_modal/style.module.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at https://mozilla.org/MPL/2.0/.

--- a/components/ai_chat/resources/page/stories/components_panel.tsx
+++ b/components/ai_chat/resources/page/stories/components_panel.tsx
@@ -655,6 +655,7 @@ function StoryContext(
         isAIChatAgentProfile: args.isAIChatAgentProfile,
         isMobile: args.isMobile,
         isHistoryFeatureEnabled: args.isHistoryEnabled,
+        isConversationShareEnabled: true,
         skillDialog: args.skillDialog,
       }}
       conversationOverrides={{

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -426,8 +426,17 @@
   <message name="IDS_CHAT_UI_NEW_CONVERSATION_BUTTON_LABEL" desc="A label for the button which starts a new conversation" formatter_data="webui=AiChat">
     Start a new conversation
   </message>
-  <message name="IDS_CHAT_UI_SHARE_CONVERSATION_BUTTON_LABEL" desc="A label for the button which shares the current conversation" formatter_data="webui=AiChat">
-    Share conversation
+  <message name="IDS_CHAT_UI_SHARE_CONVERSATION_LABEL" desc="Label for sharing the current conversation" formatter_data="webui=AiChat">
+    Share this conversation
+  </message>
+  <message name="IDS_CHAT_UI_SHARE_CONVERSATION_DIALOG_DESCRIPTION" desc="Explanatory text in the share conversation dialog describing how the conversation is encrypted before being uploaded and when the shared link expires" formatter_data="webui=AiChat">
+    Your conversation will be uploaded encrypted and can only be decrypted with the generated link. Brave will not be able to view your conversation. Only you and the people you share this link with can decrypt your shared conversation. All shared conversations will expire after 7 days.
+  </message>
+  <message name="IDS_CHAT_UI_SHARE_CONVERSATION_DIALOG_GENERATE_LINK_BUTTON_LABEL" desc="A label for the button which generates and copies a shareable link for the current conversation" formatter_data="webui=AiChat">
+    Generate link
+  </message>
+  <message name="IDS_CHAT_UI_SHARE_CONVERSATION_DIALOG_LINK_COPIED_BUTTON_LABEL" desc="A label shown on the share button after the shareable link has been copied to the clipboard" formatter_data="webui=AiChat">
+    Link copied to clipboard
   </message>
   <message name="IDS_CHAT_UI_MENU_RENAME_CONVERSATION" desc="Menu entry for renaming a conversation" formatter_data="webui=AiChat">
     Rename conversation


### PR DESCRIPTION
UI for previously-implemented share functionality. Informs the user what sharing involves before the share actually happens.

<!-- Add brave-browser issue below that this PR will resolve -->
- Series https://github.com/brave/brave-browser/issues/56444

<img width="381" height="411" alt="image" src="https://github.com/user-attachments/assets/ad117895-8f82-4f92-ad62-b0bfb75a4ec5" />
<img width="393" height="410" alt="image" src="https://github.com/user-attachments/assets/33ef1ea6-6e99-48e6-8fcb-1d8bd34a3375" />

