### PR TITLE
[ads] Fetch subdivision on network change

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -210,6 +210,8 @@ AdsServiceImpl::AdsServiceImpl(
   InitializeLocalStatePrefChangeRegistrar();
   InitializePrefChangeRegistrar();
 
+  net::NetworkChangeNotifier::AddNetworkChangeObserver(this);
+
   // Defer the initial start until the policy bundle has been merged into the
   // managed pref store, so that `BraveRewardsDisabled` (and any other policy
   // that gates ads eligibility) takes effect before the gate evaluates.
@@ -218,11 +220,11 @@ AdsServiceImpl::AdsServiceImpl(
                      weak_ptr_factory_.GetWeakPtr()));
 }
 
-AdsServiceImpl::~AdsServiceImpl() = default;
+AdsServiceImpl::~AdsServiceImpl() {
+  net::NetworkChangeNotifier::RemoveNetworkChangeObserver(this);
+}
 
 ///////////////////////////////////////////////////////////////////////////////
-
-
 
 void AdsServiceImpl::Migrate() {
   // Added 10/2025.
@@ -1770,6 +1772,17 @@ void AdsServiceImpl::OnContentSettingChanged(
     ContentSettingsTypeSet content_type_set) {
   if (content_type_set.Contains(ContentSettingsType::JAVASCRIPT)) {
     SetContentSettings();
+  }
+}
+
+void AdsServiceImpl::OnNetworkChanged(
+    net::NetworkChangeNotifier::ConnectionType connection_type) {
+  if (connection_type == net::NetworkChangeNotifier::CONNECTION_NONE) {
+    return;
+  }
+
+  if (bat_ads_client_notifier_remote_.is_bound()) {
+    bat_ads_client_notifier_remote_->NotifyNetworkConnectionChanged();
   }
 }
 

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -53,6 +53,7 @@
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "mojo/public/cpp/bindings/remote.h"
+#include "net/base/network_change_notifier.h"
 #include "ui/base/idle/idle.h"
 
 namespace brave_rewards {
@@ -89,15 +90,17 @@ class ResourceComponent;
 class ApplicationStateMonitor;
 class HttpClient;
 
-class AdsServiceImpl : public AdsService,
-                       public bat_ads::mojom::BatAdsClient,
-                       public bat_ads::mojom::BatAdsObserver,
-                       public ApplicationStateObserver,
-                       public ResourceComponentObserver,
+class AdsServiceImpl
+    : public AdsService,
+      public bat_ads::mojom::BatAdsClient,
+      public bat_ads::mojom::BatAdsObserver,
+      public ApplicationStateObserver,
+      public ResourceComponentObserver,
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
-                       public brave_rewards::RewardsServiceObserver,
+      public brave_rewards::RewardsServiceObserver,
 #endif
-                       public content_settings::Observer {
+      public content_settings::Observer,
+      public net::NetworkChangeNotifier::NetworkChangeObserver {
  public:
   // `http_client`, `history_service`, and `host_content_settings` can be
   // `nullptr` in tests. `rewards_service` can be `nullptr` when Rewards is
@@ -423,6 +426,10 @@ class AdsServiceImpl : public AdsService,
       const ContentSettingsPattern& primary_pattern,
       const ContentSettingsPattern& secondary_pattern,
       ContentSettingsTypeSet content_type_set) override;
+
+  // net::NetworkChangeNotifier::NetworkChangeObserver:
+  void OnNetworkChanged(
+      net::NetworkChangeNotifier::ConnectionType connection_type) override;
 
   bool is_ineligible_to_start_ = false;
 

--- a/components/brave_ads/browser/ads_service_impl_unittest.cc
+++ b/components/brave_ads/browser/ads_service_impl_unittest.cc
@@ -11,7 +11,6 @@
 #include "base/files/scoped_temp_dir.h"
 #include "base/functional/function_ref.h"
 #include "base/memory/raw_ptr.h"
-#include "base/numerics/safe_math.h"
 #include "base/test/run_until.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
@@ -36,6 +35,7 @@
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/testing_pref_service.h"
 #include "components/variations/pref_names.h"
+#include "net/base/network_change_notifier.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "ui/base/idle/idle.h"
@@ -136,6 +136,11 @@ class BraveAdsAdsServiceImplTest : public testing::Test {
 
   void SimulateIdleState(ui::IdleState idle_state, base::TimeDelta idle_time) {
     ads_service_->ProcessIdleState(idle_state, idle_time);
+  }
+
+  void SimulateNetworkChanged(
+      net::NetworkChangeNotifier::ConnectionType connection_type) {
+    ads_service_->OnNetworkChanged(connection_type);
   }
 
   base::test::TaskEnvironment task_environment_;
@@ -759,6 +764,48 @@ TEST_F(BraveAdsAdsServiceImplTest,
 
   // Assert
   EXPECT_FALSE(test_future.Get());
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       NotifiesNetworkConnectionChangedWhenConnected) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  Startup();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
+
+  // Act
+  SimulateNetworkChanged(net::NetworkChangeNotifier::CONNECTION_WIFI);
+
+  // Assert
+  EXPECT_TRUE(base::test::RunUntil([&] {
+    return bat_ads_service_factory_->network_connection_changed_count() == 1U;
+  }));
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       DoesNotNotifyNetworkConnectionChangedWhenDisconnected) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  Startup();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
+
+  // Act
+  SimulateNetworkChanged(net::NetworkChangeNotifier::CONNECTION_NONE);
+
+  // Assert
+  EXPECT_EQ(0U, bat_ads_service_factory_->network_connection_changed_count());
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       DoesNotNotifyNetworkConnectionChangedBeforeServiceHasStarted) {
+  // Act: the service is never started, so `bat_ads_client_notifier_remote_`
+  // is never bound.
+  SimulateNetworkChanged(net::NetworkChangeNotifier::CONNECTION_WIFI);
+
+  // Assert
+  EXPECT_EQ(0U, bat_ads_service_factory_->network_connection_changed_count());
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/browser/ads_service_impl_unittest.cc
+++ b/components/brave_ads/browser/ads_service_impl_unittest.cc
@@ -11,7 +11,6 @@
 #include "base/files/scoped_temp_dir.h"
 #include "base/functional/function_ref.h"
 #include "base/memory/raw_ptr.h"
-#include "base/numerics/safe_math.h"
 #include "base/test/run_until.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
@@ -36,6 +35,7 @@
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/testing_pref_service.h"
 #include "components/variations/pref_names.h"
+#include "net/base/network_change_notifier.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "ui/base/idle/idle.h"
@@ -136,6 +136,11 @@ class BraveAdsAdsServiceImplTest : public testing::Test {
 
   void SimulateIdleState(ui::IdleState idle_state, base::TimeDelta idle_time) {
     ads_service_->ProcessIdleState(idle_state, idle_time);
+  }
+
+  void SimulateNetworkChanged(
+      net::NetworkChangeNotifier::ConnectionType connection_type) {
+    ads_service_->OnNetworkChanged(connection_type);
   }
 
   base::test::TaskEnvironment task_environment_;
@@ -758,6 +763,48 @@ TEST_F(BraveAdsAdsServiceImplTest,
 
   // Assert
   EXPECT_FALSE(test_future.Get());
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       NotifiesNetworkConnectionChangedWhenConnected) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  Startup();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
+
+  // Act
+  SimulateNetworkChanged(net::NetworkChangeNotifier::CONNECTION_WIFI);
+
+  // Assert
+  EXPECT_TRUE(base::test::RunUntil([&] {
+    return bat_ads_service_factory_->network_connection_changed_count() == 1U;
+  }));
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       DoesNotNotifyNetworkConnectionChangedWhenDisconnected) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  Startup();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
+
+  // Act
+  SimulateNetworkChanged(net::NetworkChangeNotifier::CONNECTION_NONE);
+
+  // Assert
+  EXPECT_EQ(0U, bat_ads_service_factory_->network_connection_changed_count());
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       DoesNotNotifyNetworkConnectionChangedBeforeServiceHasStarted) {
+  // Act: the service is never started, so `bat_ads_client_notifier_remote_`
+  // is never bound.
+  SimulateNetworkChanged(net::NetworkChangeNotifier::CONNECTION_WIFI);
+
+  // Assert
+  EXPECT_EQ(0U, bat_ads_service_factory_->network_connection_changed_count());
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/browser/test/fake_bat_ads_client_notifier.cc
+++ b/components/brave_ads/browser/test/fake_bat_ads_client_notifier.cc
@@ -34,4 +34,8 @@ void FakeBatAdsClientNotifier::NotifyUserDidBecomeActive(
   last_screen_was_locked_ = screen_was_locked;
 }
 
+void FakeBatAdsClientNotifier::NotifyNetworkConnectionChanged() {
+  ++network_connection_changed_count_;
+}
+
 }  // namespace brave_ads::test

--- a/components/brave_ads/browser/test/fake_bat_ads_client_notifier.h
+++ b/components/brave_ads/browser/test/fake_bat_ads_client_notifier.h
@@ -24,8 +24,9 @@ class PendingReceiver;
 
 namespace brave_ads::test {
 
-// Records calls to `NotifyUserDidBecomeIdle` and `NotifyUserDidBecomeActive`
-// so tests can assert on idle notification counts and arguments.
+// Records calls to `NotifyUserDidBecomeIdle`, `NotifyUserDidBecomeActive`, and
+// `NotifyNetworkConnectionChanged` so tests can assert on notification counts
+// and arguments.
 class FakeBatAdsClientNotifier : public bat_ads::mojom::BatAdsClientNotifier {
  public:
   FakeBatAdsClientNotifier();
@@ -42,6 +43,9 @@ class FakeBatAdsClientNotifier : public bat_ads::mojom::BatAdsClientNotifier {
   size_t become_active_count() const { return become_active_count_; }
   base::TimeDelta last_idle_time() const { return last_idle_time_; }
   bool last_screen_was_locked() const { return last_screen_was_locked_; }
+  size_t network_connection_changed_count() const {
+    return network_connection_changed_count_;
+  }
 
   // bat_ads::mojom::BatAdsClientNotifier:
   void NotifyDidInitializeAds() override {}
@@ -72,6 +76,7 @@ class FakeBatAdsClientNotifier : public bat_ads::mojom::BatAdsClientNotifier {
   void NotifyUserDidBecomeIdle() override;
   void NotifyUserDidBecomeActive(base::TimeDelta idle_time,
                                  bool screen_was_locked) override;
+  void NotifyNetworkConnectionChanged() override;
   void NotifyBrowserDidEnterForeground() override {}
   void NotifyBrowserDidEnterBackground() override {}
   void NotifyBrowserDidBecomeActive() override {}
@@ -83,6 +88,7 @@ class FakeBatAdsClientNotifier : public bat_ads::mojom::BatAdsClientNotifier {
   size_t become_active_count_ = 0;
   base::TimeDelta last_idle_time_;
   bool last_screen_was_locked_ = false;
+  size_t network_connection_changed_count_ = 0;
 
   mojo::Receiver<bat_ads::mojom::BatAdsClientNotifier> receiver_{this};
 };

--- a/components/brave_ads/browser/test/fake_bat_ads_service_factory.cc
+++ b/components/brave_ads/browser/test/fake_bat_ads_service_factory.cc
@@ -48,6 +48,11 @@ bool FakeBatAdsServiceFactory::last_screen_was_locked() const {
   return notifier ? notifier->last_screen_was_locked() : false;
 }
 
+size_t FakeBatAdsServiceFactory::network_connection_changed_count() const {
+  const FakeBatAdsClientNotifier* const notifier = bat_ads_client_notifier();
+  return notifier ? notifier->network_connection_changed_count() : 0U;
+}
+
 mojo::Remote<bat_ads::mojom::BatAdsService> FakeBatAdsServiceFactory::Launch()
     const {
   ++launch_count_;

--- a/components/brave_ads/browser/test/fake_bat_ads_service_factory.h
+++ b/components/brave_ads/browser/test/fake_bat_ads_service_factory.h
@@ -38,6 +38,7 @@ class FakeBatAdsServiceFactory : public BatAdsServiceFactory {
   size_t become_active_count() const;
   base::TimeDelta last_idle_time() const;
   bool last_screen_was_locked() const;
+  size_t network_connection_changed_count() const;
 
   // Causes subsequently launched services to report initialization failure.
   void set_simulate_initialization_failure() {

--- a/components/brave_ads/core/internal/ads_client/ads_client_notifier.cc
+++ b/components/brave_ads/core/internal/ads_client/ads_client_notifier.cc
@@ -49,6 +49,17 @@ void AdsClientNotifier::NotifyDidInitializeAds() {
   observers_.Notify(&AdsClientNotifierObserver::OnNotifyDidInitializeAds);
 }
 
+void AdsClientNotifier::NotifyNetworkConnectionChanged() {
+  if (task_queue_->should_queue()) {
+    return task_queue_->Add(
+        base::BindOnce(&AdsClientNotifier::NotifyNetworkConnectionChanged,
+                       weak_factory_.GetWeakPtr()));
+  }
+
+  observers_.Notify(
+      &AdsClientNotifierObserver::OnNotifyNetworkConnectionChanged);
+}
+
 void AdsClientNotifier::NotifyRewardsWalletDidUpdate(
     const std::string& payment_id,
     const std::string& recovery_seed_base64) {

--- a/components/brave_ads/core/internal/common/subdivision/subdivision.cc
+++ b/components/brave_ads/core/internal/common/subdivision/subdivision.cc
@@ -85,6 +85,12 @@ void Subdivision::OnNotifyDidInitializeAds() {
   Initialize();
 }
 
+void Subdivision::OnNotifyNetworkConnectionChanged() {
+  if (subdivision_url_request_) {
+    subdivision_url_request_->Refetch();
+  }
+}
+
 void Subdivision::OnNotifyPrefDidChange(const std::string& path) {
   if (DoesMatchUserHasJoinedBraveRewardsPrefPath(path) ||
       DoesMatchUserHasOptedInToNotificationAdsPrefPath(path)) {

--- a/components/brave_ads/core/internal/common/subdivision/subdivision.cc
+++ b/components/brave_ads/core/internal/common/subdivision/subdivision.cc
@@ -85,6 +85,12 @@ void Subdivision::OnNotifyDidInitializeAds() {
   Initialize();
 }
 
+void Subdivision::OnNotifyNetworkConnectionChanged() {
+  if (subdivision_url_request_) {
+    subdivision_url_request_->Refetch();
+  }
+}
+
 void Subdivision::OnNotifyPrefDidChange(const std::string& path) {
   if (DoesMatchUserHasJoinedBraveRewardsPrefPath(path) ||
       DoesMatchNotificationAdsEnabledPrefPath(path)) {

--- a/components/brave_ads/core/internal/common/subdivision/subdivision.h
+++ b/components/brave_ads/core/internal/common/subdivision/subdivision.h
@@ -46,6 +46,7 @@ class Subdivision final : public AdsClientNotifierObserver,
 
   // AdsClientNotifierObserver:
   void OnNotifyDidInitializeAds() override;
+  void OnNotifyNetworkConnectionChanged() override;
   void OnNotifyPrefDidChange(const std::string& path) override;
 
   // SubdivisionUrlRequestDelegate:

--- a/components/brave_ads/core/internal/common/subdivision/subdivision_unittest.cc
+++ b/components/brave_ads/core/internal/common/subdivision/subdivision_unittest.cc
@@ -98,6 +98,34 @@ TEST_F(BraveAdsSubdivisionTest, DoNotFetchWhenOptingOutOfNotificationAds) {
   SetProfileBooleanPref(prefs::kOptedInToNotificationAds, false);
 }
 
+TEST_F(BraveAdsSubdivisionTest, FetchIfNetworkConnectionChanges) {
+  // Arrange
+  MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
+
+  ads_client_notifier_.NotifyDidInitializeAds();
+
+  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision("US-CA"));
+
+  // Act
+  ads_client_notifier_.NotifyNetworkConnectionChanged();
+
+  // Assert
+  EXPECT_TRUE(HasPendingTasks());
+}
+
+TEST_F(BraveAdsSubdivisionTest,
+       DoNotFetchIfNetworkConnectionChangesWhenSubdivisionFetchingIsDisabled) {
+  // Arrange
+  test::OptOutOfAllAds();
+
+  MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
+
+  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision).Times(0);
+
+  // Act & Assert
+  ads_client_notifier_.NotifyNetworkConnectionChanged();
+}
+
 TEST_F(BraveAdsSubdivisionTest, FetchWhenOptingInToNotificationAds) {
   // Arrange
   test::OptOutOfAllAds();

--- a/components/brave_ads/core/internal/common/subdivision/subdivision_unittest.cc
+++ b/components/brave_ads/core/internal/common/subdivision/subdivision_unittest.cc
@@ -98,6 +98,34 @@ TEST_F(BraveAdsSubdivisionTest, DoNotFetchWhenOptingOutOfNotificationAds) {
   SetProfileBooleanPref(prefs::kNotificationsEnabled, false);
 }
 
+TEST_F(BraveAdsSubdivisionTest, FetchIfNetworkConnectionChanges) {
+  // Arrange
+  MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
+
+  ads_client_notifier_.NotifyDidInitializeAds();
+
+  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision("US-CA"));
+
+  // Act
+  ads_client_notifier_.NotifyNetworkConnectionChanged();
+
+  // Assert
+  EXPECT_TRUE(HasPendingTasks());
+}
+
+TEST_F(BraveAdsSubdivisionTest,
+       DoNotFetchIfNetworkConnectionChangesWhenSubdivisionFetchingIsDisabled) {
+  // Arrange
+  test::OptOutOfAllAds();
+
+  MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
+
+  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision).Times(0);
+
+  // Act & Assert
+  ads_client_notifier_.NotifyNetworkConnectionChanged();
+}
+
 TEST_F(BraveAdsSubdivisionTest, FetchWhenOptingInToNotificationAds) {
   // Arrange
   test::OptOutOfAllAds();

--- a/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request.cc
+++ b/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request.cc
@@ -50,6 +50,12 @@ void SubdivisionUrlRequest::PeriodicallyFetch() {
   Fetch();
 }
 
+void SubdivisionUrlRequest::Refetch() {
+  timer_.Stop();
+  is_periodically_fetching_ = false;
+  PeriodicallyFetch();
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 void SubdivisionUrlRequest::Fetch() {

--- a/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request.h
+++ b/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request.h
@@ -33,6 +33,10 @@ class SubdivisionUrlRequest final {
 
   void PeriodicallyFetch();
 
+  // Stops any pending timer and re-triggers a fetch. Safe to call while a
+  // fetch is already in-flight; the in-flight fetch will complete normally.
+  void Refetch();
+
  private:
   void Fetch();
   void FetchCallback(const mojom::UrlResponseInfo& mojom_url_response);

--- a/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request_unittest.cc
+++ b/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request_unittest.cc
@@ -8,6 +8,8 @@
 #include <memory>
 #include <string>
 
+#include "base/time/time.h"
+#include "brave/components/brave_ads/core/internal/common/random/test/scoped_rand_time_delta_with_jitter_for_testing.h"
 #include "brave/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request_builder_util.h"
 #include "brave/components/brave_ads/core/internal/common/subdivision/url_request/test/subdivision_url_request_delegate_mock.h"
 #include "brave/components/brave_ads/core/internal/common/subdivision/url_request/test/subdivision_url_request_test_util.h"
@@ -169,6 +171,55 @@ TEST_F(BraveAdsSubdivisionUrlRequestTest,
 
   // Assert
   EXPECT_TRUE(HasPendingTasks());
+}
+
+TEST_F(BraveAdsSubdivisionUrlRequestTest, RefetchesImmediatelyWhenIdle) {
+  // Arrange
+  const test::URLResponseMap url_responses = {
+      {BuildSubdivisionUrlPath(),
+       {{net::HTTP_OK,
+         test::BuildSubdivisionUrlResponseBody(/*country_code=*/"US",
+                                               /*subdivision_code=*/"CA")}}}};
+  test::MockUrlResponses(ads_client_mock_, url_responses);
+
+  // Act
+  subdivision_url_request_->Refetch();
+
+  // Assert
+  EXPECT_TRUE(HasPendingTasks());
+}
+
+TEST_F(BraveAdsSubdivisionUrlRequestTest,
+       RefetchCancelsPendingPeriodicFetchAndFetchesImmediately) {
+  // Arrange: pin the timer's random privacy jitter to exactly `kFetchAfter` so
+  // the pending delay is deterministic instead of a random value in a range.
+  constexpr base::TimeDelta kFetchAfter = base::Days(1);
+  const test::ScopedRandTimeDeltaWithJitterForTesting
+      scoped_rand_time_delta_with_jitter(kFetchAfter);
+
+  const test::URLResponseMap url_responses = {
+      {BuildSubdivisionUrlPath(),
+       {{net::HTTP_OK,
+         test::BuildSubdivisionUrlResponseBody(/*country_code=*/"US",
+                                               /*subdivision_code=*/"CA")}}}};
+  test::MockUrlResponses(ads_client_mock_, url_responses);
+
+  subdivision_url_request_->PeriodicallyFetch();
+  ASSERT_EQ(kFetchAfter, NextPendingTaskDelay());
+
+  // Fast-forward to partway through the wait for the next periodic fetch.
+  FastForwardClockBy(base::Hours(23));
+  ASSERT_EQ(base::Hours(1), NextPendingTaskDelay());
+
+  // Act: cancels the 1 hour remaining on the periodic fetch timer scheduled
+  // by `PeriodicallyFetch` and fetches again straight away instead of
+  // waiting for it to fire.
+  subdivision_url_request_->Refetch();
+
+  // Assert: the next fetch is rescheduled a full `kFetchAfter` out again,
+  // proving the pending timer was cancelled rather than left to fire on its
+  // original schedule.
+  EXPECT_EQ(kFetchAfter, NextPendingTaskDelay());
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/public/ads_client/ads_client_notifier.h
+++ b/components/brave_ads/core/public/ads_client/ads_client_notifier.h
@@ -38,6 +38,7 @@ class AdsClientNotifier final {
   void RemoveObserver(AdsClientNotifierObserver* observer);
   void NotifyPendingObservers();
   void NotifyDidInitializeAds();
+  void NotifyNetworkConnectionChanged();
   void NotifyPrefDidChange(const std::string& path);
   void NotifyResourceComponentDidChange(const std::string& manifest_version,
                                         const std::string& id);

--- a/components/brave_ads/core/public/ads_client/ads_client_notifier_observer.h
+++ b/components/brave_ads/core/public/ads_client/ads_client_notifier_observer.h
@@ -25,6 +25,9 @@ class AdsClientNotifierObserver : public base::CheckedObserver {
   // Called when ads did initialize.
   virtual void OnNotifyDidInitializeAds() {}
 
+  // Invoked when the network connection type changes.
+  virtual void OnNotifyNetworkConnectionChanged() {}
+
   // Invoked when a preference has changed for the specified `path`.
   virtual void OnNotifyPrefDidChange(const std::string& path) {}
 

--- a/components/services/bat_ads/bat_ads_client_notifier_impl.cc
+++ b/components/services/bat_ads/bat_ads_client_notifier_impl.cc
@@ -45,6 +45,10 @@ void BatAdsClientNotifierImpl::NotifyDidInitializeAds() {
   ads_client_notifier_.NotifyDidInitializeAds();
 }
 
+void BatAdsClientNotifierImpl::NotifyNetworkConnectionChanged() {
+  ads_client_notifier_.NotifyNetworkConnectionChanged();
+}
+
 void BatAdsClientNotifierImpl::NotifyPrefDidChange(const std::string& path) {
   ads_client_notifier_.NotifyPrefDidChange(path);
 }

--- a/components/services/bat_ads/bat_ads_client_notifier_impl.h
+++ b/components/services/bat_ads/bat_ads_client_notifier_impl.h
@@ -40,6 +40,7 @@ class BatAdsClientNotifierImpl final
 
   // bat_ads::mojom::BatAdsClientNotifier:
   void NotifyDidInitializeAds() override;
+  void NotifyNetworkConnectionChanged() override;
   void NotifyPrefDidChange(const std::string& path) override;
   void NotifyResourceComponentDidChange(const std::string& manifest_version,
                                         const std::string& id) override;

--- a/components/services/bat_ads/public/interfaces/bat_ads.mojom
+++ b/components/services/bat_ads/public/interfaces/bat_ads.mojom
@@ -27,6 +27,8 @@ interface BatAdsClientNotifier {
 
   NotifyDidInitializeAds();
 
+  NotifyNetworkConnectionChanged();
+
   NotifyPrefDidChange(string path);
 
   NotifyResourceComponentDidChange(string manifest_version, string id);

--- a/ios/browser/api/ads/brave_ads.mm
+++ b/ios/browser/api/ads/brave_ads.mm
@@ -349,6 +349,9 @@ constexpr NSString* kAdsResourceComponentMetadataVersion = @".v1";
         strongSelf.networkConnectivityAvailable =
             (nw_path_get_status(path) == nw_path_status_satisfied ||
              nw_path_get_status(path) == nw_path_status_satisfiable);
+        dispatch_async(dispatch_get_main_queue(), ^{
+          [strongSelf notifyNetworkConnectionChanged];
+        });
       });
   nw_path_monitor_start(networkMonitor);
 }
@@ -1695,6 +1698,12 @@ constexpr NSString* kAdsResourceComponentMetadataVersion = @".v1";
 - (void)notifyDidCloseTab:(NSInteger)tabId {
   if (adsService) {
     adsService->NotifyDidCloseTab(static_cast<int32_t>(tabId));
+  }
+}
+
+- (void)notifyNetworkConnectionChanged {
+  if (adsService) {
+    adsService->GetAdsClientNotifier()->NotifyNetworkConnectionChanged();
   }
 }
 


### PR DESCRIPTION
Add network change observation so subdivision data is re-fetched when the connection type changes, keeping geographic ad targeting current when users switch networks.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/33273

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
