### PR TITLE
[ads] Do not affect an in-progress page land on another failed load

### DIFF
--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.cc
@@ -348,6 +348,11 @@ void SiteVisit::OnTabDidFailToLoad(const TabInfo& tab) {
     return;
   }
 
+  if (IsLandingOnPage(tab.id)) {
+    // Already landing on the page.
+    return;
+  }
+
   DidNotLandOnPage(tab.id, *ad);
 }
 

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_unittest.cc
@@ -811,6 +811,36 @@ TEST_F(BraveAdsSiteVisitTest,
   FastForwardClockBy(kPageLandAfter.Get());
 }
 
+TEST_F(
+    BraveAdsSiteVisitTest,
+    DoNotNotifyDidNotLandOnPageIfAlreadyLandingWhenAnotherNavigationFailsToLoad) {
+  // Arrange
+  const base::test::ScopedFeatureList scoped_feature_list(kSiteVisitFeature);
+
+  const AdInfo ad_1 = test::BuildAd(mojom::AdType::kNotificationAd,
+                                    /*use_random_uuids=*/true);
+  EXPECT_CALL(site_visit_observer_mock_,
+              OnMaybeLandOnPage(ad_1, /*after=*/kPageLandAfter.Get()));
+  SimulateClickingAd(ad_1, /*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
+  ASSERT_EQ(1U, GetPendingTaskCount());
+
+  const AdInfo ad_2 = test::BuildAd(mojom::AdType::kNotificationAd,
+                                    /*use_random_uuids=*/true);
+  site_visit_->set_last_clicked_ad(ad_2);
+
+  // Act
+  EXPECT_CALL(site_visit_observer_mock_, OnDidNotLandOnPage).Times(0);
+  tab_helper_.FailToLoadUrl(/*tab_id=*/1,
+                            /*redirect_chain=*/{GURL("https://brave.com")});
+
+  // Assert
+  EXPECT_CALL(site_visit_observer_mock_,
+              OnDidLandOnPage(/*tab_id=*/1, net::HTTP_OK, ad_1));
+  FastForwardClockBy(kPageLandAfter.Get());
+}
+
 TEST_F(BraveAdsSiteVisitTest,
        PageLandIsNotRecordedWhenNavigationCommitsBeforeLastClickedAdIsSet) {
   // Arrange


### PR DESCRIPTION
This applies regardless of ad type. If a tab was already evaluating whether one ad's page load counted as a landing, a different ad's failed load on that same tab could still report it as not landed, even though that ad's click was never being evaluated there. The failed load path now skips reporting an outcome while the tab is evaluating a different ad, matching how a successful load already behaves.

Part of https://github.com/brave/brave-browser/issues/42574

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
