### PR TITLE
[recipes] Add test coverage to simulation tests

### DIFF
--- a/tools/recipes/.vpython3
+++ b/tools/recipes/.vpython3
@@ -9,3 +9,10 @@ wheel: <
   name: "infra/python/wheels/protobuf-py3"
   version: "version:6.32.1"
 >
+
+# Used by the simulation test runner (engine.py test run|train) to enforce
+# 100% coverage of recipe and recipe_module source.
+wheel: <
+  name: "infra/python/wheels/coverage/${vpython_platform}"
+  version: "version:7.3.1"
+>

--- a/tools/recipes/README.md
+++ b/tools/recipes/README.md
@@ -120,6 +120,12 @@ vpython3 tools/recipes/engine.py test list     # list all test case ids
 vpython3 tools/recipes/engine.py test run --filter package_rust
 ```
 
+On a full (unfiltered) `run` or `train`, the runner also enforces 100% line
+coverage of all `recipes/` and `recipe_modules/` source, reports any module with
+no test coverage at all, and (on `run`) flags orphaned expectation files -- any
+of which fails the run. Production-only I/O backends (the `_Real*` seams, never
+exercised by simulation) are marked `# pragma: no cover`.
+
 Simulation is possible because the seam modules, such as `step`, `path`, `env`,
 `platform`, are the only ones that touch the outside world, and in test mode
 they read/mutate the case's simulated state instead. A recipe or module that
@@ -148,28 +154,33 @@ Fragment builders live on the root api (`api.test`, `api.properties`,
 module-specific precondition helpers).
 
 `post_process` checks run against the recorded steps after simulation, each
-registered with `api.post_process(<check>, <args...>)`. A failing check fails
-the test; a check may also filter the written expectation. The available checks:
+registered with `api.post_process(<check>, <args...>)`. A failing check does not
+abort its hook: it is recorded with the failing source line and the resolved
+values of its sub-expressions (AST-introspected), and fails the test. A check
+may also return a filtered `steps` mapping to narrow the written expectation.
+The available checks:
 
-| Check                 | Arguments             | Passes when                                                             |
-| --------------------- | --------------------- | ----------------------------------------------------------------------- |
-| `MustRun`             | `step_name`           | a step with that exact name ran                                         |
-| `DoesNotRun`          | `step_name`           | no step with that name ran                                              |
-| `MustRunRE`           | `pattern`             | some step name matches the regex                                        |
-| `DoesNotRunRE`        | `pattern`             | no step name matches the regex                                          |
-| `StepCommandContains` | `step_name, args`     | the step ran and its command contains `args` as an in-order subsequence |
-| `StepCommandRE`       | `step_name, patterns` | the step ran and `patterns[i]` matches `cmd[i]` for each `i`            |
-| `StepSuccess`         | `step_name`           | the step ran with retcode `0`                                           |
-| `StepFailure`         | `step_name`           | the step ran with a non-zero retcode                                    |
-| `StatusSuccess`       | _(none)_              | the overall run status is `SUCCESS`                                     |
-| `StatusFailure`       | _(none)_              | the overall run status is `FAILURE` (a checked step failed)             |
-| `StatusException`     | _(none)_              | the overall run status is `EXCEPTION` (the recipe raised)               |
-| `DropExpectation`     | _(none)_              | always; suppresses writing this test's expectation file                 |
+| Check                 | Arguments             | Passes when                                                                        |
+| --------------------- | --------------------- | ---------------------------------------------------------------------------------- |
+| `MustRun`             | `step_name...`        | every named step ran                                                               |
+| `DoesNotRun`          | `step_name...`        | none of the named steps ran                                                        |
+| `MustRunRE`           | `pattern`             | some step name matches the regex                                                   |
+| `DoesNotRunRE`        | `pattern...`          | no step name matches any regex                                                     |
+| `StepCommandContains` | `step_name, args`     | the step ran and its command contains `args` as an in-order subsequence            |
+| `StepCommandRE`       | `step_name, patterns` | the step ran, each `patterns[i]` fully matches `cmd[i]`, with no surplus of either |
+| `StepSuccess`         | `step_name`           | the step ran with retcode `0`                                                      |
+| `StepFailure`         | `step_name`           | the step ran with a non-zero retcode                                               |
+| `StatusSuccess`       | _(none)_              | the run succeeded (`$result` has no `failure`)                                     |
+| `StatusFailure`       | _(none)_              | the run had a non-infra failure (a checked step failed)                            |
+| `StatusException`     | _(none)_              | the run had an infra failure (the recipe raised)                                   |
+| `StatusAnyFailure`    | _(none)_              | the run failed, infra or non-infra                                                 |
+| `DropExpectation`     | _(none)_              | always; suppresses writing this test's expectation file                            |
 
 `DropExpectation` is filter-only (it writes/keeps no golden), and should be
 considered for cases where there are too many permutations.
 
 Modules are tested via small example recipes under
-`recipe_modules/<module>/examples/`, run through this same machinery.
-Expectation files sit next to each recipe in a `<recipe>.expected/` directory
-and are committed.
+`recipe_modules/<module>/examples/` (with focused edge cases under
+`recipe_modules/<module>/tests/`), run through this same machinery. Expectation
+files sit next to each recipe in a `<recipe>.expected/` directory and are
+committed.

--- a/tools/recipes/check.py
+++ b/tools/recipes/check.py
@@ -1,0 +1,539 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""AST-introspecting check machinery for recipe simulation tests.
+
+A post-process hook receives a `Checker` and calls it in place of `assert`:
+
+    check(cond)          # bare
+    check(hint, cond)    # with a human hint
+
+Unlike a plain `assert`, a failing `check(...)` does not raise. Instead the
+`Checker` walks the stack, parses the source line of the failing call with
+`ast`, and records a `Check` capturing the failing expression *and the resolved
+values of its sub-expressions* (the step dict's keys, the missing step name, the
+compared values, ...). All checks in a hook run, and `Check.format()` renders
+the `CHECK ... (FAIL):` block.
+
+This module carries no dependency on the engine or the step data model: it works
+on the plain `{name: step-dict}` mapping the runner builds, so `steps[name]` is a
+dict (not a Step object). Failure rendering uses the stdlib `ast.unparse`.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import inspect
+import itertools
+import re
+from collections import OrderedDict, defaultdict, deque, namedtuple
+from typing import cast
+
+# Sentinel: distinguishes `check(cond)` from `check(hint, cond)`, and marks
+# "attribute/key absent" while walking sub-expressions.
+MISSING = object()
+
+
+def _unparse(node: ast.AST) -> str:
+    """Render an AST node back to source.
+
+    Wraps `ast.unparse` (added in Python 3.9) so the no-member warning from
+    older pylint releases that predate it stays localized here.
+    """
+    return ast.unparse(node)  # pylint: disable=no-member
+
+
+class CheckFrame(namedtuple('CheckFrame', 'fname line function code varmap')):
+    """One stack frame relevant to a failed check, rendered for humans."""
+
+    def format(self, indent):
+        lines = [
+            '%s%s:%s - %s()' %
+            ((' ' * indent), self.fname, self.line, self.function)
+        ]
+        indent += 2
+        lines.append('%s`%s`' % ((' ' * indent), self.code))
+        indent += 2
+        if self.varmap:
+            lines.extend('%s%s: %s' % ((' ' * indent), k, v)
+                         for k, v in self.varmap.items())
+        return lines
+
+
+class Check(
+        namedtuple('Check', ('name ctx_filename ctx_lineno ctx_func ctx_args '
+                             'ctx_kwargs frames passed'))):
+    """A recorded check outcome plus the frames/values needed to explain it."""
+
+    # filename -> {lineno -> [statements]}
+    _PARSED_FILE_CACHE = defaultdict(lambda: defaultdict(list))
+    _LAMBDA_CACHE = defaultdict(lambda: defaultdict(list))
+
+    @classmethod
+    def create(cls,
+               name,
+               hook_context,
+               frames,
+               passed,
+               ignore_set,
+               additional_varmap=None):
+        try:
+            keep_frames = [
+                cls._process_frame(f, ignore_set, with_vars=False)
+                for f in frames[:-1]
+            ]
+            keep_frames.append(
+                cls._process_frame(frames[-1],
+                                   ignore_set,
+                                   with_vars=True,
+                                   additional_varmap=additional_varmap))
+        finally:
+            # avoid reference cycle as suggested by inspect docs.
+            del frames
+
+        return cls(
+            name,
+            hook_context.filename,
+            hook_context.lineno,
+            cls._get_name_of_callable(hook_context.func),
+            [repr(arg) for arg in hook_context.args],
+            {
+                k: repr(v)
+                for k, v in hook_context.kwargs.items()
+            },
+            keep_frames,
+            passed,
+        )
+
+    @classmethod
+    def _get_name_of_callable(cls, c):
+        if inspect.ismethod(c):
+            return c.__self__.__class__.__name__ + '.' + c.__name__
+        if inspect.isfunction(c):
+            if c.__name__ == (lambda: None).__name__:
+                filename = c.__code__.co_filename
+                cls._ensure_file_in_cache(filename, c)
+                definitions = cls._LAMBDA_CACHE[filename][
+                    c.__code__.co_firstlineno]
+                assert definitions
+                # If there's multiple definitions at the same line, there's not
+                # enough information to distinguish which lambda c refers to, so
+                # just let python's generic lambda name be used.
+                if len(definitions) == 1:
+                    return _unparse(definitions[0])
+            return c.__name__
+        if hasattr(c, '__call__'):
+            return c.__class__.__name__ + '.__call__'
+        return repr(c)
+
+    @classmethod
+    def _get_statements_for_frame(cls, frame):
+        raw_frame, filename, lineno, _, _, _ = frame
+        cls._ensure_file_in_cache(filename, raw_frame)
+        return cls._PARSED_FILE_CACHE[filename][lineno]
+
+    @classmethod
+    def _ensure_file_in_cache(cls, filename, obj_with_code):
+        """Parse *filename* and index its simple statements by line number.
+
+        Multi-statement nodes (Module, FunctionDef, ...) carry their contents in
+        attributes like `body`. The goal is to enqueue those contents and treat
+        everything else as a 'single statement' keyed by its line. Cached so
+        multiple checks in one file parse it only once. Nested lambdas are also
+        indexed so a frame executing a lambda resolves to the lambda's source.
+        """
+        if filename not in cls._PARSED_FILE_CACHE:
+            to_push = ['test', 'body', 'orelse', 'finalbody', 'excepthandler']
+            lines, _ = inspect.findsource(obj_with_code)
+            queue = deque([ast.parse(''.join(lines), filename)])
+            while queue:
+                node = queue.pop()
+                had_statements = False
+                for key in to_push:
+                    val = getattr(node, key, MISSING)
+                    if val is not MISSING:
+                        had_statements = True
+                        if isinstance(val, list):
+                            # We pop from the start of the queue and want to
+                            # append nodes in order, so reverse on extend.
+                            queue.extend(val[::-1])
+                        else:
+                            # 'test' is a single expression, not a list.
+                            queue.append(val)
+                if had_statements:
+                    continue
+
+                real_line = node.lineno
+                cls._PARSED_FILE_CACHE[filename][real_line].append(node)
+
+                # Index nested lambdas: a frame executing a lambda that is not on
+                # the expression's last line has a different line number than a
+                # frame executing the containing expression.
+                for n in ast.walk(node):
+                    if not isinstance(n, ast.Lambda):
+                        continue
+                    cls._LAMBDA_CACHE[filename][n.lineno].append(n)
+                    lambda_max_line = n.lineno
+                    if lambda_max_line != real_line:
+                        cls._PARSED_FILE_CACHE[filename][
+                            lambda_max_line].append(n)
+
+    @classmethod
+    def _process_frame(cls,
+                       frame,
+                       ignore_set,
+                       with_vars,
+                       additional_varmap=None):
+        """Turn a stack frame into a `CheckFrame`.
+
+        When `with_vars` is set (only the innermost frame), the parsed statement
+        is run through `_checkTransformer` to resolve the interesting
+        sub-expressions to their runtime values, omitting callables and the step
+        mapping itself, and rendering each value with `render_user_value`.
+        """
+        nodes = cls._get_statements_for_frame(frame)
+        raw_frame, filename, lineno, func_name, _, _ = frame
+
+        varmap = None
+        if with_vars:
+            varmap = dict(additional_varmap or {})
+
+            xfrmr = _checkTransformer(raw_frame.f_locals, raw_frame.f_globals)
+            xfrmd = xfrmr.visit(ast.Module(copy.deepcopy(nodes), []))
+
+            for n in itertools.chain(ast.walk(xfrmd), xfrmr.extras):
+                if isinstance(n, _resolved):
+                    val = n.value
+                    if isinstance(val, ast.AST):
+                        continue
+                    if n.representation in ('True', 'False', 'None'):
+                        continue
+                    if callable(val) or id(val) in ignore_set:
+                        continue
+                    if n.representation not in varmap:
+                        varmap[n.representation] = render_user_value(val)
+
+        return CheckFrame(filename, lineno, func_name,
+                          '; '.join(_unparse(n) for n in nodes), varmap)
+
+    def format(self):
+        """Return the lines that make up this check failure.
+
+        Example:
+        CHECK "something was run" (FAIL):
+          /.../post_process.py:77 - MustRun()
+            `check(('step %r must run' % step_name), (step_name in _run_steps))`
+              step_name: 'fakiestep'
+          added /.../allowlist_steps.py:28
+            MustRun('fakiestep')
+        """
+        ret = [
+            'CHECK%(name)s(%(passed)s):' % {
+                'name': ' %r ' % self.name if self.name else '',
+                'passed': 'PASS' if self.passed else 'FAIL',
+            }
+        ]
+        for frame in self.frames:
+            ret.extend(frame.format(indent=2))
+
+        ret.append('  added %s:%d' % (self.ctx_filename, self.ctx_lineno))
+        func = '%s(' % self.ctx_func
+        if self.ctx_args:
+            func += ', '.join(self.ctx_args)
+        if self.ctx_kwargs:
+            if self.ctx_args:
+                func += ', '
+            func += ', '.join(['%s=%s' % i for i in self.ctx_kwargs.items()])
+        func += ')'
+        ret.append('    ' + func)
+        return ret
+
+
+class _resolved(ast.AST):
+    """A fake AST node standing in for a resolved sub-expression.
+
+    `_checkTransformer` replaces portions of the parsed statement with these.
+    `valid` indicates the value matches the source value, so further source
+    operations (attribute access, subscription) may be applied; when False the
+    value is a stand-in (e.g. a dict replaced with its keys) and must not be
+    operated on further.
+    """
+
+    def __init__(self, representation, value, valid=True):
+        super().__init__()
+        self.representation = representation
+        self.value = value
+        self.valid = valid
+
+
+class _checkTransformer(ast.NodeTransformer):
+    """Extracts the helpful sub-expressions from a `check(...)` statement.
+
+    Transformations:
+      * identifiers resolve to their local/global value;
+      * `___ in <dict>` prints `dict.keys()` instead of the whole dict;
+      * `a[b][c]` prints `a[b]` and `a[b][c]` (recursively).
+
+    The result is NOT a valid python AST: each reduced sub-expression becomes a
+    `_resolved` whose `representation` is the source code and whose `value` is
+    the evaluated value. Extra `_resolved` nodes that don't fit the tree land in
+    `self.extras`.
+    """
+
+    def __init__(self, lvars, gvars):
+        self.lvars = lvars
+        self.gvars = gvars
+        self.extras = []
+
+    @staticmethod
+    def _is_valid_resolved(node) -> _resolved | None:
+        if isinstance(node, _resolved) and node.valid:
+            return node
+        return None
+
+    def visit_Compare(self, node: ast.Compare):
+        """Match `___ in instanceof(dict)` to print the dict's keys."""
+        node = cast(ast.Compare, self.generic_visit(node))
+
+        if len(node.ops) == 1 and isinstance(node.ops[0], (ast.In, ast.NotIn)):
+            cmps = node.comparators
+            if len(cmps) == 1 and (rslvd := self._is_valid_resolved(cmps[0])):
+                if isinstance(rslvd.value, (dict, OrderedDict)):
+                    node = ast.Compare(node.left, node.ops, [
+                        _resolved(rslvd.representation + '.keys()',
+                                  sorted(rslvd.value.keys()),
+                                  valid=False)
+                    ])
+
+        return node
+
+    def visit_Attribute(self, node: ast.Attribute):
+        """Follow attribute access so the resulting value can be printed."""
+        node = cast(ast.Attribute, self.generic_visit(node))
+
+        if (rslvd := self._is_valid_resolved(node.value)):
+            return _resolved('%s.%s' % (rslvd.representation, node.attr),
+                             getattr(rslvd.value, node.attr))
+
+        return node
+
+    def visit_Subscript(self, node: ast.Subscript):
+        """Match `__[x]` for constant or resolvable `x`, printing `__[x]`."""
+        node = cast(ast.Subscript, self.generic_visit(node))
+
+        node_value_resolved = self._is_valid_resolved(node.value)
+        if not node_value_resolved:
+            return node
+
+        sliceVal = MISSING
+        sliceRepr = ''
+
+        if (rslvd := self._is_valid_resolved(node.slice)):
+            # (a[b])[c] -- include `a[b]` in the extras.
+            self.extras.append(rslvd)
+            sliceVal = rslvd.value
+            sliceRepr = rslvd.representation
+        elif isinstance(node.slice, ast.Constant):
+            sliceVal = node.slice.value
+            sliceRepr = repr(sliceVal)
+
+        if sliceVal is not MISSING:
+            try:
+                return _resolved(
+                    '%s[%s]' % (node_value_resolved.representation, sliceRepr),
+                    node_value_resolved.value[sliceVal])
+            except KeyError:
+                if not isinstance(node_value_resolved.value,
+                                  (dict, OrderedDict)):
+                    raise
+                return _resolved(node_value_resolved.representation +
+                                 '.keys()',
+                                 sorted(node_value_resolved.value.keys()),
+                                 valid=False)
+
+        return node
+
+    def visit_Name(self, node):
+        """Resolve a bare identifier from constants, then locals, then globals."""
+        consts = {'True': True, 'False': False, 'None': None}
+        val = consts.get(
+            node.id, self.lvars.get(node.id, self.gvars.get(node.id, MISSING)))
+        if val is not MISSING:
+            return _resolved(node.id, val)
+        return node
+
+
+def render_user_value(val):
+    """Render a sub-expression value as an (ideally eval-able) string."""
+    if isinstance(val, re.Pattern):
+        return render_re(val)
+    return repr(val)
+
+
+def render_re(regex):
+    """Render a repr()-style value for a compiled regular expression."""
+    actual_flags = []
+    if regex.flags:
+        flags = [
+            (re.IGNORECASE, 'IGNORECASE'),
+            (re.LOCALE, 'LOCALE'),
+            (re.UNICODE, 'UNICODE'),
+            (re.MULTILINE, 'MULTILINE'),
+            (re.DOTALL, 'DOTALL'),
+            (re.VERBOSE, 'VERBOSE'),
+        ]
+        for val, name in flags:
+            if regex.flags & val:
+                actual_flags.append(name)
+    if actual_flags:
+        return 're.compile(%r, %s)' % (regex.pattern, '|'.join(actual_flags))
+    return 're.compile(%r)' % regex.pattern
+
+
+class Checker:
+    """Collects `Check` failures for a single post-process hook.
+
+    Calling the checker records (but does not raise) failures, so a hook reports
+    every failed assertion in one pass. The checker MUST be stored in a local
+    variable of the caller running the hook: `_call_impl` walks the stack to find
+    the frame where the checker is a local, and keeps the frames below it (the
+    hook and anything it calls) for the failure backtrace.
+    """
+
+    def __init__(self, hook_context, *ignores):
+        self.failed_checks: list[Check] = []
+
+        # Objects we never print as sub-expression values. Seed it with the
+        # checker itself (printing that has no value).
+        self._ignore_set = {id(x) for x in ignores + (self, )}
+
+        self._hook_context = hook_context
+
+    def _call_impl(self, hint, exp):
+        if exp:
+            return
+
+        # Grab the frames between (non-inclusive) the checker's creation and
+        # self.__call__, innermost last.
+        try:
+            frames = inspect.stack()[2:][::-1]
+
+            # Seed defaults so both names are defined even for an empty stack
+            # (i = -1 keeps the whole list; f = None makes the `del` safe).
+            i, f = -1, None
+            try:
+                for i, f in enumerate(frames):
+                    # The first frame with self in its locals is where the
+                    # checker was created. Use `is` to avoid invoking __eq__.
+                    if any(self is obj for obj in f[0].f_locals.values()):
+                        break
+                frames = frames[i + 1:]
+            finally:
+                del f
+
+            self.failed_checks.append(
+                Check.create(
+                    hint,
+                    self._hook_context,
+                    frames,
+                    False,
+                    self._ignore_set,
+                ))
+        finally:
+            # avoid reference cycle as suggested by inspect docs.
+            del frames
+
+    def __call__(self, arg1, arg2=MISSING):
+        if arg2 is not MISSING:
+            hint = arg1
+            exp = arg2
+        else:
+            hint = None
+            exp = arg1
+        self._call_impl(hint, exp)
+        return bool(exp)
+
+
+def VerifySubset(a, b):
+    """Verify that `a` is a subset of `b` (both JSON-ish, OrderedDict allowed).
+
+    `a` may introduce no extra dict keys / list elements, must keep the order of
+    entries in ordered types, and must keep types consistent. Empty and
+    single-element dicts count as subsets of an OrderedDict even though the types
+    differ. Returns None when `a` is a valid subset, otherwise a descriptive
+    message of what went wrong, e.g.:
+
+      >>> 'object' + VerifySubset({'a': 'thing'}, {'b': 'x', 'a': 'prime'})
+      "object['a']: 'thing' != 'prime'"
+    """
+    if a is b:
+        return None
+
+    if isinstance(b, OrderedDict) and isinstance(a, dict):
+        # 0 and 1-element dicts can stand in for OrderedDicts.
+        if len(a) == 0:
+            return None
+        if len(a) == 1:
+            a = OrderedDict(a)
+
+    if type(a) is not type(b):
+        return ': type mismatch: %r v %r' % (type(a).__name__,
+                                             type(b).__name__)
+
+    if isinstance(a, OrderedDict):
+        last_idx = 0
+        b_reverse_index = {k: (i, v) for i, (k, v) in enumerate(b.items())}
+        for k, v in a.items():
+            j, b_val = b_reverse_index.get(k, (MISSING, MISSING))
+            if j is MISSING:
+                return ': added key %r' % k
+
+            if j < last_idx:
+                return ': key %r is out of order' % k
+            # j == last_idx is not possible, these are OrderedDicts
+            last_idx = j
+
+            msg = VerifySubset(v, b_val)
+            if msg:
+                return '[%r]%s' % (k, msg)
+
+    elif isinstance(a, dict):
+        for k, v in a.items():
+            b_val = b.get(k, MISSING)
+            if b_val is MISSING:
+                return ': added key %r' % k
+
+            msg = VerifySubset(v, b_val)
+            if msg:
+                return '[%r]%s' % (k, msg)
+
+    elif isinstance(a, list):
+        if len(a) > len(b):
+            return ': too long: %d v %d' % (len(a), len(b))
+
+        if not (a or b):
+            return None
+
+        bi = ai = 0
+        while bi < len(b) - 1 and ai < len(a) - 1:
+            msg = VerifySubset(a[ai], b[bi])
+            if msg is None:
+                ai += 1
+            bi += 1
+        if ai != len(a) - 1:
+            return ': added %d elements' % (len(a) - 1 - ai)
+
+    elif isinstance(a, (str, int, bool, type(None))):
+        if a != b:
+            return ': %r != %r' % (a, b)
+
+    else:
+        return ': unknown type: %r' % (type(a).__name__)
+
+    return None
+
+
+class PostProcessError(ValueError):
+    """Raised when a post-process hook returns a non-subset expectation."""

--- a/tools/recipes/engine.py
+++ b/tools/recipes/engine.py
@@ -150,7 +150,7 @@ class _Engine:
         for dep_name in deps:
             setattr(inst.m, dep_name,
                     self._instantiate_module(dep_name, chain + [name]))
-        # A module can reach itself via `self.m.<own_name>`, as in recipes_py.
+        # A module can reach itself via `self.m.<own_name>`.
         setattr(inst.m, name, inst)
 
         # Seed the simulation context (test mode only) after DEPS are wired but

--- a/tools/recipes/engine_env.py
+++ b/tools/recipes/engine_env.py
@@ -39,7 +39,7 @@ def merge_envs(
         return result
 
     # Backing for `%(KEY)s` substitution: unknown keys resolve to '' rather than
-    # raising, matching the upstream behaviour.
+    # raising.
     subst: Mapping[str, str] = defaultdict(str, **dict(original))
 
     merged: set[str] = set()

--- a/tools/recipes/engine_env_test.py
+++ b/tools/recipes/engine_env_test.py
@@ -3,9 +3,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Tests for `engine_env.merge_envs` (the env composition ported from
-recipe_engine). Covers prefix/suffix joining, override folding, `%(VAR)s`
-substitution, and variable removal."""
+"""Tests for `engine_env.merge_envs` (the env composition). Covers prefix/suffix
+joining, override folding, `%(VAR)s` substitution, and variable removal."""
 
 from __future__ import annotations
 

--- a/tools/recipes/post_process.py
+++ b/tools/recipes/post_process.py
@@ -4,173 +4,180 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """Post-process checks for recipe simulation tests.
 
-A minimal mirror of `recipe_engine.post_process`. A recipe's `GenTests` attaches
-checks with `api.post_process(func, *args)`; after simulation the test runner
-calls each `func(check, steps, *args)`, where:
+A recipe's `GenTests` attaches checks with `api.post_process(func, *args)`.
+After running a simulation the runner calls each `func(check, steps, *args)`,
+where:
 
-  * `check` is a `Checker`. Call it as `check(cond)` or `check(hint, cond)`.
-    Failures are collected (not raised), so every check in a hook runs.
+  * `check` is a `check.Checker`. Call it as `check(cond)` or
+    `check(hint, cond)`. Failures are recorded (not raised) with an
+    AST-introspected rendering of the failing expression and its sub-values, so
+    every check in a hook runs. See `check.py`.
   * `steps` is an ordered `dict` mapping step name -> step dict
-    (`{'name', 'cmd', 'cwd'?, 'env'?, 'retcode'}`), plus the terminal
-    `'$result'` entry (`{'name': '$result', 'status': ...}`).
+    (`{'name', 'cmd', 'cwd'?, 'env'?, 'retcode'?}`), plus the terminal
+    `'$result'` entry. `$result` has no `failure` key on success. On a non-infra
+    failure it is `{'failure': {'failure': {}, 'humanReason': ...}}`; on an
+    infra failure/exception it is `{'failure': {'humanReason': ...}}`.
 
 A check function returns `None` to only assert, or a (subset) `dict` to *filter*
-the recorded steps for the written expectation. Returning an empty dict drops
-the expectation file entirely (see `DropExpectation`).
-
-Simplifications vs upstream: no AST-introspected failure rendering (checks carry
-a caller-supplied hint), and the returned-dict filter is used verbatim rather
-than subset-verified.
+the recorded steps for the written expectation; the runner subset-verifies that
+returned dict (see `check.VerifySubset`). Returning an empty dict drops the
+expectation file entirely (see `DropExpectation`).
 """
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 import re
-from typing import Any
+from typing import TYPE_CHECKING
 
-# The '$result' pseudo-step name holding the overall run status.
+if TYPE_CHECKING:
+    from check import Checker
+
+# The '$result' pseudo-step name holding the overall run result.
 RESULT_STEP = '$result'
 
 # A step dict, or the $result dict.
 Step = dict
-Steps = dict  # OrderedDict-like {name: Step}
-
-# Sentinel distinguishing `check(cond)` from `check(hint, cond)`.
-_MISSING = object()
-
-
-class Checker:
-    """Collects check failures for a single post-process hook.
-
-    Calling the checker records (but does not raise) failures, so a hook reports
-    every failed assertion in one pass. `failures` is a list of human-readable
-    strings, each prefixed with the `api.post_process(...)` call site.
-    """
-
-    def __init__(self, context: str) -> None:
-        self._context = context
-        self.failures: list[str] = []
-
-    def __call__(self, arg1: Any, arg2: Any = _MISSING) -> bool:
-        """`check(cond)` or `check(hint, cond)`; returns `bool(cond)`."""
-        if arg2 is _MISSING:
-            hint, cond = None, arg1
-        else:
-            hint, cond = arg1, arg2
-        if not cond:
-            message = f'{self._context}: check failed'
-            if hint:
-                message += f': {hint}'
-            self.failures.append(message)
-        return bool(cond)
-
-
-def _run_steps(steps: Steps) -> Steps:
-    """Return only the executed steps (drops the `$result` pseudo-step)."""
-    return {name: step for name, step in steps.items() if name != RESULT_STEP}
+Steps = dict  # ordered {name: Step}
 
 
 # -- Presence -----------------------------------------------------------------
 
 
-def MustRun(check: Checker, steps: Steps, step_name: str) -> None:
-    check(f'step {step_name!r} must run', step_name in _run_steps(steps))
+def MustRun(check: Checker, step_odict: Steps, *steps: str) -> None:
+    """Assert that steps with the given names are in the expectations."""
+    for step_name in steps:
+        check(step_name in step_odict)
 
 
-def DoesNotRun(check: Checker, steps: Steps, step_name: str) -> None:
-    check(f'step {step_name!r} must not run', step_name
-          not in _run_steps(steps))
+def DoesNotRun(check: Checker, step_odict: Steps, *steps: str) -> None:
+    """Assert that the given steps don't run."""
+    ban_set = set(steps)
+    for step_name in step_odict:
+        check(step_name not in ban_set)
 
 
-def MustRunRE(check: Checker, steps: Steps, pattern: str) -> None:
-    regex = re.compile(pattern)
-    check(f'a step matching {pattern!r} must run',
-          any(regex.search(name) for name in _run_steps(steps)))
+def MustRunRE(check: Checker,
+              step_odict: Steps,
+              step_regex: str | re.Pattern,
+              at_least: int = 1,
+              at_most: int | None = None) -> None:
+    """Assert that steps matching the given regex are in the expectations."""
+    compiled_regex = re.compile(step_regex)
+    matches = 0
+    for step_name in step_odict:
+        if compiled_regex.match(step_name):
+            matches += 1
+    check(matches >= at_least)
+    if at_most is not None:
+        check(matches <= at_most)
 
 
-def DoesNotRunRE(check: Checker, steps: Steps, pattern: str) -> None:
-    regex = re.compile(pattern)
-    check(f'no step may match {pattern!r}',
-          not any(regex.search(name) for name in _run_steps(steps)))
+def DoesNotRunRE(check: Checker, step_odict: Steps, *step_regexes:
+                 str) -> None:
+    """Assert that no steps matching any of the regexes have run."""
+    compiled_regexes = [re.compile(r) for r in step_regexes]
+    for step_name in step_odict:
+        for regex in compiled_regexes:
+            check(not regex.match(step_name))
 
 
 # -- Command inspection -------------------------------------------------------
 
 
+def _fullmatch(pattern: str | re.Pattern, string: str) -> bool:
+    match = re.match(pattern, string)
+    return bool(match and match.span()[1] == len(string))
+
+
 def _is_subsequence(sub: list, seq: list) -> bool:
-    """Whether *sub* appears in *seq* in order (not always contiguously)."""
+    """Whether *sub* appears in *seq* in order (not necessarily contiguously)."""
     it = iter(seq)
     return all(item in it for item in sub)
 
 
-def StepCommandContains(check: Checker, steps: Steps, step_name: str,
-                        args: list[str]) -> None:
-    step = _run_steps(steps).get(step_name)
-    if not check(f'step {step_name!r} must run', step is not None):
-        return
-    check(f'{step_name!r} command must contain {args!r} in order',
-          _is_subsequence([str(a) for a in args], step['cmd']))
+def StepCommandContains(check: Checker, step_odict: Steps, step: str,
+                        argument_sequence: Sequence[str]) -> None:
+    """Assert that a step's command contained the given argument sequence."""
+    check(
+        'command line for step %s contained %s' % (step, argument_sequence),
+        _is_subsequence([str(a) for a in argument_sequence],
+                        step_odict[step]['cmd']))
 
 
-def StepCommandRE(check: Checker, steps: Steps, step_name: str,
-                  patterns: list[str]) -> None:
-    step = _run_steps(steps).get(step_name)
-    if not check(f'step {step_name!r} must run', step is not None):
-        return
-    cmd = step['cmd']
-    for i, pattern in enumerate(patterns):
-        matched = i < len(cmd) and re.search(pattern, cmd[i]) is not None
-        check(f'{step_name!r} cmd[{i}] must match {pattern!r}', matched)
+def StepCommandRE(check: Checker, step_odict: Steps, step: str,
+                  expected_patterns: Sequence[str | re.Pattern]) -> None:
+    """Assert that a step's command matches the given list of regexes.
+
+    The i-th command argument is matched against the i-th pattern. A pattern
+    that does not match the entire argument is a failure, as are surplus
+    arguments or unused patterns.
+    """
+    cmd = step_odict[step]['cmd']
+    for expected, actual in zip(expected_patterns, cmd):
+        check(_fullmatch(expected, actual))
+    unmatched = cmd[len(expected_patterns):]
+    check('all arguments matched', not unmatched)
+    unused = expected_patterns[len(cmd):]
+    check('all patterns used', not unused)
 
 
 # -- Per-step status ----------------------------------------------------------
 
 
-def StepSuccess(check: Checker, steps: Steps, step_name: str) -> None:
-    step = _run_steps(steps).get(step_name)
-    if not check(f'step {step_name!r} must run', step is not None):
-        return
-    check(f'step {step_name!r} must succeed', step.get('retcode', 0) == 0)
+def StepSuccess(check: Checker, step_odict: Steps, step: str) -> None:
+    """Assert that a step succeeded (its simulated retcode was zero)."""
+    check(step_odict[step].get('retcode', 0) == 0)
 
 
-def StepFailure(check: Checker, steps: Steps, step_name: str) -> None:
-    step = _run_steps(steps).get(step_name)
-    if not check(f'step {step_name!r} must run', step is not None):
-        return
-    check(f'step {step_name!r} must fail', step.get('retcode', 0) != 0)
+def StepFailure(check: Checker, step_odict: Steps, step: str) -> None:
+    """Assert that a step failed (its simulated retcode was non-zero)."""
+    check(step_odict[step].get('retcode', 0) != 0)
 
 
 # -- Overall result -----------------------------------------------------------
 
 
-def _status(steps: Steps) -> str | None:
-    result = steps.get(RESULT_STEP)
-    return result.get('status') if result else None
+def StatusSuccess(check: Checker, step_odict: Steps) -> None:
+    """Assert that the recipe finished successfully."""
+    failure = step_odict[RESULT_STEP].get('failure')
+    check('recipe succeeded (found failure instead)', failure is None)
 
 
-def StatusSuccess(check: Checker, steps: Steps) -> None:
-    check(f'overall status must be SUCCESS (was {_status(steps)})',
-          _status(steps) == 'SUCCESS')
+def StatusAnyFailure(check: Checker, step_odict: Steps) -> None:
+    """Assert that the recipe failed (infra or non-infra)."""
+    check('recipe failed (found success instead)', 'failure'
+          in step_odict[RESULT_STEP])
 
 
-def StatusFailure(check: Checker, steps: Steps) -> None:
-    check(f'overall status must be FAILURE (was {_status(steps)})',
-          _status(steps) == 'FAILURE')
+def StatusFailure(check: Checker, step_odict: Steps) -> None:
+    """Assert that the recipe had a non-infra failure."""
+    result = step_odict[RESULT_STEP]
+    if not check('recipe failed (found success instead)', 'failure' in result):
+        return
+    check('expected failure but recipe had infra failure', 'failure'
+          in result['failure'])
 
 
-def StatusException(check: Checker, steps: Steps) -> None:
-    check(f'overall status must be EXCEPTION (was {_status(steps)})',
-          _status(steps) == 'EXCEPTION')
+def StatusException(check: Checker, step_odict: Steps) -> None:
+    """Assert that the recipe had an infra failure."""
+    result = step_odict[RESULT_STEP]
+    if not check('recipe had infra failure (found success instead)', 'failure'
+                 in result):
+        return
+    check('recipe had infra failure (found non-infra failure instead)',
+          'failure' not in result['failure'])
 
 
 # -- Expectation control ------------------------------------------------------
 
 
-def DropExpectation(_check: Checker, _steps: Steps) -> Steps:
+def DropExpectation(_check: Checker, _step_odict: Steps) -> Steps:
     """Suppress writing this test's expectation file.
 
-    Returning an empty mapping signals the runner to write (and, in train mode,
-    remove any stale) expectation file. Handy for tests that assert only via
-    other post-process checks and don't need a golden file.
+    Returning an empty mapping signals the runner to write no expectation (and,
+    in train mode, to remove any stale one). Handy for tests that assert only via
+    other post-process checks and don't need a golden file. Must be the last
+    check in a case: no steps remain for later checks to evaluate.
     """
     return {}

--- a/tools/recipes/recipe_api.py
+++ b/tools/recipes/recipe_api.py
@@ -4,9 +4,8 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """Base class for Brave recipe modules.
 
-Deliberately tiny mirror of `recipe_engine.recipe_api.RecipeApi` from
-chrome-infra's recipes_py. Every recipe module exposes exactly one `RecipeApi`
-subclass (in its `api.py`). After constructing it, the engine attaches the
+A deliberately tiny base class. Every recipe module exposes exactly one
+`RecipeApi` subclass (in its `api.py`). After constructing it, the engine attaches the
 module's resolved `DEPS` onto `self.m`, which is the "module injection site",
 so a module reaches each dependency as `self.m.<dep_name>` (and itself as
 `self.m.<own_name>`).

--- a/tools/recipes/recipe_modules/brave_core_shallow/examples/full.expected/clone.json
+++ b/tools/recipes/recipe_modules/brave_core_shallow/examples/full.expected/clone.json
@@ -26,7 +26,6 @@
     "name": "sparse-checkout add"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/brave_core_shallow/examples/full.expected/reuse.json
+++ b/tools/recipes/recipe_modules/brave_core_shallow/examples/full.expected/reuse.json
@@ -35,7 +35,6 @@
     "name": "sparse-checkout add"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/brave_core_shallow/test_api.py
+++ b/tools/recipes/recipe_modules/brave_core_shallow/test_api.py
@@ -6,7 +6,7 @@
 
 Exposes the module's simulated preconditions as helpers so a *recipe* that
 merely depends on `brave_core_shallow` can arrange them without itself depending
-on `path`, mirroring how recipes_py modules provide their own test seams.
+on `path`.
 """
 
 from __future__ import annotations

--- a/tools/recipes/recipe_modules/brave_core_shallow/tests/__init__.py
+++ b/tools/recipes/recipe_modules/brave_core_shallow/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Focused tests for the `brave_core_shallow` module."""

--- a/tools/recipes/recipe_modules/brave_core_shallow/tests/errors.py
+++ b/tools/recipes/recipe_modules/brave_core_shallow/tests/errors.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for the `brave_core_shallow` module's argument validation."""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['brave_core_shallow']
+
+
+def RunSteps(api):
+    # deploy() requires at least one path.
+    api.brave_core_shallow.deploy([])
+
+
+def GenTests(api):
+    yield api.test(
+        'empty paths',
+        api.post_process(post_process.StatusException),
+        api.post_process(post_process.DropExpectation),
+        status='EXCEPTION',
+    )

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/existing_branch.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/existing_branch.json
@@ -58,7 +58,6 @@
     "name": "gclient sync"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/fresh_tag.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/fresh_tag.json
@@ -57,7 +57,6 @@
     "name": "gclient sync"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_hermetic_toolchain.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_hermetic_toolchain.json
@@ -65,7 +65,6 @@
     "name": "win toolchain env"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/chromium_checkout/tests/__init__.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Focused tests for the `chromium_checkout` module's git-cache handling."""

--- a/tools/recipes/recipe_modules/chromium_checkout/tests/git_cache.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/tests/git_cache.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `chromium_checkout`'s git-cache resolution and checkout probing.
+
+The behaviour under test is selected by a seeded `MODE` env var, so each case
+drives one branch of `set_git_cache` / `validate_git_cache` / `ensure_checkout`
+without needing a typed PROPERTIES message.
+"""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['chromium_checkout', 'env', 'path', 'step']
+
+
+def RunSteps(api):
+    mode = api.env.get('MODE')
+    if mode == 'with_cache':
+        api.chromium_checkout.ensure_checkout(ref='main', git_cache='/b/cache')
+    elif mode == 'default_home':
+        api.chromium_checkout.set_git_cache()
+    elif mode == 'already_set':
+        api.chromium_checkout.set_git_cache('/b/cache')
+    elif mode == 'bad_dir':
+        api.chromium_checkout.set_git_cache('/b/nonexistent')
+    elif mode == 'validate_bad_dir':
+        api.chromium_checkout.validate_git_cache()
+    elif mode == 'invalid_checkout':
+        api.chromium_checkout.ensure_checkout(ref='main')
+
+
+def GenTests(api):
+    # An explicit git_cache dir is set (and validated) before the checkout.
+    yield api.test(
+        'ensure with cache',
+        api.env.set('MODE', 'with_cache'),
+        api.path.dirs('/b/cache'),
+        api.path.files('chromium/src/chrome/VERSION'),
+        api.env.on_path('gclient', '/dt/gclient'),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )
+    # set_git_cache() with no argument defaults to <HOME>/cache.
+    yield api.test(
+        'default home cache',
+        api.env.set('MODE', 'default_home'),
+        api.path.dirs('/b/home/cache'),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )
+    # set_git_cache when GIT_CACHE_PATH is already set is an error.
+    yield api.test(
+        'already set',
+        api.env.set('MODE', 'already_set'),
+        api.env.set('GIT_CACHE_PATH', '/b/cache'),
+        api.post_process(post_process.StatusException),
+        api.post_process(post_process.DropExpectation),
+        status='EXCEPTION',
+    )
+    # set_git_cache pointed at a non-existent directory is an error.
+    yield api.test(
+        'bad cache dir',
+        api.env.set('MODE', 'bad_dir'),
+        api.post_process(post_process.StatusException),
+        api.post_process(post_process.DropExpectation),
+        status='EXCEPTION',
+    )
+    # validate_git_cache with GIT_CACHE_PATH pointing at a non-dir is an error.
+    yield api.test(
+        'validate bad dir',
+        api.env.set('MODE', 'validate_bad_dir'),
+        api.env.set('GIT_CACHE_PATH', '/b/nope'),
+        api.post_process(post_process.StatusException),
+        api.post_process(post_process.DropExpectation),
+        status='EXCEPTION',
+    )
+    # A failing `check chrome/VERSION` means the checkout isn't valid, so
+    # ensure_checkout falls back to cloning.
+    yield api.test(
+        'invalid checkout falls back to clone',
+        api.env.set('MODE', 'invalid_checkout'),
+        api.chromium_checkout.with_git_cache(),
+        api.chromium_checkout.existing_checkout(),
+        api.env.on_path('gclient', '/dt/gclient'),
+        api.step.data('check chrome/VERSION', retcode=1),
+        api.post_process(post_process.MustRun, 'check chrome/VERSION'),
+        api.post_process(post_process.MustRun, 'fetch chromium'),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )

--- a/tools/recipes/recipe_modules/context/api.py
+++ b/tools/recipes/recipe_modules/context/api.py
@@ -78,8 +78,8 @@ class ContextApi(RecipeApi):
                 substituted from the startup environment when the step runs;
                 `None` removes the variable.
         """
-        # member name -> value to restore on exit (mirrors upstream's
-        # `deferred_assignments`), so the `finally` unwinds exactly what changed.
+        # member name -> value to restore on exit, so the `finally` unwinds
+        # exactly what changed.
         deferred: dict[str, Any] = {}
 
         def _push(member: str, new: Any) -> None:

--- a/tools/recipes/recipe_modules/context/examples/full.expected/basic.json
+++ b/tools/recipes/recipe_modules/context/examples/full.expected/basic.json
@@ -29,6 +29,11 @@
         "[WORKSPACE]/node/bin"
       ]
     },
+    "env_suffixes": {
+      "LD_LIBRARY_PATH": [
+        "/opt/lib"
+      ]
+    },
     "name": "nested context"
   },
   {
@@ -39,7 +44,6 @@
     "name": "outside context"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/context/examples/full.py
+++ b/tools/recipes/recipe_modules/context/examples/full.py
@@ -21,6 +21,7 @@ def RunSteps(api):
         # Nested contexts compose: a second PATH prefix stacks in front, and
         # cwd applies only within the inner block.
         with api.context(env_prefixes={'PATH': ['/opt/extra']},
+                         env_suffixes={'LD_LIBRARY_PATH': ['/opt/lib']},
                          cwd=api.path.out):
             api.step('nested context', ['node', 'build.js'])
 

--- a/tools/recipes/recipe_modules/context/tests/__init__.py
+++ b/tools/recipes/recipe_modules/context/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Focused tests for the `context` module's input validation."""

--- a/tools/recipes/recipe_modules/context/tests/errors.py
+++ b/tools/recipes/recipe_modules/context/tests/errors.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for the `context` module's rejection of bad inputs.
+
+A seeded `MODE` env var selects which input to feed `api.context`; the invalid
+ones raise on `__enter__`, the valid one runs the block.
+"""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['context', 'env', 'step']
+
+
+def RunSteps(api):
+    mode = api.env.get('MODE')
+    if mode == 'bad_cwd':
+        # cwd must be a str/Path; an int is rejected by _check_type.
+        cm = api.context(cwd=123)
+    elif mode == 'bad_env':
+        # A bare `%s` is not a valid `%(VAR)s` env template and is rejected.
+        cm = api.context(env={'BAD': '%s'})
+    else:
+        cm = api.context(env={'OK': 'value'})
+    with cm:
+        api.step('inside context', ['echo', 'ok'])
+
+
+def GenTests(api):
+    yield api.test(
+        'bad cwd type',
+        api.env.set('MODE', 'bad_cwd'),
+        api.post_process(post_process.StatusException),
+        api.post_process(post_process.DropExpectation),
+        status='EXCEPTION',
+    )
+    yield api.test(
+        'bad env format',
+        api.env.set('MODE', 'bad_env'),
+        api.post_process(post_process.StatusException),
+        api.post_process(post_process.DropExpectation),
+        status='EXCEPTION',
+    )
+    yield api.test(
+        'valid context',
+        api.env.set('MODE', 'ok'),
+        api.post_process(post_process.MustRun, 'inside context'),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )

--- a/tools/recipes/recipe_modules/depot_tools/examples/full.expected/already_deployed.json
+++ b/tools/recipes/recipe_modules/depot_tools/examples/full.expected/already_deployed.json
@@ -1,17 +1,6 @@
 [
   {
     "cmd": [
-      "git",
-      "clone",
-      "--depth",
-      "1",
-      "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/chromium/third_party/depot_tools"
-    ],
-    "name": "clone depot_tools"
-  },
-  {
-    "cmd": [
       "gclient"
     ],
     "name": "verify gclient"

--- a/tools/recipes/recipe_modules/depot_tools/examples/full.expected/already_on_path.json
+++ b/tools/recipes/recipe_modules/depot_tools/examples/full.expected/already_on_path.json
@@ -7,7 +7,6 @@
     "name": "use vpython3"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/depot_tools/examples/full.expected/windows.json
+++ b/tools/recipes/recipe_modules/depot_tools/examples/full.expected/windows.json
@@ -24,7 +24,6 @@
     "name": "use vpython3"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/depot_tools/examples/full.py
+++ b/tools/recipes/recipe_modules/depot_tools/examples/full.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import post_process
 
-DEPS = ['depot_tools', 'env', 'platform', 'step']
+DEPS = ['depot_tools', 'env', 'path', 'platform', 'step']
 
 
 def RunSteps(api):
@@ -23,7 +23,7 @@ def GenTests(api):
         api.post_process(post_process.MustRun, 'clone depot_tools'),
         api.post_process(post_process.MustRun, 'verify gclient'),
         api.post_process(post_process.StepCommandRE, 'use vpython3',
-                         [r'vpython3$', r'--version']),
+                         [r'.*vpython3', r'--version']),
         api.post_process(post_process.StatusSuccess),
     )
     yield api.test(
@@ -33,9 +33,18 @@ def GenTests(api):
         api.post_process(post_process.StatusSuccess),
     )
     yield api.test(
+        'already deployed',
+        api.platform.name('linux'),
+        # A standalone depot_tools already sits under the Chromium checkout.
+        api.path.files('chromium/third_party/depot_tools/gclient'),
+        api.post_process(post_process.DoesNotRun, 'clone depot_tools'),
+        api.post_process(post_process.MustRun, 'verify gclient'),
+        api.post_process(post_process.StatusSuccess),
+    )
+    yield api.test(
         'windows',
         api.platform.name('win'),
         api.post_process(post_process.StepCommandRE, 'use vpython3',
-                         [r'vpython3\.bat$', r'--version']),
+                         [r'.*vpython3\.bat', r'--version']),
         api.post_process(post_process.StatusSuccess),
     )

--- a/tools/recipes/recipe_modules/env/api.py
+++ b/tools/recipes/recipe_modules/env/api.py
@@ -19,7 +19,7 @@ import shutil
 from recipe_api import RecipeApi
 
 
-class _RealEnv:
+class _RealEnv:  # pragma: no cover - production env backend, not simulated.
     """Production backend: the real process environment and PATH lookup."""
 
     def get(self, key: str, default: str | None) -> str | None:

--- a/tools/recipes/recipe_modules/env/examples/full.expected/gclient_absent.json
+++ b/tools/recipes/recipe_modules/env/examples/full.expected/gclient_absent.json
@@ -7,7 +7,6 @@
     "name": "flag set"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/path/api.py
+++ b/tools/recipes/recipe_modules/path/api.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from recipe_api import RecipeApi
 
 
-class _RealFs:
+class _RealFs:  # pragma: no cover - production filesystem backend.
     """Production backend: the real filesystem."""
 
     def exists(self, path: str | Path) -> bool:
@@ -74,11 +74,10 @@ class _SimFs:
 class PathApi(RecipeApi):
     """Named, workspace-relative job paths, seeded by the engine.
 
-    Mirrors (in miniature) `recipe_engine/path`: recipes build paths from these
-    named roots instead of hardcoding them or taking them as properties. Only
-    the workspace root is configurable (engine `--workspace`); everything else
-    is derived from it, so the on-disk layout is fixed and consistent across
-    recipes.
+    Recipes build paths from these named roots instead of hardcoding them or
+    taking them as properties. Only the workspace root is configurable (engine
+    `--workspace`); everything else is derived from it, so the on-disk layout is
+    fixed and consistent across recipes.
     """
 
     @property

--- a/tools/recipes/recipe_modules/path/examples/full.expected/absent.json
+++ b/tools/recipes/recipe_modules/path/examples/full.expected/absent.json
@@ -7,7 +7,20 @@
     "name": "out ready"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "cmd": [
+      "echo",
+      "[HOME]"
+    ],
+    "name": "home"
+  },
+  {
+    "cmd": [
+      "echo",
+      "[HOME]/cache"
+    ],
+    "name": "cache"
+  },
+  {
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/path/examples/full.expected/seeded.json
+++ b/tools/recipes/recipe_modules/path/examples/full.expected/seeded.json
@@ -14,7 +14,20 @@
     "name": "out ready"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "cmd": [
+      "echo",
+      "[HOME]"
+    ],
+    "name": "home"
+  },
+  {
+    "cmd": [
+      "echo",
+      "[HOME]/cache"
+    ],
+    "name": "cache"
+  },
+  {
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/path/examples/full.py
+++ b/tools/recipes/recipe_modules/path/examples/full.py
@@ -19,6 +19,9 @@ def RunSteps(api):
     api.path.mkdir(api.path.out)
     if api.path.is_dir(api.path.out):
         api.step('out ready', ['echo', str(api.path.out)])
+    # Exercise the home() seam and `~`-expansion via abs().
+    api.step('home', ['echo', str(api.path.home())])
+    api.step('cache', ['echo', str(api.path.abs('~/cache'))])
 
 
 def GenTests(api):
@@ -29,6 +32,9 @@ def GenTests(api):
         api.post_process(post_process.MustRun, 'out ready'),
         api.post_process(post_process.StepCommandContains, 'out ready',
                          ['[WORKSPACE]/out']),
+        api.post_process(post_process.StepCommandContains, 'home', ['[HOME]']),
+        api.post_process(post_process.StepCommandContains, 'cache',
+                         ['[HOME]/cache']),
         api.post_process(post_process.StatusSuccess),
     )
     yield api.test(

--- a/tools/recipes/recipe_modules/platform/api.py
+++ b/tools/recipes/recipe_modules/platform/api.py
@@ -16,11 +16,11 @@ import sys
 
 from recipe_api import RecipeApi
 
-# Canonical short platform names, matching recipes_py.
+# Canonical short platform names.
 _VALID = ('linux', 'mac', 'win')
 
 
-def _host_name() -> str:
+def _host_name() -> str:  # pragma: no cover - production host detection.
     if sys.platform == 'win32':
         return 'win'
     if sys.platform == 'darwin':
@@ -35,7 +35,7 @@ class PlatformApi(RecipeApi):
         super().__init__()
         # Default to the real host; refined in initialise() once the engine has
         # seeded `_test`. Accessors below just read `self._name`. No per-call
-        # test-mode branching (mirrors recipes_py's PlatformApi).
+        # test-mode branching.
         self._name = _host_name()
 
     def initialise(self) -> None:

--- a/tools/recipes/recipe_modules/platform/examples/full.expected/linux.json
+++ b/tools/recipes/recipe_modules/platform/examples/full.expected/linux.json
@@ -7,7 +7,13 @@
     "name": "report platform"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "cmd": [
+      "echo",
+      "linux"
+    ],
+    "name": "linux only"
+  },
+  {
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/platform/examples/full.expected/mac.json
+++ b/tools/recipes/recipe_modules/platform/examples/full.expected/mac.json
@@ -2,16 +2,16 @@
   {
     "cmd": [
       "echo",
-      "/depot_tools/gclient"
+      "mac"
     ],
-    "name": "resolved gclient"
+    "name": "report platform"
   },
   {
     "cmd": [
       "echo",
-      "on"
+      "mac"
     ],
-    "name": "flag set"
+    "name": "mac only"
   },
   {
     "name": "$result"

--- a/tools/recipes/recipe_modules/platform/examples/full.expected/win.json
+++ b/tools/recipes/recipe_modules/platform/examples/full.expected/win.json
@@ -14,7 +14,6 @@
     "name": "windows only"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/platform/examples/full.py
+++ b/tools/recipes/recipe_modules/platform/examples/full.py
@@ -15,6 +15,10 @@ def RunSteps(api):
     api.step('report platform', ['echo', api.platform.name])
     if api.platform.is_win:
         api.step('windows only', ['echo', 'win'])
+    if api.platform.is_mac:
+        api.step('mac only', ['echo', 'mac'])
+    if api.platform.is_linux:
+        api.step('linux only', ['echo', 'linux'])
 
 
 def GenTests(api):
@@ -24,6 +28,7 @@ def GenTests(api):
         api.post_process(post_process.StepCommandContains, 'report platform',
                          ['linux']),
         api.post_process(post_process.DoesNotRun, 'windows only'),
+        api.post_process(post_process.MustRun, 'linux only'),
         api.post_process(post_process.StatusSuccess),
     )
     yield api.test(
@@ -32,5 +37,13 @@ def GenTests(api):
         api.post_process(post_process.StepCommandContains, 'report platform',
                          ['win']),
         api.post_process(post_process.MustRun, 'windows only'),
+        api.post_process(post_process.DoesNotRun, 'mac only'),
+        api.post_process(post_process.StatusSuccess),
+    )
+    yield api.test(
+        'mac',
+        api.platform.name('mac'),
+        api.post_process(post_process.MustRun, 'mac only'),
+        api.post_process(post_process.DoesNotRun, 'windows only'),
         api.post_process(post_process.StatusSuccess),
     )

--- a/tools/recipes/recipe_modules/step/api.py
+++ b/tools/recipes/recipe_modules/step/api.py
@@ -18,7 +18,7 @@ class StepApi(RecipeApi):
     """Runs a subprocess as a named build step.
 
     The instance is callable, so recipes and modules invoke it as
-    `api.step(name, cmd, ...)`, mirroring `recipe_engine/step`. This is the one
+    `api.step(name, cmd, ...)`. This is the one
     place work actually happens; everything else describes work in terms of
     steps. The API only *describes* a step (name + command + cwd/env) and hands
     it to a step runner: in production a `SubprocessStepRunner` shells out (with
@@ -39,8 +39,11 @@ class StepApi(RecipeApi):
         self._prod_runner = None
 
     def _runner(self):
-        if self._test is not None:
-            return self._test.step_runner
+        if self._test is None:  # pragma: no cover - production step backend.
+            return self._prod_runner_lazy()
+        return self._test.step_runner
+
+    def _prod_runner_lazy(self):  # pragma: no cover - production step backend.
         if self._prod_runner is None:
             # Imported lazily so `step` stays dependency-free at import time and
             # simulation code isn't loaded on the production path until needed.
@@ -81,7 +84,7 @@ class StepApi(RecipeApi):
         # Draw cwd/env from the ambient context, letting explicit arguments
         # override. The env overrides and the path prefix/suffix affixes are
         # carried separately so the runner can compose them (production) or
-        # record them (simulation), mirroring recipe_engine's split.
+        # record them (simulation).
         context = self.m.context
         env_overrides = {**context.env, **(env or {})}
         step = {

--- a/tools/recipes/recipe_modules/step/examples/full.expected/all_pass.json
+++ b/tools/recipes/recipe_modules/step/examples/full.expected/all_pass.json
@@ -20,7 +20,6 @@
     "name": "after"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/step/examples/full.expected/step_fails.json
+++ b/tools/recipes/recipe_modules/step/examples/full.expected/step_fails.json
@@ -14,7 +14,10 @@
     "retcode": 1
   },
   {
-    "name": "$result",
-    "status": "FAILURE"
+    "failure": {
+      "failure": {},
+      "humanReason": "Step('might fail') failed"
+    },
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/step/examples/full.py
+++ b/tools/recipes/recipe_modules/step/examples/full.py
@@ -28,7 +28,8 @@ def GenTests(api):
     )
     yield api.test(
         'step fails',
-        api.step_data('might fail', retcode=1),
+        # Uses the step module's own `api.step.data(...)` seeding helper.
+        api.step.data('might fail', retcode=1),
         api.post_process(post_process.MustRun, 'might fail'),
         api.post_process(post_process.StepFailure, 'might fail'),
         api.post_process(post_process.DoesNotRun, 'after'),

--- a/tools/recipes/recipe_modules/step/test_api.py
+++ b/tools/recipes/recipe_modules/step/test_api.py
@@ -5,8 +5,8 @@
 """Test API for the `step` module: seed a step's simulated result.
 
 `api.step_data(...)` on the root api is the usual entry point; this exposes the
-same thing as `api.step.data(...)` for symmetry with recipes_py, so a step's
-retcode/output can be seeded next to other `api.step.*` fragments.
+same thing as `api.step.data(...)`, so a step's retcode/output can be seeded next
+to other `api.step.*` fragments.
 """
 
 from __future__ import annotations

--- a/tools/recipes/recipe_test_api.py
+++ b/tools/recipes/recipe_test_api.py
@@ -22,8 +22,7 @@ injected as `api.<module>`, so a recipe writes, e.g.:
 Each `api.*` call returns a `TestData` *fragment*; `api.test(name, *fragments)`
 folds them together (via `TestData.__add__`) into the case the engine runs.
 
-Notable simplifications vs upstream: no output placeholders, and a simple
-`check(cond, hint)` collector rather than the AST-introspecting `Checker`.
+Notable simplification: no output placeholders.
 """
 
 from __future__ import annotations
@@ -74,12 +73,17 @@ class StepTestData:
         )
 
 
-class PostprocessHook(NamedTuple):
-    """A `post_process` callback plus where it was registered (for messages)."""
+class PostprocessHookContext(NamedTuple):
+    """A `post_process` callback plus where it was registered.
+
+    `filename`/`lineno` locate the `api.post_process(...)` call site, so a failed
+    check can render the `added <file>:<lineno>` footer and the call repr.
+    """
     func: Callable[..., Any]
     args: tuple
     kwargs: dict
-    context: str  # "<file>:<lineno>" of the api.post_process(...) call.
+    filename: str
+    lineno: int
 
 
 class TestData:
@@ -104,7 +108,7 @@ class TestData:
         # (e.g. mod_data['platform'] = {'name': 'mac'}).
         self.mod_data: dict[str, dict[str, Any]] = {}
         # post_process checks run against the recorded steps after simulation.
-        self.post_process_hooks: list[PostprocessHook] = []
+        self.post_process_hooks: list[PostprocessHookContext] = []
         # Expected overall status ('SUCCESS' | 'FAILURE' | 'EXCEPTION'); None
         # means "don't assert" (a mismatch during a run is still reported).
         self.expected_status: str | None = None
@@ -246,7 +250,7 @@ class RecipeTestApi:
     # -- Fragment builders available on the root api (and inherited by modules).
 
     # `api.properties(...)` / `api.properties.environ(...)`. A shared, stateless
-    # builder (mirrors recipes_py's `properties` module TEST_API).
+    # builder.
     properties = _PropertiesTestApi()
 
     @staticmethod
@@ -286,11 +290,12 @@ class RecipeTestApi:
         """A fragment registering a post-process check (see `post_process`)."""
         frame = inspect.currentframe()
         caller = frame.f_back if frame is not None else None
-        context = (f'{caller.f_code.co_filename}:{caller.f_lineno}'
-                   if caller is not None else '<unknown>')
+        filename = (caller.f_code.co_filename
+                    if caller is not None else '<unknown>')
+        lineno = caller.f_lineno if caller is not None else 0
         data = TestData()
         data.post_process_hooks.append(
-            PostprocessHook(func, args, kwargs, context))
+            PostprocessHookContext(func, args, kwargs, filename, lineno))
         return data
 
     @staticmethod

--- a/tools/recipes/recipe_test_runner.py
+++ b/tools/recipes/recipe_test_runner.py
@@ -16,8 +16,8 @@ both `RunSteps` and `GenTests` -- then, for each `TestData` a recipe's
   5. compares the result against the checked-in expectation JSON (`run`) or
      writes it (`train`).
 
-Modules are tested the recipes_py way: via small example recipes that exercise
-them, run through this very machinery.
+Modules are tested via small example recipes that exercise them, run through
+this very machinery.
 """
 
 from __future__ import annotations
@@ -25,16 +25,22 @@ from __future__ import annotations
 import argparse
 import difflib
 import importlib
+import io
 import json
 import logging
 from pathlib import Path
 import re
 import subprocess
 import sys
+import time
+from typing import TYPE_CHECKING
 
 import engine
 import simulation
 from recipe_test_api import RecipeTestApi, TestData
+
+if TYPE_CHECKING:
+    import coverage
 
 # -- TEST_API discovery & injection (mirrors engine's DEPS resolution) --------
 
@@ -170,20 +176,35 @@ def _rel(path: Path) -> str:
 # -- Running ------------------------------------------------------------------
 
 
+# A failure "block": its kind (grouped under one `FAIL (<kind>) - <case>`
+# header) and the lines that describe it.
+Block = tuple[str, list[str]]
+
+
 class _Results:
     """Accumulates per-case verdicts for the final report."""
 
-    def __init__(self) -> None:
+    def __init__(self, verbose: bool = False) -> None:
+        self.verbose = verbose
         self.passed = 0
+        self.total = 0
         self.written = 0
         self.removed = 0
-        self.failures: list[tuple[str, list[str]]] = []
+        self.failures: list[tuple[str, list[Block]]] = []
 
-    def record(self, case_id: str, failures: list[str]) -> None:
-        if failures:
-            self.failures.append((case_id, failures))
+    def record(self, case_id: str, blocks: list[Block]) -> None:
+        """Record a finished case, print its progress icon, buffer failures."""
+        self.total += 1
+        failed = bool(blocks)
+        if failed:
+            self.failures.append((case_id, blocks))
         else:
             self.passed += 1
+        if self.verbose:
+            print(f'{case_id} ... {"FAIL" if failed else "ok"}')
+        else:
+            sys.stdout.write('F' if failed else '.')
+            sys.stdout.flush()
 
 
 def _simulate(
@@ -196,35 +217,59 @@ def _simulate(
     eng = engine._Engine(  # pylint: disable=protected-access
         brave_core_ref=test_data.brave_core_ref,
         test=ctx)
-    status, reason = 'SUCCESS', None
+    # `failure` becomes the `$result` payload: None on success; a non-infra
+    # failure carries an inner `{'failure': {}}`; an infra failure/exception
+    # carries only `humanReason`.
+    failure: dict | None = None
     try:
         eng.run_loaded_recipe(recipe, recipe_id, test_data.properties)
     except subprocess.CalledProcessError:
-        # A checked step returned non-zero: the recipe failed as designed.
-        status = 'FAILURE'
+        # A checked step returned non-zero: the recipe failed as designed. The
+        # failing step is the last one the runner recorded before it raised.
+        recorded = ctx.step_runner.recorded_steps
+        name = recorded[-1]['name'] if recorded else '<unknown>'
+        failure = {'failure': {}, 'humanReason': f'Step({name!r}) failed'}
     except Exception as exc:  # pylint: disable=broad-except
         # Any other exception is an infra/logic error (bad input, missing dep).
-        status, reason = 'EXCEPTION', str(exc)
-    steps = simulation.build_steps(ctx.step_runner, status, reason, ctx)
+        failure = {'humanReason': str(exc)}
+    steps = simulation.build_steps(ctx.step_runner, failure, ctx)
     return steps, ctx
+
+
+def _result_status(result: dict) -> str:
+    """Derive the SUCCESS/FAILURE/EXCEPTION label from a `$result` dict."""
+    failure = result.get('failure')
+    if failure is None:
+        return 'SUCCESS'
+    return 'FAILURE' if 'failure' in failure else 'EXCEPTION'
 
 
 def _run_case(recipe, recipe_id: str, test_data: TestData, train: bool,
               results: _Results, seen: set[Path]) -> None:
+    case_id = f'{recipe_id}.{test_data.name}'
     steps, _ = _simulate(recipe, recipe_id, test_data)
-    filtered, failures = simulation.apply_post_process(
-        test_data.post_process_hooks, steps)
-
-    status = steps[simulation.pp.RESULT_STEP]['status']
-    if (test_data.expected_status is not None
-            and test_data.expected_status != status):
-        reason = steps[simulation.pp.RESULT_STEP].get('reason')
-        failures.append(f'expected overall status '
-                        f'{test_data.expected_status!r}, got {status!r}' +
-                        (f' ({reason})' if reason else ''))
-
     expect_file = _expect_file(recipe, test_data.name)
     seen.add(expect_file)
+
+    blocks: list[Block] = []
+    try:
+        filtered, failed_checks = simulation.apply_post_process(
+            test_data.post_process_hooks, steps)
+    except simulation.PostProcessError as exc:
+        # A hook returned a non-subset expectation: the test itself is broken.
+        results.record(case_id, [('bad_test', [str(exc)])])
+        return
+    blocks.extend(('check', chk.format()) for chk in failed_checks)
+
+    result = steps[simulation.pp.RESULT_STEP]
+    status = _result_status(result)
+    if (test_data.expected_status is not None
+            and test_data.expected_status != status):
+        reason = (result.get('failure') or {}).get('humanReason')
+        blocks.append(('bad_test', [
+            f'expected overall status {test_data.expected_status!r}, '
+            f'got {status!r}' + (f' ({reason})' if reason else '')
+        ]))
 
     if filtered is None:  # DropExpectation.
         if expect_file.exists():
@@ -232,9 +277,10 @@ def _run_case(recipe, recipe_id: str, test_data: TestData, train: bool,
                 expect_file.unlink()
                 results.removed += 1
             else:
-                failures.append(
+                blocks.append(('bad_test', [
                     f'{_rel(expect_file)} exists but the test drops its '
-                    f'expectation; delete it or run `test train`')
+                    f'expectation; delete it or run `test train`'
+                ]))
     else:
         payload = _dump(filtered)
         if train:
@@ -244,8 +290,10 @@ def _run_case(recipe, recipe_id: str, test_data: TestData, train: bool,
                 _write_expectation(expect_file, payload)
                 results.written += 1
         elif not expect_file.exists():
-            failures.append(f'missing expectation {_rel(expect_file)} '
-                            f'(run `engine.py test train`)')
+            blocks.append(('bad_test', [
+                f'missing expectation {_rel(expect_file)} '
+                f'(run `engine.py test train`)'
+            ]))
         else:
             current = _read_expectation(expect_file)
             if current != payload:
@@ -255,19 +303,103 @@ def _run_case(recipe, recipe_id: str, test_data: TestData, train: bool,
                     fromfile=f'{_rel(expect_file)} (expected)',
                     tofile='actual',
                     lineterm='')
-                failures.append('expectation mismatch:\n' + '\n'.join(diff))
+                blocks.append(('diff', list(diff)))
 
-    results.record(f'{recipe_id}.{test_data.name}', failures)
+    results.record(case_id, blocks)
+
+
+# -- Coverage & structural gates ----------------------------------------------
+
+
+def _start_coverage() -> coverage.Coverage:
+    """Start a run-wide `coverage` session over recipe/module source.
+
+    Must be called before recipes/modules are imported so their import-time
+    definitions count as covered. Returns the started `Coverage` object.
+    """
+    import coverage  # Local import: only the full-run path needs the wheel.
+    root = engine.RECIPES_ROOT
+    cov = coverage.Coverage(config_file=False,
+                            data_file=None,
+                            include=[
+                                str(root / engine.RECIPES_PKG / '*'),
+                                str(root / engine.MODULES_PKG / '*'),
+                            ])
+    # `if TYPE_CHECKING:` blocks never execute at runtime; the default
+    # `# pragma: no cover` still applies for the production I/O seams that
+    # simulation intentionally never exercises.
+    cov.exclude(r'^\s*if TYPE_CHECKING:')
+    cov.start()
+    return cov
+
+
+def _report_coverage(cov: coverage.Coverage) -> bool:
+    """Report total coverage; return True if it is below 100% (a failure)."""
+    import coverage  # Local import: mirrors `_start_coverage`.
+    if not cov.get_data().measured_files():
+        return False
+    buf = io.StringIO()
+    pct = 0
+    try:
+        pct = cov.report(file=buf, show_missing=True, skip_covered=True)
+    except coverage.CoverageException as ex:
+        print('%s: %s' % (ex.__class__.__name__, ex))
+    if int(pct) != 100:
+        print(buf.getvalue())
+        print('FATAL: Insufficient total coverage (%.2f%%)' % pct)
+        print()
+        return True
+    return False
+
+
+def _uncovered_modules() -> list[str]:
+    """Modules with no test coverage at all (no examples/tests, not exempt)."""
+    modules_root = engine.RECIPES_ROOT / engine.MODULES_PKG
+    uncovered: list[str] = []
+    for module in sorted(engine._module_names()):  # pylint: disable=protected-access
+        mod_dir = modules_root / module
+        has_tests = any((mod_dir / sub).is_dir() and any(
+            p.name != '__init__.py' for p in (mod_dir / sub).rglob('*.py'))
+                        for sub in ('examples', 'tests'))
+        if has_tests:
+            continue
+        package = importlib.import_module(f'{engine.MODULES_PKG}.{module}')
+        if getattr(package, 'DISABLE_STRICT_COVERAGE', False):
+            continue
+        uncovered.append(module)
+    return uncovered
+
+
+def _all_expectation_files() -> list[Path]:
+    root = engine.RECIPES_ROOT
+    files: list[Path] = []
+    for base in (engine.RECIPES_PKG, engine.MODULES_PKG):
+        for expect_dir in (root / base).rglob('*.expected'):
+            if expect_dir.is_dir():
+                files.extend(expect_dir.glob('*.json'))
+    return files
+
+
+# -- Running ------------------------------------------------------------------
 
 
 def run_tests(train: bool = False,
               filter_: str | None = None,
-              list_only: bool = False) -> int:
+              list_only: bool = False,
+              verbose: bool = False) -> int:
     """Run (or train, or list) all recipe simulation tests; return an exit code.
     """
     engine._ensure_on_sys_path()  # pylint: disable=protected-access
-    results = _Results()
+    results = _Results(verbose=verbose)
 
+    # Coverage/structural gates run only on a full, unfiltered `run`/`train`.
+    # Start coverage before any recipe/module import so import-time definitions
+    # are measured.
+    gated = not filter_ and not list_only
+    cov = _start_coverage() if gated else None
+
+    start = time.monotonic()
+    seen_all: set[Path] = set()
     for recipe_id, recipe in _testable_recipes():
         root_api = _build_root_test_api(list(getattr(recipe, 'DEPS', [])))
         seen: set[Path] = set()
@@ -282,31 +414,87 @@ def run_tests(train: bool = False,
 
         # Train mode prunes stale expectation files (only on a full, unfiltered
         # run, so a filtered train never deletes another case's golden).
-        if train and not list_only and not filter_:
+        if train and gated:
             expect_dir = _expect_dir(recipe)
             if expect_dir.is_dir():
                 for stale in sorted(expect_dir.glob('*.json')):
                     if stale not in seen:
                         stale.unlink()
                         results.removed += 1
+        seen_all |= seen
 
     if list_only:
         return 0
-    return _report(results, train)
+
+    duration = time.monotonic() - start
+    if cov is not None:
+        cov.stop()
+
+    # `run` reports orphaned goldens; `train` already deleted them above.
+    unused = ([] if train else sorted(p for p in _all_expectation_files()
+                                      if p not in seen_all)) if gated else []
+    uncovered = _uncovered_modules() if gated else []
+    return _report(results, train, duration, cov, uncovered, unused)
 
 
-def _report(results: _Results, train: bool) -> int:
-    for case_id, failures in results.failures:
-        print(f'FAIL {case_id}')
-        for failure in failures:
-            for line in failure.splitlines():
-                print(f'    {line}')
+def _print_case_failure(case_id: str, blocks: list[Block]) -> None:
+    """Print one failed case's detail, grouped by kind."""
+    by_kind: dict[str, list[list[str]]] = {}
+    for kind, lines in blocks:
+        by_kind.setdefault(kind, []).append(lines)
+    for kind in ('bad_test', 'check', 'diff'):
+        groups = by_kind.get(kind)
+        if not groups:
+            continue
+        print('=' * 70)
+        print(f'FAIL ({kind}) - {case_id}')
+        print('-' * 70)
+        for lines in groups:
+            for line in lines:
+                print(line)
+            print()
+
+
+def _report(results: _Results, train: bool, duration: float,
+            cov: coverage.Coverage | None, uncovered: list[str],
+            unused: list[Path]) -> int:
+    if not results.verbose:
+        print()  # Terminate the progress-dots line.
+    for case_id, blocks in results.failures:
+        _print_case_failure(case_id, blocks)
+
+    print('-' * 70)
+    print('Ran %d tests in %0.3fs' % (results.total, duration))
+    print()
+
+    fail = bool(results.failures)
+
+    if cov is not None:
+        fail = _report_coverage(cov) or fail
+
+    if uncovered:
+        fail = True
+        print('------')
+        print('ERROR: The following modules lack any form of test coverage:')
+        for modname in uncovered:
+            print('  ', modname)
+        print()
+
+    if unused:
+        fail = True
+        print('------')
+        print(
+            'ERROR: The below expectation files have no associated test case:')
+        for path in unused:
+            print('  ', _rel(path))
+        print()
+
     summary = [f'{results.passed} passed', f'{len(results.failures)} failed']
     if train:
         summary.append(f'{results.written} written')
         summary.append(f'{results.removed} removed')
-    print(f'\nrecipe tests: {", ".join(summary)}')
-    return 1 if results.failures else 0
+    print(f'recipe tests: {", ".join(summary)}')
+    return 1 if fail else 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -331,7 +519,8 @@ def main(argv: list[str] | None = None) -> int:
         level=logging.DEBUG if args.verbose else logging.WARNING)
     return run_tests(train=args.subcommand == 'train',
                      filter_=args.filter,
-                     list_only=args.subcommand == 'list')
+                     list_only=args.subcommand == 'list',
+                     verbose=args.verbose)
 
 
 if __name__ == '__main__':

--- a/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
@@ -98,7 +98,6 @@
     "name": "build rust toolchain"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipes/toolchains/xcode/build_xcode_toolchain.expected/mac.json
+++ b/tools/recipes/recipes/toolchains/xcode/build_xcode_toolchain.expected/mac.json
@@ -55,7 +55,6 @@
     "name": "build xcode toolchain"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/linux.json
+++ b/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/linux.json
@@ -95,7 +95,6 @@
     "name": "package ast-grep"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipes/tools/node/package_node.expected/basic.json
+++ b/tools/recipes/recipes/tools/node/package_node.expected/basic.json
@@ -60,7 +60,6 @@
     "name": "package node"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipes/tools/node/package_node.expected/reuse_checkout.json
+++ b/tools/recipes/recipes/tools/node/package_node.expected/reuse_checkout.json
@@ -69,7 +69,6 @@
     "name": "package node"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipes/tools/node/package_node_modules.expected/basic.json
+++ b/tools/recipes/recipes/tools/node/package_node_modules.expected/basic.json
@@ -61,7 +61,6 @@
     "name": "package node_modules"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "name": "$result"
   }
 ]

--- a/tools/recipes/recipes/tools/node/package_node_modules.expected/reuse_checkout.json
+++ b/tools/recipes/recipes/tools/node/package_node_modules.expected/reuse_checkout.json
@@ -70,7 +70,6 @@
     "name": "package node_modules"
   },
   {
-    "name": "$result",
-    "status": "SUCCESS"
+    "name": "$result"
   }
 ]

--- a/tools/recipes/simulation.py
+++ b/tools/recipes/simulation.py
@@ -16,7 +16,7 @@ Holds everything needed to run a recipe with zero real side effects:
     live in `StepApi`); simulation records an ordered step list and returns
     canned results.
   * expectation helpers: `stabilize` (machine paths -> `[WORKSPACE]`/`[HOME]`
-    tokens), `serialize_steps`, and `apply_post_process`.
+    tokens), `build_steps`, and `apply_post_process`.
 
 Deliberately never imports `engine` (the engine imports this), so there is no
 cycle: the test runner in `engine.py` drives a recipe, then hands the recorded
@@ -27,13 +27,16 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 import copy
+import inspect
 from pathlib import Path, PurePosixPath
 import subprocess
+import sys
 from typing import Any
 
+from check import Check, Checker, PostProcessError, VerifySubset
 from engine_env import merge_envs
 import post_process as pp
-from recipe_test_api import StepTestData, TestData
+from recipe_test_api import PostprocessHookContext, StepTestData, TestData
 
 # Fixed synthetic locations used in test mode. They are never touched on disk;
 # they exist only so module-derived paths are deterministic, and are rewritten
@@ -240,12 +243,15 @@ def stabilize(value: str, context: TestContext | None = None) -> str:
     return value.replace(home, HOME_TOKEN)
 
 
-def build_steps(runner: SimulationStepRunner, status: str, reason: str | None,
+def build_steps(runner: SimulationStepRunner, failure: dict | None,
                 context: TestContext) -> dict[str, dict]:
     """Assemble the ordered `{name: step}` map (+ `$result`) for post-process.
 
-    Paths are stabilized here so post-process checks and the written
-    expectation see the same tokenized commands.
+    Paths are stabilized here so post-process checks and the written expectation
+    see the same tokenized commands. `failure` is `None` for a successful run,
+    otherwise it is the terminal result's `failure` payload. A non-infra failure
+    carries an inner `{'failure': {}}`, which an infra failure does not. Any
+    machine paths in its `humanReason` are stabilized too.
     """
     steps: dict[str, dict] = {}
     for step in runner.recorded_steps:
@@ -270,34 +276,67 @@ def build_steps(runner: SimulationStepRunner, status: str, reason: str | None,
             entry['retcode'] = step['retcode']
         steps[step['name']] = entry
 
-    result: dict[str, Any] = {'name': pp.RESULT_STEP, 'status': status}
-    if reason is not None:
-        result['reason'] = reason
+    result: dict[str, Any] = {'name': pp.RESULT_STEP}
+    if failure is not None:
+        if 'humanReason' in failure:
+            failure = {
+                **failure,
+                'humanReason': stabilize(failure['humanReason'], context),
+            }
+        result['failure'] = failure
     steps[pp.RESULT_STEP] = result
     return steps
 
 
 def apply_post_process(
-        hooks, steps: dict[str,
-                           dict]) -> tuple[dict[str, dict] | None, list[str]]:
-    """Run post-process hooks; return (filtered steps or None, failures).
+        hooks: list[PostprocessHookContext],
+        steps: dict[str, dict]) -> tuple[dict[str, dict] | None, list[Check]]:
+    """Run post-process hooks.
 
-    Each hook gets its own `Checker` and a deep copy of the current steps. A
-    hook that returns a mapping replaces the steps for later hooks and for the
-    written expectation; an empty mapping drops the expectation (returns None).
+    Each hook gets its own `Checker` and a deep copy of the current steps (the
+    checker MUST be a local so its stack walk can find the frames to blame). A
+    `KeyError` from a hook (e.g. indexing a step that didn't run) is rendered as
+    a failed check rather than aborting the case. A hook that returns a mapping
+    filters the steps for later hooks and for the written expectation, but only
+    after `VerifySubset` confirms it introduced no new keys / reordering /
+    changed values, otherwise a `PostProcessError` is raised. An empty mapping
+    drops the expectation (returns `None`).
     """
-    failures: list[str] = []
+    failed_checks: list[Check] = []
     for hook in hooks:
-        check = pp.Checker(hook.context)
         working = copy.deepcopy(steps)
+        # Kept in a local named `check`: `Checker._call_impl` walks the stack for
+        # the frame in which the checker is a local variable.
+        check = Checker(hook, working)
         try:
             result = hook.func(check, working, *hook.args, **hook.kwargs)
-        except Exception as exc:  # pylint: disable=broad-except
-            failures.append(f'{hook.context}: hook raised {exc!r}')
+        except KeyError:
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            try:
+                failed_checks.append(
+                    Check.create(
+                        '',
+                        hook,
+                        inspect.getinnerframes(exc_traceback)[1:],
+                        False,
+                        check._ignore_set,  # pylint: disable=protected-access
+                        {
+                            'raised exception': '%s: %s' %
+                            (exc_type.__name__, exc_value)
+                        },
+                    ))
+            finally:
+                # avoid reference cycle as suggested by inspect docs.
+                del exc_traceback
             continue
-        failures.extend(check.failures)
+        failed_checks += check.failed_checks
         if result is not None:
-            if not result:
-                return None, failures  # DropExpectation.
+            msg = VerifySubset(result, steps)
+            if msg:
+                raise PostProcessError('post process: steps' + msg)
+            # Restore 'name' if a filter dropped it.
+            for name, step in result.items():
+                step['name'] = name
             steps = result
-    return steps, failures
+    # An empty mapping means drop the expectation.
+    return (steps if steps else None), failed_checks

--- a/tools/recipes/unittests/check_test.py
+++ b/tools/recipes/unittests/check_test.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for the AST-introspecting check machinery in check.py."""
+
+import os
+import re
+import sys
+import unittest
+from collections import OrderedDict
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# pylint: disable=wrong-import-position
+from check import (Checker, CheckFrame, PostProcessError, VerifySubset,
+                   render_re)
+from recipe_test_api import PostprocessHookContext
+
+
+def _noop(check, steps):
+    del check, steps
+
+
+# A hook context standing in for an `api.post_process(...)` registration site.
+HOOK = PostprocessHookContext(_noop, ('arg', ), {'k': 'v'}, '<caller>', 7)
+
+
+class CheckerTest(unittest.TestCase):
+    """The Checker records failures with AST-rendered source and values."""
+
+    def _sanitize(self, frame):
+        # File/line vary by machine; only the code + varmap are asserted.
+        return frame._replace(line=0, fname='')
+
+    def test_no_calls(self):
+        checker = Checker(HOOK)
+
+        def body(check):
+            del check
+
+        body(checker)
+        self.assertEqual(checker.failed_checks, [])
+
+    def test_passing_call_records_nothing(self):
+        checker = Checker(HOOK)
+
+        def body(check):
+            check(True)
+            check('hint', 1 < 2)
+
+        body(checker)
+        self.assertEqual(checker.failed_checks, [])
+
+    def test_failing_call_renders_source(self):
+        checker = Checker(HOOK)
+
+        def body(check):
+            check(1 == 2)
+
+        body(checker)
+        self.assertEqual(len(checker.failed_checks), 1)
+        frame = checker.failed_checks[0].frames[-1]
+        self.assertEqual(
+            self._sanitize(frame),
+            CheckFrame(fname='',
+                       line=0,
+                       function='body',
+                       code='check(1 == 2)',
+                       varmap={}))
+
+    def test_hint_is_recorded_as_name(self):
+        checker = Checker(HOOK)
+
+        def body(check):
+            check('the hint', False)
+
+        body(checker)
+        self.assertEqual(checker.failed_checks[0].name, 'the hint')
+
+    def test_membership_renders_dict_keys(self):
+        checker = Checker(HOOK)
+
+        def body(check):
+            steps = {'b': 1, 'a': 2}
+            check('x' in steps)
+
+        body(checker)
+        varmap = checker.failed_checks[0].frames[-1].varmap
+        # The dict itself is elided in favour of its (sorted) keys.
+        self.assertEqual(varmap, {'steps.keys()': "['a', 'b']"})
+
+    def test_subscript_resolves_value(self):
+        checker = Checker(HOOK)
+
+        def body(check):
+            data = {'k': 'v'}
+            check(data['k'] == 'other')
+
+        body(checker)
+        varmap = checker.failed_checks[0].frames[-1].varmap
+        self.assertEqual(varmap["data['k']"], "'v'")
+
+    def test_local_variable_is_rendered(self):
+        checker = Checker(HOOK)
+
+        def body(check):
+            name = 'missing'
+            check(name == 'present')
+
+        body(checker)
+        varmap = checker.failed_checks[0].frames[-1].varmap
+        self.assertEqual(varmap['name'], "'missing'")
+
+    def test_format_block(self):
+        checker = Checker(HOOK)
+
+        def body(check):
+            check('must exist', False)
+
+        body(checker)
+        lines = checker.failed_checks[0].format()
+        self.assertEqual(lines[0], "CHECK 'must exist' (FAIL):")
+        # The footer names the registration site and the call repr.
+        self.assertIn('added <caller>:7', lines[-2])
+        self.assertEqual(lines[-1].strip(), "_noop('arg', k='v')")
+
+
+class VerifySubsetTest(unittest.TestCase):
+    """VerifySubset accepts subsets and describes any violation."""
+
+    def test_identical_and_subset(self):
+        self.assertIsNone(VerifySubset({'a': 1}, {'a': 1}))
+        self.assertIsNone(VerifySubset({'a': 1}, {'a': 1, 'b': 2}))
+
+    def test_added_key(self):
+        self.assertEqual(VerifySubset({
+            'a': 1,
+            'c': 3
+        }, {'a': 1}), ": added key 'c'")
+
+    def test_value_mismatch(self):
+        self.assertEqual(VerifySubset({'a': 'x'}, {'a': 'y'}),
+                         "['a']: 'x' != 'y'")
+
+    def test_type_mismatch(self):
+        self.assertIn('type mismatch', VerifySubset({'a': 1}, {'a': [1]}))
+
+    def test_list_too_long(self):
+        self.assertIn('too long', VerifySubset([1, 2, 3], [1, 2]))
+
+    def test_ordered_out_of_order(self):
+        a = OrderedDict([('b', 1), ('a', 2)])
+        b = OrderedDict([('a', 2), ('b', 1)])
+        self.assertIn('out of order', VerifySubset(a, b))
+
+    def test_empty_dict_is_subset_of_ordereddict(self):
+        self.assertIsNone(VerifySubset({}, OrderedDict([('a', 1)])))
+
+
+class RenderReTest(unittest.TestCase):
+
+    def test_plain_and_flagged(self):
+        # Python's `re` carries the UNICODE flag by default on str patterns.
+        self.assertEqual(render_re(re.compile('foo')),
+                         "re.compile('foo', UNICODE)")
+        self.assertIn('IGNORECASE', render_re(re.compile('foo', re.I)))
+
+
+class PostProcessErrorTest(unittest.TestCase):
+
+    def test_is_value_error(self):
+        self.assertTrue(issubclass(PostProcessError, ValueError))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/recipes/unittests/post_process_test.py
+++ b/tools/recipes/unittests/post_process_test.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Tests for the post_process check library."""
+"""Tests for the post_process check functions."""
 
 import os
 import sys
@@ -12,11 +12,17 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # pylint: disable=wrong-import-position
+import check as check_mod
 import post_process as pp
+from recipe_test_api import PostprocessHookContext
+
+# A non-infra failure carries an inner `failure`; an infra failure does not.
+_FAILURE = {'failure': {}, 'humanReason': 'boom'}
+_INFRA = {'humanReason': 'boom'}
 
 
-def _steps(status='SUCCESS'):
-    return {
+def _steps(failure=None):
+    steps = {
         'compile': {
             'name': 'compile',
             'cmd': ['ninja', '-C', 'out'],
@@ -28,27 +34,21 @@ def _steps(status='SUCCESS'):
             'retcode': 1
         },
         '$result': {
-            'name': '$result',
-            'status': status
+            'name': '$result'
         },
     }
+    if failure is not None:
+        steps['$result']['failure'] = failure
+    return steps
 
 
 def _run(func, steps, *args):
     """Run a check hook, returning (failure_count, return_value)."""
-    check = pp.Checker('ctx')
+    hook = PostprocessHookContext(func, args, {}, __file__, 0)
+    # `check` must be a local: the Checker walks the stack for its own frame.
+    check = check_mod.Checker(hook, steps)
     result = func(check, steps, *args)
-    return len(check.failures), result
-
-
-class CheckerTest(unittest.TestCase):
-
-    def test_collects_without_raising(self):
-        check = pp.Checker('ctx')
-        check(True)
-        check('hint', False)
-        self.assertEqual(len(check.failures), 1)
-        self.assertIn('hint', check.failures[0])
+    return len(check.failed_checks), result
 
 
 class PresenceTest(unittest.TestCase):
@@ -57,17 +57,24 @@ class PresenceTest(unittest.TestCase):
         self.assertEqual(_run(pp.MustRun, _steps(), 'compile')[0], 0)
         self.assertEqual(_run(pp.MustRun, _steps(), 'missing')[0], 1)
 
+    def test_must_run_variadic(self):
+        # Both present -> 0; one missing -> 1.
+        self.assertEqual(_run(pp.MustRun, _steps(), 'compile', 'test')[0], 0)
+        self.assertEqual(_run(pp.MustRun, _steps(), 'compile', 'nope')[0], 1)
+
     def test_does_not_run(self):
         self.assertEqual(_run(pp.DoesNotRun, _steps(), 'missing')[0], 0)
         self.assertEqual(_run(pp.DoesNotRun, _steps(), 'compile')[0], 1)
 
     def test_run_re(self):
         self.assertEqual(_run(pp.MustRunRE, _steps(), r'^comp')[0], 0)
+        self.assertEqual(_run(pp.MustRunRE, _steps(), r'^zzz')[0], 1)
         self.assertEqual(_run(pp.DoesNotRunRE, _steps(), r'^zzz')[0], 0)
+        self.assertEqual(_run(pp.DoesNotRunRE, _steps(), r'^comp')[0], 1)
 
-    def test_result_is_not_a_run_step(self):
-        # The $result pseudo-step must not satisfy MustRun.
-        self.assertEqual(_run(pp.MustRun, _steps(), '$result')[0], 1)
+    def test_run_re_bounds(self):
+        # at_most caps the number of matches.
+        self.assertEqual(_run(pp.MustRunRE, _steps(), r'.', 1, 1)[0], 1)
 
 
 class CommandTest(unittest.TestCase):
@@ -84,6 +91,11 @@ class CommandTest(unittest.TestCase):
         self.assertEqual(
             _run(pp.StepCommandRE, _steps(), 'compile',
                  [r'ninja', r'-C', r'out'])[0], 0)
+        # A pattern that doesn't fully match its argument fails (full-match
+        # semantics: 'ninj' does not match all of 'ninja').
+        self.assertEqual(
+            _run(pp.StepCommandRE, _steps(), 'compile',
+                 [r'ninj', r'-C', r'out'])[0], 1)
 
 
 class StatusTest(unittest.TestCase):
@@ -94,9 +106,18 @@ class StatusTest(unittest.TestCase):
         self.assertEqual(_run(pp.StepSuccess, _steps(), 'test')[0], 1)
 
     def test_overall_status(self):
-        self.assertEqual(_run(pp.StatusSuccess, _steps('SUCCESS'))[0], 0)
-        self.assertEqual(_run(pp.StatusFailure, _steps('FAILURE'))[0], 0)
-        self.assertEqual(_run(pp.StatusException, _steps('SUCCESS'))[0], 1)
+        self.assertEqual(_run(pp.StatusSuccess, _steps())[0], 0)
+        self.assertEqual(_run(pp.StatusFailure, _steps(_FAILURE))[0], 0)
+        self.assertEqual(_run(pp.StatusException, _steps(_INFRA))[0], 0)
+        self.assertEqual(_run(pp.StatusAnyFailure, _steps(_FAILURE))[0], 0)
+
+    def test_status_discriminates_infra_from_regular(self):
+        # A regular failure is not an exception, and vice versa.
+        self.assertEqual(_run(pp.StatusException, _steps(_FAILURE))[0], 1)
+        self.assertEqual(_run(pp.StatusFailure, _steps(_INFRA))[0], 1)
+        # Success satisfies none of the failure checks.
+        self.assertEqual(_run(pp.StatusFailure, _steps())[0], 1)
+        self.assertEqual(_run(pp.StatusAnyFailure, _steps())[0], 1)
 
 
 class DropExpectationTest(unittest.TestCase):

--- a/tools/recipes/unittests/recipe_test_api_test.py
+++ b/tools/recipes/unittests/recipe_test_api_test.py
@@ -73,7 +73,8 @@ class RecipeTestApiTest(unittest.TestCase):
     def test_post_process_records_context(self):
         td = RecipeTestApi.post_process(lambda c, s: None)
         hook = td.post_process_hooks[0]
-        self.assertIn('recipe_test_api_test.py:', hook.context)
+        self.assertIn('recipe_test_api_test.py', hook.filename)
+        self.assertGreater(hook.lineno, 0)
 
     def test_root_is_its_own_injection_site(self):
         root = RecipeTestApi(module=None)

--- a/tools/recipes/unittests/recipe_test_runner_test.py
+++ b/tools/recipes/unittests/recipe_test_runner_test.py
@@ -53,7 +53,7 @@ class TestApiInjectionTest(unittest.TestCase):
     def test_root_api_exposes_dep_helpers(self):
         root = runner._build_root_test_api(['platform', 'step'])
         # api.platform.name(...) and api.step.data(...) resolve to the module
-        # test apis, mirroring the recipes_py example.
+        # test apis.
         self.assertEqual(
             root.platform.name('mac').mod_data['platform']['name'], 'mac')
         self.assertIn('s', root.step.data('s', retcode=2).step_data)

--- a/tools/recipes/unittests/simulation_test.py
+++ b/tools/recipes/unittests/simulation_test.py
@@ -114,7 +114,7 @@ class ExpectationTest(unittest.TestCase):
         self.assertEqual(simulation.stabilize('/b/home/.cache', ctx),
                          '[HOME]/.cache')
 
-    def test_build_steps_appends_result(self):
+    def test_build_steps_success_result(self):
         runner = simulation.SimulationStepRunner()
         runner.run({
             'name': 'a',
@@ -122,36 +122,49 @@ class ExpectationTest(unittest.TestCase):
         },
                    check=True,
                    capture_output=False)
-        steps = simulation.build_steps(runner, 'EXCEPTION', 'boom',
-                                       simulation.TestContext())
+        steps = simulation.build_steps(runner, None, simulation.TestContext())
         self.assertEqual(steps['a']['cmd'], ['[WORKSPACE]/out/tool'])
-        self.assertEqual(steps[pp.RESULT_STEP], {
-            'name': '$result',
-            'status': 'EXCEPTION',
-            'reason': 'boom',
-        })
+        # A successful run's $result carries no failure key.
+        self.assertEqual(steps[pp.RESULT_STEP], {'name': '$result'})
+
+    def test_build_steps_failure_result_stabilizes_reason(self):
+        runner = simulation.SimulationStepRunner()
+        failure = {'humanReason': 'boom at /b/s/out/tool'}
+        steps = simulation.build_steps(runner, failure,
+                                       simulation.TestContext())
+        # An infra failure carries only humanReason (paths stabilized).
+        self.assertEqual(
+            steps[pp.RESULT_STEP], {
+                'name': '$result',
+                'failure': {
+                    'humanReason': 'boom at [WORKSPACE]/out/tool'
+                },
+            })
 
     def test_apply_post_process_filter_and_drop(self):
-        steps = {
-            'a': {
-                'name': 'a'
-            },
-            '$result': {
-                'name': '$result',
-                'status': 'SUCCESS'
-            }
-        }
+        steps = {'a': {'name': 'a'}, '$result': {'name': '$result'}}
         # A filtering hook narrows the steps for the written expectation.
         keep_a = RecipeTestApi.post_process(lambda c, s: {'a': s['a']})
-        filtered, failures = simulation.apply_post_process(
+        filtered, failed_checks = simulation.apply_post_process(
             keep_a.post_process_hooks, steps)
         self.assertEqual(list(filtered), ['a'])
-        self.assertEqual(failures, [])
+        self.assertEqual(failed_checks, [])
         # DropExpectation -> None.
         drop = RecipeTestApi.post_process(pp.DropExpectation)
         filtered, _ = simulation.apply_post_process(drop.post_process_hooks,
                                                     steps)
         self.assertIsNone(filtered)
+
+    def test_apply_post_process_rejects_superset(self):
+        steps = {'a': {'name': 'a'}, '$result': {'name': '$result'}}
+        # A hook that adds a step is not a subset of the recorded steps.
+        add = RecipeTestApi.post_process(lambda c, s: {
+            **s, 'b': {
+                'name': 'b'
+            }
+        })
+        with self.assertRaises(simulation.PostProcessError):
+            simulation.apply_post_process(add.post_process_hooks, steps)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change introduces coverage enforcement to the recipe simulation
suite. With this change, recipes and modules have to excercise  all
branches. There's now a coverage gate to `engine.py test run|train`: a
full run now fails unless every line under recipes/ and recipe_modules/
is exercised and every expectation file is claimed by a test.

Additionally, two other gaps have been closed that made the recipe
simulation tests weaker than they looked:

- A failed post-process check only printed a hand-written hint, so a
  failure told you which assertion tripped but not why. You had to go
  re-run and add prints to see the actual step data.
- A check could return a "filtered" steps mapping that silently *added*
  or reordered steps, quietly rewriting the golden it was supposed to be
  narrowing.

This reworks the check machinery so a failure renders the failing source
line with the resolved values of its sub-expressions, and so a returned
mapping is verified to be a genuine subset before it's accepted.

Along the way the terminal `$result` moves to the standard shape (success
is the absence of a failure, rather than an explicit status string) so the
Status* checks and the expectation files match the format the rest of the
ecosystem reads.

Bug: https://github.com/brave/brave-browser/issues/56748
