### PR TITLE
[plaster][ast-grep] `add_to_public` rewriter

### DIFF
--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -138,6 +138,7 @@ introduce more rewriters. These are the ones we have supported for now.
 | `after_function_impl`   | AST  | Wraps a C++ function body and runs code after.    |
 | `rename_class`          | AST  | Renames a C++ class.                              |
 | `add_to_protected`      | AST  | Adds a member to a class `protected:` section.    |
+| `add_to_public`         | AST  | Appends a member to a class `public:` section.    |
 
 Use `plaster --help` to discover rewriters and read their full docs:
 

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -1509,20 +1509,39 @@ class AddToProtected(_AstGrepRewriter):
               description: str,
               blank_for_parse: bool = False) -> tuple[str, list[str]]:
         # The code is inserted exactly once either in an existing protected
-        # section or in a new one created just before a private section.
+        # section or in a new one created just before a private section. Each
+        # placement is indented to the anchor's real column (Chromium members
+        # sit one space in from their access specifier), so a nested class is
+        # indented correctly rather than at the top-level column.
         del count, description
         engine = AstRewriter(RewritersEval.load(),
                              contents,
                              blank_for_parse=blank_for_parse)
-        code = _indent_yaml(self._code).replace('\\', '\\\\')
-        inputs = {'class_name': self._class_name, 'code': code}
-        op = Operation(self._ADD_TO_EXISTING, inputs,
-                       MatchExpectation.exactly(1))
+        source = contents.encode('utf-8')
+        class_inputs = {'class_name': self._class_name}
+
+        anchor = engine.first_match(
+            Operation(self._ADD_TO_EXISTING, class_inputs))
+        if anchor is not None:
+            member = len(_leading_indent(source, anchor.start)) + 1
+            op = Operation(
+                self._ADD_TO_EXISTING, {
+                    'class_name': self._class_name,
+                    'code': _indent_code(self._code, member),
+                }, MatchExpectation.exactly(1))
+        else:
+            anchor = engine.first_match(
+                Operation(self._CREATE_BEFORE_PRIVATE, class_inputs))
+            # A missing anchor leaves the run to report the count shortfall.
+            indent = _leading_indent(source, anchor.start) if anchor else ''
+            op = Operation(
+                self._CREATE_BEFORE_PRIVATE, {
+                    'class_name': self._class_name,
+                    'code': _indent_code(self._code,
+                                         len(indent) + 1),
+                    'indent': indent,
+                }, MatchExpectation.exactly(1))
         changes = engine.run(op)
-        if changes == 0:
-            op = Operation(self._CREATE_BEFORE_PRIVATE, inputs,
-                           MatchExpectation.exactly(1))
-            changes = engine.run(op)
         error = op.expectation.error_for(changes)
         return engine.content, [error] if error else []
 
@@ -1549,11 +1568,130 @@ class AddToProtected(_AstGrepRewriter):
         return cls(class_name=body['class_name'], code=body['code'])
 
 
+class AddToPublic(_AstGrepRewriter):
+    """Append a member declaration to the end of a C++ class's `public:` section
+    """
+
+    NAME: Final = 'add_to_public'
+    # Two ops share the work (see `apply`); this names the language and a
+    # representative op for the base's helpers.
+    OP_ID: Final = 'cxx.append_to_public_before_section'
+    SUMMARY: Final = 'Append code to the end of a class public section.'
+    # Authored in Markdown; `Help` renders it with rich.
+    HELP: Final = r"""
+        Appends code to a C++ class's `public:` section, at the end of it.
+
+        Fields:
+
+        - `class_name` — the class to add to.
+        - `code` — free-form text to append to the public section, e.g. a
+          declaration like `virtual void OnFoo();`.
+
+        Example:
+
+        ```yaml
+        substitutions:
+          - description: Expose a Brave hook on the public interface.
+            add_to_public:
+              class_name: TestLauncher_ChromiumImpl
+              code: 'virtual const TestResult& OnTestResult(const TestResult& result);'
+        ```
+    """
+
+    # This rewriter appends either before the section that follows public, or
+    # -- when public is the last/only section -- before the class's closing
+    # brace.
+    _APPEND_BEFORE_SECTION: Final = 'cxx.append_to_public_before_section'
+    _APPEND_BEFORE_CLOSE: Final = 'cxx.append_to_public_before_close'
+
+    @classmethod
+    def validate_count(cls, count: int, description: str) -> None:
+        # The code is inserted once, into whichever placement applies, so a
+        # `count:` other than 1 is meaningless here.
+        if count != 1:
+            raise ValueError(f'{cls.NAME} adds the code exactly once and does '
+                             f'not accept a count other than 1 '
+                             f'(in "{description}")')
+
+    def __init__(self, *, class_name: str, code: str):
+        super().__init__()
+        self._class_name = class_name
+        self._code = code
+
+    def apply(self,
+              contents: str,
+              *,
+              count: int,
+              description: str,
+              blank_for_parse: bool = False) -> tuple[str, list[str]]:
+        # The code is appended exactly once, either just before the section
+        # that follows public or, when public is last, before the closing brace.
+        # Each placement is indented to the anchor's real column so a nested
+        # class is indented correctly rather than at the top-level column.
+        del count, description
+        engine = AstRewriter(RewritersEval.load(),
+                             contents,
+                             blank_for_parse=blank_for_parse)
+        source = contents.encode('utf-8')
+        class_inputs = {'class_name': self._class_name}
+
+        anchor = engine.first_match(
+            Operation(self._APPEND_BEFORE_SECTION, class_inputs))
+        if anchor is not None:
+            indent = _leading_indent(source, anchor.start)
+            op = Operation(
+                self._APPEND_BEFORE_SECTION, {
+                    'class_name': self._class_name,
+                    'code': _indent_code(self._code,
+                                         len(indent) + 1),
+                    'indent': indent,
+                }, MatchExpectation.exactly(1))
+        else:
+            anchor = engine.first_match(
+                Operation(self._APPEND_BEFORE_CLOSE, class_inputs))
+            # The closing brace is the last byte of the matched body; a missing
+            # anchor leaves the run to report the count shortfall.
+            indent = (_leading_indent(source, anchor.end -
+                                      1) if anchor else '')
+            op = Operation(
+                self._APPEND_BEFORE_CLOSE, {
+                    'class_name': self._class_name,
+                    'code': _indent_code(self._code,
+                                         len(indent) + 2),
+                    'indent': indent,
+                }, MatchExpectation.exactly(1))
+        changes = engine.run(op)
+        error = op.expectation.error_for(changes)
+        return engine.content, [error] if error else []
+
+    @classmethod
+    def parse(cls, body: object, *, description: str) -> AddToPublic:
+        """Validate an `add_to_public:` body of string args."""
+        if not isinstance(body, dict):
+            raise ValueError(
+                f'"{cls.NAME}" must be a mapping (in "{description}")')
+        required = {'class_name', 'code'}
+        unknown = sorted(set(body) - required)
+        if unknown:
+            raise ValueError(
+                f'Unrecognised {cls.NAME} arg(s): '
+                f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
+        missing = sorted(required - set(body))
+        if missing:
+            raise ValueError(f'{cls.NAME} requires arg(s): '
+                             f'{", ".join(missing)} (in "{description}")')
+        for key in sorted(required):
+            if not isinstance(body[key], str) or not body[key]:
+                raise ValueError(f'{cls.NAME} `{key}` must be a non-empty '
+                                 f'string (in "{description}")')
+        return cls(class_name=body['class_name'], code=body['code'])
+
+
 _REWRITERS: MappingProxyType[str, type[Rewriter]] = MappingProxyType({
     rewriter.NAME: rewriter
     for rewriter in (Regex, MakeVirtual, AddFriend, DropFinal,
                      PreemptFunctionImpl, AfterFunctionImpl, RenameClass,
-                     AddToProtected)
+                     AddToProtected, AddToPublic)
 })
 
 
@@ -1754,8 +1892,9 @@ _MATCHER_SCHEMA = {
 # A rewriter op: locates nodes through a matcher op and edits each via a regex
 # substitution. `inputs` is its public interface (validated against the
 # templates it feeds in `_check_cross_references`); `replace` may name adjacent
-# tokens to fold into each rewritten span. `first_match`, when true, rewrites
-# only the first match (in source order) and ignores any later ones.
+# tokens to fold into each rewritten span, which are `{input}`-formatted like
+# `replace` itself. `first_match`, when true, rewrites only the first match (in
+# source order) and ignores any later ones.
 _REWRITER_SCHEMA = {
     'matcher': _NON_EMPTY_STR,
     'inputs': [str],
@@ -1892,8 +2031,11 @@ class RewritersEval:
                     f'{ref!r} node {matcher_node!r}')
 
             declared = set(spec['inputs'])
+            replace = spec['replace']
             used = (_placeholders(matcher['template'])
-                    | _placeholders(spec['replace']['replace']))
+                    | _placeholders(replace['replace'])
+                    | _placeholders(replace.get('consume_before', ''))
+                    | _placeholders(replace.get('consume_after', '')))
             undeclared = sorted(used - declared)
             if undeclared:
                 raise RewritersSchemaError(
@@ -1953,6 +2095,27 @@ def _indent_yaml(text: str, spaces: int = 2) -> str:
     pad = ' ' * spaces
     return '\n'.join(pad + line if line.strip() else line
                      for line in text.splitlines())
+
+
+def _indent_code(text: str, spaces: int) -> str:
+    """Indent `code` to a member level and escape it for a `re.sub` replacement.
+
+    A member-level rewriter splices `code` into an ast-grep op's `re.sub`
+    replacement, so it is indented to the target column and its backslashes are
+    doubled (a backslash is special in a replacement string).
+    """
+    return _indent_yaml(text, spaces).replace('\\', '\\\\')
+
+
+def _leading_indent(source: bytes, pos: int) -> str:
+    """The leading whitespace of the line containing byte offset `pos`.
+
+    Used to anchor an insertion to the real indentation of a class member,
+    keyword or brace, rather than assuming the top-level column.
+    """
+    line_start = source.rfind(b'\n', 0, pos) + 1
+    line = source[line_start:pos]
+    return line[:len(line) - len(line.lstrip(b' \t'))].decode('utf-8')
 
 
 def run_ast_grep(*, language: str, rule_body: str,
@@ -2057,21 +2220,8 @@ class AstRewriter:
         return self._CXX_CONDITIONAL_RE.sub(
             lambda line: ' ' * len(line.group(0)), source)
 
-    def run(self, op: Operation) -> int:
-        """Run one bound `Operation`, mutate content, return the change count.
-
-        Locates nodes via the op's matcher template, applies the op's `replace`
-        regex substitution (with `op.inputs` filled into the replacement
-        template) to each matched node, and splices the results back into the
-        held contents from the end so earlier byte offsets stay valid. Returns
-        the total number of substitutions made.
-
-        An op's `replace` may name `consume_before` / `consume_after` literals
-        that sit immediately before / after each matched node; they are folded
-        into the rewritten span when the node kind stops short of an adjacent
-        token (e.g. the `:` after an access_specifier, or the space before a
-        `final` specifier). An op that sets `first_match` rewrites only the
-        first match (in source order), leaving any later matches untouched.
+    def _locate(self, op: Operation) -> list[AstMatch]:
+        """Every match for `op`'s matcher, in source order.
         """
         rewriter = self._rewriters.rewriter(op.op_id)
         matcher = self._rewriters.matcher(rewriter['matcher'])
@@ -2083,17 +2233,49 @@ class AstRewriter:
         blank = self._blank_for_parse and op.op_id.startswith('cxx.')
         source_for_parse = (self._prepare_cxx_for_parse()
                             if blank else self._source)
-        matches = run_ast_grep(language=language,
-                               rule_body=rule_body,
-                               source=source_for_parse)
+        return run_ast_grep(language=language,
+                            rule_body=rule_body,
+                            source=source_for_parse)
+
+    def first_match(self, op: Operation) -> AstMatch | None:
+        """The first match for `op`'s matcher, or None. Does not mutate content.
+
+        Parse-normalisation preserves byte offsets, so a caller can read the
+        real source (e.g. to derive an insertion's indentation) at the returned
+        offsets before running the op.
+        """
+        matches = self._locate(op)
+        return matches[0] if matches else None
+
+    def run(self, op: Operation) -> int:
+        """Run one bound `Operation`, mutate content, return the change count.
+
+        Locates nodes via the op's matcher template, applies the op's `replace`
+        regex substitution (with `op.inputs` filled into the replacement
+        template) to each matched node, and splices the results back into the
+        held contents from the end so earlier byte offsets stay valid. Returns
+        the total number of substitutions made.
+
+        An op's `replace` may name `consume_before` / `consume_after` tokens
+        (themselves `op.inputs`-formatted) that sit immediately before / after
+        each matched node; they are folded into the rewritten span when the node
+        kind stops short of an adjacent token (e.g. the `:` after an
+        access_specifier, or the space before a `final` specifier). An op that
+        sets `first_match` rewrites only the first match (in source order),
+        leaving any later matches untouched.
+        """
+        rewriter = self._rewriters.rewriter(op.op_id)
+        matches = self._locate(op)
         if rewriter.get('first_match'):
             matches = matches[:1]
 
         replace = rewriter['replace']
         pattern = replace['re_pattern']
         replacement = replace['replace'].format(**op.inputs)
-        before = replace.get('consume_before', '').encode('utf-8')
-        after = replace.get('consume_after', '').encode('utf-8')
+        before = replace.get('consume_before',
+                             '').format(**op.inputs).encode('utf-8')
+        after = replace.get('consume_after',
+                            '').format(**op.inputs).encode('utf-8')
 
         source = self._source.encode('utf-8')
         edits = []

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -2083,6 +2083,241 @@ class RewriterFormsTest(unittest.TestCase):
             '      code: virtual void Bar() = 0;\n',
             'does not accept a count other than 1')
 
+    def test_add_to_protected_creates_section_in_nested_class(self):
+        # A nested class is indented to its own column: the new protected
+        # section and its member follow the nested class's indentation, not the
+        # top-level one.
+        result = self._apply(
+            'prot_nested_class.h', 'class Outer {\n public:\n  class C {\n'
+            '   public:\n    void Foo();\n   private:\n    int x_;\n'
+            '  };\n};\n', 'substitutions:\n'
+            '  - description: add a protected hook to the nested class\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar() = 0;\n')
+        self.assertEqual(
+            result, 'class Outer {\n public:\n  class C {\n'
+            '   public:\n    void Foo();\n'
+            '   protected:\n    virtual void Bar() = 0;\n\n'
+            '   private:\n    int x_;\n  };\n};\n')
+
+    def test_add_to_protected_reuses_section_in_nested_class(self):
+        # Reusing an existing protected section in a nested class indents the
+        # inserted member to the nested member column.
+        result = self._apply(
+            'prot_nested_reuse.h', 'class Outer {\n public:\n  class C {\n'
+            '   protected:\n    void Existing();\n   private:\n    int x_;\n'
+            '  };\n};\n', 'substitutions:\n'
+            '  - description: reuse the nested protected section\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar() = 0;\n')
+        self.assertEqual(
+            result, 'class Outer {\n public:\n  class C {\n'
+            '   protected:\n    virtual void Bar() = 0;\n    void Existing();\n'
+            '   private:\n    int x_;\n  };\n};\n')
+
+    # -- add_to_public op (real ast-grep binary) --------------------
+
+    def test_add_to_public_appends_before_following_section(self):
+        # The code becomes the last public member, right before the private
+        # section that follows public -- not the first public line.
+        result = self._apply(
+            'pub_before_priv.h',
+            'class C {\n public:\n  void Foo();\n private:\n  int x_;\n};\n',
+            'substitutions:\n'
+            '  - description: expose a public hook\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar();\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            '  virtual void Bar();\n\n private:\n  int x_;\n};\n')
+
+    def test_add_to_public_appends_before_first_following_section(self):
+        # With both a protected and a private section, the append lands before
+        # the first one after public (protected) -- the end of public.
+        result = self._apply(
+            'pub_before_prot.h',
+            'class C {\n public:\n  void Foo();\n protected:\n  void P();\n'
+            ' private:\n  int x_;\n};\n', 'substitutions:\n'
+            '  - description: expose a public hook\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar();\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            '  virtual void Bar();\n\n protected:\n  void P();\n'
+            ' private:\n  int x_;\n};\n')
+
+    def test_add_to_public_appends_before_closing_brace(self):
+        # A pure interface (only a public section): with no following specifier
+        # to anchor on, the code lands just before the class's closing brace.
+        result = self._apply(
+            'pub_only.h', 'class C {\n public:\n  void Foo();\n};\n',
+            'substitutions:\n'
+            '  - description: expose a public hook\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar();\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            '  virtual void Bar();\n};\n')
+
+    def test_add_to_public_reordered_sections_use_closing_brace(self):
+        # `public:` is the last section (private declared first): nothing
+        # follows public, so the append falls back to the closing brace.
+        result = self._apply(
+            'pub_last.h',
+            'class C {\n private:\n  int x_;\n public:\n  void Foo();\n};\n',
+            'substitutions:\n'
+            '  - description: expose a public hook\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar();\n')
+        self.assertEqual(
+            result,
+            'class C {\n private:\n  int x_;\n public:\n  void Foo();\n'
+            '  virtual void Bar();\n};\n')
+
+    def test_add_to_public_scoped_to_named_class(self):
+        # Only the named class is touched; a sibling class is left alone.
+        result = self._apply(
+            'pub_scope.h', 'class C {\n public:\n  void Foo();\n'
+            ' private:\n  int c_;\n};\n\n'
+            'class D {\n public:\n  void Baz();\n private:\n  int d_;\n};\n',
+            'substitutions:\n'
+            '  - description: add only to C\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar();\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            '  virtual void Bar();\n\n private:\n  int c_;\n};\n\n'
+            'class D {\n public:\n  void Baz();\n private:\n  int d_;\n};\n')
+
+    def test_add_to_public_multiline_code(self):
+        # A multi-line `code` block appends several declarations, each indented
+        # to the member level.
+        result = self._apply(
+            'pub_multi.h',
+            'class C {\n public:\n  void Foo();\n private:\n  int x_;\n};\n',
+            'substitutions:\n'
+            '  - description: add two public hooks\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: |-\n'
+            '        virtual void A();\n'
+            '        virtual void B();\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            '  virtual void A();\n  virtual void B();\n\n'
+            ' private:\n  int x_;\n};\n')
+
+    def test_add_to_public_first_of_multiple_public_sections(self):
+        # A reopened `public:` appends to the *first* public section (the append
+        # anchors on the first following section, here the private one).
+        result = self._apply(
+            'pub_reopen.h', 'class C {\n public:\n  void A();\n'
+            ' private:\n  int x_;\n public:\n  void B();\n};\n',
+            'substitutions:\n'
+            '  - description: append to the first public section\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar();\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void A();\n'
+            '  virtual void Bar();\n\n private:\n  int x_;\n public:\n'
+            '  void B();\n};\n')
+
+    def test_add_to_public_no_public_fails(self):
+        # A class with no public section has nothing to append to.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'pub_none.h', 'class C {\n private:\n  int x_;\n};\n',
+                'substitutions:\n'
+                '  - description: no public section\n'
+                '    add_to_public:\n'
+                '      class_name: C\n'
+                '      code: virtual void Bar();\n')
+
+    def test_add_to_public_unknown_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: typo arg\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      cod: virtual void Bar();\n',
+            'Unrecognised add_to_public arg')
+
+    def test_add_to_public_missing_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: missing code\n'
+            '    add_to_public:\n'
+            '      class_name: C\n', 'add_to_public requires arg')
+
+    def test_add_to_public_count_other_than_one_rejected(self):
+        # It always adds exactly once, so any other count is a config error.
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: bogus count\n'
+            '    count: 2\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar();\n',
+            'does not accept a count other than 1')
+
+    def test_add_to_public_appends_before_section_in_nested_class(self):
+        # A nested class is indented to its own column: the appended member sits
+        # at the nested member column and the following section keeps its own.
+        result = self._apply(
+            'pub_nested_section.h', 'class Outer {\n public:\n  class C {\n'
+            '   public:\n    void Foo();\n   private:\n    int x_;\n'
+            '  };\n};\n', 'substitutions:\n'
+            '  - description: expose a public hook on the nested class\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar();\n')
+        self.assertEqual(
+            result, 'class Outer {\n public:\n  class C {\n'
+            '   public:\n    void Foo();\n    virtual void Bar();\n\n'
+            '   private:\n    int x_;\n  };\n};\n')
+
+    def test_add_to_public_appends_before_close_in_nested_class(self):
+        # A nested pure-interface class: the appended member sits at the nested
+        # member column and the closing brace keeps its own indentation.
+        result = self._apply(
+            'pub_nested_close.h', 'class Outer {\n public:\n  class C {\n'
+            '   public:\n    void Foo();\n  };\n};\n', 'substitutions:\n'
+            '  - description: expose a public hook on the nested interface\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar();\n')
+        self.assertEqual(
+            result, 'class Outer {\n public:\n  class C {\n'
+            '   public:\n    void Foo();\n    virtual void Bar();\n'
+            '  };\n};\n')
+
+    def test_add_to_public_multiline_indents_uniformly_when_nested(self):
+        # Every appended line lands at the same nested member column -- the
+        # first line is not indented differently from the rest.
+        result = self._apply(
+            'pub_nested_multi.h', 'class Outer {\n public:\n  class C {\n'
+            '   public:\n    void Foo();\n   private:\n    int x_;\n'
+            '  };\n};\n', 'substitutions:\n'
+            '  - description: add two nested public hooks\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: |-\n'
+            '        virtual void A();\n'
+            '        virtual void B();\n')
+        self.assertEqual(
+            result, 'class Outer {\n public:\n  class C {\n'
+            '   public:\n    void Foo();\n'
+            '    virtual void A();\n    virtual void B();\n\n'
+            '   private:\n    int x_;\n  };\n};\n')
+
     # -- after_function_impl op (real ast-grep binary) -------------------------
 
     def test_after_function_impl_void(self):
@@ -2800,6 +3035,24 @@ class RewritersEvalTest(unittest.TestCase):
         replace = rewriters.rewriter('cxx.make_virtual')['replace']
         self.assertEqual(replace['consume_before'], ' ')
         self.assertEqual(replace['consume_after'], ':')
+
+    def test_rewriter_consume_placeholder_must_be_declared(self):
+        # A `{placeholder}` used only in a consume token is an input like any
+        # other, so it must appear in `inputs`.
+        self._assert_invalid(
+            lambda s: s['ast.rewriter']['cxx.make_virtual']['replace'].
+            __setitem__('consume_before', '{indent}'), 'undeclared input')
+
+    def test_rewriter_consume_placeholder_declared_is_valid(self):
+        # Declaring the consume token's placeholder in `inputs` makes it valid.
+        spec = self._valid_spec()
+        spec['ast.rewriter']['cxx.make_virtual']['replace'][
+            'consume_before'] = '{indent}'
+        spec['ast.rewriter']['cxx.make_virtual']['inputs'].append('indent')
+        rewriters = plaster.RewritersEval(repr(spec))
+        self.assertEqual(
+            rewriters.rewriter('cxx.make_virtual')['replace']
+            ['consume_before'], '{indent}')
 
     def test_rewriter_first_match_is_optional_bool(self):
         # `first_match` is an optional flag; when present it must be a bool and

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -21,10 +21,11 @@
 #                 can be rendered.
 #       replace:  { re_pattern, replace }, re.sub'd over each match's source;
 #                 `replace` is {input}-formatted first (literal braces: {{ }}).
-#                 Optional `consume_before` / `consume_after` literals are
-#                 folded into the rewritten span when the matched node stops
-#                 short of an adjacent token (e.g. the `:` after an
-#                 access_specifier, or the space before a `final` specifier).
+#                 Optional `consume_before` / `consume_after` tokens (also
+#                 {input}-formatted) are folded into the rewritten span when the
+#                 matched node stops short of an adjacent token (e.g. the `:`
+#                 after an access_specifier, the space before a `final`
+#                 specifier, or a class member's leading indentation).
 #       first_match: optional bool; when true only the first match (in source
 #                 order) is rewritten and any later matches are ignored. Use it
 #                 when the matcher can legitimately find several nodes but the
@@ -108,6 +109,47 @@ inside:
 """,
             "result": {
                 "node": "access_specifier",
+            },
+        },
+
+        # Finds the first access specifier after the `public:` section, the
+        # first match being the boundary of the `public:` section.
+        "cxx.find_section_after_public": {
+            "template": """\
+kind: access_specifier
+regex: ^(private|protected)$
+follows:
+  kind: access_specifier
+  regex: ^public$
+  stopBy: end
+inside:
+  kind: field_declaration_list
+  inside:
+    kind: class_specifier
+    has:
+      field: name
+      regex: ^{class_name}$
+""",
+            "result": {
+                "node": "access_specifier",
+            },
+        },
+
+        # The body of a class after the `public:` section is found.
+        "cxx.find_class_body_with_public": {
+            "template": """\
+kind: field_declaration_list
+has:
+  kind: access_specifier
+  regex: ^public$
+inside:
+  kind: class_specifier
+  has:
+    field: name
+    regex: ^{class_name}$
+""",
+            "result": {
+                "node": "field_declaration_list",
             },
         },
 
@@ -307,17 +349,59 @@ regex: ^{class_name}$
         },
 
         # Inserts a fresh `protected:` section just before an existing
-        # `private:` one, and adds `code` under it.
+        # `private:` one, and adds `code` under it. The matched `private`
+        # keyword's own leading whitespace prefixes the new `protected:`, so it
+        # inherits the class's indentation; `code` arrives at the member level
+        # and `indent` re-emits the `private` keyword at its original column.
         "cxx.add_protected_before_private": {
             "matcher": "cxx.find_class_private_section",
-            "inputs": ["class_name", "code"],
+            "inputs": ["class_name", "code", "indent"],
             "first_match": True,
             "replace": {
                 "re_pattern": "^private$",
-                "replace": "protected:\\n{code}\\n\\n private",
+                "replace": "protected:\\n{code}\\n\\n{indent}private",
             },
             "result": {
                 "node": "access_specifier",
+            },
+        },
+
+        # Appends `code` at the end of `class_name`'s public section, just
+        # before the section that follows it. `consume_before` folds the
+        # keyword's entire leading indentation (`indent`) into the span so the
+        # replacement controls all whitespace: `code` (already member-indented)
+        # becomes the last public line(s), a blank line separates it, then the
+        # boundary keyword (`\1`) is re-emitted at that same `indent`.
+        "cxx.append_to_public_before_section": {
+            "matcher": "cxx.find_section_after_public",
+            "inputs": ["class_name", "code", "indent"],
+            "first_match": True,
+            "replace": {
+                "consume_before": "{indent}",
+                "re_pattern": "^(private|protected)$",
+                "replace": "{code}\\n\\n{indent}\\1",
+            },
+            "result": {
+                "node": "access_specifier",
+            },
+        },
+
+        # Appends `code` at the end of `class_name`'s public section when it is
+        # the last (or only) section, inserting it just before the body's
+        # closing brace. The pattern consumes the final `}` together with the
+        # newline and indentation on its line, so inline method bodies earlier
+        # in the class are left alone and the brace is re-emitted at its
+        # original column (`indent`) after the appended, member-indented `code`.
+        "cxx.append_to_public_before_close": {
+            "matcher": "cxx.find_class_body_with_public",
+            "inputs": ["class_name", "code", "indent"],
+            "first_match": True,
+            "replace": {
+                "re_pattern": "\\n[ \\t]*\\}$",
+                "replace": "\\n{code}\\n{indent}}}",
+            },
+            "result": {
+                "node": "field_declaration_list",
             },
         },
     },


### PR DESCRIPTION
This rewriter will permit us to have a proper anchor for when we just
want to add methods to the public interface of a type.

This PR also does some further improvements around identation for these
rewriters.

Fixed https://github.com/brave/brave-browser/issues/57392
