### PR TITLE
Sync shows error dialog in a loop without Play Services

### DIFF
--- a/android/java/org/chromium/chrome/browser/omnibox/BraveLocationBarQRDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/omnibox/BraveLocationBarQRDialogFragment.java
@@ -36,6 +36,7 @@ public class BraveLocationBarQRDialogFragment extends DialogFragment
 
     private QRCodeCameraManager mCameraManager;
     private BraveLocationBarMediator mLocationBarMediator;
+    private Dialog mPlayServicesErrorDialog;
 
     // The Android Fragment framework requires a zero-argument constructor to
     // instantiate fragments. It usually happens on a fragment re-creation
@@ -99,10 +100,21 @@ public class BraveLocationBarQRDialogFragment extends DialogFragment
 
     @Override
     public void onDestroy() {
+        dismissPlayServicesErrorDialog();
         if (mCameraManager != null) {
             mCameraManager.release();
         }
         super.onDestroy();
+    }
+
+    /** Dismisses the Google Play Services error dialog without dismissing this fragment again. */
+    private void dismissPlayServicesErrorDialog() {
+        if (mPlayServicesErrorDialog == null) {
+            return;
+        }
+        mPlayServicesErrorDialog.setOnDismissListener(null);
+        mPlayServicesErrorDialog.dismiss();
+        mPlayServicesErrorDialog = null;
     }
 
     @Override
@@ -171,10 +183,19 @@ public class BraveLocationBarQRDialogFragment extends DialogFragment
 
     @Override
     public void onPlayServicesUnavailable(Dialog errorDialog) {
-        if (errorDialog != null && isHostValid()) {
-            errorDialog.show();
+        if (errorDialog == null || !isHostValid()) {
+            dismiss();
+            return;
         }
-        dismiss();
+        // The dialog is attached to the activity window, so this fragment stays around until the
+        // user acknowledges it and dismisses it in onDestroy, otherwise the window is leaked.
+        mPlayServicesErrorDialog = errorDialog;
+        errorDialog.setOnDismissListener(
+                dialog -> {
+                    mPlayServicesErrorDialog = null;
+                    dismiss();
+                });
+        errorDialog.show();
     }
 
     // QRCodeCameraManager.HostProvider implementation

--- a/android/java/org/chromium/chrome/browser/omnibox/BraveLocationBarQRDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/omnibox/BraveLocationBarQRDialogFragment.java
@@ -170,12 +170,11 @@ public class BraveLocationBarQRDialogFragment extends DialogFragment
     }
 
     @Override
-    public boolean onPlayServicesUnavailable(Dialog errorDialog) {
-        if (errorDialog != null) {
+    public void onPlayServicesUnavailable(Dialog errorDialog) {
+        if (errorDialog != null && isHostValid()) {
             errorDialog.show();
         }
         dismiss();
-        return true;
     }
 
     // QRCodeCameraManager.HostProvider implementation

--- a/android/java/org/chromium/chrome/browser/omnibox/BraveLocationBarQRDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/omnibox/BraveLocationBarQRDialogFragment.java
@@ -183,7 +183,7 @@ public class BraveLocationBarQRDialogFragment extends DialogFragment
 
     @Override
     public void onPlayServicesUnavailable(Dialog errorDialog) {
-        if (errorDialog == null || !isHostValid()) {
+        if (errorDialog == null || !isHostValid() || requireActivity().isFinishing()) {
             dismiss();
             return;
         }

--- a/android/java/org/chromium/chrome/browser/qrreader/QRCodeCameraManager.java
+++ b/android/java/org/chromium/chrome/browser/qrreader/QRCodeCameraManager.java
@@ -8,7 +8,6 @@ package org.chromium.chrome.browser.qrreader;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Dialog;
-import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.hardware.Camera;
 import android.hardware.display.DisplayManager;
@@ -44,10 +43,12 @@ public class QRCodeCameraManager
         /** Called when a QR code is detected. */
         void onDetectedQrCode(Barcode barcode);
 
-        /** Called when Google Play Services is not available. Returns true if handled. */
-        default boolean onPlayServicesUnavailable(@Nullable Dialog errorDialog) {
-            return false;
-        }
+        /**
+         * Called when Google Play Services is not available, which means barcode detection cannot
+         * run. No camera source is created in that case. The host owns the error UI: it decides
+         * whether to show {@code errorDialog} and where to send the user instead.
+         */
+        void onPlayServicesUnavailable(@Nullable Dialog errorDialog);
     }
 
     /** Interface for providing activity context and fragment state. */
@@ -146,6 +147,21 @@ public class QRCodeCameraManager
         }
         Context context = activity.getApplicationContext();
 
+        // Barcode detection is backed by Google Play Services, so there is nothing to create
+        // without it. The check lives here, on the path taken when the host opens the scanner,
+        // rather than in startCameraSource(), which also runs on every window focus change, resume
+        // and rotation. Notifying the host from there made the error dialog reappear in a loop:
+        // showing it took window focus away, dismissing it gave the focus back, and regaining the
+        // focus restarted the camera source, which showed the dialog again.
+        int playServicesStatus =
+                GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context);
+        if (playServicesStatus != ConnectionResult.SUCCESS) {
+            mCallback.onPlayServicesUnavailable(
+                    GoogleApiAvailability.getInstance()
+                            .getErrorDialog(activity, playServicesStatus, RC_HANDLE_GMS));
+            return;
+        }
+
         // A barcode detector is created to track barcodes. An associated multi-processor instance
         // is set to receive the barcode detection results, track the barcodes, and maintain
         // graphics for each barcode on screen. The factory is used by the multi-processor to
@@ -192,34 +208,6 @@ public class QRCodeCameraManager
             return false;
         }
         if (!mCameraSourcePreview.mCameraExist) {
-            return false;
-        }
-
-        Activity activity = mHostProvider.getHostActivity();
-        if (activity == null) {
-            return false;
-        }
-
-        // Check that the device has play services available.
-        try {
-            int code =
-                    GoogleApiAvailability.getInstance()
-                            .isGooglePlayServicesAvailable(activity.getApplicationContext());
-            if (code != ConnectionResult.SUCCESS) {
-                Dialog dlg =
-                        GoogleApiAvailability.getInstance()
-                                .getErrorDialog(activity, code, RC_HANDLE_GMS);
-                if (mCallback.onPlayServicesUnavailable(dlg)) {
-                    return false;
-                }
-                if (dlg != null) {
-                    dlg.show();
-                }
-            }
-        } catch (ActivityNotFoundException e) {
-            Log.e(TAG, "Unable to start camera source.", e);
-            mCameraSource.release();
-            mCameraSource = null;
             return false;
         }
 
@@ -301,15 +289,17 @@ public class QRCodeCameraManager
 
     /** Recreates and restarts the camera source to handle 180-degree rotation. */
     private void recreateCameraSource() {
-        if (mCameraSourcePreview == null) {
+        // A null camera source means there is nothing to recreate, either because the host never
+        // opened the scanner or because creating it was refused, for instance when Google Play
+        // Services is missing. Recreating it here would notify the host of that again on every
+        // 180 degree rotation.
+        if (mCameraSourcePreview == null || mCameraSource == null) {
             return;
         }
 
         mCameraSourcePreview.stop();
-        if (mCameraSource != null) {
-            mCameraSource.release();
-            mCameraSource = null;
-        }
+        mCameraSource.release();
+        mCameraSource = null;
 
         createCameraSource(true, false);
         try {

--- a/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
@@ -128,6 +128,7 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
     private FrameLayout mLayoutMobile;
     private FrameLayout mLayoutLaptop;
     private AlertDialog mFinalWarningDialog;
+    private Dialog mPlayServicesErrorDialog;
     private TabLayout mTabLayout;
 
     // Below enum is matching the values of GetDeviceTypeString() in brave_device_info.cc
@@ -1059,6 +1060,11 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
     @Override
     public void onDestroy() {
         super.onDestroy();
+        if (mPlayServicesErrorDialog != null) {
+            mPlayServicesErrorDialog.setOnDismissListener(null);
+            mPlayServicesErrorDialog.dismiss();
+            mPlayServicesErrorDialog = null;
+        }
         if (mCameraManager != null) {
             mCameraManager.release();
         }
@@ -1631,6 +1637,10 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
         if (errorDialog == null || !isHostValid() || requireActivity().isFinishing()) {
             return;
         }
+        // The dialog is attached to the activity window, so it has to be dismissed before this
+        // fragment goes away, otherwise the window is leaked.
+        mPlayServicesErrorDialog = errorDialog;
+        errorDialog.setOnDismissListener(dialog -> mPlayServicesErrorDialog = null);
         errorDialog.show();
     }
 

--- a/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
@@ -1061,7 +1061,6 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
     public void onDestroy() {
         super.onDestroy();
         if (mPlayServicesErrorDialog != null) {
-            mPlayServicesErrorDialog.setOnDismissListener(null);
             mPlayServicesErrorDialog.dismiss();
             mPlayServicesErrorDialog = null;
         }

--- a/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
@@ -7,6 +7,7 @@ package org.chromium.chrome.browser.settings;
 
 import android.Manifest;
 import android.app.Activity;
+import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.pm.PackageManager;
@@ -1620,6 +1621,17 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
         if (null != view) {
             view.setBackgroundColor(Color.TRANSPARENT);
         }
+    }
+
+    // QRCodeCameraManager.Callback implementation
+    @Override
+    public void onPlayServicesUnavailable(Dialog errorDialog) {
+        // Scanning the QR code is not possible without Google Play Services, but the code words
+        // button on this screen still is, so the user stays here after acknowledging the error.
+        if (errorDialog == null || !isHostValid() || requireActivity().isFinishing()) {
+            return;
+        }
+        errorDialog.show();
     }
 
     // QRCodeCameraManager.HostProvider implementation


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/11477

<img width="577" height="1178" alt="Screenshot 2026-07-22 at 12 10 48 PM" src="https://github.com/user-attachments/assets/81fb25e9-95db-4faf-b48d-985d23b0ed4f" />

Based on the investigation in #36829 by @dark-penguin, this PR takes a different approach to the fix.

Setting up Sync by QR code on a device without Google Play Services showed the "Google Play Services is missing" error dialog in an endless loop, making the Sync setup screen unusable.

The loop was introduced because Play Services availability check lived in `startCameraSource()` and showed the error dialog inline. Showing the dialog took window focus away from the preview, which stopped the camera source. Dismissing the dialog gave the focus back, which restarted the camera source, which ran the check and showed the dialog again.

## Fix Description

The availability check moves from `startCameraSource()` to `createCameraSource()`. `createCameraSource()` runs when the host opens the scanner, while `startCameraSource()` also runs on every window focus change, resume, configuration change and rotation, which is what turned a single check into a loop. Play Services availability cannot change while the scanner is on screen, so checking it once on the path the user actually takes is both sufficient and immune to the feedback cycle.

When Play Services is missing no camera source is created at all, so `startCameraSource()` returns early on its existing null check and nothing else in the class needs to know about it. `recreateCameraSource()` now early return when there is no camera source, so a 180 degree rotation does not resurrect the check either.

`QRCodeCameraManager` no longer shows any UI of its own. `Callback.onPlayServicesUnavailable` is now a mandatory `void` method rather than a `default` returning a boolean, so each host decides what to show and where to send the user. That fallback branch inside the manager, where it showed the dialog itself if the host did not claim it, is what produced the original bug.

`BraveSyncScreensPreference` implements the callback by showing the dialog once and leaving the user on the scan screen, where the "Enter code words" button already lives, so Sync can still be set up by code words. `BraveLocationBarQRDialogFragment` keeps its existing behavior of showing the dialog and closing the scanner.

Both hosts now hold a reference to the dialog and dismiss it when they are destroyed. Previously the dialog was attached to the activity window and never tracked, so destroying the host while it was showing leaked the window. In the omnibox case this also meant the fragment closed itself immediately and left the dialog with no owner at all, so the fragment now stays until the user acknowledges the error and closes itself from the dialog dismiss listener.

The `try`/`catch (ActivityNotFoundException)` around the old check is removed as it could never fire: none of the three calls it wrapped starts an activity, and the only `startActivityForResult` in that flow is in the error dialog button listener, which runs on the looper long after the `try` block returns. `play-services-base` already catches it there itself (`zaj.onClick`, logged as "Failed to start resolution intent." under tag `DialogRedirect`), so the removal changes nothing at runtime.

On a device without Play Services the camera preview no longer starts at all, where before it started a live but permanently dead preview, since barcode detection needs Play Services to work. The scan screen now shows an empty preview area alongside the code words button.

## Test Plan

Google Play Services can be turned off on an emulator running a Google APIs image, or on a real device, with:

```
adb shell pm disable-user --user 0 com.google.android.gms
```

and restored afterwards with:

```
adb shell pm enable com.google.android.gms
```

Run `adb logcat | grep -i "WindowLeaked\|DialogRedirect"` alongside the steps below.

### Without Play Services

1. Disable Play Services with the command above, then open Settings, Sync, "I have a Sync Code" so the QR scanner screen opens.
2. The error dialog appears once. Dismiss it. It must not come back.
3. Rotate the device several times, including a full 180 degree turn, and switch to another app and back. The dialog must not reappear at any point.
4. Tap "Enter code words", enter a valid Sync code, and confirm the chain is joined.
5. Repeat steps 1 to 3 with the address bar QR scanner, opened from the search box QR icon. The dialog appears once and the scanner closes when it is dismissed.
6. With the error dialog on screen, rotate the device. No crash, and no `WindowLeaked` entry in logcat.
7. With the error dialog on screen, tap its action button. No crash. A "Failed to start resolution intent." line under tag `DialogRedirect` is expected on a device with no Play Store.

### With Play Services restored

8. Re-enable Play Services and scan a Sync QR code from another device. The chain is joined as before.
9. While scanning, rotate the device 180 degrees. The preview stays upright and keeps detecting.
10. While scanning, switch to another app and back. The preview resumes.
11. Scan a QR code from the address bar scanner and confirm the URL or search query is used.
12. Revoke the camera permission, open the Sync scanner, and confirm the permission prompt still appears and that granting it starts the preview.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
