### PR TITLE
[recipes][ast-grep] Bump to `0.44.1` and upload with python

### DIFF
--- a/third_party/ast-grep/build_ast_grep.py
+++ b/third_party/ast-grep/build_ast_grep.py
@@ -29,7 +29,7 @@ from run_cargo import DEFAULT_SYSROOT, RunCargo  # noqa: E402
 
 # ast-grep upstream details.
 AST_GREP_GIT_URL = 'https://github.com/ast-grep/ast-grep.git'
-AST_GREP_REF = '0.44.0'
+AST_GREP_REF = '0.44.1'
 
 # Additional paths under `third_party/` for the source checkout, intermediate
 # build state, and final binary output.

--- a/third_party/ast-grep/package_ast_grep.py
+++ b/third_party/ast-grep/package_ast_grep.py
@@ -21,7 +21,13 @@ import platform
 import sys
 import tarfile
 
+sys.path.insert(
+    0,
+    str(Path(__file__).resolve().parents[2] / 'tools' / 'cr' / 'toolchains'))
+
+# pylint: disable=wrong-import-position
 import build_ast_grep
+from upload import S3Uploader, sha256_file, summarise
 
 
 def _platform_tag() -> str:
@@ -80,6 +86,10 @@ def main() -> int:
     parser.add_argument('--verbose',
                         action='store_true',
                         help='Enable debug logging.')
+    parser.add_argument('--upload',
+                        action='store_true',
+                        help='Upload the packaged tarball to our public '
+                        'bucket.')
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO,
@@ -88,8 +98,17 @@ def main() -> int:
     build_ast_grep.build(args.jobs, clean=args.clean)
     archive = _create_archive(args.out_dir.expanduser().resolve())
 
+    if args.upload:
+        result = S3Uploader(bucket='brave-build-deps-public').upload(
+            archive, prefix='ast-grep')
+        logging.info('Upload summary:\n%s', summarise(result))
+        sha256, size = result.sha256, result.size_bytes
+    else:
+        sha256, size = sha256_file(archive), archive.stat().st_size
+
     logging.info('Done.')
     logging.info('ast-grep package: %s', archive)
+    logging.info('  sha256: %s  (%d bytes)', sha256, size)
     return 0
 
 

--- a/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/linux.json
+++ b/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/linux.json
@@ -78,7 +78,8 @@
       "[WORKSPACE]/chromium/src/brave",
       "sparse-checkout",
       "add",
-      "third_party/ast-grep"
+      "third_party/ast-grep",
+      "tools/cr/toolchains"
     ],
     "name": "sparse-checkout add"
   },
@@ -88,7 +89,8 @@
       "[WORKSPACE]/chromium/src/brave/third_party/ast-grep/package_ast_grep.py",
       "--clean",
       "--out-dir",
-      "[WORKSPACE]/out"
+      "[WORKSPACE]/out",
+      "--upload"
     ],
     "name": "package ast-grep"
   },

--- a/tools/recipes/recipes/tools/ast_grep/package_ast_grep.py
+++ b/tools/recipes/recipes/tools/ast_grep/package_ast_grep.py
@@ -28,7 +28,10 @@ def RunSteps(api: RecipeScriptApi, properties: InputProperties,
                                           git_cache=env_properties.GIT_CACHE
                                           or None)
 
-    brave_root = api.brave_core_shallow.deploy('third_party/ast-grep')
+    brave_root = api.brave_core_shallow.deploy([
+        'third_party/ast-grep',
+        'tools/cr/toolchains',
+    ])
 
     vpython3 = api.depot_tools.vpython3()
     api.step('package ast-grep', [
@@ -37,6 +40,7 @@ def RunSteps(api: RecipeScriptApi, properties: InputProperties,
         '--clean',
         '--out-dir',
         api.path.out,
+        '--upload',
     ])
 
 
@@ -44,7 +48,8 @@ def GenTests(api):
     yield api.test(
         'linux',
         api.chromium_checkout.with_git_cache(),
-        api.brave_core_shallow.deployed('third_party/ast-grep'),
+        api.brave_core_shallow.deployed('third_party/ast-grep',
+                                        'tools/cr/toolchains'),
         api.properties(chromium_ref='151.0.7917.1'),
         api.post_process(post_process.MustRun, 'fetch chromium'),
         api.post_process(post_process.MustRun, 'package ast-grep'),


### PR DESCRIPTION
This change bumps the version to `0.44.1`, and also introduce upload to
the packaging script, so we can handle that in CI too.

Bug: https://github.com/brave/brave-browser/issues/56748
