### PR TITLE
[iOS] Validate snapshot size is finite before rendering the view

### DIFF
--- a/ios/brave-ios/Sources/Brave/Extensions/UIViewExtensions.swift
+++ b/ios/brave-ios/Sources/Brave/Extensions/UIViewExtensions.swift
@@ -12,9 +12,9 @@ extension UIView {
 
     let offset = offset ?? .zero
 
-    // Temporary check to handle _UIGraphicsBeginImageContextWithOptions zero size error
+    // Temporary check to handle _UIGraphicsBeginImageContextWithOptions zero/invalid size error
     // Should be replaced with UIGraphicsImageRenderer
-    guard size.width > 0, size.height > 0 else {
+    guard size.width.isFinite, size.height.isFinite, size.width > 0, size.height > 0 else {
       return nil
     }
 


### PR DESCRIPTION
This adds a finite check on the size when calling the `UIView.snapshot` which is used by `ScreenshotHelper` for taking tab screenshots. This is a speculative crash fix where `UIGraphicsBeginImageContextWithOptions` is possibly being called with non-finite values and throwing an exception due to invalid geometry

Resolves https://github.com/brave/brave-browser/issues/57337