### PR TITLE
Implement support for landscape layout for NetworkSelectorActivity

### DIFF
--- a/android/java/AndroidManifest.xml
+++ b/android/java/AndroidManifest.xml
@@ -42,9 +42,7 @@
     android:theme="@style/Theme.Chromium.Activity"/>
 
 <activity android:name="org.chromium.chrome.browser.crypto_wallet.activities.NetworkSelectorActivity"
-    android:theme="@style/Theme.Chromium.Activity"
-    android:screenOrientation="sensorPortrait"
-    tools:ignore="LockedOrientationActivity,DiscouragedApi"/>
+    android:theme="@style/Theme.Chromium.Activity" />
 
 <activity android:name="org.chromium.chrome.browser.crypto_wallet.activities.AccountSelectorActivity"
     android:theme="@style/Theme.Chromium.Activity"

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NetworkSelectorActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NetworkSelectorActivity.java
@@ -13,7 +13,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.widget.Toast;
 
-import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.appbar.MaterialToolbar;
@@ -22,6 +21,8 @@ import org.chromium.base.Log;
 import org.chromium.base.task.PostTask;
 import org.chromium.base.task.TaskTraits;
 import org.chromium.brave_wallet.mojom.NetworkInfo;
+import org.chromium.build.annotations.NullMarked;
+import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.app.BraveActivity;
 import org.chromium.chrome.browser.app.domain.NetworkModel;
@@ -36,15 +37,13 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+@NullMarked
 public class NetworkSelectorActivity extends BraveWalletBaseActivity
         implements NetworkSelectorAdapter.NetworkClickListener {
     private static final String TAG = "NetworkSelector";
     private RecyclerView mRVNetworkSelector;
-    private NetworkSelectorAdapter mNetworkSelectorAdapter;
-    private MaterialToolbar mToolbar;
-    private SettingsNavigation mSettingsLauncher;
-    private WalletModel mWalletModel;
-    private NetworkModel mNetworkModel;
+    private @Nullable SettingsNavigation mSettingsLauncher;
+    private @Nullable NetworkModel mNetworkModel;
 
     /**
      * Creates an Intent object to open network selector activity.
@@ -52,8 +51,7 @@ public class NetworkSelectorActivity extends BraveWalletBaseActivity
      * @return Intent object to open network selector activity.
      *     <p><b>Note:</b>: It should only be called if the wallet is set up and unlocked.
      */
-    @NonNull
-    public static Intent createIntent(@NonNull final Context context) {
+    public static Intent createIntent(final Context context) {
         final Intent intent = new Intent(context, NetworkSelectorActivity.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         return intent;
@@ -62,9 +60,9 @@ public class NetworkSelectorActivity extends BraveWalletBaseActivity
     @Override
     protected void triggerLayoutInflation() {
         setContentView(R.layout.activity_network_selector);
-        mToolbar = findViewById(R.id.toolbar);
-        mToolbar.setTitle(R.string.brave_wallet_select_network_title);
-        mToolbar.setOnMenuItemClickListener(
+        final MaterialToolbar toolbar = findViewById(R.id.toolbar);
+        toolbar.setTitle(R.string.brave_wallet_select_network_title);
+        toolbar.setOnMenuItemClickListener(
                 item -> {
                     if (item.getItemId() == R.id.menu_network_selector_close) {
                         finish();
@@ -80,23 +78,24 @@ public class NetworkSelectorActivity extends BraveWalletBaseActivity
     @Override
     public void finishNativeInitialization() {
         super.finishNativeInitialization();
-        initState();
-    }
 
-    private void initState() {
+        final WalletModel walletModel;
         try {
             BraveActivity activity = BraveActivity.getBraveActivity();
-            mWalletModel = activity.getWalletModel();
+            walletModel = activity.getWalletModel();
         } catch (BraveActivity.BraveActivityNotFoundException e) {
             Log.e(TAG, "initState", e);
             return;
         }
+        if (walletModel == null) {
+            return;
+        }
 
         mSettingsLauncher = new BraveSettingsLauncherImpl();
-        mNetworkModel = mWalletModel.getCryptoModel().getNetworkModel();
-        NetworkModel.NetworkLists networkLists = mNetworkModel.mNetworkLists.getValue();
-        NetworkInfo selectedNetwork =
-                mWalletModel.getCryptoModel().getNetworkModel().mDefaultNetwork.getValue();
+        final NetworkModel networkModel = walletModel.getCryptoModel().getNetworkModel();
+        mNetworkModel = networkModel;
+        NetworkModel.NetworkLists networkLists = networkModel.mNetworkLists.getValue();
+        NetworkInfo selectedNetwork = networkModel.mDefaultNetwork.getValue();
         // See GitHub issue https://github.com/brave/brave-browser/issues/37399.
         // When live data will be refactored this check can be removed.
         if (networkLists == null || selectedNetwork == null) {
@@ -105,19 +104,15 @@ public class NetworkSelectorActivity extends BraveWalletBaseActivity
             return;
         }
 
-        mNetworkSelectorAdapter =
+        NetworkSelectorAdapter networkSelectorAdapter =
                 new NetworkSelectorAdapter(
-                        this,
-                        filterSupportedDapp(networkLists),
-                        mWalletModel.getCryptoModel().getNetworkModel().mDefaultNetwork.getValue(),
-                        this);
-        mRVNetworkSelector.setAdapter(mNetworkSelectorAdapter);
+                        this, filterSupportedDapp(networkLists), selectedNetwork, this);
+        mRVNetworkSelector.setAdapter(networkSelectorAdapter);
     }
 
-    @NonNull
     @SuppressWarnings("NoStreams")
     private NetworkModel.NetworkLists filterSupportedDapp(
-            @NonNull final NetworkModel.NetworkLists networkLists) {
+            final NetworkModel.NetworkLists networkLists) {
         final Predicate<NetworkInfo> supportedNetworkFilter =
                 networkInfo ->
                         WalletConstants.SUPPORTED_COIN_TYPES_ON_DAPPS.contains(networkInfo.coin);
@@ -139,18 +134,26 @@ public class NetworkSelectorActivity extends BraveWalletBaseActivity
     }
 
     private void launchAddNetwork() {
+        final SettingsNavigation settingsLauncher = mSettingsLauncher;
+        if (settingsLauncher == null) {
+            return;
+        }
         Bundle fragmentArgs = new Bundle();
         fragmentArgs.putString(ADD_NETWORK_FRAGMENT_ARG_CHAIN_ID, "");
         fragmentArgs.putBoolean(ADD_NETWORK_FRAGMENT_ARG_ACTIVE_NETWORK, false);
         Intent intent =
-                mSettingsLauncher.createSettingsIntent(
+                settingsLauncher.createSettingsIntent(
                         this, BraveWalletAddNetworksFragment.class, fragmentArgs);
         startActivity(intent);
     }
 
     @Override
-    public void onNetworkItemSelected(@NonNull final NetworkInfo networkInfo) {
-        mNetworkModel.setNetworkWithAccountCheck(
+    public void onNetworkItemSelected(final NetworkInfo networkInfo) {
+        final NetworkModel networkModel = mNetworkModel;
+        if (networkModel == null) {
+            return;
+        }
+        networkModel.setNetworkWithAccountCheck(
                 networkInfo, false, isSelected -> updateNetworkUi(networkInfo, isSelected));
     }
 

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NetworkSelectorActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NetworkSelectorActivity.java
@@ -54,9 +54,9 @@ public class NetworkSelectorActivity extends BraveWalletBaseActivity
      */
     @NonNull
     public static Intent createIntent(@NonNull final Context context) {
-        Intent braveNetworkSelectionIntent = new Intent(context, NetworkSelectorActivity.class);
-        braveNetworkSelectionIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        return braveNetworkSelectionIntent;
+        final Intent intent = new Intent(context, NetworkSelectorActivity.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        return intent;
     }
 
     @Override

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/modal/BraveWalletPanel.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/modal/BraveWalletPanel.java
@@ -468,8 +468,7 @@ public class BraveWalletPanel implements DialogInterface {
         mBtnSelectedNetwork = mPopupView.findViewById(R.id.btn_dapps_panel_networks);
         mBtnSelectedNetwork.setOnClickListener(
                 v -> {
-                    Intent intent = new Intent(mActivity, NetworkSelectorActivity.class);
-                    intent.setAction(Intent.ACTION_VIEW);
+                    final Intent intent = NetworkSelectorActivity.createIntent(mActivity);
                     mActivity.startActivity(intent);
                 });
         mCvSolConnectionStatus = mPopupView.findViewById(R.id.v_dapps_panel_sol_connection_status);


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/57396

<img width="721" height="1115" alt="Screenshot 2026-07-21 at 6 34 21 PM" src="https://github.com/user-attachments/assets/572d2a8c-26d6-4799-92ca-53f66346cd62" />

The wallet Network Selector screen was pinned to `sensorPortrait`. This PR removes that orientation lock so the screen follows device rotation, which matters on tablets and foldables where users expect landscape, and it hardens the activity for the configuration change recreation that unlocking now allows. 

It also migrates `NetworkSelectorActivity` to NullAway null safety and uses proper `createIntent` public method to launch the activity.

## Test plan

- Set up and unlock the wallet.
- Navigate to Metamask test Dapp (https://metamask.github.io/test-dapp/).
- Tap on Wallet icon in the omnibox.
- Tap on network name in badge in the upper right of the Wallet panel.
- Observe Network Selector screen is shown correctly.
- Rotate between portrait and landscape. 
- Confirm the list re-renders, the current network keeps its checkmark, and there is no crash.
- Tap a network and immediately rotate. 
- Confirm the selection still commits and there is no crash.


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
