### PR TITLE
[plaster][ast-grep] Add `after_function_impl`

### DIFF
--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -135,6 +135,7 @@ introduce more rewriters. These are the ones we have supported for now.
 | `add_friend`            | AST  | Adds a `friend` declaration to a private section. |
 | `drop_final`            | AST  | Removes `final` from a C++ class declaration.     |
 | `preempt_function_impl` | AST  | Inserts at the top of a C++ function body.        |
+| `after_function_impl`   | AST  | Wraps a C++ function body and runs code after.    |
 | `rename_class`          | AST  | Renames a C++ class.                              |
 | `add_to_protected`      | AST  | Adds a member to a class `protected:` section.    |
 

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -1281,6 +1281,146 @@ class PreemptFunctionImpl(_AstGrepRewriter):
         return f'if ({condition}) return{value};'
 
 
+class AfterFunctionImpl(_AstGrepRewriter):
+    """Wrap a function body in a lambda and run a code block after it.
+
+    The upstream body runs first, then our code. The idea of this rewriter is to
+    eliminate the need for certain cases where we either rename a function in
+    upstream to an inner `_ChromiumImpl` and call it, or when we subclass a
+    function to override it and call the base.
+
+    This rewriter offers a third option: wrap the upstream body in a lambda and
+    run a code block after it.
+    """
+
+    NAME: Final = 'after_function_impl'
+    OP_ID: Final = 'cxx.after_function_impl'
+    SUMMARY: Final = 'Run a statement block after a function body, wrapped so '\
+                     'it always runs.'
+    # Authored in Markdown; `Help` renders it with rich.
+    HELP: Final = r"""
+        Wraps a C++ function's whole body in an immediately-invoked `[&]` lambda
+        and runs a statement block after it, so that code always runs before the
+        function ends. This is an alternative to renaming the function to an
+        inner `_ChromiumImpl`, or to subclassing and calling the base, when you
+        want to run code after the upstream body.
+
+        The upstream body becomes `[&]() { ... }();`: a lambda capturing
+        everything (including `this`) by reference and invoked immediately.
+
+        Fields:
+
+        - `function_name` — the function's name exactly as its definition
+          writes it: a qualified `Class::Method` for a member, or the bare name
+          for a free function.
+        - `code` — the statement block to append.
+        - `result_var` — optional. For a non-void function, names a variable
+          bound to the wrapped body's return value (`auto <result_var> = [&]()
+          { ... }();`) so the appended `code` can use it. When set, the appended
+          `code` owns the function's final `return`.
+
+        Each overload sharing the name is one match, so an overloaded method
+        needs a matching `count`.
+
+        Examples:
+
+        ```yaml
+        substitutions:
+          - description: Record a metric after the upstream body always runs.
+            after_function_impl:
+              function_name: DownloadDisplayController::OnButtonPressed
+              code: |-
+                RecordBraveDownloadInteraction();
+
+          - description: Let Brave adjust the computed value before returning.
+            after_function_impl:
+              function_name: OmniboxController::ComputeScore
+              result_var: score
+              code: |-
+                return ComputeScore_BraveImpl(score);
+        ```
+
+        The second entry turns this upstream definition:
+
+        ```cpp
+        int OmniboxController::ComputeScore() {
+          // ... upstream body with its own returns ...
+        }
+        ```
+
+        into (the upstream body is wrapped, not reindented):
+
+        ```cpp
+        int OmniboxController::ComputeScore() {
+          auto score = [&]() {
+          // ... upstream body with its own returns ...
+          }();
+          return ComputeScore_BraveImpl(score);
+        }
+        ```
+    """
+
+    def __init__(self, *, function_name: str, capture: str, epilogue: str):
+        super().__init__()
+        self._function_name = function_name
+        self._capture = capture
+        self._epilogue = epilogue
+
+    def operations(self, count: int) -> list[Operation]:
+        # Escape backslashes last in both spliced values, since they are spliced
+        # into a `re.sub` replacement where a backslash is special.
+        epilogue = _indent_yaml(self._epilogue).replace('\\', '\\\\')
+        capture = self._capture.replace('\\', '\\\\')
+        return [
+            Operation(
+                self.OP_ID, {
+                    'function_name': self._function_name,
+                    'capture': capture,
+                    'epilogue': epilogue,
+                }, MatchExpectation.from_count(count))
+        ]
+
+    @classmethod
+    def parse(cls, body: object, *, description: str) -> AfterFunctionImpl:
+        """Validate an `after_function_impl:` body and resolve what to append.
+
+        Requires `function_name` and `code`. `result_var` is optional and, when
+        given, binds the wrapped body's value to `auto <result_var>`.
+        """
+        if not isinstance(body, dict):
+            raise ValueError(
+                f'"{cls.NAME}" must be a mapping (in "{description}")')
+        allowed = {'function_name', 'code', 'result_var'}
+        unknown = sorted(set(body) - allowed)
+        if unknown:
+            raise ValueError(
+                f'Unrecognised {cls.NAME} arg(s): '
+                f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
+        if not isinstance(body.get('function_name'),
+                          str) or not body['function_name']:
+            raise ValueError(f'{cls.NAME} `function_name` must be a non-empty '
+                             f'string (in "{description}")')
+        code = body.get('code')
+        if not isinstance(code, str) or not code:
+            raise ValueError(f'{cls.NAME} `code` must be a non-empty string '
+                             f'(in "{description}")')
+        capture = cls._resolve_capture(body, description)
+        return cls(function_name=body['function_name'],
+                   capture=capture,
+                   epilogue=code)
+
+    @classmethod
+    def _resolve_capture(cls, body: dict, description: str) -> str:
+        """Build the `auto <result_var> = ` lead, or empty for a void wrap."""
+        if 'result_var' not in body:
+            return ''
+        result_var = body['result_var']
+        if not isinstance(result_var, str) or not result_var:
+            raise ValueError(f'{cls.NAME} `result_var` must be a non-empty '
+                             f'string (in "{description}")')
+        return f'auto {result_var} = '
+
+
 class RenameClass(_AstGrepRewriter):
     """Rename a C++ class."""
 
@@ -1412,7 +1552,8 @@ class AddToProtected(_AstGrepRewriter):
 _REWRITERS: MappingProxyType[str, type[Rewriter]] = MappingProxyType({
     rewriter.NAME: rewriter
     for rewriter in (Regex, MakeVirtual, AddFriend, DropFinal,
-                     PreemptFunctionImpl, RenameClass, AddToProtected)
+                     PreemptFunctionImpl, AfterFunctionImpl, RenameClass,
+                     AddToProtected)
 })
 
 

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -2045,6 +2045,177 @@ class RewriterFormsTest(unittest.TestCase):
             '      code: virtual void Bar() = 0;\n',
             'does not accept a count other than 1')
 
+    # -- after_function_impl op (real ast-grep binary) -------------------------
+
+    def test_after_function_impl_void(self):
+        # A void function: the body is wrapped in a bare IIFE lambda and the
+        # appended code runs after it, unconditionally.
+        result = self._apply(
+            'append.cc', 'void C::Foo() {\n  Upstream();\n}\n',
+            'substitutions:\n'
+            '  - description: always run Brave code after the body\n'
+            '    after_function_impl:\n'
+            '      function_name: C::Foo\n'
+            '      code: |-\n'
+            '        RecordBraveMetric();\n')
+        self.assertEqual(
+            result, 'void C::Foo() {\n  [&]() {\n  Upstream();\n  }();\n'
+            '  RecordBraveMetric();\n}\n')
+
+    def test_after_function_impl_captures_result(self):
+        # A non-void function: `result_var` binds the wrapped body's value so
+        # the appended code can use it and own the final return.
+        result = self._apply(
+            'append_result.cc', 'int C::Compute() {\n  return real_;\n}\n',
+            'substitutions:\n'
+            '  - description: adjust the computed value for Brave\n'
+            '    after_function_impl:\n'
+            '      function_name: C::Compute\n'
+            '      result_var: score\n'
+            '      code: |-\n'
+            '        return BraveAdjust(score);\n')
+        self.assertEqual(
+            result, 'int C::Compute() {\n  auto score = [&]() {\n'
+            '  return real_;\n  }();\n  return BraveAdjust(score);\n}\n')
+
+    def test_after_function_impl_wraps_early_returns(self):
+        # Every `return` in the upstream body only returns from the lambda, so
+        # the appended code still runs. The body's own lines are untouched.
+        source = ('void C::Foo() {\n'
+                  '  if (!ready_) {\n'
+                  '    return;\n'
+                  '  }\n'
+                  '  Work();\n'
+                  '}\n')
+        result = self._apply(
+            'append_early.cc', source, 'substitutions:\n'
+            '  - description: guarantee cleanup runs\n'
+            '    after_function_impl:\n'
+            '      function_name: C::Foo\n'
+            '      code: |-\n'
+            '        BraveCleanup();\n')
+        self.assertEqual(
+            result, 'void C::Foo() {\n  [&]() {\n'
+            '  if (!ready_) {\n    return;\n  }\n  Work();\n  }();\n'
+            '  BraveCleanup();\n}\n')
+
+    def test_after_function_impl_free_function(self):
+        result = self._apply(
+            'append_free.cc', 'void FreeFunc(int x) {\n  Upstream(x);\n}\n',
+            'substitutions:\n'
+            '  - description: append to a free function\n'
+            '    after_function_impl:\n'
+            '      function_name: FreeFunc\n'
+            '      code: |-\n'
+            '        AfterFree(x);\n')
+        self.assertEqual(
+            result, 'void FreeFunc(int x) {\n  [&]() {\n  Upstream(x);\n'
+            '  }();\n  AfterFree(x);\n}\n')
+
+    def test_after_function_impl_multiline_code_indented(self):
+        # A multi-line `code` block is authored flush-left and indented to the
+        # body level as a whole; a blank line stays empty.
+        result = self._apply(
+            'append_block.cc', 'void C::Foo() {\n  Upstream();\n}\n',
+            'substitutions:\n'
+            '  - description: append a two-statement block\n'
+            '    after_function_impl:\n'
+            '      function_name: C::Foo\n'
+            '      code: |-\n'
+            '        Prepare();\n'
+            '\n'
+            '        Track();\n')
+        self.assertEqual(
+            result, 'void C::Foo() {\n  [&]() {\n  Upstream();\n  }();\n'
+            '  Prepare();\n\n  Track();\n}\n')
+
+    def test_after_function_impl_targets_named_function_only(self):
+        # Only the named function's body is wrapped, not a sibling.
+        result = self._apply(
+            'append_siblings.cc',
+            'void C::A() {\n  a();\n}\n\nvoid C::B() {\n  b();\n}\n',
+            'substitutions:\n'
+            '  - description: append only to B\n'
+            '    after_function_impl:\n'
+            '      function_name: C::B\n'
+            '      code: |-\n'
+            '        after_b();\n')
+        self.assertEqual(
+            result, 'void C::A() {\n  a();\n}\n\n'
+            'void C::B() {\n  [&]() {\n  b();\n  }();\n  after_b();\n}\n')
+
+    def test_after_function_impl_overloads_need_count(self):
+        result = self._apply(
+            'append_overloads.cc',
+            'void C::F() {\n  a();\n}\n\nvoid C::F(int x) {\n  b();\n}\n',
+            'substitutions:\n'
+            '  - description: append to both overloads\n'
+            '    count: 2\n'
+            '    after_function_impl:\n'
+            '      function_name: C::F\n'
+            '      code: |-\n'
+            '        done();\n')
+        self.assertEqual(
+            result,
+            'void C::F() {\n  [&]() {\n  a();\n  }();\n  done();\n}\n\n'
+            'void C::F(int x) {\n  [&]() {\n  b();\n  }();\n  done();\n}\n')
+
+    def test_after_function_impl_overload_count_mismatch_fails(self):
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'append_overloads_bad.cc',
+                'void C::F() {\n  a();\n}\n\nvoid C::F(int x) {\n  b();\n}\n',
+                'substitutions:\n'
+                '  - description: forgot the count\n'
+                '    after_function_impl:\n'
+                '      function_name: C::F\n'
+                '      code: |-\n'
+                '        done();\n')
+
+    def test_after_function_impl_absent_function_fails(self):
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'append_missing.cc', 'void C::Foo() {\n}\n', 'substitutions:\n'
+                '  - description: no such function\n'
+                '    after_function_impl:\n'
+                '      function_name: C::Nope\n'
+                '      code: |-\n'
+                '        x();\n')
+
+    def test_after_function_impl_missing_code_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: missing code\n'
+            '    after_function_impl:\n'
+            '      function_name: C::F\n',
+            'after_function_impl `code` must be a non-empty string')
+
+    def test_after_function_impl_missing_function_name_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: missing function_name\n'
+            '    after_function_impl:\n'
+            '      code: x();\n',
+            'after_function_impl `function_name` must be a non-empty string')
+
+    def test_after_function_impl_empty_result_var_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: empty result_var\n'
+            '    after_function_impl:\n'
+            '      function_name: C::F\n'
+            '      result_var: \'\'\n'
+            '      code: x();\n',
+            'after_function_impl `result_var` must be a non-empty string')
+
+    def test_after_function_impl_unknown_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: typo arg\n'
+            '    after_function_impl:\n'
+            '      function_name: C::F\n'
+            '      cod: x();\n', 'Unrecognised after_function_impl arg')
+
     # -- export-macro classes (real ast-grep binary) ----------------------
     #
     # tree-sitter cannot parse `class MACRO_EXPORT Name`, so the engine blanks

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -246,6 +246,29 @@ regex: ^{class_name}$
             },
         },
 
+        # The function body wrapped in an immediately-invoked `[&]` lambda, with
+        # `epilogue` appended after it. The matcher lands on the whole
+        # compound_statement; a DOTALL `^{ ... }$` capture folds the entire
+        # upstream body (`\1`) between a lambda prefix and its `}();`
+        # invocation, so the body's own lines are re-emitted verbatim, then
+        # appends `epilogue` as the body's trailing statements.
+        # `capture` is empty (a void wrap: `[&]() {...}();`) or an
+        # `auto <var> =` lead so the epilogue can read the wrapped body's return
+        # value. The caller passes `epilogue` indented to the body level and
+        # both spliced values with backslashes escaped for the `re.sub`
+        # replacement.
+        "cxx.after_function_impl": {
+            "matcher": "cxx.find_function_body",
+            "inputs": ["function_name", "capture", "epilogue"],
+            "replace": {
+                "re_pattern": "(?s)^\\{(.*)\\}$",
+                "replace": "{{\\n  {capture}[&]() {{\\1  }}();\\n{epilogue}\\n}}",
+            },
+            "result": {
+                "node": "compound_statement",
+            },
+        },
+
         # Each matched name token replaced with `rename`. The matcher already
         # pinned every match's text to exactly `class_name`, so the whole token
         # (`^.+$`) is swapped for the new name.


### PR DESCRIPTION
This rewriter is the counterpart for `preempt_function_impl`, providing
a way to append our own code at the end of a function block, and
guaranteeing it gets run at the end.

This rewriter will help us avoid subclassing/renaming functions that can
be simply handled like this.

Fixed: https://github.com/brave/brave-browser/issues/57359
