### PR TITLE
[cr151][Android] Fixed Sync Screen titles at multicolumn settings

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
@@ -580,6 +580,27 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
         return mPageTitle;
     }
 
+    /**
+     * Sets the title shown for the current Sync (sub-)screen.
+     *
+     * <p>On a phone (single-pane settings) the sole toolbar shows the current screen, which is
+     * driven by the activity title. In cr151 Multi-column Settings the activity title is the left
+     * list-pane toolbar ("Settings") and must not be overwritten by a Sync sub-screen; the detail
+     * (right) pane title is driven by {@link #getPageTitle()} instead, so update that supplier.
+     */
+    private void setScreenTitle(int titleResId) {
+        Activity activity = getActivity();
+        if (activity == null) {
+            return;
+        }
+        if (activity instanceof SettingsActivity settingsActivity
+                && settingsActivity.isTwoColumnSettingsVisible()) {
+            mPageTitle.set(getString(titleResId));
+        } else {
+            activity.setTitle(titleResId);
+        }
+    }
+
     @Override
     public String getMainMenuKey() {
         return "brave_sync_layout";
@@ -594,7 +615,7 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
         getActivity()
                 .getWindow()
                 .setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
-        getActivity().setTitle(R.string.sync_category_title);
+        setScreenTitle(R.string.sync_category_title);
 
         boolean firstSetupComplete = getBraveSyncWorker().isInitialSyncFeatureSetupComplete();
 
@@ -767,7 +788,7 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
                 mScrollViewEnterCodeWords.setVisibility(View.VISIBLE);
             }
             updateBackPressState();
-            getActivity().setTitle(R.string.brave_sync_code_words_title);
+            setScreenTitle(R.string.brave_sync_code_words_title);
             if (null != mCodeWords && null != mBraveSyncWordCountTitle) {
                 mCodeWords.addTextChangedListener(
                         new TextWatcher() {
@@ -1357,7 +1378,7 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
             mCameraManager.createCameraSource();
         }
 
-        getActivity().setTitle(R.string.brave_sync_scan_chain_code);
+        setScreenTitle(R.string.brave_sync_scan_chain_code);
         if (null != mScrollViewSyncChainCode) {
             mScrollViewSyncChainCode.setVisibility(View.VISIBLE);
         }
@@ -1382,7 +1403,7 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
     }
 
     private void setNewChainLayout() {
-        getActivity().setTitle(R.string.brave_sync_start_new_chain);
+        setScreenTitle(R.string.brave_sync_start_new_chain);
         if (null != mScrollViewSyncInitial) {
             mScrollViewSyncInitial.setVisibility(View.GONE);
         }
@@ -1424,7 +1445,7 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
     }
 
     private void setAddMobileDeviceLayout() {
-        getActivity().setTitle(R.string.brave_sync_btn_mobile);
+        setScreenTitle(R.string.brave_sync_btn_mobile);
 
         getActivity().getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
 
@@ -1470,7 +1491,7 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
     }
 
     private void setAddLaptopLayout() {
-        getActivity().setTitle(R.string.brave_sync_btn_laptop);
+        setScreenTitle(R.string.brave_sync_btn_laptop);
 
         getActivity().getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
 
@@ -1524,7 +1545,7 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
         getActivity()
                 .getWindow()
                 .setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
-        getActivity().setTitle(R.string.sync_category_title);
+        setScreenTitle(R.string.sync_category_title);
         if (mCameraManager != null) {
             mCameraManager.stopCameraSource();
         }


### PR DESCRIPTION
On tablets, `cr151` enabled Multi-column Settings by default, which broke Titles on the Sync screen (`BraveSyncScreensPreference`):
Sync sub-screens overwrote the left list-pane "Settings" title. Titles now route to the activity title on phones (single toolbar) and to the detail-pane page title on multi-column tablets, leaving "Settings" intact. Phone (single-column) behavior is unchanged.

#### Screenshots
<img width="1280" height="801" alt="photo_5400003931510873902_y" src="https://github.com/user-attachments/assets/f785da13-1a21-4b09-805f-c351f53320a4" />|<img width="1280" height="801" alt="photo_5400003931510873901_y" src="https://github.com/user-attachments/assets/ee5a24d7-81ae-4b6d-8e5f-cdbd013f4600" />|<img width="1280" height="801" alt="photo_5400003931510873900_y" src="https://github.com/user-attachments/assets/4cfb75d2-8eab-4d0a-b4f6-26351f0dc945" />
--|--|--
<img width="1280" height="801" alt="photo_5400003931510873899_y" src="https://github.com/user-attachments/assets/cbc148a7-71a5-4f44-9e20-c02374e648e5" />|<img width="1280" height="801" alt="photo_5400003931510873898_y" src="https://github.com/user-attachments/assets/f3941ef8-972a-48e4-a048-0329d872a89b" />|<img width="1280" height="801" alt="photo_5400003931510873897_y" src="https://github.com/user-attachments/assets/409b6ab0-38f2-4e9f-ae07-16abb2edc39d" />

Resolves https://github.com/brave/brave-browser/issues/57277

<!-- Add brave-browser issue below that this PR will resolve -->


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
