### PR TITLE
[Wallet]: Fix Connect With Site Panel Width

### DIFF
--- a/components/brave_wallet_ui/panel/style.ts
+++ b/components/brave_wallet_ui/panel/style.ts
@@ -17,6 +17,10 @@ export const PanelWrapper = styled.div<{
   width: ${(p) => (p.width ? p.width : 320)}px;
   height: ${(p) => (p.height ? p.height : p.isLonger ? 540 : 400)}px;
   background-color: ${leo.color.page.background};
+  /* Cr151+ bubble autosize uses document scrollWidth; clip overflow so
+     absolute/fixed children cannot inflate the panel beyond its set size. */
+  overflow: hidden;
+  contain: layout;
 `
 
 export const WelcomePanelWrapper = styled.div`
@@ -25,6 +29,8 @@ export const WelcomePanelWrapper = styled.div`
   justify-content: center;
   width: 320px;
   height: 250px;
+  overflow: hidden;
+  contain: layout;
 `
 
 export const SendWrapper = styled.div`

--- a/components/brave_wallet_ui/panel/wallet_panel.html
+++ b/components/brave_wallet_ui/panel/wallet_panel.html
@@ -12,8 +12,17 @@
     html,
     body {
       margin: 0;
+      overflow: hidden;
       font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
         'Helvetica Neue', Arial, sans-serif;
+    }
+
+    /* Shrink-wrap the panel so Cr151+ WebUI bubble autosize (scrollWidth)
+       follows PanelWrapper instead of any overflowing descendants. */
+    #mountPoint {
+      width: max-content;
+      max-width: 100%;
+      overflow: hidden;
     }
   </style>
 </head>


### PR DESCRIPTION
## Description 

Fixes a bug where the `Connect With Site` panel's width was to wide, caused by `AutoSizeUsesScrollWidthForOverflow` being shipped as `stable` in `Chromium 151,`

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/57207>

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

Test Plan:

1. Navigate to a `DApp` and attempt to connect with the site
2. Once your are prompt to connect the panel should not be wide and broken

Before:

<img width="497" height="630" alt="Screenshot 73" src="https://github.com/user-attachments/assets/478bc74f-cbdd-4df8-8e1c-b6f650eb1e0c" />

After:

<img width="411" height="619" alt="Screenshot 75" src="https://github.com/user-attachments/assets/3ad2b8ec-6da4-4583-ba89-382808d9910f" />
