### PR TITLE
[bootstrap] Support older `python3` for downloading

### DIFF
--- a/tools/cr/bootstrap/bootstrap.py
+++ b/tools/cr/bootstrap/bootstrap.py
@@ -178,7 +178,10 @@ def _read(path: Path) -> str:
 
 def _write(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text, encoding='utf-8', newline='')
+    # `write_bytes` (not `write_text(newline=...)`, whose `newline` kwarg is
+    # Python 3.10+) so the UTF-8 text lands verbatim with LF endings under any
+    # `python3`. These are POSIX shell rc files, so LF is intended.
+    path.write_bytes(text.encode('utf-8'))
 
 
 def _install_posix(shells: list[str]) -> int:

--- a/tools/cr/tarball_installer.py
+++ b/tools/cr/tarball_installer.py
@@ -229,7 +229,15 @@ class TarballInstaller:
                 return names
         with tarfile.open(archive_path, mode='r:*') as tar:
             names = tar.getnames()
-            tar.extractall(path=self.dest_dir, filter='data')
+            # The `filter='data'` extraction guard (PEP 706) only exists on
+            # Python 3.12+ and the 3.8.17/3.9.17/3.10.12/3.11.4 backports. This
+            # script runs under whatever bare `python3` invoked `launcher.py`
+            # (no vpython guarantee), so fall back when the runtime is older.
+            # `tarfile.data_filter` is present exactly when the kwarg is.
+            if hasattr(tarfile, 'data_filter'):
+                tar.extractall(path=self.dest_dir, filter='data')
+            else:
+                tar.extractall(path=self.dest_dir)
             return names
 
     def _write_sidecars(self, member_names: list[str]) -> None:
@@ -239,10 +247,11 @@ class TarballInstaller:
             '_content_names': json.dumps(member_names),
         }
         for suffix, content in contents.items():
+            # `write_bytes` (not `write_text(newline=...)`, whose `newline`
+            # kwarg is Python 3.10+) so the exact `\n`-terminated UTF-8 lands on
+            # disk without platform newline translation, on any `python3`.
             sidecar_path(self.dest_dir, self.object_name,
-                         suffix).write_text(f'{content}\n',
-                                            encoding='utf-8',
-                                            newline='')
+                         suffix).write_bytes(f'{content}\n'.encode('utf-8'))
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tools/cr/tarball_installer_test.py
+++ b/tools/cr/tarball_installer_test.py
@@ -53,6 +53,34 @@ def _make_zip(members: list[tuple[str, bytes]]):
     return buf.getvalue()
 
 
+@contextlib.contextmanager
+def _simulate_pre_pep706_python():
+    """Make the runtime look like a `tarfile` without the PEP 706 filter.
+
+    Drops `tarfile.data_filter` and makes `extractall` reject the `filter`
+    kwarg, mimicking Python 3.12 predecessors (and pre-backport 3.8-3.11) so a
+    regression to an unconditional `filter='data'` call would fail here.
+    """
+    had_attr = hasattr(tarfile, 'data_filter')
+    saved_attr = getattr(tarfile, 'data_filter', None)
+    real_extractall = tarfile.TarFile.extractall
+
+    def _reject_filter(tar_self, *args, **kwargs):
+        if 'filter' in kwargs:
+            raise TypeError(
+                "extractall() got an unexpected keyword argument 'filter'")
+        return real_extractall(tar_self, *args, **kwargs)
+
+    if had_attr:
+        del tarfile.data_filter
+    with mock.patch.object(tarfile.TarFile, 'extractall', _reject_filter):
+        try:
+            yield
+        finally:
+            if had_attr:
+                tarfile.data_filter = saved_attr
+
+
 class TarballInstallerTest(unittest.TestCase):
     """Tests for `TarballInstaller` fetch/extract/sidecar mechanics."""
 
@@ -90,6 +118,17 @@ class TarballInstallerTest(unittest.TestCase):
         data = _make_tar([('bin/node', b'node'), ('README.md', b'hi')])
         installer = self._installer(data)
         self.assertTrue(installer.install(self._download(data)))
+        self.assertEqual((self.dest / 'bin/node').read_bytes(), b'node')
+        self.assertEqual((self.dest / 'README.md').read_bytes(), b'hi')
+        self.assertTrue(installer.is_installed())
+
+    def test_install_extracts_tarball_without_pep706_filter(self):
+        """Extraction still works on a Python that lacks the `filter='data'`
+        guard (this script runs under whatever bare `python3` is on $PATH)."""
+        data = _make_tar([('bin/node', b'node'), ('README.md', b'hi')])
+        installer = self._installer(data)
+        with _simulate_pre_pep706_python():
+            self.assertTrue(installer.install(self._download(data)))
         self.assertEqual((self.dest / 'bin/node').read_bytes(), b'node')
         self.assertEqual((self.dest / 'README.md').read_bytes(), b'hi')
         self.assertTrue(installer.is_installed())


### PR DESCRIPTION
This PR relaxes a bit our reliance on newer python implmentations when
extracting a tarball, so bootstrap can work correctly when running on
machines with an older python version.

Bug: https://github.com/brave/brave-browser/issues/56529
