### PR TITLE
[plaster] Fix `rename_class` on forwarding constructors

### DIFF
--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1761,6 +1761,44 @@ class RewriterFormsTest(unittest.TestCase):
             result, 'Foo_ChromiumImpl::Foo_ChromiumImpl() {}\n'
             'void Foo_ChromiumImpl::Bar() {}\n')
 
+    def test_rename_class_renames_forwarding_constructor(self):
+        # A forwarding (delegating) constructor names the class again in its
+        # member initializer list -- `: Foo(...)` -- which tree-sitter parses as
+        # a field_identifier, not the identifier/type_identifier the other uses
+        # are. That token must be renamed along with the rest (the real-world
+        # miss was `CookieMonster::CookieMonster(...) : CookieMonster(...)`).
+        result = self._apply(
+            'rename_fwd_ctor.cc', 'Foo::Foo(int a)\n'
+            '    : Foo(base::PassKey<Foo>(), a) {}\n'
+            '\n'
+            'Foo::Foo(base::PassKey<Foo>, int a) {}\n', 'substitutions:\n'
+            '  - description: rename Foo, forwarding ctor included\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      rename: Foo_ChromiumImpl\n')
+        self.assertEqual(
+            result, 'Foo_ChromiumImpl::Foo_ChromiumImpl(int a)\n'
+            '    : Foo_ChromiumImpl(base::PassKey<Foo_ChromiumImpl>(), a) {}\n'
+            '\n'
+            'Foo_ChromiumImpl::Foo_ChromiumImpl('
+            'base::PassKey<Foo_ChromiumImpl>, int a) {}\n')
+
+    def test_rename_class_leaves_member_access_in_initializer_untouched(self):
+        # The forwarding-ctor fix only claims the *name* slot of a member
+        # initializer (`: Foo(...)`). A same-spelled member access passed as an
+        # argument (`other.Foo`) is not that slot and must survive, or the fix
+        # would over-match member accesses that merely share the class name.
+        result = self._apply(
+            'rename_init_member.cc', 'Foo::Foo(const Other& other)\n'
+            '    : value_(other.Foo) {}\n', 'substitutions:\n'
+            '  - description: rename Foo but keep the member access\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      rename: Foo_ChromiumImpl\n')
+        self.assertEqual(
+            result, 'Foo_ChromiumImpl::Foo_ChromiumImpl(const Other& other)\n'
+            '    : value_(other.Foo) {}\n')
+
     def test_rename_class_leaves_string_literal_untouched(self):
         # The whole point of matching AST identifier nodes: a same-spelled
         # string literal survives. The exact-quote-adjacent form (`"Foo"`) is

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -158,17 +158,24 @@ inside:
             },
         },
 
-        # Every identifier-family token whose text is exactly `class_name`: the
-        # name in the class declaration and in type positions (type_identifier),
-        # the `Class::` qualifier on out-of-line members (namespace_identifier),
-        # and the constructor/destructor name plus any other bare use
-        # (identifier).
+        # Every identifier-family token whose text is exactly `class_name`:
+        # type positions (type_identifier), the `Class::` qualifier
+        # (namespace_identifier), the ctor/dtor name and bare uses (identifier),
+        # and the delegating/base name in a member initializer (`: Class(...)`,
+        # a field_identifier). The last is scoped to the name slot (first child
+        # of a field_initializer), so a member access like `other.Class` in the
+        # argument list is left untouched.
         "cxx.find_class_name_tokens": {
             "template": """\
 any:
   - kind: type_identifier
   - kind: namespace_identifier
   - kind: identifier
+  - all:
+      - kind: field_identifier
+      - nthChild: 1
+      - inside:
+          kind: field_initializer
 regex: ^{class_name}$
 """,
             "result": {


### PR DESCRIPTION
A delegating (forwarding) constructor names the class again in its
member initialiser list, which the tree-sitter ends up parsing as a
`field_identifier`, which was not covered by
`cxx.find_class_name_tokens`.

This PR adds `field_identifier` branch to the matcher, but scopes it
down to the name slot.

Fixed: https://github.com/brave/brave-browser/issues/57363
