### PR TITLE
[iOS] Improve reader mode language parsing

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Reader/ReaderModeUtils.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Reader/ReaderModeUtils.swift
@@ -25,6 +25,7 @@ struct ReaderModeUtils {
       let tmplPath = Bundle.module.url(forResource: "Reader", withExtension: "html"),
       let tmpl = await AsyncFileManager.default.utf8Contents(at: tmplPath)
     else { return nil }
+    let languageCode = Locale.LanguageCode(readabilityResult.documentLanguage)
 
     // This MUST be the first line/replacement!
     return tmpl.replacingOccurrences(of: "%READER-TITLE-NONCE%", with: titleNonce)
@@ -35,8 +36,7 @@ struct ReaderModeUtils {
       .replacingOccurrences(of: "%READER-URL%", with: readabilityResult.url)
       .replacingOccurrences(
         of: "%READER-PAGE-LANGUAGE%",
-        with: readabilityResult.documentLanguage.javaScriptEscapedString?.unquotedIfNecessary
-          ?? ""
+        with: languageCode.isISOLanguage ? languageCode.identifier : ""
       )
       .replacingOccurrences(
         of: "%READER-TITLE%",


### PR DESCRIPTION
This ensures that the language set on the reader mode page itself is a valid ISO language code otherwise its ignored

Resolves https://github.com/brave/brave-browser/issues/56569
