### PR TITLE
Carplay playback auto skip to next item on error

### DIFF
--- a/ios/brave-ios/Sources/PlaylistUI/CarPlayController.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/CarPlayController.swift
@@ -72,7 +72,6 @@ public class CarPlayController {
   private var currentFolderListTemplate: CPListTemplate?
   private var currentItemListTemplate: CPListTemplate?
   private var selectedFolderID: PlaylistFolder.ID?
-  private var isErrorPresented: Bool = false
   private var downloadStates: [String: PlaylistDownloadManager.CacheState] = [:]
 
   @MainActor private func updateFoldersList() {
@@ -87,55 +86,11 @@ public class CarPlayController {
   }
 
   @MainActor private func handlePlayerError() {
-    if isErrorPresented, player.error == nil, interface.presentedTemplate is CPAlertTemplate {
-      // Handle the case where a user dismisses an error in the app while CarPlay is open
-      interface.dismissTemplate(animated: true) { [weak self] _, _ in
-        self?.isErrorPresented = false
-      }
-      return
-    }
-
-    guard let error = player.error, let title = error.failureReason ?? error.errorDescription,
-      !isErrorPresented
-    else {
-      return
-    }
-
-    let alert = CPAlertTemplate(
-      titleVariants: [title],
-      actions: [
-        CPAlertAction(
-          title: Strings.PlayList.okayButtonTitle,
-          style: .default,
-          handler: { [weak self] _ in
-            self?.interface.dismissTemplate(
-              animated: true,
-              completion: { success, error in
-                guard let self else { return }
-                self.player.error?.handler?()
-                self.player.error = nil
-                self.isErrorPresented = false
-                if self.interface.topTemplate == CPNowPlayingTemplate.shared {
-                  self.interface.popTemplate(animated: true, completion: nil)
-                }
-              }
-            )
-          }
-        )
-      ]
-    )
-
-    // Preemptively set this so repeat object changes dont present multiple times
-    isErrorPresented = true
-    interface.presentTemplate(
-      alert,
-      animated: true,
-      completion: { [weak self] success, _ in
-        if !success {
-          self?.isErrorPresented = false
-        }
-      }
-    )
+    // Can't show an error alert while in CarPlay, so invoke the error's recovery handler
+    // (which advances to the next item) instead of presenting it to the driver.
+    guard let error = player.error else { return }
+    error.handler?()
+    player.error = nil
   }
 
   private var cancellables: Set<AnyCancellable> = []

--- a/ios/brave-ios/Sources/PlaylistUI/CarPlayController.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/CarPlayController.swift
@@ -86,8 +86,8 @@ public class CarPlayController {
   }
 
   @MainActor private func handlePlayerError() {
-    // Can't show an error alert while in CarPlay, so invoke the error's recovery handler
-    // (which advances to the next item) instead of presenting it to the driver.
+    // Avoid showing error alerts so as not to distract the driver in scenarios where the where the user is the driver.
+    // Invoke the error's recovery handler which advances to the next item (for better user experience)
     guard let error = player.error else { return }
     error.handler?()
     player.error = nil


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54341

**Summary**
This PR prevents the user from interacting with a cascade of playback error alerts by not presenting alerts in CarPlay

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
