### PR TITLE
[AI Chat] (04) Wire redesigned model selector into the live UI

### DIFF
--- a/components/ai_chat/resources/page/components/model_selector/index.test.tsx
+++ b/components/ai_chat/resources/page/components/model_selector/index.test.tsx
@@ -5,11 +5,22 @@
 
 import * as React from 'react'
 import * as Mojom from '../../../common/mojom'
-import { render, act, within, waitFor } from '@testing-library/react'
+import { render, act, waitFor } from '@testing-library/react'
 import { ModelSelector } from '.'
 import '@testing-library/jest-dom'
 import { MockContext } from '../../state/mock_context'
 import { clearAllDataForTesting } from '$web-common/api'
+import {
+  LOCAL_VENDOR_KEY,
+  PINNED_VENDOR_KEY,
+} from '../../../common/vendor_icon_map'
+
+function withCapabilities(
+  model: Mojom.Model,
+  capabilities: Mojom.ModelCapability[] = [],
+): Mojom.Model {
+  return { ...model, capabilities }
+}
 
 describe('ModelSelector', () => {
   beforeEach(() => {
@@ -17,121 +28,135 @@ describe('ModelSelector', () => {
   })
 
   const mockModels: Mojom.Model[] = [
-    {
-      key: 'chat-automatic',
-      displayName: 'Automatic',
-      isSuggestedModel: true,
-      isNearModel: false,
-      visionSupport: true,
-      supportsTools: true,
-      supportedCapabilities: [
-        Mojom.ConversationCapability.CHAT,
-        Mojom.ConversationCapability.CONTENT_AGENT,
+    withCapabilities(
+      {
+        key: 'chat-automatic',
+        displayName: 'Automatic',
+        isSuggestedModel: true,
+        isNearModel: false,
+        visionSupport: true,
+        supportsTools: true,
+        supportedCapabilities: [
+          Mojom.ConversationCapability.CHAT,
+          Mojom.ConversationCapability.CONTENT_AGENT,
+        ],
+        options: {
+          customModelOptions: undefined,
+          leoModelOptions: {
+            name: 'A model',
+            displayMaker: '',
+            category: Mojom.ModelCategory.CHAT,
+            longConversationWarningCharacterLimit: 1,
+            maxAssociatedContentLength: 2,
+            access: Mojom.ModelAccess.BASIC_AND_PREMIUM,
+          },
+        },
+      },
+      [
+        Mojom.ModelCapability.SEARCH,
+        Mojom.ModelCapability.VISION,
+        Mojom.ModelCapability.TOOLS,
       ],
-      capabilities: [],
-      options: {
-        customModelOptions: undefined,
-        leoModelOptions: {
-          name: 'A model',
-          displayMaker: 'Brave',
-          category: Mojom.ModelCategory.CHAT,
-          longConversationWarningCharacterLimit: 1,
-          maxAssociatedContentLength: 2,
-          access: Mojom.ModelAccess.BASIC_AND_PREMIUM,
+    ),
+    withCapabilities(
+      {
+        key: 'chat-basic',
+        displayName: 'Basic Model',
+        isSuggestedModel: true,
+        isNearModel: false,
+        supportsTools: true,
+        supportedCapabilities: [
+          Mojom.ConversationCapability.CHAT,
+          Mojom.ConversationCapability.CONTENT_AGENT,
+        ],
+        visionSupport: true,
+        options: {
+          customModelOptions: undefined,
+          leoModelOptions: {
+            name: 'A model',
+            displayMaker: 'Anthropic',
+            category: Mojom.ModelCategory.CHAT,
+            longConversationWarningCharacterLimit: 1,
+            maxAssociatedContentLength: 2,
+            access: Mojom.ModelAccess.BASIC_AND_PREMIUM,
+          },
         },
       },
-    },
-    {
-      key: 'chat-basic',
-      displayName: 'Basic Model',
-      isSuggestedModel: true,
-      isNearModel: false,
-      supportsTools: true,
-      supportedCapabilities: [
-        Mojom.ConversationCapability.CHAT,
-        Mojom.ConversationCapability.CONTENT_AGENT,
-      ],
-      capabilities: [],
-      visionSupport: true,
-      options: {
-        customModelOptions: undefined,
-        leoModelOptions: {
-          name: 'A model',
-          displayMaker: 'Brave',
-          category: Mojom.ModelCategory.CHAT,
-          longConversationWarningCharacterLimit: 1,
-          maxAssociatedContentLength: 2,
-          access: Mojom.ModelAccess.BASIC_AND_PREMIUM,
+      [Mojom.ModelCapability.FAST, Mojom.ModelCapability.VISION],
+    ),
+    withCapabilities(
+      {
+        key: 'another-chat-basic',
+        displayName: 'Another Basic Model',
+        isSuggestedModel: false,
+        isNearModel: false,
+        supportsTools: false,
+        supportedCapabilities: [Mojom.ConversationCapability.CHAT],
+        visionSupport: true,
+        options: {
+          customModelOptions: undefined,
+          leoModelOptions: {
+            name: 'A model',
+            displayMaker: 'OpenAI',
+            category: Mojom.ModelCategory.CHAT,
+            longConversationWarningCharacterLimit: 1,
+            maxAssociatedContentLength: 2,
+            access: Mojom.ModelAccess.BASIC_AND_PREMIUM,
+          },
         },
       },
-    },
-    {
-      key: 'another-chat-basic',
-      displayName: 'Another Basic Model',
-      isSuggestedModel: false,
-      isNearModel: false,
-      supportsTools: false,
-      supportedCapabilities: [Mojom.ConversationCapability.CHAT],
-      capabilities: [],
-      visionSupport: true,
-      options: {
-        customModelOptions: undefined,
-        leoModelOptions: {
-          name: 'A model',
-          displayMaker: 'Brave',
-          category: Mojom.ModelCategory.CHAT,
-          longConversationWarningCharacterLimit: 1,
-          maxAssociatedContentLength: 2,
-          access: Mojom.ModelAccess.BASIC_AND_PREMIUM,
+      [Mojom.ModelCapability.THINKING],
+    ),
+    withCapabilities(
+      {
+        key: 'chat-premium',
+        displayName: 'Premium Model',
+        isSuggestedModel: true,
+        isNearModel: true,
+        supportsTools: true,
+        supportedCapabilities: [
+          Mojom.ConversationCapability.CHAT,
+          Mojom.ConversationCapability.CONTENT_AGENT,
+        ],
+        visionSupport: true,
+        options: {
+          customModelOptions: undefined,
+          leoModelOptions: {
+            name: 'A model',
+            displayMaker: 'Z.ai',
+            category: Mojom.ModelCategory.CHAT,
+            longConversationWarningCharacterLimit: 1,
+            maxAssociatedContentLength: 2,
+            access: Mojom.ModelAccess.PREMIUM,
+          },
         },
       },
-    },
-    {
-      key: 'chat-premium',
-      displayName: 'Premium Model',
-      isSuggestedModel: true,
-      isNearModel: true,
-      supportsTools: true,
-      supportedCapabilities: [
-        Mojom.ConversationCapability.CHAT,
-        Mojom.ConversationCapability.CONTENT_AGENT,
-      ],
-      capabilities: [],
-      visionSupport: true,
-      options: {
-        customModelOptions: undefined,
-        leoModelOptions: {
-          name: 'A model',
-          displayMaker: 'Brave',
-          category: Mojom.ModelCategory.CHAT,
-          longConversationWarningCharacterLimit: 1,
-          maxAssociatedContentLength: 2,
-          access: Mojom.ModelAccess.PREMIUM,
+      [Mojom.ModelCapability.SEARCH],
+    ),
+    withCapabilities(
+      {
+        key: 'another-chat-premium',
+        displayName: 'Another Premium Model',
+        isSuggestedModel: false,
+        isNearModel: false,
+        supportsTools: false,
+        supportedCapabilities: [Mojom.ConversationCapability.CHAT],
+        visionSupport: true,
+        options: {
+          customModelOptions: undefined,
+          leoModelOptions: {
+            name: 'A model',
+            displayMaker: 'Anthropic',
+            category: Mojom.ModelCategory.CHAT,
+            longConversationWarningCharacterLimit: 1,
+            maxAssociatedContentLength: 2,
+            access: Mojom.ModelAccess.PREMIUM,
+          },
         },
       },
-    },
-    {
-      key: 'another-chat-premium',
-      displayName: 'Another Premium Model',
-      isSuggestedModel: false,
-      isNearModel: false,
-      supportsTools: false,
-      supportedCapabilities: [Mojom.ConversationCapability.CHAT],
-      capabilities: [],
-      visionSupport: true,
-      options: {
-        customModelOptions: undefined,
-        leoModelOptions: {
-          name: 'A model',
-          displayMaker: 'Brave',
-          category: Mojom.ModelCategory.CHAT,
-          longConversationWarningCharacterLimit: 1,
-          maxAssociatedContentLength: 2,
-          access: Mojom.ModelAccess.PREMIUM,
-        },
-      },
-    },
-    {
+      [Mojom.ModelCapability.VISION, Mojom.ModelCapability.TOOLS],
+    ),
+    withCapabilities({
       key: 'chat-brave-summary',
       displayName: 'Brave Summary',
       isSuggestedModel: false,
@@ -139,7 +164,6 @@ describe('ModelSelector', () => {
       visionSupport: true,
       supportsTools: false,
       supportedCapabilities: [Mojom.ConversationCapability.CHAT],
-      capabilities: [],
       options: {
         customModelOptions: undefined,
         leoModelOptions: {
@@ -151,16 +175,14 @@ describe('ModelSelector', () => {
           access: Mojom.ModelAccess.BASIC_AND_PREMIUM,
         },
       },
-    },
-
-    {
+    }),
+    withCapabilities({
       key: 'chat-custom',
       displayName: 'Custom Model',
       isNearModel: false,
       visionSupport: false,
       supportsTools: false,
       supportedCapabilities: [Mojom.ConversationCapability.CHAT],
-      capabilities: [],
       isSuggestedModel: false,
       options: {
         leoModelOptions: undefined,
@@ -176,7 +198,7 @@ describe('ModelSelector', () => {
           },
         },
       },
-    },
+    }),
   ]
 
   const getAnchorButton = () => {
@@ -193,13 +215,14 @@ describe('ModelSelector', () => {
     return menu
   }
 
-  const getShowAllModelsButton = () => {
-    const showAllModelsButton = document.querySelector<HTMLElement>(
-      'leo-menu-item[data-testid="show-all-models-button"]',
-    )
-    expect(showAllModelsButton).toBeInTheDocument()
-    expect(showAllModelsButton).toBeVisible()
-    return showAllModelsButton
+  const openMenu = async () => {
+    const anchorButton = getAnchorButton()
+    await act(async () => {
+      anchorButton?.shadowRoot?.querySelector('button')?.click()
+    })
+    const menu = getMenu()
+    expect(menu).toHaveAttribute('isOpen', 'true')
+    return menu
   }
 
   const renderModelSelector = (
@@ -212,6 +235,9 @@ describe('ModelSelector', () => {
             allModels: mockModels,
             currentModelKey: 'chat-basic',
           },
+          serviceState: {
+            pinnedModelKeys: ['chat-basic', 'chat-premium'],
+          },
           ...props?.initialState,
         }}
         aiChatOverrides={{
@@ -220,6 +246,7 @@ describe('ModelSelector', () => {
           ...props?.aiChatOverrides,
         }}
         conversationHandler={props?.conversationHandler}
+        service={props?.service}
       >
         <ModelSelector />
       </MockContext>,
@@ -229,106 +256,124 @@ describe('ModelSelector', () => {
   it('renders the component with the current model', async () => {
     renderModelSelector()
 
-    // Make sure the anchor button is visible
     const anchorButton = getAnchorButton()
     expect(anchorButton).toHaveTextContent('Basic Model')
 
-    // Make sure the menu is visible
     const menu = getMenu()
     expect(menu).toHaveAttribute('isOpen', 'false')
-    await act(async () => {
-      anchorButton?.shadowRoot?.querySelector('button')?.click()
-    })
-    expect(menu).toHaveAttribute('isOpen', 'true')
+    await openMenu()
 
-    // Make sure the default menu items are visible
-    const menuItems = document.querySelectorAll<HTMLElement>('leo-menu-item')
-    expect(menuItems).toHaveLength(4)
-    expect(menuItems[0]).toHaveTextContent('Automatic')
-    expect(menuItems[1]).toHaveTextContent('Basic Model')
-    expect(menuItems[2]).toHaveTextContent('Premium Model')
+    // Pinned view: Auto + pinned keys
+    const menuItems = document.querySelectorAll<HTMLElement>(
+      '.modelList leo-menu-item, [class*="modelList"] leo-menu-item',
+    )
+    // Fallback: all leo-menu-item that are models (exclude capability filter)
+    const modelItems = Array.from(
+      document.querySelectorAll<HTMLElement>('leo-menu-item[data-key]'),
+    )
+    expect(modelItems.length).toBeGreaterThanOrEqual(3)
+    expect(modelItems[0]).toHaveTextContent('Automatic')
+    expect(
+      modelItems.some((item) => item.textContent?.includes('Basic Model')),
+    ).toBe(true)
+    expect(
+      modelItems.some((item) => item.textContent?.includes('Premium Model')),
+    ).toBe(true)
   })
 
-  it('shows all models if Show all models button is clicked', async () => {
+  it('filters models by vendor from the rail', async () => {
     renderModelSelector()
+    await openMenu()
 
-    // Click the anchor button to show menu
-    const anchorButton = getAnchorButton()
+    const anthropicButton = document.querySelector<HTMLButtonElement>(
+      `button[data-testid="vendor-rail-Anthropic"]`,
+    )
+    expect(anthropicButton).toBeInTheDocument()
     await act(async () => {
-      anchorButton?.shadowRoot?.querySelector('button')?.click()
+      anthropicButton?.click()
     })
 
-    // Test Show all models button
-    const showAllModelsButton = getShowAllModelsButton()
-    expect(showAllModelsButton).toHaveTextContent(
-      'CHAT_UI_SHOW_ALL_MODELS_BUTTON',
-    )
-
-    // Click the show all models button
-    await act(async () => {
-      showAllModelsButton?.click()
-    })
-
-    // Check that the button text has changed
-    expect(showAllModelsButton).toHaveTextContent(
-      'CHAT_UI_RECOMMENDED_MODELS_BUTTON',
-    )
-
-    // Check that all model items are visible (wait for re-render).
-    // SUMMARY category (chat-brave-summary) is hidden, so 6 models + footer = 7 items.
     await waitFor(() => {
-      const allMenuItems =
-        document.querySelectorAll<HTMLElement>('leo-menu-item')
-      expect(allMenuItems).toHaveLength(7)
+      const modelItems = Array.from(
+        document.querySelectorAll<HTMLElement>('leo-menu-item[data-key]'),
+      )
+      expect(modelItems.map((i) => i.getAttribute('data-key'))).toEqual(
+        expect.arrayContaining(['chat-basic', 'another-chat-premium']),
+      )
+      expect(
+        modelItems.every(
+          (i) =>
+            i.getAttribute('data-key') === 'chat-basic'
+            || i.getAttribute('data-key') === 'another-chat-premium',
+        ),
+      ).toBe(true)
     })
-    const allMenuItems = document.querySelectorAll<HTMLElement>('leo-menu-item')
-    expect(allMenuItems[0]).toHaveTextContent('Automatic')
-    expect(allMenuItems[1]).toHaveTextContent('Basic Model')
-    expect(allMenuItems[2]).toHaveTextContent('Another Basic Model')
-    expect(allMenuItems[3]).toHaveTextContent('Premium Model')
-    expect(allMenuItems[4]).toHaveTextContent('Another Premium Model')
-    expect(allMenuItems[5]).toHaveTextContent('Custom Model')
-    expect(allMenuItems[6]).toHaveTextContent(
-      'CHAT_UI_RECOMMENDED_MODELS_BUTTON',
+  })
+
+  it('filters models by search query', async () => {
+    renderModelSelector()
+    await openMenu()
+
+    const search = document.querySelector('leo-input') as HTMLElement & {
+      onInput?: (detail: { value: string }) => void
+    }
+    expect(search).toBeInTheDocument()
+    await act(async () => {
+      // Leo CE exposes onInput as a property; set it through that path so the
+      // Svelte forward() handler receives InputEventDetail.
+      search.onInput?.({ value: 'Premium' })
+    })
+
+    await waitFor(() => {
+      const modelItems = Array.from(
+        document.querySelectorAll<HTMLElement>('leo-menu-item[data-key]'),
+      )
+      expect(modelItems.length).toBeGreaterThanOrEqual(1)
+      expect(modelItems.every((i) => i.textContent?.includes('Premium'))).toBe(
+        true,
+      )
+    })
+  })
+
+  it('shows local models empty state when none exist on Local rail', async () => {
+    const modelsWithoutCustom = mockModels.filter(
+      (m) => !m.options.customModelOptions,
     )
+    renderModelSelector({
+      initialState: {
+        conversationState: {
+          allModels: modelsWithoutCustom,
+          currentModelKey: 'chat-basic',
+        },
+        serviceState: {
+          pinnedModelKeys: ['chat-basic'],
+        },
+      },
+    })
+    await openMenu()
 
-    const labels = document.querySelectorAll<HTMLElement>('leo-label')
-
-    // Check that current model label is visible
-    expect(labels[0]).toBeInTheDocument()
-    expect(labels[0]).toBeVisible()
-    expect(labels[0]).toHaveTextContent('CHAT_UI_CURRENT_LABEL')
-
-    // Check that premium model label is visible
-    expect(labels[2]).toBeInTheDocument()
-    expect(labels[2]).toBeVisible()
-    expect(labels[2]).toHaveTextContent(
-      'CHAT_UI_MODEL_PREMIUM_LABEL_NON_PREMIUM',
+    const localButton = document.querySelector<HTMLButtonElement>(
+      `button[data-testid="vendor-rail-${LOCAL_VENDOR_KEY}"]`,
     )
+    expect(localButton).toBeInTheDocument()
+    await act(async () => {
+      localButton?.click()
+    })
 
-    // Check that local label is visible
-    expect(labels[3]).toBeInTheDocument()
-    expect(labels[3]).toBeVisible()
-    expect(labels[3]).toHaveTextContent('CHAT_UI_MODEL_LOCAL_LABEL')
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-testid="model-selector-empty"]'),
+      ).toHaveTextContent('CHAT_UI_LOCAL_MODELS_EMPTY')
+    })
   })
 
   it('hides internal models from the dropdown', async () => {
     renderModelSelector()
-
-    const anchorButton = getAnchorButton()
-    await act(async () => {
-      anchorButton?.shadowRoot?.querySelector('button')?.click()
-    })
+    await openMenu()
 
     const menu = getMenu()
     expect(menu).not.toHaveTextContent('Brave Ocelot')
-
-    const showAllModelsButton = getShowAllModelsButton()
-    await act(async () => {
-      showAllModelsButton?.click()
-    })
-
-    expect(menu).not.toHaveTextContent('Brave Ocelot')
+    expect(menu).not.toHaveTextContent('Brave Summary')
   })
 
   it('should call setCurrentModel when a model is clicked', async () => {
@@ -340,45 +385,102 @@ describe('ModelSelector', () => {
       },
     })
 
-    // Click the anchor button to show menu
-    const anchorButton = getAnchorButton()
-    expect(anchorButton).toHaveTextContent('Basic Model')
+    await openMenu()
+
+    const basic = document.querySelector<HTMLElement>(
+      'leo-menu-item[data-testid="chat-basic"]',
+    )
+    expect(basic).toBeInTheDocument()
     await act(async () => {
-      anchorButton?.shadowRoot?.querySelector('button')?.click()
+      basic?.click()
     })
 
-    // Make sure the menu is open
-    const menu = getMenu()
-    expect(menu).toHaveAttribute('isOpen', 'true')
-
-    // Click the show all models button
-    const showAllModelsButton = getShowAllModelsButton()
-    await act(async () => {
-      showAllModelsButton?.click()
-    })
-
-    // Wait for re-render and select another model
-    await waitFor(() => {
-      const items = document.querySelectorAll<HTMLElement>('leo-menu-item')
-      expect(items).toHaveLength(7)
-    })
-    const allMenuItems = document.querySelectorAll<HTMLElement>('leo-menu-item')
-    await act(async () => {
-      allMenuItems[1].click()
-    })
-
-    // Verify setCurrentModel was called with the model key
     expect(mockSetCurrentModel).toHaveBeenCalledWith(mockModels[1].key)
-    expect(menu).toHaveAttribute('isOpen', 'false')
+  })
+
+  it('should call setModelPinned when pin is chosen from options menu', async () => {
+    const setModelPinned = jest.fn()
+    renderModelSelector({
+      service: {
+        setModelPinned,
+      },
+      initialState: {
+        conversationState: {
+          allModels: mockModels,
+          currentModelKey: 'chat-basic',
+        },
+        serviceState: {
+          pinnedModelKeys: ['chat-basic'],
+        },
+      },
+    })
+
+    await openMenu()
+
+    const optionsButton = document.querySelector<HTMLElement>(
+      '[data-testid="model-options-chat-basic"]',
+    )
+    expect(optionsButton).toBeInTheDocument()
+    await act(async () => {
+      optionsButton?.click()
+    })
+
+    const pinItem = document.querySelector<HTMLElement>(
+      '[data-testid="pin-chat-basic"]',
+    )
+    expect(pinItem).toBeInTheDocument()
+    await act(async () => {
+      pinItem?.click()
+    })
+
+    expect(setModelPinned).toHaveBeenCalledWith('chat-basic', false)
+  })
+
+  it('should call setDefaultModelKey when set as default is chosen', async () => {
+    const setDefaultModelKey = jest.fn()
+    renderModelSelector({
+      service: {
+        setDefaultModelKey,
+      },
+      initialState: {
+        conversationState: {
+          allModels: mockModels,
+          currentModelKey: 'chat-basic',
+          defaultModelKey: 'chat-basic',
+        },
+        serviceState: {
+          // Keep premium in the default pinned view so its options
+          // control is in the DOM without switching vendors.
+          pinnedModelKeys: ['chat-basic', 'chat-premium'],
+        },
+      },
+    })
+
+    await openMenu()
+
+    const optionsButton = document.querySelector<HTMLElement>(
+      '[data-testid="model-options-chat-premium"]',
+    )
+    expect(optionsButton).toBeInTheDocument()
+    await act(async () => {
+      optionsButton?.click()
+    })
+
+    const setDefaultItem = document.querySelector<HTMLElement>(
+      '[data-testid="set-default-chat-premium"]',
+    )
+    expect(setDefaultItem).toBeInTheDocument()
+    await act(async () => {
+      setDefaultItem?.click()
+    })
+
+    expect(setDefaultModelKey).toHaveBeenCalledWith('chat-premium')
   })
 
   it(
     'should only show compatible models in the model selector if in'
       + 'agent mode',
     async () => {
-      // Simulate the real context behavior: in agent mode,
-      // filter models by supportedCapabilities. This mimics the logic
-      // in Conversation Context.
       const filteredModels = mockModels.filter((model) =>
         model.supportedCapabilities.includes(
           Mojom.ConversationCapability.CONTENT_AGENT,
@@ -391,6 +493,9 @@ describe('ModelSelector', () => {
             allModels: filteredModels,
             currentModelKey: 'chat-basic',
           },
+          serviceState: {
+            pinnedModelKeys: ['chat-basic', 'chat-premium'],
+          },
         },
         aiChatOverrides: {
           isAIChatAgentProfileFeatureEnabled: true,
@@ -398,62 +503,43 @@ describe('ModelSelector', () => {
         },
       })
 
-      // Click the anchor button to show menu
-      const anchorButton = getAnchorButton()
-      await act(async () => {
-        anchorButton?.shadowRoot?.querySelector('button')?.click()
-      })
+      await openMenu()
 
-      // Test Show all models button
-      const showAllModelsButton = getShowAllModelsButton()
-      expect(showAllModelsButton).toHaveTextContent(
-        'CHAT_UI_SHOW_ALL_MODELS_BUTTON',
+      const modelItems = Array.from(
+        document.querySelectorAll<HTMLElement>('leo-menu-item[data-key]'),
       )
+      expect(
+        modelItems.every((item) =>
+          ['chat-automatic', 'chat-basic', 'chat-premium'].includes(
+            item.getAttribute('data-key') ?? '',
+          ),
+        ),
+      ).toBe(true)
 
-      // Click the show all models button
-      await act(async () => {
-        showAllModelsButton?.click()
-      })
-
-      // Check that all model items are visible
-      const allMenuItems =
-        document.querySelectorAll<HTMLElement>('leo-menu-item')
-      expect(allMenuItems).toHaveLength(4)
-      expect(allMenuItems[0]).toHaveTextContent('Automatic')
-      expect(allMenuItems[1]).toHaveTextContent('Basic Model')
-      expect(allMenuItems[2]).toHaveTextContent('Premium Model')
-
-      // Check that the AI Agent profile alert is visible
       const alert = document.querySelector<HTMLElement>('leo-alert')
       expect(alert).toBeInTheDocument()
       expect(alert).toBeVisible()
       expect(alert).toHaveTextContent('CHAT_UI_AGENT_MODE_MODEL_INFO')
     },
   )
+
   it('should display near icon and beta label for near models', async () => {
     renderModelSelector()
+    await openMenu()
 
-    // Make sure the anchor button is visible
-    const anchorButton = getAnchorButton()
-    expect(anchorButton).toHaveTextContent('Basic Model')
+    const labels = document.querySelectorAll<HTMLElement>('leo-label')
+    const beta = Array.from(labels).find((l) =>
+      l.textContent?.includes('CHAT_UI_MODEL_BETA_LABEL'),
+    )
+    expect(beta).toBeTruthy()
+  })
 
-    // Make sure the menu is visible
-    const menu = getMenu()
-    expect(menu).toHaveAttribute('isOpen', 'false')
-    await act(async () => {
-      anchorButton?.shadowRoot?.querySelector('button')?.click()
-    })
-    expect(menu).toHaveAttribute('isOpen', 'true')
-
-    // Make sure the default menu items are visible
-    const menuItems = document.querySelectorAll<HTMLElement>('leo-menu-item')
-    const nearMenuItem = menuItems[2]
-
-    // Check that the beta label is visible
-    expect(nearMenuItem).toHaveTextContent('CHAT_UI_MODEL_BETA_LABEL')
-
-    // Check that the near icon is present in the Premium Model menu item
-    const nearIcon = within(nearMenuItem).getByRole('img')
-    expect(nearIcon).toHaveClass('nearIcon')
+  it('keeps pinned rail selected by default', async () => {
+    renderModelSelector()
+    await openMenu()
+    const pinned = document.querySelector(
+      `button[data-testid="vendor-rail-${PINNED_VENDOR_KEY}"]`,
+    )
+    expect(pinned).toHaveAttribute('aria-selected', 'true')
   })
 })

--- a/components/ai_chat/resources/page/components/model_selector/index.tsx
+++ b/components/ai_chat/resources/page/components/model_selector/index.tsx
@@ -15,103 +15,220 @@ import {
   AUTOMATIC_MODEL_KEY,
   NEAR_AI_LEARN_MORE_URL,
 } from '../../../common/constants'
+import {
+  LOCAL_VENDOR_KEY,
+  PINNED_VENDOR_KEY,
+} from '../../../common/vendor_icon_map'
 import { useAIChat } from '../../state/ai_chat_context'
 import { useConversation } from '../../state/conversation_context'
-import { isSelectableModel } from '../../model_utils'
+import {
+  getAvailableModelCapabilities,
+  getVendorRailEntries,
+  isSelectableModel,
+  modelHasAllCapabilities,
+} from '../../model_utils'
 import { ModelMenuItem } from '../model_menu_item/model_menu_item'
 import { NearIcon } from '../near_label/near_label'
+import { FuzzyFinder } from '../filter_menu/fuzzy_finder'
+import { matches } from '../filter_menu/query'
+import { CapabilityFilter } from './capability_filter'
+import { ModelSearch } from './model_search'
+import { VendorRail } from './vendor_rail'
 import styles from './style.module.scss'
+
+function matchesModelQuery(query: string, model: Mojom.Model) {
+  if (!query) {
+    return true
+  }
+  const finder = new FuzzyFinder(query)
+  const nameMatch = matches(finder, model.displayName)
+  const maker = model.options.leoModelOptions?.displayMaker ?? ''
+  const makerMatch = maker ? matches(finder, maker) : undefined
+  const requestName = model.options.customModelOptions?.modelRequestName ?? ''
+  const requestMatch = requestName ? matches(finder, requestName) : undefined
+  return !!(nameMatch || makerMatch || requestMatch)
+}
 
 export function ModelSelector() {
   const aiChatContext = useAIChat()
   const conversationContext = useConversation()
 
-  // State
   const [isOpen, setIsOpen] = React.useState(false)
-  const [showAllModels, setShowAllModels] = React.useState(false)
+  const [selectedVendorKey, setSelectedVendorKey] =
+    React.useState(PINNED_VENDOR_KEY)
+  const [searchQuery, setSearchQuery] = React.useState('')
+  const [capabilityFilters, setCapabilityFilters] = React.useState<
+    Mojom.ModelCapability[]
+  >([])
+  // Only one nested popover (filter or a model's options) can be open.
+  const [openPopover, setOpenPopover] = React.useState<
+    null | { kind: 'filter' } | { kind: 'model-options'; modelKey: string }
+  >(null)
 
-  // Memos
   const selectableModels = React.useMemo(
     () => conversationContext.allModels.filter(isSelectableModel),
     [conversationContext.allModels],
   )
 
-  const suggestedModels = React.useMemo(
-    () => selectableModels.filter((model) => model.isSuggestedModel),
+  const availableCapabilities = React.useMemo(
+    () => getAvailableModelCapabilities(selectableModels),
     [selectableModels],
   )
 
-  const models = React.useMemo(() => {
-    // Show all BASIC_AND_PREMIUM models if showAllModels is true
-    if (showAllModels) {
-      return selectableModels.filter(
-        (model) =>
-          model.options.leoModelOptions?.access
-          === Mojom.ModelAccess.BASIC_AND_PREMIUM,
+  // Drop selections for capabilities that no longer appear on any model.
+  React.useEffect(() => {
+    setCapabilityFilters((prev) => {
+      const next = prev.filter((capability) =>
+        availableCapabilities.includes(capability),
       )
+      return next.length === prev.length ? prev : next
+    })
+  }, [availableCapabilities])
+
+  const pinnedModelKeys = React.useMemo(() => {
+    const keys = aiChatContext.pinnedModelKeys ?? []
+    if (keys.length > 0) {
+      return keys
     }
 
-    // Find the Auto model (chat-automatic)
-    const autoModel = selectableModels.find(
-      (model) => model.key === AUTOMATIC_MODEL_KEY,
-    )
+    // Empty pref: seed with the same models that used to appear in the
+    // recommended short list (excluding Auto, which is always shown first).
+    const defaultKeys: string[] = []
     const defaultModel = conversationContext.userDefaultModel
     const currentModel = conversationContext.currentModel
-    const recommendedList: Mojom.Model[] = []
 
-    // Keep Auto model first in list
-    if (autoModel) {
-      recommendedList.push(autoModel)
-    }
-
-    // Add defaultModel if it exists and is not Auto
     if (
       defaultModel
       && defaultModel.key !== AUTOMATIC_MODEL_KEY
       && isSelectableModel(defaultModel)
     ) {
-      recommendedList.push(defaultModel)
+      defaultKeys.push(defaultModel.key)
     }
 
-    // Add currentModel if it exists and is not Auto or defaultModel
     if (
       currentModel
       && currentModel.key !== AUTOMATIC_MODEL_KEY
       && currentModel.key !== defaultModel?.key
       && isSelectableModel(currentModel)
     ) {
-      recommendedList.push(currentModel)
+      defaultKeys.push(currentModel.key)
     }
 
-    // Add suggestedModels that are not already in the list
-    const existingKeys = new Set(recommendedList.map((model) => model.key))
-    const filteredSuggestedModels = suggestedModels.filter(
-      (model) => !existingKeys.has(model.key),
-    )
-    recommendedList.push(...filteredSuggestedModels)
+    const existing = new Set(defaultKeys)
+    for (const model of selectableModels) {
+      if (
+        model.isSuggestedModel
+        && model.key !== AUTOMATIC_MODEL_KEY
+        && !existing.has(model.key)
+      ) {
+        defaultKeys.push(model.key)
+      }
+    }
 
-    return recommendedList
+    return defaultKeys
   }, [
-    showAllModels,
+    aiChatContext.pinnedModelKeys,
     selectableModels,
     conversationContext.userDefaultModel,
     conversationContext.currentModel,
-    suggestedModels,
   ])
 
-  const premiumModels = React.useMemo(
-    () =>
-      selectableModels.filter(
-        (model) =>
-          model.options.leoModelOptions?.access === Mojom.ModelAccess.PREMIUM,
-      ),
+  const pinnedKeySet = React.useMemo(
+    () => new Set(pinnedModelKeys),
+    [pinnedModelKeys],
+  )
+
+  const vendorEntries = React.useMemo(
+    () => getVendorRailEntries(selectableModels),
     [selectableModels],
   )
 
-  const customModels = React.useMemo(
-    () => selectableModels.filter((model) => model.options.customModelOptions),
-    [selectableModels],
-  )
+  // Count models shown on the pinned tab; drives the fixed menu height so
+  // the panel grows with pins up to the max without resizing on vendor change.
+  const pinnedItemCount = React.useMemo(() => {
+    let count = 0
+    if (selectableModels.some((model) => model.key === AUTOMATIC_MODEL_KEY)) {
+      count++
+    }
+    for (const key of pinnedModelKeys) {
+      if (key === AUTOMATIC_MODEL_KEY) {
+        continue
+      }
+      if (selectableModels.some((model) => model.key === key)) {
+        count++
+      }
+    }
+    return count
+  }, [selectableModels, pinnedModelKeys])
+
+  const models = React.useMemo(() => {
+    const query = searchQuery.trim()
+
+    // Search is global across all models; vendor rail only scopes the list
+    // when the search box is empty.
+    let list: Mojom.Model[] = []
+    if (query) {
+      list = selectableModels.slice()
+    } else if (selectedVendorKey === PINNED_VENDOR_KEY) {
+      const autoModel = selectableModels.find(
+        (model) => model.key === AUTOMATIC_MODEL_KEY,
+      )
+      if (autoModel) {
+        list.push(autoModel)
+      }
+      for (const key of pinnedModelKeys) {
+        if (key === AUTOMATIC_MODEL_KEY) {
+          continue
+        }
+        const model = selectableModels.find((m) => m.key === key)
+        if (model) {
+          list.push(model)
+        }
+      }
+    } else if (selectedVendorKey === LOCAL_VENDOR_KEY) {
+      list = selectableModels.filter(
+        (model) => !!model.options.customModelOptions,
+      )
+    } else {
+      list = selectableModels.filter(
+        (model) =>
+          model.options.leoModelOptions?.displayMaker === selectedVendorKey,
+      )
+    }
+
+    if (capabilityFilters.length > 0) {
+      // Keep Automatic visible on the pinned tab even when it has no
+      // matching capability tags.
+      list = list.filter(
+        (model) =>
+          (selectedVendorKey === PINNED_VENDOR_KEY
+            && !query
+            && model.key === AUTOMATIC_MODEL_KEY)
+          || modelHasAllCapabilities(model, capabilityFilters),
+      )
+    }
+
+    if (query) {
+      list = list.filter((model) => matchesModelQuery(query, model))
+    }
+
+    // Automatic is always first whenever it appears in the list.
+    const automaticIndex = list.findIndex(
+      (model) => model.key === AUTOMATIC_MODEL_KEY,
+    )
+    if (automaticIndex > 0) {
+      const [automaticModel] = list.splice(automaticIndex, 1)
+      list.unshift(automaticModel)
+    }
+
+    return list
+  }, [
+    selectedVendorKey,
+    selectableModels,
+    pinnedModelKeys,
+    capabilityFilters,
+    searchQuery,
+  ])
 
   const onClickLearnMore = React.useCallback(() => {
     aiChatContext.api.uiHandler?.openURL({
@@ -119,18 +236,38 @@ export function ModelSelector() {
     })
   }, [aiChatContext.api.uiHandler])
 
+  const handleClose = React.useCallback(() => {
+    setIsOpen(false)
+    setSearchQuery('')
+    setCapabilityFilters([])
+    setSelectedVendorKey(PINNED_VENDOR_KEY)
+    setOpenPopover(null)
+  }, [])
+
+  const emptyMessage = React.useMemo(() => {
+    if (selectedVendorKey === LOCAL_VENDOR_KEY && !searchQuery) {
+      return getLocale(S.CHAT_UI_LOCAL_MODELS_EMPTY)
+    }
+    return getLocale(S.CHAT_UI_NO_MODELS_FOUND)
+  }, [selectedVendorKey, searchQuery])
+
   return (
     <ButtonMenu
       className={styles.buttonMenu}
       isOpen={isOpen}
-      onClose={() => setIsOpen(false)}
+      onChange={(e) => {
+        if (e.isOpen) {
+          setIsOpen(true)
+        } else {
+          handleClose()
+        }
+      }}
       positionStrategy='fixed'
     >
       <Button
         slot='anchor-content'
         kind='plain-faint'
         size='tiny'
-        onClick={() => setIsOpen(!isOpen)}
         className={classnames({
           [styles.anchorButton]: true,
           [styles.anchorButtonOpen]: isOpen,
@@ -169,73 +306,123 @@ export function ModelSelector() {
           </Alert>
         )}
 
-      {models.map((model) => {
-        return (
-          <ModelMenuItem
-            key={model.key}
-            model={model}
-            isCurrent={model.key === conversationContext.currentModel?.key}
-            showPremiumLabel={!aiChatContext.isPremiumUser}
-            showDetails={true}
-            onClick={() => conversationContext.setCurrentModel(model)}
-            onClickLearnMore={onClickLearnMore}
-          />
-        )
-      })}
-
-      {showAllModels
-        && premiumModels.map((model) => {
-          return (
-            <ModelMenuItem
-              key={model.key}
-              model={model}
-              isCurrent={model.key === conversationContext.currentModel?.key}
-              showPremiumLabel={!aiChatContext.isPremiumUser}
-              showDetails={true}
-              onClick={() => conversationContext.setCurrentModel(model)}
-              onClickLearnMore={onClickLearnMore}
-            />
-          )
-        })}
-
-      {showAllModels
-        && customModels.map((model) => {
-          return (
-            <ModelMenuItem
-              key={model.key}
-              model={model}
-              isCurrent={model.key === conversationContext.currentModel?.key}
-              showPremiumLabel={!aiChatContext.isPremiumUser}
-              showDetails={true}
-              onClick={() => conversationContext.setCurrentModel(model)}
-            />
-          )
-        })}
-
-      <div className={styles.footerGap} />
       <div
-        className={classnames({
-          [styles.menuFooter]: true,
-          [styles.menuFooterExtraPadding]: !showAllModels,
-        })}
+        className={styles.menuBody}
+        style={
+          {
+            '--vendor-rail-count': vendorEntries.length,
+            '--pinned-item-count': pinnedItemCount,
+          } as React.CSSProperties
+        }
       >
-        <leo-menu-item
-          data-testid='show-all-models-button'
-          onClick={(e) => {
-            e.stopPropagation()
-            setShowAllModels(!showAllModels)
-          }}
-        >
-          <div className={styles.menuFooterIconAndText}>
-            {showAllModels && <Icon name='carat-left' />}
-            {getLocale(
-              showAllModels
-                ? S.CHAT_UI_RECOMMENDED_MODELS_BUTTON
-                : S.CHAT_UI_SHOW_ALL_MODELS_BUTTON,
+        <VendorRail
+          entries={vendorEntries}
+          selectedKey={selectedVendorKey}
+          onSelect={setSelectedVendorKey}
+        />
+        <div className={styles.mainPane}>
+          <div className={styles.searchAndFilters}>
+            <ModelSearch
+              value={searchQuery}
+              onChange={setSearchQuery}
+            />
+            <CapabilityFilter
+              available={availableCapabilities}
+              selected={capabilityFilters}
+              onChange={setCapabilityFilters}
+              isOpen={openPopover?.kind === 'filter'}
+              onOpenChange={(open) =>
+                setOpenPopover(open ? { kind: 'filter' } : null)
+              }
+            />
+          </div>
+          <div className={styles.modelList}>
+            {models.length === 0 ? (
+              <div
+                className={styles.emptyState}
+                data-testid='model-selector-empty'
+              >
+                {emptyMessage}
+              </div>
+            ) : (
+              models.map((model) => {
+                const isPinned = pinnedKeySet.has(model.key)
+                const isDefault =
+                  model.key === conversationContext.userDefaultModel?.key
+                return (
+                  <ModelMenuItem
+                    key={model.key}
+                    model={model}
+                    isCurrent={
+                      model.key === conversationContext.currentModel?.key
+                    }
+                    isPinned={isPinned}
+                    isDefault={isDefault}
+                    showPremiumLabel={!aiChatContext.isPremiumUser}
+                    showDetails={true}
+                    showCapabilitySubtitle={true}
+                    isMobile={aiChatContext.isMobile}
+                    isOptionsOpen={
+                      openPopover?.kind === 'model-options'
+                      && openPopover.modelKey === model.key
+                    }
+                    onOptionsOpenChange={(open) =>
+                      setOpenPopover(
+                        open
+                          ? { kind: 'model-options', modelKey: model.key }
+                          : null,
+                      )
+                    }
+                    onClick={() => {
+                      conversationContext.setCurrentModel(model)
+                      handleClose()
+                    }}
+                    onClickLearnMore={onClickLearnMore}
+                    onSetAsDefault={() =>
+                      aiChatContext.setDefaultModelKey(model.key)
+                    }
+                    onTogglePin={
+                      // Automatic is always in the pinned list and cannot be
+                      // pinned/unpinned by the user.
+                      model.key === AUTOMATIC_MODEL_KEY
+                        ? undefined
+                        : () => {
+                            const persisted =
+                              aiChatContext.pinnedModelKeys ?? []
+                            if (persisted.length === 0) {
+                              // Pref is empty and the UI is using the
+                              // recommended-list seed — materialize that set
+                              // into the pref before/while applying this pin
+                              // change so other defaults aren't lost.
+                              // setModelPinned prepends, so walk the seed
+                              // reverse and pin the toggled model last so it
+                              // ends up first when pinning.
+                              const seedWithout = pinnedModelKeys.filter(
+                                (key) => key !== model.key,
+                              )
+                              for (
+                                let i = seedWithout.length - 1;
+                                i >= 0;
+                                i--
+                              ) {
+                                aiChatContext.setModelPinned(
+                                  seedWithout[i],
+                                  true,
+                                )
+                              }
+                              aiChatContext.setModelPinned(model.key, !isPinned)
+                              return
+                            }
+
+                            aiChatContext.setModelPinned(model.key, !isPinned)
+                          }
+                    }
+                  />
+                )
+              })
             )}
           </div>
-          {!showAllModels && <Icon name='carat-right' />}
-        </leo-menu-item>
+        </div>
       </div>
     </ButtonMenu>
   )

--- a/components/ai_chat/resources/page/components/model_selector/model_selector.stories.tsx
+++ b/components/ai_chat/resources/page/components/model_selector/model_selector.stories.tsx
@@ -6,17 +6,8 @@
 import * as React from 'react'
 import { Meta } from '@storybook/react'
 import * as Mojom from '../../../common/mojom'
-import { PINNED_VENDOR_KEY } from '../../../common/vendor_icon_map'
-import {
-  getAvailableModelCapabilities,
-  getVendorRailEntries,
-  modelHasAllCapabilities,
-} from '../../model_utils'
-import { ModelMenuItem } from '../model_menu_item/model_menu_item'
-import { CapabilityFilter } from './capability_filter'
-import { ModelSearch } from './model_search'
-import { VendorRail } from './vendor_rail'
-import styles from './style.module.scss'
+import { MockContext } from '../../state/mock_context'
+import { ModelSelector } from '.'
 
 const MODELS: Mojom.Model[] = [
   {
@@ -153,137 +144,30 @@ const MODELS: Mojom.Model[] = [
   },
 ]
 
-function ModelSelectorChrome() {
-  const [selectedVendorKey, setSelectedVendorKey] =
-    React.useState(PINNED_VENDOR_KEY)
-  const [searchQuery, setSearchQuery] = React.useState('')
-  const [capabilityFilters, setCapabilityFilters] = React.useState<
-    Mojom.ModelCapability[]
-  >([])
-  const [filterOpen, setFilterOpen] = React.useState(false)
-  const [pinnedKeys, setPinnedKeys] = React.useState<string[]>([
-    'chat-claude-sonnet',
-    'chat-gpt-mini',
-  ])
-  const [defaultModelKey, setDefaultModelKey] = React.useState(
-    'chat-claude-sonnet',
-  )
-  const [currentModelKey, setCurrentModelKey] = React.useState(
-    'chat-claude-sonnet',
-  )
-  const [openOptionsKey, setOpenOptionsKey] = React.useState<string | null>(
-    null,
-  )
-
-  const vendorEntries = React.useMemo(
-    () => getVendorRailEntries(MODELS),
-    [],
-  )
-  const availableCapabilities = React.useMemo(
-    () => getAvailableModelCapabilities(MODELS),
-    [],
-  )
-
-  const filteredModels = React.useMemo(() => {
-    const query = searchQuery.trim().toLowerCase()
-    return MODELS.filter((model) => {
-      if (
-        capabilityFilters.length > 0
-        && !modelHasAllCapabilities(model, capabilityFilters)
-      ) {
-        return false
-      }
-      if (!query) {
-        return true
-      }
-      const maker = model.options.leoModelOptions?.displayMaker ?? ''
-      const requestName =
-        model.options.customModelOptions?.modelRequestName ?? ''
-      return (
-        model.displayName.toLowerCase().includes(query)
-        || maker.toLowerCase().includes(query)
-        || requestName.toLowerCase().includes(query)
-      )
-    })
-  }, [searchQuery, capabilityFilters])
-
-  return (
-    <div className={styles.menuBody}>
-      <VendorRail
-        entries={vendorEntries}
-        selectedKey={selectedVendorKey}
-        onSelect={setSelectedVendorKey}
-      />
-      <div className={styles.mainPane}>
-        <div className={styles.searchAndFilters}>
-          <ModelSearch
-            value={searchQuery}
-            onChange={setSearchQuery}
-          />
-          <CapabilityFilter
-            available={availableCapabilities}
-            selected={capabilityFilters}
-            onChange={setCapabilityFilters}
-            isOpen={filterOpen}
-            onOpenChange={(open) => {
-              setFilterOpen(open)
-              if (open) {
-                setOpenOptionsKey(null)
-              }
-            }}
-          />
-        </div>
-        <div className={styles.modelList}>
-          {filteredModels.length === 0 ? (
-            <div className={styles.emptyState}>No models found</div>
-          ) : (
-            filteredModels.map((model) => {
-              const isPinned = pinnedKeys.includes(model.key)
-              return (
-                <ModelMenuItem
-                  key={model.key}
-                  model={model}
-                  isCurrent={model.key === currentModelKey}
-                  isPinned={isPinned}
-                  isDefault={model.key === defaultModelKey}
-                  showPremiumLabel={true}
-                  showDetails={true}
-                  showCapabilitySubtitle={true}
-                  isOptionsOpen={openOptionsKey === model.key}
-                  onOptionsOpenChange={(open) => {
-                    setOpenOptionsKey(open ? model.key : null)
-                    if (open) {
-                      setFilterOpen(false)
-                    }
-                  }}
-                  onClick={() => setCurrentModelKey(model.key)}
-                  onSetAsDefault={() => setDefaultModelKey(model.key)}
-                  onTogglePin={
-                    model.key === 'chat-automatic'
-                      ? undefined
-                      : () => {
-                          setPinnedKeys((prev) =>
-                            prev.includes(model.key)
-                              ? prev.filter((key) => key !== model.key)
-                              : [model.key, ...prev],
-                          )
-                        }
-                  }
-                />
-              )
-            })
-          )}
-        </div>
+export const _ModelSelector = {
+  render: () => {
+    return (
+      <div style={{ padding: 24, maxWidth: 400 }}>
+        <MockContext
+          conversationOverrides={{
+            allModels: MODELS,
+            currentModel: MODELS[1],
+            userDefaultModel: MODELS[1],
+          }}
+          initialState={{
+            serviceState: {
+              pinnedModelKeys: ['chat-claude-sonnet', 'chat-gpt-mini'],
+            },
+          }}
+        >
+          <ModelSelector />
+        </MockContext>
       </div>
-    </div>
-  )
-}
-
-export const _SearchFilterRailAndModelItems = {
-  render: () => <ModelSelectorChrome />,
+    )
+  },
 }
 
 export default {
-  title: 'AI Chat/Model Selector Building Blocks',
-  component: ModelSelectorChrome,
-} as Meta<typeof ModelSelectorChrome>
+  title: 'AI Chat/Model Selector',
+  component: ModelSelector,
+} as Meta<typeof ModelSelector>

--- a/components/ai_chat/resources/page/components/model_selector/style.module.scss
+++ b/components/ai_chat/resources/page/components/model_selector/style.module.scss
@@ -40,83 +40,32 @@
 
 .buttonMenu {
   --leo-menu-max-height: calc(100svh - 136px);
-  leo-menu-item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--leo-spacing-l);
-    padding: var(--leo-spacing-s) var(--leo-spacing-m);
-    max-width: 270px;
-  }
 }
-
-.menuFooterIconAndText {
-  --leo-icon-size: 20px;
-  --leo-icon-color: var(--leo-color-icon-default);
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: var(--leo-spacing-m);
-  font: var(--leo-font-default-regular);
-}
-
-.menuFooter {
-  display: flex;
-  width: 100%;
-  padding: var(--leo-spacing-s);
-  background-color: var(--leo-color-container-background);
-  position: absolute;
-  bottom: 0;
-  inset-inline: 0;
-  background-color: var(--leo-color-container-background);
-  border-radius: 0px 0px 8px 8px;
-  border: 1px solid var(--leo-color-divider-subtle);
-  leo-menu-item {
-    width: 100%;
-    justify-content: space-between;
-    border-radius: var(--leo-radius-s);
-    padding: var(--leo-spacing-m);
-    gap: var(--leo-spacing-m);
-    &:hover {
-      background-color: var(--leo-color-container-highlight);
-    }
-  }
-}
-
-.menuFooterExtraPadding {
-  leo-menu-item {
-    padding: var(--leo-spacing-m) var(--leo-spacing-m) var(--leo-spacing-m)
-      var(--leo-spacing-l);
-  }
-}
-
-.footerGap {
-  min-height: 48px;
-}
-
-.alert {
-  --leo-alert-padding: var(--leo-spacing-l);
-  margin: var(--leo-spacing-s) var(--leo-spacing-s) 0 var(--leo-spacing-s);
-  max-width: 270px;
-}
-
-.alertText {
-  font: var(--leo-font-small-regular);
-}
-
-.icons {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  gap: var(--leo-spacing-s);
-}
-
-
-/* New model-selector building blocks (storybook / upcoming UI). Live
- * index.tsx still uses the footer styles above until integration. */
 
 .menuBody {
+  --menu-body-max-height: min(472px, calc(100svh - 160px));
+  --vendor-button-size: 32px;
+  // Detailed model row: 32px icon / 40px name+subtitle + item padding.
+  --model-row-height: 48px;
+  // Search + filter toolbar: padding + tiny control + bottom border.
+  --search-filters-height: calc(2 * var(--leo-spacing-s) + 28px + 1px);
+  --vendor-rail-height: calc(
+    2 * var(--leo-spacing-s) + var(--vendor-rail-count, 0) *
+      var(--vendor-button-size) + max(0, var(--vendor-rail-count, 0) - 1) *
+      var(--leo-spacing-s)
+  );
+  --pinned-list-height: calc(
+    var(--search-filters-height) + 2 * var(--leo-spacing-s) +
+      var(--pinned-item-count, 0) * var(--model-row-height) +
+      max(0, var(--pinned-item-count, 0) - 1) * var(--leo-spacing-s)
+  );
+  // Grow with the pinned list (and never shorter than the vendor rail),
+  // capped at the menu max so switching vendors / filters doesn't resize.
+  --menu-body-height: min(
+    max(var(--vendor-rail-height), var(--pinned-list-height)),
+    var(--menu-body-max-height)
+  );
+
   display: flex;
   flex-direction: row;
   align-items: stretch;
@@ -124,11 +73,13 @@
   width: 320px;
   min-width: 320px;
   max-width: 320px;
-  height: 360px;
+  height: var(--menu-body-height);
+  min-height: var(--menu-body-height);
+  max-height: var(--menu-body-height);
   overflow: hidden;
-  border: 1px solid var(--leo-color-divider-subtle);
-  border-radius: var(--leo-radius-m);
-  background: var(--leo-color-container-background);
+  // Leo's popup sizes to its content. Without containment, a row's
+  // min-content (e.g. after the "Default" label appears) can widen it.
+  contain: inline-size;
 }
 
 .vendorRail {
@@ -289,6 +240,9 @@
 
   // Scope to the model list only so nested menus (filter / item options)
   // keep Nala's default menu-item sizing.
+  // Leo's built-in item hover only targets direct/slotted children of
+  // .leo-menu-popup (or items in leo-menu-section) — our rows are nested
+  // under .menuBody, so restore the Nala hover highlight here.
   leo-menu-item {
     display: flex;
     align-items: center;
@@ -319,4 +273,22 @@
   text-align: center;
   font: var(--leo-font-small-regular);
   color: var(--leo-color-text-tertiary);
+}
+
+.alert {
+  --leo-alert-padding: var(--leo-spacing-l);
+  margin: var(--leo-spacing-s) var(--leo-spacing-s) 0 var(--leo-spacing-s);
+  max-width: 320px;
+}
+
+.alertText {
+  font: var(--leo-font-small-regular);
+}
+
+.icons {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: var(--leo-spacing-s);
 }

--- a/components/ai_chat/resources/page/state/ai_chat_context.tsx
+++ b/components/ai_chat/resources/page/state/ai_chat_context.tsx
@@ -132,6 +132,18 @@ export default function useProvideAIChatContext(props: AIChatContextProps) {
     dismissPremiumPrompt: () => api.service.dismissPremiumPrompt(),
 
     /**
+     * @deprecated use api.service.setModelPinned directly instead
+     */
+    setModelPinned: (modelKey: string, pinned: boolean) =>
+      api.service.setModelPinned(modelKey, pinned),
+
+    /**
+     * @deprecated use api.service.setDefaultModelKey directly instead
+     */
+    setDefaultModelKey: (modelKey: string) =>
+      api.service.setDefaultModelKey(modelKey),
+
+    /**
      * @deprecated use api.[action] directly instead
      */
     userRefreshPremiumSession: () => api.uiHandler.refreshPremiumSession(),


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/48382

## Summary
- Replaces the live `ModelSelector` with vendor rail + global search + capability filters + pinning + default-model actions
- Adds `ai_chat_context` wrappers and full `index.test.tsx` coverage
- Updates Storybook to render the integrated `ModelSelector`

Depends on PR 3 (`leo-model-selector-pr3`). This is **PR 4/4** (final integration).

## Test plan
- [ ] Open Leo model selector in the browser: vendor rail, search, filters work
- [ ] Pin / unpin models; newly pinned appear first; Automatic stays pinned and cannot be toggled
- [ ] Set as default updates the default indicator
- [ ] Empty states for Local and no-match search/filter
- [ ] `index.test.tsx` passes
- [ ] Storybook **AI Chat / Model Selector** opens the integrated control
