### PR TITLE
Add the spaces button when workspaces enabled for vertical tabs

### DIFF
--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -12,11 +12,13 @@
 #include "base/check.h"
 #include "base/check_deref.h"
 #include "base/check_op.h"
+#include "base/feature_list.h"
 #include "base/functional/bind.h"
 #include "base/i18n/rtl.h"
 #include "brave/app/brave_command_ids.h"
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
+#include "brave/browser/ui/tabs/public/vertical_tab_controller.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/frame/focus_mode_top_overlay.h"
@@ -26,10 +28,14 @@
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/browser/ui/views/toolbar/bookmark_button.h"
 #include "brave/browser/ui/views/toolbar/side_panel_button.h"
+#include "brave/browser/ui/views/workspaces/workspaces_bubble_controller.h"
+#include "brave/browser/workspaces/features.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
+#include "brave/components/vector_icons/vector_icons.h"
+#include "brave/grit/brave_generated_resources.h"
 #include "chrome/app/chrome_command_ids.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/defaults.h"
@@ -285,6 +291,7 @@ void BraveToolbarView::Init() {
                                    self->UpdateVerticalTabToggleVisibility();
                                    self->UpdateVerticalTabTogglePlacement();
                                    self->UpdateComboButtonState();
+                                   self->UpdateWorkspaceButtonVisibility();
                                  },
                                  base::Unretained(this)));
     show_title_bar_on_vertical_tabs_.Init(
@@ -336,6 +343,8 @@ void BraveToolbarView::Init() {
     UpdateVerticalTabToggleVisibility();
     UpdateVerticalTabToggleState();
     UpdateComboButtonState();
+
+    CreateWorkspaceButtonIfNeeded();
   }
 
   bookmark_ =
@@ -748,6 +757,9 @@ void BraveToolbarView::UpdateVerticalTabTogglePlacement() {
   }
 
   ReorderChildView(vertical_tab_toggle_, target_idx);
+
+  // Workspace button is always relative to the vertical tabs toggle button.
+  UpdateWorkspaceButtonPlacement();
 }
 
 void BraveToolbarView::UpdateVerticalTabToggleState() {
@@ -784,6 +796,70 @@ void BraveToolbarView::OnVerticalTabTogglePressed() {
   }
 
   region_view->ToggleState();
+}
+
+void BraveToolbarView::CreateWorkspaceButtonIfNeeded() {
+  if (!base::FeatureList::IsEnabled(features::kWorkspaces) ||
+      browser_->GetType() != BrowserWindowInterface::Type::TYPE_NORMAL) {
+    return;
+  }
+
+  auto toggle_idx = GetIndexOf(vertical_tab_toggle_);
+  CHECK(toggle_idx.has_value());
+  workspaces_button_ =
+      AddChildViewAt(std::make_unique<ToolbarButton>(base::BindRepeating(
+                         &BraveToolbarView::OnWorkspacesButtonPressed,
+                         base::Unretained(this))),
+                     *toggle_idx + 1);
+  workspaces_button_->SetVectorIcon(kLeoSpacesIcon);
+  workspaces_button_->SetTooltipText(
+      l10n_util::GetStringUTF16(IDS_TOOLTIP_WORKSPACES_BUTTON));
+  workspaces_button_->GetViewAccessibility().SetName(
+      l10n_util::GetStringUTF16(IDS_ACCNAME_WORKSPACES_BUTTON));
+  workspaces_button_->SetVisible(VerticalTabController::FromBrowser(browser_)
+                                     ->ShouldShowBraveVerticalTabs());
+}
+
+void BraveToolbarView::OnWorkspacesButtonPressed() {
+  auto* controller =
+      browser_->browser_window_features()->workspaces_bubble_controller();
+  CHECK(controller);
+  controller->ShowBubble(workspaces_button_, browser_->profile());
+}
+
+void BraveToolbarView::UpdateWorkspaceButtonVisibility() {
+  if (!workspaces_button_) {
+    return;
+  }
+  workspaces_button_->SetVisible(VerticalTabController::FromBrowser(browser_)
+                                     ->ShouldShowBraveVerticalTabs());
+}
+
+void BraveToolbarView::UpdateWorkspaceButtonPlacement() {
+  CHECK(vertical_tab_toggle_);
+  if (!workspaces_button_) {
+    return;
+  }
+
+  const auto vertical_tab_toggle_index = GetIndexOf(vertical_tab_toggle_);
+  CHECK(vertical_tab_toggle_index.has_value());
+
+  const auto workspace_index = GetIndexOf(workspaces_button_);
+  CHECK(workspace_index.has_value());
+
+  // Folks can have vertical tabs on LEFT (default) or on the right. The spaces
+  // button should always come AFTER (to the right) of the vertical tab toggle
+  // in either case.
+  //
+  // When vertical tab position is changed from left to right, the spaces
+  // button is already in the view hierarchy (on the left) and has a lower
+  // index than the vertical tab toggle (which moved to the right when
+  // UpdateVerticalTabTogglePlacement ran). When ReorderChildView is called,
+  // the spaces button is removed and the indices shift. +1 not needed.
+  const size_t new_index = (*workspace_index < *vertical_tab_toggle_index)
+                               ? *vertical_tab_toggle_index
+                               : *vertical_tab_toggle_index + 1;
+  ReorderChildView(workspaces_button_, new_index);
 }
 
 void BraveToolbarView::UpdateComboButtonState() {

--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -46,6 +46,9 @@ class BraveToolbarView : public ToolbarView,
   ToolbarButton* vertical_tab_toggle_button() const {
     return vertical_tab_toggle_;
   }
+  ToolbarButton* workspaces_button_for_testing() const {
+    return workspaces_button_;
+  }
   TabStripComboButton* combo_button() const { return combo_button_; }
 #if BUILDFLAG(ENABLE_AI_CHAT)
   AIChatButton* ai_chat_button() const { return ai_chat_button_; }
@@ -82,6 +85,10 @@ class BraveToolbarView : public ToolbarView,
   void UpdateVerticalTabTogglePlacement();
   void UpdateVerticalTabToggleState();
   void OnVerticalTabTogglePressed();
+  void CreateWorkspaceButtonIfNeeded();
+  void OnWorkspacesButtonPressed();
+  void UpdateWorkspaceButtonVisibility();
+  void UpdateWorkspaceButtonPlacement();
   void OnCompactModePrefChanged();
   void UpdateComboButtonState();
   bool IsFocusModeOverlayActive() const;
@@ -101,6 +108,7 @@ class BraveToolbarView : public ToolbarView,
   raw_ptr<TabStripComboButton> combo_button_ = nullptr;
 
   raw_ptr<ToolbarButton> vertical_tab_toggle_ = nullptr;
+  raw_ptr<ToolbarButton> workspaces_button_ = nullptr;
   raw_ptr<BraveBookmarkButton> bookmark_ = nullptr;
   // Tracks the preference to determine whether bookmark editing is allowed.
   BooleanPrefMember edit_bookmarks_enabled_;

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -19,6 +19,7 @@
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/browser/ui/views/toolbar/bookmark_button.h"
 #include "brave/browser/ui/views/toolbar/side_panel_button.h"
+#include "brave/browser/workspaces/features.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
@@ -790,4 +791,103 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
   prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled, false);
   RunScheduledLayouts();
   EXPECT_FALSE(toolbar_view_->GetBorder()) << "after disabling vertical tabs";
+}
+
+// ---- Workspaces toolbar button tests ----------------------------------------
+
+class BraveToolbarViewTest_WorkspacesEnabled : public BraveToolbarViewTest {
+ public:
+  BraveToolbarViewTest_WorkspacesEnabled() {
+    scoped_feature_list_.InitAndEnableFeature(features::kWorkspaces);
+  }
+
+ protected:
+  base::test::ScopedFeatureList scoped_feature_list_;
+};
+
+// Without kWorkspaces the button is never created.
+IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
+                       WorkspacesButtonAbsentWhenFeatureDisabled) {
+  EXPECT_EQ(toolbar_view_->workspaces_button_for_testing(), nullptr);
+}
+
+// The workspaces button is visible only while vertical tabs are active.
+IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest_WorkspacesEnabled,
+                       WorkspacesButtonVisibilityTracksVerticalTabs) {
+  auto* prefs = browser()->profile()->GetPrefs();
+  auto* button = toolbar_view_->workspaces_button_for_testing();
+  ASSERT_TRUE(button);
+
+  // Vertical tabs are off by default — button should be hidden.
+  EXPECT_FALSE(prefs->GetBoolean(brave_tabs::kVerticalTabsEnabled));
+  EXPECT_FALSE(button->GetVisible());
+
+  // Enable vertical tabs — button should become visible.
+  prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled, true);
+  EXPECT_TRUE(button->GetVisible());
+
+  // Disable vertical tabs — button should hide again.
+  prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled, false);
+  EXPECT_FALSE(button->GetVisible());
+}
+
+// The workspaces button always sits immediately after the vertical tab toggle
+// in the toolbar's child order, regardless of whether the tab strip is on the
+// left or right and even when the toggle itself is hidden (vertical tabs
+// disabled). GetIndexOf works on all children regardless of visibility, so the
+// ordering invariant can be verified in each state.
+IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest_WorkspacesEnabled,
+                       WorkspacesButtonAlwaysImmediatelyAfterToggle) {
+  auto* prefs = browser()->profile()->GetPrefs();
+  auto* toggle = toolbar_view_->vertical_tab_toggle_button();
+  auto* workspaces = toolbar_view_->workspaces_button_for_testing();
+  ASSERT_TRUE(toggle);
+  ASSERT_TRUE(workspaces);
+
+  // ---- Tabs on the left (default) ----
+  prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled, true);
+  prefs->SetBoolean(brave_tabs::kVerticalTabsOnRight, false);
+  RunScheduledLayouts();
+
+  const auto toggle_ix_left = toolbar_view_->GetIndexOf(toggle);
+  const auto workspace_ix_left = toolbar_view_->GetIndexOf(workspaces);
+  ASSERT_TRUE(toggle_ix_left.has_value())
+      << "toggle missing from toolbar (tabs on left)";
+  ASSERT_TRUE(workspace_ix_left.has_value())
+      << "workspaces button missing from toolbar (tabs on left)";
+  EXPECT_EQ(*workspace_ix_left, *toggle_ix_left + 1)
+      << "workspaces button should be immediately after toggle (tabs on left)";
+
+  // ---- Tabs on the right ----
+  prefs->SetBoolean(brave_tabs::kVerticalTabsOnRight, true);
+  RunScheduledLayouts();
+
+  const auto toggle_ix_right = toolbar_view_->GetIndexOf(toggle);
+  const auto workspace_ix_right = toolbar_view_->GetIndexOf(workspaces);
+  ASSERT_TRUE(toggle_ix_right.has_value())
+      << "toggle missing from toolbar (tabs on right)";
+  ASSERT_TRUE(workspace_ix_right.has_value())
+      << "workspaces button missing from toolbar (tabs on right)";
+  EXPECT_EQ(*workspace_ix_right, *toggle_ix_right + 1)
+      << "workspaces button should be immediately after toggle (tabs on right)";
+
+  // ---- Toggle hidden (vertical tabs disabled) ----
+  // Both buttons become invisible, but they stay in the hierarchy. The child
+  // order must still be maintained so re-enabling snaps back correctly.
+  prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled, false);
+  RunScheduledLayouts();
+
+  EXPECT_FALSE(toggle->GetVisible()) << "toggle should be hidden";
+  EXPECT_FALSE(workspaces->GetVisible())
+      << "workspaces button should be hidden";
+
+  const auto toggle_ix_hidden = toolbar_view_->GetIndexOf(toggle);
+  const auto workspace_ix_hidden = toolbar_view_->GetIndexOf(workspaces);
+  ASSERT_TRUE(toggle_ix_hidden.has_value())
+      << "toggle unexpectedly removed from toolbar when hidden";
+  ASSERT_TRUE(workspace_ix_hidden.has_value())
+      << "workspaces button unexpectedly removed from toolbar when hidden";
+  EXPECT_EQ(*workspace_ix_hidden, *toggle_ix_hidden + 1)
+      << "workspaces button should remain immediately after toggle even when "
+         "both are hidden";
 }

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1217,6 +1217,7 @@ test("brave_browser_tests") {
 
   if (!is_android) {
     deps += [
+      "//brave/browser/workspaces",
       "//chrome/browser/profile_resetter:profile_resetter_test_base",
       "//chrome/browser/ui/frame",
       "//chrome/browser/ui/side_panel",


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/56728

--------------

Please note that it's intended for the spaces button to ALWAYS be displayed next to the vertical tabs toggle button.

When `Show on the left` is chosen (default)
<kbd><img width="278" height="223" alt="image" src="https://github.com/user-attachments/assets/780e933c-0a85-493f-a8ed-8936fe0d33a5" /></kbd>

And when `Show on the right` is chosen
<kbd><img width="356" height="272" alt="image" src="https://github.com/user-attachments/assets/c383199f-ae24-46bd-80ae-0be54146337a" /></kbd>

--------------

Clicking brings up the Spaces button - which behaves exactly the same as in regular tabs mode.
<kbd><img width="314" height="217" alt="image" src="https://github.com/user-attachments/assets/e980a02d-3170-4158-875d-d61cc7386eee" /></kbd>
<kbd><img width="307" height="238" alt="image" src="https://github.com/user-attachments/assets/faafdf5d-43f6-4a1a-86ca-903fea95b553" /></kbd>
