### PR TITLE
Implement support for landscape layout for AddAccountActivity

### DIFF
--- a/android/java/AndroidManifest.xml
+++ b/android/java/AndroidManifest.xml
@@ -39,8 +39,7 @@
     tools:ignore="LockedOrientationActivity,DiscouragedApi"/>
 
 <activity android:name="org.chromium.chrome.browser.crypto_wallet.activities.AddAccountActivity"
-    android:theme="@style/Theme.Chromium.Activity"
-    tools:ignore="LockedOrientationActivity,DiscouragedApi"/>
+    android:theme="@style/Theme.Chromium.Activity"/>
 
 <activity android:name="org.chromium.chrome.browser.crypto_wallet.activities.NetworkSelectorActivity"
     android:theme="@style/Theme.Chromium.Activity"

--- a/android/java/AndroidManifest.xml
+++ b/android/java/AndroidManifest.xml
@@ -40,7 +40,6 @@
 
 <activity android:name="org.chromium.chrome.browser.crypto_wallet.activities.AddAccountActivity"
     android:theme="@style/Theme.Chromium.Activity"
-    android:screenOrientation="sensorPortrait"
     tools:ignore="LockedOrientationActivity,DiscouragedApi"/>
 
 <activity android:name="org.chromium.chrome.browser.crypto_wallet.activities.NetworkSelectorActivity"

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AddAccountActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AddAccountActivity.java
@@ -38,12 +38,14 @@ import org.chromium.chrome.browser.crypto_wallet.util.Utils;
 import org.chromium.chrome.browser.crypto_wallet.util.WalletUtils;
 import org.chromium.chrome.browser.util.LiveDataUtil;
 import org.chromium.ui.base.BraveClipboardHelper;
+import org.jni_zero.NullMarked;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Arrays;
 
+@NullMarked
 public class AddAccountActivity extends BraveWalletBaseActivity {
     private static final String TAG = "AddAccountActivity";
 

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AddAccountActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AddAccountActivity.java
@@ -22,7 +22,6 @@ import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.TextView;
 
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
 
@@ -30,6 +29,8 @@ import org.chromium.base.Log;
 import org.chromium.brave_wallet.mojom.AccountInfo;
 import org.chromium.brave_wallet.mojom.BraveWalletConstants;
 import org.chromium.brave_wallet.mojom.CoinType;
+import org.chromium.build.annotations.NullMarked;
+import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.app.BraveActivity;
 import org.chromium.chrome.browser.app.domain.KeyringModel.FilecoinNetworkType;
@@ -38,7 +39,6 @@ import org.chromium.chrome.browser.crypto_wallet.util.Utils;
 import org.chromium.chrome.browser.crypto_wallet.util.WalletUtils;
 import org.chromium.chrome.browser.util.LiveDataUtil;
 import org.chromium.ui.base.BraveClipboardHelper;
-import org.jni_zero.NullMarked;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
@@ -53,17 +53,18 @@ public class AddAccountActivity extends BraveWalletBaseActivity {
     private static final int FILECOIN_TESTNET_POSITION = 1;
 
     private @CoinType.EnumType int mCoinForNewAccount;
-    private AccountInfo mEditedAccountInfo;
+    private @Nullable AccountInfo mEditedAccountInfo;
 
     private EditText mPrivateKeyControl;
     private EditText mAddAccountText;
     private EditText mImportAccountPasswordText;
     private Spinner mFilecoinNetworkSpinner;
     private static final int FILE_PICKER_REQUEST_CODE = 1;
-    private WalletModel mWalletModel;
-    @FilecoinNetworkType private String mSelectedFilecoinNetwork;
+    private @Nullable WalletModel mWalletModel;
 
-    @NonNull
+    @FilecoinNetworkType
+    private String mSelectedFilecoinNetwork = BraveWalletConstants.FILECOIN_MAINNET;
+
     public static Intent createIntentToAddAccount(
             final Context context, @CoinType.EnumType final int coinForNewAccount) {
         final Intent intent = new Intent(context, AddAccountActivity.class);
@@ -78,7 +79,6 @@ public class AddAccountActivity extends BraveWalletBaseActivity {
             mCoinForNewAccount = intent.getIntExtra(Utils.COIN_TYPE, -1);
             mEditedAccountInfo = WalletUtils.getAccountInfoFromIntent(intent);
         }
-        mSelectedFilecoinNetwork = BraveWalletConstants.FILECOIN_MAINNET;
     }
 
     @Override
@@ -97,8 +97,11 @@ public class AddAccountActivity extends BraveWalletBaseActivity {
 
         final Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
-        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-        getSupportActionBar().setTitle(getResources().getString(R.string.add_account));
+        final ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true);
+            actionBar.setTitle(getResources().getString(R.string.add_account));
+        }
 
         mAddAccountText = findViewById(R.id.add_account_text);
         mPrivateKeyControl = findViewById(R.id.import_account_text);
@@ -148,7 +151,7 @@ public class AddAccountActivity extends BraveWalletBaseActivity {
                         return;
                     }
                     if (mEditedAccountInfo != null) {
-                        updateAccountName();
+                        updateAccountName(mEditedAccountInfo);
                         return;
                     }
 
@@ -214,7 +217,7 @@ public class AddAccountActivity extends BraveWalletBaseActivity {
     }
 
     @Override
-    protected void onRestoreInstanceState(@NonNull Bundle savedInstanceState) {
+    protected void onRestoreInstanceState(@Nullable Bundle savedInstanceState) {
         super.onRestoreInstanceState(savedInstanceState);
         // View visibility is not part of the saved view hierarchy state. Show
         // the password field again when the restored private key content is a
@@ -226,13 +229,17 @@ public class AddAccountActivity extends BraveWalletBaseActivity {
     }
 
     @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         switch (requestCode) {
             case FILE_PICKER_REQUEST_CODE:
-                if (resultCode == -1) {
+                final Uri fileUri =
+                        resultCode == Activity.RESULT_OK && data != null ? data.getData() : null;
+                if (fileUri != null) {
                     try {
-                        Uri fileUri = data.getData();
                         InputStream inputStream = getContentResolver().openInputStream(fileUri);
+                        if (inputStream == null) {
+                            break;
+                        }
                         BufferedReader br = new BufferedReader(new InputStreamReader(inputStream));
                         StringBuilder sb = new StringBuilder();
                         String line;
@@ -266,9 +273,9 @@ public class AddAccountActivity extends BraveWalletBaseActivity {
         }
     }
 
-    private void updateAccountName() {
+    private void updateAccountName(final AccountInfo editedAccountInfo) {
         mKeyringService.setAccountName(
-                mEditedAccountInfo.accountId,
+                editedAccountInfo.accountId,
                 mAddAccountText.getText().toString(),
                 this::handleUpdateAccount);
     }
@@ -319,6 +326,12 @@ public class AddAccountActivity extends BraveWalletBaseActivity {
     }
 
     private void addAccount(@CoinType.EnumType int coinType) {
+        if (mWalletModel == null) {
+            // Unreachable in practice: when the wallet model is unavailable the
+            // activity finishes during native initialization, before the add
+            // button can be clicked.
+            return;
+        }
         mWalletModel
                 .getKeyringModel()
                 .addAccount(

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AddAccountActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AddAccountActivity.java
@@ -9,6 +9,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -80,6 +81,16 @@ public class AddAccountActivity extends BraveWalletBaseActivity {
 
     @Override
     protected void triggerLayoutInflation() {
+        if (mEditedAccountInfo == null) {
+            // The screen may show a private key or a password. Secure the window
+            // before any content is rendered, as restoring the instance state
+            // after a configuration change can populate these fields well before
+            // native initialization completes.
+            getWindow()
+                    .setFlags(
+                            WindowManager.LayoutParams.FLAG_SECURE,
+                            WindowManager.LayoutParams.FLAG_SECURE);
+        }
         setContentView(R.layout.activity_add_account);
 
         Toolbar toolbar = findViewById(R.id.toolbar);
@@ -127,6 +138,13 @@ public class AddAccountActivity extends BraveWalletBaseActivity {
 
         btnAdd.setOnClickListener(
                 v -> {
+                    if (mKeyringService == null) {
+                        // Wallet services are unavailable until native
+                        // initialization completes. Restoring the instance state
+                        // after a configuration change re-enables the button
+                        // before that happens, so ignore early clicks.
+                        return;
+                    }
                     if (mEditedAccountInfo != null) {
                         updateAccountName();
                         return;
@@ -159,7 +177,11 @@ public class AddAccountActivity extends BraveWalletBaseActivity {
         if (mEditedAccountInfo != null) {
             Button btnAdd = findViewById(R.id.btn_add);
             btnAdd.setText(getResources().getString(R.string.wallet_accounts_update));
-            mAddAccountText.setText(mEditedAccountInfo.name);
+            // Prefill the current account name only when the field is empty,
+            // preserving the text restored after a configuration change.
+            if (TextUtils.isEmpty(mAddAccountText.getText().toString().trim())) {
+                mAddAccountText.setText(mEditedAccountInfo.name);
+            }
             ActionBar actionBar = getSupportActionBar();
             if (actionBar != null) {
                 actionBar.setTitle(getResources().getString(R.string.update_account));
@@ -169,17 +191,36 @@ public class AddAccountActivity extends BraveWalletBaseActivity {
             return;
         }
 
-        getWindow()
-                .setFlags(
-                        WindowManager.LayoutParams.FLAG_SECURE,
-                        WindowManager.LayoutParams.FLAG_SECURE);
+        if (mWalletModel == null) {
+            // Account creation cannot work without the wallet model. This may
+            // happen when the activity is restored after its process was killed
+            // and BraveActivity has not been recreated yet.
+            finish();
+            return;
+        }
         LiveDataUtil.observeOnce(
                 mWalletModel.getKeyringModel().mAccountInfos,
                 accounts -> {
-                    mAddAccountText.setText(
-                            WalletUtils.generateUniqueAccountName(
-                                    mCoinForNewAccount, accounts.toArray(new AccountInfo[0])));
+                    // Prefill a generated name only when the field is empty,
+                    // preserving the text restored after a configuration change.
+                    if (TextUtils.isEmpty(mAddAccountText.getText().toString().trim())) {
+                        mAddAccountText.setText(
+                                WalletUtils.generateUniqueAccountName(
+                                        mCoinForNewAccount, accounts.toArray(new AccountInfo[0])));
+                    }
                 });
+    }
+
+    @Override
+    protected void onRestoreInstanceState(@NonNull Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+        // View visibility is not part of the saved view hierarchy state. Show
+        // the password field again when the restored private key content is a
+        // JSON keystore, mirroring the file picker flow.
+        if (mEditedAccountInfo == null
+                && Utils.isJSONValid(mPrivateKeyControl.getText().toString())) {
+            findViewById(R.id.import_account_password_layout).setVisibility(View.VISIBLE);
+        }
     }
 
     @Override

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AddAccountActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AddAccountActivity.java
@@ -63,15 +63,15 @@ public class AddAccountActivity extends BraveWalletBaseActivity {
 
     @NonNull
     public static Intent createIntentToAddAccount(
-            @NonNull Context context, @CoinType.EnumType int coinForNewAccount) {
-        Intent intent = new Intent(context, AddAccountActivity.class);
+            final Context context, @CoinType.EnumType final int coinForNewAccount) {
+        final Intent intent = new Intent(context, AddAccountActivity.class);
         intent.putExtra(Utils.COIN_TYPE, coinForNewAccount);
         return intent;
     }
 
     @Override
     protected void onPreCreate() {
-        Intent intent = getIntent();
+        final Intent intent = getIntent();
         if (intent != null) {
             mCoinForNewAccount = intent.getIntExtra(Utils.COIN_TYPE, -1);
             mEditedAccountInfo = WalletUtils.getAccountInfoFromIntent(intent);
@@ -93,7 +93,7 @@ public class AddAccountActivity extends BraveWalletBaseActivity {
         }
         setContentView(R.layout.activity_add_account);
 
-        Toolbar toolbar = findViewById(R.id.toolbar);
+        final Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setTitle(getResources().getString(R.string.add_account));
@@ -131,7 +131,7 @@ public class AddAccountActivity extends BraveWalletBaseActivity {
                     @Override
                     public void onTextChanged(CharSequence s, int start, int before, int count) {
                         // Disable add button if input is empty.
-                        String inputText = s.toString().trim();
+                        final String inputText = s.toString().trim();
                         btnAdd.setEnabled(!TextUtils.isEmpty(inputText));
                     }
                 });


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/57338

<img width="565" height="1151" alt="Screenshot 2026-07-20 at 5 09 18 PM" src="https://github.com/user-attachments/assets/6444920f-da60-4859-abb0-e209079620d9" />


`AddAccountActivity` was locked to portrait. This PR removes the lock and makes the screen handle orientation changes correctly, including tablets and large screen devices where Android ignores orientation locks anyway.  


- The three text fields and the Filecoin network spinner are preserved across rotation by the framework's view state restore, since all views have IDs.

- The generated account name (add mode) and the current account name (edit mode) are prefilled only when the name field is empty, so text typed by the user survives recreation. Previously `finishNativeInitialization` unconditionally overwrote the restored text on every configuration change.

- The JSON keystore password section is shown again after recreation when the restored private key content is valid JSON, since view visibility is not part of the saved view hierarchy state.

- `FLAG_SECURE` is now applied before `setContentView` instead of at native init, so restored private key content is never rendered on an unsecured window.

- Clicks on the add button are ignored until native initialization completes, because state restore re-enables the button immediately after recreation while the wallet services are still null.

- The activity finishes gracefully when the wallet model is unavailable (recreation after process death with `BraveActivity` gone), which previously crashed with an NPE.

- `onActivityResult` guards against a null intent, null file URI, and null input stream.

- Annotated the class with `@NullMarked` and made it NullAway clean.

## Test Plan

1. Unlock Brave Wallet.
2. Navigate to https://metamask.github.io/test-dapp/.
3. Tap on Wallet icon in the omnibox.
4. Tap on Connect button.
5. Tap on New Account.
6. Modify the account name, rotate the device, verify the modified name is preserved and the add button stays enabled.
7. Type a private key, rotate, verify the content is preserved.
8. Import a JSON keystore file, verify the password field appears, rotate, verify the password field is still visible and both the key content and the typed password are preserved.
9. Create a Filecoin account, select testnet in the toolbar spinner, rotate, verify the selection is preserved and the account is created on testnet.
11. Rotate repeatedly on all the above screens and verify no crashes.
12. Verify screenshots are still blocked on the add account screen (secure window flag).

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
