### PR TITLE
[deps] Add `setdep` for `EXTRA_DEPS`

### DIFF
--- a/tools/cr/README.md
+++ b/tools/cr/README.md
@@ -80,6 +80,18 @@ Shared abstractions used by the entry points and tests:
   Invoke with the `sync` subcommand and the target path, e.g.
   `install_extra_deps.py sync src/path/to/install/dir`.
 
+  Repin an entry in place with the `setdep` subcommand, which rewrites the
+  archive's `object_name`, `sha256sum`, and `size_bytes` while preserving every
+  comment, blank line, and quote style in the `EXTRA_DEPS` file:
+
+  ```sh
+  install_extra_deps.py setdep \
+    -r src/path/to/install/dir@<archive>.tar.xz,<hex sha256>,<size_bytes>
+  ```
+
+  Join a multi-object (e.g. per-platform) entry's objects with `?`, in the
+  entry's existing order. Repeat `-r` to repin several entries at once.
+
 ## Subdirectories
 
 - `alias/` — `git cr` git-alias subcommands (`commit`, `mv`, `follow-renames`,

--- a/tools/cr/extra_deps.py
+++ b/tools/cr/extra_deps.py
@@ -19,22 +19,22 @@ from pathlib import Path
 _STAMP = '.stamp'
 
 # Our EXTRA_DEPS file at the root of the repo.
-_EXTRA_DEPS_FILE = Path(__file__).resolve().parents[2] / 'EXTRA_DEPS'
+EXTRA_DEPS_FILE = Path(__file__).resolve().parents[2] / 'EXTRA_DEPS'
 
 
 def _load_extra_deps() -> dict:
-    """Load the `extra_deps` literal from `_EXTRA_DEPS_FILE`.
+    """Load the `extra_deps` literal from `EXTRA_DEPS_FILE`.
 
     The file is a pure declarative table: its `extra_deps = {...}` assignment is
     read with `ast.literal_eval`, never executed.
     """
-    source = _EXTRA_DEPS_FILE.read_text(encoding='utf-8')
+    source = EXTRA_DEPS_FILE.read_text(encoding='utf-8')
     for node in ast.parse(source).body:
         if (isinstance(node, ast.Assign) and len(node.targets) == 1
                 and isinstance(node.targets[0], ast.Name)
                 and node.targets[0].id == 'extra_deps'):
             return ast.literal_eval(node.value)
-    raise ValueError(f'No extra_deps assignment found in {_EXTRA_DEPS_FILE}')
+    raise ValueError(f'No extra_deps assignment found in {EXTRA_DEPS_FILE}')
 
 
 EXTRA_DEPS = _load_extra_deps()

--- a/tools/cr/install_extra_deps.py
+++ b/tools/cr/install_extra_deps.py
@@ -14,9 +14,12 @@ it deployed more generic, and reusable for other cases.
 from __future__ import annotations
 
 import argparse
+import ast
 from collections.abc import Mapping
+from io import StringIO
 import logging
 import sys
+import tokenize
 from pathlib import Path
 
 # `src/` directory (this script lives at src/brave/tools/cr/).
@@ -34,7 +37,8 @@ import gclient_eval  # pylint: disable=wrong-import-position,import-error
 import gclient_paths  # pylint: disable=wrong-import-position,import-error
 import gclient_utils  # pylint: disable=wrong-import-position,import-error
 
-from extra_deps import EXTRA_DEPS  # pylint: disable=wrong-import-position
+from extra_deps import (  # pylint: disable=wrong-import-position
+    EXTRA_DEPS, EXTRA_DEPS_FILE)
 from tarball_installer import (  # pylint: disable=wrong-import-position
     TarballInstaller)
 
@@ -62,6 +66,93 @@ def _select_object(objects: list[dict],
         raise RuntimeError('Multiple objects match the resolved variables: ' +
                            ', '.join(obj['object_name'] for obj in matches))
     return matches[0]
+
+
+# Object keys `setdep` rewrites
+_SETDEP_OBJECT_KEYS = ('object_name', 'sha256sum', 'size_bytes')
+
+
+def _parse_object_spec(spec: str) -> dict[str, str]:
+    """Parse one `object_name,sha256sum,size_bytes` triple from a setdep arg."""
+    fields = [field.strip() for field in spec.split(',')]
+    if len(fields) != len(_SETDEP_OBJECT_KEYS) or not all(fields):
+        raise ValueError(
+            f'Object {spec!r} must be `{",".join(_SETDEP_OBJECT_KEYS)}` (all '
+            f'fields required).')
+    obj = dict(zip(_SETDEP_OBJECT_KEYS, fields))
+    if not obj['size_bytes'].isdigit():
+        raise ValueError(f'size_bytes must be a non-negative integer, got '
+                         f'{obj["size_bytes"]!r}.')
+    return obj
+
+
+def _load_editable_extra_deps() -> gclient_eval._NodeDict:
+    """Parse the EXTRA_DEPS file into gclient's token-aware, editable form.
+
+    We drive the tokeniser, capturing every comment, blank line, and quote
+    style.
+
+    gclient's in-place editor (`SetGCS`) and renderer key off a top-level
+    `deps` mapping, so the table is also exposed under `deps` (sharing the very
+    same nodes and tokens) to drive that machinery unchanged.
+    """
+    content = EXTRA_DEPS_FILE.read_text(encoding='utf-8')
+    filename = str(EXTRA_DEPS_FILE)
+
+    # pylint: disable=protected-access
+    tokens = {
+        token[2]: list(token)
+        for token in tokenize.generate_tokens(StringIO(content).readline)
+    }
+    scope = gclient_eval._NodeDict({}, tokens)
+    for statement in ast.parse(content, filename=filename).body:
+        if (not isinstance(statement, ast.Assign)
+                or len(statement.targets) != 1
+                or not isinstance(statement.targets[0], ast.Name)):
+            raise ValueError(
+                f'{filename}: only simple `name = ...` assignments are '
+                f'supported.')
+        scope.SetNode(statement.targets[0].id,
+                      gclient_eval._gclient_eval(statement.value, filename),
+                      statement.value)
+
+    if 'extra_deps' not in scope:
+        raise ValueError(f'{filename}: no `extra_deps` assignment found.')
+    scope.SetNode('deps', scope['extra_deps'], scope.GetNode('extra_deps'))
+    return scope
+
+
+def setdep(revisions: list[str]) -> None:
+    """Repin one or more EXTRA_DEPS entries in place, preserving formatting.
+
+    Each `revisions` element is a `DEP@object[?object...]` string (as
+    `gclient setdep -r` takes), where every object is an
+    `object_name,sha256sum,size_bytes` triple. The number of objects must match
+    the entry's current object count, and their order is preserved.
+    """
+    scope = _load_editable_extra_deps()
+    for revision in revisions:
+        path, separator, objects_spec = revision.partition('@')
+        if not separator or not path or not objects_spec:
+            raise ValueError(
+                f'Revision {revision!r} must be of the form `DEP@object,...`.')
+        if path not in EXTRA_DEPS:
+            raise ValueError(f'Unknown EXTRA_DEPS entry {path!r}. Known '
+                             f'entries: {sorted(EXTRA_DEPS)}.')
+        new_objects = [
+            _parse_object_spec(obj) for obj in objects_spec.split('?')
+        ]
+        # `SetGCS` rewrites the matching string tokens in place, and raises if
+        # the object count does not match the entry's current count.
+        gclient_eval.SetGCS(scope, path, new_objects)
+        _LOG.info('Repinned %s', path)
+
+    # `RenderDEPSFile` untokenizes the (now-mutated) tokens back to source, so
+    # everything the edit did not touch is byte-for-byte preserved. `newline=''`
+    # keeps the file's `\n` line endings intact on every platform.
+    EXTRA_DEPS_FILE.write_text(gclient_eval.RenderDEPSFile(scope),
+                               encoding='utf-8',
+                               newline='')
 
 
 class ExtraDepsRunner:
@@ -233,7 +324,28 @@ def main() -> int:
         'install. Entries whose condition is false on this host are skipped, '
         'so a single invocation may list every per-platform variant.')
 
+    setdep_parser = subparsers.add_parser(
+        'setdep',
+        help='Repin EXTRA_DEPS entries in place, preserving comments and '
+        'formatting (like `gclient setdep`).')
+    setdep_parser.add_argument(
+        '-r',
+        '--revision',
+        action='append',
+        dest='revisions',
+        required=True,
+        metavar='DEP@object_name,sha256sum,size_bytes[?...]',
+        help='Repin the EXTRA_DEPS entry DEP to the given object(s). Each '
+        'object is an `object_name,sha256sum,size_bytes` triple; join multiple '
+        'objects with `?`, in the entry\'s existing order. The object count '
+        'must match the entry\'s current count. May be repeated to repin '
+        'several entries in one invocation.')
+
     args = parser.parse_args()
+
+    if args.command == 'setdep':
+        setdep(args.revisions)
+        return 0
 
     runner = ExtraDepsRunner.from_checkout()
     for dep in args.deps:

--- a/tools/cr/install_extra_deps_test.py
+++ b/tools/cr/install_extra_deps_test.py
@@ -507,6 +507,123 @@ class MainTest(unittest.TestCase):
                             m.main()
                 checkout.assert_not_called()
 
+    def test_dispatches_setdep(self):
+        """The `setdep` subcommand forwards its revisions to `setdep` and never
+        touches the checkout (it only edits the EXTRA_DEPS file)."""
+        revision = 'src/path/to/dep@pkg.tar.gz,abc,1'
+        with mock.patch.object(m, 'setdep') as setdep:
+            with mock.patch.object(m.ExtraDepsRunner,
+                                   'from_checkout') as checkout:
+                with mock.patch.object(
+                        sys, 'argv',
+                    ['install_extra_deps', 'setdep', '-r', revision]):
+                    self.assertEqual(m.main(), 0)
+        setdep.assert_called_once_with([revision])
+        checkout.assert_not_called()
+
+    def test_setdep_requires_a_revision(self):
+        """`setdep` with no `-r` is rejected by argparse before any work."""
+        with mock.patch.object(m, 'setdep') as setdep:
+            with mock.patch.object(sys, 'argv',
+                                   ['install_extra_deps', 'setdep']):
+                with contextlib.redirect_stderr(io.StringIO()):
+                    with self.assertRaises(SystemExit):
+                        m.main()
+        setdep.assert_not_called()
+
+
+class ParseObjectSpecTest(unittest.TestCase):
+    """Tests for the `_parse_object_spec` setdep-argument parser."""
+
+    def test_parses_a_triple_and_strips_whitespace(self):
+        self.assertEqual(
+            m._parse_object_spec('pkg.tar.gz , abc123 , 42'), {
+                'object_name': 'pkg.tar.gz',
+                'sha256sum': 'abc123',
+                'size_bytes': '42',
+            })
+
+    def test_rejects_wrong_field_count(self):
+        with self.assertRaises(ValueError):
+            m._parse_object_spec('pkg.tar.gz,abc123')
+
+    def test_rejects_an_empty_field(self):
+        with self.assertRaises(ValueError):
+            m._parse_object_spec('pkg.tar.gz,,42')
+
+    def test_rejects_a_non_integer_size(self):
+        with self.assertRaises(ValueError):
+            m._parse_object_spec('pkg.tar.gz,abc123,huge')
+
+
+class SetDepTest(unittest.TestCase):
+    """Tests for `setdep`, the comment-preserving EXTRA_DEPS editor.
+
+    Each test points `EXTRA_DEPS_FILE` at a temp fixture and patches the loaded
+    `EXTRA_DEPS` table so path validation matches it, then checks the rendered
+    file byte-for-byte where it matters.
+    """
+
+    _SOURCE = '''\
+# A leading comment that must survive the edit.
+extra_deps = {
+    'src/path/to/dep': {
+        'bucket': 'https://downloads.invalid/',
+        'condition': 'host_os == "linux"',
+        'objects': [
+            {
+                'object_name': 'old.tar.gz',
+                'sha256sum': 'oldsha',
+                'size_bytes': 1,
+                'overlayed_on': 'upstream/old.tar.gz',
+                'condition': 'host_os == "linux"',
+            },
+        ],
+    },
+}
+'''
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self._path = Path(tmp.name) / 'EXTRA_DEPS'
+        self._path.write_text(self._SOURCE, encoding='utf-8')
+        # `setdep` reads/writes the file at `EXTRA_DEPS_FILE` and validates dep
+        # paths against `EXTRA_DEPS`; point both at the fixture. The table's
+        # values are unused (only membership is checked).
+        for patcher in (mock.patch.object(m, 'EXTRA_DEPS_FILE', self._path),
+                        mock.patch.object(m, 'EXTRA_DEPS',
+                                          {'src/path/to/dep': None})):
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def test_updates_only_the_object_fields(self):
+        """The three object fields change; comments and other keys are kept."""
+        m.setdep(['src/path/to/dep@new.tar.gz,newsha,222'])
+        result = self._path.read_text(encoding='utf-8')
+        self.assertIn("'object_name': 'new.tar.gz',", result)
+        self.assertIn("'sha256sum': 'newsha',", result)
+        # `size_bytes` renders as a bare int, not a quoted string.
+        self.assertIn("'size_bytes': 222,", result)
+        # The comment and the keys setdep does not touch survive verbatim.
+        self.assertIn('# A leading comment that must survive the edit.',
+                      result)
+        self.assertIn("'overlayed_on': 'upstream/old.tar.gz',", result)
+        self.assertIn("'bucket': 'https://downloads.invalid/',", result)
+
+    def test_rejects_an_unknown_entry_without_writing(self):
+        with self.assertRaises(ValueError):
+            m.setdep(['src/does/not/exist@new.tar.gz,newsha,222'])
+        self.assertEqual(self._path.read_text(encoding='utf-8'), self._SOURCE)
+
+    def test_rejects_an_object_count_mismatch(self):
+        with self.assertRaises(ValueError):
+            m.setdep(['src/path/to/dep@a.tar.gz,sa,1?b.tar.gz,sb,2'])
+
+    def test_rejects_a_malformed_revision(self):
+        with self.assertRaises(ValueError):
+            m.setdep(['src/path/to/dep'])  # Missing `@object,...`.
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This command should serve as the basis for editing `EXTRA_DEPS` whenever
a given dependency is updated.

Bug: https://github.com/brave/brave-browser/issues/56723
