### PR TITLE
[Wallet]: Fix Origin Favicon After DAppRadar

### DIFF
--- a/components/brave_wallet_ui/components/extension/allow_add_change_network_panel/allow_add_change_network_panel.test.tsx
+++ b/components/brave_wallet_ui/components/extension/allow_add_change_network_panel/allow_add_change_network_panel.test.tsx
@@ -134,9 +134,12 @@ describe('AllowAddChangeNetworkPanel', () => {
         mockAddChainRequest.originInfo.eTldPlusOne,
       )
 
-      // Check if the favicon is displayed
-      const favIcon = container.querySelector('img[src*="chrome://favicon2"]')
+      // In tests/Storybook, site favicons are unavailable so a placeholder
+      // icon stub is shown instead of chrome://favicon2.
+      const originCard = screen.getByTestId('origin-info-card')
+      const favIcon = originCard.querySelector('img')
       expect(favIcon).toBeInTheDocument()
+      expect(favIcon).toHaveAttribute('src', 'test-file-stub')
     })
   })
 })

--- a/components/brave_wallet_ui/components/extension/origin_info_card/origin_info_card.tsx
+++ b/components/brave_wallet_ui/components/extension/origin_info_card/origin_info_card.tsx
@@ -7,6 +7,7 @@ import * as React from 'react'
 
 // Images
 import BraveIcon from '../../../assets/svg-icons/brave-icon.svg'
+import PlaceholderIcon from '../../../assets/svg-icons/nft-placeholder.svg'
 
 // Types
 import { BraveWallet } from '../../../constants/types'
@@ -59,15 +60,10 @@ export const OriginInfoCard = (props: Props) => {
 
   const originDisplayName = dapp ? dapp.name : origin.eTldPlusOne
 
-  const dappIcon = dapp
-    ? isStorybook
-      ? dapp.logo
-      : `chrome://image?url=${encodeURIComponent(dapp.logo)}&staticEncode=true`
-    : undefined
-
-  const iconSrc =
-    dappIcon
-    ?? 'chrome://favicon2?size=64&pageUrl='
+  // In Storybook, show a placeholder icon.
+  const iconSrc = isStorybook
+    ? PlaceholderIcon
+    : 'chrome://favicon2?size=64&pageUrl='
       + encodeURIComponent(origin.originSpec)
 
   return (


### PR DESCRIPTION
## Description 

Removes the use of `DAppRadar` icons for favicon, since they are no longer active.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <>

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

Test Plan:

1. Connect to a `DApp` and create a transaction
2. Once you are prompt to sign the transaction the `favicon` should not be broken

Before:

<img width="410" height="672" alt="Screenshot 72" src="https://github.com/user-attachments/assets/a1dee297-cbed-4827-abdb-00738cef2d77" />

After:

<img width="401" height="660" alt="Screenshot 76" src="https://github.com/user-attachments/assets/2face108-6493-4bc8-9905-aa136948dce4" />
