### PR TITLE
[iOS] Check if window scene is still connected after profile load

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
@@ -142,6 +142,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     Task { @MainActor in
       let (profileController, profileState) = await loadDefaultProfile()
+
+      // The scene may have disconnected while `loadDefaultProfile` was awaiting. UIKit clears
+      // `session.scene` back to nil once a scene disconnects, so use that to detect this rather
+      // than tracking our own state. Creating a new `UIWindow` for a windowScene that has
+      // already disconnected will crash, so bail out if that's the case.
+      guard windowScene.session.scene != nil else { return }
+
       Self.profileState = profileState
       PlaylistCoordinator.shared.isPlaylistAvailable =
         profileController.profile.prefs.isPlaylistAvailable


### PR DESCRIPTION
This is a speculative crash fix where attempting to create a `WindowProtection`–which creates a new `UIWindow` on the window scene–will crash because the scene has already disconnected. This change adds a check post profile load to ensure that the scene is still connected before continuing

Resolves https://github.com/brave/brave-browser/issues/57342
