### PR TITLE
Leo - Attachment menu - Use the current site favicon for the "This tab" option

### DIFF
--- a/components/ai_chat/resources/page/components/attachment_button_menu/index.tsx
+++ b/components/ai_chat/resources/page/components/attachment_button_menu/index.tsx
@@ -133,14 +133,15 @@ export default function AttachmentButtonMenu(props: Props) {
         {props.associateDefaultContent && (
           <leo-menu-item
             onClick={() => {
-              props.associateDefaultContent?.()
+              props.associateDefaultContent?.associate()
               props.focusInput()
             }}
           >
             <div className={styles.buttonContent}>
-              <Icon
-                className={styles.buttonIcon}
-                name='window-tab'
+              <img
+                className={styles.favicon}
+                src={`//favicon2?size=64&pageUrl=${encodeURIComponent(props.associateDefaultContent.url)}&allowGoogleServerFallback=0`}
+                alt=''
               />
               {getLocale(S.AI_CHAT_CURRENT_TAB_CONTENTS_BUTTON_LABEL)}
             </div>

--- a/components/ai_chat/resources/page/components/attachment_button_menu/style.module.scss
+++ b/components/ai_chat/resources/page/components/attachment_button_menu/style.module.scss
@@ -21,11 +21,19 @@
 
 .buttonContent {
   display: flex;
+  align-items: center;
   gap: var(--leo-spacing-xl);
 }
 
 .buttonIcon {
   --leo-icon-size: 20px;
+}
+
+.favicon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  object-fit: contain;
 }
 
 .anchor {

--- a/components/ai_chat/resources/page/state/conversation_context.tsx
+++ b/components/ai_chat/resources/page/state/conversation_context.tsx
@@ -415,11 +415,14 @@ export function useProvideConversationContext(props: ConversationContextProps) {
     )
 
     return aiChat.defaultTabContentId && !existingAttachedContent && tab
-      ? () => {
-          aiChat.api.uiHandler.associateTab(
-            tab,
-            conversationState.conversationUuid,
-          )
+      ? {
+          url: tab.url.url,
+          associate: () => {
+            aiChat.api.uiHandler.associateTab(
+              tab,
+              conversationState.conversationUuid,
+            )
+          },
         }
       : undefined
   }, [


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/50375

## Summary

Updates Leo's attachment menu so the **"This tab" / current tab contents** option shows the current site's favicon instead of the generic `window-tab` icon, making the action more clearly tied to the active page.

### Changes
- Replace the `window-tab` Leo icon with an `<img>` loaded via the existing `//favicon2` favicon service (same pattern used elsewhere in Leo attachment UIs)
- Change `associateDefaultContent` from a bare callback to `{ url, associate }` so the menu can both render the favicon and associate the tab on click
- Add `.favicon` styles (20×20 to match other menu icons) and `align-items: center` on `.buttonContent` so the favicon lines up vertically with the label and other items

### Files
- `components/ai_chat/resources/page/components/attachment_button_menu/index.tsx`
- `components/ai_chat/resources/page/components/attachment_button_menu/style.module.scss`
- `components/ai_chat/resources/page/state/conversation_context.tsx`

## Previous

<img width="495" height="322" alt="image" src="https://github.com/user-attachments/assets/1748928e-b389-4208-8f22-0143b6c61b90" />

## New

<img width="487" height="313" alt="image" src="https://github.com/user-attachments/assets/ebd522be-4b6f-464c-8e45-bdc45c2181fa" />

## Test plan
- [ ] Open Leo on a page with a clear site favicon (e.g. brave.com)
- [ ] Open the attachment menu and confirm **"Current tab contents"** shows that site's favicon instead of the generic tab icon
- [ ] Confirm the favicon is vertically aligned with the label and matches the size of the other menu icons
- [ ] Click **"Current tab contents"** and confirm the current tab is still associated with the conversation as before
- [ ] Switch to a different tab/site and reopen the menu — favicon should update to the new site
- [ ] Open a page with no / missing favicon and confirm the menu item still renders without layout issues
- [ ] Confirm other attachment menu items (upload, screenshot, open tabs, bookmarks, history) are unchanged
- [ ] Spot-check light and dark theme

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->