### PR TITLE
[plaster][ast-grep] Blank C++ macros for `ast-grep` parsing

### DIFF
--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -142,6 +142,15 @@ tools/cr/plaster.py --help                # overview of commands and rewriters
 tools/cr/plaster.py --help make_virtual   # full docs for a specific rewriter
 ```
 
+### File-wide options
+
+Besides `substitutions:`, a plaster file may set file-wide options at the top
+level:
+
+| Key                            | Default | Description                                                   |
+| ------------------------------ | ------- | ------------------------------------------------------------- |
+| `blank_macros_for_ast_parsing` | `false` | Blank parse-blocking macros/conditionals before AST matching. |
+
 ### Applying a plaster
 
 To apply this plaster file, just run `plaster.py`:

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -406,8 +406,12 @@ class Rewriter(abc.ABC):
     HELP: ClassVar[str] = ''
 
     @abc.abstractmethod
-    def apply(self, contents: str, *, count: int,
-              description: str) -> tuple[str, list[str]]:
+    def apply(self,
+              contents: str,
+              *,
+              count: int,
+              description: str,
+              blank_for_parse: bool = False) -> tuple[str, list[str]]:
         """Transform `contents`, returning (new_contents, validation_errors).
 
         `count` is the entry's `count:` (default 1, `0` meaning "one or more").
@@ -415,7 +419,8 @@ class Rewriter(abc.ABC):
         the expected number of matches. A composed rewriter may instead give
         each of its operations its own expectation. `errors` is the list of
         human-readable count/validation failures (empty when the entry applied
-        as expected).
+        as expected). `blank_for_parse` is the file-wide
+        `blank_macros_for_ast_parsing` flag used by AST rewriters.
         """
 
     @classmethod
@@ -427,6 +432,43 @@ class Rewriter(abc.ABC):
     def help_text(cls) -> str:
         """The full, user-facing help for this rewriter as dedented Markdown."""
         return textwrap.dedent(cls.HELP or cls.__doc__ or '').strip('\n')
+
+    def source_language(self) -> str | None:
+        """The source language this rewriter requires, or None if agnostic.
+
+        AST rewriters parse the target in a specific language (the `<lang>.`
+        prefix of their op id), so they may only be used on sources of that
+        language. Text rewriters are language-agnostic and return None.
+        """
+        return None
+
+
+# The file-wide plaster keys allowed at the top level of a YAML plaster.
+_TOP_LEVEL_KEYS: Final = frozenset(
+    {'substitutions', 'blank_macros_for_ast_parsing'})
+
+# Target-source suffixes plaster treats as C++. `blank_macros_for_ast_parsing`
+# blanks constructs for the tree-sitter C++ parser, so it is only meaningful for
+# these.
+_CXX_SOURCE_SUFFIXES: Final = frozenset(
+    {'.h', '.hpp', '.hxx', '.h++', '.cc', '.cpp', '.cxx', '.c++', '.mm'})
+
+
+def _is_cxx_source(plaster_path: Path) -> bool:
+    """True if the plaster's target source (its path minus `.yaml`) is C++."""
+    return plaster_path.with_suffix('').suffix in _CXX_SOURCE_SUFFIXES
+
+
+@dataclass(frozen=True)
+class PlasterSpec:
+    """A parsed plaster file: its substitutions plus its file-wide options."""
+
+    # The `substitutions:` entries, in order.
+    substitutions: list[Substitution]
+
+    # Indicates to the AST-rewriter that it needs to blank all cxx preprocessor
+    # directives that can interfere with parsing.
+    blank_macros_for_ast_parsing: bool = False
 
 
 @dataclass(frozen=True)
@@ -447,16 +489,16 @@ class Substitution:
     # The rewriter this entry composes; `apply` delegates to it.
     rewriter: Rewriter
 
-    def apply(self, contents: str) -> tuple[str, list[str]]:
+    def apply(self,
+              contents: str,
+              *,
+              blank_for_parse: bool = False) -> tuple[str, list[str]]:
         """Apply the composed rewriter, returning (new_contents, errors).
-
-        The envelope's `expected_count`/`description` are handed to the
-        rewriter, which owns count validation (per-operation for composed
-        rewriters) and reports any failures as error strings.
         """
         return self.rewriter.apply(contents,
                                    count=self.expected_count,
-                                   description=self.description)
+                                   description=self.description,
+                                   blank_for_parse=blank_for_parse)
 
     class _NoDupSafeLoader(yaml.SafeLoader):
         """`yaml.SafeLoader` that rejects duplicate mapping keys.
@@ -491,16 +533,27 @@ class Substitution:
         }
 
     @staticmethod
-    def from_yaml(contents: str) -> list[Substitution]:
-        """Parse all substitutions from the contents of a YAML plaster file.
+    def from_yaml(contents: str) -> PlasterSpec:
+        """Parse a YAML plaster file into a `PlasterSpec`.
 
-        YAML plasters use a top-level `substitutions:` list.
+        YAML plasters use a top-level `substitutions:` list, plus file-level
+        values.
         """
         data = yaml.load(contents, Loader=Substitution._NoDupSafeLoader)
         if data is None:
             data = {}
         if not isinstance(data, dict):
             raise ValueError('Plaster YAML must be a mapping at the top level')
+        unknown = sorted(set(data) - _TOP_LEVEL_KEYS)
+        if unknown:
+            raise ValueError('Unrecognised top-level plaster key(s): ' +
+                             ', '.join(repr(k)
+                                       for k in unknown) + '; allowed: ' +
+                             ', '.join(sorted(_TOP_LEVEL_KEYS)))
+        blank_for_parse = data.get('blank_macros_for_ast_parsing', False)
+        if not isinstance(blank_for_parse, bool):
+            raise ValueError(
+                '`blank_macros_for_ast_parsing` must be a boolean')
         raw = data.get('substitutions')
         if raw is None:
             raise ValueError(
@@ -511,7 +564,9 @@ class Substitution:
             raise ValueError(
                 'Plaster YAML `substitutions:` must contain at least one entry'
             )
-        return [Substitution._from_item(entry) for entry in raw]
+        return PlasterSpec(
+            substitutions=[Substitution._from_item(entry) for entry in raw],
+            blank_macros_for_ast_parsing=blank_for_parse)
 
     @staticmethod
     def _from_item(data: object) -> Substitution:
@@ -685,9 +740,14 @@ class Regex(Rewriter):
         self._replace = replace
         self._re_flags = re_flags
 
-    def apply(self, contents: str, *, count: int,
-              description: str) -> tuple[str, list[str]]:
+    def apply(self,
+              contents: str,
+              *,
+              count: int,
+              description: str,
+              blank_for_parse: bool = False) -> tuple[str, list[str]]:
         del description  # Only the count matters for the regex diagnostic.
+        del blank_for_parse  # Text substitution never parses; nothing to relax.
         # `count=0` here means "replace every match"; how many were expected is
         # validated afterwards against the entry's `count:`.
         content, matches = re.subn(self._re_pattern,
@@ -806,6 +866,14 @@ class _AstGrepRewriter(Rewriter):
         # subclasses hold their own parsed shape and leave this empty.
         self._inputs = inputs if inputs is not None else {}
 
+    def source_language(self) -> str:
+        """The `<lang>.` prefix for the op (e.g. `cxx` for `cxx.make_virtual`).
+
+        AST rewriters parse the target in this language, so they are only valid
+        on sources of it.
+        """
+        return self.OP_ID.split('.', 1)[0]
+
     def operations(self, count: int) -> list[Operation]:
         """The ordered ast-grep operations this rewriter expands to.
 
@@ -819,9 +887,15 @@ class _AstGrepRewriter(Rewriter):
                       MatchExpectation.from_count(count))
         ]
 
-    def apply(self, contents: str, *, count: int,
-              description: str) -> tuple[str, list[str]]:
-        engine = AstRewriter(RewritersEval.load(), contents)
+    def apply(self,
+              contents: str,
+              *,
+              count: int,
+              description: str,
+              blank_for_parse: bool = False) -> tuple[str, list[str]]:
+        engine = AstRewriter(RewritersEval.load(),
+                             contents,
+                             blank_for_parse=blank_for_parse)
         outcomes = [(op, engine.run(op)) for op in self.operations(count)]
         return engine.content, self.validate_outcomes(outcomes, description)
 
@@ -877,7 +951,9 @@ class MakeVirtual(_AstGrepRewriter):
     SUMMARY: Final = 'Prepend `virtual ` to a class method declaration.'
     # Authored in Markdown; `Help` renders it with rich.
     HELP: Final = r"""
-        Prepends `virtual ` to a C++ method declaration.
+        Adds `virtual ` to a C++ method declaration. A leading attribute like
+        `[[nodiscard]]` is kept first, so `virtual` lands after it
+        (`[[nodiscard]] virtual T Foo()`), as the grammar requires.
 
         Fields:
 
@@ -1114,18 +1190,30 @@ class PlasterFile:
 
         info = PatchinfoBuilder(self.path)
         if suffix == '.yaml':
-            substitutions = Substitution.from_yaml(info.plaster_contents)
+            doc = Substitution.from_yaml(info.plaster_contents)
+            is_cxx = _is_cxx_source(self.path)
+            if doc.blank_macros_for_ast_parsing and not is_cxx:
+                raise ValueError(
+                    '`blank_macros_for_ast_parsing` is only supported for C++ '
+                    f'sources (in {self.path})')
+            if not is_cxx:
+                for substitution in doc.substitutions:
+                    if substitution.rewriter.source_language() == 'cxx':
+                        raise ValueError(
+                            f'the `{substitution.rewriter.NAME}` rewriter is '
+                            f'only supported for C++ sources (in {self.path})')
         else:
             raise ValueError(f'Unsupported plaster file extension: {suffix}')
         contents = repository.chromium.read_file(info.source)
         errors = []
 
         try:
-            for substitution in substitutions:
+            for substitution in doc.substitutions:
                 # Each substitution owns its count validation (per-operation for
                 # composed rewriters) and reports any failures; we just attach
                 # the file being patched.
-                contents, sub_errors = substitution.apply(contents)
+                contents, sub_errors = substitution.apply(
+                    contents, blank_for_parse=doc.blank_macros_for_ast_parsing)
                 errors.extend(f'{error} in {self.path}'
                               for error in sub_errors)
 
@@ -1470,14 +1558,59 @@ class AstRewriter:
     operations to run.
     """
 
-    def __init__(self, rewriters: RewritersEval, content: str):
+    # Class-head export macro (e.g. `MODULES_EXPORT`, `COMPONENT_EXPORT(FOO)`):
+    # the keyword and its space, the macro, then the start of the real name.
+    # Used by `_prepare_cxx_for_parse`.
+    _EXPORT_MACRO_RE = re.compile(r'(\b(?:class|struct)\s+)'
+                                  r'([A-Z][A-Z0-9_]*_EXPORT(?:\s*\([^()]*\))?)'
+                                  r'(\s+[A-Za-z_])')
+
+    # A preprocessor conditional directive line (`#if`, `#ifdef` ...), matched
+    # without its trailing newline. Used by `_prepare_cxx_for_parse`.
+    _CXX_CONDITIONAL_RE = re.compile(
+        r'(?m)^[ \t]*#[ \t]*(?:if|ifdef|ifndef|elif|else|endif)\b.*$')
+
+    def __init__(self,
+                 rewriters: RewritersEval,
+                 content: str,
+                 *,
+                 blank_for_parse: bool = False):
         self._rewriters = rewriters
-        self._content = content
+        self._source = content
+        # When set, blank constructs tree-sitter cannot parse before matching
+        # (see `_prepare_cxx_for_parse`). Off by default. Opt-in per file.
+        self._blank_for_parse = blank_for_parse
 
     @property
     def content(self) -> str:
         """The current file contents, reflecting every applied rewrite."""
-        return self._content
+        return self._source
+
+    def _prepare_cxx_for_parse(self) -> str:
+        """Normalise C++ source for tree-sitter parsing
+
+        Two constructs are handled:
+
+        - A class-head export macro (`class MODULES_EXPORT Foo`): tree-sitter
+          has no macro definitions, so it reads the macro as the class name and
+          drops the real name, any `final`, and the body into an error node.
+          Blanking the macro leaves a plain `class Foo ...`.
+        - A preprocessor conditional (`#if`/`#endif`/...), most damaging inside
+          a base-specifier list (`#if defined(USE_AURA)`), which has no grammar
+          node and breaks the class head. Blanking the directive lines, keeping
+          the guarded code, makes the head parse.
+
+        Both substitutions only replace characters in place, so every byte
+        offset is preserved. Blanking every conditional file-wide is safe
+        because the caller opts in per file via `blank_macros_for_ast_parsing`,
+        and a directive guarding an alternative definition would leave two
+        matches that the count check flags.
+        """
+        source = self._EXPORT_MACRO_RE.sub(
+            lambda m: m.group(1) + ' ' * len(m.group(2)) + m.group(3),
+            self._source)
+        return self._CXX_CONDITIONAL_RE.sub(
+            lambda line: ' ' * len(line.group(0)), source)
 
     def run(self, op: Operation) -> int:
         """Run one bound `Operation`, mutate content, return the change count.
@@ -1500,9 +1633,14 @@ class AstRewriter:
         language = self._rewriters.language_of(op.op_id)
         rule_body = matcher['template'].format(**op.inputs)
 
+        # `_prepare_cxx_for_parse` blanks C++-specific constructs, so it only
+        # applies to `cxx.` ops.
+        blank = self._blank_for_parse and op.op_id.startswith('cxx.')
+        source_for_parse = (self._prepare_cxx_for_parse()
+                            if blank else self._source)
         matches = run_ast_grep(language=language,
                                rule_body=rule_body,
-                               source=self._content)
+                               source=source_for_parse)
         if rewriter.get('first_match'):
             matches = matches[:1]
 
@@ -1512,7 +1650,7 @@ class AstRewriter:
         before = replace.get('consume_before', '').encode('utf-8')
         after = replace.get('consume_after', '').encode('utf-8')
 
-        source = self._content.encode('utf-8')
+        source = self._source.encode('utf-8')
         edits = []
         total = 0
         for match in matches:
@@ -1533,7 +1671,7 @@ class AstRewriter:
         # Apply from the end so each splice leaves earlier offsets unchanged.
         for start, end, new_text in sorted(edits, reverse=True):
             source = source[:start] + new_text.encode('utf-8') + source[end:]
-        self._content = source.decode('utf-8')
+        self._source = source.decode('utf-8')
         return total
 
 

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1508,6 +1508,181 @@ class RewriterFormsTest(unittest.TestCase):
             '  - description: missing arg\n'
             '    drop_final: {}\n', 'drop_final requires arg')
 
+    # -- export-macro classes (real ast-grep binary) ----------------------
+    #
+    # tree-sitter cannot parse `class MACRO_EXPORT Name`, so the engine blanks
+    # the macro before matching. These confirm the AST rewriters reach a class
+    # declared with an export macro while leaving the macro itself in place.
+
+    def test_drop_final_on_export_macro_class(self):
+        result = self._apply(
+            'exp_final.h',
+            'class MODULES_EXPORT C final : public Base {\n};\n',
+            'blank_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: drop final on an exported class\n'
+            '    drop_final:\n'
+            '      class_name: C\n')
+        self.assertEqual(result,
+                         'class MODULES_EXPORT C : public Base {\n};\n')
+
+    def test_make_virtual_on_export_macro_class(self):
+        result = self._apply(
+            'exp_virt.h', 'class MODULES_EXPORT C {\n  void Foo();\n};\n',
+            'blank_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: make Foo virtual on an exported class\n'
+            '    make_virtual:\n'
+            '      class_name: C\n'
+            '      method_name: Foo\n')
+        self.assertEqual(
+            result, 'class MODULES_EXPORT C {\n  virtual void Foo();\n};\n')
+
+    def test_add_friend_on_parenthesised_export_macro_class(self):
+        # The parenthesised `COMPONENT_EXPORT(FOO)` form is blanked too.
+        result = self._apply(
+            'exp_friend.h',
+            'class COMPONENT_EXPORT(FOO) C {\n private:\n  int x_;\n};\n',
+            'blank_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: friend an exported class\n'
+            '    add_friend:\n'
+            '      class_name: C\n'
+            '      friend_type: class BraveC\n')
+        self.assertEqual(
+            result, 'class COMPONENT_EXPORT(FOO) C {\n'
+            ' private:\n  friend class BraveC;\n  int x_;\n};\n')
+
+    # -- classes with base-list preprocessor conditionals -----------------
+    #
+    # A `#if` in the base-specifier list stops tree-sitter from resolving the
+    # class; the engine blanks it before matching. These confirm the AST
+    # rewriters reach such a class while the conditional survives in the output.
+
+    _AURA_CLASS = ('class C : public A\n'
+                   '#if defined(USE_AURA)\n'
+                   '    ,\n'
+                   '         public D\n'
+                   '#endif  // defined(USE_AURA)\n'
+                   '{\n'
+                   ' public:\n'
+                   '  void Foo();\n'
+                   ' private:\n'
+                   '  int x_;\n'
+                   '};\n')
+
+    def test_make_virtual_through_base_list_conditional(self):
+        result = self._apply(
+            'aura_virt.h', self._AURA_CLASS,
+            'blank_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: make Foo virtual despite the aura base\n'
+            '    make_virtual:\n'
+            '      class_name: C\n'
+            '      method_name: Foo\n')
+        self.assertEqual(
+            result,
+            self._AURA_CLASS.replace('  void Foo();', '  virtual void Foo();'))
+
+    def test_add_friend_through_base_list_conditional(self):
+        result = self._apply(
+            'aura_friend.h', self._AURA_CLASS,
+            'blank_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: friend despite the aura base\n'
+            '    add_friend:\n'
+            '      class_name: C\n'
+            '      friend_type: class BraveC\n')
+        self.assertEqual(
+            result,
+            self._AURA_CLASS.replace(' private:\n',
+                                     ' private:\n  friend class BraveC;\n'))
+
+    def test_blanking_is_off_by_default(self):
+        # Without `blank_macros_for_ast_parsing`, the export-macro class is
+        # unparseable, so the rewriter matches nothing and the apply fails.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'no_blank.h', 'class MODULES_EXPORT C final {\n};\n',
+                'substitutions:\n'
+                '  - description: no blanking, so final is invisible\n'
+                '    drop_final:\n'
+                '      class_name: C\n')
+
+    def test_blank_flag_false_does_not_blank(self):
+        # Explicit `false` behaves like the default: still unparseable.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'blank_false.h', 'class MODULES_EXPORT C final {\n};\n',
+                'blank_macros_for_ast_parsing: false\n'
+                'substitutions:\n'
+                '  - description: blanking explicitly off\n'
+                '    drop_final:\n'
+                '      class_name: C\n')
+
+    def test_blank_flag_must_be_boolean(self):
+        self._expect_value_error(
+            'blank_macros_for_ast_parsing: yes please\n'
+            'substitutions:\n'
+            '  - description: bad flag type\n'
+            '    drop_final:\n'
+            '      class_name: C\n',
+            '`blank_macros_for_ast_parsing` must be a boolean')
+
+    def test_unknown_top_level_key_rejected(self):
+        self._expect_value_error(
+            'blank_macros: true\n'
+            'substitutions:\n'
+            '  - description: typo in the top-level flag\n'
+            '    drop_final:\n'
+            '      class_name: C\n', 'Unrecognised top-level plaster key')
+
+    def test_blank_flag_rejected_for_non_cxx_source(self):
+        # `_expect_value_error` targets a `.idl` source; the flag only applies
+        # to C++ files, so it is rejected there.
+        self._expect_value_error(
+            'blank_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: flag on a non-C++ source\n'
+            '    regex:\n'
+            "      re_pattern: 'x'\n"
+            "      replace: 'y'\n",
+            '`blank_macros_for_ast_parsing` is only supported for C++ sources')
+
+    def test_blank_flag_allowed_for_cxx_source(self):
+        # The same flag is accepted for a `.h` source (here with no AST work to
+        # do, so it just applies the regex).
+        result = self._apply(
+            'cxx_flag.h', 'A Chromium thing.\n',
+            'blank_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: flag on a C++ source\n'
+            '    regex:\n'
+            "      re_pattern: 'Chromium'\n"
+            "      replace: 'Brave'\n")
+        self.assertEqual(result, 'A Brave thing.\n')
+
+    def test_ast_rewriter_rejected_for_non_cxx_source(self):
+        # AST rewriters (cxx.* ops) only work on C++ sources; the `.idl` target
+        # of `_expect_value_error` is not one.
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: AST rewriter on a non-C++ source\n'
+            '    make_virtual:\n'
+            '      class_name: C\n'
+            '      method_name: Foo\n',
+            'the `make_virtual` rewriter is only supported for C++ sources')
+
+    def test_regex_rewriter_allowed_for_non_cxx_source(self):
+        # Text rewriters are language-agnostic, so they work on any source.
+        result = self._apply(
+            'plain.idl', 'A Chromium thing.\n', 'substitutions:\n'
+            '  - description: regex on a non-C++ source\n'
+            '    regex:\n'
+            "      re_pattern: 'Chromium'\n"
+            "      replace: 'Brave'\n")
+        self.assertEqual(result, 'A Brave thing.\n')
+
     # -- validation ---------------------------------------------------------
 
     def test_two_op_keys_rejected(self):
@@ -1992,6 +2167,94 @@ _SYNTHETIC_SPEC = {
         },
     },
 }
+
+
+class PrepareForParseTest(unittest.TestCase):
+    """Unit tests for AstRewriter._prepare_cxx_for_parse (no ast-grep binary)."""
+
+    def _prepared(self, source: str) -> str:
+        """Return the parse-prepared source, asserting length is preserved.
+
+        `_prepare_cxx_for_parse` only reads the held source and the class regexes,
+        so the rewriters registry is irrelevant and left as None here.
+        """
+        result = plaster.AstRewriter(None, source)._prepare_cxx_for_parse()
+        # The whole point is that offsets are preserved for byte-for-byte
+        # remapping onto the untouched source.
+        self.assertEqual(len(result.encode('utf-8')),
+                         len(source.encode('utf-8')))
+        return result
+
+    def _assert_blanks(self, source: str, macro: str):
+        """Assert `macro` is replaced by equal-length spaces, nothing else."""
+        self.assertEqual(self._prepared(source),
+                         source.replace(macro, ' ' * len(macro), 1))
+
+    # -- export macros ----------------------------------------------------
+
+    def test_blanks_simple_export_macro(self):
+        self._assert_blanks('class MODULES_EXPORT Foo final {};',
+                            'MODULES_EXPORT')
+
+    def test_blanks_parenthesised_export_macro(self):
+        self._assert_blanks('class COMPONENT_EXPORT(BASE) Foo {};',
+                            'COMPONENT_EXPORT(BASE)')
+
+    def test_blanks_struct_and_multiline_head(self):
+        self._assert_blanks('struct NET_EXPORT\n    Foo {};', 'NET_EXPORT')
+
+    def test_leaves_plain_class_untouched(self):
+        for src in ('class Foo final {};', 'class Foo : public Base {};',
+                    'class FooBar {};'):
+            self.assertEqual(self._prepared(src), src)
+
+    def test_leaves_all_caps_class_name_untouched(self):
+        # An all-caps name without an `_EXPORT` suffix is not a macro.
+        self.assertEqual(self._prepared('class URL final {};'),
+                         'class URL final {};')
+
+    def test_only_touches_class_head_macro(self):
+        # An `_EXPORT`-suffixed token elsewhere (a member, a value) is left be.
+        result = self._prepared(
+            'class MODULES_EXPORT Foo {\n  int MY_EXPORT = 1;\n};')
+        self.assertIn('int MY_EXPORT = 1;', result)
+        self.assertNotIn('MODULES_EXPORT', result)
+
+    # -- preprocessor conditionals ----------------------------------------
+
+    def test_blanks_conditionals_anywhere(self):
+        # Directives are blanked wherever they sit -- base list or class body --
+        # while the code they guarded stays put.
+        result = self._prepared('class C : public A\n'
+                                '#if defined(USE_AURA)\n'
+                                '    ,\n'
+                                '         public D\n'
+                                '#endif  // defined(USE_AURA)\n'
+                                '{\n'
+                                ' public:\n'
+                                '#ifdef FOO\n'
+                                '  void OnFoo();\n'
+                                '#else\n'
+                                '  void OnBar();\n'
+                                '#endif\n'
+                                '};\n')
+        for directive in ('#if', '#ifdef', '#else', '#endif'):
+            self.assertNotIn(directive, result)
+        # Guarded code survives.
+        for kept in ('public D', 'void OnFoo();', 'void OnBar();'):
+            self.assertIn(kept, result)
+
+    def test_blanks_every_directive_kind(self):
+        for directive in ('#if X', '#ifdef X', '#ifndef X', '#elif X', '#else',
+                          '#endif'):
+            self.assertEqual(self._prepared(f'a\n{directive}\nb\n'),
+                             f'a\n{" " * len(directive)}\nb\n')
+
+    def test_leaves_non_conditional_directives_untouched(self):
+        # `#include` / `#define` are not conditionals and must be preserved.
+        for src in ('#include <memory>\n', '#define FOO 1\n',
+                    '#pragma once\n'):
+            self.assertEqual(self._prepared(src), src)
 
 
 class RunAstGrepTest(unittest.TestCase):


### PR DESCRIPTION
This PR introduces a file-wide option, `blank_macros_for_ast_parsing`,
that permits plaster to blank all macros in a C++ source before
providing it to `ast-grep`. This permits us to manage parsing certain
C++ sources that `ast-grep` was choking at. The flag is being provided
because we do not want this behaviour by default.

This feature will blank common C++ macros (e.g. `#if`, `#endif`, etc),
but it also target the `FOO_EXPORT` macros in class declarations that
have the potential to interfere with parsing.

Fixed https://github.com/brave/brave-browser/issues/57283
