### PR TITLE
Fix blank CarPlay screen on cold launch

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
@@ -69,6 +69,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     AppState.shared.state = .launching(options: launchOptions ?? [:], active: false)
 
+    // Since CarPlay can connect directly from a cold launch initiated from the CarPlay screen,
+    // it needs its own way to load BraveCore's default profile which must be set before any scene connects.
+    PlaylistCoordinator.shared.loadDefaultProfileController = {
+      await AppState.shared.defaultProfileLoader.profileController(
+        braveCore: AppState.shared.braveCore
+      )
+    }
+
     // Set the Safari UA for browsing.
     setUserAgent()
 

--- a/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
@@ -69,14 +69,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     AppState.shared.state = .launching(options: launchOptions ?? [:], active: false)
 
-    // Since CarPlay can connect directly from a cold launch initiated from the CarPlay screen,
-    // it needs its own way to load BraveCore's default profile which must be set before any scene connects.
-    PlaylistCoordinator.shared.loadDefaultProfileController = {
-      await AppState.shared.defaultProfileLoader.profileController(
-        braveCore: AppState.shared.braveCore
-      )
-    }
-
     // Set the Safari UA for browsing.
     setUserAgent()
 

--- a/ios/brave-ios/App/iOS/Delegates/AppState.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppState.swift
@@ -134,7 +134,7 @@ public class AppState {
       if let task {
         return await task.value
       }
-      let task = Task { @MainActor in
+      let task = Task {
         await braveCore.loadDefaultProfile()
       }
       self.task = task

--- a/ios/brave-ios/App/iOS/Delegates/AppState.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppState.swift
@@ -38,6 +38,7 @@ public class AppState {
   public let profile: LegacyBrowserProfile
   public let newsFeedDataSource: FeedDataSource
   public let uptimeMonitor = UptimeMonitor()
+  public let defaultProfileLoader = DefaultProfileLoader()
   private var didBecomeActive = false
 
   public var state: State = .launching(options: [:], active: false) {
@@ -119,6 +120,26 @@ public class AppState {
     case active
     case backgrounded
     case terminating
+  }
+
+  /// Loads BraveCore's default profile at most once, even when requested concurrently by multiple scenes
+  public final class DefaultProfileLoader {
+    private var task: Task<BraveProfileController, Never>?
+
+    @MainActor
+    public func profileController(braveCore: BraveCoreMain) async -> BraveProfileController {
+      if let profileController = braveCore.profileController {
+        return profileController
+      }
+      if let task {
+        return await task.value
+      }
+      let task = Task { @MainActor in
+        await braveCore.loadDefaultProfile()
+      }
+      self.task = task
+      return await task.value
+    }
   }
 
   private static func setupConstants() {

--- a/ios/brave-ios/App/iOS/Delegates/AppState.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppState.swift
@@ -138,6 +138,7 @@ public class AppState {
         await braveCore.loadDefaultProfile()
       }
       self.task = task
+      defer { self.task = nil }
       return await task.value
     }
   }

--- a/ios/brave-ios/App/iOS/Delegates/CPTemplateApplicationSceneDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/CPTemplateApplicationSceneDelegate.swift
@@ -60,8 +60,17 @@ extension CarplayTemplateApplicationSceneDelegate: CPTemplateApplicationSceneDel
   ) {
     log.debug("Template application scene did connect.")
 
-    DispatchQueue.main.async {
-      PlaylistCoordinator.shared.connect(interfaceController: interfaceController)
+    Task { @MainActor in
+      // CarPlay can connect independently of a `BrowserViewController` as a result
+      // of cold-launching directly from the CarPlay screen,
+      // so ensure the default profile is loaded here first.
+      let profileController = await AppState.shared.defaultProfileLoader.profileController(
+        braveCore: AppState.shared.braveCore
+      )
+      PlaylistCoordinator.shared.connect(
+        interfaceController: interfaceController,
+        profile: profileController.profile
+      )
     }
   }
 

--- a/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
@@ -291,13 +291,16 @@ extension SceneDelegate {
 
   @MainActor private func loadDefaultProfile() async -> (BraveProfileController, ProfileState) {
     let braveCore = AppState.shared.braveCore
-    if let profileController = braveCore.profileController, let profileState = Self.profileState {
+    let profileController = await AppState.shared.defaultProfileLoader.profileController(
+      braveCore: braveCore
+    )
+    if let profileState = Self.profileState {
       return (profileController, profileState)
     }
-    // Setup default profile & profile state
-    let defaultProfileController = await braveCore.loadDefaultProfile()
-    let profileState = ProfileState(profileController: defaultProfileController)
-    return (defaultProfileController, profileState)
+    // Setup profile state.
+    // Note that the profile itself may have already been loaded by CarPlay connecting independently of this scene.
+    let profileState = ProfileState(profileController: profileController)
+    return (profileController, profileState)
   }
 
   @objc private func enableUserSelectedTypesForSync() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCoordinator.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCoordinator.swift
@@ -29,6 +29,11 @@ public class PlaylistCoordinator: NSObject {
 
   public weak var browserController: BrowserViewController?
 
+
+  /// For CarPlay to load BraveCore's default profile at launch independently of a `BrowserViewController`,
+  /// which never exists if the app is cold-launched directly from the CarPlay screen
+  public var loadDefaultProfileController: (() async -> BraveProfileController)?
+
   var currentlyPlayingItemIndex = -1
   var currentPlaylistItem: PlaylistInfo?
   var isPlaylistControllerPresented = false
@@ -217,10 +222,14 @@ public class PlaylistCoordinator: NSObject {
     // pass it to the carplay controller
     if isCarPlayAvailable {
       // Protect against reentrancy.
-      if carPlayController == nil, let browserController {
-        carPlayController = getCarPlayController(
-          profile: browserController.profileController.profile
-        )
+      guard carPlayController == nil, let loadDefaultProfileController else { return }
+
+      Task { @MainActor in
+        let profileController = await loadDefaultProfileController()
+        // Bail if CarPlay disconnected (or a controller was already created) while we were loading the profile.
+        guard self.isCarPlayAvailable, self.carPlayController == nil else { return }
+        self.isPlaylistAvailable = profileController.profile.prefs.isPlaylistAvailable
+        self.carPlayController = self.getCarPlayController(profile: profileController.profile)
       }
     } else {
       carPlayController = nil

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCoordinator.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCoordinator.swift
@@ -29,11 +29,6 @@ public class PlaylistCoordinator: NSObject {
 
   public weak var browserController: BrowserViewController?
 
-
-  /// For CarPlay to load BraveCore's default profile at launch independently of a `BrowserViewController`,
-  /// which never exists if the app is cold-launched directly from the CarPlay screen
-  public var loadDefaultProfileController: (() async -> BraveProfileController)?
-
   var currentlyPlayingItemIndex = -1
   var currentPlaylistItem: PlaylistInfo?
   var isPlaylistControllerPresented = false
@@ -215,21 +210,16 @@ public class PlaylistCoordinator: NSObject {
     }
   }
 
-  private func attemptInterfaceConnection(isCarPlayAvailable: Bool) {
+  private func attemptInterfaceConnection(isCarPlayAvailable: Bool, profile: (any Profile)?) {
     self.isCarPlayAvailable = isCarPlayAvailable
 
     // If there is no media player, create one,
     // pass it to the carplay controller
-    if isCarPlayAvailable {
+    if isCarPlayAvailable, let profile {
       // Protect against reentrancy.
-      guard carPlayController == nil, let loadDefaultProfileController else { return }
-
-      Task { @MainActor in
-        let profileController = await loadDefaultProfileController()
-        // Bail if CarPlay disconnected (or a controller was already created) while we were loading the profile.
-        guard self.isCarPlayAvailable, self.carPlayController == nil else { return }
-        self.isPlaylistAvailable = profileController.profile.prefs.isPlaylistAvailable
-        self.carPlayController = self.getCarPlayController(profile: profileController.profile)
+      if carPlayController == nil {
+        isPlaylistAvailable = profile.prefs.isPlaylistAvailable
+        carPlayController = getCarPlayController(profile: profile)
       }
     } else {
       carPlayController = nil
@@ -243,14 +233,17 @@ public class PlaylistCoordinator: NSObject {
 }
 
 extension PlaylistCoordinator: CPSessionConfigurationDelegate {
-  public func connect(interfaceController: CPInterfaceController) {
+  /// - parameter profile: BraveCore's default profile, which the caller must ensure is already loaded before connecting
+  ///
+  /// CarPlay launches independently of a `BrowserViewController` when cold-launched from the CarPlay screen
+  public func connect(interfaceController: CPInterfaceController, profile: any Profile) {
     carplayInterface = interfaceController
     carplaySessionConfiguration = CPSessionConfiguration(delegate: self)
 
     isCarPlayAvailable = true
 
     DispatchQueue.main.async {
-      self.attemptInterfaceConnection(isCarPlayAvailable: true)
+      self.attemptInterfaceConnection(isCarPlayAvailable: true, profile: profile)
     }
   }
 
@@ -260,7 +253,7 @@ extension PlaylistCoordinator: CPSessionConfigurationDelegate {
     carplayInterface = nil
 
     DispatchQueue.main.async {
-      self.attemptInterfaceConnection(isCarPlayAvailable: false)
+      self.attemptInterfaceConnection(isCarPlayAvailable: false, profile: nil)
     }
   }
 


### PR DESCRIPTION
## Summary
The bug is that CarPlay's only source for a profile was `browserController`, which isn't guaranteed to exist. CarPlay wouldn't connect properly unless a browser component was already set up first. This restriction was caused by a regression from https://github.com/brave/brave-core/pull/34214, which requires user profiles when creating browser tabs.

## Test Plan
- [ ] Ensure that the app is not running on your phone
- [ ] Connect phone to CarPlay, look for the Brave app icon, and launch it. Verify that it launches to the Brave Playlist screen on the CarPlay screen
- [ ] Disconnect phone from CarPlay and open Brave on the phone. Reconnect to CarPlay and tap on Brave in CarPlay. Confirm that the Playlist screen is displayed on the CarPlay screen

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55775

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
