### PR TITLE
[Android] Fix private NTP favicon appearance

### DIFF
--- a/browser/ui/android/favicon/java/src/org/chromium/chrome/browser/ui/favicon/BraveTabListFaviconProvider.java
+++ b/browser/ui/android/favicon/java/src/org/chromium/chrome/browser/ui/favicon/BraveTabListFaviconProvider.java
@@ -14,6 +14,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 
 import androidx.annotation.ColorInt;
+import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.content.res.AppCompatResources;
 
 import org.chromium.build.annotations.NullMarked;
@@ -31,6 +32,14 @@ import java.util.Objects;
 /** Provides Brave favicon variants for Chromium tab-list UI. */
 @NullMarked
 public class BraveTabListFaviconProvider extends TabListFaviconProvider {
+    @VisibleForTesting
+    static final int BRAVE_NTP_FAVICON_DRAWABLE_ID_OUTLINE =
+            R.drawable.ic_social_brave_outline_favicon_fullheight;
+
+    @VisibleForTesting
+    static final int BRAVE_NTP_FAVICON_DRAWABLE_ID_FILLED =
+            R.drawable.ic_social_brave_carved_favicon_fullheight;
+
     private final Context mContext;
     private final boolean mIsTabStrip;
     private final int mDefaultFaviconSize;
@@ -55,7 +64,7 @@ public class BraveTabListFaviconProvider extends TabListFaviconProvider {
             return super.getRoundedChromeFavicon(isIncognito);
         }
 
-        int drawableId = getBraveNtpFaviconDrawableId();
+        int drawableId = getBraveNtpFaviconDrawableId(isIncognito);
         @Nullable Drawable braveNtpSourceDrawable =
                 AppCompatResources.getDrawable(mContext, drawableId);
         if (braveNtpSourceDrawable == null) {
@@ -81,11 +90,11 @@ public class BraveTabListFaviconProvider extends TabListFaviconProvider {
                 selectedIconColor);
     }
 
-    private int getBraveNtpFaviconDrawableId() {
-        if (ColorUtils.inNightMode(mContext)) {
-            return R.drawable.ic_social_brave_carved_favicon_fullheight;
+    int getBraveNtpFaviconDrawableId(boolean isIncognito) {
+        if (isIncognito || ColorUtils.inNightMode(mContext)) {
+            return BRAVE_NTP_FAVICON_DRAWABLE_ID_FILLED;
         }
-        return R.drawable.ic_social_brave_outline_favicon_fullheight;
+        return BRAVE_NTP_FAVICON_DRAWABLE_ID_OUTLINE;
     }
 
     private Drawable createTintedDrawable(Bitmap bitmap, @ColorInt int color) {

--- a/browser/ui/android/favicon/junit/src/org/chromium/chrome/browser/ui/favicon/BraveTabListFaviconProviderTest.java
+++ b/browser/ui/android/favicon/junit/src/org/chromium/chrome/browser/ui/favicon/BraveTabListFaviconProviderTest.java
@@ -70,6 +70,27 @@ public class BraveTabListFaviconProviderTest {
     }
 
     @Test
+    public void testGetBraveNtpFaviconDrawableIdPrivateTabsMatchDarkVariant() {
+        ColorUtils.setInNightModeForTesting(false);
+        BraveTabListFaviconProvider provider = createProvider(/* isTabStrip= */ false);
+
+        Assert.assertEquals(
+                BraveTabListFaviconProvider.BRAVE_NTP_FAVICON_DRAWABLE_ID_OUTLINE,
+                provider.getBraveNtpFaviconDrawableId(/* isIncognito= */ false));
+        Assert.assertEquals(
+                BraveTabListFaviconProvider.BRAVE_NTP_FAVICON_DRAWABLE_ID_FILLED,
+                provider.getBraveNtpFaviconDrawableId(/* isIncognito= */ true));
+
+        ColorUtils.setInNightModeForTesting(true);
+        Assert.assertEquals(
+                BraveTabListFaviconProvider.BRAVE_NTP_FAVICON_DRAWABLE_ID_FILLED,
+                provider.getBraveNtpFaviconDrawableId(/* isIncognito= */ false));
+        Assert.assertEquals(
+                BraveTabListFaviconProvider.BRAVE_NTP_FAVICON_DRAWABLE_ID_FILLED,
+                provider.getBraveNtpFaviconDrawableId(/* isIncognito= */ true));
+    }
+
+    @Test
     public void testGetRoundedChromeFaviconTabStripDelegatesToUpstream() {
         TabFavicon favicon = createProvider(/* isTabStrip= */ true).getRoundedChromeFavicon(false);
 


### PR DESCRIPTION

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57270.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Summary

The desired behavior is:

<table>
  <thead>
    <tr>
      <th></th>
      <th>Normal tab</th>
      <th>Private tab</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th>Light background</th>
      <td>Outline</td>
      <td>Filled</td>
    </tr>
    <tr>
      <th>Dark background</th>
      <td>Filled</td>
      <td>Filled</td>
    </tr>
  </tbody>
</table>

## Changes 

**Android: fix private NTP favicon appearance** (a5c933942c3)
- Private NTP favicon always uses `BRAVE_NTP_FAVICON_DRAWABLE_ID_FILLED`.
- Add tests

## Screenshots

&nbsp;|Normal tab|Private tab
--|--|--
Light theme |<img width="1080" height="2400" alt="Screenshot-light-normal" src="https://github.com/user-attachments/assets/ffef3fab-52af-4db9-b1f0-dbf749c5823c" />|<img width="1080" height="2400" alt="Screenshot-light-private" src="https://github.com/user-attachments/assets/145fc7e1-8a64-4b7c-8727-e90f4e5276cc" />
Dark theme |<img width="1080" height="2400" alt="Screenshot-dark-normal" src="https://github.com/user-attachments/assets/b753bb9f-57e8-42a7-8c04-c2e27b2cce4e" />|<img width="1080" height="2400" alt="Screenshot-dark-private" src="https://github.com/user-attachments/assets/2a4f9101-8938-435a-8914-5b32b511a85d" />




