### PR TITLE
[plaster] Remove deprecated regex format

### DIFF
--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -117,22 +117,6 @@ substitutions:
       re_flags: [] # traditional Python `re` flag names, e.g. [DOTALL]
 ```
 
-For backward compatibility, the `regex` fields may also be placed bare directly
-on the item, without the `regex:` key:
-
-```yaml
-substitutions:
-  - description: ''
-    re_pattern: '' # or `pattern:` for a literal, escaped match
-    replace: ''
-```
-
-> [!WARNING]
->
-> This bare form is deprecated (`TODO(brave.dev/bug/56854)`) and will be removed
-> once all plasters are migrated. Prefer the `regex:` form above for all new
-> plasters.
-
 Use YAML's `|` / `|-` block scalars when you need multi-line `replace` or
 `description` values — `|` keeps a trailing newline, `|-` strips it.
 Single-quoted YAML strings preserve backslashes literally, which is useful for

--- a/tools/cr/alias/follow_renames_test.py
+++ b/tools/cr/alias/follow_renames_test.py
@@ -460,8 +460,9 @@ class PlasterApplyTest(_Base):
 
     _SUBST_YAML = ('substitutions:\n'
                    '  - description: Replace old_func\n'
-                   '    pattern: old_func\n'
-                   '    replace: new_func\n')
+                   '    regex:\n'
+                   '      pattern: old_func\n'
+                   '      replace: new_func\n')
 
     def test_patch_created_at_new_location(self) -> None:
         """Plaster writes patches/B-foo.cc.patch after an upstream rename."""
@@ -599,8 +600,9 @@ class PatchFileRepairTest(_Base):
         """Patch deleted by _repair_plaster_files is not re-renamed here."""
         _SUBST_YAML = ('substitutions:\n'
                        '  - description: test\n'
-                       '    pattern: old_func\n'
-                       '    replace: new_func\n')
+                       '    regex:\n'
+                       '      pattern: old_func\n'
+                       '      replace: new_func\n')
         before = self._chromium_head()
         self._chromium_commit(self._OLD_REL, 'void old_func() {}\n')
         self._brave_commit('rewrite/A/foo.cc.yaml', _SUBST_YAML)

--- a/tools/cr/alias/mv_test.py
+++ b/tools/cr/alias/mv_test.py
@@ -615,8 +615,9 @@ class PlasterApplyTest(_Base):
 
     _SUBST_YAML = ('substitutions:\n'
                    '  - description: Replace old_func\n'
-                   '    pattern: old_func\n'
-                   '    replace: new_func\n')
+                   '    regex:\n'
+                   '      pattern: old_func\n'
+                   '      replace: new_func\n')
 
     def _commit_chromium(self, rel: str, content: str) -> None:
         self._repo.write_and_stage_file(rel, content, self._repo.chromium)

--- a/tools/cr/patchfile_test.py
+++ b/tools/cr/patchfile_test.py
@@ -707,8 +707,9 @@ class PatchfilePlasterApplyTest(unittest.TestCase):
     # count = 0 means "replace all matches, bypass count validation".
     _WORKING_YAML = ('substitutions:\n'
                      '  - description: Replace old_func\n'
-                     '    pattern: old_func\n'
-                     '    replace: new_func\n'
+                     '    regex:\n'
+                     '      pattern: old_func\n'
+                     '      replace: new_func\n'
                      '    count: 0\n')
 
     # No substitutions key → missing required key → PLASTER_BROKEN.

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -501,12 +501,12 @@ class Substitution:
     def _from_item(data: object) -> Substitution:
         """Validate one `substitutions:` entry and build its rewriter.
 
-        An entry names a rewriter when it carries one of `_REWRITERS` as a key.
-        `description` and the optional `count` are item-level for every form.
+        An entry names a rewriter by carrying one of `_REWRITERS` as a key,
+        alongside the item-level `description` and optional `count`.
 
         Raises:
-            ValueError: on a malformed entry (missing/typo'd keys, mixed
-                forms, or invalid rewriter-specific fields).
+            ValueError: on a malformed entry (missing/typo'd keys, a missing
+                or unknown rewriter, or invalid rewriter-specific fields).
         """
         if not isinstance(data, dict):
             raise ValueError(f'substitution entry must be a mapping, got '
@@ -524,13 +524,6 @@ class Substitution:
             raise ValueError(
                 f'Only one rewriter allowed per entry, got '
                 f'{", ".join(rewriter_keys)} (in "{description}")')
-        # TODO(brave.dev/bug/56854): the bare regex form (regex fields placed
-        # directly on the item, without a `regex:` key) is deprecated. Once all
-        # plasters are migrated, delete this mixing check -- with no bare form
-        # there is nothing to mix.
-        if rewriter_keys and (keys & Regex._FIELD_KEYS):
-            raise ValueError(f'Cannot mix the "{rewriter_keys[0]}" rewriter '
-                             f'with bare regex fields (in "{description}")')
 
         if rewriter_keys:
             name = rewriter_keys[0]
@@ -546,32 +539,24 @@ class Substitution:
                                 expected_count=expected_count,
                                 rewriter=rewriter)
 
-        # No rewriter key: tolerated bare regex (the legacy form).
-        #
-        # TODO(brave.dev/bug/56854): the bare regex form (regex fields placed
-        # directly on the item, without a `regex:` key) is deprecated. Once all
-        # plasters are migrated, delete this whole block and require a rewriter
-        # key above, so an entry with no rewriter key becomes an error.
-        unknown = sorted(keys - ({'description', 'count'} | Regex._FIELD_KEYS))
+        # Every entry must name a rewriter. Surface the most helpful error we
+        # can: a mapping-valued stray key is almost certainly an attempt to use
+        # a rewriter that is not registered -- point the user at the ones that
+        # are; anything else is an unrecognised key.
+        unknown = sorted(keys - {'description', 'count'})
+        bad_rewriters = [k for k in unknown if isinstance(data[k], dict)]
+        if bad_rewriters:
+            available = ', '.join(sorted(_REWRITERS)) or '(none)'
+            raise ValueError(
+                f'Unknown rewriter(s): '
+                f'{", ".join(repr(k) for k in bad_rewriters)}; available '
+                f'rewriters: {available} (in "{description}")')
         if unknown:
-            # Every rewriter body is a mapping, so an unknown key carrying one
-            # is almost certainly an attempt to use a rewriter that is not
-            # registered -- point the user at the ones that are.
-            bad_rewriters = [k for k in unknown if isinstance(data[k], dict)]
-            if bad_rewriters:
-                available = ', '.join(sorted(_REWRITERS)) or '(none)'
-                raise ValueError(
-                    f'Unknown rewriter(s): '
-                    f'{", ".join(repr(k) for k in bad_rewriters)}; available '
-                    f'rewriters: {available} (in "{description}")')
             raise ValueError('Unrecognised substitution key(s): '
                              f'{", ".join(repr(k) for k in unknown)}')
-        # Compose a `regex:` body from the bare fields and hand it to Regex.
-        fields = {k: data[k] for k in keys & Regex._FIELD_KEYS}
-        rewriter = Regex.parse(fields, description=description)
-        return Substitution(description=description,
-                            expected_count=expected_count,
-                            rewriter=rewriter)
+        raise ValueError(
+            f'No rewriter specified (in "{description}"); expected one of: '
+            f'{", ".join(sorted(_REWRITERS)) or "(none)"}')
 
     @staticmethod
     def _parse_count(data: dict[str, object], description: str) -> int:
@@ -618,12 +603,7 @@ class Regex(Rewriter):
         ```
     """
 
-    # The pattern/replacement fields, valid either bare on the item or nested
-    # under a `regex:` op key.
-    #
-    # TODO(brave.dev/bug/56854): the bare placement is deprecated; this set
-    # stays for the `regex:` form, but once all plasters are migrated its bare
-    # use in `Substitution._from_item` should go.
+    # The pattern/replacement fields, nested under the `regex:` op key.
     _FIELD_KEYS = frozenset(('pattern', 're_pattern', 'replace', 're_flags'))
 
     def __init__(self, *, re_pattern: str, replace: str, re_flags: int = 0):
@@ -642,7 +622,7 @@ class Regex(Rewriter):
 
     @classmethod
     def parse(cls, body: object, *, description: str) -> Regex:
-        """Build from a regex field mapping (a `regex:` body or bare keys)."""
+        """Build from a `regex:` body (a mapping of the regex fields)."""
         if not isinstance(body, dict):
             raise ValueError(f'"regex" must be a mapping (in "{description}")')
         unknown = sorted(set(body) - cls._FIELD_KEYS)

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -87,8 +87,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: Simple test substitution
-              re_pattern: 'Chromium'
-              replace: 'Plaster'
+              regex:
+                re_pattern: 'Chromium'
+                replace: 'Plaster'
         ''')
 
         # Use PlasterFile to apply the .yaml file to the committed file.
@@ -198,8 +199,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path.parent.mkdir(parents=True, exist_ok=True)
         plaster_path.write_text('substitutions:\n'
                                 '  - description: Simple yaml substitution\n'
-                                "    re_pattern: 'Chromium'\n"
-                                "    replace: 'Plaster'\n")
+                                '    regex:\n'
+                                "      re_pattern: 'Chromium'\n"
+                                "      replace: 'Plaster'\n")
 
         plaster.PlasterFile(plaster_path).apply()
 
@@ -227,16 +229,19 @@ class PlasterTest(unittest.TestCase):
         cases = [
             ('substitutions:\n'
              '  - description: Both patterns specified\n'
-             "    pattern: 'Chromium'\n"
-             "    re_pattern: 'Chromium'\n"
-             "    replace: 'Plaster'\n",
+             '    regex:\n'
+             "      pattern: 'Chromium'\n"
+             "      re_pattern: 'Chromium'\n"
+             "      replace: 'Plaster'\n",
              'Please specify either pattern or re_pattern'),
             ('substitutions:\n'
              '  - description: No pattern specified\n'
-             "    replace: 'Plaster'\n", 'No pattern specified'),
+             '    regex:\n'
+             "      replace: 'Plaster'\n", 'No pattern specified'),
             ('substitutions:\n'
              '  - description: No replace specified\n'
-             "    pattern: 'Chromium'\n", 'No replace value specified'),
+             '    regex:\n'
+             "      pattern: 'Chromium'\n", 'No replace value specified'),
         ]
 
         for yaml_content, expected_error in cases:
@@ -335,8 +340,9 @@ class PlasterTest(unittest.TestCase):
             rewrite_path.write_text(f'''
               substitutions:
                 - description: Replace {orig} with {repl}
-                  re_pattern: '{orig}'
-                  replace: '{repl}'
+                  regex:
+                    re_pattern: '{orig}'
+                    replace: '{repl}'
             ''')
             # Apply the rewrite so files are up-to-date
             plaster_file = plaster.PlasterFile(rewrite_path)
@@ -373,8 +379,9 @@ class PlasterTest(unittest.TestCase):
             rewrite_path.write_text(f'''
               substitutions:
                 - description: Replace {orig} with {repl}
-                  re_pattern: '{orig}'
-                  replace: '{repl}'
+                  regex:
+                    re_pattern: '{orig}'
+                    replace: '{repl}'
             ''')
             plaster_file = plaster.PlasterFile(rewrite_path)
             plaster_file.apply()
@@ -394,8 +401,9 @@ class PlasterTest(unittest.TestCase):
         changed_path.write_text('''
           substitutions:
             - description: Break the rule
-              re_pattern: 'foo2'
-              replace: 'DIFFERENT'
+              regex:
+                re_pattern: 'foo2'
+                replace: 'DIFFERENT'
         ''')
         # Now check should raise PlasterFileNeedsRegen with the path included.
         with self.assertRaises(plaster.PlasterFileNeedsRegen) as context:
@@ -421,9 +429,10 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: Test multiple flags in array work
-              re_pattern: 'chromium'
-              replace: 'Brave'
-              re_flags: ['IGNORECASE', 'MULTILINE']
+              regex:
+                re_pattern: 'chromium'
+                replace: 'Brave'
+                re_flags: ['IGNORECASE', 'MULTILINE']
         ''')
 
         plaster_file = plaster.PlasterFile(plaster_path)
@@ -464,9 +473,10 @@ class PlasterTest(unittest.TestCase):
                 plaster_path.write_text(f'''
                   substitutions:
                     - description: Test invalid flag rejection
-                      re_pattern: 'Chromium'
-                      replace: 'Brave'
-                      re_flags: ['{invalid_flag}']
+                      regex:
+                        re_pattern: 'Chromium'
+                        replace: 'Brave'
+                        re_flags: ['{invalid_flag}']
                 ''')
 
                 plaster_file = plaster.PlasterFile(plaster_path)
@@ -495,9 +505,10 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: Test empty flags list
-              re_pattern: 'chromium'
-              replace: 'Brave'
-              re_flags: []
+              regex:
+                re_pattern: 'chromium'
+                replace: 'Brave'
+                re_flags: []
         ''')
 
         plaster_file = plaster.PlasterFile(plaster_path)
@@ -538,8 +549,9 @@ class PlasterTest(unittest.TestCase):
                 plaster_path.write_text(f'''
                   substitutions:
                     - description: Test invalid regex rejection
-                      re_pattern: '{invalid_pattern}'
-                      replace: 'Brave'
+                      regex:
+                        re_pattern: '{invalid_pattern}'
+                        replace: 'Brave'
                 ''')
 
                 plaster_file = plaster.PlasterFile(plaster_path)
@@ -567,19 +579,22 @@ class PlasterTest(unittest.TestCase):
             ('''
               substitutions:
                 - description: Both patterns specified
-                  pattern: 'Chromium'
-                  re_pattern: 'Chromium'
-                  replace: 'Plaster'
+                  regex:
+                    pattern: 'Chromium'
+                    re_pattern: 'Chromium'
+                    replace: 'Plaster'
             ''', 'Please specify either pattern or re_pattern'),
             ('''
               substitutions:
                 - description: No pattern specified
-                  replace: 'Plaster'
+                  regex:
+                    replace: 'Plaster'
             ''', 'No pattern specified'),
             ('''
               substitutions:
                 - description: No replace specified
-                  pattern: 'Chromium'
+                  regex:
+                    pattern: 'Chromium'
             ''', 'No replace value specified'),
         ]
 
@@ -617,8 +632,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: Replace exact pattern
-              pattern: 'Chromium++'
-              replace: 'Brave++'
+              regex:
+                pattern: 'Chromium++'
+                replace: 'Brave++'
         ''')
 
         # Apply the plaster file
@@ -651,8 +667,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: Replace regex pattern
-              re_pattern: 'Chromium\\w+'
-              replace: 'Brave'
+              regex:
+                re_pattern: 'Chromium\\w+'
+                replace: 'Brave'
               count: 2
         ''')
 
@@ -685,8 +702,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path1.write_text('''
           substitutions:
             - description: Replace exact brackets
-              pattern: '[brackets]'
-              replace: '{braces}'
+              regex:
+                pattern: '[brackets]'
+                replace: '{braces}'
         ''')
 
         plaster_file1 = plaster.PlasterFile(plaster_path1)
@@ -711,8 +729,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path2.write_text('''
           substitutions:
             - description: Replace using regex
-              re_pattern: '\\[\\w+\\]'
-              replace: '{braces}'
+              regex:
+                re_pattern: '\\[\\w+\\]'
+                replace: '{braces}'
         ''')
 
         plaster_file2 = plaster.PlasterFile(plaster_path2)
@@ -742,8 +761,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: Test count mismatch
-              re_pattern: 'Chromium'
-              replace: 'Brave'
+              regex:
+                re_pattern: 'Chromium'
+                replace: 'Brave'
               count: 2
         ''')
 
@@ -773,8 +793,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path_correct.write_text('''
           substitutions:
             - description: Test default count with 1 match
-              re_pattern: 'Chromium'
-              replace: 'Brave'
+              regex:
+                re_pattern: 'Chromium'
+                replace: 'Brave'
         ''')
 
         # Should succeed because there's exactly 1 match (matches default)
@@ -801,8 +822,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path_incorrect.write_text('''
           substitutions:
             - description: Test default count with 2 matches
-              re_pattern: 'Chromium'
-              replace: 'Brave'
+              regex:
+                re_pattern: 'Chromium'
+                replace: 'Brave'
         ''')
 
         # Should fail because there are 2 matches but default expects 1
@@ -838,8 +860,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: Test count 0 replaces all
-              re_pattern: 'Chromium'
-              replace: 'Brave'
+              regex:
+                re_pattern: 'Chromium'
+                replace: 'Brave'
               count: 0
         ''')
 
@@ -876,8 +899,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: replace a pattern that is absent
-              re_pattern: 'DoesNotAppear'
-              replace: 'X'
+              regex:
+                re_pattern: 'DoesNotAppear'
+                replace: 'X'
               count: 0
         ''')
 
@@ -912,12 +936,14 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: Replace single Chromium
-              re_pattern: 'Chromium'
-              replace: 'Brave'
+              regex:
+                re_pattern: 'Chromium'
+                replace: 'Brave'
               count: 1
             - description: Replace all browsers
-              re_pattern: 'browser'
-              replace: 'application'
+              regex:
+                re_pattern: 'browser'
+                replace: 'application'
               count: 3
         ''')
 
@@ -946,8 +972,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: Replace Chromium with Brave
-              re_pattern: 'Chromium'
-              replace: 'Brave'
+              regex:
+                re_pattern: 'Chromium'
+                replace: 'Brave'
         ''')
         plaster_file = plaster.PlasterFile(plaster_path)
         plaster_file.apply()
@@ -982,8 +1009,9 @@ class PlasterTest(unittest.TestCase):
         plaster_file.path.write_text('''
           substitutions:
             - description: A different rule
-              re_pattern: 'Brave'
-              replace: 'Lion'
+              regex:
+                re_pattern: 'Brave'
+                replace: 'Lion'
         ''')
         os.utime(plaster_file.path, (later, later))
         self.assertTrue(plaster_file.needs_apply())
@@ -1117,8 +1145,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path.parent.mkdir(parents=True, exist_ok=True)
         plaster_path.write_text('substitutions:\n'
                                 '  - description: Touch the destructor body\n'
-                                "    pattern: 'MARKER_LINE;'\n"
-                                "    replace: 'MARKER_LINE_CHANGED;'\n")
+                                '    regex:\n'
+                                "      pattern: 'MARKER_LINE;'\n"
+                                "      replace: 'MARKER_LINE_CHANGED;'\n")
 
         plaster.PlasterFile(plaster_path).apply()
 
@@ -1179,9 +1208,9 @@ class RewriterFormsTest(unittest.TestCase):
             self._apply('validation.idl', 'dummy', yaml_body)
         self.assertIn(substr, str(ctx.exception))
 
-    # -- regex op (explicit form of the legacy bare regex) ------------------
+    # -- regex op -----------------------------------------------------------
 
-    def test_regex_op_matches_bare_form(self):
+    def test_regex_op_applies(self):
         result = self._apply(
             'regex_op.idl', 'A Chromium thing.', 'substitutions:\n'
             '  - description: explicit regex op\n'
@@ -1200,13 +1229,15 @@ class RewriterFormsTest(unittest.TestCase):
             '      re_flags: [IGNORECASE, MULTILINE]\n')
         self.assertEqual(result, 'foo\nbaz\n')
 
-    def test_bare_regex_still_applies(self):
-        result = self._apply(
-            'bare.idl', 'A Chromium thing.', 'substitutions:\n'
+    def test_bare_regex_is_rejected(self):
+        # The bare regex form (regex fields directly on the item, without a
+        # `regex:` key) is no longer supported: with no rewriter key it is an
+        # entry that names no rewriter.
+        self._expect_value_error(
+            'substitutions:\n'
             '  - description: legacy bare regex\n'
             "    re_pattern: 'Chromium'\n"
-            "    replace: 'Brave'\n")
-        self.assertEqual(result, 'A Brave thing.')
+            "    replace: 'Brave'\n", 'Unrecognised substitution key')
 
     # -- make_virtual op (real ast-grep binary) -----------------------------
 
@@ -1338,14 +1369,16 @@ class RewriterFormsTest(unittest.TestCase):
             '      class_name: C\n'
             '      method_name: Foo\n', 'Only one rewriter')
 
-    def test_cannot_mix_op_and_bare_regex(self):
+    def test_stray_field_alongside_rewriter_rejected(self):
+        # A stray item-level field next to a rewriter key is an unrecognised
+        # key for that rewriter.
         self._expect_value_error(
             'substitutions:\n'
-            '  - description: mixed\n'
+            '  - description: stray field\n'
             '    regex:\n'
             "      re_pattern: 'x'\n"
             "      replace: 'y'\n"
-            "    re_pattern: 'z'\n", 'Cannot mix')
+            "    re_pattern: 'z'\n", 'Unrecognised key(s) for the "regex"')
 
     def test_unknown_regex_field_rejected(self):
         self._expect_value_error(
@@ -1377,11 +1410,12 @@ class RewriterFormsTest(unittest.TestCase):
         self.assertIn('make_virtual', message)
 
     def test_stray_scalar_key_is_unrecognised(self):
-        # A non-mapping stray key is a bare-field typo, not a rewriter attempt,
-        # so it keeps the generic "Unrecognised substitution key" error.
+        # Non-mapping stray keys name no rewriter, so they get the generic
+        # "Unrecognised substitution key" error rather than the unknown-rewriter
+        # one (which is reserved for mapping-valued keys).
         self._expect_value_error(
             'substitutions:\n'
-            '  - description: typo bare field\n'
+            '  - description: stray fields\n'
             "    re_pattern: 'x'\n"
             "    replace: 'y'\n"
             '    re_flag: [DOTALL]\n', 'Unrecognised substitution key')

--- a/tools/cr/test/plasters/add_header_after_line.cc.yaml
+++ b/tools/cr/test/plasters/add_header_after_line.cc.yaml
@@ -5,7 +5,8 @@
 
 substitutions:
   - description: Test for adding a header after another line
-    re_pattern: '#include "extensions/buildflags/buildflags.h"'
-    replace: |-
-      #include "extensions/buildflags/buildflags.h"
-      #include "brave/browser/autocomplete/brave_autocomplete_scheme_classifier.h"
+    regex:
+      re_pattern: '#include "extensions/buildflags/buildflags.h"'
+      replace: |-
+        #include "extensions/buildflags/buildflags.h"
+        #include "brave/browser/autocomplete/brave_autocomplete_scheme_classifier.h"

--- a/tools/cr/test/plasters/simple_replacement.cc.yaml
+++ b/tools/cr/test/plasters/simple_replacement.cc.yaml
@@ -5,5 +5,6 @@
 
 substitutions:
   - description: Test for indiscriminte replacements
-    re_pattern: ChromeAutocompleteSchemeClassifier
-    replace: BraveAutocompleteSchemeClassifier
+    regex:
+      re_pattern: ChromeAutocompleteSchemeClassifier
+      replace: BraveAutocompleteSchemeClassifier


### PR DESCRIPTION
We have migrated all plaster files to use `regex:` key. This change
removes support for the old format.

Bug: https://github.com/brave/brave-browser/issues/56854
