### PR TITLE
[plaster][ast-grep] Add a `rename_class` rewriter

### DIFF
--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -135,6 +135,7 @@ introduce more rewriters. These are the ones we have supported for now.
 | `add_friend`            | AST  | Adds a `friend` declaration to a private section. |
 | `drop_final`            | AST  | Removes `final` from a C++ class declaration.     |
 | `preempt_function_impl` | AST  | Inserts at the top of a C++ function body.        |
+| `rename_class`          | AST  | Renames a C++ class.                              |
 
 Use `plaster --help` to discover rewriters and read their full docs:
 

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -398,6 +398,9 @@ class Rewriter(abc.ABC):
     # The `<name>:` key that selects this rewriter in a `substitutions:` entry.
     NAME: ClassVar[str] = ''
 
+    # A rewriter-specific override for the default value of `count:`.
+    DEFAULT_COUNT: ClassVar[int | None] = None
+
     # One-line summary shown in the `Rewriters` help index.
     SUMMARY: ClassVar[str] = ''
 
@@ -588,8 +591,6 @@ class Substitution:
         if not isinstance(description, str):
             raise ValueError('No description specified for substitution entry')
 
-        expected_count = Substitution._parse_count(data, description)
-
         rewriter_keys = sorted(keys & _REWRITERS.keys())
         if len(rewriter_keys) > 1:
             raise ValueError(
@@ -604,6 +605,9 @@ class Substitution:
                                  f'rewriter: '
                                  f'{", ".join(repr(k) for k in unknown)} '
                                  f'(in "{description}")')
+            # The chosen rewriter decides what an omitted `count:` means.
+            expected_count = Substitution._parse_count(
+                data, description, _REWRITERS[name].DEFAULT_COUNT)
             rewriter = _REWRITERS[name].parse(data[name],
                                               description=description)
             return Substitution(description=description,
@@ -630,8 +634,10 @@ class Substitution:
             f'{", ".join(sorted(_REWRITERS)) or "(none)"}')
 
     @staticmethod
-    def _parse_count(data: dict[str, object], description: str) -> int:
-        expected_count = data.get('count', 1)
+    def _parse_count(data: dict[str, object],
+                     description: str,
+                     default: int | None = None) -> int:
+        expected_count = data.get('count', 1 if default is None else default)
         # bool is a subclass of int; reject it explicitly.
         if (not isinstance(expected_count, int)
                 or isinstance(expected_count, bool)):
@@ -1269,10 +1275,42 @@ class PreemptFunctionImpl(_AstGrepRewriter):
 
 
 # A set with all the rewriters available in plaster.
+class RenameClass(_AstGrepRewriter):
+    """Rename a C++ class -- its declaration, type uses, `Class::` qualifiers
+    and con/destructor names -- via the ast-grep rewriters."""
+
+    NAME: Final = 'rename_class'
+    OP_ID: Final = 'cxx.rename_class'
+    SUMMARY: Final = 'Rename a class and every code token of its name.'
+    # For this rewriter we have less of a concerns about `count`.
+    DEFAULT_COUNT: Final = 0
+    # Authored in Markdown; `Help` renders it with rich.
+    HELP: Final = r"""
+        Renames a C++ class everywhere its name appears as a *code token*: the
+        class declaration, type positions (`Foo*`, `<Foo>`), the `Foo::`
+        qualifier on out-of-line members, and constructor/destructor names.
+
+        Fields:
+
+        - `class_name` — the current class name.
+        - `rename` — the name to rename it to (e.g. `Foo_ChromiumImpl`).
+
+        Example:
+
+        ```yaml
+        substitutions:
+          - description: Rename so the Brave subclass can reuse the name.
+            rename_class:
+              class_name: TestLauncher
+              rename: TestLauncher_ChromiumImpl
+        ```
+    """
+
+
 _REWRITERS: MappingProxyType[str, type[Rewriter]] = MappingProxyType({
     rewriter.NAME: rewriter
     for rewriter in (Regex, MakeVirtual, AddFriend, DropFinal,
-                     PreemptFunctionImpl)
+                     PreemptFunctionImpl, RenameClass)
 })
 
 

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1727,6 +1727,152 @@ class RewriterFormsTest(unittest.TestCase):
             "      return_if: 'g()'\n",
             'preempt_function_impl `function_name` must be a non-empty string')
 
+    # -- rename_class op (real ast-grep binary) -----------------------------
+
+    # `count` is omitted throughout: rename_class defaults to `count: 0` (one or
+    # more), unlike every other rewriter (which defaults to exactly one).
+
+    def test_rename_class_renames_declaration_and_type_uses(self):
+        # The class declaration and a type-position use are both renamed; a
+        # different class that merely shares a prefix is left alone.
+        result = self._apply(
+            'rename.h',
+            'class Foo {\n};\n\nclass FooBar {\n  Foo* foo_;\n};\n',
+            'substitutions:\n'
+            '  - description: rename Foo to Foo_ChromiumImpl\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      rename: Foo_ChromiumImpl\n')
+        self.assertEqual(
+            result, 'class Foo_ChromiumImpl {\n};\n\n'
+            'class FooBar {\n  Foo_ChromiumImpl* foo_;\n};\n')
+
+    def test_rename_class_renames_qualifiers_and_ctor(self):
+        # The `Foo::` qualifier and the out-of-line constructor name are both
+        # renamed.
+        result = self._apply(
+            'rename_ctor.cc', 'Foo::Foo() {}\nvoid Foo::Bar() {}\n',
+            'substitutions:\n'
+            '  - description: rename Foo\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      rename: Foo_ChromiumImpl\n')
+        self.assertEqual(
+            result, 'Foo_ChromiumImpl::Foo_ChromiumImpl() {}\n'
+            'void Foo_ChromiumImpl::Bar() {}\n')
+
+    def test_rename_class_leaves_string_literal_untouched(self):
+        # The whole point of matching AST identifier nodes: a same-spelled
+        # string literal survives. The exact-quote-adjacent form (`"Foo"`) is
+        # the case a `#define`/regex token rename would wrongly rewrite.
+        result = self._apply(
+            'rename_str.cc', 'void Foo::Run() {\n  Register("Foo");\n}\n',
+            'substitutions:\n'
+            '  - description: rename Foo but keep the string\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      rename: Foo_ChromiumImpl\n')
+        self.assertEqual(
+            result, 'void Foo_ChromiumImpl::Run() {\n  Register("Foo");\n}\n')
+
+    def test_rename_class_leaves_token_inside_a_larger_string_untouched(self):
+        # `Foo` sits in the *middle* of a string, not adjacent to a quote -- the
+        # case a `(?<!")...(?!")` regex guard would still rewrite, but an AST
+        # match never can (the whole literal is one string node).
+        result = self._apply(
+            'rename_midstr.cc',
+            'void Foo::Log() {\n  LOG(INFO) << "start Foo done";\n}\n',
+            'substitutions:\n'
+            '  - description: rename Foo, keep it inside the message string\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      rename: Foo_ChromiumImpl\n')
+        self.assertEqual(
+            result, 'void Foo_ChromiumImpl::Log() {\n'
+            '  LOG(INFO) << "start Foo done";\n}\n')
+
+    def test_rename_class_leaves_line_and_block_comments_untouched(self):
+        # Neither a `//` line comment nor a `/* */` block comment mentioning the
+        # name is rewritten -- comments are not identifier nodes.
+        result = self._apply(
+            'rename_comment.cc', '// Foo does things.\n'
+            '/* Foo again, and Foo. */\n'
+            'void Foo::Run() {\n}\n', 'substitutions:\n'
+            '  - description: rename Foo but keep both comments\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      rename: Foo_ChromiumImpl\n')
+        self.assertEqual(
+            result, '// Foo does things.\n'
+            '/* Foo again, and Foo. */\n'
+            'void Foo_ChromiumImpl::Run() {\n}\n')
+
+    def test_rename_class_default_count_renames_all_occurrences(self):
+        # With the default `count: 0`, omitting `count` renames every occurrence
+        # (here four tokens across two lines) instead of demanding exactly one.
+        result = self._apply(
+            'rename_many.cc', 'Foo::Foo() {}\nvoid Foo::Bar() {}\n',
+            'substitutions:\n'
+            '  - description: rename Foo everywhere, no count needed\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      rename: Foo_ChromiumImpl\n')
+        self.assertEqual(
+            result, 'Foo_ChromiumImpl::Foo_ChromiumImpl() {}\n'
+            'void Foo_ChromiumImpl::Bar() {}\n')
+
+    def test_rename_class_explicit_count_still_asserts_exact(self):
+        # An explicit `count` overrides the default and asserts an exact number;
+        # here two tokens match the stated two.
+        result = self._apply(
+            'rename_exact.h', 'class Foo {\n  Foo* self_;\n};\n',
+            'substitutions:\n'
+            '  - description: rename the two Foo tokens\n'
+            '    count: 2\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      rename: Foo_ChromiumImpl\n')
+        self.assertEqual(
+            result,
+            'class Foo_ChromiumImpl {\n  Foo_ChromiumImpl* self_;\n};\n')
+
+    def test_rename_class_explicit_count_mismatch_fails(self):
+        # Two tokens match, but the entry asserts one.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'rename_bad_count.h', 'class Foo {\n  Foo* self_;\n};\n',
+                'substitutions:\n'
+                '  - description: wrong explicit count\n'
+                '    count: 1\n'
+                '    rename_class:\n'
+                '      class_name: Foo\n'
+                '      rename: Foo_ChromiumImpl\n')
+
+    def test_rename_class_absent_fails(self):
+        # The default `count: 0` is "one or more", so zero matches still fails.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'rename_absent.h', 'class Bar {\n};\n', 'substitutions:\n'
+                '  - description: no such class\n'
+                '    rename_class:\n'
+                '      class_name: Foo\n'
+                '      rename: Foo_ChromiumImpl\n')
+
+    def test_rename_class_unknown_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: typo arg\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      renam: Bar\n', 'Unrecognised rename_class arg')
+
+    def test_rename_class_missing_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: missing rename\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n', 'rename_class requires arg')
+
     # -- export-macro classes (real ast-grep binary) ----------------------
     #
     # tree-sitter cannot parse `class MACRO_EXPORT Name`, so the engine blanks

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -139,6 +139,24 @@ inside:
                 "node": "compound_statement",
             },
         },
+
+        # Every identifier-family token whose text is exactly `class_name`: the
+        # name in the class declaration and in type positions (type_identifier),
+        # the `Class::` qualifier on out-of-line members (namespace_identifier),
+        # and the constructor/destructor name plus any other bare use
+        # (identifier).
+        "cxx.find_class_name_tokens": {
+            "template": """\
+any:
+  - kind: type_identifier
+  - kind: namespace_identifier
+  - kind: identifier
+regex: ^{class_name}$
+""",
+            "result": {
+                "node": "identifier",
+            },
+        },
     },
     "ast.rewriter": {
 
@@ -207,6 +225,21 @@ inside:
             },
             "result": {
                 "node": "compound_statement",
+            },
+        },
+
+        # Each matched name token replaced with `rename`. The matcher already
+        # pinned every match's text to exactly `class_name`, so the whole token
+        # (`^.+$`) is swapped for the new name.
+        "cxx.rename_class": {
+            "matcher": "cxx.find_class_name_tokens",
+            "inputs": ["class_name", "rename"],
+            "replace": {
+                "re_pattern": "^.+$",
+                "replace": "{rename}",
+            },
+            "result": {
+                "node": "identifier",
             },
         },
     },


### PR DESCRIPTION
This rewriter is being added to replace macros like this:

```cxx
#define TestLauncher TestLauncher_ChromiumImpl
```

This rewriter only targets actual identifiers, leaving strings and
comments untouched.

Bug: https://github.com/brave/brave-browser/issues/57334
