### PR TITLE
Keep hierarchy when moving multiple tabs in a tree

### DIFF
--- a/browser/ui/tabs/brave_tree_tab_strip_collection_delegate.cc
+++ b/browser/ui/tabs/brave_tree_tab_strip_collection_delegate.cc
@@ -245,10 +245,31 @@ BraveTreeTabStripCollectionDelegate::CompactMovingTabs(
       types_to_compact.Has(tabs::TabCollection::Type::GROUP);
   const bool compact_splits =
       types_to_compact.Has(tabs::TabCollection::Type::SPLIT);
+  const bool compact_tree =
+      types_to_compact.Has(tabs::TabCollection::Type::TREE_NODE);
 
   base::flat_set<tab_groups::TabGroupId> compacted_groups;
   base::flat_set<split_tabs::SplitTabId> compacted_splits;
+  base::flat_set<tabs::TabInterface*> moving_tabs_set;
+  if (compact_tree) {
+    moving_tabs_set = base::flat_set<tabs::TabInterface*>(moving_tabs.begin(),
+                                                          moving_tabs.end());
+  }
   for (auto* tab : moving_tabs) {
+    // If this tab sits under a tree node whose ancestor tree node is also
+    // moving (whether that ancestor is a bare tab, or wraps a group/split
+    // that is fully selected), the ancestor will be detached as a whole and
+    // will carry this tab's entire subtree along with it, since
+    // MoveTabsRecursive keeps connected subtrees nested. This applies
+    // regardless of whether |tab| itself is a bare tree-node tab or a member
+    // of a group/split wrapped by a tree node, so this check must run before
+    // the group/split compaction below.
+    if (compact_tree &&
+        IsTreeNodeCoveredByMovingAncestor(GetParentTreeNodeCollectionOfTab(tab),
+                                          moving_tabs_set)) {
+      continue;
+    }
+
     if (compact_groups) {
       if (auto group = tab->GetGroup()) {
         if (compacted_groups.contains(group.value())) {
@@ -282,6 +303,23 @@ BraveTreeTabStripCollectionDelegate::CompactMovingTabs(
   }
 
   return compacted_tabs;
+}
+
+bool BraveTreeTabStripCollectionDelegate::IsTreeNodeCoveredByMovingAncestor(
+    tabs::TreeTabNodeTabCollection* tree_node,
+    const base::flat_set<tabs::TabInterface*>& moving_tabs) const {
+  for (auto* ancestor = tree_node->GetParentCollection();
+       ancestor && ancestor->type() == tabs::TabCollection::Type::TREE_NODE;
+       ancestor = ancestor->GetParentCollection()) {
+    auto* ancestor_node =
+        static_cast<tabs::TreeTabNodeTabCollection*>(ancestor);
+    if (ancestor_node->current_value_type() ==
+            tabs::TreeTabNodeTabCollection::CurrentValueType::kTab &&
+        moving_tabs.contains(ancestor_node->GetCurrentTab())) {
+      return true;
+    }
+  }
+  return false;
 }
 
 base::expected<void, std::unique_ptr<tabs::TabInterface>>
@@ -625,18 +663,25 @@ void BraveTreeTabStripCollectionDelegate::MoveTabsRecursive(
           ? original_parent_collection->GetIndexOfCollection(first_tree_node)
           : std::nullopt;
 
-  // Before removing the tree tab node from the parent, make sure all
-  // children of the tree tab node are moved to the parent.
+  // Before removing the tree tab node from the parent, make sure any
+  // children of the tree tab node that are not also being moved are hoisted
+  // to the parent. Children that are moving together with their parent (a
+  // connected subtree) are left nested so the hierarchy is preserved instead
+  // of being flattened.
+  const base::flat_set<tabs::TabInterface*> moving_tabs_set(moving_tabs.begin(),
+                                                            moving_tabs.end());
   for (auto* moving_tab : base::Reversed(moving_tabs)) {
     auto* moving_tab_tree_node = GetParentTreeNodeCollectionOfTab(moving_tab);
-    MoveChildrenOfTreeTabNodeToParent(
-        static_cast<tabs::TreeTabNodeTabCollection*>(moving_tab_tree_node));
+    MoveNonSelectedChildrenOfTreeTabNodeToParent(
+        static_cast<tabs::TreeTabNodeTabCollection*>(moving_tab_tree_node),
+        moving_tabs_set);
   }
 
   // Remove the moving tab first from the original parent.
-  auto compacted_moving_tabs = CompactMovingTabs(
-      moving_tabs,
-      {tabs::TabCollection::Type::GROUP, tabs::TabCollection::Type::SPLIT});
+  auto compacted_moving_tabs =
+      CompactMovingTabs(moving_tabs, {tabs::TabCollection::Type::GROUP,
+                                      tabs::TabCollection::Type::SPLIT,
+                                      tabs::TabCollection::Type::TREE_NODE});
   std::vector<std::unique_ptr<tabs::TabCollection>>
       unique_moving_tab_collections_reversed;
   for (auto& tab_or_collection : base::Reversed(compacted_moving_tabs)) {
@@ -1357,6 +1402,50 @@ void BraveTreeTabStripCollectionDelegate::MoveChildrenOfTreeTabNodeToNode(
               target_collection->AddCollection(
                   tree_tab_node_collection->MaybeRemoveCollection(collection),
                   target_index);
+            }},
+        child);
+  }
+}
+
+void BraveTreeTabStripCollectionDelegate::
+    MoveNonSelectedChildrenOfTreeTabNodeToParent(
+        tabs::TreeTabNodeTabCollection* tree_tab_node_collection,
+        const base::flat_set<tabs::TabInterface*>& moving_tabs) const {
+  auto* tree_node_owner_collection =
+      tree_tab_node_collection->GetParentCollection();
+  auto local_index = tree_node_owner_collection->GetIndexOfCollection(
+      tree_tab_node_collection);
+  CHECK(local_index.has_value());
+
+  auto children = tree_tab_node_collection->GetTreeNodeChildren();
+  for (auto& child : base::Reversed(children)) {
+    std::visit(
+        absl::Overload{
+            [&](tabs::TabInterface* tab) {
+              if (moving_tabs.contains(tab)) {
+                // This tab is moving together with its parent tree node, so
+                // keep it nested instead of hoisting it out.
+                return;
+              }
+
+              tree_node_owner_collection->AddTab(
+                  tree_tab_node_collection->MaybeRemoveTab(tab), *local_index);
+            },
+            [&](tabs::TabCollection* collection) {
+              auto recursive_tabs = collection->GetTabsRecursive();
+              if (!recursive_tabs.empty() &&
+                  std::ranges::all_of(recursive_tabs, [&](auto* tab) {
+                    return moving_tabs.contains(tab);
+                  })) {
+                // Every tab in this child subtree is also moving with its
+                // parent, so keep the subtree nested to preserve the
+                // hierarchy instead of flattening it.
+                return;
+              }
+
+              tree_node_owner_collection->AddCollection(
+                  tree_tab_node_collection->MaybeRemoveCollection(collection),
+                  *local_index);
             }},
         child);
   }

--- a/browser/ui/tabs/brave_tree_tab_strip_collection_delegate.h
+++ b/browser/ui/tabs/brave_tree_tab_strip_collection_delegate.h
@@ -133,6 +133,16 @@ class BraveTreeTabStripCollectionDelegate
       tabs::TabCollection* target_collection,
       size_t target_index) const;
 
+  // Like MoveChildrenOfTreeTabNodeToParent(), but a child is left nested
+  // under |tree_tab_node_collection| when every tab it contains is also in
+  // |moving_tabs| - i.e. the child is a connected subtree moving together
+  // with its parent, so the hierarchy should be preserved instead of
+  // flattened. Children that aren't fully part of the move are hoisted to
+  // the parent as before.
+  void MoveNonSelectedChildrenOfTreeTabNodeToParent(
+      tabs::TreeTabNodeTabCollection* tree_tab_node_collection,
+      const base::flat_set<tabs::TabInterface*>& moving_tabs) const;
+
   // Groups where every tab in the group is in |moving_tabs|, so the move should
   // relocate the whole group collection. Empty when whole-group detection does
   // not apply (e.g. moving into a group or pinning).
@@ -149,6 +159,15 @@ class BraveTreeTabStripCollectionDelegate
   CompactMovingTabs(
       const std::vector<tabs::TabInterface*>& moving_tabs,
       const tabs::TabCollection::TypeEnumSet& types_to_compact) const;
+
+  // Returns true if an ancestor of |tree_node| (walking up while still under
+  // TreeTabNodeTabCollections) is itself one of |moving_tabs| - i.e.
+  // |tree_node| (whether it holds a bare tab, or wraps a group/split) will
+  // already be carried along nested when that ancestor is detached as a
+  // whole, so it should not be compacted/detached separately.
+  bool IsTreeNodeCoveredByMovingAncestor(
+      tabs::TreeTabNodeTabCollection* tree_node,
+      const base::flat_set<tabs::TabInterface*>& moving_tabs) const;
 
   // Returns the tab's parent collection in the strip; if the direct parent is
   // a split or group, returns the split/group's parent (e.g. group). This is

--- a/browser/ui/tabs/test/tree_tabs_browsertest.cc
+++ b/browser/ui/tabs/test/tree_tabs_browsertest.cc
@@ -3152,6 +3152,241 @@ IN_PROC_BROWSER_TEST_F(
   EXPECT_EQ(unpinned_collection().ChildCount(), 2u);
 }
 
+// Selecting a parent tab together with only one of its two children (the
+// other child is left unselected) and moving them as a block must keep the
+// selected child nested under the parent's tree node, while the unselected
+// child is hoisted out to become a top-level sibling instead of being
+// dragged along.
+IN_PROC_BROWSER_TEST_F(
+    TreeTabsBrowserTest,
+    MoveSelectedTabsTo_ParentAndOneOfTwoChildrenSelected_KeepsSelectedChildNested) {
+  SetTreeTabsEnabled(true);
+
+  auto* parent_tab = tab_strip_model().GetTabAtIndex(0);
+
+  // Add two children under the parent tab: |child_b| and |child_c|.
+  for (int i = 0; i < 2; ++i) {
+    auto tab_interface = std::make_unique<tabs::TabModel>(CreateWebContents(),
+                                                          &tab_strip_model());
+    tab_interface->set_opener(parent_tab);
+    tab_strip_model().AddTab(std::move(tab_interface), -1,
+                             ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  }
+  auto* child_b = tab_strip_model().GetTabAtIndex(1);
+  auto* child_c = tab_strip_model().GetTabAtIndex(2);
+
+  // Add an extra top-level tab so there's somewhere to move past. Add it
+  // directly with ADD_NONE and no opener - AddTab() (AppendWebContents with
+  // foreground=true) would set ADD_INHERIT_OPENER and chain it off the
+  // currently active tab instead of creating a separate top-level node.
+  auto extra_tab_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  tab_strip_model().AddTab(std::move(extra_tab_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  ASSERT_EQ(4, tab_strip_model().count());
+  auto* extra_tab = tab_strip_model().GetTabAtIndex(3);
+
+  // Parent's tree node has 3 children (child_b, child_c), plus the extra tab.
+  ASSERT_EQ(unpinned_collection().ChildCount(), 2u);
+
+  // Select the parent and only child_b (not child_c), then move the block to
+  // the end.
+  ui::ListSelectionModel selection_model;
+  selection_model.AddIndexToSelection(0);
+  selection_model.AddIndexToSelection(1);
+  selection_model.set_active(1);
+  selection_model.set_anchor(0);
+  tab_strip_model().SetSelectionFromModel(selection_model);
+  tab_strip_model().MoveSelectedTabsTo(2, std::nullopt);
+
+  ASSERT_EQ(4, tab_strip_model().count());
+  // child_c is hoisted out to become a top-level sibling, taking the
+  // parent's old slot; extra_tab follows it; the moved block (parent with
+  // child_b nested) lands at the end.
+  EXPECT_EQ(tab_strip_model().GetTabAtIndex(0), child_c);
+  EXPECT_EQ(tab_strip_model().GetTabAtIndex(1), extra_tab);
+  EXPECT_EQ(tab_strip_model().GetTabAtIndex(2), parent_tab);
+  EXPECT_EQ(tab_strip_model().GetTabAtIndex(3), child_b);
+
+  // child_b must remain nested under the parent's tree node.
+  EXPECT_EQ(child_b->GetParentCollection()->GetParentCollection(),
+            parent_tab->GetParentCollection());
+  EXPECT_EQ(parent_tab->GetParentCollection()->ChildCount(), 2u);
+
+  // child_c must have been hoisted out to become its own top-level tree
+  // node, no longer nested under the parent's tree node.
+  EXPECT_EQ(child_c->GetParentCollection()->GetParentCollection(),
+            &unpinned_collection());
+  EXPECT_EQ(unpinned_collection().ChildCount(), 3u);
+}
+
+// A three-level partial selection: parent tab with two children, the second
+// of which has its own child (a grandchild of the parent). Selecting the
+// parent and both children, but not the grandchild, must keep the selected
+// nodes nested together while the unselected grandchild is hoisted out.
+IN_PROC_BROWSER_TEST_F(
+    TreeTabsBrowserTest,
+    MoveSelectedTabsTo_ParentTwoChildrenAndGrandchildSelected_KeepsHierarchy) {
+  SetTreeTabsEnabled(true);
+
+  auto* parent_tab = tab_strip_model().GetTabAtIndex(0);
+
+  auto child_b_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  child_b_interface->set_opener(parent_tab);
+  tab_strip_model().AddTab(std::move(child_b_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  auto* child_b = tab_strip_model().GetTabAtIndex(1);
+
+  auto child_c_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  child_c_interface->set_opener(parent_tab);
+  tab_strip_model().AddTab(std::move(child_c_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  auto* child_c = tab_strip_model().GetTabAtIndex(2);
+
+  auto grandchild_d_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  grandchild_d_interface->set_opener(child_c);
+  tab_strip_model().AddTab(std::move(grandchild_d_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  auto* grandchild_d = tab_strip_model().GetTabAtIndex(3);
+  ASSERT_EQ(grandchild_d->GetParentCollection()->GetParentCollection(),
+            child_c->GetParentCollection());
+
+  // Add an extra top-level tab so there's somewhere to move past. Add it
+  // directly with ADD_NONE and no opener - AddTab() (AppendWebContents with
+  // foreground=true) would set ADD_INHERIT_OPENER and chain it off the
+  // currently active tab instead of creating a separate top-level node.
+  auto extra_tab_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  tab_strip_model().AddTab(std::move(extra_tab_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  ASSERT_EQ(5, tab_strip_model().count());
+  auto* extra_tab = tab_strip_model().GetTabAtIndex(4);
+
+  ASSERT_EQ(unpinned_collection().ChildCount(), 2u);
+
+  // Select the parent, child_b, and child_c, but not grandchild_d, then move
+  // the block to the end.
+  ui::ListSelectionModel selection_model;
+  selection_model.AddIndexToSelection(0);
+  selection_model.AddIndexToSelection(1);
+  selection_model.AddIndexToSelection(2);
+  selection_model.set_active(2);
+  selection_model.set_anchor(0);
+  tab_strip_model().SetSelectionFromModel(selection_model);
+  tab_strip_model().MoveSelectedTabsTo(2, std::nullopt);
+
+  ASSERT_EQ(5, tab_strip_model().count());
+  // grandchild_d is hoisted out to become a top-level sibling, taking the
+  // parent's old slot; extra_tab follows it; the moved block (parent with
+  // child_b and child_c nested) lands at the end.
+  EXPECT_EQ(tab_strip_model().GetTabAtIndex(0), grandchild_d);
+  EXPECT_EQ(tab_strip_model().GetTabAtIndex(1), extra_tab);
+  EXPECT_EQ(tab_strip_model().GetTabAtIndex(2), parent_tab);
+  EXPECT_EQ(tab_strip_model().GetTabAtIndex(3), child_b);
+  EXPECT_EQ(tab_strip_model().GetTabAtIndex(4), child_c);
+
+  // child_b and child_c must remain nested under the parent's tree node.
+  EXPECT_EQ(child_b->GetParentCollection()->GetParentCollection(),
+            parent_tab->GetParentCollection());
+  EXPECT_EQ(child_c->GetParentCollection()->GetParentCollection(),
+            parent_tab->GetParentCollection());
+  EXPECT_EQ(parent_tab->GetParentCollection()->ChildCount(), 3u);
+
+  // grandchild_d must have been hoisted all the way out to become its own
+  // top-level tree node.
+  EXPECT_EQ(grandchild_d->GetParentCollection()->GetParentCollection(),
+            &unpinned_collection());
+  EXPECT_EQ(unpinned_collection().ChildCount(), 3u);
+}
+
+// Selecting a parent tab together with a nested split that lives entirely
+// underneath it, and moving them as one block, must keep the split's
+// wrapping tree node nested under the parent's tree node instead of
+// flattening it out to become a top-level sibling.
+IN_PROC_BROWSER_TEST_F(
+    TreeTabsBrowserTest,
+    MoveSelectedTabsTo_ParentAndNestedSplitBothSelected_KeepsSplitNested) {
+  SetTreeTabsEnabled(true);
+
+  // Build parent -> tab_a -> tab_b (three levels).
+  auto* parent_tab = tab_strip_model().GetTabAtIndex(0);
+
+  auto tab_a_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  tab_a_interface->set_opener(parent_tab);
+  tab_strip_model().AddTab(std::move(tab_a_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  auto* tab_a = tab_strip_model().GetTabAtIndex(1);
+
+  auto tab_b_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  tab_b_interface->set_opener(tab_a);
+  tab_strip_model().AddTab(std::move(tab_b_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  auto* tab_b = tab_strip_model().GetTabAtIndex(2);
+
+  // Add an extra top-level tab so there's something else in the strip. Add it
+  // directly with ADD_NONE and no opener - AddTab() (AppendWebContents with
+  // foreground=true) would set ADD_INHERIT_OPENER and chain it off the
+  // currently active tab (parent_tab) instead of making it a separate
+  // top-level node.
+  auto extra_tab_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  tab_strip_model().AddTab(std::move(extra_tab_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  ASSERT_EQ(4, tab_strip_model().count());
+
+  // Split tab_a and tab_b together. This should wrap them in a tree node that
+  // takes over tab_a's old position, nested under the parent's tree node.
+  CreateSplitWithTabs(&tab_strip_model(),
+                      tab_strip_model().GetIndexOfTab(tab_a),
+                      tab_strip_model().GetIndexOfTab(tab_b));
+  VerifySplitCreated(&tab_strip_model(), &tab_strip_collection());
+  split_tabs::SplitTabId split_id =
+      *tab_strip_collection().ListSplits().begin();
+
+  const tabs::TabCollection* split_collection = tab_a->GetParentCollection();
+  ASSERT_EQ(split_collection->type(), tabs::TabCollection::Type::SPLIT);
+  const tabs::TabCollection* split_tree_node =
+      split_collection->GetParentCollection();
+  ASSERT_EQ(split_tree_node->type(), tabs::TabCollection::Type::TREE_NODE);
+  ASSERT_EQ(split_tree_node->GetParentCollection(),
+            parent_tab->GetParentCollection());
+  ASSERT_EQ(unpinned_collection().ChildCount(), 2u)
+      << "parent's tree node (containing the nested split) + 1 extra tab";
+
+  // Select the parent tab and both split tabs together and move the whole
+  // block.
+  ui::ListSelectionModel selection_model;
+  selection_model.AddIndexToSelection(
+      tab_strip_model().GetIndexOfTab(parent_tab));
+  selection_model.AddIndexToSelection(tab_strip_model().GetIndexOfTab(tab_a));
+  selection_model.AddIndexToSelection(tab_strip_model().GetIndexOfTab(tab_b));
+  selection_model.set_active(tab_strip_model().GetIndexOfTab(tab_b));
+  selection_model.set_anchor(tab_strip_model().GetIndexOfTab(parent_tab));
+  tab_strip_model().SetSelectionFromModel(selection_model);
+  tab_strip_model().MoveSelectedTabsTo(1, std::nullopt);
+
+  ASSERT_EQ(4, tab_strip_model().count());
+  EXPECT_TRUE(tab_strip_model().ContainsSplit(split_id));
+
+  // The split's tree node must still be nested under the parent's tree node,
+  // not flattened out to become a top-level sibling.
+  const tabs::TabCollection* split_collection_after =
+      tab_a->GetParentCollection();
+  ASSERT_EQ(split_collection_after->type(), tabs::TabCollection::Type::SPLIT);
+  const tabs::TabCollection* split_tree_node_after =
+      split_collection_after->GetParentCollection();
+  ASSERT_EQ(split_tree_node_after->type(),
+            tabs::TabCollection::Type::TREE_NODE);
+  EXPECT_EQ(split_tree_node_after->GetParentCollection(),
+            parent_tab->GetParentCollection());
+  EXPECT_EQ(unpinned_collection().ChildCount(), 2u);
+}
+
 IN_PROC_BROWSER_TEST_F(TreeTabsBrowserTest,
                        AddTab_EmptyNewTab_NoNestedTreeTab) {
   SetTreeTabsEnabled(true);

--- a/browser/ui/tabs/test/tree_tabs_browsertest.cc
+++ b/browser/ui/tabs/test/tree_tabs_browsertest.cc
@@ -3006,6 +3006,152 @@ IN_PROC_BROWSER_TEST_F(TreeTabsBrowserTest,
             group_b);
 }
 
+// Selecting a parent tab together with its (connected) child and moving them
+// as one block must keep the child nested under the parent's tree node
+// instead of flattening it out to become a top-level sibling.
+IN_PROC_BROWSER_TEST_F(
+    TreeTabsBrowserTest,
+    MoveSelectedTabsTo_ParentAndChildBothSelected_KeepsChildNested) {
+  SetTreeTabsEnabled(true);
+
+  auto* parent_tab = tab_strip_model().GetTabAtIndex(0);
+
+  // Add a child under the parent tab.
+  auto tab_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  tab_interface->set_opener(parent_tab);
+  tab_strip_model().AddTab(std::move(tab_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  auto* child_tab = tab_strip_model().GetTabAtIndex(1);
+  ASSERT_EQ(child_tab->GetParentCollection()->GetParentCollection(),
+            parent_tab->GetParentCollection());
+
+  // Add two more top-level tabs so there's somewhere to move past. Add them
+  // directly with ADD_NONE and no opener - AddTab() (AppendWebContents with
+  // foreground=true) would set ADD_INHERIT_OPENER and chain each new tab off
+  // the currently active tab instead of creating separate top-level nodes.
+  for (int i = 0; i < 2; ++i) {
+    auto other_tab_interface = std::make_unique<tabs::TabModel>(
+        CreateWebContents(), &tab_strip_model());
+    tab_strip_model().AddTab(std::move(other_tab_interface), -1,
+                             ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  }
+  ASSERT_EQ(4, tab_strip_model().count());
+  auto* other_tab_a = tab_strip_model().GetTabAtIndex(2);
+  auto* other_tab_b = tab_strip_model().GetTabAtIndex(3);
+
+  // Parent+child form a single tree node, plus 2 more top-level tabs.
+  ASSERT_EQ(unpinned_collection().ChildCount(), 3u);
+
+  // Select the parent and its child together and move the block to the end.
+  ui::ListSelectionModel selection_model;
+  selection_model.AddIndexToSelection(0);
+  selection_model.AddIndexToSelection(1);
+  selection_model.set_active(1);
+  selection_model.set_anchor(0);
+  tab_strip_model().SetSelectionFromModel(selection_model);
+  tab_strip_model().MoveSelectedTabsTo(2, std::nullopt);
+
+  ASSERT_EQ(4, tab_strip_model().count());
+  // The block moved past the two other tabs, which are now first.
+  EXPECT_EQ(tab_strip_model().GetTabAtIndex(0), other_tab_a);
+  EXPECT_EQ(tab_strip_model().GetTabAtIndex(1), other_tab_b);
+  EXPECT_EQ(tab_strip_model().GetTabAtIndex(2), parent_tab);
+  EXPECT_EQ(tab_strip_model().GetTabAtIndex(3), child_tab);
+
+  // The child must remain nested under the parent's tree node, not flattened
+  // out to become a top-level sibling.
+  EXPECT_EQ(child_tab->GetParentCollection()->GetParentCollection(),
+            parent_tab->GetParentCollection());
+  EXPECT_EQ(parent_tab->GetParentCollection()->ChildCount(), 2u);
+  EXPECT_EQ(unpinned_collection().ChildCount(), 3u);
+}
+
+// Selecting a parent tab together with a nested group/split that lives
+// entirely underneath it, and moving them as one block, must keep the
+// group's wrapping tree node nested under the parent's tree node instead of
+// flattening it out to become a top-level sibling.
+IN_PROC_BROWSER_TEST_F(
+    TreeTabsBrowserTest,
+    MoveSelectedTabsTo_ParentAndNestedGroupBothSelected_KeepsGroupNested) {
+  EnsureTabGroupSyncServiceInitialized();
+  SetTreeTabsEnabled(true);
+
+  // Build parent -> tab_a -> tab_b (three levels).
+  auto* parent_tab = tab_strip_model().GetTabAtIndex(0);
+
+  auto tab_a_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  tab_a_interface->set_opener(parent_tab);
+  tab_strip_model().AddTab(std::move(tab_a_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  auto* tab_a = tab_strip_model().GetTabAtIndex(1);
+
+  auto tab_b_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  tab_b_interface->set_opener(tab_a);
+  tab_strip_model().AddTab(std::move(tab_b_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  auto* tab_b = tab_strip_model().GetTabAtIndex(2);
+
+  // Add an extra top-level tab so there's something else in the strip. Add it
+  // directly with ADD_NONE and no opener - AddTab() (AppendWebContents with
+  // foreground=true) would set ADD_INHERIT_OPENER and chain it off the
+  // currently active tab (parent_tab) instead of making it a separate
+  // top-level node.
+  auto extra_tab_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  tab_strip_model().AddTab(std::move(extra_tab_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  ASSERT_EQ(4, tab_strip_model().count());
+
+  // Group tab_a and tab_b together. This should wrap them in a tree node that
+  // takes over tab_a's old position, nested under the parent's tree node.
+  tab_groups::TabGroupId group_id =
+      tab_strip_model().AddToNewGroup({tab_strip_model().GetIndexOfTab(tab_a),
+                                       tab_strip_model().GetIndexOfTab(tab_b)});
+  ASSERT_TRUE(tab_strip_model().group_model()->ContainsTabGroup(group_id));
+
+  const tabs::TabCollection* group_collection = tab_a->GetParentCollection();
+  ASSERT_EQ(group_collection->type(), tabs::TabCollection::Type::GROUP);
+  const tabs::TabCollection* group_tree_node =
+      group_collection->GetParentCollection();
+  ASSERT_EQ(group_tree_node->type(), tabs::TabCollection::Type::TREE_NODE);
+  ASSERT_EQ(group_tree_node->GetParentCollection(),
+            parent_tab->GetParentCollection());
+  ASSERT_EQ(unpinned_collection().ChildCount(), 2u)
+      << "parent's tree node (containing the nested group) + 1 extra tab";
+
+  // Select the parent tab and both grouped tabs together and move the whole
+  // block.
+  ui::ListSelectionModel selection_model;
+  selection_model.AddIndexToSelection(
+      tab_strip_model().GetIndexOfTab(parent_tab));
+  selection_model.AddIndexToSelection(tab_strip_model().GetIndexOfTab(tab_a));
+  selection_model.AddIndexToSelection(tab_strip_model().GetIndexOfTab(tab_b));
+  selection_model.set_active(tab_strip_model().GetIndexOfTab(tab_b));
+  selection_model.set_anchor(tab_strip_model().GetIndexOfTab(parent_tab));
+  tab_strip_model().SetSelectionFromModel(selection_model);
+  tab_strip_model().MoveSelectedTabsTo(1, std::nullopt);
+
+  ASSERT_EQ(4, tab_strip_model().count());
+  EXPECT_TRUE(tab_strip_model().group_model()->ContainsTabGroup(group_id));
+  ExpectGroupModelTabListCount(group_id, 2u);
+
+  // The group's tree node must still be nested under the parent's tree node,
+  // not flattened out to become a top-level sibling.
+  const tabs::TabCollection* group_collection_after =
+      tab_a->GetParentCollection();
+  ASSERT_EQ(group_collection_after->type(), tabs::TabCollection::Type::GROUP);
+  const tabs::TabCollection* group_tree_node_after =
+      group_collection_after->GetParentCollection();
+  ASSERT_EQ(group_tree_node_after->type(),
+            tabs::TabCollection::Type::TREE_NODE);
+  EXPECT_EQ(group_tree_node_after->GetParentCollection(),
+            parent_tab->GetParentCollection());
+  EXPECT_EQ(unpinned_collection().ChildCount(), 2u);
+}
+
 IN_PROC_BROWSER_TEST_F(TreeTabsBrowserTest,
                        AddTab_EmptyNewTab_NoNestedTreeTab) {
   SetTreeTabsEnabled(true);


### PR DESCRIPTION
Previously, we flattened the hierarchy when moving multiple tabs in a tree. This change keeps the hierarchy when moving multiple tabs in a tree.

<!-- Add brave-browser issue below that this PR will resolve -->
- part of https://github.com/brave/brave-browser/issues/57228
<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
