### PR TITLE
FindBar/FindInPage: Find Nth - Allow Arbitrary Access to Matches

### DIFF
--- a/browser/ui/android/strings/android_chrome_strings.grd
+++ b/browser/ui/android/strings/android_chrome_strings.grd
@@ -4894,6 +4894,12 @@ To change this setting, <ph name="BEGIN_LINK">BEGIN_LINK</ph>delete the Brave da
       <message name="IDS_ACCESSIBLE_FIND_IN_PAGE_NO_RESULTS" desc="Accessible text to be spoken when the user does a find in page query and no results are found.">
         No results
       </message>
+      <message name="IDS_HINT_FIND_IN_PAGE_NTH_MATCH_EDITTEXT" desc="Hint text to show for the find in page search field when the search field is empty.">
+        N
+      </message>
+      <message name="IDS_FIND_IN_PAGE_COUNT_SEPARATOR" desc="Text to show between N ordinal EditText and Last Match Button.">
+        /
+      </message>
 
       <!-- Omnibox -->
       <message name="IDS_LOCATION_BAR_VERBOSE_STATUS_OFFLINE" desc="Verbose indication of offline status in the location bar. [CHAR_LIMIT=20]">

--- a/components/components_strings.grd
+++ b/components/components_strings.grd
@@ -523,6 +523,15 @@
       <message name="IDS_ACCNAME_OPEN_IN_NEW_TAB" desc="The accessible name for the Open in New Tab button.">
         Open in new tab
       </message>
+        <message name="IDS_ACCNAME_NTH" desc="The accessible name for the nth match textfield.">
+        Nth Match
+      </message>
+      <message name="IDS_ACCNAME_MATCH_SEPARATOR" desc="The accessible name for the separator text between active match number and total match count.">
+        Separator
+      </message>
+      <message name="IDS_ACCNAME_LAST" desc="The accessible name for the last match button.">
+        Last Match
+      </message>
       <message name="IDS_ACCNAME_PREVIOUS" desc="The accessible name for the previous button.">
         Previous
       </message>
@@ -574,49 +583,19 @@
       <message name="IDS_INTERNAL_DEBUG_PAGES_DISABLED_HEADING" desc="This is the heading for the page that appears when a user attempts to load an internal developer debugging page when such pages are disabled by a pref.">
         Internal debugging pages are currently disabled.
       </message>
-      <!-- Clear browsing data strings. -->
-      <message name="IDS_SETTINGS_MANAGE_IN_GOOGLE_PASSWORD_MANAGER" desc="Description for the 'Passwords and Passkeys' linkout in the 'Other Brave Data' subpage inside the 'Delete browsing data' dialog. This lets users know that passwords and passkeys can be managed and deleted in Brave password manager.">
-        Manage in Brave Password Manager
+      <!-- Send Tab To Self strings -->
+      <message name="IDS_SEND_TAB_TO_SELF_DEVICE_LAST_UPDATE_DAYS" desc="The label of valid device button inside omnibox bubble or the Send Tab To Self dialog, which shows the last activated time of a valid device.">
+        {DAYS, plural, =0 {Active today} =1 {Active 1 day ago} other {Active # days ago}}
       </message>
-      <message name="IDS_SETTINGS_MANAGE_IN_YOUR_GOOGLE_ACCOUNT" desc="Description for the MyActivity and Search History linkouts in the 'Other Brave Data' subpage inside the 'Delete browsing data' dialog. This lets users know that this data can be managed and deleted in their Brave account.">
-        Manage in your Brave sync chain
+      <message name="IDS_SEND_TAB_TO_SELF_DEVICE_ACTIVE_NOW" desc="The label of valid device button inside omnibox bubble, which shows the last activated time of a valid device.">
+        Active now
       </message>
-      <message name="IDS_SETTINGS_MANAGE_OTHER_DATA_LABEL" desc="Label for the 'Manage other data' subpage entry-point in the 'Delete Browsing Data' dialog where the user can find link-outs to manage their data outside of Brave. This is the label shown when the user does not have Brave as their default search engine.">
-        Manage other data
+      <message name="IDS_SEND_TAB_TO_SELF_DEVICE_ACTIVE_MINUTES" desc="The label of valid device button inside omnibox bubble, which shows the last activated time of a valid device.">
+        {MINUTES, plural, =1 {Active 1 minute ago} other {Active # minutes ago}}
       </message>
-      <message name="IDS_SETTINGS_MANAGE_OTHER_GOOGLE_DATA_LABEL" desc="Label for the 'Manage other Brave data' subpage entry-point in the 'Delete Browsing Data' dialog where the user can find link-outs to manage their data outside of Brave. This is the label shown when the user has Brave as their default search engine.">
-        Manage other Brave data
+      <message name="IDS_SEND_TAB_TO_SELF_DEVICE_ACTIVE_HOURS" desc="The label of valid device button inside omnibox bubble, which shows the last activated time of a valid device.">
+        {HOURS, plural, =1 {Active 1 hour ago} other {Active # hours ago}}
       </message>
-      <message name="IDS_SETTINGS_MY_ACTIVITY" desc="Label for the 'My Activity' linkout in the 'Other Brave Data' subpage inside the 'Delete browsing data' dialog, where the user can see and manage data that is stored outside of Brave. This linkout is specifically for activity data stored in the user's Brave account.">
-        My Activity
-      </message>
-       <message name="IDS_SETTINGS_OTHER_DATA_TITLE" desc="Title for the 'Other Data' subpage inside the 'Delete browsing data' dialog, where the user can see and manage data that is stored outside of Brave. This is the title shown when the user did not set Brave as their default search engine, indicating that they may have data stored outside of Brave.">
-         Other data
-       </message>
-       <message name="IDS_SETTINGS_OTHER_GOOGLE_DATA_TITLE" desc="Title for the 'Other Brave Data' subpage inside the 'Delete browsing data' dialog, where the user can see and manage data that is stored outside of Brave. This is the title shown when the user set Brave as their default search engine, indicating that all data linked in this subpage is stored within Brave.">
-         Other Brave data
-       </message>
-       <message name="IDS_SETTINGS_PASSWORDS_AND_PASSKEYS" desc="Label for the 'Passwords and Passkeys' linkout in the 'Other Brave Data' subpage inside the 'Delete browsing data' dialog, where the user can see and manage data that is stored outside of Brave. This linkout is specifically for passwords and passkeys stored in Brave password manager.">
-         Passwords and passkeys
-       </message>
-       <message name="IDS_SETTINGS_MANAGE_PASSWORDS_SUB_LABEL" desc="Sub-label for the 'Manage other Data' subpage entrypoint in the 'Delete Browsing Data' dialog, explaining to the user that passwords can only be deleted in their management settings.">
-        Passwords can be deleted in their management settings
-      </message>
-       <message name="IDS_SETTINGS_SEARCH_HISTORY" desc="Label for the 'Search history' linkout in the 'Other Brave Data' subpage inside the 'Delete browsing data' dialog, where the user can see and manage data that is stored outside of Brave. This linkout is specifically for search history stored in the user's default search engine account.">
-         Search history
-       </message>
-       <message name="IDS_SETTINGS_MANAGE_OTHER_DATA_SUB_LABEL" desc="Sub-label for the 'Manage other Brave Data' option in the 'Delete Browsing Data' dialog, explaining to the user that search history and passwords can be deleted outside of Brave in their respective management settings.">
-         Search history and passwords can be deleted in their management settings
-       </message>
-       <message name="IDS_SETTINGS_OTHER_DATA_DESCRIPTION" desc="Description text at the top of the 'Other Brave data' subpage in the 'Delete browsing data' settings dialog. It informs users that data linked in this page are not managed or deleted in Brave.">
-         To delete this data, go to its management settings
-       </message>
-       <message name="IDS_SETTINGS_CLEAR_NON_GOOGLE_SEARCH_HISTORY_NON_PREPOPULATED_DSE" desc="A description informing the user about the way to clear their search history when their Default Search Engine is not Brave.">
-         See your search engine's instructions for deleting your search history, if applicable
-       </message>
-       <message name="IDS_SETTINGS_CLEAR_NON_GOOGLE_SEARCH_HISTORY_PREPOPULATED_DSE" desc="A description informing the user about the way to clear their search history when their Default Search Engine is not Brave.">
-         Your search engine is <ph name="DSE">$1<ex>Bing</ex></ph>. See their instructions for deleting your search history, if applicable.
-       </message>
     </messages>
   </release>
 </grit>

--- a/components/find_in_page_strings.grdp
+++ b/components/find_in_page_strings.grdp
@@ -8,6 +8,24 @@
   <message name="IDS_FIND_IN_PAGE_COUNT" desc="How many matches found and what item we are showing">
     <ph name="ACTIVE_MATCH">$1</ph>/<ph name="TOTAL_MATCHCOUNT">$2</ph>
   </message>
+ <message name="IDS_FIND_IN_PAGE_NTH_MATCH_NUM" desc="Of the matches found, what item we are showing">
+    <ph name="NTH_MATCH">$1</ph>
+  </message>
+  <message name="IDS_FIND_IN_PAGE_NTH_MATCH_PLACEHOLDER_TEXT" desc="The text displayed in the Nth match textfield when there's no other valued typed in">
+    N
+  </message>
+  <message name="IDS_FIND_IN_PAGE_NTH_MATCH_TOOLTIP" desc="The tooltip displayed when the Nth match textfield is hovered">
+    Nth Match
+  </message>
+  <message name="IDS_FIND_IN_PAGE_MATCHES_SEPARATOR_TEXT" desc="The separator between the active match number and the total match count">
+    /
+  </message>
+  <message name="IDS_FIND_IN_PAGE_TOTAL_MATCH_COUNT" desc="How many matches found">
+    <ph name="TOTAL_MATCHCOUNT">$1</ph>
+  </message>
+  <message name="IDS_FIND_IN_PAGE_LAST_MATCH_BUTTON_TOOLTIP" desc="The tooltip displayed when the last match button is hovered">
+    Last Match
+  </message>
   <message name="IDS_ACCESSIBLE_FIND_IN_PAGE_COUNT" desc="Accessible text to be spoken when the user is doing a find in page so they know how many results are on the page and which one is active.">
     Result <ph name="RESULT_NUMBER">
       $1<ex>3</ex>

--- a/patches/android_webview-browser-aw_contents.cc.patch
+++ b/patches/android_webview-browser-aw_contents.cc.patch
@@ -1,0 +1,16 @@
+diff --git a/android_webview/browser/aw_contents.cc b/android_webview/browser/aw_contents.cc
+index 81bc4304c6919ebdfc222a1bf02da6bf4db8230e..7bc088638fc5e4385a7bd41b800826700e9adbd0 100644
+--- a/android_webview/browser/aw_contents.cc
++++ b/android_webview/browser/aw_contents.cc
+@@ -815,6 +815,11 @@ void AwContents::FindNext(JNIEnv* env, bool forward) {
+   GetFindHelper()->FindNext(forward);
+ }
+ 
++void AwContents::FindNth(JNIEnv* env, int match_ordinal) {
++  DCHECK_CURRENTLY_ON(BrowserThread::UI);
++  GetFindHelper()->FindNth(match_ordinal);
++}
++
+ void AwContents::ClearMatches(JNIEnv* env) {
+   DCHECK_CURRENTLY_ON(BrowserThread::UI);
+   GetFindHelper()->ClearMatches();

--- a/patches/android_webview-browser-aw_contents.h.patch
+++ b/patches/android_webview-browser-aw_contents.h.patch
@@ -1,0 +1,12 @@
+diff --git a/android_webview/browser/aw_contents.h b/android_webview/browser/aw_contents.h
+index 9f347aa19d1b7c12bc7231ad1d54d64fcd629583..1dc05e7ef3cd93fe4a813e7a2fc9d08bc095ae26 100644
+--- a/android_webview/browser/aw_contents.h
++++ b/android_webview/browser/aw_contents.h
+@@ -256,6 +256,7 @@ class AwContents : public FindHelper::Listener,
+   void FindAllAsync(JNIEnv* env,
+                     const base::android::JavaRef<jstring>& search_string);
+   void FindNext(JNIEnv* env, bool forward);
++  void FindNth(JNIEnv* env, int match_ordinal);
+   void ClearMatches(JNIEnv* env);
+   FindHelper* GetFindHelper();
+ 

--- a/patches/android_webview-browser-find_helper.cc.patch
+++ b/patches/android_webview-browser-find_helper.cc.patch
@@ -1,0 +1,29 @@
+diff --git a/android_webview/browser/find_helper.cc b/android_webview/browser/find_helper.cc
+index 906c24d94c1ede961b06258890814457363c64df..35176130a0e93dc3c4c2b1ca4a7edbe9e9dc06f1 100644
+--- a/android_webview/browser/find_helper.cc
++++ b/android_webview/browser/find_helper.cc
+@@ -71,6 +71,24 @@ void FindHelper::FindNext(bool forward) {
+                         std::move(options), /*skip_delay=*/false);
+ }
+ 
++void FindHelper::FindNext(int match_ordinal) {
++  if (!async_find_started_)
++    return;
++
++  current_request_id_ = find_request_id_counter_++;
++
++  if (MaybeHandleEmptySearch(last_search_string_))
++    return;
++
++  auto options = blink::mojom::FindOptions::New();
++  options->match_case = false;
++  options->new_session = false;
++  options->match_ordinal = match_ordinal;
++
++  GetWebContents().Find(current_request_id_, last_search_string_,
++                        std::move(options), /*skip_delay=*/false);
++}
++
+ void FindHelper::ClearMatches() {
+   GetWebContents().StopFinding(content::STOP_FIND_ACTION_CLEAR_SELECTION);
+ 

--- a/patches/android_webview-browser-find_helper.h.patch
+++ b/patches/android_webview-browser-find_helper.h.patch
@@ -1,0 +1,25 @@
+diff --git a/android_webview/browser/find_helper.h b/android_webview/browser/find_helper.h
+index 8cec5086866509594ced8bfa3004317172d20813..5771e537e522451bb7acdf6401fa068f49fb6d97 100644
+--- a/android_webview/browser/find_helper.h
++++ b/android_webview/browser/find_helper.h
+@@ -22,9 +22,9 @@ class FindHelper : public content::WebContentsUserData<FindHelper> {
+  public:
+   class Listener {
+    public:
+-    // Called when receiving a new find-in-page update.
+-    // This will be triggered when the results of FindAllSync, FindAllAsync and
+-    // FindNext are available. The value provided in active_ordinal is 0-based.
++     // Called when receiving a new find-in-page update.
++    // This will be triggered when the results of FindAllSync, FindAllAsync, 
++    // FindNext, and FindNth are available. The value provided in active_ordinal is 0-based.
+     virtual void OnFindResultReceived(int active_ordinal,
+                                       int match_count,
+                                       bool finished) = 0;
+@@ -49,6 +49,7 @@ class FindHelper : public content::WebContentsUserData<FindHelper> {
+ 
+   // Methods valid in both synchronous and asynchronous modes.
+   void FindNext(bool forward);
++  void FindNth(int match_ordinal);
+   void ClearMatches();
+ 
+  private:

--- a/patches/android_webview-glue-java-src-com-android-webview-chromium-WebViewChromium.java.patch
+++ b/patches/android_webview-glue-java-src-com-android-webview-chromium-WebViewChromium.java.patch
@@ -1,0 +1,62 @@
+diff --git a/android_webview/glue/java/src/com/android/webview/chromium/WebViewChromium.java b/android_webview/glue/java/src/com/android/webview/chromium/WebViewChromium.java
+index f2eaa10d6c5ee69614c43e065ab3f6b5db313e4b..cd75f1f80c38463c90c9e9aac67bc23a697db01a 100644
+--- a/android_webview/glue/java/src/com/android/webview/chromium/WebViewChromium.java
++++ b/android_webview/glue/java/src/com/android/webview/chromium/WebViewChromium.java
+@@ -173,6 +173,7 @@ class WebViewChromium
+         ApiCall.EVALUATE_JAVASCRIPT,
+         ApiCall.EXTRACT_SMART_CLIP_DATA,
+         ApiCall.FIND_NEXT,
++        ApiCall.FIND_NTH,
+         ApiCall.GET_CERTIFICATE,
+         ApiCall.GET_CONTENT_HEIGHT,
+         ApiCall.GET_CONTENT_WIDTH,
+@@ -630,6 +631,7 @@ class WebViewChromium
+         int WEBVIEW_CHROMIUM_INIT = 236;
+         int WEBVIEW_CHROMIUM_INIT_FOR_REAL = 237;
+         int COUNT = 238;
++        int FIND_NTH = 239;
+     }
+ 
+     // LINT.ThenChange(/tools/metrics/histograms/metadata/android/enums.xml:WebViewApiCall)
+@@ -691,6 +693,7 @@ class WebViewChromium
+         ApiCallUserAction.WEBVIEW_INSTANCE_FIND_ALL_ASYNC,
+         ApiCallUserAction.WEBVIEW_INSTANCE_FIND_FOCUS,
+         ApiCallUserAction.WEBVIEW_INSTANCE_FIND_NEXT,
++        ApiCallUserAction.WEBVIEW_INSTANCE_FIND_NTH,
+         ApiCallUserAction.WEBVIEW_INSTANCE_FLING_SCROLL,
+         ApiCallUserAction.WEBVIEW_INSTANCE_GET_ACCESSIBILITY_NODE_PROVIDER,
+         ApiCallUserAction.WEBVIEW_INSTANCE_GET_CERTIFICATE,
+@@ -953,6 +956,7 @@ class WebViewChromium
+         String WEBVIEW_INSTANCE_FIND_ALL_ASYNC = "WebViewInstanceFindAllAsync";
+         String WEBVIEW_INSTANCE_FIND_FOCUS = "WebViewInstanceFindFocus";
+         String WEBVIEW_INSTANCE_FIND_NEXT = "WebViewInstanceFindNext";
++        String WEBVIEW_INSTANCE_FIND_NTH = "WebViewInstanceFindNth";
+         String WEBVIEW_INSTANCE_FLING_SCROLL = "WebViewInstanceFlingScroll";
+         String WEBVIEW_INSTANCE_GET_ACCESSIBILITY_NODE_PROVIDER =
+                 "WebViewInstanceGetAccessibilityNodeProvider";
+@@ -2784,6 +2788,25 @@ class WebViewChromium
+         }
+     }
+ 
++     @Override
++    public void findNth(final int matchOrdinal) {
++        forbidBuilderConfiguration();
++        if (checkNeedsPost()) {
++            mFactory.addTask(
++                    new Runnable() {
++                        @Override
++                        public void run() {
++                            findNth(matchOrdinal);
++                        }
++                    });
++            return;
++        }
++        try (TraceEvent event = TraceEvent.scoped("WebView.APICall.Framework.FIND_NTH")) {
++            recordWebViewApiCall(ApiCall.FIND_NTH, ApiCallUserAction.WEBVIEW_INSTANCE_FIND_NTH);
++            mAwContents.findNth(matchOrdinal);
++        }
++    }
++
+     @Override
+     public int findAll(final String searchString) {
+         findAllAsync(searchString);

--- a/patches/android_webview-java-src-org-chromium-android_webview-AwContents.java.patch
+++ b/patches/android_webview-java-src-org-chromium-android_webview-AwContents.java.patch
@@ -1,0 +1,27 @@
+diff --git a/android_webview/java/src/org/chromium/android_webview/AwContents.java b/android_webview/java/src/org/chromium/android_webview/AwContents.java
+index 93ad7b99e6aa47d9ad94696c8fe176af1247c2ab..966dc95896e26053bce56d138122c554f789b82c 100644
+--- a/android_webview/java/src/org/chromium/android_webview/AwContents.java
++++ b/android_webview/java/src/org/chromium/android_webview/AwContents.java
+@@ -2186,6 +2186,13 @@ public class AwContents implements SmartClipProvider {
+         }
+     }
+ 
++    public void findNth(int matchOrdinal) {
++        if (TRACE) Log.i(TAG, "%s findNth", this);
++        if (!isDestroyed(WARN)) {
++            AwContentsJni.get().findNth(mNativeAwContents, matchOrdinal);
++        }
++    }
++
+     public void clearMatches() {
+         if (TRACE) Log.i(TAG, "%s clearMatches", this);
+         if (!isDestroyed(WARN)) {
+@@ -4988,6 +4995,8 @@ public class AwContents implements SmartClipProvider {
+         void findAllAsync(long nativeAwContents, String searchString);
+ 
+         void findNext(long nativeAwContents, boolean forward);
++        
++        void findNth(long nativeAwContents, int matchOrdinal);
+ 
+         void clearMatches(long nativeAwContents);
+ 

--- a/patches/chrome-android-java-res-layout-find_in_page.xml.patch
+++ b/patches/chrome-android-java-res-layout-find_in_page.xml.patch
@@ -1,0 +1,61 @@
+diff --git a/chrome/android/java/res/layout/find_in_page.xml b/chrome/android/java/res/layout/find_in_page.xml
+index af6944c2a9d2660aeefe1933cddf95ef9a4e2053..7883e97af25cdbed2ac30c0bb16d7b64b7cf3b7f 100644
+--- a/chrome/android/java/res/layout/find_in_page.xml
++++ b/chrome/android/java/res/layout/find_in_page.xml
+@@ -27,6 +27,48 @@ found in the LICENSE file.
+         android:imeOptions="actionSearch|flagNoExtractUi"
+         android:singleLine="true"
+         android:textAppearance="@style/TextAppearance.TextLarge.Primary" />
++        
++    <!-- Composite of N ordinal EditText, "/" separator, and Last Match Button-->    
++    <LinearLayout
++        xmlns:android="http://schemas.android.com/apk/res/android"
++        xmlns:app="http://schemas.android.com/apk/res-auto"
++        android:layout_width="wrap_content"
++        android:layout_height="wrap_content"
++        android:orientation="horizontal"
++        style="@android:style/Theme.Holo.Light">
++        <EditText
++            android:id="@+id/nth_match_edittext"
++            android:layout_width="wrap_content"
++            android:layout_height="wrap_content"
++            android:layout_gravity="center_vertical"
++            android:background="@null"
++            android:hint="@string/hint_find_in_page_nth_match_edittext"
++            android:imeOptions="actionSearch|flagNoExtractUi"
++            android:singleLine="true"
++            android:visibility="gone"
++            android:layout_marginEnd="16dp"/>
++        <TextView
++            android:id="@+id/match_count_separator"
++            android:layout_width="wrap_content"
++            android:layout_height="wrap_content"
++            android:layout_marginEnd="16dp"
++            android:background="@null"
++            android:singleLine="true"
++            android:visibility="gone"
++            android:text="@string/find_in_page_count_separator"
++            android:textAppearance="@style/TextAppearance.TextLarge.Secondary" />
++        <org.chromium.ui.widget.ButtonCompat
++            android:id="@+id/last_match_button"
++            android:layout_width="wrap_content"
++            android:layout_height="wrap_content"
++            android:layout_marginEnd="16dp"
++            android:background="@null"
++            android:singleLine="true"
++            android:visibility="gone"
++            android:textAppearance="@style/TextAppearance.TextLarge.Secondary"/>
++    </LinearLayout>
++
++    <!--Invisible match status string. Kept for accessibility-->
+     <TextView
+         android:id="@+id/find_status"
+         android:layout_width="wrap_content"
+@@ -34,6 +76,7 @@ found in the LICENSE file.
+         android:layout_marginEnd="16dp"
+         android:background="@null"
+         android:singleLine="true"
++        android:visibility="gone"
+         android:textAppearance="@style/TextAppearance.TextLarge.Secondary" />
+     <View
+         android:id="@+id/find_separator"

--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-findinpage-FindToolbar.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-findinpage-FindToolbar.java.patch
@@ -1,0 +1,232 @@
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/findinpage/FindToolbar.java b/chrome/android/java/src/org/chromium/chrome/browser/findinpage/FindToolbar.java
+index 5786682fd2216b2348de257e4fbfad2dafb83c63..ff1898487796c6b6f1106833eb6bb200de95aef3 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/findinpage/FindToolbar.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/findinpage/FindToolbar.java
+@@ -29,6 +29,9 @@ import android.view.inputmethod.InputConnection;
+ import android.widget.ImageButton;
+ import android.widget.LinearLayout;
+ import android.widget.TextView;
++import android.widget.EditText;
++import android.widget.TextView;
++import org.chromium.ui.widget.ButtonCompat;
+ 
+ import androidx.annotation.IntDef;
+ import androidx.annotation.VisibleForTesting;
+@@ -89,9 +92,15 @@ public class FindToolbar extends LinearLayout implements BackPressHandler {
+     private final TabModelObserver mTabModelObserver;
+     private final TabObserver mTabObserver;
+ 
++    private final static int mMinOrdinal = 1;
++    private int mMaxOrdinal;
++
+     // Toolbar UI
+     private TextView mFindStatus;
+     protected FindQuery mFindQuery;
++    protected EditText mNthMatchEditText;
++    protected TextView mMatchesSeparator;
++    protected ButtonCompat mLastMatchButton;
+     protected ImageButton mCloseFindButton;
+     protected ImageButton mFindPrevButton;
+     protected ImageButton mFindNextButton;
+@@ -112,6 +121,9 @@ public class FindToolbar extends LinearLayout implements BackPressHandler {
+     /** Whether toolbar text is being set automatically (not typed by user). */
+     private boolean mSettingFindTextProgrammatically;
+ 
++    /** Whether toolbar N text is being set automatically (not typed by user). */
++    private boolean mSettingNthMatchTextProgrammatically;
++
+     /** Whether the search key should trigger a new search. */
+     private boolean mSearchKeyShouldTriggerSearch;
+ 
+@@ -289,7 +301,7 @@ public class FindToolbar extends LinearLayout implements BackPressHandler {
+                             // Don't clearResults() as that would cause flicker.
+                             // Just wait until onFindResultReceived updates it.
+                             mSearchKeyShouldTriggerSearch = false;
+-                            mFindInPageBridge.startFinding(s.toString(), true, false);
++                            mFindInPageBridge.startFinding(s.toString(), true, false, 0);
+                         } else {
+                             clearResults();
+                             mFindInPageBridge.stopFinding(true);
+@@ -326,6 +338,88 @@ public class FindToolbar extends LinearLayout implements BackPressHandler {
+         setStatus("", false);
+         mFindStatus.setAccessibilityLiveRegion(View.ACCESSIBILITY_LIVE_REGION_POLITE);
+ 
++        mNthMatchEditText = findViewById(R.id.nth_match_edittext);
++        mNthMatchEditText.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_TEXT_VARIATION_FILTER);
++        mNthMatchEditText.setOnFocusChangeListener(
++                new View.OnFocusChangeListener() {
++                    @Override
++                    public void onFocusChange(View v, boolean hasFocus) {
++                        if (!hasFocus) {
++                            if (assumeNonNull(mNthMatchEditText.getText()).length() > 0) {
++                                mSearchKeyShouldTriggerSearch = true;
++                            }
++                            mWindowAndroid.getKeyboardDelegate().hideKeyboard(mNthMatchEditText);
++                        }
++                    }
++                });
++        mNthMatchEditText.addTextChangedListener(
++            new EmptyTextWatcher() {
++                @Override
++                public void onTextChanged(CharSequence s, int start, int before, int count) {
++                    if (mFindInPageBridge == null) return;
++
++                    if (mSettingFindTextProgrammatically || mSettingNthMatchTextProgrammatically) return;
++
++                    // If we're called during onRestoreInstanceState() the current
++                    // view won't have been set yet. TODO(husky): Find a better fix.
++                    assert mCurrentTab != null;
++                    assert mCurrentTab.getWebContents() != null;
++                    if (mCurrentTab.getWebContents() == null) return;
++
++                    if (s.length() > 0) {
++                        // Don't clearResults() as that would cause flicker.
++                        // Just wait until onFindResultReceived updates it.
++                        mSearchKeyShouldTriggerSearch = false;
++                        int inputOrdinal = Integer.valueOf(s.toString()).intValue();
++                        if (inputOrdinal > mMaxOrdinal) {
++                            inputOrdinal = mMaxOrdinal;
++                            setNthMatchTextQuietly(mMaxOrdinal);
++                        }
++                        else if (inputOrdinal < mMinOrdinal) {
++                            inputOrdinal = mMinOrdinal;
++                            setNthMatchTextQuietly(mMinOrdinal);
++                        }
++
++                        hideKeyboardAndFindNth(inputOrdinal);
++                    }
++                }
++            });
++        mNthMatchEditText.setOnEditorActionListener(
++            new TextView.OnEditorActionListener() {
++                @Override
++                public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
++                    if (event != null && event.getAction() == KeyEvent.ACTION_UP) return false;
++
++                    if (mFindInPageBridge == null) return false;
++
++                    // Only trigger a new find if the text was set programmatically.
++                    // Otherwise just revisit the current active match.
++                    if (mSearchKeyShouldTriggerSearch) {
++                        mSearchKeyShouldTriggerSearch = false;
++                        int inputOrdinal = ensureBoundedOrdinal(Integer.valueOf(v.getText().toString()).intValue());
++
++                        hideKeyboardAndFindNth(inputOrdinal);
++                    } else {
++                        mWindowAndroid.getKeyboardDelegate().hideKeyboard(mFindQuery);
++                        mFindInPageBridge.activateFindInPageResultForAccessibility();
++                    }
++                    return true;
++                }
++            });
++
++        mMatchesSeparator = findViewById(R.id.match_count_separator);
++        mMatchesSeparator.setText(new String("/").toCharArray(), 0, 1);
++        mLastMatchButton = findViewById(R.id.last_match_button);
++        mLastMatchButton.setOnClickListener(
++            new OnClickListener() {
++                @Override
++                public void onClick(View v) {
++                    // Triggers nthMatchEditText's onTextChanged(...) event.
++                    mNthMatchEditText.setText(String.valueOf(mMaxOrdinal));
++                }
++            }
++        );
++
+         mFindPrevButton = findViewById(R.id.find_prev_button);
+         mFindPrevButton.setOnClickListener(
+                 new OnClickListener() {
+@@ -387,6 +481,26 @@ public class FindToolbar extends LinearLayout implements BackPressHandler {
+     // Overridden by subclasses.
+     protected void findResultSelected(Rect rect) {}
+ 
++    private int ensureBoundedOrdinal(int ordinal) {
++        if (ordinal < mMinOrdinal) {
++            ordinal = mMinOrdinal;
++        }
++        else if (ordinal > mMaxOrdinal) {
++            ordinal = mMaxOrdinal;
++        }
++        return ordinal;
++    }
++
++    private void setNthMatchTextQuietly(int ordinal) {
++
++        mSettingNthMatchTextProgrammatically = true;
++
++        mNthMatchEditText.setText(String.valueOf(ordinal));
++        mNthMatchEditText.setSelection(mNthMatchEditText.getText().length()); // Move the cursor to the end.
++
++        mSettingNthMatchTextProgrammatically = false;
++    }
++
+     private void hideKeyboardAndStartFinding(boolean forward) {
+         if (mFindInPageBridge == null) return;
+ 
+@@ -394,10 +508,23 @@ public class FindToolbar extends LinearLayout implements BackPressHandler {
+         if (findQuery.length() == 0) return;
+ 
+         mWindowAndroid.getKeyboardDelegate().hideKeyboard(mFindQuery);
+-        mFindInPageBridge.startFinding(findQuery, forward, false);
++        mFindInPageBridge.startFinding(findQuery, forward, false, 0);
+         mFindInPageBridge.activateFindInPageResultForAccessibility();
+     }
+ 
++    private void hideKeyboardAndFindNth(int match_ordinal) {
++
++        if (mFindInPageBridge == null) return;
++
++        final String findQuery = assumeNonNull(mFindQuery.getText()).toString();
++        if (findQuery.length() == 0) return;
++
++        mWindowAndroid.getKeyboardDelegate().hideKeyboard(mFindQuery);
++        mFindInPageBridge.startFinding(findQuery, true, false, match_ordinal);
++        mFindInPageBridge.activateFindInPageResultForAccessibility();
++    }
++
++
+     private boolean mShowKeyboardOnceWindowIsFocused;
+ 
+     @Override
+@@ -494,6 +621,11 @@ public class FindToolbar extends LinearLayout implements BackPressHandler {
+                         R.string.find_in_page_count,
+                         Math.max(result.activeMatchOrdinal, 0),
+                         result.numberOfMatches);
++
++        mMaxOrdinal = result.numberOfMatches;
++        setNthMatchTextQuietly(result.activeMatchOrdinal);
++        mLastMatchButton.setText(String.valueOf(mMaxOrdinal));
++
+         setStatus(text, result.numberOfMatches == 0);
+ 
+         setPrevNextEnabled(result.numberOfMatches > 0);
+@@ -727,6 +859,11 @@ public class FindToolbar extends LinearLayout implements BackPressHandler {
+         }
+         mFindQuery.setText(findText);
+         mSettingFindTextProgrammatically = false;
++
++        final String findQuery = assumeNonNull(mFindQuery.getText()).toString();
++        if (findQuery.length() > 0) {
++            mFindInPageBridge.startFinding(findQuery, true, false, 0);
++        }
+     }
+ 
+     /** Sets the find query text string. */
+@@ -767,7 +904,16 @@ public class FindToolbar extends LinearLayout implements BackPressHandler {
+         mFindStatus.setText(text);
+         mFindStatus.setContentDescription(null);
+         mFindStatus.setTextColor(getStatusColor(failed, isIncognito()));
+-        mFindStatus.setVisibility(TextUtils.isEmpty(text) ? GONE : VISIBLE);
++
++        if (
++            mNthMatchEditText != null &&
++            mMatchesSeparator != null &&
++            mLastMatchButton != null
++            ) {
++            mNthMatchEditText.setVisibility(TextUtils.isEmpty(text) ? GONE : VISIBLE);
++            mMatchesSeparator.setVisibility(TextUtils.isEmpty(text) ? GONE : VISIBLE);
++            mLastMatchButton.setVisibility(TextUtils.isEmpty(text) ? GONE : VISIBLE);
++        }
+     }
+ 
+     /**

--- a/patches/chrome-android-javatests-src-org-chromium-chrome-browser-findinpage-FindTest.java.patch
+++ b/patches/chrome-android-javatests-src-org-chromium-chrome-browser-findinpage-FindTest.java.patch
@@ -1,0 +1,127 @@
+diff --git a/chrome/android/javatests/src/org/chromium/chrome/browser/findinpage/FindTest.java b/chrome/android/javatests/src/org/chromium/chrome/browser/findinpage/FindTest.java
+index 73730823f145c09952d0a68e232d30bbb83b3eca..f44615747a7717f81dc41bf68e7e176a25d62ad5 100644
+--- a/chrome/android/javatests/src/org/chromium/chrome/browser/findinpage/FindTest.java
++++ b/chrome/android/javatests/src/org/chromium/chrome/browser/findinpage/FindTest.java
+@@ -149,6 +149,25 @@ public class FindTest {
+         return waitForFindResults(expectedResult);
+     }
+ 
++     private String findNthStringInPage(final String query, int match_ordinal, String expectedResult) {
++        findInPageFromMenu();
++        final EditText nthMatchEditText = getNthMatchEditText();
++
++        // We have to send each key 1-by-1 to trigger the right listeners in the toolbar.
++        KeyCharacterMap keyCharacterMap = KeyCharacterMap.load(KeyCharacterMap.VIRTUAL_KEYBOARD);
++        final KeyEvent[] events = keyCharacterMap.getEvents(String.valueOf(match_ordinal).toCharArray());
++        Assert.assertNotNull(events);
++        ThreadUtils.runOnUiThreadBlocking(
++                () -> {
++                    for (int i = 0; i < events.length; i++) {
++                        if (!nthMatchEditText.dispatchKeyEventPreIme(events[i])) {
++                            nthMatchEditText.dispatchKeyEvent(events[i]);
++                        }
++                    }
++                });
++        return waitForFindResults(expectedResult);
++    }
++
+     private void loadTestAndVerifyFindInPage(String query, String expectedResult) {
+         mActivityTestRule.loadUrl(mActivityTestRule.getTestServer().getURL(FILEPATH));
+         String findResults = findStringInPage(query, expectedResult);
+@@ -162,6 +181,19 @@ public class FindTest {
+                 findResults.contains(expectedResult));
+     }
+ 
++    private void loadTestAndVerifyFindNthInPage(String query, int match_ordinal, String expectedResult) {
++        mActivityTestRule.loadUrl(mActivityTestRule.getTestServer().getURL(FILEPATH));
++        String findResults = findNthStringInPage(query, match_ordinal, expectedResult);
++        Assert.assertTrue(
++                "Expected: "
++                        + expectedResult
++                        + " Got: "
++                        + findResults
++                        + " for: "
++                        + mActivityTestRule.getTestServer().getURL(FILEPATH),
++                findResults.contains(expectedResult));
++    }
++
+     private FindToolbar getFindToolbar() {
+         final FindToolbar findToolbar =
+                 (FindToolbar) mActivityTestRule.getActivity().findViewById(R.id.find_toolbar);
+@@ -176,6 +208,14 @@ public class FindTest {
+         return findQueryText;
+     }
+ 
++
++    private EditText getNthMatchEditText() {
++        final EditText nthMatchText =
++                (EditText) mActivityTestRule.getActivity().findViewById(R.id.nth_match_edittext);
++        Assert.assertNotNull("NthMatchText not found", nthMatchText);
++        return nthMatchText;
++    }
++
+     /** Verify Find In Page is not case sensitive. */
+     @Test
+     @MediumTest
+@@ -217,6 +257,61 @@ public class FindTest {
+         loadTestAndVerifyFindInPage(multiLineSearchTerm, "0/0");
+     }
+ 
++    /** Verify Find In Page supports random access matching by match_ordinal N (in-bounds). */
++    @Test
++    @MediumTest
++    @Feature({"FindNthInPage", "N In-Bounds"})
++    public void testFindNthInBounds() {
++        loadTestAndVerifyFindNthInPage("pitts", 6, "6/7");
++        loadTestAndVerifyFindNthInPage("pitts", 3, "3/7");
++        loadTestAndVerifyFindNthInPage("pitts", 7, "7/7");
++        loadTestAndVerifyFindNthInPage("pitts", 1, "1/7");
++    }
++
++    /** Verify Find In Page supports random access matching and 
++     *  clamps match_ordinal N to a min/max if it falls out-of-bounds.
++     **/
++    @Test
++    @MediumTest
++    @Feature({"FindNthInPage", "N Out-of-Bounds"})
++    public void testFindNthOutOfBounds() {
++        // Clamp an underflowing N to the first match ordinal.
++        loadTestAndVerifyFindNthInPage("pitts", 0, "1/7"); 
++        loadTestAndVerifyFindNthInPage("pitts", -1, "1/7");
++        loadTestAndVerifyFindNthInPage("pitts", -2, "1/7");
++
++        // Clamp an overflowing N to the last match ordinal.
++        loadTestAndVerifyFindNthInPage("pitts", 8, "7/7");
++        loadTestAndVerifyFindNthInPage("pitts", 9, "7/7");
++        loadTestAndVerifyFindNthInPage("pitts", 10, "7/7");
++    }
++
++    /** Verify Find In Page selects the last match when the Last Match Button is pressed. */
++    @Test
++    @MediumTest
++    @Feature({"FindLastInPage"})
++    public void testFindLast() {
++        // Find all matches and select the first.
++        loadTestAndVerifyFindInPage("pitts", "1/7"); 
++
++        // Press the Last Match Button.
++        TouchCommon.singleClickView(
++                mActivityTestRule.getActivity().findViewById(R.id.last_match_button));
++
++        String expectedResult = "7/7";
++        String findResults = waitForFindResults(expectedResult);
++
++        // Assert the last match was selected.
++        Assert.assertTrue(
++                "Expected: "
++                        + expectedResult
++                        + " Got: "
++                        + findResults
++                        + " for: "
++                        + mActivityTestRule.getTestServer().getURL(FILEPATH),
++                findResults.contains(expectedResult));
++    }
++
+     /** Verify Find In Page Next button. */
+     @Test
+     @MediumTest

--- a/patches/chrome-browser-ui-view_ids.h.patch
+++ b/patches/chrome-browser-ui-view_ids.h.patch
@@ -1,0 +1,16 @@
+diff --git a/chrome/browser/ui/view_ids.h b/chrome/browser/ui/view_ids.h
+index 7f361e60874f758845776d800a065950375bd95d..cb24a4db8823b4ceeb8c493e36fd0451277aca80 100644
+--- a/chrome/browser/ui/view_ids.h
++++ b/chrome/browser/ui/view_ids.h
+@@ -82,7 +82,10 @@ enum ViewID {
+   VIEW_ID_BOOKMARK_BAR_ELEMENT,
+ 
+   // Find in page.
+-  VIEW_ID_FIND_IN_PAGE_TEXT_FIELD,  
++  VIEW_ID_FIND_IN_PAGE_TEXT_FIELD,
++  VIEW_ID_FIND_IN_PAGE_NTH_MATCH_TEXT_FIELD,
++  VIEW_ID_FIND_IN_PAGE_MATCHES_SEPARATOR_TEXT,
++  VIEW_ID_FIND_IN_PAGE_LAST_MATCH_BUTTON,
+   VIEW_ID_FIND_IN_PAGE_PREVIOUS_BUTTON,
+   VIEW_ID_FIND_IN_PAGE_NEXT_BUTTON,
+   VIEW_ID_FIND_IN_PAGE_CLOSE_BUTTON,

--- a/patches/chrome-browser-ui-views-controls-hover_button.cc.patch
+++ b/patches/chrome-browser-ui-views-controls-hover_button.cc.patch
@@ -1,0 +1,24 @@
+diff --git a/chrome/browser/ui/views/controls/hover_button.cc b/chrome/browser/ui/views/controls/hover_button.cc
+index 13c032448cc7bf0fb8cedcd14affdae129604a1d..03845b51176273495f36a14ad0efcf7bea56e5d9 100644
+--- a/chrome/browser/ui/views/controls/hover_button.cc
++++ b/chrome/browser/ui/views/controls/hover_button.cc
+@@ -30,6 +30,7 @@
+ #include "ui/views/focus/focus_manager.h"
+ #include "ui/views/layout/box_layout.h"
+ #include "ui/views/layout/flex_layout.h"
++#include "ui/views/layout/layout_provider.h"
+ #include "ui/views/style/typography.h"
+ #include "ui/views/style/typography_provider.h"
+ #include "ui/views/view_class_properties.h"
+@@ -102,7 +103,10 @@ HoverButton::HoverButton()
+       this,
+       std::make_unique<views::Button::DefaultButtonControllerDelegate>(this)));
+ 
+-  views::InstallRectHighlightPathGenerator(this);
++  auto corner_radius = views::LayoutProvider::Get()->GetCornerRadiusMetric(
++      views::ShapeContextTokens::kTextfieldRadius, gfx::Size()
++  );
++  views::InstallRoundRectHighlightPathGenerator(this, gfx::Insets(), corner_radius);
+ 
+   SetInstallFocusRingOnFocus(false);
+   SetFocusBehavior(FocusBehavior::ALWAYS);

--- a/patches/chrome-browser-ui-views-find_bar_view.cc.patch
+++ b/patches/chrome-browser-ui-views-find_bar_view.cc.patch
@@ -1,0 +1,585 @@
+diff --git a/chrome/browser/ui/views/find_bar_view.cc b/chrome/browser/ui/views/find_bar_view.cc
+index 23692d2bc42d1e681320e50969e977aff8541f1c..2ba9c1188eff1e2b15ed8e5ac0ab49548efef45f 100644
+--- a/chrome/browser/ui/views/find_bar_view.cc
++++ b/chrome/browser/ui/views/find_bar_view.cc
+@@ -9,10 +9,12 @@
+ #include <string_view>
+ 
+ #include <utility>
++#include <cwctype>
+ 
+ #include "base/feature_list.h"
+ #include "base/i18n/number_formatting.h"
+ #include "base/strings/string_util.h"
++#include "base/time/time.h"
+ #include "build/build_config.h"
+ #include "chrome/app/vector_icons/vector_icons.h"
+ #include "chrome/browser/enterprise/data_protection/data_protection_clipboard_utils.h"
+@@ -77,94 +79,16 @@ void SetCommonButtonAttributes(views::ImageButton* button) {
+ 
+ DEFINE_CLASS_ELEMENT_IDENTIFIER_VALUE(FindBarView, kElementId);
+ DEFINE_CLASS_ELEMENT_IDENTIFIER_VALUE(FindBarView, kTextField);
++DEFINE_CLASS_ELEMENT_IDENTIFIER_VALUE(FindBarView, kMatchControls);
++
++DEFINE_CLASS_ELEMENT_IDENTIFIER_VALUE(FindBarMatchCountControls, kNthMatchTextField);
++DEFINE_CLASS_ELEMENT_IDENTIFIER_VALUE(FindBarMatchCountControls, kMatchesSeparatorLabel);
++DEFINE_CLASS_ELEMENT_IDENTIFIER_VALUE(FindBarMatchCountControls, kLastMatchTextButton);
+ 
+ DEFINE_CLASS_ELEMENT_IDENTIFIER_VALUE(FindBarView, kPreviousButtonElementId);
+ DEFINE_CLASS_ELEMENT_IDENTIFIER_VALUE(FindBarView, kNextButtonElementId);
+ DEFINE_CLASS_ELEMENT_IDENTIFIER_VALUE(FindBarView, kCloseButtonElementId);
+ 
+-class FindBarMatchCountLabel : public views::Label {
+-  METADATA_HEADER(FindBarMatchCountLabel, views::Label)
+-
+- public:
+-  FindBarMatchCountLabel() {
+-    GetViewAccessibility().SetRole(ax::mojom::Role::kStatus);
+-    UpdateAccessibleName();
+-  }
+-
+-  FindBarMatchCountLabel(const FindBarMatchCountLabel&) = delete;
+-  FindBarMatchCountLabel& operator=(const FindBarMatchCountLabel&) = delete;
+-
+-  ~FindBarMatchCountLabel() override = default;
+-
+-  gfx::Size CalculatePreferredSize(
+-      const views::SizeBounds& available_size) const override {
+-    // We need to return at least 1dip so that box layout adds padding on either
+-    // side (otherwise there will be a jump when our size changes between empty
+-    // and non-empty).
+-    gfx::Size size = views::Label::CalculatePreferredSize(available_size);
+-    size.set_width(std::max(1, size.width()));
+-    return size;
+-  }
+-
+-  void UpdateAccessibleName() {
+-    if (!last_result_) {
+-      GetViewAccessibility().SetName(
+-          std::string(), ax::mojom::NameFrom::kAttributeExplicitlyEmpty);
+-    } else if (last_result_->number_of_matches() < 1) {
+-      GetViewAccessibility().SetName(
+-          l10n_util::GetStringUTF16(IDS_ACCESSIBLE_FIND_IN_PAGE_NO_RESULTS));
+-    } else {
+-      GetViewAccessibility().SetName(l10n_util::GetStringFUTF16(
+-          IDS_ACCESSIBLE_FIND_IN_PAGE_COUNT,
+-          base::FormatNumber(last_result_->active_match_ordinal()),
+-          base::FormatNumber(last_result_->number_of_matches())));
+-    }
+-  }
+-
+-  void SetResult(const find_in_page::FindNotificationDetails& result) {
+-    if (last_result_ && result == *last_result_) {
+-      return;
+-    }
+-
+-    last_result_ = result;
+-    // TODO(crbug.com/40939931): Get NO_RESULTS to be announced under Orca and
+-    // ChromeVox.
+-
+-    SetText(l10n_util::GetStringFUTF16(
+-        IDS_FIND_IN_PAGE_COUNT,    
+-        base::FormatNumber(last_result_->active_match_ordinal()),
+-        base::FormatNumber(last_result_->number_of_matches())));
+-    UpdateAccessibleName();
+-
+-    if (last_result_->final_update()) {
+-      GetViewAccessibility().AnnouncePolitely(
+-          GetViewAccessibility().GetCachedName());
+-    }
+-  }
+-
+-  void ClearResult() {
+-    last_result_.reset();
+-    SetText(std::u16string());
+-    UpdateAccessibleName();
+-  }
+-
+-
+-std::optional<find_in_page::FindNotificationDetails> GetLastResult() {
+-  return last_result_;
+-}
+-
+-
+- private:
+-  std::optional<find_in_page::FindNotificationDetails> last_result_;
+-};
+-
+-BEGIN_VIEW_BUILDER(/* No Export */, FindBarMatchCountLabel, views::Label)
+-END_VIEW_BUILDER
+-
+-DEFINE_VIEW_BUILDER(/* No Export */, FindBarMatchCountLabel)
+-
+-BEGIN_METADATA(FindBarMatchCountLabel)
+-END_METADATA
+ 
+ 
+ ////////////////////////////////////////////////////////////////////////////////
+@@ -179,7 +103,6 @@ FindBarView::FindBarView(FindBarHost* host) {
+   // we place views directly adjacent, with horizontal margins on each view
+   // that will add up to the right spacing amounts.
+ 
+-  PLOG(ERROR) << "[CUSTOM LOG] FindBarView::FindBarView(...) START constructor \t";
+ 
+   ChromeLayoutProvider* layout_provider = ChromeLayoutProvider::Get();
+   const auto horizontal_margin =
+@@ -211,12 +134,30 @@ FindBarView::FindBarView(FindBarHost* host) {
+   gfx::Insets textfield_hover_padding = vector_button;
+   textfield_hover_padding.set_top_bottom(0, 0);
+ 
++  const auto toast_label_vertical_margin = gfx::Insets::VH(
++    layout_provider->GetDistanceMetric(DISTANCE_TOAST_LABEL_VERTICAL), 0);
++
++  auto inside_border_insets =
++    gfx::Insets(layout_provider->GetInsetsMetric(INSETS_TOAST) -
++                horizontal_margin);
++
++  // Repurpose the match count widget to be an interactive composite of
++  // nth_match_textfield_, separator_label_, and last_match_button_.
++  match_count_controls_ = raw_ptr<FindBarMatchCountControls>(new FindBarMatchCountControls(
++    find_bar_view_weak_ptr_factory_.GetWeakPtr(),
++    FindBarView::ViewChildStyleProps({
++      horizontal_margin,
++      toast_control_vertical_margin,
++      toast_label_vertical_margin,
++      image_button_margins,
++      textfield_hover_padding
++    }))
++  );
++
+   auto main_container =
+       views::Builder<views::BoxLayoutView>()
+           .SetOrientation(views::BoxLayout::Orientation::kHorizontal)
+-          .SetInsideBorderInsets(
+-              gfx::Insets(layout_provider->GetInsetsMetric(INSETS_TOAST) -
+-                          horizontal_margin))
++          .SetInsideBorderInsets(inside_border_insets)
+           .AddChildren(
+               views::Builder<views::Textfield>()
+                   .CopyAddressTo(&find_text_)
+@@ -232,14 +173,8 @@ FindBarView::FindBarView(FindBarHost* host) {
+                                toast_control_vertical_margin +
+                                    horizontal_margin - textfield_hover_padding)
+                   .SetController(this),
+-              views::Builder<FindBarMatchCountLabel>()
+-                  .CopyAddressTo(&match_count_text_)
+-                  .SetBackgroundColor(kColorFindBarBackground)
+-                  .SetEnabledColor(kColorFindBarMatchCount)
+-                  .SetCanProcessEventsWithinSubtree(false)
+-                  .SetProperty(views::kMarginsKey,
+-                               gfx::Insets(toast_label_vertical_margin +
+-                                           horizontal_margin)),      
++
++              match_count_controls_->CreateLayout(inside_border_insets),
+ 
+               views::Builder<views::Separator>()
+                   .CopyAddressTo(&separator_)
+@@ -382,7 +317,11 @@ std::u16string_view FindBarView::GetFindSelectedText() const {
+ }
+ 
+ std::u16string_view FindBarView::GetMatchCountText() const {
+-  return match_count_text_->GetText();
++  return match_count_controls_->GetText();
++}
++
++std::u16string_view FindBarView::GetNthMatchTextfieldText() const {
++  return match_count_controls_->GetNthMatchTextfieldText();
+ }
+ 
+ void FindBarView::UpdateForResult(
+@@ -412,6 +351,12 @@ void FindBarView::UpdateForResult(
+     return;
+   }
+ 
++  match_count_controls_->SetResult(result);
++
++  // We know the total number of matches now,
++  // so don't allow inputs to the nth match textfield that are greater than the total.
++  match_count_controls_->SetMaxValue(result.number_of_matches());
++
+   UpdateMatchCountAppearance(result.number_of_matches() == 0 &&
+                              result.final_update());
+ 
+@@ -423,7 +368,7 @@ void FindBarView::UpdateForResult(
+ }
+ 
+ void FindBarView::ClearMatchCount() {
+-  match_count_text_->ClearResult();
++  match_count_controls_->ClearResult();
+   UpdateMatchCountAppearance(false);
+   DeprecatedLayoutImmediately();
+   SchedulePaint();
+@@ -456,7 +401,7 @@ bool FindBarView::OnMousePressed(const ui::MouseEvent& event) {
+ 
+ const views::ViewAccessibility&
+ FindBarView::GetFindBarMatchCountLabelViewAccessibilityForTesting() {
+-  return match_count_text_->GetViewAccessibility();
++  return match_count_controls_->GetViewAccessibility();
+ }
+ 
+ gfx::Size FindBarView::CalculatePreferredSize(
+@@ -465,7 +410,7 @@ gfx::Size FindBarView::CalculatePreferredSize(
+   // Ignore the preferred size for the match count label, and just let it take
+   // up part of the space for the input textfield. This prevents the overall
+   // width from changing every time the match count text changes.
+-    size.set_width(size.width() - match_count_text_->GetPreferredSize().width());
++    size.set_width(size.width() - match_count_controls_->GetPreferredSize().width());
+     return size;
+ }
+ 
+@@ -625,6 +570,23 @@ void FindBarView::FindNext(bool reverse) {
+   }
+ }
+ 
++void FindBarView::FindNth(int n) {
++  if (!find_bar_host_) {
++    return;
++  }
++  if (!find_text_->GetText().empty()) {
++    find_in_page::FindTabHelper* find_tab_helper =
++        find_in_page::FindTabHelper::FromWebContents(
++            find_bar_host_->GetFindBarController()->web_contents());
++    find_tab_helper->StartFinding(std::u16string(find_text_->GetText()),
++                                  true, /* forward_direction */
++                                  false,    /* case_sensitive */
++                                  true, /* find_match */
++                                  false, /* run_synchronously_for_testing */
++                                  n /* match_ordinal */);
++  }
++}
++
+ void FindBarView::EndFindSession() {
+   if (!find_bar_host_) {
+     return;
+@@ -641,3 +603,331 @@ void FindBarView::UpdateMatchCountAppearance(bool no_match) {
+ 
+ BEGIN_METADATA(FindBarView)
+ END_METADATA
++
++///////////////////////////////////////////////////////////////////////////////
++// FindBarMatchCountControls, public:
++
++FindBarMatchCountControls::FindBarMatchCountControls(
++    base::WeakPtr<FindBarView> find_bar_view,
++    FindBarView::ViewChildStyleProps style_props
++  ) : find_bar_view_(find_bar_view),
++      style_props_(style_props) {
++    GetViewAccessibility().SetRole(ax::mojom::Role::kStatus);
++    UpdateAccessibleName();
++  }
++
++  FindBarMatchCountControls::~FindBarMatchCountControls() = default;
++
++  views::internal::Builder<views::BoxLayoutView> FindBarMatchCountControls::CreateLayout(gfx::Insets inside_border_insets) {
++    auto match_count_container =
++      views::Builder<views::BoxLayoutView>()
++      .SetOrientation(views::BoxLayout::Orientation::kHorizontal)
++      .SetInsideBorderInsets(gfx::Insets(0))
++      .SetProperty(views::kElementIdentifierKey, FindBarView::kMatchControls)
++      .AddChildren(
++        views::Builder<views::Textfield>()
++                .CopyAddressTo(&nth_match_textfield_)
++                .SetAccessibleName(l10n_util::GetStringUTF16(IDS_ACCNAME_NTH))
++                .SetBorder(views::CreateEmptyBorder(style_props_.textfield_hover_padding))
++                .SetMinimumWidthInChars(1)
++                .SetDefaultWidthInChars(textfield_default_num_chars_)
++                .SetHorizontalAlignment(gfx::ALIGN_CENTER)
++                .SetID(VIEW_ID_FIND_IN_PAGE_NTH_MATCH_TEXT_FIELD)
++                .SetPlaceholderText(l10n_util::GetStringUTF16(IDS_FIND_IN_PAGE_NTH_MATCH_PLACEHOLDER_TEXT))
++                .SetPlaceholderTextHorizontalAlignment(gfx::Canvas::TEXT_ALIGN_CENTER)
++                .SetProperty(views::kElementIdentifierKey, kNthMatchTextField)
++                .SetProperty(views::kMarginsKey,
++                            style_props_.toast_control_vertical_margin +
++                                style_props_.horizontal_margin - style_props_.textfield_hover_padding)
++                .SetTextInputType(ui::TextInputType::TEXT_INPUT_TYPE_NUMBER)
++                .SetTextInputFlags(ui::TEXT_INPUT_FLAG_AUTOCORRECT_OFF)
++                .SetController(this),
++        views::Builder<views::Label>()
++                  .CopyAddressTo(&matches_separator_label_)
++                  .SetAccessibleName(
++                    l10n_util::GetStringUTF16(IDS_ACCNAME_MATCH_SEPARATOR))
++                  .SetBorder(views::CreateEmptyBorder(style_props_.textfield_hover_padding))
++                  .SetHorizontalAlignment(gfx::ALIGN_CENTER)
++                  .SetID(VIEW_ID_FIND_IN_PAGE_MATCHES_SEPARATOR_TEXT)
++                  .SetProperty(views::kElementIdentifierKey, kMatchesSeparatorLabel)
++                  .SetProperty(views::kMarginsKey,
++                               style_props_.toast_control_vertical_margin +
++                                   style_props_.horizontal_margin - style_props_.textfield_hover_padding)
++                  .SetText(l10n_util::GetStringUTF16(IDS_FIND_IN_PAGE_MATCHES_SEPARATOR_TEXT)),
++        views::Builder<HoverButton>()
++                  .CopyAddressTo(&last_match_button_)
++                  .SetAccessibleName(
++                     l10n_util::GetStringUTF16(IDS_ACCNAME_LAST))
++                  .SetID(VIEW_ID_FIND_IN_PAGE_LAST_MATCH_BUTTON)
++                  .SetProperty(views::kElementIdentifierKey, kLastMatchTextButton)
++                  .SetTooltipText(l10n_util::GetStringUTF16(IDS_FIND_IN_PAGE_LAST_MATCH_BUTTON_TOOLTIP))
++                  .SetCallback(base::BindRepeating(&FindBarMatchCountControls::HandleLastMatchBtnClick, base::Unretained(this)))
++                  .SetProperty(views::kMarginsKey, style_props_.image_button_margins)
++      );
++
++      return match_count_container;
++  }
++
++  gfx::Size FindBarMatchCountControls::CalculatePreferredSize (const views::SizeBounds& available_size) const {
++    // We need to return at least 1dip so that box layout adds padding on either
++    // side (otherwise there will be a jump when our size changes between empty
++    // and non-empty).
++    gfx::Size size = views::BoxLayoutView::CalculatePreferredSize(available_size);
++    size.set_width(std::max(1, size.width()));
++    return size;
++  }
++
++  void FindBarMatchCountControls::UpdateAccessibleName() {
++    if (!last_result_) {
++      GetViewAccessibility().SetName(
++          std::string(), ax::mojom::NameFrom::kAttributeExplicitlyEmpty);
++    } else if (last_result_->number_of_matches() < 1) {
++      GetViewAccessibility().SetName(
++          l10n_util::GetStringUTF16(IDS_ACCESSIBLE_FIND_IN_PAGE_NO_RESULTS));
++    } else {
++      GetViewAccessibility().SetName(l10n_util::GetStringFUTF16(
++          IDS_ACCESSIBLE_FIND_IN_PAGE_COUNT,
++          base::FormatNumber(last_result_->active_match_ordinal()),
++          base::FormatNumber(last_result_->number_of_matches())));
++    }
++  }
++
++  void FindBarMatchCountControls::SetText() {
++    last_composite_text_ =
++      l10n_util::GetStringFUTF16(
++        IDS_FIND_IN_PAGE_COUNT,
++        base::FormatNumber(last_result_->active_match_ordinal()),
++        base::FormatNumber(last_result_->number_of_matches()));
++  }
++
++  std::u16string_view FindBarMatchCountControls::GetText() {
++    return last_composite_text_;
++  }
++
++  std::u16string_view FindBarMatchCountControls::GetNthMatchTextfieldText() { 
++    return nth_match_textfield_->GetText();
++  }
++
++  void FindBarMatchCountControls::UpdateNthMatchTextfieldWidth() {
++    // Update the nth match texfield's width to reflect the width of its value.
++    std::size_t new_text_length = nth_match_textfield_->GetText().length();
++
++    // Adjust for the comma in a value of thousands or tens of thousands.
++    // Add 2 more chars' worth of horizontal padding, 1 char for each side.
++    // new_text_length = new_text_length >= 5 ? new_text_length + static_cast<std::size_t>(2) : new_text_length;
++    new_text_length = new_text_length >= textfield_default_num_chars_ ? new_text_length + static_cast<std::size_t>(2) : new_text_length;
++
++    int num_chars = static_cast<int>(std::max(textfield_default_num_chars_, new_text_length));
++    nth_match_textfield_->SetDefaultWidthInChars(num_chars);
++    nth_match_textfield_->PreferredSizeChanged();
++  }
++
++  void FindBarMatchCountControls::SetResult(const find_in_page::FindNotificationDetails& result) {
++    if (last_result_ && result == *last_result_) {
++      return;
++    }
++
++    last_result_ = result;
++    SetText();
++
++    // TODO(crbug.com/40939931): Get NO_RESULTS to be announced under Orca and
++    // ChromeVox.
++
++    // Update the match controls with values from the new result.
++    nth_match_textfield_->SetText(l10n_util::GetStringFUTF16Int(IDS_FIND_IN_PAGE_NTH_MATCH_NUM, result.active_match_ordinal()));
++    last_match_button_->SetText(l10n_util::GetStringFUTF16Int(IDS_FIND_IN_PAGE_TOTAL_MATCH_COUNT, result.number_of_matches()));
++
++    // Show the match controls
++    nth_match_textfield_->SetVisible(true);
++    matches_separator_label_->SetVisible(true);
++    last_match_button_->SetVisible(true);
++
++    UpdateNthMatchTextfieldWidth();
++    UpdateAccessibleName();
++
++    if (last_result_->final_update()) {
++      GetViewAccessibility().AnnouncePolitely(
++          GetViewAccessibility().GetCachedName());
++    }
++  }
++
++  void FindBarMatchCountControls::ClearResult() {
++    last_result_.reset();
++
++    // Clear text inside controls.
++    nth_match_textfield_->SetText(std::u16string());
++    last_match_button_->SetText(std::u16string());
++
++    // Hide the match controls since they're empty now.
++    nth_match_textfield_->SetVisible(false);
++    matches_separator_label_->SetVisible(false);
++    last_match_button_->SetVisible(false);
++
++    UpdateAccessibleName();
++  }
++
++
++std::optional<find_in_page::FindNotificationDetails> FindBarMatchCountControls::GetLastResult() {
++  return last_result_;
++}
++
++
++////////////////////////////////////////////////////////////////////////////////
++// FindBarMatchCountControls, FindNth helper methods:
++
++void FindBarMatchCountControls::SetMaxValue(int max) {
++  nth_match_textfield_max_ = max;
++}
++
++int FindBarMatchCountControls::EnsureNumericValue(std::u16string raw_value) {
++  if (raw_value.empty()) {
++    return 0;
++  }
++
++  auto isCharAlphabetical = [](char16_t c) {
++    return std::iswalpha(static_cast<wint_t>(c)) != 0;
++  };
++
++  // Default and escape if any non-numerics are found.
++  for (const char16_t c : raw_value) {
++    if (isCharAlphabetical(c)) {
++      return 0;
++    }
++  }
++
++  std::string parsable_value = base::UTF16ToUTF8(raw_value);
++
++  // Remove any commas if the value is thousands or tens of thousands.
++  while (parsable_value.find(",") != std::string::npos) {
++    parsable_value.replace(parsable_value.find(","), 1, "");
++  }
++
++  int num_value = std::stoi(parsable_value);
++
++  return num_value;
++}
++
++int FindBarMatchCountControls::GetBoundedValue(int n) {
++   // Clamp to the min if the user input underflows.
++   if (n < nth_match_textfield_min_) {
++    n = nth_match_textfield_min_;
++  }
++
++  // Clamp to the max if the user input overflows.
++  else if (n > nth_match_textfield_max_) {
++    n = nth_match_textfield_max_;
++  }
++
++  return n;
++}
++
++void FindBarMatchCountControls::HandleLastMatchBtnClick() {
++  int n = GetBoundedValue(last_result_->number_of_matches());
++  std::u16string nth_match_text(base::UTF8ToUTF16(std::to_string(n)));
++  last_n_text_ = nth_match_text;
++
++  // Update the UI to reflect the sanitized/clamped value.
++  nth_match_textfield_->SetText(nth_match_text);
++  find_bar_view_->FindNth(n);
++}
++
++
++////////////////////////////////////////////////////////////////////////////////
++// FindBarMatchCountControls, TextfieldController implementation:
++
++bool FindBarMatchCountControls::HandleKeyEvent(views::Textfield* sender,
++                    const ui::KeyEvent& event) {
++  // Do not try to send a reply if no text has been input.
++  if (!find_bar_view_ || find_bar_view_->find_text_->GetText().empty()) {
++    return false;
++  }
++
++  // Arrow key Handling
++  if (event.type() == ui::EventType::kKeyPressed &&
++      event.key_code() == ui::VKEY_UP) {
++    // Go to previous match.
++    find_bar_view_->FindNext(true);
++    return true;
++  }
++
++  if (event.type() == ui::EventType::kKeyPressed &&
++      event.key_code() == ui::VKEY_DOWN) {
++    // Go to next match.
++    find_bar_view_->FindNext(false);
++    return true;
++  }
++
++  return false;
++}
++
++bool FindBarMatchCountControls::HandleMouseEvent(views::Textfield* sender, const ui::MouseEvent& event) {
++
++  int64_t millis_since_last_scroll = std::abs(last_accepted_textfield_scroll_time_.InMillisecondsSinceUnixEpoch() -
++                                base::Time::NowFromSystemTime().InMillisecondsSinceUnixEpoch());
++
++  if (event.type() == ui::EventType::kMousewheel && 
++      millis_since_last_scroll >= min_millis_since_last_scroll_) {
++        
++    last_accepted_textfield_scroll_time_ = base::Time::NowFromSystemTime();
++
++    std::u16string nth_match_text(sender->GetText());
++    int n_parsed_int = GetBoundedValue(EnsureNumericValue(nth_match_text));
++    last_n_text_ = nth_match_text;
++
++    const ui::MouseWheelEvent* wheel_event = event.AsMouseWheelEvent();
++
++    int x_offset = wheel_event->x_offset();
++    int y_offset = wheel_event->y_offset();
++
++    // User scrolled up/left.
++    // Decrement N to get the previous match.
++    if (y_offset >= 0 || x_offset < 0) {
++      // If N - 1 underflows, then wrap around to the max.
++      if (n_parsed_int - 1 < nth_match_textfield_min_) {
++        n_parsed_int = nth_match_textfield_max_;
++      }
++      else {
++        n_parsed_int--;
++      }
++    }
++
++    // User scrolled down/right.
++    // Increment N to get the next match.
++    else if (y_offset < 0 || x_offset >= 0) {
++      // If N + 1 overflows, then wrap around to the min.
++      if (n_parsed_int + 1 > nth_match_textfield_max_) {
++        n_parsed_int = nth_match_textfield_min_;
++      }
++      else {
++        n_parsed_int++;
++      }
++    }
++
++    nth_match_textfield_->SetText(base::UTF8ToUTF16(std::to_string(n_parsed_int)));
++    find_bar_view_->FindNth(n_parsed_int);
++    return true;
++  }
++
++  return false;
++}
++
++void FindBarMatchCountControls::OnAfterUserAction(views::Textfield* sender) {
++  // The composition text wouldn't be what the user is really looking for.
++  // We delay the search until the user commits the composition text.
++  if (!sender->IsIMEComposing() && !sender->GetText().empty() &&
++      sender->GetText() != last_n_text_)
++  {
++    std::u16string nth_match_text(sender->GetText());
++    int n_parsed_int = GetBoundedValue(EnsureNumericValue(nth_match_text));
++
++    last_n_text_ = nth_match_text;
++
++    // Update the UI to reflect the sanitized/clamped value.
++    nth_match_textfield_->SetText(base::UTF8ToUTF16(std::to_string(n_parsed_int)));
++
++    find_bar_view_->FindNth(n_parsed_int);
++  }
++}
++
++BEGIN_METADATA(FindBarMatchCountControls)
++END_METADATA

--- a/patches/chrome-browser-ui-views-find_bar_view.cc.patch
+++ b/patches/chrome-browser-ui-views-find_bar_view.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/find_bar_view.cc b/chrome/browser/ui/views/find_bar_view.cc
-index 23692d2bc42d1e681320e50969e977aff8541f1c..2ba9c1188eff1e2b15ed8e5ac0ab49548efef45f 100644
+index 23692d2bc42d1e681320e50969e977aff8541f1c..97bc7d0d186ac819a63e2832f7ac77db31bceee1 100644
 --- a/chrome/browser/ui/views/find_bar_view.cc
 +++ b/chrome/browser/ui/views/find_bar_view.cc
 @@ -9,10 +9,12 @@
@@ -187,20 +187,17 @@ index 23692d2bc42d1e681320e50969e977aff8541f1c..2ba9c1188eff1e2b15ed8e5ac0ab4954
  }
  
  void FindBarView::UpdateForResult(
-@@ -412,6 +351,12 @@ void FindBarView::UpdateForResult(
+@@ -412,6 +351,9 @@ void FindBarView::UpdateForResult(
      return;
    }
  
 +  match_count_controls_->SetResult(result);
-+
-+  // We know the total number of matches now,
-+  // so don't allow inputs to the nth match textfield that are greater than the total.
 +  match_count_controls_->SetMaxValue(result.number_of_matches());
 +
    UpdateMatchCountAppearance(result.number_of_matches() == 0 &&
                               result.final_update());
  
-@@ -423,7 +368,7 @@ void FindBarView::UpdateForResult(
+@@ -423,7 +365,7 @@ void FindBarView::UpdateForResult(
  }
  
  void FindBarView::ClearMatchCount() {
@@ -209,7 +206,7 @@ index 23692d2bc42d1e681320e50969e977aff8541f1c..2ba9c1188eff1e2b15ed8e5ac0ab4954
    UpdateMatchCountAppearance(false);
    DeprecatedLayoutImmediately();
    SchedulePaint();
-@@ -456,7 +401,7 @@ bool FindBarView::OnMousePressed(const ui::MouseEvent& event) {
+@@ -456,7 +398,7 @@ bool FindBarView::OnMousePressed(const ui::MouseEvent& event) {
  
  const views::ViewAccessibility&
  FindBarView::GetFindBarMatchCountLabelViewAccessibilityForTesting() {
@@ -218,7 +215,7 @@ index 23692d2bc42d1e681320e50969e977aff8541f1c..2ba9c1188eff1e2b15ed8e5ac0ab4954
  }
  
  gfx::Size FindBarView::CalculatePreferredSize(
-@@ -465,7 +410,7 @@ gfx::Size FindBarView::CalculatePreferredSize(
+@@ -465,7 +407,7 @@ gfx::Size FindBarView::CalculatePreferredSize(
    // Ignore the preferred size for the match count label, and just let it take
    // up part of the space for the input textfield. This prevents the overall
    // width from changing every time the match count text changes.
@@ -227,7 +224,7 @@ index 23692d2bc42d1e681320e50969e977aff8541f1c..2ba9c1188eff1e2b15ed8e5ac0ab4954
      return size;
  }
  
-@@ -625,6 +570,23 @@ void FindBarView::FindNext(bool reverse) {
+@@ -625,6 +567,23 @@ void FindBarView::FindNext(bool reverse) {
    }
  }
  
@@ -251,7 +248,7 @@ index 23692d2bc42d1e681320e50969e977aff8541f1c..2ba9c1188eff1e2b15ed8e5ac0ab4954
  void FindBarView::EndFindSession() {
    if (!find_bar_host_) {
      return;
-@@ -641,3 +603,331 @@ void FindBarView::UpdateMatchCountAppearance(bool no_match) {
+@@ -641,3 +600,307 @@ void FindBarView::UpdateMatchCountAppearance(bool no_match) {
  
  BEGIN_METADATA(FindBarView)
  END_METADATA
@@ -366,10 +363,12 @@ index 23692d2bc42d1e681320e50969e977aff8541f1c..2ba9c1188eff1e2b15ed8e5ac0ab4954
 +
 +    // Adjust for the comma in a value of thousands or tens of thousands.
 +    // Add 2 more chars' worth of horizontal padding, 1 char for each side.
-+    // new_text_length = new_text_length >= 5 ? new_text_length + static_cast<std::size_t>(2) : new_text_length;
-+    new_text_length = new_text_length >= textfield_default_num_chars_ ? new_text_length + static_cast<std::size_t>(2) : new_text_length;
++    new_text_length = new_text_length >= textfield_default_num_chars_ ? 
++        new_text_length + static_cast<std::size_t>(2) : 
++        new_text_length;
 +
-+    int num_chars = static_cast<int>(std::max(textfield_default_num_chars_, new_text_length));
++    int num_chars = 
++      static_cast<int>(std::max(textfield_default_num_chars_, new_text_length));
 +    nth_match_textfield_->SetDefaultWidthInChars(num_chars);
 +    nth_match_textfield_->PreferredSizeChanged();
 +  }
@@ -459,7 +458,7 @@ index 23692d2bc42d1e681320e50969e977aff8541f1c..2ba9c1188eff1e2b15ed8e5ac0ab4954
 +  return num_value;
 +}
 +
-+int FindBarMatchCountControls::GetBoundedValue(int n) {
++int FindBarMatchCountControls::EnsureBoundedValue(int n) {
 +   // Clamp to the min if the user input underflows.
 +   if (n < nth_match_textfield_min_) {
 +    n = nth_match_textfield_min_;
@@ -474,13 +473,9 @@ index 23692d2bc42d1e681320e50969e977aff8541f1c..2ba9c1188eff1e2b15ed8e5ac0ab4954
 +}
 +
 +void FindBarMatchCountControls::HandleLastMatchBtnClick() {
-+  int n = GetBoundedValue(last_result_->number_of_matches());
-+  std::u16string nth_match_text(base::UTF8ToUTF16(std::to_string(n)));
-+  last_n_text_ = nth_match_text;
-+
-+  // Update the UI to reflect the sanitized/clamped value.
-+  nth_match_textfield_->SetText(nth_match_text);
-+  find_bar_view_->FindNth(n);
++  int n_validated = EnsureBoundedValue(last_result_->number_of_matches());
++  last_n_text_ = l10n_util::GetStringFUTF16Int(IDS_FIND_IN_PAGE_NTH_MATCH_NUM, n_validated);
++  find_bar_view_->FindNth(n_validated);
 +}
 +
 +
@@ -522,41 +517,22 @@ index 23692d2bc42d1e681320e50969e977aff8541f1c..2ba9c1188eff1e2b15ed8e5ac0ab4954
 +        
 +    last_accepted_textfield_scroll_time_ = base::Time::NowFromSystemTime();
 +
-+    std::u16string nth_match_text(sender->GetText());
-+    int n_parsed_int = GetBoundedValue(EnsureNumericValue(nth_match_text));
-+    last_n_text_ = nth_match_text;
-+
 +    const ui::MouseWheelEvent* wheel_event = event.AsMouseWheelEvent();
 +
 +    int x_offset = wheel_event->x_offset();
 +    int y_offset = wheel_event->y_offset();
 +
 +    // User scrolled up/left.
-+    // Decrement N to get the previous match.
-+    if (y_offset >= 0 || x_offset < 0) {
-+      // If N - 1 underflows, then wrap around to the max.
-+      if (n_parsed_int - 1 < nth_match_textfield_min_) {
-+        n_parsed_int = nth_match_textfield_max_;
-+      }
-+      else {
-+        n_parsed_int--;
-+      }
++    // Go to previous match.
++    if (y_offset > 0 || x_offset < 0) {
++      find_bar_view_->FindNext(true);
 +    }
 +
 +    // User scrolled down/right.
-+    // Increment N to get the next match.
-+    else if (y_offset < 0 || x_offset >= 0) {
-+      // If N + 1 overflows, then wrap around to the min.
-+      if (n_parsed_int + 1 > nth_match_textfield_max_) {
-+        n_parsed_int = nth_match_textfield_min_;
-+      }
-+      else {
-+        n_parsed_int++;
-+      }
++    // Go to next match.
++    else if (y_offset < 0 || x_offset > 0) {
++      find_bar_view_->FindNext(false);
 +    }
-+
-+    nth_match_textfield_->SetText(base::UTF8ToUTF16(std::to_string(n_parsed_int)));
-+    find_bar_view_->FindNth(n_parsed_int);
 +    return true;
 +  }
 +
@@ -564,20 +540,17 @@ index 23692d2bc42d1e681320e50969e977aff8541f1c..2ba9c1188eff1e2b15ed8e5ac0ab4954
 +}
 +
 +void FindBarMatchCountControls::OnAfterUserAction(views::Textfield* sender) {
++    std::u16string nth_match_text(sender->GetText());
++
 +  // The composition text wouldn't be what the user is really looking for.
 +  // We delay the search until the user commits the composition text.
 +  if (!sender->IsIMEComposing() && !sender->GetText().empty() &&
-+      sender->GetText() != last_n_text_)
++      nth_match_text != last_n_text_)
 +  {
-+    std::u16string nth_match_text(sender->GetText());
-+    int n_parsed_int = GetBoundedValue(EnsureNumericValue(nth_match_text));
++    int n_validated = EnsureBoundedValue(EnsureNumericValue(nth_match_text));
++    last_n_text_ = l10n_util::GetStringFUTF16Int(IDS_FIND_IN_PAGE_NTH_MATCH_NUM, n_validated);
 +
-+    last_n_text_ = nth_match_text;
-+
-+    // Update the UI to reflect the sanitized/clamped value.
-+    nth_match_textfield_->SetText(base::UTF8ToUTF16(std::to_string(n_parsed_int)));
-+
-+    find_bar_view_->FindNth(n_parsed_int);
++    find_bar_view_->FindNth(n_validated);
 +  }
 +}
 +

--- a/patches/chrome-browser-ui-views-find_bar_view.h.patch
+++ b/patches/chrome-browser-ui-views-find_bar_view.h.patch
@@ -1,0 +1,205 @@
+diff --git a/chrome/browser/ui/views/find_bar_view.h b/chrome/browser/ui/views/find_bar_view.h
+index c5c7be0bb4cd45edf35578ebdaaa04e89db929d1..36f40313ec93fc40626012830bc844f195fd63b1 100644
+--- a/chrome/browser/ui/views/find_bar_view.h
++++ b/chrome/browser/ui/views/find_bar_view.h
+@@ -12,7 +12,10 @@
+ #include "base/gtest_prod_util.h"
+ #include "base/memory/raw_ptr.h"
+ #include "chrome/browser/ui/views/chrome_views_export.h"
++#include "chrome/browser/ui/views/controls/hover_button.h"
++#include "components/find_in_page/find_notification_details.h"
+ #include "ui/base/interaction/element_identifier.h"
++#include "ui/base/l10n/l10n_util.h"
+ #include "ui/views/controls/button/button.h"
+ #include "ui/views/controls/button/image_button.h"
+ #include "ui/views/controls/textfield/textfield.h"
+@@ -21,7 +24,7 @@
+ #include "ui/views/metadata/view_factory.h"
+ 
+ class FindBarHost;
+-class FindBarMatchCountLabel;
++class FindBarMatchCountControls;
+ 
+ namespace find_in_page {
+ class FindNotificationDetails;
+@@ -35,7 +38,6 @@ namespace views {
+ class Painter;
+ class Separator;
+ class Textfield;
+-class LabelButton;
+ }  // namespace views
+ 
+ ////////////////////////////////////////////////////////////////////////////////
+@@ -53,8 +55,7 @@ class FindBarView : public views::BoxLayoutView,
+   // Element IDs for ui::ElementTracker
+   DECLARE_CLASS_ELEMENT_IDENTIFIER_VALUE(kElementId);
+   DECLARE_CLASS_ELEMENT_IDENTIFIER_VALUE(kTextField);
+-  DECLARE_CLASS_ELEMENT_IDENTIFIER_VALUE(kNthMatchTextField);
+-  DECLARE_CLASS_ELEMENT_IDENTIFIER_VALUE(kLastMatchTextButton);
++  DECLARE_CLASS_ELEMENT_IDENTIFIER_VALUE(kMatchControls);
+   DECLARE_CLASS_ELEMENT_IDENTIFIER_VALUE(kPreviousButtonElementId);
+   DECLARE_CLASS_ELEMENT_IDENTIFIER_VALUE(kNextButtonElementId);
+   DECLARE_CLASS_ELEMENT_IDENTIFIER_VALUE(kCloseButtonElementId);
+@@ -66,6 +67,14 @@ class FindBarView : public views::BoxLayoutView,
+ 
+   ~FindBarView() override;
+ 
++  struct ViewChildStyleProps {
++    const gfx::Insets horizontal_margin;
++    const gfx::Insets toast_control_vertical_margin;
++    const gfx::Insets toast_label_vertical_margin;
++    const gfx::Insets image_button_margins;
++    gfx::Insets textfield_hover_padding;
++  };
++
+   void SetHost(FindBarHost* host);
+ 
+   // Accessors for the text and selection displayed in the text box.
+@@ -80,6 +89,9 @@ class FindBarView : public views::BoxLayoutView,
+   // Gets the match count text displayed in the text box.
+   std::u16string_view GetMatchCountText() const;
+ 
++  // Gets the match ordinal text displayed in the Nth Match textfield.
++  std::u16string_view GetNthMatchTextfieldText() const;
++
+   // Updates the label inside the Find text box that shows the ordinal of the
+   // active item and how many matches were found.
+   void UpdateForResult(const find_in_page::FindNotificationDetails& result,
+@@ -121,6 +133,8 @@ class FindBarView : public views::BoxLayoutView,
+   const views::ViewAccessibility&
+   GetFindBarMatchCountLabelViewAccessibilityForTesting();
+ 
++  friend class FindBarMatchCountControls;
++
+   // Starts finding |search_text|.  If the text is empty, stops finding.
+   void Find(std::u16string_view search_text);
+ 
+@@ -128,6 +142,9 @@ class FindBarView : public views::BoxLayoutView,
+   // next/previous button.
+   void FindNext(bool reverse = false);
+ 
++  // Find the Nth occurrence of search text relative to its peers. N is 1-based.
++  void FindNth(int n);
++
+   // End the current find session and close the find bubble.
+   void EndFindSession();
+ 
+@@ -147,13 +164,14 @@ class FindBarView : public views::BoxLayoutView,
+ 
+   // The controls in the window.
+   raw_ptr<views::Textfield> find_text_;
++  raw_ptr<FindBarMatchCountControls> match_count_controls_;
+   std::unique_ptr<views::Painter> find_text_border_;
+-  raw_ptr<FindBarMatchCountLabel> match_count_text_;
+-    
+   raw_ptr<views::Separator> separator_;
+   raw_ptr<views::ImageButton> find_previous_button_;
+   raw_ptr<views::ImageButton> find_next_button_;
+   raw_ptr<views::ImageButton> close_button_;
++
++  base::WeakPtrFactory<FindBarView> find_bar_view_weak_ptr_factory_{this};
+ };
+ 
+ BEGIN_VIEW_BUILDER(/* no export */, FindBarView, views::BoxLayoutView)
+@@ -162,4 +180,101 @@ END_VIEW_BUILDER
+ 
+ DEFINE_VIEW_BUILDER(/* no export */, FindBarView)
+ 
++///////////////////////////////////////////////////////////////////////////////
++//
++// FindBarMatchCountControls is responsible for handling the
++// states and interactions of the Nth Match Textfield and Last Match Button.
++// It communicates the user's desired match number to the FindBarView by issuing
++// FindNth() commands.
++//
++////////////////////////////////////////////////////////////////////////////////
++class FindBarMatchCountControls : public views::BoxLayoutView,
++                                  public views::TextfieldController {
++  METADATA_HEADER(FindBarMatchCountControls, views::BoxLayoutView)
++
++ public:
++  DECLARE_CLASS_ELEMENT_IDENTIFIER_VALUE(kNthMatchTextField);
++  DECLARE_CLASS_ELEMENT_IDENTIFIER_VALUE(kMatchesSeparatorLabel);
++  DECLARE_CLASS_ELEMENT_IDENTIFIER_VALUE(kLastMatchTextButton);
++
++  FindBarMatchCountControls();
++
++  explicit FindBarMatchCountControls(
++      base::WeakPtr<FindBarView> find_bar_view,
++      FindBarView::ViewChildStyleProps style_props);
++
++  FindBarMatchCountControls(const FindBarMatchCountControls&) = delete;
++  FindBarMatchCountControls& operator=(const FindBarMatchCountControls&) =
++      delete;
++
++  ~FindBarMatchCountControls() override;
++
++  views::internal::Builder<BoxLayoutView> CreateLayout(
++      gfx::Insets inside_border_insets);
++
++  gfx::Size CalculatePreferredSize(
++      const views::SizeBounds& available_size) const override;
++
++  void UpdateAccessibleName();
++
++  void SetText();
++
++  std::u16string_view GetText();
++
++  std::u16string_view GetNthMatchTextfieldText();
++
++  void UpdateNthMatchTextfieldWidth();
++
++  void SetResult(const find_in_page::FindNotificationDetails& result);
++
++  void ClearResult();
++
++  std::optional<find_in_page::FindNotificationDetails> GetLastResult();
++
++  ////////////////////////////////////////////////////////////////////////////////
++  // FindBarMatchCountControls, FindNth helper methods:
++
++  void SetMaxValue(int max);
++
++  int EnsureNumericValue(std::u16string raw_value);
++
++  int GetBoundedValue(int n);
++
++  void HandleLastMatchBtnClick();
++
++  ////////////////////////////////////////////////////////////////////////////////
++  // FindBarMatchCountControls, TextfieldController implementation:
++
++  bool HandleKeyEvent(views::Textfield* sender,
++                      const ui::KeyEvent& event) override;
++
++  bool HandleMouseEvent(views::Textfield* sender,
++                        const ui::MouseEvent& event) override;
++
++  void OnAfterUserAction(views::Textfield* sender) override;
++
++ private:
++  base::WeakPtr<FindBarView> find_bar_view_;
++  FindBarView::ViewChildStyleProps style_props_;
++  raw_ptr<views::Textfield> nth_match_textfield_;
++  raw_ptr<views::Label> matches_separator_label_;
++  raw_ptr<HoverButton> last_match_button_;
++
++  std::u16string last_n_text_;
++  std::u16string last_composite_text_;
++  int nth_match_textfield_min_ = 1;
++  int nth_match_textfield_max_;
++
++  std::size_t textfield_default_num_chars_ = static_cast<std::size_t>(3);
++  base::Time last_accepted_textfield_scroll_time_;
++  int64_t min_millis_since_last_scroll_ = 80;
++
++  std::optional<find_in_page::FindNotificationDetails> last_result_;
++};
++
++BEGIN_VIEW_BUILDER(/* No Export */, FindBarMatchCountControls, views::BoxLayoutView)
++END_VIEW_BUILDER
++
++DEFINE_VIEW_BUILDER(/* No Export */, FindBarMatchCountControls)
++
+ #endif  // CHROME_BROWSER_UI_VIEWS_FIND_BAR_VIEW_H_

--- a/patches/chrome-browser-ui-views-find_bar_view.h.patch
+++ b/patches/chrome-browser-ui-views-find_bar_view.h.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/find_bar_view.h b/chrome/browser/ui/views/find_bar_view.h
-index c5c7be0bb4cd45edf35578ebdaaa04e89db929d1..36f40313ec93fc40626012830bc844f195fd63b1 100644
+index c5c7be0bb4cd45edf35578ebdaaa04e89db929d1..b6da8cc8cc67e44e2f999467d089edd9627b869c 100644
 --- a/chrome/browser/ui/views/find_bar_view.h
 +++ b/chrome/browser/ui/views/find_bar_view.h
 @@ -12,7 +12,10 @@
@@ -163,7 +163,7 @@ index c5c7be0bb4cd45edf35578ebdaaa04e89db929d1..36f40313ec93fc40626012830bc844f1
 +
 +  int EnsureNumericValue(std::u16string raw_value);
 +
-+  int GetBoundedValue(int n);
++  int EnsureBoundedValue(int n);
 +
 +  void HandleLastMatchBtnClick();
 +

--- a/patches/chrome-browser-ui-views-find_bar_views_interactive_uitest.cc.patch
+++ b/patches/chrome-browser-ui-views-find_bar_views_interactive_uitest.cc.patch
@@ -1,0 +1,666 @@
+diff --git a/chrome/browser/ui/views/find_bar_views_interactive_uitest.cc b/chrome/browser/ui/views/find_bar_views_interactive_uitest.cc
+index 3782312a904b96c9de20eff979ea25df0c5ee814..6aebf47ae369f08ce9a968078477cb7208c6f7cb 100644
+--- a/chrome/browser/ui/views/find_bar_views_interactive_uitest.cc
++++ b/chrome/browser/ui/views/find_bar_views_interactive_uitest.cc
+@@ -2,6 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
++#include <string>
+ #include "base/i18n/number_formatting.h"
+ #include "base/strings/string_util.h"
+ #include "base/strings/utf_string_conversions.h"
+@@ -43,6 +44,7 @@
+ #include "content/public/test/browser_test.h"
+ #include "content/public/test/browser_test_utils.h"
+ #include "content/public/test/focus_changed_observer.h"
++#include "find_bar_view.h"
+ #include "net/dns/mock_host_resolver.h"
+ #include "net/test/embedded_test_server/embedded_test_server.h"
+ #include "third_party/blink/public/common/switches.h"
+@@ -72,6 +74,7 @@ using ui_test_utils::IsViewFocused;
+ 
+ namespace {
+ const char kSimplePage[] = "/find_in_page/simple.html";
++const char kLargePage[] = "/find_in_page/largepage.html";
+ 
+ std::unique_ptr<net::test_server::HttpResponse> HandleHttpRequest(
+     const net::test_server::HttpRequest& request) {
+@@ -195,6 +198,57 @@ class LegacyFindInPageTest : public InProcessBrowserTest {
+     view->OnGestureEvent(&event);
+   }
+ 
++  void EnterNumericText(std::u16string number_as_string) {
++     // Type-in a value to the focused element, digit-by-digit.
++  for (const char16_t digit_char : number_as_string) {
++    int digit = std::stoi(base::UTF16ToUTF8(std::u16string(&digit_char)));
++    switch (digit) {
++      case 0: 
++        ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_0, false,
++                                              false, false, false));
++        break;
++      case 1: 
++        ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_1, false,
++                                              false, false, false));
++        break;
++      case 2: 
++        ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_2, false,
++                                              false, false, false));
++        break;
++      case 3: 
++        ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_3, false,
++                                              false, false, false));
++        break;
++      case 4: 
++        ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_4, false,
++                                              false, false, false));
++        break;
++      case 5: 
++        ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_5, false,
++                                              false, false, false));
++        break;
++      case 6: 
++        ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_6, false,
++                                              false, false, false));
++        break;
++      case 7: 
++        ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_7, false,
++                                              false, false, false));
++        break;
++      case 8: 
++        ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_8, false,
++                                              false, false, false));
++        break;
++      case 9: 
++        ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_9, false,
++                                              false, false, false));
++        break;
++      default:
++        break;
++    }
++  }
++  }
++
+   find_in_page::FindNotificationDetails WaitForFindResult() {
+     WebContents* web_contents =
+         browser()->tab_strip_model()->GetActiveWebContents();
+@@ -371,7 +425,9 @@ IN_PROC_BROWSER_TEST_F(FindBarViewsUiTest, NavigationByKeyEvent) {
+               testing::Ne(FindResultState::kInitialActiveMatchOrdinalCount))),
+       // Press the [Tab] key and [Enter], the previous button should still be
+       // focused.
+-      SendKeyPress(ui::VKEY_TAB, false, false),
++      SendKeyPress(ui::VKEY_TAB, false, false), // Tab to Nth Match Textfield 
++      SendKeyPress(ui::VKEY_TAB, false, false), // Tab to Last Match HoverButton
++      SendKeyPress(ui::VKEY_TAB, false, false), // Tab to Previous Match ImageButton 
+       SendKeyPress(ui::VKEY_RETURN, false, false),
+       CheckHasFocus(FindBarView::kPreviousButtonElementId),
+       // Press the [Tab] key and [Enter], the next button should still be
+@@ -457,22 +513,42 @@ IN_PROC_BROWSER_TEST_F(LegacyFindInPageTest, ButtonsDoNotAlterFocus) {
+       find_bar_view->GetViewByID(VIEW_ID_FIND_IN_PAGE_NEXT_BUTTON);
+   views::View* previous_button =
+       find_bar_view->GetViewByID(VIEW_ID_FIND_IN_PAGE_PREVIOUS_BUTTON);
++  views::View* last_match_button =
++      find_bar_view->GetViewByID(VIEW_ID_FIND_IN_PAGE_LAST_MATCH_BUTTON);
+ 
+-  // Clicking the next and previous buttons should not alter the focused view.
++  // Clicking the next, previous, and last match buttons should not alter the focused view.
+   ClickOnView(next_button);
+   EXPECT_EQ(2, WaitForFinalFindResult().active_match_ordinal());
+   EXPECT_TRUE(IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_TEXT_FIELD));
+   ClickOnView(previous_button);
+   EXPECT_EQ(1, WaitForFinalFindResult().active_match_ordinal());
+   EXPECT_TRUE(IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_TEXT_FIELD));
++  ClickOnView(last_match_button);
++  EXPECT_EQ(match_count, WaitForFinalFindResult().active_match_ordinal());
++  EXPECT_TRUE(IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_TEXT_FIELD));
++
++  // Reset the find results to point to the first match.
++  int first_match_ordinal = 1;
++  ui_test_utils::FindInPage(
++    browser()->tab_strip_model()->GetActiveWebContents(), u"e", true, false,
++    &first_match_ordinal, nullptr);
+ 
+-  // Tapping the next and previous buttons should not alter the focused view.
++  // Tapping the next, previous, and last match buttons should not alter the focused view.
+   TapOnView(next_button);
+   EXPECT_EQ(2, WaitForFinalFindResult().active_match_ordinal());
+   EXPECT_TRUE(IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_TEXT_FIELD));
+   TapOnView(previous_button);
+   EXPECT_EQ(1, WaitForFinalFindResult().active_match_ordinal());
+   EXPECT_TRUE(IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_TEXT_FIELD));
++  ClickOnView(last_match_button);
++  EXPECT_EQ(match_count, WaitForFinalFindResult().active_match_ordinal());
++  EXPECT_TRUE(IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_TEXT_FIELD));
++
++  // Reset the find results to point to the first match.
++  first_match_ordinal = 1;
++  ui_test_utils::FindInPage(
++    browser()->tab_strip_model()->GetActiveWebContents(), u"e", true, false,
++    &first_match_ordinal, nullptr);
+ 
+   // The same should be true even when the previous button is focused.
+   previous_button->RequestFocus();
+@@ -1349,3 +1425,523 @@ IN_PROC_BROWSER_TEST_P(FindBarViewsUiTest, DISABLED_CopyBlockedByPolicy) {
+       WaitForViewProperty(FindBarView::kTextField, views::Textfield, Text,
+                           u"some text"));
+ }
++
++IN_PROC_BROWSER_TEST_F(LegacyFindInPageTest, FindNthMatchWhenNthMatchTextChanges) {
++
++  ASSERT_TRUE(embedded_test_server()->Start());
++
++  // Make sure Chrome is in the foreground, otherwise sending input
++  // won't do anything and the test will hang.
++  ASSERT_TRUE(ui_test_utils::BringBrowserWindowToFront(browser()));
++
++  // First we navigate to any page.
++  ASSERT_TRUE(ui_test_utils::NavigateToURL(
++      browser(), embedded_test_server()->GetURL(kLargePage)));
++
++  // Show the Find bar.
++  browser()->GetFeatures().GetFindBarController()->Show();
++  EXPECT_TRUE(IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_TEXT_FIELD));
++
++  FindBarView* find_bar_view = GetFindBarView();
++
++  // Enter phrase " the " to start the initial find operation.
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_SPACE, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_T, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_H, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_E, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_SPACE, false,
++                                              false, false, false));
++ 
++  // Wait for events to settle.
++  auto last_result = WaitForFinalFindResult();
++
++  // Assert the find bar textfield displays the correct value.
++  EXPECT_EQ(GetFindBarText(), base::UTF8ToUTF16(std::string(" the ")));
++
++
++  // Assert the number of matches found in the browser is correct.
++  EXPECT_EQ(447, last_result.number_of_matches());
++
++  // Set N in-bounds.
++  int n = 20;
++  std::u16string n_string(base::UTF8ToUTF16(std::to_string(n)));
++
++  // Press the Tab key to focus the Nth match textfield.
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_TAB, false,
++                                              false, false, false));
++
++  EXPECT_TRUE(
++    IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_NTH_MATCH_TEXT_FIELD));
++
++  // Type-in the value for N.
++  EnterNumericText(n_string);
++
++  // Wait for events to settle.
++  last_result = WaitForFinalFindResult();
++
++  // Assert the Nth match textfield displays the correct value.
++  EXPECT_EQ(n_string, find_bar_view->GetNthMatchTextfieldText());
++
++  // Assert the Nth match is active.
++  EXPECT_EQ(n, last_result.active_match_ordinal());
++}
++
++IN_PROC_BROWSER_TEST_F(LegacyFindInPageTest, FindPreviousMatchNthMatchTextfieldFocusedUpArrowKeyPressed) {
++
++  ASSERT_TRUE(embedded_test_server()->Start());
++
++  // Make sure Chrome is in the foreground, otherwise sending input
++  // won't do anything and the test will hang.
++  ASSERT_TRUE(ui_test_utils::BringBrowserWindowToFront(browser()));
++
++  // First we navigate to any page.
++  ASSERT_TRUE(ui_test_utils::NavigateToURL(
++      browser(), embedded_test_server()->GetURL(kLargePage)));
++
++  // Show the Find bar.
++  browser()->GetFeatures().GetFindBarController()->Show();
++  EXPECT_TRUE(IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_TEXT_FIELD));
++
++  FindBarView* find_bar_view = GetFindBarView();
++
++  // Enter phrase " the " to start the initial find operation.
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_SPACE, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_T, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_H, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_E, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_SPACE, false,
++                                              false, false, false));
++
++  // Assert the find bar textfield displays the correct value.
++  EXPECT_EQ(GetFindBarText(), base::UTF8ToUTF16(std::string(" the ")));
++
++  // Wait for events to settle.
++  auto last_result = WaitForFinalFindResult();
++
++  std::u16string nth_match_textfield_text(find_bar_view->GetNthMatchTextfieldText());
++  
++  // Assert the first match is highlighted by default.
++  // and the number of matches found in the browser is correct.
++  EXPECT_EQ(1, last_result.active_match_ordinal()); 
++  EXPECT_EQ(447, last_result.number_of_matches());
++  EXPECT_EQ(std::u16string(u"1"), nth_match_textfield_text);
++
++  // Press the Tab key to focus the Nth match textfield.
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_TAB, false,
++                                              false, false, false));
++  EXPECT_TRUE(
++      IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_NTH_MATCH_TEXT_FIELD));
++
++  // Press the Up Arrow key.
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_UP, false,
++                                              false, false, false));
++
++  // Wait for events to settle.
++  last_result = WaitForFinalFindResult();
++
++  nth_match_textfield_text = find_bar_view->GetNthMatchTextfieldText();
++  
++  // Assert that pressing the Up Arrow key underflowed N 
++  // and wrapped it back around to the max.
++  EXPECT_EQ(
++    nth_match_textfield_text,
++    base::UTF8ToUTF16(std::to_string(last_result.number_of_matches())));
++
++  // Assert the previous match is the active match.
++  EXPECT_EQ(
++    nth_match_textfield_text, 
++    base::UTF8ToUTF16(std::to_string(last_result.active_match_ordinal())));
++  
++  // -------------- Next round ------------------
++ 
++  int n_before_up_arrow = std::stoi(base::UTF16ToUTF8(nth_match_textfield_text));
++
++  // Press the Up Arrow key.
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_UP, false,
++                                              false, false, false));
++  // Wait for events to settle.
++  last_result = WaitForFinalFindResult();      
++  
++  nth_match_textfield_text = find_bar_view->GetNthMatchTextfieldText();
++
++  // Assert that pressing the Up Arrow key decreased N by 1.
++  EXPECT_EQ(
++    nth_match_textfield_text,
++    base::UTF8ToUTF16(std::to_string(n_before_up_arrow - 1))
++  );
++
++  // Assert the previous match is the active match.
++  EXPECT_EQ(
++    nth_match_textfield_text, 
++    base::UTF8ToUTF16(std::to_string(last_result.active_match_ordinal())));
++}
++
++IN_PROC_BROWSER_TEST_F(LegacyFindInPageTest, FindNextMatchNthMatchTextfieldFocusedDownArrowKeyPressed) {
++
++  ASSERT_TRUE(embedded_test_server()->Start());
++
++  // Make sure Chrome is in the foreground, otherwise sending input
++  // won't do anything and the test will hang.
++  ASSERT_TRUE(ui_test_utils::BringBrowserWindowToFront(browser()));
++
++  // First we navigate to any page.
++  ASSERT_TRUE(ui_test_utils::NavigateToURL(
++      browser(), embedded_test_server()->GetURL(kLargePage)));
++
++  // Show the Find bar.
++  browser()->GetFeatures().GetFindBarController()->Show();
++  EXPECT_TRUE(IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_TEXT_FIELD));
++
++  FindBarView* find_bar_view = GetFindBarView();
++
++  // Enter phrase " the " to start the initial find operation.
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_SPACE, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_T, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_H, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_E, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_SPACE, false,
++                                              false, false, false));
++
++  // Assert the find bar textfield displays the correct value.
++  EXPECT_EQ(GetFindBarText(), base::UTF8ToUTF16(std::string(" the ")));
++
++  // Wait for events to settle.
++  auto last_result = WaitForFinalFindResult();
++
++  std::u16string nth_match_textfield_text(find_bar_view->GetNthMatchTextfieldText());
++  
++  // Assert the first match is highlighted,
++  // the number of matches found in the browser is correct,
++  // and the value in the Nth match textfield is correct.
++  EXPECT_EQ(1, last_result.active_match_ordinal()); 
++  EXPECT_EQ(447, last_result.number_of_matches());
++  EXPECT_EQ(std::u16string(u"1"), nth_match_textfield_text);
++
++  // Press the Tab key to focus the Nth match textfield.
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_TAB, false,
++                                              false, false, false));
++  EXPECT_TRUE(
++      IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_NTH_MATCH_TEXT_FIELD));
++
++  // Jump to the last match to demonstrate wrap-around.
++  EnterNumericText(base::UTF8ToUTF16(std::to_string(last_result.number_of_matches())));
++
++  // Wait for events to settle.
++  last_result = WaitForFinalFindResult();
++
++  nth_match_textfield_text = find_bar_view->GetNthMatchTextfieldText();
++
++  // Assert the last match is highlighted,
++  // the number of matches found in the browser is correct,
++  // and the value in the Nth match textfield is correct.
++  EXPECT_EQ(
++    last_result.number_of_matches(), 
++    last_result.active_match_ordinal()); 
++  EXPECT_EQ(447, last_result.number_of_matches());
++  EXPECT_EQ(std::u16string(u"447"), nth_match_textfield_text);
++
++  // Press the Down Arrow key.
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_DOWN, false,
++                                              false, false, false));
++
++  // Wait for events to settle.
++  last_result = WaitForFinalFindResult();
++
++  nth_match_textfield_text = find_bar_view->GetNthMatchTextfieldText();
++  
++  // Assert that pressing the Down Arrow key overflowed N 
++  // and wrapped it back around to the min.
++  EXPECT_EQ(
++    nth_match_textfield_text,
++    base::UTF8ToUTF16(std::to_string(1)));
++
++  // Assert the next match is the active match.
++  EXPECT_EQ(
++    nth_match_textfield_text, 
++    base::UTF8ToUTF16(std::to_string(last_result.active_match_ordinal())));
++
++
++  /* -------------- Next round ------------------ */
++ 
++  int n_before_down_arrow = std::stoi(base::UTF16ToUTF8(nth_match_textfield_text));
++
++  // Press the Down Arrow key.
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_DOWN, false,
++                                              false, false, false));
++  // Wait for events to settle.
++  last_result = WaitForFinalFindResult();      
++  
++  nth_match_textfield_text = find_bar_view->GetNthMatchTextfieldText();
++
++  // Assert that pressing the Down Arrow key increased N by 1.
++  EXPECT_EQ(
++    nth_match_textfield_text,
++    base::UTF8ToUTF16(std::to_string(n_before_down_arrow + 1))
++  );
++
++  // Assert the next match is the active match.
++  EXPECT_EQ(
++    nth_match_textfield_text, 
++    base::UTF8ToUTF16(std::to_string(last_result.active_match_ordinal())));
++}
++
++
++IN_PROC_BROWSER_TEST_F(LegacyFindInPageTest, FindFirstMatchWhenNthMatchTextIsNotNumeric) {
++
++  ASSERT_TRUE(embedded_test_server()->Start());
++
++  // Make sure Chrome is in the foreground, otherwise sending input
++  // won't do anything and the test will hang.
++  ASSERT_TRUE(ui_test_utils::BringBrowserWindowToFront(browser()));
++
++  // First we navigate to any page.
++  ASSERT_TRUE(ui_test_utils::NavigateToURL(
++      browser(), embedded_test_server()->GetURL(kLargePage)));
++
++  // Show the Find bar.
++  browser()->GetFeatures().GetFindBarController()->Show();
++  EXPECT_TRUE(IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_TEXT_FIELD));
++
++  FindBarView* find_bar_view = GetFindBarView();
++
++  // Enter phrase " the " to start the initial find operation.
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_SPACE, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_T, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_H, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_E, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_SPACE, false,
++                                              false, false, false)); 
++
++  // Assert the find bar textfield displays the correct value.
++  EXPECT_EQ(GetFindBarText(), base::UTF8ToUTF16(std::string(" the ")));
++
++  // Wait for events to settle.
++  auto last_result = WaitForFinalFindResult();   
++  
++  // Assert the number of matches found in the browser is correct.
++  EXPECT_EQ(447, last_result.number_of_matches());
++
++  // Press the Tab key to focus the Nth match textfield.
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_TAB, false,
++                                              false, false, false));
++
++  EXPECT_TRUE(
++      IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_NTH_MATCH_TEXT_FIELD));
++
++  // Type-in "abc" as N.
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_A, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_B, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_C, false,
++                                              false, false, false));
++
++  // Assert the Nth match textfield rejected the alphabetical input and
++  // clamped the display value to the min (1).
++  EXPECT_EQ(std::u16string(u"1"), find_bar_view->GetNthMatchTextfieldText());
++
++  // Assert the 1st match is active.
++  EXPECT_EQ(1, last_result.active_match_ordinal());
++}
++
++IN_PROC_BROWSER_TEST_F(LegacyFindInPageTest, FindFirstMatchWhenNthMatchTextUnderflowsMin) {
++  
++  ASSERT_TRUE(embedded_test_server()->Start());
++
++  // Make sure Chrome is in the foreground, otherwise sending input
++  // won't do anything and the test will hang.
++  ASSERT_TRUE(ui_test_utils::BringBrowserWindowToFront(browser()));
++
++  // First we navigate to any page.
++  ASSERT_TRUE(ui_test_utils::NavigateToURL(
++      browser(), embedded_test_server()->GetURL(kLargePage)));
++
++  // Show the Find bar.
++  browser()->GetFeatures().GetFindBarController()->Show();
++  EXPECT_TRUE(IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_TEXT_FIELD));
++
++  FindBarView* find_bar_view = GetFindBarView();
++
++  // Enter phrase " the " to start the initial find operation.
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_SPACE, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_T, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_H, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_E, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_SPACE, false,
++                                              false, false, false));
++
++  // Assert the find bar textfield displays the correct value.
++  EXPECT_EQ(GetFindBarText(), base::UTF8ToUTF16(std::string(" the ")));
++
++  // Wait for events to settle.
++  auto last_result = WaitForFinalFindResult();   
++  
++  // Assert the number of matches found in the browser is correct.
++  EXPECT_EQ(447, last_result.number_of_matches());
++
++  // Set N out-of-bounds to the left.
++  int n = 0;
++  std::u16string n_string(base::UTF8ToUTF16(std::to_string(n)));
++
++  // Press the Tab key to focus the Nth match textfield.
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_TAB, false,
++                                              false, false, false));
++
++  EXPECT_TRUE(
++      IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_NTH_MATCH_TEXT_FIELD));
++
++  // Type-in the value for N.
++  EnterNumericText(n_string);
++
++  // Wait for events to settle.
++  last_result = WaitForFinalFindResult();   
++
++  // Assert the Nth match textfield rejected the underflowing input and
++  // clamped the display value to the min (1).
++  EXPECT_EQ(std::u16string(u"1"), find_bar_view->GetNthMatchTextfieldText());
++
++  // Assert the first match is active.
++  EXPECT_EQ(1, last_result.active_match_ordinal());
++}
++
++IN_PROC_BROWSER_TEST_F(LegacyFindInPageTest, FindLastMatchWhenNthMatchTextOverflowsMax) {
++
++  ASSERT_TRUE(embedded_test_server()->Start());
++
++  // Make sure Chrome is in the foreground, otherwise sending input
++  // won't do anything and the test will hang.
++  ASSERT_TRUE(ui_test_utils::BringBrowserWindowToFront(browser()));
++
++  // First we navigate to any page.
++  ASSERT_TRUE(ui_test_utils::NavigateToURL(
++      browser(), embedded_test_server()->GetURL(kLargePage)));
++
++  // Show the Find bar.
++  browser()->GetFeatures().GetFindBarController()->Show();
++  EXPECT_TRUE(IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_TEXT_FIELD));
++
++  FindBarView* find_bar_view = GetFindBarView();
++
++  // Enter phrase " the " to start the initial find operation.
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_SPACE, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_T, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_H, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_E, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_SPACE, false,
++                                              false, false, false));
++
++  // Assert the find bar textfield displays the correct value.
++  EXPECT_EQ(GetFindBarText(), base::UTF8ToUTF16(std::string(" the ")));
++
++  // Wait for events to settle.
++  auto last_result = WaitForFindResult();
++
++  // Assert the number of matches found in the browser is correct.
++  EXPECT_EQ(447, last_result.number_of_matches());
++
++  // Set N out-of-bounds to the right.
++  int n = last_result.number_of_matches() + 1;
++  std::u16string n_string(base::UTF8ToUTF16(std::to_string(n)));
++
++  // Press the Tab key to focus the Nth match textfield.
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_TAB, false,
++                                              false, false, false));
++
++  EXPECT_TRUE(
++      IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_NTH_MATCH_TEXT_FIELD));
++
++  // Type-in the value for N.
++  EnterNumericText(n_string);
++
++  // Wait for events to settle.
++  last_result = WaitForFindResult();
++
++  // Assert the Nth match textfield rejected the overflowing input and
++  // clamped the display value to the max (number_of_matches).
++  EXPECT_EQ(
++    find_bar_view->GetNthMatchTextfieldText(),
++    base::UTF8ToUTF16(std::to_string(last_result.number_of_matches())));
++
++  // Assert the last match is active.
++  EXPECT_EQ(last_result.active_match_ordinal(), last_result.number_of_matches());
++}
++
++IN_PROC_BROWSER_TEST_F(LegacyFindInPageTest, FindLastMatchWhenLastMatchButtonPressed) {
++  ASSERT_TRUE(embedded_test_server()->Start());
++
++  // Make sure Chrome is in the foreground, otherwise sending input
++  // won't do anything and the test will hang.
++  ASSERT_TRUE(ui_test_utils::BringBrowserWindowToFront(browser()));
++
++  // First we navigate to any page.
++  ASSERT_TRUE(ui_test_utils::NavigateToURL(
++      browser(), embedded_test_server()->GetURL(kLargePage)));
++
++  // Show the Find bar.
++  browser()->GetFeatures().GetFindBarController()->Show();
++  EXPECT_TRUE(IsViewFocused(browser(), VIEW_ID_FIND_IN_PAGE_TEXT_FIELD));
++
++  FindBarView* find_bar_view = GetFindBarView();
++
++  // Enter phrase " the " to start the initial find operation.
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_SPACE, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_T, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_H, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_E, false,
++                                              false, false, false));
++  ASSERT_TRUE(ui_test_utils::SendKeyPressSync(browser(), ui::VKEY_SPACE, false,
++                                              false, false, false));
++
++  // Assert the find bar textfield displays the correct value.
++  EXPECT_EQ(GetFindBarText(), base::UTF8ToUTF16(std::string(" the ")));
++
++  // Wait for events to settle.
++  auto last_result = WaitForFindResult();
++
++  // Assert the number of matches found in the browser is correct.
++  EXPECT_EQ(447, last_result.number_of_matches());
++
++  views::View* last_match_button =
++      find_bar_view->GetViewByID(VIEW_ID_FIND_IN_PAGE_LAST_MATCH_BUTTON);
++
++  ClickOnView(last_match_button);
++
++  // Wait for events to settle.
++  last_result = WaitForFindResult();
++
++  // Assert the Nth match textfield displays the last match ordinal
++  // (number_of_matches).
++  EXPECT_EQ(
++    find_bar_view->GetNthMatchTextfieldText(),
++    base::UTF8ToUTF16(std::to_string(last_result.number_of_matches())));
++
++  // Assert the last match is active.
++  EXPECT_EQ(last_result.active_match_ordinal(), last_result.number_of_matches());
++}

--- a/patches/chrome-test-base-ui_test_utils.cc.patch
+++ b/patches/chrome-test-base-ui_test_utils.cc.patch
@@ -1,0 +1,18 @@
+diff --git a/chrome/test/base/ui_test_utils.cc b/chrome/test/base/ui_test_utils.cc
+index 9877c264191f65e8d2bd551a4b69bfe48b467a7c..c1e49a5f0726aa1d920f475c083af92698a986e5 100644
+--- a/chrome/test/base/ui_test_utils.cc
++++ b/chrome/test/base/ui_test_utils.cc
+@@ -504,9 +504,10 @@ int FindInPage(WebContents* tab,
+                gfx::Rect* selection_rect) {
+   find_in_page::FindTabHelper* find_tab_helper =
+       find_in_page::FindTabHelper::FromWebContents(tab);
+-  find_tab_helper->StartFinding(search_string, forward, match_case,
+-                                true, /* find_match */
+-                                true /* run_synchronously_for_testing */);
++      find_tab_helper->StartFinding(search_string, forward, match_case,
++                                    true, /* find_match */
++                                    true, /* run_synchronously_for_testing */
++                                    ordinal ? *ordinal : 0/* match_ordinal (N) */);
+   FindResultWaiter observer(tab);
+   observer.Wait();
+   if (ordinal)

--- a/patches/components-find_in_page-android-find_in_page_bridge.cc.patch
+++ b/patches/components-find_in_page-android-find_in_page_bridge.cc.patch
@@ -1,0 +1,23 @@
+diff --git a/components/find_in_page/android/find_in_page_bridge.cc b/components/find_in_page/android/find_in_page_bridge.cc
+index 67c3e6cc6f1ca5e4d26e514ef6ae2c04724d14b5..1afa706c21cd3dad5d52a6d21e897caa2c6fdbc5 100644
+--- a/components/find_in_page/android/find_in_page_bridge.cc
++++ b/components/find_in_page/android/find_in_page_bridge.cc
+@@ -32,12 +32,16 @@ void FindInPageBridge::Destroy(JNIEnv*) {
+ void FindInPageBridge::StartFinding(JNIEnv* env,
+                                     const JavaRef<jstring>& search_string,
+                                     bool forward_direction,
+-                                    bool case_sensitive) {
++                                    bool case_sensitive,
++                                    int match_ordinal) {
+   find_in_page::FindTabHelper::FromWebContents(web_contents_)
+       ->StartFinding(
+           base::android::ConvertJavaStringToUTF16(env, search_string),
+           forward_direction, case_sensitive,
+-          true /* find_match */);
++          true, /* find_match */
++          false, /* run_synchronously_for_testing */
++          match_ordinal /* N */
++        );
+ }
+ 
+ void FindInPageBridge::StopFinding(JNIEnv* env, bool clearSelection) {

--- a/patches/components-find_in_page-android-find_in_page_bridge.h.patch
+++ b/patches/components-find_in_page-android-find_in_page_bridge.h.patch
@@ -1,0 +1,15 @@
+diff --git a/components/find_in_page/android/find_in_page_bridge.h b/components/find_in_page/android/find_in_page_bridge.h
+index db65f8b2486307095e569e805600989475c556a9..eb3bbc16b2467f88b19dc299af911c22eeab2c5b 100644
+--- a/components/find_in_page/android/find_in_page_bridge.h
++++ b/components/find_in_page/android/find_in_page_bridge.h
+@@ -25,7 +25,9 @@ class FindInPageBridge {
+   void StartFinding(JNIEnv* env,
+                     const base::android::JavaRef<jstring>& search_string,
+                     bool forward_direction,
+-                    bool case_sensitive);
++                    bool case_sensitive,
++                    int match_ordinal = 0
++                  );
+ 
+   void StopFinding(JNIEnv* env, bool clearSelection);
+ 

--- a/patches/components-find_in_page-android-java-src-org-chromium-components-find_in_page-FindInPageBridge.java.patch
+++ b/patches/components-find_in_page-android-java-src-org-chromium-components-find_in_page-FindInPageBridge.java.patch
@@ -1,0 +1,28 @@
+diff --git a/components/find_in_page/android/java/src/org/chromium/components/find_in_page/FindInPageBridge.java b/components/find_in_page/android/java/src/org/chromium/components/find_in_page/FindInPageBridge.java
+index 445946497873a23db174cd16a2d4bb201626db97..8a3f59888667b25172ed96a1a50edda2a916cb19 100644
+--- a/components/find_in_page/android/java/src/org/chromium/components/find_in_page/FindInPageBridge.java
++++ b/components/find_in_page/android/java/src/org/chromium/components/find_in_page/FindInPageBridge.java
+@@ -32,11 +32,11 @@ public class FindInPageBridge {
+      * This function does not block while a search is in progress.
+      * Set a listener using setFindResultListener to receive the results.
+      */
+-    public void startFinding(String searchString, boolean forwardDirection, boolean caseSensitive) {
++    public void startFinding(String searchString, boolean forwardDirection, boolean caseSensitive, int matchOrdinal) {
+         assert mNativeFindInPageBridge != 0;
+         FindInPageBridgeJni.get()
+                 .startFinding(
+-                        mNativeFindInPageBridge, searchString, forwardDirection, caseSensitive);
++                        mNativeFindInPageBridge, searchString, forwardDirection, caseSensitive, matchOrdinal);
+     }
+ 
+     /**
+@@ -89,7 +89,8 @@ public class FindInPageBridge {
+                 long nativeFindInPageBridge,
+                 String searchString,
+                 boolean forwardDirection,
+-                boolean caseSensitive);
++                boolean caseSensitive,
++                int matchOrdinal);
+ 
+         void stopFinding(long nativeFindInPageBridge, boolean clearSelection);
+ 

--- a/patches/components-find_in_page-find_tab_helper.cc.patch
+++ b/patches/components-find_in_page-find_tab_helper.cc.patch
@@ -1,0 +1,22 @@
+diff --git a/components/find_in_page/find_tab_helper.cc b/components/find_in_page/find_tab_helper.cc
+index d3482760ad8a5ad31f51cc9493ce3999a638e2a1..1046a447565641300249dca30b4a515d34c51955 100644
+--- a/components/find_in_page/find_tab_helper.cc
++++ b/components/find_in_page/find_tab_helper.cc
+@@ -46,7 +46,8 @@ void FindTabHelper::StartFinding(std::u16string search_string,
+                                  bool forward_direction,
+                                  bool case_sensitive,
+                                  bool find_match,
+-                                 bool run_synchronously_for_testing){
++                                 bool run_synchronously_for_testing,
++                                 int match_ordinal){
+   // Remove the carriage return character, which generally isn't in web content.
+   const char16_t kInvalidChars[] = u"\r";
+   base::RemoveChars(search_string, kInvalidChars, &search_string);
+@@ -88,6 +89,7 @@ void FindTabHelper::StartFinding(std::u16string search_string,
+   options->new_session = new_session;
+   options->find_match = find_match;
+   options->run_synchronously_for_testing = run_synchronously_for_testing;
++  options->match_ordinal = match_ordinal;
+   GetWebContents().Find(current_find_request_id_, find_text_,
+                         std::move(options), /*skip_delay=*/false);
+ }

--- a/patches/components-find_in_page-find_tab_helper.h.patch
+++ b/patches/components-find_in_page-find_tab_helper.h.patch
@@ -1,0 +1,15 @@
+diff --git a/components/find_in_page/find_tab_helper.h b/components/find_in_page/find_tab_helper.h
+index 2575c4cc992c90241f46b0f7af8f2254161198f9..be0b3f4739698409671304cf5f8c09bc15580f36 100644
+--- a/components/find_in_page/find_tab_helper.h
++++ b/components/find_in_page/find_tab_helper.h
+@@ -56,7 +56,9 @@ class FindTabHelper : public content::WebContentsUserData<FindTabHelper> {
+                     bool forward_direction,
+                     bool case_sensitive,
+                     bool find_match,
+-                    bool run_synchronously_for_testing = false);
++                    bool run_synchronously_for_testing = false,
++                    int match_ordinal = 0
++                  );
+ 
+   // Stops the current Find operation.
+   void StopFinding(SelectionAction selection_action);

--- a/patches/content-browser-find_request_manager.cc.patch
+++ b/patches/content-browser-find_request_manager.cc.patch
@@ -1,0 +1,29 @@
+diff --git a/content/browser/find_request_manager.cc b/content/browser/find_request_manager.cc
+index 5912020d07186f243989e794ce8b46f509d4fdcc..8b2c2a8e2c3546efbdcb48b5eb216db73f4798a6 100644
+--- a/content/browser/find_request_manager.cc
++++ b/content/browser/find_request_manager.cc
+@@ -441,9 +441,15 @@ void FindRequestManager::UpdatedFrameNumberOfMatches(RenderFrameHostImpl* rfh,
+   number_of_matches_ += new_count;
+ 
+   // All matches may have been removed since the last find reply.
+-  if (rfh == active_frame_ && !new_count)
++  if (rfh == active_frame_ && !new_count) {
+     relative_active_match_ordinal_ = 0;
++  }
+ 
++  // Give priority to the calling frame (rfh) if
++  // no frame has claimed the active status yet.
++  if (!active_frame_ && rfh) {
++    active_frame_ = rfh;
++  }
+   // The active match ordinal may need updating since the number of matches
+   // before the active match may have changed.
+   UpdateActiveMatchOrdinal();
+@@ -857,7 +863,6 @@ void FindRequestManager::UpdateActiveMatchOrdinal() {
+   active_match_ordinal_ = 0;
+ 
+   if (!active_frame_ || !relative_active_match_ordinal_) {
+-    DCHECK(!active_frame_ && !relative_active_match_ordinal_);
+     return;
+   }
+ 

--- a/patches/content-browser-find_request_manager_browsertest.cc.patch
+++ b/patches/content-browser-find_request_manager_browsertest.cc.patch
@@ -6,7 +6,7 @@ index 5ed6a16141296c809b9131ee0dc49df420cb4298..f9954054273e8b5732db9e3fbd6ebb81
    int last_request_id_;
  };
  
-+//// TODO: REVISIT
++//// TODO: REVISIT - This is very strange place. 👀
  class FindRequestManagerTest : public FindRequestManagerTestBase,
                                 public testing::WithParamInterface<bool> {
   protected:

--- a/patches/content-browser-find_request_manager_browsertest.cc.patch
+++ b/patches/content-browser-find_request_manager_browsertest.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/content/browser/find_request_manager_browsertest.cc b/content/browser/find_request_manager_browsertest.cc
+index 5ed6a16141296c809b9131ee0dc49df420cb4298..f9954054273e8b5732db9e3fbd6ebb81bc9e91f8 100644
+--- a/content/browser/find_request_manager_browsertest.cc
++++ b/content/browser/find_request_manager_browsertest.cc
+@@ -176,6 +176,7 @@ class FindRequestManagerTestBase : public ContentBrowserTest {
+   int last_request_id_;
+ };
+ 
++//// TODO: REVISIT
+ class FindRequestManagerTest : public FindRequestManagerTestBase,
+                                public testing::WithParamInterface<bool> {
+  protected:

--- a/patches/extensions-browser-api-guest_view-web_view-web_view_internal_api.cc.patch
+++ b/patches/extensions-browser-api-guest_view-web_view-web_view_internal_api.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/extensions/browser/api/guest_view/web_view/web_view_internal_api.cc b/extensions/browser/api/guest_view/web_view/web_view_internal_api.cc
+index fc1edfa353e838e47917c273232c18d0ad4031f8..3c3d2b2e15c9aee4b4f9125b7e1ed6503d71dd91 100644
+--- a/extensions/browser/api/guest_view/web_view/web_view_internal_api.cc
++++ b/extensions/browser/api/guest_view/web_view/web_view_internal_api.cc
+@@ -862,6 +862,8 @@ ExtensionFunction::ResponseAction WebViewInternalFindFunction::Run() {
+         params->options->backward ? !*params->options->backward : true;
+     options->match_case =
+         params->options->match_case ? *params->options->match_case : false;
++    options->match_ordinal = 
++      params->options->match_ordinal ? *params->options->match_ordinal : 0;
+   }
+ 
+   GetGuest().StartFind(

--- a/patches/extensions-common-api-web_view_internal.json.patch
+++ b/patches/extensions-common-api-web_view_internal.json.patch
@@ -1,0 +1,16 @@
+diff --git a/extensions/common/api/web_view_internal.json b/extensions/common/api/web_view_internal.json
+index a6284e0c17e2a9a1ad30060d44569ebc2c05d60c..7cc05e14e7b44ae262ae0975af45f0481c7edc16 100644
+--- a/extensions/common/api/web_view_internal.json
++++ b/extensions/common/api/web_view_internal.json
+@@ -486,6 +486,11 @@
+                 "type": "boolean",
+                 "description": "Flag to match |searchText| with case-sensitivity.",
+                 "optional": true
++              },
++              "matchOrdinal": {
++                "type": "integer",
++                "description": "1-based index to locate desired match of |searchText| relative to its peer matches.",
++                "optional": true
+               }
+             }
+           }

--- a/patches/extensions-test-data-web_view-apitest-main.js.patch
+++ b/patches/extensions-test-data-web_view-apitest-main.js.patch
@@ -1,0 +1,86 @@
+diff --git a/extensions/test/data/web_view/apitest/main.js b/extensions/test/data/web_view/apitest/main.js
+index 7747cfae037a1e106a38f3803d3593330a2c0460..cd30f754a90d7d31d17bc91485f61a9218004b42 100644
+--- a/extensions/test/data/web_view/apitest/main.js
++++ b/extensions/test/data/web_view/apitest/main.js
+@@ -839,20 +839,67 @@ function testFindAPI() {
+             webview.find("dog");
+             webview.find("cat");
+ 
+-            // Test find results when looking for something that isn't there.
+-            webview.find("fish", {}, function(results) {
+-              embedder.test.assertEq(results.numberOfMatches, 0);
+-              embedder.test.assertEq(results.activeMatchOrdinal, 0);
+-              embedder.test.assertEq(results.selectionRect.left, 0);
+-              embedder.test.assertEq(results.selectionRect.top, 0);
+-              embedder.test.assertEq(results.selectionRect.width, 0);
+-              embedder.test.assertEq(results.selectionRect.height, 0);
+-
+-              // Test following a link with stopFinding().
+-              webview.removeEventListener('loadstop', loadstopListener1);
+-              webview.addEventListener('loadstop', loadstopListener2);
+-              webview.find("click here!", {}, function() {
+-                webview.stopFinding("activate");
++            // Reset for Nth match.
++            webview.find("dog");
++
++            // Find a match by its ordinal N.
++            webview.find("dog", { matchOrdinal: 20 }, function (results) {
++              embedder.test.assertEq(results.numberOfMatches, 100);
++              embedder.test.assertEq(results.activeMatchOrdinal, 20); // N
++              embedder.test.assertTrue(results.selectionRect.width > 0);
++              embedder.test.assertTrue(results.selectionRect.height > 0);
++
++
++              // Find an earlier match out of order.
++              webview.find("dog", { matchOrdinal: 10 }, function (results) {
++                embedder.test.assertEq(results.numberOfMatches, 100);
++                embedder.test.assertEq(results.activeMatchOrdinal, 10); // N
++                embedder.test.assertTrue(results.selectionRect.width > 0);
++                embedder.test.assertTrue(results.selectionRect.height > 0);
++
++                // ------------------------ Bounds checking---------------------------
++                // Webview client should validate against N being out-of-bounds. 
++                // Here, we document the downstream system's expected behavior 
++                // in the absence of client-side validation.
++
++                // Find a match out-of-bounds to the left.
++                webview.find("dog", { matchOrdinal: -1 }, function (results) {
++                  //// TODO: webview client should reject and clamp the underflowing N to the min.
++                  // N is invalid, so the downstream system interprets N as absent
++                  // and defaults to 'Find Next/Previous' depending on the |'backward'| flag.
++                  embedder.test.assertEq(results.numberOfMatches, 100);
++                  embedder.test.assertEq(results.activeMatchOrdinal, 11); // N
++                  embedder.test.assertTrue(results.selectionRect.width > 0);
++                  embedder.test.assertTrue(results.selectionRect.height > 0);
++
++                  // Find a match out-of-bounds to the right.
++                  webview.find("dog", { matchOrdinal: 101 }, function (results) {
++                    // N exceeds the max, so as expected, 
++                    // the downstream system wraps N back around to the min.
++                    embedder.test.assertEq(results.numberOfMatches, 100);
++                    embedder.test.assertEq(results.activeMatchOrdinal, 1); // N
++                    embedder.test.assertTrue(results.selectionRect.width > 0);
++                    embedder.test.assertTrue(results.selectionRect.height > 0);
++
++
++                    // Test find results when looking for something that isn't there.
++                    webview.find("fish", {}, function(results) {
++                      embedder.test.assertEq(results.numberOfMatches, 0);
++                      embedder.test.assertEq(results.activeMatchOrdinal, 0);
++                      embedder.test.assertEq(results.selectionRect.left, 0);
++                      embedder.test.assertEq(results.selectionRect.top, 0);
++                      embedder.test.assertEq(results.selectionRect.width, 0);
++                      embedder.test.assertEq(results.selectionRect.height, 0);
++
++                      // Test following a link with stopFinding().
++                      webview.removeEventListener('loadstop', loadstopListener1);
++                      webview.addEventListener('loadstop', loadstopListener2);
++                      webview.find("click here!", {}, function() {
++                        webview.stopFinding("activate");
++                      });
++                    });
++                  });
++                });
+               });
+             });
+           });

--- a/patches/pdf-pdf_view_web_plugin.cc.patch
+++ b/patches/pdf-pdf_view_web_plugin.cc.patch
@@ -1,0 +1,69 @@
+diff --git a/pdf/pdf_view_web_plugin.cc b/pdf/pdf_view_web_plugin.cc
+index a880fb5be0c47884c1f5fe439eddd53471f37ebe..a2ba9bab8dc2b447222039b4c140795b53b6dc7b 100644
+--- a/pdf/pdf_view_web_plugin.cc
++++ b/pdf/pdf_view_web_plugin.cc
+@@ -528,7 +528,8 @@ bool PdfViewWebPlugin::Initialize(blink::WebPluginContainer* container) {
+   return InitializeCommon();
+ }
+ 
+-bool PdfViewWebPlugin::InitializeForTesting() {
++bool PdfViewWebPlugin::InitializeForTesting(bool bypass_container_init) {
++  SetContainerInitBypassForTesting(bypass_container_init);
+   return InitializeCommon();
+ }
+ 
+@@ -546,7 +547,7 @@ bool PdfViewWebPlugin::InitializeCommon() {
+   initial_params_ = {};
+ 
+   if (!params.has_value()) {
+-    return false;
++    return bypass_plugin_container_init_for_testing_ ? true : false;
+   }
+ 
+   // Sets crash keys like `ppapi::proxy::PDFResource::SetCrashData()`. Note that
+@@ -603,6 +604,14 @@ bool PdfViewWebPlugin::InitializeCommon() {
+   return true;
+ }
+ 
++void PdfViewWebPlugin::ResetContainerInitBypass() {
++  SetContainerInitBypassForTesting(false);
++}
++
++void PdfViewWebPlugin::SetContainerInitBypassForTesting(bool should_bypass) {
++  bypass_plugin_container_init_for_testing_ = should_bypass;
++}
++
+ void PdfViewWebPlugin::SendSetSmoothScrolling() {
+   client_->PostMessage(
+       base::DictValue()
+@@ -635,6 +644,7 @@ void PdfViewWebPlugin::Destroy() {
+     PerProcessInitializer::GetInstance().Release();
+   }
+ 
++  ResetContainerInitBypass();
+   client_->SetPluginContainer(nullptr);
+ 
+   delete this;
+@@ -1011,6 +1021,13 @@ void PdfViewWebPlugin::SelectFindResult(bool forward, int identifier) {
+   engine_->SelectFindResult(forward);
+ }
+ 
++void PdfViewWebPlugin::SelectNthFindResult(int match_ordinal, int identifier) {
++  find_identifier_ = identifier;
++  engine_->SelectNthFindResult(match_ordinal);
++}
++
++void PdfViewWebPlugin::SetSearchInProgress(bool in_progress) { search_in_progress_ = in_progress; }
++
+ void PdfViewWebPlugin::StopFind() {
+   find_identifier_ = -1;
+   engine_->StopFind();
+@@ -1251,7 +1268,7 @@ void PdfViewWebPlugin::NotifyNumberOfFindResultsChanged(int total,
+ 
+ void PdfViewWebPlugin::NotifySelectedFindResultChanged(int current_find_index,
+                                                        bool final_result) {
+-  if (find_identifier_ == -1 || !client_->PluginContainer()) {
++  if (find_identifier_ == -1 || (!bypass_plugin_container_init_for_testing_ && !client_->PluginContainer())) {
+     return;
+   }
+ 

--- a/patches/pdf-pdf_view_web_plugin.h.patch
+++ b/patches/pdf-pdf_view_web_plugin.h.patch
@@ -1,0 +1,56 @@
+diff --git a/pdf/pdf_view_web_plugin.h b/pdf/pdf_view_web_plugin.h
+index 6a4cd1d5596ee34480c6414d63c77b8ec8fd6e34..924dd160409ecf0b07900af8d72e67ff36e07ec0 100644
+--- a/pdf/pdf_view_web_plugin.h
++++ b/pdf/pdf_view_web_plugin.h
+@@ -322,6 +322,9 @@ class PdfViewWebPlugin final : public PDFiumEngineClient,
+                  bool case_sensitive,
+                  int identifier) override;
+   void SelectFindResult(bool forward, int identifier) override;
++  void SelectNthFindResult(int match_ordinal, int identifier) override;
++  void SetSearchInProgress(bool in_progress) override;
++  bool IsSearchInProgress() { return search_in_progress_; }
+   void StopFind() override;
+   bool CanRotateView() override;
+   void RotateView(blink::WebPlugin::RotationType type) override;
+@@ -480,7 +483,11 @@ class PdfViewWebPlugin final : public PDFiumEngineClient,
+   void RemoveAgentsOfType(blink::mojom::AnnotationType type) override;
+ 
+   // Initializes the plugin for testing, bypassing certain consistency checks.
+-  bool InitializeForTesting();
++  bool InitializeForTesting(bool bypass_container_init = false);
++
++  // Undo the testing bypass to avoid side-effects between consecutive test runs
++  // and/or normal program execution.
++  void ResetContainerInitBypass();
+ 
+   const gfx::Rect& GetPluginRectForTesting() const { return plugin_rect_; }
+ 
+@@ -602,6 +609,10 @@ class PdfViewWebPlugin final : public PDFiumEngineClient,
+ 
+   bool InitializeCommon();
+ 
++  // Conditionally bypass blink::WebPluginContainer initialization during tests. 
++  // Initialization is non-trivial and has a high impedance.
++  void SetContainerInitBypassForTesting(bool should_bypass);
++
+   // Sends whether to do smooth scrolling.
+   void SendSetSmoothScrolling();
+ 
+@@ -824,6 +835,8 @@ class PdfViewWebPlugin final : public PDFiumEngineClient,
+ 
+   bool plugin_can_save_ = false;
+ 
++  bool bypass_plugin_container_init_for_testing_ = false;
++
+   blink::WebString selected_text_;
+ 
+   std::unique_ptr<Client> const client_;
+@@ -951,6 +964,8 @@ class PdfViewWebPlugin final : public PDFiumEngineClient,
+   // transformations are applied.
+   gfx::Vector2dF scroll_offset_at_last_raster_;
+ 
++  bool search_in_progress_ = false;
++
+   // If this is true, then don't scroll the plugin in response to calls to
+   // `UpdateScroll()`. This will be true when the extension page is in the
+   // process of zooming the plugin so that flickering doesn't occur while

--- a/patches/pdf-pdf_view_web_plugin_unittest.cc.patch
+++ b/patches/pdf-pdf_view_web_plugin_unittest.cc.patch
@@ -1,0 +1,53 @@
+diff --git a/pdf/pdf_view_web_plugin_unittest.cc b/pdf/pdf_view_web_plugin_unittest.cc
+index f1d4f298c929a27bba7bdb4f07dbb7defba30cf6..4678393bf16f77799a53195411524eccbb50c7fb 100644
+--- a/pdf/pdf_view_web_plugin_unittest.cc
++++ b/pdf/pdf_view_web_plugin_unittest.cc
+@@ -1850,6 +1850,48 @@ TEST_F(PdfViewWebPluginTest, NotifyNumberOfFindResultsChanged) {
+   plugin_->NotifyNumberOfFindResultsChanged(/*total=*/5, /*final_result=*/true);
+ }
+ 
++TEST_F(PdfViewWebPluginTest, SelectNthFindResult) {
++  EXPECT_TRUE(plugin_->InitializeForTesting(/*bypass_container_init*/true));
++
++  plugin_->StartFind("x", /*case_sensitive=*/false, /*identifier=*/123);
++
++  while(plugin_->IsSearchInProgress()) { /*no-op*/ }
++
++  ASSERT_TRUE(!plugin_->IsSearchInProgress());
++  
++  const std::vector<gfx::Rect> tickmarks = {gfx::Rect(1, 2), gfx::Rect(3, 4)};
++  plugin_->UpdateTickMarks(tickmarks);
++  
++  int num_matches = 5;
++  EXPECT_CALL(*client_ptr_, ReportFindInPageTickmarks(tickmarks));
++  EXPECT_CALL(*client_ptr_, ReportFindInPageMatchCount(123, num_matches, true));
++  plugin_->NotifyNumberOfFindResultsChanged(/*total=*/num_matches, /*final_result=*/true);
++
++  int n = 2;
++  plugin_->SelectNthFindResult(n, /*identifier=*/123);
++  EXPECT_CALL(*client_ptr_, ReportFindInPageSelection(123, n, true));
++  plugin_->NotifySelectedFindResultChanged(/*current_find_index=*/n - 1, /*final_result=*/true);
++
++  n = 4;
++  plugin_->SelectNthFindResult(n, /*identifier=*/123);
++  EXPECT_CALL(*client_ptr_, ReportFindInPageSelection(123, n, true));
++  plugin_->NotifySelectedFindResultChanged(/*current_find_index=*/n - 1, /*final_result=*/true);
++
++  // Out-of-bounds to the left. 
++  // Clamp to first match.
++  n = -1;
++  plugin_->SelectNthFindResult(n, /*identifier=*/123);
++  EXPECT_CALL(*client_ptr_, ReportFindInPageSelection(123, 1, true)); // First match
++  plugin_->NotifySelectedFindResultChanged(/*current_find_index=*/0, /*final_result=*/true);
++
++  // Out-of-bounds to the right.
++  // Clamp to last match.
++  n = num_matches + 1;
++  plugin_->SelectNthFindResult(n, /*identifier=*/123);
++  EXPECT_CALL(*client_ptr_, ReportFindInPageSelection(123, num_matches, true)); // Last match
++  plugin_->NotifySelectedFindResultChanged(/*current_find_index=*/num_matches - 1, /*final_result=*/true);
++}
++
+ TEST_F(PdfViewWebPluginTest, OnDocumentLoadComplete) {
+   auto message =
+       base::DictValue()

--- a/patches/pdf-pdfium-pdfium_engine.cc.patch
+++ b/patches/pdf-pdfium-pdfium_engine.cc.patch
@@ -1,0 +1,116 @@
+diff --git a/pdf/pdfium/pdfium_engine.cc b/pdf/pdfium/pdfium_engine.cc
+index 1e69739e184afb67e043c1b721352273da89e020..7ff291aa4bc3bb39024d97d8a9b018634b8b27d6 100644
+--- a/pdf/pdfium/pdfium_engine.cc
++++ b/pdf/pdfium/pdfium_engine.cc
+@@ -2286,7 +2286,6 @@ void PDFiumEngine::StartFind(const std::u16string& text, bool case_sensitive) {
+ #if BUILDFLAG(ENABLE_SCREEN_AI_SERVICE)
+   client_->MaybeShowSearchifyInProgress();
+ #endif
+-
+   bool first_search = (current_find_text_ != text);
+   int char_to_start_searching_from = 0;
+   if (first_search) {
+@@ -2309,6 +2308,7 @@ void PDFiumEngine::StartFind(const std::u16string& text, bool case_sensitive) {
+       last_page_to_search_ = next_page_to_search_;
+     }
+     search_in_progress_ = true;
++    client_->SetSearchInProgress(search_in_progress_);
+   }
+ 
+   int current_page = next_page_to_search_;
+@@ -2346,6 +2346,7 @@ void PDFiumEngine::StartFind(const std::u16string& text, bool case_sensitive) {
+ 
+   if (end_of_search) {
+     search_in_progress_ = false;
++    client_->SetSearchInProgress(search_in_progress_);
+ 
+     // Send the final notification.
+     client_->NotifyNumberOfFindResultsChanged(find_results_.size(), true);
+@@ -2494,10 +2495,13 @@ bool PDFiumEngine::SelectFindResult(bool forward) {
+     resume_find_index_.reset();
+   } else if (current_find_index_) {
+     size_t current_index = current_find_index_.value();
+-    if ((forward && current_index >= last_index) ||
+-        (!forward && current_index == 0)) {
+-      current_find_index_.reset();
+-      client_->NotifySelectedFindResultChanged(-1, /*final_result=*/false);
++    bool leftBoundExceeded = !forward && current_index == 0;
++    bool rightBoundExceeded = forward && current_index >= last_index;
++    if (leftBoundExceeded || rightBoundExceeded) {
++      current_find_index_ = new_index = leftBoundExceeded ? last_index : 0;
++      ClearTextSelection();
++      ScrollToBoundingRects(find_results_[new_index], /*force_smooth_scroll=*/false);
++      client_->NotifySelectedFindResultChanged(new_index , /*final_result=*/false);
+       client_->NotifyNumberOfFindResultsChanged(find_results_.size(),
+                                                 /*final_result=*/true);
+       return true;
+@@ -2509,9 +2513,7 @@ bool PDFiumEngine::SelectFindResult(bool forward) {
+   }
+   current_find_index_ = new_index;
+ 
+-  // Clear the current text selection.
+-  SelectionChangeInvalidator selection_invalidator(this);
+-  selection_.clear();
++  ClearTextSelection();
+ 
+   // If the result is not in view, scroll to it.
+   ScrollToBoundingRects(find_results_[current_find_index_.value()],
+@@ -2522,6 +2524,47 @@ bool PDFiumEngine::SelectFindResult(bool forward) {
+   return true;
+ }
+ 
++bool PDFiumEngine::SelectNthFindResult(int match_ordinal) {
++  if (find_results_.empty()) {
++    return false;
++  }
++
++  // Invalidate the previous find selection.
++  FindResultChangeInvalidator find_change_invalidator(this);
++  
++  if (!current_find_index_.has_value()) {
++    current_find_index_ = -1;
++  }
++
++  // Validate match_ordinal (N).
++  if (match_ordinal <= 0) { // N exceeds left bound. 
++    // Clamp to the first match.
++    current_find_index_ = 0; 
++  } 
++  else if (static_cast<size_t>(match_ordinal) > find_results_.size()) { // N exceeds right bound.
++    // Clamp to the last match.
++    current_find_index_ = find_results_.size() - 1; 
++  } 
++  else {
++    // Adjust N for 0-based indexing.
++    current_find_index_ = static_cast<size_t>(match_ordinal - 1);
++  }
++  
++  ClearTextSelection();
++
++  PDFiumRange match = find_results_[current_find_index_.value()];
++
++  // If the result is not in view, scroll to it.
++  ScrollToBoundingRects(match, /*force_smooth_scroll=*/false);
++
++  SelectRange(match);
++
++  client_->NotifySelectedFindResultChanged(
++    current_find_index_.value(), /*final_result=*/!search_in_progress_);
++
++  return true;
++}
++
+ void PDFiumEngine::StopFind() {
+   FindResultChangeInvalidator find_change_invalidator(this);
+ 
+@@ -2746,6 +2789,10 @@ bool PDFiumEngine::HasPermission(DocumentPermission permission) const {
+   return permissions_->HasPermission(permission);
+ }
+ 
++void PDFiumEngine::SelectRange(PDFiumRange range) {
++  selection_.push_back(std::move(range));
++}
++
+ void PDFiumEngine::SelectAll() {
+   if (IsReadOnly()) {
+     return;

--- a/patches/pdf-pdfium-pdfium_engine.h.patch
+++ b/patches/pdf-pdfium-pdfium_engine.h.patch
@@ -1,0 +1,40 @@
+diff --git a/pdf/pdfium/pdfium_engine.h b/pdf/pdfium/pdfium_engine.h
+index d88ddfd14d6bc5f706e97e97f36cb90daaa54a8b..30b7630e8f93f63f1645730258cf30156b5c7fdc 100644
+--- a/pdf/pdfium/pdfium_engine.h
++++ b/pdf/pdfium/pdfium_engine.h
+@@ -226,6 +226,7 @@ class PDFiumEngine : public DocumentLoader::Client,
+   void PrintEnd();
+   void StartFind(const std::u16string& text, bool case_sensitive);
+   bool SelectFindResult(bool forward);
++  bool SelectNthFindResult(int match_ordinal);
+   void StopFind();
+   virtual void ZoomUpdated(double new_zoom_level);
+   void RotateClockwise();
+@@ -272,6 +273,7 @@ class PDFiumEngine : public DocumentLoader::Client,
+   virtual bool HasPermission(DocumentPermission permission) const;
+ 
+   virtual void SelectAll();
++  virtual void SelectRange(PDFiumRange range);
+ 
+   // Gets the list of DocumentAttachmentInfo from the document.
+   virtual const std::vector<DocumentAttachmentInfo>&
+@@ -612,6 +614,19 @@ class PDFiumEngine : public DocumentLoader::Client,
+     return find_results_;
+   }
+ 
++  // Reports |current_find_index_| (for testing)
++  std::optional<size_t> GetCurrentFindIndex() { return current_find_index_; }
++
++  // Reports |selection_|  (for testing)
++  std::vector<PDFiumRange> GetSelections() { return selection_; }
++
++  // Reports |search_in_progress_| (for testing)
++  bool IsSearchInProgress() { return search_in_progress_; }
++
++  // Reports |pages_| emptiness state (for testing)
++  bool IsPagesEmpty() { return pages_.empty(); }
++  
++
+  private:
+   // This is a base class for shared functions and data needed for change
+   // invalidators. Subclasses are used to detect the difference in change rects

--- a/patches/pdf-pdfium-pdfium_engine_client.h.patch
+++ b/patches/pdf-pdfium-pdfium_engine_client.h.patch
@@ -1,0 +1,13 @@
+diff --git a/pdf/pdfium/pdfium_engine_client.h b/pdf/pdfium/pdfium_engine_client.h
+index e3d4b25a9b273054107b7771884b1e1380557b73..a60b509685a680b35059d0bf20bc174feb5ee0d7 100644
+--- a/pdf/pdfium/pdfium_engine_client.h
++++ b/pdf/pdfium/pdfium_engine_client.h
+@@ -224,6 +224,8 @@ class PDFiumEngineClient {
+   // indicator is not showing.
+   virtual void MaybeShowSearchifyInProgress() = 0;
+ #endif
++
++  virtual void SetSearchInProgress(bool in_progress) {}
+ };
+ 
+ }  // namespace chrome_pdf

--- a/patches/pdf-pdfium-pdfium_engine_unittest.cc.patch
+++ b/patches/pdf-pdfium-pdfium_engine_unittest.cc.patch
@@ -1,0 +1,84 @@
+diff --git a/pdf/pdfium/pdfium_engine_unittest.cc b/pdf/pdfium/pdfium_engine_unittest.cc
+index 71e97c617c42a5a8d2fc8ecc95e1d817c1298cab..efc2eebac3fb502f3789a46362e60e4542a21771 100644
+--- a/pdf/pdfium/pdfium_engine_unittest.cc
++++ b/pdf/pdfium/pdfium_engine_unittest.cc
+@@ -1026,6 +1026,79 @@ TEST_P(PDFiumEngineTest, IsSynthesizedNewline) {
+   EXPECT_TRUE(engine->IsSynthesizedNewline({0, 22}));
+ }
+ 
++TEST_P(PDFiumEngineTest, SelectNthFindResult) {  
++  NiceMock<MockTestClient> client(/*use_skia_renderer=*/GetParam());
++  std::unique_ptr<PDFiumEngine> engine = InitializeEngine(&client, FILE_PATH_LITERAL("hello_world2.pdf"));
++
++  ASSERT_TRUE(engine);
++
++  engine->StartFind(u"e", false);
++  
++  // Wait for search to end.
++  while(engine->IsSearchInProgress()) { /*no-op*/ }
++  
++  ASSERT_TRUE(!engine->IsSearchInProgress());
++  ASSERT_TRUE(!engine->IsPagesEmpty());
++  
++  ASSERT_TRUE(!engine->find_results_for_testing().empty());
++  EXPECT_EQ(engine->find_results_for_testing().size(), static_cast<size_t>(4));
++
++  // Set N to a value in-bounds.
++  int n = 2;
++
++  // Select the Nth match.
++  engine->SelectNthFindResult(n);
++  
++  // Assert state reflects the selection.
++  ASSERT_TRUE(engine->GetCurrentFindIndex().has_value());
++  EXPECT_EQ(engine->GetCurrentFindIndex().value(), static_cast<size_t>(n - 1));
++  EXPECT_EQ(engine->GetSelections().size(), static_cast<size_t>(1));
++  EXPECT_EQ(GetPlatformTextExpectation(base::UTF16ToUTF8(u"e")),
++            engine->GetSelectedText());
++
++  // Get a later match out of order and in-bounds.
++  n = 4;
++
++  // Select the Nth match.
++  engine->SelectNthFindResult(n);
++  
++  // Assert state reflects the selection.
++  ASSERT_TRUE(engine->GetCurrentFindIndex().has_value());
++  EXPECT_EQ(engine->GetCurrentFindIndex().value(), static_cast<size_t>(n - 1));
++  EXPECT_EQ(engine->GetSelections().size(), static_cast<size_t>(1));
++  EXPECT_EQ(GetPlatformTextExpectation(base::UTF16ToUTF8(u"e")),
++            engine->GetSelectedText());
++
++   // Out-of-bounds to the left.
++   n = -1;
++
++   // Select the Nth match.
++  engine->SelectNthFindResult(n);
++  
++  // Assert the engine rejected the underflowing N,
++  // and clamped to the min (first match).
++  ASSERT_TRUE(engine->GetCurrentFindIndex().has_value());
++  EXPECT_EQ(engine->GetCurrentFindIndex().value(), static_cast<size_t>(0)); // Clamp to the min.
++  EXPECT_EQ(engine->GetSelections().size(), static_cast<size_t>(1));
++  EXPECT_EQ(GetPlatformTextExpectation(base::UTF16ToUTF8(u"e")),
++            engine->GetSelectedText());
++
++  // Out-of-bounds to the right.
++  size_t last_match_ordinal = engine->find_results_for_testing().size();
++  n = last_match_ordinal + 1;
++
++  // Select the Nth match.
++ engine->SelectNthFindResult(n);
++ 
++ // Assert the engine rejected the overflowing N,
++ // and clamped to the max (last match).
++ ASSERT_TRUE(engine->GetCurrentFindIndex().has_value());
++ EXPECT_EQ(engine->GetCurrentFindIndex().value(), last_match_ordinal - 1); // Clamp to the max.
++ EXPECT_EQ(engine->GetSelections().size(), static_cast<size_t>(1));
++ EXPECT_EQ(GetPlatformTextExpectation(base::UTF16ToUTF8(u"e")),
++           engine->GetSelectedText());
++}
++
+ INSTANTIATE_TEST_SUITE_P(All, PDFiumEngineTest, testing::Bool());
+ 
+ class PDFiumEngineSelectionTest : public PDFiumEngineTest {

--- a/patches/pdf-test-test_client.cc.patch
+++ b/patches/pdf-test-test_client.cc.patch
@@ -1,0 +1,21 @@
+diff --git a/pdf/test/test_client.cc b/pdf/test/test_client.cc
+index eecfcc6bdc29c85b863f8db6f7ac6e6b144e2619..f7c00a9846b0dfc9adc5f6a15f2e32b44897d391 100644
+--- a/pdf/test/test_client.cc
++++ b/pdf/test/test_client.cc
+@@ -9,6 +9,7 @@
+ #include "base/time/time.h"
+ #include "pdf/buildflags.h"
+ #include "pdf/document_layout.h"
++#include "pdf/text_search.h"
+ #include "pdf/loader/url_loader.h"
+ #include "pdf/pdfium/pdfium_engine.h"
+ #include "pdf/test/test_helpers.h"
+@@ -59,7 +60,7 @@ std::vector<PDFiumEngineClient::SearchStringResult> TestClient::SearchString(
+     const std::u16string& needle,
+     const std::u16string& haystack,
+     bool case_sensitive) {
+-  return std::vector<SearchStringResult>();
++  return TextSearch(/*needle=*/needle, /*haystack=*/haystack, case_sensitive);
+ }
+ 
+ bool TestClient::IsPrintPreview() const {

--- a/patches/third_party-blink-public-mojom-frame-find_in_page.mojom.patch
+++ b/patches/third_party-blink-public-mojom-frame-find_in_page.mojom.patch
@@ -1,0 +1,14 @@
+diff --git a/third_party/blink/public/mojom/frame/find_in_page.mojom b/third_party/blink/public/mojom/frame/find_in_page.mojom
+index 8cfd8cdab180babdfca7496373b088a20e5bae03..8e7069a94e81ab3348d0e2802a1bcb9486aa5535 100644
+--- a/third_party/blink/public/mojom/frame/find_in_page.mojom
++++ b/third_party/blink/public/mojom/frame/find_in_page.mojom
+@@ -122,4 +122,9 @@ struct FindOptions {
+   // Signifies whether we should force text scoping to happen immediately
+   // or not. Only used for testing purposes.
+   bool run_synchronously_for_testing = false;
++
++  // N, The 1-based index of the desired match relative to its peers.
++  // We default the value to 0 to indicate the common case in which 
++  // the user does not actively provide N.
++  int32 match_ordinal = 0;
+ };

--- a/patches/third_party-blink-public-web-web_plugin.h.patch
+++ b/patches/third_party-blink-public-web-web_plugin.h.patch
@@ -1,0 +1,15 @@
+diff --git a/third_party/blink/public/web/web_plugin.h b/third_party/blink/public/web/web_plugin.h
+index f083546406fc8e7311c04f0c5133c1e7fa2ae83e..358f02192eaa0275668ff9987db9a7aedcac5520 100644
+--- a/third_party/blink/public/web/web_plugin.h
++++ b/third_party/blink/public/web/web_plugin.h
+@@ -242,6 +242,10 @@ class WebPlugin {
+   }
+   // Tells the plugin to jump forward or backward in the list of find results.
+   virtual void SelectFindResult(bool forward, int identifier) {}
++  
++  // Tells the plugin to jump directly to the find result at |match_ordinal - 1|.
++  virtual void SelectNthFindResult(int match_ordinal, int identifier) {}
++  
+   // Tells the plugin that the user has stopped the find operation.
+   virtual void StopFind() {}
+ 

--- a/patches/third_party-blink-renderer-core-editing-finder-find_options.h.patch
+++ b/patches/third_party-blink-renderer-core-editing-finder-find_options.h.patch
@@ -1,0 +1,30 @@
+diff --git a/third_party/blink/renderer/core/editing/finder/find_options.h b/third_party/blink/renderer/core/editing/finder/find_options.h
+index 47ed259aceeb47c560da72fd497b0f892e9704ca..ed7513a10c7b7f2d15fe7211090c05f7aaed5c70 100644
+--- a/third_party/blink/renderer/core/editing/finder/find_options.h
++++ b/third_party/blink/renderer/core/editing/finder/find_options.h
+@@ -82,6 +82,17 @@ class FindOptions {
+     return *this;
+   }
+ 
++  bool IsMatchOrdinalProvided() const { return match_ordinal_ > 0; }
++
++  constexpr FindOptions& SetMatchOrdinal(int n) {
++    match_ordinal_ = n;
++    return *this;
++  }
++
++  constexpr int GetMatchOrdinal() const {
++    return match_ordinal_;
++  }
++
+  private:
+   bool case_insensitive_ : 1 = false;
+   bool backwards_ : 1 = false;
+@@ -90,6 +101,7 @@ class FindOptions {
+   bool whole_word_ : 1 = false;
+   bool find_api_call_ : 1 = false;
+   bool ruby_supported_ : 1 = false;
++  int match_ordinal_ = 0;
+ 
+ };
+ 

--- a/patches/third_party-blink-renderer-core-editing-finder-text_finder.cc.patch
+++ b/patches/third_party-blink-renderer-core-editing-finder-text_finder.cc.patch
@@ -1,0 +1,113 @@
+diff --git a/third_party/blink/renderer/core/editing/finder/text_finder.cc b/third_party/blink/renderer/core/editing/finder/text_finder.cc
+index edd24ab6e511a46d4a8aeba29955cce7de4e917d..30d7515c0b6fb7c9646b3710ba210269bf215dc3 100644
+--- a/third_party/blink/renderer/core/editing/finder/text_finder.cc
++++ b/third_party/blink/renderer/core/editing/finder/text_finder.cc
+@@ -252,10 +252,58 @@ bool TextFinder::FindInternal(int identifier,
+                                 .SetWrappingAround(wrap_within_frame)
+                                 .SetStartingInSelection(options.new_session)
+                                 .SetRubySupported(true)
+-  active_match_ = Editor::FindRangeOfString(
+-      *OwnerFrame().GetFrame()->GetDocument(), search_text,
+-      EphemeralRangeInFlatTree(active_match_.Get()), find_options,
+-      &wrapped_around);
++                                .SetMatchOrdinal(options.match_ordinal);
++
++  // IMPORTANT: Read from cache whenever possible to avoid unnecessary work.
++
++  // Validate the active_match_index_ before potentially using it on the cache.
++  // ASIDE: Together, early validation and subsequent cache read address the marker_controller 
++  // race condition in Textfinder::Scroll().
++  if (options.forward && options.match_ordinal <= 0) {
++    ++active_match_index_;
++  } else if (!options.forward && options.match_ordinal <= 0) {
++    --active_match_index_;
++  } else if (options.match_ordinal > 0) {
++    // match_ordinal (N) is 1-based when it arrives from the UI, so decrement to
++    // convert it to 0-based.
++    active_match_index_ = options.match_ordinal - 1;
++  }
++  
++  // Validate one last time to ensure the index falls in-bounds. 
++  // If match_ordinal (N), a user-generated value, was factored into active_match_index_, 
++  // then the index might no longer be in bounds. Correct that here.
++  if (active_match_index_ + 1 > find_task_controller_->CurrentMatchCount() && options.forward) {
++        active_match_index_ = 0;
++  }
++  else if (active_match_index_ < 0) {
++    active_match_index_ = find_task_controller_->CurrentMatchCount() - 1;
++  }
++
++  // DRY helper
++  auto searchForMatchInDOM = [this, search_text, find_options,
++                              &wrapped_around](Range* active_match) {
++    return Editor::FindRangeOfString(
++        *OwnerFrame().GetFrame()->GetDocument(), search_text,
++        EphemeralRangeInFlatTree(active_match_.Get()), find_options,
++        &wrapped_around);
++  };
++
++  // Read from the cache if it's populated.
++  if (find_matches_cache_.size() > 0) {
++    Range* cached_match = GetCachedMatchAtIndex(active_match_index_);
++    if (cached_match) {
++      // Cache HIT. Use the cached match. 
++      active_match_ = *cached_match;
++    } else { 
++      // Cache MISS. Traverse the DOM to find the active match.
++      active_match_ = searchForMatchInDOM(active_match_);
++    } 
++  }
++  else {
++    // Cache EMPTY. Traverse the DOM to find the active match.
++    active_match_ = searchForMatchInDOM(active_match_);
++  }
++  
+ 
+   if (!active_match_) {
+     if (current_active_match_frame_ && options.new_session)
+@@ -310,7 +358,6 @@ bool TextFinder::FindInternal(int identifier,
+         scroll_task_.callback());
+   }
+ 
+-  bool was_active_frame = current_active_match_frame_;
+   current_active_match_frame_ = true;
+ 
+   bool is_active = SetMarkerActive(active_match_.Get(), true);
+@@ -330,28 +377,11 @@ bool TextFinder::FindInternal(int identifier,
+     // we set the flag to ask the scoping effort to find the active rect for
+     // us and report it back to the UI.
+     should_locate_active_rect_ = true;
+-  } else {
+-    if (!was_active_frame) {
+-      if (options.forward)
+-        active_match_index_ = 0;
+-      else
+-        active_match_index_ = find_task_controller_->CurrentMatchCount() - 1;
+-    } else {
+-      if (options.forward)
+-        ++active_match_index_;
+-      else
+-        --active_match_index_;
+-
+-      if (active_match_index_ + 1 > find_task_controller_->CurrentMatchCount())
+-        active_match_index_ = 0;
+-      else if (active_match_index_ < 0)
+-        active_match_index_ = find_task_controller_->CurrentMatchCount() - 1;
+     }
+     gfx::Rect selection_rect = OwnerFrame().GetFrameView()->ConvertToRootFrame(
+         active_match_->BoundingBox());
+     ReportFindInPageSelection(selection_rect, active_match_index_ + 1,
+                               identifier);
+-  }
+ 
+   // We found something, so the result of the previous scoping may be outdated.
+   find_task_controller_->ResetLastFindRequestCompletedWithNoMatches();
+@@ -950,8 +980,6 @@ void TextFinder::Scroll(std::unique_ptr<AsyncScrollContext> context) {
+   if (!context->options.run_synchronously_for_testing &&
+       !marker_controller.FirstMarkerIntersectingEphemeralRange(
+           ephemeral_range, DocumentMarker::MarkerTypes::TextMatch())) {
+-    marker_controller.AddTextMatchMarker(ephemeral_range,
+-                                         TextMatchMarker::MatchStatus::kActive);
+     SetMarkerActive(context->range, true);
+   }
+ }

--- a/patches/third_party-blink-renderer-core-editing-finder-text_finder.cc.patch
+++ b/patches/third_party-blink-renderer-core-editing-finder-text_finder.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/third_party/blink/renderer/core/editing/finder/text_finder.cc b/third_party/blink/renderer/core/editing/finder/text_finder.cc
-index edd24ab6e511a46d4a8aeba29955cce7de4e917d..30d7515c0b6fb7c9646b3710ba210269bf215dc3 100644
+index edd24ab6e511a46d4a8aeba29955cce7de4e917d..ef6a879aa777e2136f3dcf6772393100b5ca4e8b 100644
 --- a/third_party/blink/renderer/core/editing/finder/text_finder.cc
 +++ b/third_party/blink/renderer/core/editing/finder/text_finder.cc
 @@ -252,10 +252,58 @@ bool TextFinder::FindInternal(int identifier,
@@ -15,15 +15,15 @@ index edd24ab6e511a46d4a8aeba29955cce7de4e917d..30d7515c0b6fb7c9646b3710ba210269
 +  // IMPORTANT: Read from cache whenever possible to avoid unnecessary work.
 +
 +  // Validate the active_match_index_ before potentially using it on the cache.
-+  // ASIDE: Together, early validation and subsequent cache read address the marker_controller 
-+  // race condition in Textfinder::Scroll().
++  // ASIDE: Together, early index validation and subsequent cache read 
++  // address the marker_controller race condition in Textfinder::Scroll().
 +  if (options.forward && options.match_ordinal <= 0) {
 +    ++active_match_index_;
 +  } else if (!options.forward && options.match_ordinal <= 0) {
 +    --active_match_index_;
 +  } else if (options.match_ordinal > 0) {
-+    // match_ordinal (N) is 1-based when it arrives from the UI, so decrement to
-+    // convert it to 0-based.
++    // match_ordinal (N) is 1-based when it arrives from the UI, 
++    // so decrement to convert it to 0-based.
 +    active_match_index_ = options.match_ordinal - 1;
 +  }
 +  

--- a/patches/third_party-blink-renderer-core-editing-finder-text_finder.h.patch
+++ b/patches/third_party-blink-renderer-core-editing-finder-text_finder.h.patch
@@ -1,0 +1,21 @@
+diff --git a/third_party/blink/renderer/core/editing/finder/text_finder.h b/third_party/blink/renderer/core/editing/finder/text_finder.h
+index b250b59a905916e3c33cad1ffa8651aaeb0d0178..efc66958cff5a51ff2d7453f49b8e9059f7e8c06 100644
+--- a/third_party/blink/renderer/core/editing/finder/text_finder.h
++++ b/third_party/blink/renderer/core/editing/finder/text_finder.h
+@@ -96,6 +96,16 @@ class CORE_EXPORT TextFinder final : public GarbageCollected<TextFinder> {
+   // the local frame has no active match.
+   Range* ActiveMatch() const { return active_match_.Get(); }
+ 
++  int GetMatchesCacheSize() const { return find_matches_cache_.size(); }
++
++  Range* GetCachedMatchAtIndex(int index) const { 
++    int cacheSize = GetMatchesCacheSize();
++    if (cacheSize == 0 || index < 0 || index > cacheSize - 1) {
++      return nullptr;
++    }
++    return find_matches_cache_[index].range_; 
++  }
++
+   void FlushCurrentScoping();
+ 
+   // A match has been found by the current finding effort, so we should

--- a/patches/third_party-blink-renderer-core-editing-finder-text_finder_test.cc.patch
+++ b/patches/third_party-blink-renderer-core-editing-finder-text_finder_test.cc.patch
@@ -1,0 +1,241 @@
+diff --git a/third_party/blink/renderer/core/editing/finder/text_finder_test.cc b/third_party/blink/renderer/core/editing/finder/text_finder_test.cc
+index 7495327a3bb52854024e244cd98e437e7d8ae6cd..fe4f853be180168eee82a7893bbf1e282f488d1e 100644
+--- a/third_party/blink/renderer/core/editing/finder/text_finder_test.cc
++++ b/third_party/blink/renderer/core/editing/finder/text_finder_test.cc
+@@ -874,4 +874,234 @@ TEST_F(TextFinderTest, CommentAfterDoucmentElement) {
+   EXPECT_FALSE(GetTextFinder().ScopingInProgress());
+ }
+ 
+-}  // namespace blink
++TEST_F(TextFinderTest, FindNthMatchText) {
++  GetDocument().body()->SetInnerHTMLWithoutTrustedTypes(
++      "XXXXFindMeYYYYfindmeZZZZ");
++  GetDocument().UpdateStyleAndLayout(DocumentUpdateReason::kTest);
++  Node* text_node = GetDocument().body()->firstChild();
++
++  int identifier = 0;
++  String search_text("FindMe");
++  auto find_options =
++      mojom::blink::FindOptions::New();  // Default  add testing flag.
++  bool wrap_within_frame = true;
++
++  find_options->run_synchronously_for_testing = true;
++  find_options->match_case = false;
++
++  // Start a new find operation, resetting all relevant state.
++  GetTextFinder().InitNewSession(*find_options);
++  GetTextFinder().StartScopingStringMatches(identifier, search_text,
++    *find_options);
++
++  // Set N.
++  find_options->match_ordinal = 2;
++
++  // Perform the initial find to discover all matches.
++  ASSERT_TRUE(GetTextFinder().Find(identifier, search_text, *find_options,
++                                   wrap_within_frame));
++
++  int match_count = GetTextFinder().TotalMatchCount();
++  EXPECT_EQ(2, match_count);
++
++  // Assert the highlighted match is the second match in the DOM.
++  Range* active_match = GetTextFinder().ActiveMatch();
++  ASSERT_TRUE(active_match);
++  EXPECT_EQ(text_node, active_match->startContainer());
++  EXPECT_EQ(14u, active_match->startOffset());
++  EXPECT_EQ(text_node, active_match->endContainer());
++  EXPECT_EQ(20u, active_match->endOffset());
++
++  // Assert the highligted match is the (N - 1)th match in the cache.
++  EXPECT_EQ(active_match, GetTextFinder().GetCachedMatchAtIndex(find_options->match_ordinal - 1));
++
++  find_options->new_session = false;
++
++  // Set N again.
++  find_options->match_ordinal = 1;
++
++  // Search again.
++  ASSERT_TRUE(GetTextFinder().Find(identifier, search_text, *find_options,
++                                   wrap_within_frame));
++
++  // Assert the highlighted match is the first match in the DOM.
++  active_match = GetTextFinder().ActiveMatch();
++  ASSERT_TRUE(active_match);
++  EXPECT_EQ(text_node, active_match->startContainer());
++  EXPECT_EQ(4u, active_match->startOffset());
++  EXPECT_EQ(text_node, active_match->endContainer());
++  EXPECT_EQ(10u, active_match->endOffset());
++
++  // Assert the highligted match is the (N - 1)th match in the cache.
++  EXPECT_EQ(active_match, GetTextFinder().GetCachedMatchAtIndex(find_options->match_ordinal - 1));
++}
++
++TEST_F(TextFinderTest, FindLastMatchText) {
++  GetDocument().body()->SetInnerHTMLWithoutTrustedTypes(
++      "XXXXFindMeYYYYfindmeZZZZFiNdMeΩΩΩ");
++  GetDocument().UpdateStyleAndLayout(DocumentUpdateReason::kTest);
++  Node* text_node = GetDocument().body()->firstChild();
++  int identifier = 0;
++  String search_text("FindMe");
++  auto find_options =
++      mojom::blink::FindOptions::New();  // Default  add testing flag.
++  bool wrap_within_frame = true;
++  find_options->match_case = false;
++  find_options->run_synchronously_for_testing = true;
++
++
++  // Start a new find operation, resetting all relevant state.
++  GetTextFinder().InitNewSession(*find_options);
++  GetTextFinder().StartScopingStringMatches(identifier, search_text,
++    *find_options);
++
++  // Perform the initial find to discover all matches.
++  ASSERT_TRUE(GetTextFinder().Find(identifier, search_text, *find_options,
++                                  wrap_within_frame));
++  Range* active_match = GetTextFinder().ActiveMatch();
++  ASSERT_TRUE(active_match);
++
++  // Get the last match ordinal.
++  int last_match_ordinal = GetTextFinder().TotalMatchCount();
++  EXPECT_EQ(3, last_match_ordinal);
++
++  // Set N to the last match ordinal.
++  find_options->match_ordinal = last_match_ordinal;
++
++  // Search for the Nth (last) match by its ordinal.
++  ASSERT_TRUE(GetTextFinder().Find(identifier, search_text, *find_options,
++                                   wrap_within_frame));
++
++  // Assert the highligted match is the last match in the DOM.
++  active_match = GetTextFinder().ActiveMatch();
++  ASSERT_TRUE(active_match);
++  EXPECT_EQ(text_node, active_match->startContainer());
++  EXPECT_EQ(24u, active_match->startOffset());
++  EXPECT_EQ(text_node, active_match->endContainer());
++  EXPECT_EQ(30u, active_match->endOffset());
++
++  // Assert the highligted match is the last match in the cache.
++  EXPECT_EQ(active_match, GetTextFinder().GetCachedMatchAtIndex(last_match_ordinal - 1));
++
++  // Prepare for case-sensitive search.
++  find_options->match_case = true;
++  
++  // Start a new session since a changed match_case constitutes a new find operation.
++  GetTextFinder().InitNewSession(*find_options);
++  GetTextFinder().StartScopingStringMatches(identifier, search_text,
++    *find_options);
++
++  // Search again to get all case-sensitive results.
++  ASSERT_TRUE(GetTextFinder().Find(identifier, search_text, *find_options,
++    wrap_within_frame));
++
++  // Get the last match ordinal again.
++  last_match_ordinal = GetTextFinder().TotalMatchCount();
++
++  // Assert the first ordinal is the last ordinal,
++  // since the first points to the only case-matching occurrence.
++  EXPECT_EQ(1, last_match_ordinal);
++
++  // Set N to the last_match_ordinal again.
++  find_options->match_ordinal = last_match_ordinal;
++
++  // Search for the last match again.
++  ASSERT_TRUE(GetTextFinder().Find(identifier, search_text, *find_options,
++      wrap_within_frame));
++  
++  // Assert the first match is highlighted since it's 
++  // the only case-matching occurrence.
++  active_match = GetTextFinder().ActiveMatch();
++  ASSERT_TRUE(active_match);
++  EXPECT_EQ(text_node, active_match->startContainer());
++  EXPECT_EQ(4u, active_match->startOffset());
++  EXPECT_EQ(text_node, active_match->endContainer());
++  EXPECT_EQ(10u, active_match->endOffset());
++
++  // Assert the highligted match is the last match in the cache.
++  EXPECT_EQ(active_match, GetTextFinder().GetCachedMatchAtIndex(last_match_ordinal - 1));
++}
++
++
++TEST_F(TextFinderTest, MatchesCachePopulatedReadOutOfBoundsReturnNull) {
++  GetDocument().body()->SetInnerHTMLWithoutTrustedTypes(
++      "XXXXFindMeYYYYfindmeZZZZ");
++  GetDocument().UpdateStyleAndLayout(DocumentUpdateReason::kTest);
++  
++
++  int identifier = 0;
++  String search_text("FindMe");
++  auto find_options =
++      mojom::blink::FindOptions::New();  // Default  add testing flag.
++  bool wrap_within_frame = true;
++
++  find_options->run_synchronously_for_testing = true;
++  find_options->match_case = false;
++
++  // Start a new find operation, resetting all relevant state.
++  GetTextFinder().InitNewSession(*find_options);
++  GetTextFinder().StartScopingStringMatches(identifier, search_text,
++                                            *find_options);
++
++  // Assert the initial find discovered matches. The cache should be populated now.
++  ASSERT_TRUE(GetTextFinder().Find(identifier, search_text, *find_options,
++                                   wrap_within_frame));
++
++  int match_count = GetTextFinder().TotalMatchCount();
++  EXPECT_EQ(2, match_count);
++
++  // Assert the cache is populated with the correct number of matches.
++  EXPECT_EQ(match_count, GetTextFinder().GetMatchesCacheSize());
++
++  // Set N out-of-bounds to the left.
++  find_options->match_ordinal = 0;
++ 
++  // Assert the cache returns nothing.
++  ASSERT_TRUE(!GetTextFinder().GetCachedMatchAtIndex(find_options->match_ordinal - 1));
++
++  // Set N out-of-bounds to the right.
++  find_options->match_ordinal = match_count + 1;
++
++  // Assert the cache returns nothing.
++  ASSERT_TRUE(!GetTextFinder().GetCachedMatchAtIndex(find_options->match_ordinal - 1));
++}
++
++TEST_F(TextFinderTest, MatchesCacheEmptyReturnNull) {
++  GetDocument().body()->SetInnerHTMLWithoutTrustedTypes(
++      "XXXXFindMeYYYYfindmeZZZZ");
++  GetDocument().UpdateStyleAndLayout(DocumentUpdateReason::kTest);
++  
++
++  int identifier = 0;
++  String search_text("Nowhere"); // Nonexistent in test body.
++  auto find_options =
++      mojom::blink::FindOptions::New();  // Default  add testing flag.
++  bool wrap_within_frame = true;
++
++  find_options->run_synchronously_for_testing = true;
++  find_options->match_case = false;
++
++  // Start a new find operation, resetting all relevant state.
++  GetTextFinder().InitNewSession(*find_options);
++  GetTextFinder().StartScopingStringMatches(identifier, search_text,
++                                            *find_options);
++
++  // Assert that no matches were found for the nonexistent string.
++  ASSERT_TRUE(!GetTextFinder().Find(identifier, search_text, *find_options,
++                                   wrap_within_frame));
++
++  int match_count = GetTextFinder().TotalMatchCount();
++  EXPECT_EQ(0, match_count);
++
++  // Assert the cache is populated with the correct number of matches.
++  EXPECT_EQ(match_count, GetTextFinder().GetMatchesCacheSize());
++
++  // Set N so it's hypothetically inbounds.
++  find_options->match_ordinal = 1;
++ 
++  // Assert the cache still returns nothing.
++  ASSERT_TRUE(!GetTextFinder().GetCachedMatchAtIndex(find_options->match_ordinal - 1));
++
++}
++
++}  // namespace blink
+\ No newline at end of file

--- a/patches/third_party-blink-renderer-core-frame-find_in_page.cc.patch
+++ b/patches/third_party-blink-renderer-core-frame-find_in_page.cc.patch
@@ -1,0 +1,20 @@
+diff --git a/third_party/blink/renderer/core/frame/find_in_page.cc b/third_party/blink/renderer/core/frame/find_in_page.cc
+index db1e2da7cf9d20de9ffb4eab6e30c4f1b1cdcfa7..b0de41896e67314590501fffba3e91459950118b 100644
+--- a/third_party/blink/renderer/core/frame/find_in_page.cc
++++ b/third_party/blink/renderer/core/frame/find_in_page.cc
+@@ -72,8 +72,13 @@ void FindInPage::Find(int request_id,
+   // Check if the plugin still exists in the document.
+   if (plugin) {
+     if (!options->new_session) {
+-      // Just navigate back/forward.
+-      plugin->SelectFindResult(options->forward, request_id);
++      if (options->match_ordinal <= 0) {
++        // Just navigate back/forward.
++        plugin->SelectFindResult(options->forward, request_id);
++      }
++      else {
++        plugin->SelectNthFindResult(options->match_ordinal, request_id);
++      }
+       LocalFrame* core_frame = frame_->GetFrame();
+       core_frame->GetPage()->GetFocusController().SetFocusedFrame(core_frame);
+     } else if (!plugin->StartFind(search_text, options->match_case,

--- a/patches/ui-views-controls-textfield-textfield.cc.patch
+++ b/patches/ui-views-controls-textfield-textfield.cc.patch
@@ -1,0 +1,23 @@
+diff --git a/ui/views/controls/textfield/textfield.cc b/ui/views/controls/textfield/textfield.cc
+index 0387f622e0cd3ea6fb3d5967a563f9cf0716a719..db7fbae90fc475266f685761f204834b1c701474 100644
+--- a/ui/views/controls/textfield/textfield.cc
++++ b/ui/views/controls/textfield/textfield.cc
+@@ -531,6 +531,18 @@ void Textfield::SetPlaceholderText(std::u16string_view text) {
+   OnPropertyChanged(&placeholder_text_, PropertyEffects::kPaint);
+ }
+ 
++int Textfield::GetPlaceholderTextHorizontalAlignment() {
++  return placeholder_text_draw_flags_;
++}
++
++void Textfield::SetPlaceholderTextHorizontalAlignment(int alignmentFlag) {
++  set_placeholder_text_draw_flags(alignmentFlag);
++}
++
++void Textfield::SetPlaceholderTextDrawFlags(int flags) {
++  placeholder_text_draw_flags_ = flags;
++}
++
+ gfx::HorizontalAlignment Textfield::GetHorizontalAlignment() const {
+   return GetRenderText()->horizontal_alignment();
+ }

--- a/patches/ui-views-controls-textfield-textfield.h.patch
+++ b/patches/ui-views-controls-textfield-textfield.h.patch
@@ -1,0 +1,25 @@
+diff --git a/ui/views/controls/textfield/textfield.h b/ui/views/controls/textfield/textfield.h
+index 2ddf0e6d6c5631875a597c09a5c058109d67e6d8..55e2572431ed5f6b91d5817dd4bfddac9e53229a 100644
+--- a/ui/views/controls/textfield/textfield.h
++++ b/ui/views/controls/textfield/textfield.h
+@@ -250,6 +250,12 @@ class VIEWS_EXPORT Textfield : public View,
+   std::u16string_view GetPlaceholderText() const;
+   void SetPlaceholderText(std::u16string_view text);
+ 
++  // Gets/Sets the horizontal alignment of the placeholder text
++  int GetPlaceholderTextHorizontalAlignment();
++  void SetPlaceholderTextHorizontalAlignment(int alignmentFlag);
++  
++  void SetPlaceholderTextDrawFlags(int flags);
++
+   void set_placeholder_text_color(SkColor color) {
+     placeholder_text_color_ = color;
+   }
+@@ -991,6 +997,7 @@ VIEW_BUILDER_PROPERTY(gfx::HorizontalAlignment, HorizontalAlignment)
+ VIEW_BUILDER_PROPERTY(bool, Invalid)
+ VIEW_BUILDER_PROPERTY(int, MinimumWidthInChars)
+ VIEW_BUILDER_PROPERTY(std::u16string, PlaceholderText)
++VIEW_BUILDER_PROPERTY(int, PlaceholderTextHorizontalAlignment)
+ VIEW_BUILDER_PROPERTY(bool, ReadOnly)
+ VIEW_BUILDER_PROPERTY(gfx::Range, SelectedRange)
+ VIEW_BUILDER_PROPERTY(SkColor, SelectionBackgroundColor)

--- a/patches/ui-views-controls-textfield-textfield_unittest.cc.patch
+++ b/patches/ui-views-controls-textfield-textfield_unittest.cc.patch
@@ -1,0 +1,26 @@
+diff --git a/ui/views/controls/textfield/textfield_unittest.cc b/ui/views/controls/textfield/textfield_unittest.cc
+index 0f809b8772e7b92da96cff11ab7714fc93707b8c..34660b0f7fbb417980f517c9a197b478f4815a9b 100644
+--- a/ui/views/controls/textfield/textfield_unittest.cc
++++ b/ui/views/controls/textfield/textfield_unittest.cc
+@@ -4546,6 +4546,21 @@ TEST_F(TextfieldTest, AccessibleNameFromLabel) {
+             label_data.id);
+ }
+ 
++TEST_F(TextfieldTest, PlaceholderTextAlignmentSetAndGetTest) {
++  InitTextfield();
++
++  textfield_->SetPlaceholderText(u"Some placeholder");
++
++  textfield_->SetPlaceholderTextHorizontalAlignment(gfx::ALIGN_LEFT);
++  EXPECT_EQ(textfield_->GetPlaceholderTextHorizontalAlignment(), gfx::ALIGN_LEFT);
++
++  textfield_->SetPlaceholderTextHorizontalAlignment(gfx::ALIGN_RIGHT);
++  EXPECT_EQ(textfield_->GetPlaceholderTextHorizontalAlignment(), gfx::ALIGN_RIGHT);
++
++  textfield_->SetPlaceholderTextHorizontalAlignment(gfx::ALIGN_CENTER);
++  EXPECT_EQ(textfield_->GetPlaceholderTextHorizontalAlignment(), gfx::ALIGN_CENTER);
++}
++
+ #if BUILDFLAG(IS_CHROMEOS)
+ // Check that when accessibility virtual keyboard is enabled, windows are
+ // shifted up when focused and restored when focus is lost.

--- a/patches/ui-views-view.h.patch
+++ b/patches/ui-views-view.h.patch
@@ -1,12 +1,28 @@
 diff --git a/ui/views/view.h b/ui/views/view.h
-index 97c8014fadf2231321c05a1f74d91418946bf9fc..acdfcfb7b147b01b5102912091d904441a107a2b 100644
+index 9467392dc31dd71ecf607882304d4d59e7582bad..0d2c815b03c0d3c9821eddc9e933e42434aa0e2f 100644
 --- a/ui/views/view.h
 +++ b/ui/views/view.h
-@@ -325,6 +325,7 @@ class VIEWS_EXPORT View : public ui::LayerDelegate,
-     FRIEND_TEST_ALL_PREFIXES(WebViewUnitTest, CrashedOverlayView);
+@@ -1824,6 +1824,12 @@ class VIEWS_EXPORT View : public ui::LayerDelegate,
  
-     OwnedByClientPassKey() = default;
-+    BRAVE_VIEW_OWNED_BY_CLIENT_PASS_KEY
-   };
+   LifeCycleState life_cycle_state() const { return life_cycle_state_; }
  
-   using PassKey = base::NonCopyablePassKey<View>;
++
++  // Invalidates the layout and calls ChildPreferredSizeChanged() on the parent
++  // if there is one. Be sure to call PreferredSizeChanged() when overriding
++  // such that the layout is properly invalidated.
++  virtual void PreferredSizeChanged();
++
+  protected:
+   // Used to track a drag. RootView passes this into
+   // ProcessMousePressed/Dragged.
+@@ -1863,10 +1869,6 @@ class VIEWS_EXPORT View : public ui::LayerDelegate,
+   // an opportunity to do a fresh layout if that makes sense.
+   virtual void ChildVisibilityChanged(View* child) {}
+ 
+-  // Invalidates the layout and calls ChildPreferredSizeChanged() on the parent
+-  // if there is one. Be sure to call PreferredSizeChanged() when overriding
+-  // such that the layout is properly invalidated.
+-  virtual void PreferredSizeChanged();
+ 
+   // Override returning true when the view needs to be notified when its visible
+   // bounds relative to the root view may have changed. Only used by


### PR DESCRIPTION
### Summary:
Allow users to access find results arbitrarily using an inline input field in the `chrome::FindBarView` widget.

### Motivation:
For large sets of find results, cycling through matches sequentially can be painstaking and time-consuming, especially if the user already has intuition about the document, and the position of the desired match is known with some certainty. An input allows the user to jump directly to the desired match or to at least get closer to it much faster.

### Resolves
https://github.com/brave/brave-browser/issues/57395

### Features

- Numeric and bounded input validation on N edit field.
- Find Previous  on up arrow keypress or mousewheel/scroll up.  (Desktop)
- Find Next on down arrow keypress or mousewheel/scroll down. (Desktop)
- Jump to last match on match count button click.


### Documents Supported
- Standard text/html documents in-browser
- PDFs (rendered in the PDF Viewer plugin)

### Pending Platform Support

~~- Android~~ IMPLEMENTED
- iOS
- macOS
- ChromeOS



### Previews
Standard HTML Documents:

https://github.com/user-attachments/assets/8ca71a03-3ae5-4b01-b030-06a563a75697


PDFs:


https://github.com/user-attachments/assets/b6037937-ef31-48de-aee1-b0ddb3192105


Android APK:


https://github.com/user-attachments/assets/b65565cf-f43c-4fd5-9396-beae3d65a650


https://github.com/user-attachments/assets/ab14c019-8911-4c26-9f9f-6b7fb8543110


