### PR TITLE
[plaster] Make rewriters composable

### DIFF
--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -406,8 +406,17 @@ class Rewriter(abc.ABC):
     HELP: ClassVar[str] = ''
 
     @abc.abstractmethod
-    def apply(self, contents: str) -> tuple[str, int]:
-        """Transform `contents`, returning (new_contents, num_changes)."""
+    def apply(self, contents: str, *, count: int,
+              description: str) -> tuple[str, list[str]]:
+        """Transform `contents`, returning (new_contents, validation_errors).
+
+        `count` is the entry's `count:` (default 1, `0` meaning "one or more").
+        Each rewriter decides how it applies. For a single-site rewriter it is
+        the expected number of matches. A composed rewriter may instead give
+        each of its operations its own expectation. `errors` is the list of
+        human-readable count/validation failures (empty when the entry applied
+        as expected).
+        """
 
     @classmethod
     @abc.abstractmethod
@@ -438,9 +447,16 @@ class Substitution:
     # The rewriter this entry composes; `apply` delegates to it.
     rewriter: Rewriter
 
-    def apply(self, contents: str) -> tuple[str, int]:
-        """Apply the composed rewriter, returning (new_contents, changes)."""
-        return self.rewriter.apply(contents)
+    def apply(self, contents: str) -> tuple[str, list[str]]:
+        """Apply the composed rewriter, returning (new_contents, errors).
+
+        The envelope's `expected_count`/`description` are handed to the
+        rewriter, which owns count validation (per-operation for composed
+        rewriters) and reports any failures as error strings.
+        """
+        return self.rewriter.apply(contents,
+                                   count=self.expected_count,
+                                   description=self.description)
 
     class _NoDupSafeLoader(yaml.SafeLoader):
         """`yaml.SafeLoader` that rejects duplicate mapping keys.
@@ -568,6 +584,64 @@ class Substitution:
         return expected_count
 
 
+@dataclass(frozen=True)
+class MatchExpectation:
+    """How many matches an operation must make to count as correctly applied.
+
+    A closed range `[minimum, maximum]`; `maximum is None` means unbounded. The
+    canonical forms cover every case plaster needs:
+
+    - `exactly(n)`   — precisely `n` matches (the default, `exactly(1)`).
+    - `at_least_one` — one or more (the `count: 0` form).
+    - `optional`     — any number including zero; never fails on its own. Use
+      for an operation that may legitimately find nothing, leaving a
+      cross-operation rule (e.g. "at least one of these") to a rewriter's own
+      validation.
+    """
+
+    minimum: int
+    maximum: int | None
+
+    @classmethod
+    def exactly(cls, n: int) -> MatchExpectation:
+        return cls(n, n)
+
+    @classmethod
+    def at_least_one(cls) -> MatchExpectation:
+        return cls(1, None)
+
+    @classmethod
+    def optional(cls) -> MatchExpectation:
+        return cls(0, None)
+
+    @classmethod
+    def from_count(cls, count: int) -> MatchExpectation:
+        """Map an entry's `count:` to an expectation (`0` -> one-or-more)."""
+        return cls.at_least_one() if count == 0 else cls.exactly(count)
+
+    def accepts(self, matches: int) -> bool:
+        """True if `matches` satisfies this expectation."""
+        return matches >= self.minimum and (self.maximum is None
+                                            or matches <= self.maximum)
+
+    def error_for(self, matches: int) -> str | None:
+        """A failure message if `matches` is unacceptable, else None.
+
+        The `exactly`/`at_least_one` wordings match plaster's historical count
+        errors so existing diagnostics are unchanged.
+        """
+        if self.accepts(matches):
+            return None
+        if self.minimum == 1 and self.maximum is None:
+            return 'Expected at least one match but found none'
+        if self.minimum == self.maximum:
+            return (f'Unexpected number of matches ({matches} vs '
+                    f'{self.minimum})')
+        upper = 'any' if self.maximum is None else self.maximum
+        return (f'Unexpected number of matches ({matches} vs '
+                f'{self.minimum}..{upper})')
+
+
 class Regex(Rewriter):
     """A regex substitution applied with `re.subn` (the native rewriter).
     """
@@ -611,14 +685,18 @@ class Regex(Rewriter):
         self._replace = replace
         self._re_flags = re_flags
 
-    def apply(self, contents: str) -> tuple[str, int]:
-        # `count=0` is provided here so all substitutions are applied, and then
-        # the number of them gets validated by the callers.
-        return re.subn(self._re_pattern,
-                       self._replace,
-                       contents,
-                       flags=self._re_flags,
-                       count=0)
+    def apply(self, contents: str, *, count: int,
+              description: str) -> tuple[str, list[str]]:
+        del description  # Only the count matters for the regex diagnostic.
+        # `count=0` here means "replace every match"; how many were expected is
+        # validated afterwards against the entry's `count:`.
+        content, matches = re.subn(self._re_pattern,
+                                   self._replace,
+                                   contents,
+                                   flags=self._re_flags,
+                                   count=0)
+        error = MatchExpectation.from_count(count).error_for(matches)
+        return content, [error] if error else []
 
     @classmethod
     def parse(cls, body: object, *, description: str) -> Regex:
@@ -674,58 +752,121 @@ class Regex(Rewriter):
         return re_flags
 
 
+@dataclass(frozen=True)
+class Operation:
+    """One planned ast-grep op invocation: the whole contract to the engine.
+
+    `op_id` names an `ast.rewriter` in `rewriters.pyl`; `inputs` binds each of
+    that op's declared `inputs` to a concrete string. Everything else the engine
+    needs -- which matcher to run, which adjacent tokens to consume, the
+    replacement template -- lives in the op spec, so a frontend `Rewriter`
+    composes purely by emitting `Operation`s (one, several of the same op, or a
+    mix of different ops) and never touches engine internals.
+
+    `expectation` is how many matches this operation must make to be considered
+    correctly applied; it is validation metadata that `AstRewriter.run` ignores
+    (the engine just reports how many matches it made) and the composing
+    `Rewriter` checks. A composed rewriter sets a per-operation expectation --
+    e.g. `add_friend` expects each friend inserted exactly once regardless of
+    how many friends there are -- rather than folding everything into one total.
+    """
+
+    # The `rewriters.pyl` rewriter op id this invokes (e.g. `cxx.make_virtual`).
+    op_id: str
+
+    # Values bound to the op's declared `inputs`, injected into its templates.
+    inputs: dict[str, str]
+
+    # How many matches this operation must make (default: exactly one).
+    expectation: MatchExpectation = MatchExpectation.exactly(1)
+
+
 class _AstGrepRewriter(Rewriter):
     """Base for rewriters backed by an ast-grep op declared in `rewriters.pyl`.
 
     A concrete subclass sets the usual `NAME`/`SUMMARY`/`HELP` metadata plus the
-    `OP_ID` it resolves to, the string arguments its body accepts (`_ARG_KEYS`),
-    and any adjacent tokens the op consumes (`_CONSUME_BEFORE`/`_CONSUME_AFTER`,
-    engine details -- see `AstRewriter.apply`). `parse` validates the body as a
-    mapping of exactly those string args and `apply` runs the op, so subclasses
-    are pure declarations.
+    `OP_ID` it resolves to. `apply` runs whatever `operations` returns against
+    the engine, so a subclass expresses itself entirely by *composing*
+    operations rather than by driving the engine.
+
+    The default `operations`/`parse` cover the common 1:1 case: the YAML body is
+    a flat mapping of exactly the op's declared `inputs` (read from the spec,
+    the single source of truth), producing a single operation whose expectation
+    is the entry's `count:`. Subclasses that take a richer body (e.g. a list-
+    valued field expanding to several operations) override `parse` and
+    `operations`, and may override `validate_outcomes` to add cross-operation
+    rules (e.g. "at least one of these optional operations must apply").
     """
 
     # The `rewriters.pyl` op id this resolves to (e.g. `cxx.make_virtual`).
     OP_ID: ClassVar[str] = ''
 
-    # The string argument names the op body must supply.
-    _ARG_KEYS: ClassVar[frozenset[str]] = frozenset()
+    def __init__(self, inputs: dict[str, str] | None = None):
+        # The flat default binds these to the op's single operation; composing
+        # subclasses hold their own parsed shape and leave this empty.
+        self._inputs = inputs if inputs is not None else {}
 
-    # Literals the op assumes sit immediately before / after each matched node.
-    _CONSUME_BEFORE: ClassVar[str] = ''
-    _CONSUME_AFTER: ClassVar[str] = ''
+    def operations(self, count: int) -> list[Operation]:
+        """The ordered ast-grep operations this rewriter expands to.
 
-    def __init__(self, args: dict[str, str]):
-        self._args = args
+        `count` is the entry's `count:`; the default single operation adopts it
+        as its expectation, so a flat rewriter keeps plaster's original count
+        semantics. Composed rewriters typically ignore it in favour of a
+        per-operation expectation.
+        """
+        return [
+            Operation(self.OP_ID, self._inputs,
+                      MatchExpectation.from_count(count))
+        ]
 
-    def apply(self, contents: str) -> tuple[str, int]:
-        rewriter = AstRewriter(RewritersEval.load(), contents)
-        count = rewriter.apply(self.OP_ID,
-                               self._args,
-                               consume_before=self._CONSUME_BEFORE,
-                               consume_after=self._CONSUME_AFTER)
-        return rewriter.content, count
+    def apply(self, contents: str, *, count: int,
+              description: str) -> tuple[str, list[str]]:
+        engine = AstRewriter(RewritersEval.load(), contents)
+        outcomes = [(op, engine.run(op)) for op in self.operations(count)]
+        return engine.content, self.validate_outcomes(outcomes, description)
+
+    def validate_outcomes(self, outcomes: list[tuple[Operation, int]],
+                          description: str) -> list[str]:
+        """Errors for `(operation, matches)` outcomes; empty when all applied.
+
+        The default checks each operation against its own `expectation`.
+        Override to add cross-operation rules -- an override typically calls
+        `super().validate_outcomes(...)` first, then appends group checks.
+        """
+        del description  # Historical count diagnostics do not name the entry.
+        errors = []
+        for op, matches in outcomes:
+            error = op.expectation.error_for(matches)
+            if error:
+                errors.append(error)
+        return errors
+
+    @classmethod
+    def declared_inputs(cls) -> frozenset[str]:
+        """The op's declared `inputs`, read from the `rewriters.pyl` spec."""
+        return frozenset(RewritersEval.load().rewriter(cls.OP_ID)['inputs'])
 
     @classmethod
     def parse(cls, body: object, *, description: str) -> _AstGrepRewriter:
         """Validate a `<NAME>:` body of string args and build the rewriter."""
+        keys = cls.declared_inputs()
         if not isinstance(body, dict):
             raise ValueError(
                 f'"{cls.NAME}" must be a mapping (in "{description}")')
-        unknown = sorted(set(body) - cls._ARG_KEYS)
+        unknown = sorted(set(body) - keys)
         if unknown:
             raise ValueError(
                 f'Unrecognised {cls.NAME} arg(s): '
                 f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
-        missing = sorted(cls._ARG_KEYS - set(body))
+        missing = sorted(keys - set(body))
         if missing:
             raise ValueError(f'{cls.NAME} requires arg(s): '
                              f'{", ".join(missing)} (in "{description}")')
-        for key in sorted(cls._ARG_KEYS):
+        for key in sorted(keys):
             if not isinstance(body[key], str):
                 raise ValueError(f'{cls.NAME} `{key}` must be a string '
                                  f'(in "{description}")')
-        return cls({key: body[key] for key in cls._ARG_KEYS})
+        return cls({key: body[key] for key in keys})
 
 
 class MakeVirtual(_AstGrepRewriter):
@@ -734,7 +875,6 @@ class MakeVirtual(_AstGrepRewriter):
     NAME: Final = 'make_virtual'
     OP_ID: Final = 'cxx.make_virtual'
     SUMMARY: Final = 'Prepend `virtual ` to a class method declaration.'
-    _ARG_KEYS: Final = frozenset(('class_name', 'method_name'))
     # Authored in Markdown; `Help` renders it with rich.
     HELP: Final = r"""
         Prepends `virtual ` to a C++ method declaration.
@@ -761,26 +901,23 @@ class MakeVirtual(_AstGrepRewriter):
 
 
 class AddFriend(_AstGrepRewriter):
-    """Add a `friend` declaration to a C++ class's private section, via the
-    ast-grep rewriters."""
+    """Add one or more `friend` declarations to a C++ class's private section,
+    via the ast-grep rewriters."""
 
     NAME: Final = 'add_friend'
     OP_ID: Final = 'cxx.add_friend'
-    SUMMARY: Final = 'Add a `friend` declaration to a class private section.'
-    _ARG_KEYS: Final = frozenset(('class_name', 'friend_type'))
-    # The matcher stops at the `private` keyword; the op re-emits the `:` that
-    # follows, so consume the original one.
-    _CONSUME_AFTER: Final = ':'
+    SUMMARY: Final = 'Add `friend` declaration(s) to a class private section.'
     # Authored in Markdown; `Help` renders it with rich.
     HELP: Final = r"""
-        Inserts a `friend` declaration as the first line of a class's private
-        section. The class must have a `private:` section.
+        Inserts one or more `friend` declarations as the first lines of a
+        class's private section. The class must have a `private:` section.
 
         Fields:
 
         - `class_name` — the class to befriend from.
         - `friend_type` — the friend's declaration body, e.g. `class BraveFoo`
-          becomes `friend class BraveFoo;`.
+          becomes `friend class BraveFoo;`. May be a single string, or a list
+          of them.
 
         Example:
 
@@ -790,8 +927,78 @@ class AddFriend(_AstGrepRewriter):
             add_friend:
               class_name: MultiContentsView
               friend_type: class BraveMultiContentsView
+
+          - description: Friend the Brave worker and its test.
+            add_friend:
+              class_name: DataTypeWorker
+              friend_type:
+                - class BraveDataTypeWorker
+                - class BraveDataTypeWorkerTest
         ```
     """
+
+    def __init__(self, *, class_name: str, friend_types: list[str]):
+        # This rewriter holds its own parsed shape and builds operations from
+        # it, so the base's flat inputs stay empty.
+        super().__init__()
+        self._class_name = class_name
+        self._friend_types = friend_types
+
+    def operations(self, count: int) -> list[Operation]:
+        # Each friend targets the class's single private section, so it is
+        # expected exactly once -- independent of how many friends are listed,
+        # which is why the entry's `count:` is not used here.
+        #
+        # `add_friend` inserts each friend as the *first* private line, so a
+        # later insertion ends up above an earlier one. Emit in reverse so the
+        # friends land in the order the user listed them.
+        del count
+        return [
+            Operation(self.OP_ID, {
+                'class_name': self._class_name,
+                'friend_type': friend_type,
+            }, MatchExpectation.exactly(1))
+            for friend_type in reversed(self._friend_types)
+        ]
+
+    @classmethod
+    def parse(cls, body: object, *, description: str) -> AddFriend:
+        """Validate an `add_friend:` body, accepting a single friend or a list.
+
+        `friend_type` may be a string (one friend) or a non-empty list of
+        strings (several); everything else matches the flat-args form.
+        """
+        if not isinstance(body, dict):
+            raise ValueError(
+                f'"{cls.NAME}" must be a mapping (in "{description}")')
+        required = {'class_name', 'friend_type'}
+        unknown = sorted(set(body) - required)
+        if unknown:
+            raise ValueError(
+                f'Unrecognised {cls.NAME} arg(s): '
+                f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
+        missing = sorted(required - set(body))
+        if missing:
+            raise ValueError(f'{cls.NAME} requires arg(s): '
+                             f'{", ".join(missing)} (in "{description}")')
+        if not isinstance(body['class_name'], str):
+            raise ValueError(f'{cls.NAME} `class_name` must be a string '
+                             f'(in "{description}")')
+        return cls(class_name=body['class_name'],
+                   friend_types=cls._parse_friend_types(
+                       body['friend_type'], description))
+
+    @staticmethod
+    def _parse_friend_types(value: object, description: str) -> list[str]:
+        """Normalise `friend_type` to a non-empty list of strings."""
+        if isinstance(value, str):
+            return [value]
+        if (isinstance(value, list) and value
+                and all(isinstance(item, str) for item in value)):
+            return list(value)
+        raise ValueError(
+            f'{AddFriend.NAME} `friend_type` must be a string or a non-empty '
+            f'list of strings (in "{description}")')
 
 
 class DropFinal(_AstGrepRewriter):
@@ -801,10 +1008,6 @@ class DropFinal(_AstGrepRewriter):
     NAME: Final = 'drop_final'
     OP_ID: Final = 'cxx.drop_final'
     SUMMARY: Final = 'Remove the `final` specifier from a class declaration.'
-    _ARG_KEYS: Final = frozenset(('class_name', ))
-    # The matcher stops at the `final` keyword; consume the space before it so
-    # dropping `final` leaves no doubled space.
-    _CONSUME_BEFORE: Final = ' '
     # Authored in Markdown; `Help` renders it with rich.
     HELP: Final = r"""
         Removes the `final` specifier from a C++ class declaration, so the class
@@ -919,19 +1122,12 @@ class PlasterFile:
 
         try:
             for substitution in substitutions:
-                contents, num_changes = substitution.apply(contents)
-
-                # count == 0 means "one or more matches", but zero matches still
-                # result in a failure.
-                if substitution.expected_count == 0:
-                    if num_changes == 0:
-                        errors.append(
-                            'Expected at least one match but found none in '
-                            f'{self.path}')
-                elif num_changes != substitution.expected_count:
-                    errors.append(
-                        f'Unexpected number of matches ({num_changes} vs '
-                        f'{substitution.expected_count}) in {self.path}')
+                # Each substitution owns its count validation (per-operation for
+                # composed rewriters) and reports any failures; we just attach
+                # the file being patched.
+                contents, sub_errors = substitution.apply(contents)
+                errors.extend(f'{error} in {self.path}'
+                              for error in sub_errors)
 
         except re.error as e:
             errors.append(f'Invalid regex: {e} in {self.path}')
@@ -992,28 +1188,12 @@ def _is_op_id(op_id: str) -> bool:
     return bool(name) and prefix in _LANGUAGE_BY_PREFIX
 
 
-def _template_args_match(spec: dict) -> dict:
-    """schema validator: a matcher's template uses exactly its declared args.
-
-    Returns the spec unchanged on success or raises schema.SchemaError if the
-    template references a placeholder that is not a declared arg, or declares
-    an arg the template never uses, catching any typos.
-    """
-    placeholders = {
+def _placeholders(template: str) -> set[str]:
+    """The set of named `{placeholder}` fields referenced in `template`."""
+    return {
         name
-        for _, name, _, _ in string.Formatter().parse(spec['template']) if name
+        for _, name, _, _ in string.Formatter().parse(template) if name
     }
-    declared = set(spec['args'])
-    undeclared = sorted(placeholders - declared)
-    if undeclared:
-        raise schema.SchemaError(
-            f'template uses undeclared placeholder(s): {", ".join(undeclared)}'
-        )
-    unused = sorted(declared - placeholders)
-    if unused:
-        raise schema.SchemaError(
-            f'declared arg(s) never used in template: {", ".join(unused)}')
-    return spec
 
 
 # Reusable leaf schemas.
@@ -1031,19 +1211,23 @@ _RESULT_SCHEMA = {
     'node': _NON_EMPTY_STR,
 }
 
-# A matcher op: a templated ast-grep query plus its result shape.
-_MATCHER_SCHEMA = schema.And(
-    {
-        'args': [str],
-        'template': _NON_EMPTY_STR,
-        'result': _RESULT_SCHEMA,
-    }, _template_args_match)
+# A matcher op: a templated ast-grep query plus its result shape. Its inputs
+# are the template's `{placeholder}`s, inferred rather than declared.
+_MATCHER_SCHEMA = {
+    'template': _NON_EMPTY_STR,
+    'result': _RESULT_SCHEMA,
+}
 
 # A rewriter op: locates nodes through a matcher op and edits each via a regex
-# substitution.
+# substitution. `inputs` is its public interface (validated against the
+# templates it feeds in `_check_cross_references`); `replace` may name adjacent
+# tokens to fold into each rewritten span.
 _REWRITER_SCHEMA = {
     'matcher': _NON_EMPTY_STR,
+    'inputs': [str],
     'replace': {
+        schema.Optional('consume_before'): str,
+        schema.Optional('consume_after'): str,
         're_pattern': _REGEX_STR,
         'replace': str,
     },
@@ -1151,9 +1335,12 @@ class RewritersEval:
     def _check_cross_references(self) -> None:
         """Validate rules that span records, which schema cannot express.
 
-        Each rewriter must reference a matcher that exists, and must declare the
+        Each rewriter must reference a matcher that exists, must declare the
         same result node as that matcher (it replaces the node the matcher
-        locates, so the two must agree).
+        locates, so the two must agree), and its declared `inputs` must be
+        exactly the `{placeholder}`s used across the matcher template and the
+        `replace` template -- so the op's advertised interface never drifts from
+        what its templates actually consume.
         """
         for op_id, spec in self._rewriters.items():
             ref = spec['matcher']
@@ -1161,12 +1348,27 @@ class RewritersEval:
                 raise RewritersSchemaError(
                     f'{self._source}: rewriter {op_id!r} references unknown '
                     f'matcher {ref!r}')
-            matcher_node = self._matchers[ref]['result']['node']
+            matcher = self._matchers[ref]
+            matcher_node = matcher['result']['node']
             if spec['result']['node'] != matcher_node:
                 raise RewritersSchemaError(
                     f'{self._source}: rewriter {op_id!r} result node '
                     f'{spec["result"]["node"]!r} does not match matcher '
                     f'{ref!r} node {matcher_node!r}')
+
+            declared = set(spec['inputs'])
+            used = (_placeholders(matcher['template'])
+                    | _placeholders(spec['replace']['replace']))
+            undeclared = sorted(used - declared)
+            if undeclared:
+                raise RewritersSchemaError(
+                    f'{self._source}: rewriter {op_id!r} templates use '
+                    f'undeclared input(s): {", ".join(undeclared)}')
+            unused = sorted(declared - used)
+            if unused:
+                raise RewritersSchemaError(
+                    f'{self._source}: rewriter {op_id!r} declares input(s) '
+                    f'never used in its templates: {", ".join(unused)}')
 
 
 def _ast_grep_platform_dir() -> str:
@@ -1258,11 +1460,12 @@ class AstRewriter:
     """Applies ast-grep rewriter ops to the contents of a single file.
 
     Constructed with an already-parsed `RewritersEval` and the target file's
-    contents. `apply` runs one rewriter op (by id) over the current contents,
+    contents. `run` executes one bound `Operation` over the current contents,
     mutating them in place and returning how many places changed; call it
-    repeatedly to accumulate edits. Op-specific conveniences (which op id and
-    which adjacent tokens to consume) belong with the `Rewriter` classes that
-    drive this engine, not here.
+    repeatedly to accumulate edits. The engine is fully self-contained: an op's
+    matcher, replacement, and any adjacent tokens to consume all come from the
+    op spec, so the `Rewriter` classes that drive it only choose which
+    operations to run.
     """
 
     def __init__(self, rewriters: RewritersEval, content: str):
@@ -1274,40 +1477,35 @@ class AstRewriter:
         """The current file contents, reflecting every applied rewrite."""
         return self._content
 
-    def apply(self,
-              op_id: str,
-              args: dict[str, str],
-              *,
-              consume_before: str = '',
-              consume_after: str = '') -> int:
-        """Run rewriter `op_id` with `args`, mutate content, return count.
+    def run(self, op: Operation) -> int:
+        """Run one bound `Operation`, mutate content, return the change count.
 
         Locates nodes via the op's matcher template, applies the op's `replace`
-        regex substitution (with `args` filled into the replacement template)
-        to each matched node, and splices the results back into the held
-        contents from the end so earlier byte offsets stay valid. Returns the
-        total number of substitutions made.
+        regex substitution (with `op.inputs` filled into the replacement
+        template) to each matched node, and splices the results back into the
+        held contents from the end so earlier byte offsets stay valid. Returns
+        the total number of substitutions made.
 
-        `consume_before` / `consume_after` are literals the op assumes
-        immediately precede / follow each matched node. They are folded into the
-        rewritten span used when the node kind stops short of an adjacent
+        An op's `replace` may name `consume_before` / `consume_after` literals
+        that sit immediately before / after each matched node; they are folded
+        into the rewritten span when the node kind stops short of an adjacent
         token (e.g. the `:` after an access_specifier, or the space before a
-        `final` specifier). They are engine details, not part of the rewriters
-        spec.
+        `final` specifier).
         """
-        rewriter = self._rewriters.rewriter(op_id)
+        rewriter = self._rewriters.rewriter(op.op_id)
         matcher = self._rewriters.matcher(rewriter['matcher'])
-        language = self._rewriters.language_of(op_id)
-        rule_body = matcher['template'].format(**args)
+        language = self._rewriters.language_of(op.op_id)
+        rule_body = matcher['template'].format(**op.inputs)
 
         matches = run_ast_grep(language=language,
                                rule_body=rule_body,
                                source=self._content)
 
-        pattern = rewriter['replace']['re_pattern']
-        replacement = rewriter['replace']['replace'].format(**args)
-        before = consume_before.encode('utf-8')
-        after = consume_after.encode('utf-8')
+        replace = rewriter['replace']
+        pattern = replace['re_pattern']
+        replacement = replace['replace'].format(**op.inputs)
+        before = replace.get('consume_before', '').encode('utf-8')
+        after = replace.get('consume_after', '').encode('utf-8')
 
         source = self._content.encode('utf-8')
         edits = []

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1331,6 +1331,65 @@ class RewriterFormsTest(unittest.TestCase):
             '      class_name: C\n'
             '      freind: class BraveC\n', 'Unrecognised add_friend arg')
 
+    def test_add_friend_list_inserts_in_authored_order(self):
+        # A list-valued `friend_type` befriends several types in one entry. Each
+        # is inserted once into the single private section, so no `count:` is
+        # needed; they land in the source in the order listed here even though
+        # each is inserted as the first line.
+        result = self._apply(
+            'friends.h',
+            'class C {\n public:\n  void Foo();\n private:\n  int x_;\n};\n',
+            'substitutions:\n'
+            '  - description: friend the Brave subclass and its test\n'
+            '    add_friend:\n'
+            '      class_name: C\n'
+            '      friend_type:\n'
+            '        - class BraveC\n'
+            '        - class BraveCTest\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            ' private:\n  friend class BraveC;\n  friend class BraveCTest;\n'
+            '  int x_;\n};\n')
+
+    def test_add_friend_list_fails_when_private_section_absent(self):
+        # Each friend is validated on its own: with no private section every
+        # per-friend operation matches nothing and fails.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'friends2.h', 'class C {\n public:\n  void Foo();\n};\n',
+                'substitutions:\n'
+                '  - description: no private section for the friends\n'
+                '    add_friend:\n'
+                '      class_name: C\n'
+                '      friend_type:\n'
+                '        - class BraveC\n'
+                '        - class BraveCTest\n')
+
+    def test_add_friend_friend_type_must_be_string_or_list(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: bad friend_type\n'
+            '    add_friend:\n'
+            '      class_name: C\n'
+            '      friend_type: 42\n',
+            'friend_type` must be a string or a non-empty list')
+
+    def test_add_friend_friend_type_empty_list_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: empty friend list\n'
+            '    add_friend:\n'
+            '      class_name: C\n'
+            '      friend_type: []\n',
+            'friend_type` must be a string or a non-empty list')
+
+    def test_add_friend_missing_class_name_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: missing class\n'
+            '    add_friend:\n'
+            '      friend_type: class BraveC\n', 'add_friend requires arg')
+
     # -- drop_final op (real ast-grep binary) -----------------------------
 
     def test_drop_final_op(self):
@@ -1440,6 +1499,69 @@ class RewriterRegistryTest(unittest.TestCase):
             self.assertTrue(cls.help_text(), f'{name} is missing help text')
 
 
+class AstGrepCompositionTest(unittest.TestCase):
+    """Frontend rewriters compose into `Operation`s fed to the engine.
+
+    These exercise the parse -> `operations()` seam directly (no ast-grep run),
+    against the shipped rewriters.pyl so `declared_inputs()` reads real specs.
+    """
+
+    def test_declared_inputs_read_from_spec(self):
+        # The accepted arg keys come from the op spec, not a duplicated class
+        # constant.
+        self.assertEqual(plaster.MakeVirtual.declared_inputs(),
+                         frozenset({'class_name', 'method_name'}))
+        self.assertEqual(plaster.DropFinal.declared_inputs(),
+                         frozenset({'class_name'}))
+
+    def test_flat_rewriter_expands_to_one_operation(self):
+        rewriter = plaster.MakeVirtual.parse(
+            {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            }, description='d')
+        self.assertEqual(rewriter.operations(1), [
+            plaster.Operation('cxx.make_virtual', {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            })
+        ])
+
+    def test_add_friend_single_expands_to_one_operation(self):
+        rewriter = plaster.AddFriend.parse(
+            {
+                'class_name': 'C',
+                'friend_type': 'class BraveC'
+            },
+            description='d')
+        self.assertEqual(rewriter.operations(1), [
+            plaster.Operation('cxx.add_friend', {
+                'class_name': 'C',
+                'friend_type': 'class BraveC'
+            })
+        ])
+
+    def test_add_friend_list_expands_reversed_to_preserve_order(self):
+        # Each insertion goes to the top of the private section, so the ops are
+        # emitted in reverse of the authored list to land them in order.
+        rewriter = plaster.AddFriend.parse(
+            {
+                'class_name': 'C',
+                'friend_type': ['class BraveC', 'class BraveCTest'],
+            },
+            description='d')
+        self.assertEqual(rewriter.operations(1), [
+            plaster.Operation('cxx.add_friend', {
+                'class_name': 'C',
+                'friend_type': 'class BraveCTest'
+            }),
+            plaster.Operation('cxx.add_friend', {
+                'class_name': 'C',
+                'friend_type': 'class BraveC'
+            }),
+        ])
+
+
 class RewritersEvalTest(unittest.TestCase):
     """Schema evaluation and access tests for plaster.RewritersEval."""
 
@@ -1455,7 +1577,6 @@ class RewritersEvalTest(unittest.TestCase):
         return {
             'ast.matcher': {
                 'cxx.find_class_method_decl': {
-                    'args': ['class_name', 'method_name'],
                     'template': ('kind: field_declaration\n'
                                  'has:\n'
                                  '  regex: ^{method_name}$\n'
@@ -1469,6 +1590,7 @@ class RewritersEvalTest(unittest.TestCase):
             'ast.rewriter': {
                 'cxx.make_virtual': {
                     'matcher': 'cxx.find_class_method_decl',
+                    'inputs': ['class_name', 'method_name'],
                     'replace': {
                         're_pattern': '^',
                         'replace': 'virtual '
@@ -1512,11 +1634,14 @@ class RewritersEvalTest(unittest.TestCase):
     def test_accessors_return_specs(self):
         rewriters = self._eval_valid()
         self.assertEqual(
-            rewriters.matcher('cxx.find_class_method_decl')['args'],
-            ['class_name', 'method_name'])
+            rewriters.matcher('cxx.find_class_method_decl')['result']['node'],
+            'field_declaration')
         self.assertEqual(
             rewriters.rewriter('cxx.make_virtual')['matcher'],
             'cxx.find_class_method_decl')
+        self.assertEqual(
+            rewriters.rewriter('cxx.make_virtual')['inputs'],
+            ['class_name', 'method_name'])
 
     def test_unknown_op_access_raises(self):
         rewriters = self._eval_valid()
@@ -1600,23 +1725,6 @@ class RewritersEvalTest(unittest.TestCase):
             lambda s: s['ast.matcher']['cxx.find_class_method_decl'].update(
                 {'language': 'cpp'}), 'Wrong keys')
 
-    def test_matcher_args_not_list_of_strings(self):
-        self._assert_invalid(
-            lambda s: s['ast.matcher']['cxx.find_class_method_decl'].
-            __setitem__('args', 'class_name'), "should be instance of 'list'")
-
-    def test_matcher_undeclared_placeholder(self):
-        self._assert_invalid(
-            lambda s: s['ast.matcher']
-            ['cxx.find_class_method_decl'].__setitem__(
-                'template', 'regex: ^{class_name}$ ^{method_name}$ ^{bogus}$'),
-            'undeclared placeholder')
-
-    def test_matcher_unused_arg(self):
-        self._assert_invalid(
-            lambda s: s['ast.matcher']['cxx.find_class_method_decl']['args'].
-            append('unused'), 'never used')
-
     def test_matcher_bad_result(self):
         self._assert_invalid(
             lambda s: s['ast.matcher']['cxx.find_class_method_decl']['result'].
@@ -1648,6 +1756,36 @@ class RewritersEvalTest(unittest.TestCase):
         self._assert_invalid(
             lambda s: s['ast.rewriter']['cxx.make_virtual'].update(
                 {'append': '!'}), 'Wrong keys')
+
+    def test_rewriter_inputs_not_list_of_strings(self):
+        self._assert_invalid(
+            lambda s: s['ast.rewriter']['cxx.make_virtual'].__setitem__(
+                'inputs', 'class_name'), "should be instance of 'list'")
+
+    def test_rewriter_undeclared_input(self):
+        # The templates reference `method_name`, but it is dropped from the
+        # declared `inputs`, so the op's interface no longer covers them.
+        self._assert_invalid(
+            lambda s: s['ast.rewriter']['cxx.make_virtual'].__setitem__(
+                'inputs', ['class_name']), 'undeclared input')
+
+    def test_rewriter_unused_input(self):
+        self._assert_invalid(
+            lambda s: s['ast.rewriter']['cxx.make_virtual']['inputs'].append(
+                'unused'), 'never used')
+
+    def test_rewriter_replace_consume_tokens_are_optional(self):
+        # `consume_before` / `consume_after` are optional; adding them keeps the
+        # spec valid (and they must be strings).
+        spec = self._valid_spec()
+        spec['ast.rewriter']['cxx.make_virtual']['replace'].update({
+            'consume_before': ' ',
+            'consume_after': ':',
+        })
+        rewriters = plaster.RewritersEval(repr(spec))
+        replace = rewriters.rewriter('cxx.make_virtual')['replace']
+        self.assertEqual(replace['consume_before'], ' ')
+        self.assertEqual(replace['consume_after'], ':')
 
 
 # ast-grep matcher templates used to build synthetic RewritersEval specs for
@@ -1690,21 +1828,18 @@ _FINAL_RULE = ('kind: virtual_specifier\n'
 _SYNTHETIC_SPEC = {
     'ast.matcher': {
         'cxx.find_class_method_decl': {
-            'args': ['class_name', 'method_name'],
             'template': _METHOD_DECL_RULE,
             'result': {
                 'node': 'field_declaration'
             },
         },
         'cxx.find_class_private_section': {
-            'args': ['class_name'],
             'template': _PRIVATE_SECTION_RULE,
             'result': {
                 'node': 'access_specifier'
             },
         },
         'cxx.find_class_final': {
-            'args': ['class_name'],
             'template': _FINAL_RULE,
             'result': {
                 'node': 'virtual_specifier'
@@ -1714,6 +1849,7 @@ _SYNTHETIC_SPEC = {
     'ast.rewriter': {
         'cxx.make_virtual': {
             'matcher': 'cxx.find_class_method_decl',
+            'inputs': ['class_name', 'method_name'],
             'replace': {
                 're_pattern': '^',
                 'replace': 'virtual '
@@ -1724,7 +1860,9 @@ _SYNTHETIC_SPEC = {
         },
         'cxx.add_friend': {
             'matcher': 'cxx.find_class_private_section',
+            'inputs': ['class_name', 'friend_type'],
             'replace': {
+                'consume_after': ':',
                 're_pattern': '$',
                 'replace': ':\\n  friend {friend_type};'
             },
@@ -1734,7 +1872,9 @@ _SYNTHETIC_SPEC = {
         },
         'cxx.drop_final': {
             'matcher': 'cxx.find_class_final',
+            'inputs': ['class_name'],
             'replace': {
+                'consume_before': ' ',
                 're_pattern': '^final$',
                 'replace': ''
             },
@@ -1789,8 +1929,10 @@ class RunAstGrepTest(unittest.TestCase):
 class AstRewriterTest(unittest.TestCase):
     """Integration tests for plaster.AstRewriter (real ast-grep binary).
 
-    Driven with a synthetic RewritersEval built from `_SYNTHETIC_SPEC`, since
-    the shipped rewriters.pyl carries no ops yet.
+    Driven with a synthetic RewritersEval built from `_SYNTHETIC_SPEC`, so the
+    engine is exercised in isolation from whatever the shipped rewriters.pyl
+    currently carries. Each op is invoked through a bound `Operation`; the
+    consume tokens now live in the spec, not in the call.
     """
 
     _SRC = 'class C {\n  void Foo();\n  void Bar();\n};\n'
@@ -1801,10 +1943,11 @@ class AstRewriterTest(unittest.TestCase):
 
     def test_make_virtual_single(self):
         rewriter = self._rewriter()
-        count = rewriter.apply('cxx.make_virtual', {
-            'class_name': 'C',
-            'method_name': 'Foo'
-        })
+        count = rewriter.run(
+            plaster.Operation('cxx.make_virtual', {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            }))
         self.assertEqual(count, 1)
         self.assertEqual(
             rewriter.content,
@@ -1814,10 +1957,11 @@ class AstRewriterTest(unittest.TestCase):
         # Destructors parse as `declaration` with a `destructor_name`, not the
         # `field_declaration`/`field_identifier` of a regular method.
         rewriter = self._rewriter('class C {\n public:\n  ~C();\n};\n')
-        count = rewriter.apply('cxx.make_virtual', {
-            'class_name': 'C',
-            'method_name': '~C'
-        })
+        count = rewriter.run(
+            plaster.Operation('cxx.make_virtual', {
+                'class_name': 'C',
+                'method_name': '~C'
+            }))
         self.assertEqual(count, 1)
         self.assertEqual(rewriter.content,
                          'class C {\n public:\n  virtual ~C();\n};\n')
@@ -1825,10 +1969,11 @@ class AstRewriterTest(unittest.TestCase):
     def test_make_virtual_overloads_count_each(self):
         rewriter = self._rewriter(
             'class C {\n  void Foo();\n  void Foo(int x);\n};\n')
-        count = rewriter.apply('cxx.make_virtual', {
-            'class_name': 'C',
-            'method_name': 'Foo'
-        })
+        count = rewriter.run(
+            plaster.Operation('cxx.make_virtual', {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            }))
         self.assertEqual(count, 2)
         # Splicing from the end keeps the earlier overload's offset valid.
         self.assertEqual(
@@ -1838,22 +1983,25 @@ class AstRewriterTest(unittest.TestCase):
     def test_no_match_leaves_content_unchanged(self):
         rewriter = self._rewriter()
         self.assertEqual(
-            rewriter.apply('cxx.make_virtual', {
-                'class_name': 'C',
-                'method_name': 'Nope'
-            }), 0)
+            rewriter.run(
+                plaster.Operation('cxx.make_virtual', {
+                    'class_name': 'C',
+                    'method_name': 'Nope'
+                })), 0)
         self.assertEqual(rewriter.content, self._SRC)
 
     def test_content_accumulates_across_calls(self):
         rewriter = self._rewriter()
-        rewriter.apply('cxx.make_virtual', {
-            'class_name': 'C',
-            'method_name': 'Foo'
-        })
-        rewriter.apply('cxx.make_virtual', {
-            'class_name': 'C',
-            'method_name': 'Bar'
-        })
+        rewriter.run(
+            plaster.Operation('cxx.make_virtual', {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            }))
+        rewriter.run(
+            plaster.Operation('cxx.make_virtual', {
+                'class_name': 'C',
+                'method_name': 'Bar'
+            }))
         self.assertEqual(
             rewriter.content,
             'class C {\n  virtual void Foo();\n  virtual void Bar();\n};\n')
@@ -1861,11 +2009,11 @@ class AstRewriterTest(unittest.TestCase):
     def test_add_friend_inserts_after_private_colon(self):
         rewriter = self._rewriter(
             'class C {\n public:\n  void Foo();\n private:\n  int x_;\n};\n')
-        count = rewriter.apply('cxx.add_friend', {
-            'class_name': 'C',
-            'friend_type': 'class BraveC'
-        },
-                               consume_after=':')
+        count = rewriter.run(
+            plaster.Operation('cxx.add_friend', {
+                'class_name': 'C',
+                'friend_type': 'class BraveC'
+            }))
         self.assertEqual(count, 1)
         # The friend lands as the first private line; the `:` is not duplicated.
         self.assertEqual(
@@ -1875,11 +2023,11 @@ class AstRewriterTest(unittest.TestCase):
     def test_add_friend_no_private_section(self):
         rewriter = self._rewriter('class C {\n public:\n  void Foo();\n};\n')
         self.assertEqual(
-            rewriter.apply('cxx.add_friend', {
-                'class_name': 'C',
-                'friend_type': 'class BraveC'
-            },
-                           consume_after=':'), 0)
+            rewriter.run(
+                plaster.Operation('cxx.add_friend', {
+                    'class_name': 'C',
+                    'friend_type': 'class BraveC'
+                })), 0)
         self.assertEqual(rewriter.content,
                          'class C {\n public:\n  void Foo();\n};\n')
 
@@ -1889,24 +2037,246 @@ class AstRewriterTest(unittest.TestCase):
         rewriter = self._rewriter(
             'class C final : public Base {\n  void f() final;\n};\n')
         self.assertEqual(
-            rewriter.apply('cxx.drop_final', {'class_name': 'C'},
-                           consume_before=' '), 1)
+            rewriter.run(
+                plaster.Operation('cxx.drop_final', {'class_name': 'C'})), 1)
         self.assertEqual(rewriter.content,
                          'class C : public Base {\n  void f() final;\n};\n')
 
     def test_drop_final_no_base(self):
         rewriter = self._rewriter('class C final {\n};\n')
         self.assertEqual(
-            rewriter.apply('cxx.drop_final', {'class_name': 'C'},
-                           consume_before=' '), 1)
+            rewriter.run(
+                plaster.Operation('cxx.drop_final', {'class_name': 'C'})), 1)
         self.assertEqual(rewriter.content, 'class C {\n};\n')
 
     def test_drop_final_absent(self):
         rewriter = self._rewriter('class C {\n};\n')
         self.assertEqual(
-            rewriter.apply('cxx.drop_final', {'class_name': 'C'},
-                           consume_before=' '), 0)
+            rewriter.run(
+                plaster.Operation('cxx.drop_final', {'class_name': 'C'})), 0)
         self.assertEqual(rewriter.content, 'class C {\n};\n')
+
+
+class _FlatAstGrepRewriter(plaster._AstGrepRewriter):
+    """Minimal `_AstGrepRewriter` subclass: inherits the base parse/operations.
+
+    Bound to `cxx.make_virtual` purely so the base's default 1:1 behaviour has a
+    real op to resolve against; it adds nothing of its own.
+    """
+
+    NAME = 'flat_test_op'
+    OP_ID = 'cxx.make_virtual'
+
+
+class _ComposingAstGrepRewriter(plaster._AstGrepRewriter):
+    """`_AstGrepRewriter` subclass that expands one body into several ops.
+
+    Exists only to prove the base's `apply` drives and accumulates across an
+    arbitrary `operations()` list -- the composition seam itself, with no
+    concrete rewriter (MakeVirtual/AddFriend/DropFinal) in the picture.
+    """
+
+    NAME = 'composing_test_op'
+    OP_ID = 'cxx.make_virtual'
+
+    def __init__(self, class_name: str, method_names: list[str]):
+        super().__init__()
+        self._class_name = class_name
+        self._method_names = method_names
+
+    def operations(self, count: int) -> list[plaster.Operation]:
+        del count  # Each method is its own exactly-once operation.
+        return [
+            plaster.Operation('cxx.make_virtual', {
+                'class_name': self._class_name,
+                'method_name': method_name,
+            }) for method_name in self._method_names
+        ]
+
+
+class _OptionalPairAstGrepRewriter(plaster._AstGrepRewriter):
+    """Two optional ops plus a group rule: at least one must apply.
+
+    Mirrors the shape of a hypothetical `make_class_overridable` (drop `final`
+    or override the dtor -- either may be absent, but not both), to exercise
+    per-op optionality and a cross-operation check via `validate_outcomes`.
+    """
+
+    NAME = 'optional_pair_test_op'
+    OP_ID = 'cxx.make_virtual'
+
+    def __init__(self, method_names: list[str]):
+        super().__init__()
+        self._method_names = method_names
+
+    def operations(self, count: int) -> list[plaster.Operation]:
+        del count
+        return [
+            plaster.Operation('cxx.make_virtual', {
+                'class_name': 'C',
+                'method_name': method_name,
+            }, plaster.MatchExpectation.optional())
+            for method_name in self._method_names
+        ]
+
+    def validate_outcomes(self, outcomes, description):
+        errors = super().validate_outcomes(outcomes, description)
+        if outcomes and all(matches == 0 for _, matches in outcomes):
+            errors.append('at least one operation must apply')
+        return errors
+
+
+class AstGrepRewriterBaseTest(unittest.TestCase):
+    """Unit tests for the `_AstGrepRewriter` base class on its own.
+
+    The base is exercised through the two synthetic subclasses above, with a
+    `RewritersEval` built from `_SYNTHETIC_SPEC` injected as the process
+    singleton so `apply`/`declared_inputs` resolve against it instead of the
+    shipped rewriters.pyl. Nothing here touches the concrete rewriters.
+    """
+
+    _SRC = 'class C {\n  void Foo();\n  void Bar();\n};\n'
+
+    def setUp(self):
+        plaster.RewritersEval._instance = plaster.RewritersEval(
+            repr(_SYNTHETIC_SPEC))
+        self.addCleanup(setattr, plaster.RewritersEval, '_instance', None)
+
+    # -- declared_inputs (reads the spec, not a class constant) -------------
+
+    def test_declared_inputs_read_from_injected_spec(self):
+        self.assertEqual(_FlatAstGrepRewriter.declared_inputs(),
+                         frozenset({'class_name', 'method_name'}))
+
+    # -- default parse (flat body validation) -------------------------------
+
+    def test_parse_builds_from_declared_inputs(self):
+        rewriter = _FlatAstGrepRewriter.parse(
+            {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            }, description='d')
+        self.assertIsInstance(rewriter, _FlatAstGrepRewriter)
+
+    def test_parse_rejects_non_mapping_body(self):
+        with self.assertRaises(ValueError) as ctx:
+            _FlatAstGrepRewriter.parse('nope', description='d')
+        self.assertIn('must be a mapping', str(ctx.exception))
+
+    def test_parse_rejects_unknown_arg(self):
+        with self.assertRaises(ValueError) as ctx:
+            _FlatAstGrepRewriter.parse(
+                {
+                    'class_name': 'C',
+                    'method_name': 'Foo',
+                    'bogus': 'x'
+                },
+                description='d')
+        self.assertIn('Unrecognised flat_test_op arg', str(ctx.exception))
+
+    def test_parse_rejects_missing_arg(self):
+        with self.assertRaises(ValueError) as ctx:
+            _FlatAstGrepRewriter.parse({'class_name': 'C'}, description='d')
+        message = str(ctx.exception)
+        self.assertIn('flat_test_op requires arg', message)
+        self.assertIn('method_name', message)
+
+    def test_parse_rejects_non_string_arg(self):
+        with self.assertRaises(ValueError) as ctx:
+            _FlatAstGrepRewriter.parse({
+                'class_name': 'C',
+                'method_name': 5
+            },
+                                       description='d')
+        self.assertIn('`method_name` must be a string', str(ctx.exception))
+
+    # -- default operations -------------------------------------------------
+
+    def test_default_operations_is_a_single_operation(self):
+        rewriter = _FlatAstGrepRewriter.parse(
+            {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            }, description='d')
+        self.assertEqual(rewriter.operations(1), [
+            plaster.Operation('cxx.make_virtual', {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            })
+        ])
+
+    def test_default_operation_adopts_entry_count(self):
+        # The flat single operation takes the entry's `count:` as its
+        # expectation, preserving plaster's original count semantics.
+        rewriter = _FlatAstGrepRewriter.parse(
+            {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            }, description='d')
+        self.assertEqual(
+            rewriter.operations(2)[0].expectation,
+            plaster.MatchExpectation.exactly(2))
+        self.assertEqual(
+            rewriter.operations(0)[0].expectation,
+            plaster.MatchExpectation.at_least_one())
+
+    # -- apply: drives the engine, then validates per operation -------------
+
+    def test_apply_runs_a_single_operation(self):
+        rewriter = _FlatAstGrepRewriter.parse(
+            {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            }, description='d')
+        content, errors = rewriter.apply(self._SRC, count=1, description='d')
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            content, 'class C {\n  virtual void Foo();\n  void Bar();\n};\n')
+
+    def test_apply_runs_every_composed_operation(self):
+        # The whole point of the base: `apply` runs every op `operations()`
+        # yields against the same engine, so the edits from each land in the
+        # final content.
+        rewriter = _ComposingAstGrepRewriter('C', ['Foo', 'Bar'])
+        content, errors = rewriter.apply(self._SRC, count=1, description='d')
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            content,
+            'class C {\n  virtual void Foo();\n  virtual void Bar();\n};\n')
+
+    def test_apply_validates_each_operation_independently(self):
+        # A composed op that matches nothing fails its own expectation (exactly
+        # one), while the matching one still applies to the content.
+        rewriter = _ComposingAstGrepRewriter('C', ['Foo', 'Nope'])
+        content, errors = rewriter.apply(self._SRC, count=1, description='d')
+        self.assertEqual(errors, ['Unexpected number of matches (0 vs 1)'])
+        self.assertEqual(
+            content, 'class C {\n  virtual void Foo();\n  void Bar();\n};\n')
+
+    def test_apply_with_no_operations_is_a_noop(self):
+        rewriter = _ComposingAstGrepRewriter('C', [])
+        content, errors = rewriter.apply(self._SRC, count=1, description='d')
+        self.assertEqual(errors, [])
+        self.assertEqual(content, self._SRC)
+
+    # -- optional operations and cross-operation (group) rules -------------
+
+    def test_optional_operation_never_fails_on_its_own(self):
+        # 'Foo' matches; the optional 'Nope' matches nothing but, being
+        # optional, contributes no error, and the group rule is satisfied.
+        rewriter = _OptionalPairAstGrepRewriter(['Foo', 'Nope'])
+        content, errors = rewriter.apply(self._SRC, count=1, description='d')
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            content, 'class C {\n  virtual void Foo();\n  void Bar();\n};\n')
+
+    def test_group_rule_fails_when_no_optional_operation_applies(self):
+        # Neither optional op matches, so the cross-operation rule fires even
+        # though no individual op reported a count error.
+        rewriter = _OptionalPairAstGrepRewriter(['Nope1', 'Nope2'])
+        content, errors = rewriter.apply(self._SRC, count=1, description='d')
+        self.assertEqual(errors, ['at least one operation must apply'])
+        self.assertEqual(content, self._SRC)
 
 
 class HelpTest(unittest.TestCase):

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -10,18 +10,25 @@
 # resolved in code):
 #
 #   "ast.matcher" — a structural query:
-#       args:     arg names the caller supplies; each is a {placeholder}.
-#       template: ast-grep rule body (the part under `rule:`); {arg}s filled.
+#       template: ast-grep rule body (the part under `rule:`). Its {placeholder}
+#                 fields are the matcher's inputs; they are inferred from the
+#                 template, not declared.
 #       result:   { node: <tree-sitter kind> } each match is.
 #
 #   "ast.rewriter" — edits each node a matcher finds:
 #       matcher:  id of the "ast.matcher" op locating the node(s).
+#       inputs:   the interface the rewriter requires, so the template it uses
+#                 can be rendered.
 #       replace:  { re_pattern, replace }, re.sub'd over each match's source;
-#                 `replace` is {arg}-formatted first (literal braces: {{ }}).
+#                 `replace` is {input}-formatted first (literal braces: {{ }}).
+#                 Optional `consume_before` / `consume_after` literals are
+#                 folded into the rewritten span when the matched node stops
+#                 short of an adjacent token (e.g. the `:` after an
+#                 access_specifier, or the space before a `final` specifier).
 #       result:   { node: <kind> } being replaced.
 #
 # An op yields every match in source order; the caller (plaster) decides how
-# many it expects. Arg values are injected verbatim into the rule's `regex:`
+# many it expects. Input values are injected verbatim into the rule's `regex:`
 # fields, so the caller escapes any regex metacharacters.
 
 {
@@ -34,7 +41,6 @@
         # sharing the name each produce their own match. The result node is a
         # field_declaration for methods and a declaration for con/destructors.
         "cxx.find_class_method_decl": {
-            "args": ["class_name", "method_name"],
             "template": """\
 any:
   - kind: field_declaration
@@ -61,7 +67,6 @@ inside:
         # The node is the `private` keyword; the `:` that follows is a separate
         # token immediately after it.
         "cxx.find_class_private_section": {
-            "args": ["class_name"],
             "template": """\
 kind: access_specifier
 regex: ^private$
@@ -82,7 +87,6 @@ inside:
         # class-head `final` matches; a method's trailing `final` is nested
         # under its declaration, not directly inside the class.
         "cxx.find_class_final": {
-            "args": ["class_name"],
             "template": """\
 kind: virtual_specifier
 regex: ^final$
@@ -103,6 +107,7 @@ inside:
         # semicolon included) with `virtual ` prepended.
         "cxx.make_virtual": {
             "matcher": "cxx.find_class_method_decl",
+            "inputs": ["class_name", "method_name"],
             "replace": {
                 "re_pattern": "^",
                 "replace": "virtual ",
@@ -113,10 +118,13 @@ inside:
         },
 
         # The class's `private:` section with a `friend` declaration inserted as
-        # its first line.
+        # its first line. The matcher stops at the `private` keyword, so the op
+        # consumes the original `:` and re-emits it.
         "cxx.add_friend": {
             "matcher": "cxx.find_class_private_section",
+            "inputs": ["class_name", "friend_type"],
             "replace": {
+                "consume_after": ":",
                 "re_pattern": "$",
                 "replace": ":\\n  friend {friend_type};",
             },
@@ -126,11 +134,13 @@ inside:
         },
 
         # `class_name`'s declaration with its `final` specifier removed, so the
-        # class can be subclassed. The drop_final engine also consumes the
-        # leading space before `final` so no doubled space is left behind.
+        # class can be subclassed. `consume_before` also drops the leading space
+        # before `final` so no doubled space is left behind.
         "cxx.drop_final": {
             "matcher": "cxx.find_class_final",
+            "inputs": ["class_name"],
             "replace": {
+                "consume_before": " ",
                 "re_pattern": "^final$",
                 "replace": "",
             },


### PR DESCRIPTION
This pr reworks the rewriter internals so a frontend rewriter composes
an ordered list of backend operations, and each operation carries its
own match expectation. This replaces the previous model where
`_AstGrepRewriter` made a single opaque `AstRewriter.apply` call and
count was validated as a file-wide total.

Changes to `rewriters.pyl` specs:
- Matchers drop `args` as they were not being used, and they were
  merely duplicating the template's placeholders.
- Rewriters now declare `inputs` (their public interface, validated
  against the matcher + replace templates) and fold `consume_before`/
  `consume_after` into `replace`, so an op is fully self-describing.

With these changes `add_friend` can now accept a list of classes.
