### PR TITLE
Re-enable sidebar browsertest

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -45,7 +45,6 @@
 #include "brave/browser/ui/views/toolbar/side_panel_button.h"
 #include "brave/common/pref_names.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
-#include "brave/components/brave_news/common/buildflags/buildflags.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/constants/brave_switches.h"
@@ -102,10 +101,6 @@
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/core/common/features.h"
-#endif
-
-#if BUILDFLAG(ENABLE_BRAVE_NEWS)
-#include "brave/components/brave_news/common/features.h"
 #endif
 
 #if BUILDFLAG(ENABLE_PLAYLIST)
@@ -297,35 +292,8 @@ class SidebarBrowserTest : public InProcessBrowserTest {
   base::RunLoop* run_loop() const { return run_loop_.get(); }
 
   size_t GetDefaultItemCount() const {
-    // kDefaultBuiltInItemTypes.size() already accounts for buildflags
-    // (ENABLE_BRAVE_TALK, ENABLE_AI_CHAT) at compile time.
-    auto item_count =
-        std::size(SidebarServiceFactory::kDefaultBuiltInItemTypes) -
-        1 /* for history*/;
-#if BUILDFLAG(ENABLE_PLAYLIST)
-    if (!base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
-      item_count -= 1;
-    }
-#endif
-
-#if BUILDFLAG(ENABLE_AI_CHAT)
-    if (!ai_chat::features::IsAIChatEnabled()) {
-      item_count -= 1;
-    }
-#endif
-
-#if BUILDFLAG(ENABLE_BRAVE_NEWS)
-    if (!base::FeatureList::IsEnabled(
-            brave_news::features::kBraveNewsSidebar)) {
-      item_count -= 1;
-    }
-#endif
-
-#if !BUILDFLAG(ENABLE_BRAVE_WALLET)
-    item_count -= 1;
-#endif
-
-    return item_count;
+    return SidebarServiceFactory::GetForProfile(browser()->profile())
+        ->GetDefaultSidebarItemsCountForTesting();
   }
 
   int GetFirstPanelItemIndex() {

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -353,10 +353,7 @@ class SidebarBrowserTest : public InProcessBrowserTest {
   base::WeakPtrFactory<SidebarBrowserTest> weak_factory_{this};
 };
 
-// Started to fail from cr151. Disabled temporarily to prevent blocking
-// other PR merging.
-// TODO(https://github.com/brave/brave-browser/issues/57167): Enable it.
-IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, DISABLED_BasicTest) {
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, BasicTest) {
   EXPECT_TRUE(!!GetSidePanelToolbarButton()->context_menu_controller());
 
   // Initially, active index is not set.
@@ -461,10 +458,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, DISABLED_BasicTest) {
               Optional(browser_view->children().size() - 1));
 }
 
-// Started to fail from cr151. Disabled temporarily to prevent blocking
-// other PR merging.
-// TODO(https://github.com/brave/brave-browser/issues/57167): Enable it.
-IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, DISABLED_WebTypePanelTest) {
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, WebTypePanelTest) {
   auto expected_count = GetDefaultItemCount();
   EXPECT_EQ(expected_count, model()->GetAllSidebarItems().size());
 

--- a/components/sidebar/browser/sidebar_service.cc
+++ b/components/sidebar/browser/sidebar_service.cc
@@ -540,6 +540,10 @@ bool SidebarService::IsEditableItemAt(size_t index) const {
   return items_[index].is_web_type();
 }
 
+size_t SidebarService::GetDefaultSidebarItemsCountForTesting() const {
+  return GetDefaultSidebarItems().size();
+}
+
 void SidebarService::SetSidebarShowOption(ShowSidebarOption show_options) {
   DCHECK_NE(ShowSidebarOption::kShowOnClick, show_options);
   prefs_->SetInteger(kSidebarShowOption, static_cast<int>(show_options));

--- a/components/sidebar/browser/sidebar_service.h
+++ b/components/sidebar/browser/sidebar_service.h
@@ -91,6 +91,8 @@ class SidebarService : public KeyedService {
   std::optional<SidebarItem> GetDefaultPanelItem() const;
   bool IsEditableItemAt(size_t index) const;
 
+  size_t GetDefaultSidebarItemsCountForTesting() const;
+
   SidebarService(const SidebarService&) = delete;
   SidebarService& operator=(const SidebarService&) = delete;
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57167

Enabled SidebarBrowserTest.BasicTest/WebTypePanelTest
It was failed due to mismatch of SidebarBrowserTest::GetDefaultItemCount() and SidebarService::GetDefaultSidebarItems().size(). Both should give same value.
As SidebarBrowserTest::GetDefaultItemCount() doesn't check brave news opt in prefs, it gives one more value.
Fixed by removing re-calculating items count from text fixture. Test can use service's default items count directly.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
