### PR TITLE
Fixed crash when detaching split tabs

### DIFF
--- a/browser/ui/views/frame/brave_contents_view_util.cc
+++ b/browser/ui/views/frame/brave_contents_view_util.cc
@@ -135,13 +135,20 @@ gfx::RoundedCornersF BraveContentsViewUtil::GetRoundedCornersForContentsView(
   if (tab && tab->IsSplit()) {
     auto split_tab_id = tab->GetSplit();
     auto* tab_strip_model = browser_window_interface->GetTabStripModel();
-    auto* split_data = tab_strip_model->GetSplitData(*split_tab_id);
 
-    // Handle each split tab's lower edge.
-    if (split_data->ListTabs()[0] == tab) {
-      has_right_side_ui = true;
-    } else {
-      has_left_side_ui = true;
+    // While a split tab is being detached (e.g. dragged into a new window),
+    // TabStripModel removes the split collection before notifying observers,
+    // yet |tab| still reports itself as split. GetSplitData() CHECK-fails on
+    // a missing split, so confirm the split still exists in the model first.
+    if (tab_strip_model->ContainsSplit(*split_tab_id)) {
+      auto* split_data = tab_strip_model->GetSplitData(*split_tab_id);
+
+      // Handle each split tab's lower edge.
+      if (split_data->ListTabs()[0] == tab) {
+        has_right_side_ui = true;
+      } else {
+        has_left_side_ui = true;
+      }
     }
   }
 

--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -573,6 +573,39 @@ IN_PROC_BROWSER_TEST_F(SplitViewWithRoundedCornersTest,
   EXPECT_EQ(contents_view->layer()->rounded_corner_radii(), border_radius);
 }
 
+// Regression test for https://github.com/brave/brave-browser/issues/57245:
+// detaching a split tab into a new window used to CHECK-crash in
+// BraveContentsViewUtil::GetRoundedCornersForContentsView().
+IN_PROC_BROWSER_TEST_F(SplitViewWithRoundedCornersTest,
+                       DetachSplitTabToNewWindowDoesNotCrash) {
+  // Keep an extra, non-split tab so the source window survives the move.
+  chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
+
+  NewSplitTab();
+  auto* tab_strip_model = browser()->tab_strip_model();
+  ASSERT_TRUE(IsActiveTabSplit(tab_strip_model));
+
+  auto split_id =
+      tab_strip_model->GetSplitForTab(tab_strip_model->active_index());
+  ASSERT_TRUE(split_id);
+  const gfx::Range range =
+      tab_strip_model->GetSplitData(*split_id)->GetIndexRange();
+  std::vector<int> split_indices;
+  for (uint32_t i = range.start(); i < range.end(); ++i) {
+    split_indices.push_back(static_cast<int>(i));
+  }
+
+  auto browser_created_observer =
+      std::make_optional<ui_test_utils::BrowserCreatedObserver>();
+
+  chrome::MoveTabsToNewWindow(browser(), split_indices);
+  Browser* new_browser = browser_created_observer->Wait();
+
+  ASSERT_TRUE(new_browser);
+  EXPECT_FALSE(tab_strip_model->ContainsSplit(*split_id));
+  EXPECT_TRUE(IsActiveTabSplit(new_browser->tab_strip_model()));
+}
+
 IN_PROC_BROWSER_TEST_F(SplitViewBrowserTest, SplitTabInsetsTest) {
   brave::ToggleVerticalTabStrip(browser());
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57245

When a split tab is detached (e.g. dragged into a new window), TabStripModel removes
the split collection from the model before notifying observers.
BraveContentsViewUtil::GetRoundedCornersForContentsView() was called from that observer
notification and called TabStripModel::GetSplitData() on the now-stale split id, hitting
`CHECK(split)` and crashing.

Fixed by checking TabStripModel::ContainsSplit() before calling GetSplitData()

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
