### PR TITLE
[Abandoned] Fix vertical tab strip sometimes not collapsing when mouse exits

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -1299,7 +1299,7 @@ void BraveBrowserView::HandleBrowserWindowMouseEvent(
       VerticalTabController::FromBrowser(browser())
           ->ShouldShowBraveVerticalTabs()) {
     vertical_tab_strip_container_view_->vertical_tab_strip_region_view()
-        ->ShowVerticalTabStripOnMouseOver(point_in_screen);
+        ->HandleMouseEvent(point_in_screen);
   }
 }
 

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -788,6 +788,12 @@ void BraveVerticalTabStripRegionView::OnMouseEntered() {
   ScheduleFloatingModeTimer();
 }
 
+void BraveVerticalTabStripRegionView::HandleMouseEvent(
+    const gfx::PointF& point_in_screen) {
+  ShowVerticalTabStripOnMouseOver(point_in_screen);
+  CollapseVerticalTabStripOnMouseOut(point_in_screen);
+}
+
 void BraveVerticalTabStripRegionView::ShowVerticalTabStripOnMouseOver(
     const gfx::PointF& point_in_screen) {
   if (!IsFloatingVerticalTabsEnabled()) {
@@ -815,6 +821,20 @@ void BraveVerticalTabStripRegionView::ShowVerticalTabStripOnMouseOver(
     OnMouseEntered();
     return;
   }
+}
+
+void BraveVerticalTabStripRegionView::CollapseVerticalTabStripOnMouseOut(
+    const gfx::PointF& point_in_screen) {
+  if (state_ != State::kFloating) {
+    return;
+  }
+
+  if (gfx::RectF(GetBoundsInScreen()).Contains(point_in_screen)) {
+    return;
+  }
+
+  mouse_enter_timer_.Stop();
+  ScheduleCollapseTimer();
 }
 
 void BraveVerticalTabStripRegionView::OnMousePressedInTree() {

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
@@ -101,9 +101,15 @@ class BraveVerticalTabStripRegionView : public views::View,
   void ListenFullscreenChanges();
   void StopListeningFullscreenChanges();
 
-  // Show vertical tab strip when mouse moves around the hot corner
-  // when it's completely hidden.
-  void ShowVerticalTabStripOnMouseOver(const gfx::PointF& point_in_screen);
+  // Handles a mouse move event from the browser-wide mouse move monitor.
+  // Shows the vertical tab strip when the mouse moves around the hot corner
+  // while it's completely hidden, and collapses it when the mouse moves out
+  // of its area while floating. The collapse check is a self-correcting
+  // fallback for OnMouseExited(): that callback can rely on a stale
+  // IsMouseHovered() reading right at the boundary with web contents and
+  // never schedule a collapse, whereas this re-checks the live cursor
+  // position on every subsequent move.
+  void HandleMouseEvent(const gfx::PointF& point_in_screen);
 
   // views::View:
   gfx::Size CalculatePreferredSize(
@@ -175,6 +181,14 @@ class BraveVerticalTabStripRegionView : public views::View,
   void ScheduleFloatingModeTimer();
   void ScheduleCollapseTimer();
   void OnMouseEntered();
+
+  // Show vertical tab strip when mouse moves around the hot corner when it's
+  // completely hidden.
+  void ShowVerticalTabStripOnMouseOver(const gfx::PointF& point_in_screen);
+
+  // Collapse vertical tab strip when mouse moves out of its area while
+  // floating.
+  void CollapseVerticalTabStripOnMouseOut(const gfx::PointF& point_in_screen);
   void OnMousePressedInTree();
   void UpdateBubbleArrow();
 


### PR DESCRIPTION
Why: BraveVerticalTabStripRegionView::OnMouseExited() only collapses the floating strip if IsMouseHovered() reports the cursor as no longer over the view. That check re-queries the live cursor position at the moment the exit event dispatches, which can be racy right at the boundary with web contents (fast mouse moves, event dispatch lag, the view visually overlapping web contents while floating). When it falsely reports "still hovered", OnMouseExited() bails out without scheduling a collapse, and nothing else ever retries the decision, so the strip can stay expanded indefinitely.

How: Add a self-correcting fallback driven by the existing app-wide mouse-move monitor in BraveBrowserView (the same one that already drives ShowVerticalTabStripOnMouseOver). On every subsequent mouse move, CollapseVerticalTabStripOnMouseOut() independently re-checks the fresh cursor position against the region view's actual screen bounds and schedules a collapse if it's outside, regardless of what OnMouseExited() decided. Both the show and collapse checks are now exposed through a single HandleMouseEvent() entry point.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/50579
- 
<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
