### PR TITLE
[iOS] Make WebKit data store settings page internal

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdvancedShieldsSettingsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdvancedShieldsSettingsView.swift
@@ -12,7 +12,6 @@ import SwiftUI
 
 struct AdvancedShieldsSettingsView: View {
   @ObservedObject private var settings: AdvancedShieldsSettings
-  @State private var showManageWebsiteData = false
 
   var openURLAction: ((URL) -> Void)?
 
@@ -26,27 +25,6 @@ struct AdvancedShieldsSettingsView: View {
       ClearDataSectionView(settings: settings)
 
       Section {
-        Button {
-          showManageWebsiteData = true
-        } label: {
-          // Hack to show the disclosure
-          NavigationLink(
-            destination: { EmptyView() },
-            label: {
-              LabelView(
-                title: Strings.manageWebsiteDataTitle,
-                subtitle: nil
-              )
-              .frame(maxWidth: .infinity, alignment: .leading)
-              .contentShape(.rect)
-            }
-          )
-        }
-        .buttonStyle(.plain)
-        .sheet(isPresented: $showManageWebsiteData) {
-          ManageWebsiteDataView()
-        }
-
         NavigationLink {
           PrivacyReportSettingsView()
         } label: {

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/ManageWebsiteDataView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/ManageWebsiteDataView.swift
@@ -92,104 +92,101 @@ struct ManageWebsiteDataView: View {
   }
 
   var body: some View {
-    NavigationView {
-      let visibleRecords = filteredRecords
-      List(selection: $selectedRecordDisplayNames) {
-        Section {
-          if isLoading {
-            HStack {
-              ProgressView()
-              Text(Strings.loadingWebsiteData)
-            }
-          } else {
-            ForEach(visibleRecords, id: \.displayName) { record in
-              VStack(alignment: .leading, spacing: 2) {
-                let types = Set(
-                  record.dataTypes.compactMap(localizedStringForDataRecordType)
-                ).sorted()
-                Text(record.displayName)
-                if !types.isEmpty {
-                  Text(ListFormatter.localizedString(byJoining: types))
-                    .font(.footnote)
-                }
-              }
-              .frame(maxWidth: .infinity, alignment: .leading)
-              .swipeActions(edge: .trailing) {
-                Button(role: .destructive) {
-                  removeRecords([record])
-                } label: {
-                  Label(Strings.removeDataRecord, systemImage: "trash")
-                }
+    let visibleRecords = filteredRecords
+    List(selection: $selectedRecordDisplayNames) {
+      Section {
+        if isLoading {
+          HStack {
+            ProgressView()
+            Text(Strings.loadingWebsiteData)
+          }
+        } else {
+          ForEach(visibleRecords, id: \.displayName) { record in
+            VStack(alignment: .leading, spacing: 2) {
+              let types = Set(
+                record.dataTypes.compactMap(localizedStringForDataRecordType)
+              ).sorted()
+              Text(record.displayName)
+              if !types.isEmpty {
+                Text(ListFormatter.localizedString(byJoining: types))
+                  .font(.footnote)
               }
             }
-            .onDelete { indexSet in
-              let recordsToDelete = indexSet.map { visibleRecords[$0] }
-              removeRecords(recordsToDelete)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .swipeActions(edge: .trailing) {
+              Button(role: .destructive) {
+                removeRecords([record])
+              } label: {
+                Label(Strings.removeDataRecord, systemImage: "trash")
+              }
             }
+          }
+          .onDelete { indexSet in
+            let recordsToDelete = indexSet.map { visibleRecords[$0] }
+            removeRecords(recordsToDelete)
           }
         }
       }
-      .listStyle(.plain)
-      .environment(\.editMode, $editMode)
-      .overlay(
-        Group {
-          if !isLoading && visibleRecords.isEmpty {
-            Text(Strings.noSavedWebsiteData)
-              .font(.headline)
-              .foregroundColor(.secondary)
-          }
-        }
-      )
-      .toolbar {
-        ToolbarItemGroup(placement: .confirmationAction) {
-          Button {
-            presentationMode.dismiss()
-          } label: {
-            Text(Strings.done)
-              .foregroundColor(Color(braveSystemName: .textInteractive))
-          }
-        }
-        ToolbarItemGroup(placement: .bottomBar) {
-          Button {
-            withAnimation {
-              editMode = editMode.isEditing ? .inactive : .active
-              if editMode == .inactive {
-                selectedRecordDisplayNames = []
-              }
-            }
-          } label: {
-            Text(editMode.isEditing ? Strings.done : Strings.edit)
-              .foregroundColor(
-                visibleRecords.isEmpty
-                  ? Color(braveSystemName: .neutral20) : Color(braveSystemName: .textInteractive)
-              )
-          }
-          .disabled(visibleRecords.isEmpty)
-          Spacer()
-          Button {
-            if isEditMode {
-              let recordsToRemove = visibleSelectedRecordDisplayNames(visibleRecords)
-              removeRecordsWithDisplayNames(Array(recordsToRemove))
-              selectedRecordDisplayNames = []
-            } else {
-              removeRecords(visibleRecords)
-            }
-          } label: {
-            Text(removeButtonTitle(visibleRecords: visibleRecords))
-              .foregroundColor(visibleRecords.isEmpty ? Color(braveSystemName: .neutral20) : .red)
-              .animation(nil, value: isEditMode)
-          }
-          .disabled(visibleRecords.isEmpty)
-        }
-      }
-      .searchable(
-        text: $filter,
-        placement: .navigationBarDrawer(displayMode: .always)
-      )
-      .navigationTitle(Strings.manageWebsiteDataTitle)
-      .navigationBarTitleDisplayMode(.inline)
     }
-    .navigationViewStyle(.stack)
+    .listStyle(.plain)
+    .environment(\.editMode, $editMode)
+    .overlay(
+      Group {
+        if !isLoading && visibleRecords.isEmpty {
+          Text(Strings.noSavedWebsiteData)
+            .font(.headline)
+            .foregroundColor(.secondary)
+        }
+      }
+    )
+    .toolbar {
+      ToolbarItemGroup(placement: .confirmationAction) {
+        Button {
+          presentationMode.dismiss()
+        } label: {
+          Text(Strings.done)
+            .foregroundColor(Color(braveSystemName: .textInteractive))
+        }
+      }
+      ToolbarItemGroup(placement: .bottomBar) {
+        Button {
+          withAnimation {
+            editMode = editMode.isEditing ? .inactive : .active
+            if editMode == .inactive {
+              selectedRecordDisplayNames = []
+            }
+          }
+        } label: {
+          Text(editMode.isEditing ? Strings.done : Strings.edit)
+            .foregroundColor(
+              visibleRecords.isEmpty
+                ? Color(braveSystemName: .neutral20) : Color(braveSystemName: .textInteractive)
+            )
+        }
+        .disabled(visibleRecords.isEmpty)
+        Spacer()
+        Button {
+          if isEditMode {
+            let recordsToRemove = visibleSelectedRecordDisplayNames(visibleRecords)
+            removeRecordsWithDisplayNames(Array(recordsToRemove))
+            selectedRecordDisplayNames = []
+          } else {
+            removeRecords(visibleRecords)
+          }
+        } label: {
+          Text(removeButtonTitle(visibleRecords: visibleRecords))
+            .foregroundColor(visibleRecords.isEmpty ? Color(braveSystemName: .neutral20) : .red)
+            .animation(nil, value: isEditMode)
+        }
+        .disabled(visibleRecords.isEmpty)
+      }
+    }
+    .searchable(
+      text: $filter,
+      placement: .navigationBarDrawer(displayMode: .always)
+    )
+    .navigationTitle(Strings.manageWebsiteDataTitle)
+    .navigationBarTitleDisplayMode(.inline)
     .onAppear(perform: loadRecords)
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -1840,6 +1840,15 @@ class SettingsViewController: TableViewController, BraveAccountAuthenticationObs
           cellClass: MultilineButtonCell.self
         ),
         Row(
+          text: "Manage WebKit Website Data Store",
+          selection: { [unowned self] in
+            let controller = UIHostingController(rootView: ManageWebsiteDataView())
+            self.navigationController?.pushViewController(controller, animated: true)
+          },
+          accessory: .disclosureIndicator,
+          cellClass: MultilineValue1Cell.self
+        ),
+        Row(
           text: "VPN Logs",
           selection: { [unowned self] in
             self.navigationController?.pushViewController(VPNLogsViewController(), animated: true)


### PR DESCRIPTION
This screen allowed viewing and removal of data directly from the WebKit data store which we dont really want to expose directly, since lots of data is stored in the history/databases as well.
