### PR TITLE
[Android] Fix Fresh NTP cached flag init in `BraveCachedFlags`

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/flags/BraveCachedFlags.java
+++ b/android/java/org/chromium/chrome/browser/app/flags/BraveCachedFlags.java
@@ -5,48 +5,36 @@
 
 package org.chromium.chrome.browser.app.flags;
 
-import org.chromium.base.BraveFeatureList;
 import org.chromium.build.annotations.NullMarked;
-import org.chromium.chrome.browser.flags.ChromeFeatureMap;
+import org.chromium.chrome.browser.ntp.BraveFreshNtpHelper;
 import org.chromium.chrome.browser.util.BraveDynamicColors;
 import org.chromium.components.cached_flags.BraveCachedFeatureParam;
 import org.chromium.components.cached_flags.BraveCachedFlagUtils;
 import org.chromium.components.cached_flags.CachedFeatureParam;
 import org.chromium.components.cached_flags.CachedFlag;
-import org.chromium.components.cached_flags.StringCachedFeatureParam;
 
 import java.util.List;
 
 @NullMarked
 public class BraveCachedFlags extends ChromeCachedFlags {
-    // Cached feature flag for fresh NTP after idle expiration - safe to access before native is
-    // ready
-    public static final CachedFlag sBraveFreshNtpAfterIdleExperimentEnabled =
-            new CachedFlag(
-                    ChromeFeatureMap.getInstance(),
-                    BraveFeatureList.BRAVE_FRESH_NTP_AFTER_IDLE_EXPERIMENT,
-                    false);
-
-    // Cached variant parameter for fresh NTP experiment - safe to access before native is ready
-    public static final StringCachedFeatureParam sBraveFreshNtpAfterIdleExperimentVariant =
-            new StringCachedFeatureParam(
-                    ChromeFeatureMap.getInstance(),
-                    BraveFeatureList.BRAVE_FRESH_NTP_AFTER_IDLE_EXPERIMENT,
-                    "variant",
-                    "A");
-
     // List of cached flags for Brave features - safe to access before native is ready
     private static final List<CachedFlag> sBraveFlagsCached =
             List.of(
                     BraveDynamicColors.sDynamicColorsEnabled,
-                    sBraveFreshNtpAfterIdleExperimentEnabled);
+                    BraveFreshNtpHelper.sBraveFreshNtpAfterIdleExperimentEnabled);
     // List of cached feature params for Brave features - safe to access before native is ready
     private static final List<CachedFeatureParam<?>> sBraveFeatureParamsCached =
-            List.of(sBraveFreshNtpAfterIdleExperimentVariant);
+            List.of(BraveFreshNtpHelper.sBraveFreshNtpAfterIdleExperimentVariant);
 
-    BraveCachedFlags() {
+    // The build-time bytecode rewriter changes the allocation in
+    // `ChromeCachedFlags.<clinit>` from `new ChromeCachedFlags()` to `new BraveCachedFlags()`.
+    // Set Brave's cached flags and parameters here, after the lists above. Do not
+    // set them in the constructor, which can run before those lists initialize.
+    static {
         BraveCachedFeatureParam.setBraveParams(sBraveFeatureParamsCached);
         BraveCachedFlagUtils.setBraveFlags(sBraveFlagsCached);
         BraveCachedFlagUtils.setBraveParams(sBraveFeatureParamsCached);
     }
+
+    BraveCachedFlags() {}
 }

--- a/android/java/org/chromium/chrome/browser/ntp/BraveFreshNtpHelper.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveFreshNtpHelper.java
@@ -5,8 +5,11 @@
 
 package org.chromium.chrome.browser.ntp;
 
+import org.chromium.base.BraveFeatureList;
 import org.chromium.build.annotations.NullMarked;
-import org.chromium.chrome.browser.app.flags.BraveCachedFlags;
+import org.chromium.chrome.browser.flags.ChromeFeatureMap;
+import org.chromium.components.cached_flags.CachedFlag;
+import org.chromium.components.cached_flags.StringCachedFeatureParam;
 
 /**
  * Helper class for managing fresh NTP after idle expiration feature. This feature shows a refreshed
@@ -15,12 +18,28 @@ import org.chromium.chrome.browser.app.flags.BraveCachedFlags;
  */
 @NullMarked
 public class BraveFreshNtpHelper {
+    // Cached feature flag for fresh NTP after idle expiration - safe to access before native is
+    // ready.
+    public static final CachedFlag sBraveFreshNtpAfterIdleExperimentEnabled =
+            new CachedFlag(
+                    ChromeFeatureMap.getInstance(),
+                    BraveFeatureList.BRAVE_FRESH_NTP_AFTER_IDLE_EXPERIMENT,
+                    false);
+
+    // Cached variant parameter for fresh NTP experiment - safe to access before native is ready.
+    public static final StringCachedFeatureParam sBraveFreshNtpAfterIdleExperimentVariant =
+            new StringCachedFeatureParam(
+                    ChromeFeatureMap.getInstance(),
+                    BraveFeatureList.BRAVE_FRESH_NTP_AFTER_IDLE_EXPERIMENT,
+                    "variant",
+                    "A");
+
     /**
      * @return Whether the fresh NTP after idle expiration feature is enabled. This uses a cached
      *     flag, so it's safe to call even before native is ready.
      */
     public static boolean isEnabled() {
-        return BraveCachedFlags.sBraveFreshNtpAfterIdleExperimentEnabled.isEnabled();
+        return sBraveFreshNtpAfterIdleExperimentEnabled.isEnabled();
     }
 
     /**
@@ -31,6 +50,6 @@ public class BraveFreshNtpHelper {
      * @return The variant string.
      */
     public static String getVariant() {
-        return BraveCachedFlags.sBraveFreshNtpAfterIdleExperimentVariant.getValue();
+        return sBraveFreshNtpAfterIdleExperimentVariant.getValue();
     }
 }

--- a/android/javatests/org/chromium/chrome/browser/ntp/BraveFreshNtpHelperTest.java
+++ b/android/javatests/org/chromium/chrome/browser/ntp/BraveFreshNtpHelperTest.java
@@ -1,0 +1,40 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.ntp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import androidx.test.filters.SmallTest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.chromium.base.test.util.DoNotBatch;
+import org.chromium.chrome.browser.app.flags.BraveCachedFlags;
+import org.chromium.chrome.browser.app.flags.ChromeCachedFlags;
+import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
+import org.chromium.components.cached_flags.BraveCachedFeatureParam;
+
+/** Tests Fresh NTP cached state in a fresh process. */
+@RunWith(ChromeJUnit4ClassRunner.class)
+@DoNotBatch(reason = "Requires a fresh process for cached-state initialization.")
+public class BraveFreshNtpHelperTest {
+    @Test
+    @SmallTest
+    public void testDirectCachedStateAccessBeforeChromeCachedFlagsInitialization() {
+        // Access this helper-owned cached flag before initializing ChromeCachedFlags.
+        assertNotNull(
+                BraveFreshNtpHelper.sBraveFreshNtpAfterIdleExperimentEnabled.getFeatureName());
+        // The rewritten ChromeCachedFlags singleton must be BraveCachedFlags.
+        assertEquals(BraveCachedFlags.class, ChromeCachedFlags.getInstance().getClass());
+        
+        assertTrue(
+                BraveCachedFeatureParam.sAllBraveInstances.contains(
+                        BraveFreshNtpHelper.sBraveFreshNtpAfterIdleExperimentVariant));
+    }
+}

--- a/android/javatests/org/chromium/chrome/browser/ntp/BraveFreshNtpHelperTest.java
+++ b/android/javatests/org/chromium/chrome/browser/ntp/BraveFreshNtpHelperTest.java
@@ -32,7 +32,7 @@ public class BraveFreshNtpHelperTest {
                 BraveFreshNtpHelper.sBraveFreshNtpAfterIdleExperimentEnabled.getFeatureName());
         // The rewritten ChromeCachedFlags singleton must be BraveCachedFlags.
         assertEquals(BraveCachedFlags.class, ChromeCachedFlags.getInstance().getClass());
-        
+
         assertTrue(
                 BraveCachedFeatureParam.sAllBraveInstances.contains(
                         BraveFreshNtpHelper.sBraveFreshNtpAfterIdleExperimentVariant));

--- a/android/junit/src/org/chromium/chrome/browser/tasks/BraveReturnToChromeUtilUnitTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/tasks/BraveReturnToChromeUtilUnitTest.java
@@ -15,7 +15,6 @@ import android.net.Uri;
 
 import androidx.test.filters.SmallTest;
 
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,8 +30,7 @@ import org.chromium.base.test.BaseRobolectricTestRunner;
 import org.chromium.base.test.util.Features.EnableFeatures;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.ChromeInactivityTracker;
-import org.chromium.chrome.browser.app.flags.BraveCachedFlags;
-import org.chromium.chrome.browser.app.flags.ChromeCachedFlags;
+import org.chromium.chrome.browser.ntp.BraveFreshNtpHelper;
 import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
 import org.chromium.components.browser_ui.media.MediaNotificationController;
 import org.chromium.components.browser_ui.media.MediaNotificationInfo;
@@ -46,13 +44,6 @@ import org.chromium.services.media_session.MediaMetadata;
 public class BraveReturnToChromeUtilUnitTest {
     @Rule public final MockitoRule mMockitoRule = MockitoJUnit.rule();
     @Mock private ChromeInactivityTracker mInactivityTracker;
-
-    @Before
-    public void setUp() {
-        // Force the ChromeCachedFlags superclass to initialize first so the BraveCachedFlags
-        // singleton is fully constructed before any of its static fields are accessed.
-        ChromeCachedFlags.getInstance();
-    }
 
     @Test
     @SmallTest
@@ -156,7 +147,7 @@ public class BraveReturnToChromeUtilUnitTest {
      * option and a background duration that comfortably exceeds the threshold.
      */
     private void setUpInactivityVariant() {
-        BraveCachedFlags.sBraveFreshNtpAfterIdleExperimentVariant.setForTesting("B");
+        BraveFreshNtpHelper.sBraveFreshNtpAfterIdleExperimentVariant.setForTesting("B");
         ChromeSharedPreferences.getInstance()
                 .writeInt(
                         BravePreferenceKeys.BRAVE_NEW_TAB_PAGE_OPENING_SCREEN,

--- a/docs/best-practices/android.md
+++ b/docs/best-practices/android.md
@@ -448,6 +448,62 @@ production APK size by preventing code shrinking.
 
 ---
 
+<a id="AND-024"></a>
+
+## ✅ Keep Bytecode-Redirected Constructors Free of Class Static State
+
+**When bytecode rewriting redirects an allocation to a subclass or replacement
+type, that type's constructor must not read its own static state.**
+
+For example, an upstream class can appear to construct only itself in source:
+
+```java
+// Upstream source
+private static final UpstreamClass INSTANCE = new UpstreamClass();
+
+// Rewritten bytecode, conceptually
+private static final UpstreamClass INSTANCE = new BraveClass();
+```
+
+If a read of a `BraveClass` static field is what first triggers `BraveClass`
+initialization, Java first initializes `UpstreamClass`. The rewritten allocation
+in `UpstreamClass` can then re-enter the `BraveClass` constructor before
+`BraveClass`'s static fields have initialized.
+
+```java
+// ❌ WRONG - a redirected constructor can run before sEntries is initialized
+class BraveClass extends UpstreamClass {
+    private static final List<Entry> sEntries = List.of(new Entry());
+
+    BraveClass() {
+        Registry.register(sEntries);
+    }
+}
+```
+
+```java
+// ✅ CORRECT - registration runs after sEntries is initialized
+class BraveClass extends UpstreamClass {
+    private static final List<Entry> sEntries = List.of(new Entry());
+
+    static {
+        Registry.register(sEntries);
+    }
+
+    BraveClass() {}
+}
+```
+
+Java runs static initialization once in source order. The static block is not
+lazy: place it after the fields it consumes so they initialize before
+registration runs. Keep constructors on this path free of reads from their own
+class-initialized static state.
+
+Test the static-field-first path in an isolated class loader or fresh process
+when an earlier test could initialize either class.
+
+---
+
 <a id="AND-025"></a>
 
 ## ✅ Use `@VisibleForTesting` for Package-Private Test Accessors

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1608,6 +1608,7 @@ if (is_android) {
       "//brave/android/javatests/org/chromium/chrome/browser/autofill/settings/BraveAutofillPaymentMethodsFragmentTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/homepage/settings/BraveHomepageSettingsTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/language/settings/BraveLanguageSettingsTest.java",
+      "//brave/android/javatests/org/chromium/chrome/browser/ntp/BraveFreshNtpHelperTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/origin/settings/BraveOriginPreferencesTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/privacy/settings/BravePrivacySettingsTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/safe_browsing/settings/BraveSafeBrowsingSettingsFragmentTest.java",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/53759

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

- Move Fresh NTP cached flag/param ownership into `BraveFreshNtpHelper` and register `BraveCachedFlags` via a static initializer
- Add a regression test for static-field-first access
- Add an Android best practice for keeping bytecode-redirected constructors free of class static state


### Notes

* I inserted this best practice at slot `AND-024`, which was empty, and near another bytecode related entry. If it would be preferable to append new entries to the end of the file, please let me know and I'll move it.
* I looked for other Brave subclasses that touch their own static state from a bytecode-redirected constructor, but I didn’t find any.
