### PR TITLE
[iOS] Dismiss deep link presented Origin Paywall when a URL is opened (uplift to 1.93.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Origin.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Origin.swift
@@ -85,6 +85,7 @@ extension BrowserViewController {
                 isPrivate: privateBrowsingManager.isPrivateBrowsing,
                 isPrivileged: url.scheme == InternalURL.scheme
               )
+              dismiss(animated: true)
               return .handled
             }
           )


### PR DESCRIPTION
Uplift of #38035
Resolves https://github.com/brave/brave-browser/issues/57137

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.