### PR TITLE
[recipes] Add composable module configs

### DIFF
--- a/tools/recipes/README.md
+++ b/tools/recipes/README.md
@@ -106,6 +106,197 @@ def GenTests(api):
 `api.properties` also accepts top-level keyword arguments as a shorthand, e.g.
 `api.properties(chromium_ref='151.0.7917.1', brave_subrevision=1)`.
 
+## Configs
+
+**Configs are a way for a module to expose its "global" state in a reusable,
+composable way.** Where [Properties](#properties) are the recipe's _input_,
+configs are a module's _tunable internal state_: a module declares the shape of
+that state as a schema, then offers named, composable "config items" that a
+recipe selects from.
+
+A common problem in building things is an inordinately large matrix of
+configuration. A checkout module, for example, has axes like target platform,
+target arch, build config, git-cache layout, hermetic-toolchain source, and so
+on. There are many combinations but only a relatively small number of _valid_
+ones. Configs let a module represent the valid states as named recipes to
+follow, rather than leaving every recipe to assemble raw values correctly.
+
+The `hello` recipe module (`recipe_modules/hello/`) is a small, fully worked
+example of everything below; the snippets here are drawn from it.
+
+### Declaring a schema
+
+A module opts into the config system by adding a `config.py` next to its
+`api.py`. It first defines a _schema_: a callable returning a `ConfigGroup` that
+describes the "config blob" the module deals with.
+
+```python
+# recipe_modules/hello/config.py
+from config import BadConf, ConfigGroup, Single, Static, config_item_context
+
+def BaseConfig(TARGET='Bob'):
+    # A config blob is not complete() until every required entry has a value.
+    return ConfigGroup(
+        verb=Single(str),
+        tool=Single(str, required=True),
+        # Schema-factory arguments are ALL_CAPS by convention and threaded in as
+        # Static (read-only input) data. This avoids name clashes with the
+        # per-invocation CONFIG_VARS described below.
+        TARGET=Static(str(TARGET)),
+    )
+
+config_ctx = config_item_context(BaseConfig)
+```
+
+`BaseConfig` must return a `ConfigGroup`; every blob you get from this context
+is a modified copy of what the schema returns. The building blocks (all imported
+from `config`) are:
+
+| Type          | Holds                                                         |
+| ------------- | ------------------------------------------------------------- |
+| `Single`      | one scalar of a given type (`required` controls completeness) |
+| `Static`      | one immutable, write-once input value (hidden by default)     |
+| `Enum`        | one value restricted to a fixed set                           |
+| `List`        | an ordered, type-checked list of scalars                      |
+| `Set`         | a type-checked set of scalars                                 |
+| `Dict`        | a dict with an optional value-type constraint                 |
+| `ConfigGroup` | a nested named struct (schemas nest arbitrarily)              |
+| `ConfigList`  | an ordered list of `ConfigGroup`s                             |
+
+You manipulate a blob like plain Python data (`c.tool = 'echo'`,
+`c.some_set.add(x)`), but assignment is type-checked and the schema is _closed_:
+assigning an unknown attribute is an error, and a `Static` member cannot be
+reassigned after construction.
+
+`config_ctx` is the context for all config items in this file. The engine
+discovers the single `config_item_context(...)` result in a module's `config.py`
+and exposes it to the module's `RecipeApi` automatically -- no wiring needed.
+
+### Defining config items
+
+A _config item_ is a function decorated with `config_ctx` that takes a config
+blob `c` and mutates it in place (it must not return a value).
+
+```python
+# recipe_modules/hello/config.py (continued)
+
+# is_root means every config item applies this one first. At most one per module.
+@config_ctx(is_root=True)
+def BASE(c):
+    if c.TARGET == 'DarthVader':
+        c.verb = 'Die in a fire %s!'
+    else:
+        c.verb = 'Hello %s'
+
+@config_ctx(group='tool')  # Items in the same group are mutually exclusive.
+def super_tool(c):
+    if c.TARGET != 'Charlie':
+        raise BadConf('Can only use super tool for Charlie!')
+    c.tool = 'unicorn.py'
+
+@config_ctx(group='tool')
+def default_tool(c):
+    c.tool = 'echo'
+```
+
+The `config_ctx` decorator accepts:
+
+- **`is_root`** -- marks the single "basis" item, applied implicitly before
+  every other item on a blob. At most one root per module.
+- **`group`** -- items sharing a group are mutually exclusive on one blob;
+  applying a second member raises `BadConf`.
+- **`includes`** -- names of other config items to run against the blob _before_
+  this item's body (already-applied includes are skipped).
+- **`deps`** -- group names that must already be satisfied on the blob before
+  this item may apply; otherwise `BadConf`.
+
+Any violation (double application, group conflict, unmet `deps`, a failing
+`include`) raises `BadConf`.
+
+### Using a config
+
+`RecipeApi` provides all the plumbing. A module reads its current blob as
+`self.c`, and a recipe reaches it directly as `api.<module>.c`.
+
+```python
+# recipe_modules/hello/api.py
+from recipe_api import RecipeApi
+
+class HelloApi(RecipeApi):
+    def greet(self):
+        self.m.step('Greet Admired Individual', [
+            self.m.path.workspace / self.c.tool,
+            self.c.verb % self.c.TARGET,
+        ])
+```
+
+A recipe (or another module) selects a config with `set_config`:
+
+```python
+# recipe_modules/hello/examples/simple.py
+DEPS = ['hello']
+
+def RunSteps(api):
+    api.hello.set_config('default_tool')
+    api.hello.greet()  # Greets 'Bob' with echo.
+```
+
+`set_config(name, **CONFIG_VARS)` builds a fresh blob and assigns it to
+`api.hello.c`. It does so by:
+
+1. computing the schema arguments (`CONFIG_VARS`), lowest-to-highest precedence:
+   `get_config_defaults()` (overridable on the api to compute defaults
+   dynamically), then the keyword arguments to `set_config`;
+2. instantiating the schema with those arguments (`BaseConfig(**CONFIG_VARS)`);
+3. applying the named config item -- and its root and `includes` -- to the blob.
+
+So passing a `CONFIG_VARS` value steers both the schema and the items that
+branch on it:
+
+```python
+api.hello.set_config('super_tool', TARGET='Charlie')  # -> unicorn.py, 'Hello Charlie'
+api.hello.set_config('default_tool', TARGET='DarthVader')  # -> echo, 'Die in a fire ...'
+```
+
+Two lower-level entry points are also available, though `set_config` is
+preferred:
+
+- **`make_config(name,
+  **CONFIG_VARS)`** returns a blob without storing it in `self.c`.
+- **`apply_config(name)`** applies an additional named item on top of the
+  existing `self.c`, layering configs after an initial `set_config`.
+
+> **Note:** older versions of chrome-infra's `set_config` also applied the named
+> item across the module's `DEPS`. That behaviour was
+> [recognized as a design mistake](https://chromium.googlesource.com/infra/luci/recipes-py/)
+> and removed upstream; this engine matches current upstream and does **not** do
+> it. `set_config` only ever touches the current module's own `self.c`.
+
+### Testing configs
+
+Config code is subject to the same 100% coverage requirement as the rest of a
+module (see [Testing](#testing)), so exercise each item and each branch from
+example/test recipes. A config item that raises `BadConf` surfaces as an
+`EXCEPTION`-status run, which a `tests/` recipe can assert:
+
+```python
+# recipe_modules/hello/tests/badconf.py
+from post_process import DropExpectation, StatusException
+
+DEPS = ['hello']
+
+def RunSteps(api):
+    api.hello.set_config('super_tool', TARGET='Not Charlie')  # raises BadConf
+
+def GenTests(api):
+    yield api.test(
+        'badconf',
+        api.post_process(StatusException),
+        api.post_process(DropExpectation),
+        status='EXCEPTION',
+    )
+```
+
 ## Testing
 
 Recipes and recipe modules are tested by _simulation_: a recipe declares

--- a/tools/recipes/config.py
+++ b/tools/recipes/config.py
@@ -1,0 +1,756 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Recipe configuration meta-DSL (a faithful, trimmed port of chrome-infra's
+`recipe_engine/config.py`).
+
+This module is, essentially, a DSL for writing composable configurations. You
+start by defining a *schema* describing how your configuration blobs are
+structured and what data they may hold. For example:
+
+    def FakeSchema(main_val=True, mode='Happy'):
+        return ConfigGroup(
+            config_group=ConfigGroup(
+                item_a=Single(int),
+                item_b=Dict(),
+            ),
+            extra_setting=Set(str),
+            MAIN_DETERMINANT=Static(main_val),
+            CONFIG_MODE=Static(mode),
+        )
+
+In short, a schema is a callable which takes zero or more arguments (with sane
+defaults) and returns a `ConfigGroup`.
+
+Every type used in a schema derives from `ConfigBase`: a fixed-type container
+that impersonates the data type it stores (so you manipulate config objects like
+plain Python data) while also enforcing type checking (so blobs render cleanly
+to JSON).
+
+From a schema you create a configuration context:
+
+    config_ctx = config_item_context(FakeSchema)
+
+`config_ctx` is a decorator you use to define composable *config items*:
+
+    @config_ctx()
+    def cool(c):
+        if c.CONFIG_MODE == 'Happy':
+            c.config_group.item_a = 100
+        else:
+            c.config_group.item_a = -100
+
+    @config_ctx()
+    def gnarly(c):
+        c.extra_setting.add('gnarly!')
+
+    @config_ctx(includes=('cool', 'gnarly'))
+    def combo(c):
+        if c.MAIN_DETERMINANT:
+            c.config_group.item_b['nickname'] = 'purple'
+        else:
+            c.config_group.item_b['nickname'] = 'sad times'
+
+Calling `combo()` returns a configuration object whose schema is `FakeSchema`
+and whose data is the accumulation of `cool()`, `gnarly()`, and `combo()`. You
+can keep manipulating it, read its data, or render it to JSON via
+`as_jsonish()`.
+
+Differences from the upstream module (all cosmetic, none behavioural for the
+config DSL itself):
+  * The protobuf `schema_proto()` doc-export methods are omitted (the engine
+    has no doc tooling).
+  * The `config_types.Path` carve-out in `Static` is omitted; values are always
+    hashed to enforce immutability (`pathlib.Path` is hashable).
+  * `ConfigGroupSchema`/`ReturnSchema` (the separate recipe *return*-value
+    feature) are omitted.
+  * Python 2 shims (`basestring`, `from builtins import object`) are dropped.
+"""
+
+from __future__ import annotations
+
+import collections.abc
+import functools
+import types
+
+
+class BadConf(Exception):
+    """Raised for any apply-time configuration violation.
+
+    Double application of an item, an unfulfilled `deps` group, a `group`
+    mutual-exclusion conflict, or a failing `includes` all surface as `BadConf`.
+    """
+
+
+def typeAssert(obj, typearg):
+    """Assert `obj` is an instance of `typearg`, raising `TypeError` if not."""
+    if not isinstance(obj, typearg):
+        raise TypeError('Expected %r to be of type %r' % (obj, typearg))
+
+
+class ConfigContext:
+    """A configuration context for a recipe module.
+
+    Holds the configuration schema and a registry of config items, and acts as
+    the `config_ctx` decorator that populates that registry. A recipe module
+    defines at most one such context (in its `config.py`).
+    """
+
+    def __init__(self, CONFIG_SCHEMA):
+        self.CONFIG_ITEMS = {}
+        self.MUTEX_GROUPS = {}
+        self.CONFIG_SCHEMA = CONFIG_SCHEMA
+        self.ROOT_CONFIG_ITEM = None
+
+    def __call__(self, group=None, includes=None, deps=None, is_root=False):
+        """Decorator for functions which modify a config blob.
+
+        Args:
+            group(str): Members of a group are mutually exclusive on the same
+                config blob -- only one item of a given group may be applied.
+            includes(iterable(str)): Config items to run against the blob before
+                the decorated function's body. An include already applied to the
+                blob is skipped.
+            deps(iterable(str)): Group names which must already be satisfied on
+                the blob (some member applied with `final=True`) before this item
+                may apply; otherwise `BadConf`.
+            is_root(bool): Marks this the single 'basis' item, implicitly applied
+                before every other item. At most one root per context.
+
+        Returns:
+            A decorated version of the function (see `inner`).
+        """
+
+        def decorator(f):
+            name = f.__name__
+
+            @functools.wraps(f)
+            def inner(config=None, final=True, optional=False, **kwargs):
+                """Apply this config item to a config blob and return the blob.
+
+                Args:
+                    config: The config blob to manipulate. A fresh blob is made
+                        from the schema when None. The item mutates it in place.
+                    final(bool): When True (default), records this item's
+                        application on the blob, preventing re-application and
+                        allowing it to satisfy later `deps`. Apply with
+                        `final=False` to seed defaults a later item may override.
+                    optional(bool): When True, a double application returns the
+                        blob unchanged instead of raising `BadConf`.
+                    **kwargs: Passed through to the decorated function.
+
+                Returns the (mutated) config blob; the body's return value is
+                ignored (and asserted to be None).
+                """
+                if config is None:
+                    config = self.CONFIG_SCHEMA()
+                assert isinstance(config, ConfigGroup)
+                inclusions = config._inclusions  # pylint: disable=protected-access
+
+                # Auto-apply the root item first, unless we are the root or it
+                # has already run on this blob.
+                if (self.ROOT_CONFIG_ITEM and not inner.IS_ROOT
+                        and self.ROOT_CONFIG_ITEM.__name__ not in inclusions):
+                    self.ROOT_CONFIG_ITEM(config)
+
+                if name in inclusions:
+                    if optional:
+                        return config
+                    raise BadConf(
+                        'config_ctx "%s" is already in this config "%s"' %
+                        (name, config.as_jsonish(include_hidden=True)))
+                if final:
+                    inclusions.add(name)
+
+                for include in includes or []:
+                    if include in inclusions:
+                        continue
+                    try:
+                        self.CONFIG_ITEMS[include](config)
+                    except BadConf as e:
+                        raise BadConf('config "%s" includes "%s", but [%s]' %
+                                      (name, include, e)) from e
+
+                # deps are group names; every group must already be represented.
+                for dep_group in deps or []:
+                    if not inclusions & self.MUTEX_GROUPS[dep_group]:
+                        raise BadConf(
+                            'dep group "%s" is unfulfilled for "%s"' %
+                            (dep_group, name))
+
+                if group:
+                    overlap = inclusions & self.MUTEX_GROUPS[group]
+                    overlap.discard(name)
+                    if overlap:
+                        raise BadConf(
+                            '"%s" is a member of group "%s", but %s already ran'
+                            % (name, group, tuple(overlap)))
+
+                ret = f(config, **kwargs)
+                assert ret is None, 'Got return value (%s) from "%s"?' % (ret,
+                                                                          name)
+
+                return config
+
+            inner.WRAPPED = f
+            inner.INCLUDES = includes or []
+
+            assert name not in self.CONFIG_ITEMS, (
+                '%s is already in CONFIG_ITEMS' % name)
+            self.CONFIG_ITEMS[name] = inner
+            if group:
+                self.MUTEX_GROUPS.setdefault(group, set()).add(name)
+            inner.IS_ROOT = is_root
+            if is_root:
+                assert not self.ROOT_CONFIG_ITEM, (
+                    'may only have one root config_ctx!')
+                self.ROOT_CONFIG_ITEM = inner
+            return inner
+
+        return decorator
+
+
+def config_item_context(CONFIG_SCHEMA):
+    """Create a configuration context.
+
+    Args:
+        CONFIG_SCHEMA: A callable taking zero or more (defaulted) arguments and
+            returning a `ConfigGroup`. It defines the schema for all config
+            blobs manipulated in this context.
+
+    Returns:
+        A `ConfigContext` (the `config_ctx` decorator) for this context.
+    """
+    return ConfigContext(CONFIG_SCHEMA)
+
+
+class AutoHide:
+    """Sentinel `hidden` mode: render a field only when not at its default."""
+
+
+AutoHide = AutoHide()
+
+
+class ConfigBase:
+    """The root interface for all config schema types."""
+
+    # Declared at class scope so static analysis sees them; each instance
+    # assigns its own via object.__setattr__ in __init__ (which bypasses the
+    # subclass __setattr__ overrides, e.g. ConfigGroup's).
+    _hidden_mode: object
+    _inclusions: set
+
+    def __init__(self, hidden=AutoHide):
+        """
+        Args:
+            hidden:
+                True: excluded from `ConfigGroup.as_jsonish()` output (you keep
+                    full read/write access otherwise).
+                False: always rendered by `as_jsonish()`.
+                AutoHide: rendered only when `_is_default()` is False.
+        """
+        # Bypass subclasses that override __setattr__.
+        object.__setattr__(self, '_hidden_mode', hidden)
+        object.__setattr__(self, '_inclusions', set())
+
+    def get_val(self):
+        """Return the native value of this config object."""
+        return self
+
+    def set_val(self, val):
+        """Reset this config object's value from `val`."""
+        raise NotImplementedError
+
+    def reset(self):
+        """Reset this config object to its initial state."""
+        raise NotImplementedError
+
+    def as_jsonish(self, include_hidden=False):
+        """Return this config object's value as simple JSON-compatible types."""
+        raise NotImplementedError
+
+    def complete(self):
+        """Return True iff this blob is fully viable (required fields set)."""
+        raise NotImplementedError
+
+    def _is_default(self):
+        """Return True iff this blob is at its default value."""
+        raise NotImplementedError
+
+    @property
+    def _hidden(self):
+        """Return True iff this blob is hidden from `as_jsonish()`."""
+        if self._hidden_mode is AutoHide:
+            return self._is_default()
+        return self._hidden_mode
+
+
+class ConfigGroup(ConfigBase):
+    """Provides hierarchy to a configuration schema.
+
+    Example:
+        config_blob = ConfigGroup(
+            some_item=Single(str),
+            group=ConfigGroup(
+                numbahs=Set(int),
+            ),
+        )
+        config_blob.some_item = 'hello'
+        config_blob.group.numbahs.update(range(10))
+    """
+
+    def __init__(self, hidden=AutoHide, **type_map):
+        """Expects `type_map` to be a `{python_name -> ConfigBase}` mapping."""
+        super().__init__(hidden)
+        assert type_map, 'A ConfigGroup with no type_map is meaningless.'
+
+        object.__setattr__(self, '_type_map', type_map)
+        for name, typeval in self._type_map.items():
+            typeAssert(typeval, ConfigBase)
+            object.__setattr__(self, name, typeval)
+
+    def __getattribute__(self, name):
+        obj = object.__getattribute__(self, name)
+        if isinstance(obj, ConfigBase):
+            return obj.get_val()
+        return obj
+
+    def __setattr__(self, name, val):
+        obj = object.__getattribute__(self, name)
+        typeAssert(obj, ConfigBase)
+        obj.set_val(val)
+
+    def __delattr__(self, name):
+        obj = object.__getattribute__(self, name)
+        typeAssert(obj, ConfigBase)
+        obj.reset()
+
+    def set_val(self, val):
+        if isinstance(val, ConfigBase):
+            val = val.as_jsonish(include_hidden=True)
+        typeAssert(val, collections.abc.Mapping)
+
+        val = dict(val)  # Copied because we pop below.
+        for name, config_obj in self._type_map.items():
+            if name in val:
+                try:
+                    config_obj.set_val(val.pop(name))
+                except Exception as e:
+                    raise type(e)('While assigning key %r: %s' % (name, e))
+
+        if val:
+            raise TypeError('Got extra keys while setting ConfigGroup: %s' %
+                            val)
+
+    def as_jsonish(self, include_hidden=False):
+        return {
+            n: v.as_jsonish(include_hidden)
+            for n, v in self._type_map.items()
+            if include_hidden or not v._hidden  # pylint: disable=protected-access
+        }
+
+    def reset(self):
+        for v in self._type_map.values():
+            v.reset()
+
+    def complete(self):
+        return all(v.complete() for v in self._type_map.values())
+
+    def _is_default(self):
+        # pylint: disable=protected-access
+        return all(v._is_default() for v in self._type_map.values())
+
+
+class ConfigList(ConfigBase, collections.abc.MutableSequence):
+    """Provides ordered repetition to a configuration schema.
+
+    Example:
+        config_blob = ConfigGroup(
+            some_items=ConfigList(
+                lambda: ConfigGroup(
+                    herp=Single(int),
+                    derp=Single(str),
+                )
+            )
+        )
+        config_blob.some_items.append({'herp': 1})
+        config_blob.some_items[0].derp = 'bob'
+    """
+
+    def __init__(self, item_schema, hidden=AutoHide):
+        """
+        Args:
+            item_schema: A function returning an instance of `ConfigGroup` -- the
+                schema of each element.
+        """
+        super().__init__(hidden=hidden)
+        typeAssert(item_schema, types.FunctionType)
+        typeAssert(item_schema(), ConfigGroup)
+        self.item_schema = item_schema
+        self.data = []
+
+    def __getitem__(self, index):
+        return self.data.__getitem__(index)
+
+    def __setitem__(self, index, value):
+        datum = self.item_schema()
+        datum.set_val(value)
+        return self.data.__setitem__(index, datum)
+
+    def __delitem__(self, index):
+        return self.data.__delitem__(index)
+
+    def __len__(self):
+        return len(self.data)
+
+    def insert(self, index, value):
+        datum = self.item_schema()
+        datum.set_val(value)
+        return self.data.insert(index, datum)
+
+    def add(self):
+        self.append({})
+        return self[-1]
+
+    def reset(self):
+        self.data = []
+
+    def complete(self):
+        return all(i.complete() for i in self.data)
+
+    def set_val(self, val):
+        if isinstance(val, ConfigList):
+            val = val.as_jsonish(include_hidden=True)
+
+        typeAssert(val, list)
+        self.reset()
+        for item in val:
+            self.append(item)
+
+    def as_jsonish(self, include_hidden=False):
+        return [
+            i.as_jsonish(include_hidden) for i in self.data
+            if include_hidden or not i._hidden  # pylint: disable=protected-access
+        ]
+
+    def _is_default(self):
+        # pylint: disable=protected-access
+        return all(v._is_default() for v in self.data)
+
+
+class Dict(ConfigBase, collections.abc.MutableMapping):
+    """Provides a semi-homogeneous dict()-like configuration object."""
+
+    def __init__(self,
+                 item_fn=lambda i: i,
+                 jsonish_fn=dict,
+                 value_type=None,
+                 hidden=AutoHide):
+        """
+        Args:
+            item_fn: Renders (k, v) pairs to input items for `jsonish_fn`.
+                Defaults to the identity function.
+            jsonish_fn: Renders the list of `item_fn` outputs to a
+                JSON-compatible type. Defaults to `dict`.
+            value_type: A type used to constrain assigned values. When None any
+                type is accepted.
+            hidden: See `ConfigBase`.
+        """
+        super().__init__(hidden)
+        self.value_type = value_type
+        self.item_fn = item_fn
+        self.jsonish_fn = jsonish_fn
+        self.data = {}
+
+    def __getitem__(self, k):
+        return self.data.__getitem__(k)
+
+    def __setitem__(self, k, v):
+        if self.value_type:
+            typeAssert(v, self.value_type)
+        return self.data.__setitem__(k, v)
+
+    def __delitem__(self, k):
+        return self.data.__delitem__(k)
+
+    def __iter__(self):
+        return iter(self.data)
+
+    def __len__(self):
+        return len(self.data)
+
+    def __repr__(self):
+        return repr(self.data)
+
+    def __str__(self):
+        return str(self.data)
+
+    def set_val(self, val):
+        if isinstance(val, Dict):
+            val = val.data
+        typeAssert(val, collections.abc.Mapping)
+        if self.value_type:
+            for v in val.values():
+                typeAssert(v, self.value_type)
+        self.data = val
+
+    def as_jsonish(self, _include_hidden=None):
+        return self.jsonish_fn([
+            self.item_fn(item)
+            for item in sorted(self.data.items(), key=lambda x: x[0])
+        ])
+
+    def reset(self):
+        self.data.clear()
+
+    def complete(self):
+        return True
+
+    def _is_default(self):
+        return not self.data
+
+
+class List(ConfigBase, collections.abc.MutableSequence):
+    """Provides a semi-homogeneous list()-like configuration object."""
+
+    def __init__(self, inner_type, jsonish_fn=list, hidden=AutoHide):
+        """
+        Args:
+            inner_type: The type of data in this list (e.g. str, int, ...). May
+                be a tuple of types to allow more than one.
+            jsonish_fn: Reduces the list to a JSON-compatible type. Defaults to
+                `list`.
+            hidden: See `ConfigBase`.
+        """
+        super().__init__(hidden)
+        self.inner_type = inner_type
+        self.jsonish_fn = jsonish_fn
+        self.data = []
+
+    def __getitem__(self, index):
+        return self.data[index]
+
+    def __setitem__(self, index, value):
+        typeAssert(value, self.inner_type)
+        self.data[index] = value
+
+    def __delitem__(self, index):
+        del self.data[index]
+
+    def __len__(self):
+        return len(self.data)
+
+    def __radd__(self, other):
+        if not isinstance(other, list):
+            other = list(other)
+        return other + self.data
+
+    def insert(self, index, value):
+        typeAssert(value, self.inner_type)
+        self.data.insert(index, value)
+
+    def set_val(self, val):
+        for v in val:
+            typeAssert(v, self.inner_type)
+        self.data = list(val)
+
+    def as_jsonish(self, _include_hidden=None):
+        return self.jsonish_fn(self.data)
+
+    def reset(self):
+        self.data = []
+
+    def complete(self):
+        return True
+
+    def _is_default(self):
+        return not self.data
+
+
+class Set(ConfigBase, collections.abc.MutableSet):
+    """Provides a semi-homogeneous set()-like configuration object."""
+
+    def __init__(self, inner_type, jsonish_fn=list, hidden=AutoHide):
+        """
+        Args:
+            inner_type: The type of data in this set (e.g. str, int, ...). May be
+                a tuple of types to allow more than one.
+            jsonish_fn: Reduces the set to a JSON-compatible type. Defaults to
+                `list`.
+            hidden: See `ConfigBase`.
+        """
+        super().__init__(hidden)
+        self.inner_type = inner_type
+        self.jsonish_fn = jsonish_fn
+        self.data = set()
+
+    def __contains__(self, val):
+        return val in self.data
+
+    def __iter__(self):
+        return iter(self.data)
+
+    def __len__(self):
+        return len(self.data)
+
+    def add(self, value):
+        typeAssert(value, self.inner_type)
+        self.data.add(value)
+
+    def update(self, values):
+        for value in values:
+            if value not in self:
+                self.add(value)
+
+    def discard(self, value):
+        self.data.discard(value)
+
+    def set_val(self, val):
+        for v in val:
+            typeAssert(v, self.inner_type)
+        self.data = set(val)
+
+    def as_jsonish(self, _include_hidden=None):
+        return self.jsonish_fn(sorted(self.data))
+
+    def reset(self):
+        self.data = set()
+
+    def complete(self):
+        return True
+
+    def _is_default(self):
+        return not self.data
+
+
+class Single(ConfigBase):
+    """Provides a configuration object which holds a single 'simple' type."""
+
+    def __init__(self,
+                 inner_type,
+                 jsonish_fn=lambda x: x,
+                 empty_val=None,
+                 required=True,
+                 hidden=AutoHide):
+        """
+        Args:
+            inner_type: The type of data held (e.g. str, int, ...). May be a
+                tuple of types to allow more than one.
+            jsonish_fn: Reduces the data to a JSON-compatible type. Defaults to
+                the identity function.
+            empty_val: The value used to initialize this object and on `reset()`.
+            required(bool): True iff this item must hold a non-`empty_val` value
+                for the blob to be `complete()`.
+            hidden: See `ConfigBase`.
+        """
+        super().__init__(hidden)
+        self.inner_type = inner_type
+        self.jsonish_fn = jsonish_fn
+        self.empty_val = empty_val
+        self.data = empty_val
+        self.required = required
+
+    def get_val(self):
+        return self.data
+
+    def set_val(self, val):
+        if isinstance(val, Single):
+            val = val.data
+        if val is not self.empty_val:
+            typeAssert(val, self.inner_type)
+        self.data = val
+
+    def as_jsonish(self, _include_hidden=None):
+        return self.jsonish_fn(self.data)
+
+    def reset(self):
+        self.data = self.empty_val
+
+    def complete(self):
+        return not self.required or self.data is not self.empty_val
+
+    def _is_default(self):
+        return self.data is self.empty_val
+
+
+class Static(ConfigBase):
+    """Holds a single, hidden, immutable data object.
+
+    Very useful for holding the 'input' configuration values threaded in through
+    the schema factory's arguments (the `CONFIG_VARS` a caller passes).
+    """
+
+    def __init__(self, value, hidden=AutoHide):
+        super().__init__(hidden=hidden)
+        # Hash the value to ensure it is immutable all the way down.
+        hash(value)
+        self.data = value
+
+    def get_val(self):
+        return self.data
+
+    def set_val(self, val):
+        raise TypeError('Cannot assign to a Static config member')
+
+    def as_jsonish(self, _include_hidden=None):
+        return self.data
+
+    def reset(self):
+        assert False
+
+    def complete(self):
+        return True
+
+    def _is_default(self):
+        return True
+
+
+class Enum(ConfigBase):
+    """Provides a configuration object which holds one of a fixed set of values.
+    """
+
+    def __init__(self, *values, **kwargs):
+        """
+        Args:
+            values: The list of acceptable values.
+            inner_type: The type of data held (e.g. str, int, ...). May be a
+                tuple of types. Defaults to `str`.
+            jsonish_fn: Reduces the data to a JSON-compatible type. Defaults to
+                the identity function.
+            required(bool): True iff this item must hold a value for the blob to
+                be `complete()`.
+            hidden: See `ConfigBase`.
+        """
+        super().__init__(kwargs.get('hidden', AutoHide))
+        if not values:
+            raise ValueError('Enumerations cannot be empty')
+        self.values = values
+        self.inner_type = kwargs.get('inner_type', str)
+        self.jsonish_fn = kwargs.get('jsonish_fn', lambda x: x)
+        self.data = None
+        self.required = kwargs.get('required', True)
+
+    def get_val(self):
+        return self.data
+
+    def set_val(self, val):
+        if isinstance(val, Enum):
+            val = val.data
+        typeAssert(val, self.inner_type)
+        if val not in self.values:
+            raise ValueError('Expected %r to be one of %r' %
+                             (val, ', '.join(self.values)))
+        self.data = val
+
+    def as_jsonish(self, _include_hidden=None):
+        return self.jsonish_fn(self.data)
+
+    def reset(self):
+        self.data = None
+
+    def complete(self):
+        return not self.required or self.data is not None
+
+    def _is_default(self):
+        return self.data is None

--- a/tools/recipes/engine.py
+++ b/tools/recipes/engine.py
@@ -97,6 +97,32 @@ def _find_api_class(api_module: types.ModuleType,
     return classes[0]
 
 
+def _load_config_ctx(module_name: str):
+    """Return the `ConfigContext` from a module's `config.py`, or None.
+
+    A module opts into the config system by defining a `config.py` that assigns
+    exactly one `config_item_context(...)` result at module scope (the module's
+    CONFIG_CTX). Modules without a `config.py` return None (they have no
+    config). See the "Configs" section of README.md.
+    """
+    config_path = RECIPES_ROOT / MODULES_PKG / module_name / 'config.py'
+    if not config_path.exists():
+        return None
+    from config import ConfigContext  # pylint: disable=import-outside-toplevel
+    config_module = importlib.import_module(f'{MODULES_PKG}.{module_name}'
+                                            '.config')
+    contexts = [
+        value for value in vars(config_module).values()
+        if isinstance(value, ConfigContext)
+    ]
+    if len(contexts) != 1:
+        raise RuntimeError(
+            f"recipe module '{module_name}' has a config.py but defines "
+            f'{len(contexts)} config contexts; expected exactly one '
+            '(from config_item_context(...))')
+    return contexts[0]
+
+
 class _Engine:
     """Resolves DEPS and instantiates module APIs, caching by module name."""
 
@@ -142,11 +168,13 @@ class _Engine:
         api_class = _find_api_class(api_module, name)
 
         inst = api_class()
-        # Seed engine-provided values (workspace, brave-core ref) so modules can
-        # use them. setattr keeps the engine out of the instance's protected
-        # members directly.
+        # Seed engine-provided values (workspace, brave-core ref, and the
+        # module's name and config context) so modules can use them. setattr
+        # keeps the engine out of the instance's protected members directly.
         setattr(inst, '_workspace', self._workspace)
         setattr(inst, '_brave_core_ref', self._brave_core_ref)
+        setattr(inst, '_module_name', name)
+        setattr(inst, '_config_ctx', _load_config_ctx(name))
         for dep_name in deps:
             setattr(inst.m, dep_name,
                     self._instantiate_module(dep_name, chain + [name]))

--- a/tools/recipes/recipe_api.py
+++ b/tools/recipes/recipe_api.py
@@ -50,6 +50,103 @@ class RecipeApi:
         # touch the real machine. When set, they read/mutate this instead. Its
         # presence (`self._test is not None`) is the sole test-mode flag.
         self._test = None
+        # The module's name, seeded by the engine (used in config error text).
+        self._module_name: str = type(self).__name__
+        # The module's configuration context (the `ConfigContext` from its
+        # `config.py`), seeded by the engine, or None if the module has no
+        # config. See `set_config`/`make_config`/`apply_config` below and the
+        # "Configs" section of README.md.
+        self._config_ctx = None
+        # The module's current config blob (a `config.ConfigGroup`), or None
+        # until a config is applied. A module reads it as `self.c`, and its
+        # users reach it directly as `api.<module>.c`.
+        self.c = None
 
     def initialise(self) -> None:
         """Hook run once after DEPS are injected. Override for setup."""
+
+    # -- Configs (see the "Configs" section of README.md) ---------------------
+
+    def get_config_defaults(self) -> dict:
+        """Return dynamic default `CONFIG_VARS` for this module's schema.
+
+        Override to compute default schema arguments at runtime. They are the
+        lowest-precedence source of `CONFIG_VARS`, overridden per-invocation by
+        the keyword arguments passed to `set_config`/`make_config`.
+        """
+        return {}
+
+    def make_config(self,
+                    config_name: str | None = None,
+                    optional: bool = False,
+                    **CONFIG_VARS):
+        """Return a fresh config blob for this module (without storing it)."""
+        return self.make_config_params(config_name, optional, **CONFIG_VARS)[0]
+
+    def _get_config_item(self, config_name: str, optional: bool = False):
+        """Look up a named config item in this module's context.
+
+        Returns None when `optional` and the name is unknown; otherwise raises
+        `KeyError` listing the module's valid config names.
+        """
+        ctx = self._config_ctx
+        try:
+            return ctx.CONFIG_ITEMS[config_name]
+        except KeyError:
+            if optional:
+                return None
+            raise KeyError(
+                '%s is not the name of a configuration for module %s: %s' %
+                (config_name, self._module_name, sorted(
+                    ctx.CONFIG_ITEMS))) from None
+
+    def make_config_params(self,
+                           config_name: str | None,
+                           optional: bool = False,
+                           **CONFIG_VARS):
+        """Return `(config_blob, params)` for this module.
+
+        `params` are merged from, in increasing precedence:
+          * `get_config_defaults()`
+          * `CONFIG_VARS`
+        and splatted into the schema factory. When `config_name` is given, the
+        named config item (with its root and includes) is applied to the blob.
+        """
+        generic_params = self.get_config_defaults()  # generic defaults
+        generic_params.update(CONFIG_VARS)  # per-invocation values
+
+        ctx = self._config_ctx
+        if optional and not ctx:
+            return None, generic_params
+
+        assert ctx, '%s has no config context' % self._module_name
+        params = self.get_config_defaults()  # generic defaults
+        itm = None
+        if config_name:
+            itm = self._get_config_item(config_name, optional)
+            if not itm:
+                return None, generic_params
+        params.update(CONFIG_VARS)  # per-invocation values
+
+        base = ctx.CONFIG_SCHEMA(**params)
+        if config_name is None:
+            return base, params
+        return itm(base), params
+
+    def set_config(self,
+                   config_name: str | None = None,
+                   optional: bool = False,
+                   **CONFIG_VARS) -> None:
+        """Set `self.c` to the named configuration for this module."""
+        config, _ = self.make_config_params(config_name, optional,
+                                            **CONFIG_VARS)
+        if config:
+            self.c = config
+
+    def apply_config(self,
+                     config_name: str,
+                     config_object=None,
+                     optional: bool = False) -> None:
+        """Apply a named config item on top of an existing blob (`self.c`)."""
+        itm = self._get_config_item(config_name)
+        itm(config_object or self.c, optional=optional)

--- a/tools/recipes/recipe_modules/hello/__init__.py
+++ b/tools/recipes/recipe_modules/hello/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""`hello` module: a worked example of the config system (see README.md)."""
+
+DEPS = ['path', 'step']

--- a/tools/recipes/recipe_modules/hello/api.py
+++ b/tools/recipes/recipe_modules/hello/api.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""The `hello` module API: greets its configured TARGET with its configured tool.
+"""
+
+from __future__ import annotations
+
+from recipe_api import RecipeApi
+
+
+class HelloApi(RecipeApi):
+    """Greets the configured TARGET, running the configured tool as a step."""
+
+    def greet(self) -> None:
+        """Greet `self.c.TARGET`, invoking `self.c.tool` as the step command."""
+        self.m.step('Greet Admired Individual', [
+            self.m.path.workspace / self.c.tool,
+            self.c.verb % self.c.TARGET,
+        ])

--- a/tools/recipes/recipe_modules/hello/config.py
+++ b/tools/recipes/recipe_modules/hello/config.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Configuration schema and items for the `hello` module.
+"""
+
+from __future__ import annotations
+
+from config import BadConf, ConfigGroup, Single, Static, config_item_context
+
+
+def BaseConfig(TARGET='Bob'):
+    # The schema for the 'config blobs' the hello module deals with. A blob is
+    # not complete() until every required entry has a value. Schema factory
+    # arguments are ALL_CAPS by convention and are threaded in as Static (input)
+    # data via set_config(..., TARGET=...).
+    return ConfigGroup(
+        verb=Single(str),
+        tool=Single(str, required=True),
+        TARGET=Static(str(TARGET)),
+    )
+
+
+config_ctx = config_item_context(BaseConfig)
+
+
+# `is_root` means every config item applies this one first.
+@config_ctx(is_root=True)
+def BASE(c):
+    if c.TARGET == 'DarthVader':
+        c.verb = 'Die in a fire %s!'
+    else:
+        c.verb = 'Hello %s'
+
+
+@config_ctx(group='tool')  # Items in the same group are mutually exclusive.
+def super_tool(c):
+    if c.TARGET != 'Charlie':
+        raise BadConf('Can only use super tool for Charlie!')
+    c.tool = 'unicorn.py'
+
+
+@config_ctx(group='tool')
+def default_tool(c):
+    c.tool = 'echo'

--- a/tools/recipes/recipe_modules/hello/examples/__init__.py
+++ b/tools/recipes/recipe_modules/hello/examples/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tools/recipes/recipe_modules/hello/examples/evil.py
+++ b/tools/recipes/recipe_modules/hello/examples/evil.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example: a schema arg steering a config item's behaviour (DarthVader)."""
+
+from __future__ import annotations
+
+from post_process import DropExpectation, StepCommandRE
+
+DEPS = ['hello']
+
+
+def RunSteps(api):
+    api.hello.set_config('default_tool', TARGET='DarthVader')
+    api.hello.greet()  # Causes 'DarthVader' to despair, with echo.
+
+
+def GenTests(api):
+    yield api.test(
+        'darth',
+        api.post_process(StepCommandRE, 'Greet Admired Individual',
+                         [r'.*\becho', 'Die in a fire DarthVader!']),
+        api.post_process(DropExpectation),
+    )

--- a/tools/recipes/recipe_modules/hello/examples/rainbow.py
+++ b/tools/recipes/recipe_modules/hello/examples/rainbow.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example: overriding a schema arg via CONFIG_VARS (`super_tool`, 'Charlie')."""
+
+from __future__ import annotations
+
+from post_process import DropExpectation, StepCommandRE
+
+DEPS = ['hello']
+
+
+def RunSteps(api):
+    api.hello.set_config('super_tool', TARGET='Charlie')
+    api.hello.greet()  # Greets 'Charlie' with unicorn.py.
+
+
+def GenTests(api):
+    yield api.test(
+        'charlie',
+        api.post_process(StepCommandRE, 'Greet Admired Individual',
+                         [r'.*\bunicorn.py', 'Hello Charlie']),
+        api.post_process(DropExpectation),
+    )

--- a/tools/recipes/recipe_modules/hello/examples/simple.py
+++ b/tools/recipes/recipe_modules/hello/examples/simple.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example: the plain default configuration (`default_tool`, TARGET 'Bob')."""
+
+from __future__ import annotations
+
+from post_process import DropExpectation, StepCommandRE
+
+DEPS = ['hello']
+
+
+def RunSteps(api):
+    api.hello.set_config('default_tool')
+    api.hello.greet()  # Greets 'Bob' with echo.
+
+
+def GenTests(api):
+    yield api.test(
+        'bob',
+        api.post_process(StepCommandRE, 'Greet Admired Individual',
+                         [r'.*\becho', 'Hello Bob']),
+        api.post_process(DropExpectation),
+    )

--- a/tools/recipes/recipe_modules/hello/tests/__init__.py
+++ b/tools/recipes/recipe_modules/hello/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tools/recipes/recipe_modules/hello/tests/badconf.py
+++ b/tools/recipes/recipe_modules/hello/tests/badconf.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Edge case: a config item raising `BadConf` surfaces as an EXCEPTION."""
+
+from __future__ import annotations
+
+from post_process import DropExpectation, StatusException
+
+DEPS = ['hello']
+
+
+def RunSteps(api):
+    # super_tool only accepts TARGET 'Charlie'; anything else raises BadConf.
+    api.hello.set_config('super_tool', TARGET='Not Charlie')
+
+
+def GenTests(api):
+    yield api.test(
+        'badconf',
+        api.post_process(StatusException),
+        api.post_process(DropExpectation),
+        status='EXCEPTION',
+    )

--- a/tools/recipes/unittests/config_test.py
+++ b/tools/recipes/unittests/config_test.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for the config DSL (config.py) and its RecipeApi/engine wiring."""
+
+# White-box tests: they exercise engine internals (`_Engine`,
+# `_load_config_ctx`) and RecipeApi config plumbing, so protected-access is
+# intentional.
+# pylint: disable=protected-access
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# pylint: disable=wrong-import-position
+import config
+import engine
+from config import (BadConf, ConfigContext, ConfigGroup, ConfigList, Dict,
+                    Enum, List, Set, Single, Static, config_item_context)
+from recipe_api import RecipeApi
+
+
+def _schema(TARGET='Bob'):
+    return ConfigGroup(
+        verb=Single(str),
+        tool=Single(str, required=True),
+        TARGET=Static(str(TARGET)),
+    )
+
+
+class SingleTest(unittest.TestCase):
+
+    def test_typecheck_and_complete(self):
+        s = Single(int)
+        self.assertFalse(s.complete())  # required, still empty_val
+        self.assertTrue(s._is_default())
+        s.set_val(5)
+        self.assertEqual(s.get_val(), 5)
+        self.assertTrue(s.complete())
+        self.assertFalse(s._is_default())
+        with self.assertRaises(TypeError):
+            s.set_val('nope')
+
+    def test_not_required_is_complete_when_empty(self):
+        self.assertTrue(Single(int, required=False).complete())
+
+    def test_reset_and_set_from_single(self):
+        s = Single(int)
+        s.set_val(3)
+        other = Single(int)
+        other.set_val(s)  # accepts another Single
+        self.assertEqual(other.get_val(), 3)
+        s.reset()
+        self.assertIsNone(s.get_val())
+
+
+class StaticTest(unittest.TestCase):
+
+    def test_immutable_and_always_complete(self):
+        st = Static('x')
+        self.assertEqual(st.get_val(), 'x')
+        self.assertTrue(st.complete())
+        self.assertTrue(st._is_default())
+        with self.assertRaises(TypeError):
+            st.set_val('y')
+
+    def test_unhashable_value_rejected(self):
+        with self.assertRaises(TypeError):
+            Static(['a', 'list', 'is', 'mutable'])
+
+
+class EnumTest(unittest.TestCase):
+    # astroid's enum brain misfires on our config.Enum (a plain ConfigBase
+    # subclass, not enum.Enum): `Enum('a', 'b')` matches the stdlib functional
+    # Enum API, so it infers instances as enum members lacking our methods. The
+    # methods exist and the tests pass at runtime.
+    # pylint: disable=no-member
+
+    def test_membership_and_type(self):
+        e = Enum('a', 'b')
+        self.assertFalse(e.complete())
+        e.set_val('a')
+        self.assertEqual(e.get_val(), 'a')
+        self.assertTrue(e.complete())
+        with self.assertRaises(ValueError):
+            e.set_val('c')
+        with self.assertRaises(TypeError):
+            e.set_val(1)
+
+    def test_empty_values_rejected(self):
+        with self.assertRaises(ValueError):
+            Enum()
+
+    def test_reset_and_not_required(self):
+        e = Enum('a', required=False)
+        self.assertTrue(e.complete())
+        e.set_val('a')
+        e.reset()
+        self.assertIsNone(e.get_val())
+
+    def test_set_from_enum(self):
+        src = Enum('a', 'b')
+        src.set_val('b')
+        dst = Enum('a', 'b')
+        dst.set_val(src)
+        self.assertEqual(dst.get_val(), 'b')
+
+
+class ContainerTest(unittest.TestCase):
+
+    def test_dict_value_type_and_jsonish_sorted(self):
+        d = Dict(value_type=int)
+        d['b'] = 2
+        d['a'] = 1
+        self.assertTrue(d.complete())
+        self.assertFalse(d._is_default())
+        self.assertEqual(d.as_jsonish(), {'a': 1, 'b': 2})
+        self.assertIn("'a': 1", repr(d))
+        self.assertIn("'a': 1", str(d))
+        with self.assertRaises(TypeError):
+            d['c'] = 'not int'
+        del d['a']
+        self.assertEqual(len(d), 1)
+        d.reset()
+        self.assertTrue(d._is_default())
+
+    def test_dict_set_val_typechecks(self):
+        d = Dict(value_type=int)
+        d.set_val({'a': 1})
+        self.assertEqual(d.as_jsonish(), {'a': 1})
+        with self.assertRaises(TypeError):
+            d.set_val({'a': 'x'})
+        other = Dict()
+        other.set_val(d)  # accepts another Dict
+        self.assertEqual(dict(other), {'a': 1})
+
+    def test_list_typecheck_and_radd(self):
+        li = List(int)
+        li.append(1)
+        li.insert(0, 0)
+        self.assertEqual([0] + li, [0, 0, 1])  # __radd__
+        li[0] = 9
+        self.assertEqual(li.as_jsonish(), [9, 1])
+        del li[0]
+        with self.assertRaises(TypeError):
+            li.append('x')
+        li.set_val([3, 4])
+        self.assertEqual(li.as_jsonish(), [3, 4])
+        with self.assertRaises(TypeError):
+            li.set_val(['x'])
+        li.reset()
+        self.assertTrue(li._is_default())
+
+    def test_set_add_update_discard(self):
+        s = Set(int)
+        s.add(1)
+        s.update([1, 2, 3])  # dedups
+        self.assertEqual(s.as_jsonish(), [1, 2, 3])
+        self.assertIn(2, s)
+        self.assertEqual(len(s), 3)
+        s.discard(2)
+        self.assertNotIn(2, s)
+        with self.assertRaises(TypeError):
+            s.add('x')
+        s.set_val([7, 8])
+        self.assertEqual(s.as_jsonish(), [7, 8])
+        with self.assertRaises(TypeError):
+            s.set_val(['x'])
+        s.reset()
+        self.assertTrue(s._is_default())
+
+
+class ConfigListTest(unittest.TestCase):
+
+    def _factory(self):
+        return lambda: ConfigGroup(herp=Single(int), derp=Single(str))
+
+    def test_append_index_add_complete(self):
+        cl = ConfigList(self._factory())
+        cl.append({'herp': 1})
+        cl[0].derp = 'bob'
+        self.assertEqual(cl[0].derp, 'bob')
+        self.assertTrue(cl.complete())  # both required fields now set
+        item = cl.add()
+        item.herp = 2
+        self.assertEqual(len(cl), 2)
+        cl.insert(0, {'herp': 9})
+        self.assertEqual(cl[0].herp, 9)
+        del cl[0]
+        self.assertEqual(len(cl), 2)
+        self.assertEqual(cl.as_jsonish()[0]['herp'], 1)
+
+    def test_set_val_and_reset(self):
+        cl = ConfigList(self._factory())
+        cl.set_val([{'herp': 1}])
+        self.assertEqual(cl[0].herp, 1)
+        other = ConfigList(self._factory())
+        other.set_val(cl)  # accepts another ConfigList
+        self.assertEqual(other[0].herp, 1)
+        cl.reset()
+        self.assertEqual(len(cl), 0)
+        self.assertTrue(cl._is_default())
+
+    def test_bad_item_schema(self):
+        with self.assertRaises(TypeError):
+            ConfigList('not a function')
+        with self.assertRaises(TypeError):
+            ConfigList(lambda: Single(int))  # not a ConfigGroup
+
+
+class ConfigGroupTest(unittest.TestCase):
+
+    def test_attr_proxy_and_closed_schema(self):
+        c = _schema()
+        self.assertEqual(c.TARGET, 'Bob')  # Static unwrapped
+        c.verb = 'Hi %s'
+        self.assertEqual(c.verb, 'Hi %s')
+        with self.assertRaises(AttributeError):
+            c.unknown = 1  # cannot add keys (name is not a schema member)
+        with self.assertRaises(TypeError):
+            c.TARGET = 'x'  # Static rejects assignment
+
+    def test_set_val_extra_keys_and_from_group(self):
+        c = _schema()
+        c.set_val({'verb': 'V', 'tool': 'echo'})
+        self.assertEqual(c.tool, 'echo')
+        with self.assertRaises(TypeError):
+            c.set_val({'nope': 1})
+        # set_val wraps the child's error with the offending key name.
+        with self.assertRaises(TypeError) as ctx:
+            c.set_val({'tool': 123})
+        self.assertIn("'tool'", str(ctx.exception))
+        # A group can be seeded from another group (via its jsonish form). Uses
+        # a Static-free group: Static members reject assignment, so a group with
+        # one cannot be copied wholesale.
+        src = ConfigGroup(tool=Single(str))
+        src.tool = 'echo'
+        dst = ConfigGroup(tool=Single(str))
+        dst.set_val(src)
+        self.assertEqual(dst.tool, 'echo')
+
+    def test_as_jsonish_hidden_modes(self):
+        c = ConfigGroup(
+            shown=Single(str, hidden=False),
+            auto=Single(str),  # AutoHide: hidden while default
+            always=Single(str, hidden=True),
+        )
+        # Defaults: shown always present, auto hidden (default), always hidden.
+        self.assertEqual(set(c.as_jsonish()), {'shown'})
+        self.assertEqual(set(c.as_jsonish(include_hidden=True)),
+                         {'shown', 'auto', 'always'})
+        c.auto = 'now-set'
+        self.assertEqual(set(c.as_jsonish()), {'shown', 'auto'})
+
+    def test_delattr_resets(self):
+        c = _schema()
+        c.verb = 'V'
+        del c.verb
+        self.assertIsNone(c.verb)
+
+    def test_complete(self):
+        c = _schema()
+        self.assertFalse(c.complete())  # verb and tool are required
+        c.verb = 'Hi %s'
+        c.tool = 'echo'
+        self.assertTrue(c.complete())  # TARGET (Static) is always complete
+
+    def test_reset(self):
+        # A group containing a Static cannot be reset (Static is write-once), so
+        # reset() is only meaningful on a Static-free group.
+        c = ConfigGroup(verb=Single(str), tool=Single(str))
+        c.verb = 'Hi %s'
+        c.tool = 'echo'
+        self.assertTrue(c.complete())
+        c.reset()
+        self.assertFalse(c.complete())
+
+    def test_empty_type_map_rejected(self):
+        with self.assertRaises(AssertionError):
+            ConfigGroup()
+
+
+class ConfigContextTest(unittest.TestCase):
+
+    def test_config_item_context_returns_context(self):
+        self.assertIsInstance(config_item_context(_schema), ConfigContext)
+
+    def test_root_auto_applied_and_includes(self):
+        ctx = config_item_context(_schema)
+
+        @ctx(is_root=True)
+        def BASE(c):  # pylint: disable=unused-variable
+            c.verb = 'Hello %s'
+
+        @ctx()
+        def use_echo(c):  # pylint: disable=unused-variable
+            c.tool = 'echo'
+
+        @ctx(includes=('use_echo', ))
+        def combo(c):  # pylint: disable=unused-variable
+            c.verb = 'Yo %s'
+
+        blob = ctx.CONFIG_ITEMS['combo'](None)
+        self.assertEqual(blob.tool, 'echo')  # via include
+        self.assertEqual(blob.verb, 'Yo %s')  # root ran, then combo overrode
+
+    def test_double_apply_raises_unless_optional(self):
+        ctx = config_item_context(_schema)
+
+        @ctx()
+        def item(c):  # pylint: disable=unused-variable
+            c.tool = 'echo'
+
+        blob = ctx.CONFIG_ITEMS['item'](None)
+        with self.assertRaises(BadConf):
+            ctx.CONFIG_ITEMS['item'](blob)
+        # optional=True makes re-application a silent no-op.
+        self.assertIs(ctx.CONFIG_ITEMS['item'](blob, optional=True), blob)
+
+    def test_group_mutual_exclusion(self):
+        ctx = config_item_context(_schema)
+
+        @ctx(group='tool')
+        def a(c):  # pylint: disable=unused-variable
+            c.tool = 'a'
+
+        @ctx(group='tool')
+        def b(c):  # pylint: disable=unused-variable
+            c.tool = 'b'
+
+        blob = ctx.CONFIG_ITEMS['a'](None)
+        with self.assertRaises(BadConf):
+            ctx.CONFIG_ITEMS['b'](blob)
+
+    def test_deps_satisfied_and_unfulfilled(self):
+        ctx = config_item_context(_schema)
+
+        @ctx(group='g')
+        def provider(c):  # pylint: disable=unused-variable
+            c.tool = 'echo'
+
+        @ctx(deps=('g', ))
+        def consumer(c):  # pylint: disable=unused-variable
+            c.verb = 'Hi %s'
+
+        with self.assertRaises(BadConf):
+            ctx.CONFIG_ITEMS['consumer'](None)  # 'g' unfulfilled
+        blob = ctx.CONFIG_ITEMS['provider'](None)
+        ctx.CONFIG_ITEMS['consumer'](blob)  # now satisfied
+        self.assertEqual(blob.verb, 'Hi %s')
+
+    def test_final_false_allows_reapplication(self):
+        ctx = config_item_context(_schema)
+
+        @ctx()
+        def item(c):  # pylint: disable=unused-variable
+            c.tool = 'echo'
+
+        blob = ctx.CONFIG_ITEMS['item'](None, final=False)
+        # Not recorded, so it can be applied again without BadConf.
+        ctx.CONFIG_ITEMS['item'](blob)
+
+    def test_include_propagates_badconf(self):
+        ctx = config_item_context(_schema)
+
+        @ctx()
+        def boom(c):  # pylint: disable=unused-variable
+            raise BadConf('kaboom')
+
+        @ctx(includes=('boom', ))
+        def outer(c):  # pylint: disable=unused-variable,unused-argument
+            pass
+
+        with self.assertRaises(BadConf) as exc:
+            ctx.CONFIG_ITEMS['outer'](None)
+        self.assertIn('includes "boom"', str(exc.exception))
+
+    def test_body_returning_value_asserts(self):
+        ctx = config_item_context(_schema)
+
+        @ctx()
+        def bad(c):  # pylint: disable=unused-variable,unused-argument
+            return 'nope'
+
+        with self.assertRaises(AssertionError):
+            ctx.CONFIG_ITEMS['bad'](None)
+
+    def test_duplicate_name_and_multiple_roots(self):
+        ctx = config_item_context(_schema)
+
+        @ctx()
+        def dup(c):  # pylint: disable=unused-variable,unused-argument
+            pass
+
+        with self.assertRaises(AssertionError):
+
+            @ctx()
+            def dup(c):  # noqa: F811  pylint: disable=function-redefined,unused-variable,unused-argument
+                pass
+
+        ctx2 = config_item_context(_schema)
+
+        @ctx2(is_root=True)
+        def root1(c):  # pylint: disable=unused-variable,unused-argument
+            pass
+
+        with self.assertRaises(AssertionError):
+
+            @ctx2(is_root=True)
+            def root2(c):  # pylint: disable=unused-variable,unused-argument
+                pass
+
+
+class RecipeApiConfigTest(unittest.TestCase):
+    """The RecipeApi config plumbing, exercised on the `hello` module."""
+
+    def _hello(self):
+        return engine._Engine()._instantiate_module('hello', [])
+
+    def test_set_config_and_greet_blob(self):
+        hello = self._hello()
+        hello.set_config('default_tool')
+        self.assertEqual(hello.c.tool, 'echo')
+        self.assertEqual(hello.c.TARGET, 'Bob')
+
+    def test_config_vars_override_defaults(self):
+        hello = self._hello()
+        blob = hello.make_config('super_tool', TARGET='Charlie')
+        self.assertEqual(blob.tool, 'unicorn.py')
+        self.assertEqual(blob.TARGET, 'Charlie')
+
+    def test_make_config_params_precedence(self):
+        hello = self._hello()
+        _, params = hello.make_config_params('default_tool', TARGET='Zed')
+        self.assertEqual(params['TARGET'], 'Zed')
+
+    def test_get_config_defaults_feeds_schema(self):
+        hello = self._hello()
+        hello.get_config_defaults = lambda: {'TARGET': 'Ada'}
+        hello.set_config('default_tool')
+        self.assertEqual(hello.c.TARGET, 'Ada')
+
+    def test_unknown_config_name_raises(self):
+        hello = self._hello()
+        with self.assertRaises(KeyError):
+            hello.set_config('does_not_exist')
+        # optional=True swallows the unknown name and leaves c unset.
+        hello.set_config('does_not_exist', optional=True)
+        self.assertIsNone(hello.c)
+
+    def test_apply_config_layers_onto_existing_blob(self):
+        hello = self._hello()
+        hello.set_config('default_tool')
+        with self.assertRaises(BadConf):
+            # default_tool already ran; super_tool is in the same group.
+            hello.apply_config('super_tool')
+
+    def test_module_without_config_ctx(self):
+        step = engine._Engine()._instantiate_module('step', [])
+        self.assertIsNone(step._config_ctx)
+        # optional make on a context-less module yields no blob.
+        self.assertIsNone(step.make_config(optional=True))
+        with self.assertRaises(AssertionError):
+            step.make_config_params(None)
+
+
+class EngineConfigDiscoveryTest(unittest.TestCase):
+
+    def test_loads_hello_context(self):
+        ctx = engine._load_config_ctx('hello')
+        self.assertIsInstance(ctx, ConfigContext)
+        self.assertEqual(set(ctx.CONFIG_ITEMS),
+                         {'BASE', 'super_tool', 'default_tool'})
+
+    def test_no_config_py_returns_none(self):
+        self.assertIsNone(engine._load_config_ctx('step'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is a recipe configuration DSL so a module can expose its tunable
"global" state as a schema plus a set of named, composable config items
that recipes select from.

Examples of use are provided in the README.

Bug: https://github.com/brave/brave-browser/issues/56748
