### PR TITLE
[Nala]: Bump version to main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/brave-ui": "0.40.6",
-        "@brave/leo": "github:brave/leo#9a2dbab610d619b6f7b39c853b9aff8c031f39d9",
-        "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#8edabba30a40320d2a9e6353a7c945cf528cf18d",
+        "@brave/leo": "github:brave/leo#a9fe69615e3cc3d7f2388fac1ddfa3db1e12a30a",
+        "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#f601277fdcd837c3e6b7239b73537603c7539119",
         "@brave/wallet-standard-brave": "0.0.16",
         "@dnd-kit/core": "6.3.1",
         "@dnd-kit/sortable": "7.0.1",
@@ -760,8 +760,8 @@
     },
     "node_modules/@brave/leo": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/brave/leo.git#9a2dbab610d619b6f7b39c853b9aff8c031f39d9",
-      "integrity": "sha512-neNDMdTVeCEV6cYkD/gebZbnTfwSLvA1bDF6H/t6+UtZfM7DxGXixEk8x/30exJS+Rn8C19u3NIcoznR/zchrg==",
+      "resolved": "git+ssh://git@github.com/brave/leo.git#a9fe69615e3cc3d7f2388fac1ddfa3db1e12a30a",
+      "integrity": "sha512-JtdZySnPrZu2UKkswH3dNE0wjukgEeB59sclFYiHjbIQt+UPN/crEnWLDhZQvtL9Zt+rgB3d4j5OOHNoIaGQUA==",
       "license": "MIT",
       "dependencies": {
         "@storybook/test": "8.6.15",
@@ -791,9 +791,9 @@
       }
     },
     "node_modules/@brave/leo-sf-symbols": {
-      "version": "1.0.100",
-      "resolved": "git+ssh://git@github.com/brave/leo-sf-symbols.git#8edabba30a40320d2a9e6353a7c945cf528cf18d",
-      "integrity": "sha512-9VsqEPLp7BLXRn5qqsTQIY5dMdgt6ur6iqT674XetIo6PCcfOTfvgMq4LyRBOsXy4S04e98w6VTdY4Oiy2YrLg==",
+      "version": "1.0.101",
+      "resolved": "git+ssh://git@github.com/brave/leo-sf-symbols.git#f601277fdcd837c3e6b7239b73537603c7539119",
+      "integrity": "sha512-gw/jqaSoXLpOtXdn28UqHDvXcrYgc3wi51CF4eyjHPdrgc+lNf4/+XeaAp6e5AfpJpLFiCD7lq3Vmzx4bSjuKg==",
       "license": "MPL-2.0"
     },
     "node_modules/@brave/leo/node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -209,8 +209,8 @@
   },
   "dependencies": {
     "@brave/brave-ui": "0.40.6",
-    "@brave/leo": "github:brave/leo#9a2dbab610d619b6f7b39c853b9aff8c031f39d9",
-    "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#8edabba30a40320d2a9e6353a7c945cf528cf18d",
+    "@brave/leo": "github:brave/leo#a9fe69615e3cc3d7f2388fac1ddfa3db1e12a30a",
+    "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#f601277fdcd837c3e6b7239b73537603c7539119",
     "@brave/wallet-standard-brave": "0.0.16",
     "@dnd-kit/core": "6.3.1",
     "@dnd-kit/sortable": "7.0.1",


### PR DESCRIPTION
Changes https://github.com/brave/leo/compare/9a2dbab610d619b6f7b39c853b9aff8c031f39d9...a9fe69615e3cc3d7f2388fac1ddfa3db1e12a30a
- [Icons]: Update icons from Figma ([#1421](https://github.com/brave/leo/pull/1421))
- Add scrollable dialog & fix CSS selectors ([#1423](https://github.com/brave/leo/pull/1423))
- [Icons]: Update icons from Figma ([#1415](https://github.com/brave/leo/pull/1415))
- [Link]: Only use flex if icon(s) present ([#1420](https://github.com/brave/leo/pull/1420))
- [socket]: Clean up socket-fix action and get commit signing working ([#1405](https://github.com/brave/leo/pull/1405))

<!-- Add brave-browser issue below that this PR will resolve -->
<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
