### PR TITLE
[recipes][bootstrap] Use `node` boostrap for packaging modules

### DIFF
--- a/third_party/node/package_node_modules.py
+++ b/third_party/node/package_node_modules.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import logging
 import sys
 import tarfile
@@ -28,6 +29,19 @@ _NODE_DIR = Path(__file__).resolve().parent
 
 # The directory `download_node_modules.py` populates.
 NODE_MODULES_DIR = _NODE_DIR / 'node_modules'
+
+# The lockfile whose hash pins the packaged node_modules to a specific state.
+PACKAGE_LOCK = _NODE_DIR / 'package-lock.json'
+
+# Number of leading hex characters of the lockfile hash to embed in the tarball
+# name (matches git's default short-hash length).
+_HASH_PREFIX_LEN = 7
+
+
+def package_lock_hash() -> str:
+    """Return the leading hex chars of the `package-lock.json` sha256."""
+    digest = hashlib.sha256(PACKAGE_LOCK.read_bytes()).hexdigest()
+    return digest[:_HASH_PREFIX_LEN]
 
 
 def package(tarball_name: str, output_dir: Path) -> Path | None:
@@ -68,7 +82,7 @@ def main() -> int:
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
-    tarball_name = 'node_modules.tar.gz'
+    tarball_name = f'node_modules-{package_lock_hash()}.tar.gz'
     tarball = package(tarball_name, args.output_dir)
     if tarball is None:
         return 1

--- a/tools/recipes/recipe_modules/brave_core_shallow/__init__.py
+++ b/tools/recipes/recipe_modules/brave_core_shallow/__init__.py
@@ -4,4 +4,4 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """`brave_core_shallow` module: sparse-deploy brave-core subpaths."""
 
-DEPS = ['path', 'step']
+DEPS = ['context', 'path', 'step']

--- a/tools/recipes/recipe_modules/brave_core_shallow/api.py
+++ b/tools/recipes/recipe_modules/brave_core_shallow/api.py
@@ -7,13 +7,17 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+import contextlib
 import logging
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from recipe_api import RecipeApi
 
 # Default SSH remote for the brave-core repository.
 REPO_URL = 'git@github.com:brave/brave-core.git'
+
+# The path in brave-core for the bootstrap scripts that may be added to PATH.
+BOOTSTRAP_PATH = 'tools/cr/bootstrap'
 
 
 class BraveCoreShallowApi(RecipeApi):
@@ -115,13 +119,26 @@ class BraveCoreShallowApi(RecipeApi):
             ]
             self.m.step('clone brave-core (shallow, sparse)', clone_cmd)
 
-        # Extend the sparse working tree with the requested subtrees. `add`
-        # (rather than `set`) accumulates, so subtrees checked out by a prior
-        # call or an external bootstrap into this same checkout survive.
-        self.m.step(
-            'sparse-checkout add',
-            ['git', '-C',
-             str(dest), 'sparse-checkout', 'add', *rel_paths])
+        # Ask the checkout which subtrees are already present and drop any
+        # request it (or an ancestor) already covers, so a path is never
+        # deployed twice.
+        deployed = {PurePosixPath(d) for d in self._sparse_checkout_list(dest)}
+        new_paths = []
+        for p in rel_paths:
+            lineage = PurePosixPath(p)
+            # Covered when the path itself, or a deployed ancestor, is in the
+            # sparse set: a cone entry brings its whole subtree.
+            if deployed.isdisjoint((lineage, *lineage.parents)):
+                new_paths.append(p)
+
+        if new_paths:
+            # Extend the sparse working tree with the not-yet-present subtrees.
+            # `add` (rather than `set`) accumulates, so subtrees checked out by
+            # a prior call or an external bootstrap into this checkout survive.
+            self.m.step(
+                'sparse-checkout add',
+                ['git', '-C',
+                 str(dest), 'sparse-checkout', 'add', *new_paths])
 
         for rel in rel_paths:
             if not self.m.path.exists(dest / rel):
@@ -130,3 +147,45 @@ class BraveCoreShallowApi(RecipeApi):
                     f'(looked under {dest})')
 
         return dest
+
+    def _sparse_checkout_list(self, dest: Path) -> set[str]:
+        """Return the checkout's current cone-mode sparse directories.
+
+        Empty when the sparse set lists nothing (e.g. a just-cloned tree whose
+        cone is still empty) or is uninitialised. Non-zero is treated as
+        "nothing deployed yet" rather than an error.
+        """
+        result = self.m.step(
+            'sparse-checkout list',
+            ['git', '-C', str(dest), 'sparse-checkout', 'list'],
+            check=False,
+            capture_output=True)
+        if result.returncode != 0 or not result.stdout:
+            return set()
+        return {
+            line.strip()
+            for line in result.stdout.splitlines() if line.strip()
+        }
+
+    @contextlib.contextmanager
+    def bootstrap_on_path(self,
+                          *,
+                          dest: str | Path | None = None,
+                          url: str = REPO_URL,
+                          ref: str | None = None,
+                          depth: int = 2):
+        """Deploy `tools/cr/bootstrap` and put it first on PATH for the block.
+
+        Args:
+            dest, url, ref, depth: Forwarded to `deploy` (see its docs).
+
+        Yields:
+            The absolute `Path` to the brave-core checkout root.
+        """
+        root = self.deploy(BOOTSTRAP_PATH,
+                           dest=dest,
+                           url=url,
+                           ref=ref,
+                           depth=depth)
+        with self.m.context(env_prefixes={'PATH': [root / BOOTSTRAP_PATH]}):
+            yield root

--- a/tools/recipes/recipe_modules/brave_core_shallow/examples/full.expected/already_deployed.json
+++ b/tools/recipes/recipe_modules/brave_core_shallow/examples/full.expected/already_deployed.json
@@ -26,17 +26,6 @@
   },
   {
     "cmd": [
-      "git",
-      "-C",
-      "[WORKSPACE]/chromium/src/brave",
-      "sparse-checkout",
-      "add",
-      "tools/cr/bootstrap"
-    ],
-    "name": "sparse-checkout add"
-  },
-  {
-    "cmd": [
       "npm",
       "--version"
     ],

--- a/tools/recipes/recipe_modules/brave_core_shallow/examples/full.expected/reuse.json
+++ b/tools/recipes/recipe_modules/brave_core_shallow/examples/full.expected/reuse.json
@@ -29,10 +29,32 @@
       "-C",
       "[WORKSPACE]/chromium/src/brave",
       "sparse-checkout",
+      "list"
+    ],
+    "name": "sparse-checkout list"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "sparse-checkout",
       "add",
-      "third_party/node"
+      "tools/cr/bootstrap"
     ],
     "name": "sparse-checkout add"
+  },
+  {
+    "cmd": [
+      "npm",
+      "--version"
+    ],
+    "env_prefixes": {
+      "PATH": [
+        "[WORKSPACE]/chromium/src/brave/tools/cr/bootstrap"
+      ]
+    },
+    "name": "npm version"
   },
   {
     "name": "$result"

--- a/tools/recipes/recipe_modules/brave_core_shallow/examples/full.py
+++ b/tools/recipes/recipe_modules/brave_core_shallow/examples/full.py
@@ -13,17 +13,23 @@ DEPS = ['brave_core_shallow', 'path', 'step']
 
 def RunSteps(api):
     api.brave_core_shallow.deploy('third_party/node')
+    # Deploy the bootstrap shims and put them first on PATH for the block; the
+    # prefix is dropped again once the `with` exits.
+    with api.brave_core_shallow.bootstrap_on_path():
+        api.step('npm version', ['npm', '--version'])
 
 
 def GenTests(api):
     # Fresh clone: `.git` absent, so it clones and sparse-checks-out; the
-    # requested path is seeded so the post-checkout existence check passes.
+    # requested paths are seeded so the post-checkout existence checks pass.
     yield api.test(
         'clone',
-        api.path.files('chromium/src/brave/third_party/node'),
+        api.path.files('chromium/src/brave/third_party/node',
+                       'chromium/src/brave/tools/cr/bootstrap'),
         api.post_process(post_process.MustRun,
                          'clone brave-core (shallow, sparse)'),
         api.post_process(post_process.MustRun, 'sparse-checkout add'),
+        api.post_process(post_process.MustRun, 'npm version'),
         api.post_process(post_process.StatusSuccess),
     )
     # Existing checkout: `.git` present, so it fetches/checks-out the ref
@@ -31,11 +37,25 @@ def GenTests(api):
     yield api.test(
         'reuse',
         api.path.dirs('chromium/src/brave/.git'),
-        api.path.files('chromium/src/brave/third_party/node'),
+        api.path.files('chromium/src/brave/third_party/node',
+                       'chromium/src/brave/tools/cr/bootstrap'),
         api.post_process(post_process.MustRun, 'fetch brave-core ref'),
         api.post_process(post_process.MustRun, 'checkout brave-core ref'),
         api.post_process(post_process.DoesNotRun,
                          'clone brave-core (shallow, sparse)'),
+        api.post_process(post_process.StatusSuccess),
+    )
+    # Already deployed: the live sparse set already covers both requested
+    # paths (`third_party/node` directly, `tools/cr/bootstrap` via its
+    # `tools/cr` ancestor), so nothing is re-added.
+    yield api.test(
+        'already deployed',
+        api.path.files('chromium/src/brave/third_party/node',
+                       'chromium/src/brave/tools/cr/bootstrap'),
+        api.step_data('sparse-checkout list',
+                      stdout='third_party/node\ntools/cr\n'),
+        api.post_process(post_process.DoesNotRun, 'sparse-checkout add'),
+        api.post_process(post_process.MustRun, 'npm version'),
         api.post_process(post_process.StatusSuccess),
     )
     # Requested path missing after checkout -> the module raises.

--- a/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
@@ -77,6 +77,16 @@
       "-C",
       "[WORKSPACE]/chromium/src/brave",
       "sparse-checkout",
+      "list"
+    ],
+    "name": "sparse-checkout list"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "sparse-checkout",
       "add",
       "tools/cr/toolchains"
     ],

--- a/tools/recipes/recipes/toolchains/xcode/build_xcode_toolchain.expected/mac.json
+++ b/tools/recipes/recipes/toolchains/xcode/build_xcode_toolchain.expected/mac.json
@@ -20,6 +20,16 @@
       "-C",
       "[WORKSPACE]/chromium/src/brave",
       "sparse-checkout",
+      "list"
+    ],
+    "name": "sparse-checkout list"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "sparse-checkout",
       "add",
       "tools/cr/toolchains"
     ],

--- a/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/linux.json
+++ b/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/linux.json
@@ -77,6 +77,16 @@
       "-C",
       "[WORKSPACE]/chromium/src/brave",
       "sparse-checkout",
+      "list"
+    ],
+    "name": "sparse-checkout list"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "sparse-checkout",
       "add",
       "third_party/ast-grep",
       "tools/cr/toolchains"

--- a/tools/recipes/recipes/tools/node/package_node.expected/basic.json
+++ b/tools/recipes/recipes/tools/node/package_node.expected/basic.json
@@ -20,6 +20,16 @@
       "-C",
       "[WORKSPACE]/chromium/src/brave",
       "sparse-checkout",
+      "list"
+    ],
+    "name": "sparse-checkout list"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "sparse-checkout",
       "add",
       "third_party/node"
     ],

--- a/tools/recipes/recipes/tools/node/package_node.expected/reuse_checkout.json
+++ b/tools/recipes/recipes/tools/node/package_node.expected/reuse_checkout.json
@@ -29,6 +29,16 @@
       "-C",
       "[WORKSPACE]/chromium/src/brave",
       "sparse-checkout",
+      "list"
+    ],
+    "name": "sparse-checkout list"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "sparse-checkout",
       "add",
       "third_party/node"
     ],

--- a/tools/recipes/recipes/tools/node/package_node_modules.expected/basic.json
+++ b/tools/recipes/recipes/tools/node/package_node_modules.expected/basic.json
@@ -20,9 +20,18 @@
       "-C",
       "[WORKSPACE]/chromium/src/brave",
       "sparse-checkout",
+      "list"
+    ],
+    "name": "sparse-checkout list"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "sparse-checkout",
       "add",
-      "third_party/node",
-      "tools/cr/toolchains"
+      "tools/cr/bootstrap"
     ],
     "name": "sparse-checkout add"
   },
@@ -48,6 +57,11 @@
       "[WORKSPACE]/chromium/third_party/depot_tools/vpython3",
       "[WORKSPACE]/chromium/src/brave/third_party/node/download_node_modules.py"
     ],
+    "env_prefixes": {
+      "PATH": [
+        "[WORKSPACE]/chromium/src/brave/tools/cr/bootstrap"
+      ]
+    },
     "name": "download node_modules"
   },
   {
@@ -58,6 +72,11 @@
       "[WORKSPACE]/out",
       "--upload"
     ],
+    "env_prefixes": {
+      "PATH": [
+        "[WORKSPACE]/chromium/src/brave/tools/cr/bootstrap"
+      ]
+    },
     "name": "package node_modules"
   },
   {

--- a/tools/recipes/recipes/tools/node/package_node_modules.expected/reuse_checkout.json
+++ b/tools/recipes/recipes/tools/node/package_node_modules.expected/reuse_checkout.json
@@ -29,9 +29,18 @@
       "-C",
       "[WORKSPACE]/chromium/src/brave",
       "sparse-checkout",
+      "list"
+    ],
+    "name": "sparse-checkout list"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/chromium/src/brave",
+      "sparse-checkout",
       "add",
-      "third_party/node",
-      "tools/cr/toolchains"
+      "tools/cr/bootstrap"
     ],
     "name": "sparse-checkout add"
   },
@@ -57,6 +66,11 @@
       "[WORKSPACE]/chromium/third_party/depot_tools/vpython3",
       "[WORKSPACE]/chromium/src/brave/third_party/node/download_node_modules.py"
     ],
+    "env_prefixes": {
+      "PATH": [
+        "[WORKSPACE]/chromium/src/brave/tools/cr/bootstrap"
+      ]
+    },
     "name": "download node_modules"
   },
   {
@@ -67,6 +81,11 @@
       "[WORKSPACE]/out",
       "--upload"
     ],
+    "env_prefixes": {
+      "PATH": [
+        "[WORKSPACE]/chromium/src/brave/tools/cr/bootstrap"
+      ]
+    },
     "name": "package node_modules"
   },
   {

--- a/tools/recipes/recipes/tools/node/package_node_modules.py
+++ b/tools/recipes/recipes/tools/node/package_node_modules.py
@@ -26,24 +26,26 @@ def RunSteps(api: RecipeScriptApi) -> None:
 
     vpython3 = api.depot_tools.vpython3()
     node_dir = brave_root / 'third_party/node'
-    api.step('download node_modules', [
-        vpython3,
-        node_dir / 'download_node_modules.py',
-    ])
-    api.step('package node_modules', [
-        vpython3,
-        node_dir / 'package_node_modules.py',
-        '--output-dir',
-        api.path.out,
-        '--upload',
-    ])
+    with api.brave_core_shallow.bootstrap_on_path():
+        api.step('download node_modules', [
+            vpython3,
+            node_dir / 'download_node_modules.py',
+        ])
+        api.step('package node_modules', [
+            vpython3,
+            node_dir / 'package_node_modules.py',
+            '--output-dir',
+            api.path.out,
+            '--upload',
+        ])
 
 
 def GenTests(api):
     yield api.test(
         'basic',
         api.brave_core_shallow.deployed('third_party/node',
-                                        'tools/cr/toolchains'),
+                                        'tools/cr/toolchains',
+                                        'tools/cr/bootstrap'),
         api.post_process(post_process.MustRun,
                          'clone brave-core (shallow, sparse)'),
         api.post_process(post_process.MustRun, 'download node_modules'),
@@ -55,7 +57,8 @@ def GenTests(api):
         'reuse checkout',
         api.brave_core_shallow.existing_checkout(),
         api.brave_core_shallow.deployed('third_party/node',
-                                        'tools/cr/toolchains'),
+                                        'tools/cr/toolchains',
+                                        'tools/cr/bootstrap'),
         api.post_process(post_process.MustRun, 'fetch brave-core ref'),
         api.post_process(post_process.DoesNotRun,
                          'clone brave-core (shallow, sparse)'),


### PR DESCRIPTION
This PR adds the machanism for the `package_node_modules.py` recipe to
use the boostrap node deployment. This involves introducing the
context-manager-based machanism in the brave module.

Bug: https://github.com/brave/brave-browser/issues/56748
Bug: https://github.com/brave/brave-browser/issues/56529
