### PR TITLE
[AI Chat] Sharing - include browser version in encrypted payload

### DIFF
--- a/browser/ui/webui/ai_chat/BUILD.gn
+++ b/browser/ui/webui/ai_chat/BUILD.gn
@@ -38,6 +38,7 @@ source_set("ai_chat") {
     "//brave/components/resources:static_resources_grit",
     "//brave/components/resources:strings_grit",
     "//brave/components/screenshot/core/browser",
+    "//brave/components/version_info",
     "//chrome/browser/bookmarks",
     "//chrome/browser/favicon",
     "//chrome/browser/history",

--- a/browser/ui/webui/ai_chat/ai_chat_ui.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.cc
@@ -30,6 +30,7 @@
 #include "brave/components/ai_chat/core/common/pref_names.h"
 #include "brave/components/ai_chat/resources/grit/ai_chat_ui_generated_map.h"
 #include "brave/components/constants/webui_url_constants.h"
+#include "brave/components/version_info/version_info.h"
 #include "chrome/browser/bookmarks/bookmark_model_factory.h"
 #include "chrome/browser/history/history_service_factory.h"
 #include "chrome/browser/profiles/profile.h"
@@ -104,6 +105,9 @@ AIChatUI::AIChatUI(content::WebUI* web_ui)
   source->AddBoolean("isConversationShareEnabled",
                      base::FeatureList::IsEnabled(
                          ai_chat::features::kAIChatConversationShare));
+  // Brave client version, used to tag serialized conversations for sharing.
+  source->AddString("braveVersion",
+                    version_info::GetBraveVersionWithoutChromiumMajorVersion());
 
   web_ui->AddRequestableScheme(content::kChromeUIUntrustedScheme);
   source->OverrideContentSecurityPolicy(

--- a/components/ai_chat/resources/common/conversation_serialization.test.ts
+++ b/components/ai_chat/resources/common/conversation_serialization.test.ts
@@ -3,6 +3,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* eslint-disable import/first */
+
+// Set up loadTimeData mock BEFORE importing the module under test
+;(window as any).loadTimeData = {
+  getString: (key: string) => (key === 'braveVersion' ? '1.93.8' : ''),
+}
+
 import { describe, it, expect } from '@jest/globals'
 import ComplexConversation from '../page/stories/conversations/multi_tool_multi_turn'
 import {

--- a/components/ai_chat/resources/common/conversation_serialization.ts
+++ b/components/ai_chat/resources/common/conversation_serialization.ts
@@ -3,11 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import { loadTimeData } from '$web-common/loadTimeData'
 import * as Mojom from './mojom'
-
-// TODO(https://github.com/brave/brave-browser/issues/56444): get current client
-// version from loadTimeData.
-export const CONVERSATION_EXPORT_VERSION = '1.93.8'
 
 type ConversationData = Mojom.ConversationTurn[]
 
@@ -73,7 +70,9 @@ export function serializeConversationForSharing(
   // the parsing of the conversation data, the above algorithm of which may
   // change over time, and will be deployed with that version of the UI code.
   const payload: SerializedConversation = {
-    version: CONVERSATION_EXPORT_VERSION,
+    // The Brave client version that produced this payload, so the viewer can
+    // choose the correct parsing algorithm for the data below.
+    version: loadTimeData.getString('braveVersion'),
     data: stringifyConversationData(data),
   }
 

--- a/ios/browser/ui/webui/ai_chat/BUILD.gn
+++ b/ios/browser/ui/webui/ai_chat/BUILD.gn
@@ -26,6 +26,7 @@ source_set("ai_chat") {
     "//brave/components/constants",
     "//brave/components/resources:static_resources",
     "//brave/components/resources:strings_grit",
+    "//brave/components/version_info",
     "//brave/ios/browser/ai_chat",
     "//brave/ios/browser/api/profile",
     "//brave/ios/browser/api/web_view",

--- a/ios/browser/ui/webui/ai_chat/DEPS
+++ b/ios/browser/ui/webui/ai_chat/DEPS
@@ -3,4 +3,5 @@ include_rules = [
   "+brave/components/ai_chat/ios/browser",
   "+brave/components/ai_chat/resources/grit",
   "+brave/components/constants",
+  "+brave/components/version_info",
 ]

--- a/ios/browser/ui/webui/ai_chat/ai_chat_ui.mm
+++ b/ios/browser/ui/webui/ai_chat/ai_chat_ui.mm
@@ -24,6 +24,7 @@
 #include "brave/components/ai_chat/core/common/mojom/untrusted_frame.mojom.h"
 #include "brave/components/ai_chat/resources/grit/ai_chat_ui_generated_map.h"
 #include "brave/components/constants/webui_url_constants.h"
+#include "brave/components/version_info/version_info.h"
 #include "brave/ios/browser/ai_chat/ai_chat_service_factory.h"
 #include "brave/ios/browser/ai_chat/ai_chat_ui_handler_bridge.h"
 #include "brave/ios/browser/ai_chat/ai_chat_ui_handler_bridge_holder.h"
@@ -72,6 +73,9 @@ AIChatUI::AIChatUI(web::WebUIIOS* web_ui, const GURL& url)
   source->AddBoolean("isConversationShareEnabled",
                      base::FeatureList::IsEnabled(
                          ai_chat::features::kAIChatConversationShare));
+  // Brave client version, used to tag serialized conversations for sharing.
+  source->AddString("braveVersion",
+                    version_info::GetBraveVersionWithoutChromiumMajorVersion());
 
   source->OverrideContentSecurityPolicy(
       network::mojom::CSPDirectiveName::ScriptSrc,


### PR DESCRIPTION
Previously this used a hardcoded version (sharing feature is still disabled behind a feature flag)

<!-- Add brave-browser issue below that this PR will resolve -->
- Series https://github.com/brave/brave-browser/issues/56444
