### PR TITLE
[plaster][ast-grep] More AST-based migrations

### DIFF
--- a/patches/third_party-blink-renderer-modules-websockets-websocket_channel_impl.h.patch
+++ b/patches/third_party-blink-renderer-modules-websockets-websocket_channel_impl.h.patch
@@ -1,5 +1,5 @@
 diff --git a/third_party/blink/renderer/modules/websockets/websocket_channel_impl.h b/third_party/blink/renderer/modules/websockets/websocket_channel_impl.h
-index 3886a8337be2bd21df18680fa344185d0fc1df43..14d612fd9b53937a5b7f1d3be7090c8d679d3a50 100644
+index 3886a8337be2bd21df18680fa344185d0fc1df43..79248619a9607df622fc2b17ae654b9cd92d9628 100644
 --- a/third_party/blink/renderer/modules/websockets/websocket_channel_impl.h
 +++ b/third_party/blink/renderer/modules/websockets/websocket_channel_impl.h
 @@ -82,7 +82,7 @@ class WebSocketHandshakeThrottle;
@@ -11,11 +11,12 @@ index 3886a8337be2bd21df18680fa344185d0fc1df43..14d612fd9b53937a5b7f1d3be7090c8d
      : public WebSocketChannel,
        public network::mojom::blink::WebSocketHandshakeClient,
        public network::mojom::blink::WebSocketClient {
-@@ -379,6 +379,7 @@ class MODULES_EXPORT WebSocketChannelImpl final
+@@ -379,7 +379,7 @@ class MODULES_EXPORT WebSocketChannelImpl final
    void OnConnectionError(const base::Location& set_from,
                           uint32_t custom_reason,
                           const std::string& description);
-+  virtual /* Explicit via patch, because Dispose() used everywhere in Blink. */
-   void Dispose();
+-  void Dispose();
++  virtual void Dispose();
  
    const Member<WebSocketChannelClient> client_;
+   KURL url_;

--- a/rewrite/chrome/browser/ui/omnibox/chrome_omnibox_client.h.yaml
+++ b/rewrite/chrome/browser/ui/omnibox/chrome_omnibox_client.h.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: 'Remove final from ChromeOmniboxClient to allow subclassing'
+    drop_final:
+      class_name: ChromeOmniboxClient

--- a/rewrite/chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.h.yaml
+++ b/rewrite/chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.h.yaml
@@ -9,9 +9,8 @@ substitutions:
 
       Brave derives BraveHorizontalTabStripRegionView from this view, so the
       upstream `final` specifier has to be dropped.
-    regex:
-      pattern: 'class HorizontalTabStripRegionView final'
-      replace: 'class HorizontalTabStripRegionView'
+    drop_final:
+      class_name: HorizontalTabStripRegionView
 
   - description: |
       Expose new_tab_button() to Brave

--- a/rewrite/chrome/browser/ui/views/side_panel/side_panel_coordinator.h.yaml
+++ b/rewrite/chrome/browser/ui/views/side_panel/side_panel_coordinator.h.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: 'Remove final from SidePanelCoordinator to allow subclassing'
+    drop_final:
+      class_name: SidePanelCoordinator

--- a/rewrite/chrome/browser/ui/views/tabs/dragging/dragging_tabs_session.h.yaml
+++ b/rewrite/chrome/browser/ui/views/tabs/dragging/dragging_tabs_session.h.yaml
@@ -6,9 +6,8 @@
 substitutions:
   - description:
       'Remove final keyword from DraggingTabsSession to allow subclassing'
-    regex:
-      pattern: 'class DraggingTabsSession final {'
-      replace: 'class DraggingTabsSession {'
+    drop_final:
+      class_name: DraggingTabsSession
 
   - description:
       'Make the DraggingTabsSession destructor virtual to allow subclassing'

--- a/rewrite/chrome/browser/ui/views/tabs/dragging/tab_drag_controller.h.yaml
+++ b/rewrite/chrome/browser/ui/views/tabs/dragging/tab_drag_controller.h.yaml
@@ -3,30 +3,28 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# NOTE: The `make_virtual` and `add_friend` AST rewriters cannot be used on this
-# file because the `#if defined(USE_AURA)` conditional in the `TabDragController`
-# base-class list prevents the C++ parser from resolving the class. These
-# substitutions prepend `virtual` and add the friend declaration with plain regex
-# matches instead.
+# The `#if defined(USE_AURA)` conditional in the `TabDragController` base-class
+# list stops tree-sitter from resolving the class, so the AST rewriters below
+# need the base-list conditional blanked out at parse time.
+blank_macros_for_ast_parsing: true
+
 substitutions:
-  - description: 'Add virtual keyword to Init()'
-    regex:
-      pattern: '[[nodiscard]] Liveness Init('
-      replace: '[[nodiscard]] virtual Liveness Init('
+  - description: 'Make Init() virtual'
+    make_virtual:
+      class_name: TabDragController
+      method_name: Init
 
   - description: 'Make DetachAndAttachToNewContext virtual'
-    regex:
-      pattern: 'void DetachAndAttachToNewContext('
-      replace: 'virtual void DetachAndAttachToNewContext('
+    make_virtual:
+      class_name: TabDragController
+      method_name: DetachAndAttachToNewContext
 
   - description: 'Make StartDraggingTabsSession virtual'
-    regex:
-      pattern: 'void StartDraggingTabsSession('
-      replace: 'virtual void StartDraggingTabsSession('
+    make_virtual:
+      class_name: TabDragController
+      method_name: StartDraggingTabsSession
 
   - description: 'Friend BraveTabDragController'
-    regex:
-      re_pattern: '( private:)'
-      replace: |-
-        \1
-          friend class BraveTabDragController;
+    add_friend:
+      class_name: TabDragController
+      friend_type: class BraveTabDragController

--- a/rewrite/chrome/browser/ui/views/toolbar/app_menu.h.yaml
+++ b/rewrite/chrome/browser/ui/views/toolbar/app_menu.h.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: 'Remove final from AppMenu to allow subclassing'
+    drop_final:
+      class_name: AppMenu

--- a/rewrite/third_party/blink/renderer/modules/websockets/websocket_channel_impl.h.yaml
+++ b/rewrite/third_party/blink/renderer/modules/websockets/websocket_channel_impl.h.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# `class MODULES_EXPORT WebSocketChannelImpl` cannot be parsed by tree-sitter
+# with the export macro in place, so blank it out for AST matching.
+blank_macros_for_ast_parsing: true
+
+substitutions:
+  - description: 'Remove final from WebSocketChannelImpl to allow subclassing'
+    drop_final:
+      class_name: WebSocketChannelImpl
+
+  - description:
+      'Make Dispose() virtual, because Dispose() is used everywhere in Blink'
+    make_virtual:
+      class_name: WebSocketChannelImpl
+      method_name: Dispose


### PR DESCRIPTION
This change introduces more transformations using the AST-based
rewriters. Some of these were just pending transitions, while others are
only now possible with the introduction of
`blank_macros_for_ast_parsing`.

Bug: https://github.com/brave/brave-browser/issues/57283
