### PR TITLE
[Settings] Fix settings subpage virtualization scrolling by adding position:relative to #main

### DIFF
--- a/browser/resources/settings/br/settings_ui.ts
+++ b/browser/resources/settings/br/settings_ui.ts
@@ -87,6 +87,7 @@ RegisterStyleOverride(
         background: var(--leo-color-page-background);
         border-radius: var(--leo-radius-xl) var(--leo-radius-m) var(--leo-radius-m) var(--leo-radius-xl);
         overflow: auto;
+        position: relative;
       }
       #right {
         /* this element is only a space filler in chromium */


### PR DESCRIPTION
Hi team @rebron @benjaminknox,

I have identified the root cause of this issue and committed a fix on my fork:

### Root Cause
Brave uses custom scroll target behavior setting #main as the global scroll target in settings_ui.ts. However, #main was not styled with position: relative. As a result, Chromium's <settings-subpage> (which is styled with position: absolute; height: 100%; width: 100%;) positioned itself relative to #container instead of #main. This mismatched layout prevented scroll events from reaching <iron-list>'s scroll target listener, breaking element virtualization.

### Fix
Added position: relative; to the #main selector styles in rowser/resources/settings/br/settings_ui.ts.

Fixes https://github.com/brave/brave-browser/issues/44696