### PR TITLE
Fix Android unused-import formatter on macOS

### DIFF
--- a/tools/android/checkstyle/remove_unused_imports.sh
+++ b/tools/android/checkstyle/remove_unused_imports.sh
@@ -6,10 +6,11 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 SCRIPT_DIR="$( dirname -- "${BASH_SOURCE[0]}"; )"
-SCRIPT_DIR="$( realpath -e -- "$SCRIPT_DIR"; )"
+# `cd` requires an existing directory, while `-P` resolves symbolic links.
+SCRIPT_DIR="$( cd -P -- "$SCRIPT_DIR" && pwd -P; )"
 
 CHROMIUM_CHECKSTYLE_DIR="$SCRIPT_DIR/../../../../tools/android/checkstyle"
-CHROMIUM_CHECKSTYLE_DIR="$( realpath -e -- "$CHROMIUM_CHECKSTYLE_DIR"; )"
+CHROMIUM_CHECKSTYLE_DIR="$( cd -P -- "$CHROMIUM_CHECKSTYLE_DIR" && pwd -P; )"
 export PYTHONPATH="$CHROMIUM_CHECKSTYLE_DIR"
 
 python3  "$SCRIPT_DIR/remove_unused_imports.py"


### PR DESCRIPTION

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57322.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Changes

**Fix Android unused-import formatter on macOS** (7e9f2f9da423b19065525315490cfab47297b944)

macOS `/bin/realpath` does not support the GNU `realpath -e` option, so the formatter fails before it starts.

Modify `remove_unused_imports.sh` to use `cd -P` and `pwd -P` to resolve `SCRIPT_DIR` and `CHROMIUM_CHECKSTYLE_DIR`.


## Validation

### Before

```sh
./tools/android/checkstyle/remove_unused_imports.sh
realpath: illegal option -- e
usage: realpath [-q] [path ...]
realpath: illegal option -- e
usage: realpath [-q] [path ...]
/opt/homebrew/Cellar/python@3.14/3.14.5/Frameworks/Python.framework/Versions/3.14/Resources/Python.app/Contents/MacOS/Python: can't open file '/remove_unused_imports.py': [Errno 2] No such file or directory
```

### After 

```sh
./tools/android/checkstyle/remove_unused_imports.sh
There are no changed .java files.
```


@AlexeyBarabash - I only verified this on MacOS. I presume you have access to a linux machine to verify? Please let me know of any issues. Many thanks. 