### PR TITLE
[deps] Add size check to `EXTRA_DEPS`

### DIFF
--- a/EXTRA_DEPS
+++ b/EXTRA_DEPS
@@ -9,7 +9,8 @@
 #
 #   bucket      an https prefix `object_name` is appended to.
 #   condition   dep-level gate (host_os/host_cpu/...); resolved during sync.
-#   objects     one or more archives, each with `object_name` + `sha256sum`, an
+#   objects     one or more archives, each with `object_name`, `sha256sum`, and
+#               `size_bytes` (the exact archive size, checked on download), an
 #               optional per-object `condition`, and optional `overlayed_on`:
 #                 * overlayed_on -- extracted on top of that upstream archive.
 #                 * omitted      -- owns its destination (wiped each install).
@@ -27,24 +28,28 @@ extra_deps = {
             {
                 'object_name': 'linux-x64-rust-toolchain-b998449636a48e2c4a362809085b600a0174e1f2-2-llvmorg-23-init-19482-g53d18800-1.tar.xz',
                 'sha256sum': 'c0f111bdb9721719346cc9099fb6582b7bda05a08083bafa9c1c2d604768f67f',
+                'size_bytes': 43313388,
                 'overlayed_on': 'Linux_x64/rust-toolchain-b998449636a48e2c4a362809085b600a0174e1f2-2-llvmorg-23-init-19482-g53d18800.tar.xz',
                 'condition': 'host_os == "linux"',
             },
             {
                 'object_name': 'mac-arm64-rust-toolchain-b998449636a48e2c4a362809085b600a0174e1f2-2-llvmorg-23-init-19482-g53d18800-1.tar.xz',
                 'sha256sum': 'ee2499d7cdfcb10c102d9e427f88e4922f19e7aa698793083178e8c4dc738ac4',
+                'size_bytes': 40340368,
                 'overlayed_on': 'Mac_arm64/rust-toolchain-b998449636a48e2c4a362809085b600a0174e1f2-2-llvmorg-23-init-19482-g53d18800.tar.xz',
                 'condition': 'host_os == "mac" and host_cpu == "arm64"',
             },
             {
                 'object_name': 'mac-rust-toolchain-b998449636a48e2c4a362809085b600a0174e1f2-2-llvmorg-23-init-19482-g53d18800-1.tar.xz',
                 'sha256sum': 'd8b4c695b9dcc46d5ba92f25fc51dd9d3d6dc687de5b671c2d7b6b919514b563',
+                'size_bytes': 43051448,
                 'overlayed_on': 'Mac/rust-toolchain-b998449636a48e2c4a362809085b600a0174e1f2-2-llvmorg-23-init-19482-g53d18800.tar.xz',
                 'condition': 'host_os == "mac" and host_cpu == "x64"',
             },
             {
                 'object_name': 'win-rust-toolchain-b998449636a48e2c4a362809085b600a0174e1f2-2-llvmorg-23-init-19482-g53d18800-1.tar.xz',
                 'sha256sum': '60e5e33ea1841aac3f4364b459a9c9d43594b957267dca29563be0a9e63474d2',
+                'size_bytes': 43731456,
                 'overlayed_on': 'Win/rust-toolchain-b998449636a48e2c4a362809085b600a0174e1f2-2-llvmorg-23-init-19482-g53d18800.tar.xz',
                 'condition': 'host_os == "win"',
             },
@@ -57,6 +62,7 @@ extra_deps = {
             {
                 'object_name': 'node-v24.18.0-linux-x64.tar.gz',
                 'sha256sum': '2e8e150bf8ca55cc7b1d89c9d71138d57a1b7900c5687b3fb1e03d5e6ba1231c',
+                'size_bytes': 57371867,
             },
         ],
     },
@@ -67,6 +73,7 @@ extra_deps = {
             {
                 'object_name': 'node-v24.18.0-mac-x64.tar.gz',
                 'sha256sum': 'c33ce3dfc0fb84dd6b54ebd6fdc5646ae4358e164f11a80af3abf09d40954871',
+                'size_bytes': 53417350,
             },
         ],
     },
@@ -77,6 +84,7 @@ extra_deps = {
             {
                 'object_name': 'node-v24.18.0-mac-arm64.tar.gz',
                 'sha256sum': '96c7a5b4c9d096084137333fa5a964514d593f859d0328a574f4509d4e3d6522',
+                'size_bytes': 52225821,
             },
         ],
     },
@@ -87,6 +95,7 @@ extra_deps = {
             {
                 'object_name': 'node-v24.18.0-win-x64.tar.gz',
                 'sha256sum': 'c0a0e3b9fe5cadfedc4c6e82943a3c1201460716449c8e4cd188256751cca386',
+                'size_bytes': 37681514,
             },
         ],
     },
@@ -97,6 +106,7 @@ extra_deps = {
             {
                 'object_name': 'ast-grep-0.44.1-linux-x64.tar.gz',
                 'sha256sum': 'e2d0696358940a5c09a54ef1266b369036717293d9f9312513da6edf98a13176',
+                'size_bytes': 7935160,
             },
         ],
     },
@@ -107,6 +117,7 @@ extra_deps = {
             {
                 'object_name': 'ast-grep-0.44.1-mac.tar.gz',
                 'sha256sum': '38e9259845066f0fc6b2a947f1760305add3c52a8d53d198bd1ae830e12569dc',
+                'size_bytes': 7775908,
             },
         ],
     },
@@ -117,6 +128,7 @@ extra_deps = {
             {
                 'object_name': 'ast-grep-0.44.1-mac-arm64.tar.gz',
                 'sha256sum': 'ef1cf3f749796c0318c3f6badd75df3e5090ce4cf07c0e7cf89f34c0db452e75',
+                'size_bytes': 7774326,
             },
         ],
     },
@@ -127,6 +139,7 @@ extra_deps = {
             {
                 'object_name': 'ast-grep-0.44.1-win.tar.gz',
                 'sha256sum': 'c1e06394908573ddf334f41809b63e9b80122b11048412c41c2b66c52106ea47',
+                'size_bytes': 7667559,
             },
         ],
     },

--- a/tools/cr/extra_deps_test.py
+++ b/tools/cr/extra_deps_test.py
@@ -141,6 +141,16 @@ class ExtraDepsTableTest(unittest.TestCase):
         for path, spec in m.EXTRA_DEPS.items():
             self.assertTrue(spec['bucket'].startswith('https://'), path)
 
+    def test_every_object_declares_size_and_sha(self):
+        """Each object carries a sha256 and a positive `size_bytes`; the
+        installer validates the downloaded archive against both."""
+        for path, spec in m.EXTRA_DEPS.items():
+            for obj in spec['objects']:
+                name = f'{path}:{obj.get("object_name")}'
+                self.assertIsInstance(obj.get('sha256sum'), str, name)
+                self.assertIsInstance(obj.get('size_bytes'), int, name)
+                self.assertGreater(obj['size_bytes'], 0, name)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tools/cr/install_extra_deps.py
+++ b/tools/cr/install_extra_deps.py
@@ -197,6 +197,7 @@ class ExtraDepsRunner:
                                      url=spec['bucket'] + obj['object_name'],
                                      object_name=obj['object_name'],
                                      sha256sum=obj['sha256sum'],
+                                     size_bytes=obj['size_bytes'],
                                      owns_dest=not overlayed_on)
 
         # An overlay must sit on the base it was built against: validate it

--- a/tools/cr/install_extra_deps_test.py
+++ b/tools/cr/install_extra_deps_test.py
@@ -247,6 +247,7 @@ class InstallTest(unittest.TestCase):
             'objects': [{
                 'object_name': 'node.tar.gz',
                 'sha256sum': _sha256(data),
+                'size_bytes': len(data),
                 'condition': 'host_os == "linux"'
             }],
         }
@@ -267,6 +268,7 @@ class InstallTest(unittest.TestCase):
             'objects': [{
                 'object_name': 'overlay.tar.gz',
                 'sha256sum': _sha256(data),
+                'size_bytes': len(data),
                 'overlayed_on': 'Linux_x64/base.tar.xz',
                 'condition': 'host_os == "linux"',
             }],
@@ -286,6 +288,7 @@ class InstallTest(unittest.TestCase):
             'objects': [{
                 'object_name': 'overlay.tar.gz',
                 'sha256sum': 'a',
+                'size_bytes': 1,
                 'overlayed_on': 'Linux_x64/base.tar.xz',
                 'condition': 'host_os == "linux"',
             }],
@@ -394,11 +397,13 @@ class FromCheckoutIntegrationTest(unittest.TestCase):
                 {
                     'object_name': 'node-linux.tar.gz',
                     'sha256sum': _sha256(data),
+                    'size_bytes': len(data),
                     'condition': 'host_os == "linux"',
                 },
                 {
                     'object_name': 'node-mac.tar.gz',
                     'sha256sum': 'unused',
+                    'size_bytes': 0,
                     'condition': 'host_os == "mac"',
                 },
             ],

--- a/tools/cr/tarball_installer.py
+++ b/tools/cr/tarball_installer.py
@@ -4,8 +4,9 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """`TarballInstaller`: fetch, verify, and extract one `EXTRA_DEPS` object.
 
-Stdlib-only: it downloads over HTTP, verifies the sha256, extracts the archive,
-and writes the sidecar files that record what is deployed. Also runnable as a
+Stdlib-only: it downloads over HTTP, verifies the size and sha256, extracts the
+archive, and writes the sidecar files that record what is deployed. Also runnable
+as a
 CLI to deploy a single-object `EXTRA_DEPS` entry into the checkout.
 """
 
@@ -43,8 +44,9 @@ _INSTALLABLE = sorted(path for path, spec in EXTRA_DEPS.items()
 class TarballInstaller:
     """Installs one resolved `EXTRA_DEPS` object into its destination.
 
-    Handles the mechanics for a single object: sha256 verification, extraction
-    (wiping the destination first when it owns it), and writing the sidecar
+    Handles the mechanics for a single object: size + sha256 verification,
+    extraction (wiping the destination first when it owns it), and writing the
+    sidecar
     files `extra_deps` reads back to tell a deployed tree from a stale one:
 
       .{prefix}_hash                the object's sha256
@@ -61,6 +63,8 @@ class TarballInstaller:
     object_name: str
     # The expected sha256 of the archive.
     sha256sum: str
+    # The expected size of the archive in bytes.
+    size_bytes: int
     # True when the dep owns dest_dir (wiped before extract); False when it
     # overlays an existing upstream tree (extracted on top).
     owns_dest: bool
@@ -84,6 +88,7 @@ class TarballInstaller:
                    url=spec['bucket'] + obj['object_name'],
                    object_name=obj['object_name'],
                    sha256sum=obj['sha256sum'],
+                   size_bytes=obj['size_bytes'],
                    owns_dest=not obj.get('overlayed_on'))
 
     def is_installed(self) -> bool:
@@ -116,7 +121,13 @@ class TarballInstaller:
         return True
 
     def _verify(self, archive_path: Path) -> None:
-        """Raise `ValueError` unless `archive_path` hashes to `sha256sum`."""
+        """Raise `ValueError` unless `archive_path` matches size and sha256.
+        """
+        actual_size = archive_path.stat().st_size
+        if actual_size != self.size_bytes:
+            raise ValueError(f'size mismatch for {self.url}\n'
+                             f'  expected: {self.size_bytes} bytes\n'
+                             f'  actual:   {actual_size} bytes')
         digest = hashlib.sha256()
         # Not using mmap to make this script more tolerable to a larger range
         # of Python versions, as this script is called by `launcher.py` without

--- a/tools/cr/tarball_installer_test.py
+++ b/tools/cr/tarball_installer_test.py
@@ -67,13 +67,15 @@ class TarballInstallerTest(unittest.TestCase):
                    *,
                    object_name: str = 'pkg.tar.gz',
                    sha256sum: str | None = None,
+                   size_bytes: int | None = None,
                    owns_dest: bool = True) -> m.TarballInstaller:
-        """A `TarballInstaller` for `data`, defaulting to its true sha256."""
+        """A `TarballInstaller` for `data`, defaulting to its true size/sha256."""
         return m.TarballInstaller(
             dest_dir=self.dest,
             url=f'https://downloads.invalid/{object_name}',
             object_name=object_name,
             sha256sum=_sha256(data) if sha256sum is None else sha256sum,
+            size_bytes=len(data) if size_bytes is None else size_bytes,
             owns_dest=owns_dest)
 
     def _download(self, data: bytes):
@@ -140,6 +142,16 @@ class TarballInstallerTest(unittest.TestCase):
         self.assertFalse(self.dest.exists())
         self.assertFalse(installer.is_installed())
 
+    def test_size_mismatch_raises_and_installs_nothing(self):
+        data = _make_tar([('f', b'x')])
+        # Right bytes (so the sha would pass), but the pinned size is wrong: the
+        # size check must fire first and abort before anything is extracted.
+        installer = self._installer(data, size_bytes=len(data) + 1)
+        with self.assertRaisesRegex(ValueError, 'size mismatch'):
+            installer.install(self._download(data))
+        self.assertFalse(self.dest.exists())
+        self.assertFalse(installer.is_installed())
+
     def test_download_refuses_non_https_url(self):
         installer = self._installer(_make_tar([('f', b'x')]))
         with self.assertRaisesRegex(ValueError, 'non-https'):
@@ -192,6 +204,7 @@ class ProgressTest(unittest.TestCase):
                                   url='https://downloads.invalid/pkg',
                                   object_name='pkg.tar.gz',
                                   sha256sum='a',
+                                  size_bytes=len(data),
                                   owns_dest=True)
         err = io.StringIO()
         with mock.patch.object(m, 'urlopen', return_value=_FakeResponse(data)):
@@ -205,6 +218,7 @@ class ProgressTest(unittest.TestCase):
                                   url='u',
                                   object_name='node.tar.gz',
                                   sha256sum='a',
+                                  size_bytes=0,
                                   owns_dest=True)
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
@@ -225,12 +239,14 @@ class ForDepTest(unittest.TestCase):
             Path('/ws'), 'src/p',
             self._spec([{
                 'object_name': 'x.tar.gz',
-                'sha256sum': 'abc'
+                'sha256sum': 'abc',
+                'size_bytes': 123
             }]))
         self.assertEqual(inst.dest_dir, Path('/ws/src/p'))
         self.assertEqual(inst.url, 'https://downloads.invalid/x.tar.gz')
         self.assertEqual(inst.object_name, 'x.tar.gz')
         self.assertEqual(inst.sha256sum, 'abc')
+        self.assertEqual(inst.size_bytes, 123)
         self.assertTrue(inst.owns_dest)
 
     def test_overlay_object_does_not_own_dest(self):
@@ -239,6 +255,7 @@ class ForDepTest(unittest.TestCase):
             self._spec([{
                 'object_name': 'x.tar.gz',
                 'sha256sum': 'abc',
+                'size_bytes': 123,
                 'overlayed_on': 'base.tar.xz'
             }]))
         self.assertFalse(inst.owns_dest)
@@ -247,11 +264,13 @@ class ForDepTest(unittest.TestCase):
         spec = self._spec([
             {
                 'object_name': 'a.tar.gz',
-                'sha256sum': '1'
+                'sha256sum': '1',
+                'size_bytes': 1
             },
             {
                 'object_name': 'b.tar.gz',
-                'sha256sum': '2'
+                'sha256sum': '2',
+                'size_bytes': 2
             },
         ])
         with self.assertRaisesRegex(ValueError, 'single-object'):


### PR DESCRIPTION
Adding size check to align our extra deps more to what it would look
like in a depot_tools fork. This also improves the safety of our check.

Bug: https://github.com/brave/brave-browser/issues/56723
