### PR TITLE
Migrated VerticalTabFullscreenTest.Fullscreen to interactive test

### DIFF
--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
@@ -6,7 +6,6 @@
 #include <algorithm>
 
 #include "base/i18n/rtl.h"
-#include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/test/bind.h"
 #include "base/test/run_until.h"
@@ -41,8 +40,6 @@
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface_iterator.h"
 #include "chrome/browser/ui/browser_window/public/global_browser_collection.h"
-#include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
-#include "chrome/browser/ui/exclusive_access/fullscreen_controller.h"
 #include "chrome/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/views/frame/browser_frame_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
@@ -86,62 +83,6 @@
 #include "ui/ozone/public/ozone_platform.h"
 #include "ui/platform_window/common/platform_window_defaults.h"
 #endif
-
-namespace {
-
-class FullscreenNotificationObserver {
- public:
-  explicit FullscreenNotificationObserver(Browser* browser);
-
-  FullscreenNotificationObserver(const FullscreenNotificationObserver&) =
-      delete;
-  FullscreenNotificationObserver& operator=(
-      const FullscreenNotificationObserver&) = delete;
-
-  ~FullscreenNotificationObserver();
-
-  // Runs a loop until a fullscreen change is seen (unless one has already been
-  // observed, in which case it returns immediately).
-  void Wait();
-
-  void OnFullscreenStateChanged();
-
- protected:
-  bool observed_change_ = false;
-  // Subscription to be notified when the browser window enters fullscreen.
-  base::CallbackListSubscription fullscreen_subscription_;
-  base::RunLoop run_loop_;
-};
-
-FullscreenNotificationObserver::FullscreenNotificationObserver(
-    Browser* browser) {
-  // Observe changes to fullscreen state.
-  fullscreen_subscription_ =
-      ExclusiveAccessManager::From(browser)
-          ->fullscreen_controller()
-          ->RegisterOnFullscreenStateChanged(base::BindRepeating(
-              &FullscreenNotificationObserver::OnFullscreenStateChanged,
-              base::Unretained(this)));
-}
-
-FullscreenNotificationObserver::~FullscreenNotificationObserver() = default;
-
-void FullscreenNotificationObserver::OnFullscreenStateChanged() {
-  observed_change_ = true;
-  if (run_loop_.running()) {
-    run_loop_.Quit();
-  }
-}
-
-void FullscreenNotificationObserver::Wait() {
-  if (observed_change_) {
-    return;
-  }
-
-  run_loop_.Run();
-}
-
-}  // namespace
 
 class VerticalTabStripBrowserTest : public InProcessBrowserTest {
  public:
@@ -499,110 +440,6 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, VisualState) {
     region_view->OnMouseEntered(event);
     EXPECT_NE(State::kFloating, region_view->state());
   }
-}
-
-#if BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
-// * Mac test bots are not able to enter fullscreen.
-// * On Linux this test is flaky.
-#define MAYBE_Fullscreen DISABLED_Fullscreen
-#else
-#define MAYBE_Fullscreen Fullscreen
-#endif
-
-IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, MAYBE_Fullscreen) {
-  ToggleVerticalTabStrip();
-  ASSERT_TRUE(browser_view()
-                  ->vertical_tab_strip_host_view_->GetPreferredSize()
-                  .width());
-
-  auto* region_view = browser_view()
-                          ->vertical_tab_strip_container_view()
-                          ->vertical_tab_strip_region_view();
-  ASSERT_TRUE(region_view);
-  ASSERT_EQ(BraveVerticalTabStripRegionView::State::kExpanded,
-            region_view->state());
-
-  auto* fullscreen_controller = browser_view()
-                                    ->browser()
-                                    ->GetFeatures()
-                                    .exclusive_access_manager()
-                                    ->fullscreen_controller();
-  {
-    auto observer = FullscreenNotificationObserver(browser());
-    fullscreen_controller->ToggleBrowserFullscreenMode(/*user_initiated=*/true);
-    observer.Wait();
-  }
-
-  // Vertical tab strip should be invisible on browser fullscreen.
-  ASSERT_TRUE(fullscreen_controller->IsFullscreenForBrowser());
-  ASSERT_TRUE(browser_view()->IsFullscreen());
-  EXPECT_FALSE(browser_view()
-                   ->vertical_tab_strip_host_view_->GetPreferredSize()
-                   .width());
-
-  {
-    auto observer = FullscreenNotificationObserver(browser());
-    fullscreen_controller->ToggleBrowserFullscreenMode(/*user_initiated=*/true);
-    observer.Wait();
-  }
-  ASSERT_FALSE(fullscreen_controller->IsFullscreenForBrowser());
-  ASSERT_FALSE(browser_view()->IsFullscreen());
-
-  // Exiting browser fullscreen restores the pre-fullscreen expanded state and
-  // makes the strip visible again.
-  EXPECT_EQ(BraveVerticalTabStripRegionView::State::kExpanded,
-            region_view->state());
-  EXPECT_TRUE(region_view->GetVisible());
-  EXPECT_TRUE(browser_view()
-                  ->vertical_tab_strip_host_view_->GetPreferredSize()
-                  .width());
-
-  {
-    auto observer = FullscreenNotificationObserver(browser());
-    // Vertical tab strip should become invisible on tab fullscreen.
-    fullscreen_controller->EnterFullscreenModeForTab(
-        browser_view()
-            ->browser()
-            ->tab_strip_model()
-            ->GetActiveWebContents()
-            ->GetPrimaryMainFrame());
-
-    observer.Wait();
-  }
-  ASSERT_TRUE(fullscreen_controller->IsTabFullscreen());
-  if (!browser_view()
-           ->vertical_tab_strip_host_view_->GetPreferredSize()
-           .width()) {
-    return;
-  }
-
-  base::RunLoop run_loop;
-  auto wait_until = base::BindLambdaForTesting(
-      [&](base::RepeatingCallback<bool()> predicate) {
-        if (predicate.Run()) {
-          return;
-        }
-
-        base::RepeatingTimer scheduler;
-        scheduler.Start(FROM_HERE, base::Milliseconds(100),
-                        base::BindLambdaForTesting([&]() {
-                          if (predicate.Run()) {
-                            run_loop.Quit();
-                          } else {
-                            LOG(ERROR) << browser_view()
-                                              ->vertical_tab_strip_host_view_
-                                              ->GetPreferredSize()
-                                              .width();
-                          }
-                        }));
-        run_loop.Run();
-      });
-
-  wait_until.Run(base::BindLambdaForTesting([&]() {
-    return !browser_view()
-                ->vertical_tab_strip_host_view_->GetPreferredSize()
-                .width();
-  }));
 }
 
 IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, LayoutSanity) {

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_interactive_ui_tests.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_interactive_ui_tests.cc
@@ -8,6 +8,7 @@
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_container_view.h"
 #include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h"
+#include "build/build_config.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
@@ -29,8 +30,17 @@ class VerticalTabStripInteractiveUITest : public InteractiveBrowserTest {
   void ToggleVerticalTabStrip() { brave::ToggleVerticalTabStrip(browser()); }
 };
 
+#if BUILDFLAG(IS_MAC)
+// Fullscreen test flaky on macOS: https://crbug.com/41393319
+#define MAYBE_TabFullscreenUpdatesHostViewBounds \
+  DISABLED_TabFullscreenUpdatesHostViewBounds
+#else
+#define MAYBE_TabFullscreenUpdatesHostViewBounds \
+  TabFullscreenUpdatesHostViewBounds
+#endif
+
 IN_PROC_BROWSER_TEST_F(VerticalTabStripInteractiveUITest,
-                       TabFullscreenUpdatesHostViewBounds) {
+                       MAYBE_TabFullscreenUpdatesHostViewBounds) {
   ToggleVerticalTabStrip();
 
   auto* host_view = browser_view()->vertical_tab_strip_host_view_for_testing();
@@ -80,8 +90,17 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripInteractiveUITest,
   EXPECT_EQ(State::kExpanded, region_view->state());
 }
 
+#if BUILDFLAG(IS_MAC)
+// Fullscreen test flaky on macOS: https://crbug.com/41393319
+#define MAYBE_BrowserFullscreenUpdatesHostViewBounds \
+  DISABLED_BrowserFullscreenUpdatesHostViewBounds
+#else
+#define MAYBE_BrowserFullscreenUpdatesHostViewBounds \
+  BrowserFullscreenUpdatesHostViewBounds
+#endif
+
 IN_PROC_BROWSER_TEST_F(VerticalTabStripInteractiveUITest,
-                       BrowserFullscreenUpdatesHostViewBounds) {
+                       MAYBE_BrowserFullscreenUpdatesHostViewBounds) {
   ToggleVerticalTabStrip();
 
   auto* host_view = browser_view()->vertical_tab_strip_host_view_for_testing();

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_interactive_ui_tests.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_interactive_ui_tests.cc
@@ -79,3 +79,50 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripInteractiveUITest,
       [&]() { return host_view->GetPreferredSize().width() > 0; }));
   EXPECT_EQ(State::kExpanded, region_view->state());
 }
+
+IN_PROC_BROWSER_TEST_F(VerticalTabStripInteractiveUITest,
+                       BrowserFullscreenUpdatesHostViewBounds) {
+  ToggleVerticalTabStrip();
+
+  auto* host_view = browser_view()->vertical_tab_strip_host_view_for_testing();
+  ASSERT_TRUE(host_view);
+
+  auto* region_view = browser_view()
+                          ->vertical_tab_strip_container_view()
+                          ->vertical_tab_strip_region_view();
+  ASSERT_TRUE(region_view);
+  ASSERT_EQ(State::kExpanded, region_view->state());
+  ASSERT_GT(host_view->GetPreferredSize().width(), 0);
+
+  auto* fullscreen_controller = browser()
+                                    ->GetFeatures()
+                                    .exclusive_access_manager()
+                                    ->fullscreen_controller();
+
+  {
+    ui_test_utils::FullscreenWaiter waiter(browser(),
+                                           {.browser_fullscreen = true});
+    fullscreen_controller->ToggleBrowserFullscreenMode(/*user_initiated=*/true);
+    waiter.Wait();
+  }
+  ASSERT_TRUE(fullscreen_controller->IsFullscreenForBrowser());
+
+  // Vertical tab strip should be invisible on browser fullscreen.
+  EXPECT_TRUE(base::test::RunUntil(
+      [&]() { return host_view->GetPreferredSize().width() == 0; }));
+
+  {
+    ui_test_utils::FullscreenWaiter waiter(browser(),
+                                           {.browser_fullscreen = false});
+    fullscreen_controller->ToggleBrowserFullscreenMode(/*user_initiated=*/true);
+    waiter.Wait();
+  }
+  ASSERT_FALSE(fullscreen_controller->IsFullscreenForBrowser());
+
+  // Exiting browser fullscreen restores the pre-fullscreen expanded state
+  // and makes the strip visible again.
+  EXPECT_EQ(State::kExpanded, region_view->state());
+  EXPECT_TRUE(region_view->GetVisible());
+  EXPECT_TRUE(base::test::RunUntil(
+      [&]() { return host_view->GetPreferredSize().width() > 0; }));
+}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves no issue for test migration. Just test code refactoring
Issue: https://github.com/brave/brave-browser/issues/57257

Migrated VerticalTabFullscreenTest.Fullscreen to
VerticalTabStripInteractiveUITest.BrowserFullscreenUpdatesHostViewBounds.
As existing TabFullscreenUpdatesHostViewBounds covers tab fullscreen scenario,
browser fullscreen test scenario is migraged.

VerticalTabFullscreenTest.Fullscreen didn't work well. It didn't catch https://github.com/brave/brave-browser/issues/57212.
Also disabled fullscreen interactive test on macOS. It's flaky. Knonw upstream issue.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
