### PR TITLE
Fixed vertical tab region is allocated in tab fullscreen

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -195,6 +195,10 @@ class BraveBrowserView : public BrowserView,
     return top_container_separator_;
   }
 
+  views::View* vertical_tab_strip_host_view_for_testing() const {
+    return vertical_tab_strip_host_view_;
+  }
+
 #if BUILDFLAG(ENABLE_EXTENSIONS)
   // Returns the PWA Shields toolbar button, if it exists. Note that this
   // returns valid pointer only when it's web app browser.

--- a/browser/ui/views/frame/vertical_tabs/BUILD.gn
+++ b/browser/ui/views/frame/vertical_tabs/BUILD.gn
@@ -84,3 +84,24 @@ source_set("browser_tests") {
     ]
   }
 }
+
+source_set("interactive_ui_tests") {
+  testonly = true
+  defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+
+  sources = [ "vertical_tab_strip_interactive_ui_tests.cc" ]
+
+  deps = [
+    ":vertical_tabs",
+    "//brave/browser/ui/tabs:tabs_public",
+    "//brave/browser/ui/views/frame",
+    "//chrome/browser",
+    "//chrome/browser/ui",
+    "//chrome/browser/ui/exclusive_access",
+    "//chrome/test:test_support_ui",
+    "//content/public/browser",
+    "//content/test:test_support",
+    "//testing/gtest",
+    "//ui/views",
+  ]
+}

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_interactive_ui_tests.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_interactive_ui_tests.cc
@@ -1,0 +1,81 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/test/run_until.h"
+#include "brave/browser/ui/browser_commands.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_container_view.h"
+#include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
+#include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
+#include "chrome/browser/ui/exclusive_access/fullscreen_controller.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "chrome/test/interaction/interactive_browser_test.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+
+using State = BraveVerticalTabStripRegionView::State;
+
+class VerticalTabStripInteractiveUITest : public InteractiveBrowserTest {
+ public:
+  BraveBrowserView* browser_view() {
+    return static_cast<BraveBrowserView*>(browser()->window());
+  }
+
+  void ToggleVerticalTabStrip() { brave::ToggleVerticalTabStrip(browser()); }
+};
+
+IN_PROC_BROWSER_TEST_F(VerticalTabStripInteractiveUITest,
+                       TabFullscreenUpdatesHostViewBounds) {
+  ToggleVerticalTabStrip();
+
+  auto* host_view = browser_view()->vertical_tab_strip_host_view_for_testing();
+  ASSERT_TRUE(host_view);
+
+  auto* region_view = browser_view()
+                          ->vertical_tab_strip_container_view()
+                          ->vertical_tab_strip_region_view();
+  ASSERT_TRUE(region_view);
+  ASSERT_EQ(State::kExpanded, region_view->state());
+  ASSERT_GT(host_view->GetPreferredSize().width(), 0);
+
+  auto* fullscreen_controller = browser()
+                                    ->GetFeatures()
+                                    .exclusive_access_manager()
+                                    ->fullscreen_controller();
+  auto* web_contents = browser()->tab_strip_model()->GetActiveWebContents();
+
+  {
+    ui_test_utils::FullscreenWaiter waiter(browser(), {.tab_fullscreen = true});
+    fullscreen_controller->EnterFullscreenModeForTab(
+        web_contents->GetPrimaryMainFrame());
+    waiter.Wait();
+  }
+  ASSERT_TRUE(fullscreen_controller->IsTabFullscreen());
+
+  // The vertical tab strip should no longer be reserving any space for the
+  // host view while in tab fullscreen.
+  EXPECT_TRUE(base::test::RunUntil(
+      [&]() { return host_view->GetPreferredSize().width() == 0; }));
+
+  // Tab fullscreen shouldn't have changed the pref-based expanded/collapsed
+  // state - it's a temporary, layout-only change.
+  EXPECT_EQ(State::kExpanded, region_view->state());
+
+  {
+    ui_test_utils::FullscreenWaiter waiter(
+        browser(), ui_test_utils::FullscreenWaiter::kNoFullscreen);
+    fullscreen_controller->ExitFullscreenModeForTab(web_contents);
+    waiter.Wait();
+  }
+  ASSERT_FALSE(fullscreen_controller->IsTabFullscreen());
+
+  // Exiting tab fullscreen should restore the previously allocated space.
+  EXPECT_TRUE(base::test::RunUntil(
+      [&]() { return host_view->GetPreferredSize().width() > 0; }));
+  EXPECT_EQ(State::kExpanded, region_view->state());
+}

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -1154,7 +1154,6 @@ void BraveVerticalTabStripRegionView::UpdateFloatingStateForBrowserMode() {
       width_animation_.Stop();
       SetVisible(false);
       SetState(State::kCollapsed);
-      PreferredSizeChanged();
     }
   } else if (floating_restore_state_) {
     // When exiting floating mode based on the current browser mode, restore the
@@ -1163,8 +1162,12 @@ void BraveVerticalTabStripRegionView::UpdateFloatingStateForBrowserMode() {
     floating_restore_state_.reset();
     SetVisible(true);
     SetState(restore_state);
-    PreferredSizeChanged();
   }
+
+  // This method is called whenever browser mode(fullscreen or focus mode) is
+  // changed. Even floating state is not changed, host view's preferred size
+  // should be updated. Notify to VerticalTabStripContainerView to do it.
+  PreferredSizeChanged();
 }
 
 void BraveVerticalTabStripRegionView::ScheduleFloatingModeTimer() {

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -811,6 +811,7 @@ if (!is_android) {
       ":browser_test_support",
       "//brave:packed_resources",
       "//brave/browser/ui/sidebar:interactive_ui_tests",
+      "//brave/browser/ui/views/frame/vertical_tabs:interactive_ui_tests",
       "//chrome:packed_resources",
       "//chrome/browser",
       "//chrome/test:chrome_test_launcher",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57212

Whenever browser mode changes, VerticalTabStripContainerView should get preferred size
changed noti from child to update host view's bounds.

It was called whenever fullscreen mode changed but it's accidently removed by https://github.com/brave/brave-core/pull/37834/changes.

TEST=VerticalTabStripInteractiveUITest.TabFullscreenUpdatesHostViewBounds

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
