### PR TITLE
[iOS] Fix Playlist pageSrc fallback MediaSource swizzle on WKWebView

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCacheLoader.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCacheLoader.swift
@@ -58,18 +58,11 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
     super.init(frame: .zero)
 
     tab.browserData = .init(tab: tab)
-    if !FeatureList.kUseProfileWebViewConfiguration.enabled {
-      tab.browserData?.setScript(
-        script: .playlistMediaSource,
-        enabled: true
-      )
-    } else {
+    if FeatureList.kUseProfileWebViewConfiguration.enabled {
       tab.playlist = .init(tab: tab, delegate: self)
     }
     tab.createWebView()
-    if FeatureList.kUseProfileWebViewConfiguration.enabled {
-      BraveWebView.from(tab: tab)?.enablePlaylistCompatibilityMode()
-    }
+    ensurePlaylistMediaSourceSwizzle()
     tab.webViewProxy?.scrollView?.layer.masksToBounds = true
 
     self.addSubview(tab.view)
@@ -84,6 +77,14 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
 
   deinit {
     self.removeFromSuperview()
+  }
+
+  private func ensurePlaylistMediaSourceSwizzle() {
+    if FeatureList.kUseProfileWebViewConfiguration.enabled {
+      BraveWebView.from(tab: tab)?.enablePlaylistCompatibilityMode()
+    } else {
+      tab.browserData?.setScript(script: .playlistMediaSource, enabled: true)
+    }
   }
 
   @MainActor
@@ -118,6 +119,7 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
       }
 
       tab.view.frame = superview?.bounds ?? self.bounds
+      ensurePlaylistMediaSourceSwizzle()
       tab.loadRequest(
         URLRequest(url: url, cachePolicy: .reloadIgnoringCacheData, timeoutInterval: 60.0)
       )
@@ -248,11 +250,12 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
         return
       }
 
-      // For now, we ignore base64 video mime-types loaded via the `data:` scheme.
-      if item.duration <= 0.0 && !item.detected || item.src.isEmpty || item.src.hasPrefix("data:")
-        || item.src.hasPrefix("blob:")
-      {
-        cancelRequest()
+      // Ignore transient or non-streamable sources and keep waiting for a playable URL.
+      if item.src.hasPrefix("data:") || item.src.hasPrefix("blob:") {
+        return
+      }
+
+      if item.src.isEmpty || (item.duration <= 0.0 && !item.detected) {
         return
       }
 
@@ -290,8 +293,10 @@ extension LivePlaylistWebLoader: PlaylistTabHelperDelegate {
     guard let item else { return }
 
     if item.src.hasPrefix("data:") || item.src.hasPrefix("blob:") {
-      handler?(nil)
-      tab?.stopLoading()
+      return
+    }
+
+    if item.src.isEmpty || (item.duration <= 0.0 && !item.detected) {
       return
     }
 
@@ -313,6 +318,10 @@ extension LivePlaylistWebLoader: PlaylistTabHelperDelegate {
 }
 
 extension LivePlaylistWebLoader: TabObserver {
+  func tabDidCreateWebView(_ tab: some TabState) {
+    ensurePlaylistMediaSourceSwizzle()
+  }
+
   func tabDidCommitNavigation(_ tab: some TabState) {
     if !FeatureList.kUseProfileWebViewConfiguration.enabled {
       tab.evaluateJavaScript(
@@ -385,6 +394,7 @@ extension LivePlaylistWebLoader: TabPolicyDecider {
             isGPCEnabled: true
           ) ?? []
         if !FeatureList.kUseProfileWebViewConfiguration.enabled {
+          ensurePlaylistMediaSourceSwizzle()
           tab.browserData?.setCustomUserScript(scripts: scriptTypes)
         }
       }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCacheLoader.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCacheLoader.swift
@@ -62,7 +62,14 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
       tab.playlist = .init(tab: tab, delegate: self)
     }
     tab.createWebView()
-    ensurePlaylistMediaSourceSwizzle()
+    if !FeatureList.kUseProfileWebViewConfiguration.enabled {
+      tab.browserData?.setScript(
+        script: .playlistMediaSource,
+        enabled: true
+      )
+    } else {
+      BraveWebView.from(tab: tab)?.enablePlaylistCompatibilityMode()
+    }
     tab.webViewProxy?.scrollView?.layer.masksToBounds = true
 
     self.addSubview(tab.view)
@@ -77,14 +84,6 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
 
   deinit {
     self.removeFromSuperview()
-  }
-
-  private func ensurePlaylistMediaSourceSwizzle() {
-    if FeatureList.kUseProfileWebViewConfiguration.enabled {
-      BraveWebView.from(tab: tab)?.enablePlaylistCompatibilityMode()
-    } else {
-      tab.browserData?.setScript(script: .playlistMediaSource, enabled: true)
-    }
   }
 
   @MainActor
@@ -119,7 +118,6 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
       }
 
       tab.view.frame = superview?.bounds ?? self.bounds
-      ensurePlaylistMediaSourceSwizzle()
       tab.loadRequest(
         URLRequest(url: url, cachePolicy: .reloadIgnoringCacheData, timeoutInterval: 60.0)
       )
@@ -250,12 +248,11 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
         return
       }
 
-      // Ignore transient or non-streamable sources and keep waiting for a playable URL.
-      if item.src.hasPrefix("data:") || item.src.hasPrefix("blob:") {
-        return
-      }
-
-      if item.src.isEmpty || (item.duration <= 0.0 && !item.detected) {
+      // For now, we ignore base64 video mime-types loaded via the `data:` scheme.
+      if item.duration <= 0.0 && !item.detected || item.src.isEmpty || item.src.hasPrefix("data:")
+        || item.src.hasPrefix("blob:")
+      {
+        cancelRequest()
         return
       }
 
@@ -293,10 +290,8 @@ extension LivePlaylistWebLoader: PlaylistTabHelperDelegate {
     guard let item else { return }
 
     if item.src.hasPrefix("data:") || item.src.hasPrefix("blob:") {
-      return
-    }
-
-    if item.src.isEmpty || (item.duration <= 0.0 && !item.detected) {
+      handler?(nil)
+      tab?.stopLoading()
       return
     }
 
@@ -318,10 +313,6 @@ extension LivePlaylistWebLoader: PlaylistTabHelperDelegate {
 }
 
 extension LivePlaylistWebLoader: TabObserver {
-  func tabDidCreateWebView(_ tab: some TabState) {
-    ensurePlaylistMediaSourceSwizzle()
-  }
-
   func tabDidCommitNavigation(_ tab: some TabState) {
     if !FeatureList.kUseProfileWebViewConfiguration.enabled {
       tab.evaluateJavaScript(
@@ -394,7 +385,6 @@ extension LivePlaylistWebLoader: TabPolicyDecider {
             isGPCEnabled: true
           ) ?? []
         if !FeatureList.kUseProfileWebViewConfiguration.enabled {
-          ensurePlaylistMediaSourceSwizzle()
           tab.browserData?.setCustomUserScript(scripts: scriptTypes)
         }
       }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/57223

## Test plan
- [ ] With `brave-use-profile-web-views-configuration` **disabled** (default), add a YouTube video from `m.youtube.com` to Playlist
- [ ] Play the item from Playlist and confirm playback succeeds
- [ ] Confirm pageSrc fallback resolves an `https:` stream URL (not `blob:`)
- [ ] Replay the same item and confirm direct stream works after URL is updated
- [ ] With `brave-use-profile-web-views-configuration` **enabled**, confirm playback still works via the profile webview path


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
