### PR TITLE
PWA traffic lights in compact mode - Centering issue

### DIFF
--- a/browser/ui/views/frame/brave_browser_native_widget_mac.mm
+++ b/browser/ui/views/frame/brave_browser_native_widget_mac.mm
@@ -52,7 +52,7 @@ void BraveBrowserNativeWidgetMac::GetWindowFrameTitlebarHeight(
   if (*override_titlebar_height && !browser_view_->ShouldDrawTabStrip()) {
     if (tabs::UseCompactHorizontalTabs()) {
       // Upstream always adds kWebAppMenuMargin * 2 (14px) to the titlebar
-      // height. In Compact mode use a tighter 10px of vertical padding
+      // height. In Compact mode use a tighter 5px of vertical padding
       // instead.
       constexpr int kCompactWebAppTitlebarPadding = 5;
       *titlebar_height -=

--- a/browser/ui/views/frame/brave_browser_native_widget_mac.mm
+++ b/browser/ui/views/frame/brave_browser_native_widget_mac.mm
@@ -51,9 +51,12 @@ void BraveBrowserNativeWidgetMac::GetWindowFrameTitlebarHeight(
 
   if (*override_titlebar_height && !browser_view_->ShouldDrawTabStrip()) {
     if (tabs::UseCompactHorizontalTabs()) {
-      // Upstream always adds kWebAppMenuMargin * 2 to the titlebar height, but
-      // we don't want that for Brave in case Compact mode is on.
-      *titlebar_height -= kWebAppMenuMargin * 2;
+      // Upstream always adds kWebAppMenuMargin * 2 (14px) to the titlebar
+      // height. In Compact mode use a tighter 10px of vertical padding
+      // instead.
+      constexpr int kCompactWebAppTitlebarPadding = 5;
+      *titlebar_height -=
+          (kWebAppMenuMargin * 2) - kCompactWebAppTitlebarPadding;
     }
   }
 }


### PR DESCRIPTION
- Resolves https://github.com/brave/brave-browser/issues/57261

## Solution

In compact mode, desktop PWAs on macOS were removing Chromium's full `kWebAppMenuMargin * 2` (14px) titlebar padding, which left the traffic lights poorly centered against the shorter toolbar.

Instead of stripping that padding entirely, keep a tighter **5px** of vertical padding so AppKit centers the traffic lights correctly in the compact PWA titlebar.

## Test plan

- [ ] On macOS, enable Compact mode (Appearance / Tabs settings)
- [ ] Install or open a desktop PWA window
- [ ] Confirm traffic lights are vertically centered against the compact PWA toolbar (not too high / not clipped)
- [ ] Toggle Compact mode off and confirm regular-mode PWA traffic lights still look correct (full Chromium 14px padding)
- [ ] With Compact mode on, confirm a normal browser window (with tab strip) traffic lights are unchanged / still centered
- [ ] With Compact mode off, confirm a normal browser window traffic lights are unchanged
- [ ] Resize the PWA window and confirm traffic light alignment stays correct

## Traffic lights in compact mode browser
<img width="1362" height="943" alt="image" src="https://github.com/user-attachments/assets/f47c4a28-2671-4f8f-b532-1efc2c03c20d" />


## Traffic lights in compact mode PWA
<img width="1281" height="949" alt="image" src="https://github.com/user-attachments/assets/164d19e3-f7ca-4ed0-b0c6-a3ac4b084b0e" />



## Traffic lights in regular mode browser
<img width="1362" height="943" alt="image" src="https://github.com/user-attachments/assets/0ecf8619-6952-4f20-9bb5-c65780a0dc40" />

## Traffic lights in regular mode PWA
<img width="1281" height="949" alt="image" src="https://github.com/user-attachments/assets/cfa9a8e8-ded5-47f1-ae86-5c4d21f8525f" />



<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->