### PR TITLE
[Android] Add "Dynamic Colors" user preference

### DIFF
--- a/android/java/brave-res/xml/brave_appearance_preferences.xml
+++ b/android/java/brave-res/xml/brave_appearance_preferences.xml
@@ -9,6 +9,13 @@
         android:key="navigation_section"
         android:title="@string/appearance_navigation_section_title" />
 
+    <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
+        android:key="brave_android_dynamic_colors_enabled"
+        android:icon="@drawable/ic_themes"
+        android:title="@string/brave_android_dynamic_colors_title"
+        android:summary="@string/brave_android_dynamic_colors_summary"
+        app:isPreferenceVisible="false" />
+
     <org.chromium.components.browser_ui.settings.ChromeBasePreference
         android:fragment="org.chromium.brave.browser.customize_menu.settings.BraveCustomizeMenuPreferenceFragment"
         android:key="brave_customize_menu"
@@ -47,7 +54,8 @@
         android:icon="@drawable/ic_share"
         android:title="@string/brave_sharing_hub_title"
         android:summaryOn="@string/text_on"
-        android:summaryOff="@string/text_off" />
+        android:summaryOff="@string/text_off"
+        app:isPreferenceVisible="false" />
 
     <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
         android:key="show_brave_rewards_icon"

--- a/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
@@ -35,6 +35,7 @@ import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
 import org.chromium.chrome.browser.profiles.Profile;
 import org.chromium.chrome.browser.settings.search.ChromeBaseSearchIndexProvider;
 import org.chromium.chrome.browser.tasks.tab_management.BraveTabUiFeatureUtilities;
+import org.chromium.chrome.browser.theme.BraveDynamicColors;
 import org.chromium.chrome.browser.toolbar.ToolbarPositionController;
 import org.chromium.chrome.browser.toolbar.adaptive.AdaptiveToolbarButtonVariant;
 import org.chromium.chrome.browser.toolbar.adaptive.AdaptiveToolbarPrefs;
@@ -102,6 +103,13 @@ public class AppearancePreferences extends AppearanceSettingsFragment
         setPreferenceVisibleIfPresent(
                 PREF_BRAVE_DISABLE_SHARING_HUB, shouldShowSharingHubPreference());
 
+        if (BraveDynamicColors.isDynamicColorsAvailable()) {
+            setPreferenceVisibleIfPresent(
+                    BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, true);
+        } else {
+            removePreferenceIfPresent(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED);
+        }
+
         if (BraveTabUiFeatureUtilities.isBraveAndroidTabGroupsSettingsFeatureEnabled()) {
             removePreferenceIfPresent(PREF_BRAVE_ENABLE_TAB_GROUPS);
             removePreferenceIfPresent(PREF_SHOW_UNDO_WHEN_TABS_CLOSED);
@@ -160,6 +168,14 @@ public class AppearancePreferences extends AppearanceSettingsFragment
                 findPreference(BravePreferenceKeys.BRAVE_BOTTOM_TOOLBAR_ENABLED_KEY);
         if (enableBottomToolbar != null) {
             enableBottomToolbar.setOnPreferenceChangeListener(this);
+        }
+
+        ChromeSwitchPreference dynamicColorsPref =
+                (ChromeSwitchPreference)
+                        findPreference(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED);
+        if (dynamicColorsPref != null) {
+            dynamicColorsPref.setChecked(BraveDynamicColors.isDynamicColorsEnabled());
+            dynamicColorsPref.setOnPreferenceChangeListener(this);
         }
 
         Preference sharingHub = findPreference(PREF_BRAVE_DISABLE_SHARING_HUB);
@@ -288,6 +304,9 @@ public class AppearancePreferences extends AppearanceSettingsFragment
             BraveFeatureUtil.enableFeature(
                     BraveFeatureList.ENABLE_FORCE_DARK, (boolean) newValue, true);
             shouldRelaunch = true;
+        } else if (BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED.equals(key)) {
+            ChromeSharedPreferences.getInstance().writeBoolean(key, (boolean) newValue);
+            shouldRelaunch = true;
         } else if (PREF_BRAVE_DISABLE_SHARING_HUB.equals(key)) {
             setSharingHubEnabled((boolean) newValue);
         } else if (PREF_BRAVE_ENABLE_TAB_GROUPS.equals(key)) {
@@ -386,19 +405,20 @@ public class AppearancePreferences extends AppearanceSettingsFragment
     private void applyOrdering() {
         setPreferenceOrder(PREF_NAVIGATION_SECTION, 0);
         setPreferenceOrder(AppearanceSettingsFragment.PREF_UI_THEME, 1);
-        setPreferenceOrder(PREF_BRAVE_CUSTOMIZE_MENU, 2);
-        setPreferenceOrder(AppearanceSettingsFragment.PREF_TOOLBAR_SHORTCUT, 3);
-        setPreferenceOrder(PREF_ADDRESS_BAR, 4);
-        setPreferenceOrder(BravePreferenceKeys.BRAVE_BOTTOM_TOOLBAR_ENABLED_KEY, 5);
-        setPreferenceOrder(PREF_ENABLE_MULTI_WINDOWS, 6);
-        setPreferenceOrder(PREF_GENERAL_SECTION, 7);
-        setPreferenceOrder(PREF_BRAVE_NIGHT_MODE_ENABLED, 8);
-        setPreferenceOrder(PREF_BRAVE_DISABLE_SHARING_HUB, 9);
-        setPreferenceOrder(PREF_SHOW_BRAVE_REWARDS_ICON, 10);
-        setPreferenceOrder(PREF_ADS_SWITCH, 11);
-        setPreferenceOrder(AppearanceSettingsFragment.PREF_BOOKMARK_BAR, 12);
-        setPreferenceOrder(PREF_BRAVE_ENABLE_TAB_GROUPS, 13);
-        setPreferenceOrder(PREF_SHOW_UNDO_WHEN_TABS_CLOSED, 14);
+        setPreferenceOrder(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, 2);
+        setPreferenceOrder(PREF_BRAVE_CUSTOMIZE_MENU, 3);
+        setPreferenceOrder(AppearanceSettingsFragment.PREF_TOOLBAR_SHORTCUT, 4);
+        setPreferenceOrder(PREF_ADDRESS_BAR, 5);
+        setPreferenceOrder(BravePreferenceKeys.BRAVE_BOTTOM_TOOLBAR_ENABLED_KEY, 6);
+        setPreferenceOrder(PREF_ENABLE_MULTI_WINDOWS, 7);
+        setPreferenceOrder(PREF_GENERAL_SECTION, 8);
+        setPreferenceOrder(PREF_BRAVE_NIGHT_MODE_ENABLED, 9);
+        setPreferenceOrder(PREF_BRAVE_DISABLE_SHARING_HUB, 10);
+        setPreferenceOrder(PREF_SHOW_BRAVE_REWARDS_ICON, 11);
+        setPreferenceOrder(PREF_ADS_SWITCH, 12);
+        setPreferenceOrder(AppearanceSettingsFragment.PREF_BOOKMARK_BAR, 13);
+        setPreferenceOrder(PREF_BRAVE_ENABLE_TAB_GROUPS, 14);
+        setPreferenceOrder(PREF_SHOW_UNDO_WHEN_TABS_CLOSED, 15);
     }
 
     private void setPreferenceOrder(String key, int order) {
@@ -489,6 +509,11 @@ public class AppearancePreferences extends AppearanceSettingsFragment
 
                     if (!shouldShowSharingHubPreference()) {
                         indexData.removeEntryForKey(frag, PREF_BRAVE_DISABLE_SHARING_HUB);
+                    }
+
+                    if (!BraveDynamicColors.isDynamicColorsAvailable()) {
+                        indexData.removeEntryForKey(
+                                frag, BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED);
                     }
 
                     if (BraveTabUiFeatureUtilities

--- a/android/javatests/org/chromium/chrome/browser/settings/BraveAppearancePreferencesTest.java
+++ b/android/javatests/org/chromium/chrome/browser/settings/BraveAppearancePreferencesTest.java
@@ -7,6 +7,7 @@ package org.chromium.chrome.browser.settings;
 
 import static org.junit.Assert.assertTrue;
 
+import android.os.Build;
 import android.os.Looper;
 
 import androidx.annotation.Nullable;
@@ -61,6 +62,7 @@ public class BraveAppearancePreferencesTest {
         final String[] sortedPrefKeys = {
             AppearancePreferences.PREF_NAVIGATION_SECTION,
             AppearanceSettingsFragment.PREF_UI_THEME,
+            BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED,
             AppearancePreferences.PREF_BRAVE_CUSTOMIZE_MENU,
             AppearanceSettingsFragment.PREF_TOOLBAR_SHORTCUT,
             AppearancePreferences.PREF_ADDRESS_BAR,
@@ -88,6 +90,23 @@ public class BraveAppearancePreferencesTest {
                     "\"" + prevPref.getTitle() + "\" should precede \"" + pref.getTitle() + "\"",
                     pref.getOrder() > prevPref.getOrder());
             prevPref = pref;
+        }
+    }
+
+    @Test
+    @SmallTest
+    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
+    public void testDynamicColorsPreferenceAvailability() {
+        startSettings();
+
+        Preference dynamicColorsPreference =
+                mAppearancePreferences.findPreference(
+                        BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            Assert.assertNotNull(dynamicColorsPreference);
+            assertTrue(dynamicColorsPreference.isVisible());
+        } else {
+            Assert.assertNull(dynamicColorsPreference);
         }
     }
 

--- a/android/nala/icons.gni
+++ b/android/nala/icons.gni
@@ -164,6 +164,7 @@ nala_icons = [
   "ic_social_brave_outline_favicon_fullheight.xml",
   "ic_social_brave_release_favicon_fullheight_color.xml",
   "ic_theme_dark.xml",
+  "ic_themes.xml",
   "ic_trash.xml",
   "ic_tune.xml",
   "ic_widget_generic.xml",

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -1686,6 +1686,12 @@ Are you sure you want to do this?
       <message name="IDS_NIGHT_MODE_SUMMARY" desc="Summary for Night Mode, which forces web content into dark mode.">
         Force dark mode for web content
       </message>
+      <message name="IDS_BRAVE_ANDROID_DYNAMIC_COLORS_TITLE" desc="Title for the Android Appearance preference that enables dynamic colors.">
+        Dynamic colors
+      </message>
+      <message name="IDS_BRAVE_ANDROID_DYNAMIC_COLORS_SUMMARY" desc="Summary for the Android Appearance preference that enables dynamic colors.">
+        Change the color palette to match user settings and wallpaper colors
+      </message>
       <message name="IDS_ACCESSIBILITY_TOOLBAR_BTN_SEARCH_ACCELERATOR" desc="Content description for the search accelerator button">
         Search
       </message>

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -1690,7 +1690,7 @@ Are you sure you want to do this?
         Dynamic colors
       </message>
       <message name="IDS_BRAVE_ANDROID_DYNAMIC_COLORS_SUMMARY" desc="Summary for the Android Appearance preference that enables dynamic colors.">
-        Change the color palette to match user settings and wallpaper colors
+        App theme matches wallpaper colors
       </message>
       <message name="IDS_ACCESSIBILITY_TOOLBAR_BTN_SEARCH_ACCELERATOR" desc="Content description for the search accelerator button">
         Search


### PR DESCRIPTION

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/55968.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Summary of changes

**Add "Dynamic Colors" user preference (53153ffd04a746a5ed9952f355b311eff72980d8)**
- add "Dynamic colors" preference, which only displays if `BraveDynamicColors.isDynamicColorsAvailable()` is `true`
- add required strings
- define `ic_themes.xml` icon

## Screenshots

&nbsp;|`#brave-android-dynamic-colors` flag `enabled`|`#brave-android-dynamic-colors` flag `disabled`
--|--|--
Android 12+ |<img width="1080" height="2400" src="https://github.com/user-attachments/assets/20b273dc-63e0-4f17-93f9-a01d875c5e89" />|<img width="1080" height="2400" src="https://github.com/user-attachments/assets/e058f7f6-e025-4e06-bc04-43af752ec994" />
<= Android 11 |<img width="1080" height="2400" src="https://github.com/user-attachments/assets/cbb1432b-2220-4c90-95d4-980cf9877661" />|<img width="1080" height="2400" src="https://github.com/user-attachments/assets/cbb1432b-2220-4c90-95d4-980cf9877661" />

## Notes

This ticket adds the UI for the preference added in #38117 / https://github.com/brave/brave-core/commit/26e833de76ac8a915af09469e07c01ca3d73d039. Enabling this setting will be handled via https://github.com/brave/brave-browser/issues/57121.