### PR TITLE
[AI Chat] (03) Redesign model menu item with pin and default actions

### DIFF
--- a/components/ai_chat/resources/page/components/model_menu_item/model_menu_item.tsx
+++ b/components/ai_chat/resources/page/components/model_menu_item/model_menu_item.tsx
@@ -4,14 +4,23 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react'
+import Button from '@brave/leo/react/button'
+import ButtonMenu from '@brave/leo/react/buttonMenu'
 import Icon from '@brave/leo/react/icon'
 import Label from '@brave/leo/react/label'
 import classnames from '$web-common/classnames'
 import { getLocale } from '$web-common/locale'
 import * as Mojom from '../../../common/mojom'
-import { getModelIcon, NEAR_AI_LEARN_MORE_URL } from '../../../common/constants'
+import {
+  AUTOMATIC_MODEL_KEY,
+  getModelIcon,
+  NEAR_AI_LEARN_MORE_URL,
+} from '../../../common/constants'
+import { formatModelCapabilitiesSubtitle } from '../../model_utils'
 import { NearIcon } from '../near_label/near_label'
 import styles from './model_menu_item_style.module.scss'
+
+const LONG_PRESS_MS = 500
 
 interface ModelContentProps {
   model: Mojom.Model
@@ -19,7 +28,10 @@ interface ModelContentProps {
   showDetails?: boolean
   showPremiumLabel?: boolean
   isDisabled?: boolean
+  isPinned?: boolean
+  showCapabilitySubtitle?: boolean
   onClickLearnMore?: () => void
+  trailingContent?: React.ReactNode
 }
 
 const ModelContent = (props: ModelContentProps) => {
@@ -29,7 +41,9 @@ const ModelContent = (props: ModelContentProps) => {
     showDetails,
     showPremiumLabel,
     isDisabled,
+    showCapabilitySubtitle,
     onClickLearnMore,
+    trailingContent,
   } = props
 
   const isCustomModel = model.options.customModelOptions
@@ -92,6 +106,30 @@ const ModelContent = (props: ModelContentProps) => {
     return null
   }, [isCurrent, showPremiumLabel, isCustomModel, isOllamaModel, model])
 
+  const subtitle = React.useMemo(() => {
+    if (isCustomModel) {
+      return model.options.customModelOptions?.modelRequestName ?? ''
+    }
+
+    if (showCapabilitySubtitle) {
+      // Auto and Near models keep their descriptive localized subtitle.
+      if (
+        model.key === AUTOMATIC_MODEL_KEY
+        || model.isNearModel
+        || !model.capabilities?.length
+      ) {
+        return getLocale(
+          `CHAT_UI_${model.key.toUpperCase().replaceAll('-', '_')}_SUBTITLE`,
+        )
+      }
+      return formatModelCapabilitiesSubtitle(model.capabilities)
+    }
+
+    return getLocale(
+      `CHAT_UI_${model.key.toUpperCase().replaceAll('-', '_')}_SUBTITLE`,
+    )
+  }, [isCustomModel, model, showCapabilitySubtitle])
+
   return (
     <>
       <div
@@ -112,22 +150,14 @@ const ModelContent = (props: ModelContentProps) => {
               [styles.disabled]: isDisabled,
             })}
           >
-            {model.displayName}
+            <span className={styles.modelNameText}>{model.displayName}</span>
             {model.isNearModel && <NearIcon />}
           </div>
-          {label}
+          <div className={styles.labelAndActions}>{label}</div>
         </div>
         {showDetails && (
           <>
-            <p className={styles.modelSubtitle}>
-              {isCustomModel
-                ? model.options.customModelOptions?.modelRequestName
-                : getLocale(
-                    `CHAT_UI_${model.key
-                      .toUpperCase()
-                      .replaceAll('-', '_')}_SUBTITLE`,
-                  )}
-            </p>
+            <p className={styles.modelSubtitle}>{subtitle}</p>
             {onClickLearnMore && model.isNearModel && (
               <a
                 // While we preventDefault, we still need to pass the href
@@ -146,12 +176,158 @@ const ModelContent = (props: ModelContentProps) => {
           </>
         )}
       </div>
+      {/* Sibling of icon/column so the overlay can span the full item height. */}
+      {trailingContent}
     </>
   )
 }
 
+interface ModelOptionsMenuProps {
+  modelKey: string
+  isPinned?: boolean
+  isDefault?: boolean
+  isOpen: boolean
+  canPin: boolean
+  canSetDefault: boolean
+  onOpenChange: (open: boolean) => void
+  onTogglePin?: () => void
+  onSetAsDefault?: () => void
+}
+
+function ModelOptionsMenu(props: ModelOptionsMenuProps) {
+  const {
+    modelKey,
+    isPinned,
+    isDefault,
+    isOpen,
+    canPin,
+    canSetDefault,
+    onOpenChange,
+    onTogglePin,
+    onSetAsDefault,
+  } = props
+
+  const wrapRef = React.useRef<HTMLDivElement>(null)
+
+  // Closing returns focus to the more button; that leaves the parent
+  // leo-menu-item matching :focus-within, which keeps our hover styles on.
+  const setOpen = React.useCallback(
+    (open: boolean) => {
+      onOpenChange(open)
+      if (open) {
+        return
+      }
+      queueMicrotask(() => {
+        const wrap = wrapRef.current
+        const active = document.activeElement
+        if (
+          wrap
+          && active instanceof HTMLElement
+          && (wrap === active || wrap.contains(active))
+        ) {
+          active.blur()
+        }
+      })
+    },
+    [onOpenChange],
+  )
+
+  return (
+    <div
+      ref={wrapRef}
+      className={classnames({
+        [styles.optionsWrap]: true,
+        [styles.optionsWrapOpen]: isOpen,
+      })}
+      onClick={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+      }}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <ButtonMenu
+        className={styles.optionsMenu}
+        isOpen={isOpen}
+        onChange={(e) => setOpen(e.isOpen)}
+        positionStrategy='fixed'
+        placement='bottom-end'
+      >
+        <Button
+          slot='anchor-content'
+          fab
+          kind='plain-faint'
+          size='tiny'
+          className={styles.moreButton}
+          aria-label={getLocale(S.CHAT_UI_MODEL_MORE_OPTIONS)}
+          data-testid={`model-options-${modelKey}`}
+          onClick={(e) => {
+            // Stop bubbling so the parent model row isn't selected, and
+            // toggle here because stopPropagation also blocks Leo's anchor
+            // click handler on this nested ButtonMenu.
+            e.preventDefault()
+            e.stopPropagation()
+            setOpen(!isOpen)
+          }}
+        >
+          <Icon name='more-vertical' />
+        </Button>
+        {canPin && (
+          <leo-menu-item
+            class={styles.leoDropdownItem}
+            data-testid={`pin-${modelKey}`}
+            onClick={(e) => {
+              e.stopPropagation()
+              onTogglePin?.()
+              setOpen(false)
+            }}
+          >
+            <Icon name={isPinned ? 'pin-disable' : 'pin'} />
+            <span className={styles.leoDropdownItemLabel}>
+              {getLocale(
+                isPinned ? S.CHAT_UI_UNPIN_LABEL : S.CHAT_UI_PIN_LABEL,
+              )}
+            </span>
+          </leo-menu-item>
+        )}
+        {canSetDefault && (
+          <leo-menu-item
+            class={classnames({
+              [styles.leoDropdownItem]: true,
+              [styles.leoDropdownItemSelected]: isDefault,
+            })}
+            data-testid={`set-default-${modelKey}`}
+            aria-selected={isDefault ? 'true' : null}
+            onClick={(e) => {
+              e.stopPropagation()
+              if (isDefault) {
+                setOpen(false)
+                return
+              }
+              onSetAsDefault?.()
+              setOpen(false)
+            }}
+          >
+            <Icon
+              name={isDefault ? 'check-circle-filled' : 'check-circle-outline'}
+            />
+            <span className={styles.leoDropdownItemLabel}>
+              {getLocale(S.CHAT_UI_SET_AS_DEFAULT_MODEL)}
+            </span>
+          </leo-menu-item>
+        )}
+      </ButtonMenu>
+    </div>
+  )
+}
+
 interface MenuItemProps extends ModelContentProps {
+  isDefault?: boolean
   onClick: () => void
+  isMobile?: boolean
+  isOptionsOpen?: boolean
+  onOptionsOpenChange?: (open: boolean) => void
+  onTogglePin?: () => void
+  onSetAsDefault?: () => void
 }
 
 export function ModelMenuItem(props: MenuItemProps) {
@@ -161,30 +337,136 @@ export function ModelMenuItem(props: MenuItemProps) {
     showDetails,
     showPremiumLabel,
     isDisabled,
+    isPinned,
+    isDefault,
+    showCapabilitySubtitle,
+    isMobile,
+    isOptionsOpen = false,
+    onOptionsOpenChange,
     onClick,
     onClickLearnMore,
+    onTogglePin,
+    onSetAsDefault,
   } = props
+
+  const longPressTimer = React.useRef<number | undefined>(undefined)
+  const didLongPress = React.useRef(false)
+
+  // Automatic cannot be pinned; other models with a pin handler can.
+  const canPin = !!onTogglePin && model.key !== AUTOMATIC_MODEL_KEY
+  const canSetDefault = !!onSetAsDefault
+  const showOptions = canPin || canSetDefault
+
+  const setOptionsOpen = React.useCallback(
+    (open: boolean) => {
+      onOptionsOpenChange?.(open)
+    },
+    [onOptionsOpenChange],
+  )
+
+  const clearLongPressTimer = React.useCallback(() => {
+    if (longPressTimer.current !== undefined) {
+      window.clearTimeout(longPressTimer.current)
+      longPressTimer.current = undefined
+    }
+  }, [])
+
+  React.useEffect(() => clearLongPressTimer, [clearLongPressTimer])
+
+  // Touch/context handlers live on an inner wrapper — Leo's leo-menu-item
+  // typings only expose onClick, not React touch event props.
+  const enableLongPress = isMobile && showOptions
+
+  const handleTouchStart = React.useCallback(() => {
+    if (!enableLongPress) {
+      return
+    }
+    didLongPress.current = false
+    clearLongPressTimer()
+    longPressTimer.current = window.setTimeout(() => {
+      didLongPress.current = true
+      setOptionsOpen(true)
+    }, LONG_PRESS_MS)
+  }, [clearLongPressTimer, enableLongPress, setOptionsOpen])
+
+  const handleContextMenu = React.useCallback(
+    (e: React.MouseEvent) => {
+      if (!enableLongPress) {
+        return
+      }
+      e.preventDefault()
+      e.stopPropagation()
+      clearLongPressTimer()
+      didLongPress.current = true
+      setOptionsOpen(true)
+    },
+    [clearLongPressTimer, enableLongPress, setOptionsOpen],
+  )
+
   return (
     <leo-menu-item
+      class={isOptionsOpen ? styles.menuItemOptionsOpen : undefined}
       data-key={model.key}
       data-testid={model.key}
       aria-selected={isCurrent ? 'true' : null}
-      onClick={onClick}
+      onClick={(e) => {
+        if (didLongPress.current) {
+          e.preventDefault()
+          e.stopPropagation()
+          didLongPress.current = false
+          return
+        }
+        onClick()
+      }}
     >
-      <ModelContent
-        model={model}
-        isCurrent={isCurrent}
-        showPremiumLabel={showPremiumLabel}
-        showDetails={showDetails}
-        isDisabled={isDisabled}
-        onClickLearnMore={onClickLearnMore}
-      />
+      <div
+        className={styles.menuItemHitArea}
+        onTouchStart={enableLongPress ? handleTouchStart : undefined}
+        onTouchEnd={enableLongPress ? clearLongPressTimer : undefined}
+        onTouchMove={enableLongPress ? clearLongPressTimer : undefined}
+        onTouchCancel={enableLongPress ? clearLongPressTimer : undefined}
+        onContextMenu={enableLongPress ? handleContextMenu : undefined}
+      >
+        <ModelContent
+          model={model}
+          isCurrent={isCurrent}
+          showPremiumLabel={showPremiumLabel}
+          showDetails={showDetails}
+          isDisabled={isDisabled}
+          isPinned={isPinned}
+          showCapabilitySubtitle={showCapabilitySubtitle}
+          onClickLearnMore={onClickLearnMore}
+          trailingContent={
+            showOptions ? (
+              <ModelOptionsMenu
+                modelKey={model.key}
+                isPinned={isPinned}
+                isDefault={isDefault}
+                isOpen={isOptionsOpen}
+                canPin={canPin}
+                canSetDefault={canSetDefault}
+                onOpenChange={setOptionsOpen}
+                onTogglePin={onTogglePin}
+                onSetAsDefault={onSetAsDefault}
+              />
+            ) : undefined
+          }
+        />
+      </div>
     </leo-menu-item>
   )
 }
 
 export function ModelOption(props: ModelContentProps) {
-  const { model, isCurrent, showDetails, showPremiumLabel, isDisabled } = props
+  const {
+    model,
+    isCurrent,
+    showDetails,
+    showPremiumLabel,
+    isDisabled,
+    isPinned,
+    showCapabilitySubtitle,
+  } = props
 
   const content = (
     <ModelContent
@@ -193,6 +475,8 @@ export function ModelOption(props: ModelContentProps) {
       showPremiumLabel={showPremiumLabel}
       showDetails={showDetails}
       isDisabled={isDisabled}
+      isPinned={isPinned}
+      showCapabilitySubtitle={showCapabilitySubtitle}
     />
   )
 

--- a/components/ai_chat/resources/page/components/model_menu_item/model_menu_item_style.module.scss
+++ b/components/ai_chat/resources/page/components/model_menu_item/model_menu_item_style.module.scss
@@ -3,6 +3,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+.menuItemHitArea {
+  position: relative;
+  display: flex;
+  flex: 1;
+  align-items: center;
+  gap: var(--leo-spacing-l);
+  min-width: 0;
+  width: 100%;
+  align-self: stretch;
+}
+
 .modelIcon {
   --leo-icon-size: 20px;
   --leo-icon-color: var(--leo-color-icon-default);
@@ -36,16 +47,26 @@
   flex-grow: 1;
   display: flex;
   flex-direction: column;
+  min-width: 0;
 }
 
 .modelName {
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
+  min-width: 0;
+  flex: 1;
   font: var(--leo-font-default-regular);
   color: var(--leo-color-text-primary);
   gap: var(--leo-spacing-s);
+}
+
+.modelNameText {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .modelSubtitle {
@@ -61,11 +82,117 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
+  min-width: 0;
   gap: var(--leo-spacing-s);
 }
 
 .modelLabel {
   display: flex;
+}
+
+.labelAndActions {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--leo-spacing-s);
+  flex-shrink: 0;
+}
+
+// Absolutely overlays the trailing label (e.g. Premium) with a fade into the
+// row background so content softens under the more control.
+.optionsWrap {
+  // Default matches hover; selected (non-hover) uses interactive below.
+  --options-fade-color: var(--leo-color-container-highlight);
+
+  position: absolute;
+  inset-block: 0;
+  inset-inline-end: 0;
+  // Avoid z-index here: it would create a stacking context that traps the
+  // nested position:fixed Leo popup below later rows' hover overlays.
+  display: none;
+  align-items: center;
+  justify-content: flex-end;
+  // Wide enough that the Premium badge meaningfully fades before the icon.
+  padding-inline-start: 40px;
+  pointer-events: none;
+  background: linear-gradient(
+    to right,
+    transparent 0%,
+    var(--options-fade-color) 55%,
+    var(--options-fade-color) 100%
+  );
+}
+
+// Match modelList's selected background when the row isn't hovered
+// (e.g. more-menu open on the current model).
+:global(leo-menu-item[aria-selected]:not(:hover)) .optionsWrap {
+  --options-fade-color: var(--leo-color-container-interactive);
+}
+
+:global([dir='rtl']) .optionsWrap {
+  background: linear-gradient(
+    to left,
+    transparent 0%,
+    var(--options-fade-color) 55%,
+    var(--options-fade-color) 100%
+  );
+}
+
+.optionsWrapOpen {
+  display: flex;
+}
+
+// Raise the whole model row while its more-menu is open so later rows'
+// hover gradients cannot paint over the open popup.
+.menuItemOptionsOpen {
+  position: relative;
+  z-index: 2;
+}
+
+@media (hover: hover) {
+  :global(leo-menu-item:hover) .optionsWrap,
+  :global(leo-menu-item:focus-within) .optionsWrap {
+    display: flex;
+  }
+}
+
+.optionsMenu {
+  line-height: 0;
+  pointer-events: auto;
+}
+
+.moreButton {
+  --leo-icon-size: 18px;
+  --leo-button-padding: 4px;
+  color: var(--leo-color-icon-default);
+  pointer-events: auto;
+}
+
+// Nala Dropdown list-item layout for Pin / Set as default.
+// See: https://nala.bravesoftware.com/?path=/story/components-dropdown--both-icons
+.leoDropdownItem {
+  --leo-icon-size: 18px;
+  --leo-icon-color: var(--leo-color-icon-default);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--leo-spacing-xl);
+  min-width: 180px;
+}
+
+.leoDropdownItemLabel {
+  flex: 1;
+  font: var(--leo-font-default-regular);
+  color: var(--leo-color-text-primary);
+}
+
+.leoDropdownItemSelected {
+  --leo-icon-color: var(--leo-color-icon-interactive);
+  color: var(--leo-color-text-interactive);
+
+  .leoDropdownItemLabel {
+    color: var(--leo-color-text-interactive);
+  }
 }
 
 .learnMoreLink {

--- a/components/ai_chat/resources/page/components/model_selector/model_selector.stories.tsx
+++ b/components/ai_chat/resources/page/components/model_selector/model_selector.stories.tsx
@@ -12,6 +12,7 @@ import {
   getVendorRailEntries,
   modelHasAllCapabilities,
 } from '../../model_utils'
+import { ModelMenuItem } from '../model_menu_item/model_menu_item'
 import { CapabilityFilter } from './capability_filter'
 import { ModelSearch } from './model_search'
 import { VendorRail } from './vendor_rail'
@@ -160,6 +161,19 @@ function ModelSelectorChrome() {
     Mojom.ModelCapability[]
   >([])
   const [filterOpen, setFilterOpen] = React.useState(false)
+  const [pinnedKeys, setPinnedKeys] = React.useState<string[]>([
+    'chat-claude-sonnet',
+    'chat-gpt-mini',
+  ])
+  const [defaultModelKey, setDefaultModelKey] = React.useState(
+    'chat-claude-sonnet',
+  )
+  const [currentModelKey, setCurrentModelKey] = React.useState(
+    'chat-claude-sonnet',
+  )
+  const [openOptionsKey, setOpenOptionsKey] = React.useState<string | null>(
+    null,
+  )
 
   const vendorEntries = React.useMemo(
     () => getVendorRailEntries(MODELS),
@@ -183,7 +197,8 @@ function ModelSelectorChrome() {
         return true
       }
       const maker = model.options.leoModelOptions?.displayMaker ?? ''
-      const requestName = model.options.customModelOptions?.modelRequestName ?? ''
+      const requestName =
+        model.options.customModelOptions?.modelRequestName ?? ''
       return (
         model.displayName.toLowerCase().includes(query)
         || maker.toLowerCase().includes(query)
@@ -210,35 +225,53 @@ function ModelSelectorChrome() {
             selected={capabilityFilters}
             onChange={setCapabilityFilters}
             isOpen={filterOpen}
-            onOpenChange={setFilterOpen}
+            onOpenChange={(open) => {
+              setFilterOpen(open)
+              if (open) {
+                setOpenOptionsKey(null)
+              }
+            }}
           />
         </div>
         <div className={styles.modelList}>
           {filteredModels.length === 0 ? (
             <div className={styles.emptyState}>No models found</div>
           ) : (
-            filteredModels.map((model) => (
-              <div
-                key={model.key}
-                style={{
-                  padding: '8px 12px',
-                  borderRadius: 8,
-                  font: 'var(--leo-font-default-regular)',
-                }}
-              >
-                {model.displayName}
-                <div
-                  style={{
-                    font: 'var(--leo-font-small-regular)',
-                    color: 'var(--leo-color-text-tertiary)',
+            filteredModels.map((model) => {
+              const isPinned = pinnedKeys.includes(model.key)
+              return (
+                <ModelMenuItem
+                  key={model.key}
+                  model={model}
+                  isCurrent={model.key === currentModelKey}
+                  isPinned={isPinned}
+                  isDefault={model.key === defaultModelKey}
+                  showPremiumLabel={true}
+                  showDetails={true}
+                  showCapabilitySubtitle={true}
+                  isOptionsOpen={openOptionsKey === model.key}
+                  onOptionsOpenChange={(open) => {
+                    setOpenOptionsKey(open ? model.key : null)
+                    if (open) {
+                      setFilterOpen(false)
+                    }
                   }}
-                >
-                  {model.options.leoModelOptions?.displayMaker
-                    || model.options.customModelOptions?.modelRequestName
-                    || ' '}
-                </div>
-              </div>
-            ))
+                  onClick={() => setCurrentModelKey(model.key)}
+                  onSetAsDefault={() => setDefaultModelKey(model.key)}
+                  onTogglePin={
+                    model.key === 'chat-automatic'
+                      ? undefined
+                      : () => {
+                          setPinnedKeys((prev) =>
+                            prev.includes(model.key)
+                              ? prev.filter((key) => key !== model.key)
+                              : [model.key, ...prev],
+                          )
+                        }
+                  }
+                />
+              )
+            })
           )}
         </div>
       </div>
@@ -246,7 +279,7 @@ function ModelSelectorChrome() {
   )
 }
 
-export const _SearchFilterAndVendorRail = {
+export const _SearchFilterRailAndModelItems = {
   render: () => <ModelSelectorChrome />,
 }
 

--- a/components/ai_chat/resources/page/components/model_selector/style.module.scss
+++ b/components/ai_chat/resources/page/components/model_selector/style.module.scss
@@ -286,6 +286,28 @@
   overflow-y: auto;
   flex: 1;
   min-height: 0;
+
+  // Scope to the model list only so nested menus (filter / item options)
+  // keep Nala's default menu-item sizing.
+  leo-menu-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--leo-spacing-l);
+    padding: var(--leo-spacing-s) var(--leo-spacing-m);
+    max-width: 100%;
+    border-radius: var(--leo-radius-m);
+    cursor: pointer;
+
+    &:hover {
+      background: var(--leo-color-container-highlight);
+    }
+
+    &[aria-selected]:not(:hover) {
+      background: var(--leo-color-container-interactive);
+      color: var(--leo-color-text-interactive);
+    }
+  }
 }
 
 .emptyState {


### PR DESCRIPTION
## Summary
- Redesigns `ModelMenuItem` with capability subtitles, nested pin / set-as-default options menu, and mobile long-press
- New props are optional so the current live selector keeps the same behavior
- Extends the Storybook story to demo pinned / default / current states

Depends on PR 2 (`leo-model-selector-pr2`). This is **PR 3/4**.

## Test plan
- [ ] Storybook: pin / unpin and set-as-default work on model items
- [ ] Capability subtitle renders for models with tags
- [ ] Live in-browser selector (without new props) looks/behaves as before
- [ ] Regenerated-answer / skill-modal `ModelMenuItem` / `ModelOption` usage still works

