### PR TITLE
[Wallet]: Fix Welcome Panel Sizing

### DIFF
--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -32,7 +32,7 @@ import {
 } from '../components/extension/public_encryption_key_panels/decrypt_message_request_panel'
 
 import { LongWrapper, ConnectWithSiteWrapper } from '../stories/style'
-import { PanelWrapper, WelcomePanelWrapper } from './style'
+import { PanelWrapper } from './style'
 import { FullScreenWrapper } from '../page/screens/page-screen.styles'
 
 import { TransactionStatus } from '../components/extension/post-confirmation'
@@ -162,11 +162,12 @@ function Container() {
 
   if (!isWalletCreated) {
     return (
-      <WelcomePanelWrapper>
-        <LongWrapper>
-          <WelcomePanel />
-        </LongWrapper>
-      </WelcomePanelWrapper>
+      <PanelWrapper
+        width={390}
+        height={650}
+      >
+        <WelcomePanel />
+      </PanelWrapper>
     )
   }
 

--- a/components/brave_wallet_ui/panel/style.ts
+++ b/components/brave_wallet_ui/panel/style.ts
@@ -23,16 +23,6 @@ export const PanelWrapper = styled.div<{
   contain: layout;
 `
 
-export const WelcomePanelWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 320px;
-  height: 250px;
-  overflow: hidden;
-  contain: layout;
-`
-
 export const SendWrapper = styled.div`
   flex: 1;
   flex-direction: column;


### PR DESCRIPTION
## Description 

Fixes the Wallet `Welcome Panel` size

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/57271>

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:

1. Create a new `Profile` and then click to open the Wallet `Panel`
2. The UI should not be broken and should be the normal panel size.

Before:

<img width="1312" height="1152" alt="Screenshot 84" src="https://github.com/user-attachments/assets/e1941a06-201f-4c79-b845-e2788062f632" />

After:

<img width="1312" height="1152" alt="Screenshot 85" src="https://github.com/user-attachments/assets/81d13b99-b74f-47d6-887d-b31e07e678c3" />