### PR TITLE
[ads] Do not record landing for network error pages

### DIFF
--- a/browser/brave_ads/tabs/ads_tab_helper.cc
+++ b/browser/brave_ads/tabs/ads_tab_helper.cc
@@ -238,8 +238,9 @@ bool AdsTabHelper::ShouldNotifyTabContentDidChange() const {
   // Don't notify about content changes if the ads service is not available, the
   // tab was restored, was a previously committed navigation, the web contents
   // are still loading, or an error page was displayed. `http_status_code_` can
-  // be `std::nullopt` if the navigation never finishes which can occur if the
-  // user constantly refreshes the page.
+  // be `std::nullopt` if the navigation never finishes, which can occur if the
+  // user constantly refreshes the page, or if the committed navigation was a
+  // network error page.
   return ads_service_ && !was_restored_ && is_new_navigation_ &&
          !redirect_chain_.empty() && http_status_code_ &&
          !IsHttpErrorStatusCode(*http_status_code_);
@@ -356,14 +357,35 @@ void AdsTabHelper::DidFinishNavigation(
 
   redirect_chain_ = navigation_handle->GetRedirectChain();
 
-  http_status_code_ = HttpStatusCode(navigation_handle).value_or(net::HTTP_OK);
+  http_status_code_ = HttpStatusCode(navigation_handle);
 
   MaybeNotifyUserGestureEventTriggered(navigation_handle);
 
   // Notify of tab changes after navigation completes but before notifying that
   // the tab has loaded, so that any listeners can process the tab changes
-  // before the tab is considered loaded.
+  // before the tab is considered loaded. This must also happen before
+  // `MaybeNotifyTabDidFailToLoad()` below, as `TabManager` only knows about a
+  // tab once it has observed a tab change for it, and looks up the tab by id
+  // to include its details in the fail-to-load notification.
   MaybeNotifyTabDidChange();
+
+  if (navigation_handle->IsErrorPage()) {
+    // Reset `http_status_code_` as the page failed to load, even if response
+    // headers with a non-error status code were received before the network
+    // error occurred.
+    http_status_code_.reset();
+
+    // Notify the tab failed to load, instead of the tab loaded, to prevent an
+    // ad landing from being incorrectly recorded for network error pages.
+    MaybeNotifyTabDidFailToLoad();
+    return;
+  }
+
+  if (!http_status_code_) {
+    // No response headers were received, but the navigation did not commit an
+    // error page, so treat it as HTTP OK.
+    http_status_code_ = net::HTTP_OK;
+  }
 
   MaybeNotifyTabDidLoad();
 

--- a/browser/brave_ads/tabs/ads_tab_helper_browsertest.cc
+++ b/browser/brave_ads/tabs/ads_tab_helper_browsertest.cc
@@ -522,6 +522,33 @@ IN_PROC_BROWSER_TEST_F(BraveAdsTabHelperTest,
   SimulateHttpStatusCodePage(net::HTTP_OK);
 }
 
+IN_PROC_BROWSER_TEST_F(BraveAdsTabHelperTest,
+                       DoNotNotifyTabDidLoadForNetErrorPage) {
+  // Port 1 is not open, so the connection is refused with no response
+  // headers, producing a committed error page. Verifies that no landing
+  // confirmation is recorded for network error pages.
+  EXPECT_CALL(GetAdsServiceMock(), NotifyTabDidLoad).Times(0);
+  EXPECT_CALL(GetAdsServiceMock(), NotifyTabDidFailToLoad(TabId()));
+  content::NavigateToURLBlockUntilNavigationsComplete(
+      GetActiveWebContents(), GURL("http://brave.com:1/"),
+      /*number_of_navigations=*/1,
+      /*ignore_uncommitted_navigations=*/true);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveAdsTabHelperTest,
+                       NotifyTabDidLoadForSameDocumentNavigation) {
+  NavigateToRelativeURL(kSinglePageApplicationWebpage,
+                        /*has_user_gesture=*/true);
+
+  // A same-document navigation has no response headers and is not an error
+  // page, so it should fall back to reporting HTTP OK.
+  EXPECT_CALL(GetAdsServiceMock(), NotifyTabDidLoad(TabId(), net::HTTP_OK));
+  SimulateClick(kSinglePageApplicationClickSelector,
+                /*has_user_gesture=*/true);
+
+  EXPECT_TRUE(WaitForActiveWebContentsToLoad());
+}
+
 IN_PROC_BROWSER_TEST_F(
     BraveAdsTabHelperTest,
     NotifyTabTextContentDidChangeForRewardsUserOptedInToNotificationAds) {

--- a/components/brave_ads/core/internal/common/test/tab_test_helper.cc
+++ b/components/brave_ads/core/internal/common/test/tab_test_helper.cc
@@ -46,6 +46,20 @@ void TabHelper::NavigateToUrl(int32_t tab_id,
   ads_client_notifier_->NotifyTabDidLoad(tab_id, http_status_code);
 }
 
+void TabHelper::FailToLoadUrl(int32_t tab_id,
+                              const std::vector<GURL>& redirect_chain) {
+  CHECK(redirect_chains_.contains(tab_id)) << "Tab does not exist";
+
+  redirect_chains_[tab_id] = redirect_chain;
+
+  const bool is_visible = tab_id == visible_tab_id_;
+
+  ads_client_notifier_->NotifyTabDidChange(tab_id, redirect_chain,
+                                           /*is_new_navigation=*/true,
+                                           /*is_restoring=*/false, is_visible);
+  ads_client_notifier_->NotifyTabDidFailToLoad(tab_id);
+}
+
 void TabHelper::SelectTab(int32_t tab_id) {
   CHECK(redirect_chains_.contains(tab_id)) << "Tab does not exist";
 

--- a/components/brave_ads/core/internal/common/test/tab_test_helper.h
+++ b/components/brave_ads/core/internal/common/test/tab_test_helper.h
@@ -38,6 +38,7 @@ class TabHelper final {
   void NavigateToUrl(int32_t tab_id,
                      const std::vector<GURL>& redirect_chain,
                      int http_status_code);
+  void FailToLoadUrl(int32_t tab_id, const std::vector<GURL>& redirect_chain);
   void SelectTab(int32_t tab_id);
   void CloseTab(int32_t tab_id);
 

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.cc
@@ -340,6 +340,17 @@ void SiteVisit::OnTabDidLoad(const TabInfo& tab, int http_status_code) {
   MaybeLandOnPage(tab, http_status_code);
 }
 
+void SiteVisit::OnTabDidFailToLoad(const TabInfo& tab) {
+  MaybeCancelPageLand(tab.id);
+
+  const std::optional<AdInfo> ad = MaybeGetLastClickedAdIfAllowedToLandOnPage();
+  if (!ad) {
+    return;
+  }
+
+  DidNotLandOnPage(tab.id, *ad);
+}
+
 void SiteVisit::OnDidCloseTab(int32_t tab_id) {
   CancelPageLand(tab_id);
 }

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.h
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.h
@@ -100,6 +100,7 @@ class SiteVisit final : public BrowserManagerObserver,
   void OnTabDidChangeFocus(int32_t tab_id) override;
   void OnTabDidChange(const TabInfo& tab) override;
   void OnTabDidLoad(const TabInfo& tab, int http_status_code) override;
+  void OnTabDidFailToLoad(const TabInfo& tab) override;
   void OnDidCloseTab(int32_t tab_id) override;
 
   base::ObserverList<SiteVisitObserver> observers_;

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_unittest.cc
@@ -749,6 +749,68 @@ TEST_F(BraveAdsSiteVisitTest, CancelPageLandIfTheTabIsClosed) {
   tab_helper_.CloseTab(/*tab_id=*/1);
 }
 
+TEST_F(BraveAdsSiteVisitTest, DoNotLandOnPageIfNavigationFailsToLoad) {
+  // Arrange
+  const base::test::ScopedFeatureList scoped_feature_list(kSiteVisitFeature);
+
+  const AdInfo ad = test::BuildAd(mojom::AdType::kNotificationAd,
+                                  /*use_random_uuids=*/true);
+  tab_helper_.OpenTab(/*tab_id=*/1,
+                      /*redirect_chain=*/{GURL("https://brave.com")},
+                      net::HTTP_OK);
+  site_visit_->set_last_clicked_ad(ad);
+
+  // Act & Assert
+  EXPECT_CALL(site_visit_observer_mock_, OnDidNotLandOnPage(/*tab_id=*/1, ad));
+  tab_helper_.FailToLoadUrl(/*tab_id=*/1,
+                            /*redirect_chain=*/{ad.target_url});
+}
+
+TEST_F(BraveAdsSiteVisitTest,
+       DoNotNotifyDidNotLandOnPageIfNavigationFailsToLoadForNonRewardsUser) {
+  // Arrange
+  const base::test::ScopedFeatureList scoped_feature_list(kSiteVisitFeature);
+
+  test::DisableBraveRewards();
+
+  const AdInfo ad = test::BuildAd(mojom::AdType::kNotificationAd,
+                                  /*use_random_uuids=*/true);
+  tab_helper_.OpenTab(/*tab_id=*/1,
+                      /*redirect_chain=*/{GURL("https://brave.com")},
+                      net::HTTP_OK);
+  site_visit_->set_last_clicked_ad(ad);
+
+  // Act & Assert
+  EXPECT_CALL(site_visit_observer_mock_, OnDidNotLandOnPage).Times(0);
+  tab_helper_.FailToLoadUrl(/*tab_id=*/1,
+                            /*redirect_chain=*/{ad.target_url});
+}
+
+TEST_F(BraveAdsSiteVisitTest,
+       DoNotLandOnUnrelatedPageAfterNavigationFailsToLoad) {
+  // Arrange
+  const base::test::ScopedFeatureList scoped_feature_list(kSiteVisitFeature);
+
+  const AdInfo ad = test::BuildAd(mojom::AdType::kNotificationAd,
+                                  /*use_random_uuids=*/true);
+  tab_helper_.OpenTab(/*tab_id=*/1,
+                      /*redirect_chain=*/{GURL("https://brave.com")},
+                      net::HTTP_OK);
+  site_visit_->set_last_clicked_ad(ad);
+
+  EXPECT_CALL(site_visit_observer_mock_, OnDidNotLandOnPage(/*tab_id=*/1, ad));
+  tab_helper_.FailToLoadUrl(/*tab_id=*/1,
+                            /*redirect_chain=*/{ad.target_url});
+
+  // Act & Assert
+  EXPECT_CALL(site_visit_observer_mock_, OnDidLandOnPage).Times(0);
+  tab_helper_.NavigateToUrl(
+      /*tab_id=*/1,
+      /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
+      net::HTTP_OK);
+  FastForwardClockBy(kPageLandAfter.Get());
+}
+
 TEST_F(BraveAdsSiteVisitTest,
        PageLandIsNotRecordedWhenNavigationCommitsBeforeLastClickedAdIsSet) {
   // Arrange

--- a/ios/browser/brave_ads/ads_tab_helper.mm
+++ b/ios/browser/brave_ads/ads_tab_helper.mm
@@ -130,8 +130,23 @@ void AdsTabHelper::DidFinishNavigation(
 
   // Notify of tab changes after navigation completes but before notifying that
   // the tab has loaded, so that any listeners can process the tab changes
-  // before the tab is considered loaded.
+  // before the tab is considered loaded. This must also happen before
+  // `MaybeNotifyTabDidFailToLoad()` below, as `TabManager` only knows about a
+  // tab once it has observed a tab change for it, and looks up the tab by id
+  // to include its details in the fail-to-load notification.
   MaybeNotifyTabDidChange();
+
+  if (navigation_context->GetError()) {
+    // Reset `http_status_code_` as the page failed to load, even if response
+    // headers with a non-error status code were received before the network
+    // error occurred.
+    http_status_code_.reset();
+
+    // Notify the tab failed to load, instead of the tab loaded, to prevent an
+    // ad landing from being incorrectly recorded for network error pages.
+    MaybeNotifyTabDidFailToLoad();
+    return;
+  }
 
   MaybeNotifyTabDidLoad();
 
@@ -198,8 +213,9 @@ bool AdsTabHelper::ShouldNotifyTabContentDidChange() const {
   // Don't notify about content changes if the ads service is not available, the
   // tab was restored, was a previously committed navigation, the web contents
   // are still loading, or an error page was displayed. `http_status_code_` can
-  // be `std::nullopt` if the navigation never finishes which can occur if the
-  // user constantly refreshes the page.
+  // be `std::nullopt` if the navigation never finishes, which can occur if the
+  // user constantly refreshes the page, or if the committed navigation was a
+  // network error page.
   return !was_restored_ && is_new_navigation_ && !redirect_chain_.empty() &&
          http_status_code_ && !IsHttpErrorStatusCode(*http_status_code_);
 }


### PR DESCRIPTION
When an ad click failed to load due to no internet connection, it was treated as a successful page load and incorrectly recorded as a landed ad. Network error pages are now reported as failed to load instead, so no landing is recorded, and the pending ad click is cleared rather than carried over to a later, unrelated page.

Part of https://github.com/brave/brave-browser/issues/42574

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
