### PR TITLE
Fix dangling raw_ptr in SidebarItemAddedFeedbackBubble on shutdown

### DIFF
--- a/browser/ui/views/sidebar/sidebar_item_added_feedback_bubble.cc
+++ b/browser/ui/views/sidebar/sidebar_item_added_feedback_bubble.cc
@@ -106,6 +106,13 @@ void SidebarItemAddedFeedbackBubble::OnViewBoundsChanged(View* observed_view) {
   SizeToContents();
 }
 
+void SidebarItemAddedFeedbackBubble::OnViewIsDeleting(View* observed_view) {
+  // The observed SidebarItemsContentsView is going away (e.g. on browser
+  // shutdown, before this bubble's widget is destroyed). Stop observing so the
+  // ScopedObservation is not torn down against freed memory.
+  observed_.Reset();
+}
+
 void SidebarItemAddedFeedbackBubble::AddChildViews() {
   auto* layout_manager = SetLayoutManager(std::make_unique<views::BoxLayout>(
       views::BoxLayout::Orientation::kVertical));

--- a/browser/ui/views/sidebar/sidebar_item_added_feedback_bubble.h
+++ b/browser/ui/views/sidebar/sidebar_item_added_feedback_bubble.h
@@ -47,6 +47,7 @@ class SidebarItemAddedFeedbackBubble : public views::BubbleDialogDelegateView,
 
   // views::ViewObserver overrides:
   void OnViewBoundsChanged(View* observed_view) override;
+  void OnViewIsDeleting(View* observed_view) override;
 
  private:
   SidebarItemAddedFeedbackBubble(views::View* anchor_view,


### PR DESCRIPTION
SidebarItemAddedFeedbackBubble observes the SidebarItemsContentsView to reposition itself,
but never stopped observing when that view was destroyed. On browser shutdown the contents
view is torn down before the bubble's widget, so ~SidebarItemAddedFeedbackBubble tore down
its ScopedObservation against already-freed memory.

This mainly surfaces in browser tests: the dangling raw_ptr detector is enabled there and the
window is torn down abruptly while the bubble is still alive (caught by SidebarBrowserTestWithPlaylist.Incognito).
It is hard to reproduce in production, where the bubble auto-fades and closes seconds after appearing,
well before shutdown, and the detector is not active.

Reset the observation in views::ViewObserver::OnViewIsDeleting() so it is released as soon as
the observed view goes away.

TEST=SidebarBrowserTestWithPlaylist.Incognito

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57178

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
