### PR TITLE
[iOS] Check if window scene is still connected after profile load (uplift to 1.93.x)

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
@@ -142,6 +142,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     Task { @MainActor in
       let (profileController, profileState) = await loadDefaultProfile()
+
+      // The scene may have disconnected while `loadDefaultProfile` was awaiting. UIKit clears
+      // `session.scene` back to nil once a scene disconnects, so use that to detect this rather
+      // than tracking our own state. Creating a new `UIWindow` for a windowScene that has
+      // already disconnected will crash, so bail out if that's the case.
+      guard windowScene.session.scene != nil else { return }
+
       Self.profileState = profileState
       PlaylistCoordinator.shared.isPlaylistAvailable =
         profileController.profile.prefs.isPlaylistAvailable


### PR DESCRIPTION
Uplift of #38182
Resolves https://github.com/brave/brave-browser/issues/57342

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.