### PR TITLE
[plaster][ast-grep] Fix `add_friend` mismatches

### DIFF
--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -1221,10 +1221,12 @@ _MATCHER_SCHEMA = {
 # A rewriter op: locates nodes through a matcher op and edits each via a regex
 # substitution. `inputs` is its public interface (validated against the
 # templates it feeds in `_check_cross_references`); `replace` may name adjacent
-# tokens to fold into each rewritten span.
+# tokens to fold into each rewritten span. `first_match`, when true, rewrites
+# only the first match (in source order) and ignores any later ones.
 _REWRITER_SCHEMA = {
     'matcher': _NON_EMPTY_STR,
     'inputs': [str],
+    schema.Optional('first_match'): bool,
     'replace': {
         schema.Optional('consume_before'): str,
         schema.Optional('consume_after'): str,
@@ -1490,7 +1492,8 @@ class AstRewriter:
         that sit immediately before / after each matched node; they are folded
         into the rewritten span when the node kind stops short of an adjacent
         token (e.g. the `:` after an access_specifier, or the space before a
-        `final` specifier).
+        `final` specifier). An op that sets `first_match` rewrites only the
+        first match (in source order), leaving any later matches untouched.
         """
         rewriter = self._rewriters.rewriter(op.op_id)
         matcher = self._rewriters.matcher(rewriter['matcher'])
@@ -1500,6 +1503,8 @@ class AstRewriter:
         matches = run_ast_grep(language=language,
                                rule_body=rule_body,
                                source=self._content)
+        if rewriter.get('first_match'):
+            matches = matches[:1]
 
         replace = rewriter['replace']
         pattern = replace['re_pattern']

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1313,6 +1313,74 @@ class RewriterFormsTest(unittest.TestCase):
             result, 'class C {\n public:\n  void Foo();\n'
             ' private:\n  friend class BraveC;\n  int x_;\n};\n')
 
+    def test_add_friend_inserts_into_first_private_section_only(self):
+        # A class may reopen `private:` more than once. The friend must land in
+        # the first private section only; the later one is left untouched.
+        result = self._apply(
+            'twoprivate.h', 'class C {\n public:\n  void Foo();\n'
+            ' private:\n  int x_;\n'
+            ' private:\n  int y_;\n};\n', 'substitutions:\n'
+            '  - description: friend the Brave subclass\n'
+            '    add_friend:\n'
+            '      class_name: C\n'
+            '      friend_type: class BraveC\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            ' private:\n  friend class BraveC;\n  int x_;\n'
+            ' private:\n  int y_;\n};\n')
+
+    def test_add_friend_list_into_first_private_section_only(self):
+        # The same holds for a list of friends: all of them go into the first
+        # private section, in the order listed, and the later one is untouched.
+        result = self._apply(
+            'twoprivate_list.h', 'class C {\n public:\n  void Foo();\n'
+            ' private:\n  int x_;\n'
+            ' private:\n  int y_;\n};\n', 'substitutions:\n'
+            '  - description: friend the Brave subclass and its test\n'
+            '    add_friend:\n'
+            '      class_name: C\n'
+            '      friend_type:\n'
+            '        - class BraveC\n'
+            '        - class BraveCTest\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            ' private:\n  friend class BraveC;\n  friend class BraveCTest;\n'
+            '  int x_;\n private:\n  int y_;\n};\n')
+
+    def test_add_friend_ignores_nested_class_private_after(self):
+        # A nested class has its own private section. When befriending the outer
+        # class, the friend must land in the outer class's private section, never
+        # the nested one -- here the nested `private:` comes *after* the outer's.
+        result = self._apply(
+            'nested_after.h', 'class Foo {\n private:\n  int x_;\n'
+            '  class Bar {\n   private:\n    int y_;\n  };\n};\n',
+            'substitutions:\n'
+            '  - description: friend the Brave subclass of the outer class\n'
+            '    add_friend:\n'
+            '      class_name: Foo\n'
+            '      friend_type: class BraveFoo\n')
+        self.assertEqual(
+            result, 'class Foo {\n private:\n  friend class BraveFoo;\n'
+            '  int x_;\n'
+            '  class Bar {\n   private:\n    int y_;\n  };\n};\n')
+
+    def test_add_friend_ignores_nested_class_private_before(self):
+        # As above, but the nested class (and so its `private:`) appears *before*
+        # the outer class's own private section. The nested section is earlier in
+        # source order, so this guards against naively taking the first match.
+        result = self._apply(
+            'nested_before.h', 'class Foo {\n public:\n'
+            '  class Bar {\n   private:\n    int y_;\n  };\n'
+            ' private:\n  int x_;\n};\n', 'substitutions:\n'
+            '  - description: friend the Brave subclass of the outer class\n'
+            '    add_friend:\n'
+            '      class_name: Foo\n'
+            '      friend_type: class BraveFoo\n')
+        self.assertEqual(
+            result, 'class Foo {\n public:\n'
+            '  class Bar {\n   private:\n    int y_;\n  };\n'
+            ' private:\n  friend class BraveFoo;\n  int x_;\n};\n')
+
     def test_add_friend_no_private_section_fails(self):
         with self.assertRaises(plaster.PlasterApplyError):
             self._apply(
@@ -1787,6 +1855,19 @@ class RewritersEvalTest(unittest.TestCase):
         self.assertEqual(replace['consume_before'], ' ')
         self.assertEqual(replace['consume_after'], ':')
 
+    def test_rewriter_first_match_is_optional_bool(self):
+        # `first_match` is an optional flag; when present it must be a bool and
+        # is exposed on the rewriter spec.
+        spec = self._valid_spec()
+        spec['ast.rewriter']['cxx.make_virtual']['first_match'] = True
+        rewriters = plaster.RewritersEval(repr(spec))
+        self.assertIs(
+            rewriters.rewriter('cxx.make_virtual')['first_match'], True)
+
+    def test_rewriter_first_match_must_be_bool(self):
+        self._assert_invalid(lambda spec: spec['ast.rewriter'][
+            'cxx.make_virtual'].update({'first_match': 'yes'}))
+
 
 # ast-grep matcher templates used to build synthetic RewritersEval specs for
 # the engine tests below. The shipped rewriters.pyl is empty until the ops that
@@ -1811,11 +1892,12 @@ _METHOD_DECL_RULE = ('any:\n'
 _PRIVATE_SECTION_RULE = ('kind: access_specifier\n'
                          'regex: ^private$\n'
                          'inside:\n'
-                         '  kind: class_specifier\n'
-                         '  stopBy: end\n'
-                         '  has:\n'
-                         '    field: name\n'
-                         '    regex: ^{class_name}$\n')
+                         '  kind: field_declaration_list\n'
+                         '  inside:\n'
+                         '    kind: class_specifier\n'
+                         '    has:\n'
+                         '      field: name\n'
+                         '      regex: ^{class_name}$\n')
 
 _FINAL_RULE = ('kind: virtual_specifier\n'
                'regex: ^final$\n'
@@ -1861,6 +1943,7 @@ _SYNTHETIC_SPEC = {
         'cxx.add_friend': {
             'matcher': 'cxx.find_class_private_section',
             'inputs': ['class_name', 'friend_type'],
+            'first_match': True,
             'replace': {
                 'consume_after': ':',
                 're_pattern': '$',

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -25,6 +25,11 @@
 #                 folded into the rewritten span when the matched node stops
 #                 short of an adjacent token (e.g. the `:` after an
 #                 access_specifier, or the space before a `final` specifier).
+#       first_match: optional bool; when true only the first match (in source
+#                 order) is rewritten and any later matches are ignored. Use it
+#                 when the matcher can legitimately find several nodes but the
+#                 rewrite belongs to only the first (e.g. a class that reopens
+#                 `private:` more than once).
 #       result:   { node: <kind> } being replaced.
 #
 # An op yields every match in source order; the caller (plaster) decides how
@@ -65,17 +70,23 @@ inside:
 
         # The `private` access specifier opening `class_name`'s private section.
         # The node is the `private` keyword; the `:` that follows is a separate
-        # token immediately after it.
+        # token immediately after it. The specifier must be a *direct* member of
+        # `class_name`: its immediate parent is the class body
+        # (field_declaration_list), whose immediate parent is the class. Nesting
+        # through the body with the default (neighbor) `stopBy` -- rather than an
+        # `stopBy: end` ancestor search -- keeps a nested class's own `private:`
+        # from matching the enclosing class.
         "cxx.find_class_private_section": {
             "template": """\
 kind: access_specifier
 regex: ^private$
 inside:
-  kind: class_specifier
-  stopBy: end
-  has:
-    field: name
-    regex: ^{class_name}$
+  kind: field_declaration_list
+  inside:
+    kind: class_specifier
+    has:
+      field: name
+      regex: ^{class_name}$
 """,
             "result": {
                 "node": "access_specifier",
@@ -117,12 +128,15 @@ inside:
             },
         },
 
-        # The class's `private:` section with a `friend` declaration inserted as
-        # its first line. The matcher stops at the `private` keyword, so the op
-        # consumes the original `:` and re-emits it.
+        # The class's first `private:` section with a `friend` declaration
+        # inserted as its first line. The matcher stops at the `private`
+        # keyword, so the op consumes the original `:` and re-emits it. A class
+        # may reopen `private:` more than once, so `first_match` keeps the
+        # friend in the first section only.
         "cxx.add_friend": {
             "matcher": "cxx.find_class_private_section",
             "inputs": ["class_name", "friend_type"],
+            "first_match": True,
             "replace": {
                 "consume_after": ":",
                 "re_pattern": "$",


### PR DESCRIPTION
This change fixes two issues with `add_friend`:

 - `add_friend` was breaking when a class had more than one `private`
   section.
 - add friend was matching the private section of nested classed.

Bug: https://github.com/brave/brave-browser/issues/57129
