### PR TITLE
[ads] Fixes shutdown crash and dismiss notification ads on quit

### DIFF
--- a/browser/brave_ads/BUILD.gn
+++ b/browser/brave_ads/BUILD.gn
@@ -44,6 +44,8 @@ source_set("impl") {
     "application_state/notification_helper/notification_helper.h",
     "application_state/notification_helper/notification_helper_impl.cc",
     "application_state/notification_helper/notification_helper_impl.h",
+    "application_state/shutdown_monitor_impl.cc",
+    "application_state/shutdown_monitor_impl.h",
     "virtual_pref_provider_delegate.cc",
   ]
 
@@ -67,6 +69,8 @@ source_set("impl") {
     "//chrome/browser:primitives",
     "//chrome/browser/content_settings:content_settings_factory",
     "//chrome/browser/history",
+    "//chrome/browser/lifetime",
+    "//chrome/browser/lifetime:termination_notification",
     "//chrome/browser/notifications",
     "//chrome/browser/profiles:profile",
     "//chrome/browser/profiles:profile_manager",
@@ -150,6 +154,7 @@ source_set("browser_tests") {
   testonly = true
 
   sources = [
+    "ads_service_delegate_browsertest.cc",
     "ads_service_waiter.cc",
     "ads_service_waiter.h",
     "analytics/p3a/brave_stats_helper_browsertest.cc",
@@ -161,6 +166,7 @@ source_set("browser_tests") {
     ":brave_ads",
     ":impl",
     "//chrome/browser",
+    "//chrome/browser/lifetime",
     "//chrome/test:test_support",
   ]
 

--- a/browser/brave_ads/ads_service_delegate.cc
+++ b/browser/brave_ads/ads_service_delegate.cc
@@ -26,6 +26,7 @@
 #include "content/public/browser/page_navigator.h"
 #else
 #include "chrome/browser/fullscreen.h"
+#include "chrome/browser/lifetime/browser_shutdown.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_window/public/profile_browser_collection.h"
 #include "chrome/browser/ui/navigator/browser_navigator.h"
@@ -58,6 +59,14 @@ void AdsServiceDelegate::OpenNewTabWithUrl(const GURL& url) {
   ServiceTabLauncher::GetInstance()->LaunchTab(
       &*profile_, params, base::BindOnce([](content::WebContents*) {}));
 #else
+  if (browser_shutdown::HasShutdownStarted()) {
+    // The last browser window can close, and `browser_shutdown` can start,
+    // before `AdsServiceImpl::Shutdown()` runs for this profile. Bail out
+    // here rather than creating a new `Browser` and navigating on a profile
+    // that is mid-teardown.
+    return;
+  }
+
   auto* browser = ProfileBrowserCollection::GetForProfile(&*profile_)
                       ->FindTabbedBrowser()
                       ->GetBrowserForMigrationOnly();

--- a/browser/brave_ads/ads_service_delegate_browsertest.cc
+++ b/browser/brave_ads/ads_service_delegate_browsertest.cc
@@ -1,0 +1,102 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_ads/ads_service_delegate.h"
+
+#include <memory>
+
+#include "build/build_config.h"
+
+// `AdsServiceDelegate::OpenNewTabWithUrl` only drives `Navigate()` and
+// `Browser::Create()` on non-Android desktop platforms; Android uses
+// `ServiceTabLauncher` instead, which is untouched by this fix.
+#if !BUILDFLAG(IS_ANDROID)
+
+#include "chrome/browser/browser_process.h"
+#include "chrome/browser/lifetime/browser_shutdown.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace brave_ads {
+
+class AdsServiceDelegateBrowserTest : public InProcessBrowserTest {
+ public:
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+
+    ASSERT_TRUE(embedded_test_server()->Start());
+  }
+
+  void TearDownOnMainThread() override {
+    // `delegate_` holds a `raw_ref` to `g_browser_process->local_state()`,
+    // which is destroyed during browser shutdown inside
+    // `BrowserTestBase::SetUp()`. Release it here, while the browser process
+    // is still alive, rather than letting it dangle until the fixture itself
+    // is destroyed.
+    delegate_.reset();
+
+    InProcessBrowserTest::TearDownOnMainThread();
+  }
+
+ protected:
+  AdsServiceDelegate& delegate() {
+    if (!delegate_) {
+      delegate_ = std::make_unique<AdsServiceDelegate>(
+          *browser()->profile(), *g_browser_process->local_state(),
+          /*adaptive_captcha_service=*/nullptr);
+    }
+
+    return *delegate_;
+  }
+
+ private:
+  std::unique_ptr<AdsServiceDelegate> delegate_;
+};
+
+IN_PROC_BROWSER_TEST_F(AdsServiceDelegateBrowserTest,
+                       OpenNewTabWithUrlNavigatesToUrl) {
+  const GURL url = embedded_test_server()->GetURL("/title1.html");
+
+  delegate().OpenNewTabWithUrl(url);
+
+  content::WebContents* const web_contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+  ASSERT_TRUE(web_contents);
+  EXPECT_TRUE(content::WaitForLoadStop(web_contents));
+  EXPECT_EQ(url, web_contents->GetLastCommittedURL());
+}
+
+IN_PROC_BROWSER_TEST_F(AdsServiceDelegateBrowserTest,
+                       OpenNewTabWithUrlDoesNotNavigateAfterShutdownStarted) {
+  const GURL url = embedded_test_server()->GetURL("/title1.html");
+  content::WebContents* const web_contents_before =
+      browser()->tab_strip_model()->GetActiveWebContents();
+  ASSERT_TRUE(web_contents_before);
+  const int tab_count_before = browser()->tab_strip_model()->count();
+
+  browser_shutdown::OnShutdownStarting(
+      browser_shutdown::ShutdownType::kWindowClose);
+
+  delegate().OpenNewTabWithUrl(url);
+
+  EXPECT_EQ(tab_count_before, browser()->tab_strip_model()->count());
+  EXPECT_EQ(web_contents_before,
+            browser()->tab_strip_model()->GetActiveWebContents());
+  EXPECT_NE(url, web_contents_before->GetLastCommittedURL());
+
+  browser_shutdown::ResetShutdownGlobalsForTesting();
+}
+
+}  // namespace brave_ads
+
+#endif  // !BUILDFLAG(IS_ANDROID)

--- a/browser/brave_ads/ads_service_factory.cc
+++ b/browser/brave_ads/ads_service_factory.cc
@@ -14,6 +14,7 @@
 #include "base/no_destructor.h"
 #include "brave/browser/brave_adaptive_captcha/brave_adaptive_captcha_service_factory.h"
 #include "brave/browser/brave_ads/ads_service_delegate.h"
+#include "brave/browser/brave_ads/application_state/shutdown_monitor_impl.h"
 #include "brave/browser/brave_ads/device_id/device_id_impl.h"
 #include "brave/browser/brave_ads/services/bat_ads_service_factory_impl.h"
 #include "brave/browser/brave_ads/tooltips/ads_tooltips_delegate_impl.h"
@@ -22,10 +23,12 @@
 #include "brave/common/brave_channel_info.h"
 #include "brave/components/brave_ads/browser/ads_service_impl.h"
 #include "brave/components/brave_ads/browser/application_state/application_state_monitor.h"
+#include "brave/components/brave_ads/browser/application_state/shutdown_monitor.h"
 #include "brave/components/brave_ads/core/browser/service/ads_service.h"
 #include "brave/components/brave_ads/core/public/ads_util.h"
 #include "brave/components/brave_policy/policy_initialization_waiter.h"
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
+#include "build/build_config.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/history/history_service_factory.h"
@@ -100,6 +103,11 @@ AdsServiceFactory::CreateAdsTooltipsDelegate() const {
 #endif
 }
 
+std::unique_ptr<ShutdownMonitor> AdsServiceFactory::CreateShutdownMonitor()
+    const {
+  return std::make_unique<ShutdownMonitorImpl>();
+}
+
 std::unique_ptr<KeyedService>
 AdsServiceFactory::BuildServiceInstanceForBrowserContext(
     content::BrowserContext* context) const {
@@ -153,7 +161,7 @@ AdsServiceFactory::BuildServiceInstanceForBrowserContext(
       brave::GetChannelName(), profile->GetPath(), CreateAdsTooltipsDelegate(),
       std::make_unique<DeviceIdImpl>(),
       std::make_unique<BatAdsServiceFactoryImpl>(),
-      ApplicationStateMonitor::Create(),
+      ApplicationStateMonitor::Create(), CreateShutdownMonitor(),
       CHECK_DEREF(g_brave_browser_process->resource_component()),
       history_service,
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)

--- a/browser/brave_ads/ads_service_factory.h
+++ b/browser/brave_ads/ads_service_factory.h
@@ -21,6 +21,7 @@ namespace brave_ads {
 
 class AdsService;
 class AdsTooltipsDelegateImpl;
+class ShutdownMonitor;
 
 // Singleton that owns all AdsService and associates them with Profiles.
 class AdsServiceFactory final : public BrowserContextKeyedServiceFactory {
@@ -40,6 +41,7 @@ class AdsServiceFactory final : public BrowserContextKeyedServiceFactory {
   ~AdsServiceFactory() override;
 
   std::unique_ptr<AdsTooltipsDelegateImpl> CreateAdsTooltipsDelegate() const;
+  std::unique_ptr<ShutdownMonitor> CreateShutdownMonitor() const;
 
   // BrowserContextKeyedServiceFactory:
   std::unique_ptr<KeyedService> BuildServiceInstanceForBrowserContext(

--- a/browser/brave_ads/application_state/shutdown_monitor_impl.cc
+++ b/browser/brave_ads/application_state/shutdown_monitor_impl.cc
@@ -1,0 +1,19 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_ads/application_state/shutdown_monitor_impl.h"
+
+#include <utility>
+
+#include "chrome/browser/lifetime/termination_notification.h"
+
+namespace brave_ads {
+
+base::CallbackListSubscription ShutdownMonitorImpl::AddAppTerminatingCallback(
+    base::OnceClosure callback) {
+  return browser_shutdown::AddAppTerminatingCallback(std::move(callback));
+}
+
+}  // namespace brave_ads

--- a/browser/brave_ads/application_state/shutdown_monitor_impl.h
+++ b/browser/brave_ads/application_state/shutdown_monitor_impl.h
@@ -1,0 +1,31 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_BRAVE_ADS_APPLICATION_STATE_SHUTDOWN_MONITOR_IMPL_H_
+#define BRAVE_BROWSER_BRAVE_ADS_APPLICATION_STATE_SHUTDOWN_MONITOR_IMPL_H_
+
+#include "brave/components/brave_ads/browser/application_state/shutdown_monitor.h"
+
+namespace brave_ads {
+
+// Desktop implementation of `ShutdownMonitor`, which chrome/browser/ code can
+// depend on but components/ code cannot.
+class ShutdownMonitorImpl final : public ShutdownMonitor {
+ public:
+  ShutdownMonitorImpl() = default;
+
+  ShutdownMonitorImpl(const ShutdownMonitorImpl&) = delete;
+  ShutdownMonitorImpl& operator=(const ShutdownMonitorImpl&) = delete;
+
+  ~ShutdownMonitorImpl() override = default;
+
+  // ShutdownMonitor:
+  base::CallbackListSubscription AddAppTerminatingCallback(
+      base::OnceClosure callback) override;
+};
+
+}  // namespace brave_ads
+
+#endif  // BRAVE_BROWSER_BRAVE_ADS_APPLICATION_STATE_SHUTDOWN_MONITOR_IMPL_H_

--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -102,6 +102,8 @@ source_set("test_support") {
     "test/fake_bat_ads_service_factory.h",
     "test/fake_device_id.cc",
     "test/fake_device_id.h",
+    "test/fake_shutdown_monitor.cc",
+    "test/fake_shutdown_monitor.h",
     "test/fake_virtual_pref_provider_delegate.cc",
     "test/fake_virtual_pref_provider_delegate.h",
   ]

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -150,6 +150,7 @@ AdsServiceImpl::AdsServiceImpl(
     std::unique_ptr<DeviceId> device_id,
     std::unique_ptr<BatAdsServiceFactory> bat_ads_service_factory,
     std::unique_ptr<ApplicationStateMonitor> application_state_monitor,
+    std::unique_ptr<ShutdownMonitor> shutdown_monitor,
     ResourceComponent& resource_component,
     history::HistoryService* history_service,
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
@@ -179,12 +180,22 @@ AdsServiceImpl::AdsServiceImpl(
       rewards_service_(rewards_service),
 #endif
       application_state_monitor_(std::move(application_state_monitor)),
+      shutdown_monitor_(std::move(shutdown_monitor)),
       policy_initialization_waiter_(std::move(policy_initialization_waiter)),
       bat_ads_client_associated_receiver_(this) {
   CHECK(device_id_);
   CHECK(bat_ads_service_factory_);
   CHECK(application_state_monitor_);
+  CHECK(shutdown_monitor_);
   CHECK(policy_initialization_waiter_);
+
+  // Chrome only ever notifies app termination once per process, so subscribe
+  // immediately rather than waiting for `InitializeBatAdsCallback`, otherwise
+  // a profile that finishes initializing after that single notification has
+  // already fired would never hear about it.
+  app_terminating_subscription_ = shutdown_monitor_->AddAppTerminatingCallback(
+      base::BindOnce(&AdsServiceImpl::OnBrowserWillShutdown,
+                     weak_ptr_factory_.GetWeakPtr()));
 
   if (!http_client_ || !history_service_ || !host_content_settings_map_) {
     CHECK_IS_TEST();
@@ -935,7 +946,6 @@ void AdsServiceImpl::CloseAllNotificationAds() {
   }
 
   const auto& list = prefs_->GetList(prefs::kNotificationAds);
-
   const base::circular_deque<NotificationAdInfo> ads =
       NotificationAdsFromList(list);
 
@@ -957,7 +967,10 @@ void AdsServiceImpl::MaybeOpenNewTabWithAd() {
 }
 
 void AdsServiceImpl::OpenNewTabWithAd(const std::string& placement_id) {
-  if (StopNotificationAdTimeOutTimer(placement_id)) {
+  // `CloseNotificationAd` already cancels the timeout for reminders, so only
+  // cancel it here for the branches that do not call it.
+  if (!IsReminder(placement_id) &&
+      StopNotificationAdTimeOutTimer(placement_id)) {
     VLOG(2) << "Canceled timeout for notification ad with placement id "
             << placement_id;
   }
@@ -1066,6 +1079,8 @@ void AdsServiceImpl::ShutdownAdsService() {
 #endif
 
   application_state_monitor_observation_.Reset();
+
+  app_terminating_subscription_ = {};
 
   CloseAllNotificationAds();
 
@@ -1480,6 +1495,8 @@ void AdsServiceImpl::ShowNotificationAd(
 }
 
 void AdsServiceImpl::CloseNotificationAd(const std::string& placement_id) {
+  StopNotificationAdTimeOutTimer(placement_id);
+
   delegate_->CloseNotificationAd(placement_id);
 }
 
@@ -1694,6 +1711,12 @@ void AdsServiceImpl::OnBrowserDidResignActive() {
 #endif  // BUILDFLAG(IS_ANDROID)
     bat_ads_client_notifier_remote_->NotifyBrowserDidEnterBackground();
   }
+}
+
+void AdsServiceImpl::OnBrowserWillShutdown() {
+  // Runs before `ShutdownAdsService()`'s call, closing the ad as soon as
+  // quitting starts instead of leaving it clickable until profile teardown.
+  CloseAllNotificationAds();
 }
 
 void AdsServiceImpl::OnResourceComponentDidChange(

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -14,6 +14,7 @@
 #include <string_view>
 #include <vector>
 
+#include "base/callback_list.h"
 #include "base/files/file_path.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ref.h"
@@ -27,6 +28,7 @@
 #include "brave/components/brave_adaptive_captcha/brave_adaptive_captcha_service.h"
 #include "brave/components/brave_ads/browser/application_state/application_state_monitor.h"
 #include "brave/components/brave_ads/browser/application_state/application_state_observer.h"
+#include "brave/components/brave_ads/browser/application_state/shutdown_monitor.h"
 #include "brave/components/brave_ads/browser/component_updater/resource_component.h"
 #include "brave/components/brave_ads/browser/component_updater/resource_component_observer.h"
 #include "brave/components/brave_ads/core/browser/network/http_client.h"
@@ -117,6 +119,7 @@ class AdsServiceImpl : public AdsService,
       std::unique_ptr<DeviceId> device_id,
       std::unique_ptr<BatAdsServiceFactory> bat_ads_service_factory,
       std::unique_ptr<ApplicationStateMonitor> application_state_monitor,
+      std::unique_ptr<ShutdownMonitor> shutdown_monitor,
       ResourceComponent& resource_component,
       history::HistoryService* history_service,
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
@@ -399,6 +402,9 @@ class AdsServiceImpl : public AdsService,
   void OnBrowserDidBecomeActive() override;
   void OnBrowserDidResignActive() override;
 
+  // ShutdownMonitor:
+  void OnBrowserWillShutdown();
+
   // ResourceComponentObserver:
   void OnResourceComponentDidChange(const std::string& manifest_version,
                                     const std::string& id) override;
@@ -485,6 +491,9 @@ class AdsServiceImpl : public AdsService,
   std::unique_ptr<ApplicationStateMonitor> application_state_monitor_;
   base::ScopedObservation<ApplicationStateMonitor, ApplicationStateObserver>
       application_state_monitor_observation_{this};
+
+  std::unique_ptr<ShutdownMonitor> shutdown_monitor_;
+  base::CallbackListSubscription app_terminating_subscription_;
 
   // Reset eagerly in Shutdown() so the observer is detached from
   // PolicyService before the destructor runs.

--- a/components/brave_ads/browser/ads_service_impl_unittest.cc
+++ b/components/brave_ads/browser/ads_service_impl_unittest.cc
@@ -21,6 +21,7 @@
 #include "brave/components/brave_ads/browser/test/fake_ads_tooltips_delegate.h"
 #include "brave/components/brave_ads/browser/test/fake_bat_ads_service_factory.h"
 #include "brave/components/brave_ads/browser/test/fake_device_id.h"
+#include "brave/components/brave_ads/browser/test/fake_shutdown_monitor.h"
 #include "brave/components/brave_ads/browser/test/fake_virtual_pref_provider_delegate.h"
 #include "brave/components/brave_ads/browser/test/mock_resource_component.h"
 #include "brave/components/brave_ads/core/public/prefs/pref_names.h"
@@ -85,6 +86,9 @@ class BraveAdsAdsServiceImplTest : public testing::Test {
         std::make_unique<test::FakeBatAdsServiceFactory>();
     bat_ads_service_factory_ = bat_ads_service_factory.get();
 
+    auto shutdown_monitor = std::make_unique<test::FakeShutdownMonitor>();
+    shutdown_monitor_ = shutdown_monitor.get();
+
     ads_service_ = std::make_unique<AdsServiceImpl>(
         std::make_unique<test::FakeAdsServiceDelegate>(), prefs_, local_state_,
         std::make_unique<brave_policy::PolicyInitializationWaiter>(
@@ -94,7 +98,8 @@ class BraveAdsAdsServiceImplTest : public testing::Test {
         /*channel_name=*/"foo", profile_dir_.GetPath(),
         std::make_unique<test::FakeAdsTooltipsDelegate>(), std::move(device_id),
         std::move(bat_ads_service_factory),
-        std::make_unique<ApplicationStateMonitor>(), mock_resource_component_,
+        std::make_unique<ApplicationStateMonitor>(),
+        std::move(shutdown_monitor), mock_resource_component_,
         /*history_service=*/nullptr,
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
         &rewards_service_,
@@ -106,6 +111,7 @@ class BraveAdsAdsServiceImplTest : public testing::Test {
     // Null before reset to avoid `raw_ptr` dangling detection.
     device_id_ = nullptr;
     bat_ads_service_factory_ = nullptr;
+    shutdown_monitor_ = nullptr;
     ads_service_->Shutdown();
     ads_service_.reset();
   }
@@ -118,6 +124,10 @@ class BraveAdsAdsServiceImplTest : public testing::Test {
   }
 
   void Shutdown() { ads_service_->Shutdown(); }
+
+  void NotifyBrowserWillShutdown() {
+    shutdown_monitor_->NotifyAppTerminating();
+  }
 
   void SimulateIdleState(ui::IdleState idle_state, base::TimeDelta idle_time) {
     ads_service_->ProcessIdleState(idle_state, idle_time);
@@ -136,6 +146,8 @@ class BraveAdsAdsServiceImplTest : public testing::Test {
 
   raw_ptr<test::FakeBatAdsServiceFactory>
       bat_ads_service_factory_;  // Not owned.
+
+  raw_ptr<test::FakeShutdownMonitor> shutdown_monitor_;  // Not owned.
 
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
   test::FakeRewardsService rewards_service_;
@@ -635,6 +647,37 @@ TEST_F(BraveAdsAdsServiceImplTest,
 
   // Act
   Shutdown();
+
+  // Assert
+  EXPECT_THAT(prefs_.GetList(prefs::kNotificationAds), testing::IsEmpty());
+}
+
+TEST_F(
+    BraveAdsAdsServiceImplTest,
+    DoesNotClearNotificationAdsPrefOnBrowserWillShutdownIfUserHasNotOptedInToNotificationAds) {
+  // Arrange
+  prefs_.SetList(prefs::kNotificationAds, base::ListValue().Append("foo"));
+
+  // Act
+  NotifyBrowserWillShutdown();
+
+  // Assert
+  EXPECT_THAT(prefs_.GetList(prefs::kNotificationAds),
+              testing::Not(testing::IsEmpty()));
+}
+
+TEST_F(
+    BraveAdsAdsServiceImplTest,
+    ClearsNotificationAdsPrefOnBrowserWillShutdownIfUserHasOptedInToNotificationAds) {
+  // Arrange: the browser can start quitting well before `Shutdown()` runs for
+  // this profile, so notification ads must be closed as soon as
+  // `OnBrowserWillShutdown()` fires rather than only at `Shutdown()`.
+  prefs_.SetBoolean(brave_rewards::prefs::kEnabled, true);
+  prefs_.SetBoolean(prefs::kOptedInToNotificationAds, true);
+  prefs_.SetList(prefs::kNotificationAds, base::ListValue().Append("foo"));
+
+  // Act
+  NotifyBrowserWillShutdown();
 
   // Assert
   EXPECT_THAT(prefs_.GetList(prefs::kNotificationAds), testing::IsEmpty());

--- a/components/brave_ads/browser/application_state/BUILD.gn
+++ b/components/brave_ads/browser/application_state/BUILD.gn
@@ -12,6 +12,7 @@ source_set("application_state") {
     "application_state_monitor.cc",
     "application_state_monitor.h",
     "application_state_observer.h",
+    "shutdown_monitor.h",
   ]
 
   public_deps = [ "//base" ]

--- a/components/brave_ads/browser/application_state/shutdown_monitor.h
+++ b/components/brave_ads/browser/application_state/shutdown_monitor.h
@@ -1,0 +1,30 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_APPLICATION_STATE_SHUTDOWN_MONITOR_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_APPLICATION_STATE_SHUTDOWN_MONITOR_H_
+
+#include "base/callback_list.h"
+#include "base/functional/callback_forward.h"
+
+namespace brave_ads {
+
+// Runs registered callbacks once the browser has started terminating.
+class ShutdownMonitor {
+ public:
+  ShutdownMonitor() = default;
+
+  ShutdownMonitor(const ShutdownMonitor&) = delete;
+  ShutdownMonitor& operator=(const ShutdownMonitor&) = delete;
+
+  virtual ~ShutdownMonitor() = default;
+
+  virtual base::CallbackListSubscription AddAppTerminatingCallback(
+      base::OnceClosure callback) = 0;
+};
+
+}  // namespace brave_ads
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_APPLICATION_STATE_SHUTDOWN_MONITOR_H_

--- a/components/brave_ads/browser/test/fake_shutdown_monitor.cc
+++ b/components/brave_ads/browser/test/fake_shutdown_monitor.cc
@@ -1,0 +1,25 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/browser/test/fake_shutdown_monitor.h"
+
+#include <utility>
+
+namespace brave_ads::test {
+
+FakeShutdownMonitor::FakeShutdownMonitor() = default;
+
+FakeShutdownMonitor::~FakeShutdownMonitor() = default;
+
+base::CallbackListSubscription FakeShutdownMonitor::AddAppTerminatingCallback(
+    base::OnceClosure callback) {
+  return app_terminating_callbacks_.Add(std::move(callback));
+}
+
+void FakeShutdownMonitor::NotifyAppTerminating() {
+  app_terminating_callbacks_.Notify();
+}
+
+}  // namespace brave_ads::test

--- a/components/brave_ads/browser/test/fake_shutdown_monitor.h
+++ b/components/brave_ads/browser/test/fake_shutdown_monitor.h
@@ -1,0 +1,37 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_TEST_FAKE_SHUTDOWN_MONITOR_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_TEST_FAKE_SHUTDOWN_MONITOR_H_
+
+#include "base/callback_list.h"
+#include "brave/components/brave_ads/browser/application_state/shutdown_monitor.h"
+
+namespace brave_ads::test {
+
+// Defers `AddAppTerminatingCallback`'s callback until `NotifyAppTerminating`
+// is called, letting tests control when the browser appears to quit.
+class FakeShutdownMonitor : public ShutdownMonitor {
+ public:
+  FakeShutdownMonitor();
+
+  FakeShutdownMonitor(const FakeShutdownMonitor&) = delete;
+  FakeShutdownMonitor& operator=(const FakeShutdownMonitor&) = delete;
+
+  ~FakeShutdownMonitor() override;
+
+  // ShutdownMonitor:
+  base::CallbackListSubscription AddAppTerminatingCallback(
+      base::OnceClosure callback) override;
+
+  void NotifyAppTerminating();
+
+ private:
+  base::OnceClosureList app_terminating_callbacks_;
+};
+
+}  // namespace brave_ads::test
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_TEST_FAKE_SHUTDOWN_MONITOR_H_


### PR DESCRIPTION
Clicking a notification ad while Brave was quitting could crash the browser. The service now guards against that and also closes any visible notification ad as soon as quitting begins, so a user cannot interact with one that is about to stop working.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57005

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
