### PR TITLE
[plaster] Fix a few remaining regex keys missing

### DIFF
--- a/patches/chrome-browser-ui-views-page_action-page_action_view.cc.patch
+++ b/patches/chrome-browser-ui-views-page_action-page_action_view.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/page_action/page_action_view.cc b/chrome/browser/ui/views/page_action/page_action_view.cc
-index 415e8f510fc4051e18caa829942226670adc5e19..373a60344257237839f46d0383eef6786f3aca3a 100644
+index 415e8f510fc4051e18caa829942226670adc5e19..c8c3c422f7d94bc894a1fd92be5bed9217f8f575 100644
 --- a/chrome/browser/ui/views/page_action/page_action_view.cc
 +++ b/chrome/browser/ui/views/page_action/page_action_view.cc
 @@ -238,7 +238,7 @@ void PageActionView::HandleSlideAndCrossfadeTransition(
@@ -24,7 +24,7 @@ index 415e8f510fc4051e18caa829942226670adc5e19..373a60344257237839f46d0383eef678
                static_cast<std::underlying_type_t<PageActionEntryPoint>>(
                    PageActionEntryPoint::kSuggestionChip))
 +          .SetProperty(kBravePageActionEventFlagKey,
-+                       event.IsMouseEvent() ? event.flags() : ui::EF_NONE)
++                      event.IsMouseEvent() ? event.flags() : ui::EF_NONE)
            .Build());
  }
  

--- a/rewrite/chrome/browser/ui/views/location_bar/icon_label_bubble_view.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/location_bar/icon_label_bubble_view.cc.yaml
@@ -6,11 +6,12 @@
 substitutions:
   - description:
       'Use rounded corners from layout constants in GetHighlightPath()'
-    re_pattern:
-      'const SkRect rect = RectToSkRect\(highlight_bounds\);[\s\S]*?return
-      SkPath::RRect\(SkRRect::MakeRectRadii\(rect, sk_radii\)\);'
-    replace: |-
-      const int layout_radius =
-            GetLayoutConstant(LayoutConstant::kLocationBarChildCornerRadius);
-        return SkPath::RRect(gfx::RectToSkRect(highlight_bounds), layout_radius,
-                             layout_radius);
+    regex:
+      re_pattern:
+        'const SkRect rect = RectToSkRect\(highlight_bounds\);[\s\S]*?return
+        SkPath::RRect\(SkRRect::MakeRectRadii\(rect, sk_radii\)\);'
+      replace: |-
+        const int layout_radius =
+              GetLayoutConstant(LayoutConstant::kLocationBarChildCornerRadius);
+          return SkPath::RRect(gfx::RectToSkRect(highlight_bounds), layout_radius,
+                               layout_radius);

--- a/rewrite/chrome/browser/ui/views/location_bar/standard_icon_label_bubble_layout_strategy.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/location_bar/standard_icon_label_bubble_layout_strategy.cc.yaml
@@ -9,17 +9,19 @@ substitutions:
 
       Widens the "expand to fit the label" condition so that page actions whose
       label must always be shown are not clamped to their minimum size.
-    re_pattern:
-      'if (\(host->ShouldShowLabel\(\)
-      &&\s+host->label\(\)->GetElideBehavior\(\) != gfx::NO_ELIDE\)) {'
-    replace: 'if (\1 || host->ShouldAlwaysShowLabel()) {'
+    regex:
+      re_pattern:
+        'if (\(host->ShouldShowLabel\(\)
+        &&\s+host->label\(\)->GetElideBehavior\(\) != gfx::NO_ELIDE\)) {'
+      replace: 'if (\1 || host->ShouldAlwaysShowLabel()) {'
 
   - description: |
       Force should_use_label_bounds to true when ShouldAlwaysShowLabel is true.
 
       Forces the image container to use the label bounds whenever the label must
       always be shown.
-    re_pattern: 'const bool should_use_label_bounds =([\s\S]*?);'
-    replace: |-
-      bool should_use_label_bounds =\1;
-        should_use_label_bounds = should_use_label_bounds || host->ShouldAlwaysShowLabel();
+    regex:
+      re_pattern: 'const bool should_use_label_bounds =([\s\S]*?);'
+      replace: |-
+        bool should_use_label_bounds =\1;
+          should_use_label_bounds = should_use_label_bounds || host->ShouldAlwaysShowLabel();

--- a/rewrite/chrome/browser/ui/views/page_action/page_action_view.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/page_action/page_action_view.cc.yaml
@@ -10,8 +10,9 @@ substitutions:
       Upstream only animates the chip in when it is acting as a suggestion
       chip. Brave has page actions whose label must remain visible regardless,
       so we widen the condition to also cover `model.GetAlwaysShowLabel()`.
-    re_pattern: 'if \((model.ShouldShowSuggestionChip\(\))\)'
-    replace: 'if (\1 || model.GetAlwaysShowLabel())'
+    regex:
+      re_pattern: 'if \((model.ShouldShowSuggestionChip\(\))\)'
+      replace: 'if (\1 || model.GetAlwaysShowLabel())'
 
   - description: |
       Let Brave adjust the border insets before UpdateBorder() applies them.
@@ -20,11 +21,12 @@ substitutions:
       SetBorder(). Inserting a MaybeOverrideBorder() hook just before that call
       gives Brave a chance to tweak the insets without duplicating the whole
       method.
-    re_pattern: '(void PageActionView::UpdateBorder\(\).*?)(SetBorder\()'
-    re_flags: [DOTALL]
-    replace: |-
-      \1MaybeOverrideBorder(observation_.GetSource(), border_insets);
-        \2
+    regex:
+      re_pattern: '(void PageActionView::UpdateBorder\(\).*?)(SetBorder\()'
+      re_flags: [DOTALL]
+      replace: |-
+        \1MaybeOverrideBorder(observation_.GetSource(), border_insets);
+          \2
 
   - description: |
       Propagate the click event flags through the page action invocation.
@@ -33,9 +35,10 @@ substitutions:
       modifier flags, so Brave action handlers cannot tell e.g. a plain click
       from a ctrl/shift click. We attach them via `kBravePageActionEventFlagKey`
       on the builder in NotifyClick() right before `.Build()`.
-    re_pattern: '(void PageActionView::NotifyClick\(.*?\n)(\s*\.Build\(\)\);)'
-    re_flags: [DOTALL]
-    replace: |-
-      \1          .SetProperty(kBravePageActionEventFlagKey,
-                             event.IsMouseEvent() ? event.flags() : ui::EF_NONE)
-      \2
+    regex:
+      re_pattern: '(void PageActionView::NotifyClick\(.*?\n)(\s*\.Build\(\)\);)'
+      re_flags: [DOTALL]
+      replace: |-
+        \1          .SetProperty(kBravePageActionEventFlagKey,
+                              event.IsMouseEvent() ? event.flags() : ui::EF_NONE)
+        \2

--- a/rewrite/chrome/browser/ui/webui/cr_components/searchbox/searchbox_handler.cc.yaml
+++ b/rewrite/chrome/browser/ui/webui/cr_components/searchbox/searchbox_handler.cc.yaml
@@ -10,28 +10,30 @@ substitutions:
       This regex looks for the DUMP_WILL_BE_NOTREACHED at the end of the
       function, making sure it is in fact the last one, and inserts our code
       just before it, meaning, at the end of the function.
-    re_pattern:
-      '(SearchboxHandler::AutocompleteIconToResourceName\(.*?\) const
-      \{.*?)(DUMP_WILL_BE_NOTREACHED\b.*?;)(?=(?:(?!DUMP_WILL_BE_NOTREACHED).)*?\n\})'
-    re_flags: [DOTALL]
-    replace: |-
-      \1if (icon.name == kLeoWindowTabNewIcon.name) {
-          return kLeoWindowTabNewIconResourceName;
-        } else if (icon.name == kLeoMessageBubbleAskIcon.name) {
-          return kLeoMessageBubbleAskIconResourceName;
-        }
-        // This function is used for the WebUI Omnibox which isn't enabled in
-        // Brave, so its okay to disable the DUMP_WILL_BE_NOTREACHED() check
-        // here and use the default icon instead.
-        if ((true)) return "";
-        \2
+    regex:
+      re_pattern:
+        '(SearchboxHandler::AutocompleteIconToResourceName\(.*?\) const
+        \{.*?)(DUMP_WILL_BE_NOTREACHED\b.*?;)(?=(?:(?!DUMP_WILL_BE_NOTREACHED).)*?\n\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1if (icon.name == kLeoWindowTabNewIcon.name) {
+            return kLeoWindowTabNewIconResourceName;
+          } else if (icon.name == kLeoMessageBubbleAskIcon.name) {
+            return kLeoMessageBubbleAskIconResourceName;
+          }
+          // This function is used for the WebUI Omnibox which isn't enabled in
+          // Brave, so its okay to disable the DUMP_WILL_BE_NOTREACHED() check
+          // here and use the default icon instead.
+          if ((true)) return "";
+          \2
 
   - description: |
       Force keyword mode in the NTP realbox.
 
       We tweak a few AutocompleteInput settings because unlike Chromium we only
       want keyword search results.
-    re_pattern: 'autocomplete_input\.set_in_keyword_mode\(false\);\s*autocomplete_input\.set_allow_exact_keyword_match\(false\);'
-    replace: |-
-      autocomplete_input.set_in_keyword_mode(true);
-        autocomplete_input.set_allow_exact_keyword_match(true);
+    regex:
+      re_pattern: 'autocomplete_input\.set_in_keyword_mode\(false\);\s*autocomplete_input\.set_allow_exact_keyword_match\(false\);'
+      replace: |-
+        autocomplete_input.set_in_keyword_mode(true);
+          autocomplete_input.set_allow_exact_keyword_match(true);


### PR DESCRIPTION
This corrects a few files that were left behind without their keys
migrated.

Bug: https://github.com/brave/brave-browser/issues/56760
