### PR TITLE
[iOS] Avoid double-scaling font size of weighted text styles

### DIFF
--- a/ios/brave-ios/App/Client.xcodeproj/Brave.xctestplan
+++ b/ios/brave-ios/App/Client.xcodeproj/Brave.xctestplan
@@ -163,6 +163,13 @@
         "identifier" : "PlaylistUITests",
         "name" : "PlaylistUITests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "BraveUITests",
+        "name" : "BraveUITests"
+      }
     }
   ],
   "version" : 1

--- a/ios/brave-ios/Package.swift
+++ b/ios/brave-ios/Package.swift
@@ -304,6 +304,7 @@ var package = Package(
       ],
       plugins: ["LoggerPlugin"]
     ),
+    .testTarget(name: "BraveUITests", dependencies: ["BraveUI"]),
     .target(
       name: "BraveShields",
       dependencies: ["Strings", "Preferences", "BraveCore", "Web", "Data"],

--- a/ios/brave-ios/Sources/BraveUI/Extensions/UIFontExtensions.swift
+++ b/ios/brave-ios/Sources/BraveUI/Extensions/UIFontExtensions.swift
@@ -15,14 +15,11 @@ extension UIFont {
     weight: Weight,
     traitCollection: UITraitCollection? = nil
   ) -> UIFont {
-    let fontMetrics = UIFontMetrics(forTextStyle: style)
     let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(
       withTextStyle: style,
       compatibleWith: traitCollection
     )
-    let font = UIFont.systemFont(ofSize: fontDescriptor.pointSize, weight: weight)
-
-    return fontMetrics.scaledFont(for: font)
+    return UIFont.systemFont(ofSize: fontDescriptor.pointSize, weight: weight)
   }
 
   public func with(traits: UIFontDescriptor.SymbolicTraits?) -> UIFont {

--- a/ios/brave-ios/Tests/BraveUITests/UIFontExtensionTests.swift
+++ b/ios/brave-ios/Tests/BraveUITests/UIFontExtensionTests.swift
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveUI
+import UIKit
+import XCTest
+
+extension UIFont {
+  fileprivate var weight: UIFont.Weight? {
+    if let traits = fontDescriptor.object(forKey: .traits) as? [UIFontDescriptor.TraitKey: Any],
+      let weight = traits[.weight] as? UIFont.Weight.RawValue
+    {
+      return UIFont.Weight(rawValue: weight)
+    }
+    return nil
+  }
+}
+
+class UIFontExtensionTests: XCTestCase {
+  func testPreferredFontWithWeightNoTraits() {
+    let body = UIFont.preferredFont(forTextStyle: .body)
+    let bodyMedium = UIFont.preferredFont(for: .body, weight: .medium)
+    XCTAssertEqual(body.pointSize, bodyMedium.pointSize)
+    XCTAssertEqual(bodyMedium.weight, .medium)
+  }
+
+  func testPreferredFontWithWeightCompatibleTraits() {
+    let traits = UITraitCollection(preferredContentSizeCategory: .extraExtraLarge)
+    let body = UIFont.preferredFont(forTextStyle: .body, compatibleWith: traits)
+    let bodyMedium = UIFont.preferredFont(for: .body, weight: .medium, traitCollection: traits)
+    XCTAssertEqual(body.pointSize, bodyMedium.pointSize)
+    XCTAssertEqual(bodyMedium.weight, .medium)
+  }
+}


### PR DESCRIPTION
We scaled the font created with the `UIFontDescriptor` with a `UIFontMetrics` but this seems to doubly-scale the font now even though we dont provide a trait collection to the metrics. This changes removes the extra scaling and introduces tests to validate the point size & weight are correct.
