### PR TITLE
[AI Chat]: Tweak the naming of first party tools to not include the origin.

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -1127,6 +1127,22 @@ void BraveContentBrowserClient::AppendExtraCommandLineSwitches(
         translate::switches::kBraveTranslateUseGoogleEndpoint,
     };
     command_line->CopySwitchesFrom(browser_command_line, kSwitchNames);
+
+    // The Leo "workspace" tools rely on the WebMCP runtime feature
+    // (navigator.modelContext) to register their tools from the workspace page.
+    // WebMCP is experimental and off by default, so enable it for all renderers
+    // while the workspace-tools feature is on (off by default).
+    if (base::FeatureList::IsEnabled(
+            ai_chat::features::kAIChatWorkspaceTools)) {
+      std::string blink_features =
+          command_line->GetSwitchValueASCII(switches::kEnableBlinkFeatures);
+      if (!blink_features.empty()) {
+        blink_features += ",";
+      }
+      blink_features += "WebMCP";
+      command_line->AppendSwitchASCII(switches::kEnableBlinkFeatures,
+                                      blink_features);
+    }
   }
 }
 

--- a/components/ai_chat/content/browser/content_tool.cc
+++ b/components/ai_chat/content/browser/content_tool.cc
@@ -20,6 +20,7 @@
 #include "brave/components/ai_chat/core/browser/tools/tool_utils.h"
 #include "brave/components/ai_chat/core/common/mojom/page_content_extractor.mojom.h"
 #include "content/public/browser/render_frame_host.h"
+#include "content/public/common/url_constants.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/service_manager/public/cpp/interface_provider.h"
 #include "third_party/blink/public/mojom/content_extraction/script_tools.mojom.h"
@@ -32,23 +33,33 @@ ContentTool::ContentTool(const blink::mojom::ScriptTool& script_tool,
     : rfh_(std::move(rfh)), internal_tool_name_(script_tool.name) {
   const GURL& url = rfh_.AsRenderFrameHostIfValid()->GetLastCommittedURL();
 
-  // Name of the ContentTool is {host}_tool_name. Only the host is used (not the
-  // full path) to keep the name within Bedrock's 64-char tool-name limit.
-  name_ = base::StrCat({url.host(), "_", script_tool.name});
+  if (url.SchemeIs(content::kChromeUIUntrustedScheme)) {
+    // First-party WebUI (e.g. the Leo workspace page at
+    // chrome-untrusted://workspace) that registers tools via WebMCP. These are
+    // system-owned, so surface the tool's own name and description verbatim: no
+    // host prefix (the page is unique and controls its names) and no
+    // "website-provided" framing.
+    name_ = script_tool.name;
+    description_ = script_tool.description;
+  } else {
+    // Name of the ContentTool is {host}_tool_name. Only the host is used (not
+    // the full path) to keep the name within Bedrock's 64-char tool-name limit.
+    name_ = base::StrCat({url.host(), "_", script_tool.name});
+
+    // We add some additional information to the description of the content tool
+    // to make it obvious the tool is coming from a website.
+    description_ = base::StrCat(
+        {"Website-provided tool for the current page at ", url.spec(), ".",
+         "Name: ", script_tool.name, ".",
+         "Website-provided description: ", script_tool.description, ".",
+         "Only use this tool when it is relevant to the user's request on this "
+         "page."});
+  }
 
   // Toolnames only allow alphanumeric characters and underscores.
   std::replace_if(
       name_.begin(), name_.end(),
       [](char c) { return !absl::ascii_isalnum(c) && c != '_'; }, '_');
-
-  // We add some additional information to the description of the content tool
-  // to make it obvious the tool is coming from a website.
-  description_ = base::StrCat(
-      {"Website-provided tool for the current page at ", url.spec(), ".",
-       "Name: ", script_tool.name, ".",
-       "Website-provided description: ", script_tool.description, ".",
-       "Only use this tool when it is relevant to the user's request on this "
-       "page."});
 
   if (!script_tool.input_schema) {
     return;

--- a/components/ai_chat/content/browser/content_tool.cc
+++ b/components/ai_chat/content/browser/content_tool.cc
@@ -39,7 +39,7 @@ ContentTool::ContentTool(const blink::mojom::ScriptTool& script_tool,
     // system-owned, so surface the tool's own name and description verbatim: no
     // host prefix (the page is unique and controls its names) and no
     // "website-provided" framing.
-    name_ = base::StrCat({"web_", script_tool.name});
+    name_ = script_tool.name;
     description_ = script_tool.description;
   } else {
     // Name of the ContentTool is {host}_tool_name. Only the host is used (not

--- a/components/ai_chat/content/browser/content_tool.cc
+++ b/components/ai_chat/content/browser/content_tool.cc
@@ -20,6 +20,7 @@
 #include "brave/components/ai_chat/core/browser/tools/tool_utils.h"
 #include "brave/components/ai_chat/core/common/mojom/page_content_extractor.mojom.h"
 #include "content/public/browser/render_frame_host.h"
+#include "content/public/common/url_constants.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/service_manager/public/cpp/interface_provider.h"
 #include "third_party/blink/public/mojom/content_extraction/script_tools.mojom.h"
@@ -32,24 +33,33 @@ ContentTool::ContentTool(const blink::mojom::ScriptTool& script_tool,
     : rfh_(std::move(rfh)), internal_tool_name_(script_tool.name) {
   const GURL& url = rfh_.AsRenderFrameHostIfValid()->GetLastCommittedURL();
 
-  // Name of the ContentTool is web_{host}_tool_name. Only the host is used
-  // (not the full path) to keep the name within Bedrock's 64-char tool-name
-  // limit.
-  name_ = base::StrCat({"web_", url.host(), "_", script_tool.name});
+  if (url.SchemeIs(content::kChromeUIUntrustedScheme)) {
+    // First-party WebUI (e.g. the Leo workspace page at
+    // chrome-untrusted://workspace) that registers tools via WebMCP. These are
+    // system-owned, so surface the tool's own name and description verbatim: no
+    // host prefix (the page is unique and controls its names) and no
+    // "website-provided" framing.
+    name_ = base::StrCat({"web_", script_tool.name});
+    description_ = script_tool.description;
+  } else {
+    // Name of the ContentTool is {host}_tool_name. Only the host is used (not
+    // the full path) to keep the name within Bedrock's 64-char tool-name limit.
+    name_ = base::StrCat({"web_", url.host(), "_", script_tool.name});
+
+    // We add some additional information to the description of the content tool
+    // to make it obvious the tool is coming from a website.
+    description_ = base::StrCat(
+        {"Website-provided tool for the current page at ", url.spec(), ".",
+         "Name: ", script_tool.name, ".",
+         "Website-provided description: ", script_tool.description, ".",
+         "Only use this tool when it is relevant to the user's request on this "
+         "page."});
+  }
 
   // Toolnames only allow alphanumeric characters and underscores.
   std::replace_if(
       name_.begin(), name_.end(),
       [](char c) { return !absl::ascii_isalnum(c) && c != '_'; }, '_');
-
-  // We add some additional information to the description of the content tool
-  // to make it obvious the tool is coming from a website.
-  description_ = base::StrCat(
-      {"Website-provided tool for the current page at ", url.spec(), ".",
-       "Name: ", script_tool.name, ".",
-       "Website-provided description: ", script_tool.description, ".",
-       "Only use this tool when it is relevant to the user's request on this "
-       "page."});
 
   if (!script_tool.input_schema) {
     return;


### PR DESCRIPTION
Plumbing for Leo's workspace tools:

- \`brave_content_browser_client\`: enable the WebMCP runtime feature (\`--enable-blink-features=WebMCP\`) in renderers when \`kAIChatWorkspaceTools\` is on, so the workspace page can register tools via \`navigator.modelContext\`.
- \`content_tool\`: for \`chrome-untrusted://\` first-party WebUI, surface the tool's own name and description verbatim (no host/path prefix, no "website-provided" framing), since these are system-owned tools.

Depends on the feature flag CL (base branch).

- Series https://github.com/brave/brave-browser/issues/57388