### PR TITLE
[ai_chat] Add chrome-untrusted://workspace WebUI + TS file-ops bundle

### DIFF
--- a/browser/ui/webui/ai_chat/BUILD.gn
+++ b/browser/ui/webui/ai_chat/BUILD.gn
@@ -19,6 +19,8 @@ source_set("ai_chat") {
     "chart_display_ui.h",
     "code_sandbox_ui.cc",
     "code_sandbox_ui.h",
+    "workspace_ui.cc",
+    "workspace_ui.h",
   ]
 
   deps = [
@@ -55,6 +57,7 @@ source_set("ai_chat") {
     "//printing",
     "//services/data_decoder/public/cpp",
     "//ui/gfx/codec",
+    "//ui/shell_dialogs",
     "//ui/webui",
   ]
 

--- a/browser/ui/webui/ai_chat/workspace_ui.cc
+++ b/browser/ui/webui/ai_chat/workspace_ui.cc
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/webui/ai_chat/workspace_ui.h"
+
+#include <string>
+
+#include "base/feature_list.h"
+#include "brave/common/webui_url_constants.h"
+#include "brave/components/ai_chat/core/browser/utils.h"
+#include "brave/components/ai_chat/core/common/features.h"
+#include "brave/components/ai_chat/resources/grit/ai_chat_ui_generated_map.h"
+#include "components/grit/brave_components_resources.h"
+#include "components/user_prefs/user_prefs.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/browser/web_ui.h"
+#include "content/public/browser/web_ui_data_source.h"
+#include "content/public/common/url_constants.h"
+#include "ui/webui/webui_util.h"
+#include "url/gurl.h"
+
+namespace ai_chat {
+
+// WorkspaceUIConfig implementation
+bool WorkspaceUIConfig::IsWebUIEnabled(
+    content::BrowserContext* browser_context) {
+  return IsAIChatEnabled(user_prefs::UserPrefs::Get(browser_context)) &&
+         base::FeatureList::IsEnabled(features::kAIChatWorkspaceTools);
+}
+
+std::unique_ptr<content::WebUIController>
+WorkspaceUIConfig::CreateWebUIController(content::WebUI* web_ui,
+                                         const GURL& url) {
+  return std::make_unique<WorkspaceUI>(web_ui);
+}
+
+WorkspaceUIConfig::WorkspaceUIConfig()
+    : WebUIConfig(content::kChromeUIUntrustedScheme, kWorkspaceUIHost) {}
+
+WorkspaceUIConfig::~WorkspaceUIConfig() = default;
+
+WorkspaceUI::WorkspaceUI(content::WebUI* web_ui)
+    : ui::UntrustedWebUIController(web_ui) {
+  auto* browser_context = web_ui->GetWebContents()->GetBrowserContext();
+  auto* source =
+      content::WebUIDataSource::CreateAndAdd(browser_context, kWorkspaceUIURL);
+
+  webui::SetupWebUIDataSource(source, kAiChatUiGenerated,
+                              IDR_AI_CHAT_WORKSPACE_HTML);
+
+  // This page runs its own first-party module bundle only. No network, no
+  // frames, no embedding by other pages. The FileSystemDirectoryHandle it
+  // operates on is delivered out-of-band (launchQueue), not fetched.
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::DefaultSrc, "default-src 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::ScriptSrc,
+      "script-src 'self' chrome-untrusted://resources;");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::StyleSrc,
+      "style-src 'self' 'unsafe-inline' chrome-untrusted://resources;");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::ConnectSrc, "connect-src 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::ObjectSrc, "object-src 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::FrameSrc, "frame-src 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::FrameAncestors,
+      "frame-ancestors 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::WorkerSrc, "worker-src 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::FormAction, "form-action 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::BaseURI, "base-uri 'none';");
+}
+
+WorkspaceUI::~WorkspaceUI() = default;
+
+}  // namespace ai_chat

--- a/browser/ui/webui/ai_chat/workspace_ui.h
+++ b/browser/ui/webui/ai_chat/workspace_ui.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_BROWSER_UI_WEBUI_AI_CHAT_WORKSPACE_UI_H_
+#define BRAVE_BROWSER_UI_WEBUI_AI_CHAT_WORKSPACE_UI_H_
+
+#include <memory>
+
+#include "content/public/browser/webui_config.h"
+#include "ui/webui/untrusted_web_ui_controller.h"
+
+namespace ai_chat {
+
+class WorkspaceUIConfig : public content::WebUIConfig {
+ public:
+  WorkspaceUIConfig();
+  ~WorkspaceUIConfig() override;
+
+  // content::WebUIConfig:
+  bool IsWebUIEnabled(content::BrowserContext* browser_context) override;
+  std::unique_ptr<content::WebUIController> CreateWebUIController(
+      content::WebUI* web_ui,
+      const GURL& url) override;
+};
+
+// Hidden, headless Untrusted WebUI that hosts the Leo "workspace" tools. The
+// page receives a FileSystemDirectoryHandle (delivered by the browser via
+// launchQueue) for a user-picked folder, implements the file tools in
+// JavaScript against it, and registers them with Leo via WebMCP
+// (navigator.modelContext). One instance is created per conversation and served
+// at chrome-untrusted://workspace/<guid>; it runs with a locked-down CSP that
+// only permits its own first-party bundle.
+class WorkspaceUI : public ui::UntrustedWebUIController {
+ public:
+  explicit WorkspaceUI(content::WebUI* web_ui);
+  ~WorkspaceUI() override;
+
+  WorkspaceUI(const WorkspaceUI&) = delete;
+  WorkspaceUI& operator=(const WorkspaceUI&) = delete;
+};
+
+}  // namespace ai_chat
+
+#endif  // BRAVE_BROWSER_UI_WEBUI_AI_CHAT_WORKSPACE_UI_H_

--- a/chromium_src/chrome/browser/ui/webui/chrome_untrusted_web_ui_configs.cc
+++ b/chromium_src/chrome/browser/ui/webui/chrome_untrusted_web_ui_configs.cc
@@ -28,6 +28,7 @@
 #include "brave/browser/ui/webui/ai_chat/ai_chat_untrusted_conversation_ui.h"
 #include "brave/browser/ui/webui/ai_chat/chart_display_ui.h"
 #include "brave/browser/ui/webui/ai_chat/code_sandbox_ui.h"
+#include "brave/browser/ui/webui/ai_chat/workspace_ui.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #endif
 
@@ -112,6 +113,8 @@ void RegisterChromeUntrustedWebUIConfigs() {
         std::make_unique<ai_chat::ChartDisplayUIConfig>());
     content::WebUIConfigMap::GetInstance().AddUntrustedWebUIConfig(
         std::make_unique<ai_chat::CodeSandboxUIConfig>());
+    content::WebUIConfigMap::GetInstance().AddUntrustedWebUIConfig(
+        std::make_unique<ai_chat::WorkspaceUIConfig>());
   }
 #endif  // BUILDFLAG(ENABLE_AI_CHAT)
 #if BUILDFLAG(ENABLE_BRAVE_NEWS) && !BUILDFLAG(IS_ANDROID)

--- a/common/webui_url_constants.h
+++ b/common/webui_url_constants.h
@@ -14,4 +14,7 @@ inline constexpr char kAIChatChartDisplayUIURL[] =
     "chrome-untrusted://aichat-chart-display/";
 inline constexpr char kAIChatChartDisplayUIHost[] = "aichat-chart-display";
 
+inline constexpr char kWorkspaceUIURL[] = "chrome-untrusted://workspace/";
+inline constexpr char kWorkspaceUIHost[] = "workspace";
+
 #endif  // BRAVE_COMMON_WEBUI_URL_CONSTANTS_H_

--- a/components/ai_chat/resources/BUILD.gn
+++ b/components/ai_chat/resources/BUILD.gn
@@ -25,6 +25,10 @@ transpile_web_ui("ai_chat_ui") {
       "chart_display",
       rebase_path("chart_display/index.tsx"),
     ],
+    [
+      "workspace",
+      rebase_path("workspace/index.tsx"),
+    ],
   ]
 
   imports_from = [ "//brave/components/ai_chat/resources/" ]
@@ -43,6 +47,7 @@ preprocess_if_expr("preprocess_html") {
     "code_sandbox/code_sandbox.html",
     "page/ai_chat_ui.html",
     "untrusted_conversation_frame/untrusted_conversation_frame.html",
+    "workspace/workspace.html",
   ]
   out_folder = "$target_gen_dir/preprocessed"
 }

--- a/components/ai_chat/resources/ai_chat_ui_resources.grdp
+++ b/components/ai_chat/resources/ai_chat_ui_resources.grdp
@@ -16,6 +16,9 @@
   <include name="IDR_AI_CHAT_CHART_DISPLAY_HTML" file="${root_gen_dir}/brave/components/ai_chat/resources/preprocessed/chart_display/chart_display.html"
     use_base_dir="false"
     type="BINDATA" />
+  <include name="IDR_AI_CHAT_WORKSPACE_HTML" file="${root_gen_dir}/brave/components/ai_chat/resources/preprocessed/workspace/workspace.html"
+    use_base_dir="false"
+    type="BINDATA" />
   <include name="IDR_AI_CHAT_BIGNUMBER_JS" file="../../node_modules/bignumber.js/bignumber.js"
     type="BINDATA" />
   <include name="IDR_AI_CHAT_INTERFACE_REMOVAL_JS" file="../ai_chat/resources/code_sandbox/interface_removal.js"

--- a/components/ai_chat/resources/workspace/file_ops.ts
+++ b/components/ai_chat/resources/workspace/file_ops.ts
@@ -1,0 +1,332 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// File tools for the Leo workspace, implemented against a
+// FileSystemDirectoryHandle using the Web File System Access API. Path
+// confinement comes from the platform: getFileHandle/getDirectoryHandle take a
+// single path segment and reject '..' and separators, and the handle is scoped
+// to the picked folder, so there is no way to escape the workspace root.
+
+// Caps to keep tool output within reason for the model.
+const kMaxGrepMatches = 200
+const kMaxGlobResults = 500
+
+function splitPath(rel: string): string[] {
+  const parts = rel
+    .split('/')
+    .map((s) => s.trim())
+    .filter((s) => s !== '' && s !== '.')
+  for (const p of parts) {
+    if (p === '..') {
+      throw new Error(`path escapes the workspace root: ${rel}`)
+    }
+  }
+  return parts
+}
+
+function basename(rel: string): string {
+  const parts = splitPath(rel)
+  return parts.length ? parts[parts.length - 1] : ''
+}
+
+async function getDir(
+  root: FileSystemDirectoryHandle,
+  rel: string,
+  create = false,
+): Promise<FileSystemDirectoryHandle> {
+  let dir = root
+  for (const seg of splitPath(rel)) {
+    dir = await dir.getDirectoryHandle(seg, { create })
+  }
+  return dir
+}
+
+async function getFile(
+  root: FileSystemDirectoryHandle,
+  rel: string,
+  create = false,
+): Promise<FileSystemFileHandle> {
+  const parts = splitPath(rel)
+  if (parts.length === 0) {
+    throw new Error('empty file path')
+  }
+  const name = parts.pop() as string
+  let dir = root
+  for (const seg of parts) {
+    dir = await dir.getDirectoryHandle(seg, { create })
+  }
+  return dir.getFileHandle(name, { create })
+}
+
+async function fileExists(
+  root: FileSystemDirectoryHandle,
+  rel: string,
+): Promise<boolean> {
+  try {
+    await getFile(root, rel)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Whether |rel| resolves to a directory (an empty path is the root directory).
+export async function isDirectory(
+  root: FileSystemDirectoryHandle,
+  rel: string,
+): Promise<boolean> {
+  try {
+    await getDir(root, rel)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function readText(
+  root: FileSystemDirectoryHandle,
+  rel: string,
+): Promise<string> {
+  const fh = await getFile(root, rel)
+  return (await fh.getFile()).text()
+}
+
+async function writeText(
+  root: FileSystemDirectoryHandle,
+  rel: string,
+  content: string,
+): Promise<void> {
+  const fh = await getFile(root, rel, true)
+  const writable = await fh.createWritable()
+  await writable.write(content)
+  await writable.close()
+}
+
+// dirHandle.entries() isn't in every TS lib; access via a loose type.
+function entriesOf(
+  dir: FileSystemDirectoryHandle,
+): AsyncIterable<[string, FileSystemHandle]> {
+  return (
+    dir as unknown as {
+      entries(): AsyncIterable<[string, FileSystemHandle]>
+    }
+  ).entries()
+}
+
+function join(base: string, name: string): string {
+  return base ? `${base}/${name}` : name
+}
+
+function globToRegExp(glob: string): RegExp {
+  let re = ''
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i]
+    if (c === '*') {
+      if (glob[i + 1] === '*') {
+        re += '.*'
+        i++
+        if (glob[i + 1] === '/') {
+          i++
+        }
+      } else {
+        re += '[^/]*'
+      }
+    } else if (c === '?') {
+      re += '[^/]'
+    } else if ('.+^${}()|[]\\'.includes(c)) {
+      re += '\\' + c
+    } else {
+      re += c
+    }
+  }
+  return new RegExp('^' + re + '$')
+}
+
+// Recursively yields the relative path of every file under |dir|.
+async function* walkFiles(
+  dir: FileSystemDirectoryHandle,
+  prefix = '',
+): AsyncGenerator<{ path: string; handle: FileSystemFileHandle }> {
+  for await (const [name, handle] of entriesOf(dir)) {
+    const rel = join(prefix, name)
+    if (handle.kind === 'directory') {
+      yield* walkFiles(handle as FileSystemDirectoryHandle, rel)
+    } else {
+      yield { path: rel, handle: handle as FileSystemFileHandle }
+    }
+  }
+}
+
+export async function listDir(
+  root: FileSystemDirectoryHandle,
+  path: string,
+  depth: number,
+): Promise<string> {
+  const start = await getDir(root, path)
+  const lines: string[] = []
+  const maxDepth = depth && depth > 0 ? depth : 2
+
+  async function recurse(
+    dir: FileSystemDirectoryHandle,
+    rel: string,
+    d: number,
+  ) {
+    const names: Array<[string, FileSystemHandle]> = []
+    for await (const entry of entriesOf(dir)) {
+      names.push(entry)
+    }
+    names.sort((a, b) => a[0].localeCompare(b[0]))
+    for (const [name, handle] of names) {
+      const childRel = join(rel, name)
+      if (handle.kind === 'directory') {
+        lines.push(`${childRel}/`)
+        if (d < maxDepth) {
+          await recurse(handle as FileSystemDirectoryHandle, childRel, d + 1)
+        }
+      } else {
+        lines.push(childRel)
+      }
+    }
+  }
+
+  await recurse(start, path.replace(/\/+$/, '').replace(/^\/+/, ''), 1)
+  return lines.length ? lines.join('\n') : '(empty)'
+}
+
+export async function viewFile(
+  root: FileSystemDirectoryHandle,
+  path: string,
+  range: number[] | undefined,
+): Promise<string> {
+  const text = await readText(root, path)
+  const lines = text.split('\n')
+  let start = 1
+  let end = lines.length
+  if (range && range.length >= 1) {
+    start = Math.max(1, range[0])
+  }
+  if (range && range.length >= 2 && range[1] !== -1) {
+    end = Math.min(lines.length, range[1])
+  }
+  const out: string[] = []
+  for (let i = start; i <= end; i++) {
+    out.push(`${i}\t${lines[i - 1] ?? ''}`)
+  }
+  return out.join('\n')
+}
+
+export async function grep(
+  root: FileSystemDirectoryHandle,
+  path: string,
+  pattern: string,
+  include: string,
+): Promise<string> {
+  const re = new RegExp(pattern)
+  const includeRe = include ? globToRegExp(include) : null
+  const dir = await getDir(root, path)
+  const base = path.replace(/\/+$/, '').replace(/^\/+/, '')
+  const matches: string[] = []
+  for await (const { path: rel, handle } of walkFiles(dir, base)) {
+    if (includeRe && !includeRe.test(rel) && !includeRe.test(basename(rel))) {
+      continue
+    }
+    let text: string
+    try {
+      text = await (await handle.getFile()).text()
+    } catch {
+      continue
+    }
+    const fileLines = text.split('\n')
+    for (let i = 0; i < fileLines.length; i++) {
+      if (re.test(fileLines[i])) {
+        matches.push(`${rel}:${i + 1}: ${fileLines[i]}`)
+        if (matches.length >= kMaxGrepMatches) {
+          matches.push(`... (truncated at ${kMaxGrepMatches} matches)`)
+          return matches.join('\n')
+        }
+      }
+    }
+  }
+  return matches.length ? matches.join('\n') : '(no matches)'
+}
+
+export async function glob(
+  root: FileSystemDirectoryHandle,
+  path: string,
+  pattern: string,
+): Promise<string> {
+  const re = globToRegExp(pattern)
+  const dir = await getDir(root, path)
+  const base = path.replace(/\/+$/, '').replace(/^\/+/, '')
+  const results: string[] = []
+  for await (const { path: rel } of walkFiles(dir, base)) {
+    if (re.test(rel) || re.test(basename(rel))) {
+      results.push(rel)
+      if (results.length >= kMaxGlobResults) {
+        results.push(`... (truncated at ${kMaxGlobResults} results)`)
+        break
+      }
+    }
+  }
+  return results.length ? results.join('\n') : '(no matches)'
+}
+
+export async function appendFile(
+  root: FileSystemDirectoryHandle,
+  path: string,
+  content: string,
+): Promise<string> {
+  const existed = await fileExists(root, path)
+  const previous = existed ? await readText(root, path) : ''
+  await writeText(root, path, previous + content)
+  return `Appended ${content.length} bytes to ${path}`
+}
+
+export async function createFile(
+  root: FileSystemDirectoryHandle,
+  path: string,
+  fileText: string,
+): Promise<string> {
+  // Matches the text-editor `create` semantics: creates the file, overwriting
+  // it if it already exists.
+  const existed = await fileExists(root, path)
+  await writeText(root, path, fileText)
+  return `${existed ? 'Overwrote' : 'Created'} ${path} (${fileText.length} bytes)`
+}
+
+export async function strReplace(
+  root: FileSystemDirectoryHandle,
+  path: string,
+  oldStr: string,
+  newStr: string,
+): Promise<string> {
+  const text = await readText(root, path)
+  const first = text.indexOf(oldStr)
+  if (first === -1) {
+    throw new Error('old_str was not found in the file')
+  }
+  if (text.includes(oldStr, first + 1)) {
+    throw new Error('old_str is not unique in the file')
+  }
+  const updated =
+    text.slice(0, first) + newStr + text.slice(first + oldStr.length)
+  await writeText(root, path, updated)
+  return `Replaced text in ${path}`
+}
+
+export async function insert(
+  root: FileSystemDirectoryHandle,
+  path: string,
+  insertLine: number,
+  newStr: string,
+): Promise<string> {
+  const text = await readText(root, path)
+  const lines = text.split('\n')
+  const at = Math.max(0, Math.min(insertLine, lines.length))
+  const inserted = newStr.split('\n')
+  lines.splice(at, 0, ...inserted)
+  await writeText(root, path, lines.join('\n'))
+  return `Inserted ${inserted.length} line(s) into ${path} after line ${at}`
+}

--- a/components/ai_chat/resources/workspace/index.tsx
+++ b/components/ai_chat/resources/workspace/index.tsx
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Headless workspace page. This bundle runs inside the hidden
+// chrome-untrusted://workspace/<guid> WebContents that is attached to a Leo
+// conversation. It receives a FileSystemDirectoryHandle for the user-picked
+// folder (delivered by the browser via window.launchQueue), implements the file
+// tools against it, and registers them with Leo via WebMCP
+// (navigator.modelContext). There is no visible UI.
+//
+// The handle is delivered via launchQueue; once captured, the file tools are
+// registered with Leo via WebMCP (see tools.ts / file_ops.ts).
+
+import { registerTools } from './tools'
+
+// launchQueue is not in the default TS DOM lib; declare the minimal surface we
+// use. The delivered file entries are FileSystemDirectoryHandle objects.
+interface LaunchParams {
+  files: FileSystemHandle[]
+}
+interface LaunchQueue {
+  setConsumer(consumer: (params: LaunchParams) => void): void
+}
+declare global {
+  interface Window {
+    launchQueue?: LaunchQueue
+  }
+}
+
+let rootHandle: FileSystemDirectoryHandle | null = null
+
+function onLaunch(params: LaunchParams) {
+  const entry = params.files?.[0]
+  if (!entry || entry.kind !== 'directory') {
+    console.error(
+      '[workspace] launch params missing a directory handle',
+      params,
+    )
+    return
+  }
+  rootHandle = entry as FileSystemDirectoryHandle
+  console.log('[workspace] received directory handle:', rootHandle.name)
+  void registerTools(rootHandle)
+}
+
+function initialize() {
+  console.log('[workspace] bundle loaded at', window.location.pathname)
+  if (window.launchQueue) {
+    window.launchQueue.setConsumer(onLaunch)
+  } else {
+    console.error('[workspace] window.launchQueue is unavailable')
+  }
+}
+
+document.addEventListener('DOMContentLoaded', initialize)

--- a/components/ai_chat/resources/workspace/tools.ts
+++ b/components/ai_chat/resources/workspace/tools.ts
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Registers the workspace file tools with Leo via the WebMCP API
+// (navigator.modelContext). The primary editing tool follows Anthropic's
+// text-editor tool ("str_replace_based_edit_tool"): a single tool with a
+// `command` enum (view / create / str_replace / insert) and matching parameter
+// names, so it lands in the model's training distribution. Search and
+// repo-structure helpers with no text-editor analog are registered as separate
+// auxiliary tools. All ops run against the FileSystemDirectoryHandle in
+// file_ops.
+
+import * as ops from './file_ops'
+
+interface ModelContextTool {
+  name: string
+  description: string
+  inputSchema?: object
+  execute: (input: Record<string, unknown>) => Promise<unknown>
+}
+interface ModelContext {
+  registerTool(tool: ModelContextTool): Promise<void>
+}
+declare global {
+  interface Navigator {
+    modelContext?: ModelContext
+  }
+}
+
+function schema(
+  properties: Record<string, object>,
+  required?: string[],
+): object {
+  return { type: 'object', properties, required: required ?? [] }
+}
+const str = (description: string) => ({ type: 'string', description })
+const int = (description: string) => ({ type: 'integer', description })
+const strEnum = (values: string[], description: string) => ({
+  type: 'string',
+  enum: values,
+  description,
+})
+const intArray = (description: string) => ({
+  type: 'array',
+  description,
+  items: { type: 'integer' },
+})
+
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v : ''
+}
+function asInt(v: unknown, fallback: number): number {
+  return typeof v === 'number' ? v : fallback
+}
+
+export async function registerTools(
+  root: FileSystemDirectoryHandle,
+): Promise<void> {
+  const mc = navigator.modelContext
+  if (!mc) {
+    console.error('[workspace] navigator.modelContext is unavailable')
+    return
+  }
+
+  const reg = (
+    name: string,
+    description: string,
+    inputSchema: object,
+    run: (input: Record<string, unknown>) => Promise<string>,
+  ) =>
+    mc.registerTool({
+      name,
+      description,
+      inputSchema,
+      execute: async (input) => {
+        try {
+          return await run(input ?? {})
+        } catch (e) {
+          return `Error: ${e instanceof Error ? e.message : String(e)}`
+        }
+      },
+    })
+
+  // The text-editor tool: one tool, dispatched on `command`. Paths are relative
+  // to the workspace root and confined to it by the File System Access API.
+  await reg(
+    'str_replace_based_edit_tool',
+    'Tool for viewing, creating and editing files in the workspace, modeled '
+      + "on Anthropic's text editor tool. Commands:\n"
+      + '- view: show a file with 1-indexed line numbers, or list a directory. '
+      + 'Optionally pass view_range=[start, end] (end -1 = end of file) to show '
+      + 'part of a file.\n'
+      + '- create: create a file with `file_text`, overwriting it if it exists. '
+      + 'IMPORTANT: a large `file_text` gets truncated and rejected. For anything '
+      + 'longer than a few lines, call create with an empty or very short '
+      + '`file_text`, then add the rest with repeated append_file calls, one '
+      + 'small chunk per call.\n'
+      + '- str_replace: replace the unique occurrence of `old_str` with '
+      + '`new_str`. `old_str` must match exactly once, including whitespace. '
+      + 'Keep `new_str` small for the same reason.\n'
+      + '- insert: insert `insert_text` after 1-indexed line `insert_line` (0 = '
+      + 'start of file). Keep `insert_text` small.',
+    schema(
+      {
+        command: strEnum(
+          ['view', 'create', 'str_replace', 'insert'],
+          'The edit command to run.',
+        ),
+        path: str('File or directory path relative to the workspace root.'),
+        file_text: str('For create: full contents of the file.'),
+        old_str: str(
+          'For str_replace: exact existing text to replace (must be unique).',
+        ),
+        new_str: str('For str_replace: replacement text.'),
+        insert_line: int(
+          'For insert: line number to insert after (0 = start of file).',
+        ),
+        insert_text: str('For insert: text to insert.'),
+        view_range: intArray(
+          'For view on a file: optional [start, end] 1-indexed line range. '
+            + 'Use end of -1 to read through the end of the file.',
+        ),
+      },
+      ['command', 'path'],
+    ),
+    async (i) => {
+      const path = asString(i.path)
+      switch (i.command) {
+        case 'view':
+          return (await ops.isDirectory(root, path))
+            ? ops.listDir(root, path, 2)
+            : ops.viewFile(
+                root,
+                path,
+                Array.isArray(i.view_range)
+                  ? (i.view_range as number[])
+                  : undefined,
+              )
+        case 'create':
+          return ops.createFile(root, path, asString(i.file_text))
+        case 'str_replace':
+          return ops.strReplace(
+            root,
+            path,
+            asString(i.old_str),
+            asString(i.new_str),
+          )
+        case 'insert':
+          return ops.insert(
+            root,
+            path,
+            asInt(i.insert_line, 0),
+            asString(i.insert_text),
+          )
+        default:
+          throw new Error(`unknown command: ${String(i.command)}`)
+      }
+    },
+  )
+
+  // Auxiliary tools with no text-editor analog.
+  await reg(
+    'grep',
+    'Search file contents within the workspace for a regular expression.',
+    schema(
+      {
+        pattern: str('Regular expression to search for.'),
+        path: str(
+          'Directory to search under, relative to the workspace root. Empty '
+            + 'searches the whole workspace.',
+        ),
+        include: str(
+          'Optional glob restricting which files are searched by their '
+            + 'relative path, e.g. *.ts',
+        ),
+      },
+      ['pattern'],
+    ),
+    (i) =>
+      ops.grep(
+        root,
+        asString(i.path),
+        asString(i.pattern),
+        asString(i.include),
+      ),
+  )
+
+  await reg(
+    'glob',
+    'Find files in the workspace whose relative path matches a glob.',
+    schema(
+      {
+        pattern: str('Glob to match file paths, e.g. **/*.ts'),
+        path: str(
+          'Directory to search under, relative to the workspace root. Empty '
+            + 'searches the whole workspace.',
+        ),
+      },
+      ['pattern'],
+    ),
+    (i) => ops.glob(root, asString(i.path), asString(i.pattern)),
+  )
+
+  await reg(
+    'append_file',
+    'Append `content` to the end of a workspace file, creating it if needed. '
+      + 'Use this to build a file across several calls: create an empty file, '
+      + 'then append_file one small chunk at a time. Prefer this over a single '
+      + 'large create, whose big `file_text` argument gets truncated and '
+      + 'rejected.',
+    schema(
+      {
+        path: str('File path relative to the workspace root.'),
+        content: str('Text to append to the end of the file.'),
+      },
+      ['path', 'content'],
+    ),
+    (i) => ops.appendFile(root, asString(i.path), asString(i.content)),
+  )
+
+  console.log('[workspace] registered WebMCP tools')
+}

--- a/components/ai_chat/resources/workspace/workspace.html
+++ b/components/ai_chat/resources/workspace/workspace.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Workspace</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <!-- Absolute path: the page is served at /<guid>, so a relative reference
+         would not resolve to the bundle at the host root. -->
+    <script src="/workspace.bundle.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
Scaffolds the hidden workspace WebUI page that Leo's workspace tools run in. The page is served from \`chrome-untrusted://workspace\` with a locked-down CSP (no remote script) and loads a first-party TypeScript bundle that implements file operations over a \`FileSystemDirectoryHandle\` using the Web File System Access API:

- \`str_replace_based_edit_tool\` (view/create/str_replace/insert)
- \`grep\`, \`glob\`, \`append_file\`

Tools are self-registered via \`navigator.modelContext\` (WebMCP) in a later CL. This CL only adds the page, its resources, and the bundle; it is inert until the integration lands.

Depends on the feature flag CL (base branch).

- Series https://github.com/brave/brave-browser/issues/57388