### PR TITLE
[ai_chat] Add kAIChatWorkspaceTools feature flag

### DIFF
--- a/components/ai_chat/core/common/features.cc
+++ b/components/ai_chat/core/common/features.cc
@@ -74,6 +74,11 @@ bool IsAIChatFirstEnabled() {
 
 BASE_FEATURE(kAIChatUserChoiceTool, base::FEATURE_DISABLED_BY_DEFAULT);
 
+// Enables experimental "workspace" local coding-agent tools that let Leo view,
+// search, and edit files within a user-selected local folder.
+// See https://github.com/brave/brave-browser/issues/57388.
+BASE_FEATURE(kAIChatWorkspaceTools, base::FEATURE_DISABLED_BY_DEFAULT);
+
 BASE_FEATURE(kAIChatAgentProfile, base::FEATURE_DISABLED_BY_DEFAULT);
 
 bool IsAIChatAgentProfileEnabled() {

--- a/components/ai_chat/core/common/features.h
+++ b/components/ai_chat/core/common/features.h
@@ -84,6 +84,8 @@ COMPONENT_EXPORT(AI_CHAT_COMMON) bool IsAIChatFirstEnabled();
 
 COMPONENT_EXPORT(AI_CHAT_COMMON) BASE_DECLARE_FEATURE(kAIChatUserChoiceTool);
 
+COMPONENT_EXPORT(AI_CHAT_COMMON) BASE_DECLARE_FEATURE(kAIChatWorkspaceTools);
+
 // Enables experimental features being enabled in a separate profile. If
 // disabled, the features will not be enabled anywhere.
 COMPONENT_EXPORT(AI_CHAT_COMMON) BASE_DECLARE_FEATURE(kAIChatAgentProfile);


### PR DESCRIPTION
Adds the `kAIChatWorkspaceTools` feature flag (disabled by default). This is the foundation for Leo's experimental local workspace tools, which let Leo view, search, and edit files within a user-selected local folder.

This CL is inert on its own; subsequent CLs in the series build on the flag.

- Series https://github.com/brave/brave-browser/issues/57388
- Sec Review https://github.com/brave/reviews/issues/2318