### PR TITLE
Add option to show/hide the vertical tabs toggle button

### DIFF
--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -354,6 +354,8 @@ const PrefsUtil::TypedPrefMap& BravePrefsUtil::GetAllowlistedKeys() {
       settings_api::PrefType::kBoolean;
   (*s_brave_allowlist)[brave_tabs::kVerticalTabsHideCompletelyWhenCollapsed] =
       settings_api::PrefType::kBoolean;
+  (*s_brave_allowlist)[brave_tabs::kVerticalTabsShowToggleButton] =
+      settings_api::PrefType::kBoolean;
 
   // Horizontal tabs settings
   (*s_brave_allowlist)[brave_tabs::kCompactHorizontalTabs] =

--- a/browser/prefs/brave_pref_service_incognito_allowlist.cc
+++ b/browser/prefs/brave_pref_service_incognito_allowlist.cc
@@ -40,6 +40,7 @@ base::span<const base::cstring_view> GetBravePersistentPrefNames() {
       brave_tabs::kVerticalTabsEnabled,
       brave_tabs::kVerticalTabsCollapsed,
       brave_tabs::kVerticalTabsFloatingEnabled,
+      brave_tabs::kVerticalTabsShowToggleButton,
       brave_tabs::kVerticalTabsShowTitleOnWindow,
       brave_tabs::kVerticalTabsOnRight,
       brave_tabs::kVerticalTabsShowScrollbar,

--- a/browser/resources/settings/brave_appearance_page/tabs.html
+++ b/browser/resources/settings/brave_appearance_page/tabs.html
@@ -27,27 +27,20 @@
         pref="{{prefs.brave.tabs.vertical_tabs_hide_completely_when_collapsed}}"
         label="$i18n{SETTINGS_APPEARANCE_SETTINGS_TABS_HIDE_COMPLETELY_WHEN_COLLPASED}">
       </settings-checkbox>
-      <template is="dom-if" if="[[prefs.brave.tabs.vertical_tabs_hide_completely_when_collapsed.value]]">
-        <!-- Show always checked and disabled checkbox. When 
-             vertical_tabs_hide_completely_when_collapsed is true
-             "Float on mouse over" is always enabled -->
-        <settings-checkbox
-          class="list-item"
-          disabled="true"
-          no-set-pref
-          pref="{{prefs.brave.tabs.vertical_tabs_hide_completely_when_collapsed}}"
-          label="$i18n{appearanceSettingsTabsFloatOnMouseOver}">
-        </settings-checkbox>
-      </template>
-      <template is="dom-if" if="[[!prefs.brave.tabs.vertical_tabs_hide_completely_when_collapsed.value]]">
-        <settings-checkbox
-          class="list-item"
-          pref="{{prefs.brave.tabs.vertical_tabs_floating_enabled}}"
-          label="$i18n{appearanceSettingsTabsFloatOnMouseOver}">
-        </settings-checkbox>
-      </template>
     </template>
-    <template is="dom-if" if="[[!isHideVerticalTabCompletelyFlagEnabled()]]">
+    <template is="dom-if" if="[[shouldForceFloatOnMouseOver_(prefs.brave.tabs.vertical_tabs_hide_completely_when_collapsed.value, prefs.brave.tabs.vertical_tabs_show_toggle_button.value)]]">
+      <!-- Show always checked and disabled checkbox. "Float on mouse over" is
+           forced on when vertical_tabs_hide_completely_when_collapsed is true,
+           or when the vertical tabs toggle button is hidden (there would be no
+           other way to expand collapsed tabs). -->
+      <settings-checkbox
+        class="list-item"
+        disabled="true"
+        checked="true"
+        label="$i18n{appearanceSettingsTabsFloatOnMouseOver}">
+      </settings-checkbox>
+    </template>
+    <template is="dom-if" if="[[!shouldForceFloatOnMouseOver_(prefs.brave.tabs.vertical_tabs_hide_completely_when_collapsed.value, prefs.brave.tabs.vertical_tabs_show_toggle_button.value)]]">
       <settings-checkbox
         class="list-item"
         pref="{{prefs.brave.tabs.vertical_tabs_floating_enabled}}"

--- a/browser/resources/settings/brave_appearance_page/tabs.ts
+++ b/browser/resources/settings/brave_appearance_page/tabs.ts
@@ -133,6 +133,18 @@ export class SettingsBraveAppearanceTabsElement extends SettingsBraveAppearanceT
     return loadTimeData.getBoolean('isHideVerticalTabCompletelyFlagEnabled');
   }
 
+  // "Float on mouse over" (auto-expand on hover) is forced on, and its
+  // checkbox shown as checked and disabled, when there is no other way for
+  // the user to expand collapsed vertical tabs: either because the vertical
+  // tab strip is fully hidden when collapsed, or because the toggle button
+  // used to expand/collapse it is hidden.
+  private shouldForceFloatOnMouseOver_(
+      hideCompletelyWhenCollapsed: boolean, showToggleButton: boolean) {
+    return (this.isHideVerticalTabCompletelyFlagEnabled() &&
+            hideCompletelyWhenCollapsed) ||
+        !showToggleButton
+  }
+
   private isScrollableHorizontalTabStripFlagEnabled() {
     return loadTimeData.getBoolean('isScrollableHorizontalTabStripEnabled');
   }

--- a/browser/ui/tabs/brave_tab_prefs.cc
+++ b/browser/ui/tabs/brave_tab_prefs.cc
@@ -31,6 +31,7 @@ void RegisterBraveProfilePrefs(PrefRegistrySimple* registry) {
   }
 
   registry->RegisterBooleanPref(kVerticalTabsFloatingEnabled, true);
+  registry->RegisterBooleanPref(kVerticalTabsShowToggleButton, true);
   registry->RegisterIntegerPref(kVerticalTabsExpandedWidth, 220);
   registry->RegisterBooleanPref(kVerticalTabsOnRight, false);
   registry->RegisterBooleanPref(kVerticalTabsShowScrollbar, false);

--- a/browser/ui/tabs/brave_tab_prefs.h
+++ b/browser/ui/tabs/brave_tab_prefs.h
@@ -27,6 +27,8 @@ inline constexpr char kVerticalTabsHideCompletelyWhenCollapsed[] =
     "brave.tabs.vertical_tabs_hide_completely_when_collapsed";
 inline constexpr char kVerticalTabsFloatingEnabled[] =
     "brave.tabs.vertical_tabs_floating_enabled";
+inline constexpr char kVerticalTabsShowToggleButton[] =
+    "brave.tabs.vertical_tabs_show_toggle_button";
 inline constexpr char kVerticalTabsExpandedWidth[] =
     "brave.tabs.vertical_tabs_expanded_width";
 inline constexpr char kVerticalTabsOnRight[] =

--- a/browser/ui/tabs/public/vertical_tab_controller.h
+++ b/browser/ui/tabs/public/vertical_tab_controller.h
@@ -49,6 +49,10 @@ class VerticalTabController {
   // bar regardless of the setting of kVerticalTabsFloatingEnabled.
   bool ShouldHideVerticalTabsCompletelyWhenCollapsed() const;
 
+  // Returns true when the vertical tab toggle button (the button used to
+  // expand/collapse the vertical tab strip) should be shown.
+  bool ShouldShowVerticalTabToggleButton() const;
+
  private:
   BrowserWindowInterface::Type type_;
   raw_ptr<PrefService> prefs_;

--- a/browser/ui/tabs/test/vertical_tab_controller_unittest.cc
+++ b/browser/ui/tabs/test/vertical_tab_controller_unittest.cc
@@ -105,6 +105,32 @@ TEST_F(VerticalTabControllerUnitTest,
   EXPECT_FALSE(controller->IsFloatingVerticalTabsEnabled());
 }
 
+TEST_F(VerticalTabControllerUnitTest,
+       ShouldShowVerticalTabToggleButtonDefault) {
+  pref_service_.SetBoolean(brave_tabs::kVerticalTabsEnabled, true);
+  // kVerticalTabsShowToggleButton defaults to true
+  auto controller = MakeController();
+  EXPECT_TRUE(controller->ShouldShowVerticalTabToggleButton());
+}
+
+TEST_F(VerticalTabControllerUnitTest,
+       ShouldShowVerticalTabToggleButtonFalseWhenVerticalTabsOff) {
+  auto controller = MakeController();
+  EXPECT_FALSE(controller->ShouldShowVerticalTabToggleButton());
+}
+
+TEST_F(VerticalTabControllerUnitTest,
+       IsFloatingVerticalTabsEnabledWhenToggleButtonHidden) {
+  pref_service_.SetBoolean(brave_tabs::kVerticalTabsEnabled, true);
+  pref_service_.SetBoolean(brave_tabs::kVerticalTabsFloatingEnabled, false);
+  pref_service_.SetBoolean(brave_tabs::kVerticalTabsShowToggleButton, false);
+  auto controller = MakeController();
+  EXPECT_FALSE(controller->ShouldShowVerticalTabToggleButton());
+  // Floating mode is forced on when there is no toggle button to expand
+  // collapsed tabs, regardless of kVerticalTabsFloatingEnabled.
+  EXPECT_TRUE(controller->IsFloatingVerticalTabsEnabled());
+}
+
 TEST_F(VerticalTabControllerUnitTest, IsVerticalTabOnRightDefault) {
   auto controller = MakeController();
   EXPECT_FALSE(controller->IsVerticalTabOnRight());

--- a/browser/ui/tabs/vertical_tab_controller.cc
+++ b/browser/ui/tabs/vertical_tab_controller.cc
@@ -88,6 +88,13 @@ bool VerticalTabController::IsFloatingVerticalTabsEnabled() const {
     return true;
   }
 
+  if (!ShouldShowVerticalTabToggleButton()) {
+    // When the toggle button is hidden, there is no other way to expand
+    // collapsed vertical tabs, so floating mode must stay on regardless of
+    // the setting of kVerticalTabsFloatingEnabled.
+    return true;
+  }
+
   return prefs_->GetBoolean(brave_tabs::kVerticalTabsFloatingEnabled);
 }
 
@@ -100,4 +107,12 @@ bool VerticalTabController::ShouldHideVerticalTabsCompletelyWhenCollapsed()
   return base::FeatureList::IsEnabled(tabs::kBraveVerticalTabHideCompletely) &&
          prefs_->GetBoolean(
              brave_tabs::kVerticalTabsHideCompletelyWhenCollapsed);
+}
+
+bool VerticalTabController::ShouldShowVerticalTabToggleButton() const {
+  if (!ShouldShowBraveVerticalTabs()) {
+    return false;
+  }
+
+  return prefs_->GetBoolean(brave_tabs::kVerticalTabsShowToggleButton);
 }

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -220,6 +220,8 @@ class BraveBrowserView : public BrowserView,
   FRIEND_TEST_ALL_PREFIXES(SpeedReaderBrowserTest, ToolbarLangs);
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest, ExpandedState);
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest, ExpandedWidth);
+  FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest,
+                           HidingToggleButtonCollapsesAndForcesFloating);
   FRIEND_TEST_ALL_PREFIXES(SplitViewBrowserTest, BraveMultiContentsViewTest);
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripHideCompletelyTest, GetMinimumWidth);
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripHideCompletelyTest,

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
@@ -2206,6 +2206,38 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripHideCompletelyTest,
   EXPECT_FALSE(region_view->GetVisible());
 }
 
+IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest,
+                       HidingToggleButtonCollapsesAndForcesFloating) {
+  ToggleVerticalTabStrip();
+
+  auto* prefs = browser()->profile()->GetPrefs();
+  auto* container_view =
+      browser_view()->vertical_tab_strip_container_view_.get();
+  ASSERT_TRUE(container_view);
+  auto* region_view = container_view->vertical_tab_strip_region_view();
+  ASSERT_TRUE(region_view);
+
+  // Vertical tabs default to expanded. Explicitly turn off floating mode.
+  prefs->SetBoolean(brave_tabs::kVerticalTabsFloatingEnabled, false);
+  ASSERT_EQ(BraveVerticalTabStripRegionView::State::kExpanded,
+            region_view->state());
+
+  // Hiding the toggle button should force the tab strip to collapse, since
+  // there is no other way to expand/collapse it, and should force floating
+  // mode on regardless of kVerticalTabsFloatingEnabled.
+  prefs->SetBoolean(brave_tabs::kVerticalTabsShowToggleButton, false);
+  EXPECT_EQ(BraveVerticalTabStripRegionView::State::kCollapsed,
+            region_view->state());
+  EXPECT_TRUE(prefs->GetBoolean(brave_tabs::kVerticalTabsCollapsed));
+  EXPECT_TRUE(VerticalTabController::FromBrowser(browser())
+                  ->IsFloatingVerticalTabsEnabled());
+
+  // Re-showing the toggle button should restore normal floating behavior.
+  prefs->SetBoolean(brave_tabs::kVerticalTabsShowToggleButton, true);
+  EXPECT_FALSE(VerticalTabController::FromBrowser(browser())
+                   ->IsFloatingVerticalTabsEnabled());
+}
+
 // Verifies that the vertical tab strip host view and the web contents are
 // positioned correctly in RTL mode for both "tab on left" and "tab on right"
 // user preferences. The layout flips the pref into a leading-edge boolean in

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -386,6 +386,12 @@ BraveVerticalTabStripRegionView::BraveVerticalTabStripRegionView(
                             base::Unretained(this)));
   }
 
+  show_toggle_button_pref_.Init(
+      brave_tabs::kVerticalTabsShowToggleButton, prefs,
+      base::BindRepeating(
+          &BraveVerticalTabStripRegionView::OnShowToggleButtonPrefChanged,
+          base::Unretained(this)));
+
   widget_observation_.Observe(browser_view->GetWidget());
 
   if (auto* focus_mode_controller =
@@ -399,7 +405,7 @@ BraveVerticalTabStripRegionView::BraveVerticalTabStripRegionView(
                           base::Unretained(this)));
 
   // Note: This should happen after all the PrefMembers have been initialized.
-  OnFloatingModePrefChanged();
+  OnShowToggleButtonPrefChanged();
 
   set_context_menu_controller(this);
 }
@@ -1038,6 +1044,19 @@ void BraveVerticalTabStripRegionView::
   // updating widget bounds at
   // BraveVerticalTabStripContainerView::UpdateVerticalTabBounds().
   PreferredSizeChanged();
+}
+
+void BraveVerticalTabStripRegionView::OnShowToggleButtonPrefChanged() {
+  if (!show_toggle_button_pref_.GetValue()) {
+    // There is no other way to expand collapsed vertical tabs when the
+    // toggle button is hidden, so force the base/resting state to collapsed.
+    collapsed_pref_.SetValue(true);
+    SetState(State::kCollapsed);
+  }
+
+  // Floating mode is forced on when the toggle button is hidden; make sure
+  // this state change is applied immediately.
+  OnFloatingModePrefChanged();
 }
 
 void BraveVerticalTabStripRegionView::OnExpandedWidthPrefChanged() {

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
@@ -166,6 +166,7 @@ class BraveVerticalTabStripRegionView : public views::View,
   void OnExpandedStatePerWindowPrefChanged();
   void OnExpandedWidthPrefChanged();
   void OnHideComopletelyWhenCollapsedPrefChanged();
+  void OnShowToggleButtonPrefChanged();
 
   bool IsFloatingVerticalTabsEnabled() const;
   bool IsFloatingEnabledForBrowserFullscreen() const;
@@ -231,6 +232,7 @@ class BraveVerticalTabStripRegionView : public views::View,
   BooleanPrefMember expanded_state_per_window_pref_;
   BooleanPrefMember floating_mode_pref_;
   BooleanPrefMember hide_completely_when_collapsed_pref_;
+  BooleanPrefMember show_toggle_button_pref_;
 
   IntegerPrefMember expanded_width_pref_;
   int expanded_width_ = 220;

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -17,6 +17,7 @@
 #include "brave/app/brave_command_ids.h"
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
+#include "brave/browser/ui/tabs/public/vertical_tab_controller.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/frame/focus_mode_top_overlay.h"
@@ -300,6 +301,11 @@ void BraveToolbarView::Init() {
         brave_tabs::kVerticalTabsOnRight, profile->GetPrefs(),
         base::BindRepeating(&BraveToolbarView::UpdateVerticalTabTogglePlacement,
                             base::Unretained(this)));
+    show_vertical_tab_toggle_button_.Init(
+        brave_tabs::kVerticalTabsShowToggleButton, profile->GetPrefs(),
+        base::BindRepeating(
+            &BraveToolbarView::UpdateVerticalTabToggleVisibility,
+            base::Unretained(this)));
 #if BUILDFLAG(IS_LINUX)
     use_custom_chrome_frame_.Init(
         prefs::kUseCustomChromeFrame, profile->GetOriginalProfile()->GetPrefs(),
@@ -706,8 +712,8 @@ void BraveToolbarView::UpdateVerticalTabToggleVisibility() {
     return;
   }
 
-  vertical_tab_toggle_->SetVisible(
-      tabs::utils::ShouldShowBraveVerticalTabs(browser_));
+  vertical_tab_toggle_->SetVisible(VerticalTabController::FromBrowser(browser_)
+                                       ->ShouldShowVerticalTabToggleButton());
 }
 
 void BraveToolbarView::UpdateVerticalTabTogglePlacement() {

--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -136,6 +136,7 @@ class BraveToolbarView : public ToolbarView,
   BooleanPrefMember show_title_bar_on_vertical_tabs_;
   BooleanPrefMember vertical_tabs_collapsed_;
   BooleanPrefMember vertical_tabs_on_right_;
+  BooleanPrefMember show_vertical_tab_toggle_button_;
 #if BUILDFLAG(IS_LINUX)
   BooleanPrefMember use_custom_chrome_frame_;
 #endif  // BUILDFLAG(IS_LINUX)

--- a/browser/ui/webui/side_panel/customize_chrome/BUILD.gn
+++ b/browser/ui/webui/side_panel/customize_chrome/BUILD.gn
@@ -18,6 +18,8 @@ source_set("customize_chrome") {
 
   deps = [
     "//base",
+    "//brave/app/vector_icons",
+    "//brave/browser/ui:brave_tab_prefs",
     "//brave/browser/ui/screenshot",
     "//brave/components/ai_chat/core/common/buildflags",
     "//brave/components/brave_news/common/buildflags",
@@ -96,6 +98,8 @@ source_set("unit_tests") {
   deps = [
     ":customize_chrome",
     "//base",
+    "//brave/app/vector_icons",
+    "//brave/browser/ui:brave_tab_prefs",
     "//brave/browser/ui/screenshot",
     "//brave/components/ai_chat/core/common/buildflags",
     "//brave/components/brave_news/common/buildflags",

--- a/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/brave_action.h
+++ b/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/brave_action.h
@@ -7,6 +7,8 @@
 #define BRAVE_BROWSER_UI_WEBUI_SIDE_PANEL_CUSTOMIZE_CHROME_CUSTOMIZE_TOOLBAR_BRAVE_ACTION_H_
 
 #include "base/containers/fixed_flat_map.h"
+#include "brave/app/vector_icons/vector_icons.h"
+#include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/ai_chat/core/common/pref_names.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
@@ -130,6 +132,17 @@ inline constexpr BraveAction kShowScreenshotAction = {
     .pref_name = kShowScreenshotButton,
     .icon = kLeoScreenshotIcon};
 
+inline constexpr BraveAction kShowVerticalTabToggleButtonAction = {
+    .id = side_panel::customize_chrome::mojom::ActionId::
+        kShowVerticalTabToggleButton,
+    .display_name_resource_id =
+        IDS_CUSTOMIZE_TOOLBAR_TOGGLE_VERTICAL_TAB_BUTTON,
+    .anchor =
+        side_panel::customize_chrome::mojom::ActionId::kShowAddBookmarkButton,
+    .category = side_panel::customize_chrome::mojom::CategoryId::kNavigation,
+    .pref_name = brave_tabs::kVerticalTabsShowToggleButton,
+    .icon = kLeoWindowTabsVerticalExpandedIcon};
+
 inline constexpr BraveAction kShowPwaInstallAction = {
     .id = side_panel::customize_chrome::mojom::ActionId::kShowPwaInstall,
     .display_name_resource_id = IDS_CUSTOMIZE_TOOLBAR_TOGGLE_PWA_INSTALL,
@@ -161,6 +174,8 @@ inline constexpr auto kBraveActions =
 #if BUILDFLAG(ENABLE_BRAVE_NEWS)
         {kShowBraveNews.id, &kShowBraveNews},
 #endif  // BUILDFLAG(ENABLE_BRAVE_NEWS)
+        {kShowVerticalTabToggleButtonAction.id,
+         &kShowVerticalTabToggleButtonAction},
         {kShowPwaInstallAction.id, &kShowPwaInstallAction},
     });
 

--- a/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/list_action_modifiers.cc
+++ b/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/list_action_modifiers.cc
@@ -12,6 +12,7 @@
 #include "base/containers/fixed_flat_set.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/browser/ui/screenshot/features.h"
+#include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/brave_action.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
@@ -189,6 +190,7 @@ std::vector<ActionPtr> ApplyBraveSpecificModifications(
   // Brave specific actions
   // Navigation
   //   kShowAddBookmarkButton,
+  //   kShowVerticalTabToggleButtonAction,
   //   kShowSidePanel,
   //   kShowWallet,
   //   kShowAIChat,
@@ -232,6 +234,10 @@ std::vector<BraveAction> ListBraveSpecificActions(
 
   std::vector<BraveAction> brave_actions;
   brave_actions.push_back(kShowAddBookmarkButton);
+  if (prefs->GetBoolean(brave_tabs::kVerticalTabsEnabled)) {
+    brave_actions.push_back(kShowVerticalTabToggleButtonAction);
+  }
+
   brave_actions.push_back(kShowSidePanelAction);
 
   // Followings are dynamic actions: anchor to TabSearchButton and append to

--- a/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/list_action_modifiers.h
+++ b/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/list_action_modifiers.h
@@ -41,9 +41,10 @@ FilterUnsupportedChromiumActions(
 //        we use for App menu.
 // 3. Adds Brave-specific actions.
 //   e.g. In 'Navigation' category:
-//        `kShowAddBookmarkButton`, `kShowSidePanel`, `kShowWallet`,
-//        `kShowAIChat`, `kShowVPN`, `kShowScreenshot`.
-//        In 'Address bar' category: `kShowReward`, `kShowBraveNews`.
+//        `kShowAddBookmarkButton`, `kShowVerticalTabToggleButtonAction`,
+//        `kShowSidePanel`, `kShowWallet`, `kShowAIChat`, `kShowVPN`,
+//        `kShowScreenshot`. In 'Address bar' category: `kShowReward`,
+//        `kShowBraveNews`.
 std::vector<side_panel::customize_chrome::mojom::ActionPtr>
 ApplyBraveSpecificModifications(
     content::WebContents* web_contents,

--- a/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/list_action_modifiers_unittest.cc
+++ b/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/list_action_modifiers_unittest.cc
@@ -10,6 +10,7 @@
 #include "base/containers/fixed_flat_set.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/ui/screenshot/features.h"
+#include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
@@ -395,6 +396,31 @@ TEST_F(ListActionModifiersUnitTest,
                         &side_panel::customize_chrome::mojom::Action::id);
   ASSERT_NE(screenshot_it, modified_actions.end());
   EXPECT_EQ((*screenshot_it)->category,
+            side_panel::customize_chrome::mojom::CategoryId::kNavigation);
+}
+
+TEST_F(ListActionModifiersUnitTest,
+       ApplyBraveSpecificModifications_VerticalTabToggleNotAddedByDefault) {
+  ASSERT_FALSE(prefs()->GetBoolean(brave_tabs::kVerticalTabsEnabled));
+  auto modified_actions = customize_chrome::ApplyBraveSpecificModifications(
+      web_contents_.get(), GetBasicActions());
+  auto toggle_it = std::ranges::find(
+      modified_actions, ActionId::kShowVerticalTabToggleButton,
+      &side_panel::customize_chrome::mojom::Action::id);
+  EXPECT_EQ(toggle_it, modified_actions.end());
+}
+
+TEST_F(
+    ListActionModifiersUnitTest,
+    ApplyBraveSpecificModifications_VerticalTabToggleAddedWhenVerticalTabsEnabled) {
+  prefs()->SetBoolean(brave_tabs::kVerticalTabsEnabled, true);
+  auto modified_actions = customize_chrome::ApplyBraveSpecificModifications(
+      web_contents_.get(), GetBasicActions());
+  auto toggle_it = std::ranges::find(
+      modified_actions, ActionId::kShowVerticalTabToggleButton,
+      &side_panel::customize_chrome::mojom::Action::id);
+  ASSERT_NE(toggle_it, modified_actions.end());
+  EXPECT_EQ((*toggle_it)->category,
             side_panel::customize_chrome::mojom::CategoryId::kNavigation);
 }
 

--- a/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar.mojom
+++ b/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar.mojom
@@ -14,6 +14,7 @@ enum ActionId {
   kShowVPN,
   kShowSidePanel,
   kShowScreenshot,
+  kShowVerticalTabToggleButton,
 
   // Actions in the "Address bar" category.
   kShowReward,

--- a/components/resources/customize_toolbar_ui_strings.grdp
+++ b/components/resources/customize_toolbar_ui_strings.grdp
@@ -36,4 +36,7 @@
   <message name="IDS_CUSTOMIZE_TOOLBAR_TOGGLE_SCREENSHOT" desc="Title for a toggle button to show or hide screenshot button">
     Screenshot
   </message>
+  <message name="IDS_CUSTOMIZE_TOOLBAR_TOGGLE_VERTICAL_TAB_BUTTON" desc="Title for a toggle button to show or hide the vertical tabs expand/collapse button">
+    Vertical tabs toggle button
+  </message>
 </grit-part>


### PR DESCRIPTION
Adds a new pref-backed option, exposed via the Customize Toolbar side panel, to hide the vertical tabs expand/collapse button. When the button is hidden, floating (auto-expand on hover) mode is forced on so collapsed tabs remain reachable, mirroring the existing behavior for "hide vertical tabs completely".

Hiding the vertical tabs toggle button now also forces the tab strip into its collapsed resting state, since there is no other way to expand/collapse it manually. Extends the existing "Float on mouse over" forced-checked/disabled treatment in settings to also apply in this case, matching the existing behavior for "hide completely".

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves brave/brave-browser#56859

<img width="808" height="422" alt="image" src="https://github.com/user-attachments/assets/ad9ce1af-3499-484a-a06b-59fd370d426a" />


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
