### PR TITLE
[ads][CodeHealth] Extract the last clicked ad lookup logic

### DIFF
--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.cc
@@ -58,18 +58,27 @@ bool SiteVisit::IsLandingOnPage(int32_t tab_id) const {
   return page_lands_.contains(tab_id);
 }
 
-void SiteVisit::MaybeLandOnPage(const TabInfo& tab, int http_status_code) {
+std::optional<AdInfo> SiteVisit::MaybeGetLastClickedAdIfAllowedToLandOnPage() {
   if (!last_clicked_ad_) {
     // No ad interactions have occurred in the current browsing session.
-    return;
+    return std::nullopt;
   }
-  const AdInfo ad = *last_clicked_ad_;
+  AdInfo ad = *last_clicked_ad_;
 
   // Reset the last clicked ad to prevent multiple landings on the same ad.
   last_clicked_ad_.reset();
 
   if (!IsAllowedToLandOnPage(ad.type)) {
     // Not allowed to land on the page.
+    return std::nullopt;
+  }
+
+  return ad;
+}
+
+void SiteVisit::MaybeLandOnPage(const TabInfo& tab, int http_status_code) {
+  const std::optional<AdInfo> ad = MaybeGetLastClickedAdIfAllowedToLandOnPage();
+  if (!ad) {
     return;
   }
 
@@ -79,18 +88,18 @@ void SiteVisit::MaybeLandOnPage(const TabInfo& tab, int http_status_code) {
   }
 
   if (!IsSuccessfulHttpStatusCode(http_status_code)) {
-    if (DidSearchResultAdClickRedirectFail(tab, ad)) {
+    if (DidSearchResultAdClickRedirectFail(tab, *ad)) {
       return BLOG(1,
                   "Navigation to the search result ad redirect URL failed "
                   "without reaching the target page");
     }
 
     // If the page did not load successfully, immediately land on the page.
-    return LandedOnPage(tab.id, http_status_code, ad);
+    return LandedOnPage(tab.id, http_status_code, *ad);
   }
 
   // The page loaded successfully, so land on the page after a delay.
-  MaybeLandOnPageAfter(tab, http_status_code, ad, kPageLandAfter.Get());
+  MaybeLandOnPageAfter(tab, http_status_code, *ad, kPageLandAfter.Get());
 }
 
 void SiteVisit::MaybeLandOnPageAfter(const TabInfo& tab,

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.h
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.h
@@ -55,8 +55,9 @@ class SiteVisit final : public BrowserManagerObserver,
   }
 
  private:
-  // Returns true if the tab is currently landing on a page.
   bool IsLandingOnPage(int32_t tab_id) const;
+
+  std::optional<AdInfo> MaybeGetLastClickedAdIfAllowedToLandOnPage();
 
   void MaybeLandOnPage(const TabInfo& tab, int http_status_code);
   void MaybeLandOnPageAfter(const TabInfo& tab,


### PR DESCRIPTION
The logic that reads and consumes the last clicked ad was inlined into page load handling. Extracting it makes it reusable by other handling that will need the same logic. No behavioral changes.

Part of https://github.com/brave/brave-browser/issues/42574

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
