### PR TITLE
Fix BraveTranslate* flakiness

### DIFF
--- a/browser/translate/brave_translate_browsertest.cc
+++ b/browser/translate/brave_translate_browsertest.cc
@@ -211,7 +211,16 @@ class BraveTranslateBrowserTest : public InProcessBrowserTest {
                             "cr.googleTranslate.onTranslateElementLoad()")));
   }
 
-  void WaitUntilLanguageDetermined() { language_determined_waiter_->Wait(); }
+  // Waits until the active tab's source language is detected as
+  // |expected_lang|. Designed to skip unwanted language-determination events
+  // (e.g. the initial about:blank tab).
+  void WaitUntilLanguageDetermined(const std::string& expected_lang) {
+    while (GetChromeTranslateClient()->GetLanguageState().source_language() !=
+           expected_lang) {
+      language_determined_waiter_->Wait();
+      ResetObserver();
+    }
+  }
 
   void WaitUntilPageTranslated() {
     translate::CreateTranslateWaiter(
@@ -255,10 +264,9 @@ class BraveTranslateBrowserTest : public InProcessBrowserTest {
 };
 
 IN_PROC_BROWSER_TEST_F(BraveTranslateBrowserTest, InternalTranslation) {
-  ResetObserver();
   ASSERT_TRUE(ui_test_utils::NavigateToURL(
       browser(), embedded_test_server()->GetURL("/espanol_page.html")));
-  WaitUntilLanguageDetermined();
+  WaitUntilLanguageDetermined("es");
 
   SetupTestScriptExpectations();
 
@@ -320,10 +328,9 @@ IN_PROC_BROWSER_TEST_F(BraveTranslateBrowserTest, NoAutoTranslate) {
   GetChromeTranslateClient()
       ->GetTranslatePrefs()
       ->AddLanguagePairToAlwaysTranslateList("es", "en");
-  ResetObserver();
   ASSERT_TRUE(ui_test_utils::NavigateToURL(
       browser(), embedded_test_server()->GetURL("/espanol_page.html")));
-  WaitUntilLanguageDetermined();
+  WaitUntilLanguageDetermined("es");
 
   auto* bubble = CHECK_DEREF(TranslateBubbleController::From(browser()))
                      .GetTranslateBubble();
@@ -351,11 +358,9 @@ class BraveTranslateBrowserGoogleRedirectTest
 
 IN_PROC_BROWSER_TEST_F(BraveTranslateBrowserGoogleRedirectTest,
                        JsRedirectionsSelectivity) {
-  ResetObserver();
-
   ASSERT_TRUE(ui_test_utils::NavigateToURL(
       browser(), embedded_test_server()->GetURL("/espanol_page.html")));
-  WaitUntilLanguageDetermined();
+  WaitUntilLanguageDetermined("es");
 
   SetupTestScriptExpectations();
   GetTranslateManager()->TranslatePage("es", "en", true);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56767

The root cause is about:blank `LanguageDetermined` notification.
verified via `yarn test brave_browser_tests Static --filter="BraveTranslate*" --single-process-test --gtest_repeat=10`
before the fix (with a patch to reproduce): 7 failures (out of 30)
after: 0 failures 


The patch to reproduce the issue:
```patch
diff --git a/patches/components-translate-content-renderer-translate_agent.cc.patch b/patches/components-translate-content-renderer-translate_agent.cc.patch
index c04a1cf9eba..353a3762ed0 100644
--- a/patches/components-translate-content-renderer-translate_agent.cc.patch
+++ b/patches/components-translate-content-renderer-translate_agent.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/components/translate/content/renderer/translate_agent.cc b/components/translate/content/renderer/translate_agent.cc
-index c8539862fefc8737fc351eb5ac9bda7b53b83808..b30dfab16b38230a6fb06e8812293f41eb23ec9b 100644
+index c8539862fefc8737fc351eb5ac9bda7b53b83808..652516fbece41cb6ef14e8a17f7d642423e396bd 100644
 --- a/components/translate/content/renderer/translate_agent.cc
 +++ b/components/translate/content/renderer/translate_agent.cc
 @@ -61,7 +61,7 @@ const int kTranslateInitCheckDelayMs = 150;
@@ -11,3 +11,17 @@ index c8539862fefc8737fc351eb5ac9bda7b53b83808..b30dfab16b38230a6fb06e8812293f41
  
  // The delay we wait in milliseconds before checking whether the translation has
  // finished.
+@@ -169,6 +169,13 @@ void TranslateAgent::PageCaptured(
+     details.time = base::Time::Now();
+     details.url = url;
+     details.has_run_lang_detection = false;
++    // Reproduce the issue: delay delivery of the initial
++    // about:blank language-detection
++    if (url.IsAboutBlank()) {
++      LOG(ERROR) << "[repro] about:blank PageCaptured, sleeping 3s before "
++                    "RegisterPage";
++      base::PlatformThread::Sleep(base::Seconds(3));
++    }
+     RegisterPageInternal(std::move(details),
+                          /*page_level_translation_criteria_met=*/false);
+     return;
```
<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
