### PR TITLE
[ast-grep][plaster] `add_to_protected` rewriter

### DIFF
--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -136,6 +136,7 @@ introduce more rewriters. These are the ones we have supported for now.
 | `drop_final`            | AST  | Removes `final` from a C++ class declaration.     |
 | `preempt_function_impl` | AST  | Inserts at the top of a C++ function body.        |
 | `rename_class`          | AST  | Renames a C++ class.                              |
+| `add_to_protected`      | AST  | Adds a member to a class `protected:` section.    |
 
 Use `plaster --help` to discover rewriters and read their full docs:
 

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -432,6 +432,11 @@ class Rewriter(abc.ABC):
         """Build a rewriter from its YAML body, validating its fields."""
 
     @classmethod
+    def validate_count(cls, count: int, description: str) -> None:
+        """Reject an unsupported `count:` for this rewriter.
+        """
+
+    @classmethod
     def help_text(cls) -> str:
         """The full, user-facing help for this rewriter as dedented Markdown."""
         return textwrap.dedent(cls.HELP or cls.__doc__ or '').strip('\n')
@@ -605,9 +610,11 @@ class Substitution:
                                  f'rewriter: '
                                  f'{", ".join(repr(k) for k in unknown)} '
                                  f'(in "{description}")')
-            # The chosen rewriter decides what an omitted `count:` means.
+            # The chosen rewriter decides what an omitted `count:` means, and
+            # may reject a count it does not support.
             expected_count = Substitution._parse_count(
                 data, description, _REWRITERS[name].DEFAULT_COUNT)
+            _REWRITERS[name].validate_count(expected_count, description)
             rewriter = _REWRITERS[name].parse(data[name],
                                               description=description)
             return Substitution(description=description,
@@ -1274,10 +1281,8 @@ class PreemptFunctionImpl(_AstGrepRewriter):
         return f'if ({condition}) return{value};'
 
 
-# A set with all the rewriters available in plaster.
 class RenameClass(_AstGrepRewriter):
-    """Rename a C++ class -- its declaration, type uses, `Class::` qualifiers
-    and con/destructor names -- via the ast-grep rewriters."""
+    """Rename a C++ class."""
 
     NAME: Final = 'rename_class'
     OP_ID: Final = 'cxx.rename_class'
@@ -1307,10 +1312,107 @@ class RenameClass(_AstGrepRewriter):
     """
 
 
+class AddToProtected(_AstGrepRewriter):
+    """Add a member declaration to a C++ class's `protected:` section"""
+
+    NAME: Final = 'add_to_protected'
+    # Two ops share the work (see `operations`); this names the language and a
+    # representative op for the base's helpers.
+    OP_ID: Final = 'cxx.add_to_protected'
+    SUMMARY: Final = 'Add code to a class protected section (creating one if '\
+                     'needed).'
+    # Authored in Markdown; `Help` renders it with rich.
+    HELP: Final = r"""
+        Adds code to a C++ class's `protected:` section. It will either use an
+        existing `protected:` section or create a new one.
+
+        Fields:
+
+        - `class_name` — the class to add to.
+        - `code` — free-form text to insert in the protected section, e.g. a
+          declaration like `virtual void OnFoo() = 0;`.
+
+        Example:
+
+        ```yaml
+        substitutions:
+          - description: Add a protected hook for the Brave subclass to override.
+            add_to_protected:
+              class_name: TestLauncher_ChromiumImpl
+              code: 'virtual const TestResult& OnTestResult(const TestResult& result) = 0;'
+        ```
+    """
+
+    # This rewriter uses composite operations that look for an existing
+    # protected section, or add one before `private:`.
+    _ADD_TO_EXISTING: Final = 'cxx.add_to_protected'
+    _CREATE_BEFORE_PRIVATE: Final = 'cxx.add_protected_before_private'
+
+    @classmethod
+    def validate_count(cls, count: int, description: str) -> None:
+        # The code is inserted once, into whichever placement applies, so a
+        # `count:` other than 1 is meaningless here.
+        if count != 1:
+            raise ValueError(f'{cls.NAME} adds the code exactly once and does '
+                             f'not accept a count other than 1 '
+                             f'(in "{description}")')
+
+    def __init__(self, *, class_name: str, code: str):
+        super().__init__()
+        self._class_name = class_name
+        self._code = code
+
+    def apply(self,
+              contents: str,
+              *,
+              count: int,
+              description: str,
+              blank_for_parse: bool = False) -> tuple[str, list[str]]:
+        # The code is inserted exactly once either in an existing protected
+        # section or in a new one created just before a private section.
+        del count, description
+        engine = AstRewriter(RewritersEval.load(),
+                             contents,
+                             blank_for_parse=blank_for_parse)
+        code = _indent_yaml(self._code).replace('\\', '\\\\')
+        inputs = {'class_name': self._class_name, 'code': code}
+        op = Operation(self._ADD_TO_EXISTING, inputs,
+                       MatchExpectation.exactly(1))
+        changes = engine.run(op)
+        if changes == 0:
+            op = Operation(self._CREATE_BEFORE_PRIVATE, inputs,
+                           MatchExpectation.exactly(1))
+            changes = engine.run(op)
+        error = op.expectation.error_for(changes)
+        return engine.content, [error] if error else []
+
+    @classmethod
+    def parse(cls, body: object, *, description: str) -> AddToProtected:
+        """Validate an `add_to_protected:` body of string args."""
+        if not isinstance(body, dict):
+            raise ValueError(
+                f'"{cls.NAME}" must be a mapping (in "{description}")')
+        required = {'class_name', 'code'}
+        unknown = sorted(set(body) - required)
+        if unknown:
+            raise ValueError(
+                f'Unrecognised {cls.NAME} arg(s): '
+                f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
+        missing = sorted(required - set(body))
+        if missing:
+            raise ValueError(f'{cls.NAME} requires arg(s): '
+                             f'{", ".join(missing)} (in "{description}")')
+        for key in sorted(required):
+            if not isinstance(body[key], str) or not body[key]:
+                raise ValueError(f'{cls.NAME} `{key}` must be a non-empty '
+                                 f'string (in "{description}")')
+        return cls(class_name=body['class_name'], code=body['code'])
+
+
 _REWRITERS: MappingProxyType[str, type[Rewriter]] = MappingProxyType({
     rewriter.NAME: rewriter
     for rewriter in (Regex, MakeVirtual, AddFriend, DropFinal,
-                     PreemptFunctionImpl, RenameClass)
+                     PreemptFunctionImpl, RenameClass, AddToProtected)
 })
 
 

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1873,6 +1873,178 @@ class RewriterFormsTest(unittest.TestCase):
             '    rename_class:\n'
             '      class_name: Foo\n', 'rename_class requires arg')
 
+    # -- add_to_protected op (real ast-grep binary) -----------------
+
+    def test_add_to_protected_creates_section_before_private(self):
+        # No existing protected section: a fresh `protected:` is created just
+        # before `private:`.
+        result = self._apply(
+            'prot_new.h',
+            'class C {\n public:\n  void Foo();\n private:\n  int x_;\n};\n',
+            'substitutions:\n'
+            '  - description: add a protected hook\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar() = 0;\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            ' protected:\n  virtual void Bar() = 0;\n\n'
+            ' private:\n  int x_;\n};\n')
+
+    def test_add_to_protected_reuses_existing_protected(self):
+        # An existing protected section is reused: the code becomes its first
+        # line, and no second protected section is created before private.
+        result = self._apply(
+            'prot_reuse.h', 'class C {\n protected:\n  void Existing();\n'
+            ' private:\n  int x_;\n};\n', 'substitutions:\n'
+            '  - description: reuse the protected section\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar() = 0;\n')
+        self.assertEqual(
+            result, 'class C {\n protected:\n  virtual void Bar() = 0;\n'
+            '  void Existing();\n private:\n  int x_;\n};\n')
+
+    def test_add_to_protected_scoped_to_named_class(self):
+        # Only the named class is touched; a sibling class with its own private
+        # section is left alone (the matchers are scoped by class_name).
+        result = self._apply(
+            'prot_scope.h', 'class C {\n private:\n  int c_;\n};\n\n'
+            'class D {\n private:\n  int d_;\n};\n', 'substitutions:\n'
+            '  - description: add only to C\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar() = 0;\n')
+        self.assertEqual(
+            result, 'class C {\n protected:\n  virtual void Bar() = 0;\n\n'
+            ' private:\n  int c_;\n};\n\n'
+            'class D {\n private:\n  int d_;\n};\n')
+
+    def test_add_to_protected_multiline_code(self):
+        # A multi-line `code` block inserts several declarations, each indented
+        # to the member level.
+        result = self._apply(
+            'prot_multi.h', 'class C {\n private:\n  int x_;\n};\n',
+            'substitutions:\n'
+            '  - description: add two protected hooks\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: |-\n'
+            '        virtual void A() = 0;\n'
+            '        virtual void B() = 0;\n')
+        self.assertEqual(
+            result, 'class C {\n'
+            ' protected:\n  virtual void A() = 0;\n  virtual void B() = 0;\n\n'
+            ' private:\n  int x_;\n};\n')
+
+    def test_add_to_protected_indents_flush_left_nested_code(self):
+        # A flush-left `code` block is indented to the member level (two spaces),
+        # and its own relative indentation is preserved (the nested `DoStuff();`
+        # ends up two spaces deeper) -- like preempt_function_impl's `code`.
+        result = self._apply(
+            'prot_nested.h', 'class C {\n private:\n  int x_;\n};\n',
+            'substitutions:\n'
+            '  - description: add a hook with an inline body\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: |-\n'
+            '        void OnFoo() {\n'
+            '          DoStuff();\n'
+            '        }\n')
+        self.assertEqual(
+            result, 'class C {\n'
+            ' protected:\n  void OnFoo() {\n    DoStuff();\n  }\n\n'
+            ' private:\n  int x_;\n};\n')
+
+    def test_add_to_protected_blank_line_in_code_stays_empty(self):
+        # A blank line inside the `code` block stays empty -- no trailing
+        # whitespace from the member-level indentation.
+        result = self._apply(
+            'prot_blank.h', 'class C {\n private:\n  int x_;\n};\n',
+            'substitutions:\n'
+            '  - description: two declarations split by a blank line\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: |-\n'
+            '        virtual void A() = 0;\n'
+            '\n'
+            '        virtual void B() = 0;\n')
+        self.assertEqual(
+            result, 'class C {\n'
+            ' protected:\n  virtual void A() = 0;\n\n  virtual void B() = 0;\n\n'
+            ' private:\n  int x_;\n};\n')
+
+    def test_add_to_protected_reused_section_indents_code(self):
+        # Indentation is applied the same way when reusing an existing protected
+        # section: the multi-line block lands at the member level above the
+        # existing members.
+        result = self._apply(
+            'prot_reuse_multi.h',
+            'class C {\n protected:\n  void Existing();\n'
+            ' private:\n  int x_;\n};\n', 'substitutions:\n'
+            '  - description: add two hooks to the existing protected section\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: |-\n'
+            '        void A();\n'
+            '        void B();\n')
+        self.assertEqual(
+            result, 'class C {\n protected:\n  void A();\n  void B();\n'
+            '  void Existing();\n private:\n  int x_;\n};\n')
+
+    def test_add_to_protected_no_anchor_fails(self):
+        # A class with neither a protected nor a private section has nothing to
+        # anchor on.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'prot_none.h', 'class C {\n public:\n  void Foo();\n};\n',
+                'substitutions:\n'
+                '  - description: no anchor\n'
+                '    add_to_protected:\n'
+                '      class_name: C\n'
+                '      code: virtual void Bar() = 0;\n')
+
+    def test_add_to_protected_unknown_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: typo arg\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      cod: virtual void Bar() = 0;\n',
+            'Unrecognised add_to_protected arg')
+
+    def test_add_to_protected_missing_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: missing code\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n', 'add_to_protected requires arg')
+
+    def test_add_to_protected_explicit_count_one_ok(self):
+        # An explicit `count: 1` is the only count accepted; it applies normally.
+        result = self._apply(
+            'prot_count_ok.h', 'class C {\n private:\n  int x_;\n};\n',
+            'substitutions:\n'
+            '  - description: explicit count of one\n'
+            '    count: 1\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar() = 0;\n')
+        self.assertEqual(
+            result, 'class C {\n protected:\n  virtual void Bar() = 0;\n\n'
+            ' private:\n  int x_;\n};\n')
+
+    def test_add_to_protected_count_other_than_one_rejected(self):
+        # It always adds exactly once, so any other count is a config error.
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: bogus count\n'
+            '    count: 2\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar() = 0;\n',
+            'does not accept a count other than 1')
+
     # -- export-macro classes (real ast-grep binary) ----------------------
     #
     # tree-sitter cannot parse `class MACRO_EXPORT Name`, so the engine blanks

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -93,6 +93,24 @@ inside:
             },
         },
 
+        # Finds the protected section in a given class.
+        "cxx.find_class_protected_section": {
+            "template": """\
+kind: access_specifier
+regex: ^protected$
+inside:
+  kind: field_declaration_list
+  inside:
+    kind: class_specifier
+    has:
+      field: name
+      regex: ^{class_name}$
+""",
+            "result": {
+                "node": "access_specifier",
+            },
+        },
+
         # The `final` specifier on `class_name`'s declaration (the
         # virtual_specifier node holding the `final` keyword). Only the
         # class-head `final` matches; a method's trailing `final` is nested
@@ -240,6 +258,36 @@ regex: ^{class_name}$
             },
             "result": {
                 "node": "identifier",
+            },
+        },
+
+        # Inserts `code` under an existing `protected:` specifier for the class.
+        "cxx.add_to_protected": {
+            "matcher": "cxx.find_class_protected_section",
+            "inputs": ["class_name", "code"],
+            "first_match": True,
+            "replace": {
+                "consume_after": ":",
+                "re_pattern": "$",
+                "replace": ":\\n{code}",
+            },
+            "result": {
+                "node": "access_specifier",
+            },
+        },
+
+        # Inserts a fresh `protected:` section just before an existing
+        # `private:` one, and adds `code` under it.
+        "cxx.add_protected_before_private": {
+            "matcher": "cxx.find_class_private_section",
+            "inputs": ["class_name", "code"],
+            "first_match": True,
+            "replace": {
+                "re_pattern": "^private$",
+                "replace": "protected:\\n{code}\\n\\n private",
+            },
+            "result": {
+                "node": "access_specifier",
             },
         },
     },


### PR DESCRIPTION
This rewriter should be used for cases where we want to add functions to
the interface of a type as protected.

Fixed: https://github.com/brave/brave-browser/issues/57343
