### PR TITLE
[Android] Move captcha attestation to Chromium network stack

### DIFF
--- a/android/java/org/chromium/base/BraveCommandLineInitUtil.java
+++ b/android/java/org/chromium/base/BraveCommandLineInitUtil.java
@@ -48,7 +48,7 @@ public abstract class BraveCommandLineInitUtil {
         if (sharedPreferences.getBoolean(PREF_QA_VLOG_REWARDS, false)) {
             qaCommandLine += " --enable-logging=stderr";
             qaCommandLine +=
-                    " --vmodule=*/brave_ads/*=6,*/brave_user_model/*=6,*/bat_ads/*=6,*/brave_rewards/*=6"; // presubmit: ignore-long-line
+                    " --vmodule=*/brave_ads/*=6,*/brave_user_model/*=6,*/bat_ads/*=6,*/brave_rewards/*=6,*/brave_adaptive_captcha/*=6"; // presubmit: ignore-long-line
         }
 
         // For testing we need custom variations server url prior to the first time run, so we try

--- a/android/java/org/chromium/chrome/browser/BraveRewardsNativeWorker.java
+++ b/android/java/org/chromium/chrome/browser/BraveRewardsNativeWorker.java
@@ -17,6 +17,7 @@ import org.jni_zero.NativeMethods;
 import org.json.JSONException;
 
 import org.chromium.brave_rewards.mojom.PublisherStatus;
+import org.chromium.chrome.browser.rewards.adaptive_captcha.AdaptiveCaptchaHelper;
 import org.chromium.chrome.browser.tab.Tab;
 import org.chromium.components.embedder_support.util.UrlConstants;
 
@@ -277,25 +278,34 @@ public class BraveRewardsNativeWorker {
         }
     }
 
-    public String getCaptchaSolutionURL(String paymentId, String captchaId) {
+    public void startAttestation(String captchaId, String paymentId) {
         synchronized (sLock) {
-            return BraveRewardsNativeWorkerJni.get().getCaptchaSolutionURL(
-                    mNativeBraveRewardsNativeWorker, paymentId, captchaId);
+            BraveRewardsNativeWorkerJni.get()
+                    .startAttestation(mNativeBraveRewardsNativeWorker, captchaId, paymentId);
         }
     }
 
-    public String getAttestationURL() {
+    public void attestPaymentId(
+            String captchaId,
+            String paymentId,
+            String integrityToken,
+            String uniqueValue,
+            String packageName) {
         synchronized (sLock) {
-            return BraveRewardsNativeWorkerJni.get().getAttestationURL(
-                    mNativeBraveRewardsNativeWorker);
+            BraveRewardsNativeWorkerJni.get()
+                    .attestPaymentId(
+                            mNativeBraveRewardsNativeWorker,
+                            captchaId,
+                            paymentId,
+                            integrityToken,
+                            uniqueValue,
+                            packageName);
         }
     }
 
-    public String getAttestationURLWithPaymentId(String paymentId) {
-        synchronized (sLock) {
-            return BraveRewardsNativeWorkerJni.get().getAttestationURLWithPaymentId(
-                    mNativeBraveRewardsNativeWorker, paymentId);
-        }
+    @CalledByNative
+    public void onAttestationNeedsIntegrityToken(String captchaId, String paymentId, String nonce) {
+        AdaptiveCaptchaHelper.fetchPlayIntegrityToken(captchaId, paymentId, nonce);
     }
 
     public String getPublisherFavIconURL(int tabId) {
@@ -747,13 +757,16 @@ public class BraveRewardsNativeWorker {
 
         String getPublisherURL(long nativeBraveRewardsNativeWorker, int tabId);
 
-        String getCaptchaSolutionURL(
-                long nativeBraveRewardsNativeWorker, String paymentId, String captchaId);
+        void startAttestation(
+                long nativeBraveRewardsNativeWorker, String captchaId, String paymentId);
 
-        String getAttestationURL(long nativeBraveRewardsNativeWorker);
-
-        String getAttestationURLWithPaymentId(
-                long nativeBraveRewardsNativeWorker, String paymentId);
+        void attestPaymentId(
+                long nativeBraveRewardsNativeWorker,
+                String captchaId,
+                String paymentId,
+                String integrityToken,
+                String uniqueValue,
+                String packageName);
 
         String getPublisherFavIconURL(long nativeBraveRewardsNativeWorker, int tabId);
 

--- a/android/java/org/chromium/chrome/browser/rewards/adaptive_captcha/AdaptiveCaptchaHelper.java
+++ b/android/java/org/chromium/chrome/browser/rewards/adaptive_captcha/AdaptiveCaptchaHelper.java
@@ -11,307 +11,55 @@ import com.google.android.play.core.integrity.IntegrityManagerFactory;
 import com.google.android.play.core.integrity.IntegrityTokenRequest;
 import com.google.android.play.core.integrity.IntegrityTokenResponse;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import org.chromium.base.ContextUtils;
 import org.chromium.base.Log;
-import org.chromium.base.task.PostTask;
-import org.chromium.base.task.TaskTraits;
 import org.chromium.chrome.browser.BraveRewardsNativeWorker;
-import org.chromium.chrome.browser.preferences.BravePref;
-import org.chromium.chrome.browser.profiles.ProfileManager;
-import org.chromium.chrome.browser.settings.developer.BraveQAPreferences;
-import org.chromium.components.user_prefs.UserPrefs;
-import org.chromium.net.ChromiumNetworkAdapter;
-import org.chromium.net.NetworkTrafficAnnotationTag;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-
+/**
+ * Drives the Android device-attestation captcha flow. The attestation HTTP requests run in native
+ * (BraveRewardsNativeWorker); this class only fetches the Play Integrity token, which requires a
+ * Java-only Google Play API.
+ */
 public class AdaptiveCaptchaHelper {
     public static final String TAG = "adaptive_captcha";
-    private static final String POST_METHOD = "POST";
-    private static final String PUT_METHOD = "PUT";
 
+    // Entry point: starts the attestation flow in native. Native calls back into
+    // fetchPlayIntegrityToken() once the server issues the attestation nonce.
     public static void startAttestation(String captchaId, String paymentId) {
-        PostTask.postTask(
-                TaskTraits.BEST_EFFORT_MAY_BLOCK,
-                () -> {
-                    HttpURLConnection urlConnection = null;
-                    BraveRewardsNativeWorker worker = BraveRewardsNativeWorker.getInstance();
-                    if (worker == null) {
-                        return;
-                    }
-                    String startAttestationUrl = worker.getAttestationURL();
-                    if (BraveQAPreferences.shouldVlogRewards()) {
-                        Log.e(TAG, startAttestationUrl);
-                    }
-                    NetworkTrafficAnnotationTag annotation =
-                            NetworkTrafficAnnotationTag.createComplete(
-                                    "Brave attestation api android",
-                                    "semantics {"
-                                            + "  sender: 'Brave Android app'"
-                                            + "  description: "
-                                            + "    'This api gets unique value for payment ID'"
-                                            + "  trigger: 'When payment id as captcha scheduled'"
-                                            + "  data:"
-                                            + "    'payment id'"
-                                            + "  destination: Brave grant endpoint"
-                                            + "}"
-                                            + "policy {"
-                                            + "  cookies_allowed: NO"
-                                            + "  policy_exception_justification: 'Not implemented.'"
-                                            + "}");
-                    String logMessage = "";
-                    try {
-                        URL url = new URL(startAttestationUrl);
-                        urlConnection = getUrlConnection(POST_METHOD, url, annotation);
-
-                        writeRequestOutput(getStartAttestationBody(paymentId), urlConnection);
-
-                        int responseCode = urlConnection.getResponseCode();
-                        if (responseCode == HttpURLConnection.HTTP_CREATED) {
-                            JSONObject jsonResponse = new JSONObject(readResponse(urlConnection));
-                            if (jsonResponse.has("uniqueValue")) {
-                                getPlayIntegrityToken(
-                                        jsonResponse.optString("uniqueValue"),
-                                        captchaId,
-                                        paymentId);
-                                logMessage = "Start attestation call is successful";
-                            }
-                        } else {
-                            recordFailureAttempt();
-                            logMessage =
-                                    "Start attestation failed with "
-                                            + responseCode
-                                            + " : "
-                                            + urlConnection.getResponseMessage();
-                        }
-                    } catch (Exception e) {
-                        Log.e(TAG, e.getMessage());
-                    } finally {
-                        if (urlConnection != null) urlConnection.disconnect();
-                        if (BraveQAPreferences.shouldVlogRewards()) {
-                            Log.e(TAG, logMessage);
-                        }
-                    }
-                });
+        BraveRewardsNativeWorker worker = BraveRewardsNativeWorker.getInstance();
+        if (worker != null) {
+            worker.startAttestation(captchaId, paymentId);
+        }
     }
 
-    private static void getPlayIntegrityToken(String nonce, String captchaId, String paymentId) {
+    // Called from native with the server-issued nonce. Requests a Play Integrity
+    // token for it and hands the result back to native. An empty token signals a
+    // failure so native records the attempt.
+    public static void fetchPlayIntegrityToken(String captchaId, String paymentId, String nonce) {
         IntegrityManager integrityManager =
                 IntegrityManagerFactory.create(ContextUtils.getApplicationContext());
         Task<IntegrityTokenResponse> integrityTokenResponseTask =
                 integrityManager.requestIntegrityToken(
                         IntegrityTokenRequest.builder().setNonce(nonce).build());
         integrityTokenResponseTask.addOnSuccessListener(
-                response -> { attestPaymentId(captchaId, paymentId, response.token(), nonce); });
-        integrityTokenResponseTask.addOnFailureListener(e -> {
-            Log.e(TAG, "addOnFailureListener : " + e.getMessage());
-            recordFailureAttempt();
-        });
+                response -> attestPaymentId(captchaId, paymentId, response.token(), nonce));
+        integrityTokenResponseTask.addOnFailureListener(
+                e -> {
+                    Log.e(TAG, "Play Integrity token request failed: " + e.getMessage());
+                    attestPaymentId(captchaId, paymentId, "", nonce);
+                });
     }
 
     private static void attestPaymentId(
-            String captchaId, String paymentId, String integrityToken, String uniqueValue) {
-        PostTask.postTask(
-                TaskTraits.BEST_EFFORT_MAY_BLOCK,
-                () -> {
-                    HttpURLConnection urlConnection = null;
-                    BraveRewardsNativeWorker worker = BraveRewardsNativeWorker.getInstance();
-                    if (worker == null) {
-                        return;
-                    }
-                    String attestPaymentIdUrl = worker.getAttestationURLWithPaymentId(paymentId);
-                    if (BraveQAPreferences.shouldVlogRewards()) {
-                        Log.e(TAG, attestPaymentIdUrl);
-                    }
-                    NetworkTrafficAnnotationTag annotation =
-                            NetworkTrafficAnnotationTag.createComplete(
-                                    "Brave attestation api android",
-                                    "semantics {  sender: 'Brave Android app'  description:    "
-                                        + " 'This api attests play integrity token for the given"
-                                        + " payment ID'  trigger: 'When payment id as captcha"
-                                        + " scheduled with integrity token'  data:    'integrity"
-                                        + " token, unique value, package name'  destination: Brave"
-                                        + " grant endpoint}policy {  cookies_allowed: NO "
-                                        + " policy_exception_justification: 'Not implemented.'}");
-                    String logMessage = "";
-                    try {
-                        URL url = new URL(attestPaymentIdUrl);
-                        urlConnection = getUrlConnection(PUT_METHOD, url, annotation);
-
-                        writeRequestOutput(
-                                getAttestPaymentIdBody(integrityToken, uniqueValue), urlConnection);
-
-                        int responseCode = urlConnection.getResponseCode();
-                        if (responseCode == HttpURLConnection.HTTP_OK) {
-                            solveCaptcha(captchaId, paymentId);
-                            logMessage = "Attest payment Id call is successful";
-                        } else {
-                            logMessage =
-                                    "Attest payment Id failed with "
-                                            + responseCode
-                                            + " : "
-                                            + urlConnection.getResponseMessage();
-                            recordFailureAttempt();
-                        }
-                    } catch (Exception e) {
-                        Log.e(TAG, e.getMessage());
-                    } finally {
-                        if (urlConnection != null) urlConnection.disconnect();
-                        if (BraveQAPreferences.shouldVlogRewards()) {
-                            Log.e(TAG, logMessage);
-                        }
-                    }
-                });
-    }
-
-    private static void solveCaptcha(String captchaId, String paymentId) {
-        PostTask.postTask(
-                TaskTraits.BEST_EFFORT_MAY_BLOCK,
-                () -> {
-                    HttpURLConnection urlConnection = null;
-                    BraveRewardsNativeWorker worker = BraveRewardsNativeWorker.getInstance();
-                    if (worker == null) {
-                        return;
-                    }
-                    String solveCaptchaUrl = worker.getCaptchaSolutionURL(paymentId, captchaId);
-                    if (BraveQAPreferences.shouldVlogRewards()) {
-                        Log.e(TAG, solveCaptchaUrl);
-                    }
-                    NetworkTrafficAnnotationTag annotation =
-                            NetworkTrafficAnnotationTag.createComplete(
-                                    "Brave attestation api android",
-                                    "semantics {  sender: 'Brave Android app'  description:    "
-                                        + " 'This api solves captcha for the given payment ID' "
-                                        + " trigger: 'When attestation is successful with the give"
-                                        + " integrity token for provided payment id'  data:   "
-                                        + " 'payment id'  destination: Brave grant endpoint}policy"
-                                        + " {  cookies_allowed: NO  policy_exception_justification:"
-                                        + " 'Not implemented.'}");
-
-                    String logMessage = "";
-                    try {
-                        URL url = new URL(String.format(solveCaptchaUrl, paymentId, captchaId));
-                        urlConnection = getUrlConnection(POST_METHOD, url, annotation);
-                        urlConnection.connect();
-
-                        writeRequestOutput(getSolveCaptchaBody(paymentId), urlConnection);
-
-                        int responseCode = urlConnection.getResponseCode();
-                        if (responseCode == HttpURLConnection.HTTP_OK) {
-                            clearCaptchaPrefs();
-                            logMessage = "Captcha has been solved.";
-                        } else {
-                            recordFailureAttempt();
-                            logMessage =
-                                    "Captcha solution failed with "
-                                            + responseCode
-                                            + " : "
-                                            + urlConnection.getResponseMessage();
-                        }
-                    } catch (Exception e) {
-                        Log.e(TAG, e.getMessage());
-                    } finally {
-                        if (urlConnection != null) urlConnection.disconnect();
-                        if (BraveQAPreferences.shouldVlogRewards()) {
-                            Log.e(TAG, logMessage);
-                        }
-                    }
-                });
-    }
-
-    private static void clearCaptchaPrefs() {
-        UserPrefs.get(ProfileManager.getLastUsedRegularProfile())
-                .setInteger(BravePref.SCHEDULED_CAPTCHA_FAILED_ATTEMPTS, 0);
-        UserPrefs.get(ProfileManager.getLastUsedRegularProfile())
-                .setString(BravePref.SCHEDULED_CAPTCHA_ID, "");
-        UserPrefs.get(ProfileManager.getLastUsedRegularProfile())
-                .setString(BravePref.SCHEDULED_CAPTCHA_PAYMENT_ID, "");
-        UserPrefs.get(ProfileManager.getLastUsedRegularProfile())
-                .setBoolean(BravePref.SCHEDULED_CAPTCHA_PAUSED, false);
-    }
-
-    private static void recordFailureAttempt() {
-        UserPrefs.get(ProfileManager.getLastUsedRegularProfile())
-                .setInteger(
-                        BravePref.SCHEDULED_CAPTCHA_FAILED_ATTEMPTS,
-                        UserPrefs.get(ProfileManager.getLastUsedRegularProfile())
-                                        .getInteger(BravePref.SCHEDULED_CAPTCHA_FAILED_ATTEMPTS)
-                                + 1);
-    }
-
-    private static HttpURLConnection getUrlConnection(String requestMethod, URL url,
-            NetworkTrafficAnnotationTag annotation) throws IOException {
-        HttpURLConnection urlConnection =
-                (HttpURLConnection) ChromiumNetworkAdapter.openConnection(url, annotation);
-        urlConnection.setDoOutput(true);
-        urlConnection.setRequestMethod(requestMethod);
-        urlConnection.setUseCaches(false);
-        urlConnection.setRequestProperty("Content-Type", "application/json");
-        return urlConnection;
-    }
-
-    private static void writeRequestOutput(String body, HttpURLConnection urlConnection)
-            throws IOException {
-        OutputStream outputStream = null;
-        try {
-            outputStream = urlConnection.getOutputStream();
-            byte[] input = body.getBytes(StandardCharsets.UTF_8);
-            outputStream.write(input, 0, input.length);
-            outputStream.flush();
-        } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
-        } finally {
-            if (outputStream != null) {
-                outputStream.close();
-            }
+            String captchaId, String paymentId, String integrityToken, String nonce) {
+        BraveRewardsNativeWorker worker = BraveRewardsNativeWorker.getInstance();
+        if (worker != null) {
+            worker.attestPaymentId(
+                    captchaId,
+                    paymentId,
+                    integrityToken,
+                    nonce,
+                    ContextUtils.getApplicationContext().getPackageName());
         }
-    }
-
-    private static String readResponse(HttpURLConnection urlConnection) throws IOException {
-        String responseString = "";
-        try (BufferedReader br =
-                new BufferedReader(
-                        new InputStreamReader(
-                                urlConnection.getInputStream(), StandardCharsets.UTF_8))) {
-            StringBuilder sb = new StringBuilder();
-            String line = null;
-            while ((line = br.readLine()) != null) {
-                sb.append(line + "\n");
-            }
-            responseString = sb.toString();
-        } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
-        }
-        return responseString;
-    }
-
-    private static String getStartAttestationBody(String paymentId) throws JSONException {
-        JSONObject jsonParam = new JSONObject();
-        jsonParam.put("paymentId", paymentId);
-        return jsonParam.toString();
-    }
-
-    private static String getAttestPaymentIdBody(String integrityToken, String uniqueValue)
-            throws JSONException {
-        JSONObject jsonParam = new JSONObject();
-        jsonParam.put("integrityToken", integrityToken);
-        jsonParam.put("uniqueValue", uniqueValue);
-        jsonParam.put("packageName", ContextUtils.getApplicationContext().getPackageName());
-        return jsonParam.toString();
-    }
-
-    private static String getSolveCaptchaBody(String paymentId) throws JSONException {
-        JSONObject jsonParam = new JSONObject();
-        jsonParam.put("solution", paymentId);
-        return jsonParam.toString();
     }
 }

--- a/browser/brave_rewards/android/brave_rewards_native_worker.cc
+++ b/browser/brave_rewards/android/brave_rewards_native_worker.cc
@@ -15,9 +15,9 @@
 #include "base/feature_list.h"
 #include "base/json/json_writer.h"
 #include "base/time/time.h"
+#include "brave/browser/brave_adaptive_captcha/brave_adaptive_captcha_service_factory.h"
 #include "brave/browser/brave_rewards/rewards_service_factory.h"
 #include "brave/components/brave_adaptive_captcha/brave_adaptive_captcha_service.h"
-#include "brave/components/brave_adaptive_captcha/server_util.h"
 #include "brave/components/brave_ads/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/content/rewards_p3a.h"
 #include "brave/components/brave_rewards/content/rewards_service.h"
@@ -30,7 +30,6 @@
 #include "chrome/browser/profiles/profile_manager.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/url_data_source.h"
-#include "third_party/abseil-cpp/absl/strings/str_format.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
 #include "brave/browser/brave_ads/ads_service_factory.h"
@@ -53,6 +52,11 @@ BraveRewardsNativeWorker::BraveRewardsNativeWorker(
 
   brave_rewards_service_ = brave_rewards::RewardsServiceFactory::GetForProfile(
       profile.GetOriginalProfile());
+  // Rewards (and therefore the adaptive captcha) is not available in
+  // OTR/incognito, so always use the original profile.
+  adaptive_captcha_service_ =
+      brave_adaptive_captcha::BraveAdaptiveCaptchaServiceFactory::GetForProfile(
+          profile.GetOriginalProfile());
   if (brave_rewards_service_) {
     rewards_service_observation_.Observe(brave_rewards_service_);
 
@@ -323,41 +327,81 @@ BraveRewardsNativeWorker::GetPublisherFavIconURL(JNIEnv* env, uint64_t tabId) {
   return res;
 }
 
-base::android::ScopedJavaLocalRef<jstring>
-BraveRewardsNativeWorker::GetCaptchaSolutionURL(
+void BraveRewardsNativeWorker::StartAttestation(
     JNIEnv* env,
-    const base::android::JavaRef<jstring>& paymentId,
-    const base::android::JavaRef<jstring>& captchaId) {
-  const std::string path =
-      absl::StrFormat("/v3/captcha/solution/%s/%s",
-                      base::android::ConvertJavaStringToUTF8(env, paymentId),
-                      base::android::ConvertJavaStringToUTF8(env, captchaId));
-  std::string captcha_solution_url =
-      brave_adaptive_captcha::ServerUtil::GetInstance()->GetServerUrl(path);
+    const base::android::JavaRef<jstring>& captcha_id,
+    const base::android::JavaRef<jstring>& payment_id) {
+  if (!adaptive_captcha_service_) {
+    return;
+  }
 
-  return base::android::ConvertUTF8ToJavaString(env, captcha_solution_url);
+  const std::string captcha_id_str =
+      base::android::ConvertJavaStringToUTF8(env, captcha_id);
+  const std::string payment_id_str =
+      base::android::ConvertJavaStringToUTF8(env, payment_id);
+  adaptive_captcha_service_->StartAttestation(
+      payment_id_str,
+      base::BindOnce(&BraveRewardsNativeWorker::OnStartAttestation,
+                     weak_factory_.GetWeakPtr(), captcha_id_str,
+                     payment_id_str));
 }
 
-base::android::ScopedJavaLocalRef<jstring>
-BraveRewardsNativeWorker::GetAttestationURL(JNIEnv* env) {
-  const std::string path = "/v1/attestations/android";
-  std::string captcha_solution_url =
-      brave_adaptive_captcha::ServerUtil::GetInstance()->GetServerUrl(path);
+void BraveRewardsNativeWorker::OnStartAttestation(
+    const std::string& captcha_id,
+    const std::string& payment_id,
+    const std::string& unique_value) {
+  if (unique_value.empty()) {
+    if (adaptive_captcha_service_) {
+      adaptive_captcha_service_->UpdateScheduledCaptchaResult(false);
+    }
+    return;
+  }
 
-  return base::android::ConvertUTF8ToJavaString(env, captcha_solution_url);
+  // The Play Integrity token must be obtained on the Java side using the
+  // server-issued nonce; Java then calls back into AttestPaymentId().
+  JNIEnv* env = base::android::AttachCurrentThread();
+  Java_BraveRewardsNativeWorker_onAttestationNeedsIntegrityToken(
+      env, weak_java_brave_rewards_native_worker_.get(env),
+      base::android::ConvertUTF8ToJavaString(env, captcha_id),
+      base::android::ConvertUTF8ToJavaString(env, payment_id),
+      base::android::ConvertUTF8ToJavaString(env, unique_value));
 }
 
-base::android::ScopedJavaLocalRef<jstring>
-BraveRewardsNativeWorker::GetAttestationURLWithPaymentId(
+void BraveRewardsNativeWorker::AttestPaymentId(
     JNIEnv* env,
-    const base::android::JavaRef<jstring>& paymentId) {
-  const std::string path =
-      base::StrCat({"/v1/attestations/android/",
-                    base::android::ConvertJavaStringToUTF8(env, paymentId)});
-  std::string captcha_solution_url =
-      brave_adaptive_captcha::ServerUtil::GetInstance()->GetServerUrl(path);
+    const base::android::JavaRef<jstring>& captcha_id,
+    const base::android::JavaRef<jstring>& payment_id,
+    const base::android::JavaRef<jstring>& integrity_token,
+    const base::android::JavaRef<jstring>& unique_value,
+    const base::android::JavaRef<jstring>& package_name) {
+  if (!adaptive_captcha_service_) {
+    return;
+  }
 
-  return base::android::ConvertUTF8ToJavaString(env, captcha_solution_url);
+  const std::string integrity_token_str =
+      base::android::ConvertJavaStringToUTF8(env, integrity_token);
+  // An empty token means the Java Play Integrity request failed.
+  if (integrity_token_str.empty()) {
+    adaptive_captcha_service_->UpdateScheduledCaptchaResult(false);
+    return;
+  }
+
+  adaptive_captcha_service_->AttestPaymentId(
+      base::android::ConvertJavaStringToUTF8(env, payment_id),
+      base::android::ConvertJavaStringToUTF8(env, captcha_id),
+      integrity_token_str,
+      base::android::ConvertJavaStringToUTF8(env, unique_value),
+      base::android::ConvertJavaStringToUTF8(env, package_name),
+      base::BindOnce(&BraveRewardsNativeWorker::OnAttestResult,
+                     weak_factory_.GetWeakPtr()));
+}
+
+void BraveRewardsNativeWorker::OnAttestResult(bool success) {
+  if (adaptive_captcha_service_) {
+    // UpdateScheduledCaptchaResult clears the scheduled captcha on success and
+    // records a failed attempt (pausing after the max) otherwise.
+    adaptive_captcha_service_->UpdateScheduledCaptchaResult(success);
+  }
 }
 
 base::android::ScopedJavaLocalRef<jstring>

--- a/browser/brave_rewards/android/brave_rewards_native_worker.h
+++ b/browser/brave_rewards/android/brave_rewards_native_worker.h
@@ -29,6 +29,10 @@ namespace brave_rewards {
 class RewardsService;
 }
 
+namespace brave_adaptive_captcha {
+class BraveAdaptiveCaptchaService;
+}
+
 namespace chrome {
 namespace android {
 
@@ -94,14 +98,18 @@ class BraveRewardsNativeWorker
 
   base::android::ScopedJavaLocalRef<jstring> GetPublisherName(JNIEnv* env,
                                                               uint64_t tabId);
-  base::android::ScopedJavaLocalRef<jstring> GetCaptchaSolutionURL(
-      JNIEnv* env,
-      const base::android::JavaRef<jstring>& paymentId,
-      const base::android::JavaRef<jstring>& captchaId);
-  base::android::ScopedJavaLocalRef<jstring> GetAttestationURL(JNIEnv* env);
-  base::android::ScopedJavaLocalRef<jstring> GetAttestationURLWithPaymentId(
-      JNIEnv* env,
-      const base::android::JavaRef<jstring>& paymentId);
+  // Starts the device-attestation flow to solve a scheduled captcha. The Play
+  // Integrity token is fetched on the Java side, which then calls back into
+  // AttestPaymentId().
+  void StartAttestation(JNIEnv* env,
+                        const base::android::JavaRef<jstring>& captcha_id,
+                        const base::android::JavaRef<jstring>& payment_id);
+  void AttestPaymentId(JNIEnv* env,
+                       const base::android::JavaRef<jstring>& captcha_id,
+                       const base::android::JavaRef<jstring>& payment_id,
+                       const base::android::JavaRef<jstring>& integrity_token,
+                       const base::android::JavaRef<jstring>& unique_value,
+                       const base::android::JavaRef<jstring>& package_name);
 
   base::android::ScopedJavaLocalRef<jstring> GetPublisherId(JNIEnv* env,
                                                             uint64_t tabId);
@@ -241,6 +249,11 @@ class BraveRewardsNativeWorker
                           const std::string& publisher_key);
 
  private:
+  void OnStartAttestation(const std::string& captcha_id,
+                          const std::string& payment_id,
+                          const std::string& unique_value);
+  void OnAttestResult(bool success);
+
   void OnGetUserType(const brave_rewards::mojom::UserType user_type);
 
   void OnBalance(brave_rewards::mojom::BalancePtr balance);
@@ -249,6 +262,8 @@ class BraveRewardsNativeWorker
 
   JavaObjectWeakGlobalRef weak_java_brave_rewards_native_worker_;
   raw_ptr<brave_rewards::RewardsService> brave_rewards_service_ = nullptr;
+  raw_ptr<brave_adaptive_captcha::BraveAdaptiveCaptchaService>
+      adaptive_captcha_service_ = nullptr;
   brave_rewards::mojom::RewardsParametersPtr parameters_;
   brave_rewards::mojom::Balance balance_;
   PublishersInfoMap map_publishers_info_;

--- a/components/brave_adaptive_captcha/BUILD.gn
+++ b/components/brave_adaptive_captcha/BUILD.gn
@@ -19,6 +19,13 @@ source_set("brave_adaptive_captcha") {
     "server_util.h",
   ]
 
+  if (is_android) {
+    sources += [
+      "android/attest_android.cc",
+      "android/attest_android.h",
+    ]
+  }
+
   deps = [
     "//base",
     "//brave/components/api_request_helper",

--- a/components/brave_adaptive_captcha/android/attest_android.cc
+++ b/components/brave_adaptive_captcha/android/attest_android.cc
@@ -1,0 +1,188 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_adaptive_captcha/android/attest_android.h"
+
+#include <string>
+#include <utility>
+
+#include "base/functional/bind.h"
+#include "base/json/json_writer.h"
+#include "base/logging.h"
+#include "base/strings/strcat.h"
+#include "base/values.h"
+#include "brave/components/brave_adaptive_captcha/server_util.h"
+#include "net/http/http_status_code.h"
+#include "net/traffic_annotation/network_traffic_annotation.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
+#include "url/gurl.h"
+
+// `VLOG` is dead-code-stripped in official Android release builds:
+// base/logging.h compiles the templated `GetVlogLevel()` to a constexpr -1
+// there (a binary size optimization), so every `VLOG` site — string literals
+// included — is removed and never reaches logcat. This honors the
+// `*/brave_adaptive_captcha/*` vmodule that the "Verbose Logs for Ad-Rewards".
+#define CAPTCHA_VLOG(verbose_level)                                         \
+  LAZY_STREAM(                                                              \
+      ::logging::LogMessage(__FILE__, __LINE__, -(verbose_level)).stream(), \
+      (verbose_level) <=                                                    \
+          ::logging::GetVlogLevelHelper(__FILE__, sizeof(__FILE__)))
+
+namespace brave_adaptive_captcha {
+
+namespace {
+
+constexpr char kContentType[] = "application/json";
+
+net::NetworkTrafficAnnotationTag kAnnotationTag =
+    net::DefineNetworkTrafficAnnotation("brave_adaptive_captcha_attestation",
+                                        R"(
+        semantics {
+          sender: "Brave Rewards"
+          description:
+            "Performs Android device attestation to solve a scheduled Brave "
+            "Rewards captcha: requests an attestation nonce, submits a Google "
+            "Play Integrity token for it, then posts the captcha solution."
+          trigger:
+            "A captcha was scheduled for the user's Brave Rewards payment id."
+          data:
+            "Brave Rewards payment id, a Play Integrity token, and the app "
+            "package name."
+          destination: WEBSITE
+        }
+        policy {
+          cookies_allowed: NO
+          setting: "This feature cannot be disabled by settings."
+          policy_exception_justification: "Not implemented."
+        })");
+
+std::string ToJson(const base::DictValue& dict) {
+  std::string json;
+  base::JSONWriter::Write(dict, &json);
+  return json;
+}
+
+}  // namespace
+
+AttestAndroid::AttestAndroid(
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory)
+    : api_request_helper_(kAnnotationTag, std::move(url_loader_factory)) {}
+
+AttestAndroid::~AttestAndroid() = default;
+
+void AttestAndroid::StartAttestation(const std::string& payment_id,
+                                     OnStartAttestation callback) {
+  const std::string url =
+      ServerUtil::GetInstance()->GetServerUrl("/v1/attestations/android");
+  CAPTCHA_VLOG(1) << "Start attestation: " << url;
+
+  base::DictValue body;
+  body.Set("paymentId", payment_id);
+
+  api_request_helper_.Request(
+      "POST", GURL(url), ToJson(body), kContentType,
+      base::BindOnce(&AttestAndroid::OnStartAttestationResponse,
+                     base::Unretained(this), std::move(callback)));
+}
+
+void AttestAndroid::OnStartAttestationResponse(
+    OnStartAttestation callback,
+    api_request_helper::APIRequestResult api_request_result) {
+  if (api_request_result.response_code() != net::HTTP_CREATED) {
+    CAPTCHA_VLOG(1) << "Start attestation failed, HTTP status: "
+                    << api_request_result.response_code();
+    std::move(callback).Run(std::string());
+    return;
+  }
+
+  const base::Value& body = api_request_result.value_body();
+  if (!body.is_dict()) {
+    CAPTCHA_VLOG(1) << "Start attestation returned an invalid response";
+    std::move(callback).Run(std::string());
+    return;
+  }
+
+  const std::string* unique_value = body.GetDict().FindString("uniqueValue");
+  if (!unique_value) {
+    CAPTCHA_VLOG(1) << "Start attestation response is missing uniqueValue";
+    std::move(callback).Run(std::string());
+    return;
+  }
+
+  CAPTCHA_VLOG(1) << "Start attestation call is successful";
+  std::move(callback).Run(*unique_value);
+}
+
+void AttestAndroid::AttestPaymentId(const std::string& payment_id,
+                                    const std::string& captcha_id,
+                                    const std::string& integrity_token,
+                                    const std::string& unique_value,
+                                    const std::string& package_name,
+                                    OnAttestResult callback) {
+  const std::string url = ServerUtil::GetInstance()->GetServerUrl(
+      base::StrCat({"/v1/attestations/android/", payment_id}));
+  CAPTCHA_VLOG(1) << "Attest payment id: " << url;
+
+  base::DictValue body;
+  body.Set("integrityToken", integrity_token);
+  body.Set("uniqueValue", unique_value);
+  body.Set("packageName", package_name);
+
+  api_request_helper_.Request(
+      "PUT", GURL(url), ToJson(body), kContentType,
+      base::BindOnce(&AttestAndroid::OnAttestPaymentIdResponse,
+                     base::Unretained(this), payment_id, captcha_id,
+                     std::move(callback)));
+}
+
+void AttestAndroid::OnAttestPaymentIdResponse(
+    const std::string& payment_id,
+    const std::string& captcha_id,
+    OnAttestResult callback,
+    api_request_helper::APIRequestResult api_request_result) {
+  if (api_request_result.response_code() != net::HTTP_OK) {
+    CAPTCHA_VLOG(1) << "Attest payment id failed, HTTP status: "
+                    << api_request_result.response_code();
+    std::move(callback).Run(false);
+    return;
+  }
+
+  CAPTCHA_VLOG(1) << "Attest payment id call is successful";
+  SolveCaptcha(payment_id, captcha_id, std::move(callback));
+}
+
+void AttestAndroid::SolveCaptcha(const std::string& payment_id,
+                                 const std::string& captcha_id,
+                                 OnAttestResult callback) {
+  const std::string url = ServerUtil::GetInstance()->GetServerUrl(
+      absl::StrFormat("/v3/captcha/solution/%s/%s", payment_id, captcha_id));
+  CAPTCHA_VLOG(1) << "Solve captcha: " << url;
+
+  base::DictValue body;
+  body.Set("solution", payment_id);
+
+  api_request_helper_.Request(
+      "POST", GURL(url), ToJson(body), kContentType,
+      base::BindOnce(&AttestAndroid::OnSolveCaptchaResponse,
+                     base::Unretained(this), std::move(callback)));
+}
+
+void AttestAndroid::OnSolveCaptchaResponse(
+    OnAttestResult callback,
+    api_request_helper::APIRequestResult api_request_result) {
+  const bool success = api_request_result.response_code() == net::HTTP_OK;
+  if (success) {
+    CAPTCHA_VLOG(1) << "Captcha has been solved.";
+  } else {
+    CAPTCHA_VLOG(1) << "Captcha solution failed, HTTP status: "
+                    << api_request_result.response_code();
+  }
+  std::move(callback).Run(success);
+}
+
+}  // namespace brave_adaptive_captcha
+
+#undef CAPTCHA_VLOG

--- a/components/brave_adaptive_captcha/android/attest_android.cc
+++ b/components/brave_adaptive_captcha/android/attest_android.cc
@@ -37,6 +37,12 @@ namespace {
 
 constexpr char kContentType[] = "application/json";
 
+constexpr char kPaymentIdKey[] = "paymentId";
+constexpr char kUniqueValueKey[] = "uniqueValue";
+constexpr char kIntegrityTokenKey[] = "integrityToken";
+constexpr char kPackageNameKey[] = "packageName";
+constexpr char kSolutionKey[] = "solution";
+
 net::NetworkTrafficAnnotationTag kAnnotationTag =
     net::DefineNetworkTrafficAnnotation("brave_adaptive_captcha_attestation",
                                         R"(
@@ -80,7 +86,7 @@ void AttestAndroid::StartAttestation(const std::string& payment_id,
   CAPTCHA_VLOG(1) << "Start attestation: " << url;
 
   base::DictValue body;
-  body.Set("paymentId", payment_id);
+  body.Set(kPaymentIdKey, payment_id);
 
   api_request_helper_.Request(
       "POST", GURL(url), ToJson(body), kContentType,
@@ -105,7 +111,7 @@ void AttestAndroid::OnStartAttestationResponse(
     return;
   }
 
-  const std::string* unique_value = body.GetDict().FindString("uniqueValue");
+  const std::string* unique_value = body.GetDict().FindString(kUniqueValueKey);
   if (!unique_value) {
     CAPTCHA_VLOG(1) << "Start attestation response is missing uniqueValue";
     std::move(callback).Run(std::string());
@@ -127,9 +133,9 @@ void AttestAndroid::AttestPaymentId(const std::string& payment_id,
   CAPTCHA_VLOG(1) << "Attest payment id: " << url;
 
   base::DictValue body;
-  body.Set("integrityToken", integrity_token);
-  body.Set("uniqueValue", unique_value);
-  body.Set("packageName", package_name);
+  body.Set(kIntegrityTokenKey, integrity_token);
+  body.Set(kUniqueValueKey, unique_value);
+  body.Set(kPackageNameKey, package_name);
 
   api_request_helper_.Request(
       "PUT", GURL(url), ToJson(body), kContentType,
@@ -162,7 +168,7 @@ void AttestAndroid::SolveCaptcha(const std::string& payment_id,
   CAPTCHA_VLOG(1) << "Solve captcha: " << url;
 
   base::DictValue body;
-  body.Set("solution", payment_id);
+  body.Set(kSolutionKey, payment_id);
 
   api_request_helper_.Request(
       "POST", GURL(url), ToJson(body), kContentType,

--- a/components/brave_adaptive_captcha/android/attest_android.h
+++ b/components/brave_adaptive_captcha/android/attest_android.h
@@ -1,0 +1,85 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADAPTIVE_CAPTCHA_ANDROID_ATTEST_ANDROID_H_
+#define BRAVE_COMPONENTS_BRAVE_ADAPTIVE_CAPTCHA_ANDROID_ATTEST_ANDROID_H_
+
+#include <string>
+
+#include "base/functional/callback.h"
+#include "base/memory/scoped_refptr.h"
+#include "brave/components/api_request_helper/api_request_helper.h"
+
+// Issues the Android Rewards attestation / captcha-solve requests against the
+// Brave grant endpoint via APIRequestHelper.
+//
+// The flow is split into two public steps because obtaining the Play Integrity
+// token (between them) requires a Java-only Google Play API:
+//
+//   StartAttestation: POST /v1/attestations/android      -> "uniqueValue" (201)
+//   (Java fetches the Play Integrity token for the nonce)
+//   AttestPaymentId:  PUT  /v1/attestations/android/{id} -> 200, then chains to
+//                     POST /v3/captcha/solution/{id}/{c}  -> 200
+//
+// The PUT -> POST transition is entirely server-side, so it is chained inside
+// AttestPaymentId rather than bounced back through JNI.
+
+namespace network {
+class SharedURLLoaderFactory;
+}  // namespace network
+
+namespace brave_adaptive_captcha {
+
+class AttestAndroid {
+ public:
+  // Returns the server-issued nonce, or the empty string on failure.
+  using OnStartAttestation =
+      base::OnceCallback<void(const std::string& unique_value)>;
+  using OnAttestResult = base::OnceCallback<void(bool success)>;
+
+  explicit AttestAndroid(
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
+  ~AttestAndroid();
+
+  AttestAndroid(const AttestAndroid&) = delete;
+  AttestAndroid& operator=(const AttestAndroid&) = delete;
+
+  void StartAttestation(const std::string& payment_id,
+                        OnStartAttestation callback);
+
+  // Submits the Play Integrity token, then on success solves the captcha.
+  // |callback| reports the final result.
+  void AttestPaymentId(const std::string& payment_id,
+                       const std::string& captcha_id,
+                       const std::string& integrity_token,
+                       const std::string& unique_value,
+                       const std::string& package_name,
+                       OnAttestResult callback);
+
+ private:
+  void OnStartAttestationResponse(
+      OnStartAttestation callback,
+      api_request_helper::APIRequestResult api_request_result);
+
+  void OnAttestPaymentIdResponse(
+      const std::string& payment_id,
+      const std::string& captcha_id,
+      OnAttestResult callback,
+      api_request_helper::APIRequestResult api_request_result);
+
+  void SolveCaptcha(const std::string& payment_id,
+                    const std::string& captcha_id,
+                    OnAttestResult callback);
+
+  void OnSolveCaptchaResponse(
+      OnAttestResult callback,
+      api_request_helper::APIRequestResult api_request_result);
+
+  api_request_helper::APIRequestHelper api_request_helper_;
+};
+
+}  // namespace brave_adaptive_captcha
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADAPTIVE_CAPTCHA_ANDROID_ATTEST_ANDROID_H_

--- a/components/brave_adaptive_captcha/android/attest_android_unittest.cc
+++ b/components/brave_adaptive_captcha/android/attest_android_unittest.cc
@@ -1,0 +1,165 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_adaptive_captcha/android/attest_android.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "base/test/bind.h"
+#include "base/test/task_environment.h"
+#include "base/test/test_future.h"
+#include "base/test/values_test_util.h"
+#include "brave/components/brave_adaptive_captcha/server_util.h"
+#include "net/http/http_status_code.h"
+#include "services/network/public/cpp/resource_request.h"
+#include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
+#include "services/network/test/test_url_loader_factory.h"
+#include "services/network/test/test_utils.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+// npm run test -- brave_unit_tests --filter=AttestAndroidTest.*
+
+namespace brave_adaptive_captcha {
+
+namespace {
+
+constexpr char kServerHost[] = "https://grants.rewards.brave.com";
+constexpr char kStartUrl[] =
+    "https://grants.rewards.brave.com/v1/attestations/android";
+constexpr char kAttestUrl[] =
+    "https://grants.rewards.brave.com/v1/attestations/android/payment_id";
+constexpr char kSolveUrl[] =
+    "https://grants.rewards.brave.com/v3/captcha/solution/payment_id/"
+    "captcha_id";
+
+struct CapturedRequest {
+  std::string method;
+  GURL url;
+  std::string body;
+};
+
+}  // namespace
+
+class AttestAndroidTest : public testing::Test {
+ public:
+  AttestAndroidTest() {
+    ServerUtil::GetInstance()->SetServerHostForTesting(kServerHost);
+    attest_ = std::make_unique<AttestAndroid>(
+        test_url_loader_factory_.GetSafeWeakWrapper());
+    test_url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
+        [this](const network::ResourceRequest& request) {
+          requests_.push_back(
+              {request.method, request.url, network::GetUploadData(request)});
+        }));
+  }
+
+ protected:
+  base::test::TaskEnvironment task_environment_;
+  network::TestURLLoaderFactory test_url_loader_factory_;
+  std::unique_ptr<AttestAndroid> attest_;
+  std::vector<CapturedRequest> requests_;
+};
+
+TEST_F(AttestAndroidTest, StartAttestationSuccess) {
+  test_url_loader_factory_.AddResponse(kStartUrl, R"({"uniqueValue":"nonce"})",
+                                       net::HTTP_CREATED);
+
+  base::test::TestFuture<std::string> future;
+  attest_->StartAttestation(
+      "payment_id",
+      base::BindLambdaForTesting([&](const std::string& unique_value) {
+        future.SetValue(unique_value);
+      }));
+
+  EXPECT_EQ(future.Get(), "nonce");
+  ASSERT_EQ(requests_.size(), 1u);
+  EXPECT_EQ(requests_[0].method, "POST");
+  EXPECT_EQ(requests_[0].url, kStartUrl);
+  EXPECT_EQ(base::test::ParseJson(requests_[0].body),
+            base::test::ParseJson(R"({"paymentId":"payment_id"})"));
+}
+
+TEST_F(AttestAndroidTest, StartAttestationHttpError) {
+  test_url_loader_factory_.AddResponse(kStartUrl, "",
+                                       net::HTTP_INTERNAL_SERVER_ERROR);
+
+  base::test::TestFuture<std::string> future;
+  attest_->StartAttestation(
+      "payment_id",
+      base::BindLambdaForTesting([&](const std::string& unique_value) {
+        future.SetValue(unique_value);
+      }));
+
+  EXPECT_EQ(future.Get(), "");
+}
+
+TEST_F(AttestAndroidTest, StartAttestationMissingUniqueValue) {
+  test_url_loader_factory_.AddResponse(kStartUrl, "{}", net::HTTP_CREATED);
+
+  base::test::TestFuture<std::string> future;
+  attest_->StartAttestation(
+      "payment_id",
+      base::BindLambdaForTesting([&](const std::string& unique_value) {
+        future.SetValue(unique_value);
+      }));
+
+  EXPECT_EQ(future.Get(), "");
+}
+
+TEST_F(AttestAndroidTest, AttestPaymentIdSolvesCaptcha) {
+  test_url_loader_factory_.AddResponse(kAttestUrl, "", net::HTTP_OK);
+  test_url_loader_factory_.AddResponse(kSolveUrl, "", net::HTTP_OK);
+
+  base::test::TestFuture<bool> future;
+  attest_->AttestPaymentId("payment_id", "captcha_id", "integrity_token",
+                           "nonce", "package_name", future.GetCallback());
+
+  EXPECT_TRUE(future.Get());
+  ASSERT_EQ(requests_.size(), 2u);
+
+  EXPECT_EQ(requests_[0].method, "PUT");
+  EXPECT_EQ(requests_[0].url, kAttestUrl);
+  EXPECT_EQ(base::test::ParseJson(requests_[0].body),
+            base::test::ParseJson(R"({"integrityToken":"integrity_token",
+                                      "uniqueValue":"nonce",
+                                      "packageName":"package_name"})"));
+
+  EXPECT_EQ(requests_[1].method, "POST");
+  EXPECT_EQ(requests_[1].url, kSolveUrl);
+  EXPECT_EQ(base::test::ParseJson(requests_[1].body),
+            base::test::ParseJson(R"({"solution":"payment_id"})"));
+}
+
+TEST_F(AttestAndroidTest, AttestPaymentIdRejectedDoesNotSolve) {
+  test_url_loader_factory_.AddResponse(kAttestUrl, "", net::HTTP_UNAUTHORIZED);
+
+  base::test::TestFuture<bool> future;
+  attest_->AttestPaymentId("payment_id", "captcha_id", "integrity_token",
+                           "nonce", "package_name", future.GetCallback());
+
+  EXPECT_FALSE(future.Get());
+  // The captcha solution request must not be issued when attestation fails.
+  ASSERT_EQ(requests_.size(), 1u);
+  EXPECT_EQ(requests_[0].url, kAttestUrl);
+}
+
+TEST_F(AttestAndroidTest, AttestPaymentIdSolveFails) {
+  test_url_loader_factory_.AddResponse(kAttestUrl, "", net::HTTP_OK);
+  test_url_loader_factory_.AddResponse(kSolveUrl, "",
+                                       net::HTTP_INTERNAL_SERVER_ERROR);
+
+  base::test::TestFuture<bool> future;
+  attest_->AttestPaymentId("payment_id", "captcha_id", "integrity_token",
+                           "nonce", "package_name", future.GetCallback());
+
+  EXPECT_FALSE(future.Get());
+  ASSERT_EQ(requests_.size(), 2u);
+  EXPECT_EQ(requests_[1].url, kSolveUrl);
+}
+
+}  // namespace brave_adaptive_captcha

--- a/components/brave_adaptive_captcha/brave_adaptive_captcha_service.cc
+++ b/components/brave_adaptive_captcha/brave_adaptive_captcha_service.cc
@@ -11,6 +11,7 @@
 #include "base/check.h"
 #include "brave/components/brave_adaptive_captcha/pref_names.h"
 #include "brave/components/brave_adaptive_captcha/server_util.h"
+#include "build/build_config.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
@@ -68,7 +69,12 @@ BraveAdaptiveCaptchaService::BraveAdaptiveCaptchaService(
       delegate_(std::move(delegate)),
       api_request_helper_(kAnnotationTag, url_loader_factory),
       get_captcha_challenge_(
-          std::make_unique<GetAdaptiveCaptchaChallenge>(&api_request_helper_)) {
+          std::make_unique<GetAdaptiveCaptchaChallenge>(&api_request_helper_))
+#if BUILDFLAG(IS_ANDROID)
+      ,
+      attest_android_(std::make_unique<AttestAndroid>(url_loader_factory))
+#endif
+{
   DCHECK(prefs);
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
   DCHECK(rewards_service);
@@ -154,6 +160,26 @@ void BraveAdaptiveCaptchaService::ClearScheduledCaptcha() {
   prefs_->SetString(prefs::kScheduledCaptchaId, "");
   prefs_->SetBoolean(prefs::kScheduledCaptchaPaused, false);
 }
+
+#if BUILDFLAG(IS_ANDROID)
+void BraveAdaptiveCaptchaService::StartAttestation(
+    const std::string& payment_id,
+    AttestAndroid::OnStartAttestation callback) {
+  attest_android_->StartAttestation(payment_id, std::move(callback));
+}
+
+void BraveAdaptiveCaptchaService::AttestPaymentId(
+    const std::string& payment_id,
+    const std::string& captcha_id,
+    const std::string& integrity_token,
+    const std::string& unique_value,
+    const std::string& package_name,
+    AttestAndroid::OnAttestResult callback) {
+  attest_android_->AttestPaymentId(payment_id, captcha_id, integrity_token,
+                                   unique_value, package_name,
+                                   std::move(callback));
+}
+#endif
 
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
 void BraveAdaptiveCaptchaService::OnCompleteReset(const bool success) {

--- a/components/brave_adaptive_captcha/brave_adaptive_captcha_service.h
+++ b/components/brave_adaptive_captcha/brave_adaptive_captcha_service.h
@@ -14,11 +14,16 @@
 #include "brave/components/brave_adaptive_captcha/brave_adaptive_captcha_delegate.h"
 #include "brave/components/brave_adaptive_captcha/get_adaptive_captcha_challenge.h"
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
+#include "build/build_config.h"
 #include "components/keyed_service/core/keyed_service.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
 #include "brave/components/brave_rewards/content/rewards_service.h"
 #include "brave/components/brave_rewards/content/rewards_service_observer.h"
+#endif
+
+#if BUILDFLAG(IS_ANDROID)
+#include "brave/components/brave_adaptive_captcha/android/attest_android.h"
 #endif
 
 namespace network {
@@ -77,6 +82,19 @@ class BraveAdaptiveCaptchaService : public KeyedService
   // Clears the currently scheduled captcha, if any.
   void ClearScheduledCaptcha();
 
+#if BUILDFLAG(IS_ANDROID)
+  // Android device-attestation captcha flow. The Play Integrity token is
+  // obtained on the Java side between StartAttestation and AttestPaymentId.
+  void StartAttestation(const std::string& payment_id,
+                        AttestAndroid::OnStartAttestation callback);
+  void AttestPaymentId(const std::string& payment_id,
+                       const std::string& captcha_id,
+                       const std::string& integrity_token,
+                       const std::string& unique_value,
+                       const std::string& package_name,
+                       AttestAndroid::OnAttestResult callback);
+#endif
+
  private:
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
   // brave_rewards::RewardsServiceObserver:
@@ -91,6 +109,9 @@ class BraveAdaptiveCaptchaService : public KeyedService
   std::unique_ptr<BraveAdaptiveCaptchaDelegate> delegate_;
   api_request_helper::APIRequestHelper api_request_helper_;
   std::unique_ptr<GetAdaptiveCaptchaChallenge> get_captcha_challenge_;
+#if BUILDFLAG(IS_ANDROID)
+  std::unique_ptr<AttestAndroid> attest_android_;
+#endif
 };
 
 }  // namespace brave_adaptive_captcha

--- a/components/brave_adaptive_captcha/test/BUILD.gn
+++ b/components/brave_adaptive_captcha/test/BUILD.gn
@@ -10,6 +10,10 @@ source_set("brave_adaptive_captcha_unit_tests") {
   testonly = true
   sources = [ "//brave/components/brave_adaptive_captcha/get_adaptive_captcha_challenge_unittest.cc" ]
 
+  if (is_android) {
+    sources += [ "//brave/components/brave_adaptive_captcha/android/attest_android_unittest.cc" ]
+  }
+
   deps = [
     "//base/test:test_support",
     "//brave/components/api_request_helper",


### PR DESCRIPTION
Move the Play Integrity device-attestation captcha flow off the Java networking path and onto the Chromium network stack. Adds AttestAndroid, which drives the StartAttestation / AttestPaymentId requests through SharedURLLoaderFactory, and exposes it via BraveAdaptiveCaptchaService on Android. AdaptiveCaptchaHelper and BraveRewardsNativeWorker are updated to route through native, removing the duplicated Java HTTP handling.

Resolves https://github.com/brave/brave-browser/issues/56880
Resolves https://github.com/brave/internal/issues/1789

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

STR:
Ping me for them.