### PR TITLE
[plaster] Various `add_to_public` modernisations

### DIFF
--- a/chromium_src/chrome/browser/ui/window_feature_controller/window_feature_controller.cc
+++ b/chromium_src/chrome/browser/ui/window_feature_controller/window_feature_controller.cc
@@ -49,20 +49,3 @@ bool WindowFeatureController::UsesImmersiveFullscreenTabbedMode() const {
       UsesImmersiveFullscreenTabbedMode_ChromiumImpl();
 }
 #endif
-
-bool WindowFeatureController::NormalBrowserSupportsWindowFeature(
-    WindowFeature feature,
-    bool check_can_support) const {
-#if BUILDFLAG(IS_WIN)
-  if (feature == WindowFeature::kFeatureTitleBar) {
-    // In case of vertical tab strip is allowed, we need to have ability to
-    // show title bar on Windows.
-    return tabs::utils::ShouldShowBraveVerticalTabs(&browser_.get()) &&
-           tabs::utils::ShouldShowWindowTitleForVerticalTabs(&browser_.get());
-  }
-#endif
-
-  return WindowFeatureController::
-      NormalBrowserSupportsWindowFeature_ChromiumImpl(feature,
-                                                      check_can_support);
-}

--- a/patches/chrome-browser-ui-views-frame-horizontal_tab_strip_region_view.h.patch
+++ b/patches/chrome-browser-ui-views-frame-horizontal_tab_strip_region_view.h.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.h b/chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.h
-index 774e58392efa7349ecbde4f4fc4bcf4a5e010ec5..b146bf3deda1dc21bea42a8eb80a63bcac17078d 100644
+index 774e58392efa7349ecbde4f4fc4bcf4a5e010ec5..4d041e43f51133a94d4508eb10f2581719f14a36 100644
 --- a/chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.h
 +++ b/chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.h
 @@ -33,7 +33,7 @@ class TabStripControlButton;
@@ -11,17 +11,12 @@ index 774e58392efa7349ecbde4f4fc4bcf4a5e010ec5..b146bf3deda1dc21bea42a8eb80a63bc
    METADATA_HEADER(HorizontalTabStripRegionView, TabStripRegionView)
  
   public:
-@@ -42,6 +42,7 @@ class HorizontalTabStripRegionView final : public TabStripRegionView {
-   HorizontalTabStripRegionView& operator=(const HorizontalTabStripRegionView&) =
-       delete;
-   ~HorizontalTabStripRegionView() override;
-+  views::Button* new_tab_button() { return new_tab_button_; }
+@@ -114,13 +114,19 @@ class HorizontalTabStripRegionView final : public TabStripRegionView {
  
-   // Returns true if |point| falls within the window caption area of the
-   // horizontal tab strip. Returns false if the point hits an interactive child
-@@ -115,12 +116,16 @@ class HorizontalTabStripRegionView final : public TabStripRegionView {
    bool HasLeadingButtons() const;
  
++  views::Button* new_tab_button() { return new_tab_button_; }
++
   private:
 +  friend class BraveVerticalTabStripRegionView;
 +  friend class BraveTabStrip;

--- a/patches/chrome-browser-ui-views-frame-multi_contents_view.h.patch
+++ b/patches/chrome-browser-ui-views-frame-multi_contents_view.h.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/frame/multi_contents_view.h b/chrome/browser/ui/views/frame/multi_contents_view.h
-index 12511f171b46863215e3904361dd39f0f8392816..86da601fec22c54ed9731a9209a22a6c276622e9 100644
+index 12511f171b46863215e3904361dd39f0f8392816..f1a3b8a502edf0f09b23b156c30b9404150403fc 100644
 --- a/chrome/browser/ui/views/frame/multi_contents_view.h
 +++ b/chrome/browser/ui/views/frame/multi_contents_view.h
 @@ -63,7 +63,7 @@ class MultiContentsView
@@ -28,15 +28,7 @@ index 12511f171b46863215e3904361dd39f0f8392816..86da601fec22c54ed9731a9209a22a6c
  
    // Returns the currently inactive ContentsWebView.
    ContentsWebView* GetInactiveContentsView() const;
-@@ -87,6 +87,7 @@ class MultiContentsView
-   // adjusted for RtL (so e.g. `radii.upper_left()` is actually the corner that
-   // displays on the upper left regardless of text direction).
-   void SetBackgroundRadii(const gfx::RoundedCornersF& radii);
-+  virtual void ResetResizeArea() {}
-   const gfx::RoundedCornersF& GetBackgroundRadii() const;
- 
-   // Returns true if more than one WebContents is displayed.
-@@ -129,7 +130,7 @@ class MultiContentsView
+@@ -129,7 +129,7 @@ class MultiContentsView
  
    // Helper method to execute an arbitrary callback on each visible contents
    // view. Will execute the callback on the active contents view first.
@@ -45,15 +37,18 @@ index 12511f171b46863215e3904361dd39f0f8392816..86da601fec22c54ed9731a9209a22a6c
        base::RepeatingCallback<void(ContentsWebView*)> callback);
  
    // If in a split view, swaps the positions of the two active tabs.
-@@ -216,6 +217,7 @@ class MultiContentsView
+@@ -215,7 +215,10 @@ class MultiContentsView
+   const FocusableViewMap* GetFocusableViewsMapFor(
        const ContentsContainerView* container) const;
  
++  virtual void ResetResizeArea() {}
++
   private:
 +  friend class BraveMultiContentsView;
    FRIEND_TEST_ALL_PREFIXES(MultiContentsViewBrowserTest, DropTargetLayout);
    FRIEND_TEST_ALL_PREFIXES(MultiContentsViewBrowserTest,
                             LeadingSeparatorLayout);
-@@ -257,7 +259,7 @@ class MultiContentsView
+@@ -257,7 +260,7 @@ class MultiContentsView
  
    int GetInactiveIndex() const;
  
@@ -62,7 +57,7 @@ index 12511f171b46863215e3904361dd39f0f8392816..86da601fec22c54ed9731a9209a22a6c
    void OnNtpFooterFocused(views::WebView*);
    void OnActorOverlayFocused(views::WebView*);
    void OnReadAnythingOverlayFocused(ContentsContainerView* container,
-@@ -274,7 +276,7 @@ class MultiContentsView
+@@ -274,7 +277,7 @@ class MultiContentsView
    // `MultiContentsView`. Returns 0 if not in a split view.
    int GetMinViewSize(gfx::Rect available_space) const;
  

--- a/patches/chrome-browser-ui-views-side_panel-side_panel_web_ui_view.h.patch
+++ b/patches/chrome-browser-ui-views-side_panel-side_panel_web_ui_view.h.patch
@@ -1,12 +1,13 @@
 diff --git a/chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h b/chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h
-index 8fee06b8477a14ebcde6a588c16f0776f5cab210..82372be70459d7f57c87406a4290c69c24ce3152 100644
+index 8fee06b8477a14ebcde6a588c16f0776f5cab210..24eac41a49f85b19bd8de612a18957ea39393e23 100644
 --- a/chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h
 +++ b/chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h
-@@ -55,6 +55,7 @@ class SidePanelWebUIView : public views::WebView,
-   void HideCustomContextMenu() override;
+@@ -56,6 +56,8 @@ class SidePanelWebUIView : public views::WebView,
    bool HandleKeyboardEvent(content::WebContents* source,
                             const input::NativeWebKeyboardEvent& event) override;
-+  bool HandleContextMenu(content::RenderFrameHost& render_frame_host, const content::ContextMenuParams& params) override;
  
++  bool HandleContextMenu(content::RenderFrameHost& render_frame_host, const content::ContextMenuParams& params) override;
++
   private:
    base::RepeatingClosure on_show_cb_;
+   base::RepeatingClosure close_cb_;

--- a/patches/chrome-browser-ui-views-tabs-tab_style_views.cc.patch
+++ b/patches/chrome-browser-ui-views-tabs-tab_style_views.cc.patch
@@ -1,13 +1,12 @@
 diff --git a/chrome/browser/ui/views/tabs/tab_style_views.cc b/chrome/browser/ui/views/tabs/tab_style_views.cc
-index ed475c06560080d34de24d40f29a21dfd38991d5..5f99e7899172fd13d5d673a90f631e789f612ef6 100644
+index ed475c06560080d34de24d40f29a21dfd38991d5..d4095caae14195c6fcf72d5317ce20ba9191b2d6 100644
 --- a/chrome/browser/ui/views/tabs/tab_style_views.cc
 +++ b/chrome/browser/ui/views/tabs/tab_style_views.cc
-@@ -80,19 +80,19 @@ class TabStyleViewsImpl : public TabStyleViews {
-     return hover_controller_.get();
+@@ -81,18 +81,19 @@ class TabStyleViewsImpl : public TabStyleViews {
    }
  
-- private:
-+ protected:
+  private:
++  friend class BraveVerticalTabStyle;
    // Returns the color for the separator.
    SkColor GetTabSeparatorColor() const;
  
@@ -25,7 +24,7 @@ index ed475c06560080d34de24d40f29a21dfd38991d5..5f99e7899172fd13d5d673a90f631e78
  
    bool ShouldPaintTabBackgroundColor(
        TabStyle::TabSelectionState selection_state,
-@@ -110,7 +110,7 @@ class TabStyleViewsImpl : public TabStyleViews {
+@@ -110,7 +111,7 @@ class TabStyleViewsImpl : public TabStyleViews {
    // Returns a single separator's opacity based on whether it is the
    // logically `leading` separator. `for_layout` has the same meaning as in
    // GetSeparatorOpacities().
@@ -34,7 +33,7 @@ index ed475c06560080d34de24d40f29a21dfd38991d5..5f99e7899172fd13d5d673a90f631e78
  
    // Helper that returns an interpolated opacity if the tab or its neighbor
    // `other_tab` is mid-hover-animation. Used in almost all cases when a
-@@ -122,7 +122,7 @@ class TabStyleViewsImpl : public TabStyleViews {
+@@ -122,7 +123,7 @@ class TabStyleViewsImpl : public TabStyleViews {
    TabStyle::TabSelectionState GetSelectionState() const;
  
    // Gets the bounds for the leading and trailing separators for a tab.
@@ -43,7 +42,7 @@ index ed475c06560080d34de24d40f29a21dfd38991d5..5f99e7899172fd13d5d673a90f631e78
  
    // Returns the opacities of the separators. If `for_layout` is true, returns
    // the "layout" opacities, which ignore the effects of surrounding tabs' hover
-@@ -130,7 +130,7 @@ class TabStyleViewsImpl : public TabStyleViews {
+@@ -130,7 +131,7 @@ class TabStyleViewsImpl : public TabStyleViews {
    TabStyle::SeparatorOpacities GetSeparatorOpacities(bool for_layout) const;
  
    // Returns whether the mouse is currently hovering this tab.
@@ -52,7 +51,7 @@ index ed475c06560080d34de24d40f29a21dfd38991d5..5f99e7899172fd13d5d673a90f631e78
  
    // Returns whether the hover animation is being shown.
    bool IsHoverAnimationActive() const;
-@@ -341,6 +341,7 @@ SkPath TabStyleViewsImpl::GetPath(TabStyle::PathType path_type,
+@@ -341,6 +342,7 @@ SkPath TabStyleViewsImpl::GetPath(TabStyle::PathType path_type,
      extension_corner_radius -= 0.5f * stroke_adjustment;
    }
  
@@ -60,7 +59,7 @@ index ed475c06560080d34de24d40f29a21dfd38991d5..5f99e7899172fd13d5d673a90f631e78
    float left_extension_corner_radius = extension_corner_radius;
    if (IsLeftSplitTab(tab())) {
      top_right_corner_radius = 0;
-@@ -1012,14 +1013,18 @@ void TabStyleViewsImpl::PaintSeparators(gfx::Canvas* canvas) const {
+@@ -1012,14 +1014,18 @@ void TabStyleViewsImpl::PaintSeparators(gfx::Canvas* canvas) const {
                                                     SK_AlphaOPAQUE));
    };
  
@@ -81,7 +80,7 @@ index ed475c06560080d34de24d40f29a21dfd38991d5..5f99e7899172fd13d5d673a90f631e78
  }
  
  bool TabStyleViewsImpl::IsLeftSplitTab(const Tab* tab) const {
-@@ -1159,10 +1164,12 @@ ui::metadata::TypeConverter<TabStyle::TabColors>::GetValidStrings() {
+@@ -1159,10 +1165,12 @@ ui::metadata::TypeConverter<TabStyle::TabColors>::GetValidStrings() {
  
  // TabStyleViews ---------------------------------------------------------------
  

--- a/patches/chrome-browser-ui-views-toolbar-toolbar_view.h.patch
+++ b/patches/chrome-browser-ui-views-toolbar-toolbar_view.h.patch
@@ -1,13 +1,10 @@
 diff --git a/chrome/browser/ui/views/toolbar/toolbar_view.h b/chrome/browser/ui/views/toolbar/toolbar_view.h
-index c2d82dc622ea6025e90ae7eefa8b8bc893fe122e..100f06e3b36b3d27e58c4d7a055f612a59b17cbe 100644
+index c2d82dc622ea6025e90ae7eefa8b8bc893fe122e..742cc06e4cd5f23fb7e312d15237474f6bb877ed 100644
 --- a/chrome/browser/ui/views/toolbar/toolbar_view.h
 +++ b/chrome/browser/ui/views/toolbar/toolbar_view.h
-@@ -115,14 +115,16 @@ class ToolbarView : public views::AccessiblePaneView,
-   ToolbarView& operator=(const ToolbarView&) = delete;
+@@ -116,13 +116,13 @@ class ToolbarView : public views::AccessiblePaneView,
    ~ToolbarView() override;
  
-+  BrowserAppMenuButton* app_menu_button() const { return app_menu_button_; }
-+
    // Create the contents of the Browser Toolbar.
 -  void Init();
 +  virtual void Init();
@@ -21,7 +18,7 @@ index c2d82dc622ea6025e90ae7eefa8b8bc893fe122e..100f06e3b36b3d27e58c4d7a055f612a
  
    // Updates the toolbar's visible security state if the state has changed
    // since the last update. Returns true if the toolbar was updated.
-@@ -156,7 +158,7 @@ class ToolbarView : public views::AccessiblePaneView,
+@@ -156,7 +156,7 @@ class ToolbarView : public views::AccessiblePaneView,
        IntentPickerResponse callback);
  
    // Shows a bookmark bubble and anchors it appropriately.
@@ -30,6 +27,15 @@ index c2d82dc622ea6025e90ae7eefa8b8bc893fe122e..100f06e3b36b3d27e58c4d7a055f612a
  
    // Used to test whether `test_point` should be treated as part of the caption
    // bar, which means it can be used to drag the window or open the window
+@@ -252,6 +252,8 @@ class ToolbarView : public views::AccessiblePaneView,
+   // Updates glic button parenting after hiding glic actor task icon.
+   void FinalizeHideGlicActorTaskIcon();
+ 
++  BrowserAppMenuButton* app_menu_button() const { return app_menu_button_; }
++
+  protected:
+   // This controls Toolbar, LocationBar and CustomTabBar visibility.
+   // If we don't set all three, tab navigation from the app menu breaks
 @@ -259,6 +261,9 @@ class ToolbarView : public views::AccessiblePaneView,
    void SetToolbarVisibility(bool visible);
  

--- a/patches/chrome-browser-ui-web_modal-browser_window_modal_dialog_delegate.h.patch
+++ b/patches/chrome-browser-ui-web_modal-browser_window_modal_dialog_delegate.h.patch
@@ -1,12 +1,13 @@
 diff --git a/chrome/browser/ui/web_modal/browser_window_modal_dialog_delegate.h b/chrome/browser/ui/web_modal/browser_window_modal_dialog_delegate.h
-index b72d333bb51b47a2e5e1baaaab7659bc2ff7963a..f58b1f1a660d2405eadbf2737ca5f29720490ecf 100644
+index b72d333bb51b47a2e5e1baaaab7659bc2ff7963a..c0413e06da8abcf1ab00ba6dd7c128c7c58cec62 100644
 --- a/chrome/browser/ui/web_modal/browser_window_modal_dialog_delegate.h
 +++ b/chrome/browser/ui/web_modal/browser_window_modal_dialog_delegate.h
-@@ -31,6 +31,7 @@ class BrowserWindowModalDialogDelegate
-       BrowserWindowInterface* browser);
- 
-   // ChromeWebModalDialogManagerDelegate:
-+  bool IsWebContentsVisible(content::WebContents* web_contents) override;
-   void SetWebContentsBlocked(content::WebContents* web_contents,
-                              bool blocked) override;
+@@ -36,6 +36,8 @@ class BrowserWindowModalDialogDelegate
    web_modal::WebContentsModalDialogHost* GetWebContentsModalDialogHost(
+       content::WebContents* web_contents) override;
+ 
++  bool IsWebContentsVisible(content::WebContents* web_contents) override;
++
+  private:
+   const raw_ptr<BrowserWindowInterface> browser_;
+   ui::ScopedUnownedUserData<BrowserWindowModalDialogDelegate>

--- a/patches/chrome-browser-ui-window_feature_controller-window_feature_controller.cc.patch
+++ b/patches/chrome-browser-ui-window_feature_controller-window_feature_controller.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/window_feature_controller/window_feature_controller.cc b/chrome/browser/ui/window_feature_controller/window_feature_controller.cc
-index ec7bd3ea6cd00a5093b9bac2cfca9fe1a0bc4bfb..414df70879dde70ff5f127c763224789f830112b 100644
+index ec7bd3ea6cd00a5093b9bac2cfca9fe1a0bc4bfb..b7a5ba43bcca85e128ed9607ecd59b78b139b36c 100644
 --- a/chrome/browser/ui/window_feature_controller/window_feature_controller.cc
 +++ b/chrome/browser/ui/window_feature_controller/window_feature_controller.cc
 @@ -17,12 +17,14 @@ WindowFeatureController::WindowFeatureController(
@@ -19,12 +19,18 @@ index ec7bd3ea6cd00a5093b9bac2cfca9fe1a0bc4bfb..414df70879dde70ff5f127c763224789
  
  WindowFeatureController::~WindowFeatureController() = default;
  
-@@ -74,7 +76,7 @@ bool WindowFeatureController::UsesImmersiveFullscreenTabbedMode() const {
- }
- #endif
- 
--bool WindowFeatureController::NormalBrowserSupportsWindowFeature(
-+bool WindowFeatureController::NormalBrowserSupportsWindowFeature_ChromiumImpl(
+@@ -77,6 +79,14 @@ bool WindowFeatureController::UsesImmersiveFullscreenTabbedMode() const {
+ bool WindowFeatureController::NormalBrowserSupportsWindowFeature(
      WindowFeature feature,
      bool check_can_support) const {
++  #if BUILDFLAG(IS_WIN)
++  if (feature == WindowFeature::kFeatureTitleBar) {
++    // In case of vertical tab strip is allowed, we need to have ability to
++    // show title bar on Windows.
++    return tabs::utils::ShouldShowBraveVerticalTabs(&browser_.get()) &&
++           tabs::utils::ShouldShowWindowTitleForVerticalTabs(&browser_.get());
++  }
++  #endif
    switch (feature) {
+     case WindowFeature::kFeatureBookmarkBar:
+       return true;

--- a/patches/chrome-browser-ui-window_feature_controller-window_feature_controller.h.patch
+++ b/patches/chrome-browser-ui-window_feature_controller-window_feature_controller.h.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/window_feature_controller/window_feature_controller.h b/chrome/browser/ui/window_feature_controller/window_feature_controller.h
-index 7c203d12c129f2a7b949c5ccb5144d04b175d58b..6250948641340461f9da9ffd911150f07aec6c08 100644
+index 7c203d12c129f2a7b949c5ccb5144d04b175d58b..a6e82924284146a409e04e44b72a81aae4f8fc18 100644
 --- a/chrome/browser/ui/window_feature_controller/window_feature_controller.h
 +++ b/chrome/browser/ui/window_feature_controller/window_feature_controller.h
 @@ -38,7 +38,8 @@ class WindowFeatureController {
@@ -12,16 +12,7 @@ index 7c203d12c129f2a7b949c5ccb5144d04b175d58b..6250948641340461f9da9ffd911150f0
    ~WindowFeatureController();
  
    WindowFeatureController(const WindowFeatureController&) = delete;
-@@ -72,6 +73,8 @@ class WindowFeatureController {
-  private:
-   bool NormalBrowserSupportsWindowFeature(WindowFeature feature,
-                                           bool check_can_support) const;
-+  bool NormalBrowserSupportsWindowFeature_ChromiumImpl(WindowFeature feature,
-+                                          bool check_can_support) const;
-   bool PopupBrowserSupportsWindowFeature(WindowFeature feature,
-                                          bool check_can_support) const;
-   bool AppPopupBrowserSupportsWindowFeature(WindowFeature feature,
-@@ -94,6 +97,7 @@ class WindowFeatureController {
+@@ -94,6 +95,7 @@ class WindowFeatureController {
    const bool is_trusted_source_;
  
    ui::ScopedUnownedUserData<WindowFeatureController> scoped_unowned_user_data_;

--- a/patches/components-sync_device_info-device_info.h.patch
+++ b/patches/components-sync_device_info-device_info.h.patch
@@ -1,8 +1,8 @@
 diff --git a/components/sync_device_info/device_info.h b/components/sync_device_info/device_info.h
-index bfcb8729f6ab80ddec4bb001a6059686e736e38e..4fe6ae2d3ba96c0dc39bf35c1ff3114a4d69decd 100644
+index bfcb8729f6ab80ddec4bb001a6059686e736e38e..ad7984cb81b288c44fc9098819627b116d423721 100644
 --- a/components/sync_device_info/device_info.h
 +++ b/components/sync_device_info/device_info.h
-@@ -210,11 +210,28 @@ class DeviceInfo {
+@@ -210,7 +210,9 @@ class DeviceInfo {
                   desktop_to_ios_promo_receiving_types,
               GlicExperimentalTriggeringState glic_experimental_triggering_state,
               std::optional<int> glic_experimental_triggering_version,
@@ -13,9 +13,12 @@ index bfcb8729f6ab80ddec4bb001a6059686e736e38e..4fe6ae2d3ba96c0dc39bf35c1ff3114a
  
    DeviceInfo& operator=(const DeviceInfo&) = delete;
  
+@@ -347,6 +349,22 @@ class DeviceInfo {
+   // Glic. Pass std::nullopt if unavailable.
+   void set_glic_experimental_triggering_version(std::optional<int> version);
+ 
 +  DeviceInfo(DeviceInfo&&);
 +
-   ~DeviceInfo();
 +  SelfDeleteSupport self_delete_support() const {
 +    return self_delete_support_;
 +  }
@@ -29,10 +32,11 @@ index bfcb8729f6ab80ddec4bb001a6059686e736e38e..4fe6ae2d3ba96c0dc39bf35c1ff3114a
 +  // Converts the DeviceInfo values to a JS friendly DictionaryValue,
 +  // which extension APIs can expose to third party apps.
 +  base::DictValue ToValue() const;
- 
-   std::unique_ptr<DeviceInfo> DeepCopyForTesting() const;
- 
-@@ -426,6 +443,7 @@ class DeviceInfo {
++
+  private:
+   // Used by DeepCopyForTesting().
+   DeviceInfo(const DeviceInfo& other);
+@@ -426,6 +444,7 @@ class DeviceInfo {
    // |IsStoredLocalDeviceInfoStillAccurate| in device_info_sync_bridge.cc or
    // else changes in that member might not trigger uploads of updated
    // DeviceInfos.

--- a/patches/components-sync_device_info-device_info_sync_bridge.h.patch
+++ b/patches/components-sync_device_info-device_info_sync_bridge.h.patch
@@ -1,16 +1,17 @@
 diff --git a/components/sync_device_info/device_info_sync_bridge.h b/components/sync_device_info/device_info_sync_bridge.h
-index 800339c55f081f0b19c25d8b44692623a938d178..4ea948a36b21f51bb78e4a72e6a56a42598f3e28 100644
+index 800339c55f081f0b19c25d8b44692623a938d178..69e2e8b8e956c9dce1b80d9fa8101d8dc770b4d4 100644
 --- a/components/sync_device_info/device_info_sync_bridge.h
 +++ b/components/sync_device_info/device_info_sync_bridge.h
-@@ -61,6 +61,11 @@ class DeviceInfoSyncBridge : public DataTypeSyncBridge,
-   DeviceInfoSyncBridge& operator=(const DeviceInfoSyncBridge&) = delete;
+@@ -115,6 +115,12 @@ class DeviceInfoSyncBridge : public DataTypeSyncBridge,
+   bool IsPulseTimerRunningForTest() const;
+   void ForcePulseForTest() override;
  
-   ~DeviceInfoSyncBridge() override;
 +  void DeleteDeviceInfo(const std::string& client_id,
 +                        base::OnceClosure callback) override;
 +  std::vector<DeviceInfo> GetAllBraveDeviceInfo() const override;
 +  void OnDeviceInfoDeleted(const std::string& client_id, const int attempt,
 +                           base::OnceClosure callback);
- 
-   LocalDeviceInfoProvider* GetLocalDeviceInfoProvider();
- 
++
+  private:
+   class ImmutableDeviceInfoAndSpecifics {
+    public:

--- a/patches/third_party-blink-renderer-core-html-canvas-html_canvas_element.h.patch
+++ b/patches/third_party-blink-renderer-core-html-canvas-html_canvas_element.h.patch
@@ -1,11 +1,11 @@
 diff --git a/third_party/blink/renderer/core/html/canvas/html_canvas_element.h b/third_party/blink/renderer/core/html/canvas/html_canvas_element.h
-index 759b9d58f00d249cd05f487a8b350ab1973e4e20..809b6434886f3b539c43bbac002e46b845a1b6dc 100644
+index 759b9d58f00d249cd05f487a8b350ab1973e4e20..ce8107bc5aea5d0b885c1c0b55a8d82cc7092e8f 100644
 --- a/third_party/blink/renderer/core/html/canvas/html_canvas_element.h
 +++ b/third_party/blink/renderer/core/html/canvas/html_canvas_element.h
-@@ -103,6 +103,13 @@ class CORE_EXPORT HTMLCanvasElement final
+@@ -383,12 +383,21 @@ class CORE_EXPORT HTMLCanvasElement final
  
-   explicit HTMLCanvasElement(Document&);
-   ~HTMLCanvasElement() override;
+   ElementImage* captureElementImage(Element* element, ExceptionState&);
+ 
 +  String toDataURL(ScriptState* script_state, const String& mime_type,
 +                   const ScriptValue& quality_argument,
 +                   ExceptionState& exception_state) const;
@@ -13,10 +13,10 @@ index 759b9d58f00d249cd05f487a8b350ab1973e4e20..809b6434886f3b539c43bbac002e46b8
 +                   ExceptionState& exception_state) const {
 +    return toDataURL(script_state, mime_type, ScriptValue(), exception_state);
 +  }
- 
-   ElementType GetElementType() const final {
-     return ElementType::kHTMLCanvasElement;
-@@ -389,6 +396,7 @@ class CORE_EXPORT HTMLCanvasElement final
++
+  protected:
+   void DidMoveToNewDocument(Document& old_document) override;
+   void DidRecalcStyle(const StyleRecalcChange change) override;
    void RemovedFrom(ContainerNode& insertion_point) override;
  
   private:

--- a/rewrite/chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.h.yaml
+++ b/rewrite/chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.h.yaml
@@ -14,25 +14,32 @@ substitutions:
 
   - description: |
       Expose new_tab_button() to Brave
-    regex:
-      re_pattern: '(  ~HorizontalTabStripRegionView\(\) override;)'
-      replace: |-
-        \1
-          views::Button* new_tab_button() { return new_tab_button_; }
+    add_to_public:
+      class_name: HorizontalTabStripRegionView
+      code: 'views::Button* new_tab_button() { return new_tab_button_; }'
 
   - description: |
-      Friend the Brave tab strip classes and vertical tab strip test
+      Friend the vertical tab strip browser test
 
-      Grants the Brave tab strip subclasses and the vertical tab strip browser
-      test access to private members.
+      FRIEND_TEST_ALL_PREFIXES is a macro rather than a `friend class`, so it is
+      added with a regex. It runs before add_friend below so the friend classes
+      end up ahead of it (as add_friend prepends to the private section).
     regex:
       re_pattern: '( private:)'
       replace: |-
         \1
-          friend class BraveVerticalTabStripRegionView;
-          friend class BraveTabStrip;
-          friend class BraveHorizontalTabStripRegionView;
           FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest, MinHeight);
+
+  - description: |
+      Friend the Brave tab strip subclasses
+
+      Grants the Brave tab strip subclasses access to private members.
+    add_friend:
+      class_name: HorizontalTabStripRegionView
+      friend_type:
+        - class BraveVerticalTabStripRegionView
+        - class BraveTabStrip
+        - class BraveHorizontalTabStripRegionView
 
   - description: |
       Make UpdateTabStripMargin overridable

--- a/rewrite/chrome/browser/ui/views/frame/multi_contents_view.h.yaml
+++ b/rewrite/chrome/browser/ui/views/frame/multi_contents_view.h.yaml
@@ -47,11 +47,9 @@ substitutions:
 
       `BraveMultiContentsView` overrides this to reset the resize area
       when the web-panel layout changes.
-    regex:
-      re_pattern: '( +)(void SetBackgroundRadii\([^)]*\);)'
-      replace: |-
-        \1\2
-        \1virtual void ResetResizeArea() {}
+    add_to_public:
+      class_name: MultiContentsView
+      code: 'virtual void ResetResizeArea() {}'
 
   - description: |
       Make `ExecuteOnEachVisibleContentsView` virtual.

--- a/rewrite/chrome/browser/ui/views/profiles/avatar_toolbar_button.h.yaml
+++ b/rewrite/chrome/browser/ui/views/profiles/avatar_toolbar_button.h.yaml
@@ -9,7 +9,6 @@ substitutions:
 
       Brave subclasses AvatarToolbarButton, so it needs friend access to the
       private members.
-    regex:
-      re_pattern: '( private:\n)'
-      replace: |
-        \1  friend class BraveAvatarToolbarButton;
+    add_friend:
+      class_name: AvatarToolbarButton
+      friend_type: class BraveAvatarToolbarButton

--- a/rewrite/chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h.yaml
+++ b/rewrite/chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h.yaml
@@ -5,10 +5,8 @@
 
 substitutions:
   - description: Add more overrides to SidePanelWebUIView
-    regex:
-      re_pattern:
-        '(bool HandleKeyboardEvent\(content::WebContents\* source,\s+const
-        input::NativeWebKeyboardEvent& event\) override;)'
-      replace: |-
-        \1
-          bool HandleContextMenu(content::RenderFrameHost& render_frame_host, const content::ContextMenuParams& params) override;
+    add_to_public:
+      class_name: SidePanelWebUIView
+      code:
+        'bool HandleContextMenu(content::RenderFrameHost& render_frame_host,
+        const content::ContextMenuParams& params) override;'

--- a/rewrite/chrome/browser/ui/views/tabs/tab_style_views.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/tabs/tab_style_views.cc.yaml
@@ -8,12 +8,12 @@ substitutions:
       Expose TabStyleViewsImpl's private members to BraveVerticalTabStyle.
 
       Brave subclasses TabStyleViewsImpl (in
-      chromium_src/chrome/browser/ui/views/tabs/tab_style_views.cc), so its
-      members must be reachable from the derived class.
-    regex:
-      re_pattern: '(class TabStyleViewsImpl\b.*?)\n private:'
-      re_flags: [DOTALL]
-      replace: '\1\n protected:'
+      chromium_src/chrome/browser/ui/views/tabs/tab_style_views.cc), so it needs
+      friend access to reach the base's private members and override its private
+      virtuals.
+    add_friend:
+      class_name: TabStyleViewsImpl
+      friend_type: class BraveVerticalTabStyle
 
   - description: |-
       Virtualise GetSeparatorBounds for BraveVerticalTabStyle.

--- a/rewrite/chrome/browser/ui/views/toolbar/toolbar_view.h.yaml
+++ b/rewrite/chrome/browser/ui/views/toolbar/toolbar_view.h.yaml
@@ -28,12 +28,11 @@ substitutions:
       `app_menu_button_` has been made private in `ToolbarView`, as upstream is
       abstracting it away due to the WebUI work, so we expose an accessor for
       the concrete type that Brave still uses.
-    regex:
-      re_pattern: '(~ToolbarView\(\) override;)'
-      replace: |-
-        \1
-
-          BrowserAppMenuButton* app_menu_button() const { return app_menu_button_; }
+    add_to_public:
+      class_name: ToolbarView
+      code:
+        'BrowserAppMenuButton* app_menu_button() const { return
+        app_menu_button_; }'
 
   - description: |
       Make ToolbarView::ShowBookmarkBubble() virtual.

--- a/rewrite/chrome/browser/ui/web_modal/browser_window_modal_dialog_delegate.h.yaml
+++ b/rewrite/chrome/browser/ui/web_modal/browser_window_modal_dialog_delegate.h.yaml
@@ -5,8 +5,7 @@
 
 substitutions:
   - description: "IsWebContentsVisible override for inactive split tabs'"
-    regex:
-      re_pattern: '(  // ChromeWebModalDialogManagerDelegate:\n)'
-      replace:
-        '\1  bool IsWebContentsVisible(content::WebContents* web_contents)
-        override;\n'
+    add_to_public:
+      class_name: BrowserWindowModalDialogDelegate
+      code:
+        'bool IsWebContentsVisible(content::WebContents* web_contents) override;'

--- a/rewrite/chrome/browser/ui/window_feature_controller/window_feature_controller.cc.yaml
+++ b/rewrite/chrome/browser/ui/window_feature_controller/window_feature_controller.cc.yaml
@@ -28,10 +28,19 @@ substitutions:
               browser_(browser)\2
 
   - description: |
-      Make `NormalBrowserSupportsWindowFeature` an internal method
+      Give Brave control over NormalBrowserSupportsWindowFeature on Windows.
 
-      This is done so we can provide our own `NormalBrowserSupportsWindowFeature` with
-      specific handling for Windows.
-    regex:
-      pattern: 'WindowFeatureController::NormalBrowserSupportsWindowFeature('
-      replace: 'WindowFeatureController::NormalBrowserSupportsWindowFeature_ChromiumImpl('
+      When vertical tabs are enabled, Windows needs the ability to show the title
+      bar, so short-circuit kFeatureTitleBar before the upstream logic runs. The
+      tabs::utils helpers come from the chromium_src override's include.
+    preempt_function_impl:
+      function_name: WindowFeatureController::NormalBrowserSupportsWindowFeature
+      code: |-
+        #if BUILDFLAG(IS_WIN)
+        if (feature == WindowFeature::kFeatureTitleBar) {
+          // In case of vertical tab strip is allowed, we need to have ability to
+          // show title bar on Windows.
+          return tabs::utils::ShouldShowBraveVerticalTabs(&browser_.get()) &&
+                 tabs::utils::ShouldShowWindowTitleForVerticalTabs(&browser_.get());
+        }
+        #endif

--- a/rewrite/chrome/browser/ui/window_feature_controller/window_feature_controller.h.yaml
+++ b/rewrite/chrome/browser/ui/window_feature_controller/window_feature_controller.h.yaml
@@ -25,15 +25,3 @@ substitutions:
       replace: |-
         \1
           const raw_ref<BrowserWindowInterface> browser_;\2
-
-  - description: |
-      Mirror NormalBrowserSupportsWindowFeature as `_ChromiumImpl`
-
-      This sibling function is required for the customisation of
-      NormalBrowserSupportsWindowFeature.
-    regex:
-      re_pattern:
-        '(bool )(NormalBrowserSupportsWindowFeature)(\([\s\S]*?\) const;)'
-      replace: |-
-        \1\2\3
-          \1\2_ChromiumImpl\3

--- a/rewrite/components/sync_device_info/device_info.h.yaml
+++ b/rewrite/components/sync_device_info/device_info.h.yaml
@@ -22,43 +22,31 @@ substitutions:
                          SelfDeleteSupport::kNotSupported\2
 
   - description: |
-      Declare a move constructor for DeviceInfo
+      Add Brave-specific declarations to DeviceInfo's public interface
 
-      The defaulted move constructor is suppressed by the deleted copy operations
-      together with the user-declared destructor. We re-introduce a move
-      constructor so that Brave-specific call sites can wrap the value-returning
-      upstream `SpecificsToModel` into `std::make_unique<DeviceInfo>(...)`,
-      removing the need to duplicate the upstream argument list.
-    regex:
-      re_pattern: '(DeviceInfo& operator=\(const DeviceInfo&\) = delete;)'
-      replace: |-
-        \1
+      Re-introduces a move constructor, suppressed by the deleted copy
+      operations together with the user-declared destructor, so Brave call sites
+      can wrap the value-returning upstream `SpecificsToModel` into
+      `std::make_unique<DeviceInfo>(...)`. The remaining accessors used to exist
+      in Chromium, were dropped at some point, and are reinstated on Brave.
+    add_to_public:
+      class_name: DeviceInfo
+      code: |-
+        DeviceInfo(DeviceInfo&&);
 
-          DeviceInfo(DeviceInfo&&);
-
-  - description: |
-      Add Brave-specific methods to DeviceInfo public interface
-
-      Adding brave-specific methods to this type's interface. This methods used to
-      exist in Chromium, but they were dropped at some point, and then reinstated on
-      Brave.
-    regex:
-      re_pattern: '(~DeviceInfo\(\);)'
-      replace: |-
-        \1
-          SelfDeleteSupport self_delete_support() const {
-            return self_delete_support_;
-          }
-          void set_self_delete_support(SelfDeleteSupport self_delete_support) {
-            self_delete_support_ = self_delete_support;
-          }
-          // Gets the OS in string form.
-          std::string GetOSString() const;
-          // Gets the device type in string form.
-          std::string GetDeviceTypeString() const;
-          // Converts the DeviceInfo values to a JS friendly DictionaryValue,
-          // which extension APIs can expose to third party apps.
-          base::DictValue ToValue() const;
+        SelfDeleteSupport self_delete_support() const {
+          return self_delete_support_;
+        }
+        void set_self_delete_support(SelfDeleteSupport self_delete_support) {
+          self_delete_support_ = self_delete_support;
+        }
+        // Gets the OS in string form.
+        std::string GetOSString() const;
+        // Gets the device type in string form.
+        std::string GetDeviceTypeString() const;
+        // Converts the DeviceInfo values to a JS friendly DictionaryValue,
+        // which extension APIs can expose to third party apps.
+        base::DictValue ToValue() const;
 
   - description: |
       Add self_delete_support_ as last member of DeviceInfo

--- a/rewrite/components/sync_device_info/device_info_sync_bridge.h.yaml
+++ b/rewrite/components/sync_device_info/device_info_sync_bridge.h.yaml
@@ -13,12 +13,11 @@ substitutions:
       overrides of `DeviceInfoTracker`; `OnDeviceInfoDeleted` is the delayed
       continuation that `DeleteDeviceInfo` posts to re-check whether the
       deletion was ack'd by the sync server.
-    regex:
-      re_pattern: '( +)(~DeviceInfoSyncBridge\(\) override;)'
-      replace: |-
-        \1\2
-        \1void DeleteDeviceInfo(const std::string& client_id,
-        \1                      base::OnceClosure callback) override;
-        \1std::vector<DeviceInfo> GetAllBraveDeviceInfo() const override;
-        \1void OnDeviceInfoDeleted(const std::string& client_id, const int attempt,
-        \1                         base::OnceClosure callback);
+    add_to_public:
+      class_name: DeviceInfoSyncBridge
+      code: |-
+        void DeleteDeviceInfo(const std::string& client_id,
+                              base::OnceClosure callback) override;
+        std::vector<DeviceInfo> GetAllBraveDeviceInfo() const override;
+        void OnDeviceInfoDeleted(const std::string& client_id, const int attempt,
+                                 base::OnceClosure callback);

--- a/rewrite/third_party/blink/renderer/core/html/canvas/html_canvas_element.h.yaml
+++ b/rewrite/third_party/blink/renderer/core/html/canvas/html_canvas_element.h.yaml
@@ -3,22 +3,24 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+blank_macros_for_ast_parsing: true
+
 substitutions:
   - description: |
       Add Brave's synchronous toDataURL overloads.
 
       Brave exposes toDataURL variants that take an explicit ScriptState so it
-      can be called off the main flow; declared right after the destructor.
-    regex:
-      re_pattern: '(  ~HTMLCanvasElement\(\) override;\n)'
-      replace: |
-        \1  String toDataURL(ScriptState* script_state, const String& mime_type,
-                           const ScriptValue& quality_argument,
-                           ExceptionState& exception_state) const;
-          String toDataURL(ScriptState* script_state, const String& mime_type,
-                           ExceptionState& exception_state) const {
-            return toDataURL(script_state, mime_type, ScriptValue(), exception_state);
-          }
+      can be called off the main flow.
+    add_to_public:
+      class_name: HTMLCanvasElement
+      code: |-
+        String toDataURL(ScriptState* script_state, const String& mime_type,
+                         const ScriptValue& quality_argument,
+                         ExceptionState& exception_state) const;
+        String toDataURL(ScriptState* script_state, const String& mime_type,
+                         ExceptionState& exception_state) const {
+          return toDataURL(script_state, mime_type, ScriptValue(), exception_state);
+        }
   - description: |
       Hold the execution context used by Brave's farbling.
     regex:


### PR DESCRIPTION
This PR goes several scattered places where we could either use
`add_to_public`, or simplify things a bit with `add_friend` or
`preempt_function_impl`.

Bug: https://github.com/brave/brave-browser/issues/45050
