### PR TITLE
[toolchain] Flattening cherry-picks code

### DIFF
--- a/tools/cr/toolchains/build_rust_toolchain.py
+++ b/tools/cr/toolchains/build_rust_toolchain.py
@@ -118,6 +118,8 @@ import yaml
 # This is necessary because these scripts are used by brockit too.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from cherry_picks import (  # pylint: disable=wrong-import-position
+    _check_call, cherry_picks)
 from upload import sha256_file  # pylint: disable=wrong-import-position
 
 # Executable suffix for host tools on the current platform.
@@ -217,7 +219,7 @@ VPYTHON_PATH = Path('third_party/depot_tools') / (
 CHROME_VERSION_FILE = Path('chrome/VERSION')
 
 # Upstream cherry-picks applied onto the checkout for the build's duration (see
-# `_cherry_picks`). Each is skipped automatically if the active Chromium ref
+# `cherry_picks`). Each is skipped automatically if the active Chromium ref
 # already contains it, so commits can stay listed here across version bumps
 # until they age out of the picks we still need.
 #
@@ -233,21 +235,6 @@ CLANG_CHERRY_PICK_COMMITS = [
     'a710d2e1475f4c224290ce22f1a21c42d5fad900',
     '0210b44659fd7251672077e9ab83b5324db0c08e',
 ]
-
-# Fixed git author/committer metadata applied when we cherry-pick onto the
-# checkout. A commit's hash includes this metadata, and `rustc` encodes the
-# Chromium `HEAD` it was built from, so pinning it (together with `--no-gpg-sign`
-# on the cherry-pick) keeps the resulting HEAD — and the toolchain hash —
-# identical regardless of the local git config. Mirrors the override upstream's
-# `tools/clang/scripts/build.py` uses for its own cherry-picks.
-GIT_METADATA_OVERRIDES = {
-    'GIT_AUTHOR_NAME': 'Dummy Author',
-    'GIT_AUTHOR_EMAIL': 'none@none.com',
-    'GIT_AUTHOR_DATE': '2099-01-01 10:10:10',
-    'GIT_COMMITTER_NAME': 'Dummy Committer',
-    'GIT_COMMITTER_EMAIL': 'none@none.com',
-    'GIT_COMMITTER_DATE': '2099-01-01 10:10:10',
-}
 
 # The bucket in our infra where the rust toolchain is archived.
 TOOLCHAIN_BUCKET_URL = (
@@ -288,57 +275,6 @@ if sys.platform == 'win32':
     # Path to Git's sh.exe on Windows, which is used by
     # `tools/rust/build_rust.py` to build the toolchain on Windows.`
     GIT_SH_PRESUMED_BIN_PATH = Path(r'C:\Program Files\Git\bin\sh.exe')
-
-
-def _check_call(*command,
-                cwd=None,
-                env=None,
-                check=True,
-                capture_output=False):
-    """Run *command* as a subprocess, logging the invocation.
-
-    Logs the full command string at INFO level before executing it.  Stdout
-    and stderr are inherited from the parent process (so subprocess output
-    streams directly to the terminal) unless `capture_output` is set.
-
-    Args:
-        *command: The program and its arguments (passed as positional args,
-            not as a list).
-        cwd: Optional working directory for the subprocess.  Defaults to the
-            caller's current working directory when `None`.
-        env: Optional environment mapping for the subprocess.  Inherits the
-            parent process environment when `None`.
-        check: Raise `CalledProcessError` on a non-zero exit when True.
-        capture_output: Capture stdout/stderr (as text) instead of inheriting
-            the parent's streams.
-
-    Returns:
-        The `subprocess.CompletedProcess` for the invocation.
-
-    Raises:
-        subprocess.CalledProcessError: If `check` is True and the process exits
-            with a non-zero return code.
-        RuntimeError: On Windows, if the command cannot be resolved to an
-        executable path.
-    """
-    logging.info(' >>>> %s', ' '.join(str(a) for a in command))
-
-    if platform.system() == 'Windows':
-        # On Windows, resolve the command to an absolute path to avoid issues
-        # with bat files not matching the command name (e.g. `gclient` vs
-        # `gclient.bat`). This avoids the use of `shell=True`.
-        resolved = shutil.which(command[0])
-        if resolved is None:
-            raise RuntimeError(f'Command not found: {command[0]}')
-        if resolved != command[0]:
-            command = [resolved] + list(command[1:])
-
-    return subprocess.run(command,
-                          cwd=cwd,
-                          env=env,
-                          check=check,
-                          capture_output=capture_output,
-                          text=True)
 
 
 def _latest_index_object(index_url: str,
@@ -1231,96 +1167,6 @@ class ToolchainBuilder:
 
         return True
 
-    def _run_git(self,
-                 *args,
-                 check: bool = True,
-                 capture_output: bool = False,
-                 env: dict | None = None) -> subprocess.CompletedProcess:
-        """Run `git -C <chromium_src> <args...>` via `_check_call`.
-
-        Thin wrapper that prepends the `git -C <checkout>` prefix so git
-        operations on the Chromium source tree share one code path. See
-        `_check_call` for the argument semantics and return value.
-        """
-        return _check_call('git',
-                           '-C',
-                           str(self._chromium_src),
-                           *args,
-                           check=check,
-                           capture_output=capture_output,
-                           env=env)
-
-    @contextlib.contextmanager
-    def _cherry_picks(self, commits: list[str]):
-        """Context manager: apply upstream cherry-picks for the build's
-        duration.
-
-        Ensures every commit in *commits* is in the checkout's history while the
-        build runs, then restores the original HEAD afterwards. Used to pull in
-        upstream fixes the active Chromium ref may predate — see
-        `CLANG_CHERRY_PICK_COMMITS`, which includes the commit that pins the git
-        author/committer metadata `tools/clang/scripts/build.py` stamps onto its
-        LLVM cherry-picks so the toolchain hash is reproducible across the
-        full-toolchain and wasm32 builds.
-
-        Protocol:
-        1. For each commit, fetch it if its object is missing (the ref may have
-           branched before it landed), then skip it if it is already reachable
-           from HEAD.
-        2. If nothing needs applying, `yield` immediately and leave the checkout
-           untouched — there is nothing to clean up.
-        3. Otherwise cherry-pick the remaining commits — with
-           `GIT_METADATA_OVERRIDES` and `--no-gpg-sign` so the resulting HEAD is
-           deterministic — `yield`, and unconditionally restore the checkout to
-           its original HEAD in a `finally` block. Build outputs are untracked,
-           so the reset leaves them in place.
-        """
-        to_apply = []
-        for commit in commits:
-            object_present = self._run_git('cat-file',
-                                           '-e',
-                                           f'{commit}^{{commit}}',
-                                           check=False,
-                                           capture_output=True).returncode == 0
-            if not object_present:
-                logging.info('Fetching cherry-pick %s.', commit)
-                self._run_git('fetch', 'origin', commit)
-
-            already_applied = self._run_git(
-                'merge-base',
-                '--is-ancestor',
-                commit,
-                'HEAD',
-                check=False,
-                capture_output=True).returncode == 0
-            if already_applied:
-                logging.info('Cherry-pick %s already present; skipping.',
-                             commit)
-            else:
-                to_apply.append(commit)
-
-        if not to_apply:
-            yield
-            return
-
-        original_head = self._run_git('rev-parse', 'HEAD',
-                                      capture_output=True).stdout.strip()
-        logging.info('Cherry-picking %s.', ', '.join(to_apply))
-        self._run_git('cherry-pick',
-                      '--keep-redundant-commits',
-                      '--no-gpg-sign',
-                      *to_apply,
-                      env={
-                          **os.environ,
-                          **GIT_METADATA_OVERRIDES
-                      })
-        try:
-            yield
-        finally:
-            logging.info('Restoring checkout to %s after cherry-picks.',
-                         original_head)
-            self._run_git('reset', '--hard', original_head)
-
     def run(self,
             clear: bool = False,
             force_overwrite: bool = False,
@@ -1330,7 +1176,7 @@ class ToolchainBuilder:
 
         Coordinates the phases in order:
 
-        1. Within `_cherry_picks` (which applies `CLANG_CHERRY_PICK_COMMITS`
+        1. Within `cherry_picks` (which applies `CLANG_CHERRY_PICK_COMMITS`
            so both builds cherry-pick to identical hashes):
            a. `_package_full_rust` (only when `full_toolchain`) — build and
               package the complete Rust toolchain via `package_rust.py`.
@@ -1442,7 +1288,7 @@ class ToolchainBuilder:
 
         # Cherry picks upstream commits (committership reproducibility fix and
         # any others) that the active Chromium ref may predate.
-        with self._cherry_picks(CLANG_CHERRY_PICK_COMMITS):
+        with cherry_picks(self._chromium_src, CLANG_CHERRY_PICK_COMMITS):
             # Build and package the full Rust toolchain first, the overlay the
             # wasm32 sysroot onto it.
             base_archive = None

--- a/tools/cr/toolchains/build_xcode_toolchain.py
+++ b/tools/cr/toolchains/build_xcode_toolchain.py
@@ -82,8 +82,9 @@ from rich.progress import (BarColumn, DownloadColumn, Progress,
 # This is necessary because these scripts are used be brockit too.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from cherry_picks import _check_call  # pylint: disable=wrong-import-position
 from ephemeral_xcode import (  # pylint: disable=wrong-import-position
-    HTTP_FETCH_TIMEOUT_SECS, EphemeralXcode, MacSdkInfo, _check_call)
+    HTTP_FETCH_TIMEOUT_SECS, EphemeralXcode, MacSdkInfo)
 from upload import sha256_file  # pylint: disable=wrong-import-position
 
 # Gitiles raw-text endpoint for `build/xcode_binaries.yaml` at a given
@@ -177,7 +178,7 @@ def _brave_core_commit() -> str:
                        'rev-parse',
                        'HEAD',
                        cwd=Path(__file__).resolve().parent,
-                       capture_stdout=True).strip()
+                       capture_output=True).stdout.strip()
 
 
 def _remote_url_exists(url: str) -> bool:
@@ -437,7 +438,7 @@ class ToolchainBuilder:
         metal_bin = _check_call('xcrun',
                                 '--find',
                                 'metal',
-                                capture_stdout=True).strip()
+                                capture_output=True).stdout.strip()
         self._metal_build = _metal_build_from_path(metal_bin)
         logging.info('Metal toolchain build: %s', self._metal_build
                      or '(unknown)')

--- a/tools/cr/toolchains/cherry_picks.py
+++ b/tools/cr/toolchains/cherry_picks.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Temporarily apply upstream cherry-picks onto a git checkout for a build.
+
+Build scripts often need upstream fixes that the active checked-out ref
+predates. This module packages that "cherry-pick for the build's duration, then
+restore HEAD" dance as a reusable context manager (`cherry_picks`) so it can be
+driven against any target repository, not just the Chromium `src/` tree.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+from pathlib import Path
+import platform
+import shutil
+import subprocess
+
+# Fixed git author/committer metadata applied when we cherry-pick onto a
+# checkout to make the hash reproducible.
+GIT_METADATA_OVERRIDES = {
+    'GIT_AUTHOR_NAME': 'Dummy Author',
+    'GIT_AUTHOR_EMAIL': 'none@none.com',
+    'GIT_AUTHOR_DATE': '2099-01-01 10:10:10',
+    'GIT_COMMITTER_NAME': 'Dummy Committer',
+    'GIT_COMMITTER_EMAIL': 'none@none.com',
+    'GIT_COMMITTER_DATE': '2099-01-01 10:10:10',
+}
+
+
+def _check_call(*command,
+                cwd=None,
+                env=None,
+                check=True,
+                capture_output=False):
+    """Run *command* as a subprocess, logging the invocation.
+
+    Shared subprocess helper for the toolchain build scripts in this directory
+    (`build_rust_toolchain`, `build_xcode_toolchain`, `ephemeral_xcode`), which
+    all import it rather than carrying their own copy.
+
+    Logs the full command string at INFO level before executing it.  Stdout
+    and stderr are inherited from the parent process (so subprocess output
+    streams directly to the terminal) unless `capture_output` is set, in which
+    case both are captured on the returned `CompletedProcess` as text.  Callers
+    that want the captured stdout read `.stdout` on the result.
+
+    Args:
+        *command: The program and its arguments (passed as positional args,
+            not as a list).
+        cwd: Optional working directory for the subprocess.  Defaults to the
+            caller's current working directory when `None`.
+        env: Optional environment mapping for the subprocess.  Inherits the
+            parent process environment when `None`.
+        check: Raise `CalledProcessError` on a non-zero exit when True.
+        capture_output: Capture stdout/stderr (as text) instead of inheriting
+            the parent's streams.
+
+    Returns:
+        The `subprocess.CompletedProcess` for the invocation.  When
+        `capture_output` is True, `.stdout`/`.stderr` are decoded strings
+        (undecodable bytes are replaced rather than raising).
+
+    Raises:
+        subprocess.CalledProcessError: If `check` is True and the process exits
+            with a non-zero return code.
+        RuntimeError: On Windows, if the command cannot be resolved to an
+        executable path.
+    """
+    logging.info(' >>>> %s', ' '.join(str(a) for a in command))
+
+    if platform.system() == 'Windows':
+        # On Windows, resolve the command to an absolute path to avoid issues
+        # with bat files not matching the command name (e.g. `gclient` vs
+        # `gclient.bat`). This avoids the use of `shell=True`.
+        resolved = shutil.which(command[0])
+        if resolved is None:
+            raise RuntimeError(f'Command not found: {command[0]}')
+        if resolved != command[0]:
+            command = [resolved] + list(command[1:])
+
+    return subprocess.run(command,
+                          cwd=cwd,
+                          env=env,
+                          check=check,
+                          capture_output=capture_output,
+                          text=True,
+                          errors='replace')
+
+
+@contextlib.contextmanager
+def cherry_picks(repo_dir: str | Path,
+                 commits: list[str],
+                 metadata_overrides: dict[str, str] | None = None):
+    """Context manager: apply upstream cherry-picks for the build's duration.
+
+    Ensures every commit in *commits* is in *repo_dir*'s history while the build
+    runs, then restores the original HEAD afterwards. Used to pull in upstream
+    fixes the checked-out ref may predate — for example the commit that pins the
+    git author/committer metadata `tools/clang/scripts/build.py` stamps onto its
+    LLVM cherry-picks so a derived toolchain hash is reproducible.
+
+    Args:
+        repo_dir: Path to the git checkout the cherry-picks are applied onto.
+        commits: Commit-ish list to ensure is present in the checkout's history.
+        metadata_overrides: Environment overrides pinning the git
+            author/committer identity for the cherry-pick commits, so the
+            resulting HEAD is deterministic regardless of local git config.
+            Defaults to `GIT_METADATA_OVERRIDES` when `None`.
+
+    Protocol:
+    1. For each commit, fetch it if its object is missing (the ref may have
+       branched before it landed), then skip it if it is already reachable
+       from HEAD.
+    2. If nothing needs applying, `yield` immediately and leave the checkout
+       untouched — there is nothing to clean up.
+    3. Otherwise cherry-pick the remaining commits — with `metadata_overrides`
+       and `--no-gpg-sign` so the resulting HEAD is deterministic — `yield`, and
+       unconditionally restore the checkout to its original HEAD in a `finally`
+       block. Build outputs are untracked, so the reset leaves them in place.
+    """
+    if metadata_overrides is None:
+        metadata_overrides = GIT_METADATA_OVERRIDES
+
+    def _run_git(*args,
+                 check: bool = True,
+                 capture_output: bool = False,
+                 env: dict | None = None) -> subprocess.CompletedProcess:
+        """Run `git -C <repo_dir> <args...>` via `_check_call`."""
+        return _check_call('git',
+                           '-C',
+                           str(repo_dir),
+                           *args,
+                           check=check,
+                           capture_output=capture_output,
+                           env=env)
+
+    to_apply = []
+    for commit in commits:
+        object_present = _run_git('cat-file',
+                                  '-e',
+                                  f'{commit}^{{commit}}',
+                                  check=False,
+                                  capture_output=True).returncode == 0
+        if not object_present:
+            logging.info('Fetching cherry-pick %s.', commit)
+            _run_git('fetch', 'origin', commit)
+
+        # This tests commit *reachability*, not whether the change is still
+        # effectively present. A commit that landed and was later reverted
+        # upstream is still an ancestor, so it is treated as applied and not
+        # re-picked. Acceptable for this curated list of upstream fixes;
+        # revisit if a pick can legitimately be reverted-then-wanted.
+        already_applied = _run_git('merge-base',
+                                   '--is-ancestor',
+                                   commit,
+                                   'HEAD',
+                                   check=False,
+                                   capture_output=True).returncode == 0
+        if already_applied:
+            logging.info('Cherry-pick %s already present; skipping.', commit)
+        else:
+            to_apply.append(commit)
+
+    if not to_apply:
+        yield
+        return
+
+    original_head = _run_git('rev-parse', 'HEAD',
+                             capture_output=True).stdout.strip()
+    logging.info('Cherry-picking %s.', ', '.join(to_apply))
+    _run_git('cherry-pick',
+             '--keep-redundant-commits',
+             '--no-gpg-sign',
+             *to_apply,
+             env={
+                 **os.environ,
+                 **metadata_overrides
+             })
+    try:
+        yield
+    finally:
+        logging.info('Restoring checkout to %s after cherry-picks.',
+                     original_head)
+        _run_git('reset', '--hard', original_head)

--- a/tools/cr/toolchains/cherry_picks_test.py
+++ b/tools/cr/toolchains/cherry_picks_test.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `cherry_picks`.
+
+The module's whole job is to drive real `git` against a checkout, so the tests
+exercise it end to end over throwaway on-disk repositories rather than mocking
+subprocess. Each test builds its repos in a temp dir, runs the `cherry_picks`
+context manager, and asserts on the resulting git state (HEAD, commit metadata,
+working tree).
+
+Coverage:
+
+* `NoopTest` — the paths that must leave the checkout untouched: an empty commit
+  list, and commits already reachable from HEAD (which are skipped without even
+  contacting `origin`).
+* `ApplyTest` — a commit that needs applying is cherry-picked inside the context
+  and HEAD is restored on exit, including when the body raises and when the
+  commit must first be fetched from `origin`.
+* `MetadataTest` — the committer identity and date are pinned (author is left as
+  the original, matching `git cherry-pick` semantics) and the override table is
+  configurable.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import cherry_picks as m
+
+
+def _git(repo: Path, *args: str, env: dict | None = None) -> str:
+    """Run `git -C <repo> <args...>` and return stripped stdout."""
+    return subprocess.run(('git', '-C', str(repo), *args),
+                          check=True,
+                          capture_output=True,
+                          text=True,
+                          env=env).stdout.strip()
+
+
+def _init_repo(repo: Path) -> None:
+    """Create *repo* as a git repo with a deterministic identity and one commit.
+
+    Also enables `uploadpack.allowAnySHA1InWant` so a sibling repo can fetch an
+    arbitrary commit SHA from it over the local transport (exercising the
+    fetch-if-missing branch).
+    """
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, 'init', '-q', '-b', 'main')
+    _git(repo, 'config', 'user.name', 'Test')
+    _git(repo, 'config', 'user.email', 'test@example.com')
+    _git(repo, 'config', 'commit.gpgsign', 'false')
+    _git(repo, 'config', 'uploadpack.allowAnySHA1InWant', 'true')
+    _git(repo, 'config', 'uploadpack.allowReachableSHA1InWant', 'true')
+    _commit_file(repo, 'base.txt', 'base\n', 'base commit')
+
+
+def _commit_file(repo: Path, name: str, content: str, message: str) -> str:
+    """Write *name*, commit it in *repo*, and return the new commit SHA."""
+    (repo / name).write_text(content, encoding='utf-8')
+    _git(repo, 'add', name)
+    _git(repo, 'commit', '-q', '--no-gpg-sign', '-m', message)
+    return _git(repo, 'rev-parse', 'HEAD')
+
+
+class _RepoTestCase(unittest.TestCase):
+    """Base fixture providing a temp dir and a helper to build repos."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+    def _new_repo(self, name: str) -> Path:
+        repo = self.root / name
+        _init_repo(repo)
+        return repo
+
+    def _head(self, repo: Path) -> str:
+        return _git(repo, 'rev-parse', 'HEAD')
+
+
+class NoopTest(_RepoTestCase):
+    """Paths where nothing is applied and the checkout is left untouched."""
+
+    def test_empty_commit_list_yields_untouched(self) -> None:
+        repo = self._new_repo('repo')
+        head = self._head(repo)
+        entered = False
+        with m.cherry_picks(repo, []):
+            entered = True
+        self.assertTrue(entered)
+        self.assertEqual(self._head(repo), head)
+
+    def test_already_present_commit_is_skipped(self) -> None:
+        repo = self._new_repo('repo')
+        # A commit reachable from HEAD is already applied; the context is a
+        # no-op and HEAD is unchanged.
+        present = self._head(repo)
+        with m.cherry_picks(repo, [present]):
+            pass
+        self.assertEqual(self._head(repo), present)
+
+    def test_present_commit_does_not_contact_origin(self) -> None:
+        repo = self._new_repo('repo')
+        # Point origin at a path that does not exist. Because the commit object
+        # is already present and reachable, the fetch branch must be skipped
+        # entirely, so a broken remote is never contacted.
+        _git(repo, 'remote', 'add', 'origin',
+             str(self.root / 'does-not-exist'))
+        present = self._head(repo)
+        with m.cherry_picks(repo, [present]):
+            pass
+        self.assertEqual(self._head(repo), present)
+
+
+class ApplyTest(_RepoTestCase):
+    """A commit that needs applying is cherry-picked, then HEAD is restored."""
+
+    def _repo_with_unmerged_commit(self) -> tuple[Path, str, str]:
+        """Return (repo, base_head, commit) where commit is not on HEAD.
+
+        The commit lives on a side branch and adds a new file, so it is neither
+        reachable from `main`'s HEAD nor conflicting when cherry-picked onto it.
+        """
+        repo = self._new_repo('repo')
+        base = self._head(repo)
+        _git(repo, 'checkout', '-q', '-b', 'feature')
+        commit = _commit_file(repo, 'feature.txt', 'feature\n',
+                              'feature commit')
+        _git(repo, 'checkout', '-q', 'main')
+        self.assertEqual(self._head(repo), base)
+        return repo, base, commit
+
+    def test_applies_inside_and_restores_head_on_exit(self) -> None:
+        repo, base, commit = self._repo_with_unmerged_commit()
+        with m.cherry_picks(repo, [commit]):
+            # Inside the context the commit is applied: HEAD advanced and the
+            # file it introduced is present in the working tree.
+            self.assertNotEqual(self._head(repo), base)
+            self.assertTrue((repo / 'feature.txt').is_file())
+        # On exit the checkout is reset to exactly the original HEAD.
+        self.assertEqual(self._head(repo), base)
+        self.assertFalse((repo / 'feature.txt').is_file())
+
+    def test_head_restored_when_body_raises(self) -> None:
+        repo, base, commit = self._repo_with_unmerged_commit()
+
+        class _Boom(Exception):
+            pass
+
+        with self.assertRaises(_Boom):
+            with m.cherry_picks(repo, [commit]):
+                self.assertNotEqual(self._head(repo), base)
+                raise _Boom()
+        self.assertEqual(self._head(repo), base)
+
+    def test_untracked_build_output_survives_restore(self) -> None:
+        repo, _, commit = self._repo_with_unmerged_commit()
+        # `reset --hard` on exit must not clobber untracked files (build
+        # outputs), only tracked state.
+        (repo / 'build-output.bin').write_text('artifact', encoding='utf-8')
+        with m.cherry_picks(repo, [commit]):
+            pass
+        self.assertTrue((repo / 'build-output.bin').is_file())
+        self.assertEqual((repo / 'build-output.bin').read_text(), 'artifact')
+
+    def test_missing_object_is_fetched_from_origin(self) -> None:
+        origin = self._new_repo('origin')
+        # A commit that exists only on a side branch of `origin`, built on the
+        # shared base so it cherry-picks cleanly onto the clone's HEAD.
+        _git(origin, 'checkout', '-q', '-b', 'feature')
+        commit = _commit_file(origin, 'fetched.txt', 'fetched\n',
+                              'origin only')
+        _git(origin, 'checkout', '-q', 'main')  # main stays at the base commit
+
+        # A single-branch clone of `main` shares the base but never fetches the
+        # `feature` branch, so the side commit's object is absent locally.
+        # `--no-local` forces real fetch negotiation; without it a same-filesystem
+        # clone hardlinks the entire object database and pulls the commit anyway.
+        local = self.root / 'local'
+        _git(self.root, 'clone', '-q', '--no-local', '--single-branch',
+             '--branch', 'main', str(origin), str(local))
+        _git(local, 'config', 'user.name', 'Test')
+        _git(local, 'config', 'user.email', 'test@example.com')
+        self.assertNotEqual(
+            subprocess.run(('git', '-C', str(local), 'cat-file', '-e',
+                            f'{commit}^{{commit}}'),
+                           check=False,
+                           capture_output=True).returncode, 0)
+
+        local_base = self._head(local)
+        with m.cherry_picks(local, [commit]):
+            self.assertTrue((local / 'fetched.txt').is_file())
+        self.assertEqual(self._head(local), local_base)
+
+    def test_mixed_present_and_missing(self) -> None:
+        repo, base, commit = self._repo_with_unmerged_commit()
+        # `base` is already reachable (skipped); `commit` still needs applying.
+        with m.cherry_picks(repo, [base, commit]):
+            self.assertTrue((repo / 'feature.txt').is_file())
+        self.assertEqual(self._head(repo), base)
+
+
+class MetadataTest(_RepoTestCase):
+    """The cherry-pick commit's identity is pinned deterministically."""
+
+    def _apply_and_read(self, overrides: dict | None) -> dict[str, str]:
+        repo = self._new_repo('repo')
+        _git(repo, 'checkout', '-q', '-b', 'feature')
+        commit = _commit_file(repo, 'feature.txt', 'feature\n',
+                              'feature commit')
+        _git(repo, 'checkout', '-q', 'main')
+        fmt = '%cn%n%ce%n%cd%n%an%n%ae'
+        kwargs = {} if overrides is None else {'metadata_overrides': overrides}
+        result: dict[str, str] = {}
+        with m.cherry_picks(repo, [commit], **kwargs):
+            lines = _git(repo, 'log', '-1', f'--format={fmt}').splitlines()
+            keys = ('committer_name', 'committer_email', 'committer_date',
+                    'author_name', 'author_email')
+            result = dict(zip(keys, lines))
+        return result
+
+    def test_default_overrides_pin_committer(self) -> None:
+        got = self._apply_and_read(None)
+        # `git cherry-pick` preserves the *author* of the original commit and
+        # only the committer is rewritten, which is what the overrides pin.
+        self.assertEqual(got['committer_name'],
+                         m.GIT_METADATA_OVERRIDES['GIT_COMMITTER_NAME'])
+        self.assertEqual(got['committer_email'],
+                         m.GIT_METADATA_OVERRIDES['GIT_COMMITTER_EMAIL'])
+        self.assertIn('2099', got['committer_date'])
+        # The author is the original commit's, not the override.
+        self.assertEqual(got['author_name'], 'Test')
+        self.assertEqual(got['author_email'], 'test@example.com')
+
+    def test_custom_overrides_are_honoured(self) -> None:
+        overrides = {
+            'GIT_COMMITTER_NAME': 'Custom Person',
+            'GIT_COMMITTER_EMAIL': 'custom@example.com',
+            'GIT_COMMITTER_DATE': '2001-02-03 04:05:06',
+        }
+        got = self._apply_and_read(overrides)
+        self.assertEqual(got['committer_name'], 'Custom Person')
+        self.assertEqual(got['committer_email'], 'custom@example.com')
+        self.assertIn('2001', got['committer_date'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/cr/toolchains/ephemeral_xcode.py
+++ b/tools/cr/toolchains/ephemeral_xcode.py
@@ -13,7 +13,7 @@ import json
 import logging
 import re
 import shutil
-import subprocess
+import sys
 import tempfile
 import urllib.error
 import urllib.request
@@ -25,6 +25,13 @@ from typing import Any
 from rich.progress import (BarColumn, DownloadColumn, Progress,
                            TaskProgressColumn, TextColumn, TimeRemainingColumn,
                            TransferSpeedColumn)
+
+# `cherry_picks` is a sibling module; add this directory to the path so the
+# import resolves whether this module is imported by a sibling build script or
+# run on its own.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from cherry_picks import _check_call  # pylint: disable=wrong-import-position
 
 # Per-request timeout for the small HTTP fetches (gitiles raw files and the
 # xcodereleases.com JSON).
@@ -51,43 +58,6 @@ XCODE_ARCHIVE_BUCKET_URL = (
 # Directory where downloaded Xcodes are expanded and reused across runs, keyed
 # by build number as `xcode_<build>.app`.
 XCODE_APPS_DIR = Path('/Applications')
-
-
-def _check_call(*command,
-                cwd=None,
-                capture_stdout: bool = False) -> str | None:
-    """Run *command* as a subprocess, logging the invocation.
-
-    Logs the full command string at INFO level before executing it.  Stderr is
-    inherited from the parent process so subprocess output streams directly to
-    the terminal.
-
-    Args:
-        *command: The program and its arguments (passed as positional args, not
-            as a list).
-        cwd: Optional working directory for the subprocess.  Defaults to the
-            caller's current working directory when `None`.
-        capture_stdout: When `True`, capture the child's stdout and return it as
-            a UTF-8 decoded string.  When `False` (default), stdout is inherited
-            from the parent and the function returns `None`.
-
-    Returns:
-        The decoded stdout if `capture_stdout=True`, otherwise `None`.
-
-    Raises:
-        subprocess.CalledProcessError: If the process exits with a non-zero
-            return code.
-    """
-    logging.info(' >>>> %s', ' '.join(str(a) for a in command))
-
-    result = subprocess.run(command,
-                            cwd=cwd,
-                            check=True,
-                            stdout=subprocess.PIPE if capture_stdout else None)
-
-    if capture_stdout:
-        return result.stdout.decode('utf-8', errors='replace')
-    return None
 
 
 def _fetch_xcode_releases() -> Any:
@@ -465,7 +435,7 @@ class EphemeralXcode:
         useless archive.
         """
         developer_dir = _check_call('xcode-select', '-p',
-                                    capture_stdout=True).strip()
+                                    capture_output=True).stdout.strip()
         app = Path(developer_dir).parent.parent
         if app.suffix != '.app':
             raise RuntimeError(
@@ -489,12 +459,13 @@ class EphemeralXcode:
                              '-version',
                              '-sdk',
                              'macosx',
-                             capture_stdout=True)
+                             capture_output=True).stdout
         sdk_version = re.search(r'^SDKVersion: (.+)$', output, re.MULTILINE)
         sdk_build = re.search(r'^ProductBuildVersion: (.+)$', output,
                               re.MULTILINE)
 
-        output = _check_call('xcodebuild', '-version', capture_stdout=True)
+        output = _check_call('xcodebuild', '-version',
+                             capture_output=True).stdout
         xcode_version = re.search(r'^Xcode (.+)$', output, re.MULTILINE)
         xcode_build = re.search(r'^Build version (.+)$', output, re.MULTILINE)
 


### PR DESCRIPTION
This change removes the cherry-pick code from the rust toolchain script.
This is doing in preparation to permit us to use this in other scripts.
There is also some unifying of the definition of `_check_call`, but this
may necessitate further follow-ups for better placement.
