### PR TITLE
[ads] Add a mojo notification for a tab failing to load

### DIFF
--- a/browser/brave_ads/tabs/ads_tab_helper.cc
+++ b/browser/brave_ads/tabs/ads_tab_helper.cc
@@ -228,6 +228,12 @@ void AdsTabHelper::MaybeNotifyTabDidLoad() {
                                  *http_status_code_);
 }
 
+void AdsTabHelper::MaybeNotifyTabDidFailToLoad() {
+  if (ads_service_) {
+    ads_service_->NotifyTabDidFailToLoad(/*tab_id=*/session_id_.id());
+  }
+}
+
 bool AdsTabHelper::ShouldNotifyTabContentDidChange() const {
   // Don't notify about content changes if the ads service is not available, the
   // tab was restored, was a previously committed navigation, the web contents

--- a/browser/brave_ads/tabs/ads_tab_helper.h
+++ b/browser/brave_ads/tabs/ads_tab_helper.h
@@ -71,6 +71,7 @@ class AdsTabHelper final : public content::WebContentsObserver,
   void MaybeNotifyTabDidChange();
 
   void MaybeNotifyTabDidLoad();
+  void MaybeNotifyTabDidFailToLoad();
 
   bool ShouldNotifyTabContentDidChange() const;
   void MaybeNotifyTabTextContentDidChange();

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -1398,6 +1398,12 @@ void AdsServiceImpl::NotifyTabDidLoad(int32_t tab_id, int http_status_code) {
   }
 }
 
+void AdsServiceImpl::NotifyTabDidFailToLoad(int32_t tab_id) {
+  if (bat_ads_client_notifier_remote_.is_bound()) {
+    bat_ads_client_notifier_remote_->NotifyTabDidFailToLoad(tab_id);
+  }
+}
+
 void AdsServiceImpl::NotifyDidCloseTab(int32_t tab_id) {
   if (bat_ads_client_notifier_remote_.is_bound()) {
     bat_ads_client_notifier_remote_->NotifyDidCloseTab(tab_id);

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -312,6 +312,7 @@ class AdsServiceImpl : public AdsService,
                           bool is_restoring,
                           bool is_visible) override;
   void NotifyTabDidLoad(int32_t tab_id, int http_status_code) override;
+  void NotifyTabDidFailToLoad(int32_t tab_id) override;
   void NotifyDidCloseTab(int32_t tab_id) override;
 
   void NotifyUserGestureEventTriggered(int32_t page_transition) override;

--- a/components/brave_ads/browser/test/fake_bat_ads_client_notifier.h
+++ b/components/brave_ads/browser/test/fake_bat_ads_client_notifier.h
@@ -66,6 +66,7 @@ class FakeBatAdsClientNotifier : public bat_ads::mojom::BatAdsClientNotifier {
                           bool /*is_visible*/) override {}
   void NotifyTabDidLoad(int32_t /*tab_id*/,
                         int32_t /*http_status_code*/) override {}
+  void NotifyTabDidFailToLoad(int32_t /*tab_id*/) override {}
   void NotifyDidCloseTab(int32_t /*tab_id*/) override {}
   void NotifyUserGestureEventTriggered(int32_t /*page_transition*/) override {}
   void NotifyUserDidBecomeIdle() override;

--- a/components/brave_ads/core/browser/service/ads_service.h
+++ b/components/brave_ads/core/browser/service/ads_service.h
@@ -239,6 +239,9 @@ class AdsService : public KeyedService {
   // the HTTP status code.
   virtual void NotifyTabDidLoad(int32_t tab_id, int http_status_code) = 0;
 
+  // Called when a browser tab failed to load, e.g., due to a network error.
+  virtual void NotifyTabDidFailToLoad(int32_t tab_id) = 0;
+
   // Called when a browser tab with the specified `tab_id` is closed.
   virtual void NotifyDidCloseTab(int32_t tab_id) = 0;
 

--- a/components/brave_ads/core/browser/service/test/ads_service_mock.h
+++ b/components/brave_ads/core/browser/service/test/ads_service_mock.h
@@ -101,6 +101,7 @@ class AdsServiceMock : public AdsService {
               NotifyTabDidChange,
               (int32_t, const std::vector<GURL>&, bool, bool, bool));
   MOCK_METHOD(void, NotifyTabDidLoad, (int32_t, int));
+  MOCK_METHOD(void, NotifyTabDidFailToLoad, (int32_t));
   MOCK_METHOD(void, NotifyDidCloseTab, (int32_t));
   MOCK_METHOD(void, NotifyUserGestureEventTriggered, (int32_t));
   MOCK_METHOD(void, NotifyBrowserDidBecomeActive, ());

--- a/components/brave_ads/core/internal/ads_client/ads_client_notifier.cc
+++ b/components/brave_ads/core/internal/ads_client/ads_client_notifier.cc
@@ -162,6 +162,17 @@ void AdsClientNotifier::NotifyTabDidLoad(int32_t tab_id, int http_status_code) {
                     http_status_code);
 }
 
+void AdsClientNotifier::NotifyTabDidFailToLoad(int32_t tab_id) {
+  if (task_queue_->should_queue()) {
+    return task_queue_->Add(
+        base::BindOnce(&AdsClientNotifier::NotifyTabDidFailToLoad,
+                       weak_factory_.GetWeakPtr(), tab_id));
+  }
+
+  observers_.Notify(&AdsClientNotifierObserver::OnNotifyTabDidFailToLoad,
+                    tab_id);
+}
+
 void AdsClientNotifier::NotifyDidCloseTab(int32_t tab_id) {
   if (task_queue_->should_queue()) {
     return task_queue_->Add(

--- a/components/brave_ads/core/internal/ads_client/ads_client_notifier_unittest.cc
+++ b/components/brave_ads/core/internal/ads_client/ads_client_notifier_unittest.cc
@@ -66,6 +66,7 @@ class BraveAdsAdsClientNotifierTest : public ::testing::Test {
                                             kIsNewNavigation, kIsRestoring,
                                             kIsVisible);
     ads_client_notifier_.NotifyTabDidLoad(kTabId, kHttpResponseCode);
+    ads_client_notifier_.NotifyTabDidFailToLoad(kTabId);
     ads_client_notifier_.NotifyDidCloseTab(kTabId);
 
     ads_client_notifier_.NotifyUserGestureEventTriggered(
@@ -119,6 +120,9 @@ class BraveAdsAdsClientNotifierTest : public ::testing::Test {
         .Times(expected_call_count);
     EXPECT_CALL(ads_client_notifier_observer_mock_,
                 OnNotifyTabDidLoad(kTabId, kHttpResponseCode))
+        .Times(expected_call_count);
+    EXPECT_CALL(ads_client_notifier_observer_mock_,
+                OnNotifyTabDidFailToLoad(kTabId))
         .Times(expected_call_count);
     EXPECT_CALL(ads_client_notifier_observer_mock_, OnNotifyDidCloseTab(kTabId))
         .Times(expected_call_count);

--- a/components/brave_ads/core/internal/ads_client/ads_client_notifier_waiter.cc
+++ b/components/brave_ads/core/internal/ads_client/ads_client_notifier_waiter.cc
@@ -59,6 +59,10 @@ void AdsClientNotifierWaiter::WaitForOnNotifyTabDidLoad() {
   on_notify_tab_did_load_run_loop_.Run();
 }
 
+void AdsClientNotifierWaiter::WaitForOnNotifyTabDidFailToLoad() {
+  on_notify_tab_did_fail_to_load_run_loop_.Run();
+}
+
 void AdsClientNotifierWaiter::WaitForOnNotifyDidCloseTab() {
   on_notify_did_close_tab_run_loop_.Run();
 }
@@ -152,6 +156,10 @@ void AdsClientNotifierWaiter::OnNotifyTabDidChange(
 void AdsClientNotifierWaiter::OnNotifyTabDidLoad(int32_t /*tab_id*/,
                                                  int /*http_status_code*/) {
   on_notify_tab_did_load_run_loop_.Quit();
+}
+
+void AdsClientNotifierWaiter::OnNotifyTabDidFailToLoad(int32_t /*tab_id*/) {
+  on_notify_tab_did_fail_to_load_run_loop_.Quit();
 }
 
 void AdsClientNotifierWaiter::OnNotifyDidCloseTab(int32_t /*tab_id*/) {

--- a/components/brave_ads/core/internal/ads_client/ads_client_notifier_waiter.h
+++ b/components/brave_ads/core/internal/ads_client/ads_client_notifier_waiter.h
@@ -42,6 +42,7 @@ class AdsClientNotifierWaiter final : public AdsClientNotifierObserver {
   void WaitForOnNotifyTabDidStopPlayingMedia();
   void WaitForOnNotifyTabDidChange();
   void WaitForOnNotifyTabDidLoad();
+  void WaitForOnNotifyTabDidFailToLoad();
   void WaitForOnNotifyDidCloseTab();
   void WaitForOnNotifyUserGestureEventTriggered();
   void WaitForOnNotifyUserDidBecomeIdle();
@@ -73,6 +74,7 @@ class AdsClientNotifierWaiter final : public AdsClientNotifierObserver {
                             bool is_restoring,
                             bool is_visible) override;
   void OnNotifyTabDidLoad(int32_t tab_id, int http_status_code) override;
+  void OnNotifyTabDidFailToLoad(int32_t tab_id) override;
   void OnNotifyDidCloseTab(int32_t tab_id) override;
   void OnNotifyUserGestureEventTriggered(
       ui::PageTransition page_transition) override;
@@ -95,6 +97,7 @@ class AdsClientNotifierWaiter final : public AdsClientNotifierObserver {
   base::RunLoop on_notify_tab_did_stop_playing_media_run_loop_;
   base::RunLoop on_notify_tab_did_change_run_loop_;
   base::RunLoop on_notify_tab_did_load_run_loop_;
+  base::RunLoop on_notify_tab_did_fail_to_load_run_loop_;
   base::RunLoop on_notify_did_close_tab_run_loop_;
   base::RunLoop on_notify_user_gesture_event_triggered_run_loop_;
   base::RunLoop on_notify_user_did_become_idle_run_loop_;

--- a/components/brave_ads/core/internal/ads_client/test/ads_client_notifier_observer_mock.h
+++ b/components/brave_ads/core/internal/ads_client/test/ads_client_notifier_observer_mock.h
@@ -50,6 +50,7 @@ class AdsClientNotifierObserverMock : public AdsClientNotifierObserver {
               OnNotifyTabDidChange,
               (int32_t, const std::vector<GURL>&, bool, bool, bool));
   MOCK_METHOD(void, OnNotifyTabDidLoad, (int32_t, int));
+  MOCK_METHOD(void, OnNotifyTabDidFailToLoad, (int32_t));
   MOCK_METHOD(void, OnNotifyDidCloseTab, (int32_t));
 
   MOCK_METHOD(void, OnNotifyUserGestureEventTriggered, (ui::PageTransition));

--- a/components/brave_ads/core/internal/tabs/tab_manager.cc
+++ b/components/brave_ads/core/internal/tabs/tab_manager.cc
@@ -107,6 +107,10 @@ void TabManager::NotifyTabDidLoad(const TabInfo& tab, int http_status_code) {
   observers_.Notify(&TabManagerObserver::OnTabDidLoad, tab, http_status_code);
 }
 
+void TabManager::NotifyTabDidFailToLoad(const TabInfo& tab) {
+  observers_.Notify(&TabManagerObserver::OnTabDidFailToLoad, tab);
+}
+
 void TabManager::NotifyTabDidChangeFocus(int32_t tab_id) {
   observers_.Notify(&TabManagerObserver::OnTabDidChangeFocus, tab_id);
 }
@@ -234,6 +238,12 @@ void TabManager::OnNotifyTabDidChange(int32_t tab_id,
 void TabManager::OnNotifyTabDidLoad(int32_t tab_id, int http_status_code) {
   if (std::optional<TabInfo> tab = MaybeGetForId(tab_id)) {
     NotifyTabDidLoad(*tab, http_status_code);
+  }
+}
+
+void TabManager::OnNotifyTabDidFailToLoad(int32_t tab_id) {
+  if (std::optional<TabInfo> tab = MaybeGetForId(tab_id)) {
+    NotifyTabDidFailToLoad(*tab);
   }
 }
 

--- a/components/brave_ads/core/internal/tabs/tab_manager.h
+++ b/components/brave_ads/core/internal/tabs/tab_manager.h
@@ -54,6 +54,7 @@ class TabManager final : public AdsClientNotifierObserver {
   void NotifyTabDidChangeFocus(int32_t tab_id);
   void NotifyTabDidChange(const TabInfo& tab);
   void NotifyTabDidLoad(const TabInfo& tab, int http_status_code);
+  void NotifyTabDidFailToLoad(const TabInfo& tab);
   void NotifyDidOpenNewTab(const TabInfo& tab);
   void NotifyTextContentDidChange(int32_t tab_id,
                                   base::span<const GURL> redirect_chain,
@@ -74,6 +75,7 @@ class TabManager final : public AdsClientNotifierObserver {
                             bool is_restoring,
                             bool is_visible) override;
   void OnNotifyTabDidLoad(int32_t tab_id, int http_status_code) override;
+  void OnNotifyTabDidFailToLoad(int32_t tab_id) override;
   void OnNotifyDidCloseTab(int32_t tab_id) override;
 
   base::ObserverList<TabManagerObserver> observers_;

--- a/components/brave_ads/core/internal/tabs/tab_manager_observer.h
+++ b/components/brave_ads/core/internal/tabs/tab_manager_observer.h
@@ -25,6 +25,9 @@ class TabManagerObserver : public base::CheckedObserver {
   // Invoked when the `tab` has loaded.
   virtual void OnTabDidLoad(const TabInfo& tab, int http_status_code) {}
 
+  // Invoked when the `tab` failed to load, e.g., due to a network error.
+  virtual void OnTabDidFailToLoad(const TabInfo& tab) {}
+
   // Invoked when the tab specfied by `tab_id` changes focus.
   virtual void OnTabDidChangeFocus(int32_t tab_id) {}
 

--- a/components/brave_ads/core/internal/tabs/tab_manager_unittest.cc
+++ b/components/brave_ads/core/internal/tabs/tab_manager_unittest.cc
@@ -177,6 +177,24 @@ TEST_F(BraveAdsTabManagerTest, CloseTab) {
   ads_client_notifier_.NotifyDidCloseTab(/*tab_id=*/1);
 }
 
+TEST_F(BraveAdsTabManagerTest, FailToLoadTab) {
+  // Arrange
+  EXPECT_CALL(tab_manager_observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(tab_manager_observer_mock_, OnTabDidChangeFocus);
+  ads_client_notifier_.NotifyTabDidChange(
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false, /*is_visible=*/true);
+
+  // Act & Assert
+  EXPECT_CALL(
+      tab_manager_observer_mock_,
+      OnTabDidFailToLoad(TabInfo{/*id=*/1,
+                                 /*is_visible=*/true,
+                                 /*redirect_chain=*/{GURL("https://brave.com")},
+                                 /*is_playing_media=*/false}));
+  ads_client_notifier_.NotifyTabDidFailToLoad(/*tab_id=*/1);
+}
+
 TEST_F(BraveAdsTabManagerTest, IsPlayingMedia) {
   // Arrange
   EXPECT_CALL(tab_manager_observer_mock_, OnDidOpenNewTab);

--- a/components/brave_ads/core/internal/tabs/test/tab_manager_observer_mock.h
+++ b/components/brave_ads/core/internal/tabs/test/tab_manager_observer_mock.h
@@ -28,6 +28,8 @@ class TabManagerObserverMock : public TabManagerObserver {
 
   MOCK_METHOD(void, OnTabDidLoad, (const TabInfo&, int));
 
+  MOCK_METHOD(void, OnTabDidFailToLoad, (const TabInfo&));
+
   MOCK_METHOD(void, OnTabDidChangeFocus, (int32_t));
 
   MOCK_METHOD(void, OnTabDidChange, (const TabInfo&));

--- a/components/brave_ads/core/public/ads_client/ads_client_notifier.h
+++ b/components/brave_ads/core/public/ads_client/ads_client_notifier.h
@@ -55,6 +55,7 @@ class AdsClientNotifier final {
                           bool is_restoring,
                           bool is_visible);
   void NotifyTabDidLoad(int32_t tab_id, int http_status_code);
+  void NotifyTabDidFailToLoad(int32_t tab_id);
   void NotifyDidCloseTab(int32_t tab_id);
   void NotifyUserGestureEventTriggered(ui::PageTransition page_transition);
   void NotifyUserDidBecomeIdle();

--- a/components/brave_ads/core/public/ads_client/ads_client_notifier_observer.h
+++ b/components/brave_ads/core/public/ads_client/ads_client_notifier_observer.h
@@ -77,6 +77,9 @@ class AdsClientNotifierObserver : public base::CheckedObserver {
   // the HTTP response code.
   virtual void OnNotifyTabDidLoad(int32_t tab_id, int http_status_code) {}
 
+  // Invoked when a browser tab failed to load, e.g., due to a network error.
+  virtual void OnNotifyTabDidFailToLoad(int32_t tab_id) {}
+
   // Invoked when a browser tab with the specified `tab_id` is closed.
   virtual void OnNotifyDidCloseTab(int32_t tab_id) {}
 

--- a/components/services/bat_ads/bat_ads_client_notifier_impl.cc
+++ b/components/services/bat_ads/bat_ads_client_notifier_impl.cc
@@ -98,6 +98,10 @@ void BatAdsClientNotifierImpl::NotifyTabDidLoad(int32_t tab_id,
   ads_client_notifier_.NotifyTabDidLoad(tab_id, http_status_code);
 }
 
+void BatAdsClientNotifierImpl::NotifyTabDidFailToLoad(int32_t tab_id) {
+  ads_client_notifier_.NotifyTabDidFailToLoad(tab_id);
+}
+
 void BatAdsClientNotifierImpl::NotifyDidCloseTab(int32_t tab_id) {
   ads_client_notifier_.NotifyDidCloseTab(tab_id);
 }

--- a/components/services/bat_ads/bat_ads_client_notifier_impl.h
+++ b/components/services/bat_ads/bat_ads_client_notifier_impl.h
@@ -58,6 +58,7 @@ class BatAdsClientNotifierImpl final
                           bool is_restoring,
                           bool is_visible) override;
   void NotifyTabDidLoad(int32_t tab_id, int http_status_code) override;
+  void NotifyTabDidFailToLoad(int32_t tab_id) override;
   void NotifyDidCloseTab(int32_t tab_id) override;
   void NotifyUserGestureEventTriggered(int32_t page_transition) override;
   void NotifyUserDidBecomeIdle() override;

--- a/components/services/bat_ads/public/interfaces/bat_ads.mojom
+++ b/components/services/bat_ads/public/interfaces/bat_ads.mojom
@@ -46,6 +46,7 @@ interface BatAdsClientNotifier {
                      bool is_visible);
   NotifyTabDidLoad(int32 tab_id,
                    int32 http_status_code);
+  NotifyTabDidFailToLoad(int32 tab_id);
   NotifyDidCloseTab(int32 tab_id);
 
   NotifyUserGestureEventTriggered(int32 page_transition);

--- a/ios/browser/brave_ads/ads_service_impl_ios.h
+++ b/ios/browser/brave_ads/ads_service_impl_ios.h
@@ -133,6 +133,7 @@ class AdsServiceImplIOS : public AdsService {
                           bool is_restoring,
                           bool is_visible) override;
   void NotifyTabDidLoad(int32_t tab_id, int http_status_code) override;
+  void NotifyTabDidFailToLoad(int32_t tab_id) override;
   void NotifyDidCloseTab(int32_t tab_id) override;
 
   void NotifyUserGestureEventTriggered(int32_t page_transition) override;

--- a/ios/browser/brave_ads/ads_service_impl_ios.mm
+++ b/ios/browser/brave_ads/ads_service_impl_ios.mm
@@ -388,6 +388,10 @@ void AdsServiceImplIOS::NotifyTabDidLoad(int32_t tab_id, int http_status_code) {
   ads_client_notifier_->NotifyTabDidLoad(tab_id, http_status_code);
 }
 
+void AdsServiceImplIOS::NotifyTabDidFailToLoad(int32_t tab_id) {
+  ads_client_notifier_->NotifyTabDidFailToLoad(tab_id);
+}
+
 void AdsServiceImplIOS::NotifyDidCloseTab(int32_t tab_id) {
   ads_client_notifier_->NotifyDidCloseTab(tab_id);
 }

--- a/ios/browser/brave_ads/ads_tab_helper.h
+++ b/ios/browser/brave_ads/ads_tab_helper.h
@@ -59,6 +59,7 @@ class AdsTabHelper : public web::WebStateUserData<AdsTabHelper>,
 
   void MaybeNotifyTabDidChange();
   void MaybeNotifyTabDidLoad();
+  void MaybeNotifyTabDidFailToLoad();
   void OnVisibilityChanged(bool is_visible);
   void MaybeNotifyTabTextContentDidChange();
   bool UserHasOptedInToNotificationAds() const;

--- a/ios/browser/brave_ads/ads_tab_helper.mm
+++ b/ios/browser/brave_ads/ads_tab_helper.mm
@@ -182,6 +182,10 @@ void AdsTabHelper::MaybeNotifyTabDidLoad() {
   ads_service_->NotifyTabDidLoad(tab_id_, *http_status_code_);
 }
 
+void AdsTabHelper::MaybeNotifyTabDidFailToLoad() {
+  ads_service_->NotifyTabDidFailToLoad(tab_id_);
+}
+
 void AdsTabHelper::OnVisibilityChanged(bool is_visible) {
   const bool last_is_web_contents_visible = is_web_state_visible_;
   is_web_state_visible_ = is_visible;


### PR DESCRIPTION
Adds a new notification path so a tab that fails to load, e.g. due to a network error, can be reported separately from a tab that loaded successfully. The notification carries the full tab, matching the existing tab did load notification. Nothing calls or observes it yet.

Part of https://github.com/brave/brave-browser/issues/42574

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
