### PR TITLE
[iOS] Use correct truncation & alignment for collapsed URL bar

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
@@ -111,6 +111,8 @@ class CollapsedURLBarView: UIView {
           // Force left to right render direction
           let paragraphStyle = NSMutableParagraphStyle()
           paragraphStyle.baseWritingDirection = .leftToRight
+          paragraphStyle.lineBreakMode = .byTruncatingHead
+          paragraphStyle.alignment = .right
           let urlString = URLFormatter.formatURLOrigin(
             forDisplayOmitSchemePathAndTrivialSubdomains: URLOrigin(url: $0.strippingBlobURLAuth)
               .url?.absoluteString


### PR DESCRIPTION
These settings need to be assigned to the custom `NSParagraphStyle` as it will override the standard `textAlignment`/`lineBreakMode` settings on `UILabel`

Resolves https://github.com/brave/brave-browser/issues/57393
