### PR TITLE
[deps] All toolchain downloads validated together

### DIFF
--- a/build/mac/download_hermetic_xcode.py
+++ b/build/mac/download_hermetic_xcode.py
@@ -28,23 +28,33 @@ from urllib.error import URLError  # pylint: disable=no-name-in-module,import-er
 
 from packaging.version import parse as parse_version
 
-# Importing script explicitly, so we can call this script from the terminal
-# without needing to set up the PYTHONPATH.
-sys.path.append(str(Path(__file__).resolve().parents[2] / 'script'))
-
-import deps  # pylint: disable=wrong-import-position
+sys.path.append(str(Path(__file__).resolve().parents[2] / 'tools' / 'cr'))
+from tarball_installer import (  # pylint: disable=wrong-import-position
+    TarballInstaller)
 
 # The hash sum for the archive expected to be downloaded.
 MAC_BINARIES_HASH = '0e1a4db4cb6fc9ca78cc71872ff57f837226f1004a7fbf6ce73a5cd89345c289'
+
+# The exact size of the archive in bytes, checked on download.
+MAC_BINARIES_SIZE = 883762569
 
 # This contains binaries from Xcode 26.5 (17F42) along with the macOS 26.5 SDK
 # (25F70) and the Metal toolchain (17F42).
 MAC_SDK_OFFICIAL_VERSION = '26.5'
 MAC_SDK_OFFICIAL_BUILD_VERSION = '25F70'
-XCODE_TOOLCHAIN_DOWNLOAD_URL = (
+
+# The bucket prefix the archive object name is appended to.
+XCODE_TOOLCHAIN_BUCKET = (
     'https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-2.on.aws'
-    '/xcode-hermetic-toolchain/xcode-hermetic-toolchain-'
+    '/xcode-hermetic-toolchain/')
+
+# The archive object name; also drives the sidecar file names TarballInstaller
+# writes into MAC_BINARIES_ROOT to record what is deployed.
+XCODE_TOOLCHAIN_OBJECT = (
+    'xcode-hermetic-toolchain-'
     f'{MAC_SDK_OFFICIAL_VERSION}-{MAC_SDK_OFFICIAL_BUILD_VERSION}.tar.gz')
+
+XCODE_TOOLCHAIN_DOWNLOAD_URL = XCODE_TOOLCHAIN_BUCKET + XCODE_TOOLCHAIN_OBJECT
 
 # The toolchain will not be downloaded if the minimum OS version is not met. 19
 # is the Darwin major version number for macOS 10.15. Xcode 26.4 17E192 only
@@ -56,12 +66,6 @@ MAC_MINIMUM_OS_VERSION = [19, 4]
 # Destination for the hermetic Xcode binaries to be extracted at.
 MAC_BINARIES_ROOT = Path(
     __file__).resolve().parents[3] / 'build' / 'mac_files' / 'xcode_binaries'
-
-# The name for the hash file use to track the installation of the toolchain.
-DOWNLOADED_TOOLCHAIN_HASH = (
-    MAC_BINARIES_ROOT /
-    f'.{os.path.basename(XCODE_TOOLCHAIN_DOWNLOAD_URL).replace(".", "_")}_hash'
-)
 
 
 def _load_plist(path: Path) -> dict:
@@ -90,57 +94,21 @@ def _get_hermetic_xcode_version() -> str:
     return _load_plist(plist_path)['CFBundleShortVersionString']
 
 
-class SdkInstaller:
-    """A basic installer to handle the SDK archive.
-
-    This installer is designed to download and extract the SDK archive when
-    needed. It relies on a sidecar file to record the hash of the currently
-    installed SDK, rather than keying up the install merely by the SDK version
-    present in the destination.
-    """
-
-    def is_installed(self) -> bool:
-        """Returns True if the sidecar exists and has the expected hash.
-
-        A symlinked destination is never treated as installed, so the caller
-        always redeploys a real directory on top of it.
-        """
-        if MAC_BINARIES_ROOT.is_symlink():
-            return False
-        if not DOWNLOADED_TOOLCHAIN_HASH.is_file():
-            return False
-        return DOWNLOADED_TOOLCHAIN_HASH.read_text().rstrip(
-        ) == MAC_BINARIES_HASH
-
-    def install(self) -> bool:
-        """Downloads and extracts the SDK archive if it is not already present.
-
-        Returns True if the archive was downloaded and extracted, or False if
-        the expected hash was already in place and nothing needed to be done.
-        Also writes the expected hash to the sidecar file, which is used to
-        detect the current install. On a download failure it prints a
-        diagnostic and re-raises.
-        """
-        if self.is_installed():
-            return False
-        print(f'Downloading hermetic Xcode: {XCODE_TOOLCHAIN_DOWNLOAD_URL}')
-        try:
-            deps.DownloadAndUnpack(XCODE_TOOLCHAIN_DOWNLOAD_URL,
-                                   MAC_BINARIES_ROOT,
-                                   sha256=MAC_BINARIES_HASH)
-        except URLError:
-            print(
-                f'Failed to download hermetic Xcode: {XCODE_TOOLCHAIN_DOWNLOAD_URL}'
-            )
-            raise
-        DOWNLOADED_TOOLCHAIN_HASH.write_text(MAC_BINARIES_HASH)
-        return True
-
-
 def _install_xcode_binaries() -> int:
     """Installs the Xcode binaries needed to build Brave and accepts the
     license."""
-    SdkInstaller().install()
+    installer = TarballInstaller.for_object(
+        MAC_BINARIES_ROOT, XCODE_TOOLCHAIN_BUCKET, {
+            'object_name': XCODE_TOOLCHAIN_OBJECT,
+            'sha256sum': MAC_BINARIES_HASH,
+            'size_bytes': MAC_BINARIES_SIZE,
+        })
+    try:
+        installer.install()
+    except URLError:
+        print('Failed to download hermetic Xcode: '
+              f'{XCODE_TOOLCHAIN_DOWNLOAD_URL}')
+        raise
 
     if sys.platform != 'darwin':
         return 0

--- a/tools/cr/install_extra_deps.py
+++ b/tools/cr/install_extra_deps.py
@@ -193,12 +193,8 @@ class ExtraDepsRunner:
             return
 
         overlayed_on = obj.get('overlayed_on')
-        installer = TarballInstaller(dest_dir=_SRC_DIR.parent / path,
-                                     url=spec['bucket'] + obj['object_name'],
-                                     object_name=obj['object_name'],
-                                     sha256sum=obj['sha256sum'],
-                                     size_bytes=obj['size_bytes'],
-                                     owns_dest=not overlayed_on)
+        installer = TarballInstaller.for_object(_SRC_DIR.parent / path,
+                                                spec['bucket'], obj)
 
         # An overlay must sit on the base it was built against: validate it
         # still matches DEPS before touching the destination. No `overlayed_on`

--- a/tools/cr/tarball_installer.py
+++ b/tools/cr/tarball_installer.py
@@ -2,18 +2,17 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""`TarballInstaller`: fetch, verify, and extract one `EXTRA_DEPS` object.
+"""`TarballInstaller`: fetch, verify, and extract one bucket-hosted archive.
 
-Stdlib-only: it downloads over HTTP, verifies the size and sha256, extracts the
-archive, and writes the sidecar files that record what is deployed. Also runnable
-as a
-CLI to deploy a single-object `EXTRA_DEPS` entry into the checkout.
+This script is designed to be used with EXTRA_DEPS entries, but the object can
+also be directly provided by the caller.
 """
 
 from __future__ import annotations
 
 import argparse
 from collections.abc import Callable
+from collections.abc import Mapping
 from dataclasses import dataclass
 import hashlib
 import json
@@ -70,6 +69,20 @@ class TarballInstaller:
     owns_dest: bool
 
     @classmethod
+    def for_object(cls, dest_dir: Path, bucket: str,
+                   obj: Mapping) -> TarballInstaller:
+        """Build an installer for a single caller-provided archive object.
+
+        `obj` are expected to follow the schema format for `EXTRA_DEPS` objects.
+        """
+        return cls(dest_dir=dest_dir,
+                   url=bucket + obj['object_name'],
+                   object_name=obj['object_name'],
+                   sha256sum=obj['sha256sum'],
+                   size_bytes=obj['size_bytes'],
+                   owns_dest=not obj.get('overlayed_on'))
+
+    @classmethod
     def for_dep(cls, root: Path, path: str, spec: dict) -> TarballInstaller:
         """Build an installer for the single object of `spec` under `root`.
 
@@ -83,13 +96,7 @@ class TarballInstaller:
             raise ValueError(
                 f'{path}: only single-object entries can be installed here, '
                 f'but this one has {len(objects)}')
-        obj = objects[0]
-        return cls(dest_dir=root / path,
-                   url=spec['bucket'] + obj['object_name'],
-                   object_name=obj['object_name'],
-                   sha256sum=obj['sha256sum'],
-                   size_bytes=obj['size_bytes'],
-                   owns_dest=not obj.get('overlayed_on'))
+        return cls.for_object(root / path, spec['bucket'], objects[0])
 
     def is_installed(self) -> bool:
         """True when the `_hash` sidecar already records `sha256sum`."""
@@ -112,10 +119,16 @@ class TarballInstaller:
             with archive_path.open('wb') as archive_file:
                 download(self.url, archive_file)
             self._verify(archive_path)
-            if self.owns_dest and self.dest_dir.exists():
-                # Drop the previous extraction so nothing stale lingers;
-                # overlays deliberately keep the upstream tree they sit on.
-                shutil.rmtree(self.dest_dir)
+            if self.owns_dest and (self.dest_dir.exists()
+                                   or self.dest_dir.is_symlink()):
+                # Drop the previous extraction so nothing stale lingers. A
+                # symlinked destination is replaced by the real extracted tree
+                # (rmtree refuses a symlink). Overlays deliberately keep the
+                # upstream tree they sit on.
+                if self.dest_dir.is_symlink():
+                    self.dest_dir.unlink()
+                else:
+                    shutil.rmtree(self.dest_dir)
             member_names = self._extract(archive_path)
         self._write_sidecars(member_names)
         return True

--- a/tools/cr/tarball_installer_test.py
+++ b/tools/cr/tarball_installer_test.py
@@ -72,7 +72,7 @@ class TarballInstallerTest(unittest.TestCase):
         """A `TarballInstaller` for `data`, defaulting to its true size/sha256."""
         return m.TarballInstaller(
             dest_dir=self.dest,
-            url=f'https://downloads.invalid/{object_name}',
+            url=f'https://example.com/{object_name}',
             object_name=object_name,
             sha256sum=_sha256(data) if sha256sum is None else sha256sum,
             size_bytes=len(data) if size_bytes is None else size_bytes,
@@ -152,11 +152,22 @@ class TarballInstallerTest(unittest.TestCase):
         self.assertFalse(self.dest.exists())
         self.assertFalse(installer.is_installed())
 
+    def test_symlinked_owned_dest_is_replaced(self):
+        # A symlinked destination is unlinked and replaced with the real
+        # extracted tree (the hermetic Xcode script relies on this to overwrite
+        # a symlink to a system SDK).
+        data = _make_tar([('f', b'x')])
+        elsewhere = self.root / 'elsewhere'
+        elsewhere.mkdir()
+        self.dest.symlink_to(elsewhere)
+        self._installer(data, owns_dest=True).install(self._download(data))
+        self.assertFalse(self.dest.is_symlink())
+        self.assertTrue((self.dest / 'f').is_file())
+
     def test_download_refuses_non_https_url(self):
         installer = self._installer(_make_tar([('f', b'x')]))
         with self.assertRaisesRegex(ValueError, 'non-https'):
-            installer._download('http://downloads.invalid/pkg.tar.gz',
-                                io.BytesIO())
+            installer._download('http://example.com/pkg.tar.gz', io.BytesIO())
 
     def test_sidecar_contents(self):
         members = [('a', b'1'), ('b/c', b'2')]
@@ -201,7 +212,7 @@ class ProgressTest(unittest.TestCase):
         data = b'payload' * 5000
         out = io.BytesIO()
         inst = m.TarballInstaller(dest_dir=Path('/x'),
-                                  url='https://downloads.invalid/pkg',
+                                  url='https://example.com/pkg',
                                   object_name='pkg.tar.gz',
                                   sha256sum='a',
                                   size_bytes=len(data),
@@ -209,7 +220,7 @@ class ProgressTest(unittest.TestCase):
         err = io.StringIO()
         with mock.patch.object(m, 'urlopen', return_value=_FakeResponse(data)):
             with contextlib.redirect_stderr(err):
-                inst._download('https://downloads.invalid/pkg', out)
+                inst._download('https://example.com/pkg', out)
         self.assertEqual(out.getvalue(), data)
         self.assertTrue(err.getvalue().endswith('Done\n'))
 
@@ -232,7 +243,7 @@ class ForDepTest(unittest.TestCase):
     """Tests for the `TarballInstaller.for_dep` single-object factory."""
 
     def _spec(self, objects):
-        return {'bucket': 'https://downloads.invalid/', 'objects': objects}
+        return {'bucket': 'https://example.com/', 'objects': objects}
 
     def test_builds_single_object_installer(self):
         inst = m.TarballInstaller.for_dep(
@@ -243,7 +254,7 @@ class ForDepTest(unittest.TestCase):
                 'size_bytes': 123
             }]))
         self.assertEqual(inst.dest_dir, Path('/ws/src/p'))
-        self.assertEqual(inst.url, 'https://downloads.invalid/x.tar.gz')
+        self.assertEqual(inst.url, 'https://example.com/x.tar.gz')
         self.assertEqual(inst.object_name, 'x.tar.gz')
         self.assertEqual(inst.sha256sum, 'abc')
         self.assertEqual(inst.size_bytes, 123)
@@ -275,6 +286,34 @@ class ForDepTest(unittest.TestCase):
         ])
         with self.assertRaisesRegex(ValueError, 'single-object'):
             m.TarballInstaller.for_dep(Path('/ws'), 'src/p', spec)
+
+
+class ForObjectTest(unittest.TestCase):
+    """Tests for the `TarballInstaller.for_object` caller-supplied factory."""
+
+    def test_builds_installer_from_a_caller_object(self):
+        inst = m.TarballInstaller.for_object(Path('/dest'),
+                                             'https://example.com/', {
+                                                 'object_name': 'x.tar.gz',
+                                                 'sha256sum': 'abc',
+                                                 'size_bytes': 123,
+                                             })
+        self.assertEqual(inst.dest_dir, Path('/dest'))
+        self.assertEqual(inst.url, 'https://example.com/x.tar.gz')
+        self.assertEqual(inst.object_name, 'x.tar.gz')
+        self.assertEqual(inst.sha256sum, 'abc')
+        self.assertEqual(inst.size_bytes, 123)
+        self.assertTrue(inst.owns_dest)
+
+    def test_overlay_object_does_not_own_dest(self):
+        inst = m.TarballInstaller.for_object(
+            Path('/dest'), 'https://example.com/', {
+                'object_name': 'x.tar.gz',
+                'sha256sum': 'abc',
+                'size_bytes': 123,
+                'overlayed_on': 'base.tar.xz',
+            })
+        self.assertFalse(inst.owns_dest)
 
 
 class MainTest(unittest.TestCase):

--- a/tools/cr/toolchain.py
+++ b/tools/cr/toolchain.py
@@ -675,8 +675,9 @@ class XcodeToolchain(Toolchain):
     def _rewrite_hermetic_xcode_script(
             self, sdk_info: build_xcode_toolchain.MacSdkInfo, index: dict,
             mac_toolchain_py: str) -> bool:
-        """Pins the archive hash and SDK constants, refreshes the provenance
-        comment, and mirrors Chromium's `MAC_MINIMUM_OS_VERSION` block.
+        """Pins the archive hash, size, and SDK constants, refreshes the
+        provenance comment, and mirrors Chromium's `MAC_MINIMUM_OS_VERSION`
+        block.
 
         `mac_toolchain_py` is the upstream `build/mac_toolchain.py` source the
         minimum-OS block is lifted from.
@@ -693,6 +694,10 @@ class XcodeToolchain(Toolchain):
         content = re.sub(r"MAC_BINARIES_HASH = '[^']*'",
                          f"MAC_BINARIES_HASH = '{index['sha256sum']}'",
                          original,
+                         count=1)
+        content = re.sub(r'MAC_BINARIES_SIZE = \d+',
+                         f"MAC_BINARIES_SIZE = {index['size_bytes']}",
+                         content,
                          count=1)
         content = re.sub(r"MAC_SDK_OFFICIAL_VERSION = '[^']*'",
                          f"MAC_SDK_OFFICIAL_VERSION = '{sdk_version}'",

--- a/tools/cr/toolchain_test.py
+++ b/tools/cr/toolchain_test.py
@@ -57,11 +57,13 @@ NEW_ENTRY = {
             {
                 'object_name': 'linux-x64-rust-toolchain-2.tar.xz',
                 'sha256sum': 'newlinuxsha',
+                'size_bytes': 111,
                 'condition': 'host_os == "linux"',
             },
             {
                 'object_name': 'win-rust-toolchain-2.tar.xz',
                 'sha256sum': 'newwinsha',
+                'size_bytes': 222,
                 'condition': 'host_os == "win"',
             },
         ],
@@ -193,6 +195,7 @@ FAKE_INDEX = {
     'url': ('https://example.invalid/xcode-hermetic-toolchain/'
             'xcode-hermetic-toolchain-26.5-25F70.tar.gz'),
     'sha256sum': 'b' * 64,
+    'size_bytes': 883762569,
     'xcode_version': '26.5',
     'xcode_build': '17F42',
     'metal_build': '17E188',
@@ -425,6 +428,7 @@ HERMETIC_XCODE_SCRIPT_INITIAL = """\
 # Sample header.
 
 MAC_BINARIES_HASH = 'oldhash'
+MAC_BINARIES_SIZE = 999
 
 # This contains binaries from Xcode 26.4 (17E202) along with the macOS 26.4 SDK
 # (25E251) and the Metal toolchain (17E150).
@@ -521,9 +525,12 @@ class XcodeRepinTest(_FakeRepoTest):
         script = self._read_hermetic_xcode_script()
         self.assertIn(f"MAC_BINARIES_HASH = '{FAKE_INDEX['sha256sum']}'",
                       script)
+        self.assertIn(f"MAC_BINARIES_SIZE = {FAKE_INDEX['size_bytes']}",
+                      script)
         self.assertIn("MAC_SDK_OFFICIAL_VERSION = '26.5'", script)
         self.assertIn("MAC_SDK_OFFICIAL_BUILD_VERSION = '25F70'", script)
         self.assertNotIn("'oldhash'", script)
+        self.assertNotIn('MAC_BINARIES_SIZE = 999', script)
         sdk_info = toolchain.build_xcode_toolchain.MacSdkInfo(
             sdk_version='26.5', product_build_version='25F70')
         self.assertIn(

--- a/tools/cr/toolchains/build_rust_toolchain.py
+++ b/tools/cr/toolchains/build_rust_toolchain.py
@@ -278,12 +278,13 @@ if sys.platform == 'win32':
 
 
 def _latest_index_object(index_url: str,
-                         expected_stem: str) -> tuple[str, str]:
+                         expected_stem: str) -> tuple[str, str, int]:
     """Download a platform's YAML index and return its latest archive.
 
     The index lists builds in chronological order, so the last element is the
     most recent archive for that platform + revision. Returns
-    `(object_name, sha256sum)`, where `object_name` is the archive's basename.
+    `(object_name, sha256sum, size_bytes)`, where `object_name` is the
+    archive's basename.
 
     `expected_stem` is the `<platform>-<upstream-stem>` the archive name must
     start with. A mismatch means the index was fetched from the wrong key or is
@@ -300,16 +301,17 @@ def _latest_index_object(index_url: str,
         raise RuntimeError(f'Published toolchain index is empty: {index_url}')
     latest = entries[-1]
     if (not isinstance(latest, dict) or 'url' not in latest
-            or 'sha256sum' not in latest):
+            or 'sha256sum' not in latest or 'size_bytes' not in latest):
         raise RuntimeError(
             f'Malformed entry in toolchain index {index_url}: expected a '
-            f'mapping with "url" and "sha256sum", got {latest!r}')
+            f'mapping with "url", "sha256sum", and "size_bytes", got '
+            f'{latest!r}')
     object_name = latest['url'].rsplit('/', 1)[-1]
     if not object_name.startswith(f'{expected_stem}-'):
         raise RuntimeError(
             f'Toolchain index {index_url} yielded {object_name!r}, which does '
             f'not start with the expected {expected_stem!r} stem.')
-    return object_name, latest['sha256sum']
+    return object_name, latest['sha256sum'], latest['size_bytes']
 
 
 def rust_toolchain_extra_dep(upstream_stem: str) -> dict[str, dict]:
@@ -324,7 +326,7 @@ def rust_toolchain_extra_dep(upstream_stem: str) -> dict[str, dict]:
             'bucket': '<bucket>/',
             'condition': 'not rust_force_head_revision',
             'objects': [
-              {'object_name': ..., 'sha256sum': ...,
+              {'object_name': ..., 'sha256sum': ..., 'size_bytes': ...,
                'overlayed_on': ..., 'condition': ...},
               ...
             ],
@@ -346,11 +348,13 @@ def rust_toolchain_extra_dep(upstream_stem: str) -> dict[str, dict]:
     for platform_prefix, condition in SUPPORTED_PLATFORM_CONDITIONS.items():
         stem = f'{platform_prefix}-{upstream_stem}'
         index_url = f'{TOOLCHAIN_BUCKET_URL}/{stem}.yaml'
-        object_name, sha256sum = _latest_index_object(index_url, stem)
+        object_name, sha256sum, size_bytes = _latest_index_object(
+            index_url, stem)
         host_os = PLATFORM_PREFIX_TO_CHROMIUM_HOST_OS[platform_prefix]
         objects.append({
             'object_name': object_name,
             'sha256sum': sha256sum,
+            'size_bytes': size_bytes,
             # Upstream Chromium-built Rust toolchain this archive overlays; see
             # `sync_deps.GetRustObjectNames` for the matching naming scheme.
             'overlayed_on': f'{host_os}/{upstream_stem}.tar.xz',
@@ -830,6 +834,7 @@ class ToolchainBuilder:
           * `url`              — full bucket URL the tarball will be served at.
           * `timestamp`        — ISO 8601 UTC time of this build.
           * `sha256sum`        — hex SHA-256 of the tarball bytes.
+          * `size_bytes`       — exact size of the tarball in bytes.
           * `chromium_version` — `MAJOR.MINOR.BUILD.PATCH` parsed from
                                  `chrome/VERSION`.
           * `chromium_commit`  — HEAD commit hash in the Chromium checkout.
@@ -942,6 +947,7 @@ class ToolchainBuilder:
             'url': archive_url,
             'timestamp': datetime.now(timezone.utc).isoformat(),
             'sha256sum': archive_sha256,
+            'size_bytes': archive_path.stat().st_size,
             'chromium_version': self._chromium_version(),
             'chromium_commit': self._chromium_commit(),
             'command_line': self._command_line(),

--- a/tools/cr/toolchains/build_xcode_toolchain.py
+++ b/tools/cr/toolchains/build_xcode_toolchain.py
@@ -281,8 +281,8 @@ def fetch_published_index(sdk_info: MacSdkInfo) -> dict:
 
     Resolves the sibling YAML index for `sdk_info` on the public download
     bucket, parses it, and returns it verbatim -- the mapping `_write_index`
-    published (`url`, `sha256sum`, `xcode_version`, `xcode_build`,
-    `metal_build`, ...). This is the entry point brockit's
+    published (`url`, `sha256sum`, `size_bytes`, `xcode_version`,
+    `xcode_build`, `metal_build`, ...). This is the entry point brockit's
     `update-xcode-toolchain` consumes, mirroring how
     `build_rust_toolchain.rust_toolchain_extra_dep` serves the Rust toolchain.
 
@@ -593,6 +593,7 @@ class ToolchainBuilder:
 
           * `url`              — bucket URL the toolchain archive is served on.
           * `sha256sum`        — hex SHA-256 of the archive bytes.
+          * `size_bytes`       — exact size of the archive in bytes.
           * `xcode_xip_source_url` — Apple `.xip` URL from xcodereleases.com
                                  the toolchain was built from.
           * `xcode_xip_sha1sum` — SHA-1 of that `.xip` (from xcodereleases.com,
@@ -617,6 +618,7 @@ class ToolchainBuilder:
         index = {
             'url': PACKAGE_DOWNLOAD_URL_BASE + archive_path.name,
             'sha256sum': sha256_file(archive_path),
+            'size_bytes': archive_path.stat().st_size,
             'xcode_xip_source_url': xcode_release.download_url,
             'xcode_xip_sha1sum': xcode_release.sha1,
             'xcode_version': xcode_release.version,


### PR DESCRIPTION
This change unifies the mechanims to download all toolchains to go
through `tarball_installer.py`. This guarantees that all of them use the
same validation policies.

Bug: https://github.com/brave/brave-browser/issues/56723
