### PR TITLE
Revert "Disabled immersive tabbed mode on macOS"

### DIFF
--- a/browser/ui/views/frame/brave_browser_view_browsertest.cc
+++ b/browser/ui/views/frame/brave_browser_view_browsertest.cc
@@ -906,15 +906,6 @@ IN_PROC_BROWSER_TEST_F(
 }
 
 #if BUILDFLAG(IS_MAC)
-IN_PROC_BROWSER_TEST_F(BraveBrowserViewTest, ImmersiveTabbedMode) {
-  // We disabled tabbed mode by default.
-  // See
-  // https://github.com/brave/brave-browser/issues/56914#issuecomment-4911022632
-  // for more details.
-  EXPECT_FALSE(WindowFeatureController::From(browser())
-                   ->UsesImmersiveFullscreenTabbedMode());
-}
-
 // Immersive fullscreen: (1) when vertical tabs are off at startup, immersive
 // is available and is disabled at runtime when vertical tabs are turned on;
 // (2) when vertical tabs were on at startup, immersive stays disabled for the

--- a/chromium_src/chrome/browser/ui/window_feature_controller/window_feature_controller.cc
+++ b/chromium_src/chrome/browser/ui/window_feature_controller/window_feature_controller.cc
@@ -45,18 +45,6 @@ bool WindowFeatureController::UsesImmersiveFullscreenTabbedMode() const {
     return false;
   }
 
-  // Can't use tabbed mode due to compact mode.
-  // In tabbed mode, tab strip is drawn over title bar.
-  // As macOS has its own titlebar min-height, it could not same with
-  // tab strip height in compact mode. As tab strip height is shorter
-  // than title bar min-height, we can't avoid gab between tab strip
-  // and toolbar as toolbar is drawn below the titlebar.
-  // Due to the limitations of immersive mode implementation, it's difficult
-  // to use tabbed mode selectively in runtime.
-  if (browser_type_ == BrowserWindowInterface::Type::TYPE_NORMAL) {
-    return false;
-  }
-
   return WindowFeatureController::
       UsesImmersiveFullscreenTabbedMode_ChromiumImpl();
 }


### PR DESCRIPTION
Reverts brave/brave-core#37842

Resolves https://github.com/brave/brave-browser/issues/57117

Reverted as it added unexpected regression like https://github.com/brave/brave-browser/issues/57117
It made UX more worse. Need to find another approach for https://github.com/brave/brave-browser/issues/56914