### PR TITLE
Select/Deselect subtree when a tab is clicked

### DIFF
--- a/browser/ui/tabs/brave_tab_strip_model.cc
+++ b/browser/ui/tabs/brave_tab_strip_model.cc
@@ -91,7 +91,7 @@ std::vector<int> BraveTabStripModel::GetTreeTabDescendantIndices(int index) {
   }
 
   auto* node_collection =
-      tabs::TreeTabNodeTabCollection::GetNearestTreeTabNodeCollection(
+      tabs::TreeTabNodeTabCollection::GetTreeTabNodeCollection(
           GetTabAtIndex(index));
   if (!node_collection) {
     return {};

--- a/browser/ui/tabs/brave_tab_strip_model.cc
+++ b/browser/ui/tabs/brave_tab_strip_model.cc
@@ -85,6 +85,37 @@ void BraveTabStripModel::SelectRelativeTab(TabRelativeDirection direction,
   }
 }
 
+std::vector<int> BraveTabStripModel::GetTreeTabDescendantIndices(int index) {
+  if (!tree_tab_model_) {
+    return {};
+  }
+
+  auto* node_collection =
+      tabs::TreeTabNodeTabCollection::GetNearestTreeTabNodeCollection(
+          GetTabAtIndex(index));
+  if (!node_collection) {
+    return {};
+  }
+
+  std::vector<tree_tab::TreeTabNodeId> descendant_ids;
+  node_collection->node().CollectDescendantIds(descendant_ids);
+
+  std::vector<int> descendant_indices;
+  for (const auto& id : descendant_ids) {
+    auto* node = tree_tab_model_->GetNode(id);
+    if (!node) {
+      continue;
+    }
+    for (const tabs::TabInterface* descendant_tab : node->GetTabs()) {
+      const int descendant_index = GetIndexOfTab(descendant_tab);
+      if (descendant_index != TabStripModel::kNoTab) {
+        descendant_indices.push_back(descendant_index);
+      }
+    }
+  }
+  return descendant_indices;
+}
+
 void BraveTabStripModel::SelectMRUTab(TabRelativeDirection direction,
                                       TabStripUserGestureDetails detail) {
   if (mru_cycle_list_.empty()) {

--- a/browser/ui/tabs/brave_tab_strip_model.h
+++ b/browser/ui/tabs/brave_tab_strip_model.h
@@ -65,6 +65,13 @@ class BraveTabStripModel : public TabStripModel {
   const tree_tab::TreeTabNodeId* GetTreeTabNodeIdForGroup(
       tab_groups::TabGroupId group_id) const;
 
+  // Returns the recursive tab indices of every tab in the tree tab subtree
+  // rooted at |index|, excluding |index| itself. Returns an empty vector if
+  // tree tabs are disabled or |index|'s tab has no tree tab descendants. Used
+  // by BraveBrowserTabStripController::SelectTab() to expand a mouse click on
+  // a tree-tab parent to select its whole subtree.
+  std::vector<int> GetTreeTabDescendantIndices(int index);
+
   // TabStripModel:
   void SelectRelativeTab(TabRelativeDirection direction,
                          TabStripUserGestureDetails detail) override;

--- a/browser/ui/tabs/test/tree_tabs_browsertest.cc
+++ b/browser/ui/tabs/test/tree_tabs_browsertest.cc
@@ -25,6 +25,9 @@
 #include "chrome/browser/ui/tabs/tab_model.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/tabs/tab_strip.h"
+#include "chrome/browser/ui/views/tabs/tab_strip_controller.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "components/prefs/pref_service.h"
 #include "components/saved_tab_groups/public/tab_group_sync_service.h"
@@ -40,6 +43,7 @@
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "ui/base/models/list_selection_model.h"
+#include "ui/events/event.h"
 
 namespace {
 
@@ -144,6 +148,36 @@ class TreeTabsBrowserTest : public InProcessBrowserTest {
 
   void SetTreeTabsEnabled(bool enabled) {
     profile()->GetPrefs()->SetBoolean(brave_tabs::kTreeTabsEnabled, enabled);
+  }
+
+  // The underlying TabStrip (and its TabStripController) is used regardless
+  // of whether the tab strip is currently displayed horizontally or
+  // vertically, so this is safe to use even with vertical tabs enabled (see
+  // other tests' use of horizontal_tab_strip_for_testing() under
+  // brave/browser/ui/views/frame/vertical_tabs/).
+  TabStripController* controller() {
+    return browser()
+        ->GetBrowserView()
+        .horizontal_tab_strip_for_testing()
+        ->controller();
+  }
+
+  // Simulates clicking |model_index| with a plain (unmodified) left click,
+  // calling TabStripController::SelectTab() the same way
+  // Tab::OnMousePressed()/Tab::OnMouseReleased() do: Tab::OnMousePressed()
+  // only calls SelectTab() on press if the tab wasn't already selected;
+  // Tab::OnMouseReleased() always calls it again afterward when no drag
+  // occurred.
+  void ClickTab(int model_index) {
+    if (!tab_strip_model().IsTabSelected(model_index)) {
+      ui::MouseEvent press(ui::EventType::kMousePressed, gfx::PointF(),
+                           gfx::PointF(), base::TimeTicks::Now(), 0, 0);
+      controller()->SelectTab(model_index, press);
+    }
+
+    ui::MouseEvent release(ui::EventType::kMouseReleased, gfx::PointF(),
+                           gfx::PointF(), base::TimeTicks::Now(), 0, 0);
+    controller()->SelectTab(model_index, release);
   }
 
   // Tab group APIs used in tests require the sync service to report
@@ -3404,4 +3438,129 @@ IN_PROC_BROWSER_TEST_F(TreeTabsBrowserTest,
                 ->GetParentCollection()
                 ->type(),
             tabs::TabCollection::Type::UNPINNED);
+}
+
+// A plain mouse press on a tree-tab parent must expand the selection to
+// include its whole subtree right away - before any release/drag happens -
+// since a subsequent drag reads the live selection at press time.
+IN_PROC_BROWSER_TEST_F(TreeTabsBrowserTest,
+                       SelectTab_PressOnParent_SelectsWholeSubtreeImmediately) {
+  SetTreeTabsEnabled(true);
+
+  auto* parent_tab = tab_strip_model().GetTabAtIndex(0);
+  auto child_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  child_interface->set_opener(parent_tab);
+  tab_strip_model().AddTab(std::move(child_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  ASSERT_EQ(2, tab_strip_model().count());
+
+  ui::MouseEvent press(ui::EventType::kMousePressed, gfx::PointF(),
+                       gfx::PointF(), base::TimeTicks::Now(), 0, 0);
+  controller()->SelectTab(0, press);
+
+  EXPECT_TRUE(tab_strip_model().IsTabSelected(0));
+  EXPECT_TRUE(tab_strip_model().IsTabSelected(1));
+}
+
+// Regression test: releasing the mouse after a plain click (no drag) used to
+// call SelectTab() again with a gesture type that bypassed the subtree
+// expansion, resetting the selection back down to just the clicked tab. The
+// subtree must remain selected after the release.
+IN_PROC_BROWSER_TEST_F(
+    TreeTabsBrowserTest,
+    SelectTab_ClickOnParent_KeepsSubtreeSelectedAfterRelease) {
+  SetTreeTabsEnabled(true);
+
+  auto* parent_tab = tab_strip_model().GetTabAtIndex(0);
+  auto child_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  child_interface->set_opener(parent_tab);
+  tab_strip_model().AddTab(std::move(child_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  ASSERT_EQ(2, tab_strip_model().count());
+
+  ClickTab(0);
+
+  EXPECT_TRUE(tab_strip_model().IsTabSelected(0));
+  EXPECT_TRUE(tab_strip_model().IsTabSelected(1));
+}
+
+// A second plain click on a tree-tab parent whose whole subtree is already
+// selected must collapse the selection back down to just the clicked tab,
+// instead of leaving the subtree selected or re-expanding it.
+IN_PROC_BROWSER_TEST_F(TreeTabsBrowserTest,
+                       SelectTab_ClickParentTwice_TogglesSubtreeSelectionOff) {
+  SetTreeTabsEnabled(true);
+
+  auto* parent_tab = tab_strip_model().GetTabAtIndex(0);
+  auto child_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  child_interface->set_opener(parent_tab);
+  tab_strip_model().AddTab(std::move(child_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  ASSERT_EQ(2, tab_strip_model().count());
+
+  ClickTab(0);
+  ASSERT_TRUE(tab_strip_model().IsTabSelected(0));
+  ASSERT_TRUE(tab_strip_model().IsTabSelected(1));
+
+  ClickTab(0);
+
+  EXPECT_TRUE(tab_strip_model().IsTabSelected(0));
+  EXPECT_FALSE(tab_strip_model().IsTabSelected(1));
+}
+
+// Clicking a tab with no tree-tab descendants must behave exactly like a
+// normal single-tab click - no unrelated tabs should end up selected.
+IN_PROC_BROWSER_TEST_F(TreeTabsBrowserTest,
+                       SelectTab_ClickOnLeafTab_OnlySelectsThatTab) {
+  SetTreeTabsEnabled(true);
+
+  // Add top-level tabs directly with ADD_NONE and no opener - AddTab()
+  // (AppendWebContents with foreground=true) would set ADD_INHERIT_OPENER
+  // and chain each new tab off the currently active tab instead of creating
+  // separate top-level nodes.
+  for (int i = 0; i < 2; ++i) {
+    auto tab_interface = std::make_unique<tabs::TabModel>(CreateWebContents(),
+                                                          &tab_strip_model());
+    tab_strip_model().AddTab(std::move(tab_interface), -1,
+                             ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  }
+  ASSERT_EQ(3, tab_strip_model().count());
+
+  ClickTab(1);
+
+  EXPECT_FALSE(tab_strip_model().IsTabSelected(0));
+  EXPECT_TRUE(tab_strip_model().IsTabSelected(1));
+  EXPECT_FALSE(tab_strip_model().IsTabSelected(2));
+}
+
+// Clicking an unrelated top-level tab must not pull some other tree-tab
+// parent's subtree into the selection.
+IN_PROC_BROWSER_TEST_F(
+    TreeTabsBrowserTest,
+    SelectTab_ClickOnUnrelatedTab_DoesNotSelectOtherSubtree) {
+  SetTreeTabsEnabled(true);
+
+  auto* parent_tab = tab_strip_model().GetTabAtIndex(0);
+  auto child_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  child_interface->set_opener(parent_tab);
+  tab_strip_model().AddTab(std::move(child_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+
+  auto other_tab_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  tab_strip_model().AddTab(std::move(other_tab_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  ASSERT_EQ(3, tab_strip_model().count());
+
+  // Click the unrelated top-level tab (no descendants); the parent+child
+  // subtree must not be pulled into the selection.
+  ClickTab(2);
+
+  EXPECT_FALSE(tab_strip_model().IsTabSelected(0));
+  EXPECT_FALSE(tab_strip_model().IsTabSelected(1));
+  EXPECT_TRUE(tab_strip_model().IsTabSelected(2));
 }

--- a/browser/ui/tabs/test/tree_tabs_browsertest.cc
+++ b/browser/ui/tabs/test/tree_tabs_browsertest.cc
@@ -26,6 +26,9 @@
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/tabs/dragging/tab_drag_controller.h"
+#include "chrome/browser/ui/views/tabs/shared/tab_strip_types.h"
+#include "chrome/browser/ui/views/tabs/tab.h"
 #include "chrome/browser/ui/views/tabs/tab_strip.h"
 #include "chrome/browser/ui/views/tabs/tab_strip_controller.h"
 #include "chrome/test/base/in_process_browser_test.h"
@@ -155,11 +158,10 @@ class TreeTabsBrowserTest : public InProcessBrowserTest {
   // vertically, so this is safe to use even with vertical tabs enabled (see
   // other tests' use of horizontal_tab_strip_for_testing() under
   // brave/browser/ui/views/frame/vertical_tabs/).
-  TabStripController* controller() {
-    return browser()
-        ->GetBrowserView()
-        .horizontal_tab_strip_for_testing()
-        ->controller();
+  TabStripController* controller() { return tab_strip()->controller(); }
+
+  TabStrip* tab_strip() {
+    return browser()->GetBrowserView().horizontal_tab_strip_for_testing();
   }
 
   // Simulates clicking |model_index| with a plain (unmodified) left click,
@@ -3563,4 +3565,58 @@ IN_PROC_BROWSER_TEST_F(
   EXPECT_FALSE(tab_strip_model().IsTabSelected(0));
   EXPECT_FALSE(tab_strip_model().IsTabSelected(1));
   EXPECT_TRUE(tab_strip_model().IsTabSelected(2));
+}
+
+// Regression test for the original bug report: dragging a tree-tab parent
+// used to flatten its child out of the tree, because only the parent was
+// selected by the time the drag started. This drives the real production
+// hand-off - TabSlotController::MaybeStartDrag(), the same method
+// Tab::OnMousePressed() calls right after SelectTab() - to confirm the drag
+// session actually starts with the whole subtree as its live selection,
+// then ends the session immediately with EndDrag() (no ContinueDrag()/
+// movement - that enters the real tab-reorder + native drag-loop machinery,
+// which isn't safe to drive directly from a plain browser_test).
+IN_PROC_BROWSER_TEST_F(TreeTabsBrowserTest,
+                       DragParentTab_StartsDragWithWholeSubtreeSelected) {
+  SetTreeTabsEnabled(true);
+
+  auto* parent_tab = tab_strip_model().GetTabAtIndex(0);
+  auto child_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  child_interface->set_opener(parent_tab);
+  tab_strip_model().AddTab(std::move(child_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  ASSERT_EQ(2, tab_strip_model().count());
+
+  tab_strip()->StopAnimating();
+  Tab* parent_tab_view = tab_strip()->tab_at(0);
+  ASSERT_TRUE(parent_tab_view);
+
+  // Mirrors Tab::OnMousePressed(): snapshot the selection before anything
+  // changes, then (since the parent isn't yet selected) call SelectTab(),
+  // which is where the subtree gets expanded, then hand off to
+  // MaybeStartDrag() with the pre-click selection - exactly as the view layer
+  // does.
+  ui::ListSelectionModel original_selection = tab_strip()->GetSelectionModel();
+  ui::MouseEvent press(ui::EventType::kMousePressed,
+                       gfx::PointF(parent_tab_view->width() / 2.0f,
+                                   parent_tab_view->height() / 2.0f),
+                       gfx::PointF(), base::TimeTicks::Now(),
+                       ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON);
+  controller()->SelectTab(0, press);
+
+  ASSERT_TRUE(tab_strip_model().IsTabSelected(0));
+  ASSERT_TRUE(tab_strip_model().IsTabSelected(1));
+
+  tab_strip()->MaybeStartDrag(parent_tab_view, press, original_selection);
+  ASSERT_TRUE(TabDragController::IsActive());
+
+  // The whole point: MaybeStartDrag() reads the tab strip's live selection
+  // to decide what to drag, and it must still contain both the parent and
+  // child - i.e. a real drag started right now would carry both.
+  EXPECT_TRUE(tab_strip()->IsTabSelected(parent_tab_view));
+  EXPECT_TRUE(tab_strip()->IsTabSelected(tab_strip()->tab_at(1)));
+
+  tab_strip()->EndDrag(EndDragReason::kComplete);
+  EXPECT_FALSE(TabDragController::IsActive());
 }

--- a/browser/ui/views/tabs/brave_browser_tab_strip_controller.cc
+++ b/browser/ui/views/tabs/brave_browser_tab_strip_controller.cc
@@ -5,7 +5,11 @@
 
 #include "brave/browser/ui/views/tabs/brave_browser_tab_strip_controller.h"
 
+#include <algorithm>
+#include <optional>
+#include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include "brave/browser/ui/browser_commands.h"
 #include "brave/browser/ui/tabs/brave_tab_menu_model_factory.h"
@@ -22,11 +26,16 @@
 #include "chrome/browser/sessions/tab_restore_service_factory.h"
 #include "chrome/browser/ui/browser_commands.h"
 #include "chrome/browser/ui/tabs/features.h"
+#include "chrome/browser/ui/tabs/split_tab_util.h"
 #include "chrome/browser/ui/tabs/tab_muted_utils.h"
+#include "chrome/browser/ui/views/tabs/browser_tab_strip_controller.h"
 #include "chrome/browser/ui/views/tabs/tab_strip.h"
 #include "components/prefs/pref_service.h"
 #include "components/sessions/core/tab_restore_service.h"
+#include "components/split_tabs/split_tab_id.h"
 #include "components/tabs/public/tab_interface.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_set.h"
+#include "ui/events/event.h"
 #include "ui/views/view_utils.h"
 
 BraveBrowserTabStripController::BraveBrowserTabStripController(
@@ -326,6 +335,113 @@ void BraveBrowserTabStripController::OnTreeTabChanged(
     }
     case TreeTabChange::Type::kNodeReparented:
       break;
+  }
+}
+
+void BraveBrowserTabStripController::SelectTab(int model_index,
+                                               const ui::Event& event) {
+  auto* brave_model = static_cast<BraveTabStripModel*>(model_.get());
+  if (!brave_model->tree_model() ||
+      model_index < model_->IndexOfFirstNonPinnedTab()) {
+    BrowserTabStripController::SelectTab(model_index, event);
+    return;
+  }
+
+  // Tab::OnMousePressed() and Tab::OnMouseReleased() both funnel a plain
+  // (unmodified) click through SelectTab(): press calls it for a
+  // not-yet-selected tab, and release always calls it when no drag occurred,
+  // to reset a stale multi-selection down to just the clicked tab. Expanding
+  // a tree-tab parent's selection to its whole subtree needs to happen for
+  // both, so a subsequent drag (which reads the live selection at press time)
+  // carries the subtree along, and the expansion isn't immediately undone by
+  // the no-drag reset on release. Other callers of SelectTab() (keyboard,
+  // touch, context menu, tests) keep the default single-tab behavior.
+  // The possible scenarios are:
+  // 1. Click on a not-yet-selected tab: SelectTab() is called TWICE for the
+  //    same physical click - once on press (expanding the subtree), and
+  //    again on release right afterward (since release always fires when no
+  //    drag occurred). Without tree_tab_subtree_expanded_on_press_index_,
+  //    that second call can't tell "I'm the tail end of the click
+  //    that just expanded this subtree" apart from "I'm a separate, later
+  //    click on an already-selected subtree" - both look identical from
+  //    here - so it would misread its own press-time expansion as a
+  //    deliberate second click and collapse it right back.
+  //    - If the user instead starts dragging after the press, only the press
+  //      call happens (release's SelectTab() call is skipped when a real
+  //      drag completes), so the whole subtree is already selected by the
+  //      time the drag reads the live selection.
+  // 2. Click on an already-selected tab: press is skipped entirely (Tab::
+  //    OnMousePressed() only calls SelectTab() for a not-yet-selected tab),
+  //    so only the release call happens, and it toggles the subtree
+  //    selection on/off.
+  //    - Press on an already-selected tab and then dragging away doesn't
+  //      call SelectTab() at all, so the selection is left untouched.
+  const bool is_plain_mouse_click =
+      event.type() == ui::EventType::kMousePressed ||
+      event.type() == ui::EventType::kMouseReleased;
+
+  // Consumed at most once: read whatever the previous call left behind, then
+  // clear it so it can't leak into some unrelated later call (e.g. if a real
+  // drag intervenes and the paired release never arrives).
+  const std::optional<int> expanded_on_previous_press =
+      tree_tab_subtree_expanded_on_press_index_;
+  tree_tab_subtree_expanded_on_press_index_.reset();
+
+  std::vector<int> descendant_indices;
+  bool subtree_already_selected = false;
+  int resolved_index = model_index;
+  if (is_plain_mouse_click) {
+    // Resolve to the tab this call will actually activate (a split's last-
+    // active member), matching BrowserTabStripController::SelectTab()'s own
+    // redirect, so we consider the right tab's tree-tab descendants.
+    if (std::optional<split_tabs::SplitTabId> split_id =
+            tabstrip_->tab_at(model_index)->split();
+        split_id.has_value()) {
+      resolved_index =
+          split_tabs::GetIndexOfLastActiveTab(model_, split_id.value());
+    }
+
+    descendant_indices =
+        brave_model->GetTreeTabDescendantIndices(resolved_index);
+    if (!descendant_indices.empty()) {
+      if (event.type() == ui::EventType::kMouseReleased &&
+          expanded_on_previous_press == resolved_index) {
+        // This release is the second half of the same click that already
+        // expanded the subtree on press moments ago - not a deliberate,
+        // separate second click. Don't treat it as a toggle-off.
+        subtree_already_selected = false;
+      } else {
+        // If the whole subtree is already selected (e.g. a second, unmodified
+        // click on a tree node that was already selected together with its
+        // descendants), collapse the selection back down to just the clicked
+        // tab instead of re-expanding it.
+        subtree_already_selected =
+            model_->IsTabSelected(resolved_index) &&
+            std::ranges::all_of(descendant_indices, [this](int i) {
+              return model_->IsTabSelected(i);
+            });
+      }
+    }
+  }
+
+  BrowserTabStripController::SelectTab(model_index, event);
+
+  if (descendant_indices.empty() || subtree_already_selected) {
+    return;
+  }
+
+  absl::flat_hash_set<tabs::TabInterface*> descendant_tabs;
+  for (int descendant_index : descendant_indices) {
+    descendant_tabs.insert(model_->GetTabAtIndex(descendant_index));
+  }
+
+  tabs::TabStripModelSelectionState new_selection = model_->selection_model();
+  new_selection.AppendTabsToSelection(std::unordered_set<tabs::TabInterface*>(
+      descendant_tabs.begin(), descendant_tabs.end()));
+  model_->SetSelectionFromModel(std::move(new_selection));
+
+  if (event.type() == ui::EventType::kMousePressed) {
+    tree_tab_subtree_expanded_on_press_index_ = resolved_index;
   }
 }
 

--- a/browser/ui/views/tabs/brave_browser_tab_strip_controller.h
+++ b/browser/ui/views/tabs/brave_browser_tab_strip_controller.h
@@ -60,6 +60,7 @@ class BraveBrowserTabStripController : public BrowserTabStripController {
   void OnTreeTabChanged(const TreeTabChange& change) override;
 
   // BrowserTabStripController overrides:
+  void SelectTab(int model_index, const ui::Event& event) override;
   void ExecuteContextMenuCommand(tabs::TabInterface* tab,
                                  TabStripModel::ContextMenuCommand command_id,
                                  int event_flags) override;
@@ -77,6 +78,18 @@ class BraveBrowserTabStripController : public BrowserTabStripController {
   bool ShouldShowTreeTabs();
 
   void ExpandAllCollapsedAncestors(const tree_tab::TreeTabNodeId& id);
+
+  // Set to the resolved model index right after SelectTab() expands a
+  // tree-tab parent's subtree selection on a mouse press, and consumed (read
+  // then cleared) by the very next SelectTab() call. Tab::OnMousePressed()
+  // only calls SelectTab() on press when the tab wasn't already selected, and
+  // Tab::OnMouseReleased() unconditionally calls it again right afterward
+  // when no drag occurred - so a first click on a previously-unselected
+  // parent produces two SelectTab() calls for the same physical click. Without
+  // this, the release call would see the subtree as "already selected" (from
+  // the press moments earlier) and mistake it for a deliberate second click,
+  // collapsing what it just selected. See SelectTab() for details.
+  std::optional<int> tree_tab_subtree_expanded_on_press_index_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_BROWSER_TAB_STRIP_CONTROLLER_H_


### PR DESCRIPTION
This will allow users move a whole tab tree by clicking a parent tab. We're handling this in BraveBrowserTabStripController::SelectTab() because this method is called either mouse press or release, and won't be called after drag and drop. So it's best place to toggle selection of a tab

<!-- Add brave-browser issue below that this PR will resolve -->
- Part of https://github.com/brave/brave-browser/issues/57228

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
