### PR TITLE
[Sync] [AI Chat] (6 of n) Track local AI Chat changes and emit them to sync

### DIFF
--- a/components/ai_chat/core/browser/ai_chat_database.cc
+++ b/components/ai_chat/core/browser/ai_chat_database.cc
@@ -1568,16 +1568,43 @@ bool AIChatDatabase::DeleteAllData() {
   return LazyInit(true);
 }
 
-bool AIChatDatabase::DeleteAssociatedWebContent(
-    std::optional<base::Time> begin_time,
-    std::optional<base::Time> end_time) {
+std::optional<std::vector<ClearedAssociatedContentEntry>>
+AIChatDatabase::DeleteAssociatedWebContent(std::optional<base::Time> begin_time,
+                                           std::optional<base::Time> end_time) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   if (!LazyInit()) {
-    return false;
+    return std::nullopt;
   }
   DVLOG(4) << "Deleting associated web content for time range "
            << begin_time.value_or(base::Time()) << " to "
            << end_time.value_or(base::Time::Max());
+
+  // Collect the entries whose associated content is about to be cleared (only
+  // rows that actually still hold content), so the caller can propagate the
+  // change. This must run before the UPDATE below.
+  std::vector<ClearedAssociatedContentEntry> cleared;
+  static constexpr char kSelectQuery[] =
+      "SELECT conversation_uuid, conversation_entry_uuid"
+      " FROM associated_content"
+      " WHERE (url IS NOT NULL OR title IS NOT NULL OR last_contents IS NOT "
+      "NULL)"
+      "  AND conversation_uuid IN ("
+      "   SELECT conversation_uuid"
+      "   FROM conversation_entry"
+      "   WHERE date >= ? AND date <= ?)";
+  sql::Statement select_statement(GetDB().GetUniqueStatement(kSelectQuery));
+  CHECK(select_statement.is_valid());
+  select_statement.BindTime(0, begin_time.value_or(base::Time()));
+  select_statement.BindTime(1, end_time.value_or(base::Time::Max()));
+  while (select_statement.Step()) {
+    cleared.emplace_back(select_statement.ColumnString(0),
+                         select_statement.ColumnString(1));
+  }
+  if (!select_statement.Succeeded()) {
+    DVLOG(0) << "Failed to read affected rows for DeleteAssociatedWebContent: "
+             << db_.GetErrorMessage();
+    return std::nullopt;
+  }
 
   // Set any associated content url, title and content to NULL where
   // conversation had any entry between begin_time and end_time.
@@ -1596,9 +1623,9 @@ bool AIChatDatabase::DeleteAssociatedWebContent(
     DVLOG(0) << "Failed to execute 'associated_content' update statement for "
                 "DeleteAssociatedWebContent: "
              << db_.GetErrorMessage();
-    return false;
+    return std::nullopt;
   }
-  return true;
+  return cleared;
 }
 
 sql::Database& AIChatDatabase::GetDB() {

--- a/components/ai_chat/core/browser/ai_chat_database.h
+++ b/components/ai_chat/core/browser/ai_chat_database.h
@@ -30,6 +30,14 @@ extern const int kLowestSupportedDatabaseVersion;
 extern const int kCompatibleDatabaseVersionNumber;
 extern const int kCurrentDatabaseVersion;
 
+// Identifies a conversation entry whose associated web content was cleared by
+// DeleteAssociatedWebContent(), so callers can propagate the change (e.g.
+// re-sync the affected entries).
+struct ClearedAssociatedContentEntry {
+  std::string conversation_uuid;
+  std::string entry_uuid;
+};
+
 // Persists AI Chat conversations and associated content. Conversations are
 // mainly formed of their conversation entries. Edits to conversation entries
 // should be handled with removal and re-adding so that other classes can make
@@ -96,8 +104,13 @@ class AIChatDatabase : public syncer::SyncMetadataStore {
   // Drops all data and tables in the database, and re-creates empty tables
   virtual bool DeleteAllData();
 
-  virtual bool DeleteAssociatedWebContent(std::optional<base::Time> begin_time,
-                                          std::optional<base::Time> end_time);
+  // Clears (sets to NULL) the url/title/last_contents of associated content for
+  // every conversation that has an entry dated within [begin_time, end_time].
+  // Returns the entries whose content was actually cleared, so callers can
+  // propagate the change; returns std::nullopt if the operation failed.
+  virtual std::optional<std::vector<ClearedAssociatedContentEntry>>
+  DeleteAssociatedWebContent(std::optional<base::Time> begin_time,
+                             std::optional<base::Time> end_time);
 
   // Reads all sync metadata (entity metadata + data type state) into the batch.
   bool GetAllSyncMetadata(syncer::MetadataBatch* metadata_batch);

--- a/components/ai_chat/core/browser/ai_chat_database_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_database_unittest.cc
@@ -981,7 +981,8 @@ TEST_P(AIChatDatabaseTest, AddOrUpdateAssociatedContent_MultiContent) {
 
   // Delete the associated content
   EXPECT_TRUE(db_->DeleteAssociatedWebContent(
-      base::Time::Now() - base::Hours(3), std::nullopt));
+                     base::Time::Now() - base::Hours(3), std::nullopt)
+                  .has_value());
 
   // Verify the associated content is deleted
   result = db_->GetConversationData(uuid);
@@ -1084,8 +1085,14 @@ TEST_P(AIChatDatabaseTest, DeleteAssociatedWebContent) {
             expected_contents[0]);
 
   // Delete associated content to only consider the second conversation
-  EXPECT_TRUE(db_->DeleteAssociatedWebContent(
-      base::Time::Now() + base::Minutes(-61), std::nullopt));
+  auto cleared = db_->DeleteAssociatedWebContent(
+      base::Time::Now() + base::Minutes(-61), std::nullopt);
+  // Only the second conversation's entry was in range, so only its associated
+  // content is reported as cleared.
+  ASSERT_TRUE(cleared.has_value());
+  ASSERT_EQ(cleared->size(), 1u);
+  EXPECT_EQ((*cleared)[0].conversation_uuid, "second");
+  EXPECT_EQ((*cleared)[0].entry_uuid, history_second.front()->uuid.value());
 
   // Verify only url, title and content was deleted and only from the second
   // conversation

--- a/components/ai_chat/core/browser/ai_chat_service.cc
+++ b/components/ai_chat/core/browser/ai_chat_service.cc
@@ -812,6 +812,14 @@ void AIChatService::DeleteConversation(const std::string& id) {
   OnConversationListChanged();
   // Update database
   if (ai_chat_db_ && !temporary) {
+    // Notify the sync bridge BEFORE the DB delete so it can enumerate the
+    // conversation's entries (still present in the DB) and emit deletes for
+    // each entry sync record. Both tasks run on db_task_runner_ in order.
+    if (sync_backend_ && db_task_runner_) {
+      db_task_runner_->PostTask(
+          FROM_HERE, base::BindOnce(&AIChatSyncBackend::OnConversationDeleted,
+                                    sync_backend_, id));
+    }
     ai_chat_db_
         .AsyncCall(base::IgnoreResult(&AIChatDatabase::DeleteConversation))
         .WithArgs(id);
@@ -1097,6 +1105,17 @@ void AIChatService::HandleFirstEntry(
     ai_chat_db_.AsyncCall(base::IgnoreResult(&AIChatDatabase::AddConversation))
         .WithArgs(conversation->Clone(), std::move(associated_content),
                   entry->Clone());
+    // Notify the sync bridge of the new conversation and its first entry as
+    // separate sync records.
+    if (sync_backend_ && db_task_runner_) {
+      db_task_runner_->PostTask(
+          FROM_HERE, base::BindOnce(&AIChatSyncBackend::OnConversationAdded,
+                                    sync_backend_, conversation->uuid));
+      db_task_runner_->PostTask(
+          FROM_HERE,
+          base::BindOnce(&AIChatSyncBackend::OnConversationEntryAdded,
+                         sync_backend_, conversation->uuid, *entry->uuid));
+    }
   }
   // Record metrics
   if (ai_chat_metrics_ != nullptr) {
@@ -1138,6 +1157,19 @@ void AIChatService::HandleNewEntry(
                     CloneAssociatedContent(conversation->associated_content),
                     std::move(maybe_associated_content.value()));
     }
+    // Notify the sync bridge that a new entry exists and that conversation
+    // metadata (model_key, last_modified time) may have changed.
+    if (sync_backend_ && db_task_runner_) {
+      db_task_runner_->PostTask(
+          FROM_HERE,
+          base::BindOnce(&AIChatSyncBackend::OnConversationEntryAdded,
+                         sync_backend_, handler->get_conversation_uuid(),
+                         *entry->uuid));
+      db_task_runner_->PostTask(
+          FROM_HERE,
+          base::BindOnce(&AIChatSyncBackend::OnConversationModified,
+                         sync_backend_, handler->get_conversation_uuid()));
+    }
   }
 
   // Record metrics
@@ -1154,6 +1186,12 @@ void AIChatService::OnConversationEntryRemoved(ConversationHandler* handler,
     ai_chat_db_
         .AsyncCall(base::IgnoreResult(&AIChatDatabase::DeleteConversationEntry))
         .WithArgs(entry_uuid);
+    if (sync_backend_ && db_task_runner_) {
+      db_task_runner_->PostTask(
+          FROM_HERE,
+          base::BindOnce(&AIChatSyncBackend::OnConversationEntryDeleted,
+                         sync_backend_, entry_uuid));
+    }
   }
 }
 
@@ -1166,6 +1204,13 @@ void AIChatService::OnToolUseEventOutput(ConversationHandler* handler,
     ai_chat_db_
         .AsyncCall(base::IgnoreResult(&AIChatDatabase::UpdateToolUseEvent))
         .WithArgs(entry_uuid, event_order, std::move(tool_use));
+    if (sync_backend_ && db_task_runner_) {
+      db_task_runner_->PostTask(
+          FROM_HERE,
+          base::BindOnce(&AIChatSyncBackend::OnConversationEntryModified,
+                         sync_backend_, handler->get_conversation_uuid(),
+                         std::string(entry_uuid)));
+    }
   }
 }
 
@@ -1198,6 +1243,11 @@ void AIChatService::OnConversationTitleChanged(
     ai_chat_db_
         .AsyncCall(base::IgnoreResult(&AIChatDatabase::UpdateConversationTitle))
         .WithArgs(conversation_uuid, new_title);
+    if (sync_backend_ && db_task_runner_) {
+      db_task_runner_->PostTask(
+          FROM_HERE, base::BindOnce(&AIChatSyncBackend::OnConversationModified,
+                                    sync_backend_, conversation_uuid));
+    }
   }
 }
 

--- a/components/ai_chat/core/browser/ai_chat_service.cc
+++ b/components/ai_chat/core/browser/ai_chat_service.cc
@@ -790,19 +790,15 @@ void AIChatService::GetPremiumStatus(
 }
 
 void AIChatService::DeleteConversation(const std::string& id) {
-  auto handler_it = conversation_handlers_.find(id);
-  if (handler_it != conversation_handlers_.end()) {
-    conversation_observations_.RemoveObservation(handler_it->second.get());
-    conversation_handlers_.erase(id);
+  if (auto node = conversation_handlers_.extract(id)) {
+    conversation_observations_.RemoveObservation(node.mapped().get());
     if (ai_chat_metrics_) {
       ai_chat_metrics_->RecordConversationUnload(id);
     }
   }
   bool temporary = false;
-  auto conversation_it = conversations_.find(id);
-  if (conversation_it != conversations_.end()) {
-    temporary = (*conversation_it).second->temporary;
-    conversations_.erase(conversation_it);
+  if (auto node = conversations_.extract(id)) {
+    temporary = node.mapped()->temporary;
   }
   DVLOG(1) << "Erased conversation due to deletion request (" << id
            << "). Now have " << conversations_.size()
@@ -815,10 +811,11 @@ void AIChatService::DeleteConversation(const std::string& id) {
     // Notify the sync bridge BEFORE the DB delete so it can enumerate the
     // conversation's entries (still present in the DB) and emit deletes for
     // each entry sync record. Both tasks run on db_task_runner_ in order.
-    if (sync_backend_ && db_task_runner_) {
-      db_task_runner_->PostTask(
-          FROM_HERE, base::BindOnce(&AIChatSyncBackend::OnConversationDeleted,
-                                    sync_backend_, id));
+    if (sync_backend_) {
+      CHECK_DEREF(db_task_runner_)
+          .PostTask(FROM_HERE,
+                    base::BindOnce(&AIChatSyncBackend::OnConversationDeleted,
+                                   sync_backend_, id));
     }
     ai_chat_db_
         .AsyncCall(base::IgnoreResult(&AIChatDatabase::DeleteConversation))
@@ -1094,27 +1091,25 @@ void AIChatService::HandleFirstEntry(
            << " being persisted for first time.";
   CHECK(entry->uuid.has_value());
 
-  std::vector<std::string> associated_content;
-  if (maybe_associated_content.has_value()) {
-    associated_content = std::move(maybe_associated_content.value());
-  }
-
   // We can persist the conversation metadata for the first time as well as the
   // entry.
   if (ai_chat_db_ && !conversation->temporary) {
     ai_chat_db_.AsyncCall(base::IgnoreResult(&AIChatDatabase::AddConversation))
-        .WithArgs(conversation->Clone(), std::move(associated_content),
+        .WithArgs(conversation->Clone(),
+                  std::move(maybe_associated_content).value_or({}),
                   entry->Clone());
     // Notify the sync bridge of the new conversation and its first entry as
     // separate sync records.
-    if (sync_backend_ && db_task_runner_) {
-      db_task_runner_->PostTask(
-          FROM_HERE, base::BindOnce(&AIChatSyncBackend::OnConversationAdded,
-                                    sync_backend_, conversation->uuid));
-      db_task_runner_->PostTask(
-          FROM_HERE,
-          base::BindOnce(&AIChatSyncBackend::OnConversationEntryAdded,
-                         sync_backend_, conversation->uuid, *entry->uuid));
+    if (sync_backend_) {
+      CHECK_DEREF(db_task_runner_)
+          .PostTask(FROM_HERE,
+                    base::BindOnce(&AIChatSyncBackend::OnConversationAdded,
+                                   sync_backend_, conversation->uuid));
+      CHECK_DEREF(db_task_runner_)
+          .PostTask(
+              FROM_HERE,
+              base::BindOnce(&AIChatSyncBackend::OnConversationEntryAdded,
+                             sync_backend_, conversation->uuid, *entry->uuid));
     }
   }
   // Record metrics
@@ -1159,16 +1154,18 @@ void AIChatService::HandleNewEntry(
     }
     // Notify the sync bridge that a new entry exists and that conversation
     // metadata (model_key, last_modified time) may have changed.
-    if (sync_backend_ && db_task_runner_) {
-      db_task_runner_->PostTask(
-          FROM_HERE,
-          base::BindOnce(&AIChatSyncBackend::OnConversationEntryAdded,
-                         sync_backend_, handler->get_conversation_uuid(),
-                         *entry->uuid));
-      db_task_runner_->PostTask(
-          FROM_HERE,
-          base::BindOnce(&AIChatSyncBackend::OnConversationModified,
-                         sync_backend_, handler->get_conversation_uuid()));
+    if (sync_backend_) {
+      CHECK_DEREF(db_task_runner_)
+          .PostTask(
+              FROM_HERE,
+              base::BindOnce(&AIChatSyncBackend::OnConversationEntryAdded,
+                             sync_backend_, handler->get_conversation_uuid(),
+                             *entry->uuid));
+      CHECK_DEREF(db_task_runner_)
+          .PostTask(
+              FROM_HERE,
+              base::BindOnce(&AIChatSyncBackend::OnConversationModified,
+                             sync_backend_, handler->get_conversation_uuid()));
     }
   }
 
@@ -1186,11 +1183,12 @@ void AIChatService::OnConversationEntryRemoved(ConversationHandler* handler,
     ai_chat_db_
         .AsyncCall(base::IgnoreResult(&AIChatDatabase::DeleteConversationEntry))
         .WithArgs(entry_uuid);
-    if (sync_backend_ && db_task_runner_) {
-      db_task_runner_->PostTask(
-          FROM_HERE,
-          base::BindOnce(&AIChatSyncBackend::OnConversationEntryDeleted,
-                         sync_backend_, entry_uuid));
+    if (sync_backend_) {
+      CHECK_DEREF(db_task_runner_)
+          .PostTask(
+              FROM_HERE,
+              base::BindOnce(&AIChatSyncBackend::OnConversationEntryDeleted,
+                             sync_backend_, entry_uuid));
     }
   }
 }
@@ -1204,12 +1202,13 @@ void AIChatService::OnToolUseEventOutput(ConversationHandler* handler,
     ai_chat_db_
         .AsyncCall(base::IgnoreResult(&AIChatDatabase::UpdateToolUseEvent))
         .WithArgs(entry_uuid, event_order, std::move(tool_use));
-    if (sync_backend_ && db_task_runner_) {
-      db_task_runner_->PostTask(
-          FROM_HERE,
-          base::BindOnce(&AIChatSyncBackend::OnConversationEntryModified,
-                         sync_backend_, handler->get_conversation_uuid(),
-                         std::string(entry_uuid)));
+    if (sync_backend_) {
+      CHECK_DEREF(db_task_runner_)
+          .PostTask(
+              FROM_HERE,
+              base::BindOnce(&AIChatSyncBackend::OnConversationEntryModified,
+                             sync_backend_, handler->get_conversation_uuid(),
+                             entry_uuid));
     }
   }
 }
@@ -1243,10 +1242,11 @@ void AIChatService::OnConversationTitleChanged(
     ai_chat_db_
         .AsyncCall(base::IgnoreResult(&AIChatDatabase::UpdateConversationTitle))
         .WithArgs(conversation_uuid, new_title);
-    if (sync_backend_ && db_task_runner_) {
-      db_task_runner_->PostTask(
-          FROM_HERE, base::BindOnce(&AIChatSyncBackend::OnConversationModified,
-                                    sync_backend_, conversation_uuid));
+    if (sync_backend_) {
+      CHECK_DEREF(db_task_runner_)
+          .PostTask(FROM_HERE,
+                    base::BindOnce(&AIChatSyncBackend::OnConversationModified,
+                                   sync_backend_, conversation_uuid));
     }
   }
 }

--- a/components/ai_chat/core/browser/ai_chat_service.cc
+++ b/components/ai_chat/core/browser/ai_chat_service.cc
@@ -470,10 +470,32 @@ void AIChatService::DeleteAssociatedWebContent(
 
   ai_chat_db_.AsyncCall(&AIChatDatabase::DeleteAssociatedWebContent)
       .WithArgs(begin_time, end_time)
-      .Then(std::move(callback));
+      .Then(base::BindOnce(&AIChatService::OnAssociatedWebContentDeleted,
+                           weak_ptr_factory_.GetWeakPtr(),
+                           std::move(callback)));
 
   // Update local data
   ReloadConversations();
+}
+
+void AIChatService::OnAssociatedWebContentDeleted(
+    base::OnceCallback<void(bool)> callback,
+    std::optional<std::vector<ClearedAssociatedContentEntry>> cleared) {
+  // Notify the sync bridge that each affected entry changed so the cleared
+  // associated content propagates. This runs from the delete's reply, i.e.
+  // after the delete completed, so the bridge re-reads the now-cleared content
+  // when it rebuilds each entry's specifics.
+  if (cleared && sync_backend_) {
+    for (const auto& entry : *cleared) {
+      CHECK_DEREF(db_task_runner_)
+          .PostTask(
+              FROM_HERE,
+              base::BindOnce(&AIChatSyncBackend::OnConversationEntryModified,
+                             sync_backend_, entry.conversation_uuid,
+                             entry.entry_uuid));
+    }
+  }
+  std::move(callback).Run(cleared.has_value());
 }
 
 void AIChatService::MaybeInitStorage() {

--- a/components/ai_chat/core/browser/ai_chat_service.h
+++ b/components/ai_chat/core/browser/ai_chat_service.h
@@ -299,6 +299,12 @@ class AIChatService : public KeyedService,
       base::OnceCallback<void(ConversationHandler*)> callback,
       mojom::ConversationArchivePtr data);
 
+  // Reply for DeleteAssociatedWebContent(): emits a sync change for each entry
+  // whose associated content was cleared, then runs |callback| with success.
+  void OnAssociatedWebContentDeleted(
+      base::OnceCallback<void(bool)> callback,
+      std::optional<std::vector<ClearedAssociatedContentEntry>> cleared);
+
   // Completes ShareConversation once the sharing server has returned the viewer
   // URL: appends |key_fragment| to build the full shareable link, optionally
   // copies it to the clipboard as confidential, and returns it via |callback|.

--- a/components/ai_chat/core/browser/ai_chat_service_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_service_unittest.cc
@@ -228,7 +228,7 @@ class MockAIChatDatabase : public AIChatDatabase {
   MOCK_METHOD(bool, DeleteConversationEntry, (std::string_view), (override));
   MOCK_METHOD(bool, DeleteConversation, (std::string_view), (override));
   MOCK_METHOD(bool, DeleteAllData, (), (override));
-  MOCK_METHOD(bool,
+  MOCK_METHOD((std::optional<std::vector<ClearedAssociatedContentEntry>>),
               DeleteAssociatedWebContent,
               (std::optional<base::Time>, std::optional<base::Time>),
               (override));

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_backend.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_backend.cc
@@ -58,4 +58,51 @@ void AIChatSyncBackend::Shutdown() {
   bridge_.reset();
 }
 
+void AIChatSyncBackend::OnConversationAdded(const std::string& uuid) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (bridge_) {
+    bridge_->OnConversationAdded(uuid);
+  }
+}
+
+void AIChatSyncBackend::OnConversationModified(const std::string& uuid) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (bridge_) {
+    bridge_->OnConversationModified(uuid);
+  }
+}
+
+void AIChatSyncBackend::OnConversationDeleted(const std::string& uuid) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (bridge_) {
+    bridge_->OnConversationDeleted(uuid);
+  }
+}
+
+void AIChatSyncBackend::OnConversationEntryAdded(
+    const std::string& conversation_uuid,
+    const std::string& entry_uuid) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (bridge_) {
+    bridge_->OnConversationEntryAdded(conversation_uuid, entry_uuid);
+  }
+}
+
+void AIChatSyncBackend::OnConversationEntryModified(
+    const std::string& conversation_uuid,
+    const std::string& entry_uuid) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (bridge_) {
+    bridge_->OnConversationEntryModified(conversation_uuid, entry_uuid);
+  }
+}
+
+void AIChatSyncBackend::OnConversationEntryDeleted(
+    const std::string& entry_uuid) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (bridge_) {
+    bridge_->OnConversationEntryDeleted(entry_uuid);
+  }
+}
+
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_backend.h
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_backend.h
@@ -7,6 +7,7 @@
 #define BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_SYNC_AI_CHAT_SYNC_BACKEND_H_
 
 #include <memory>
+#include <string>
 
 #include "base/memory/ref_counted_delete_on_sequence.h"
 #include "base/memory/weak_ptr.h"
@@ -68,6 +69,17 @@ class AIChatSyncBackend
   // the sync engine holds; GetControllerDelegate() returns null after this
   // point.
   void Shutdown();
+
+  // Outbound local-change notifications, forwarded to the bridge on the owning
+  // sequence. Each call is a no-op once Shutdown() has released the bridge.
+  void OnConversationAdded(const std::string& uuid);
+  void OnConversationModified(const std::string& uuid);
+  void OnConversationDeleted(const std::string& uuid);
+  void OnConversationEntryAdded(const std::string& conversation_uuid,
+                                const std::string& entry_uuid);
+  void OnConversationEntryModified(const std::string& conversation_uuid,
+                                   const std::string& entry_uuid);
+  void OnConversationEntryDeleted(const std::string& entry_uuid);
 
  private:
   friend class base::RefCountedDeleteOnSequence<AIChatSyncBackend>;

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_bridge.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_bridge.cc
@@ -17,6 +17,7 @@
 #include "brave/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/sync/protocol/ai_chat_specifics.pb.h"
+#include "components/sync/base/deletion_origin.h"
 #include "components/sync/model/data_type_local_change_processor.h"
 #include "components/sync/model/metadata_batch.h"
 #include "components/sync/model/model_error.h"
@@ -322,6 +323,115 @@ void AIChatSyncBridge::ApplyDisableSyncChanges(
   }
   database_->ClearAllEntityMetadata();
   database_->ClearDataTypeState(syncer::AI_CHAT_CONVERSATION);
+}
+
+void AIChatSyncBridge::OnConversationAdded(const std::string& uuid) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (!this->change_processor()->IsTrackingMetadata()) {
+    return;
+  }
+  PutConversationMetadata(uuid);
+}
+
+void AIChatSyncBridge::OnConversationModified(const std::string& uuid) {
+  OnConversationAdded(uuid);
+}
+
+void AIChatSyncBridge::OnConversationDeleted(const std::string& uuid) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (!database_ || !this->change_processor()->IsTrackingMetadata()) {
+    return;
+  }
+  auto metadata_change_list = CreateMetadataChangeList();
+
+  // Emit a Delete for every entry of the conversation BEFORE deleting the
+  // conversation itself. This must run while the entries still exist in the
+  // database.
+  if (auto archive = database_->GetConversationData(uuid)) {
+    for (const auto& entry : archive->entries) {
+      if (!entry->uuid) {
+        continue;
+      }
+      this->change_processor()->Delete(
+          base::StrCat({kEntryStorageKeyPrefix, *entry->uuid}),
+          syncer::DeletionOrigin::Unspecified(), metadata_change_list.get());
+    }
+  }
+
+  this->change_processor()->Delete(
+      base::StrCat({kConversationStorageKeyPrefix, uuid}),
+      syncer::DeletionOrigin::Unspecified(), metadata_change_list.get());
+}
+
+void AIChatSyncBridge::OnConversationEntryAdded(
+    const std::string& conversation_uuid,
+    const std::string& entry_uuid) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (!this->change_processor()->IsTrackingMetadata()) {
+    return;
+  }
+  PutEntry(conversation_uuid, entry_uuid);
+}
+
+void AIChatSyncBridge::OnConversationEntryModified(
+    const std::string& conversation_uuid,
+    const std::string& entry_uuid) {
+  OnConversationEntryAdded(conversation_uuid, entry_uuid);
+}
+
+void AIChatSyncBridge::OnConversationEntryDeleted(
+    const std::string& entry_uuid) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (!this->change_processor()->IsTrackingMetadata()) {
+    return;
+  }
+  auto metadata_change_list = CreateMetadataChangeList();
+  this->change_processor()->Delete(
+      base::StrCat({kEntryStorageKeyPrefix, entry_uuid}),
+      syncer::DeletionOrigin::Unspecified(), metadata_change_list.get());
+}
+
+void AIChatSyncBridge::PutConversationMetadata(const std::string& uuid) {
+  if (!database_) {
+    return;
+  }
+  auto conversation = FindSyncableConversation(*database_, uuid);
+  if (!conversation) {
+    return;
+  }
+  auto specifics = ConversationMetadataToSpecifics(*conversation);
+  auto metadata_change_list = CreateMetadataChangeList();
+  this->change_processor()->Put(
+      base::StrCat({kConversationStorageKeyPrefix, uuid}),
+      CreateEntityDataFromSpecifics(specifics), metadata_change_list.get());
+}
+
+void AIChatSyncBridge::PutEntry(const std::string& conversation_uuid,
+                                const std::string& entry_uuid) {
+  if (!database_) {
+    return;
+  }
+  auto conversation = FindSyncableConversation(*database_, conversation_uuid);
+  if (!conversation) {
+    return;
+  }
+  auto archive = database_->GetConversationData(conversation_uuid);
+  if (!archive) {
+    return;
+  }
+  auto it = std::ranges::find_if(
+      archive->entries, [&](const mojom::ConversationTurnPtr& entry) {
+        return entry->uuid && *entry->uuid == entry_uuid;
+      });
+  if (it == archive->entries.end()) {
+    return;
+  }
+  auto specifics = EntryToSpecifics(conversation_uuid, **it,
+                                    conversation->associated_content);
+  auto metadata_change_list = CreateMetadataChangeList();
+  this->change_processor()->Put(
+      base::StrCat({kEntryStorageKeyPrefix, entry_uuid}),
+      CreateEntityDataFromSpecifics(specifics), metadata_change_list.get());
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_bridge.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_bridge.cc
@@ -327,7 +327,7 @@ void AIChatSyncBridge::ApplyDisableSyncChanges(
 
 void AIChatSyncBridge::OnConversationAdded(const std::string& uuid) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (!this->change_processor()->IsTrackingMetadata()) {
+  if (!change_processor()->IsTrackingMetadata()) {
     return;
   }
   PutConversationMetadata(uuid);
@@ -339,7 +339,7 @@ void AIChatSyncBridge::OnConversationModified(const std::string& uuid) {
 
 void AIChatSyncBridge::OnConversationDeleted(const std::string& uuid) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (!database_ || !this->change_processor()->IsTrackingMetadata()) {
+  if (!database_ || !change_processor()->IsTrackingMetadata()) {
     return;
   }
   auto metadata_change_list = CreateMetadataChangeList();
@@ -352,13 +352,13 @@ void AIChatSyncBridge::OnConversationDeleted(const std::string& uuid) {
       if (!entry->uuid) {
         continue;
       }
-      this->change_processor()->Delete(
+      change_processor()->Delete(
           base::StrCat({kEntryStorageKeyPrefix, *entry->uuid}),
           syncer::DeletionOrigin::Unspecified(), metadata_change_list.get());
     }
   }
 
-  this->change_processor()->Delete(
+  change_processor()->Delete(
       base::StrCat({kConversationStorageKeyPrefix, uuid}),
       syncer::DeletionOrigin::Unspecified(), metadata_change_list.get());
 }
@@ -367,7 +367,7 @@ void AIChatSyncBridge::OnConversationEntryAdded(
     const std::string& conversation_uuid,
     const std::string& entry_uuid) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (!this->change_processor()->IsTrackingMetadata()) {
+  if (!change_processor()->IsTrackingMetadata()) {
     return;
   }
   PutEntry(conversation_uuid, entry_uuid);
@@ -382,13 +382,13 @@ void AIChatSyncBridge::OnConversationEntryModified(
 void AIChatSyncBridge::OnConversationEntryDeleted(
     const std::string& entry_uuid) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (!this->change_processor()->IsTrackingMetadata()) {
+  if (!change_processor()->IsTrackingMetadata()) {
     return;
   }
   auto metadata_change_list = CreateMetadataChangeList();
-  this->change_processor()->Delete(
-      base::StrCat({kEntryStorageKeyPrefix, entry_uuid}),
-      syncer::DeletionOrigin::Unspecified(), metadata_change_list.get());
+  change_processor()->Delete(base::StrCat({kEntryStorageKeyPrefix, entry_uuid}),
+                             syncer::DeletionOrigin::Unspecified(),
+                             metadata_change_list.get());
 }
 
 void AIChatSyncBridge::PutConversationMetadata(const std::string& uuid) {
@@ -401,9 +401,9 @@ void AIChatSyncBridge::PutConversationMetadata(const std::string& uuid) {
   }
   auto specifics = ConversationMetadataToSpecifics(*conversation);
   auto metadata_change_list = CreateMetadataChangeList();
-  this->change_processor()->Put(
-      base::StrCat({kConversationStorageKeyPrefix, uuid}),
-      CreateEntityDataFromSpecifics(specifics), metadata_change_list.get());
+  change_processor()->Put(base::StrCat({kConversationStorageKeyPrefix, uuid}),
+                          CreateEntityDataFromSpecifics(specifics),
+                          metadata_change_list.get());
 }
 
 void AIChatSyncBridge::PutEntry(const std::string& conversation_uuid,
@@ -419,19 +419,17 @@ void AIChatSyncBridge::PutEntry(const std::string& conversation_uuid,
   if (!archive) {
     return;
   }
-  auto it = std::ranges::find_if(
-      archive->entries, [&](const mojom::ConversationTurnPtr& entry) {
-        return entry->uuid && *entry->uuid == entry_uuid;
-      });
+  auto it = std::ranges::find(archive->entries, entry_uuid,
+                              &mojom::ConversationTurn::uuid);
   if (it == archive->entries.end()) {
     return;
   }
   auto specifics = EntryToSpecifics(conversation_uuid, **it,
                                     conversation->associated_content);
   auto metadata_change_list = CreateMetadataChangeList();
-  this->change_processor()->Put(
-      base::StrCat({kEntryStorageKeyPrefix, entry_uuid}),
-      CreateEntityDataFromSpecifics(specifics), metadata_change_list.get());
+  change_processor()->Put(base::StrCat({kEntryStorageKeyPrefix, entry_uuid}),
+                          CreateEntityDataFromSpecifics(specifics),
+                          metadata_change_list.get());
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_bridge.h
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_bridge.h
@@ -77,6 +77,22 @@ class AIChatSyncBridge : public syncer::DataTypeSyncBridge {
   void ApplyDisableSyncChanges(std::unique_ptr<syncer::MetadataChangeList>
                                    delete_metadata_change_list) override;
 
+  // Conversation-metadata notifications. Called on this sequence by the
+  // service when the conversation row changes (title, model, tokens, ...).
+  void OnConversationAdded(const std::string& uuid);
+  void OnConversationModified(const std::string& uuid);
+  // Must be invoked while entries are still readable from the database, so
+  // the bridge can emit a Delete for every Entry storage key before the
+  // conversation row and its child rows are removed.
+  void OnConversationDeleted(const std::string& uuid);
+
+  // Entry-level notifications. |conversation_uuid| is the parent.
+  void OnConversationEntryAdded(const std::string& conversation_uuid,
+                                const std::string& entry_uuid);
+  void OnConversationEntryModified(const std::string& conversation_uuid,
+                                   const std::string& entry_uuid);
+  void OnConversationEntryDeleted(const std::string& entry_uuid);
+
   base::WeakPtr<AIChatSyncBridge> GetWeakPtr() {
     return weak_ptr_factory_.GetWeakPtr();
   }
@@ -92,6 +108,14 @@ class AIChatSyncBridge : public syncer::DataTypeSyncBridge {
       base::FunctionRef<bool(const std::string&)> should_include,
       base::FunctionRef<void(std::string, std::unique_ptr<syncer::EntityData>)>
           emit);
+
+  // Emits a Put for the conversation metadata of |uuid|. No-op for temporary
+  // or unknown conversations.
+  void PutConversationMetadata(const std::string& uuid);
+  // Emits a Put for the single entry |entry_uuid| belonging to
+  // |conversation_uuid|. No-op when the conversation is temporary or unknown.
+  void PutEntry(const std::string& conversation_uuid,
+                const std::string& entry_uuid);
 
   // Attached via SetDatabase()/ClearDatabase(); null before the first attach
   // and whenever on-disk storage is disabled.

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_bridge_unittest.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_bridge_unittest.cc
@@ -45,19 +45,19 @@ class AIChatSyncBridgeTest : public testing::Test {
   }
 
   // Creates the bridge and attaches the database (the common case).
-  void CreateBridge() {
-    CreateBridgeWithoutDatabase();
+  void CreateBridge(bool is_tracking_metadata = true) {
+    CreateBridgeWithoutDatabase(is_tracking_metadata);
     bridge_->SetDatabase(db_.get());
   }
 
   // Creates the bridge without attaching a database, mirroring how the service
   // installs the bridge eagerly before the database exists.
-  void CreateBridgeWithoutDatabase() {
+  void CreateBridgeWithoutDatabase(bool is_tracking_metadata = true) {
     auto processor = std::make_unique<
         testing::NiceMock<syncer::MockDataTypeLocalChangeProcessor>>();
     mock_processor_ = processor.get();
     ON_CALL(*mock_processor_, IsTrackingMetadata())
-        .WillByDefault(testing::Return(true));
+        .WillByDefault(testing::Return(is_tracking_metadata));
     bridge_ = std::make_unique<AIChatSyncBridge>(std::move(processor));
   }
 
@@ -219,14 +219,7 @@ TEST_F(AIChatSyncBridgeTest, OnConversationEntryDeletedEmitsDelete) {
 
 TEST_F(AIChatSyncBridgeTest, OnConversationAddedNoOpWhenNotTracking) {
   AddTestConversation("conv-1", "Test");
-
-  auto processor = std::make_unique<
-      testing::NiceMock<syncer::MockDataTypeLocalChangeProcessor>>();
-  mock_processor_ = processor.get();
-  ON_CALL(*mock_processor_, IsTrackingMetadata())
-      .WillByDefault(testing::Return(false));
-  bridge_ = std::make_unique<AIChatSyncBridge>(std::move(processor));
-  bridge_->SetDatabase(db_.get());
+  CreateBridge(/*is_tracking_metadata=*/false);
 
   EXPECT_CALL(*mock_processor_, Put(_, _, _)).Times(0);
   bridge_->OnConversationAdded("conv-1");

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_bridge_unittest.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_bridge_unittest.cc
@@ -184,6 +184,54 @@ TEST_F(AIChatSyncBridgeTest,
                              std::move(empty_remote));
 }
 
+TEST_F(AIChatSyncBridgeTest,
+       OnConversationDeletedEmitsDeleteForConvAndEntries) {
+  const std::string entry_uuid = AddTestConversation("conv-to-delete", "Test");
+  CreateBridge();
+
+  EXPECT_CALL(*mock_processor_, Delete("e:" + entry_uuid, _, _)).Times(1);
+  EXPECT_CALL(*mock_processor_, Delete("c:conv-to-delete", _, _)).Times(1);
+  bridge_->OnConversationDeleted("conv-to-delete");
+}
+
+TEST_F(AIChatSyncBridgeTest, OnConversationAddedEmitsConversationOnly) {
+  AddTestConversation("conv-to-add", "New Conv");
+  CreateBridge();
+
+  EXPECT_CALL(*mock_processor_, Put("c:conv-to-add", _, _)).Times(1);
+  bridge_->OnConversationAdded("conv-to-add");
+}
+
+TEST_F(AIChatSyncBridgeTest, OnConversationEntryAddedEmitsEntryOnly) {
+  const std::string entry_uuid = AddTestConversation("conv-with-entry", "Test");
+  CreateBridge();
+
+  EXPECT_CALL(*mock_processor_, Put("e:" + entry_uuid, _, _)).Times(1);
+  bridge_->OnConversationEntryAdded("conv-with-entry", entry_uuid);
+}
+
+TEST_F(AIChatSyncBridgeTest, OnConversationEntryDeletedEmitsDelete) {
+  CreateBridge();
+
+  EXPECT_CALL(*mock_processor_, Delete("e:some-entry", _, _)).Times(1);
+  bridge_->OnConversationEntryDeleted("some-entry");
+}
+
+TEST_F(AIChatSyncBridgeTest, OnConversationAddedNoOpWhenNotTracking) {
+  AddTestConversation("conv-1", "Test");
+
+  auto processor = std::make_unique<
+      testing::NiceMock<syncer::MockDataTypeLocalChangeProcessor>>();
+  mock_processor_ = processor.get();
+  ON_CALL(*mock_processor_, IsTrackingMetadata())
+      .WillByDefault(testing::Return(false));
+  bridge_ = std::make_unique<AIChatSyncBridge>(std::move(processor));
+  bridge_->SetDatabase(db_.get());
+
+  EXPECT_CALL(*mock_processor_, Put(_, _, _)).Times(0);
+  bridge_->OnConversationAdded("conv-1");
+}
+
 TEST_F(AIChatSyncBridgeTest, ApplyDisableSyncChangesClearsMetadata) {
   CreateBridge();
 


### PR DESCRIPTION
Adds the outbound half of the AI Chat sync bridge: turning local conversation/entry adds, edits and deletes into sync Put/Delete calls.

- `AIChatSyncBridge` gains `OnConversation{Added,Modified,Deleted}` and `OnConversationEntry{Added,Modified,Deleted}`, which serialize the changed record and `Put` it, or emit tombstones (enumerating a conversation's entries before it is deleted so their sync records are removed too).
- `AIChatSyncBackend` forwards those notifications to the bridge on the database sequence.
- `AIChatService` routes its `ConversationHandler` observer callbacks into the backend so ongoing local edits propagate (the initial-merge upload already lives in the bridge skeleton).
- Bridge unit tests for the notification paths.

Spec:
- https://github.com/brave/brave-core/blob/aichat-sync-flow/docs/aichat-sync.md

Based on:
- https://github.com/brave/brave-core/pull/35028
- https://github.com/brave/brave-core/pull/35242
- https://github.com/brave/brave-core/pull/37537
- https://github.com/brave/brave-core/pull/37539
- https://github.com/brave/brave-core/pull/37540
- https://github.com/brave/go-sync/pull/427 (server)

Series:
- https://github.com/brave/brave-browser/issues/53978