### PR TITLE
[plaster] Migrate `chromium_impl::` to `rename_class`

### DIFF
--- a/chromium_src/chrome/browser/ui/page_action/page_action_controller.cc
+++ b/chromium_src/chrome/browser/ui/page_action/page_action_controller.cc
@@ -67,8 +67,8 @@ std::unique_ptr<PageActionModelInterface> PageActionControllerImpl::CreateModel(
     actions::ActionId action_id,
     bool is_ephemeral) {
   if (page_action_model_factory_ != nullptr) {
-    return chromium_impl::PageActionControllerImpl::CreateModel(action_id,
-                                                                is_ephemeral);
+    return PageActionControllerImpl_ChromiumImpl::CreateModel(action_id,
+                                                              is_ephemeral);
   }
 
   return std::make_unique<PageActionModel>(is_ephemeral);

--- a/chromium_src/chrome/browser/ui/page_action/page_action_controller.h
+++ b/chromium_src/chrome/browser/ui/page_action/page_action_controller.h
@@ -21,10 +21,10 @@ namespace page_actions {
 // Brave override of the upstream concrete page-action controller. Used by
 // PartitionedStoragePageActionController to drive Brave-specific page actions
 // (chip colors, label, height, triggerable event).
-class PageActionControllerImpl
-    : public chromium_impl::PageActionControllerImpl {
+class PageActionControllerImpl : public PageActionControllerImpl_ChromiumImpl {
  public:
-  using chromium_impl::PageActionControllerImpl::PageActionControllerImpl;
+  using PageActionControllerImpl_ChromiumImpl::
+      PageActionControllerImpl_ChromiumImpl;
   ~PageActionControllerImpl() override;
 
   void SetAlwaysShowLabel(actions::ActionId action_id, bool always_show);
@@ -40,7 +40,7 @@ class PageActionControllerImpl
                          const gfx::Insets& border);
   void ClearOverrideBorder(actions::ActionId action_id);
 
-  // chromium_impl::PageActionControllerImpl:
+  // PageActionControllerImpl_ChromiumImpl:
   std::unique_ptr<PageActionModelInterface> CreateModel(
       actions::ActionId action_id,
       bool is_ephemeral) override;

--- a/chromium_src/chrome/browser/ui/page_action/page_action_model.h
+++ b/chromium_src/chrome/browser/ui/page_action/page_action_model.h
@@ -20,9 +20,9 @@ namespace page_actions {
 // PartitionedStoragePageActionController via PageActionControllerImpl to add
 // chip-color, label, height and triggerable-event overrides on top of the
 // upstream model.
-class PageActionModel : public chromium_impl::PageActionModel {
+class PageActionModel : public PageActionModel_ChromiumImpl {
  public:
-  using chromium_impl::PageActionModel::PageActionModel;
+  using PageActionModel_ChromiumImpl::PageActionModel_ChromiumImpl;
   ~PageActionModel() override;
 
   void SetOverrideChipColors(

--- a/chromium_src/chrome/browser/ui/page_action/page_action_pass_key.h
+++ b/chromium_src/chrome/browser/ui/page_action/page_action_pass_key.h
@@ -6,9 +6,10 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_PAGE_ACTION_PAGE_ACTION_PASS_KEY_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_PAGE_ACTION_PAGE_ACTION_PASS_KEY_H_
 
-namespace page_actions::chromium_impl {
-class PageActionControllerImpl;
-}  // namespace page_actions::chromium_impl
+namespace page_actions {
+class PageActionControllerImpl_ChromiumImpl;  // NOLINT(build/forward_decl):
+                                              // Needed by the shadowed file
+}  // namespace page_actions
 
 #include <chrome/browser/ui/page_action/page_action_pass_key.h>  // IWYU pragma: export
 

--- a/chromium_src/components/permissions/permission_context_base.cc
+++ b/chromium_src/components/permissions/permission_context_base.cc
@@ -17,9 +17,9 @@ PermissionContextBase::PermissionContextBase(
     content::BrowserContext* browser_context,
     ContentSettingsType content_settings_type,
     network::mojom::PermissionsPolicyFeature permissions_policy_feature)
-    : chromium_impl::PermissionContextBase(browser_context,
-                                           content_settings_type,
-                                           permissions_policy_feature) {}
+    : PermissionContextBase_ChromiumImpl(browser_context,
+                                         content_settings_type,
+                                         permissions_policy_feature) {}
 
 PermissionContextBase::~PermissionContextBase() = default;
 
@@ -47,8 +47,7 @@ void PermissionContextBase::PermissionDecided(
     }
   }
 
-  chromium_impl::PermissionContextBase::PermissionDecided(decision,
-                                                          request_data);
+  PermissionContextBase_ChromiumImpl::PermissionDecided(decision, request_data);
 }
 
 }  // namespace permissions

--- a/chromium_src/components/permissions/permission_context_base.h
+++ b/chromium_src/components/permissions/permission_context_base.h
@@ -16,7 +16,7 @@ namespace permissions {
 
 class PermissionLifetimeManager;
 
-class PermissionContextBase : public chromium_impl::PermissionContextBase {
+class PermissionContextBase : public PermissionContextBase_ChromiumImpl {
  public:
   PermissionContextBase(
       content::BrowserContext* browser_context,

--- a/chromium_src/net/cookies/cookie_monster.cc
+++ b/chromium_src/net/cookies/cookie_monster.cc
@@ -10,26 +10,26 @@ namespace net {
 CookieMonster::CookieMonster(scoped_refptr<PersistentCookieStore> store,
                              NetLog* net_log,
                              std::unique_ptr<PrefDelegate> pref_delegate)
-    : chromium_impl::CookieMonster(store, net_log, std::move(pref_delegate)),
+    : CookieMonster_ChromiumImpl(store, net_log, std::move(pref_delegate)),
       net_log_(
           NetLogWithSource::Make(net_log, NetLogSourceType::COOKIE_STORE)) {}
 
-CookieMonster::CookieMonster(base::PassKey<chromium_impl::CookieMonster> key,
+CookieMonster::CookieMonster(base::PassKey<CookieMonster_ChromiumImpl> key,
                              scoped_refptr<PersistentCookieStore> store,
                              base::TimeDelta last_access_threshold,
                              NetLog* net_log,
                              std::unique_ptr<PrefDelegate> pref_delegate)
-    : chromium_impl::CookieMonster(key,
-                                   store,
-                                   last_access_threshold,
-                                   net_log,
-                                   std::move(pref_delegate)),
+    : CookieMonster_ChromiumImpl(key,
+                                 store,
+                                 last_access_threshold,
+                                 net_log,
+                                 std::move(pref_delegate)),
       net_log_(
           NetLogWithSource::Make(net_log, NetLogSourceType::COOKIE_STORE)) {}
 
 CookieMonster::~CookieMonster() {}
 
-chromium_impl::CookieMonster*
+CookieMonster_ChromiumImpl*
 CookieMonster::GetOrCreateEphemeralCookieStoreForTopFrameURL(
     const GURL& top_frame_url) {
   std::string domain = URLToEphemeralStorageDomain(top_frame_url);
@@ -38,8 +38,8 @@ CookieMonster::GetOrCreateEphemeralCookieStoreForTopFrameURL(
     return it->second.get();
 
   return ephemeral_cookie_stores_
-      .emplace(domain, new chromium_impl::CookieMonster(nullptr /* store */,
-                                                        net_log_.net_log()))
+      .emplace(domain, new CookieMonster_ChromiumImpl(nullptr /* store */,
+                                                      net_log_.net_log()))
       .first->second.get();
 }
 
@@ -48,8 +48,8 @@ void CookieMonster::DeleteCanonicalCookieAsync(const CanonicalCookie& cookie,
   for (auto& it : ephemeral_cookie_stores_) {
     it.second->DeleteCanonicalCookieAsync(cookie, DeleteCallback());
   }
-  chromium_impl::CookieMonster::DeleteCanonicalCookieAsync(cookie,
-                                                           std::move(callback));
+  CookieMonster_ChromiumImpl::DeleteCanonicalCookieAsync(cookie,
+                                                         std::move(callback));
 }
 
 void CookieMonster::DeleteAllCreatedInTimeRangeAsync(
@@ -59,7 +59,7 @@ void CookieMonster::DeleteAllCreatedInTimeRangeAsync(
     it.second->DeleteAllCreatedInTimeRangeAsync(creation_range,
                                                 DeleteCallback());
   }
-  chromium_impl::CookieMonster::DeleteAllCreatedInTimeRangeAsync(
+  CookieMonster_ChromiumImpl::DeleteAllCreatedInTimeRangeAsync(
       creation_range, std::move(callback));
 }
 
@@ -74,15 +74,15 @@ void CookieMonster::DeleteAllMatchingInfoAsync(CookieDeletionInfo delete_info,
   for (auto& it : ephemeral_cookie_stores_) {
     it.second->DeleteAllMatchingInfoAsync(delete_info, DeleteCallback());
   }
-  chromium_impl::CookieMonster::DeleteAllMatchingInfoAsync(delete_info,
-                                                           std::move(callback));
+  CookieMonster_ChromiumImpl::DeleteAllMatchingInfoAsync(delete_info,
+                                                         std::move(callback));
 }
 
 void CookieMonster::DeleteSessionCookiesAsync(DeleteCallback callback) {
   for (auto& it : ephemeral_cookie_stores_) {
     it.second->DeleteSessionCookiesAsync(DeleteCallback());
   }
-  chromium_impl::CookieMonster::DeleteSessionCookiesAsync(std::move(callback));
+  CookieMonster_ChromiumImpl::DeleteSessionCookiesAsync(std::move(callback));
 }
 
 void CookieMonster::SetCookieableSchemes(
@@ -91,8 +91,8 @@ void CookieMonster::SetCookieableSchemes(
   for (auto& it : ephemeral_cookie_stores_) {
     it.second->SetCookieableSchemes(schemes, SetCookieableSchemesCallback());
   }
-  chromium_impl::CookieMonster::SetCookieableSchemes(std::move(schemes),
-                                                     std::move(callback));
+  CookieMonster_ChromiumImpl::SetCookieableSchemes(std::move(schemes),
+                                                   std::move(callback));
 }
 
 void CookieMonster::SetCanonicalCookieAsync(
@@ -112,7 +112,7 @@ void CookieMonster::SetCanonicalCookieAsync(
                              CookieAccessResult(cookie_inclusion_status));
       return;
     }
-    chromium_impl::CookieMonster* ephemeral_monster =
+    CookieMonster_ChromiumImpl* ephemeral_monster =
         GetOrCreateEphemeralCookieStoreForTopFrameURL(
             options.top_frame_origin()->GetURL());
     ephemeral_monster->SetCanonicalCookieAsync(std::move(cookie), source_url,
@@ -121,7 +121,7 @@ void CookieMonster::SetCanonicalCookieAsync(
     return;
   }
 
-  chromium_impl::CookieMonster::SetCanonicalCookieAsync(
+  CookieMonster_ChromiumImpl::SetCanonicalCookieAsync(
       std::move(cookie), source_url, options, std::move(callback),
       std::move(cookie_access_result));
 }
@@ -138,7 +138,7 @@ void CookieMonster::GetCookieListWithOptionsAsync(
                              CookieAccessResultList());
       return;
     }
-    chromium_impl::CookieMonster* ephemeral_monster =
+    CookieMonster_ChromiumImpl* ephemeral_monster =
         GetOrCreateEphemeralCookieStoreForTopFrameURL(
             options.top_frame_origin()->GetURL());
     ephemeral_monster->GetCookieListWithOptionsAsync(
@@ -146,7 +146,7 @@ void CookieMonster::GetCookieListWithOptionsAsync(
     return;
   }
 
-  chromium_impl::CookieMonster::GetCookieListWithOptionsAsync(
+  CookieMonster_ChromiumImpl::GetCookieListWithOptionsAsync(
       url, options, cookie_partition_key_collection, std::move(callback));
 }
 

--- a/chromium_src/net/cookies/cookie_monster.h
+++ b/chromium_src/net/cookies/cookie_monster.h
@@ -10,14 +10,14 @@
 
 namespace net {
 
-class NET_EXPORT CookieMonster : public chromium_impl::CookieMonster {
+class NET_EXPORT CookieMonster : public CookieMonster_ChromiumImpl {
  public:
   // These constructors and destructors must be kept in sync with those in
   // Chromium's CookieMonster.
   CookieMonster(scoped_refptr<PersistentCookieStore> store,
                 NetLog* net_log,
                 std::unique_ptr<PrefDelegate> pref_delegate = nullptr);
-  CookieMonster(base::PassKey<chromium_impl::CookieMonster>,
+  CookieMonster(base::PassKey<CookieMonster_ChromiumImpl>,
                 scoped_refptr<PersistentCookieStore> store,
                 base::TimeDelta last_access_threshold,
                 NetLog* net_log,
@@ -53,9 +53,9 @@ class NET_EXPORT CookieMonster : public chromium_impl::CookieMonster {
 
  private:
   NetLogWithSource net_log_;
-  std::map<std::string, std::unique_ptr<chromium_impl::CookieMonster>>
+  std::map<std::string, std::unique_ptr<CookieMonster_ChromiumImpl>>
       ephemeral_cookie_stores_;
-  chromium_impl::CookieMonster* GetOrCreateEphemeralCookieStoreForTopFrameURL(
+  CookieMonster_ChromiumImpl* GetOrCreateEphemeralCookieStoreForTopFrameURL(
       const GURL& top_frame_url);
 };
 

--- a/patches/chrome-browser-ui-page_action-page_action_controller.cc.patch
+++ b/patches/chrome-browser-ui-page_action-page_action_controller.cc.patch
@@ -1,29 +1,520 @@
 diff --git a/chrome/browser/ui/page_action/page_action_controller.cc b/chrome/browser/ui/page_action/page_action_controller.cc
-index 028ecc6d78cc90ece04305c6f2df659268fad3d5..caa4c7c6fa42d70a8f2e9dd1ccfad4218ae1d2b5 100644
+index 028ecc6d78cc90ece04305c6f2df659268fad3d5..421f3014c93958fea0efb5a8c4c4bd84a3de222f 100644
 --- a/chrome/browser/ui/page_action/page_action_controller.cc
 +++ b/chrome/browser/ui/page_action/page_action_controller.cc
-@@ -72,6 +72,7 @@ void ScopedPageActionActivity::RegisterWillDestroyControllerCallback() {
+@@ -72,7 +72,7 @@ void ScopedPageActionActivity::RegisterWillDestroyControllerCallback() {
    }
  }
  
-+namespace chromium_impl {
- PageActionControllerImpl::PageActionControllerImpl(
+-PageActionControllerImpl::PageActionControllerImpl(
++PageActionControllerImpl_ChromiumImpl::PageActionControllerImpl_ChromiumImpl(
      PinnedToolbarActionsModel* pinned_actions_model,
      PageActionModelFactory* page_action_model_factory,
-@@ -515,7 +516,7 @@ std::unique_ptr<PageActionModelInterface> PageActionControllerImpl::CreateModel(
-   if (page_action_model_factory_ != nullptr) {
-     return page_action_model_factory_->Create(action_id, is_ephemeral);
-   } else {
--    return std::make_unique<PageActionModel>(action_id, is_ephemeral);
-+    return std::make_unique<::page_actions::PageActionModel>(action_id, is_ephemeral);
+     PageActionMetricsRecorderFactory* page_action_metrics_recorder_factory)
+@@ -84,34 +84,34 @@ PageActionControllerImpl::PageActionControllerImpl(
    }
  }
  
-@@ -593,6 +594,7 @@ void PageActionControllerImpl::OnImageAnimationStarted(
-   FindPageActionModel(action_id).SetDidAnimateImage(PageActionPassKey());
+-PageActionControllerImpl::~PageActionControllerImpl() {
++PageActionControllerImpl_ChromiumImpl::~PageActionControllerImpl_ChromiumImpl() {
+   on_will_destroy_callback_list_.Notify(*this);
  }
  
-+}  // namespace chromium_impl
- std::ostream& operator<<(std::ostream& os, const SuggestionChipConfig& config) {
-   os << "{ should_animate: " << config.should_animate
-      << ", should_announce_chip: " << config.should_announce_chip << " }";
+-void PageActionControllerImpl::Initialize(
++void PageActionControllerImpl_ChromiumImpl::Initialize(
+     tabs::TabInterface& tab_interface,
+     const std::vector<actions::ActionId>& action_ids,
+     const PageActionPropertiesProviderInterface& properties_provider) {
+   tab_activated_callback_subscription_ =
+       tab_interface.RegisterDidActivate(base::BindRepeating(
+-          &PageActionControllerImpl::OnTabActivated, base::Unretained(this)));
++          &PageActionControllerImpl_ChromiumImpl::OnTabActivated, base::Unretained(this)));
+   tab_deactivated_callback_subscription_ = tab_interface.RegisterWillDeactivate(
+-      base::BindRepeating(&PageActionControllerImpl::OnTabWillDeactivate,
++      base::BindRepeating(&PageActionControllerImpl_ChromiumImpl::OnTabWillDeactivate,
+                           base::Unretained(this)));
+   chip_selector_ = CreateChipSelector(
+-      base::BindRepeating(&PageActionControllerImpl::DoShowSuggestionChip,
++      base::BindRepeating(&PageActionControllerImpl_ChromiumImpl::DoShowSuggestionChip,
+                           base::Unretained(this)),
+-      base::BindRepeating(&PageActionControllerImpl::DoHideSuggestionChip,
++      base::BindRepeating(&PageActionControllerImpl_ChromiumImpl::DoHideSuggestionChip,
+                           base::Unretained(this)),
+-      base::BindRepeating(&PageActionControllerImpl::DoShowAnchoredMessage,
++      base::BindRepeating(&PageActionControllerImpl_ChromiumImpl::DoShowAnchoredMessage,
+                           base::Unretained(this)),
+-      base::BindRepeating(&PageActionControllerImpl::DoHideAnchoredMessage,
++      base::BindRepeating(&PageActionControllerImpl_ChromiumImpl::DoHideAnchoredMessage,
+                           base::Unretained(this)));
+ 
+   metrics_recorder_ = CreateMetricsRecorder(
+       tab_interface,
+       base::BindRepeating(
+-          &PageActionControllerImpl::GetVisibleEphemeralPageActionsCount,
++          &PageActionControllerImpl_ChromiumImpl::GetVisibleEphemeralPageActionsCount,
+           base::Unretained(this)));
+ 
+   for (actions::ActionId id : action_ids) {
+@@ -128,7 +128,7 @@ void PageActionControllerImpl::Initialize(
+   }
+ }
+ 
+-void PageActionControllerImpl::Register(
++void PageActionControllerImpl_ChromiumImpl::Register(
+     actions::ActionId action_id,
+     bool is_tab_active,
+     bool is_ephemeral,
+@@ -143,21 +143,21 @@ void PageActionControllerImpl::Register(
+   activity_counters_[action_id] = 0;
+ }
+ 
+-void PageActionControllerImpl::Show(actions::ActionId action_id) {
++void PageActionControllerImpl_ChromiumImpl::Show(actions::ActionId action_id) {
+   FindPageActionModel(action_id).SetShowRequested(PageActionPassKey(),
+                                                   /*requested=*/true);
+ }
+ 
+-void PageActionControllerImpl::Hide(actions::ActionId action_id) {
++void PageActionControllerImpl_ChromiumImpl::Hide(actions::ActionId action_id) {
+   FindPageActionModel(action_id).SetShowRequested(PageActionPassKey(),
+                                                   /*requested=*/false);
+ }
+ 
+-void PageActionControllerImpl::ShowSuggestionChip(actions::ActionId action_id) {
++void PageActionControllerImpl_ChromiumImpl::ShowSuggestionChip(actions::ActionId action_id) {
+   ShowSuggestionChip(action_id, SuggestionChipConfig());
+ }
+ 
+-void PageActionControllerImpl::ShowSuggestionChip(
++void PageActionControllerImpl_ChromiumImpl::ShowSuggestionChip(
+     actions::ActionId action_id,
+     const SuggestionChipConfig& config) {
+   if (config.priority == PageActionPriorityCategory::kUnknown &&
+@@ -172,7 +172,7 @@ void PageActionControllerImpl::ShowSuggestionChip(
+   }
+ }
+ 
+-void PageActionControllerImpl::DoShowSuggestionChip(
++void PageActionControllerImpl_ChromiumImpl::DoShowSuggestionChip(
+     actions::ActionId action_id,
+     const SuggestionChipConfig& config) {
+   PageActionModelInterface& model = FindPageActionModel(action_id);
+@@ -180,18 +180,18 @@ void PageActionControllerImpl::DoShowSuggestionChip(
+   model.SetShouldShowSuggestionChip(PageActionPassKey(), /*show=*/true);
+ }
+ 
+-void PageActionControllerImpl::HideSuggestionChip(actions::ActionId action_id) {
++void PageActionControllerImpl_ChromiumImpl::HideSuggestionChip(actions::ActionId action_id) {
+   chip_selector_->RequestChipHide(action_id);
+ }
+ 
+-void PageActionControllerImpl::DoHideSuggestionChip(
++void PageActionControllerImpl_ChromiumImpl::DoHideSuggestionChip(
+     actions::ActionId action_id) {
+   FindPageActionModel(action_id).SetShouldShowSuggestionChip(
+       PageActionPassKey(),
+       /*show=*/false);
+ }
+ 
+-void PageActionControllerImpl::ShowAnchoredMessage(
++void PageActionControllerImpl_ChromiumImpl::ShowAnchoredMessage(
+     actions::ActionId action_id,
+     const AnchoredMessageConfig& config) {
+   if (config.priority == PageActionPriorityCategory::kUnknown &&
+@@ -206,7 +206,7 @@ void PageActionControllerImpl::ShowAnchoredMessage(
+   }
+ }
+ 
+-void PageActionControllerImpl::DoShowAnchoredMessage(
++void PageActionControllerImpl_ChromiumImpl::DoShowAnchoredMessage(
+     actions::ActionId action_id,
+     const AnchoredMessageConfig& config) {
+   FindPageActionModel(action_id).SetShouldShowAnchoredMessage(
+@@ -222,11 +222,11 @@ void PageActionControllerImpl::DoShowAnchoredMessage(
+   }
+   anchored_message_timeout_.Start(
+       FROM_HERE, base::Seconds(15),
+-      base::BindRepeating(&PageActionControllerImpl::DowngradeAnchoredMessage,
++      base::BindRepeating(&PageActionControllerImpl_ChromiumImpl::DowngradeAnchoredMessage,
+                           base::Unretained(this), action_id));
+ }
+ 
+-void PageActionControllerImpl::DowngradeAnchoredMessage(
++void PageActionControllerImpl_ChromiumImpl::DowngradeAnchoredMessage(
+     actions::ActionId action_id) {
+   if (active_anchored_message_ != action_id) {
+     return;
+@@ -234,12 +234,12 @@ void PageActionControllerImpl::DowngradeAnchoredMessage(
+   ShowSuggestionChip(action_id);
+ }
+ 
+-void PageActionControllerImpl::HideAnchoredMessage(
++void PageActionControllerImpl_ChromiumImpl::HideAnchoredMessage(
+     actions::ActionId action_id) {
+   chip_selector_->RequestAnchoredMessageHide(action_id);
+ }
+ 
+-void PageActionControllerImpl::DoHideAnchoredMessage(
++void PageActionControllerImpl_ChromiumImpl::DoHideAnchoredMessage(
+     actions::ActionId action_id) {
+   if (active_anchored_message_ == action_id) {
+     active_anchored_message_ = std::nullopt;
+@@ -254,7 +254,7 @@ void PageActionControllerImpl::DoHideAnchoredMessage(
+       /*show=*/false);
+ }
+ 
+-void PageActionControllerImpl::PauseAnchoredMessageTimeout(
++void PageActionControllerImpl_ChromiumImpl::PauseAnchoredMessageTimeout(
+     actions::ActionId action_id) {
+   if (active_anchored_message_ == action_id) {
+     ++anchored_message_timeout_pause_count_;
+@@ -265,7 +265,7 @@ void PageActionControllerImpl::PauseAnchoredMessageTimeout(
+   }
+ }
+ 
+-void PageActionControllerImpl::ResumeAnchoredMessageTimeout(
++void PageActionControllerImpl_ChromiumImpl::ResumeAnchoredMessageTimeout(
+     actions::ActionId action_id) {
+   if (active_anchored_message_ == action_id) {
+     --anchored_message_timeout_pause_count_;
+@@ -278,11 +278,11 @@ void PageActionControllerImpl::ResumeAnchoredMessageTimeout(
+ }
+ 
+ std::optional<actions::ActionId>
+-PageActionControllerImpl::GetActiveAnchoredMessage() const {
++PageActionControllerImpl_ChromiumImpl::GetActiveAnchoredMessage() const {
+   return active_anchored_message_;
+ }
+ 
+-ScopedPageActionActivity PageActionControllerImpl::AddActivity(
++ScopedPageActionActivity PageActionControllerImpl_ChromiumImpl::AddActivity(
+     actions::ActionId action_id) {
+   auto& counter = activity_counters_[action_id];
+   ++counter;
+@@ -290,7 +290,7 @@ ScopedPageActionActivity PageActionControllerImpl::AddActivity(
+   return ScopedPageActionActivity(*this, action_id);
+ }
+ 
+-void PageActionControllerImpl::DecrementActivityCounter(
++void PageActionControllerImpl_ChromiumImpl::DecrementActivityCounter(
+     actions::ActionId action_id) {
+   auto it = activity_counters_.find(action_id);
+   CHECK(it != activity_counters_.end());
+@@ -301,42 +301,42 @@ void PageActionControllerImpl::DecrementActivityCounter(
+   }
+ }
+ 
+-void PageActionControllerImpl::ActionItemChanged(
++void PageActionControllerImpl_ChromiumImpl::ActionItemChanged(
+     const actions::ActionItem* action_item) {
+   auto& model = FindPageActionModel(action_item->GetActionId().value());
+   model.SetActionItemProperties(PageActionPassKey(), action_item);
+ }
+ 
+-void PageActionControllerImpl::OnTabActivated(tabs::TabInterface* tab) {
++void PageActionControllerImpl_ChromiumImpl::OnTabActivated(tabs::TabInterface* tab) {
+   SetModelsTabActive(/*is_active=*/true);
+   if (anchored_message_timeout_.IsRunning()) {
+     anchored_message_timeout_.Reset();
+   }
+ }
+ 
+-void PageActionControllerImpl::OnTabWillDeactivate(tabs::TabInterface* tab) {
++void PageActionControllerImpl_ChromiumImpl::OnTabWillDeactivate(tabs::TabInterface* tab) {
+   SetModelsTabActive(/*is_active=*/false);
+ }
+ 
+-void PageActionControllerImpl::SetModelsTabActive(bool is_active) {
++void PageActionControllerImpl_ChromiumImpl::SetModelsTabActive(bool is_active) {
+   for (auto& [id, model] : page_actions_) {
+     model->SetTabActive(PageActionPassKey(), is_active);
+   }
+ }
+ 
+-void PageActionControllerImpl::OverrideText(
++void PageActionControllerImpl_ChromiumImpl::OverrideText(
+     actions::ActionId action_id,
+     const std::u16string& override_text) {
+   FindPageActionModel(action_id).SetOverrideText(PageActionPassKey(),
+                                                  override_text);
+ }
+ 
+-void PageActionControllerImpl::ClearOverrideText(actions::ActionId action_id) {
++void PageActionControllerImpl_ChromiumImpl::ClearOverrideText(actions::ActionId action_id) {
+   FindPageActionModel(action_id).SetOverrideText(
+       PageActionPassKey(), /*override_text=*/std::nullopt);
+ }
+ 
+-void PageActionControllerImpl::OverrideAccessibleName(
++void PageActionControllerImpl_ChromiumImpl::OverrideAccessibleName(
+     actions::ActionId action_id,
+     const std::u16string& override_accessible_name) {
+   FindPageActionModel(action_id).SetOverrideAccessibleName(
+@@ -344,26 +344,26 @@ void PageActionControllerImpl::OverrideAccessibleName(
+       /*override_accessible_name=*/override_accessible_name);
+ }
+ 
+-void PageActionControllerImpl::ClearOverrideAccessibleName(
++void PageActionControllerImpl_ChromiumImpl::ClearOverrideAccessibleName(
+     actions::ActionId action_id) {
+   FindPageActionModel(action_id).SetOverrideAccessibleName(
+       PageActionPassKey(), /*override_accessible_name=*/std::nullopt);
+ }
+ 
+-void PageActionControllerImpl::OverrideImage(
++void PageActionControllerImpl_ChromiumImpl::OverrideImage(
+     actions::ActionId action_id,
+     const ui::ImageModel& override_image) {
+   OverrideImage(action_id, override_image, PageActionColorSource::kForeground);
+ }
+ 
+-void PageActionControllerImpl::OverrideImage(
++void PageActionControllerImpl_ChromiumImpl::OverrideImage(
+     actions::ActionId action_id,
+     const ui::ImageModel& override_image,
+     PageActionColorSource color_source) {
+   OverrideImage(action_id, override_image, color_source, std::nullopt);
+ }
+ 
+-void PageActionControllerImpl::OverrideImage(
++void PageActionControllerImpl_ChromiumImpl::OverrideImage(
+     actions::ActionId action_id,
+     const ui::ImageModel& override_image,
+     PageActionColorSource color_source,
+@@ -372,7 +372,7 @@ void PageActionControllerImpl::OverrideImage(
+       PageActionPassKey(), override_image, color_source, animation_parameters);
+ }
+ 
+-void PageActionControllerImpl::ClearOverrideImage(actions::ActionId action_id) {
++void PageActionControllerImpl_ChromiumImpl::ClearOverrideImage(actions::ActionId action_id) {
+   auto& model = FindPageActionModel(action_id);
+   model.SetOverrideImage(PageActionPassKey(),
+                          /*override_image=*/std::nullopt,
+@@ -380,70 +380,70 @@ void PageActionControllerImpl::ClearOverrideImage(actions::ActionId action_id) {
+                          /*animation_parameters=*/std::nullopt);
+ }
+ 
+-void PageActionControllerImpl::SetAnimationStyle(
++void PageActionControllerImpl_ChromiumImpl::SetAnimationStyle(
+     actions::ActionId action_id,
+     PageActionAnimationStyle style) {
+   FindPageActionModel(action_id).SetAnimationStyle(PageActionPassKey(), style);
+ }
+ 
+-void PageActionControllerImpl::SetTrailingImage(
++void PageActionControllerImpl_ChromiumImpl::SetTrailingImage(
+     actions::ActionId action_id,
+     const ui::ImageModel& trailing_image) {
+   FindPageActionModel(action_id).SetTrailingImage(PageActionPassKey(),
+                                                   trailing_image);
+ }
+ 
+-void PageActionControllerImpl::ClearTrailingImage(actions::ActionId action_id) {
++void PageActionControllerImpl_ChromiumImpl::ClearTrailingImage(actions::ActionId action_id) {
+   FindPageActionModel(action_id).SetTrailingImage(PageActionPassKey(),
+                                                   std::nullopt);
+ }
+ 
+-void PageActionControllerImpl::SetShowTrailingIcon(actions::ActionId action_id,
++void PageActionControllerImpl_ChromiumImpl::SetShowTrailingIcon(actions::ActionId action_id,
+                                                    bool show) {
+   FindPageActionModel(action_id).SetShowTrailingIcon(PageActionPassKey(), show);
+ }
+ 
+-void PageActionControllerImpl::OverrideTooltip(
++void PageActionControllerImpl_ChromiumImpl::OverrideTooltip(
+     actions::ActionId action_id,
+     const std::u16string& override_tooltip) {
+   FindPageActionModel(action_id).SetOverrideTooltip(PageActionPassKey(),
+                                                     override_tooltip);
+ }
+ 
+-void PageActionControllerImpl::ClearOverrideTooltip(
++void PageActionControllerImpl_ChromiumImpl::ClearOverrideTooltip(
+     actions::ActionId action_id) {
+   FindPageActionModel(action_id).SetOverrideTooltip(
+       PageActionPassKey(), /*override_tooltip=*/std::nullopt);
+ }
+ 
+-void PageActionControllerImpl::SetAnchoredMessageText(
++void PageActionControllerImpl_ChromiumImpl::SetAnchoredMessageText(
+     actions::ActionId action_id,
+     const std::u16string& anchored_message_text) {
+   FindPageActionModel(action_id).SetAnchoredMessageText(PageActionPassKey(),
+                                                         anchored_message_text);
+ }
+ 
+-void PageActionControllerImpl::SetAnchoredMessageIcon(
++void PageActionControllerImpl_ChromiumImpl::SetAnchoredMessageIcon(
+     actions::ActionId action_id,
+     const ui::ImageModel& icon) {
+   FindPageActionModel(action_id).SetAnchoredMessageIcon(PageActionPassKey(),
+                                                         icon);
+ }
+ 
+-void PageActionControllerImpl::ClearAnchoredMessageIcon(
++void PageActionControllerImpl_ChromiumImpl::ClearAnchoredMessageIcon(
+     actions::ActionId action_id) {
+   FindPageActionModel(action_id).SetAnchoredMessageIcon(PageActionPassKey(),
+                                                         std::nullopt);
+ }
+ 
+-void PageActionControllerImpl::SetAnchoredMessageExpandableContent(
++void PageActionControllerImpl_ChromiumImpl::SetAnchoredMessageExpandableContent(
+     actions::ActionId action_id,
+     std::optional<AnchoredMessageExpandableContent> expandable_content) {
+   FindPageActionModel(action_id).SetAnchoredMessageExpandableContent(
+       PageActionPassKey(), std::move(expandable_content));
+ }
+ 
+-void PageActionControllerImpl::SetAnchoredMessageAction(
++void PageActionControllerImpl_ChromiumImpl::SetAnchoredMessageAction(
+     actions::ActionId action_id,
+     AnchoredMessageActionIconType action_icon_type,
+     std::unique_ptr<ui::SimpleMenuModel> model) {
+@@ -457,11 +457,11 @@ void PageActionControllerImpl::SetAnchoredMessageAction(
+       PageActionPassKey(), action_icon_type, std::move(model));
+ }
+ 
+-bool PageActionControllerImpl::ActionExists(actions::ActionId action_id) const {
++bool PageActionControllerImpl_ChromiumImpl::ActionExists(actions::ActionId action_id) const {
+   return page_actions_.contains(action_id);
+ }
+ 
+-void PageActionControllerImpl::AddObserver(
++void PageActionControllerImpl_ChromiumImpl::AddObserver(
+     actions::ActionId action_id,
+     base::ScopedObservation<PageActionModelInterface, PageActionModelObserver>&
+         observation) {
+@@ -469,17 +469,17 @@ void PageActionControllerImpl::AddObserver(
+ }
+ 
+ base::CallbackListSubscription
+-PageActionControllerImpl::CreateActionItemSubscription(
++PageActionControllerImpl_ChromiumImpl::CreateActionItemSubscription(
+     actions::ActionItem* action_item) {
+   base::CallbackListSubscription subscription =
+       action_item->AddActionChangedCallback(
+-          base::BindRepeating(&PageActionControllerImpl::ActionItemChanged,
++          base::BindRepeating(&PageActionControllerImpl_ChromiumImpl::ActionItemChanged,
+                               weak_factory_.GetWeakPtr(), action_item));
+   ActionItemChanged(action_item);
+   return subscription;
+ }
+ 
+-void PageActionControllerImpl::SetShouldHidePageActions(
++void PageActionControllerImpl_ChromiumImpl::SetShouldHidePageActions(
+     bool should_hide_page_actions) {
+   for (auto& [id, model] : page_actions_) {
+     model->SetIsSuppressedByOmnibox(PageActionPassKey(),
+@@ -487,11 +487,11 @@ void PageActionControllerImpl::SetShouldHidePageActions(
+   }
+ }
+ 
+-void PageActionControllerImpl::OnActionsChanged() {
++void PageActionControllerImpl_ChromiumImpl::OnActionsChanged() {
+   PinnedActionsModelChanged();
+ }
+ 
+-void PageActionControllerImpl::PinnedActionsModelChanged() {
++void PageActionControllerImpl_ChromiumImpl::PinnedActionsModelChanged() {
+   PinnedToolbarActionsModel* pinned_actions_model =
+       pinned_actions_observation_.GetSource();
+   CHECK(pinned_actions_model);
+@@ -501,7 +501,7 @@ void PageActionControllerImpl::PinnedActionsModelChanged() {
+   }
+ }
+ 
+-PageActionModelInterface& PageActionControllerImpl::FindPageActionModel(
++PageActionModelInterface& PageActionControllerImpl_ChromiumImpl::FindPageActionModel(
+     actions::ActionId action_id) const {
+   auto id_to_model = page_actions_.find(action_id);
+   CHECK(id_to_model != page_actions_.end());
+@@ -509,7 +509,7 @@ PageActionModelInterface& PageActionControllerImpl::FindPageActionModel(
+   return *id_to_model->second.get();
+ }
+ 
+-std::unique_ptr<PageActionModelInterface> PageActionControllerImpl::CreateModel(
++std::unique_ptr<PageActionModelInterface> PageActionControllerImpl_ChromiumImpl::CreateModel(
+     actions::ActionId action_id,
+     bool is_ephemeral) {
+   if (page_action_model_factory_ != nullptr) {
+@@ -520,7 +520,7 @@ std::unique_ptr<PageActionModelInterface> PageActionControllerImpl::CreateModel(
+ }
+ 
+ std::unique_ptr<PageActionMetricsRecorderInterface>
+-PageActionControllerImpl::CreateMetricsRecorder(
++PageActionControllerImpl_ChromiumImpl::CreateMetricsRecorder(
+     tabs::TabInterface& tab_interface,
+     VisibleEphemeralPageActionsCountCallback
+         visible_ephemeral_page_actions_count_callback) {
+@@ -535,37 +535,37 @@ PageActionControllerImpl::CreateMetricsRecorder(
+   }
+ }
+ 
+-void PageActionControllerImpl::RegisterCallbacks(PageActionPassKey,
++void PageActionControllerImpl_ChromiumImpl::RegisterCallbacks(PageActionPassKey,
+                                                  actions::ActionId action_id,
+                                                  Delegate* delegate) {
+   CHECK(delegate);
+   delegate->SetIsChipShowingChangedCallback(
+-      base::BindRepeating(&PageActionControllerImpl::OnIsChipShowingChanged,
++      base::BindRepeating(&PageActionControllerImpl_ChromiumImpl::OnIsChipShowingChanged,
+                           weak_factory_.GetWeakPtr(), action_id));
+   delegate->SetImageAnimationStartedCallback(
+-      base::BindRepeating(&PageActionControllerImpl::OnImageAnimationStarted,
++      base::BindRepeating(&PageActionControllerImpl_ChromiumImpl::OnImageAnimationStarted,
+                           weak_factory_.GetWeakPtr(), action_id));
+   delegate->SetAnchoredMessageCloseCallback(
+-      base::BindRepeating(&PageActionControllerImpl::HideAnchoredMessage,
++      base::BindRepeating(&PageActionControllerImpl_ChromiumImpl::HideAnchoredMessage,
+                           weak_factory_.GetWeakPtr(), action_id));
+   delegate->SetClickCallback(
+-      base::BindRepeating(&PageActionControllerImpl::RecordClickMetric,
++      base::BindRepeating(&PageActionControllerImpl_ChromiumImpl::RecordClickMetric,
+                           weak_factory_.GetWeakPtr(), action_id));
+   delegate->SetAnchoredMessageExpandCallback(base::BindRepeating(
+-      &PageActionControllerImpl::PauseAnchoredMessageTimeout,
++      &PageActionControllerImpl_ChromiumImpl::PauseAnchoredMessageTimeout,
+       weak_factory_.GetWeakPtr(), action_id));
+   delegate->SetAnchoredMessageCollapseCallback(base::BindRepeating(
+-      &PageActionControllerImpl::ResumeAnchoredMessageTimeout,
++      &PageActionControllerImpl_ChromiumImpl::ResumeAnchoredMessageTimeout,
+       weak_factory_.GetWeakPtr(), action_id));
+ }
+ 
+-void PageActionControllerImpl::RecordClickMetric(
++void PageActionControllerImpl_ChromiumImpl::RecordClickMetric(
+     actions::ActionId action_id,
+     PageActionTrigger trigger_source) {
+   metrics_recorder_->RecordClick(action_id, trigger_source);
+ }
+ 
+-int PageActionControllerImpl::GetVisibleEphemeralPageActionsCount() const {
++int PageActionControllerImpl_ChromiumImpl::GetVisibleEphemeralPageActionsCount() const {
+   int visible_ephemeral_page_actions_count = 0;
+   for (auto& [id, model] : page_actions_) {
+     if (model->GetVisible() && model->IsEphemeral()) {
+@@ -576,19 +576,19 @@ int PageActionControllerImpl::GetVisibleEphemeralPageActionsCount() const {
+ }
+ 
+ base::CallbackListSubscription
+-PageActionControllerImpl::RegisterOnWillDestroyCallback(
++PageActionControllerImpl_ChromiumImpl::RegisterOnWillDestroyCallback(
+     base::OnceCallback<void(PageActionController&)> callback) {
+   return on_will_destroy_callback_list_.Add(std::move(callback));
+ }
+ 
+-void PageActionControllerImpl::OnIsChipShowingChanged(
++void PageActionControllerImpl_ChromiumImpl::OnIsChipShowingChanged(
+     actions::ActionId action_id,
+     bool is_chip_showing) {
+   FindPageActionModel(action_id).SetIsChipShowing(PageActionPassKey(),
+                                                   is_chip_showing);
+ }
+ 
+-void PageActionControllerImpl::OnImageAnimationStarted(
++void PageActionControllerImpl_ChromiumImpl::OnImageAnimationStarted(
+     actions::ActionId action_id) {
+   FindPageActionModel(action_id).SetDidAnimateImage(PageActionPassKey());
+ }

--- a/patches/chrome-browser-ui-page_action-page_action_controller.h.patch
+++ b/patches/chrome-browser-ui-page_action-page_action_controller.h.patch
@@ -1,16 +1,30 @@
 diff --git a/chrome/browser/ui/page_action/page_action_controller.h b/chrome/browser/ui/page_action/page_action_controller.h
-index adae94a5f91c1fa7a750f98c6af692361061cc52..a5ac79b711721847bc953c570aa7255f5135864e 100644
+index adae94a5f91c1fa7a750f98c6af692361061cc52..1ae54783be7fc7955ac20f44c5688d255227f329 100644
 --- a/chrome/browser/ui/page_action/page_action_controller.h
 +++ b/chrome/browser/ui/page_action/page_action_controller.h
-@@ -370,6 +370,7 @@ class PageActionController {
+@@ -370,16 +370,16 @@ class PageActionController {
    virtual void DecrementActivityCounter(actions::ActionId action_id) = 0;
  };
  
-+namespace chromium_impl {
- class PageActionControllerImpl : public PageActionController,
+-class PageActionControllerImpl : public PageActionController,
++class PageActionControllerImpl_ChromiumImpl : public PageActionController,
                                   public PinnedToolbarActionsModel::Observer {
   public:
-@@ -457,6 +458,7 @@ class PageActionControllerImpl : public PageActionController,
+-  explicit PageActionControllerImpl(
++  explicit PageActionControllerImpl_ChromiumImpl(
+       PinnedToolbarActionsModel* pinned_actions_model,
+       PageActionModelFactory* page_action_model_factory = nullptr,
+       PageActionMetricsRecorderFactory* page_action_metrics_factory = nullptr);
+-  PageActionControllerImpl(const PageActionControllerImpl&) = delete;
+-  PageActionControllerImpl& operator=(const PageActionControllerImpl&) = delete;
+-  ~PageActionControllerImpl() override;
++  PageActionControllerImpl_ChromiumImpl(const PageActionControllerImpl_ChromiumImpl&) = delete;
++  PageActionControllerImpl_ChromiumImpl& operator=(const PageActionControllerImpl_ChromiumImpl&) = delete;
++  ~PageActionControllerImpl_ChromiumImpl() override;
+ 
+   void Initialize(
+       tabs::TabInterface& tab_interface,
+@@ -457,6 +457,7 @@ class PageActionControllerImpl : public PageActionController,
    void OnActionsChanged() override;
  
   private:
@@ -18,7 +32,7 @@ index adae94a5f91c1fa7a750f98c6af692361061cc52..a5ac79b711721847bc953c570aa7255f
    using PageActionModelsMap =
        std::map<actions::ActionId, std::unique_ptr<PageActionModelInterface>>;
  
-@@ -487,7 +489,7 @@ class PageActionControllerImpl : public PageActionController,
+@@ -487,7 +488,7 @@ class PageActionControllerImpl : public PageActionController,
    void ActionItemChanged(const actions::ActionItem* action_item);
    void PinnedActionsModelChanged();
  
@@ -27,12 +41,12 @@ index adae94a5f91c1fa7a750f98c6af692361061cc52..a5ac79b711721847bc953c570aa7255f
        actions::ActionId action_id,
        bool is_ephemeral);
  
-@@ -547,6 +549,8 @@ class PageActionControllerImpl : public PageActionController,
+@@ -545,7 +546,7 @@ class PageActionControllerImpl : public PageActionController,
+   std::optional<actions::ActionId> active_anchored_message_;
+   std::map<actions::ActionId, PageActionPriorityCategory> default_priorities_;
  
-   base::WeakPtrFactory<PageActionControllerImpl> weak_factory_{this};
+-  base::WeakPtrFactory<PageActionControllerImpl> weak_factory_{this};
++  base::WeakPtrFactory<PageActionControllerImpl_ChromiumImpl> weak_factory_{this};
  };
-+}  // namespace chromium_impl
-+
  
  // Returns page action IDs that are present in the browser window's root action
- // item.

--- a/patches/chrome-browser-ui-page_action-page_action_model.cc.patch
+++ b/patches/chrome-browser-ui-page_action-page_action_model.cc.patch
@@ -1,18 +1,396 @@
 diff --git a/chrome/browser/ui/page_action/page_action_model.cc b/chrome/browser/ui/page_action/page_action_model.cc
-index 57f0cd288f0a9a0508e443f9fd2209b1ba409fa6..75390cdcfb379dcecfca4f49bc57c45b16d18e70 100644
+index 57f0cd288f0a9a0508e443f9fd2209b1ba409fa6..b219b736bef46a250407cc58c64b91009bb7b640 100644
 --- a/chrome/browser/ui/page_action/page_action_model.cc
 +++ b/chrome/browser/ui/page_action/page_action_model.cc
-@@ -16,6 +16,7 @@ namespace {
+@@ -16,19 +16,19 @@ namespace {
  using ::actions::ActionItem;
  }  // namespace
  
-+namespace chromium_impl {
- PageActionModel::PageActionModel(actions::ActionId action_id, bool is_ephemeral)
+-PageActionModel::PageActionModel(actions::ActionId action_id, bool is_ephemeral)
++PageActionModel_ChromiumImpl::PageActionModel_ChromiumImpl(actions::ActionId action_id, bool is_ephemeral)
      : action_id_(action_id), is_ephemeral_(is_ephemeral) {}
  
-@@ -425,4 +426,5 @@ bool PageActionModel::GetShowTrailingIcon() const {
+-PageActionModel::~PageActionModel() {
++PageActionModel_ChromiumImpl::~PageActionModel_ChromiumImpl() {
+   observer_list_.Notify(
+       &PageActionModelObserver::OnPageActionModelWillBeDeleted, *this);
+ }
+ 
+-actions::ActionId PageActionModel::GetActionId() const {
++actions::ActionId PageActionModel_ChromiumImpl::GetActionId() const {
+   return action_id_;
+ }
+ 
+-void PageActionModel::SetShowRequested(PageActionPassKey, bool requested) {
++void PageActionModel_ChromiumImpl::SetShowRequested(PageActionPassKey, bool requested) {
+   if (show_requested_ == requested) {
+     return;
+   }
+@@ -36,7 +36,7 @@ void PageActionModel::SetShowRequested(PageActionPassKey, bool requested) {
+   NotifyChange(Property::kShowRequested);
+ }
+ 
+-void PageActionModel::SetShouldShowSuggestionChip(PageActionPassKey,
++void PageActionModel_ChromiumImpl::SetShouldShowSuggestionChip(PageActionPassKey,
+                                                   bool show) {
+   did_show_chip_ = false;
+   if (should_show_suggestion_chip_ == show) {
+@@ -46,7 +46,7 @@ void PageActionModel::SetShouldShowSuggestionChip(PageActionPassKey,
+   NotifyChange(Property::kShouldShowSuggestionChip);
+ }
+ 
+-void PageActionModel::SetSuggestionChipConfig(
++void PageActionModel_ChromiumImpl::SetSuggestionChipConfig(
+     PageActionPassKey,
+     const SuggestionChipConfig& config) {
+   if (should_animate_ == config.should_animate &&
+@@ -58,7 +58,7 @@ void PageActionModel::SetSuggestionChipConfig(
+   NotifyChange(Property::kSuggestionChipConfig);
+ }
+ 
+-void PageActionModel::SetTabActive(PageActionPassKey, bool is_active) {
++void PageActionModel_ChromiumImpl::SetTabActive(PageActionPassKey, bool is_active) {
+   if (is_tab_active_ == is_active) {
+     return;
+   }
+@@ -66,7 +66,7 @@ void PageActionModel::SetTabActive(PageActionPassKey, bool is_active) {
+   NotifyChange(Property::kTabActive);
+ }
+ 
+-void PageActionModel::SetHasPinnedIcon(PageActionPassKey,
++void PageActionModel_ChromiumImpl::SetHasPinnedIcon(PageActionPassKey,
+                                        bool has_pinned_icon) {
+   if (has_pinned_icon_ == has_pinned_icon) {
+     return;
+@@ -75,7 +75,7 @@ void PageActionModel::SetHasPinnedIcon(PageActionPassKey,
+   NotifyChange(Property::kHasPinnedIcon);
+ }
+ 
+-void PageActionModel::SetActionItemProperties(PageActionPassKey,
++void PageActionModel_ChromiumImpl::SetActionItemProperties(PageActionPassKey,
+                                               const ActionItem* action_item) {
+   bool model_changed = false;
+ 
+@@ -109,7 +109,7 @@ void PageActionModel::SetActionItemProperties(PageActionPassKey,
+   }
+ }
+ 
+-bool PageActionModel::GetVisible() const {
++bool PageActionModel_ChromiumImpl::GetVisible() const {
+   const bool hidden_by_omnibox =
+       is_suppressed_by_omnibox_ && !is_exempt_from_omnibox_suppression_;
+ 
+@@ -117,69 +117,69 @@ bool PageActionModel::GetVisible() const {
+          action_item_visible_ && show_requested_ && !has_pinned_icon_;
+ }
+ 
+-bool PageActionModel::IsChipShowing() const {
++bool PageActionModel_ChromiumImpl::IsChipShowing() const {
+   return is_chip_showing_;
+ }
+ 
+-bool PageActionModel::ShouldShowSuggestionChip() const {
++bool PageActionModel_ChromiumImpl::ShouldShowSuggestionChip() const {
+   return should_show_suggestion_chip_;
+ }
+ 
+-bool PageActionModel::GetShouldAnimateChipOut() const {
++bool PageActionModel_ChromiumImpl::GetShouldAnimateChipOut() const {
+   return should_animate_;
+ }
+ 
+-bool PageActionModel::GetShouldAnimateChipIn() const {
++bool PageActionModel_ChromiumImpl::GetShouldAnimateChipIn() const {
+   // Only animate in if the chip was not shown yet.
+   return should_animate_ && !did_show_chip_;
+ }
+ 
+-bool PageActionModel::GetShouldAnimateImage() const {
++bool PageActionModel_ChromiumImpl::GetShouldAnimateImage() const {
+   return image_animation_parameters_.has_value() && !did_animate_image_;
+ }
+ 
+-bool PageActionModel::GetShouldAnnounceChip() const {
++bool PageActionModel_ChromiumImpl::GetShouldAnnounceChip() const {
+   return should_announce_chip_;
+ }
+ 
+-const ui::ImageModel& PageActionModel::GetImage() const {
++const ui::ImageModel& PageActionModel_ChromiumImpl::GetImage() const {
+   return override_image_.has_value() ? override_image_.value()
+                                      : action_item_image_;
+ }
+ 
+ std::optional<PageActionAnimationParams>
+-PageActionModel::GetImageAnimationParameters() const {
++PageActionModel_ChromiumImpl::GetImageAnimationParameters() const {
+   return image_animation_parameters_;
+ }
+ 
+-const std::u16string& PageActionModel::GetText() const {
++const std::u16string& PageActionModel_ChromiumImpl::GetText() const {
+   return override_text_.has_value() ? override_text_.value() : text_;
+ }
+ 
+-const std::u16string& PageActionModel::GetAccessibleName() const {
++const std::u16string& PageActionModel_ChromiumImpl::GetAccessibleName() const {
+   return override_accessible_name_.has_value()
+              ? override_accessible_name_.value()
+              : text_;
+ }
+ 
+-const std::u16string& PageActionModel::GetTooltipText() const {
++const std::u16string& PageActionModel_ChromiumImpl::GetTooltipText() const {
+   return override_tooltip_.has_value() ? override_tooltip_.value() : tooltip_;
+ }
+ 
+-bool PageActionModel::GetActionItemIsShowingBubble() const {
++bool PageActionModel_ChromiumImpl::GetActionItemIsShowingBubble() const {
+   return action_item_is_showing_bubble_;
+ }
+ 
+-bool PageActionModel::GetActionActive() const {
++bool PageActionModel_ChromiumImpl::GetActionActive() const {
+   return action_active_;
+ }
+ 
+-PageActionColorSource PageActionModel::GetColorSource() const {
++PageActionColorSource PageActionModel_ChromiumImpl::GetColorSource() const {
+   return color_source_.has_value() ? *color_source_
+                                    : PageActionColorSource::kForeground;
+ }
+ 
+-void PageActionModel::SetOverrideText(
++void PageActionModel_ChromiumImpl::SetOverrideText(
+     PageActionPassKey,
+     const std::optional<std::u16string>& override_text) {
+   if (override_text_ == override_text) {
+@@ -189,7 +189,7 @@ void PageActionModel::SetOverrideText(
+   NotifyChange(Property::kOverrideText);
+ }
+ 
+-void PageActionModel::SetOverrideAccessibleName(
++void PageActionModel_ChromiumImpl::SetOverrideAccessibleName(
+     PageActionPassKey,
+     const std::optional<std::u16string>& override_accessible_name) {
+   if (override_accessible_name_ == override_accessible_name) {
+@@ -199,7 +199,7 @@ void PageActionModel::SetOverrideAccessibleName(
+   NotifyChange(Property::kOverrideAccessibleName);
+ }
+ 
+-void PageActionModel::SetOverrideImage(
++void PageActionModel_ChromiumImpl::SetOverrideImage(
+     PageActionPassKey,
+     const std::optional<ui::ImageModel>& override_image,
+     PageActionColorSource color_source,
+@@ -215,7 +215,7 @@ void PageActionModel::SetOverrideImage(
+   NotifyChange(Property::kOverrideImage);
+ }
+ 
+-void PageActionModel::SetOverrideTooltip(
++void PageActionModel_ChromiumImpl::SetOverrideTooltip(
+     PageActionPassKey,
+     const std::optional<std::u16string>& override_tooltip) {
+   if (override_tooltip_ == override_tooltip) {
+@@ -225,7 +225,7 @@ void PageActionModel::SetOverrideTooltip(
+   NotifyChange(Property::kOverrideTooltip);
+ }
+ 
+-void PageActionModel::SetIsSuppressedByOmnibox(PageActionPassKey,
++void PageActionModel_ChromiumImpl::SetIsSuppressedByOmnibox(PageActionPassKey,
+                                                bool is_suppressed) {
+   if (is_suppressed_by_omnibox_ == is_suppressed) {
+     return;
+@@ -234,7 +234,7 @@ void PageActionModel::SetIsSuppressedByOmnibox(PageActionPassKey,
+   NotifyChange(Property::kIsSuppressedByOmnibox);
+ }
+ 
+-void PageActionModel::SetExemptFromOmniboxSuppression(PageActionPassKey,
++void PageActionModel_ChromiumImpl::SetExemptFromOmniboxSuppression(PageActionPassKey,
+                                                       bool is_exempt) {
+   if (is_exempt_from_omnibox_suppression_ == is_exempt) {
+     return;
+@@ -243,7 +243,7 @@ void PageActionModel::SetExemptFromOmniboxSuppression(PageActionPassKey,
+   NotifyChange(Property::kExemptFromOmniboxSuppression);
+ }
+ 
+-void PageActionModel::SetIsChipShowing(PageActionPassKey,
++void PageActionModel_ChromiumImpl::SetIsChipShowing(PageActionPassKey,
+                                        bool is_chip_showing) {
+   did_show_chip_ |= is_chip_showing;
+   if (is_chip_showing_ == is_chip_showing) {
+@@ -254,7 +254,7 @@ void PageActionModel::SetIsChipShowing(PageActionPassKey,
+   NotifyChange(Property::kIsChipShowing);
+ }
+ 
+-void PageActionModel::SetActionActive(PageActionPassKey, bool is_active) {
++void PageActionModel_ChromiumImpl::SetActionActive(PageActionPassKey, bool is_active) {
+   if (action_active_ == is_active) {
+     return;
+   }
+@@ -263,7 +263,7 @@ void PageActionModel::SetActionActive(PageActionPassKey, bool is_active) {
+   NotifyChange(Property::kActionActive);
+ }
+ 
+-void PageActionModel::SetAnimationStyle(PageActionPassKey,
++void PageActionModel_ChromiumImpl::SetAnimationStyle(PageActionPassKey,
+                                         PageActionAnimationStyle style) {
+   if (animation_style_ == style) {
+     return;
+@@ -272,7 +272,7 @@ void PageActionModel::SetAnimationStyle(PageActionPassKey,
+   NotifyChange(Property::kAnimationStyle);
+ }
+ 
+-void PageActionModel::SetTrailingImage(
++void PageActionModel_ChromiumImpl::SetTrailingImage(
+     PageActionPassKey,
+     const std::optional<ui::ImageModel>& image) {
+   if (trailing_image_ == image) {
+@@ -282,7 +282,7 @@ void PageActionModel::SetTrailingImage(
+   NotifyChange(Property::kTrailingImage);
+ }
+ 
+-void PageActionModel::SetShowTrailingIcon(PageActionPassKey, bool show) {
++void PageActionModel_ChromiumImpl::SetShowTrailingIcon(PageActionPassKey, bool show) {
+   if (show_trailing_icon_ == show) {
+     return;
+   }
+@@ -290,15 +290,15 @@ void PageActionModel::SetShowTrailingIcon(PageActionPassKey, bool show) {
+   NotifyChange(Property::kShowTrailingIcon);
+ }
+ 
+-void PageActionModel::AddObserver(PageActionModelObserver* observer) {
++void PageActionModel_ChromiumImpl::AddObserver(PageActionModelObserver* observer) {
+   observer_list_.AddObserver(observer);
+ }
+ 
+-void PageActionModel::RemoveObserver(PageActionModelObserver* observer) {
++void PageActionModel_ChromiumImpl::RemoveObserver(PageActionModelObserver* observer) {
+   observer_list_.RemoveObserver(observer);
+ }
+ 
+-void PageActionModel::NotifyChange(Property property) {
++void PageActionModel_ChromiumImpl::NotifyChange(Property property) {
+   // Crash if the same property is modified again during notification, as this
+   // would cause an infinite loop (A notifies -> observer sets A -> notifies
+   // -> ...).
+@@ -317,11 +317,11 @@ void PageActionModel::NotifyChange(Property property) {
+   notified_properties_.Remove(property);
+ }
+ 
+-bool PageActionModel::IsEphemeral() const {
++bool PageActionModel_ChromiumImpl::IsEphemeral() const {
+   return is_ephemeral_;
+ }
+ 
+-void PageActionModel::SetShouldShowAnchoredMessage(PageActionPassKey,
++void PageActionModel_ChromiumImpl::SetShouldShowAnchoredMessage(PageActionPassKey,
+                                                    bool show) {
+   if (should_show_anchored_message_ == show) {
+     return;
+@@ -330,7 +330,7 @@ void PageActionModel::SetShouldShowAnchoredMessage(PageActionPassKey,
+   NotifyChange(Property::kShouldShowAnchoredMessage);
+ }
+ 
+-void PageActionModel::SetAnchoredMessageText(
++void PageActionModel_ChromiumImpl::SetAnchoredMessageText(
+     PageActionPassKey,
+     const std::u16string& anchored_message) {
+   if (anchored_message_text_ == anchored_message) {
+@@ -340,7 +340,7 @@ void PageActionModel::SetAnchoredMessageText(
+   NotifyChange(Property::kAnchoredMessageText);
+ }
+ 
+-void PageActionModel::SetAnchoredMessageAction(
++void PageActionModel_ChromiumImpl::SetAnchoredMessageAction(
+     PageActionPassKey,
+     const AnchoredMessageActionIconType action_icon_type,
+     std::unique_ptr<ui::SimpleMenuModel> model) {
+@@ -351,14 +351,14 @@ void PageActionModel::SetAnchoredMessageAction(
+   NotifyChange(Property::kAnchoredMessageActionIcon);
+ }
+ 
+-void PageActionModel::SetAnchoredMessageIcon(
++void PageActionModel_ChromiumImpl::SetAnchoredMessageIcon(
+     PageActionPassKey,
+     const std::optional<ui::ImageModel>& icon) {
+   anchored_message_icon_ = icon;
+   NotifyChange(Property::kAnchoredMessageIcon);
+ }
+ 
+-void PageActionModel::SetAnchoredMessageExpandableContent(
++void PageActionModel_ChromiumImpl::SetAnchoredMessageExpandableContent(
+     PageActionPassKey,
+     std::optional<AnchoredMessageExpandableContent> expandable_content) {
+   if (expandable_content_ == expandable_content) {
+@@ -368,15 +368,15 @@ void PageActionModel::SetAnchoredMessageExpandableContent(
+   NotifyChange(Property::kAnchoredMessageExpandableContent);
+ }
+ 
+-bool PageActionModel::ShouldShowAnchoredMessage() const {
++bool PageActionModel_ChromiumImpl::ShouldShowAnchoredMessage() const {
+   return should_show_anchored_message_;
+ }
+ 
+-bool PageActionModel::IsAnchoredMessageShowing() const {
++bool PageActionModel_ChromiumImpl::IsAnchoredMessageShowing() const {
+   return is_anchored_message_showing_;
+ }
+ 
+-void PageActionModel::SetIsAnchoredMessageShowing(
++void PageActionModel_ChromiumImpl::SetIsAnchoredMessageShowing(
+     PageActionPassKey,
+     bool is_anchored_message_showing) {
+   if (is_anchored_message_showing_ == is_anchored_message_showing) {
+@@ -386,42 +386,42 @@ void PageActionModel::SetIsAnchoredMessageShowing(
+   NotifyChange(Property::kIsAnchoredMessageShowing);
+ }
+ 
+-void PageActionModel::SetDidAnimateImage(PageActionPassKey pass_key) {
++void PageActionModel_ChromiumImpl::SetDidAnimateImage(PageActionPassKey pass_key) {
+   did_animate_image_ = true;
+ }
+ 
+-const std::u16string& PageActionModel::GetAnchoredMessageText() const {
++const std::u16string& PageActionModel_ChromiumImpl::GetAnchoredMessageText() const {
+   return anchored_message_text_;
+ }
+ 
+ AnchoredMessageActionIconType
+-PageActionModel::GetAnchoredMessageActionIconType() const {
++PageActionModel_ChromiumImpl::GetAnchoredMessageActionIconType() const {
+   return anchored_message_action_icon_type_;
+ }
+ 
+-ui::SimpleMenuModel* PageActionModel::GetAnchoredMessageMenuModel() const {
++ui::SimpleMenuModel* PageActionModel_ChromiumImpl::GetAnchoredMessageMenuModel() const {
+   return anchored_message_menu_model_.get();
+ }
+ 
+-const std::optional<ui::ImageModel>& PageActionModel::GetAnchoredMessageIcon()
++const std::optional<ui::ImageModel>& PageActionModel_ChromiumImpl::GetAnchoredMessageIcon()
+     const {
+   return anchored_message_icon_;
+ }
+ 
+ const std::optional<AnchoredMessageExpandableContent>&
+-PageActionModel::GetAnchoredMessageExpandableContent() const {
++PageActionModel_ChromiumImpl::GetAnchoredMessageExpandableContent() const {
+   return expandable_content_;
+ }
+ 
+-PageActionAnimationStyle PageActionModel::GetAnimationStyle() const {
++PageActionAnimationStyle PageActionModel_ChromiumImpl::GetAnimationStyle() const {
+   return animation_style_;
+ }
+ 
+-std::optional<ui::ImageModel> PageActionModel::GetTrailingImage() const {
++std::optional<ui::ImageModel> PageActionModel_ChromiumImpl::GetTrailingImage() const {
+   return trailing_image_;
+ }
+ 
+-bool PageActionModel::GetShowTrailingIcon() const {
++bool PageActionModel_ChromiumImpl::GetShowTrailingIcon() const {
    return show_trailing_icon_;
  }
  
-+}  // namespace chromium_impl
- }  // namespace page_actions

--- a/patches/chrome-browser-ui-page_action-page_action_model.h.patch
+++ b/patches/chrome-browser-ui-page_action-page_action_model.h.patch
@@ -1,8 +1,8 @@
 diff --git a/chrome/browser/ui/page_action/page_action_model.h b/chrome/browser/ui/page_action/page_action_model.h
-index a8ceae38c751f7c793777ca569e9c2bc115aea35..e4ec5ce3e337e121e958bd773216058ccb5c680a 100644
+index a8ceae38c751f7c793777ca569e9c2bc115aea35..403ae6ebdf15652744a8224597c48b8d478ec86e 100644
 --- a/chrome/browser/ui/page_action/page_action_model.h
 +++ b/chrome/browser/ui/page_action/page_action_model.h
-@@ -136,9 +136,28 @@ class PageActionModelInterface {
+@@ -136,16 +136,34 @@ class PageActionModelInterface {
    virtual bool GetShowTrailingIcon() const = 0;
  
    virtual bool IsEphemeral() const = 0;
@@ -27,11 +27,22 @@ index a8ceae38c751f7c793777ca569e9c2bc115aea35..e4ec5ce3e337e121e958bd773216058c
  };
  
  // PageActionModel represents the page action's state, scoped to a single tab.
-+namespace chromium_impl {
- class PageActionModel : public PageActionModelInterface {
+-class PageActionModel : public PageActionModelInterface {
++class PageActionModel_ChromiumImpl : public PageActionModelInterface {
   public:
-   explicit PageActionModel(actions::ActionId action_id,
-@@ -256,6 +275,7 @@ class PageActionModel : public PageActionModelInterface {
+-  explicit PageActionModel(actions::ActionId action_id,
++  explicit PageActionModel_ChromiumImpl(actions::ActionId action_id,
+                            bool is_ephemeral = false);
+-  PageActionModel(const PageActionModel&) = delete;
+-  PageActionModel& operator=(const PageActionModel&) = delete;
+-  ~PageActionModel() override;
++  PageActionModel_ChromiumImpl(const PageActionModel_ChromiumImpl&) = delete;
++  PageActionModel_ChromiumImpl& operator=(const PageActionModel_ChromiumImpl&) = delete;
++  ~PageActionModel_ChromiumImpl() override;
+ 
+   actions::ActionId GetActionId() const override;
+ 
+@@ -256,6 +274,7 @@ class PageActionModel : public PageActionModelInterface {
    bool IsEphemeral() const override;
  
   private:
@@ -39,7 +50,7 @@ index a8ceae38c751f7c793777ca569e9c2bc115aea35..e4ec5ce3e337e121e958bd773216058c
    // Identifies which property triggered a NotifyChange call, used for
    // per-property reentrancy checks.
    enum class Property {
-@@ -282,7 +302,12 @@ class PageActionModel : public PageActionModelInterface {
+@@ -282,7 +301,12 @@ class PageActionModel : public PageActionModelInterface {
      kAnimationStyle,
      kTrailingImage,
      kShowTrailingIcon,
@@ -53,11 +64,3 @@ index a8ceae38c751f7c793777ca569e9c2bc115aea35..e4ec5ce3e337e121e958bd773216058c
    };
    using PropertySet =
        base::EnumSet<Property, Property::kShowRequested, Property::kMaxValue>;
-@@ -395,6 +420,7 @@ class PageActionModel : public PageActionModelInterface {
- 
-   base::ObserverList<PageActionModelObserver> observer_list_;
- };
-+}  // namespace chromium_impl
- 
- class PageActionModelFactory {
-  public:

--- a/patches/chrome-browser-ui-page_action-page_action_pass_key.h.patch
+++ b/patches/chrome-browser-ui-page_action-page_action_pass_key.h.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/browser/ui/page_action/page_action_pass_key.h b/chrome/browser/ui/page_action/page_action_pass_key.h
-index 1c5c319b4050d21c313455242d0f9ac0a6a72a8c..d641e17a3ae1649c25690159b152c21ccf3f49d6 100644
+index 1c5c319b4050d21c313455242d0f9ac0a6a72a8c..74bbe102c4b6bc82e26d38594de11ec7cf20985b 100644
 --- a/chrome/browser/ui/page_action/page_action_pass_key.h
 +++ b/chrome/browser/ui/page_action/page_action_pass_key.h
 @@ -27,6 +27,7 @@ class PageActionPassKey {
    static PageActionPassKey PassKeyForTesting() { return PageActionPassKey(); }
  
   private:
-+  friend class page_actions::chromium_impl::PageActionControllerImpl;
++  friend class page_actions::PageActionControllerImpl_ChromiumImpl;
    friend class PageActionController;
    friend class PageActionControllerImpl;
    friend class PageActionView;

--- a/patches/components-permissions-permission_context_base.cc.patch
+++ b/patches/components-permissions-permission_context_base.cc.patch
@@ -1,16 +1,117 @@
 diff --git a/components/permissions/permission_context_base.cc b/components/permissions/permission_context_base.cc
-index 171e53dd8d5065254dc252ab6bc5b19b5dd45d9c..dbd103ab11108d09ae96651666560e151da31769 100644
+index 171e53dd8d5065254dc252ab6bc5b19b5dd45d9c..ce700b6df4c3f5392a7500eb2aba87b235cfe7d9 100644
 --- a/components/permissions/permission_context_base.cc
 +++ b/components/permissions/permission_context_base.cc
-@@ -76,7 +76,7 @@
- #include "ui/android/window_android.h"
- #endif
+@@ -93,13 +93,13 @@ void LogPermissionBlockedMessage(content::RenderFrameHost* rfh,
+ }  // namespace
  
--namespace permissions {
-+namespace permissions::chromium_impl {
- namespace {
+ // static
+-const char PermissionContextBase::kPermissionsKillSwitchFieldStudy[] =
++const char PermissionContextBase_ChromiumImpl::kPermissionsKillSwitchFieldStudy[] =
+     "PermissionsKillSwitch";
+ // static
+-const char PermissionContextBase::kPermissionsKillSwitchBlockedValue[] =
++const char PermissionContextBase_ChromiumImpl::kPermissionsKillSwitchBlockedValue[] =
+     "blocked";
  
- using PermissionStatus = blink::mojom::PermissionStatus;
+-PermissionContextBase::PermissionContextBase(
++PermissionContextBase_ChromiumImpl::PermissionContextBase_ChromiumImpl(
+     content::BrowserContext* browser_context,
+     ContentSettingsType content_settings_type,
+     network::mojom::PermissionsPolicyFeature permissions_policy_feature)
+@@ -110,12 +110,12 @@ PermissionContextBase::PermissionContextBase(
+       << content_settings_type_;
+ }
+ 
+-PermissionContextBase::~PermissionContextBase() {
++PermissionContextBase_ChromiumImpl::~PermissionContextBase_ChromiumImpl() {
+   DCHECK(permission_observers_.empty());
+   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+ }
+ 
+-void PermissionContextBase::RequestPermission(
++void PermissionContextBase_ChromiumImpl::RequestPermission(
+     std::unique_ptr<PermissionRequestData> request_data,
+     BrowserPermissionCallback callback) {
+   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+@@ -283,18 +283,18 @@ void PermissionContextBase::RequestPermission(
+   DecidePermission(std::move(request_data), std::move(callback));
+ }
+ 
+-bool PermissionContextBase::IsRestrictedToSecureOrigins() const {
++bool PermissionContextBase_ChromiumImpl::IsRestrictedToSecureOrigins() const {
+   return true;
+ }
+ 
+-void PermissionContextBase::UserMadePermissionDecision(
++void PermissionContextBase_ChromiumImpl::UserMadePermissionDecision(
+     const PermissionRequestID& id,
+     const GURL& requesting_origin,
+     const GURL& embedding_origin,
+     PermissionDecision decision) {}
+ 
+ std::unique_ptr<PermissionRequest>
+-PermissionContextBase::CreatePermissionRequest(
++PermissionContextBase_ChromiumImpl::CreatePermissionRequest(
+     content::WebContents* web_contents,
+     std::unique_ptr<PermissionRequestData> request_data,
+     PermissionRequest::PermissionDecidedCallback permission_decided_callback,
+@@ -304,11 +304,11 @@ PermissionContextBase::CreatePermissionRequest(
+       std::move(request_finished_callback), UsesAutomaticEmbargo());
+ }
+ 
+-bool PermissionContextBase::UsesAutomaticEmbargo() const {
++bool PermissionContextBase_ChromiumImpl::UsesAutomaticEmbargo() const {
+   return true;
+ }
+ 
+-const PermissionRequest* PermissionContextBase::FindPermissionRequest(
++const PermissionRequest* PermissionContextBase_ChromiumImpl::FindPermissionRequest(
+     const PermissionRequestID& id) const {
+   const auto request = pending_requests_.find(id.ToString());
+ 
+@@ -319,12 +319,12 @@ const PermissionRequest* PermissionContextBase::FindPermissionRequest(
+   return &*(request->second.first);
+ }
+ 
+-GURL PermissionContextBase::GetEffectiveEmbedderOrigin(
++GURL PermissionContextBase_ChromiumImpl::GetEffectiveEmbedderOrigin(
+     content::RenderFrameHost* rfh) const {
+   return PermissionUtil::GetLastCommittedOriginAsURL(rfh->GetMainFrame());
+ }
+ 
+-content::PermissionResult PermissionContextBase::GetPermissionStatus(
++content::PermissionResult PermissionContextBase_ChromiumImpl::GetPermissionStatus(
+     const PermissionRequestData& request_data,
+     content::RenderFrameHost* render_frame_host) const {
+   if (base::FeatureList::IsEnabled(blink::features::kGeolocationElement) &&
+@@ -348,7 +348,7 @@ content::PermissionResult PermissionContextBase::GetPermissionStatus(
+                              request_data.embedding_origin);
+ }
+ 
+-content::PermissionResult PermissionContextBase::GetPermissionStatus(
++content::PermissionResult PermissionContextBase_ChromiumImpl::GetPermissionStatus(
+     const PermissionResolver& resolver,
+     content::RenderFrameHost* render_frame_host,
+     const GURL& requesting_origin,
+@@ -491,7 +491,7 @@ content::PermissionResult PermissionContextBase::GetPermissionStatus(
+                                    retrieved_permission_data);
+ }
+ 
+-content::PermissionResult PermissionContextBase::GetPermissionStatus(
++content::PermissionResult PermissionContextBase_ChromiumImpl::GetPermissionStatus(
+     const blink::mojom::PermissionDescriptorPtr& permission_descriptor,
+     content::RenderFrameHost* render_frame_host,
+     const GURL& requesting_origin,
+@@ -501,7 +501,7 @@ content::PermissionResult PermissionContextBase::GetPermissionStatus(
+                              embedding_origin);
+ }
+ 
+-bool PermissionContextBase::IsPermissionAvailableToOrigins(
++bool PermissionContextBase_ChromiumImpl::IsPermissionAvailableToOrigins(
+     const GURL& requesting_origin,
+     const GURL& embedding_origin) const {
+   if (IsRestrictedToSecureOrigins()) {
 @@ -513,7 +513,7 @@ bool PermissionContextBase::IsPermissionAvailableToOrigins(
      // possible as this corresponds to the requirements of the secure contexts
      // spec and matches what is implemented in blink. Right now we just check
@@ -20,6 +121,65 @@ index 171e53dd8d5065254dc252ab6bc5b19b5dd45d9c..dbd103ab11108d09ae96651666560e15
              requesting_origin, embedding_origin) &&
          !network::IsUrlPotentiallyTrustworthy(embedding_origin)) {
        return false;
+@@ -523,7 +523,7 @@ bool PermissionContextBase::IsPermissionAvailableToOrigins(
+ }
+ 
+ content::PermissionResult
+-PermissionContextBase::UpdatePermissionStatusWithDeviceStatus(
++PermissionContextBase_ChromiumImpl::UpdatePermissionStatusWithDeviceStatus(
+     content::WebContents* web_contents,
+     content::PermissionResult result,
+     const GURL& requesting_origin,
+@@ -541,7 +541,7 @@ PermissionContextBase::UpdatePermissionStatusWithDeviceStatus(
+   if (result.status != blink::mojom::PermissionStatus::GRANTED) {
+     base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+         FROM_HERE, base::BindOnce(
+-                       [](base::WeakPtr<PermissionContextBase> self,
++                       [](base::WeakPtr<PermissionContextBase_ChromiumImpl> self,
+                           base::WeakPtr<content::WebContents> wc) {
+                          if (!self) {
+                            return;
+@@ -585,7 +585,7 @@ PermissionContextBase::UpdatePermissionStatusWithDeviceStatus(
+   return result;
+ }
+ 
+-void PermissionContextBase::ResetPermission(const GURL& requesting_origin,
++void PermissionContextBase_ChromiumImpl::ResetPermission(const GURL& requesting_origin,
+                                             const GURL& embedding_origin) {
+   if (!content_settings::WebsiteSettingsRegistry::GetInstance()->Get(
+           content_settings_type())) {
+@@ -598,11 +598,11 @@ void PermissionContextBase::ResetPermission(const GURL& requesting_origin,
+                                       content_settings_type(), base::Value());
+ }
+ 
+-bool PermissionContextBase::AlwaysIncludeDeviceStatus() const {
++bool PermissionContextBase_ChromiumImpl::AlwaysIncludeDeviceStatus() const {
+   return false;
+ }
+ 
+-bool PermissionContextBase::IsPermissionKillSwitchOn() const {
++bool PermissionContextBase_ChromiumImpl::IsPermissionKillSwitchOn() const {
+   const std::string param = base::GetFieldTrialParamValue(
+       kPermissionsKillSwitchFieldStudy,
+       PermissionUtil::GetPermissionString(content_settings_type_));
+@@ -610,7 +610,7 @@ bool PermissionContextBase::IsPermissionKillSwitchOn() const {
+   return param == kPermissionsKillSwitchBlockedValue;
+ }
+ 
+-PermissionSetting PermissionContextBase::GetPermissionStatusInternal(
++PermissionSetting PermissionContextBase_ChromiumImpl::GetPermissionStatusInternal(
+     content::RenderFrameHost* render_frame_host,
+     const GURL& requesting_origin,
+     const GURL& embedding_origin) const {
+@@ -620,7 +620,7 @@ PermissionSetting PermissionContextBase::GetPermissionStatusInternal(
+                              content_settings_type());
+ }
+ 
+-void PermissionContextBase::DecidePermission(
++void PermissionContextBase_ChromiumImpl::DecidePermission(
+     std::unique_ptr<PermissionRequestData> request_data,
+     BrowserPermissionCallback callback) {
+   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 @@ -629,7 +629,7 @@ void PermissionContextBase::DecidePermission(
    // origin displayed in the prompt should never differ from the top-level
    // origin. Storage access API requests are excluded as they are expected to
@@ -29,9 +189,140 @@ index 171e53dd8d5065254dc252ab6bc5b19b5dd45d9c..dbd103ab11108d09ae96651666560e15
               request_data->requesting_origin, request_data->embedding_origin) ||
           request_data->requesting_origin == request_data->embedding_origin ||
           content_settings_type_ == ContentSettingsType::STORAGE_ACCESS);
-@@ -927,4 +927,4 @@ void PermissionContextBase::NotifyObservers(
+@@ -651,8 +651,8 @@ void PermissionContextBase::DecidePermission(
+   }
+ 
+   auto decided_cb = base::BindRepeating(
+-      &PermissionContextBase::PermissionDecided, weak_factory_.GetWeakPtr());
+-  auto cleanup_cb = base::BindOnce(&PermissionContextBase::CleanUpRequest,
++      &PermissionContextBase_ChromiumImpl::PermissionDecided, weak_factory_.GetWeakPtr());
++  auto cleanup_cb = base::BindOnce(&PermissionContextBase_ChromiumImpl::CleanUpRequest,
+                                    weak_factory_.GetWeakPtr(), web_contents,
+                                    request_data->id);
+   PermissionRequestID permission_request_id = request_data->id;
+@@ -673,7 +673,7 @@ void PermissionContextBase::DecidePermission(
+   permission_request_manager->AddRequest(rfh, std::move(request));
+ }
+ 
+-void PermissionContextBase::PermissionDecided(
++void PermissionContextBase_ChromiumImpl::PermissionDecided(
+     const permissions::PermissionPromptDecision& decision,
+     const PermissionRequestData& request_data) {
+   UserMadePermissionDecision(request_data.id, request_data.requesting_origin,
+@@ -703,18 +703,18 @@ void PermissionContextBase::PermissionDecided(
+                       persist, /*permission_result=*/nullptr, decision);
+ }
+ 
+-content::BrowserContext* PermissionContextBase::browser_context() const {
++content::BrowserContext* PermissionContextBase_ChromiumImpl::browser_context() const {
+   return browser_context_;
+ }
+ 
+-void PermissionContextBase::OnContentSettingChanged(
++void PermissionContextBase_ChromiumImpl::OnContentSettingChanged(
+     const ContentSettingsPattern& primary_pattern,
+     const ContentSettingsPattern& secondary_pattern,
+     ContentSettingsTypeSet content_type_set) {
+   NotifyObservers(primary_pattern, secondary_pattern, content_type_set);
+ }
+ 
+-void PermissionContextBase::AddObserver(
++void PermissionContextBase_ChromiumImpl::AddObserver(
+     permissions::Observer* permission_observer) {
+   if (permission_observers_.empty() &&
+       !content_setting_observer_registered_by_subclass_) {
+@@ -725,7 +725,7 @@ void PermissionContextBase::AddObserver(
+   permission_observers_.AddObserver(permission_observer);
+ }
+ 
+-void PermissionContextBase::RemoveObserver(
++void PermissionContextBase_ChromiumImpl::RemoveObserver(
+     permissions::Observer* permission_observer) {
+   permission_observers_.RemoveObserver(permission_observer);
+   if (permission_observers_.empty() &&
+@@ -737,13 +737,13 @@ void PermissionContextBase::RemoveObserver(
+ }
+ 
+ std::unique_ptr<PermissionResolver>
+-PermissionContextBase::CreatePermissionResolver(
++PermissionContextBase_ChromiumImpl::CreatePermissionResolver(
+     const blink::mojom::PermissionDescriptorPtr& permission_descriptor) const {
+   return std::make_unique<ContentSettingPermissionResolver>(
+       content_settings_type_);
+ }
+ 
+-void PermissionContextBase::MaybeUpdateCachedHasDevicePermission(
++void PermissionContextBase_ChromiumImpl::MaybeUpdateCachedHasDevicePermission(
+     content::WebContents* web_contents) {
+   bool has_device_permission;
+   if (has_device_permission_for_test_.has_value()) {
+@@ -778,7 +778,7 @@ void PermissionContextBase::MaybeUpdateCachedHasDevicePermission(
    }
  }
  
--}  // namespace permissions
-+}  // namespace permissions::chromium_impl
+-content::PermissionResult PermissionContextBase::ComputeNewPermissionResult(
++content::PermissionResult PermissionContextBase_ChromiumImpl::ComputeNewPermissionResult(
+     const PermissionRequestData& request_data,
+     const permissions::PermissionPromptDecision& decision) {
+   // Note that rfh may be null, see crbug.com/426909787.
+@@ -796,7 +796,7 @@ content::PermissionResult PermissionContextBase::ComputeNewPermissionResult(
+       content::PermissionStatusSource::UNSPECIFIED, new_value);
+ }
+ 
+-void PermissionContextBase::NotifyPermissionSet(
++void PermissionContextBase_ChromiumImpl::NotifyPermissionSet(
+     const PermissionRequestData& request_data,
+     BrowserPermissionCallback callback,
+     bool persist,
+@@ -834,7 +834,7 @@ void PermissionContextBase::NotifyPermissionSet(
+     content::WebContents* web_contents =
+         content::WebContents::FromRenderFrameHost(rfh);
+     request->second.first->set_request_finished_callback(base::BindOnce(
+-        &PermissionContextBase::CleanUpRequestEmbeddedPermissionElement,
++        &PermissionContextBase_ChromiumImpl::CleanUpRequestEmbeddedPermissionElement,
+         weak_factory_.GetWeakPtr(), web_contents, request_data.id,
+         std::move(callback), decision.overall_decision, new_permission_result));
+   } else {
+@@ -842,13 +842,13 @@ void PermissionContextBase::NotifyPermissionSet(
+   }
+ }
+ 
+-void PermissionContextBase::CleanUpRequest(content::WebContents* web_contents,
++void PermissionContextBase_ChromiumImpl::CleanUpRequest(content::WebContents* web_contents,
+                                            const PermissionRequestID& id) {
+   size_t success = pending_requests_.erase(id.ToString());
+   DCHECK(success == 1) << "Missing request " << id.ToString();
+ }
+ 
+-void PermissionContextBase::CleanUpRequestEmbeddedPermissionElement(
++void PermissionContextBase_ChromiumImpl::CleanUpRequestEmbeddedPermissionElement(
+     content::WebContents* web_contents,
+     const PermissionRequestID& id,
+     BrowserPermissionCallback callback,
+@@ -864,7 +864,7 @@ void PermissionContextBase::CleanUpRequestEmbeddedPermissionElement(
+   CleanUpRequest(web_contents, id);
+ }
+ 
+-void PermissionContextBase::UpdateSetting(
++void PermissionContextBase_ChromiumImpl::UpdateSetting(
+     const PermissionRequestData& request_data,
+     const PermissionSetting& setting,
+     bool is_one_time) {
+@@ -902,7 +902,7 @@ void PermissionContextBase::UpdateSetting(
+           content_settings_type(), setting, constraints);
+ }
+ 
+-bool PermissionContextBase::PermissionAllowedByPermissionsPolicy(
++bool PermissionContextBase_ChromiumImpl::PermissionAllowedByPermissionsPolicy(
+     content::RenderFrameHost* rfh) const {
+   // Some features don't have an associated permissions policy yet. Allow those.
+   if (permissions_policy_feature_ ==
+@@ -913,7 +913,7 @@ bool PermissionContextBase::PermissionAllowedByPermissionsPolicy(
+   return rfh->IsFeatureEnabled(permissions_policy_feature_);
+ }
+ 
+-void PermissionContextBase::NotifyObservers(
++void PermissionContextBase_ChromiumImpl::NotifyObservers(
+     const ContentSettingsPattern& primary_pattern,
+     const ContentSettingsPattern& secondary_pattern,
+     ContentSettingsTypeSet content_type_set) const {

--- a/patches/components-permissions-permission_context_base.h.patch
+++ b/patches/components-permissions-permission_context_base.h.patch
@@ -1,16 +1,25 @@
 diff --git a/components/permissions/permission_context_base.h b/components/permissions/permission_context_base.h
-index fa672a2d9359973b278160e50e52185e8a09a3c7..ae746fc8793af98068ae4d4c2f54b8354280714b 100644
+index fa672a2d9359973b278160e50e52185e8a09a3c7..31d1b616cd75c4b22f1f700b09199de863af7c2f 100644
 --- a/components/permissions/permission_context_base.h
 +++ b/components/permissions/permission_context_base.h
-@@ -89,6 +89,7 @@ using BrowserPermissionCallback =
+@@ -89,13 +89,13 @@ using BrowserPermissionCallback =
  // See midi_permission_context.h/cc or push_permission_context.cc/h for some
  // examples.
  
-+namespace chromium_impl {
- class PermissionContextBase : public content_settings::Observer {
+-class PermissionContextBase : public content_settings::Observer {
++class PermissionContextBase_ChromiumImpl : public content_settings::Observer {
   public:
-   PermissionContextBase(
-@@ -302,6 +303,7 @@ class PermissionContextBase : public content_settings::Observer {
+-  PermissionContextBase(
++  PermissionContextBase_ChromiumImpl(
+       content::BrowserContext* browser_context,
+       ContentSettingsType content_settings_type,
+       network::mojom::PermissionsPolicyFeature permissions_policy_feature);
+-  ~PermissionContextBase() override;
++  ~PermissionContextBase_ChromiumImpl() override;
+ 
+   // A field trial used to enable the global permissions kill switch.
+   // This is public so permissions that don't yet inherit from
+@@ -302,6 +302,7 @@ class PermissionContextBase : public content_settings::Observer {
  #endif  // BUILDFLAG(IS_ANDROID)
  
   private:
@@ -18,7 +27,7 @@ index fa672a2d9359973b278160e50e52185e8a09a3c7..ae746fc8793af98068ae4d4c2f54b835
    friend class PermissionContextBaseTests;
  
    // Called when a request is no longer used so it can be cleaned up.
-@@ -316,7 +318,7 @@ class PermissionContextBase : public content_settings::Observer {
+@@ -316,7 +317,7 @@ class PermissionContextBase : public content_settings::Observer {
  
    // This is the callback for PermissionRequest and is called once the user
    // allows/blocks/dismisses a permission prompt.
@@ -27,11 +36,12 @@ index fa672a2d9359973b278160e50e52185e8a09a3c7..ae746fc8793af98068ae4d4c2f54b835
                           const PermissionRequestData& request_data);
  
    raw_ptr<content::BrowserContext> browser_context_;
-@@ -337,6 +339,7 @@ class PermissionContextBase : public content_settings::Observer {
-   base::WeakPtrFactory<PermissionContextBase> weak_factory_{this};
+@@ -334,7 +335,7 @@ class PermissionContextBase : public content_settings::Observer {
+ 
+   // Must be the last member, to ensure that it will be
+   // destroyed first, which will invalidate weak pointers
+-  base::WeakPtrFactory<PermissionContextBase> weak_factory_{this};
++  base::WeakPtrFactory<PermissionContextBase_ChromiumImpl> weak_factory_{this};
  };
  
-+}  // namespace chromium_impl
  }  // namespace permissions
- 
- #endif  // COMPONENTS_PERMISSIONS_PERMISSION_CONTEXT_BASE_H_

--- a/patches/net-cookies-cookie_monster.cc.patch
+++ b/patches/net-cookies-cookie_monster.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/net/cookies/cookie_monster.cc b/net/cookies/cookie_monster.cc
-index 83db80e1586859eb7eea229e294f25c5c87346a0..289fc95a250a26d3b8bb8ca8b93dce9fa69f9a42 100644
+index 83db80e1586859eb7eea229e294f25c5c87346a0..4b909c2caac2ac7a55e2e9409ee5fc25caa39250 100644
 --- a/net/cookies/cookie_monster.cc
 +++ b/net/cookies/cookie_monster.cc
 @@ -147,7 +147,7 @@ enum CookieType {
@@ -7,22 +7,911 @@ index 83db80e1586859eb7eea229e294f25c5c87346a0..289fc95a250a26d3b8bb8ca8b93dce9f
  };
  
 -void MaybeRunDeleteCallback(base::WeakPtr<net::CookieMonster> cookie_monster,
-+void MaybeRunDeleteCallback(base::WeakPtr<net::chromium_impl::CookieMonster> cookie_monster,
++void MaybeRunDeleteCallback(base::WeakPtr<net::CookieMonster_ChromiumImpl> cookie_monster,
                              base::OnceClosure callback) {
    if (cookie_monster && callback)
      std::move(callback).Run();
-@@ -222,7 +222,7 @@ void LogStoredCookieToUMA(const net::CanonicalCookie& cc,
+@@ -183,7 +183,7 @@ size_t NameValueSizeBytes(const net::CanonicalCookie& cc) {
+ }
  
- }  // namespace
+ size_t NumBytesInCookieMapForKey(
+-    const net::CookieMonster::CookieMap& cookie_map,
++    const net::CookieMonster_ChromiumImpl::CookieMap& cookie_map,
+     const std::string& key) {
+   size_t result = 0;
+   auto range = cookie_map.equal_range(key);
+@@ -194,7 +194,7 @@ size_t NumBytesInCookieMapForKey(
+ }
  
--namespace net {
-+namespace net::chromium_impl {
+ size_t NumBytesInCookieItVector(
+-    const net::CookieMonster::CookieItVector& cookie_its) {
++    const net::CookieMonster_ChromiumImpl::CookieItVector& cookie_its) {
+   size_t result = 0;
+   for (const auto& it : cookie_its) {
+     result += NameValueSizeBytes(*it->second);
+@@ -226,23 +226,23 @@ namespace net {
  
  // See comments at declaration of these variables in cookie_monster.h
  // for details.
-@@ -3028,4 +3028,4 @@ std::optional<bool> CookieMonster::SiteHasCookieInOtherPartition(
-   });
+-const size_t CookieMonster::kDomainMaxCookies = 180;
+-const size_t CookieMonster::kDomainPurgeCookies = 30;
+-const size_t CookieMonster::kMaxCookies = 3300;
+-const size_t CookieMonster::kPurgeCookies = 300;
++const size_t CookieMonster_ChromiumImpl::kDomainMaxCookies = 180;
++const size_t CookieMonster_ChromiumImpl::kDomainPurgeCookies = 30;
++const size_t CookieMonster_ChromiumImpl::kMaxCookies = 3300;
++const size_t CookieMonster_ChromiumImpl::kPurgeCookies = 300;
+ 
+-const size_t CookieMonster::kMaxDomainPurgedKeys = 100;
++const size_t CookieMonster_ChromiumImpl::kMaxDomainPurgedKeys = 100;
+ 
+-const size_t CookieMonster::kPerPartitionDomainMaxCookieBytes = 10240;
+-const size_t CookieMonster::kPerPartitionDomainMaxCookies = 180;
++const size_t CookieMonster_ChromiumImpl::kPerPartitionDomainMaxCookieBytes = 10240;
++const size_t CookieMonster_ChromiumImpl::kPerPartitionDomainMaxCookies = 180;
+ 
+-const size_t CookieMonster::kDomainCookiesQuotaLow = 30;
+-const size_t CookieMonster::kDomainCookiesQuotaMedium = 50;
+-const size_t CookieMonster::kDomainCookiesQuotaHigh =
++const size_t CookieMonster_ChromiumImpl::kDomainCookiesQuotaLow = 30;
++const size_t CookieMonster_ChromiumImpl::kDomainCookiesQuotaMedium = 50;
++const size_t CookieMonster_ChromiumImpl::kDomainCookiesQuotaHigh =
+     kDomainMaxCookies - kDomainPurgeCookies - kDomainCookiesQuotaLow -
+     kDomainCookiesQuotaMedium;
+ 
+-const int CookieMonster::kSafeFromGlobalPurgeDays = 30;
++const int CookieMonster_ChromiumImpl::kSafeFromGlobalPurgeDays = 30;
+ 
+ namespace {
+ 
+@@ -259,14 +259,14 @@ const int kDefaultAccessUpdateThresholdSeconds = 60;
+ // Comparator to sort cookies from highest creation date to lowest
+ // creation date.
+ struct OrderByCreationTimeDesc {
+-  bool operator()(const CookieMonster::CookieMap::iterator& a,
+-                  const CookieMonster::CookieMap::iterator& b) const {
++  bool operator()(const CookieMonster_ChromiumImpl::CookieMap::iterator& a,
++                  const CookieMonster_ChromiumImpl::CookieMap::iterator& b) const {
+     return a->second->CreationDate() > b->second->CreationDate();
+   }
+ };
+ 
+-bool LRACookieSorter(const CookieMonster::CookieMap::iterator& it1,
+-                     const CookieMonster::CookieMap::iterator& it2) {
++bool LRACookieSorter(const CookieMonster_ChromiumImpl::CookieMap::iterator& it1,
++                     const CookieMonster_ChromiumImpl::CookieMap::iterator& it2) {
+   if (it1->second->LastAccessDate() != it2->second->LastAccessDate())
+     return it1->second->LastAccessDate() < it2->second->LastAccessDate();
+ 
+@@ -276,8 +276,8 @@ bool LRACookieSorter(const CookieMonster::CookieMap::iterator& it1,
+ 
+ // For a CookieItVector iterator range [|it_begin|, |it_end|),
+ // sorts the first |num_sort| elements by LastAccessDate().
+-void SortLeastRecentlyAccessed(CookieMonster::CookieItVector::iterator it_begin,
+-                               CookieMonster::CookieItVector::iterator it_end,
++void SortLeastRecentlyAccessed(CookieMonster_ChromiumImpl::CookieItVector::iterator it_begin,
++                               CookieMonster_ChromiumImpl::CookieItVector::iterator it_end,
+                                size_t num_sort) {
+   DCHECK_LE(static_cast<int>(num_sort), it_end - it_begin);
+   std::partial_sort(it_begin, it_begin + num_sort, it_end, LRACookieSorter);
+@@ -288,9 +288,9 @@ void SortLeastRecentlyAccessed(CookieMonster::CookieItVector::iterator it_begin,
+ // |non_secure_cookie_its|. Both |secure_cookie_its| and |non_secure_cookie_its|
+ // must be non-NULL.
+ void SplitCookieVectorIntoSecureAndNonSecure(
+-    const CookieMonster::CookieItVector& cookie_its,
+-    CookieMonster::CookieItVector* secure_cookie_its,
+-    CookieMonster::CookieItVector* non_secure_cookie_its) {
++    const CookieMonster_ChromiumImpl::CookieItVector& cookie_its,
++    CookieMonster_ChromiumImpl::CookieItVector* secure_cookie_its,
++    CookieMonster_ChromiumImpl::CookieItVector* non_secure_cookie_its) {
+   DCHECK(secure_cookie_its && non_secure_cookie_its);
+   for (const auto& curit : cookie_its) {
+     if (curit->second->SecureAttribute()) {
+@@ -301,7 +301,7 @@ void SplitCookieVectorIntoSecureAndNonSecure(
+   }
  }
  
--}  // namespace net
-+}  // namespace net::chromium_impl
+-bool LowerBoundAccessDateComparator(const CookieMonster::CookieMap::iterator it,
++bool LowerBoundAccessDateComparator(const CookieMonster_ChromiumImpl::CookieMap::iterator it,
+                                     Time access_date) {
+   return it->second->LastAccessDate() < access_date;
+ }
+@@ -310,9 +310,9 @@ bool LowerBoundAccessDateComparator(const CookieMonster::CookieMap::iterator it,
+ // from a CookieItVector sorted by LastAccessDate(), returns the
+ // first iterator with access date >= |access_date|, or cookie_its_end if this
+ // holds for all.
+-CookieMonster::CookieItVector::iterator LowerBoundAccessDate(
+-    const CookieMonster::CookieItVector::iterator its_begin,
+-    const CookieMonster::CookieItVector::iterator its_end,
++CookieMonster_ChromiumImpl::CookieItVector::iterator LowerBoundAccessDate(
++    const CookieMonster_ChromiumImpl::CookieItVector::iterator its_begin,
++    const CookieMonster_ChromiumImpl::CookieItVector::iterator its_end,
+     Time access_date) {
+   return std::lower_bound(its_begin, its_end, access_date,
+                           LowerBoundAccessDateComparator);
+@@ -371,7 +371,7 @@ bool IsCookieEligibleForEviction(CookiePriority current_priority_level,
+ 
+ size_t CountCookiesForPossibleDeletion(
+     CookiePriority priority,
+-    const CookieMonster::CookieItVector& cookies,
++    const CookieMonster_ChromiumImpl::CookieItVector& cookies,
+     bool protect_secure_cookies) {
+   size_t cookies_count = 0U;
+   for (const auto& cookie : cookies) {
+@@ -385,8 +385,8 @@ size_t CountCookiesForPossibleDeletion(
+ }
+ 
+ struct DeletionCookieLists {
+-  std::list<CookieMonster::CookieItList::const_iterator> host_cookies;
+-  std::list<CookieMonster::CookieItList::const_iterator> domain_cookies;
++  std::list<CookieMonster_ChromiumImpl::CookieItList::const_iterator> host_cookies;
++  std::list<CookieMonster_ChromiumImpl::CookieItList::const_iterator> domain_cookies;
+ };
+ 
+ // Performs 2 tasks
+@@ -397,7 +397,7 @@ struct DeletionCookieLists {
+ size_t CountCookiesAndGenerateListsForPossibleDeletion(
+     CookiePriority priority,
+     DeletionCookieLists& could_be_deleted,
+-    const CookieMonster::CookieItList& cookies,
++    const CookieMonster_ChromiumImpl::CookieItList& cookies,
+     bool generate_for_secure) {
+   size_t total_cookies_at_priority = 0;
+ 
+@@ -432,7 +432,7 @@ size_t CountCookiesAndGenerateListsForPossibleDeletion(
+ // in `cookies`.
+ DeletionCookieLists
+ CountCookiesAndGenerateListsForPossibleDeletionPartitionedCookies(
+-    const CookieMonster::CookieItList& cookies) {
++    const CookieMonster_ChromiumImpl::CookieItList& cookies) {
+   DeletionCookieLists could_be_deleted;
+   for (auto list_it = cookies.begin(); list_it != cookies.end(); list_it++) {
+     const auto cookiemap_it = *list_it;
+@@ -471,16 +471,16 @@ void RecordPersistanceHistograms(const CanonicalCookie& cookie,
+ 
+ }  // namespace
+ 
+-CookieMonster::CookieMonster(scoped_refptr<PersistentCookieStore> store,
++CookieMonster_ChromiumImpl::CookieMonster_ChromiumImpl(scoped_refptr<PersistentCookieStore> store,
+                              NetLog* net_log,
+                              std::unique_ptr<PrefDelegate> pref_delegate)
+-    : CookieMonster(base::PassKey<CookieMonster>(),
++    : CookieMonster_ChromiumImpl(base::PassKey<CookieMonster_ChromiumImpl>(),
+                     std::move(store),
+                     base::Seconds(kDefaultAccessUpdateThresholdSeconds),
+                     net_log,
+                     std::move(pref_delegate)) {}
+ 
+-CookieMonster::CookieMonster(base::PassKey<CookieMonster>,
++CookieMonster_ChromiumImpl::CookieMonster_ChromiumImpl(base::PassKey<CookieMonster_ChromiumImpl>,
+                              scoped_refptr<PersistentCookieStore> store,
+                              base::TimeDelta last_access_threshold,
+                              NetLog* net_log,
+@@ -498,19 +498,19 @@ CookieMonster::CookieMonster(base::PassKey<CookieMonster>,
+ }
+ 
+ // static
+-std::unique_ptr<CookieMonster> CookieMonster::CreateForTesting(
++std::unique_ptr<CookieMonster_ChromiumImpl> CookieMonster_ChromiumImpl::CreateForTesting(
+     scoped_refptr<PersistentCookieStore> store,
+     base::TimeDelta last_access_threshold,
+     NetLog* net_log,
+     std::unique_ptr<PrefDelegate> pref_delegate) {
+-  return std::make_unique<CookieMonster>(
+-      base::PassKey<CookieMonster>(), std::move(store), last_access_threshold,
++  return std::make_unique<CookieMonster_ChromiumImpl>(
++      base::PassKey<CookieMonster_ChromiumImpl>(), std::move(store), last_access_threshold,
+       net_log, std::move(pref_delegate));
+ }
+ 
+ // Asynchronous CookieMonster API
+ 
+-void CookieMonster::FlushStore(base::OnceClosure callback) {
++void CookieMonster_ChromiumImpl::FlushStore(base::OnceClosure callback) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+ 
+   if (initialized_ && store_.get()) {
+@@ -521,24 +521,24 @@ void CookieMonster::FlushStore(base::OnceClosure callback) {
+   }
+ }
+ 
+-void CookieMonster::SetForceKeepSessionState() {
++void CookieMonster_ChromiumImpl::SetForceKeepSessionState() {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+ 
+   if (store_)
+     store_->SetForceKeepSessionState();
+ }
+ 
+-void CookieMonster::SetAllCookiesAsync(const CookieList& list,
++void CookieMonster_ChromiumImpl::SetAllCookiesAsync(const CookieList& list,
+                                        SetCookiesCallback callback) {
+   DoCookieCallback(base::BindOnce(
+       // base::Unretained is safe as DoCookieCallback stores
+       // the callback on |*this|, so the callback will not outlive
+       // the object.
+-      &CookieMonster::SetAllCookies, base::Unretained(this), list,
++      &CookieMonster_ChromiumImpl::SetAllCookies, base::Unretained(this), list,
+       std::move(callback)));
+ }
+ 
+-void CookieMonster::SetCanonicalCookieAsync(
++void CookieMonster_ChromiumImpl::SetCanonicalCookieAsync(
+     std::unique_ptr<CanonicalCookie> cookie,
+     const GURL& source_url,
+     const CookieOptions& options,
+@@ -555,13 +555,13 @@ void CookieMonster::SetCanonicalCookieAsync(
+           // base::Unretained is safe as DoCookieCallbackForHostOrDomain stores
+           // the callback on |*this|, so the callback will not outlive
+           // the object.
+-          &CookieMonster::SetCanonicalCookie, base::Unretained(this),
++          &CookieMonster_ChromiumImpl::SetCanonicalCookie, base::Unretained(this),
+           std::move(cookie), source_url, options, std::move(callback),
+           std::move(cookie_access_result)),
+       domain);
+ }
+ 
+-void CookieMonster::SetUnsafeCanonicalCookieForTestAsync(
++void CookieMonster_ChromiumImpl::SetUnsafeCanonicalCookieForTestAsync(
+     std::unique_ptr<CanonicalCookie> cookie,
+     SetCookiesCallback callback) {
+   CanonicalCookie::CanonicalizationResult result = cookie->IsCanonical();
+@@ -573,12 +573,12 @@ void CookieMonster::SetUnsafeCanonicalCookieForTestAsync(
+           // base::Unretained is safe as DoCookieCallbackForHostOrDomain stores
+           // the callback on |*this|, so the callback will not outlive
+           // the object.
+-          &CookieMonster::SetUnsafeCanonicalCookieForTest,
++          &CookieMonster_ChromiumImpl::SetUnsafeCanonicalCookieForTest,
+           base::Unretained(this), std::move(cookie), std::move(callback)),
+       domain);
+ }
+ 
+-void CookieMonster::GetCookieListWithOptionsAsync(
++void CookieMonster_ChromiumImpl::GetCookieListWithOptionsAsync(
+     const GURL& url,
+     const CookieOptions& options,
+     const CookiePartitionKeyCollection& cookie_partition_key_collection,
+@@ -590,67 +590,67 @@ void CookieMonster::GetCookieListWithOptionsAsync(
+           // base::Unretained is safe as DoCookieCallbackForURL stores
+           // the callback on |*this|, so the callback will not outlive
+           // the object.
+-          &CookieMonster::GetCookieListWithOptions, base::Unretained(this), url,
++          &CookieMonster_ChromiumImpl::GetCookieListWithOptions, base::Unretained(this), url,
+           options, cookie_partition_key_collection, std::move(callback)),
+       url);
+ }
+ 
+-void CookieMonster::GetAllCookiesAsync(GetAllCookiesCallback callback) {
++void CookieMonster_ChromiumImpl::GetAllCookiesAsync(GetAllCookiesCallback callback) {
+   DoCookieCallback(base::BindOnce(
+       // base::Unretained is safe as DoCookieCallback stores
+       // the callback on |*this|, so the callback will not outlive
+       // the object.
+-      &CookieMonster::GetAllCookies, base::Unretained(this),
++      &CookieMonster_ChromiumImpl::GetAllCookies, base::Unretained(this),
+       std::move(callback)));
+ }
+ 
+-void CookieMonster::GetAllCookiesWithAccessSemanticsAsync(
++void CookieMonster_ChromiumImpl::GetAllCookiesWithAccessSemanticsAsync(
+     GetAllCookiesWithAccessSemanticsCallback callback) {
+   DoCookieCallback(base::BindOnce(
+       // base::Unretained is safe as DoCookieCallback stores
+       // the callback on |*this|, so the callback will not outlive
+       // the object.
+-      &CookieMonster::GetAllCookies, base::Unretained(this),
+-      base::BindOnce(&CookieMonster::AttachAccessSemanticsListForCookieList,
++      &CookieMonster_ChromiumImpl::GetAllCookies, base::Unretained(this),
++      base::BindOnce(&CookieMonster_ChromiumImpl::AttachAccessSemanticsListForCookieList,
+                      base::Unretained(this), std::move(callback))));
+ }
+ 
+-void CookieMonster::DeleteCanonicalCookieAsync(const CanonicalCookie& cookie,
++void CookieMonster_ChromiumImpl::DeleteCanonicalCookieAsync(const CanonicalCookie& cookie,
+                                                DeleteCallback callback) {
+   DoCookieCallback(base::BindOnce(
+       // base::Unretained is safe as DoCookieCallback stores
+       // the callback on |*this|, so the callback will not outlive
+       // the object.
+-      &CookieMonster::DeleteCanonicalCookie, base::Unretained(this), cookie,
++      &CookieMonster_ChromiumImpl::DeleteCanonicalCookie, base::Unretained(this), cookie,
+       std::move(callback)));
+ }
+ 
+-void CookieMonster::DeleteAllCreatedInTimeRangeAsync(
++void CookieMonster_ChromiumImpl::DeleteAllCreatedInTimeRangeAsync(
+     const TimeRange& creation_range,
+     DeleteCallback callback) {
+   DoCookieCallback(base::BindOnce(
+       // base::Unretained is safe as DoCookieCallback stores
+       // the callback on |*this|, so the callback will not outlive
+       // the object.
+-      &CookieMonster::DeleteAllCreatedInTimeRange, base::Unretained(this),
++      &CookieMonster_ChromiumImpl::DeleteAllCreatedInTimeRange, base::Unretained(this),
+       creation_range, std::move(callback)));
+ }
+ 
+-void CookieMonster::DeleteAllMatchingInfoAsync(CookieDeletionInfo delete_info,
++void CookieMonster_ChromiumImpl::DeleteAllMatchingInfoAsync(CookieDeletionInfo delete_info,
+                                                DeleteCallback callback) {
+   auto cookie_matcher =
+-      base::BindRepeating(&CookieMonster::MatchCookieDeletionInfo,
++      base::BindRepeating(&CookieMonster_ChromiumImpl::MatchCookieDeletionInfo,
+                           base::Unretained(this), std::move(delete_info));
+ 
+   DoCookieCallback(base::BindOnce(
+       // base::Unretained is safe as DoCookieCallback stores
+       // the callback on |*this|, so the callback will not outlive
+       // the object.
+-      &CookieMonster::DeleteMatchingCookies, base::Unretained(this),
++      &CookieMonster_ChromiumImpl::DeleteMatchingCookies, base::Unretained(this),
+       std::move(cookie_matcher), DELETE_COOKIE_EXPLICIT, std::move(callback)));
+ }
+ 
+-void CookieMonster::DeleteSessionCookiesAsync(
++void CookieMonster_ChromiumImpl::DeleteSessionCookiesAsync(
+     CookieStore::DeleteCallback callback) {
+   auto session_cookie_matcher =
+       base::BindRepeating([](const net::CanonicalCookie& cookie) {
+@@ -660,23 +660,23 @@ void CookieMonster::DeleteSessionCookiesAsync(
+       // base::Unretained is safe as DoCookieCallback stores
+       // the callback on |*this|, so the callback will not outlive
+       // the object.
+-      &CookieMonster::DeleteMatchingCookies, base::Unretained(this),
++      &CookieMonster_ChromiumImpl::DeleteMatchingCookies, base::Unretained(this),
+       std::move(session_cookie_matcher), DELETE_COOKIE_EXPIRED,
+       std::move(callback)));
+ }
+ 
+-void CookieMonster::DeleteMatchingCookiesAsync(
++void CookieMonster_ChromiumImpl::DeleteMatchingCookiesAsync(
+     CookieStore::DeletePredicate predicate,
+     CookieStore::DeleteCallback callback) {
+   DoCookieCallback(base::BindOnce(
+       // base::Unretained is safe as DoCookieCallback stores
+       // the callback on |*this|, so the callback will not outlive
+       // the object.
+-      &CookieMonster::DeleteMatchingCookies, base::Unretained(this),
++      &CookieMonster_ChromiumImpl::DeleteMatchingCookies, base::Unretained(this),
+       std::move(predicate), DELETE_COOKIE_EXPLICIT, std::move(callback)));
+ }
+ 
+-void CookieMonster::SetCookieableSchemes(
++void CookieMonster_ChromiumImpl::SetCookieableSchemes(
+     std::vector<std::string> schemes,
+     SetCookieableSchemesCallback callback) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+@@ -693,7 +693,7 @@ void CookieMonster::SetCookieableSchemes(
+ }
+ 
+ // This function must be called before the CookieMonster is used.
+-void CookieMonster::SetPersistSessionCookies(bool persist_session_cookies) {
++void CookieMonster_ChromiumImpl::SetPersistSessionCookies(bool persist_session_cookies) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+   DCHECK(!initialized_);
+   net_log_.AddEntryWithBoolParams(
+@@ -703,21 +703,21 @@ void CookieMonster::SetPersistSessionCookies(bool persist_session_cookies) {
+ }
+ 
+ // static
+-std::vector<std::string> CookieMonster::GetDefaultCookieableSchemes() {
++std::vector<std::string> CookieMonster_ChromiumImpl::GetDefaultCookieableSchemes() {
+   return std::vector<std::string>{"http", "https", "ws", "wss"};
+ }
+ 
+-CookieChangeDispatcher& CookieMonster::GetChangeDispatcher() {
++CookieChangeDispatcher& CookieMonster_ChromiumImpl::GetChangeDispatcher() {
+   return change_dispatcher_;
+ }
+ 
+-CookieMonster::~CookieMonster() {
++CookieMonster_ChromiumImpl::~CookieMonster_ChromiumImpl() {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+   net_log_.EndEvent(NetLogEventType::COOKIE_STORE_ALIVE);
+ }
+ 
+ // static
+-bool CookieMonster::CookieSorter(const CanonicalCookie* cc1,
++bool CookieMonster_ChromiumImpl::CookieSorter(const CanonicalCookie* cc1,
+                                  const CanonicalCookie* cc2) {
+   // Mozilla sorts on the path length (longest first), and then it sorts by
+   // creation time (oldest first).  The RFC says the sort order for the domain
+@@ -727,7 +727,7 @@ bool CookieMonster::CookieSorter(const CanonicalCookie* cc1,
+   return cc1->Path().length() > cc2->Path().length();
+ }
+ 
+-void CookieMonster::GetAllCookies(GetAllCookiesCallback callback) {
++void CookieMonster_ChromiumImpl::GetAllCookies(GetAllCookiesCallback callback) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+ 
+   // This function is being called to scrape the cookie list for management UI
+@@ -764,7 +764,7 @@ void CookieMonster::GetAllCookies(GetAllCookiesCallback callback) {
+   MaybeRunCookieCallback(std::move(callback), cookie_list);
+ }
+ 
+-void CookieMonster::AttachAccessSemanticsListForCookieList(
++void CookieMonster_ChromiumImpl::AttachAccessSemanticsListForCookieList(
+     GetAllCookiesWithAccessSemanticsCallback callback,
+     const CookieList& cookie_list) {
+   std::vector<CookieAccessSemantics> access_semantics_list;
+@@ -775,7 +775,7 @@ void CookieMonster::AttachAccessSemanticsListForCookieList(
+                          access_semantics_list);
+ }
+ 
+-void CookieMonster::GetCookieListWithOptions(
++void CookieMonster_ChromiumImpl::GetCookieListWithOptions(
+     const GURL& url,
+     const CookieOptions& options,
+     const CookiePartitionKeyCollection& cookie_partition_key_collection,
+@@ -841,7 +841,7 @@ void CookieMonster::GetCookieListWithOptions(
+   }
+ }
+ 
+-void CookieMonster::DeleteAllCreatedInTimeRange(const TimeRange& creation_range,
++void CookieMonster_ChromiumImpl::DeleteAllCreatedInTimeRange(const TimeRange& creation_range,
+                                                 DeleteCallback callback) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+ 
+@@ -888,7 +888,7 @@ void CookieMonster::DeleteAllCreatedInTimeRange(const TimeRange& creation_range,
+                               : base::OnceClosure()));
+ }
+ 
+-bool CookieMonster::MatchCookieDeletionInfo(
++bool CookieMonster_ChromiumImpl::MatchCookieDeletionInfo(
+     const CookieDeletionInfo& delete_info,
+     const net::CanonicalCookie& cookie) {
+   bool delegate_treats_url_as_trustworthy = false;  // irrelevant if no URL.
+@@ -906,7 +906,7 @@ bool CookieMonster::MatchCookieDeletionInfo(
+                          delegate_treats_url_as_trustworthy});
+ }
+ 
+-void CookieMonster::DeleteCanonicalCookie(const CanonicalCookie& cookie,
++void CookieMonster_ChromiumImpl::DeleteCanonicalCookie(const CanonicalCookie& cookie,
+                                           DeleteCallback callback) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+   uint32_t result = 0u;
+@@ -948,7 +948,7 @@ void CookieMonster::DeleteCanonicalCookie(const CanonicalCookie& cookie,
+                               : base::OnceClosure()));
+ }
+ 
+-void CookieMonster::DeleteMatchingCookies(DeletePredicate predicate,
++void CookieMonster_ChromiumImpl::DeleteMatchingCookies(DeletePredicate predicate,
+                                           DeletionCause cause,
+                                           DeleteCallback callback) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+@@ -992,12 +992,12 @@ void CookieMonster::DeleteMatchingCookies(DeletePredicate predicate,
+                               : base::OnceClosure()));
+ }
+ 
+-void CookieMonster::MarkCookieStoreAsInitialized() {
++void CookieMonster_ChromiumImpl::MarkCookieStoreAsInitialized() {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+   initialized_ = true;
+ }
+ 
+-void CookieMonster::FetchAllCookiesIfNecessary() {
++void CookieMonster_ChromiumImpl::FetchAllCookiesIfNecessary() {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+   if (store_.get() && !started_fetching_all_cookies_) {
+     started_fetching_all_cookies_ = true;
+@@ -1005,7 +1005,7 @@ void CookieMonster::FetchAllCookiesIfNecessary() {
+   }
+ }
+ 
+-void CookieMonster::FetchAllCookies() {
++void CookieMonster_ChromiumImpl::FetchAllCookies() {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+   DCHECK(store_.get()) << "Store must exist to initialize";
+   DCHECK(!finished_fetching_all_cookies_)
+@@ -1013,12 +1013,12 @@ void CookieMonster::FetchAllCookies() {
+ 
+   // We bind in the current time so that we can report the wall-clock time for
+   // loading cookies.
+-  store_->Load(base::BindOnce(&CookieMonster::OnLoaded,
++  store_->Load(base::BindOnce(&CookieMonster_ChromiumImpl::OnLoaded,
+                               weak_ptr_factory_.GetWeakPtr(), TimeTicks::Now()),
+                net_log_);
+ }
+ 
+-void CookieMonster::OnLoaded(
++void CookieMonster_ChromiumImpl::OnLoaded(
+     TimeTicks beginning_time,
+     std::vector<std::unique_ptr<CanonicalCookie>> cookies) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+@@ -1040,7 +1040,7 @@ void CookieMonster::OnLoaded(
+   InvokeQueue();
+ }
+ 
+-void CookieMonster::OnKeyLoaded(
++void CookieMonster_ChromiumImpl::OnKeyLoaded(
+     const std::string& key,
+     std::vector<std::unique_ptr<CanonicalCookie>> cookies) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+@@ -1068,7 +1068,7 @@ void CookieMonster::OnKeyLoaded(
+   keys_loaded_.insert(key);
+ }
+ 
+-void CookieMonster::StoreLoadedCookies(
++void CookieMonster_ChromiumImpl::StoreLoadedCookies(
+     std::vector<std::unique_ptr<CanonicalCookie>> cookies) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+ 
+@@ -1133,7 +1133,7 @@ void CookieMonster::StoreLoadedCookies(
+   EnsureCookiesMapIsValid();
+ }
+ 
+-void CookieMonster::InvokeQueue() {
++void CookieMonster_ChromiumImpl::InvokeQueue() {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+ 
+   // Move all per-key tasks into the global queue, if there are any.  This is
+@@ -1162,7 +1162,7 @@ void CookieMonster::InvokeQueue() {
+   keys_loaded_.clear();
+ }
+ 
+-void CookieMonster::EnsureCookiesMapIsValid() {
++void CookieMonster_ChromiumImpl::EnsureCookiesMapIsValid() {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+ 
+   // Iterate through all the of the cookies, grouped by host.
+@@ -1204,7 +1204,7 @@ void CookieMonster::EnsureCookiesMapIsValid() {
+ // (2) For each list with more than 1 entry, keep the cookie having the
+ //     most recent creation time, and delete the others.
+ //
+-void CookieMonster::TrimDuplicateCookiesForKey(
++void CookieMonster_ChromiumImpl::TrimDuplicateCookiesForKey(
+     const std::string& key,
+     CookieMap::iterator begin,
+     CookieMap::iterator end,
+@@ -1291,10 +1291,10 @@ void CookieMonster::TrimDuplicateCookiesForKey(
+ }
+ 
+ std::vector<CanonicalCookie*>
+-CookieMonster::FindCookiesForRegistryControlledHost(
++CookieMonster_ChromiumImpl::FindCookiesForRegistryControlledHost(
+     const GURL& url,
+     CookieMap* cookie_map,
+-    CookieMonster::PartitionedCookieMap::iterator* partition_it) {
++    CookieMonster_ChromiumImpl::PartitionedCookieMap::iterator* partition_it) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+ 
+   if (!cookie_map)
+@@ -1330,7 +1330,7 @@ CookieMonster::FindCookiesForRegistryControlledHost(
+ }
+ 
+ std::vector<CanonicalCookie*>
+-CookieMonster::FindPartitionedCookiesForRegistryControlledHost(
++CookieMonster_ChromiumImpl::FindPartitionedCookiesForRegistryControlledHost(
+     const CookiePartitionKey& cookie_partition_key,
+     const GURL& url) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+@@ -1343,7 +1343,7 @@ CookieMonster::FindPartitionedCookiesForRegistryControlledHost(
+   return FindCookiesForRegistryControlledHost(url, it->second.get(), &it);
+ }
+ 
+-void CookieMonster::FilterCookiesWithOptions(
++void CookieMonster_ChromiumImpl::FilterCookiesWithOptions(
+     const GURL& url,
+     const CookieOptions& options,
+     const CookiePartitionKeyCollection& cookie_partition_key_collection,
+@@ -1485,8 +1485,8 @@ void CookieMonster::FilterCookiesWithOptions(
+   }
+ }
+ 
+-CookieMonster::CookieChangeObservability
+-CookieMonster::MaybeDeleteEquivalentCookieAndUpdateStatus(
++CookieMonster_ChromiumImpl::CookieChangeObservability
++CookieMonster_ChromiumImpl::MaybeDeleteEquivalentCookieAndUpdateStatus(
+     const std::string& key,
+     const CanonicalCookie& cookie_being_set,
+     bool allowed_to_set_secure_cookie,
+@@ -1620,7 +1620,7 @@ CookieMonster::MaybeDeleteEquivalentCookieAndUpdateStatus(
+ }
+ 
+ // static
+-CookieChangeCause CookieMonster::ToCookieChangeCause(
++CookieChangeCause CookieMonster_ChromiumImpl::ToCookieChangeCause(
+     CookieChangeObservability observability) {
+   switch (observability) {
+     case CookieChangeObservability::kWebObservable:
+@@ -1634,9 +1634,9 @@ CookieChangeCause CookieMonster::ToCookieChangeCause(
+                << static_cast<int>(observability);
+ }
+ 
+-std::variant<CookieMonster::CookieMap::iterator,
+-             CookieMonster::PartitionedCookieMapIterators>
+-CookieMonster::InternalInsertCookie(const std::string& key,
++std::variant<CookieMonster_ChromiumImpl::CookieMap::iterator,
++             CookieMonster_ChromiumImpl::PartitionedCookieMapIterators>
++CookieMonster_ChromiumImpl::InternalInsertCookie(const std::string& key,
+                                     std::unique_ptr<CanonicalCookie> cc,
+                                     bool sync_to_store,
+                                     const CookieAccessResult& access_result,
+@@ -1721,11 +1721,11 @@ CookieMonster::InternalInsertCookie(const std::string& key,
+   return inserted;
+ }
+ 
+-bool CookieMonster::ShouldUpdatePersistentStore(CanonicalCookie& cc) {
++bool CookieMonster_ChromiumImpl::ShouldUpdatePersistentStore(CanonicalCookie& cc) {
+   return (cc.IsPersistent() || persist_session_cookies_) && store_.get();
+ }
+ 
+-void CookieMonster::SetCanonicalCookie(
++void CookieMonster_ChromiumImpl::SetCanonicalCookie(
+     std::unique_ptr<CanonicalCookie> cc,
+     const GURL& source_url,
+     const CookieOptions& options,
+@@ -1874,7 +1874,7 @@ void CookieMonster::SetCanonicalCookie(
+   MaybeRunCookieCallback(std::move(callback), access_result);
+ }
+ 
+-void CookieMonster::SetAllCookies(CookieList list,
++void CookieMonster_ChromiumImpl::SetAllCookies(CookieList list,
+                                   SetCookiesCallback callback) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+ 
+@@ -1916,7 +1916,7 @@ void CookieMonster::SetAllCookies(CookieList list,
+   MaybeRunCookieCallback(std::move(callback), CookieAccessResult());
+ }
+ 
+-void CookieMonster::SetUnsafeCanonicalCookieForTest(
++void CookieMonster_ChromiumImpl::SetUnsafeCanonicalCookieForTest(
+     std::unique_ptr<CanonicalCookie> cc,
+     SetCookiesCallback callback) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+@@ -1937,7 +1937,7 @@ void CookieMonster::SetUnsafeCanonicalCookieForTest(
+   MaybeRunCookieCallback(std::move(callback), access_result);
+ }
+ 
+-void CookieMonster::InternalUpdateCookieAccessTime(CanonicalCookie& cc,
++void CookieMonster_ChromiumImpl::InternalUpdateCookieAccessTime(CanonicalCookie& cc,
+                                                    Time current) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+ 
+@@ -1956,7 +1956,7 @@ void CookieMonster::InternalUpdateCookieAccessTime(CanonicalCookie& cc,
+ 
+ // InternalDeleteCookies must not invalidate iterators other than the one being
+ // deleted.
+-void CookieMonster::InternalDeleteCookie(CookieMap::iterator it,
++void CookieMonster_ChromiumImpl::InternalDeleteCookie(CookieMap::iterator it,
+                                          bool sync_to_store,
+                                          DeletionCause deletion_cause) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+@@ -2011,7 +2011,7 @@ void CookieMonster::InternalDeleteCookie(CookieMap::iterator it,
+   cookies_.erase(it);
+ }
+ 
+-void CookieMonster::InternalDeletePartitionedCookie(
++void CookieMonster_ChromiumImpl::InternalDeletePartitionedCookie(
+     PartitionedCookieMap::iterator partition_it,
+     CookieMap::iterator cookie_it,
+     bool sync_to_store,
+@@ -2078,7 +2078,7 @@ void CookieMonster::InternalDeletePartitionedCookie(
+ 
+ // Domain expiry behavior is unchanged by key/expiry scheme (the
+ // meaning of the key is different, but that's not visible to this routine).
+-size_t CookieMonster::GarbageCollect(Time current, const std::string& key) {
++size_t CookieMonster_ChromiumImpl::GarbageCollect(Time current, const std::string& key) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+ 
+   size_t num_deleted = 0;
+@@ -2259,7 +2259,7 @@ size_t CookieMonster::GarbageCollect(Time current, const std::string& key) {
+   return num_deleted;
+ }
+ 
+-size_t CookieMonster::GarbageCollectPartitionedCookies(
++size_t CookieMonster_ChromiumImpl::GarbageCollectPartitionedCookies(
+     base::Time current,
+     const CookiePartitionKey& cookie_partition_key,
+     const std::string& key) {
+@@ -2381,7 +2381,7 @@ size_t CookieMonster::GarbageCollectPartitionedCookies(
+   return num_deleted;
+ }
+ 
+-size_t CookieMonster::PurgeLeastRecentMatches(CookieItVector& cookies,
++size_t CookieMonster_ChromiumImpl::PurgeLeastRecentMatches(CookieItVector& cookies,
+                                               CookiePriority priority,
+                                               size_t to_protect,
+                                               size_t purge_goal,
+@@ -2433,7 +2433,7 @@ size_t CookieMonster::PurgeLeastRecentMatches(CookieItVector& cookies,
+   return removed;
+ }
+ 
+-size_t CookieMonster::PurgeLeastRecentMatchesForOBC(
++size_t CookieMonster_ChromiumImpl::PurgeLeastRecentMatchesForOBC(
+     CookieItList& cookies,
+     CookiePriority priority,
+     size_t to_protect,
+@@ -2511,7 +2511,7 @@ size_t CookieMonster::PurgeLeastRecentMatchesForOBC(
+   return removed;
+ }
+ 
+-size_t CookieMonster::GarbageCollectExpired(Time current,
++size_t CookieMonster_ChromiumImpl::GarbageCollectExpired(Time current,
+                                             const CookieMapItPair& itpair,
+                                             CookieItVector* cookie_its) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+@@ -2532,7 +2532,7 @@ size_t CookieMonster::GarbageCollectExpired(Time current,
+   return num_deleted;
+ }
+ 
+-size_t CookieMonster::GarbageCollectExpiredPartitionedCookies(
++size_t CookieMonster_ChromiumImpl::GarbageCollectExpiredPartitionedCookies(
+     Time current,
+     const PartitionedCookieMap::iterator& cookie_partition_it,
+     const CookieMapItPair& itpair,
+@@ -2556,7 +2556,7 @@ size_t CookieMonster::GarbageCollectExpiredPartitionedCookies(
+   return num_deleted;
+ }
+ 
+-void CookieMonster::GarbageCollectAllExpiredPartitionedCookies(Time current) {
++void CookieMonster_ChromiumImpl::GarbageCollectAllExpiredPartitionedCookies(Time current) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+   for (auto it = partitioned_cookies_.begin();
+        it != partitioned_cookies_.end();) {
+@@ -2573,7 +2573,7 @@ void CookieMonster::GarbageCollectAllExpiredPartitionedCookies(Time current) {
+   }
+ }
+ 
+-size_t CookieMonster::GarbageCollectDeleteRange(
++size_t CookieMonster_ChromiumImpl::GarbageCollectDeleteRange(
+     Time current,
+     DeletionCause cause,
+     CookieItVector::iterator it_begin,
+@@ -2586,7 +2586,7 @@ size_t CookieMonster::GarbageCollectDeleteRange(
+   return it_end - it_begin;
+ }
+ 
+-size_t CookieMonster::GarbageCollectLeastRecentlyAccessed(
++size_t CookieMonster_ChromiumImpl::GarbageCollectLeastRecentlyAccessed(
+     base::Time current,
+     base::Time safe_date,
+     size_t purge_goal,
+@@ -2638,7 +2638,7 @@ size_t CookieMonster::GarbageCollectLeastRecentlyAccessed(
+ // non-problem).
+ //
+ // static
+-std::string CookieMonster::GetKey(std::string_view domain) {
++std::string CookieMonster_ChromiumImpl::GetKey(std::string_view domain) {
+   std::string effective_domain(
+       registry_controlled_domains::GetDomainAndRegistry(
+           domain, registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES));
+@@ -2648,7 +2648,7 @@ std::string CookieMonster::GetKey(std::string_view domain) {
+   return cookie_util::CookieDomainAsHost(effective_domain);
+ }
+ 
+-bool CookieMonster::HasCookieableScheme(const GURL& url) {
++bool CookieMonster_ChromiumImpl::HasCookieableScheme(const GURL& url) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+ 
+   // Make sure the request is on a cookie-able url scheme.
+@@ -2665,14 +2665,14 @@ bool CookieMonster::HasCookieableScheme(const GURL& url) {
+   return is_cookieable;
+ }
+ 
+-CookieAccessSemantics CookieMonster::GetAccessSemanticsForCookie(
++CookieAccessSemantics CookieMonster_ChromiumImpl::GetAccessSemanticsForCookie(
+     const CanonicalCookie& cookie) const {
+   if (cookie_access_delegate())
+     return cookie_access_delegate()->GetAccessSemantics(cookie);
+   return CookieAccessSemantics::UNKNOWN;
+ }
+ 
+-CookieScopeSemantics CookieMonster::GetScopeSemanticsForCookieDomain(
++CookieScopeSemantics CookieMonster_ChromiumImpl::GetScopeSemanticsForCookieDomain(
+     const std::string_view domain) const {
+   if (cookie_access_delegate()) {
+     return cookie_access_delegate()->GetScopeSemantics(domain);
+@@ -2680,7 +2680,7 @@ CookieScopeSemantics CookieMonster::GetScopeSemanticsForCookieDomain(
+   return CookieScopeSemantics::UNKNOWN;
+ }
+ 
+-CookieScopeSemantics CookieMonster::CheckAndActivateLegacyScopeBehavior(
++CookieScopeSemantics CookieMonster_ChromiumImpl::CheckAndActivateLegacyScopeBehavior(
+     const std::string_view domain) {
+   const std::string cookie_key = GetKey(domain);
+   CookieScopeSemantics cookie_scope_semantic =
+@@ -2718,7 +2718,7 @@ CookieScopeSemantics CookieMonster::CheckAndActivateLegacyScopeBehavior(
+   return cookie_scope_semantic;
+ }
+ 
+-void CookieMonster::DeleteAllAliasingCookies(const std::string& domain) {
++void CookieMonster_ChromiumImpl::DeleteAllAliasingCookies(const std::string& domain) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+   std::map<UniqueCookieKey, std::pair<base::Time, UniqueCookieKey>>
+       most_recent_cookies;
+@@ -2764,7 +2764,7 @@ void CookieMonster::DeleteAllAliasingCookies(const std::string& domain) {
+   }
+ }
+ 
+-void CookieMonster::UpdateMostRecentCookie(
++void CookieMonster_ChromiumImpl::UpdateMostRecentCookie(
+     const CookieMapItPair& itpair,
+     std::map<UniqueCookieKey, std::pair<base::Time, UniqueCookieKey>>&
+         most_recent_cookies) {
+@@ -2794,7 +2794,7 @@ void CookieMonster::UpdateMostRecentCookie(
+ // last_statistic_record_time_ is initialized to Now() rather than null
+ // in the constructor so that we won't take statistics right after
+ // startup, to avoid bias from browsers that are started but not used.
+-void CookieMonster::RecordPeriodicStats(base::Time current_time) {
++void CookieMonster_ChromiumImpl::RecordPeriodicStats(base::Time current_time) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+ 
+   const base::TimeDelta kRecordStatisticsIntervalTime(
+@@ -2810,7 +2810,7 @@ void CookieMonster::RecordPeriodicStats(base::Time current_time) {
+     last_statistic_record_time_ = current_time;
+ }
+ 
+-bool CookieMonster::DoRecordPeriodicStats() {
++bool CookieMonster_ChromiumImpl::DoRecordPeriodicStats() {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+ 
+   SCOPED_UMA_HISTOGRAM_TIMER("Cookie.TimeToRecordPeriodicStats");
+@@ -2896,7 +2896,7 @@ bool CookieMonster::DoRecordPeriodicStats() {
+   return true;
+ }
+ 
+-void CookieMonster::DoCookieCallback(base::OnceClosure callback) {
++void CookieMonster_ChromiumImpl::DoCookieCallback(base::OnceClosure callback) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+ 
+   MarkCookieStoreAsInitialized();
+@@ -2914,7 +2914,7 @@ void CookieMonster::DoCookieCallback(base::OnceClosure callback) {
+   std::move(callback).Run();
+ }
+ 
+-void CookieMonster::OnPreconnect(const GURL& url) {
++void CookieMonster_ChromiumImpl::OnPreconnect(const GURL& url) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+   constexpr std::string_view kCookieOnPreconnectLoadCookie =
+       "Cookie.OnPreconnect.LoadCookie";
+@@ -2924,17 +2924,17 @@ void CookieMonster::OnPreconnect(const GURL& url) {
+   }
+   base::UmaHistogramBoolean(kCookieOnPreconnectLoadCookie, true);
+   base::SingleThreadTaskRunner::GetCurrentDefault()->PostTask(
+-      FROM_HERE, base::BindOnce(&CookieMonster::DoCookieCallbackForHostOrDomain,
++      FROM_HERE, base::BindOnce(&CookieMonster_ChromiumImpl::DoCookieCallbackForHostOrDomain,
+                                 weak_ptr_factory_.GetWeakPtr(),
+                                 base::DoNothing(), std::string(url.host())));
+ }
+ 
+-void CookieMonster::DoCookieCallbackForURL(base::OnceClosure callback,
++void CookieMonster_ChromiumImpl::DoCookieCallbackForURL(base::OnceClosure callback,
+                                            const GURL& url) {
+   DoCookieCallbackForHostOrDomain(std::move(callback), url.host());
+ }
+ 
+-void CookieMonster::DoCookieCallbackForHostOrDomain(
++void CookieMonster_ChromiumImpl::DoCookieCallbackForHostOrDomain(
+     base::OnceClosure callback,
+     std::string_view host_or_domain) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+@@ -2959,7 +2959,7 @@ void CookieMonster::DoCookieCallbackForHostOrDomain(
+       auto it = tasks_pending_for_key_.find(key);
+       if (it == tasks_pending_for_key_.end()) {
+         store_->LoadCookiesForKey(
+-            key, base::BindOnce(&CookieMonster::OnKeyLoaded,
++            key, base::BindOnce(&CookieMonster_ChromiumImpl::OnKeyLoaded,
+                                 weak_ptr_factory_.GetWeakPtr(), key));
+         it = tasks_pending_for_key_
+                  .emplace(key, base::circular_deque<base::OnceClosure>())
+@@ -2973,8 +2973,8 @@ void CookieMonster::DoCookieCallbackForHostOrDomain(
+   std::move(callback).Run();
+ }
+ 
+-CookieMonster::CookieSentToSamePort
+-CookieMonster::IsCookieSentToSamePortThatSetIt(
++CookieMonster_ChromiumImpl::CookieSentToSamePort
++CookieMonster_ChromiumImpl::IsCookieSentToSamePortThatSetIt(
+     const GURL& destination,
+     int source_port,
+     CookieSourceScheme source_scheme) {
+@@ -3010,7 +3010,7 @@ CookieMonster::IsCookieSentToSamePortThatSetIt(
+   return CookieSentToSamePort::kNo;
+ }
+ 
+-std::optional<bool> CookieMonster::SiteHasCookieInOtherPartition(
++std::optional<bool> CookieMonster_ChromiumImpl::SiteHasCookieInOtherPartition(
+     const net::SchemefulSite& site,
+     const CookiePartitionKey& partition_key) const {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);

--- a/patches/net-cookies-cookie_monster.h.patch
+++ b/patches/net-cookies-cookie_monster.h.patch
@@ -1,20 +1,75 @@
 diff --git a/net/cookies/cookie_monster.h b/net/cookies/cookie_monster.h
-index c5249984334c44b593b3bd9e7d834be82260cea2..f7ae2ea139feabeac2d54c6bc1362a8359d27779 100644
+index c5249984334c44b593b3bd9e7d834be82260cea2..d3122d11c365f1dc8eed8afe7a0905d5f8e4cfc5 100644
 --- a/net/cookies/cookie_monster.h
 +++ b/net/cookies/cookie_monster.h
-@@ -58,6 +58,7 @@ class CookieInclusionStatus;
+@@ -58,7 +58,7 @@ class CookieInclusionStatus;
  // latter case, the cookie callback will be queued in tasks_pending_for_key_
  // while PermanentCookieStore loads cookies for the specified domain key on DB
  // thread.
-+namespace chromium_impl {
- class NET_EXPORT CookieMonster : public CookieStore {
+-class NET_EXPORT CookieMonster : public CookieStore {
++class NET_EXPORT CookieMonster_ChromiumImpl : public CookieStore {
   public:
    class PersistentCookieStore;
-@@ -980,6 +981,7 @@ class NET_EXPORT CookieMonster::PersistentCookieStore
-   friend class base::RefCountedThreadSafe<PersistentCookieStore>;
+ 
+@@ -182,29 +182,29 @@ class NET_EXPORT CookieMonster : public CookieStore {
+   // this class, but it must remain valid for the duration of the cookie
+   // monster's existence. If |store| is NULL, then no backing store will be
+   // updated. |net_log| must outlive the CookieMonster and can be null.
+-  CookieMonster(scoped_refptr<PersistentCookieStore> store,
++  CookieMonster_ChromiumImpl(scoped_refptr<PersistentCookieStore> store,
+                 NetLog* net_log,
+                 std::unique_ptr<PrefDelegate> pref_delegate = nullptr);
+ 
+   // Internal ctor, exposed publicly only for std::make_unique.
+   // `net_log` must outlive the CookieMonster.
+-  CookieMonster(base::PassKey<CookieMonster>,
++  CookieMonster_ChromiumImpl(base::PassKey<CookieMonster_ChromiumImpl>,
+                 scoped_refptr<PersistentCookieStore> store,
+                 base::TimeDelta last_access_threshold,
+                 NetLog* net_log,
+                 std::unique_ptr<PrefDelegate> pref_delegate);
+ 
+   // `net_log` must outlive the CookieMonster.
+-  static std::unique_ptr<CookieMonster> CreateForTesting(
++  static std::unique_ptr<CookieMonster_ChromiumImpl> CreateForTesting(
+       scoped_refptr<PersistentCookieStore> store,
+       base::TimeDelta last_access_threshold,
+       NetLog* net_log,
+       std::unique_ptr<PrefDelegate> pref_delegate);
+ 
+-  CookieMonster(const CookieMonster&) = delete;
+-  CookieMonster& operator=(const CookieMonster&) = delete;
++  CookieMonster_ChromiumImpl(const CookieMonster_ChromiumImpl&) = delete;
++  CookieMonster_ChromiumImpl& operator=(const CookieMonster_ChromiumImpl&) = delete;
+ 
+-  ~CookieMonster() override;
++  ~CookieMonster_ChromiumImpl() override;
+ 
+   // Writes all the cookies in |list| into the store, replacing all cookies
+   // currently present in store.
+@@ -627,7 +627,7 @@ class NET_EXPORT CookieMonster : public CookieStore {
+   // web observable. Different `CookieChangeCause` will be dispatched based on
+   // the `observability` value.
+   std::variant<CookieMap::iterator,
+-               CookieMonster::PartitionedCookieMapIterators>
++               CookieMonster_ChromiumImpl::PartitionedCookieMapIterators>
+   InternalInsertCookie(const std::string& key,
+                        std::unique_ptr<CanonicalCookie> cc,
+                        bool sync_to_store,
+@@ -920,13 +920,13 @@ class NET_EXPORT CookieMonster : public CookieStore {
+ 
+   THREAD_CHECKER(thread_checker_);
+ 
+-  base::WeakPtrFactory<CookieMonster> weak_ptr_factory_{this};
++  base::WeakPtrFactory<CookieMonster_ChromiumImpl> weak_ptr_factory_{this};
  };
  
-+}  // namespace chromium_impl
- }  // namespace net
+-typedef base::RefCountedThreadSafe<CookieMonster::PersistentCookieStore>
++typedef base::RefCountedThreadSafe<CookieMonster_ChromiumImpl::PersistentCookieStore>
+     RefcountedPersistentCookieStore;
  
- #endif  // NET_COOKIES_COOKIE_MONSTER_H_
+-class NET_EXPORT CookieMonster::PersistentCookieStore
++class NET_EXPORT CookieMonster_ChromiumImpl::PersistentCookieStore
+     : public RefcountedPersistentCookieStore {
+  public:
+   typedef base::OnceCallback<void(

--- a/patches/net-cookies-cookie_monster_change_dispatcher.cc.patch
+++ b/patches/net-cookies-cookie_monster_change_dispatcher.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/net/cookies/cookie_monster_change_dispatcher.cc b/net/cookies/cookie_monster_change_dispatcher.cc
-index 37a63ff41a432bdc5045cf3ef5bddafc6b4f7b73..6dbd3bea8982c9bd4d70097468373d4b34c80ea0 100644
+index 37a63ff41a432bdc5045cf3ef5bddafc6b4f7b73..4260d46826b4cde8fb7002528f5a0c22f6c6d54b 100644
 --- a/net/cookies/cookie_monster_change_dispatcher.cc
 +++ b/net/cookies/cookie_monster_change_dispatcher.cc
 @@ -113,7 +113,7 @@ void CookieMonsterChangeDispatcher::Subscription::DoDispatchChange(
@@ -7,7 +7,7 @@ index 37a63ff41a432bdc5045cf3ef5bddafc6b4f7b73..6dbd3bea8982c9bd4d70097468373d4b
  
  CookieMonsterChangeDispatcher::CookieMonsterChangeDispatcher(
 -    const CookieMonster* cookie_monster)
-+    const chromium_impl::CookieMonster* cookie_monster)
++    const CookieMonster_ChromiumImpl* cookie_monster)
      : cookie_monster_(cookie_monster) {}
  
  CookieMonsterChangeDispatcher::~CookieMonsterChangeDispatcher() {

--- a/patches/net-cookies-cookie_monster_change_dispatcher.h.patch
+++ b/patches/net-cookies-cookie_monster_change_dispatcher.h.patch
@@ -1,34 +1,31 @@
 diff --git a/net/cookies/cookie_monster_change_dispatcher.h b/net/cookies/cookie_monster_change_dispatcher.h
-index 03a9b7458ce56ae45a5e9ef0d7f715d22e8e41b0..5a8910ae8ca5954444295551ec53da5dad1481f4 100644
+index 03a9b7458ce56ae45a5e9ef0d7f715d22e8e41b0..6e77bc2aed781fd6e0b77445abf55c1061cf16a3 100644
 --- a/net/cookies/cookie_monster_change_dispatcher.h
 +++ b/net/cookies/cookie_monster_change_dispatcher.h
-@@ -24,16 +24,18 @@
+@@ -24,7 +24,7 @@
  namespace net {
  
  class CookieAccessDelegate;
-+namespace chromium_impl {
- class CookieMonster;
-+}
+-class CookieMonster;
++class CookieMonster_ChromiumImpl;
  
--// CookieChangeDispatcher implementation used by CookieMonster.
-+// CookieChangeDispatcher implementation used by chromium_impl::CookieMonster.
+ // CookieChangeDispatcher implementation used by CookieMonster.
  class CookieMonsterChangeDispatcher : public CookieChangeDispatcher {
-  public:
-   using CookieChangeCallbackList =
+@@ -33,7 +33,7 @@ class CookieMonsterChangeDispatcher : public CookieChangeDispatcher {
        base::RepeatingCallbackList<void(const CookieChangeInfo&)>;
  
    // Expects |cookie_monster| to outlive this.
 -  explicit CookieMonsterChangeDispatcher(const CookieMonster* cookie_monster);
-+  explicit CookieMonsterChangeDispatcher(const chromium_impl::CookieMonster* cookie_monster);
++  explicit CookieMonsterChangeDispatcher(const CookieMonster_ChromiumImpl* cookie_monster);
  
    CookieMonsterChangeDispatcher(const CookieMonsterChangeDispatcher&) = delete;
    CookieMonsterChangeDispatcher& operator=(
-@@ -150,7 +152,7 @@ class CookieMonsterChangeDispatcher : public CookieChangeDispatcher {
+@@ -150,7 +150,7 @@ class CookieMonsterChangeDispatcher : public CookieChangeDispatcher {
    // Called by the Subscription destructor.
    void UnlinkSubscription(Subscription* subscription);
  
 -  raw_ptr<const CookieMonster> cookie_monster_;
-+  raw_ptr<const chromium_impl::CookieMonster> cookie_monster_;
++  raw_ptr<const CookieMonster_ChromiumImpl> cookie_monster_;
  
    CookieDomainMap cookie_domain_map_;
  

--- a/patches/net-cookies-cookie_monster_unittest.cc.patch
+++ b/patches/net-cookies-cookie_monster_unittest.cc.patch
@@ -1,19 +1,1625 @@
 diff --git a/net/cookies/cookie_monster_unittest.cc b/net/cookies/cookie_monster_unittest.cc
-index c7e0dfef2acfb749b564f98595aa515e4f9c68db..c0bf205041ddc93364c5cce3eccbe06dcb01ccd7 100644
+index c7e0dfef2acfb749b564f98595aa515e4f9c68db..2eb3107b5cb826bb70ea95a8f4a8cd39613d2b11 100644
 --- a/net/cookies/cookie_monster_unittest.cc
 +++ b/net/cookies/cookie_monster_unittest.cc
-@@ -71,7 +71,7 @@
- #include "url/third_party/mozilla/url_parse.h"
- #include "url/url_constants.h"
+@@ -121,7 +121,7 @@ const char kOtherDomain[] = "http://www.mit.edu";
  
--namespace net {
-+namespace net::chromium_impl {
+ struct CookieMonsterTestTraits {
+   static std::unique_ptr<CookieStore> Create() {
+-    return std::make_unique<CookieMonster>(nullptr /* store */,
++    return std::make_unique<CookieMonster_ChromiumImpl>(nullptr /* store */,
+                                            nullptr /* netlog */);
+   }
  
- using base::Time;
- using CookieDeletionInfo = net::CookieDeletionInfo;
-@@ -8678,4 +8678,4 @@ TEST_F(CookieMonsterTest, RejectsHiddenHostHttpPrefix) {
-            EXCLUDE_AMBIGUOUS_SERIALIZATION}));
+@@ -145,16 +145,16 @@ struct CookieMonsterTestTraits {
+   static const bool dispatches_events_on_no_change_overwrite = true;
+ };
+ 
+-INSTANTIATE_TYPED_TEST_SUITE_P(CookieMonster,
++INSTANTIATE_TYPED_TEST_SUITE_P(CookieMonster_ChromiumImpl,
+                                CookieStoreTest,
+                                CookieMonsterTestTraits);
+-INSTANTIATE_TYPED_TEST_SUITE_P(CookieMonster,
++INSTANTIATE_TYPED_TEST_SUITE_P(CookieMonster_ChromiumImpl,
+                                CookieStoreChangeGlobalTest,
+                                CookieMonsterTestTraits);
+-INSTANTIATE_TYPED_TEST_SUITE_P(CookieMonster,
++INSTANTIATE_TYPED_TEST_SUITE_P(CookieMonster_ChromiumImpl,
+                                CookieStoreChangeUrlTest,
+                                CookieMonsterTestTraits);
+-INSTANTIATE_TYPED_TEST_SUITE_P(CookieMonster,
++INSTANTIATE_TYPED_TEST_SUITE_P(CookieMonster_ChromiumImpl,
+                                CookieStoreChangeNamedTest,
+                                CookieMonsterTestTraits);
+ 
+@@ -168,7 +168,7 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+   using CookieStoreTest<T>::https_www_foo_;
+ 
+   CookieList GetAllCookiesForURLWithOptions(
+-      CookieMonster* cm,
++      CookieMonster_ChromiumImpl* cm,
+       const GURL& url,
+       const CookieOptions& options,
+       const CookiePartitionKeyCollection& cookie_partition_key_collection =
+@@ -181,7 +181,7 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+     return callback.cookies();
+   }
+ 
+-  CookieList GetAllCookies(CookieMonster* cm) {
++  CookieList GetAllCookies(CookieMonster_ChromiumImpl* cm) {
+     DCHECK(cm);
+     GetAllCookiesCallback callback;
+     cm->GetAllCookiesAsync(callback.MakeCallback());
+@@ -190,7 +190,7 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+   }
+ 
+   CookieAccessResultList GetExcludedCookiesForURLWithOptions(
+-      CookieMonster* cm,
++      CookieMonster_ChromiumImpl* cm,
+       const GURL& url,
+       const CookieOptions& options,
+       const CookiePartitionKeyCollection& cookie_partition_key_collection =
+@@ -203,7 +203,7 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+     return callback.excluded_cookies();
+   }
+ 
+-  bool SetAllCookies(CookieMonster* cm, const CookieList& list) {
++  bool SetAllCookies(CookieMonster_ChromiumImpl* cm, const CookieList& list) {
+     DCHECK(cm);
+     ResultSavingCookieCallback<CookieAccessResult> callback;
+     cm->SetAllCookiesAsync(list, callback.MakeCallback());
+@@ -212,7 +212,7 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+   }
+ 
+   bool SetCookieWithCreationTime(
+-      CookieMonster* cm,
++      CookieMonster_ChromiumImpl* cm,
+       const GURL& url,
+       const std::string& cookie_line,
+       base::Time creation_time,
+@@ -231,7 +231,7 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+   }
+ 
+   bool SetUnsafeCookieWithCreationTime(
+-      CookieMonster* cm,
++      CookieMonster_ChromiumImpl* cm,
+       const GURL& url,
+       const std::string& cookie_line,
+       base::Time creation_time,
+@@ -248,7 +248,7 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+     return callback.result().status.IsInclude();
+   }
+ 
+-  uint32_t DeleteAllCreatedInTimeRange(CookieMonster* cm,
++  uint32_t DeleteAllCreatedInTimeRange(CookieMonster_ChromiumImpl* cm,
+                                        const TimeRange& creation_range) {
+     DCHECK(cm);
+     ResultSavingCookieCallback<uint32_t> callback;
+@@ -258,7 +258,7 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+     return callback.result();
+   }
+ 
+-  uint32_t DeleteAllMatchingInfo(CookieMonster* cm,
++  uint32_t DeleteAllMatchingInfo(CookieMonster_ChromiumImpl* cm,
+                                  CookieDeletionInfo delete_info) {
+     DCHECK(cm);
+     ResultSavingCookieCallback<uint32_t> callback;
+@@ -268,7 +268,7 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+     return callback.result();
+   }
+ 
+-  uint32_t DeleteMatchingCookies(CookieMonster* cm,
++  uint32_t DeleteMatchingCookies(CookieMonster_ChromiumImpl* cm,
+                                  CookieStore::DeletePredicate predicate) {
+     DCHECK(cm);
+     ResultSavingCookieCallback<uint32_t> callback;
+@@ -281,7 +281,7 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+   // Helper for PredicateSeesAllCookies test; repopulates CM with same layout
+   // each time. Returns the time which is strictly greater than any creation
+   // time which was passed to created cookies.
+-  base::Time PopulateCmForPredicateCheck(CookieMonster* cm) {
++  base::Time PopulateCmForPredicateCheck(CookieMonster_ChromiumImpl* cm) {
+     std::string url_top_level_domain_plus_1(
+         GURL(kTopLevelDomainPlus1).GetHost());
+     std::string url_top_level_domain_plus_2(
+@@ -402,12 +402,12 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+     return now + base::Milliseconds(100);
+   }
+ 
+-  Time GetFirstCookieAccessDate(CookieMonster* cm) {
++  Time GetFirstCookieAccessDate(CookieMonster_ChromiumImpl* cm) {
+     const CookieList all_cookies(this->GetAllCookies(cm));
+     return all_cookies.front().LastAccessDate();
+   }
+ 
+-  bool FindAndDeleteCookie(CookieMonster* cm,
++  bool FindAndDeleteCookie(CookieMonster_ChromiumImpl* cm,
+                            const std::string& domain,
+                            const std::string& name) {
+     CookieList cookies = this->GetAllCookies(cm);
+@@ -418,12 +418,12 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+   }
+ 
+   void TestHostGarbageCollectHelper() {
+-    int domain_max_cookies = CookieMonster::kDomainMaxCookies;
+-    int domain_purge_cookies = CookieMonster::kDomainPurgeCookies;
++    int domain_max_cookies = CookieMonster_ChromiumImpl::kDomainMaxCookies;
++    int domain_purge_cookies = CookieMonster_ChromiumImpl::kDomainPurgeCookies;
+     const int more_than_enough_cookies = domain_max_cookies + 10;
+     // Add a bunch of cookies on a single host, should purge them.
+     {
+-      auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++      auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+       for (int i = 0; i < more_than_enough_cookies; ++i) {
+         std::string cookie = base::StringPrintf("a%03d=b", i);
+         EXPECT_TRUE(SetCookie(cm.get(), http_www_foo_.url(), cookie));
+@@ -440,7 +440,7 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+     // between them.  We shouldn't go above kDomainMaxCookies for both together.
+     GURL url_google_specific(http_www_foo_.Format("http://www.gmail.%D"));
+     {
+-      auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++      auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+       for (int i = 0; i < more_than_enough_cookies; ++i) {
+         std::string cookie_general = base::StringPrintf("a%03d=b", i);
+         EXPECT_TRUE(SetCookie(cm.get(), http_www_foo_.url(), cookie_general));
+@@ -471,7 +471,7 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+     // Test histogram for the number of registrable domains affected by domain
+     // purge.
+     {
+-      auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++      auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+       GURL url;
+       for (int domain_num = 0; domain_num < 3; ++domain_num) {
+         url = GURL(base::StringPrintf("http://domain%d.test", domain_num));
+@@ -526,7 +526,7 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+   // Thus, to describe expected suriving cookies, it suffices to specify the
+   // expected population of surviving cookies per priority, i.e.,
+   // |expected_low_count|, |expected_medium_count|, and |expected_high_count|.
+-  void TestPriorityCookieCase(CookieMonster* cm,
++  void TestPriorityCookieCase(CookieMonster_ChromiumImpl* cm,
+                               const std::string& coded_priority_str,
+                               size_t expected_low_count,
+                               size_t expected_medium_count,
+@@ -670,10 +670,10 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+                                 size_t expected_secure_cookies,
+                                 size_t expected_non_secure_cookies,
+                                 const AltHosts* alt_host_entries) {
+-    std::unique_ptr<CookieMonster> cm;
++    std::unique_ptr<CookieMonster_ChromiumImpl> cm;
+ 
+     if (alt_host_entries == nullptr) {
+-      cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++      cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+     } else {
+       // When generating all of these cookies on alternate hosts, they need to
+       // be all older than the max "safe" date for GC, which is currently 30
+@@ -715,11 +715,11 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+ 
+   void TestPriorityAwareGarbageCollectHelperNonSecure() {
+     // Hard-coding limits in the test, but use DCHECK_EQ to enforce constraint.
+-    DCHECK_EQ(180U, CookieMonster::kDomainMaxCookies);
+-    DCHECK_EQ(150U, CookieMonster::kDomainMaxCookies -
+-                        CookieMonster::kDomainPurgeCookies);
++    DCHECK_EQ(180U, CookieMonster_ChromiumImpl::kDomainMaxCookies);
++    DCHECK_EQ(150U, CookieMonster_ChromiumImpl::kDomainMaxCookies -
++                        CookieMonster_ChromiumImpl::kDomainPurgeCookies);
+ 
+-    auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++    auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+     // Key:
+     // Round 1 => LN; round 2 => LS; round 3 => MN.
+     // Round 4 => HN; round 5 => MS; round 6 => HS
+@@ -781,11 +781,11 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+ 
+   void TestPriorityAwareGarbageCollectHelperSecure() {
+     // Hard-coding limits in the test, but use DCHECK_EQ to enforce constraint.
+-    DCHECK_EQ(180U, CookieMonster::kDomainMaxCookies);
+-    DCHECK_EQ(150U, CookieMonster::kDomainMaxCookies -
+-                        CookieMonster::kDomainPurgeCookies);
++    DCHECK_EQ(180U, CookieMonster_ChromiumImpl::kDomainMaxCookies);
++    DCHECK_EQ(150U, CookieMonster_ChromiumImpl::kDomainMaxCookies -
++                        CookieMonster_ChromiumImpl::kDomainPurgeCookies);
+ 
+-    auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++    auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+     // Key:
+     // Round 1 => LN; round 2 => LS; round 3 => MN.
+     // Round 4 => HN; round 5 => MS; round 6 => HS
+@@ -841,11 +841,11 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+ 
+   void TestPriorityAwareGarbageCollectHelperMixed() {
+     // Hard-coding limits in the test, but use DCHECK_EQ to enforce constraint.
+-    DCHECK_EQ(180U, CookieMonster::kDomainMaxCookies);
+-    DCHECK_EQ(150U, CookieMonster::kDomainMaxCookies -
+-                        CookieMonster::kDomainPurgeCookies);
++    DCHECK_EQ(180U, CookieMonster_ChromiumImpl::kDomainMaxCookies);
++    DCHECK_EQ(150U, CookieMonster_ChromiumImpl::kDomainMaxCookies -
++                        CookieMonster_ChromiumImpl::kDomainPurgeCookies);
+ 
+-    auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++    auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+     // Key:
+     // Round 1 => LN; round 2 => LS; round 3 => MN.
+     // Round 4 => HN; round 5 => MS; round 6 => HS
+@@ -964,8 +964,8 @@ class CookieMonsterTestBase : public CookieStoreTest<T> {
+ 
+   // Function for creating a CM with a number of cookies in it,
+   // no store (and hence no ability to affect access time).
+-  std::unique_ptr<CookieMonster> CreateMonsterForGC(int num_cookies) {
+-    auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  std::unique_ptr<CookieMonster_ChromiumImpl> CreateMonsterForGC(int num_cookies) {
++    auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+     base::Time creation_time = base::Time::Now();
+     for (int i = 0; i < num_cookies; i++) {
+       std::unique_ptr<CanonicalCookie> cc(
+@@ -1055,7 +1055,7 @@ class DeferredCookieTaskTest : public CookieMonsterTest {
+   DeferredCookieTaskTest() {
+     persistent_store_ = base::MakeRefCounted<MockPersistentCookieStore>();
+     persistent_store_->set_store_load_commands(true);
+-    cookie_monster_ = std::make_unique<CookieMonster>(persistent_store_.get(),
++    cookie_monster_ = std::make_unique<CookieMonster_ChromiumImpl>(persistent_store_.get(),
+                                                       net::NetLog::Get());
+   }
+ 
+@@ -1106,7 +1106,7 @@ class DeferredCookieTaskTest : public CookieMonsterTest {
+   // PersistentCookieStore::LoadCookiesForKey.
+   std::vector<std::unique_ptr<CanonicalCookie>> loaded_cookies_;
+ 
+-  std::unique_ptr<CookieMonster> cookie_monster_;
++  std::unique_ptr<CookieMonster_ChromiumImpl> cookie_monster_;
+   scoped_refptr<MockPersistentCookieStore> persistent_store_;
+ };
+ 
+@@ -1139,7 +1139,7 @@ class CookieMonsterLegacyScopeTest : public CookieMonsterTest {
+ 
+ // Class to create a pref_delegate for testing purposes.
+ // For testing the Get and Set functions are all that are needed.
+-class TestPrefDelegate : public CookieMonster::PrefDelegate {
++class TestPrefDelegate : public CookieMonster_ChromiumImpl::PrefDelegate {
+  public:
+   const base::DictValue& GetLegacyDomains() const override { return test_dict; }
+   void SetLegacyDomains(base::DictValue dict) override {
+@@ -1517,7 +1517,7 @@ TEST_F(DeferredCookieTaskTest, DeferredTaskOrder) {
+ 
+ TEST_F(CookieMonsterTest, TestCookieDeleteAll) {
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   CookieOptions options = CookieOptions::MakeAllInclusive();
+ 
+   EXPECT_TRUE(SetCookie(cm.get(), http_www_foo_.url(), kValidCookieLine));
+@@ -1559,7 +1559,7 @@ TEST_F(CookieMonsterTest, TestCookieDeleteAll) {
  }
  
--}  // namespace net
-+}  // namespace net::chromium_impl
+ TEST_F(CookieMonsterTest, TestCookieDeleteAllCreatedInTimeRangeTimestamps) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   Time now = Time::Now();
+ 
+@@ -1647,7 +1647,7 @@ TEST_F(CookieMonsterTest, TestCookieDeleteAllCreatedInTimeRangeTimestamps) {
+ 
+ TEST_F(CookieMonsterTest,
+        TestCookieDeleteAllCreatedInTimeRangeTimestampsWithInfo) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   Time now = Time::Now();
+ 
+@@ -1735,7 +1735,7 @@ TEST_F(CookieMonsterTest,
+ }
+ 
+ TEST_F(CookieMonsterTest, TestCookieDeleteMatchingCookies) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+   Time now = Time::Now();
+ 
+   // Nothing has been added so nothing should be deleted.
+@@ -1809,7 +1809,7 @@ static const base::TimeDelta kAccessDelay =
+     kLastAccessThreshold + base::Milliseconds(20);
+ 
+ TEST_F(CookieMonsterTest, TestLastAccess) {
+-  std::unique_ptr<CookieMonster> cm = CookieMonster::CreateForTesting(
++  std::unique_ptr<CookieMonster_ChromiumImpl> cm = CookieMonster_ChromiumImpl::CreateForTesting(
+       /*store=*/nullptr, kLastAccessThreshold, net::NetLog::Get(),
+       /*pref_delegate=*/nullptr);
+ 
+@@ -1873,11 +1873,11 @@ TEST_P(CookieMonsterTestPriorityGarbageCollectionObc,
+ TEST_P(CookieMonsterTestGarbageCollectionObc, DomainCookiesPreferred) {
+   ASSERT_TRUE(cookie_util::IsOriginBoundCookiesPartiallyEnabled());
+   // This test requires the following values.
+-  ASSERT_EQ(180U, CookieMonster::kDomainMaxCookies);
+-  ASSERT_EQ(150U, CookieMonster::kDomainMaxCookies -
+-                      CookieMonster::kDomainPurgeCookies);
++  ASSERT_EQ(180U, CookieMonster_ChromiumImpl::kDomainMaxCookies);
++  ASSERT_EQ(150U, CookieMonster_ChromiumImpl::kDomainMaxCookies -
++                      CookieMonster_ChromiumImpl::kDomainPurgeCookies);
+ 
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   // Insert an extra host cookie so that one will need to be deleted;
+   // demonstrating that host cookies will still be deleted if need be but they
+@@ -1919,9 +1919,9 @@ TEST_P(CookieMonsterTestGarbageCollectionObc,
+        DomainPartitionedCookiesPreferred) {
+   ASSERT_TRUE(cookie_util::IsOriginBoundCookiesPartiallyEnabled());
+   // This test requires the following value.
+-  ASSERT_EQ(180U, CookieMonster::kPerPartitionDomainMaxCookies);
++  ASSERT_EQ(180U, CookieMonster_ChromiumImpl::kPerPartitionDomainMaxCookies);
+ 
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+   auto cookie_partition_key =
+       CookiePartitionKey::FromURLForTesting(GURL("https://www.example.com"));
+ 
+@@ -1995,11 +1995,11 @@ TEST_P(CookieMonsterTestGarbageCollectionObc,
+ TEST_P(CookieMonsterTestGarbageCollectionObc, SecureCookiesPreferred) {
+   ASSERT_TRUE(cookie_util::IsOriginBoundCookiesPartiallyEnabled());
+   // This test requires the following values.
+-  ASSERT_EQ(180U, CookieMonster::kDomainMaxCookies);
+-  ASSERT_EQ(150U, CookieMonster::kDomainMaxCookies -
+-                      CookieMonster::kDomainPurgeCookies);
++  ASSERT_EQ(180U, CookieMonster_ChromiumImpl::kDomainMaxCookies);
++  ASSERT_EQ(150U, CookieMonster_ChromiumImpl::kDomainMaxCookies -
++                      CookieMonster_ChromiumImpl::kDomainPurgeCookies);
+ 
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   // If scheme binding is enabled then the secure url is enough, otherwise we
+   // need to also add "Secure" to the cookie line.
+@@ -2054,11 +2054,11 @@ TEST_P(CookieMonsterTestGarbageCollectionObc, SecureCookiesPreferred) {
+ TEST_P(CookieMonsterTestGarbageCollectionObc, LegacyModeGarbageCollection) {
+   ASSERT_TRUE(cookie_util::IsOriginBoundCookiesPartiallyEnabled());
+   // This test assumes the following values.
+-  ASSERT_EQ(180U, CookieMonster::kDomainMaxCookies);
+-  ASSERT_EQ(150U, CookieMonster::kDomainMaxCookies -
+-                      CookieMonster::kDomainPurgeCookies);
++  ASSERT_EQ(180U, CookieMonster_ChromiumImpl::kDomainMaxCookies);
++  ASSERT_EQ(150U, CookieMonster_ChromiumImpl::kDomainMaxCookies -
++                      CookieMonster_ChromiumImpl::kDomainPurgeCookies);
+ 
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   GURL example_with_https_port_value_80 = GURL("https://www.example.com:80/");
+ 
+@@ -2104,9 +2104,9 @@ TEST_P(CookieMonsterTestGarbageCollectionObc,
+        LegacyModeParitionedGarbageCollection) {
+   ASSERT_TRUE(cookie_util::IsOriginBoundCookiesPartiallyEnabled());
+   // This test assumes the following value.
+-  ASSERT_EQ(180U, CookieMonster::kPerPartitionDomainMaxCookies);
++  ASSERT_EQ(180U, CookieMonster_ChromiumImpl::kPerPartitionDomainMaxCookies);
+ 
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+   auto cookie_partition_key =
+       CookiePartitionKey::FromURLForTesting(GURL("https://www.example.com"));
+ 
+@@ -2156,9 +2156,9 @@ TEST_P(CookieMonsterTestGarbageCollectionObc,
+ 
+ TEST_F(CookieMonsterTest, TestPartitionedCookiesGarbageCollection_Memory) {
+   // Limit should be 10 KB.
+-  DCHECK_EQ(1024u * 10u, CookieMonster::kPerPartitionDomainMaxCookieBytes);
++  DCHECK_EQ(1024u * 10u, CookieMonster_ChromiumImpl::kPerPartitionDomainMaxCookieBytes);
+ 
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+   auto cookie_partition_key =
+       CookiePartitionKey::FromURLForTesting(GURL("https://toplevelsite1.com"));
+ 
+@@ -2187,9 +2187,9 @@ TEST_F(CookieMonsterTest, TestPartitionedCookiesGarbageCollection_Memory) {
+ 
+ TEST_F(CookieMonsterTest, TestPartitionedCookiesGarbageCollection_MaxCookies) {
+   // Partitioned cookies also limit domains to 180 cookies per partition.
+-  DCHECK_EQ(180u, CookieMonster::kPerPartitionDomainMaxCookies);
++  DCHECK_EQ(180u, CookieMonster_ChromiumImpl::kPerPartitionDomainMaxCookies);
+ 
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+   auto cookie_partition_key =
+       CookiePartitionKey::FromURLForTesting(GURL("https://toplevelsite.com"));
+ 
+@@ -2215,9 +2215,9 @@ TEST_F(CookieMonsterTest, TestPartitionedCookiesGarbageCollection_MaxCookies) {
+ }
+ 
+ TEST_F(CookieMonsterTest, SetCookieableSchemes) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+-  auto cm_foo = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm_foo = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   // Only cm_foo should allow foo:// cookies.
+   std::vector<std::string> schemes;
+@@ -2282,7 +2282,7 @@ TEST_F(CookieMonsterTest, SetCookieableSchemes) {
+ }
+ 
+ TEST_F(CookieMonsterTest, SetCookieableSchemes_StoreInitialized) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+   // Initializes the cookie store.
+   this->GetCookies(cm.get(), https_www_foo_.url(),
+                    CookiePartitionKeyCollection());
+@@ -2309,7 +2309,7 @@ TEST_F(CookieMonsterTest, SetCookieableSchemes_StoreInitialized) {
+ }
+ 
+ TEST_F(CookieMonsterTest, GetAllCookiesForURL) {
+-  std::unique_ptr<CookieMonster> cm = CookieMonster::CreateForTesting(
++  std::unique_ptr<CookieMonster_ChromiumImpl> cm = CookieMonster_ChromiumImpl::CreateForTesting(
+       /*store=*/nullptr, kLastAccessThreshold, net::NetLog::Get(),
+       /*pref_delegate=*/nullptr);
+ 
+@@ -2418,7 +2418,7 @@ TEST_F(CookieMonsterTest, GetAllCookiesForURL) {
+ }
+ 
+ TEST_F(CookieMonsterTest, GetExcludedCookiesForURL) {
+-  std::unique_ptr<CookieMonster> cm = CookieMonster::CreateForTesting(
++  std::unique_ptr<CookieMonster_ChromiumImpl> cm = CookieMonster_ChromiumImpl::CreateForTesting(
+       /*store=*/nullptr, kLastAccessThreshold, net::NetLog::Get(),
+       /*pref_delegate=*/nullptr);
+ 
+@@ -2495,7 +2495,7 @@ TEST_F(CookieMonsterTest, GetExcludedCookiesForURL) {
+ }
+ 
+ TEST_F(CookieMonsterTest, GetAllCookiesForURLPathMatching) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   CookieOptions options = CookieOptions::MakeAllInclusive();
+ 
+@@ -2534,7 +2534,7 @@ TEST_F(CookieMonsterTest, GetAllCookiesForURLPathMatching) {
+ }
+ 
+ TEST_F(CookieMonsterTest, GetExcludedCookiesForURLPathMatching) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   CookieOptions options = CookieOptions::MakeAllInclusive();
+ 
+@@ -2571,7 +2571,7 @@ TEST_F(CookieMonsterTest, GetExcludedCookiesForURLPathMatching) {
+ }
+ 
+ TEST_F(CookieMonsterTest, CookieSorting) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   base::Time system_time = base::Time::Now();
+   for (const char* cookie_line :
+@@ -2598,7 +2598,7 @@ TEST_F(CookieMonsterTest, CookieSorting) {
+ }
+ 
+ TEST_F(CookieMonsterTest, InheritCreationDate) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   base::Time the_not_so_distant_past(base::Time::Now() - base::Seconds(1000));
+   EXPECT_TRUE(SetCookieWithCreationTime(cm.get(), http_www_foo_.url(),
+@@ -2633,7 +2633,7 @@ TEST_F(CookieMonsterTest, InheritCreationDate) {
+ }
+ 
+ TEST_F(CookieMonsterTest, OverwriteSource) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   // Set cookie with unknown source.
+   EXPECT_TRUE(SetCookie(cm.get(), http_www_foo_.url(), "A=0", std::nullopt,
+@@ -2671,7 +2671,7 @@ TEST_F(CookieMonsterTest, OverwriteSource) {
+ // Check that GetAllCookiesForURL() does not return expired cookies and deletes
+ // them.
+ TEST_F(CookieMonsterTest, DeleteExpiredCookiesOnGet) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   EXPECT_TRUE(SetCookie(cm.get(), http_www_foo_.url(), "A=B;"));
+ 
+@@ -2717,7 +2717,7 @@ TEST_F(CookieMonsterTest, DeleteExpiredCookiesOnGet) {
+ // Test that cookie expiration works correctly when a cookie expires because
+ // time elapses.
+ TEST_F(CookieMonsterTest, DeleteExpiredCookiesAfterTimeElapsed) {
+-  auto cm = std::make_unique<CookieMonster>(
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(
+       /*store=*/nullptr, net::NetLog::Get());
+ 
+   EXPECT_TRUE(SetCookie(cm.get(), https_www_bar_.url(),
+@@ -2743,7 +2743,7 @@ TEST_F(CookieMonsterTest, DeleteExpiredCookiesAfterTimeElapsed) {
+ }
+ 
+ TEST_F(CookieMonsterTest, DeleteExpiredPartitionedCookiesAfterTimeElapsed) {
+-  auto cm = std::make_unique<CookieMonster>(
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(
+       /*store=*/nullptr, net::NetLog::Get());
+   auto cookie_partition_key =
+       CookiePartitionKey::FromURLForTesting(GURL("https://toplevelsite.com"));
+@@ -2777,7 +2777,7 @@ TEST_F(CookieMonsterTest, DeleteExpiredPartitionedCookiesAfterTimeElapsed) {
+ // and are not most recently deleted will be deleted.
+ TEST_F(CookieMonsterLegacyScopeTest, DeleteAllAliasCookies) {
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   base::Time now = Time::Now();
+   // Create some aliasing cookies.
+   ASSERT_TRUE(SetCookieWithCreationTime(cm.get(),
+@@ -2856,7 +2856,7 @@ TEST_F(CookieMonsterLegacyScopeTest, DeleteAllAliasCookies) {
+ // will make sure only aliases that are on the given domain
+ // and are not most recently deleted will be deleted for partitioned cookies.
+ TEST_F(CookieMonsterLegacyScopeTest, DeleteAllAliasPartitionedCookies) {
+-  auto cm = std::make_unique<CookieMonster>(
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(
+       /*store=*/nullptr, net::NetLog::Get());
+   base::Time now = Time::Now();
+ 
+@@ -2962,7 +2962,7 @@ TEST_F(CookieMonsterLegacyScopeTest, DeleteAllAliasPartitionedCookies) {
+ TEST_F(CookieMonsterLegacyScopeTest, CheckAndActivateLegacyScopeBehavior) {
+   auto pref_delegate = std::make_unique<TestPrefDelegate>();
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get(),
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get(),
+                                             std::move(pref_delegate));
+   base::Time now = Time::Now();
+   std::optional<base::Time> server_time;
+@@ -3093,7 +3093,7 @@ TEST_F(CookieMonsterLegacyScopeTest, CheckAndActivateLegacyScopeBehavior) {
+ TEST_F(CookieMonsterLegacyScopeTest,
+        CheckAndActivateLegacyScopeBehaviorNullPrefDelegate) {
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get(),
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get(),
+                                             /*pref_delegate=*/nullptr);
+   base::Time now = Time::Now();
+   std::optional<base::Time> server_time;
+@@ -3224,7 +3224,7 @@ TEST_F(CookieMonsterLegacyScopeTest, UpdateMostRecentlyCreatedCookie) {
+   using CookieMapItPair = std::pair<CookieMap::iterator, CookieMap::iterator>;
+ 
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   std::map<UniqueCookieKey, std::pair<base::Time, UniqueCookieKey>>
+       most_recent_cookies;
+@@ -3287,7 +3287,7 @@ TEST_F(CookieMonsterLegacyScopeTest,
+        DeleteAliasCookiesGetCookieListWithOptions) {
+   auto pref_delegate = std::make_unique<TestPrefDelegate>();
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get(),
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get(),
+                                             std::move(pref_delegate));
+   base::Time now = Time::Now();
+   // Create some aliasing cookies.
+@@ -3396,7 +3396,7 @@ TEST_F(CookieMonsterLegacyScopeTest,
+        DeleteAliasPartitionedCookiesGetCookieListWithOptions) {
+   auto pref_delegate = std::make_unique<TestPrefDelegate>();
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get(),
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get(),
+                                             std::move(pref_delegate));
+   base::Time now = Time::Now();
+ 
+@@ -3526,7 +3526,7 @@ TEST_F(CookieMonsterLegacyScopeTest,
+ TEST_F(CookieMonsterLegacyScopeTest, DeleteAliasCookiesSetCanonicalCookie) {
+   auto pref_delegate = std::make_unique<TestPrefDelegate>();
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get(),
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get(),
+                                             std::move(pref_delegate));
+   base::Time now = Time::Now();
+   // Create some aliasing cookies.
+@@ -3628,7 +3628,7 @@ TEST_F(CookieMonsterLegacyScopeTest,
+        DeleteAliasPartitionedCookiesSetCanonicalCookies) {
+   auto pref_delegate = std::make_unique<TestPrefDelegate>();
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get(),
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get(),
+                                             std::move(pref_delegate));
+   base::Time now = Time::Now();
+ 
+@@ -3744,7 +3744,7 @@ TEST_F(CookieMonsterLegacyScopeTest,
+ 
+ // This test is for verifying the fix of https://crbug.com/353034832.
+ TEST_F(CookieMonsterTest, ExpireSinglePartitionedCookie) {
+-  auto cm = std::make_unique<CookieMonster>(
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(
+       /*store=*/nullptr, net::NetLog::Get());
+   auto cookie_partition_key =
+       CookiePartitionKey::FromURLForTesting(GURL("https://toplevelsite.com"));
+@@ -3768,7 +3768,7 @@ TEST_F(CookieMonsterTest, ExpireSinglePartitionedCookie) {
+ }
+ 
+ TEST_F(CookieMonsterTest, DeleteExpiredAfterTimeElapsed_GetAllCookies) {
+-  auto cm = std::make_unique<CookieMonster>(
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(
+       /*store=*/nullptr, net::NetLog::Get());
+ 
+   EXPECT_TRUE(SetCookie(cm.get(), https_www_bar_.url(),
+@@ -3798,7 +3798,7 @@ TEST_F(CookieMonsterTest, DeleteExpiredAfterTimeElapsed_GetAllCookies) {
+ 
+ TEST_F(CookieMonsterTest,
+        DeleteExpiredPartitionedCookiesAfterTimeElapsed_GetAllCookies) {
+-  auto cm = std::make_unique<CookieMonster>(
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(
+       /*store=*/nullptr, net::NetLog::Get());
+   auto cookie_partition_key =
+       CookiePartitionKey::FromURLForTesting(GURL("https://toplevelsite.com"));
+@@ -3829,7 +3829,7 @@ TEST_F(CookieMonsterTest,
+ }
+ 
+ TEST_F(CookieMonsterTest, DeletePartitionedCookie) {
+-  auto cm = std::make_unique<CookieMonster>(
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(
+       /*store=*/nullptr, net::NetLog::Get());
+   auto cookie_partition_key =
+       CookiePartitionKey::FromURLForTesting(GURL("https://toplevelsite.com"));
+@@ -3919,7 +3919,7 @@ TEST_F(CookieMonsterTest, DontImportDuplicateCookies) {
+   // Inject our initial cookies into the mock PersistentCookieStore.
+   store->SetLoadExpectation(true, std::move(initial_cookies));
+ 
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   // Verify that duplicates were not imported for path "/".
+   // (If this had failed, GetCookies() would have also returned X=1, X=2, X=4).
+@@ -3967,7 +3967,7 @@ TEST_F(CookieMonsterTest, DontImportDuplicateCookies_PartitionedCookies) {
+   initial_cookies.push_back(std::move(cc));
+ 
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   store->SetLoadExpectation(true, std::move(initial_cookies));
+ 
+@@ -4019,7 +4019,7 @@ TEST_F(CookieMonsterTest, ImportDuplicateCreationTimes) {
+   // Inject our initial cookies into the mock PersistentCookieStore.
+   store->SetLoadExpectation(true, std::move(initial_cookies));
+ 
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   CookieList list(GetAllCookies(cm.get()));
+   EXPECT_EQ(2U, list.size());
+@@ -4076,7 +4076,7 @@ TEST_F(CookieMonsterTest, ImportDuplicateCreationTimes_PartitionedCookies) {
+   // Inject our initial cookies into the mock PersistentCookieStore.
+   store->SetLoadExpectation(true, std::move(initial_cookies));
+ 
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   CookieList list(GetAllCookies(cm.get()));
+   EXPECT_EQ(2U, list.size());
+@@ -4089,7 +4089,7 @@ TEST_F(CookieMonsterTest, ImportDuplicateCreationTimes_PartitionedCookies) {
+ }
+ 
+ TEST_F(CookieMonsterTest, PredicateSeesAllCookies) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   const base::Time now = PopulateCmForPredicateCheck(cm.get());
+   // We test that we can see all cookies with |delete_info|. This includes
+@@ -4117,7 +4117,7 @@ TEST_F(CookieMonsterTest, PredicateSeesAllCookies) {
+ // Mainly a test of GetEffectiveDomain, or more specifically, of the
+ // expected behavior of GetEffectiveDomain within the CookieMonster.
+ TEST_F(CookieMonsterTest, GetKey) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   // This test is really only interesting if GetKey() actually does something.
+   EXPECT_EQ("foo.com", cm->GetKey("www.foo.com"));
+@@ -4164,7 +4164,7 @@ TEST_F(CookieMonsterTest, BackingStoreCommunication) {
+   // Create new cookies and flush them to the store.
+   {
+     auto cmout =
+-        std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++        std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+     for (const auto& cookie : input_info) {
+       EXPECT_TRUE(SetCanonicalCookie(
+           cmout.get(),
+@@ -4184,7 +4184,7 @@ TEST_F(CookieMonsterTest, BackingStoreCommunication) {
+   // Create a new cookie monster and make sure that everything is correct
+   {
+     auto cmin =
+-        std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++        std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+     CookieList cookies(GetAllCookies(cmin.get()));
+     ASSERT_EQ(2u, cookies.size());
+     // Ordering is path length, then creation time.  So second cookie
+@@ -4218,7 +4218,7 @@ TEST_F(CookieMonsterTest, RestoreDifferentCookieSameCreationTime) {
+       base::MakeRefCounted<MockPersistentCookieStore>();
+ 
+   {
+-    CookieMonster cmout(store.get(), net::NetLog::Get());
++    CookieMonster_ChromiumImpl cmout(store.get(), net::NetLog::Get());
+     GURL url("http://www.example.com/");
+     EXPECT_TRUE(
+         SetCookieWithCreationTime(&cmout, url, "A=1; max-age=600", current));
+@@ -4240,7 +4240,7 @@ TEST_F(CookieMonsterTest, RestoreDifferentCookieSameCreationTime) {
+ 
+   // Now read them in. Should get two cookies, not one.
+   {
+-    CookieMonster cmin(store2.get(), net::NetLog::Get());
++    CookieMonster_ChromiumImpl cmin(store2.get(), net::NetLog::Get());
+     CookieList cookies(GetAllCookies(&cmin));
+     ASSERT_EQ(2u, cookies.size());
+   }
+@@ -4249,7 +4249,7 @@ TEST_F(CookieMonsterTest, RestoreDifferentCookieSameCreationTime) {
+ TEST_F(CookieMonsterTest, CookieListOrdering) {
+   // Put a random set of cookies into a monster and make sure
+   // they're returned in the right order.
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   EXPECT_TRUE(
+       SetCookie(cm.get(), GURL("http://d.c.b.a.foo.com/aa/x.html"), "c=1"));
+@@ -4298,52 +4298,52 @@ TEST_F(CookieMonsterTest, CookieListOrdering) {
+ // Check to make sure that a whole lot of recent cookies doesn't get rid of
+ // anything after garbage collection is checked for.
+ TEST_F(CookieMonsterTest, GarbageCollectionKeepsRecentEphemeralCookies) {
+-  std::unique_ptr<CookieMonster> cm(
+-      CreateMonsterForGC(CookieMonster::kMaxCookies * 2 /* num_cookies */));
+-  EXPECT_EQ(CookieMonster::kMaxCookies * 2, GetAllCookies(cm.get()).size());
++  std::unique_ptr<CookieMonster_ChromiumImpl> cm(
++      CreateMonsterForGC(CookieMonster_ChromiumImpl::kMaxCookies * 2 /* num_cookies */));
++  EXPECT_EQ(CookieMonster_ChromiumImpl::kMaxCookies * 2, GetAllCookies(cm.get()).size());
+   // Will trigger GC.
+   SetCookie(cm.get(), GURL("http://newdomain.com"), "b=2");
+-  EXPECT_EQ(CookieMonster::kMaxCookies * 2 + 1, GetAllCookies(cm.get()).size());
++  EXPECT_EQ(CookieMonster_ChromiumImpl::kMaxCookies * 2 + 1, GetAllCookies(cm.get()).size());
+ }
+ 
+ // A whole lot of recent cookies; GC shouldn't happen.
+ TEST_F(CookieMonsterTest, GarbageCollectionKeepsRecentCookies) {
+-  std::unique_ptr<CookieMonster> cm = CreateMonsterFromStoreForGC(
+-      CookieMonster::kMaxCookies * 2 /* num_cookies */, 0 /* num_old_cookies */,
+-      0, 0, CookieMonster::kSafeFromGlobalPurgeDays * 2);
+-  EXPECT_EQ(CookieMonster::kMaxCookies * 2, GetAllCookies(cm.get()).size());
++  std::unique_ptr<CookieMonster_ChromiumImpl> cm = CreateMonsterFromStoreForGC(
++      CookieMonster_ChromiumImpl::kMaxCookies * 2 /* num_cookies */, 0 /* num_old_cookies */,
++      0, 0, CookieMonster_ChromiumImpl::kSafeFromGlobalPurgeDays * 2);
++  EXPECT_EQ(CookieMonster_ChromiumImpl::kMaxCookies * 2, GetAllCookies(cm.get()).size());
+   // Will trigger GC.
+   SetCookie(cm.get(), GURL("http://newdomain.com"), "b=2");
+-  EXPECT_EQ(CookieMonster::kMaxCookies * 2 + 1, GetAllCookies(cm.get()).size());
++  EXPECT_EQ(CookieMonster_ChromiumImpl::kMaxCookies * 2 + 1, GetAllCookies(cm.get()).size());
+ }
+ 
+ // Test case where there are more than kMaxCookies - kPurgeCookies recent
+ // cookies. All old cookies should be garbage collected, all recent cookies
+ // kept.
+ TEST_F(CookieMonsterTest, GarbageCollectionKeepsOnlyRecentCookies) {
+-  std::unique_ptr<CookieMonster> cm = CreateMonsterFromStoreForGC(
+-      CookieMonster::kMaxCookies * 2 /* num_cookies */,
+-      CookieMonster::kMaxCookies / 2 /* num_old_cookies */, 0, 0,
+-      CookieMonster::kSafeFromGlobalPurgeDays * 2);
+-  EXPECT_EQ(CookieMonster::kMaxCookies * 2, GetAllCookies(cm.get()).size());
++  std::unique_ptr<CookieMonster_ChromiumImpl> cm = CreateMonsterFromStoreForGC(
++      CookieMonster_ChromiumImpl::kMaxCookies * 2 /* num_cookies */,
++      CookieMonster_ChromiumImpl::kMaxCookies / 2 /* num_old_cookies */, 0, 0,
++      CookieMonster_ChromiumImpl::kSafeFromGlobalPurgeDays * 2);
++  EXPECT_EQ(CookieMonster_ChromiumImpl::kMaxCookies * 2, GetAllCookies(cm.get()).size());
+   // Will trigger GC.
+   SetCookie(cm.get(), GURL("http://newdomain.com"), "b=2");
+-  EXPECT_EQ(CookieMonster::kMaxCookies * 2 - CookieMonster::kMaxCookies / 2 + 1,
++  EXPECT_EQ(CookieMonster_ChromiumImpl::kMaxCookies * 2 - CookieMonster_ChromiumImpl::kMaxCookies / 2 + 1,
+             GetAllCookies(cm.get()).size());
+ }
+ 
+ // Test case where there are exactly kMaxCookies - kPurgeCookies recent cookies.
+ // All old cookies should be deleted.
+ TEST_F(CookieMonsterTest, GarbageCollectionExactlyAllOldCookiesDeleted) {
+-  std::unique_ptr<CookieMonster> cm = CreateMonsterFromStoreForGC(
+-      CookieMonster::kMaxCookies * 2 /* num_cookies */,
+-      CookieMonster::kMaxCookies + CookieMonster::kPurgeCookies +
++  std::unique_ptr<CookieMonster_ChromiumImpl> cm = CreateMonsterFromStoreForGC(
++      CookieMonster_ChromiumImpl::kMaxCookies * 2 /* num_cookies */,
++      CookieMonster_ChromiumImpl::kMaxCookies + CookieMonster_ChromiumImpl::kPurgeCookies +
+           1 /* num_old_cookies */,
+-      0, 0, CookieMonster::kSafeFromGlobalPurgeDays * 2);
+-  EXPECT_EQ(CookieMonster::kMaxCookies * 2, GetAllCookies(cm.get()).size());
++      0, 0, CookieMonster_ChromiumImpl::kSafeFromGlobalPurgeDays * 2);
++  EXPECT_EQ(CookieMonster_ChromiumImpl::kMaxCookies * 2, GetAllCookies(cm.get()).size());
+   // Will trigger GC.
+   SetCookie(cm.get(), GURL("http://newdomain.com"), "b=2");
+-  EXPECT_EQ(CookieMonster::kMaxCookies - CookieMonster::kPurgeCookies,
++  EXPECT_EQ(CookieMonster_ChromiumImpl::kMaxCookies - CookieMonster_ChromiumImpl::kPurgeCookies,
+             GetAllCookies(cm.get()).size());
+ }
+ 
+@@ -4351,14 +4351,14 @@ TEST_F(CookieMonsterTest, GarbageCollectionExactlyAllOldCookiesDeleted) {
+ // cookies. Enough old cookies should be deleted to reach kMaxCookies -
+ // kPurgeCookies total cookies, but no more. Some old cookies should be kept.
+ TEST_F(CookieMonsterTest, GarbageCollectionTriggers5) {
+-  std::unique_ptr<CookieMonster> cm = CreateMonsterFromStoreForGC(
+-      CookieMonster::kMaxCookies * 2 /* num_cookies */,
+-      CookieMonster::kMaxCookies * 3 / 2 /* num_old_cookies */, 0, 0,
+-      CookieMonster::kSafeFromGlobalPurgeDays * 2);
+-  EXPECT_EQ(CookieMonster::kMaxCookies * 2, GetAllCookies(cm.get()).size());
++  std::unique_ptr<CookieMonster_ChromiumImpl> cm = CreateMonsterFromStoreForGC(
++      CookieMonster_ChromiumImpl::kMaxCookies * 2 /* num_cookies */,
++      CookieMonster_ChromiumImpl::kMaxCookies * 3 / 2 /* num_old_cookies */, 0, 0,
++      CookieMonster_ChromiumImpl::kSafeFromGlobalPurgeDays * 2);
++  EXPECT_EQ(CookieMonster_ChromiumImpl::kMaxCookies * 2, GetAllCookies(cm.get()).size());
+   // Will trigger GC.
+   SetCookie(cm.get(), GURL("http://newdomain.com"), "b=2");
+-  EXPECT_EQ(CookieMonster::kMaxCookies - CookieMonster::kPurgeCookies,
++  EXPECT_EQ(CookieMonster_ChromiumImpl::kMaxCookies - CookieMonster_ChromiumImpl::kPurgeCookies,
+             GetAllCookies(cm.get()).size());
+ }
+ 
+@@ -4367,17 +4367,17 @@ TEST_F(CookieMonsterTest, GarbageCollectionTriggers5) {
+ TEST_F(CookieMonsterTest, GarbageCollectWithSecureCookiesOnly) {
+   // Create a CookieMonster at its cookie limit. A bit confusing, but the second
+   // number is a subset of the first number.
+-  std::unique_ptr<CookieMonster> cm = CreateMonsterFromStoreForGC(
+-      CookieMonster::kMaxCookies /* num_secure_cookies */,
+-      CookieMonster::kMaxCookies /* num_old_secure_cookies */,
++  std::unique_ptr<CookieMonster_ChromiumImpl> cm = CreateMonsterFromStoreForGC(
++      CookieMonster_ChromiumImpl::kMaxCookies /* num_secure_cookies */,
++      CookieMonster_ChromiumImpl::kMaxCookies /* num_old_secure_cookies */,
+       0 /* num_non_secure_cookies */, 0 /* num_old_non_secure_cookies */,
+-      CookieMonster::kSafeFromGlobalPurgeDays * 2 /* days_old */);
+-  EXPECT_EQ(CookieMonster::kMaxCookies, GetAllCookies(cm.get()).size());
++      CookieMonster_ChromiumImpl::kSafeFromGlobalPurgeDays * 2 /* days_old */);
++  EXPECT_EQ(CookieMonster_ChromiumImpl::kMaxCookies, GetAllCookies(cm.get()).size());
+ 
+   // Trigger purge with a secure cookie (So there are still no insecure
+   // cookies).
+   SetCookie(cm.get(), GURL("https://newdomain.com"), "b=2; Secure");
+-  EXPECT_EQ(CookieMonster::kMaxCookies - CookieMonster::kPurgeCookies,
++  EXPECT_EQ(CookieMonster_ChromiumImpl::kMaxCookies - CookieMonster_ChromiumImpl::kPurgeCookies,
+             GetAllCookies(cm.get()).size());
+ }
+ 
+@@ -4388,7 +4388,7 @@ TEST_F(CookieMonsterTest, WhileLoadingLoadCompletesBeforeKeyLoadCompletes) {
+ 
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+   store->set_store_load_commands(true);
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   auto cookie = CanonicalCookie::CreateForTesting(
+       kUrl, "a=b", base::Time::Now(), CookieSourceType::kOther);
+@@ -4437,7 +4437,7 @@ TEST_F(CookieMonsterTest, WhileLoadingDeleteAllGetForURL) {
+ 
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+   store->set_store_load_commands(true);
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   ResultSavingCookieCallback<uint32_t> delete_callback;
+   cm->DeleteAllAsync(delete_callback.MakeCallback());
+@@ -4475,7 +4475,7 @@ TEST_F(CookieMonsterTest, WhileLoadingGetAllSetGetAll) {
+ 
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+   store->set_store_load_commands(true);
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   GetAllCookiesCallback get_cookies_callback1;
+   cm->GetAllCookiesAsync(get_cookies_callback1.MakeCallback());
+@@ -4525,7 +4525,7 @@ TEST_F(CookieMonsterTest, CheckOrderOfCookieTaskQueueWhenLoadingCompletes) {
+ 
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+   store->set_store_load_commands(true);
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   // Get all cookies task that queues a task to set a cookie when executed.
+   auto cookie = CanonicalCookie::CreateForTesting(
+@@ -4569,7 +4569,7 @@ TEST_F(CookieMonsterTest, CheckOrderOfCookieTaskQueueWhenLoadingCompletes) {
+ TEST_F(CookieMonsterTest, FlushStore) {
+   auto counter = base::MakeRefCounted<CallbackCounter>();
+   auto store = base::MakeRefCounted<FlushablePersistentStore>();
+-  auto cm = std::make_unique<CookieMonster>(store, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store, net::NetLog::Get());
+ 
+   ASSERT_EQ(0, store->flush_count());
+   ASSERT_EQ(0, counter->callback_count());
+@@ -4604,7 +4604,7 @@ TEST_F(CookieMonsterTest, FlushStore) {
+   ASSERT_EQ(2, counter->callback_count());
+ 
+   // If there's no backing store, FlushStore() is always a safe no-op.
+-  cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+   GetAllCookies(cm.get());  // Force init.
+   cm->FlushStore(base::DoNothing());
+   base::RunLoop().RunUntilIdle();
+@@ -4619,7 +4619,7 @@ TEST_F(CookieMonsterTest, FlushStore) {
+ 
+ TEST_F(CookieMonsterTest, SetAllCookies) {
+   auto store = base::MakeRefCounted<FlushablePersistentStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   cm->SetPersistSessionCookies(true);
+ 
+   EXPECT_TRUE(SetCookie(cm.get(), http_www_foo_.url(), "U=V; path=/"));
+@@ -4700,7 +4700,7 @@ TEST_F(CookieMonsterTest, SetAllCookies) {
+ // Check that DeleteAll does flush (as a quick check that flush_count() works).
+ TEST_F(CookieMonsterTest, DeleteAll) {
+   auto store = base::MakeRefCounted<FlushablePersistentStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   cm->SetPersistSessionCookies(true);
+ 
+   EXPECT_TRUE(SetCookie(cm.get(), http_www_foo_.url(), "X=Y; path=/"));
+@@ -4728,7 +4728,7 @@ TEST_F(CookieMonsterTest, DeleteAll) {
+ 
+ TEST_F(CookieMonsterTest, HistogramCheck) {
+   base::MetricsSubSampler::ScopedAlwaysSampleForTesting always_sample;
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   // Should match call in InitializeHistograms, but doesn't really matter
+   // since the histogram should have been initialized by the CM construction
+@@ -4789,7 +4789,7 @@ TEST_F(CookieMonsterTest, InvalidExpiryTime) {
+ // CookieStore if the "persist session cookies" option is on.
+ TEST_F(CookieMonsterTest, PersistSessionCookies) {
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   cm->SetPersistSessionCookies(true);
+ 
+   // All cookies set with SetCookie are session cookies.
+@@ -4826,7 +4826,7 @@ TEST_F(CookieMonsterTest, PersistSessionCookies) {
+ // Test the commands sent to the persistent cookie store.
+ TEST_F(CookieMonsterTest, PersisentCookieStorageTest) {
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   // Add a cookie.
+   EXPECT_TRUE(SetCookie(cm.get(), http_www_foo_.url(),
+@@ -4924,7 +4924,7 @@ TEST_F(CookieMonsterTest, ControlCharacterPurge) {
+   // Inject our initial cookies into the mock PersistentCookieStore.
+   store->SetLoadExpectation(true, std::move(initial_cookies));
+ 
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   EXPECT_EQ("foo=bar; hello=world",
+             GetCookies(cm.get(), url,
+@@ -4932,7 +4932,7 @@ TEST_F(CookieMonsterTest, ControlCharacterPurge) {
+ }
+ 
+ TEST_F(CookieMonsterTest, CookieCount2Histogram) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   {
+     base::HistogramTester histogram_tester;
+@@ -4963,7 +4963,7 @@ TEST_F(CookieMonsterTest, CookieCount2Histogram) {
+ }
+ 
+ TEST_F(CookieMonsterTest, CookieJarSizeHistograms) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   {
+     base::HistogramTester histogram_tester;
+@@ -5051,7 +5051,7 @@ TEST_F(CookieMonsterTest, CookieJarSizeHistograms) {
+ }
+ 
+ TEST_F(CookieMonsterTest, PartitionedCookieHistograms) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   {
+     base::HistogramTester histogram_tester;
+@@ -5231,7 +5231,7 @@ TEST_F(CookieMonsterTest, MaxSameSiteNoneCookiesPerKey) {
+   const char kHistogramName[] = "Cookie.MaxSameSiteNoneCookiesPerKey";
+ 
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   ASSERT_EQ(0u, GetAllCookies(cm.get()).size());
+ 
+   {  // Only SameSite cookies should not log a sample.
+@@ -5280,7 +5280,7 @@ TEST_F(CookieMonsterTest, MaxSameSiteNoneCookiesPerKey) {
+ // Test that localhost URLs can set and get secure cookies, even if
+ // non-cryptographic.
+ TEST_F(CookieMonsterTest, SecureCookieLocalhost) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, nullptr);
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, nullptr);
+ 
+   GURL insecure_localhost("http://localhost");
+   GURL secure_localhost("https://localhost");
+@@ -5353,7 +5353,7 @@ TEST_F(CookieMonsterTest, SecureCookieLocalhost) {
+ 
+ TEST_F(CookieMonsterTest, MaybeDeleteEquivalentCookieAndUpdateStatus) {
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   // Set a secure, httponly cookie from a secure origin
+   auto preexisting_cookie = CanonicalCookie::CreateForTesting(
+@@ -5454,7 +5454,7 @@ TEST_F(CookieMonsterTest, MaybeDeleteEquivalentCookieAndUpdateStatus) {
+ TEST_F(CookieMonsterTest,
+        MaybeDeleteEquivalentCookieAndUpdateStatus_PartitionedCookies) {
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   // Test adding two cookies with the same name, domain, and path but different
+   // partition keys.
+@@ -5504,7 +5504,7 @@ class CookieMonsterTest_MaybeDeleteEquivalentCookieAndUpdateStatus
+   // https/443 origin.
+   void InitializeTest() {
+     store_ = base::MakeRefCounted<MockPersistentCookieStore>();
+-    cm_ = std::make_unique<CookieMonster>(store_.get(), net::NetLog::Get());
++    cm_ = std::make_unique<CookieMonster_ChromiumImpl>(store_.get(), net::NetLog::Get());
+ 
+     auto preexisting_cookie_https = CanonicalCookie::CreateForTesting(
+         https_www_foo_.url(), "A=PreexistingHttps443", base::Time::Now(),
+@@ -5586,7 +5586,7 @@ class CookieMonsterTest_MaybeDeleteEquivalentCookieAndUpdateStatus
+   }
+ 
+   scoped_refptr<net::MockPersistentCookieStore> store_;
+-  std::unique_ptr<CookieMonster> cm_;
++  std::unique_ptr<CookieMonster_ChromiumImpl> cm_;
+   base::test::ScopedFeatureList scoped_feature_list_;
+ };
+ 
+@@ -5757,7 +5757,7 @@ class CookieMonsterTest_StoreLoadedCookies : public CookieMonsterTest {
+  public:
+   void InitializeTest() {
+     store_ = base::MakeRefCounted<MockPersistentCookieStore>();
+-    cm_ = std::make_unique<CookieMonster>(store_.get(), net::NetLog::Get());
++    cm_ = std::make_unique<CookieMonster_ChromiumImpl>(store_.get(), net::NetLog::Get());
+ 
+     base::Time most_recent_time = base::Time::Now();
+     base::Time middle_time = most_recent_time - base::Minutes(1);
+@@ -5824,7 +5824,7 @@ class CookieMonsterTest_StoreLoadedCookies : public CookieMonsterTest {
+   }
+ 
+   scoped_refptr<net::MockPersistentCookieStore> store_;
+-  std::unique_ptr<CookieMonster> cm_;
++  std::unique_ptr<CookieMonster_ChromiumImpl> cm_;
+   std::vector<std::unique_ptr<CanonicalCookie>> starting_list_;
+   base::test::ScopedFeatureList scoped_feature_list_;
+ };
+@@ -5909,7 +5909,7 @@ TEST_F(CookieMonsterTest_StoreLoadedCookies, YesSchemeYesPort) {
+ // multiple reasons (Secure and HttpOnly).
+ TEST_F(CookieMonsterTest, SkipDontOverwriteForMultipleReasons) {
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   // Set a secure, httponly cookie from a secure origin
+   auto preexisting_cookie = CanonicalCookie::CreateForTesting(
+@@ -5944,7 +5944,7 @@ TEST_F(CookieMonsterTest, SkipDontOverwriteForMultipleReasons) {
+ // cookie should not be set.
+ TEST_F(CookieMonsterTest, DontDeleteEquivalentCookieIfSetIsRejected) {
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   auto preexisting_cookie = CanonicalCookie::CreateForTesting(
+       http_www_foo_.url(), "cookie=foo", base::Time::Now(),
+@@ -5968,7 +5968,7 @@ TEST_F(CookieMonsterTest, DontDeleteEquivalentCookieIfSetIsRejected) {
+ }
+ 
+ TEST_F(CookieMonsterTest, SetSecureCookies) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   GURL http_url("http://www.foo.com");
+   GURL http_superdomain_url("http://foo.com");
+@@ -6153,7 +6153,7 @@ TEST_F(CookieMonsterTest, SetSecureCookies) {
+ // Check domain-match criterion: If either cookie domain matches the other,
+ // don't set the insecure cookie.
+ TEST_F(CookieMonsterTest, LeaveSecureCookiesAlone_DomainMatch) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   // These domains will domain-match each other.
+   const char* kRegistrableDomain = "foo.com";
+@@ -6328,7 +6328,7 @@ TEST_F(CookieMonsterTest, LeaveSecureCookiesAlone_DomainMatch) {
+ // Check path-match criterion: If the new cookie is for the same path or a
+ // subdirectory of the preexisting cookie's path, don't set the new cookie.
+ TEST_F(CookieMonsterTest, LeaveSecureCookiesAlone_PathMatch) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   // A path that is later in this list will path-match all the paths before it.
+   auto kPaths = std::to_array<const char*>({"/", "/1", "/1/2", "/1/2/3"});
+@@ -6431,11 +6431,11 @@ TEST_F(CookieMonsterTest, LeaveSecureCookiesAlone_PathMatch) {
+ // Tests for behavior for strict secure cookies.
+ TEST_F(CookieMonsterTest, EvictSecureCookies) {
+   // Hard-coding limits in the test, but use DCHECK_EQ to enforce constraint.
+-  DCHECK_EQ(180U, CookieMonster::kDomainMaxCookies);
+-  DCHECK_EQ(150U, CookieMonster::kDomainMaxCookies -
+-                      CookieMonster::kDomainPurgeCookies);
+-  DCHECK_EQ(3300U, CookieMonster::kMaxCookies);
+-  DCHECK_EQ(30, CookieMonster::kSafeFromGlobalPurgeDays);
++  DCHECK_EQ(180U, CookieMonster_ChromiumImpl::kDomainMaxCookies);
++  DCHECK_EQ(150U, CookieMonster_ChromiumImpl::kDomainMaxCookies -
++                      CookieMonster_ChromiumImpl::kDomainPurgeCookies);
++  DCHECK_EQ(3300U, CookieMonster_ChromiumImpl::kMaxCookies);
++  DCHECK_EQ(30, CookieMonster_ChromiumImpl::kSafeFromGlobalPurgeDays);
+ 
+   // If secure cookies for one domain hit the per domain limit (180), a
+   // non-secure cookie will not evict them (and, in fact, the non-secure cookie
+@@ -6553,7 +6553,7 @@ TEST_F(CookieMonsterTest, EvictSecureCookies) {
+ // Tests that strict secure cookies doesn't trip equivalent cookie checks
+ // accidentally. Regression test for https://crbug.com/569943.
+ TEST_F(CookieMonsterTest, EquivalentCookies) {
+-  auto cm = std::make_unique<CookieMonster>(nullptr, nullptr);
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, nullptr);
+   GURL http_url("http://www.foo.com");
+   GURL http_superdomain_url("http://foo.com");
+   GURL https_url("https://www.foo.com");
+@@ -6582,7 +6582,7 @@ TEST_F(CookieMonsterTest, SetCanonicalCookieDoesNotBlockForLoadAll) {
+       base::MakeRefCounted<MockPersistentCookieStore>();
+   // Collect load commands so we have control over their execution.
+   persistent_store->set_store_load_commands(true);
+-  CookieMonster cm(persistent_store.get(), nullptr);
++  CookieMonster_ChromiumImpl cm(persistent_store.get(), nullptr);
+ 
+   // Start of a canonical cookie set.
+   ResultSavingCookieCallback<CookieAccessResult> callback_set;
+@@ -6628,7 +6628,7 @@ TEST_F(CookieMonsterTest, DeleteDuplicateCTime) {
+   // that the implementation doesn't just happen to pick the right one because
+   // of implementation details.
+   for (const auto* name : kNames) {
+-    CookieMonster cm(nullptr, nullptr);
++    CookieMonster_ChromiumImpl cm(nullptr, nullptr);
+     Time now = Time::Now();
+     GURL url("http://www.example.com");
+ 
+@@ -6668,7 +6668,7 @@ TEST_F(CookieMonsterTest, DeleteCookieWithInheritedTimestamps) {
+   CookieOptions options = CookieOptions::MakeAllInclusive();
+   std::optional<base::Time> server_time = std::nullopt;
+   std::optional<CookiePartitionKey> partition_key = std::nullopt;
+-  CookieMonster cm(nullptr, nullptr);
++  CookieMonster_ChromiumImpl cm(nullptr, nullptr);
+ 
+   // Write a cookie created at |t1|.
+   auto cookie = CanonicalCookie::CreateForTesting(url, cookie_line, t1,
+@@ -6705,7 +6705,7 @@ TEST_F(CookieMonsterTest, RejectCreatedSameSiteCookieOnSet) {
+   GURL url("http://www.example.com");
+   std::string cookie_line = "foo=bar; SameSite=Lax";
+ 
+-  CookieMonster cm(nullptr, nullptr);
++  CookieMonster_ChromiumImpl cm(nullptr, nullptr);
+   CookieOptions env_cross_site;
+   env_cross_site.set_same_site_cookie_context(
+       CookieOptions::SameSiteCookieContext(
+@@ -6734,7 +6734,7 @@ TEST_F(CookieMonsterTest, RejectCreatedSecureCookieOnSet) {
+   GURL http_url("http://www.example.com");
+   std::string cookie_line = "foo=bar; Secure";
+ 
+-  CookieMonster cm(nullptr, nullptr);
++  CookieMonster_ChromiumImpl cm(nullptr, nullptr);
+   CookieInclusionStatus status;
+   // Cookie can be created successfully from an any url. Secure is not checked
+   // on Create.
+@@ -6760,7 +6760,7 @@ TEST_F(CookieMonsterTest, RejectCreatedHttpOnlyCookieOnSet) {
+   GURL url("http://www.example.com");
+   std::string cookie_line = "foo=bar; HttpOnly";
+ 
+-  CookieMonster cm(nullptr, nullptr);
++  CookieMonster_ChromiumImpl cm(nullptr, nullptr);
+   CookieInclusionStatus status;
+   // Cookie can be created successfully; HttpOnly is not checked on Create.
+   auto cookie = CanonicalCookie::CreateForTesting(
+@@ -6839,7 +6839,7 @@ TEST_F(CookieMonsterTest, CookiesWithoutSameSiteMustBeSecure) {
+        CookieInclusionStatus(), CookieEffectiveSameSite::LAX_MODE, kLongAge},
+   });
+ 
+-  auto cm = std::make_unique<CookieMonster>(nullptr, nullptr);
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(nullptr, nullptr);
+   GURL secure_url("https://www.example1.test");
+   GURL insecure_url("http://www.example2.test");
+ 
+@@ -6870,7 +6870,7 @@ TEST_F(CookieMonsterTest, CookiesWithoutSameSiteMustBeSecure) {
+ // Test the different cookie change causes.
+ TEST_F(CookieMonsterTest, CookieChangeCause) {
+   auto cookie_monster =
+-      std::make_unique<CookieMonster>(nullptr, net::NetLog::Get());
++      std::make_unique<CookieMonster_ChromiumImpl>(nullptr, net::NetLog::Get());
+ 
+   std::vector<CookieChangeInfo> changes;
+   auto subscription =
+@@ -6972,18 +6972,18 @@ class CookieMonsterNotificationTest : public CookieMonsterTest {
+   CookieMonsterNotificationTest()
+       : test_url_("http://www.foo.com/foo"),
+         store_(base::MakeRefCounted<MockPersistentCookieStore>()),
+-        monster_(std::make_unique<CookieMonster>(store_.get(), nullptr)) {}
++        monster_(std::make_unique<CookieMonster_ChromiumImpl>(store_.get(), nullptr)) {}
+ 
+   ~CookieMonsterNotificationTest() override = default;
+ 
+-  CookieMonster* monster() { return monster_.get(); }
++  CookieMonster_ChromiumImpl* monster() { return monster_.get(); }
+ 
+  protected:
+   const GURL test_url_;
+ 
+  private:
+   scoped_refptr<MockPersistentCookieStore> store_;
+-  std::unique_ptr<CookieMonster> monster_;
++  std::unique_ptr<CookieMonster_ChromiumImpl> monster_;
+ };
+ 
+ void RecordCookieChanges(std::vector<CanonicalCookie>* out_cookies,
+@@ -7004,7 +7004,7 @@ TEST_F(CookieMonsterNotificationTest, NoNotificationOnLoad) {
+   store->set_store_load_commands(true);
+ 
+   // Bind it to a CookieMonster
+-  auto monster = std::make_unique<CookieMonster>(store.get(), nullptr);
++  auto monster = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), nullptr);
+ 
+   // Trigger load dispatch and confirm it.
+   monster->GetAllCookiesAsync(CookieStore::GetAllCookiesCallback());
+@@ -7064,7 +7064,7 @@ TEST_F(CookieMonsterNotificationTest, NoNotificationOnLoad) {
+ class CookieMonsterLegacyCookieAccessTest : public CookieMonsterTest {
+  public:
+   CookieMonsterLegacyCookieAccessTest()
+-      : cm_(std::make_unique<CookieMonster>(nullptr /* store */,
++      : cm_(std::make_unique<CookieMonster_ChromiumImpl>(nullptr /* store */,
+                                             nullptr /* netlog */
+                                             )) {
+     // Need to reset first because there cannot be two TaskEnvironments at the
+@@ -7086,7 +7086,7 @@ class CookieMonsterLegacyCookieAccessTest : public CookieMonsterTest {
+   const std::string kDomain = "example.test";
+   const GURL kHttpsUrl = GURL("https://example.test");
+   const GURL kHttpUrl = GURL("http://example.test");
+-  std::unique_ptr<CookieMonster> cm_;
++  std::unique_ptr<CookieMonster_ChromiumImpl> cm_;
+   raw_ptr<TestCookieAccessDelegate> access_delegate_;
+ };
+ 
+@@ -7177,73 +7177,73 @@ TEST_F(CookieMonsterTest, IsCookieSentToSamePortThatSetIt) {
+   // cases where the above aren't true the value of source_scheme is irreleant.
+ 
+   // Test unspecified.
+-  ASSERT_EQ(CookieMonster::IsCookieSentToSamePortThatSetIt(
++  ASSERT_EQ(CookieMonster_ChromiumImpl::IsCookieSentToSamePortThatSetIt(
+                 GURL("https://foo.com"), url::PORT_UNSPECIFIED,
+                 CookieSourceScheme::kSecure),
+-            CookieMonster::CookieSentToSamePort::kSourcePortUnspecified);
++            CookieMonster_ChromiumImpl::CookieSentToSamePort::kSourcePortUnspecified);
+ 
+   // Test invalid.
+-  ASSERT_EQ(CookieMonster::IsCookieSentToSamePortThatSetIt(
++  ASSERT_EQ(CookieMonster_ChromiumImpl::IsCookieSentToSamePortThatSetIt(
+                 GURL("https://foo.com"), url::PORT_INVALID,
+                 CookieSourceScheme::kSecure),
+-            CookieMonster::CookieSentToSamePort::kInvalid);
++            CookieMonster_ChromiumImpl::CookieSentToSamePort::kInvalid);
+ 
+   // Test same.
+-  ASSERT_EQ(CookieMonster::IsCookieSentToSamePortThatSetIt(
++  ASSERT_EQ(CookieMonster_ChromiumImpl::IsCookieSentToSamePortThatSetIt(
+                 GURL("https://foo.com"), 443, CookieSourceScheme::kSecure),
+-            CookieMonster::CookieSentToSamePort::kYes);
++            CookieMonster_ChromiumImpl::CookieSentToSamePort::kYes);
+ 
+   ASSERT_EQ(
+-      CookieMonster::IsCookieSentToSamePortThatSetIt(
++      CookieMonster_ChromiumImpl::IsCookieSentToSamePortThatSetIt(
+           GURL("https://foo.com:1234"), 1234, CookieSourceScheme::kSecure),
+-      CookieMonster::CookieSentToSamePort::kYes);
++      CookieMonster_ChromiumImpl::CookieSentToSamePort::kYes);
+ 
+   // Test different but default.
+-  ASSERT_EQ(CookieMonster::IsCookieSentToSamePortThatSetIt(
++  ASSERT_EQ(CookieMonster_ChromiumImpl::IsCookieSentToSamePortThatSetIt(
+                 GURL("https://foo.com"), 80, CookieSourceScheme::kNonSecure),
+-            CookieMonster::CookieSentToSamePort::kNoButDefault);
++            CookieMonster_ChromiumImpl::CookieSentToSamePort::kNoButDefault);
+ 
+   ASSERT_EQ(
+-      CookieMonster::IsCookieSentToSamePortThatSetIt(
++      CookieMonster_ChromiumImpl::IsCookieSentToSamePortThatSetIt(
+           GURL("https://foo.com:443"), 80, CookieSourceScheme::kNonSecure),
+-      CookieMonster::CookieSentToSamePort::kNoButDefault);
++      CookieMonster_ChromiumImpl::CookieSentToSamePort::kNoButDefault);
+ 
+-  ASSERT_EQ(CookieMonster::IsCookieSentToSamePortThatSetIt(
++  ASSERT_EQ(CookieMonster_ChromiumImpl::IsCookieSentToSamePortThatSetIt(
+                 GURL("wss://foo.com"), 80, CookieSourceScheme::kNonSecure),
+-            CookieMonster::CookieSentToSamePort::kNoButDefault);
++            CookieMonster_ChromiumImpl::CookieSentToSamePort::kNoButDefault);
+ 
+-  ASSERT_EQ(CookieMonster::IsCookieSentToSamePortThatSetIt(
++  ASSERT_EQ(CookieMonster_ChromiumImpl::IsCookieSentToSamePortThatSetIt(
+                 GURL("http://foo.com"), 443, CookieSourceScheme::kSecure),
+-            CookieMonster::CookieSentToSamePort::kNoButDefault);
++            CookieMonster_ChromiumImpl::CookieSentToSamePort::kNoButDefault);
+ 
+-  ASSERT_EQ(CookieMonster::IsCookieSentToSamePortThatSetIt(
++  ASSERT_EQ(CookieMonster_ChromiumImpl::IsCookieSentToSamePortThatSetIt(
+                 GURL("ws://foo.com"), 443, CookieSourceScheme::kSecure),
+-            CookieMonster::CookieSentToSamePort::kNoButDefault);
++            CookieMonster_ChromiumImpl::CookieSentToSamePort::kNoButDefault);
+ 
+   // Test different.
+-  ASSERT_EQ(CookieMonster::IsCookieSentToSamePortThatSetIt(
++  ASSERT_EQ(CookieMonster_ChromiumImpl::IsCookieSentToSamePortThatSetIt(
+                 GURL("http://foo.com:9000"), 85, CookieSourceScheme::kSecure),
+-            CookieMonster::CookieSentToSamePort::kNo);
++            CookieMonster_ChromiumImpl::CookieSentToSamePort::kNo);
+ 
+-  ASSERT_EQ(CookieMonster::IsCookieSentToSamePortThatSetIt(
++  ASSERT_EQ(CookieMonster_ChromiumImpl::IsCookieSentToSamePortThatSetIt(
+                 GURL("https://foo.com"), 80, CookieSourceScheme::kSecure),
+-            CookieMonster::CookieSentToSamePort::kNo);
++            CookieMonster_ChromiumImpl::CookieSentToSamePort::kNo);
+ 
+-  ASSERT_EQ(CookieMonster::IsCookieSentToSamePortThatSetIt(
++  ASSERT_EQ(CookieMonster_ChromiumImpl::IsCookieSentToSamePortThatSetIt(
+                 GURL("wss://foo.com"), 80, CookieSourceScheme::kSecure),
+-            CookieMonster::CookieSentToSamePort::kNo);
++            CookieMonster_ChromiumImpl::CookieSentToSamePort::kNo);
+ 
+-  ASSERT_EQ(CookieMonster::IsCookieSentToSamePortThatSetIt(
++  ASSERT_EQ(CookieMonster_ChromiumImpl::IsCookieSentToSamePortThatSetIt(
+                 GURL("http://foo.com"), 443, CookieSourceScheme::kNonSecure),
+-            CookieMonster::CookieSentToSamePort::kNo);
++            CookieMonster_ChromiumImpl::CookieSentToSamePort::kNo);
+ 
+-  ASSERT_EQ(CookieMonster::IsCookieSentToSamePortThatSetIt(
++  ASSERT_EQ(CookieMonster_ChromiumImpl::IsCookieSentToSamePortThatSetIt(
+                 GURL("ws://foo.com"), 443, CookieSourceScheme::kNonSecure),
+-            CookieMonster::CookieSentToSamePort::kNo);
++            CookieMonster_ChromiumImpl::CookieSentToSamePort::kNo);
+ 
+-  ASSERT_EQ(CookieMonster::IsCookieSentToSamePortThatSetIt(
++  ASSERT_EQ(CookieMonster_ChromiumImpl::IsCookieSentToSamePortThatSetIt(
+                 GURL("http://foo.com:444"), 443, CookieSourceScheme::kSecure),
+-            CookieMonster::CookieSentToSamePort::kNo);
++            CookieMonster_ChromiumImpl::CookieSentToSamePort::kNo);
+ }
+ 
+ TEST_F(CookieMonsterTest, CookieDomainSetHistogram) {
+@@ -7252,7 +7252,7 @@ TEST_F(CookieMonsterTest, CookieDomainSetHistogram) {
+   const char kHistogramName[] = "Cookie.DomainSet.Subsampled";
+ 
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   histograms.ExpectTotalCount(kHistogramName, 0);
+ 
+@@ -7282,7 +7282,7 @@ TEST_F(CookieMonsterTest, CookiePortReadHistogram) {
+   const char kHistogramNameLocal[] = "Cookie.Port.Read.Localhost.Subsampled";
+ 
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   histograms.ExpectTotalCount(kHistogramName, 0);
+ 
+@@ -7336,7 +7336,7 @@ TEST_F(CookieMonsterTest, CookiePortSetHistogram) {
+   const char kHistogramNameLocal[] = "Cookie.Port.Set.Localhost.Subsampled";
+ 
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   histograms.ExpectTotalCount(kHistogramName, 0);
+ 
+@@ -7394,7 +7394,7 @@ TEST_F(CookieMonsterTest, CookiePortReadDiffersFromSetHistogram) {
+       "Cookie.Port.ReadDiffersFromSet.DomainSet.Subsampled";
+ 
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   histograms.ExpectTotalCount(kHistogramName, 0);
+ 
+@@ -7429,20 +7429,20 @@ TEST_F(CookieMonsterTest, CookiePortReadDiffersFromSetHistogram) {
+   EXPECT_EQ(GetCookies(cm.get(), GURL("https://www.foo.com/withport")), "A=B");
+   histograms.ExpectTotalCount(kHistogramName, 1);
+   histograms.ExpectBucketCount(kHistogramName,
+-                               CookieMonster::CookieSentToSamePort::kYes, 1);
++                               CookieMonster_ChromiumImpl::CookieSentToSamePort::kYes, 1);
+ 
+   // Try different port.
+   EXPECT_EQ(GetCookies(cm.get(), GURL("https://www.foo.com:8080/withport")),
+             "A=B");
+   histograms.ExpectTotalCount(kHistogramName, 2);
+   histograms.ExpectBucketCount(kHistogramName,
+-                               CookieMonster::CookieSentToSamePort::kNo, 1);
++                               CookieMonster_ChromiumImpl::CookieSentToSamePort::kNo, 1);
+ 
+   // Try different port, but it's the default for a different scheme.
+   EXPECT_EQ(GetCookies(cm.get(), GURL("http://www.foo.com/withport")), "A=B");
+   histograms.ExpectTotalCount(kHistogramName, 3);
+   histograms.ExpectBucketCount(
+-      kHistogramName, CookieMonster::CookieSentToSamePort::kNoButDefault, 1);
++      kHistogramName, CookieMonster_ChromiumImpl::CookieSentToSamePort::kNoButDefault, 1);
+ 
+   // Now try it with an unspecified port cookie.
+   EXPECT_EQ(GetCookies(cm.get(), GURL("http://www.foo.com/withoutport")),
+@@ -7450,14 +7450,14 @@ TEST_F(CookieMonsterTest, CookiePortReadDiffersFromSetHistogram) {
+   histograms.ExpectTotalCount(kHistogramName, 4);
+   histograms.ExpectBucketCount(
+       kHistogramName,
+-      CookieMonster::CookieSentToSamePort::kSourcePortUnspecified, 1);
++      CookieMonster_ChromiumImpl::CookieSentToSamePort::kSourcePortUnspecified, 1);
+ 
+   // Finally try it with an invalid port cookie.
+   EXPECT_EQ(GetCookies(cm.get(), GURL("http://www.foo.com/invalidport")),
+             "E=F");
+   histograms.ExpectTotalCount(kHistogramName, 5);
+   histograms.ExpectBucketCount(
+-      kHistogramName, CookieMonster::CookieSentToSamePort::kInvalid, 1);
++      kHistogramName, CookieMonster_ChromiumImpl::CookieSentToSamePort::kInvalid, 1);
+ 
+   // Make sure the correct histogram is chosen for localhost.
+   histograms.ExpectTotalCount(kHistogramNameLocal, 0);
+@@ -7466,7 +7466,7 @@ TEST_F(CookieMonsterTest, CookiePortReadDiffersFromSetHistogram) {
+   EXPECT_EQ(GetCookies(cm.get(), GURL("https://localhost")), "local=host");
+   histograms.ExpectTotalCount(kHistogramNameLocal, 1);
+   histograms.ExpectBucketCount(kHistogramNameLocal,
+-                               CookieMonster::CookieSentToSamePort::kYes, 1);
++                               CookieMonster_ChromiumImpl::CookieSentToSamePort::kYes, 1);
+ 
+   // Make sure the Domain set version works.
+   EXPECT_TRUE(SetCookie(cm.get(), GURL("https://www.foo.com/withDomain"),
+@@ -7478,12 +7478,12 @@ TEST_F(CookieMonsterTest, CookiePortReadDiffersFromSetHistogram) {
+             "W=D");
+   histograms.ExpectTotalCount(kHistogramNameDomainSet, 1);
+   histograms.ExpectBucketCount(kHistogramNameDomainSet,
+-                               CookieMonster::CookieSentToSamePort::kYes, 1);
++                               CookieMonster_ChromiumImpl::CookieSentToSamePort::kYes, 1);
+   // The RemoteHost histogram should also increase with this cookie. Domain
+   // cookies aren't special insofar as this metric is concerned.
+   histograms.ExpectTotalCount(kHistogramName, 6);
+   histograms.ExpectBucketCount(kHistogramName,
+-                               CookieMonster::CookieSentToSamePort::kYes, 2);
++                               CookieMonster_ChromiumImpl::CookieSentToSamePort::kYes, 2);
+ }
+ 
+ TEST_F(CookieMonsterTest, CookieSourceSchemeNameHistogram) {
+@@ -7492,7 +7492,7 @@ TEST_F(CookieMonsterTest, CookieSourceSchemeNameHistogram) {
+   const char kHistogramName[] = "Cookie.CookieSourceSchemeName.Subsampled";
+ 
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+ 
+   histograms.ExpectTotalCount(kHistogramName, 0);
+ 
+@@ -7550,7 +7550,7 @@ TEST_F(CookieMonsterTest, CookieSourceSchemeNameHistogram) {
+ 
+ TEST_F(CookieMonsterTest, GetAllCookiesForURLNonce) {
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   CookieOptions options = CookieOptions::MakeAllInclusive();
+ 
+   auto anonymous_iframe_key = CookiePartitionKey::FromURLForTesting(
+@@ -7611,7 +7611,7 @@ TEST_F(CookieMonsterTest, GetAllCookiesForURLNonce) {
+ 
+ TEST_F(CookieMonsterTest, SiteHasCookieInOtherPartition) {
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   CookieOptions options = CookieOptions::MakeAllInclusive();
+ 
+   GURL url("https://subdomain.example.com/");
+@@ -7672,7 +7672,7 @@ TEST_F(CookieMonsterTest, SiteHasCookieInOtherPartition) {
+ // binding is enabled.
+ TEST_F(CookieMonsterTest, FilterCookiesWithOptionsExcludeShadowingDomains) {
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   base::Time creation_time = base::Time::Now();
+   std::optional<base::Time> server_time = std::nullopt;
+   CookieOptions options = CookieOptions::MakeAllInclusive();
+@@ -7993,7 +7993,7 @@ TEST_F(CookieMonsterTest, FilterCookiesWithOptionsExcludeShadowingDomains) {
+ // scheme binding is disabled.
+ TEST_F(CookieMonsterTest, FilterCookiesWithOptionsWarnShadowingDomains) {
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+-  auto cm = std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++  auto cm = std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   base::Time creation_time = base::Time::Now();
+   std::optional<base::Time> server_time = std::nullopt;
+   CookieOptions options = CookieOptions::MakeAllInclusive();
+@@ -8355,7 +8355,7 @@ TEST_F(CookieMonsterTest, FilterCookiesWithOptionsWarnShadowingDomains) {
+ TEST_F(CookieMonsterTest, FromStorageCookieCreated300DaysAgoThenUpdatedNow) {
+   auto store = base::MakeRefCounted<FlushablePersistentStore>();
+   auto cookie_monster =
+-      std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++      std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   cookie_monster->SetPersistSessionCookies(true);
+   EXPECT_TRUE(GetAllCookies(cookie_monster.get()).empty());
+ 
+@@ -8399,7 +8399,7 @@ TEST_F(CookieMonsterTest, FromStorageCookieCreated300DaysAgoThenUpdatedNow) {
+ TEST_F(CookieMonsterTest, FromStorageCookieCreated500DaysAgoThenUpdatedNow) {
+   auto store = base::MakeRefCounted<FlushablePersistentStore>();
+   auto cookie_monster =
+-      std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++      std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   cookie_monster->SetPersistSessionCookies(true);
+   EXPECT_TRUE(GetAllCookies(cookie_monster.get()).empty());
+ 
+@@ -8443,7 +8443,7 @@ TEST_F(CookieMonsterTest, FromStorageCookieCreated500DaysAgoThenUpdatedNow) {
+ TEST_F(CookieMonsterTest, SanitizedCookieCreated300DaysAgoThenUpdatedNow) {
+   auto store = base::MakeRefCounted<FlushablePersistentStore>();
+   auto cookie_monster =
+-      std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++      std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   cookie_monster->SetPersistSessionCookies(true);
+   EXPECT_TRUE(GetAllCookies(cookie_monster.get()).empty());
+ 
+@@ -8487,7 +8487,7 @@ TEST_F(CookieMonsterTest, SanitizedCookieCreated300DaysAgoThenUpdatedNow) {
+ TEST_F(CookieMonsterTest, SanitizedCookieCreated500DaysAgoThenUpdatedNow) {
+   auto store = base::MakeRefCounted<FlushablePersistentStore>();
+   auto cookie_monster =
+-      std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++      std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   cookie_monster->SetPersistSessionCookies(true);
+   EXPECT_TRUE(GetAllCookies(cookie_monster.get()).empty());
+ 
+@@ -8534,7 +8534,7 @@ INSTANTIATE_TEST_SUITE_P(/* no label */,
+ TEST_F(CookieMonsterTest, RejectsHttpPrefixCookie) {
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+   auto cookie_monster =
+-      std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++      std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   EXPECT_TRUE(GetAllCookies(cookie_monster.get()).empty());
+ 
+   std::string cookie_line = "__Http-Test1=1; path=/; secure";
+@@ -8549,7 +8549,7 @@ TEST_F(CookieMonsterTest, RejectsHttpPrefixCookie) {
+ TEST_F(CookieMonsterTest, AcceptsHttpPrefixCookie) {
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+   auto cookie_monster =
+-      std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++      std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   EXPECT_TRUE(GetAllCookies(cookie_monster.get()).empty());
+ 
+   std::string cookie_line = "__Http-Test2=1; path=/; secure; httponly";
+@@ -8566,7 +8566,7 @@ TEST_F(CookieMonsterTest, AcceptsHttpPrefixCookie) {
+ TEST_F(CookieMonsterTest, RejectsHostHttpPrefixCookie) {
+   auto store = base::MakeRefCounted<FlushablePersistentStore>();
+   auto cookie_monster =
+-      std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++      std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   cookie_monster->SetPersistSessionCookies(true);
+   EXPECT_TRUE(GetAllCookies(cookie_monster.get()).empty());
+ 
+@@ -8582,7 +8582,7 @@ TEST_F(CookieMonsterTest, RejectsHostHttpPrefixCookie) {
+ TEST_F(CookieMonsterTest, RejectsHostHttpPrefixCookiePath) {
+   auto store = base::MakeRefCounted<FlushablePersistentStore>();
+   auto cookie_monster =
+-      std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++      std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   cookie_monster->SetPersistSessionCookies(true);
+   EXPECT_TRUE(GetAllCookies(cookie_monster.get()).empty());
+ 
+@@ -8599,7 +8599,7 @@ TEST_F(CookieMonsterTest, RejectsHostHttpPrefixCookiePath) {
+ TEST_F(CookieMonsterTest, AcceptsHostHttpPrefixCookie) {
+   auto store = base::MakeRefCounted<FlushablePersistentStore>();
+   auto cookie_monster =
+-      std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++      std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   cookie_monster->SetPersistSessionCookies(true);
+   EXPECT_TRUE(GetAllCookies(cookie_monster.get()).empty());
+ 
+@@ -8617,7 +8617,7 @@ TEST_F(CookieMonsterTest, AcceptsHostHttpPrefixCookie) {
+ TEST_F(CookieMonsterTest, RejectsHostHttpPrefixCookieWithDomain) {
+   auto store = base::MakeRefCounted<FlushablePersistentStore>();
+   auto cookie_monster =
+-      std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++      std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   cookie_monster->SetPersistSessionCookies(true);
+   EXPECT_TRUE(GetAllCookies(cookie_monster.get()).empty());
+   std::string cookie_line =
+@@ -8637,7 +8637,7 @@ TEST_F(CookieMonsterTest, RejectsHostHttpPrefixCookieWithDomain) {
+ TEST_F(CookieMonsterTest, RejectsHiddenHttpPrefix) {
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+   auto cookie_monster =
+-      std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++      std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   EXPECT_TRUE(GetAllCookies(cookie_monster.get()).empty());
+ 
+   // This cookie line has an empty name (=__Http-...) with a value that looks
+@@ -8659,7 +8659,7 @@ TEST_F(CookieMonsterTest, RejectsHiddenHttpPrefix) {
+ TEST_F(CookieMonsterTest, RejectsHiddenHostHttpPrefix) {
+   auto store = base::MakeRefCounted<MockPersistentCookieStore>();
+   auto cookie_monster =
+-      std::make_unique<CookieMonster>(store.get(), net::NetLog::Get());
++      std::make_unique<CookieMonster_ChromiumImpl>(store.get(), net::NetLog::Get());
+   EXPECT_TRUE(GetAllCookies(cookie_monster.get()).empty());
+ 
+   // This cookie line has an empty name (=__Host-Http-...) with a value that

--- a/rewrite/chrome/browser/ui/page_action/page_action_controller.cc.yaml
+++ b/rewrite/chrome/browser/ui/page_action/page_action_controller.cc.yaml
@@ -5,37 +5,7 @@
 
 substitutions:
   - description: |
-      Opens the detail namespace `chromium_impl::` in the translation unit.
-
-      The constructor is the first PageActionControllerImpl content in the TU; the
-      ScopedPageActionActivity definitions and the file-local `using PassKey` above
-      the constructor stay in page_actions::.
-    regex:
-      re_pattern: '(PageActionControllerImpl::PageActionControllerImpl\()'
-      replace: |-
-        namespace chromium_impl {
-        \1
-
-  - description: |
-      Closes the detail namespace `chromium_impl::` in the translation unit.
-
-      operator<< free function. operator<< must remain in page_actions:: so ADL on
-      page_actions::SuggestionChipConfig still finds it.
-    regex:
-      re_pattern:
-        '(std::ostream& operator<<\(std::ostream& os, const
-        SuggestionChipConfig)'
-      replace: |-
-        }  // namespace chromium_impl
-        \1
-
-  - description: |2
-       Instantiates `page_actions::PageActionModel`
-
-      `PageActionModel` gets shadowed by a brave-specifc implementation, that cannot
-      be instantiated on its own, as it is made an abstract class by another plaster.
-      This substitution corrects the resolution, so we instantiate
-      `page_actions::PageActionModel` with the parent namespace.
-    regex:
-      re_pattern: '\bPageActionModel\b'
-      replace: '::page_actions::PageActionModel'
+      Rename PageActionControllerImpl to PageActionControllerImpl_ChromiumImpl.
+    rename_class:
+      class_name: PageActionControllerImpl
+      rename: PageActionControllerImpl_ChromiumImpl

--- a/rewrite/chrome/browser/ui/page_action/page_action_controller.h.yaml
+++ b/rewrite/chrome/browser/ui/page_action/page_action_controller.h.yaml
@@ -5,28 +5,30 @@
 
 substitutions:
   - description: |
-      Wrap PageActionControllerImpl in a chromium_impl namespace.
+      Rename PageActionControllerImpl to PageActionControllerImpl_ChromiumImpl.
 
-      The abstract PageActionController base, ScopedPageActionActivity and other
-      free declarations are intentionally left in page_actions::; only the concrete
-      impl class is wrapped, so we can shadow it with our own implementation.
-    regex:
-      re_pattern: '(class PageActionControllerImpl[\s\S]*?\n\};)'
-      replace: |
-        namespace chromium_impl {
-        \1
-        }  // namespace chromium_impl
+      This lets Brave shadow the concrete controller with its own
+      `page_actions::PageActionControllerImpl` that reuses the name and derives
+      from the renamed upstream class. The abstract PageActionController base
+      and other free declarations keep their names.
+    rename_class:
+      class_name: PageActionControllerImpl
+      rename: PageActionControllerImpl_ChromiumImpl
 
   - description: |
-      Make CreateModel virtual so the brave PageActionControllerImpl override can
-      replace model construction with the brave PageActionModel.
+      Make CreateModel virtual
+
+      This allows the brave PageActionControllerImpl override to replace model
+      construction with the brave PageActionModel.
     make_virtual:
-      class_name: PageActionControllerImpl
+      class_name: PageActionControllerImpl_ChromiumImpl
       method_name: CreateModel
 
   - description: |
-      Friend the brave page_actions::PageActionControllerImpl so it can reach the
-      private members it relies on (FindPageActionModel, page_action_model_factory_).
+      Friend the brave page_actions::PageActionControllerImpl
+
+      This is done so it can reach the private members it relies on
+      (FindPageActionModel, page_action_model_factory_).
     add_friend:
-      class_name: PageActionControllerImpl
+      class_name: PageActionControllerImpl_ChromiumImpl
       friend_type: class ::page_actions::PageActionControllerImpl

--- a/rewrite/chrome/browser/ui/page_action/page_action_model.cc.yaml
+++ b/rewrite/chrome/browser/ui/page_action/page_action_model.cc.yaml
@@ -5,20 +5,7 @@
 
 substitutions:
   - description: |
-      Opens the detail namespace `chromium_impl::` in the translation unit.
-
-      The constructor is the first PageActionModel content in the TU; the file-local
-      anonymous namespace above it stays in page_actions::.
-    regex:
-      re_pattern: '(PageActionModel::PageActionModel\()'
-      replace: |-
-        namespace chromium_impl {
-        \1
-
-  - description: |
-      Closes the detail namespace `chromium_impl::` in the translation unit.
-    regex:
-      re_pattern: '(\}\s*//\s*namespace page_actions)'
-      replace: |-
-        }  // namespace chromium_impl
-        \1
+      Rename PageActionModel to PageActionModel_ChromiumImpl.
+    rename_class:
+      class_name: PageActionModel
+      rename: PageActionModel_ChromiumImpl

--- a/rewrite/chrome/browser/ui/page_action/page_action_model.h.yaml
+++ b/rewrite/chrome/browser/ui/page_action/page_action_model.h.yaml
@@ -9,39 +9,38 @@ substitutions:
 
       The brave PageActionModel override (chromium_src/.../page_action_model.h)
       implements these new interfaces and it will be used by
-      PartitionedStoragePageActionController via PageActionControllerImpl. As there's
-      also FakePageActionModel, we can't cast to the brave PageActionModel in
-      PageActionControllerImpl, so we need a default empty implementation here.
-    regex:
-      re_pattern: '(class PageActionModelInterface \{.*?)(\n\};)'
-      re_flags: [DOTALL]
-      replace: |-
-        \1
-          virtual void SetOverrideChipColors(
-              PageActionPassKey,
-              std::optional<SkColor> override_background_color,
-              std::optional<SkColor> override_foreground_color) = 0;
-          virtual void SetAlwaysShowLabel(PageActionPassKey,
-                                          bool always_show) = 0;
-          virtual void SetOverrideHeight(PageActionPassKey,
-                                         std::optional<int> height) = 0;
-          virtual void SetOverrideTriggerableEvent(PageActionPassKey,
-                                                   std::optional<int> event_flags) = 0;
-          virtual void SetOverrideBorder(PageActionPassKey,
-                                         std::optional<gfx::Insets> border) = 0;
-          virtual std::optional<SkColor> GetOverrideBackgroundColor() const = 0;
-          virtual std::optional<SkColor> GetOverrideForegroundColor() const = 0;
-          virtual bool GetAlwaysShowLabel() const = 0;
-          virtual std::optional<int> GetOverrideHeight() const = 0;
-          virtual std::optional<int> GetOverrideTriggerableEvent() const = 0;
-          virtual std::optional<gfx::Insets> GetOverrideBorder() const = 0;\2
+      PartitionedStoragePageActionController via PageActionControllerImpl. As
+      there's also FakePageActionModel, we can't cast to the brave
+      PageActionModel in PageActionControllerImpl, so we need a default empty
+      implementation here.
+    add_to_public:
+      class_name: PageActionModelInterface
+      code: |-
+        virtual void SetOverrideChipColors(
+            PageActionPassKey,
+            std::optional<SkColor> override_background_color,
+            std::optional<SkColor> override_foreground_color) = 0;
+        virtual void SetAlwaysShowLabel(PageActionPassKey,
+                                        bool always_show) = 0;
+        virtual void SetOverrideHeight(PageActionPassKey,
+                                       std::optional<int> height) = 0;
+        virtual void SetOverrideTriggerableEvent(PageActionPassKey,
+                                                 std::optional<int> event_flags) = 0;
+        virtual void SetOverrideBorder(PageActionPassKey,
+                                       std::optional<gfx::Insets> border) = 0;
+        virtual std::optional<SkColor> GetOverrideBackgroundColor() const = 0;
+        virtual std::optional<SkColor> GetOverrideForegroundColor() const = 0;
+        virtual bool GetAlwaysShowLabel() const = 0;
+        virtual std::optional<int> GetOverrideHeight() const = 0;
+        virtual std::optional<int> GetOverrideTriggerableEvent() const = 0;
+        virtual std::optional<gfx::Insets> GetOverrideBorder() const = 0;
 
   - description: |
-      Adding Property types for NotifyChange for the new set methods added above.
+      Adding Property types for NotifyChange for the new set methods added.
 
       Keys are appended at the end of the PageActionModel::Property enum, and
-      kMaxValue is re-pointed to the last Brave-added entry so PropertySet's EnumSet
-      range covers them.
+      kMaxValue is re-pointed to the last Brave-added entry so PropertySet's
+      EnumSet range covers them.
     regex:
       re_pattern: '(enum class Property \{.+?,\n)\s+kMaxValue = \w+,'
       re_flags: [DOTALL]
@@ -54,22 +53,18 @@ substitutions:
             kMaxValue = kOverrideBorder,
 
   - description: |
-      Wrap PageActionModel in a chromium_impl namespace.
+      Rename PageActionModel to PageActionModel_ChromiumImpl.
 
-      This makes our implementation of `PageActionModel` a full shadow, guaranteeing
-      that only `PageActionModel` from Brave can be instantiated by Chromium code, as
-      this class is now left as an abstract class.
-    regex:
-      re_pattern: '(class PageActionModel\b.*?\n\};)'
-      re_flags: [DOTALL]
-      replace: |-
-        namespace chromium_impl {
-        \1
-        }  // namespace chromium_impl
+      This makes the brave `page_actions::PageActionModel` a full shadow: the
+      renamed upstream class is left abstract (it does not implement the pure
+      virtuals added to PageActionModelInterface above), so only the brave
+      `PageActionModel` can be instantiated by Chromium code.
+    rename_class:
+      class_name: PageActionModel
+      rename: PageActionModel_ChromiumImpl
 
   - description: |
-      Friend the brave page_actions::PageActionModel so it can call NotifyChange and
-      use the private Property enum from its base.
+      Friend the brave PageActionModel so it can call NotifyChange.
     add_friend:
-      class_name: PageActionModel
+      class_name: PageActionModel_ChromiumImpl
       friend_type: class ::page_actions::PageActionModel

--- a/rewrite/chrome/browser/ui/page_action/page_action_pass_key.h.yaml
+++ b/rewrite/chrome/browser/ui/page_action/page_action_pass_key.h.yaml
@@ -4,8 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 substitutions:
-  - description:
-      'Befriend page_actions::chromium_impl::PageActionControllerImpl'
+  - description: 'Befriend page_actions::PageActionControllerImpl_ChromiumImpl'
     add_friend:
       class_name: PageActionPassKey
-      friend_type: class page_actions::chromium_impl::PageActionControllerImpl
+      friend_type: class page_actions::PageActionControllerImpl_ChromiumImpl

--- a/rewrite/components/permissions/permission_context_base.cc.yaml
+++ b/rewrite/components/permissions/permission_context_base.cc.yaml
@@ -4,13 +4,12 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 substitutions:
-  - description:
-      'Moving `PermissionContextBase` into `chromium_impl` as in the header.'
-    regex:
-      pattern: 'namespace permissions'
-      replace: 'namespace permissions::chromium_impl'
+  - description: |
+      Rename PermissionContextBase to PermissionContextBase_ChromiumImpl.
+    rename_class:
+      class_name: PermissionContextBase
+      rename: PermissionContextBase_ChromiumImpl
 
-    count: 2
   - description: 'Calls BraveCanBypassEmbeddingOriginCheck for wallet handling'
     regex:
       pattern: 'CanBypassEmbeddingOriginCheck('

--- a/rewrite/components/permissions/permission_context_base.h.yaml
+++ b/rewrite/components/permissions/permission_context_base.h.yaml
@@ -5,34 +5,24 @@
 
 substitutions:
   - description: |
-      Wrap PermissionContextBase class in chromium_impl namespace
+      Rename PermissionContextBase to PermissionContextBase_ChromiumImpl
 
-      This substitution moves the `PermissionContextBase` in its entirety into a
-      detail namespace called `chromium_impl`, so we can shadow that class with an
-      official brave implementation for `PermissionContextBase` that derives from
-      the `chromium_impl` one.
-
-      The namespace introduced here only wraps the class definition, so it searches
-      for the class declaration first, to avoid wrapping the forward declarations
-      or the Observer class that appear earlier in the same namespace block.
-    regex:
-      re_pattern:
-        '(class PermissionContextBase[\s\S]*?)(\n\}\s*// namespace permissions)'
-      re_flags: [MULTILINE]
-      replace: |-
-        namespace chromium_impl {
-        \1
-        }  // namespace chromium_impl\2
+      This lets Brave shadow the upstream class with its own
+      `permissions::PermissionContextBase` that reuses the name and derives from
+      the renamed upstream class.
+    rename_class:
+      class_name: PermissionContextBase
+      rename: PermissionContextBase_ChromiumImpl
 
   - description:
       'Make PermissionDecided virtual to allow Brave override in derived class'
     make_virtual:
-      class_name: PermissionContextBase
+      class_name: PermissionContextBase_ChromiumImpl
       method_name: PermissionDecided
 
   - description:
       'Add Brave PermissionContextBase as friend of
-      chromium_impl::PermissionContextBase'
+      PermissionContextBase_ChromiumImpl'
     add_friend:
-      class_name: PermissionContextBase
+      class_name: PermissionContextBase_ChromiumImpl
       friend_type: class ::permissions::PermissionContextBase

--- a/rewrite/net/cookies/cookie_monster.cc.yaml
+++ b/rewrite/net/cookies/cookie_monster.cc.yaml
@@ -4,18 +4,12 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 substitutions:
-  - description: 'Moving `CookieMonster` into `chromium_impl` as in the header.'
-    regex:
-      pattern: 'namespace net'
-      replace: 'namespace net::chromium_impl'
-
-    count: 2
   - description: |
-      Tweaking `MaybeRunDeleteCallback` to use the original class.
+      Rename CookieMonster to CookieMonster_ChromiumImpl to match the header.
 
-      Sadly this function alone sits outside in an unnamed namespace in the global
-      scope, which make its use of `net::CookieMonster` to select the Brave
-      implementation, however this is a simple case.
-    regex:
-      pattern: 'base::WeakPtr<net::CookieMonster> cookie_monster'
-      replace: 'base::WeakPtr<net::chromium_impl::CookieMonster> cookie_monster'
+      This also fixes up the lone `net::CookieMonster` reference inside the
+      unnamed-namespace `MaybeRunDeleteCallback` helper, which must keep using the
+      renamed upstream class.
+    rename_class:
+      class_name: CookieMonster
+      rename: CookieMonster_ChromiumImpl

--- a/rewrite/net/cookies/cookie_monster.h.yaml
+++ b/rewrite/net/cookies/cookie_monster.h.yaml
@@ -5,19 +5,10 @@
 
 substitutions:
   - description: |
-      Wrap CookieMonster class in chromium_impl namespace
+      Rename CookieMonster to CookieMonster_ChromiumImpl
 
-      This substitution moves the `CookieMonster` in its entirety into a detail
-      namespace called `chromium_impl`, so we can shadow that class with an official
-      brave implementation for `CookieMonster` that derives from `chromium_impl` one.
-
-      The namespace introduced here only wraps the classes in the header, so it
-      searches for the class declaration first, to avoid wrapping the forward
-      declarations.
-    regex:
-      re_pattern: '(class NET_EXPORT CookieMonster.*?)(\n\}\s*// namespace net)'
-      re_flags: [DOTALL]
-      replace: |-
-        namespace chromium_impl {
-        \1
-        }  // namespace chromium_impl\2
+      This lets Brave shadow the upstream class with its own `net::CookieMonster`
+      that reuses the name and derives from the renamed upstream class.
+    rename_class:
+      class_name: CookieMonster
+      rename: CookieMonster_ChromiumImpl

--- a/rewrite/net/cookies/cookie_monster_change_dispatcher.cc.yaml
+++ b/rewrite/net/cookies/cookie_monster_change_dispatcher.cc.yaml
@@ -4,7 +4,8 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 substitutions:
-  - description: 'Using `chromium_impl::CookieMonster` as in the header.'
-    regex:
-      re_pattern: '\bCookieMonster\b'
-      replace: 'chromium_impl::CookieMonster'
+  - description: |
+      Rename CookieMonster references to CookieMonster_ChromiumImpl.
+    rename_class:
+      class_name: CookieMonster
+      rename: CookieMonster_ChromiumImpl

--- a/rewrite/net/cookies/cookie_monster_change_dispatcher.h.yaml
+++ b/rewrite/net/cookies/cookie_monster_change_dispatcher.h.yaml
@@ -5,25 +5,11 @@
 
 substitutions:
   - description: |
-      Using `chromium_impl::CookieMonster` for this type.
+      Rename CookieMonster references to CookieMonster_ChromiumImpl.
 
-      `CookieMonsterChangeDispatcher` has to use `chromium_impl::CookieMonster`
-      because it gets used by the Chromium implementation of `CookieMonster`.
-    regex:
-      re_pattern: '\bCookieMonster\b'
-      replace: 'chromium_impl::CookieMonster'
-
-    count: 4
-  - description: |
-      Fixing foward decl for chromium_impl::CookieMonster.
-
-      The previous substitution replaces all occurrences of `CookieMonster`,
-      including the one that was foward-declaring `CookieMonster`, this results in
-      broken C++ syntax that has to be corrected, to open a namespace and then
-      forward-declare inside it.
-    regex:
-      pattern: 'class chromium_impl::CookieMonster;'
-      replace: |-
-        namespace chromium_impl {
-        class CookieMonster;
-        }
+      CookieMonsterChangeDispatcher is used by the upstream CookieMonster
+      implementation, so it refers to the renamed upstream class. rename_class
+      also rewrites the forward declaration in place, keeping valid syntax.
+    rename_class:
+      class_name: CookieMonster
+      rename: CookieMonster_ChromiumImpl

--- a/rewrite/net/cookies/cookie_monster_unittest.cc.yaml
+++ b/rewrite/net/cookies/cookie_monster_unittest.cc.yaml
@@ -5,13 +5,11 @@
 
 substitutions:
   - description: |
-      Moving all of tests into `chromium_impl` namespace.
+      Rename CookieMonster to CookieMonster_ChromiumImpl.
 
-      This is necessary because these tests require access to private members of
-      `CookieMonster` brokered through `FRIEND_TEST_ALL_PREFIXES`, and this macro
-      does has to match the namespace used.
-    regex:
-      pattern: 'namespace net'
-      replace: 'namespace net::chromium_impl'
-
-    count: 2
+      The tests access private members brokered through
+      FRIEND_TEST_ALL_PREFIXES. Keeping both the renamed class and the tests in
+      `namespace net` preserves the friend matching.
+    rename_class:
+      class_name: CookieMonster
+      rename: CookieMonster_ChromiumImpl


### PR DESCRIPTION
This PR migrates all files that were relying on the inner namespace
`chromium_impl::` trick out of that and onto the `rename_class`
rewriter. The experiment with the inner namespace was naive, as moving
things into a `chromium_impl::` namespace would inevitably result in all
Chromium classes being able to read each other, as enough classes were
to be migrated to the nested namespace.

This change migrates all these classes over to `rename_class` as the use
of a nested namespace is harder to reason, and harder to anchor too.

Bug: https://github.com/brave/brave-browser/issues/45050
