### PR TITLE
[deps] `install_extra_deps.py` with `sync` arg parser

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -202,6 +202,7 @@ hooks = [
     'pattern': '.',
     'action': ['vpython3',
                'tools/cr/install_extra_deps.py',
+               'sync',
                'src/third_party/rust-toolchain']
   },
   {
@@ -209,6 +210,7 @@ hooks = [
     'pattern': '.',
     'action': ['vpython3',
                'tools/cr/install_extra_deps.py',
+               'sync',
                'src/brave/third_party/ast-grep/ast-grep-linux',
                'src/brave/third_party/ast-grep/ast-grep-mac',
                'src/brave/third_party/ast-grep/ast-grep-mac_arm64',
@@ -219,6 +221,7 @@ hooks = [
     'pattern': '.',
     'action': ['vpython3',
                'tools/cr/install_extra_deps.py',
+               'sync',
                'src/brave/third_party/node/node-linux-x64',
                'src/brave/third_party/node/node-mac-x64',
                'src/brave/third_party/node/node-mac-arm64',

--- a/tools/cr/README.md
+++ b/tools/cr/README.md
@@ -77,8 +77,8 @@ Shared abstractions used by the entry points and tests:
   }
   ```
 
-  Invoke with the target path, e.g.
-  `install_extra_deps.py src/path/to/install/dir`.
+  Invoke with the `sync` subcommand and the target path, e.g.
+  `install_extra_deps.py sync src/path/to/install/dir`.
 
 ## Subdirectories
 

--- a/tools/cr/install_extra_deps.py
+++ b/tools/cr/install_extra_deps.py
@@ -218,7 +218,13 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description='Download and install the bucket-hosted archive(s) for the '
         'given EXTRA_DEPS entries.')
-    parser.add_argument(
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    sync_parser = subparsers.add_parser(
+        'sync',
+        help='Download and install the bucket-hosted archive(s) for the given '
+        'EXTRA_DEPS entries.')
+    sync_parser.add_argument(
         'deps',
         nargs='+',
         choices=sorted(EXTRA_DEPS),
@@ -226,6 +232,7 @@ def main() -> int:
         help='One or more path keys in EXTRA_DEPS identifying the entries to '
         'install. Entries whose condition is false on this host are skipped, '
         'so a single invocation may list every per-platform variant.')
+
     args = parser.parse_args()
 
     runner = ExtraDepsRunner.from_checkout()

--- a/tools/cr/install_extra_deps_test.py
+++ b/tools/cr/install_extra_deps_test.py
@@ -472,7 +472,7 @@ class MainTest(unittest.TestCase):
                                    'from_checkout',
                                    return_value=runner):
                 with mock.patch.object(sys, 'argv',
-                                       ['install_extra_deps', dep]):
+                                       ['install_extra_deps', 'sync', dep]):
                     self.assertEqual(m.main(), 0)
         runner.install.assert_called_once_with(dep, self._FAKE_EXTRA_DEPS[dep])
 
@@ -486,7 +486,7 @@ class MainTest(unittest.TestCase):
                                    'from_checkout',
                                    return_value=runner):
                 with mock.patch.object(sys, 'argv',
-                                       ['install_extra_deps', *deps]):
+                                       ['install_extra_deps', 'sync', *deps]):
                     self.assertEqual(m.main(), 0)
         self.assertEqual(
             runner.install.call_args_list,
@@ -499,7 +499,7 @@ class MainTest(unittest.TestCase):
                                    'from_checkout') as checkout:
                 with mock.patch.object(
                         sys, 'argv',
-                    ['install_extra_deps', 'src/does/not/exist']):
+                    ['install_extra_deps', 'sync', 'src/does/not/exist']):
                     # argparse prints a usage error to stderr before exiting;
                     # keep it out of the test output.
                     with contextlib.redirect_stderr(io.StringIO()):


### PR DESCRIPTION
This change adds a `sync` arg subparser and corrects all callers to this
script. This is being done in preparation for the introduction of an
update command similar to `gclient setdep`

Bug: https://github.com/brave/brave-browser/issues/56723
