### PR TITLE
[plaster][ast-grep] `preempt_function_impl` rewriter

### DIFF
--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -128,12 +128,13 @@ YAML).
 The keyed rewrite (`regex:` above) is a **rewriter**. There is on-going work to
 introduce more rewriters. These are the ones we have supported for now.
 
-| Rewriter       | Kind | Description                                       |
-| -------------- | ---- | ------------------------------------------------- |
-| `regex`        | text | A Python `re.subn` substitution (the default).    |
-| `make_virtual` | AST  | Prepends `virtual ` to a C++ method declaration.  |
-| `add_friend`   | AST  | Adds a `friend` declaration to a private section. |
-| `drop_final`   | AST  | Removes `final` from a C++ class declaration.     |
+| Rewriter                | Kind | Description                                       |
+| ----------------------- | ---- | ------------------------------------------------- |
+| `regex`                 | text | A Python `re.subn` substitution (the default).    |
+| `make_virtual`          | AST  | Prepends `virtual ` to a C++ method declaration.  |
+| `add_friend`            | AST  | Adds a `friend` declaration to a private section. |
+| `drop_final`            | AST  | Removes `final` from a C++ class declaration.     |
+| `preempt_function_impl` | AST  | Inserts at the top of a C++ function body.        |
 
 Use `plaster --help` to discover rewriters and read their full docs:
 

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -1105,10 +1105,174 @@ class DropFinal(_AstGrepRewriter):
     """
 
 
+class PreemptFunctionImpl(_AstGrepRewriter):
+    """Insert a statement block at the top of a C++ function body, via the
+    ast-grep rewriters.
+    """
+
+    NAME: Final = 'preempt_function_impl'
+    OP_ID: Final = 'cxx.preempt_function_impl'
+    SUMMARY: Final = 'Insert a statement block at the top of a function body.'
+    # Authored in Markdown; `Help` renders it with rich.
+    HELP: Final = r"""
+        Inserts a statement block as the first thing in a C++ function's body,
+        right after the opening brace. Use it to preempt the implementation of
+        an upstream function, rather than renaming it to an inner
+        `_ChromiumImpl`.
+
+        Fields:
+
+        - `function_name` — the function's name exactly as its definition
+          writes it: a qualified `Class::Method` for a member, or the bare name
+          for a free function.
+
+        Exactly one of the following selects what to insert:
+
+        - `return_if` — a boolean condition that expands to `if (<condition>)
+          return;`, or `if (<condition>) return <return_value>;` when
+          `return_value` is also given.
+        - `code` — a free-form statement block. Write it flush-left; the whole
+          block is indented to the body's first-statement level for you.
+
+        - `return_value` — optional, only valid with `return_if`: the value the
+          generated early return yields.
+
+        Each overload sharing the name is one match, so an overloaded method
+        needs a matching `count`.
+
+        Examples:
+
+        ```yaml
+        substitutions:
+          - description: Skip autocomplete when Brave has it disabled.
+            preempt_function_impl:
+              function_name: OmniboxController::StartAutocomplete
+              return_if: '!IsAutocompleteEnabled(client_->GetPrefs())'
+
+          - description: Never expose the feedback buttons; return false early.
+            preempt_function_impl:
+              function_name: OmniboxResultView::IsFeedbackButtonVisible
+              return_if: 'true'
+              return_value: 'false'
+
+          - description: Pin Brave-managed actions before the upstream body.
+            preempt_function_impl:
+              function_name: CustomizeToolbarHandler::PinAction
+              code: |-
+                if (PinBraveAction(action_id, prefs(), pin)) {
+                  return;
+                }
+        ```
+
+        The last entry turns this upstream definition:
+
+        ```cpp
+        void CustomizeToolbarHandler::PinAction(int action_id, bool pin) {
+          // ... upstream body ...
+        }
+        ```
+
+        into (note the flush-left `code` block indented to the body level):
+
+        ```cpp
+        void CustomizeToolbarHandler::PinAction(int action_id, bool pin) {
+          if (PinBraveAction(action_id, prefs(), pin)) {
+            return;
+          }
+          // ... upstream body ...
+        }
+        ```
+    """
+
+    # The keys that select what to insert; exactly one must be present.
+    _MODE_KEYS: Final = frozenset({'code', 'return_if'})
+
+    def __init__(self, *, function_name: str, prologue: str):
+        # This rewriter holds its own parsed shape (the resolved prologue text)
+        # and builds its operation from it, so the base's flat inputs stay
+        # empty.
+        super().__init__()
+        self._function_name = function_name
+        self._prologue = prologue
+
+    def operations(self, count: int) -> list[Operation]:
+        # A function body is matched once per overload, so the entry's `count:`
+        # carries through unchanged (an overloaded method needs a matching
+        # count).
+        #
+        # The prologue lands as the body's first statement, so indent every
+        # non-blank line to the body's first level -- two spaces, which is where
+        # an out-of-line `Class::Method` definition always sits (file/namespace
+        # scope). Escape backslashes last, since the text is spliced into a
+        # `re.sub` replacement where a backslash is special.
+        prologue = _indent_yaml(self._prologue).replace('\\', '\\\\')
+        return [
+            Operation(self.OP_ID, {
+                'function_name': self._function_name,
+                'prologue': prologue,
+            }, MatchExpectation.from_count(count))
+        ]
+
+    @classmethod
+    def parse(cls, body: object, *, description: str) -> PreemptFunctionImpl:
+        """Validate a `preempt_function_impl:` body and resolve what to insert.
+
+        Requires `function_name`, plus exactly one of `code` or `return_if`;
+        `return_value` is optional and only valid with `return_if`.
+        """
+        if not isinstance(body, dict):
+            raise ValueError(
+                f'"{cls.NAME}" must be a mapping (in "{description}")')
+        allowed = {'function_name', 'return_value'} | cls._MODE_KEYS
+        unknown = sorted(set(body) - allowed)
+        if unknown:
+            raise ValueError(
+                f'Unrecognised {cls.NAME} arg(s): '
+                f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
+        if not isinstance(body.get('function_name'),
+                          str) or not body['function_name']:
+            raise ValueError(f'{cls.NAME} `function_name` must be a non-empty '
+                             f'string (in "{description}")')
+        prologue = cls._resolve_prologue(body, description)
+        return cls(function_name=body['function_name'], prologue=prologue)
+
+    @classmethod
+    def _resolve_prologue(cls, body: dict, description: str) -> str:
+        """Build the text to insert from the `code`/`return_if` fields."""
+        modes = sorted(cls._MODE_KEYS & set(body))
+        if len(modes) != 1:
+            raise ValueError(
+                f'{cls.NAME} requires exactly one of `code` or `return_if` '
+                f'(in "{description}")')
+        mode = modes[0]
+        if mode == 'code':
+            if 'return_value' in body:
+                raise ValueError(
+                    f'{cls.NAME} `return_value` is only valid with `return_if` '
+                    f'(in "{description}")')
+            code = body['code']
+            if not isinstance(code, str) or not code:
+                raise ValueError(
+                    f'{cls.NAME} `code` must be a non-empty string '
+                    f'(in "{description}")')
+            return code
+        condition = body['return_if']
+        if not isinstance(condition, str) or not condition:
+            raise ValueError(f'{cls.NAME} `return_if` must be a non-empty '
+                             f'string (in "{description}")')
+        return_value = body.get('return_value', '')
+        if not isinstance(return_value, str):
+            raise ValueError(f'{cls.NAME} `return_value` must be a string '
+                             f'(in "{description}")')
+        value = f' {return_value}' if return_value else ''
+        return f'if ({condition}) return{value};'
+
+
 # A set with all the rewriters available in plaster.
 _REWRITERS: MappingProxyType[str, type[Rewriter]] = MappingProxyType({
     rewriter.NAME: rewriter
-    for rewriter in (Regex, MakeVirtual, AddFriend, DropFinal)
+    for rewriter in (Regex, MakeVirtual, AddFriend, DropFinal,
+                     PreemptFunctionImpl)
 })
 
 

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1508,6 +1508,225 @@ class RewriterFormsTest(unittest.TestCase):
             '  - description: missing arg\n'
             '    drop_final: {}\n', 'drop_final requires arg')
 
+    # -- preempt_function_impl op (real ast-grep binary) --------------------------
+
+    def test_preempt_function_impl_return_if(self):
+        result = self._apply(
+            'guard.cc', 'void C::Foo() {\n  Upstream();\n}\n',
+            'substitutions:\n'
+            '  - description: skip upstream when Brave has it disabled\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::Foo\n'
+            "      return_if: '!Enabled()'\n")
+        self.assertEqual(
+            result, 'void C::Foo() {\n  if (!Enabled()) return;\n'
+            '  Upstream();\n}\n')
+
+    def test_preempt_function_impl_free_function(self):
+        # A free function is named without a class qualifier -- just the bare
+        # declarator name.
+        result = self._apply(
+            'free.cc', 'void FreeFunc(int x) {\n  Upstream(x);\n}\n',
+            'substitutions:\n'
+            '  - description: guard a free function\n'
+            '    preempt_function_impl:\n'
+            '      function_name: FreeFunc\n'
+            "      return_if: '!Enabled()'\n")
+        self.assertEqual(
+            result, 'void FreeFunc(int x) {\n  if (!Enabled()) return;\n'
+            '  Upstream(x);\n}\n')
+
+    def test_preempt_function_impl_ignores_forward_declaration(self):
+        # A forward declaration is a bodyless `declaration`, not a
+        # `function_definition`, so the matcher skips it (count stays 1) and the
+        # guard lands only in the definition.
+        source = ('void FreeFunc(int x);\n\n'
+                  'void FreeFunc(int x) {\n  Upstream(x);\n}\n')
+        result = self._apply(
+            'forward.cc', source, 'substitutions:\n'
+            '  - description: guard the definition, not the declaration\n'
+            '    preempt_function_impl:\n'
+            '      function_name: FreeFunc\n'
+            "      return_if: '!Enabled()'\n")
+        self.assertEqual(
+            result,
+            source.replace('{\n  Upstream(x);',
+                           '{\n  if (!Enabled()) return;\n  Upstream(x);'))
+
+    def test_preempt_function_impl_anonymous_namespace_function(self):
+        # A function inside an anonymous namespace is named by its bare
+        # declarator -- the enclosing `namespace {}` is contextual, not part of
+        # the name.
+        source = ('namespace {\n\n'
+                  'bool ShouldProceed(int x) {\n  return x > 0;\n}\n\n'
+                  '}  // namespace\n')
+        result = self._apply(
+            'anon.cc', source, 'substitutions:\n'
+            '  - description: guard a function in an anonymous namespace\n'
+            '    preempt_function_impl:\n'
+            '      function_name: ShouldProceed\n'
+            "      return_if: '!Enabled()'\n")
+        self.assertEqual(
+            result,
+            source.replace('{\n  return x > 0;',
+                           '{\n  if (!Enabled()) return;\n  return x > 0;'))
+
+    def test_preempt_function_impl_return_if_with_value(self):
+        result = self._apply(
+            'guard_value.cc', 'bool C::IsVisible() {\n  return real_;\n}\n',
+            'substitutions:\n'
+            '  - description: force the answer for Brave\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::IsVisible\n'
+            "      return_if: 'true'\n"
+            "      return_value: 'false'\n")
+        self.assertEqual(
+            result, 'bool C::IsVisible() {\n  if (true) return false;\n'
+            '  return real_;\n}\n')
+
+    def test_preempt_function_impl_code_block(self):
+        # The `code` block is authored flush-left; the engine indents the whole
+        # block to the body's first-statement level (two spaces).
+        result = self._apply(
+            'code.cc', 'void C::Pin(int id) {\n  Upstream();\n}\n',
+            'substitutions:\n'
+            '  - description: pin Brave actions before the upstream body\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::Pin\n'
+            '      code: |-\n'
+            '        if (PinBraveAction(id)) {\n'
+            '          return;\n'
+            '        }\n')
+        self.assertEqual(
+            result, 'void C::Pin(int id) {\n  if (PinBraveAction(id)) {\n'
+            '    return;\n  }\n  Upstream();\n}\n')
+
+    def test_preempt_function_impl_code_block_blank_line_not_indented(self):
+        # A blank line inside the block stays empty -- no trailing whitespace.
+        result = self._apply(
+            'code_blank.cc', 'void C::Pin(int id) {\n  Upstream();\n}\n',
+            'substitutions:\n'
+            '  - description: two guarded statements split by a blank line\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::Pin\n'
+            '      code: |-\n'
+            '        Prepare(id);\n'
+            '\n'
+            '        Track(id);\n')
+        self.assertEqual(
+            result, 'void C::Pin(int id) {\n  Prepare(id);\n\n'
+            '  Track(id);\n  Upstream();\n}\n')
+
+    def test_preempt_function_impl_survives_braced_default_argument(self):
+        # A `= {}` default argument and a multi-line signature both defeat a
+        # naive `\\(.*?{` regex, which would stop at the argument's brace. The
+        # AST matcher lands on the real body brace regardless.
+        source = ('void C::Tricky(const Options& opts = {},\n'
+                  '               int flags = 0) {\n  Upstream();\n}\n')
+        result = self._apply(
+            'tricky.cc', source, 'substitutions:\n'
+            '  - description: guard a function with a braced default arg\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::Tricky\n'
+            "      return_if: '!ok'\n")
+        self.assertEqual(
+            result,
+            source.replace('{\n  Upstream();', '{\n  if (!ok) return;\n'
+                           '  Upstream();'))
+
+    def test_preempt_function_impl_targets_named_function_only(self):
+        # Only the named function's body is touched, not a sibling in the same
+        # file.
+        result = self._apply(
+            'siblings.cc',
+            'void C::A() {\n  a();\n}\n\nvoid C::B() {\n  b();\n}\n',
+            'substitutions:\n'
+            '  - description: guard only B\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::B\n'
+            "      return_if: 'g()'\n")
+        self.assertEqual(
+            result, 'void C::A() {\n  a();\n}\n\n'
+            'void C::B() {\n  if (g()) return;\n  b();\n}\n')
+
+    def test_preempt_function_impl_overloads_need_count(self):
+        result = self._apply(
+            'overloads.cc',
+            'void C::F() {\n  a();\n}\n\nvoid C::F(int x) {\n  b();\n}\n',
+            'substitutions:\n'
+            '  - description: guard both overloads\n'
+            '    count: 2\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::F\n'
+            "      return_if: 'g()'\n")
+        self.assertEqual(
+            result, 'void C::F() {\n  if (g()) return;\n  a();\n}\n\n'
+            'void C::F(int x) {\n  if (g()) return;\n  b();\n}\n')
+
+    def test_preempt_function_impl_overload_count_mismatch_fails(self):
+        # Two overloads match, but the default count is 1.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'overloads_bad.cc',
+                'void C::F() {\n  a();\n}\n\nvoid C::F(int x) {\n  b();\n}\n',
+                'substitutions:\n'
+                '  - description: forgot the count\n'
+                '    preempt_function_impl:\n'
+                '      function_name: C::F\n'
+                "      return_if: 'g()'\n")
+
+    def test_preempt_function_impl_absent_function_fails(self):
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'missing.cc', 'void C::Foo() {\n}\n', 'substitutions:\n'
+                '  - description: no such function\n'
+                '    preempt_function_impl:\n'
+                '      function_name: C::Nope\n'
+                "      return_if: 'g()'\n")
+
+    def test_preempt_function_impl_both_modes_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: two modes\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::F\n'
+            '      code: x;\n'
+            "      return_if: 'g()'\n", 'exactly one of `code` or `return_if`')
+
+    def test_preempt_function_impl_no_mode_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: no mode\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::F\n',
+            'exactly one of `code` or `return_if`')
+
+    def test_preempt_function_impl_return_value_requires_return_if(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: return_value with code\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::F\n'
+            '      code: x;\n'
+            "      return_value: 'false'\n",
+            '`return_value` is only valid with `return_if`')
+
+    def test_preempt_function_impl_unknown_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: typo arg\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::F\n'
+            '      cod: x;\n', 'Unrecognised preempt_function_impl arg')
+
+    def test_preempt_function_impl_missing_function_name_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: missing function_name\n'
+            '    preempt_function_impl:\n'
+            "      return_if: 'g()'\n",
+            'preempt_function_impl `function_name` must be a non-empty string')
+
     # -- export-macro classes (real ast-grep binary) ----------------------
     #
     # tree-sitter cannot parse `class MACRO_EXPORT Name`, so the engine blanks

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -111,6 +111,34 @@ inside:
                 "node": "virtual_specifier",
             },
         },
+
+        # The body (compound_statement) of the definition of `function_name`.
+        # The match is the whole `{ ... }` block of the function_definition
+        # whose declarator text is exactly `function_name` -- a qualified
+        # `Class::Method` for a member, or the bare name for a free function.
+        # The function_declarator is reached with `stopBy: end`, so
+        # return-type wrappers (pointer/reference declarators, a trailing return
+        # type) between it and the definition do not matter. Anchoring on the
+        # AST body -- rather than a regex from the signature to the first `{` --
+        # is immune to braces in the parameter list (a `= {}` default argument),
+        # a multi-line signature, or an earlier overload. Each overload sharing
+        # the name yields its own match.
+        "cxx.find_function_body": {
+            "template": """\
+kind: compound_statement
+inside:
+  kind: function_definition
+  has:
+    kind: function_declarator
+    stopBy: end
+    has:
+      field: declarator
+      regex: ^{function_name}$
+""",
+            "result": {
+                "node": "compound_statement",
+            },
+        },
     },
     "ast.rewriter": {
 
@@ -161,6 +189,24 @@ inside:
             },
             "result": {
                 "node": "virtual_specifier",
+            },
+        },
+
+        # The function body with `prologue` inserted as its first statement,
+        # right after the opening brace. The matcher lands on the whole
+        # compound_statement, so anchoring the replace on `^{` inserts after the
+        # brace and leaves the rest of the body untouched. The caller passes
+        # `prologue` already indented to the body's first-statement level and
+        # with backslashes escaped for the `re.sub` replacement.
+        "cxx.preempt_function_impl": {
+            "matcher": "cxx.find_function_body",
+            "inputs": ["function_name", "prologue"],
+            "replace": {
+                "re_pattern": "^\\{",
+                "replace": "{{\\n{prologue}",
+            },
+            "result": {
+                "node": "compound_statement",
             },
         },
     },


### PR DESCRIPTION
This PR adds a rewriter to permit us preempt a function body. This
rewriter is important, as it should be preferred to the `_ChromiumImpl`
wrapping we currently tend to do.

Fixed: https://github.com/brave/brave-browser/issues/57327
