### PR TITLE
[plaster] `MdTextButton` 🩹🩹🩹🩹

### DIFF
--- a/chromium_src/ui/views/controls/button/md_text_button.cc
+++ b/chromium_src/ui/views/controls/button/md_text_button.cc
@@ -31,9 +31,7 @@
 #include "ui/views/controls/highlight_path_generator.h"
 #include "ui/views/view_class_properties.h"
 
-#define MdTextButton MdTextButtonBase
 #include <ui/views/controls/button/md_text_button.cc>
-#undef MdTextButton
 
 namespace {
 
@@ -124,11 +122,11 @@ MdTextButton::MdTextButton(
     int button_context,
     bool use_text_color_for_icon,
     std::unique_ptr<LabelButtonImageContainer> image_container)
-    : MdTextButtonBase(std::move(callback),
-                       text,
-                       button_context,
-                       use_text_color_for_icon,
-                       std::move(image_container)) {
+    : MdTextButton_ChromiumImpl(std::move(callback),
+                                text,
+                                button_context,
+                                use_text_color_for_icon,
+                                std::move(image_container)) {
   // Disabled upstream's ink-drop as we have specific color for hover state.
   InkDrop::Get(this)->SetMode(views::InkDropHost::InkDropMode::OFF);
   SetImageLabelSpacing(6);
@@ -152,7 +150,7 @@ void MdTextButton::SetLoading(bool loading) {
 }
 
 void MdTextButton::UpdateTextColor() {
-  MdTextButtonBase::UpdateTextColor();
+  MdTextButton_ChromiumImpl::UpdateTextColor();
 
   // Use explicitely set color instead of our default colors except for
   // prominent style. As we have specific bg color for prominent, need to use
@@ -185,7 +183,7 @@ void MdTextButton::UpdateBackgroundColor() {
 }
 
 void MdTextButton::UpdateColors() {
-  MdTextButtonBase::UpdateColors();
+  MdTextButton_ChromiumImpl::UpdateColors();
 
   // Update the icon color.
   if (icon_) {

--- a/chromium_src/ui/views/controls/button/md_text_button.h
+++ b/chromium_src/ui/views/controls/button/md_text_button.h
@@ -11,20 +11,11 @@
 #include "ui/gfx/vector_icon_types.h"
 #include "ui/views/controls/button/label_button.h"
 
-// Rename MdTextButton to MdTextButtonBase
-#define MdTextButton MdTextButtonBase
-
-// Redefine UpdateTextColor as protected virtual so we can override it.
-#define UpdateTextColor     \
-  UpdateTextColor_Unused(); \
-                            \
- protected:                 \
-  virtual void UpdateTextColor
+namespace views {
+class MdTextButton;
+}  // namespace views
 
 #include <ui/views/controls/button/md_text_button.h>  // IWYU pragma: export
-
-#undef UpdateTextColor
-#undef MdTextButton
 
 namespace views {
 
@@ -32,8 +23,8 @@ namespace views {
 //  - Different hover text and boder color for non-prominent button
 //  - Different hover bg color for prominent background
 //  - No shadow for prominent background
-class VIEWS_EXPORT MdTextButton : public MdTextButtonBase {
-  METADATA_HEADER(MdTextButton, views::MdTextButtonBase)
+class VIEWS_EXPORT MdTextButton : public MdTextButton_ChromiumImpl {
+  METADATA_HEADER(MdTextButton, views::MdTextButton_ChromiumImpl)
 
  public:
   struct ButtonColors {
@@ -61,7 +52,7 @@ class VIEWS_EXPORT MdTextButton : public MdTextButtonBase {
     use_default_for_tonal_ = use_default;
   }
 
-  // MdTextButtonBase:
+  // MdTextButton_ChromiumImpl:
   void UpdateTextColor() override;
   void UpdateBackgroundColor() override;
   void UpdateColors() override;
@@ -81,6 +72,9 @@ class VIEWS_EXPORT MdTextButton : public MdTextButtonBase {
   int icon_size_ = 0;
   raw_ptr<const gfx::VectorIcon> icon_ = nullptr;
 };
+
+BEGIN_VIEW_BUILDER(VIEWS_EXPORT, MdTextButton, MdTextButton_ChromiumImpl)
+END_VIEW_BUILDER
 
 }  // namespace views
 

--- a/patches/ui-views-controls-button-md_text_button.cc.patch
+++ b/patches/ui-views-controls-button-md_text_button.cc.patch
@@ -1,0 +1,284 @@
+diff --git a/ui/views/controls/button/md_text_button.cc b/ui/views/controls/button/md_text_button.cc
+index f4f6b86afebdc20b3ad6aeffd34f64655195df77..82f7eaa32ce237bf240f348a18dbeae86163a659 100644
+--- a/ui/views/controls/button/md_text_button.cc
++++ b/ui/views/controls/button/md_text_button.cc
+@@ -43,7 +43,7 @@
+ 
+ namespace views {
+ 
+-MdTextButton::MdTextButton(
++MdTextButton_ChromiumImpl::MdTextButton_ChromiumImpl(
+     PressedCallback callback,
+     std::u16string_view text,
+     int button_context,
+@@ -58,7 +58,7 @@ MdTextButton::MdTextButton(
+   SetHasInkDropActionOnClick(true);
+   SetShowInkDropWhenHotTracked(true);
+   InkDrop::Get(this)->SetBaseColorCallback(base::BindRepeating(
+-      [](MdTextButton* host) { return host->GetHoverColor(host->GetStyle()); },
++      [](MdTextButton_ChromiumImpl* host) { return host->GetHoverColor(host->GetStyle()); },
+       this));
+ 
+   constexpr int kImageSpacing = 8;
+@@ -86,9 +86,9 @@ MdTextButton::MdTextButton(
+   UpdatePadding();
+ }
+ 
+-MdTextButton::~MdTextButton() = default;
++MdTextButton_ChromiumImpl::~MdTextButton_ChromiumImpl() = default;
+ 
+-void MdTextButton::SetStyle(ui::ButtonStyle button_style) {
++void MdTextButton_ChromiumImpl::SetStyle(ui::ButtonStyle button_style) {
+   if (style_ == button_style) {
+     return;
+   }
+@@ -99,11 +99,11 @@ void MdTextButton::SetStyle(ui::ButtonStyle button_style) {
+   UpdateColors();
+ }
+ 
+-ui::ButtonStyle MdTextButton::GetStyle() const {
++ui::ButtonStyle MdTextButton_ChromiumImpl::GetStyle() const {
+   return style_;
+ }
+ 
+-void MdTextButton::SetBgColorIdOverride(
++void MdTextButton_ChromiumImpl::SetBgColorIdOverride(
+     const std::optional<ui::ColorId> color_id) {
+   CHECK(!bg_color_override_.has_value());
+ 
+@@ -115,7 +115,7 @@ void MdTextButton::SetBgColorIdOverride(
+   OnPropertyChanged(&bg_color_id_override_, PropertyEffects::kNone);
+ }
+ 
+-void MdTextButton::SetBgColorOverrideDeprecated(
++void MdTextButton_ChromiumImpl::SetBgColorOverrideDeprecated(
+     const std::optional<SkColor>& color) {
+   CHECK(!bg_color_id_override_.has_value());
+ 
+@@ -127,15 +127,15 @@ void MdTextButton::SetBgColorOverrideDeprecated(
+   OnPropertyChanged(&bg_color_override_, PropertyEffects::kNone);
+ }
+ 
+-std::optional<SkColor> MdTextButton::GetBgColorOverrideDeprecated() const {
++std::optional<SkColor> MdTextButton_ChromiumImpl::GetBgColorOverrideDeprecated() const {
+   return bg_color_override_;
+ }
+ 
+-std::optional<ui::ColorId> MdTextButton::GetBgColorIdOverride() const {
++std::optional<ui::ColorId> MdTextButton_ChromiumImpl::GetBgColorIdOverride() const {
+   return bg_color_id_override_;
+ }
+ 
+-void MdTextButton::SetStrokeColorIdOverride(
++void MdTextButton_ChromiumImpl::SetStrokeColorIdOverride(
+     const std::optional<ui::ColorId> color_id) {
+   CHECK(!stroke_color_override_.has_value());
+ 
+@@ -147,7 +147,7 @@ void MdTextButton::SetStrokeColorIdOverride(
+   OnPropertyChanged(&stroke_color_id_override_, PropertyEffects::kNone);
+ }
+ 
+-void MdTextButton::SetStrokeColorOverrideDeprecated(
++void MdTextButton_ChromiumImpl::SetStrokeColorOverrideDeprecated(
+     const std::optional<SkColor>& color) {
+   CHECK(!stroke_color_id_override_.has_value());
+ 
+@@ -159,15 +159,15 @@ void MdTextButton::SetStrokeColorOverrideDeprecated(
+   OnPropertyChanged(&stroke_color_override_, PropertyEffects::kNone);
+ }
+ 
+-std::optional<SkColor> MdTextButton::GetStrokeColorOverrideDeprecated() const {
++std::optional<SkColor> MdTextButton_ChromiumImpl::GetStrokeColorOverrideDeprecated() const {
+   return stroke_color_override_;
+ }
+ 
+-std::optional<ui::ColorId> MdTextButton::GetStrokeColorIdOverride() const {
++std::optional<ui::ColorId> MdTextButton_ChromiumImpl::GetStrokeColorIdOverride() const {
+   return stroke_color_id_override_;
+ }
+ 
+-void MdTextButton::SetCornerRadii(const gfx::RoundedCornersF& radii) {
++void MdTextButton_ChromiumImpl::SetCornerRadii(const gfx::RoundedCornersF& radii) {
+   if (radii_ == radii) {
+     return;
+   }
+@@ -176,11 +176,11 @@ void MdTextButton::SetCornerRadii(const gfx::RoundedCornersF& radii) {
+   OnPropertyChanged(&radii_, PropertyEffects::kPaint);
+ }
+ 
+-void MdTextButton::SetCornerRadius(float radius) {
++void MdTextButton_ChromiumImpl::SetCornerRadius(float radius) {
+   SetCornerRadii(gfx::RoundedCornersF(radius));
+ }
+ 
+-gfx::RoundedCornersF MdTextButton::GetCornerRadii() const {
++gfx::RoundedCornersF MdTextButton_ChromiumImpl::GetCornerRadii() const {
+   if (radii_.has_value()) {
+     return radii_.value();
+   }
+@@ -188,60 +188,60 @@ gfx::RoundedCornersF MdTextButton::GetCornerRadii() const {
+       ShapeContextTokens::kButtonRadius, size()));
+ }
+ 
+-void MdTextButton::OnThemeChanged() {
++void MdTextButton_ChromiumImpl::OnThemeChanged() {
+   LabelButton::OnThemeChanged();
+   UpdateColors();
+ }
+ 
+-void MdTextButton::StateChanged(ButtonState old_state) {
++void MdTextButton_ChromiumImpl::StateChanged(ButtonState old_state) {
+   LabelButton::StateChanged(old_state);
+   UpdateColors();
+ }
+ 
+-void MdTextButton::SetImageModel(
++void MdTextButton_ChromiumImpl::SetImageModel(
+     ButtonState for_state,
+     const std::optional<ui::ImageModel>& image_model) {
+   LabelButton::SetImageModel(for_state, image_model);
+   UpdatePadding();
+ }
+ 
+-void MdTextButton::OnFocus() {
++void MdTextButton_ChromiumImpl::OnFocus() {
+   LabelButton::OnFocus();
+   UpdateColors();
+ }
+ 
+-void MdTextButton::OnBlur() {
++void MdTextButton_ChromiumImpl::OnBlur() {
+   LabelButton::OnBlur();
+   UpdateColors();
+ }
+ 
+-void MdTextButton::OnBoundsChanged(const gfx::Rect& previous_bounds) {
++void MdTextButton_ChromiumImpl::OnBoundsChanged(const gfx::Rect& previous_bounds) {
+   LabelButton::OnBoundsChanged(previous_bounds);
+ 
+   // A fully rounded corner radius is calculated based on the button size.
+   OnCornerRadiusValueChanged();
+ }
+ 
+-void MdTextButton::SetEnabledTextColors(std::optional<ui::ColorVariant> color) {
++void MdTextButton_ChromiumImpl::SetEnabledTextColors(std::optional<ui::ColorVariant> color) {
+   LabelButton::SetEnabledTextColors(std::move(color));
+   UpdateColors();
+ }
+ 
+-void MdTextButton::SetCustomPadding(const std::optional<gfx::Insets>& padding) {
++void MdTextButton_ChromiumImpl::SetCustomPadding(const std::optional<gfx::Insets>& padding) {
+   custom_padding_ = padding;
+   UpdatePadding();
+ }
+ 
+-std::optional<gfx::Insets> MdTextButton::GetCustomPadding() const {
++std::optional<gfx::Insets> MdTextButton_ChromiumImpl::GetCustomPadding() const {
+   return custom_padding_.value_or(CalculateDefaultPadding());
+ }
+ 
+-void MdTextButton::SetText(std::u16string_view text) {
++void MdTextButton_ChromiumImpl::SetText(std::u16string_view text) {
+   LabelButton::SetText(text);
+   UpdatePadding();
+ }
+ 
+-PropertyEffects MdTextButton::UpdateStyleToIndicateDefaultStatus() {
++PropertyEffects MdTextButton_ChromiumImpl::UpdateStyleToIndicateDefaultStatus() {
+   SetStyle(style_ == ui::ButtonStyle::kProminent || GetIsDefault()
+                ? ui::ButtonStyle::kProminent
+                : ui::ButtonStyle::kDefault);
+@@ -249,7 +249,7 @@ PropertyEffects MdTextButton::UpdateStyleToIndicateDefaultStatus() {
+   return PropertyEffects::kNone;
+ }
+ 
+-void MdTextButton::UpdatePadding() {
++void MdTextButton_ChromiumImpl::UpdatePadding() {
+   // Don't use font-based padding when there's no text visible.
+   if (GetText().empty()) {
+     SetBorder(NullBorder());
+@@ -260,7 +260,7 @@ void MdTextButton::UpdatePadding() {
+       CreateEmptyBorder(custom_padding_.value_or(CalculateDefaultPadding())));
+ }
+ 
+-gfx::Insets MdTextButton::CalculateDefaultPadding() const {
++gfx::Insets MdTextButton_ChromiumImpl::CalculateDefaultPadding() const {
+   int target_height = LayoutProvider::GetControlHeightForFont(
+       label()->GetTextContext(), style::STYLE_PRIMARY, label()->font_list());
+ 
+@@ -283,7 +283,7 @@ gfx::Insets MdTextButton::CalculateDefaultPadding() const {
+                            right_padding);
+ }
+ 
+-void MdTextButton::UpdateTextColor() {
++void MdTextButton_ChromiumImpl::UpdateTextColor() {
+   if (explicitly_set_normal_color()) {
+     return;
+   }
+@@ -311,7 +311,7 @@ void MdTextButton::UpdateTextColor() {
+   set_explicitly_set_colors(colors);
+ }
+ 
+-void MdTextButton::UpdateBackgroundColor() {
++void MdTextButton_ChromiumImpl::UpdateBackgroundColor() {
+   bool is_disabled = GetVisualState() == STATE_DISABLED;
+   const ui::ColorProvider* color_provider = GetColorProvider();
+   SkColor bg_color = color_provider->GetColor(ui::kColorButtonBackground);
+@@ -360,7 +360,7 @@ void MdTextButton::UpdateBackgroundColor() {
+           true /* antialias */, true /* should_border_scale */)));
+ }
+ 
+-void MdTextButton::UpdateIconColor() {
++void MdTextButton_ChromiumImpl::UpdateIconColor() {
+   if (use_text_color_for_icon_ && HasImage(ButtonState::STATE_NORMAL)) {
+     const std::optional<ui::ImageModel>& image_model =
+         GetImageModel(ButtonState::STATE_NORMAL);
+@@ -375,7 +375,7 @@ void MdTextButton::UpdateIconColor() {
+   }
+ }
+ 
+-void MdTextButton::UpdateColors() {
++void MdTextButton_ChromiumImpl::UpdateColors() {
+   if (GetWidget()) {
+     UpdateTextColor();
+     UpdateBackgroundColor();
+@@ -384,7 +384,7 @@ void MdTextButton::UpdateColors() {
+   }
+ }
+ 
+-SkColor MdTextButton::GetHoverColor(ui::ButtonStyle button_style) {
++SkColor MdTextButton_ChromiumImpl::GetHoverColor(ui::ButtonStyle button_style) {
+   switch (button_style) {
+     case ui::ButtonStyle::kProminent:
+       return GetColorProvider()->GetColor(ui::kColorSysStateHoverOnProminent);
+@@ -396,18 +396,18 @@ SkColor MdTextButton::GetHoverColor(ui::ButtonStyle button_style) {
+   }
+ }
+ 
+-void MdTextButton::OnCornerRadiusValueChanged() {
++void MdTextButton_ChromiumImpl::OnCornerRadiusValueChanged() {
+   LabelButton::SetFocusRingCornerRadii(GetCornerRadii());
+   // UpdateColors also updates the background border radius.
+   UpdateColors();
+ }
+ 
+-std::unique_ptr<ActionViewInterface> MdTextButton::GetActionViewInterface() {
++std::unique_ptr<ActionViewInterface> MdTextButton_ChromiumImpl::GetActionViewInterface() {
+   return std::make_unique<MdTextButtonActionViewInterface>(this);
+ }
+ 
+ MdTextButtonActionViewInterface::MdTextButtonActionViewInterface(
+-    MdTextButton* action_view)
++    MdTextButton_ChromiumImpl* action_view)
+     : LabelButtonActionViewInterface(action_view), action_view_(action_view) {}
+ 
+ void MdTextButtonActionViewInterface::ActionItemChangedImpl(
+@@ -418,7 +418,7 @@ void MdTextButtonActionViewInterface::ActionItemChangedImpl(
+                               action_item->GetImage());
+ }
+ 
+-BEGIN_METADATA(MdTextButton)
++BEGIN_METADATA(MdTextButton_ChromiumImpl)
+ ADD_PROPERTY_METADATA(gfx::RoundedCornersF, CornerRadii)
+ ADD_PROPERTY_METADATA(std::optional<SkColor>, BgColorOverrideDeprecated)
+ ADD_PROPERTY_METADATA(std::optional<ui::ColorId>, BgColorIdOverride)

--- a/patches/ui-views-controls-button-md_text_button.h.patch
+++ b/patches/ui-views-controls-button-md_text_button.h.patch
@@ -1,0 +1,75 @@
+diff --git a/ui/views/controls/button/md_text_button.h b/ui/views/controls/button/md_text_button.h
+index c098f2a19cfe9198751862487314043f334fd81b..3641b7b3fb5ea9de5d0a936baaa140898c93c362 100644
+--- a/ui/views/controls/button/md_text_button.h
++++ b/ui/views/controls/button/md_text_button.h
+@@ -29,11 +29,11 @@ namespace views {
+ enum class PropertyEffects;
+ 
+ // A button class that implements the Material Design text button spec.
+-class VIEWS_EXPORT MdTextButton : public LabelButton {
+-  METADATA_HEADER(MdTextButton, LabelButton)
++class VIEWS_EXPORT MdTextButton_ChromiumImpl : public LabelButton {
++  METADATA_HEADER(MdTextButton_ChromiumImpl, LabelButton)
+ 
+  public:
+-  explicit MdTextButton(
++  explicit MdTextButton_ChromiumImpl(
+       PressedCallback callback = PressedCallback(),
+       std::u16string_view text = {},
+       int button_context = style::CONTEXT_BUTTON_MD,
+@@ -41,10 +41,10 @@ class VIEWS_EXPORT MdTextButton : public LabelButton {
+       std::unique_ptr<LabelButtonImageContainer> image_container =
+           std::make_unique<SingleImageContainer>());
+ 
+-  MdTextButton(const MdTextButton&) = delete;
+-  MdTextButton& operator=(const MdTextButton&) = delete;
++  MdTextButton_ChromiumImpl(const MdTextButton_ChromiumImpl&) = delete;
++  MdTextButton_ChromiumImpl& operator=(const MdTextButton_ChromiumImpl&) = delete;
+ 
+-  ~MdTextButton() override;
++  ~MdTextButton_ChromiumImpl() override;
+ 
+   void SetStyle(ui::ButtonStyle button_style);
+   ui::ButtonStyle GetStyle() const;
+@@ -104,10 +104,11 @@ class VIEWS_EXPORT MdTextButton : public LabelButton {
+   virtual void UpdateColors();
+ 
+  private:
++  friend class ::views::MdTextButton;
+   void UpdatePadding();
+   gfx::Insets CalculateDefaultPadding() const;
+ 
+-  void UpdateTextColor();
++  virtual void UpdateTextColor();
+   void UpdateBackgroundColor() override;
+   void UpdateIconColor();
+ 
+@@ -141,17 +142,17 @@ class VIEWS_EXPORT MdTextButton : public LabelButton {
+ class VIEWS_EXPORT MdTextButtonActionViewInterface
+     : public LabelButtonActionViewInterface {
+  public:
+-  explicit MdTextButtonActionViewInterface(MdTextButton* action_view);
++  explicit MdTextButtonActionViewInterface(MdTextButton_ChromiumImpl* action_view);
+   ~MdTextButtonActionViewInterface() override = default;
+ 
+   // LabelButtonActionViewInterface:
+   void ActionItemChangedImpl(actions::ActionItem* action_item) override;
+ 
+  private:
+-  raw_ptr<MdTextButton> action_view_;
++  raw_ptr<MdTextButton_ChromiumImpl> action_view_;
+ };
+ 
+-BEGIN_VIEW_BUILDER(VIEWS_EXPORT, MdTextButton, LabelButton)
++BEGIN_VIEW_BUILDER(VIEWS_EXPORT, MdTextButton_ChromiumImpl, LabelButton)
+ VIEW_BUILDER_PROPERTY(gfx::RoundedCornersF, CornerRadii)
+ VIEW_BUILDER_PROPERTY(std::optional<SkColor>, BgColorOverrideDeprecated)
+ VIEW_BUILDER_PROPERTY(std::optional<ui::ColorId>, BgColorIdOverride)
+@@ -161,6 +162,6 @@ END_VIEW_BUILDER
+ 
+ }  // namespace views
+ 
+-DEFINE_VIEW_BUILDER(VIEWS_EXPORT, MdTextButton)
++DEFINE_VIEW_BUILDER(VIEWS_EXPORT, MdTextButton_ChromiumImpl)
+ 
+ #endif  // UI_VIEWS_CONTROLS_BUTTON_MD_TEXT_BUTTON_H_

--- a/rewrite/ui/views/controls/button/md_text_button.cc.yaml
+++ b/rewrite/ui/views/controls/button/md_text_button.cc.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Rename MdTextButton to MdTextButton_ChromiumImpl to match the header.
+    rename_class:
+      class_name: MdTextButton
+      rename: MdTextButton_ChromiumImpl

--- a/rewrite/ui/views/controls/button/md_text_button.h.yaml
+++ b/rewrite/ui/views/controls/button/md_text_button.h.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+blank_macros_for_ast_parsing: true
+
+substitutions:
+  - description: |
+      Rename MdTextButton to MdTextButton_ChromiumImpl
+
+      This allows us to provide a Brave-specific implementation of MdTextButton.
+    rename_class:
+      class_name: MdTextButton
+      rename: MdTextButton_ChromiumImpl
+
+  - description: |
+      Make UpdateTextColor virtual.
+    make_virtual:
+      class_name: MdTextButton_ChromiumImpl
+      method_name: UpdateTextColor
+
+  - description: |
+      Make our views::MdTextButton a friend class
+
+      This allows our class to override `UpdateTextColor`.
+    add_friend:
+      class_name: MdTextButton_ChromiumImpl
+      friend_type: class ::views::MdTextButton


### PR DESCRIPTION
This PR migrates `MdTextButton` customisations into a plaster.

Bug: https://github.com/brave/brave-browser/issues/45050
