### PR TITLE
Add Nemotron-English only streaming inference logic

### DIFF
--- a/build/webpack/BUILD.gn
+++ b/build/webpack/BUILD.gn
@@ -19,6 +19,7 @@ generated_file("build_flags_json") {
     enable_brave_wallet = enable_brave_wallet
     enable_email_aliases = enable_email_aliases
     is_brave_origin_branded = is_brave_origin_branded
+    is_official_build = is_official_build
     is_ios = is_ios
     is_android = is_android
     is_linux = is_linux

--- a/components/local_ai/resources/speech_worker/audio_features.test.ts
+++ b/components/local_ai/resources/speech_worker/audio_features.test.ts
@@ -10,255 +10,238 @@
 import { describe, expect, it } from '@jest/globals'
 
 import {
-    hannWindow,
-    initFftPower,
-    fftPower,
-    StreamingMelFrontend,
+  hannWindow,
+  initFftPower,
+  fftPower,
+  StreamingMelFrontend,
 } from './audio_features'
 
 import * as config from './configs'
 import type { FftSize } from './configs'
 
 describe('FrontEndProcessing', () => {
-    describe('hannWindow', () => {
-        // Test to verify that - 
-        // (a) Hann window formula is correct
-        // (b) Window is zero at beginning and ending
-        // (c) Window is symmetric
-        it('matches the symmetric Hann definition', () => {
-            const hann = hannWindow()
+  describe('hannWindow', () => {
+    // Test to verify that -
+    // (a) Hann window formula is correct
+    // (b) Window is zero at beginning and ending
+    // (c) Window is symmetric
+    it('matches the symmetric Hann definition', () => {
+      const hann = hannWindow()
 
-            expect(hann.length).toBe(config.WIN_LENGTH)
+      expect(hann.length).toBe(config.WIN_LENGTH)
 
-            for (let i = 0; i < config.WIN_LENGTH; i++) {
-            const expected =
-                0.5 -
-                0.5 * Math.cos(
-                (2 * Math.PI * i) /
-                (config.WIN_LENGTH - 1),
-                )
+      for (let i = 0; i < config.WIN_LENGTH; i++) {
+        const expected =
+          0.5 - 0.5 * Math.cos((2 * Math.PI * i) / (config.WIN_LENGTH - 1))
 
-            expect(hann[i]).toBeCloseTo(expected, 6) // 6 decimal places precision
-            }
-        })
-
-        it('is symmetric and zero at both ends', () => {
-            const hann = hannWindow()
-
-            expect(hann[0]).toBeCloseTo(0)
-            expect(hann[hann.length - 1]).toBeCloseTo(0)
-
-            for (let i = 0; i < hann.length; i++) {
-            expect(hann[i]).toBeCloseTo(
-                hann[hann.length - 1 - i],
-                6,
-            )
-            }
-        })
+        expect(hann[i]).toBeCloseTo(expected, 6) // 6 decimal places precision
+      }
     })
-    describe('FFTCalculations', () => {
-        // Test to verify that -
-        // (a) FFT of an impulse signal is correctly calculated
-        // (b) same about a constant signal
-        // (c) FFT puts energy in the correct freq. bin
-        it('computes the power spectrum of an impulse', () => {
-            const fft = initFftPower(config.N_FFT as FftSize)
-          
-            // impulse has 1 at index 0, and 0 at all other indices
-            fft.frame.fill(0)
-            fft.frame[0] = 1
-          
-            const power = fftPower(fft)
-          
-            // FFT of impulse is 1 at all freq points
-            expect(power.length).toBe(config.N_FFT / 2 + 1)
-          
-            for (const p of power) {
-              expect(p).toBeCloseTo(1, 5)
-            }
-        })
 
-        it('computes the power spectrum of a constant signal', () => {
-            const fft = initFftPower(config.N_FFT as FftSize)
-          
-            // constant signal is 1 for all indices
-            fft.frame.fill(1)
-          
-            const power = fftPower(fft)
-          
-            // FFT of constant is non-zero only at freq 0, the DC component
-            expect(power[0]).toBeCloseTo(
-              config.N_FFT * config.N_FFT,
-              2,
-            )
-          
-            for (let k = 1; k < power.length; k++) {
-              expect(power[k]).toBeCloseTo(0, 2)
-            }
-        })
+    it('is symmetric and zero at both ends', () => {
+      const hann = hannWindow()
 
-        it('puts a bin-centred sinusoid in the expected FFT bin', () => {
-            const fft = initFftPower(config.N_FFT as FftSize)
-            const bin = 7
-          
-            for (let n = 0; n < config.N_FFT; n++) {
-              fft.frame[n] = Math.sin(
-                2 * Math.PI * bin * n / config.N_FFT,
-              )
-            }
-          
-            const power = fftPower(fft)
-          
-            let maxBin = 0
-          
-            for (let k = 1; k < power.length; k++) {
-              if (power[k] > power[maxBin]) {
-                maxBin = k
-              }
-            }
-          
-            expect(maxBin).toBe(bin)
-        })
+      expect(hann[0]).toBeCloseTo(0)
+      expect(hann[hann.length - 1]).toBeCloseTo(0)
+
+      for (let i = 0; i < hann.length; i++) {
+        expect(hann[i]).toBeCloseTo(hann[hann.length - 1 - i], 6)
+      }
     })
-    describe('MelFrontEnd', () => {
-        // Test to verify that -
-        // (a) mel features must depend on the audio, not on the Web Speech packet boundaries
-        it('produces the same mel features regardless of audio packet boundaries', () => {
-            const fbank = createTestMelFilterbank()
-            const makeFrontend = () =>
-                new StreamingMelFrontend(
-                    fbank,
-                    hannWindow(),
-                    initFftPower(config.N_FFT as FftSize),
-                    config.TARGET_SAMPLE_RATE,
-                )
-        
-            const frontendAllAtOnce = makeFrontend()
-            const frontendChunked = makeFrontend()
-        
-            // Enough audio to produce at least one complete encoder chunk.
-            const sampleCount =
-            config.NEMO_CHUNK * config.HOP_LENGTH +
-            config.STREAMING_RIGHT_CONTEXT
-        
-            // Deterministic non-trivial signal.
-            const audio = new Float32Array(sampleCount)
-        
-            for (let i = 0; i < audio.length; i++) {
-            audio[i] =
-                0.2 * Math.sin(2 * Math.PI * 440 * i / config.TARGET_SAMPLE_RATE) +
-                0.1 * Math.sin(2 * Math.PI * 1000 * i / config.TARGET_SAMPLE_RATE)
-            }
-        
-            // Frontend A gets the entire stream in one call.
-            frontendAllAtOnce.appendAudioSamples(audio)
-        
-            // Frontend B gets exactly the same samples, but with arbitrary
-            // packet boundaries.
-            const packetSizes = [
-            17,
-            101,
-            503,
-            37,
-            1000,
-            211,
-            ]
-        
-            let offset = 0
-            let packet = 0
-        
-            while (offset < audio.length) {
-                const size = packetSizes[packet % packetSizes.length]
-                const end = Math.min(offset + size, audio.length)
-            
-                frontendChunked.appendAudioSamples(
-                    audio.subarray(offset, end),
-                )
-            
-                offset = end
-                packet++
-            }
-            
-            expect(frontendAllAtOnce.hasFullChunk()).toBe(true)
-            expect(frontendChunked.hasFullChunk()).toBe(true)
-        
-            const expected =
-            frontendAllAtOnce.makeNextEncoderInput()
-        
-            const actual =
-            frontendChunked.makeNextEncoderInput()
-        
-            expect(actual.length).toBe(expected.length)
-            
-            for (let i = 0; i < expected.length; i++) {
-            expect(actual[i]).toBeCloseTo(expected[i], 6)
-            }
-        })
+  })
+  describe('FFTCalculations', () => {
+    // Test to verify that -
+    // (a) FFT of an impulse signal is correctly calculated
+    // (b) same about a constant signal
+    // (c) FFT puts energy in the correct freq. bin
+    it('computes the power spectrum of an impulse', () => {
+      const fft = initFftPower(config.N_FFT as FftSize)
+
+      // impulse has 1 at index 0, and 0 at all other indices
+      fft.frame.fill(0)
+      fft.frame[0] = 1
+
+      const power = fftPower(fft)
+
+      // FFT of impulse is 1 at all freq points
+      expect(power.length).toBe(config.N_FFT / 2 + 1)
+
+      for (const p of power) {
+        expect(p).toBeCloseTo(1, 5)
+      }
     })
+
+    it('computes the power spectrum of a constant signal', () => {
+      const fft = initFftPower(config.N_FFT as FftSize)
+
+      // constant signal is 1 for all indices
+      fft.frame.fill(1)
+
+      const power = fftPower(fft)
+
+      // FFT of constant is non-zero only at freq 0, the DC component
+      expect(power[0]).toBeCloseTo(config.N_FFT * config.N_FFT, 2)
+
+      for (let k = 1; k < power.length; k++) {
+        expect(power[k]).toBeCloseTo(0, 2)
+      }
+    })
+
+    it('puts a bin-centred sinusoid in the expected FFT bin', () => {
+      const fft = initFftPower(config.N_FFT as FftSize)
+      const bin = 7
+
+      for (let n = 0; n < config.N_FFT; n++) {
+        fft.frame[n] = Math.sin((2 * Math.PI * bin * n) / config.N_FFT)
+      }
+
+      const power = fftPower(fft)
+
+      let maxBin = 0
+
+      for (let k = 1; k < power.length; k++) {
+        if (power[k] > power[maxBin]) {
+          maxBin = k
+        }
+      }
+
+      expect(maxBin).toBe(bin)
+    })
+  })
+  describe('MelFrontEnd', () => {
+    // Test to verify that -
+    // (a) mel features must depend on the audio, not on the Web Speech packet boundaries
+    it('produces the same mel features regardless of audio packet boundaries', () => {
+      const fbank = createTestMelFilterbank()
+      const makeFrontend = () =>
+        new StreamingMelFrontend(
+          fbank,
+          hannWindow(),
+          initFftPower(config.N_FFT as FftSize),
+          config.TARGET_SAMPLE_RATE,
+        )
+
+      const frontendAllAtOnce = makeFrontend()
+      const frontendChunked = makeFrontend()
+
+      // Enough audio to produce at least one complete encoder chunk.
+      const sampleCount =
+        config.NEMO_CHUNK * config.HOP_LENGTH + config.STREAMING_RIGHT_CONTEXT
+
+      // Deterministic non-trivial signal.
+      const audio = new Float32Array(sampleCount)
+
+      for (let i = 0; i < audio.length; i++) {
+        audio[i] =
+          0.2 * Math.sin((2 * Math.PI * 440 * i) / config.TARGET_SAMPLE_RATE)
+          + 0.1 * Math.sin((2 * Math.PI * 1000 * i) / config.TARGET_SAMPLE_RATE)
+      }
+
+      // Frontend A gets the entire stream in one call.
+      frontendAllAtOnce.appendAudioSamples(audio)
+
+      // Frontend B gets exactly the same samples, but with arbitrary
+      // packet boundaries.
+      const packetSizes = [17, 101, 503, 37, 1000, 211]
+
+      let offset = 0
+      let packet = 0
+
+      while (offset < audio.length) {
+        const size = packetSizes[packet % packetSizes.length]
+        const end = Math.min(offset + size, audio.length)
+
+        frontendChunked.appendAudioSamples(audio.subarray(offset, end))
+
+        offset = end
+        packet++
+      }
+
+      expect(frontendAllAtOnce.hasFullChunk()).toBe(true)
+      expect(frontendChunked.hasFullChunk()).toBe(true)
+
+      const expected = frontendAllAtOnce.makeNextEncoderInput()
+
+      const actual = frontendChunked.makeNextEncoderInput()
+
+      expect(actual.length).toBe(expected.length)
+
+      for (let i = 0; i < expected.length; i++) {
+        expect(actual[i]).toBeCloseTo(expected[i], 6)
+      }
+    })
+  })
 })
 
-// Helper functions to compute a Slaney-style mel filterbank 
+// Helper functions to compute a Slaney-style mel filterbank
 
 // function to convert freq. from hz to mel scale
 function hzToMelSlaney(hz: number) {
-    const fSp = 200.0 / 3.0;
-    const minLogHz = 1000.0;
-    const minLogMel = minLogHz / fSp;
-    const logStep = 0.06875177742094912;
-    return hz < minLogHz ? hz / fSp : minLogMel + Math.log(hz / minLogHz) / logStep;
+  const fSp = 200.0 / 3.0
+  const minLogHz = 1000.0
+  const minLogMel = minLogHz / fSp
+  const logStep = 0.06875177742094912
+  return hz < minLogHz
+    ? hz / fSp
+    : minLogMel + Math.log(hz / minLogHz) / logStep
 }
 
 // function to convert freq. from mel scale to hz
 function melToHzSlaney(mel: number) {
-    const fSp = 200.0 / 3.0;
-    const minLogHz = 1000.0;
-    const minLogMel = minLogHz / fSp;
-    const logStep = 0.06875177742094912;
-    return mel < minLogMel ? mel * fSp : minLogHz * Math.exp((mel - minLogMel) * logStep);
+  const fSp = 200.0 / 3.0
+  const minLogHz = 1000.0
+  const minLogMel = minLogHz / fSp
+  const logStep = 0.06875177742094912
+  return mel < minLogMel
+    ? mel * fSp
+    : minLogHz * Math.exp((mel - minLogMel) * logStep)
 }
 
-export function createMelFilterbank() {
-    const freqBins = config.N_FFT / 2 + 1;
-    const filterbank = Array.from({ length: config.N_MELS }, () => new Float32Array(freqBins));
-    const fmax = config.TARGET_SAMPLE_RATE / 2;
-    const melMin = hzToMelSlaney(0);
-    const melMax = hzToMelSlaney(fmax);
-    const melPoints = [];
+function createMelFilterbank() {
+  const freqBins = config.N_FFT / 2 + 1
+  const filterbank = Array.from(
+    { length: config.N_MELS },
+    () => new Float32Array(freqBins),
+  )
+  const fmax = config.TARGET_SAMPLE_RATE / 2
+  const melMin = hzToMelSlaney(0)
+  const melMax = hzToMelSlaney(fmax)
+  const melPoints = []
 
-    for (let i = 0; i <= config.N_MELS + 1; i++) {
-        melPoints.push(melToHzSlaney(melMin + ((melMax - melMin) * i) / (config.N_MELS + 1)));
+  for (let i = 0; i <= config.N_MELS + 1; i++) {
+    melPoints.push(
+      melToHzSlaney(melMin + ((melMax - melMin) * i) / (config.N_MELS + 1)),
+    )
+  }
+
+  const fftFreqs = Array.from(
+    { length: freqBins },
+    (_, i) => (i * config.TARGET_SAMPLE_RATE) / config.N_FFT,
+  )
+  const fdiff = melPoints.slice(1).map((v, i) => v - melPoints[i])
+
+  for (let i = 0; i < config.N_MELS; i++) {
+    const enorm = 2.0 / (melPoints[i + 2] - melPoints[i])
+    for (let k = 0; k < freqBins; k++) {
+      const lower = (fftFreqs[k] - melPoints[i]) / fdiff[i]
+      const upper = (melPoints[i + 2] - fftFreqs[k]) / fdiff[i + 1]
+      filterbank[i][k] = Math.max(0, Math.min(lower, upper)) * enorm
     }
+  }
 
-    const fftFreqs = Array.from({ length: freqBins }, (_, i) => (i * config.TARGET_SAMPLE_RATE) / config.N_FFT);
-    const fdiff = melPoints.slice(1).map((v, i) => v - melPoints[i]);
-
-    for (let i = 0; i < config.N_MELS; i++) {
-        const enorm = 2.0 / (melPoints[i + 2] - melPoints[i]);
-        for (let k = 0; k < freqBins; k++) {
-            const lower = (fftFreqs[k] - melPoints[i]) / fdiff[i];
-            const upper = (melPoints[i + 2] - fftFreqs[k]) / fdiff[i + 1];
-            filterbank[i][k] = Math.max(0, Math.min(lower, upper)) * enorm;
-        }
-    }
-
-    return filterbank;
+  return filterbank
 }
 
 // Flatten it for structural compatibility with the filterbank.bin used in production code
 function createTestMelFilterbank(): Float32Array {
-    const filterbank2d = createMelFilterbank()
-    const freqBins = config.N_FFT / 2 + 1
-  
-    const flat = new Float32Array(
-      config.N_MELS * freqBins,
-    )
-  
-    for (let m = 0; m < config.N_MELS; m++) {
-      flat.set(
-        filterbank2d[m],
-        m * freqBins,
-      )
-    }
-  
-    return flat
+  const filterbank2d = createMelFilterbank()
+  const freqBins = config.N_FFT / 2 + 1
+
+  const flat = new Float32Array(config.N_MELS * freqBins)
+
+  for (let m = 0; m < config.N_MELS; m++) {
+    flat.set(filterbank2d[m], m * freqBins)
+  }
+
+  return flat
 }

--- a/components/local_ai/resources/speech_worker/audio_features.test.ts
+++ b/components/local_ai/resources/speech_worker/audio_features.test.ts
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// These tests check the numerical correctness and streaming invariance of the audio
+// frontend, including Hann windowing, FFT power calculation, mel feature
+// generation, and independence from input packet boundaries.
+
+import { describe, expect, it } from '@jest/globals'
+
+import {
+    hannWindow,
+    initFftPower,
+    fftPower,
+    StreamingMelFrontend,
+} from './audio_features'
+
+import * as config from './configs'
+import type { FftSize } from './configs'
+
+describe('FrontEndProcessing', () => {
+    describe('hannWindow', () => {
+        // Test to verify that - 
+        // (a) Hann window formula is correct
+        // (b) Window is zero at beginning and ending
+        // (c) Window is symmetric
+        it('matches the symmetric Hann definition', () => {
+            const hann = hannWindow()
+
+            expect(hann.length).toBe(config.WIN_LENGTH)
+
+            for (let i = 0; i < config.WIN_LENGTH; i++) {
+            const expected =
+                0.5 -
+                0.5 * Math.cos(
+                (2 * Math.PI * i) /
+                (config.WIN_LENGTH - 1),
+                )
+
+            expect(hann[i]).toBeCloseTo(expected, 6) // 6 decimal places precision
+            }
+        })
+
+        it('is symmetric and zero at both ends', () => {
+            const hann = hannWindow()
+
+            expect(hann[0]).toBeCloseTo(0)
+            expect(hann[hann.length - 1]).toBeCloseTo(0)
+
+            for (let i = 0; i < hann.length; i++) {
+            expect(hann[i]).toBeCloseTo(
+                hann[hann.length - 1 - i],
+                6,
+            )
+            }
+        })
+    })
+    describe('FFTCalculations', () => {
+        // Test to verify that -
+        // (a) FFT of an impulse signal is correctly calculated
+        // (b) same about a constant signal
+        // (c) FFT puts energy in the correct freq. bin
+        it('computes the power spectrum of an impulse', () => {
+            const fft = initFftPower(config.N_FFT as FftSize)
+          
+            // impulse has 1 at index 0, and 0 at all other indices
+            fft.frame.fill(0)
+            fft.frame[0] = 1
+          
+            const power = fftPower(fft)
+          
+            // FFT of impulse is 1 at all freq points
+            expect(power.length).toBe(config.N_FFT / 2 + 1)
+          
+            for (const p of power) {
+              expect(p).toBeCloseTo(1, 5)
+            }
+        })
+
+        it('computes the power spectrum of a constant signal', () => {
+            const fft = initFftPower(config.N_FFT as FftSize)
+          
+            // constant signal is 1 for all indices
+            fft.frame.fill(1)
+          
+            const power = fftPower(fft)
+          
+            // FFT of constant is non-zero only at freq 0, the DC component
+            expect(power[0]).toBeCloseTo(
+              config.N_FFT * config.N_FFT,
+              2,
+            )
+          
+            for (let k = 1; k < power.length; k++) {
+              expect(power[k]).toBeCloseTo(0, 2)
+            }
+        })
+
+        it('puts a bin-centred sinusoid in the expected FFT bin', () => {
+            const fft = initFftPower(config.N_FFT as FftSize)
+            const bin = 7
+          
+            for (let n = 0; n < config.N_FFT; n++) {
+              fft.frame[n] = Math.sin(
+                2 * Math.PI * bin * n / config.N_FFT,
+              )
+            }
+          
+            const power = fftPower(fft)
+          
+            let maxBin = 0
+          
+            for (let k = 1; k < power.length; k++) {
+              if (power[k] > power[maxBin]) {
+                maxBin = k
+              }
+            }
+          
+            expect(maxBin).toBe(bin)
+        })
+    })
+    describe('MelFrontEnd', () => {
+        // Test to verify that -
+        // (a) mel features must depend on the audio, not on the Web Speech packet boundaries
+        it('produces the same mel features regardless of audio packet boundaries', () => {
+            const fbank = createTestMelFilterbank()
+            const makeFrontend = () =>
+                new StreamingMelFrontend(
+                    fbank,
+                    hannWindow(),
+                    initFftPower(config.N_FFT as FftSize),
+                    config.TARGET_SAMPLE_RATE,
+                )
+        
+            const frontendAllAtOnce = makeFrontend()
+            const frontendChunked = makeFrontend()
+        
+            // Enough audio to produce at least one complete encoder chunk.
+            const sampleCount =
+            config.NEMO_CHUNK * config.HOP_LENGTH +
+            config.STREAMING_RIGHT_CONTEXT
+        
+            // Deterministic non-trivial signal.
+            const audio = new Float32Array(sampleCount)
+        
+            for (let i = 0; i < audio.length; i++) {
+            audio[i] =
+                0.2 * Math.sin(2 * Math.PI * 440 * i / config.TARGET_SAMPLE_RATE) +
+                0.1 * Math.sin(2 * Math.PI * 1000 * i / config.TARGET_SAMPLE_RATE)
+            }
+        
+            // Frontend A gets the entire stream in one call.
+            frontendAllAtOnce.appendAudioSamples(audio)
+        
+            // Frontend B gets exactly the same samples, but with arbitrary
+            // packet boundaries.
+            const packetSizes = [
+            17,
+            101,
+            503,
+            37,
+            1000,
+            211,
+            ]
+        
+            let offset = 0
+            let packet = 0
+        
+            while (offset < audio.length) {
+                const size = packetSizes[packet % packetSizes.length]
+                const end = Math.min(offset + size, audio.length)
+            
+                frontendChunked.appendAudioSamples(
+                    audio.subarray(offset, end),
+                )
+            
+                offset = end
+                packet++
+            }
+            
+            expect(frontendAllAtOnce.hasFullChunk()).toBe(true)
+            expect(frontendChunked.hasFullChunk()).toBe(true)
+        
+            const expected =
+            frontendAllAtOnce.makeNextEncoderInput()
+        
+            const actual =
+            frontendChunked.makeNextEncoderInput()
+        
+            expect(actual.length).toBe(expected.length)
+            
+            for (let i = 0; i < expected.length; i++) {
+            expect(actual[i]).toBeCloseTo(expected[i], 6)
+            }
+        })
+    })
+})
+
+// Helper functions to compute a Slaney-style mel filterbank 
+
+// function to convert freq. from hz to mel scale
+function hzToMelSlaney(hz: number) {
+    const fSp = 200.0 / 3.0;
+    const minLogHz = 1000.0;
+    const minLogMel = minLogHz / fSp;
+    const logStep = 0.06875177742094912;
+    return hz < minLogHz ? hz / fSp : minLogMel + Math.log(hz / minLogHz) / logStep;
+}
+
+// function to convert freq. from mel scale to hz
+function melToHzSlaney(mel: number) {
+    const fSp = 200.0 / 3.0;
+    const minLogHz = 1000.0;
+    const minLogMel = minLogHz / fSp;
+    const logStep = 0.06875177742094912;
+    return mel < minLogMel ? mel * fSp : minLogHz * Math.exp((mel - minLogMel) * logStep);
+}
+
+export function createMelFilterbank() {
+    const freqBins = config.N_FFT / 2 + 1;
+    const filterbank = Array.from({ length: config.N_MELS }, () => new Float32Array(freqBins));
+    const fmax = config.TARGET_SAMPLE_RATE / 2;
+    const melMin = hzToMelSlaney(0);
+    const melMax = hzToMelSlaney(fmax);
+    const melPoints = [];
+
+    for (let i = 0; i <= config.N_MELS + 1; i++) {
+        melPoints.push(melToHzSlaney(melMin + ((melMax - melMin) * i) / (config.N_MELS + 1)));
+    }
+
+    const fftFreqs = Array.from({ length: freqBins }, (_, i) => (i * config.TARGET_SAMPLE_RATE) / config.N_FFT);
+    const fdiff = melPoints.slice(1).map((v, i) => v - melPoints[i]);
+
+    for (let i = 0; i < config.N_MELS; i++) {
+        const enorm = 2.0 / (melPoints[i + 2] - melPoints[i]);
+        for (let k = 0; k < freqBins; k++) {
+            const lower = (fftFreqs[k] - melPoints[i]) / fdiff[i];
+            const upper = (melPoints[i + 2] - fftFreqs[k]) / fdiff[i + 1];
+            filterbank[i][k] = Math.max(0, Math.min(lower, upper)) * enorm;
+        }
+    }
+
+    return filterbank;
+}
+
+// Flatten it for structural compatibility with the filterbank.bin used in production code
+function createTestMelFilterbank(): Float32Array {
+    const filterbank2d = createMelFilterbank()
+    const freqBins = config.N_FFT / 2 + 1
+  
+    const flat = new Float32Array(
+      config.N_MELS * freqBins,
+    )
+  
+    for (let m = 0; m < config.N_MELS; m++) {
+      flat.set(
+        filterbank2d[m],
+        m * freqBins,
+      )
+    }
+  
+    return flat
+}

--- a/components/local_ai/resources/speech_worker/audio_features.ts
+++ b/components/local_ai/resources/speech_worker/audio_features.ts
@@ -1,0 +1,387 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as config from './configs'
+import type { FftSize, FftState } from './configs'
+
+export interface StreamingMelFrontendDebugState {
+  rawSamplesReceived: number
+  rawBaseSample: number
+  rawBufferedSamples: number
+
+  melFrameBase: number
+  melBufferedFrames: number
+  nextMelFrame: number
+  nextChunkFrame: number
+
+  stableBacklogFrames: number
+  chunksReady: number
+  estimatedStableBacklogMs: number
+}
+
+// standard symmetric Hann window; following NeMo's implementation
+export function hannWindow(): Float32Array {
+  return Float32Array.from(
+    { length: config.WIN_LENGTH },
+    (_, i) => 0.5 - 0.5 * Math.cos((2 * Math.PI * i) / (config.WIN_LENGTH - 1)),
+  )
+}
+
+// Initializes reusable state and working buffers for a radix-2
+// Cooley–Tukey FFT, including a bit-reversal lookup table.
+export function initFftPower(n: FftSize): FftState {
+  if ((n & (n - 1)) !== 0) {
+    throw new Error(`N_FFT must be a power of two, got ${n}`)
+  }
+
+  const bits = Math.log2(n)
+  const bitRev = new Uint16Array(n)
+
+  for (let i = 0; i < n; i++) {
+    let x = i
+    let y = 0
+
+    for (let b = 0; b < bits; b++) {
+      y = (y << 1) | (x & 1)
+      x >>= 1
+    }
+
+    bitRev[i] = y
+  }
+
+  return {
+    n,
+    bitRev,
+    real: new Float32Array(n),
+    imag: new Float32Array(n),
+    power: new Float32Array(n / 2 + 1),
+    frame: new Float32Array(n),
+  }
+}
+
+// Compute power spectrum from a real-valued N_FFT frame.
+function fftPower(frame: Float32Array, fft: FftState): Float32Array {
+  const n = fft.n
+  const real = fft.real
+  const imag = fft.imag
+  const bitRev = fft.bitRev
+
+  // Bit-reversed copy of real input.
+  // frame is expected to have length N_FFT.
+  for (let i = 0; i < n; i++) {
+    real[i] = frame[bitRev[i]]
+    imag[i] = 0.0
+  }
+
+  // Iterative radix-2 Cooley-Tukey FFT.
+  // This matches the forward transform:
+  // X[k] = sum_n x[n] * exp(-j * 2πkn/N)
+  for (let len = 2; len <= n; len <<= 1) {
+    const halfLen = len >> 1
+    const angle = (-2.0 * Math.PI) / len
+    const wLenReal = Math.cos(angle)
+    const wLenImag = Math.sin(angle)
+
+    for (let i = 0; i < n; i += len) {
+      let wReal = 1.0
+      let wImag = 0.0
+
+      for (let j = 0; j < halfLen; j++) {
+        const evenIndex = i + j
+        const oddIndex = evenIndex + halfLen
+
+        const oddReal = real[oddIndex]
+        const oddImag = imag[oddIndex]
+
+        const vReal = oddReal * wReal - oddImag * wImag
+        const vImag = oddReal * wImag + oddImag * wReal
+
+        const uReal = real[evenIndex]
+        const uImag = imag[evenIndex]
+
+        real[evenIndex] = uReal + vReal
+        imag[evenIndex] = uImag + vImag
+
+        real[oddIndex] = uReal - vReal
+        imag[oddIndex] = uImag - vImag
+
+        const nextWReal = wReal * wLenReal - wImag * wLenImag
+        const nextWImag = wReal * wLenImag + wImag * wLenReal
+
+        wReal = nextWReal
+        wImag = nextWImag
+      }
+    }
+  }
+
+  const power = fft.power
+  const bins = n / 2 + 1
+
+  for (let k = 0; k < bins; k++) {
+    power[k] = real[k] * real[k] + imag[k] * imag[k]
+  }
+
+  return power
+}
+
+export class StreamingMelFrontend {
+  private rawAudio: number[] = []
+  private rawBaseSample = 0
+  private rawSamplesReceived = 0
+
+  private melFrames: Float32Array[] = []
+  private melFrameBase = 0
+  private nextMelFrame = 0
+  private nextChunkFrame = 0
+
+  constructor(
+    private readonly fbank: Float32Array,
+    private readonly hann: Float32Array,
+    private readonly fftPre: FftState,
+  ) {}
+
+  appendAudioSamples(samples: Float32Array): void {
+    for (let i = 0; i < samples.length; i++) {
+      this.rawAudio.push(samples[i])
+    }
+
+    this.rawSamplesReceived += samples.length
+    this.appendStableMelFrames()
+    this.trimOldBuffers()
+  }
+
+  hasFullChunk(): boolean {
+    return this.nextMelFrame - this.nextChunkFrame >= config.NEMO_CHUNK
+  }
+
+  makeNextEncoderInput(): Float32Array {
+    if (!this.hasFullChunk()) {
+      throw new Error('Not enough stable mel frames for another encoder chunk')
+    }
+
+    const chunk = new Float32Array(config.N_MELS * config.NEMO_FRAMES)
+    const mainStart = this.nextChunkFrame
+
+    // Left pre-encode mel cache. For the first chunk, this leaves the first
+    // NEMO_PRECACHE columns as zeros.
+    const cacheStart = Math.max(0, mainStart - config.NEMO_PRECACHE)
+    const cacheFrames = mainStart - cacheStart
+    const cacheOffset = config.NEMO_PRECACHE - cacheFrames
+
+    for (let f = 0; f < cacheFrames; f++) {
+      this.copyMelFrameToEncoderChunk(
+        chunk,
+        cacheOffset + f,
+        this.getMelFrame(cacheStart + f),
+      )
+    }
+
+    for (let f = 0; f < config.NEMO_CHUNK; f++) {
+      this.copyMelFrameToEncoderChunk(
+        chunk,
+        config.NEMO_PRECACHE + f,
+        this.getMelFrame(mainStart + f),
+      )
+    }
+
+    return chunk
+  }
+
+  consumeChunk(): void {
+    this.nextChunkFrame += config.NEMO_CHUNK
+    this.trimOldBuffers()
+  }
+
+  // Zero every buffer holding audio or acoustic features and reset the
+  // frontend to empty. Called at session end so the utterance does not
+  // persist in the JS heap until garbage collection.
+  wipe(): void {
+    this.rawAudio.fill(0)
+    this.rawAudio.length = 0
+    for (const frame of this.melFrames) {
+      frame.fill(0)
+    }
+    this.melFrames.length = 0
+  }
+
+  debugState(sampleRateHz: number): StreamingMelFrontendDebugState {
+    const stableBacklogFrames = this.nextMelFrame - this.nextChunkFrame
+
+    return {
+      rawSamplesReceived: this.rawSamplesReceived,
+      rawBaseSample: this.rawBaseSample,
+      rawBufferedSamples: this.rawAudio.length,
+
+      melFrameBase: this.melFrameBase,
+      melBufferedFrames: this.melFrames.length,
+      nextMelFrame: this.nextMelFrame,
+      nextChunkFrame: this.nextChunkFrame,
+
+      stableBacklogFrames,
+      chunksReady: Math.floor(stableBacklogFrames / config.NEMO_CHUNK),
+      estimatedStableBacklogMs:
+        (stableBacklogFrames * config.HOP_LENGTH * 1000) / sampleRateHz,
+    }
+  }
+
+  private appendStableMelFrames(): void {
+    // By 'stable' mel frame, we mean a mel frame whose required raw audio
+    // samples are already available, including its right-side context.
+    const stableFrames = this.stableMelFrameCountForSamples(
+      this.rawSamplesReceived,
+    )
+
+    while (this.nextMelFrame < stableFrames) {
+      this.melFrames.push(this.computeStreamingMelFrame(this.nextMelFrame))
+      this.nextMelFrame += 1
+    }
+  }
+
+  private stableMelFrameCountForSamples(sampleCount: number): number {
+    const count =
+      Math.floor(
+        (sampleCount - config.STREAMING_RIGHT_CONTEXT) / config.HOP_LENGTH,
+      ) + 1
+
+    return Math.max(0, count)
+  }
+
+  private computeStreamingMelFrame(frameIndex: number): Float32Array {
+    const frame = this.fftPre.frame
+    frame.fill(0)
+
+    // Match the full-buffer NeMo layout:
+    // window is placed at OFF inside an N_FFT-sized frame, and the raw
+    // window starts at frameIndex * HOP_LENGTH - PAD + OFF.
+    const rawStart = frameIndex * config.HOP_LENGTH - config.PAD + config.OFF
+
+    for (let i = 0; i < config.WIN_LENGTH; i++) {
+      frame[config.OFF + i] =
+        this.preemphasizedSampleAt(rawStart + i) * this.hann[i]
+    }
+
+    const power = fftPower(frame, this.fftPre)
+    const nfFreq = config.N_FFT / 2 + 1
+    const melFrame = new Float32Array(config.N_MELS)
+
+    for (let m = 0; m < config.N_MELS; m++) {
+      let acc = 0
+      const fb = m * nfFreq
+
+      for (let k = 0; k < nfFreq; k++) {
+        acc += this.fbank[fb + k] * power[k]
+      }
+
+      melFrame[m] = Math.log(acc + config.LOG_ZERO_GUARD)
+    }
+
+    return melFrame
+  }
+
+  private rawSampleAt(absSampleIndex: number): number {
+    if (absSampleIndex < 0) {
+      throw new Error(
+        `rawSampleAt called with negative index ${absSampleIndex}`,
+      )
+    }
+
+    // Should only happen if the caller intentionally requests samples beyond
+    // the real stream. During normal streaming, stable-frame gating prevents it.
+    if (absSampleIndex >= this.rawSamplesReceived) {
+      return 0.0
+    }
+
+    const rel = absSampleIndex - this.rawBaseSample
+
+    if (rel < 0 || rel >= this.rawAudio.length) {
+      throw new Error(
+        `Streaming frontend lost raw sample ${absSampleIndex}; `
+          + `base=${this.rawBaseSample}, len=${this.rawAudio.length}`,
+      )
+    }
+
+    return this.rawAudio[rel]
+  }
+
+  private preemphasizedOriginalSampleAt(absSampleIndex: number): number {
+    const x = this.rawSampleAt(absSampleIndex)
+
+    if (absSampleIndex === 0) {
+      return x
+    }
+
+    return x - config.PREEMPH * this.rawSampleAt(absSampleIndex - 1)
+  }
+
+  private preemphasizedSampleAt(absSampleIndex: number): number {
+    // Match reflect-padding semantics at the start of the stream after
+    // pre-emphasis. For example, -1 maps to preemphasized sample 1.
+    if (absSampleIndex < 0) {
+      return this.preemphasizedOriginalSampleAt(-absSampleIndex)
+    }
+
+    return this.preemphasizedOriginalSampleAt(absSampleIndex)
+  }
+
+  private getMelFrame(absFrameIndex: number): Float32Array {
+    const rel = absFrameIndex - this.melFrameBase
+
+    if (rel < 0 || rel >= this.melFrames.length) {
+      throw new Error(
+        `Streaming frontend lost mel frame ${absFrameIndex}; `
+          + `base=${this.melFrameBase}, len=${this.melFrames.length}`,
+      )
+    }
+
+    return this.melFrames[rel]
+  }
+
+  private copyMelFrameToEncoderChunk(
+    chunk: Float32Array,
+    chunkFrameOffset: number,
+    melFrame: Float32Array,
+  ): void {
+    for (let m = 0; m < config.N_MELS; m++) {
+      chunk[m * config.NEMO_FRAMES + chunkFrameOffset] = melFrame[m]
+    }
+  }
+
+  private trimOldBuffers(): void {
+    // Keep only mel frames needed for the next encoder input's 9-frame
+    // pre-encode cache.
+    const keepFromFrame = Math.max(
+      0,
+      this.nextChunkFrame - config.NEMO_PRECACHE,
+    )
+
+    const dropFrames = keepFromFrame - this.melFrameBase
+
+    if (dropFrames > 0) {
+      // Zero each dropped mel frame before releasing it. Mel features are a
+      // near complete acoustic representation, so wiping them here bounds the
+      // resident acoustics to the live window rather than leaving dropped
+      // frames in the JS heap until garbage collection.
+      for (let i = 0; i < dropFrames; i++) {
+        this.melFrames[i].fill(0)
+      }
+      this.melFrames.splice(0, dropFrames)
+      this.melFrameBase = keepFromFrame
+    }
+
+    // Keep enough raw audio to compute the next mel frame, including one
+    // previous sample for pre-emphasis continuity.
+    const firstRawNeeded = Math.max(
+      0,
+      this.nextMelFrame * config.HOP_LENGTH - config.PAD + config.OFF - 1,
+    )
+
+    const dropSamples = firstRawNeeded - this.rawBaseSample
+
+    if (dropSamples > 0) {
+      this.rawAudio.splice(0, dropSamples)
+      this.rawBaseSample += dropSamples
+    }
+  }
+}

--- a/components/local_ai/resources/speech_worker/audio_features.ts
+++ b/components/local_ai/resources/speech_worker/audio_features.ts
@@ -7,17 +7,36 @@ import * as config from './configs'
 import type { FftSize, FftState } from './configs'
 
 export interface StreamingMelFrontendDebugState {
+  // Total number of raw PCM samples appended since the stream started.
   rawSamplesReceived: number
+
+  // Absolute sample index represented by rawAudio[0].
   rawBaseSample: number
+
+  // Number of raw PCM samples currently retained in memory.
   rawBufferedSamples: number
 
+  // Absolute mel-frame index represented by melFrames[0].
   melFrameBase: number
+
+  // Number of computed mel frames currently retained in memory,
+  // including frames kept for pre-encode context.
   melBufferedFrames: number
+
+  // Absolute index of the next mel frame that has not yet been computed.
   nextMelFrame: number
+
+  // Absolute index of the first new mel frame in the next encoder chunk.
   nextChunkFrame: number
 
+  // Number of computed, stable mel frames not yet consumed as new
+  // encoder input frames.
   stableBacklogFrames: number
+
+  // Number of complete NEMO_CHUNK-sized encoder inputs currently ready.
   chunksReady: number
+
+  // Approximate duration of stableBacklogFrames in milliseconds.
   estimatedStableBacklogMs: number
 }
 
@@ -62,11 +81,12 @@ export function initFftPower(n: FftSize): FftState {
 }
 
 // Compute power spectrum from a real-valued N_FFT frame.
-function fftPower(frame: Float32Array, fft: FftState): Float32Array {
+function fftPower(fft: FftState): Float32Array {
   const n = fft.n
   const real = fft.real
   const imag = fft.imag
   const bitRev = fft.bitRev
+  const frame = fft.frame
 
   // Bit-reversed copy of real input.
   // frame is expected to have length N_FFT.
@@ -132,6 +152,17 @@ export class StreamingMelFrontend {
   private rawSamplesReceived = 0
 
   private melFrames: Float32Array[] = []
+  private freeMelFrames: Float32Array[] = []
+
+  private acquireMelFrame(): Float32Array {
+    return this.freeMelFrames.pop() ?? new Float32Array(config.N_MELS)
+  }
+
+  private releaseMelFrame(frame: Float32Array): void {
+    frame.fill(0)
+    this.freeMelFrames.push(frame)
+  }
+
   private melFrameBase = 0
   private nextMelFrame = 0
   private nextChunkFrame = 0
@@ -140,6 +171,7 @@ export class StreamingMelFrontend {
     private readonly fbank: Float32Array,
     private readonly hann: Float32Array,
     private readonly fftPre: FftState,
+    private readonly sampleRateHz: number,
   ) {}
 
   appendAudioSamples(samples: Float32Array): void {
@@ -190,6 +222,9 @@ export class StreamingMelFrontend {
   }
 
   consumeChunk(): void {
+    if (!this.hasFullChunk()) {
+      throw new Error('Cannot consume an incomplete mel chunk')
+    }  
     this.nextChunkFrame += config.NEMO_CHUNK
     this.trimOldBuffers()
   }
@@ -204,9 +239,18 @@ export class StreamingMelFrontend {
       frame.fill(0)
     }
     this.melFrames.length = 0
+    this.rawBaseSample = 0
+    this.rawSamplesReceived = 0
+    this.melFrameBase = 0
+    this.nextMelFrame = 0
+    this.nextChunkFrame = 0
+    this.fftPre.frame.fill(0)
+    this.fftPre.real.fill(0)
+    this.fftPre.imag.fill(0)
+    this.fftPre.power.fill(0)
   }
 
-  debugState(sampleRateHz: number): StreamingMelFrontendDebugState {
+  debugState(): StreamingMelFrontendDebugState {
     const stableBacklogFrames = this.nextMelFrame - this.nextChunkFrame
 
     return {
@@ -222,7 +266,7 @@ export class StreamingMelFrontend {
       stableBacklogFrames,
       chunksReady: Math.floor(stableBacklogFrames / config.NEMO_CHUNK),
       estimatedStableBacklogMs:
-        (stableBacklogFrames * config.HOP_LENGTH * 1000) / sampleRateHz,
+        (stableBacklogFrames * config.HOP_LENGTH * 1000) / this.sampleRateHz,
     }
   }
 
@@ -262,9 +306,9 @@ export class StreamingMelFrontend {
         this.preemphasizedSampleAt(rawStart + i) * this.hann[i]
     }
 
-    const power = fftPower(frame, this.fftPre)
+    const power = fftPower(this.fftPre)
     const nfFreq = config.N_FFT / 2 + 1
-    const melFrame = new Float32Array(config.N_MELS)
+    const melFrame = this.acquireMelFrame()
 
     for (let m = 0; m < config.N_MELS; m++) {
       let acc = 0
@@ -364,7 +408,7 @@ export class StreamingMelFrontend {
       // resident acoustics to the live window rather than leaving dropped
       // frames in the JS heap until garbage collection.
       for (let i = 0; i < dropFrames; i++) {
-        this.melFrames[i].fill(0)
+        this.releaseMelFrame(this.melFrames[i])
       }
       this.melFrames.splice(0, dropFrames)
       this.melFrameBase = keepFromFrame
@@ -380,6 +424,7 @@ export class StreamingMelFrontend {
     const dropSamples = firstRawNeeded - this.rawBaseSample
 
     if (dropSamples > 0) {
+      this.rawAudio.fill(0, 0, dropSamples)
       this.rawAudio.splice(0, dropSamples)
       this.rawBaseSample += dropSamples
     }

--- a/components/local_ai/resources/speech_worker/audio_features.ts
+++ b/components/local_ai/resources/speech_worker/audio_features.ts
@@ -169,7 +169,6 @@ export class StreamingMelFrontend {
     private readonly fbank: Float32Array,
     private readonly hann: Float32Array,
     private readonly fftPre: FftState,
-    private readonly sampleRateHz: number,
   ) {}
 
   appendAudioSamples(samples: Float32Array) {
@@ -265,7 +264,7 @@ export class StreamingMelFrontend {
       stableBacklogFrames,
       chunksReady: Math.floor(stableBacklogFrames / config.NEMO_CHUNK),
       estimatedStableBacklogMs:
-        (stableBacklogFrames * config.HOP_LENGTH * 1000) / this.sampleRateHz,
+        (stableBacklogFrames * config.HOP_LENGTH * 1000) / config.TARGET_SAMPLE_RATE,
     }
   }
   // </if>

--- a/components/local_ai/resources/speech_worker/audio_features.ts
+++ b/components/local_ai/resources/speech_worker/audio_features.ts
@@ -264,7 +264,8 @@ export class StreamingMelFrontend {
       stableBacklogFrames,
       chunksReady: Math.floor(stableBacklogFrames / config.NEMO_CHUNK),
       estimatedStableBacklogMs:
-        (stableBacklogFrames * config.HOP_LENGTH * 1000) / config.TARGET_SAMPLE_RATE,
+        (stableBacklogFrames * config.HOP_LENGTH * 1000)
+        / config.TARGET_SAMPLE_RATE,
     }
   }
   // </if>

--- a/components/local_ai/resources/speech_worker/audio_features.ts
+++ b/components/local_ai/resources/speech_worker/audio_features.ts
@@ -6,6 +6,7 @@
 import * as config from './configs'
 import type { FftSize, FftState } from './configs'
 
+// <if expr="!is_official_build">
 export interface StreamingMelFrontendDebugState {
   // Total number of raw PCM samples appended since the stream started.
   rawSamplesReceived: number
@@ -39,6 +40,7 @@ export interface StreamingMelFrontendDebugState {
   // Approximate duration of stableBacklogFrames in milliseconds.
   estimatedStableBacklogMs: number
 }
+// </if>
 
 // standard symmetric Hann window; following NeMo's implementation
 export function hannWindow(): Float32Array {
@@ -246,6 +248,7 @@ export class StreamingMelFrontend {
     this.fftPre.power.fill(0)
   }
 
+  // <if expr="!is_official_build">
   debugState(): StreamingMelFrontendDebugState {
     const stableBacklogFrames = this.nextMelFrame - this.nextChunkFrame
 
@@ -265,6 +268,7 @@ export class StreamingMelFrontend {
         (stableBacklogFrames * config.HOP_LENGTH * 1000) / this.sampleRateHz,
     }
   }
+  // </if>
 
   private appendStableMelFrames() {
     // By 'stable' mel frame, we mean a mel frame whose required raw audio

--- a/components/local_ai/resources/speech_worker/audio_features.ts
+++ b/components/local_ai/resources/speech_worker/audio_features.ts
@@ -82,11 +82,7 @@ export function initFftPower(n: FftSize): FftState {
 
 // Compute power spectrum from a real-valued N_FFT frame.
 function fftPower(fft: FftState): Float32Array {
-  const n = fft.n
-  const real = fft.real
-  const imag = fft.imag
-  const bitRev = fft.bitRev
-  const frame = fft.frame
+  const { n, real, imag, bitRev, frame } = fft
 
   // Bit-reversed copy of real input.
   // frame is expected to have length N_FFT.
@@ -158,7 +154,7 @@ export class StreamingMelFrontend {
     return this.freeMelFrames.pop() ?? new Float32Array(config.N_MELS)
   }
 
-  private releaseMelFrame(frame: Float32Array): void {
+  private releaseMelFrame(frame: Float32Array) {
     frame.fill(0)
     this.freeMelFrames.push(frame)
   }
@@ -174,7 +170,7 @@ export class StreamingMelFrontend {
     private readonly sampleRateHz: number,
   ) {}
 
-  appendAudioSamples(samples: Float32Array): void {
+  appendAudioSamples(samples: Float32Array) {
     for (let i = 0; i < samples.length; i++) {
       this.rawAudio.push(samples[i])
     }
@@ -184,7 +180,7 @@ export class StreamingMelFrontend {
     this.trimOldBuffers()
   }
 
-  hasFullChunk(): boolean {
+  hasFullChunk() {
     return this.nextMelFrame - this.nextChunkFrame >= config.NEMO_CHUNK
   }
 
@@ -221,7 +217,7 @@ export class StreamingMelFrontend {
     return chunk
   }
 
-  consumeChunk(): void {
+  consumeChunk() {
     if (!this.hasFullChunk()) {
       throw new Error('Cannot consume an incomplete mel chunk')
     }
@@ -232,7 +228,7 @@ export class StreamingMelFrontend {
   // Zero every buffer holding audio or acoustic features and reset the
   // frontend to empty. Called at session end so the utterance does not
   // persist in the JS heap until garbage collection.
-  wipe(): void {
+  wipe() {
     this.rawAudio.fill(0)
     this.rawAudio.length = 0
     for (const frame of this.melFrames) {
@@ -270,7 +266,7 @@ export class StreamingMelFrontend {
     }
   }
 
-  private appendStableMelFrames(): void {
+  private appendStableMelFrames() {
     // By 'stable' mel frame, we mean a mel frame whose required raw audio
     // samples are already available, including its right-side context.
     const stableFrames = this.stableMelFrameCountForSamples(
@@ -386,13 +382,13 @@ export class StreamingMelFrontend {
     chunk: Float32Array,
     chunkFrameOffset: number,
     melFrame: Float32Array,
-  ): void {
+  ) {
     for (let m = 0; m < config.N_MELS; m++) {
       chunk[m * config.NEMO_FRAMES + chunkFrameOffset] = melFrame[m]
     }
   }
 
-  private trimOldBuffers(): void {
+  private trimOldBuffers() {
     // Keep only mel frames needed for the next encoder input's 9-frame
     // pre-encode cache.
     const keepFromFrame = Math.max(

--- a/components/local_ai/resources/speech_worker/audio_features.ts
+++ b/components/local_ai/resources/speech_worker/audio_features.ts
@@ -224,7 +224,7 @@ export class StreamingMelFrontend {
   consumeChunk(): void {
     if (!this.hasFullChunk()) {
       throw new Error('Cannot consume an incomplete mel chunk')
-    }  
+    }
     this.nextChunkFrame += config.NEMO_CHUNK
     this.trimOldBuffers()
   }

--- a/components/local_ai/resources/speech_worker/audio_features.ts
+++ b/components/local_ai/resources/speech_worker/audio_features.ts
@@ -81,7 +81,7 @@ export function initFftPower(n: FftSize): FftState {
 }
 
 // Compute power spectrum from a real-valued N_FFT frame.
-function fftPower(fft: FftState): Float32Array {
+export function fftPower(fft: FftState): Float32Array {
   const { n, real, imag, bitRev, frame } = fft
 
   // Bit-reversed copy of real input.

--- a/components/local_ai/resources/speech_worker/configs.ts
+++ b/components/local_ai/resources/speech_worker/configs.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Nemotron 0.6B INT4 — cache-aware streaming RNN-T.
+// Each encoder step advances by 560 ms: 56 new mel frames plus 9
+// pre-encode left-context frames. Conformer caches are carried between
+// steps, and fixed input/cache shapes keep the encoder cost constant per step.
+
+export const DEBUG: boolean = false // if enabled, will calculate RTF numbers, turn to false in production
+
+// frontend constants
+export type FftSize =
+  | 32
+  | 64
+  | 128
+  | 256
+  | 512
+  | 1024
+  | 2048
+  | 4096
+  | 8192
+  | 16384
+  | 32768 // should be a power of 2
+export type FftState = {
+  n: number
+  bitRev: Uint16Array
+  real: Float32Array
+  imag: Float32Array
+  power: Float32Array
+  frame: Float32Array
+}
+
+export const TARGET_SAMPLE_RATE = 16000
+export const WIN_LENGTH: number = 400
+export const N_FFT: number = 512
+export const HOP_LENGTH: number = 160 // mel hop in samples (10 ms @ 16 kHz)
+export const N_MELS: number = 128
+export const PREEMPH: number = 0.97
+export const LOG_ZERO_GUARD: number = 5.9604645e-8
+export const OFF = (N_FFT - WIN_LENGTH) >> 1 // 56
+export const PAD = N_FFT >> 1 // 256
+// A streaming mel frame is stable once the right edge of the real Hann window
+// is available. Currently the WIN_LENGTH window at OFF
+// inside the N_FFT frame, so raw window is:
+// [f * HOP_LENGTH - PAD + OFF, f * HOP_LENGTH - PAD + OFF + WIN_LENGTH)
+export const STREAMING_RIGHT_CONTEXT: number = OFF + WIN_LENGTH - PAD
+
+// model specific constants
+export const NEMO_CHUNK: number = 56 // new mel frames per step (560 ms @ 10 ms hop)
+export const NEMO_PRECACHE: number = 9 // pre-encode mel cache frames prepended
+export const NEMO_BLANK: number = 1024
+export const NEMO_VOCAB: number = 1025 // 1024 + blank
+export const NEMO_MAX_SYM: number = 10
+export const NEMO_FRAMES: number = NEMO_PRECACHE + NEMO_CHUNK // 65: fixed encoder input length
+export const NEMO_NUM_ENCODER_LAYERS: number = 24
+export const NEMO_HIDDEN_DIM: number = 1024
+// note that this is different from left context at mel level;
+// its num of frames in the left context of encoder's attention blocks'
+export const NEMO_LEFT_CONTEXT: number = 70
+// its num of frames in the left context of encoder's conv blocks'
+export const NEMO_CONV_CONTEXT: number = 8
+export const NEMO_DECODER_LSTM_DIM: number = 640
+
+// On finish, append this many chunks of silence so the cache-aware encoder
+// and RNN-T decoder flush the final partial chunk — without it the trailing
+// word(s) can be dropped to right-context / emission lag. The silence frames
+// decode to RNN-T blanks, so the transcript is unaffected.
+export const SILENCE_FLUSH_CHUNKS: number = 3

--- a/components/local_ai/resources/speech_worker/configs.ts
+++ b/components/local_ai/resources/speech_worker/configs.ts
@@ -39,8 +39,31 @@ export const HOP_LENGTH: number = 160 // mel hop in samples (10 ms @ 16 kHz)
 export const N_MELS: number = 128
 export const PREEMPH: number = 0.97
 export const LOG_ZERO_GUARD: number = 5.9604645e-8
-export const OFF = (N_FFT - WIN_LENGTH) >> 1 // 56
+
+////////// PAD BEGIN ////////////
+// Zero padding applied to the raw audio before framing for FFT caculations. 
+// PAD num of left-padding is applied once per audio stream, at the beginning.
+// This is for doing 'centered framing' for the first FFT frame. Otherwise the first few raw audio samples 
+// would lie near the left edge of the Hann window,mwhere the window coefficients are close to zero, 
+// strongly attenuating their contribution to the resulting spectrum.
+
 export const PAD = N_FFT >> 1 // 256
+
+////////// PAD END ////////////
+
+////////// OFFSET BEGIN ////////////
+// We take WIN_LENGTH real audio samples, multiply them by a WIN_LENGTH point Hann window 
+// and place the result in the middle of an FFT buffer of N_FFT num. of elements. 
+// OFF tells us where the real WIN_LENGTH-sample window begins inside the FFT buffer.
+
+export const OFF = (N_FFT - WIN_LENGTH) >> 1 // 56
+
+// So, a 512-point FFT buffer would be:
+// | 56 zeros | 400 windowed audio samples | 56 zeros |
+// 0         OFF                 (WIN_LENGTH + OFF)  N_FFT
+////////// OFFSET END ////////////
+
+
 // A streaming mel frame is stable once the right edge of the real Hann window
 // is available. Currently the WIN_LENGTH window at OFF
 // inside the N_FFT frame, so raw window is:

--- a/components/local_ai/resources/speech_worker/configs.ts
+++ b/components/local_ai/resources/speech_worker/configs.ts
@@ -8,8 +8,6 @@
 // pre-encode left-context frames. Conformer caches are carried between
 // steps, and fixed input/cache shapes keep the encoder cost constant per step.
 
-export const DEBUG: boolean = false // if enabled, will calculate RTF numbers, turn to false in production
-
 // frontend constants
 export type FftSize =
   | 32

--- a/components/local_ai/resources/speech_worker/configs.ts
+++ b/components/local_ai/resources/speech_worker/configs.ts
@@ -41,10 +41,10 @@ export const PREEMPH: number = 0.97
 export const LOG_ZERO_GUARD: number = 5.9604645e-8
 
 ////////// PAD BEGIN ////////////
-// Zero padding applied to the raw audio before framing for FFT caculations. 
+// Zero padding applied to the raw audio before framing for FFT caculations.
 // PAD num of left-padding is applied once per audio stream, at the beginning.
-// This is for doing 'centered framing' for the first FFT frame. Otherwise the first few raw audio samples 
-// would lie near the left edge of the Hann window,mwhere the window coefficients are close to zero, 
+// This is for doing 'centered framing' for the first FFT frame. Otherwise the first few raw audio samples
+// would lie near the left edge of the Hann window,mwhere the window coefficients are close to zero,
 // strongly attenuating their contribution to the resulting spectrum.
 
 export const PAD = N_FFT >> 1 // 256
@@ -52,8 +52,8 @@ export const PAD = N_FFT >> 1 // 256
 ////////// PAD END ////////////
 
 ////////// OFFSET BEGIN ////////////
-// We take WIN_LENGTH real audio samples, multiply them by a WIN_LENGTH point Hann window 
-// and place the result in the middle of an FFT buffer of N_FFT num. of elements. 
+// We take WIN_LENGTH real audio samples, multiply them by a WIN_LENGTH point Hann window
+// and place the result in the middle of an FFT buffer of N_FFT num. of elements.
 // OFF tells us where the real WIN_LENGTH-sample window begins inside the FFT buffer.
 
 export const OFF = (N_FFT - WIN_LENGTH) >> 1 // 56
@@ -62,7 +62,6 @@ export const OFF = (N_FFT - WIN_LENGTH) >> 1 // 56
 // | 56 zeros | 400 windowed audio samples | 56 zeros |
 // 0         OFF                 (WIN_LENGTH + OFF)  N_FFT
 ////////// OFFSET END ////////////
-
 
 // A streaming mel frame is stable once the right edge of the real Hann window
 // is available. Currently the WIN_LENGTH window at OFF

--- a/components/local_ai/resources/speech_worker/nemotron_recognizer.test.ts
+++ b/components/local_ai/resources/speech_worker/nemotron_recognizer.test.ts
@@ -1,0 +1,1039 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// These unit tests use the real NemotronStreamSession and streaming frontend,
+// including audio buffering, chunking, processAvailable(), state propagation, and
+// RNN-T decoding. Only the model inference boundary is mocked:
+// runEncoder() and runDecoder() return synthetic encoder/decoder outputs instead
+// of invoking ONNX Runtime and the actual Nemotron model.
+
+import { describe, expect, it, jest } from '@jest/globals'
+
+jest.mock('./ort_env', () => ({
+  // Used by processAvailable(); no-op for unit tests
+  disposeOrt: jest.fn(),
+
+  // Not used by these tests, but required by OrtNemotronModel.buildFromBytes().
+  ensureOrt: jest.fn(),
+}))
+
+import {
+  NemotronStreamSession,
+  OrtNemotronModel,
+} from './nemotron_recognizer'
+
+import * as config from './configs'
+
+type TensorData = Float32Array | Int32Array | BigInt64Array
+
+class TestTensor {
+  readonly type: string
+  readonly data: TensorData
+  readonly dims: readonly number[]
+
+  constructor(
+    type: string,
+    data: TensorData,
+    dims: readonly number[],
+  ) {
+    this.type = type
+    this.data = data
+    this.dims = dims
+  }
+
+  // for structural closeness to the real OrtTensor
+  dispose(): void {}
+}
+
+// inputs to runEncoder()
+type EncoderFeeds = {
+  audio_signal: TestTensor
+  length: TestTensor
+  cache_last_channel: TestTensor
+  cache_last_time: TestTensor
+  cache_last_channel_len: TestTensor
+}
+
+// inputs to runDecoder()
+type DecoderFeeds = {
+  encoder_outputs: TestTensor
+  targets: TestTensor
+  target_length: TestTensor
+  input_states_1: TestTensor
+  input_states_2: TestTensor
+}
+
+// similar to onResult property of NemotronStreamSession
+type Result = {
+  text: string
+  isFinal: boolean
+}
+
+// Exposed as OrtNemotronModel to the session, but encoder and decoder
+// inference are replaced with Jest mocks.
+type MockModel = {
+  model: OrtNemotronModel
+  runEncoder: jest.Mock
+  runDecoder: jest.Mock
+}
+
+// Number of raw PCM samples needed for `frameCount` stable mel frames.
+// stableFrames = floor((sampleCount - STREAMING_RIGHT_CONTEXT) / HOP_LENGTH) + 1
+function samplesForStableFrames(frameCount: number): number {
+  if (frameCount <= 0) {
+    return 0
+  }
+  return (
+    config.STREAMING_RIGHT_CONTEXT
+    + (frameCount - 1) * config.HOP_LENGTH
+  )
+}
+
+// Raw samples needed before exactly `chunkCount` complete encoder chunks can be available.
+function samplesForChunks(chunkCount: number): number {
+  return samplesForStableFrames(
+    chunkCount * config.NEMO_CHUNK,
+  )
+}
+
+// Once the first chunk is available, each additional encoder chunk advances by exactly 56 * 160 samples.
+const CHUNK_ADVANCE_SAMPLES =
+  config.NEMO_CHUNK * config.HOP_LENGTH
+
+// pause until the session is no longer busy 
+async function waitForIdle(
+  session: NemotronStreamSession,
+): Promise<void> {
+  await (
+    session as unknown as {
+      inflight: Promise<void>
+    }
+  ).inflight
+}
+
+// create mock/fake encoder results
+function makeEncoderResult(
+  cacheMarker = 0,
+  cacheLen = 0,
+  nEnc = 1,
+) {
+  const nTime = 1
+
+  return {
+    outputs: new TestTensor(
+      'float32',
+      new Float32Array(
+        config.NEMO_HIDDEN_DIM * nTime,
+      ),
+      [1, config.NEMO_HIDDEN_DIM, nTime],
+    ),
+
+    encoded_lengths: new TestTensor(
+      'int64',
+      BigInt64Array.from([BigInt(nEnc)]),
+      [1],
+    ),
+
+    cache_last_channel_next: new TestTensor(
+      'float32',
+      Float32Array.from([cacheMarker]),
+      [1],
+    ),
+
+    cache_last_time_next: new TestTensor(
+      'float32',
+      Float32Array.from([cacheMarker]),
+      [1],
+    ),
+
+    cache_last_channel_next_len: new TestTensor(
+      'int64',
+      BigInt64Array.from([BigInt(cacheLen)]),
+      [1],
+    ),
+  }
+}
+
+// create mock/fake decoder results
+function makeDecoderResult(
+  token: number,
+  stateMarker = 0,
+) {
+  const logits =
+    new Float32Array(config.NEMO_VOCAB)
+
+  logits[token] = 1
+
+  return {
+    outputs: new TestTensor(
+      'float32',
+      logits,
+      [1, config.NEMO_VOCAB],
+    ),
+
+    output_states_1: new TestTensor(
+      'float32',
+      Float32Array.from([stateMarker]),
+      [1],
+    ),
+
+    output_states_2: new TestTensor(
+      'float32',
+      Float32Array.from([stateMarker]),
+      [1],
+    ),
+  }
+}
+
+// Creates a mock model for NemotronStreamSession with simulated encoder and
+// decoder inference.
+function createMockModel(): MockModel {
+  const tokens: string[] = []
+
+  tokens[1] = '▁hello'
+  tokens[2] = '▁world'
+  tokens[config.NEMO_BLANK] = '<blank>'
+
+  const runEncoder = jest.fn(
+    async () => makeEncoderResult(),
+  )
+
+  const runDecoder = jest.fn(
+    async () =>
+      makeDecoderResult(config.NEMO_BLANK),
+  )
+
+  const ort = {
+    Tensor: TestTensor,
+  }
+
+  const fbank = new Float32Array(
+    config.N_MELS * (config.N_FFT / 2 + 1),
+  )
+
+  const hann = new Float32Array(
+    config.WIN_LENGTH,
+  )
+
+  hann.fill(1)
+
+  const model = {
+    ort,
+    tokens,
+    fbank,
+    hann,
+    runEncoder,
+    runDecoder,
+  } as unknown as OrtNemotronModel // just to satisfy the type checker
+
+  return {
+    model,
+    runEncoder,
+    runDecoder,
+  }
+}
+
+// 
+function createSession(mock: MockModel) {
+  const results: Result[] = []
+
+  const onResult = jest.fn(
+    (text: string, isFinal: boolean) => {
+      results.push({
+        text,
+        isFinal,
+      })
+    },
+  )
+
+  const onError = jest.fn()
+
+  const session = new NemotronStreamSession(
+    mock.model,
+    config.TARGET_SAMPLE_RATE,
+    onResult,
+    onError,
+  )
+
+  return {
+    session,
+    results,
+    onResult,
+    onError,
+  }
+}
+
+describe('NemotronStreamSession', () => {
+  describe('construction', () => {
+    // Streaming tests for session construction verifying that - 
+    // (a) given a valid sample rate, a session can be successfully created
+    // (b) invalid sample rate shouldnt create session
+
+    it('accepts the Nemotron sample rate', () => {
+      const mock = createMockModel()
+
+      expect(
+        () =>
+          new NemotronStreamSession(
+            mock.model,
+            config.TARGET_SAMPLE_RATE,
+            () => {},
+            () => {},
+          ),
+      ).not.toThrow()
+    })
+
+    it('rejects unsupported sample rates', () => {
+      const mock = createMockModel()
+      const wrongSamplingRate = 8000
+
+      expect(
+        () =>
+          new NemotronStreamSession(
+            mock.model,
+            wrongSamplingRate,
+            () => {},
+            () => {},
+          ),
+      ).toThrow(
+        'Unsupported sample rate for Nemotron: 8000 Hz',
+      )
+    })
+  })
+
+  describe('audio buffering', () => {
+    // Streaming tests for buffering verifying that - 
+    // (a) given less than one full encoder chunk, encoder or decoder are not run
+    // (b) given one full encoder chunk only, run encoder and decoder only once
+    // (c) given N full encoder chunks, run encoder and decoder N times
+    // (d) given one full chunk and a half chunk, run encoder only once. 
+    // Then add a new half chunk and the encoder should run only once more.
+    // (e) how many encoder chunks eventually get processed is independent 
+    // of how the browser chunks the raw audio into addAudio() calls.
+    it('does not infer before one full encoder chunk is available', async () => {
+      const mock = createMockModel()
+      const { session } = createSession(mock)
+
+      session.addAudio(
+        new Float32Array(
+          samplesForChunks(1) - 1,
+        ),
+      )
+
+      await waitForIdle(session)
+
+      expect(
+        mock.runEncoder,
+      ).not.toHaveBeenCalled()
+
+      expect(
+        mock.runDecoder,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('processes exactly one encoder chunk once enough raw audio is available', async () => {
+      const mock = createMockModel()
+      const { session } = createSession(mock)
+      const N = 1
+
+      session.addAudio(
+        new Float32Array(
+          samplesForChunks(N),
+        ),
+      )
+
+      await waitForIdle(session)
+
+      expect(
+        mock.runEncoder,
+      ).toHaveBeenCalledTimes(N)
+
+      // One encoded frame (because nEnc=1), decoder immediately returns blank.
+      expect(
+        mock.runDecoder,
+      ).toHaveBeenCalledTimes(1)
+    })
+
+    it('drains all complete chunks', async () => {
+      const mock = createMockModel()
+      const { session } = createSession(mock)
+      const N = 3
+
+      session.addAudio(
+        new Float32Array(
+          samplesForChunks(N),
+        ),
+      )
+
+      await waitForIdle(session)
+
+      expect(
+        mock.runEncoder,
+      ).toHaveBeenCalledTimes(N)
+
+      // here, num of decoder runs is also N, only because nEnc=1. 
+      // if nEnc is changed in makeEncoderResult, then num of decoder calls would change
+      expect(
+        mock.runDecoder,
+      ).toHaveBeenCalledTimes(N)
+    })
+
+    it('retains incomplete audio for the next addAudio call', async () => {
+      const mock = createMockModel()
+      const { session } = createSession(mock)
+
+      const firstChunk =
+        samplesForChunks(1)
+
+      const halfAdvance =
+        CHUNK_ADVANCE_SAMPLES / 2
+
+      session.addAudio(
+        new Float32Array(
+          firstChunk + halfAdvance,
+        ),
+      )
+
+      await waitForIdle(session)
+
+      expect(
+        mock.runEncoder,
+      ).toHaveBeenCalledTimes(1)
+
+      session.addAudio(
+        new Float32Array(halfAdvance),
+      )
+
+      await waitForIdle(session)
+
+      // twice in total 
+      expect(
+        mock.runEncoder,
+      ).toHaveBeenCalledTimes(2)
+    })
+
+    it('is independent of incoming audio packet boundaries', async () => {
+      const total = samplesForChunks(2)
+    
+      const wholeMock = createMockModel()
+      const { session: wholeSession } =
+        createSession(wholeMock)
+    
+      wholeSession.addAudio(
+        new Float32Array(total),
+      )
+    
+      await waitForIdle(wholeSession)
+    
+      const splitMock = createMockModel()
+      const { session: splitSession } =
+        createSession(splitMock)
+    
+      const packetSizes = [
+        3000,
+        3000,
+        3000, // cumulative 9000 -> first encoder chunk becomes available
+        4480,
+        total - 13480,
+      ]
+    
+      for (const size of packetSizes) {
+        splitSession.addAudio(
+          new Float32Array(size),
+        )
+        await waitForIdle(splitSession)
+      }
+    
+      expect(
+        wholeMock.runEncoder,
+      ).toHaveBeenCalledTimes(2)
+    
+      expect(
+        splitMock.runEncoder,
+      ).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('encoder state', () => {
+    // Streaming tests for encoder state verifying that - 
+    // (a) the previous encoder call’s cache is fed into the next call
+    it('passes encoder cache outputs into the next encoder call', async () => {
+      const mock = createMockModel()
+
+      const firstCacheMarker = 42
+      const firstCacheLen = 1
+
+      const { session } =
+        createSession(mock)
+
+      mock.runEncoder
+        .mockImplementationOnce(
+          async () =>
+            makeEncoderResult(firstCacheMarker, firstCacheLen),
+        )
+        .mockImplementationOnce(
+          async () =>
+            makeEncoderResult(84, 2),
+        )
+
+      session.addAudio(
+        new Float32Array(
+          samplesForChunks(2),
+        ),
+      )
+
+      await waitForIdle(session)
+
+      expect(
+        mock.runEncoder,
+      ).toHaveBeenCalledTimes(2)
+
+      const secondFeeds =
+        mock.runEncoder.mock.calls[1][0] as EncoderFeeds
+
+      expect(
+        (
+          secondFeeds
+            .cache_last_channel
+            .data as Float32Array
+        )[0],
+      ).toBe(firstCacheMarker)
+
+      expect(
+        (
+          secondFeeds
+            .cache_last_time
+            .data as Float32Array
+        )[0],
+      ).toBe(firstCacheMarker)
+
+      expect(
+        (
+          secondFeeds
+            .cache_last_channel_len
+            .data as BigInt64Array
+        )[0],
+      ).toBe(BigInt(firstCacheLen))
+    })
+  })
+
+  describe('RNN-T decoding', () => {
+    // Streaming tests for RNN-T decoding verifying that -
+    // (a) the decoder stops decoding the current time frame when it emits a blank token
+    // (b) when the decoder emits a real token instead of blank, 
+      // that token is appended to hyp, converted to text, and emitted as an interim result.
+    // (c) the transcript hypothesis is persistent across encoder chunks 
+    // rather than being reset after every chunk.
+    // (d) even if blank is emitted in-between, previous non-blank token and LSTM states are 
+    // provided to later decoder calls
+    // (e) NEMO_MAX_SYM is the max num of continuous non blank tokens produced by an encoder time frame
+    // (f) if the decoder processes a chunk but emits only blanks, 
+    // the session should not send an interim transcript callback.
+    it('stops decoding a frame when blank is emitted', async () => {
+      const mock = createMockModel()
+
+      const { session } =
+        createSession(mock)
+
+      mock.runDecoder.mockResolvedValue(
+        makeDecoderResult(
+          config.NEMO_BLANK,
+        ),
+      )
+
+      session.addAudio(
+        new Float32Array(
+          samplesForChunks(1),
+        ),
+      )
+
+      await waitForIdle(session)
+
+      expect(
+        mock.runDecoder,
+      ).toHaveBeenCalledTimes(1)
+    })
+
+    it('adds non-blank tokens to the hypothesis', async () => {
+      const mock = createMockModel()
+      const fakeLSTMStateMarker = 10
+
+      const {
+        session,
+        results,
+      } = createSession(mock)
+
+      let call = 0
+
+      mock.runDecoder.mockImplementation(
+        async () => {
+          if (call++ === 0) {
+            return makeDecoderResult(
+              1,
+              fakeLSTMStateMarker,
+            )
+          }
+
+          return makeDecoderResult(
+            config.NEMO_BLANK,
+          )
+        },
+      )
+
+      session.addAudio(
+        new Float32Array(
+          samplesForChunks(1),
+        ),
+      )
+
+      await waitForIdle(session)
+
+      expect(results).toEqual([
+        {
+          text: 'hello',
+          isFinal: false,
+        },
+      ])
+    })
+
+    it('accumulates tokens across encoder chunks', async () => {
+      const mock = createMockModel()
+
+      // can be any numbers, not really relevant for this test case
+      const fakeLSTMStateMarker1 = 10
+      const fakeLSTMStateMarker2 = 20
+
+      const {
+        session,
+        results,
+      } = createSession(mock)
+
+      let call = 0
+
+      mock.runDecoder.mockImplementation(
+        async () => {
+          switch (call++) {
+            case 0:
+              return makeDecoderResult(
+                1,
+                fakeLSTMStateMarker1,
+              )
+
+            case 1:
+              return makeDecoderResult(
+                config.NEMO_BLANK,
+              )
+
+            case 2:
+              return makeDecoderResult(
+                2,
+                fakeLSTMStateMarker2,
+              )
+
+            default:
+              return makeDecoderResult(
+                config.NEMO_BLANK,
+              )
+          }
+        },
+      )
+
+      session.addAudio(
+        new Float32Array(
+          samplesForChunks(1),
+        ),
+      )
+
+      await waitForIdle(session)
+
+      session.addAudio(
+        new Float32Array(
+          CHUNK_ADVANCE_SAMPLES,
+        ),
+      )
+
+      await waitForIdle(session)
+
+      expect(results).toEqual([
+        {
+          text: 'hello',
+          isFinal: false,
+        },
+        {
+          text: 'hello world',
+          isFinal: false,
+        },
+      ])
+    })
+
+    it('passes the previous token and LSTM state to later decoder calls', async () => {
+      const mock = createMockModel()
+      const fakeLSTMStateMarker = 123
+
+      const { session } =
+        createSession(mock)
+
+      let call = 0
+
+      mock.runDecoder.mockImplementation(
+        async () => {
+          if (call++ === 0) {
+            return makeDecoderResult(
+              1,
+              fakeLSTMStateMarker,
+            )
+          }
+
+          return makeDecoderResult(
+            config.NEMO_BLANK,
+          )
+        },
+      )
+
+      session.addAudio(
+        new Float32Array(
+          samplesForChunks(2),
+        ),
+      )
+
+      await waitForIdle(session)
+
+      // decoder call 0: token 1; call 1: blank for same encoder frame
+      // call 2: next encoder chunk
+      expect(
+        mock.runDecoder,
+      ).toHaveBeenCalledTimes(3)
+
+      const secondChunkFeeds =
+        mock.runDecoder.mock.calls[2][0] as DecoderFeeds
+
+      expect(
+        (
+          secondChunkFeeds
+            .targets
+            .data as Int32Array
+        )[0],
+      ).toBe(1)
+
+      expect(
+        (
+          secondChunkFeeds
+            .input_states_1
+            .data as Float32Array
+        )[0],
+      ).toBe(fakeLSTMStateMarker)
+
+      expect(
+        (
+          secondChunkFeeds
+            .input_states_2
+            .data as Float32Array
+        )[0],
+      ).toBe(fakeLSTMStateMarker)
+    })
+
+    it('limits emissions to NEMO_MAX_SYM for one encoder frame', async () => {
+      const mock = createMockModel()
+
+      const { session } =
+        createSession(mock)
+
+      // Never emit blank.
+      mock.runDecoder.mockResolvedValue(
+        makeDecoderResult(1),
+      )
+
+      session.addAudio(
+        new Float32Array(
+          samplesForChunks(1),
+        ),
+      )
+
+      await waitForIdle(session)
+
+      expect(
+        mock.runDecoder,
+      ).toHaveBeenCalledTimes(
+        config.NEMO_MAX_SYM,
+      )
+    })
+
+    it('does not emit an empty interim result', async () => {
+      const mock = createMockModel()
+
+      const {
+        session,
+        onResult,
+      } = createSession(mock)
+
+      mock.runDecoder.mockResolvedValue(
+        makeDecoderResult(
+          config.NEMO_BLANK,
+        ),
+      )
+
+      session.addAudio(
+        new Float32Array(
+          samplesForChunks(1),
+        ),
+      )
+
+      await waitForIdle(session)
+
+      expect(
+        onResult,
+      ).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('finish', () => {
+    // Streaming tests for session finish verifying that -
+    // (a) finish() does not silently end without producing a single final callback.
+    // (b) the contents of that single callback when nothing was recognized are specifically { text: '', isFinal: true }.
+    // (c) calling finish() multiple times has the same effect as calling it once.
+    // (d) finish() closes the stream to new audio immediately, even if the async final flush is still running.
+    it('emits one final result', async () => {
+      const mock = createMockModel()
+
+      const {
+        session,
+        onResult,
+      } = createSession(mock)
+
+      session.finish()
+
+      await waitForIdle(session)
+
+      const finalCalls =
+        onResult.mock.calls.filter(
+          ([, isFinal]) => isFinal,
+        )
+
+      expect(finalCalls).toHaveLength(1)
+    })
+
+    it('can emit an empty final result', async () => {
+      const mock = createMockModel()
+
+      const {
+        session,
+        results,
+      } = createSession(mock)
+
+      session.finish()
+
+      await waitForIdle(session)
+
+      expect(
+        results.at(-1),
+      ).toEqual({
+        text: '',
+        isFinal: true,
+      })
+    })
+
+    it('is idempotent', async () => {
+      const mock = createMockModel()
+
+      const {
+        session,
+        onResult,
+      } = createSession(mock)
+
+      session.finish()
+      session.finish()
+      session.finish()
+
+      await waitForIdle(session)
+
+      const finalCalls =
+        onResult.mock.calls.filter(
+          ([, isFinal]) => isFinal,
+        )
+
+      expect(finalCalls).toHaveLength(1)
+    })
+
+    it('ignores audio after finish begins', async () => {
+      const baselineMock = createMockModel()
+      const { session: baselineSession } =
+        createSession(baselineMock)
+    
+      baselineSession.finish()
+      await waitForIdle(baselineSession)
+    
+      const baselineCalls =
+        baselineMock.runEncoder.mock.calls.length
+    
+      const mock = createMockModel()
+      const { session } = createSession(mock)
+    
+      session.finish()
+    
+      // This should be ignored because state is already "finishing".
+      session.addAudio(
+        new Float32Array(
+          samplesForChunks(1),
+        ),
+      )
+    
+      await waitForIdle(session)
+    
+      expect(
+        mock.runEncoder,
+      ).toHaveBeenCalledTimes(baselineCalls)
+    })
+  })
+
+  describe('error handling', () => {
+    // Streaming tests for handling errors verifying that -
+    // (a) encoder inference failure should terminate recognition rather than leave the pipeline hanging or continue processing subsequent audio. 
+    // (b) same as (a) for decoder inference failure
+    // (c) inference failure results in session state going to 'ended'
+    // (d) onError is called only once even if finish gets called after an inference fail
+    it('calls onError when encoder inference fails', async () => {
+      const mock = createMockModel()
+
+      const {
+        session,
+        onError,
+        onResult,
+      } = createSession(mock)
+
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      mock.runEncoder.mockRejectedValue(
+        new Error('encoder failed'),
+      )
+
+      session.addAudio(
+        new Float32Array(
+          samplesForChunks(1),
+        ),
+      )
+
+      await waitForIdle(session)
+
+      expect(
+        onError,
+      ).toHaveBeenCalledTimes(1)
+
+      expect(
+        onResult,
+      ).not.toHaveBeenCalled()
+
+      consoleSpy.mockRestore()
+    })
+
+    it('calls onError when decoder inference fails', async () => {
+      const mock = createMockModel()
+
+      const {
+        session,
+        onError,
+        onResult,
+      } = createSession(mock)
+
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      try {
+        mock.runDecoder.mockRejectedValue(
+          new Error('decoder failed'),
+        )
+
+        session.addAudio(
+          new Float32Array(
+            samplesForChunks(1),
+          ),
+        )
+
+        await waitForIdle(session)
+
+        expect(mock.runEncoder).toHaveBeenCalledTimes(1)
+        expect(mock.runDecoder).toHaveBeenCalledTimes(1)
+
+        expect(onError).toHaveBeenCalledTimes(1)
+        expect(onResult).not.toHaveBeenCalled()
+      } finally {
+        consoleSpy.mockRestore()
+      }
+    })
+
+    it('enters a terminal state after inference failure', async () => {
+      const mock = createMockModel()
+      const { session, onError } = createSession(mock)
+    
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+    
+      try {
+        mock.runEncoder.mockRejectedValueOnce(
+          new Error('encoder failed'),
+        )
+    
+        session.addAudio(
+          new Float32Array(samplesForChunks(1)),
+        )
+    
+        await waitForIdle(session)
+    
+        expect(mock.runEncoder).toHaveBeenCalledTimes(1)
+        expect(onError).toHaveBeenCalledTimes(1)
+    
+        // Stream has entered the terminal 'ended' state,
+        // so subsequent audio should be ignored.
+        session.addAudio(
+          new Float32Array(samplesForChunks(1)),
+        )
+    
+        await waitForIdle(session)
+    
+        expect(mock.runEncoder).toHaveBeenCalledTimes(1)
+        expect(onError).toHaveBeenCalledTimes(1)
+      } finally {
+        consoleSpy.mockRestore()
+      }
+    })
+
+  it('calls onError only once even if finish is called after failure', async () => {
+    const mock = createMockModel()
+    const { session, onError } = createSession(mock)
+
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+
+    try {
+        mock.runEncoder.mockRejectedValueOnce(
+          new Error('encoder failed'),
+        )
+
+        session.addAudio(
+          new Float32Array(samplesForChunks(1)),
+        )
+
+        await waitForIdle(session)
+
+        expect(mock.runEncoder).toHaveBeenCalledTimes(1)
+        expect(onError).toHaveBeenCalledTimes(1)
+
+        session.finish()
+
+        await waitForIdle(session)
+
+        expect(mock.runEncoder).toHaveBeenCalledTimes(1)
+        expect(onError).toHaveBeenCalledTimes(1)
+      } finally {
+        consoleSpy.mockRestore()
+      }
+    })
+  })
+
+})

--- a/components/local_ai/resources/speech_worker/nemotron_recognizer.test.ts
+++ b/components/local_ai/resources/speech_worker/nemotron_recognizer.test.ts
@@ -19,10 +19,7 @@ jest.mock('./ort_env', () => ({
   ensureOrt: jest.fn(),
 }))
 
-import {
-  NemotronStreamSession,
-  OrtNemotronModel,
-} from './nemotron_recognizer'
+import { NemotronStreamSession, OrtNemotronModel } from './nemotron_recognizer'
 
 import * as config from './configs'
 
@@ -33,11 +30,7 @@ class TestTensor {
   readonly data: TensorData
   readonly dims: readonly number[]
 
-  constructor(
-    type: string,
-    data: TensorData,
-    dims: readonly number[],
-  ) {
+  constructor(type: string, data: TensorData, dims: readonly number[]) {
     this.type = type
     this.data = data
     this.dims = dims
@@ -85,27 +78,19 @@ function samplesForStableFrames(frameCount: number): number {
   if (frameCount <= 0) {
     return 0
   }
-  return (
-    config.STREAMING_RIGHT_CONTEXT
-    + (frameCount - 1) * config.HOP_LENGTH
-  )
+  return config.STREAMING_RIGHT_CONTEXT + (frameCount - 1) * config.HOP_LENGTH
 }
 
 // Raw samples needed before exactly `chunkCount` complete encoder chunks can be available.
 function samplesForChunks(chunkCount: number): number {
-  return samplesForStableFrames(
-    chunkCount * config.NEMO_CHUNK,
-  )
+  return samplesForStableFrames(chunkCount * config.NEMO_CHUNK)
 }
 
 // Once the first chunk is available, each additional encoder chunk advances by exactly 56 * 160 samples.
-const CHUNK_ADVANCE_SAMPLES =
-  config.NEMO_CHUNK * config.HOP_LENGTH
+const CHUNK_ADVANCE_SAMPLES = config.NEMO_CHUNK * config.HOP_LENGTH
 
-// pause until the session is no longer busy 
-async function waitForIdle(
-  session: NemotronStreamSession,
-): Promise<void> {
+// pause until the session is no longer busy
+async function waitForIdle(session: NemotronStreamSession): Promise<void> {
   await (
     session as unknown as {
       inflight: Promise<void>
@@ -114,19 +99,13 @@ async function waitForIdle(
 }
 
 // create mock/fake encoder results
-function makeEncoderResult(
-  cacheMarker = 0,
-  cacheLen = 0,
-  nEnc = 1,
-) {
+function makeEncoderResult(cacheMarker = 0, cacheLen = 0, nEnc = 1) {
   const nTime = 1
 
   return {
     outputs: new TestTensor(
       'float32',
-      new Float32Array(
-        config.NEMO_HIDDEN_DIM * nTime,
-      ),
+      new Float32Array(config.NEMO_HIDDEN_DIM * nTime),
       [1, config.NEMO_HIDDEN_DIM, nTime],
     ),
 
@@ -157,21 +136,13 @@ function makeEncoderResult(
 }
 
 // create mock/fake decoder results
-function makeDecoderResult(
-  token: number,
-  stateMarker = 0,
-) {
-  const logits =
-    new Float32Array(config.NEMO_VOCAB)
+function makeDecoderResult(token: number, stateMarker = 0) {
+  const logits = new Float32Array(config.NEMO_VOCAB)
 
   logits[token] = 1
 
   return {
-    outputs: new TestTensor(
-      'float32',
-      logits,
-      [1, config.NEMO_VOCAB],
-    ),
+    outputs: new TestTensor('float32', logits, [1, config.NEMO_VOCAB]),
 
     output_states_1: new TestTensor(
       'float32',
@@ -196,26 +167,17 @@ function createMockModel(): MockModel {
   tokens[2] = '▁world'
   tokens[config.NEMO_BLANK] = '<blank>'
 
-  const runEncoder = jest.fn(
-    async () => makeEncoderResult(),
-  )
+  const runEncoder = jest.fn(async () => makeEncoderResult())
 
-  const runDecoder = jest.fn(
-    async () =>
-      makeDecoderResult(config.NEMO_BLANK),
-  )
+  const runDecoder = jest.fn(async () => makeDecoderResult(config.NEMO_BLANK))
 
   const ort = {
     Tensor: TestTensor,
   }
 
-  const fbank = new Float32Array(
-    config.N_MELS * (config.N_FFT / 2 + 1),
-  )
+  const fbank = new Float32Array(config.N_MELS * (config.N_FFT / 2 + 1))
 
-  const hann = new Float32Array(
-    config.WIN_LENGTH,
-  )
+  const hann = new Float32Array(config.WIN_LENGTH)
 
   hann.fill(1)
 
@@ -235,18 +197,16 @@ function createMockModel(): MockModel {
   }
 }
 
-// 
+//
 function createSession(mock: MockModel) {
   const results: Result[] = []
 
-  const onResult = jest.fn(
-    (text: string, isFinal: boolean) => {
-      results.push({
-        text,
-        isFinal,
-      })
-    },
-  )
+  const onResult = jest.fn((text: string, isFinal: boolean) => {
+    results.push({
+      text,
+      isFinal,
+    })
+  })
 
   const onError = jest.fn()
 
@@ -267,7 +227,7 @@ function createSession(mock: MockModel) {
 
 describe('NemotronStreamSession', () => {
   describe('construction', () => {
-    // Streaming tests for session construction verifying that - 
+    // Streaming tests for session construction verifying that -
     // (a) given a valid sample rate, a session can be successfully created
     // (b) invalid sample rate shouldnt create session
 
@@ -297,40 +257,30 @@ describe('NemotronStreamSession', () => {
             () => {},
             () => {},
           ),
-      ).toThrow(
-        'Unsupported sample rate for Nemotron: 8000 Hz',
-      )
+      ).toThrow('Unsupported sample rate for Nemotron: 8000 Hz')
     })
   })
 
   describe('audio buffering', () => {
-    // Streaming tests for buffering verifying that - 
+    // Streaming tests for buffering verifying that -
     // (a) given less than one full encoder chunk, encoder or decoder are not run
     // (b) given one full encoder chunk only, run encoder and decoder only once
     // (c) given N full encoder chunks, run encoder and decoder N times
-    // (d) given one full chunk and a half chunk, run encoder only once. 
+    // (d) given one full chunk and a half chunk, run encoder only once.
     // Then add a new half chunk and the encoder should run only once more.
-    // (e) how many encoder chunks eventually get processed is independent 
+    // (e) how many encoder chunks eventually get processed is independent
     // of how the browser chunks the raw audio into addAudio() calls.
     it('does not infer before one full encoder chunk is available', async () => {
       const mock = createMockModel()
       const { session } = createSession(mock)
 
-      session.addAudio(
-        new Float32Array(
-          samplesForChunks(1) - 1,
-        ),
-      )
+      session.addAudio(new Float32Array(samplesForChunks(1) - 1))
 
       await waitForIdle(session)
 
-      expect(
-        mock.runEncoder,
-      ).not.toHaveBeenCalled()
+      expect(mock.runEncoder).not.toHaveBeenCalled()
 
-      expect(
-        mock.runDecoder,
-      ).not.toHaveBeenCalled()
+      expect(mock.runDecoder).not.toHaveBeenCalled()
     })
 
     it('processes exactly one encoder chunk once enough raw audio is available', async () => {
@@ -338,22 +288,14 @@ describe('NemotronStreamSession', () => {
       const { session } = createSession(mock)
       const N = 1
 
-      session.addAudio(
-        new Float32Array(
-          samplesForChunks(N),
-        ),
-      )
+      session.addAudio(new Float32Array(samplesForChunks(N)))
 
       await waitForIdle(session)
 
-      expect(
-        mock.runEncoder,
-      ).toHaveBeenCalledTimes(N)
+      expect(mock.runEncoder).toHaveBeenCalledTimes(N)
 
       // One encoded frame (because nEnc=1), decoder immediately returns blank.
-      expect(
-        mock.runDecoder,
-      ).toHaveBeenCalledTimes(1)
+      expect(mock.runDecoder).toHaveBeenCalledTimes(1)
     })
 
     it('drains all complete chunks', async () => {
@@ -361,76 +303,52 @@ describe('NemotronStreamSession', () => {
       const { session } = createSession(mock)
       const N = 3
 
-      session.addAudio(
-        new Float32Array(
-          samplesForChunks(N),
-        ),
-      )
+      session.addAudio(new Float32Array(samplesForChunks(N)))
 
       await waitForIdle(session)
 
-      expect(
-        mock.runEncoder,
-      ).toHaveBeenCalledTimes(N)
+      expect(mock.runEncoder).toHaveBeenCalledTimes(N)
 
-      // here, num of decoder runs is also N, only because nEnc=1. 
+      // here, num of decoder runs is also N, only because nEnc=1.
       // if nEnc is changed in makeEncoderResult, then num of decoder calls would change
-      expect(
-        mock.runDecoder,
-      ).toHaveBeenCalledTimes(N)
+      expect(mock.runDecoder).toHaveBeenCalledTimes(N)
     })
 
     it('retains incomplete audio for the next addAudio call', async () => {
       const mock = createMockModel()
       const { session } = createSession(mock)
 
-      const firstChunk =
-        samplesForChunks(1)
+      const firstChunk = samplesForChunks(1)
 
-      const halfAdvance =
-        CHUNK_ADVANCE_SAMPLES / 2
+      const halfAdvance = CHUNK_ADVANCE_SAMPLES / 2
 
-      session.addAudio(
-        new Float32Array(
-          firstChunk + halfAdvance,
-        ),
-      )
+      session.addAudio(new Float32Array(firstChunk + halfAdvance))
 
       await waitForIdle(session)
 
-      expect(
-        mock.runEncoder,
-      ).toHaveBeenCalledTimes(1)
+      expect(mock.runEncoder).toHaveBeenCalledTimes(1)
 
-      session.addAudio(
-        new Float32Array(halfAdvance),
-      )
+      session.addAudio(new Float32Array(halfAdvance))
 
       await waitForIdle(session)
 
-      // twice in total 
-      expect(
-        mock.runEncoder,
-      ).toHaveBeenCalledTimes(2)
+      // twice in total
+      expect(mock.runEncoder).toHaveBeenCalledTimes(2)
     })
 
     it('is independent of incoming audio packet boundaries', async () => {
       const total = samplesForChunks(2)
-    
+
       const wholeMock = createMockModel()
-      const { session: wholeSession } =
-        createSession(wholeMock)
-    
-      wholeSession.addAudio(
-        new Float32Array(total),
-      )
-    
+      const { session: wholeSession } = createSession(wholeMock)
+
+      wholeSession.addAudio(new Float32Array(total))
+
       await waitForIdle(wholeSession)
-    
+
       const splitMock = createMockModel()
-      const { session: splitSession } =
-        createSession(splitMock)
-    
+      const { session: splitSession } = createSession(splitMock)
+
       const packetSizes = [
         3000,
         3000,
@@ -438,26 +356,20 @@ describe('NemotronStreamSession', () => {
         4480,
         total - 13480,
       ]
-    
+
       for (const size of packetSizes) {
-        splitSession.addAudio(
-          new Float32Array(size),
-        )
+        splitSession.addAudio(new Float32Array(size))
         await waitForIdle(splitSession)
       }
-    
-      expect(
-        wholeMock.runEncoder,
-      ).toHaveBeenCalledTimes(2)
-    
-      expect(
-        splitMock.runEncoder,
-      ).toHaveBeenCalledTimes(2)
+
+      expect(wholeMock.runEncoder).toHaveBeenCalledTimes(2)
+
+      expect(splitMock.runEncoder).toHaveBeenCalledTimes(2)
     })
   })
 
   describe('encoder state', () => {
-    // Streaming tests for encoder state verifying that - 
+    // Streaming tests for encoder state verifying that -
     // (a) the previous encoder call’s cache is fed into the next call
     it('passes encoder cache outputs into the next encoder call', async () => {
       const mock = createMockModel()
@@ -465,56 +377,32 @@ describe('NemotronStreamSession', () => {
       const firstCacheMarker = 42
       const firstCacheLen = 1
 
-      const { session } =
-        createSession(mock)
+      const { session } = createSession(mock)
 
       mock.runEncoder
-        .mockImplementationOnce(
-          async () =>
-            makeEncoderResult(firstCacheMarker, firstCacheLen),
+        .mockImplementationOnce(async () =>
+          makeEncoderResult(firstCacheMarker, firstCacheLen),
         )
-        .mockImplementationOnce(
-          async () =>
-            makeEncoderResult(84, 2),
-        )
+        .mockImplementationOnce(async () => makeEncoderResult(84, 2))
 
-      session.addAudio(
-        new Float32Array(
-          samplesForChunks(2),
-        ),
-      )
+      session.addAudio(new Float32Array(samplesForChunks(2)))
 
       await waitForIdle(session)
 
-      expect(
-        mock.runEncoder,
-      ).toHaveBeenCalledTimes(2)
+      expect(mock.runEncoder).toHaveBeenCalledTimes(2)
 
-      const secondFeeds =
-        mock.runEncoder.mock.calls[1][0] as EncoderFeeds
+      const secondFeeds = mock.runEncoder.mock.calls[1][0] as EncoderFeeds
 
-      expect(
-        (
-          secondFeeds
-            .cache_last_channel
-            .data as Float32Array
-        )[0],
-      ).toBe(firstCacheMarker)
+      expect((secondFeeds.cache_last_channel.data as Float32Array)[0]).toBe(
+        firstCacheMarker,
+      )
+
+      expect((secondFeeds.cache_last_time.data as Float32Array)[0]).toBe(
+        firstCacheMarker,
+      )
 
       expect(
-        (
-          secondFeeds
-            .cache_last_time
-            .data as Float32Array
-        )[0],
-      ).toBe(firstCacheMarker)
-
-      expect(
-        (
-          secondFeeds
-            .cache_last_channel_len
-            .data as BigInt64Array
-        )[0],
+        (secondFeeds.cache_last_channel_len.data as BigInt64Array)[0],
       ).toBe(BigInt(firstCacheLen))
     })
   })
@@ -522,71 +410,46 @@ describe('NemotronStreamSession', () => {
   describe('RNN-T decoding', () => {
     // Streaming tests for RNN-T decoding verifying that -
     // (a) the decoder stops decoding the current time frame when it emits a blank token
-    // (b) when the decoder emits a real token instead of blank, 
-      // that token is appended to hyp, converted to text, and emitted as an interim result.
-    // (c) the transcript hypothesis is persistent across encoder chunks 
+    // (b) when the decoder emits a real token instead of blank,
+    // that token is appended to hyp, converted to text, and emitted as an interim result.
+    // (c) the transcript hypothesis is persistent across encoder chunks
     // rather than being reset after every chunk.
-    // (d) even if blank is emitted in-between, previous non-blank token and LSTM states are 
+    // (d) even if blank is emitted in-between, previous non-blank token and LSTM states are
     // provided to later decoder calls
     // (e) NEMO_MAX_SYM is the max num of continuous non blank tokens produced by an encoder time frame
-    // (f) if the decoder processes a chunk but emits only blanks, 
+    // (f) if the decoder processes a chunk but emits only blanks,
     // the session should not send an interim transcript callback.
     it('stops decoding a frame when blank is emitted', async () => {
       const mock = createMockModel()
 
-      const { session } =
-        createSession(mock)
+      const { session } = createSession(mock)
 
-      mock.runDecoder.mockResolvedValue(
-        makeDecoderResult(
-          config.NEMO_BLANK,
-        ),
-      )
+      mock.runDecoder.mockResolvedValue(makeDecoderResult(config.NEMO_BLANK))
 
-      session.addAudio(
-        new Float32Array(
-          samplesForChunks(1),
-        ),
-      )
+      session.addAudio(new Float32Array(samplesForChunks(1)))
 
       await waitForIdle(session)
 
-      expect(
-        mock.runDecoder,
-      ).toHaveBeenCalledTimes(1)
+      expect(mock.runDecoder).toHaveBeenCalledTimes(1)
     })
 
     it('adds non-blank tokens to the hypothesis', async () => {
       const mock = createMockModel()
       const fakeLSTMStateMarker = 10
 
-      const {
-        session,
-        results,
-      } = createSession(mock)
+      const { session, results } = createSession(mock)
 
       let call = 0
 
-      mock.runDecoder.mockImplementation(
-        async () => {
-          if (call++ === 0) {
-            return makeDecoderResult(
-              1,
-              fakeLSTMStateMarker,
-            )
-          }
+      mock.runDecoder.mockImplementation(async () => {
+        if (call++ === 0) {
+          return makeDecoderResult(1, fakeLSTMStateMarker)
+        }
 
-          return makeDecoderResult(
-            config.NEMO_BLANK,
-          )
-        },
-      )
+        return makeDecoderResult(config.NEMO_BLANK)
+      })
 
-      session.addAudio(
-        new Float32Array(
-          samplesForChunks(1),
-        ),
-      )
+      session.addAudio(new Float32Array(samplesForChunks(1)))
 
       await waitForIdle(session)
 
@@ -605,54 +468,31 @@ describe('NemotronStreamSession', () => {
       const fakeLSTMStateMarker1 = 10
       const fakeLSTMStateMarker2 = 20
 
-      const {
-        session,
-        results,
-      } = createSession(mock)
+      const { session, results } = createSession(mock)
 
       let call = 0
 
-      mock.runDecoder.mockImplementation(
-        async () => {
-          switch (call++) {
-            case 0:
-              return makeDecoderResult(
-                1,
-                fakeLSTMStateMarker1,
-              )
+      mock.runDecoder.mockImplementation(async () => {
+        switch (call++) {
+          case 0:
+            return makeDecoderResult(1, fakeLSTMStateMarker1)
 
-            case 1:
-              return makeDecoderResult(
-                config.NEMO_BLANK,
-              )
+          case 1:
+            return makeDecoderResult(config.NEMO_BLANK)
 
-            case 2:
-              return makeDecoderResult(
-                2,
-                fakeLSTMStateMarker2,
-              )
+          case 2:
+            return makeDecoderResult(2, fakeLSTMStateMarker2)
 
-            default:
-              return makeDecoderResult(
-                config.NEMO_BLANK,
-              )
-          }
-        },
-      )
+          default:
+            return makeDecoderResult(config.NEMO_BLANK)
+        }
+      })
 
-      session.addAudio(
-        new Float32Array(
-          samplesForChunks(1),
-        ),
-      )
+      session.addAudio(new Float32Array(samplesForChunks(1)))
 
       await waitForIdle(session)
 
-      session.addAudio(
-        new Float32Array(
-          CHUNK_ADVANCE_SAMPLES,
-        ),
-      )
+      session.addAudio(new Float32Array(CHUNK_ADVANCE_SAMPLES))
 
       await waitForIdle(session)
 
@@ -672,119 +512,66 @@ describe('NemotronStreamSession', () => {
       const mock = createMockModel()
       const fakeLSTMStateMarker = 123
 
-      const { session } =
-        createSession(mock)
+      const { session } = createSession(mock)
 
       let call = 0
 
-      mock.runDecoder.mockImplementation(
-        async () => {
-          if (call++ === 0) {
-            return makeDecoderResult(
-              1,
-              fakeLSTMStateMarker,
-            )
-          }
+      mock.runDecoder.mockImplementation(async () => {
+        if (call++ === 0) {
+          return makeDecoderResult(1, fakeLSTMStateMarker)
+        }
 
-          return makeDecoderResult(
-            config.NEMO_BLANK,
-          )
-        },
-      )
+        return makeDecoderResult(config.NEMO_BLANK)
+      })
 
-      session.addAudio(
-        new Float32Array(
-          samplesForChunks(2),
-        ),
-      )
+      session.addAudio(new Float32Array(samplesForChunks(2)))
 
       await waitForIdle(session)
 
       // decoder call 0: token 1; call 1: blank for same encoder frame
       // call 2: next encoder chunk
-      expect(
-        mock.runDecoder,
-      ).toHaveBeenCalledTimes(3)
+      expect(mock.runDecoder).toHaveBeenCalledTimes(3)
 
-      const secondChunkFeeds =
-        mock.runDecoder.mock.calls[2][0] as DecoderFeeds
+      const secondChunkFeeds = mock.runDecoder.mock.calls[2][0] as DecoderFeeds
 
-      expect(
-        (
-          secondChunkFeeds
-            .targets
-            .data as Int32Array
-        )[0],
-      ).toBe(1)
+      expect((secondChunkFeeds.targets.data as Int32Array)[0]).toBe(1)
 
-      expect(
-        (
-          secondChunkFeeds
-            .input_states_1
-            .data as Float32Array
-        )[0],
-      ).toBe(fakeLSTMStateMarker)
+      expect((secondChunkFeeds.input_states_1.data as Float32Array)[0]).toBe(
+        fakeLSTMStateMarker,
+      )
 
-      expect(
-        (
-          secondChunkFeeds
-            .input_states_2
-            .data as Float32Array
-        )[0],
-      ).toBe(fakeLSTMStateMarker)
+      expect((secondChunkFeeds.input_states_2.data as Float32Array)[0]).toBe(
+        fakeLSTMStateMarker,
+      )
     })
 
     it('limits emissions to NEMO_MAX_SYM for one encoder frame', async () => {
       const mock = createMockModel()
 
-      const { session } =
-        createSession(mock)
+      const { session } = createSession(mock)
 
       // Never emit blank.
-      mock.runDecoder.mockResolvedValue(
-        makeDecoderResult(1),
-      )
+      mock.runDecoder.mockResolvedValue(makeDecoderResult(1))
 
-      session.addAudio(
-        new Float32Array(
-          samplesForChunks(1),
-        ),
-      )
+      session.addAudio(new Float32Array(samplesForChunks(1)))
 
       await waitForIdle(session)
 
-      expect(
-        mock.runDecoder,
-      ).toHaveBeenCalledTimes(
-        config.NEMO_MAX_SYM,
-      )
+      expect(mock.runDecoder).toHaveBeenCalledTimes(config.NEMO_MAX_SYM)
     })
 
     it('does not emit an empty interim result', async () => {
       const mock = createMockModel()
 
-      const {
-        session,
-        onResult,
-      } = createSession(mock)
+      const { session, onResult } = createSession(mock)
 
-      mock.runDecoder.mockResolvedValue(
-        makeDecoderResult(
-          config.NEMO_BLANK,
-        ),
-      )
+      mock.runDecoder.mockResolvedValue(makeDecoderResult(config.NEMO_BLANK))
 
-      session.addAudio(
-        new Float32Array(
-          samplesForChunks(1),
-        ),
-      )
+      session.addAudio(new Float32Array(samplesForChunks(1)))
 
       await waitForIdle(session)
 
-      expect(
-        onResult,
-      ).not.toHaveBeenCalled()
+      expect(onResult).not.toHaveBeenCalled()
     })
   })
 
@@ -797,19 +584,13 @@ describe('NemotronStreamSession', () => {
     it('emits one final result', async () => {
       const mock = createMockModel()
 
-      const {
-        session,
-        onResult,
-      } = createSession(mock)
+      const { session, onResult } = createSession(mock)
 
       session.finish()
 
       await waitForIdle(session)
 
-      const finalCalls =
-        onResult.mock.calls.filter(
-          ([, isFinal]) => isFinal,
-        )
+      const finalCalls = onResult.mock.calls.filter(([, isFinal]) => isFinal)
 
       expect(finalCalls).toHaveLength(1)
     })
@@ -817,18 +598,13 @@ describe('NemotronStreamSession', () => {
     it('can emit an empty final result', async () => {
       const mock = createMockModel()
 
-      const {
-        session,
-        results,
-      } = createSession(mock)
+      const { session, results } = createSession(mock)
 
       session.finish()
 
       await waitForIdle(session)
 
-      expect(
-        results.at(-1),
-      ).toEqual({
+      expect(results.at(-1)).toEqual({
         text: '',
         isFinal: true,
       })
@@ -837,10 +613,7 @@ describe('NemotronStreamSession', () => {
     it('is idempotent', async () => {
       const mock = createMockModel()
 
-      const {
-        session,
-        onResult,
-      } = createSession(mock)
+      const { session, onResult } = createSession(mock)
 
       session.finish()
       session.finish()
@@ -848,83 +621,58 @@ describe('NemotronStreamSession', () => {
 
       await waitForIdle(session)
 
-      const finalCalls =
-        onResult.mock.calls.filter(
-          ([, isFinal]) => isFinal,
-        )
+      const finalCalls = onResult.mock.calls.filter(([, isFinal]) => isFinal)
 
       expect(finalCalls).toHaveLength(1)
     })
 
     it('ignores audio after finish begins', async () => {
       const baselineMock = createMockModel()
-      const { session: baselineSession } =
-        createSession(baselineMock)
-    
+      const { session: baselineSession } = createSession(baselineMock)
+
       baselineSession.finish()
       await waitForIdle(baselineSession)
-    
-      const baselineCalls =
-        baselineMock.runEncoder.mock.calls.length
-    
+
+      const baselineCalls = baselineMock.runEncoder.mock.calls.length
+
       const mock = createMockModel()
       const { session } = createSession(mock)
-    
+
       session.finish()
-    
+
       // This should be ignored because state is already "finishing".
-      session.addAudio(
-        new Float32Array(
-          samplesForChunks(1),
-        ),
-      )
-    
+      session.addAudio(new Float32Array(samplesForChunks(1)))
+
       await waitForIdle(session)
-    
-      expect(
-        mock.runEncoder,
-      ).toHaveBeenCalledTimes(baselineCalls)
+
+      expect(mock.runEncoder).toHaveBeenCalledTimes(baselineCalls)
     })
   })
 
   describe('error handling', () => {
     // Streaming tests for handling errors verifying that -
-    // (a) encoder inference failure should terminate recognition rather than leave the pipeline hanging or continue processing subsequent audio. 
+    // (a) encoder inference failure should terminate recognition rather than leave the pipeline hanging or continue processing subsequent audio.
     // (b) same as (a) for decoder inference failure
     // (c) inference failure results in session state going to 'ended'
     // (d) onError is called only once even if finish gets called after an inference fail
     it('calls onError when encoder inference fails', async () => {
       const mock = createMockModel()
 
-      const {
-        session,
-        onError,
-        onResult,
-      } = createSession(mock)
+      const { session, onError, onResult } = createSession(mock)
 
       const consoleSpy = jest
         .spyOn(console, 'error')
         .mockImplementation(() => {})
 
-      mock.runEncoder.mockRejectedValue(
-        new Error('encoder failed'),
-      )
+      mock.runEncoder.mockRejectedValue(new Error('encoder failed'))
 
-      session.addAudio(
-        new Float32Array(
-          samplesForChunks(1),
-        ),
-      )
+      session.addAudio(new Float32Array(samplesForChunks(1)))
 
       await waitForIdle(session)
 
-      expect(
-        onError,
-      ).toHaveBeenCalledTimes(1)
+      expect(onError).toHaveBeenCalledTimes(1)
 
-      expect(
-        onResult,
-      ).not.toHaveBeenCalled()
+      expect(onResult).not.toHaveBeenCalled()
 
       consoleSpy.mockRestore()
     })
@@ -932,26 +680,16 @@ describe('NemotronStreamSession', () => {
     it('calls onError when decoder inference fails', async () => {
       const mock = createMockModel()
 
-      const {
-        session,
-        onError,
-        onResult,
-      } = createSession(mock)
+      const { session, onError, onResult } = createSession(mock)
 
       const consoleSpy = jest
         .spyOn(console, 'error')
         .mockImplementation(() => {})
 
       try {
-        mock.runDecoder.mockRejectedValue(
-          new Error('decoder failed'),
-        )
+        mock.runDecoder.mockRejectedValue(new Error('decoder failed'))
 
-        session.addAudio(
-          new Float32Array(
-            samplesForChunks(1),
-          ),
-        )
+        session.addAudio(new Float32Array(samplesForChunks(1)))
 
         await waitForIdle(session)
 
@@ -968,33 +706,27 @@ describe('NemotronStreamSession', () => {
     it('enters a terminal state after inference failure', async () => {
       const mock = createMockModel()
       const { session, onError } = createSession(mock)
-    
+
       const consoleSpy = jest
         .spyOn(console, 'error')
         .mockImplementation(() => {})
-    
+
       try {
-        mock.runEncoder.mockRejectedValueOnce(
-          new Error('encoder failed'),
-        )
-    
-        session.addAudio(
-          new Float32Array(samplesForChunks(1)),
-        )
-    
+        mock.runEncoder.mockRejectedValueOnce(new Error('encoder failed'))
+
+        session.addAudio(new Float32Array(samplesForChunks(1)))
+
         await waitForIdle(session)
-    
+
         expect(mock.runEncoder).toHaveBeenCalledTimes(1)
         expect(onError).toHaveBeenCalledTimes(1)
-    
+
         // Stream has entered the terminal 'ended' state,
         // so subsequent audio should be ignored.
-        session.addAudio(
-          new Float32Array(samplesForChunks(1)),
-        )
-    
+        session.addAudio(new Float32Array(samplesForChunks(1)))
+
         await waitForIdle(session)
-    
+
         expect(mock.runEncoder).toHaveBeenCalledTimes(1)
         expect(onError).toHaveBeenCalledTimes(1)
       } finally {
@@ -1002,22 +734,18 @@ describe('NemotronStreamSession', () => {
       }
     })
 
-  it('calls onError only once even if finish is called after failure', async () => {
-    const mock = createMockModel()
-    const { session, onError } = createSession(mock)
+    it('calls onError only once even if finish is called after failure', async () => {
+      const mock = createMockModel()
+      const { session, onError } = createSession(mock)
 
-    const consoleSpy = jest
-      .spyOn(console, 'error')
-      .mockImplementation(() => {})
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
 
-    try {
-        mock.runEncoder.mockRejectedValueOnce(
-          new Error('encoder failed'),
-        )
+      try {
+        mock.runEncoder.mockRejectedValueOnce(new Error('encoder failed'))
 
-        session.addAudio(
-          new Float32Array(samplesForChunks(1)),
-        )
+        session.addAudio(new Float32Array(samplesForChunks(1)))
 
         await waitForIdle(session)
 
@@ -1035,5 +763,4 @@ describe('NemotronStreamSession', () => {
       }
     })
   })
-
 })

--- a/components/local_ai/resources/speech_worker/nemotron_recognizer.test.ts
+++ b/components/local_ai/resources/speech_worker/nemotron_recognizer.test.ts
@@ -11,6 +11,10 @@
 
 import { describe, expect, it, jest } from '@jest/globals'
 
+import { NemotronStreamSession, OrtNemotronModel } from './nemotron_recognizer'
+
+import * as config from './configs'
+
 jest.mock('./ort_env', () => ({
   // Used by processAvailable(); no-op for unit tests
   disposeOrt: jest.fn(),
@@ -18,10 +22,6 @@ jest.mock('./ort_env', () => ({
   // Not used by these tests, but required by OrtNemotronModel.buildFromBytes().
   ensureOrt: jest.fn(),
 }))
-
-import { NemotronStreamSession, OrtNemotronModel } from './nemotron_recognizer'
-
-import * as config from './configs'
 
 type TensorData = Float32Array | Int32Array | BigInt64Array
 

--- a/components/local_ai/resources/speech_worker/nemotron_recognizer.ts
+++ b/components/local_ai/resources/speech_worker/nemotron_recognizer.ts
@@ -8,37 +8,27 @@
 // transcripts through a callback. The mojo transport glue that drives this
 // lives in speech_worker.ts.
 
-import { ensureOrt } from './ort_env'
+import {
+  hannWindow,
+  initFftPower,
+  StreamingMelFrontend,
+} from './audio_features'
+import { disposeOrt, ensureOrt } from './ort_env'
 import type { Ort, OrtSession, OrtSessionOptions, OrtTensor } from './ort_env'
+import * as config from './configs'
+import type { FftSize } from './configs'
+import { releaseBytes, argmax } from './utils'
 
-// Parse a tokens.txt ("<token> <id>" per line, id-ordered, ▁ == space) into
-// an id-indexed vocab array.
-export function parseTokens(buf: Uint8Array): string[] {
-  const vocab: string[] = []
-  for (const line of new TextDecoder().decode(buf).split('\n')) {
-    if (!line) {
-      continue
-    }
-    const sp = line.lastIndexOf(' ')
-    vocab[parseInt(line.slice(sp + 1), 10)] = line.slice(0, sp)
-  }
-  return vocab
-}
-
-// Free the model graph's JS backing store once ORT has copied it into its
-// WASM heap. (ORT-Web references its own WASM copy, so the source is no
-// longer needed.) transfer(0) detaches it immediately instead of waiting on
-// GC of the mojo-mapped shared-memory region.
-function releaseBytes(bytes: Uint8Array): void {
-  try {
-    const buffer = bytes.buffer as ArrayBuffer & {
-      transfer?: (newLength?: number) => ArrayBuffer
-    }
-    buffer.transfer?.(0)
-  } catch {
-    // Backing store isn't transferable; GC will reclaim it eventually.
-  }
-}
+// Encoder outputs we consume. `encoded_lengths` is the count of valid encoder
+// frames; the input length is fixed every call so it normally equals the
+// full time, but we clamp the decode to it defensively.
+const ENC_FETCHES = [
+  'outputs',
+  'encoded_lengths',
+  'cache_last_channel_next',
+  'cache_last_time_next',
+  'cache_last_channel_next_len',
+]
 
 // Shared, loaded-once Nemotron model: the external-data encoder + RNN-T
 // decoder sessions plus tokens and the 128-mel filterbank.
@@ -46,6 +36,7 @@ export class OrtNemotronModel {
   readonly ort: Ort
   readonly tokens: string[]
   readonly fbank: Float32Array
+  readonly hann: Float32Array
 
   // The encoder and decoder sessions are private on purpose: every run must go
   // through runEncoder/runDecoder so it is serialized against other streams.
@@ -69,6 +60,7 @@ export class OrtNemotronModel {
     this.dec = dec
     this.tokens = tokens
     this.fbank = fbank
+    this.hann = hannWindow()
   }
 
   // Serialized encoder/decoder runs. These are the only way to reach the
@@ -90,7 +82,7 @@ export class OrtNemotronModel {
   }
 
   // Build the encoder + decoder sessions from mojo BigBuffers. Only the
-  // .onnx + .onnx.data (external-data) export is supported for memory
+  // .onnx + .onnx.data external-data export is supported for memory
   // optimization.
   static async buildFromBytes(
     encoderGraph: Uint8Array,
@@ -101,11 +93,13 @@ export class OrtNemotronModel {
     fbank: Float32Array,
   ): Promise<OrtNemotronModel> {
     const ort = await ensureOrt()
+
     const sessionOptions = (
       data: Uint8Array,
       dataPath: string,
     ): OrtSessionOptions => ({
       executionProviders: ['wasm'],
+
       // int4 prepacking gives no speedup on the external-data path, so disable
       // it to avoid the extra prepacked-weight copy in WASM memory.
       extra: {
@@ -113,41 +107,370 @@ export class OrtNemotronModel {
           disable_prepacking: '1',
         },
       },
+
       externalData: [{ path: dataPath, data }],
     })
+
     const enc = await ort.InferenceSession.create(
       encoderGraph,
       sessionOptions(encData, 'encoder.onnx.data'),
     )
+
     releaseBytes(encoderGraph)
     releaseBytes(encData)
+
     const dec = await ort.InferenceSession.create(
       decoderGraph,
       sessionOptions(decData, 'decoder_joint.onnx.data'),
     )
     releaseBytes(decoderGraph)
     releaseBytes(decData)
+
     return new OrtNemotronModel(ort, enc, dec, tokens, fbank)
   }
 }
 
-// One streaming ASR session. Accepts PCM via addAudio() and delivers
-// interim/final transcripts through the onResult callback. finish() flushes
-// the final transcript at end-of-utterance.
+// One Nemotron ASR session. Uses an incremental streaming mel frontend:
+// raw samples are appended, only newly stable mel frames are computed, and
+// fixed 65-frame encoder chunks are packed from cached mel frames. Mojo-free:
+// transcripts are delivered through the onResult callback.
 export class NemotronStreamSession {
+  private readonly onResult: (text: string, isFinal: boolean) => void
+  private readonly model: OrtNemotronModel
+  private readonly sampleRateHz: number
+  private readonly frontend: StreamingMelFrontend
+
+  // Attention cache.
+  private cacheCh = new Float32Array(
+    config.NEMO_NUM_ENCODER_LAYERS
+      * config.NEMO_LEFT_CONTEXT
+      * config.NEMO_HIDDEN_DIM,
+  )
+
+  // Convolution cache.
+  private cacheTime = new Float32Array(
+    config.NEMO_NUM_ENCODER_LAYERS
+      * config.NEMO_HIDDEN_DIM
+      * config.NEMO_CONV_CONTEXT,
+  )
+
+  // Indicates how much of left context at encoder-output level is valid.
+  // This is different from left context at mel-frame level.
+  private cacheLen = BigInt64Array.from([BigInt(0)])
+
+  // Decoder LSTM state cache; 2 LSTM layers.
+  private st1 = new Float32Array(2 * config.NEMO_DECODER_LSTM_DIM)
+  private st2 = new Float32Array(2 * config.NEMO_DECODER_LSTM_DIM)
+
+  // RNN-T predictor seed. NeMo uses BLANK as the initial previous token.
+  private prevToken = config.NEMO_BLANK
+
+  // Hypothesis token IDs.
+  private readonly hyp: number[] = []
+
+  // ASR stream is closed once finish() is called. After that, addAudio() no-ops.
+  private closed = false
+
+  // Prevents overlapping async inference calls within the same stream.
+  private inflight: Promise<void> = Promise.resolve()
+
+  // Debug chunk counter.
+  private chunkIdx = 0
+
   constructor(
     model: OrtNemotronModel,
     sampleRateHz: number,
     onResult: (text: string, isFinal: boolean) => void,
-  ) {}
-
-  // Feed mono 16 kHz PCM as it arrives; streams interim transcripts.
-  addAudio(samples: Float32Array): void {
-    throw new Error('not implemented')
+  ) {
+    this.model = model
+    this.sampleRateHz = sampleRateHz
+    this.onResult = onResult
+    this.frontend = new StreamingMelFrontend(
+      model.fbank,
+      model.hann,
+      initFftPower(config.N_FFT as FftSize),
+    )
   }
 
-  // End of utterance: flush and emit the final transcript via onResult.
+  addAudio(samples: Float32Array): void {
+    if (this.closed) {
+      return
+    }
+
+    this.frontend.appendAudioSamples(samples)
+
+    if (config.DEBUG) {
+      this.debug('audio appended', {
+        samples: samples.length,
+        ms: this.samplesToMs(samples.length),
+        frontend: this.frontend.debugState(this.sampleRateHz),
+      })
+    }
+
+    this.inflight = this.inflight.then(() => this.processAvailable(false))
+  }
+
+  // Flush the trailing words and emit the final transcript. Appends silence
+  // so the streaming encoder/RNN-T drains the last partial chunk into full
+  // 65-frame chunks. Idempotent: after the first call addAudio() no-ops, so
+  // the final flush runs exactly once.
   finish(): void {
-    throw new Error('not implemented')
+    if (this.closed) {
+      return
+    }
+
+    this.closed = true
+
+    const flush =
+      config.SILENCE_FLUSH_CHUNKS * config.NEMO_CHUNK * config.HOP_LENGTH
+
+    this.frontend.appendAudioSamples(new Float32Array(flush))
+
+    if (config.DEBUG) {
+      this.debug('finish requested, appended silence', {
+        flushSamples: flush,
+        flushMs: this.samplesToMs(flush),
+        frontend: this.frontend.debugState(this.sampleRateHz),
+      })
+    }
+
+    this.inflight = this.inflight
+      .then(() => this.processAvailable(true))
+      .then(() => this.wipe())
+  }
+
+  // Zero every per-session buffer holding audio, acoustic features, or
+  // transcript once the final result has emitted, so the utterance does not
+  // linger in the JS heap until garbage collection. The shared model weights
+  // are untouched.
+  private wipe(): void {
+    this.frontend.wipe()
+    this.hyp.fill(0)
+    this.hyp.length = 0
+  }
+
+  private async processAvailable(final: boolean): Promise<void> {
+    const { ort, tokens } = this.model
+    let emitted = false
+
+    while (this.frontend.hasFullChunk()) {
+      const chunkIdx = this.chunkIdx++
+
+      const frontendBefore = config.DEBUG
+        ? this.frontend.debugState(this.sampleRateHz)
+        : undefined
+
+      const chunkStarted = performance.now()
+
+      const packStarted = performance.now()
+      const sig = this.frontend.makeNextEncoderInput()
+      const packMs = performance.now() - packStarted
+
+      // Fresh input tensors every step. Do not reuse/carry ORT tensors.
+      const encoderStarted = performance.now()
+      const eo = await this.model.runEncoder(
+        {
+          audio_signal: new ort.Tensor('float32', sig, [
+            1,
+            config.N_MELS,
+            config.NEMO_FRAMES,
+          ]),
+
+          length: new ort.Tensor(
+            'int64',
+            BigInt64Array.from([BigInt(config.NEMO_FRAMES)]),
+            [1],
+          ),
+
+          cache_last_channel: new ort.Tensor('float32', this.cacheCh, [
+            1,
+            config.NEMO_NUM_ENCODER_LAYERS,
+            config.NEMO_LEFT_CONTEXT,
+            config.NEMO_HIDDEN_DIM,
+          ]),
+
+          cache_last_time: new ort.Tensor('float32', this.cacheTime, [
+            1,
+            config.NEMO_NUM_ENCODER_LAYERS,
+            config.NEMO_HIDDEN_DIM,
+            config.NEMO_CONV_CONTEXT,
+          ]),
+
+          cache_last_channel_len: new ort.Tensor('int64', this.cacheLen, [1]),
+        },
+        ENC_FETCHES,
+      )
+      const encoderMs = performance.now() - encoderStarted
+
+      // Copy data out before disposing ORT tensors.
+      // Encoder output is laid out as [batch, hidden_dim, time].
+      const encOut = (eo.outputs.data as Float32Array).slice()
+
+      // Number of time frames at output of encoder.
+      const nTime = Number(eo.outputs.dims[2])
+
+      // Number of valid encoder frames to actually decode.
+      const nEnc = Math.min(
+        Number((eo.encoded_lengths.data as BigInt64Array)[0]),
+        nTime,
+      )
+
+      // Update encoder caches.
+      this.cacheCh = (eo.cache_last_channel_next.data as Float32Array).slice()
+
+      this.cacheTime = (eo.cache_last_time_next.data as Float32Array).slice()
+
+      // Grows until NEMO_LEFT_CONTEXT and then stays there.
+      this.cacheLen = (
+        eo.cache_last_channel_next_len.data as BigInt64Array
+      ).slice()
+
+      disposeOrt([], eo as unknown as Record<string, OrtTensor>)
+
+      // RNN-T greedy decode over this chunk's encoder frames.
+      const decodeStarted = performance.now()
+      let decoderCalls = 0
+      let emittedTokensThisChunk = 0
+      let maxSymHits = 0
+
+      // Outer loop over encoder time index.
+      for (let fi = 0; fi < nEnc; fi++) {
+        const frame = new Float32Array(config.NEMO_HIDDEN_DIM)
+
+        // Inner loop over channel/hidden-dim index.
+        for (let c = 0; c < config.NEMO_HIDDEN_DIM; c++) {
+          frame[c] = encOut[c * nTime + fi]
+        }
+
+        let sym = 0
+
+        // Decoder processes each time frame, aggregated across all channels.
+        while (sym < config.NEMO_MAX_SYM) {
+          const dout = await this.model.runDecoder({
+            encoder_outputs: new ort.Tensor('float32', frame, [
+              1,
+              config.NEMO_HIDDEN_DIM,
+              1,
+            ]),
+
+            targets: new ort.Tensor(
+              'int32',
+              Int32Array.from([this.prevToken]),
+              [1, 1],
+            ),
+
+            target_length: new ort.Tensor('int32', Int32Array.from([1]), [1]),
+
+            input_states_1: new ort.Tensor('float32', this.st1, [
+              2,
+              1,
+              config.NEMO_DECODER_LSTM_DIM,
+            ]),
+
+            input_states_2: new ort.Tensor('float32', this.st2, [
+              2,
+              1,
+              config.NEMO_DECODER_LSTM_DIM,
+            ]),
+          })
+
+          decoderCalls++
+
+          const tok = argmax(
+            dout.outputs.data as Float32Array,
+            0,
+            config.NEMO_VOCAB,
+          )
+
+          if (tok !== config.NEMO_BLANK) {
+            this.hyp.push(tok)
+            this.prevToken = tok
+            this.st1 = (dout.output_states_1.data as Float32Array).slice()
+            this.st2 = (dout.output_states_2.data as Float32Array).slice()
+            emittedTokensThisChunk++
+          }
+
+          disposeOrt([], dout as unknown as Record<string, OrtTensor>)
+
+          if (tok === config.NEMO_BLANK) {
+            break
+          }
+
+          sym++
+        }
+
+        if (sym === config.NEMO_MAX_SYM) {
+          maxSymHits++
+        }
+      }
+
+      const decodeMs = performance.now() - decodeStarted
+
+      this.frontend.consumeChunk()
+
+      if (config.DEBUG) {
+        const modelMs = encoderMs + decodeMs
+        const totalMs = performance.now() - chunkStarted
+        const chunkAudioMs = this.samplesToMs(
+          config.NEMO_CHUNK * config.HOP_LENGTH,
+        )
+
+        this.debug('chunk processed', {
+          chunkIdx,
+
+          packMs,
+          encoderMs,
+          decodeMs,
+          modelMs,
+          totalMs,
+
+          chunkAudioMs,
+          modelRtf: modelMs / chunkAudioMs,
+          totalRtf: totalMs / chunkAudioMs,
+
+          nTime,
+          nEnc,
+          decoderCalls,
+          emittedTokensThisChunk,
+          hypTokensTotal: this.hyp.length,
+          maxSymHits,
+
+          cacheLen: Number(this.cacheLen[0]),
+
+          frontendBefore,
+          frontendAfter: this.frontend.debugState(this.sampleRateHz),
+        })
+      }
+
+      emitted = true
+    }
+
+    if (emitted || final) {
+      const text = this.hyp
+        .map((id) => tokens[id] ?? '')
+        .join('')
+        .replace(/▁/g, ' ')
+        .trim()
+
+      if (text || final) {
+        this.onResult(text, final)
+      }
+    }
+  }
+
+  private samplesToMs(samples: number): number {
+    return (samples * 1000) / this.sampleRateHz
+  }
+
+  private debug(message: string, details?: Record<string, unknown>): void {
+    if (!config.DEBUG) {
+      return
+    }
+
+    const json = JSON.stringify(details ?? {}, (_key, value: unknown) =>
+      typeof value === 'bigint' ? value.toString() : value,
+    )
+
+    console.error(`[NEMO_DEBUG] ${message} ${json}`)
   }
 }

--- a/components/local_ai/resources/speech_worker/nemotron_recognizer.ts
+++ b/components/local_ai/resources/speech_worker/nemotron_recognizer.ts
@@ -183,12 +183,16 @@ export class NemotronStreamSession {
     onResult: (text: string, isFinal: boolean) => void,
   ) {
     this.model = model
+    if (sampleRateHz !== config.TARGET_SAMPLE_RATE) {
+      throw new Error(`Unsupported sample rate for Nemotron: ${sampleRateHz} Hz`)
+    }
     this.sampleRateHz = sampleRateHz
     this.onResult = onResult
     this.frontend = new StreamingMelFrontend(
       model.fbank,
       model.hann,
       initFftPower(config.N_FFT as FftSize),
+      sampleRateHz,
     )
   }
 
@@ -203,7 +207,7 @@ export class NemotronStreamSession {
       this.debug('audio appended', {
         samples: samples.length,
         ms: this.samplesToMs(samples.length),
-        frontend: this.frontend.debugState(this.sampleRateHz),
+        frontend: this.frontend.debugState(),
       })
     }
 
@@ -230,7 +234,7 @@ export class NemotronStreamSession {
       this.debug('finish requested, appended silence', {
         flushSamples: flush,
         flushMs: this.samplesToMs(flush),
-        frontend: this.frontend.debugState(this.sampleRateHz),
+        frontend: this.frontend.debugState(),
       })
     }
 
@@ -247,6 +251,12 @@ export class NemotronStreamSession {
     this.frontend.wipe()
     this.hyp.fill(0)
     this.hyp.length = 0
+    this.cacheCh.fill(0)
+    this.cacheTime.fill(0)
+    this.cacheLen.fill(BigInt(0))
+    this.st1.fill(0)
+    this.st2.fill(0)
+    this.prevToken = config.NEMO_BLANK
   }
 
   private async processAvailable(final: boolean): Promise<void> {
@@ -257,7 +267,7 @@ export class NemotronStreamSession {
       const chunkIdx = this.chunkIdx++
 
       const frontendBefore = config.DEBUG
-        ? this.frontend.debugState(this.sampleRateHz)
+        ? this.frontend.debugState()
         : undefined
 
       const chunkStarted = performance.now()
@@ -438,7 +448,7 @@ export class NemotronStreamSession {
           cacheLen: Number(this.cacheLen[0]),
 
           frontendBefore,
-          frontendAfter: this.frontend.debugState(this.sampleRateHz),
+          frontendAfter: this.frontend.debugState(),
         })
       }
 

--- a/components/local_ai/resources/speech_worker/nemotron_recognizer.ts
+++ b/components/local_ai/resources/speech_worker/nemotron_recognizer.ts
@@ -297,7 +297,7 @@ export class NemotronStreamSession {
 
   private async processAvailable(final: boolean): Promise<void> {
     const { ort, tokens } = this.model
-    let emitted = false
+    let atLeastOneChunkProcessed = false
 
     while (this.frontend.hasFullChunk()) {
       const chunkIdx = this.chunkIdx++
@@ -424,8 +424,6 @@ export class NemotronStreamSession {
 
           const tok = argmax(
             dout.outputs.data as Float32Array,
-            0,
-            config.NEMO_VOCAB,
           )
 
           if (tok !== config.NEMO_BLANK) {
@@ -488,10 +486,10 @@ export class NemotronStreamSession {
         })
       }
 
-      emitted = true
+      atLeastOneChunkProcessed = true
     }
 
-    if (emitted || final) {
+    if (atLeastOneChunkProcessed || final) {
       const text = this.hyp
         .map((id) => tokens[id] ?? '')
         .join('')

--- a/components/local_ai/resources/speech_worker/nemotron_recognizer.ts
+++ b/components/local_ai/resources/speech_worker/nemotron_recognizer.ts
@@ -133,9 +133,11 @@ export class OrtNemotronModel {
 // One Nemotron ASR session. Uses an incremental streaming mel frontend:
 // raw samples are appended, only newly stable mel frames are computed, and
 // fixed 65-frame encoder chunks are packed from cached mel frames. Mojo-free:
-// transcripts are delivered through the onResult callback.
+// transcripts are delivered through the onResult callback and failures
+// through onError.
 export class NemotronStreamSession {
   private readonly onResult: (text: string, isFinal: boolean) => void
+  private readonly onError: () => void
   private readonly model: OrtNemotronModel
   private readonly sampleRateHz: number
   private readonly frontend: StreamingMelFrontend
@@ -168,8 +170,9 @@ export class NemotronStreamSession {
   // Hypothesis token IDs.
   private readonly hyp: number[] = []
 
-  // ASR stream is closed once finish() is called. After that, addAudio() no-ops.
-  private closed = false
+  // Audio is accepted only while streaming. The final flush runs in finishing
+  // and can still fail. ended is terminal and fires onResult or onError once.
+  private state: 'streaming' | 'finishing' | 'ended' = 'streaming'
 
   // Prevents overlapping async inference calls within the same stream.
   private inflight: Promise<void> = Promise.resolve()
@@ -181,13 +184,17 @@ export class NemotronStreamSession {
     model: OrtNemotronModel,
     sampleRateHz: number,
     onResult: (text: string, isFinal: boolean) => void,
+    onError: () => void,
   ) {
     this.model = model
     if (sampleRateHz !== config.TARGET_SAMPLE_RATE) {
-      throw new Error(`Unsupported sample rate for Nemotron: ${sampleRateHz} Hz`)
+      throw new Error(
+        `Unsupported sample rate for Nemotron: ${sampleRateHz} Hz`,
+      )
     }
     this.sampleRateHz = sampleRateHz
     this.onResult = onResult
+    this.onError = onError
     this.frontend = new StreamingMelFrontend(
       model.fbank,
       model.hann,
@@ -197,11 +204,16 @@ export class NemotronStreamSession {
   }
 
   addAudio(samples: Float32Array): void {
-    if (this.closed) {
+    if (this.state !== 'streaming') {
       return
     }
 
-    this.frontend.appendAudioSamples(samples)
+    try {
+      this.frontend.appendAudioSamples(samples)
+    } catch (error) {
+      this.fail(error)
+      return
+    }
 
     if (config.DEBUG) {
       this.debug('audio appended', {
@@ -211,7 +223,9 @@ export class NemotronStreamSession {
       })
     }
 
-    this.inflight = this.inflight.then(() => this.processAvailable(false))
+    this.inflight = this.inflight
+      .then(() => this.processAvailable(false))
+      .catch((error) => this.fail(error))
   }
 
   // Flush the trailing words and emit the final transcript. Appends silence
@@ -219,16 +233,21 @@ export class NemotronStreamSession {
   // 65-frame chunks. Idempotent: after the first call addAudio() no-ops, so
   // the final flush runs exactly once.
   finish(): void {
-    if (this.closed) {
+    if (this.state !== 'streaming') {
       return
     }
 
-    this.closed = true
+    this.state = 'finishing'
 
     const flush =
       config.SILENCE_FLUSH_CHUNKS * config.NEMO_CHUNK * config.HOP_LENGTH
 
-    this.frontend.appendAudioSamples(new Float32Array(flush))
+    try {
+      this.frontend.appendAudioSamples(new Float32Array(flush))
+    } catch (error) {
+      this.fail(error)
+      return
+    }
 
     if (config.DEBUG) {
       this.debug('finish requested, appended silence', {
@@ -240,13 +259,30 @@ export class NemotronStreamSession {
 
     this.inflight = this.inflight
       .then(() => this.processAvailable(true))
-      .then(() => this.wipe())
+      .then(() => {
+        this.state = 'ended'
+        this.wipe()
+      })
+      .catch((error) => this.fail(error))
+  }
+
+  // Single terminal path for a failure. Every error ends the recognition,
+  // since the browser cannot be told more than that no result is coming.
+  private fail(error: unknown): void {
+    if (this.state === 'ended') {
+      return
+    }
+
+    this.state = 'ended'
+    console.error('[speech-worker] inference failed:', error)
+    this.wipe()
+    this.onError()
   }
 
   // Zero every per-session buffer holding audio, acoustic features, or
-  // transcript once the final result has emitted, so the utterance does not
-  // linger in the JS heap until garbage collection. The shared model weights
-  // are untouched.
+  // transcript once the recognition has ended, whether it emitted a final
+  // result or failed, so the utterance does not linger in the JS heap until
+  // garbage collection. The shared model weights are untouched.
   private wipe(): void {
     this.frontend.wipe()
     this.hyp.fill(0)

--- a/components/local_ai/resources/speech_worker/nemotron_recognizer.ts
+++ b/components/local_ai/resources/speech_worker/nemotron_recognizer.ts
@@ -178,7 +178,9 @@ export class NemotronStreamSession {
   private inflight: Promise<void> = Promise.resolve()
 
   // Debug chunk counter.
+  // <if expr="!is_official_build">
   private chunkIdx = 0
+  // </if>
 
   constructor(
     model: OrtNemotronModel,
@@ -215,13 +217,13 @@ export class NemotronStreamSession {
       return
     }
 
-    if (config.DEBUG) {
-      this.debug('audio appended', {
-        samples: samples.length,
-        ms: this.samplesToMs(samples.length),
-        frontend: this.frontend.debugState(),
-      })
-    }
+    // <if expr="!is_official_build">
+    this.debug('audio appended', {
+      samples: samples.length,
+      ms: this.samplesToMs(samples.length),
+      frontend: this.frontend.debugState(),
+    })
+    // </if>
 
     this.inflight = this.inflight
       .then(() => this.processAvailable(false))
@@ -249,13 +251,13 @@ export class NemotronStreamSession {
       return
     }
 
-    if (config.DEBUG) {
-      this.debug('finish requested, appended silence', {
-        flushSamples: flush,
-        flushMs: this.samplesToMs(flush),
-        frontend: this.frontend.debugState(),
-      })
-    }
+    // <if expr="!is_official_build">
+    this.debug('finish requested, appended silence', {
+      flushSamples: flush,
+      flushMs: this.samplesToMs(flush),
+      frontend: this.frontend.debugState(),
+    })
+    // </if>
 
     this.inflight = this.inflight
       .then(() => this.processAvailable(true))
@@ -300,20 +302,21 @@ export class NemotronStreamSession {
     let atLeastOneChunkProcessed = false
 
     while (this.frontend.hasFullChunk()) {
+      // <if expr="!is_official_build">
       const chunkIdx = this.chunkIdx++
-
-      const frontendBefore = config.DEBUG
-        ? this.frontend.debugState()
-        : undefined
-
+      const frontendBefore = this.frontend.debugState()
       const chunkStarted = performance.now()
-
       const packStarted = performance.now()
+      // </if>
+
       const sig = this.frontend.makeNextEncoderInput()
+
+      // <if expr="!is_official_build">
       const packMs = performance.now() - packStarted
+      const encoderStarted = performance.now()
+      // </if>
 
       // Fresh input tensors every step. Do not reuse/carry ORT tensors.
-      const encoderStarted = performance.now()
       const eo = await this.model.runEncoder(
         {
           audio_signal: new ort.Tensor('float32', sig, [
@@ -346,7 +349,10 @@ export class NemotronStreamSession {
         },
         ENC_FETCHES,
       )
+
+      // <if expr="!is_official_build">
       const encoderMs = performance.now() - encoderStarted
+      // </if>
 
       // Copy data out before disposing ORT tensors.
       // Encoder output is laid out as [batch, hidden_dim, time].
@@ -374,10 +380,12 @@ export class NemotronStreamSession {
       disposeOrt([], eo as unknown as Record<string, OrtTensor>)
 
       // RNN-T greedy decode over this chunk's encoder frames.
+      // <if expr="!is_official_build">
       const decodeStarted = performance.now()
       let decoderCalls = 0
       let emittedTokensThisChunk = 0
       let maxSymHits = 0
+      // </if>
 
       // Outer loop over encoder time index.
       for (let fi = 0; fi < nEnc; fi++) {
@@ -420,7 +428,9 @@ export class NemotronStreamSession {
             ]),
           })
 
+          // <if expr="!is_official_build">
           decoderCalls++
+          // </if>
 
           const tok = argmax(dout.outputs.data as Float32Array)
 
@@ -429,7 +439,9 @@ export class NemotronStreamSession {
             this.prevToken = tok
             this.st1 = (dout.output_states_1.data as Float32Array).slice()
             this.st2 = (dout.output_states_2.data as Float32Array).slice()
+            // <if expr="!is_official_build">
             emittedTokensThisChunk++
+            // </if>
           }
 
           disposeOrt([], dout as unknown as Record<string, OrtTensor>)
@@ -441,48 +453,52 @@ export class NemotronStreamSession {
           sym++
         }
 
+        // <if expr="!is_official_build">
         if (sym === config.NEMO_MAX_SYM) {
           maxSymHits++
         }
+        // </if>
       }
 
+      // <if expr="!is_official_build">
       const decodeMs = performance.now() - decodeStarted
+      // </if>
 
       this.frontend.consumeChunk()
 
-      if (config.DEBUG) {
-        const modelMs = encoderMs + decodeMs
-        const totalMs = performance.now() - chunkStarted
-        const chunkAudioMs = this.samplesToMs(
-          config.NEMO_CHUNK * config.HOP_LENGTH,
-        )
+      // <if expr="!is_official_build">
+      const modelMs = encoderMs + decodeMs
+      const totalMs = performance.now() - chunkStarted
+      const chunkAudioMs = this.samplesToMs(
+        config.NEMO_CHUNK * config.HOP_LENGTH,
+      )
 
-        this.debug('chunk processed', {
-          chunkIdx,
+      this.debug('chunk processed', {
+        chunkIdx,
 
-          packMs,
-          encoderMs,
-          decodeMs,
-          modelMs,
-          totalMs,
+        packMs,
+        encoderMs,
+        decodeMs,
+        modelMs,
+        totalMs,
 
-          chunkAudioMs,
-          modelRtf: modelMs / chunkAudioMs,
-          totalRtf: totalMs / chunkAudioMs,
+        chunkAudioMs,
+        modelRtf: modelMs / chunkAudioMs,
+        totalRtf: totalMs / chunkAudioMs,
 
-          nTime,
-          nEnc,
-          decoderCalls,
-          emittedTokensThisChunk,
-          hypTokensTotal: this.hyp.length,
-          maxSymHits,
+        nTime,
+        nEnc,
+        decoderCalls,
+        emittedTokensThisChunk,
+        hypTokensTotal: this.hyp.length,
+        maxSymHits,
 
-          cacheLen: Number(this.cacheLen[0]),
+        cacheLen: Number(this.cacheLen[0]),
 
-          frontendBefore,
-          frontendAfter: this.frontend.debugState(),
-        })
-      }
+        frontendBefore,
+        frontendAfter: this.frontend.debugState(),
+      })
+      // </if>
 
       atLeastOneChunkProcessed = true
     }
@@ -500,19 +516,17 @@ export class NemotronStreamSession {
     }
   }
 
+  // <if expr="!is_official_build">
   private samplesToMs(samples: number): number {
     return (samples * 1000) / this.sampleRateHz
   }
 
   private debug(message: string, details?: Record<string, unknown>): void {
-    if (!config.DEBUG) {
-      return
-    }
-
     const json = JSON.stringify(details ?? {}, (_key, value: unknown) =>
       typeof value === 'bigint' ? value.toString() : value,
     )
 
     console.error(`[NEMO_DEBUG] ${message} ${json}`)
   }
+  // </if>
 }

--- a/components/local_ai/resources/speech_worker/nemotron_recognizer.ts
+++ b/components/local_ai/resources/speech_worker/nemotron_recognizer.ts
@@ -422,9 +422,7 @@ export class NemotronStreamSession {
 
           decoderCalls++
 
-          const tok = argmax(
-            dout.outputs.data as Float32Array,
-          )
+          const tok = argmax(dout.outputs.data as Float32Array)
 
           if (tok !== config.NEMO_BLANK) {
             this.hyp.push(tok)

--- a/components/local_ai/resources/speech_worker/nemotron_recognizer.ts
+++ b/components/local_ai/resources/speech_worker/nemotron_recognizer.ts
@@ -139,7 +139,6 @@ export class NemotronStreamSession {
   private readonly onResult: (text: string, isFinal: boolean) => void
   private readonly onError: () => void
   private readonly model: OrtNemotronModel
-  private readonly sampleRateHz: number
   private readonly frontend: StreamingMelFrontend
 
   // Attention cache.
@@ -194,14 +193,12 @@ export class NemotronStreamSession {
         `Unsupported sample rate for Nemotron: ${sampleRateHz} Hz`,
       )
     }
-    this.sampleRateHz = sampleRateHz
     this.onResult = onResult
     this.onError = onError
     this.frontend = new StreamingMelFrontend(
       model.fbank,
       model.hann,
       initFftPower(config.N_FFT as FftSize),
-      sampleRateHz,
     )
   }
 
@@ -518,7 +515,7 @@ export class NemotronStreamSession {
 
   // <if expr="!is_official_build">
   private samplesToMs(samples: number): number {
-    return (samples * 1000) / this.sampleRateHz
+    return (samples * 1000) / config.TARGET_SAMPLE_RATE
   }
 
   private debug(message: string, details?: Record<string, unknown>): void {

--- a/components/local_ai/resources/speech_worker/speech_worker.ts
+++ b/components/local_ai/resources/speech_worker/speech_worker.ts
@@ -16,7 +16,6 @@ import {
   SpeechRecognitionFactoryInterface,
   SpeechRecognitionFactoryReceiver,
 } from 'gen/brave/components/local_ai/core/on_device_speech_recognition.mojom.m.js'
-import { BigBuffer } from 'gen/mojo/public/mojom/base/big_buffer.mojom-webui.js'
 import {
   AsrStreamInputInterface,
   AsrStreamInputPendingReceiver,
@@ -27,28 +26,9 @@ import {
 } from 'gen/services/on_device_model/public/mojom/on_device_model.mojom.m.js'
 
 import { installTrustedTypesPolicy } from './ort_env'
-import {
-  NemotronStreamSession,
-  OrtNemotronModel,
-  parseTokens,
-} from './nemotron_recognizer'
+import { NemotronStreamSession, OrtNemotronModel } from './nemotron_recognizer'
 
-// BigBuffer is a mojo union: either inlined bytes or a shared-memory
-// handle the renderer maps in.
-function readBigBuffer(buffer: BigBuffer, name: string): Uint8Array {
-  if (buffer.bytes) {
-    return new Uint8Array(buffer.bytes)
-  }
-  if (buffer.sharedMemory) {
-    const { buffer: mapped, result } =
-      buffer.sharedMemory.bufferHandle.mapBuffer(0, buffer.sharedMemory.size)
-    if (result !== Mojo.RESULT_OK) {
-      throw new Error(`Failed to map ${name} shared buffer`)
-    }
-    return new Uint8Array(mapped)
-  }
-  throw new Error(`Invalid ${name} BigBuffer`)
-}
+import { parseTokens, readBigBuffer } from './utils'
 
 // Thin mojo endpoint for one ASR stream: owns the receiver and responder
 // and bridges AsrStreamInput calls to a mojo-free NemotronStreamSession.

--- a/components/local_ai/resources/speech_worker/speech_worker.ts
+++ b/components/local_ai/resources/speech_worker/speech_worker.ts
@@ -44,14 +44,21 @@ class AsrStreamInputAdapter implements AsrStreamInputInterface {
     responder: AsrStreamResponderRemote,
     onClose: () => void,
   ) {
+    const onResult = (text: string, isFinal: boolean) => {
+      // Empty transcript means nothing was recognized. Send an empty
+      // vector rather than a bogus [FINAL] "" (still ends the session).
+      responder.onResponse(text ? [{ transcript: text, isFinal }] : [])
+    }
+
+    // AsrStreamResponder carries results only, so a closed pipe is how the
+    // engine learns inference was aborted and ends the recognition in error.
+    const onError = () => responder.$.close()
+
     this.session = new NemotronStreamSession(
       model,
       sampleRateHz,
-      (text, isFinal) => {
-        // Empty transcript means nothing was recognized. Send an empty
-        // vector rather than a bogus [FINAL] "" (still ends the session).
-        responder.onResponse(text ? [{ transcript: text, isFinal }] : [])
-      },
+      onResult,
+      onError,
     )
     this.receiver = new AsrStreamInputReceiver(this)
     this.receiver.$.bindHandle(pending.handle)
@@ -107,15 +114,25 @@ class SpeechRecognitionFactoryImpl
   ) {
     if (!this.model) {
       console.error('[speech-worker] createAsrStream before init')
+      responder.$.close()
       return
     }
-    const adapter = new AsrStreamInputAdapter(
-      this.model,
-      options.sampleRateHz,
-      stream,
-      responder,
-      () => this.streams.delete(adapter),
-    )
+
+    let adapter: AsrStreamInputAdapter
+    try {
+      adapter = new AsrStreamInputAdapter(
+        this.model,
+        options.sampleRateHz,
+        stream,
+        responder,
+        () => this.streams.delete(adapter),
+      )
+    } catch (error) {
+      console.error('[speech-worker] createAsrStream failed:', error)
+      responder.$.close()
+      return
+    }
+
     this.streams.add(adapter)
   }
 }

--- a/components/local_ai/resources/speech_worker/utils.ts
+++ b/components/local_ai/resources/speech_worker/utils.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { BigBuffer } from 'gen/mojo/public/mojom/base/big_buffer.mojom-webui.js'
+
+// Parse a tokens.txt ("<token> <id>" per line, id-ordered, ▁ == space) into
+// an id-indexed vocab array.
+export function parseTokens(buf: Uint8Array): string[] {
+  const vocab: string[] = []
+  for (const line of new TextDecoder().decode(buf).split('\n')) {
+    if (!line) {
+      continue
+    }
+    const sp = line.lastIndexOf(' ')
+    vocab[parseInt(line.slice(sp + 1), 10)] = line.slice(0, sp)
+  }
+  return vocab
+}
+
+// Free the model graph's JS backing store once ORT has copied it into its
+// WASM heap. (ORT-Web references its own WASM copy, so the source is no
+// longer needed.) transfer(0) detaches it immediately instead of waiting on
+// GC of the mojo-mapped shared-memory region.
+export function releaseBytes(bytes: Uint8Array): void {
+  try {
+    const buffer = bytes.buffer as ArrayBuffer & {
+      transfer?: (newLength?: number) => ArrayBuffer
+    }
+    buffer.transfer?.(0)
+  } catch {
+    // Backing store isn't transferable; GC will reclaim it eventually.
+  }
+}
+
+// BigBuffer is a mojo union: either inlined bytes or a shared-memory
+// handle the renderer maps in.
+export function readBigBuffer(buffer: BigBuffer, name: string): Uint8Array {
+  if (buffer.bytes) {
+    return new Uint8Array(buffer.bytes)
+  }
+  if (buffer.sharedMemory) {
+    const { buffer: mapped, result } =
+      buffer.sharedMemory.bufferHandle.mapBuffer(0, buffer.sharedMemory.size)
+    if (result !== Mojo.RESULT_OK) {
+      throw new Error(`Failed to map ${name} shared buffer`)
+    }
+    return new Uint8Array(mapped)
+  }
+  throw new Error(`Invalid ${name} BigBuffer`)
+}
+
+// Argmax over a sub-range [start, end) of a flat array; returns the index
+// relative to `start`.
+export function argmax(a: Float32Array, start: number, end: number): number {
+  let best = start
+  for (let i = start + 1; i < end; i++) {
+    if (a[i] > a[best]) {
+      best = i
+    }
+  }
+  return best - start
+}

--- a/components/local_ai/resources/speech_worker/utils.ts
+++ b/components/local_ai/resources/speech_worker/utils.ts
@@ -51,8 +51,7 @@ export function readBigBuffer(buffer: BigBuffer, name: string): Uint8Array {
   throw new Error(`Invalid ${name} BigBuffer`)
 }
 
-// Argmax over a sub-range [start, end) of a flat array; returns the index
-// relative to `start`.
+// Argmax over a flat array; returns the index of max value
 export function argmax(a: Float32Array): number {
   let best = 0
   for (let i = 1; i < a.length; i++) {

--- a/components/local_ai/resources/speech_worker/utils.ts
+++ b/components/local_ai/resources/speech_worker/utils.ts
@@ -53,12 +53,12 @@ export function readBigBuffer(buffer: BigBuffer, name: string): Uint8Array {
 
 // Argmax over a sub-range [start, end) of a flat array; returns the index
 // relative to `start`.
-export function argmax(a: Float32Array, start: number, end: number): number {
-  let best = start
-  for (let i = start + 1; i < end; i++) {
+export function argmax(a: Float32Array): number {
+  let best = 0
+  for (let i = 1; i < a.length; i++) {
     if (a[i] > a[best]) {
       best = i
     }
   }
-  return best - start
+  return best
 }


### PR DESCRIPTION
PR containing implementation of Nemotron streaming-session interface and modularisation: [https://github.com/brave/brave-browser/issues/56487](https://github.com/brave/brave-browser/issues/56487)

WIP spec: [https://docs.google.com/document/d/1OyPc16jIJhopBkFHd7YutnILhGvf4tNglbfKLup8cpI/edit?tab=t.0#heading=h.bc7nb9ga2jo5](https://docs.google.com/document/d/1OyPc16jIJhopBkFHd7YutnILhGvf4tNglbfKLup8cpI/edit?tab=t.0#heading=h.bc7nb9ga2jo5)

Implementation mostly followed the streaming inference logic from Nvidia's own [NeMo framework](https://github.com/NVIDIA-NeMo/Speech)
Model - [Nemotron-English only 0.6b](https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b)
Reference POC  - https://github.com/brave-experiments/on-device-experiments/tree/nemotron_ortweb/nemotron_ort/ort_web_demo_mic