### PR TITLE
[iOS] Enable find interaction by default on Chromium web views

### DIFF
--- a/chromium_src/ios/web/web_state/web_view_internal_creation_util.mm
+++ b/chromium_src/ios/web/web_state/web_view_internal_creation_util.mm
@@ -15,6 +15,16 @@
 
 @implementation BraveCRWWebView
 
+- (instancetype)initWithFrame:(CGRect)frame
+                configuration:(WKWebViewConfiguration*)configuration {
+  if ((self = [super initWithFrame:frame configuration:configuration])) {
+    // In Brave we want this to be enabled by default, Chromium enables it
+    // lazily based on first explicit activation of find in page
+    self.findInteractionEnabled = YES;
+  }
+  return self;
+}
+
 - (void)buildMenuWithBuilder:(id<UIMenuBuilder>)builder {
   [super buildMenuWithBuilder:builder];
   // Typically Chromium only calls buildMenuWithBuilder when there is text


### PR DESCRIPTION
Typically this property is enabled lazily when the user first uses find in page, but we want this enabled always for Brave as we keep the `lookup` menu when building the web views edit menu.

Resolves https://github.com/brave/brave-browser/issues/53391
