### PR TITLE
[iOS] Validate snapshot size is finite before rendering the view (uplift to 1.93.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Extensions/UIViewExtensions.swift
+++ b/ios/brave-ios/Sources/Brave/Extensions/UIViewExtensions.swift
@@ -12,9 +12,9 @@ extension UIView {
 
     let offset = offset ?? .zero
 
-    // Temporary check to handle _UIGraphicsBeginImageContextWithOptions zero size error
+    // Temporary check to handle _UIGraphicsBeginImageContextWithOptions zero/invalid size error
     // Should be replaced with UIGraphicsImageRenderer
-    guard size.width > 0, size.height > 0 else {
+    guard size.width.isFinite, size.height.isFinite, size.width > 0, size.height > 0 else {
       return nil
     }
 


### PR DESCRIPTION
Uplift of #38177
Resolves https://github.com/brave/brave-browser/issues/57337

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.