### PR TITLE
Internal settings pages - Revert chromium 151 overrides

### DIFF
--- a/browser/resources/settings/br/settings_subpage.ts
+++ b/browser/resources/settings/br/settings_subpage.ts
@@ -3,39 +3,38 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import {RegisterStyleOverride} from 'chrome://resources/brave/polymer_overriding.js'
-import {html} from 'chrome://resources/polymer/v3_0/polymer/polymer_bundled.min.js'
+import {injectStyle} from '//resources/brave/lit_overriding.js'
+import {css} from '//resources/lit/v3_0/lit.rollup.js'
 
-RegisterStyleOverride(
-  'settings-subpage', html`
-  <style include="settings-shared">
-    :host {
-        min-height: auto !important;
-        display: inline;
-        position: relative;
-    }
-    :host(:not(.multi-card)) {
-        background-color: var(--leo-color-page-background) !important;
-        box-shadow: none !important;
-    }
-    :host(:not(.multi-card):not([id=safetyHub])) slot {
-        box-shadow: var(--leo-effect-elevation-01) !important;
-        background-color: var(--leo-color-container-background) !important;
-        border-radius: var(--leo-radius-m) !important;
-        display: block;
-        padding-bottom: var(--leo-spacing-2xl);
-    }
-    #headerLine {
-        padding-top: 0 !important;
-        padding-left: var(--leo-spacing-m) !important;
-        padding-right: var(--leo-spacing-m) !important;
-        padding-bottom: 0 !important;
-        margin-top: var(--cr-section-vertical-margin);
-    }
-    .cr-title-text {
-        color: var(--cr-title-text-color);
-        font-weight: 600 !important;
-        font-size: var(--leo-typography-heading-h4-font-size) !important;
-    }
-  </style>`
-)
+import {SettingsSubpageElement} from '../settings_page/settings_subpage.js'
+
+injectStyle(SettingsSubpageElement, css`
+  :host {
+    min-height: auto !important;
+    display: inline;
+    position: relative;
+  }
+  :host(:not(.multi-card)) {
+    background-color: var(--leo-color-page-background) !important;
+    box-shadow: none !important;
+  }
+  :host(:not(.multi-card):not([id=safetyHub])) slot {
+    box-shadow: var(--leo-effect-elevation-01) !important;
+    background-color: var(--leo-color-container-background) !important;
+    border-radius: var(--leo-radius-m) !important;
+    display: block;
+    padding-bottom: var(--leo-spacing-2xl);
+  }
+  #headerLine {
+    padding-top: 0 !important;
+    padding-left: var(--leo-spacing-m) !important;
+    padding-right: var(--leo-spacing-m) !important;
+    padding-bottom: 0 !important;
+    margin-top: var(--cr-section-vertical-margin);
+  }
+  .cr-title-text {
+    color: var(--cr-title-text-color);
+    font-weight: 600 !important;
+    font-size: var(--leo-typography-heading-h4-font-size) !important;
+  }
+`)

--- a/patches/chrome-browser-resources-settings-settings_shared_lit.css.patch
+++ b/patches/chrome-browser-resources-settings-settings_shared_lit.css.patch
@@ -1,0 +1,14 @@
+diff --git a/chrome/browser/resources/settings/settings_shared_lit.css b/chrome/browser/resources/settings/settings_shared_lit.css
+index f2f139ff32ea5103fc2e71f9a78a8f1a6e554186..2ca79d920ee9cce08e2b4fabe366271132bd4534 100644
+--- a/chrome/browser/resources/settings/settings_shared_lit.css
++++ b/chrome/browser/resources/settings/settings_shared_lit.css
+@@ -8,7 +8,8 @@
+  * #import=chrome://resources/cr_elements/cr_shared_vars.css.js
+  * #import=chrome://resources/cr_elements/search_highlight_style_lit.css.js
+  * #import=./settings_vars.css.js
+- * #include=cr-shared-style-lit search-highlight-style-lit
++ * #import=//resources/brave/page_specific/settings/br_settings_shared_lit.css.js
++ * #include=cr-shared-style-lit search-highlight-style-lit br-settings-shared-lit
+  * #css_wrapper_metadata_end */
+ 
+ /* Common styles for Material Design settings. */

--- a/ui/webui/resources/BUILD.gn
+++ b/ui/webui/resources/BUILD.gn
@@ -52,7 +52,10 @@ if (include_polymer) {
     mojo_files = [ "$root_gen_dir/brave/ui/webui/resources/js/brave_browser_command/brave_browser_command.mojom-webui.ts" ]
     mojo_files_deps = [ "js/brave_browser_command:mojo_bindings_ts__generator" ]
 
-    css_files = [ "page_specific/settings/br_settings_shared.css" ]
+    css_files = [
+      "page_specific/settings/br_settings_shared.css",
+      "page_specific/settings/br_settings_shared_lit.css",
+    ]
 
     ts_composite = true
     generate_grdp = true

--- a/ui/webui/resources/page_specific/settings/br_settings_shared_lit.css
+++ b/ui/webui/resources/page_specific/settings/br_settings_shared_lit.css
@@ -1,7 +1,7 @@
 /* Copyright (c) 2026 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * you can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /* #css_wrapper_metadata_start
  * #type=style-lit

--- a/ui/webui/resources/page_specific/settings/br_settings_shared_lit.css
+++ b/ui/webui/resources/page_specific/settings/br_settings_shared_lit.css
@@ -1,0 +1,16 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * you can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* #css_wrapper_metadata_start
+ * #type=style-lit
+ * #css_wrapper_metadata_end */
+
+a[href] {
+  text-decoration: none !important;
+}
+
+.content-settings-header {
+  padding-top: var(--leo-spacing-2xl) !important;
+}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57102

## Summary

Chromium 151 migrated `settings-subpage` to Lit, so Brave's Polymer-only `RegisterStyleOverride` stopped applying. Internal settings pages (e.g. `brave://settings/security`) fell back to Chromium's card background/shadow instead of Brave's Leo styling.

This PR restores Brave's previous look by:

- Migrating `br/settings_subpage.ts` from Polymer `RegisterStyleOverride` to Lit `injectStyle(SettingsSubpageElement, …)` with the existing Leo card/layout rules (page background, elevated content card, header padding, title typography) — same pattern used for the About page Lit migration
- Adding a Lit twin of Brave shared settings styles (`br_settings_shared_lit.css`) and registering it in `ui/webui/resources/BUILD.gn`
- Patching Chromium's `settings_shared_lit.css` to include those Brave shared Lit styles (link underline / content-settings header padding), mirroring the existing Polymer `settings_shared.css` patch

## Previous

<img width="1610" height="1228" alt="image" src="https://github.com/user-attachments/assets/d634c53a-b520-4767-a5d3-7975029789d1" />

<img width="1610" height="1228" alt="image" src="https://github.com/user-attachments/assets/4b3ef943-bb76-4c28-9f85-5fa3373f3c70" />

<img width="1610" height="1228" alt="image" src="https://github.com/user-attachments/assets/cbcdc357-3624-4909-bae3-8d10ca08e121" />

<img width="1610" height="1228" alt="image" src="https://github.com/user-attachments/assets/1eadfc01-399b-4e8a-ad63-dcf04b195619" />

## Results

<img width="1538" height="1223" alt="image" src="https://github.com/user-attachments/assets/1eba9571-686b-444b-a67e-c8bdb2d2ad54" />

<img width="1538" height="1223" alt="image" src="https://github.com/user-attachments/assets/92795ae7-f200-4a3f-b15d-6f3b37c538ff" />

<img width="1538" height="1223" alt="image" src="https://github.com/user-attachments/assets/edac5625-a181-4dc0-8a1b-63435ca46f33" />

<img width="1538" height="1223" alt="image" src="https://github.com/user-attachments/assets/65e888b1-d80e-4b4f-a4c6-ac4440cfda7c" />

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->