### PR TITLE
[cr151][Android] Fix Sync settings screen squeezed in multi-column mode after rotation on tablets

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
@@ -185,6 +185,13 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
      * device list so the dynamically-added rows are re-measured against the correct width. This
      * runs from a posted runnable (not from within a layout pass) so the forced re-layout is
      * honored.
+     *
+     * <p>Since cr151 the Multi-column Settings feature (default-on) hosts this fragment in a narrow
+     * detail pane rather than full screen. In that mode the screenWidthDp-based centering padding
+     * is wrong (it is computed for the whole screen, not the pane) and would collapse the content,
+     * so we skip it and let the pane constrain the width - mirroring upstream WideDisplayPadding,
+     * which does not attach a ViewResizer when {@link
+     * SettingsActivity#isTwoColumnSettingsVisible()}.
      */
     private void correctWideDisplayLayoutAfterRotation() {
         // Post twice so this runs after the framework's rotation layout pass and the ViewResizer
@@ -210,7 +217,14 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
         }
         int screenWidthDp = getResources().getConfiguration().screenWidthDp;
         int padding = 0;
-        if (screenWidthDp >= UiConfig.WIDE_DISPLAY_STYLE_MIN_WIDTH_DP) {
+        // In Multi-column Settings mode this fragment lives in a narrow detail pane, which already
+        // constrains the width. Applying the full-screen centering padding here would squeeze the
+        // content, so only compute it in single-column (full-width) mode. The host is always a
+        // SettingsActivity (getActivity() null case is handled by the early return above).
+        FragmentActivity activity = requireActivity();
+        assert activity instanceof SettingsActivity;
+        boolean twoColumn = ((SettingsActivity) activity).isTwoColumnSettingsVisible();
+        if (!twoColumn && screenWidthDp >= UiConfig.WIDE_DISPLAY_STYLE_MIN_WIDTH_DP) {
             int minWidePadding =
                     getResources().getDimensionPixelSize(R.dimen.settings_wide_display_min_padding);
             int excessWidthDp = screenWidthDp - UiConfig.WIDE_DISPLAY_STYLE_MIN_WIDTH_DP;


### PR DESCRIPTION
On tablets, the Sync settings screen collapsed into a narrow column after a device rotation once Multi-column Settings was enabled by default (`cr151`).

Root cause: our earlier rotation fix (#37776) re-applies a centering padding computed from the full-screen width on every onConfigurationChanged. In multi-column mode the Sync fragment is hosted in a narrow detail pane, so full-screen padding over-pads it and squeezes the content.

Fix: skip the full-screen centering padding when `SettingsActivity.isTwoColumnSettingsVisible()` is true, letting the detail pane constrain the width itself - mirroring upstream `WideDisplayPadding`, which doesn't attach a `ViewResizer` in two-column mode.

Verified: tablet Sync landing + QR/enter-code screens (fixed), phone Sync (unchanged), VPN server region (no regression).

Resolves https://github.com/brave/brave-browser/issues/57279

<!-- Add brave-browser issue below that this PR will resolve -->


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
