### PR TITLE
[cr151 follow up] Fixes dropdowns in Settings

### DIFF
--- a/browser/resources/settings/brave_appearance_page/bookmark_bar.ts
+++ b/browser/resources/settings/brave_appearance_page/bookmark_bar.ts
@@ -134,8 +134,14 @@ export class SettingsBraveAppearanceBookmarkBarElement
   private onPrefsChanged_() {
     this.setControlValueFromPrefs()
   }
-  private onShowOptionChanged_() {
-    const state = this.bookmarkBarStatePref_.value
+  private onShowOptionChanged_(e: Event) {
+    // Since cr151 `settings-dropdown-menu` is a Lit control that no longer
+    // writes back to the bound `pref` object (it persists via `pref-key`). This
+    // control uses a synthetic pref, so read the selected value directly from
+    // the dropdown instead of the (now stale) `bookmarkBarStatePref_`.
+    const state = Number(
+      (e.target as unknown as {getSelectedValue(): string})
+        .getSelectedValue()) as BookmarkBarState
     if (state === BookmarkBarState.ALWAYS) {
       this.bookmarkBarShowEnabledLabel_ =
         this.i18n('appearanceSettingsBookmarBarAlwaysDesc')
@@ -147,7 +153,7 @@ export class SettingsBraveAppearanceBookmarkBarElement
         this.i18n('appearanceSettingsBookmarBarNeverDesc')
     }
 
-    this.saveBookmarkBarStateToPrefs(this.bookmarkBarStatePref_.value)
+    this.saveBookmarkBarStateToPrefs(state)
   }
 
 }

--- a/browser/resources/settings/brave_appearance_page/sidebar.html
+++ b/browser/resources/settings/brave_appearance_page/sidebar.html
@@ -18,7 +18,7 @@
       </div>
     </div>
     <settings-dropdown-menu
-      pref="{{prefs.brave.sidebar.sidebar_show_option}}"
+      pref-key="brave.sidebar.sidebar_show_option"
       on-settings-control-change="onShowOptionChanged_"
       menu-options="[[sidebarShowOptions_]]">
     </settings-dropdown-menu>

--- a/browser/resources/settings/brave_appearance_page/tabs.html
+++ b/browser/resources/settings/brave_appearance_page/tabs.html
@@ -147,7 +147,7 @@
     <div class="label">$i18n{appearanceSettingsTabHoverMode}</div>
   </div>
   <settings-dropdown-menu
-    pref="{{prefs.brave.tabs.hover_mode}}"
+    pref-key="brave.tabs.hover_mode"
     menu-options="[[tabTooltipModes_]]">
   </settings-dropdown-menu>
 </div>

--- a/browser/resources/settings/brave_appearance_page/tabs.html
+++ b/browser/resources/settings/brave_appearance_page/tabs.html
@@ -128,9 +128,8 @@
         <div class="label">$i18n{appearanceSettingsTabMinWidthMode}</div>
       </div>
       <settings-dropdown-menu
-        pref="{{prefs.brave.tabs.min_width_mode}}"
-        menu-options="[[tabMinWidthModes_]]"
-        selection-value-aliases="[[tabMinWidthSelectionAliases_]]">
+        pref-key="brave.tabs.min_width_mode"
+        menu-options="[[tabMinWidthModes_]]">
       </settings-dropdown-menu>
     </div>
     <settings-toggle-button

--- a/browser/resources/settings/brave_appearance_page/tabs.ts
+++ b/browser/resources/settings/brave_appearance_page/tabs.ts
@@ -34,13 +34,6 @@ export class SettingsBraveAppearanceTabsElement extends SettingsBraveAppearanceT
 
   static get properties() {
     return {
-      tabMinWidthSelectionAliases_: {
-        readOnly: true,
-        type: Object,
-        value() {
-          return {'0': '1'}
-        },
-      },
       tabMinWidthModes_: {
         readOnly: true,
         type: Array,
@@ -97,7 +90,6 @@ export class SettingsBraveAppearanceTabsElement extends SettingsBraveAppearanceT
     }
   }
 
-  declare private tabMinWidthSelectionAliases_: Record<string, string>
   declare private tabMinWidthModes_: Array<{
     value: number,
     name: string,

--- a/browser/resources/settings/brave_content_page/content.html
+++ b/browser/resources/settings/brave_content_page/content.html
@@ -9,7 +9,7 @@
         $i18n{fontSize}
     </div>
     <settings-dropdown-menu id="defaultFontSize" label="$i18n{fontSize}"
-        pref="{{prefs.webkit.webprefs.default_font_size}}"
+        pref-key="webkit.webprefs.default_font_size"
         menu-options="[[fontSizeOptions_]]">
     </settings-dropdown-menu>
 </div>

--- a/browser/resources/settings/brave_new_tab_page/brave_new_tab_page.html
+++ b/browser/resources/settings/brave_new_tab_page/brave_new_tab_page.html
@@ -13,7 +13,7 @@
     </div>
     <settings-dropdown-menu
       label="$i18n{braveNewTabNewTabPageShows}"
-      pref="{{prefs.brave.new_tab_page.shows_options}}"
+      pref-key="brave.new_tab_page.shows_options"
       menu-options="[[newTabShowOptions_]]">
     </settings-dropdown-menu>
   </div>

--- a/browser/resources/settings/brave_privacy_page/brave_personalization_options.html
+++ b/browser/resources/settings/brave_privacy_page/brave_personalization_options.html
@@ -13,7 +13,7 @@
     </a>
   </div>
   <settings-dropdown-menu label="$i18n{webRTCLearnMoreURL}"
-      pref="{{prefs.webrtc.ip_handling_policy}}"
+      pref-key="webrtc.ip_handling_policy"
       menu-options="[[webRTCPolicies_]]">
   </settings-dropdown-menu>
 </div>
@@ -36,7 +36,7 @@
     </div>
   </div>
   <settings-dropdown-menu id="historyRetention"
-      pref="{{prefs.brave.history.retention_days}}"
+      pref-key="brave.history.retention_days"
       menu-options="[[historyRetentionOptions_]]">
   </settings-dropdown-menu>
 </div>
@@ -67,7 +67,7 @@
         <div class="label">$i18n{requestOTRLabel}</div>
     </div>
     <settings-dropdown-menu id="defaultRequestOTR"
-                            pref="{{prefs.brave.request_otr.request_otr_action_option}}"
+                            pref-key="brave.request_otr.request_otr_action_option"
                             menu-options="[[requestOTRActions_]]">
     </settings-dropdown-menu>
 </div>

--- a/browser/resources/settings/brave_wallet_page/brave_wallet_page.html
+++ b/browser/resources/settings/brave_wallet_page/brave_wallet_page.html
@@ -77,14 +77,14 @@
   <div class="settings-box first">
     <div class="start">$i18n{defaultEthereumWalletDesc}</div>
     <settings-dropdown-menu id="defaultEthereumWalletType"
-      pref="{{prefs.brave.wallet.default_wallet2}}"
+      pref-key="brave.wallet.default_wallet2"
       menu-options="[[ethereum_provider_options_]]">
     </settings-dropdown-menu>
   </div>
   <div class="settings-box">
     <div class="start">$i18n{defaultSolanaWalletDesc}</div>
     <settings-dropdown-menu id="defaultSolanaWalletType"
-      pref="{{prefs.brave.wallet.default_solana_wallet}}"
+      pref-key="brave.wallet.default_solana_wallet"
       menu-options="[[solana_provider_options_]]">
     </settings-dropdown-menu>
   </div>
@@ -92,7 +92,7 @@
     <div class="settings-box">
       <div class="start">$i18n{defaultCardanoWalletDesc}</div>
       <settings-dropdown-menu id="defaultCardanoWalletType"
-        pref="{{prefs.brave.wallet.default_cardano_wallet}}"
+        pref-key="brave.wallet.default_cardano_wallet"
         menu-options="[[cardano_provider_options_]]">
       </settings-dropdown-menu>
     </div>
@@ -100,21 +100,21 @@
   <div class="settings-box">
     <div class="start">$i18n{defaultBaseCurrencyDesc}</div>
     <settings-dropdown-menu id="defaultBaseCurrencyType"
-      pref="{{prefs.brave.wallet.default_base_currency}}"
+      pref-key="brave.wallet.default_base_currency"
       menu-options="[[currency_list_]]">
     </settings-dropdown-menu>
   </div>
   <div class="settings-box">
     <div class="start">$i18n{defaultBaseCryptocurrencyDesc}</div>
     <settings-dropdown-menu id="defaultBaseCryptocurrencyType"
-      pref="{{prefs.brave.wallet.default_base_cryptocurrency}}"
+      pref-key="brave.wallet.default_base_cryptocurrency"
       menu-options="[[cryptocurrency_list_]]">
     </settings-dropdown-menu>
   </div>
   <div class="settings-box" hidden="[[!isTransactionSimulationsFeatureEnabled]]">
     <div class="start">$i18nRaw{transactionSimulationDesc}</div>
     <settings-dropdown-menu id="transactionSimulationOptInStatus"
-      pref="{{prefs.brave.wallet.transaction_simulation_opt_in_status}}"
+      pref-key="brave.wallet.transaction_simulation_opt_in_status"
       menu-options="[[transaction_simulation_opt_in_options_]]">
     </settings-dropdown-menu>
   </div>

--- a/browser/resources/settings/brave_web3_domains_page/brave_web3_domains_page.html
+++ b/browser/resources/settings/brave_web3_domains_page/brave_web3_domains_page.html
@@ -19,14 +19,14 @@
     <div class="secondary">$i18nRaw{resolveUnstoppableDomainsSubDesc}</div>
   </div>
   <settings-dropdown-menu id="unstoppableDomainsResolveMethodType"
-                          pref="{{prefs.brave.unstoppable_domains.resolve_method}}"
+                          pref-key="brave.unstoppable_domains.resolve_method"
                           menu-options="[[resolveMethod_]]">
   </settings-dropdown-menu>
 </div>
 <div class="settings-box">
   <div class="start">$i18n{resolveENSDesc}</div>
   <settings-dropdown-menu id="ensResolveMethodType"
-                          pref="{{prefs.brave.ens.resolve_method}}"
+                          pref-key="brave.ens.resolve_method"
                           on-settings-control-change="updateShowENSOffchainLookupRow_"
                           menu-options="[[resolveMethod_]]">
   </settings-dropdown-menu>
@@ -38,14 +38,14 @@
       <div class="secondary">$i18nRaw{ensOffchainLookupDesc}</div>
     </div>
     <settings-dropdown-menu id="ensOffchainLookupMethod"
-      pref="{{prefs.brave.ens.offchain_resolve_method}}" menu-options="[[ensOffchainResolveMethod_]]">
+      pref-key="brave.ens.offchain_resolve_method" menu-options="[[ensOffchainResolveMethod_]]">
     </settings-dropdown-menu>
   </div>
 </template>
 <div class="settings-box">
   <div class="start">$i18n{resolveSnsDesc}</div>
   <settings-dropdown-menu id="snsResolveMethodType"
-                          pref="{{prefs.brave.sns.resolve_method}}"
+                          pref-key="brave.sns.resolve_method"
                           menu-options="[[resolveMethod_]]">
   </settings-dropdown-menu>
 </div>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57243
- Resolves https://github.com/brave/brave-browser/issues/57222
- Resolves https://github.com/brave/brave-browser/issues/57237
- Resolves https://github.com/brave/brave-browser/issues/57240

Chromium changes:
http://chromium.googlesource.com/chromium/src.git/+/cd482a1ab8161

commit cd482a1ab816187bc4155cf979b0366649d43fa9
Author: dpapad <dpapad@chromium.org>
Date:   Mon Jun 29 14:23:07 2026 -0700

    [Reland] Settings Lit: Update settings-dropdown-menu to use PrefService.

    Reland notes: In keyboard_shortcut_page_test.ts in the original CL
    forgot to use TestPrefsBrowserProxy which caused the tests to call the
    prod C++ prefs backend which is fragile during tests. Updated it to use
    TestPrefsBrowserProxy and also updated speed_page_test.ts to use it
    across all suite() calls.

    Specifically:
      - Add a new 'prefKey' property in SettingsDropdownMenuElement.
        Note that the 'pref' property can't be removed (or made private)
        yet because it is also used by CrPolicyPrefMixin.
      - Update all client code to use prefKey, and remove previously used
        2-way {{prefs...}} bindings.
      - Use PrefService within settings-dropdown-menu instead of relying on
        the old settings-prefs mechanism which relies on the 2-way Polymer
        bindings.
      - Remove usage of PrefsMixin in KeyboardShortcutPageElement since it
        is no longer necessary.

    This is in preparation of migrating UI elements that use
    settings-dropdown-menu to Lit.

    Bug: 393471368
    Change-Id: Ib167dd6f72fa73b811224d575481e0741bf8b019
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8007619
    Commit-Queue: Demetrios Papadopoulos <dpapad@chromium.org>
    Reviewed-by: John Lee <johntlee@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#1654363}

https://chromium.googlesource.com/chromium/src.git/+/20be1bd21ff75

commit 20be1bd21ff7561043f346f6e0fa22ef726ae99b
Author: dpapad <dpapad@chromium.org>
Date:   Mon Jun 29 15:23:32 2026 -0700

    Settings Lit: Migrate settings-dropdown-menu.

    Bug: 393471368
    Change-Id: Ib326b99c8ed0fa213fa46f1ea1c7edfb461b27de
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7995039
    Reviewed-by: Rebekah Potter <rbpotter@chromium.org>
    Commit-Queue: Demetrios Papadopoulos <dpapad@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#1654405}


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
