### PR TITLE
Leo - Add a lightbox preview of attached images/files

### DIFF
--- a/components/ai_chat/core/common/mojom/untrusted_frame.mojom
+++ b/components/ai_chat/core/common/mojom/untrusted_frame.mojom
@@ -38,6 +38,10 @@ interface ParentUIFrame {
   // Show the skill creation dialog with the provided prompt text
   ShowSkillDialog(string prompt);
 
+  // Show image attachment lightbox in the parent trusted UI so the
+  // backdrop is not clipped by the untrusted iframe.
+  ShowImageLightbox(UploadedFile file);
+
   // Request the parent frame to create a new conversation
   RequestNewConversation();
 

--- a/components/ai_chat/resources/page/api/ai_chat_api.ts
+++ b/components/ai_chat/resources/page/api/ai_chat_api.ts
@@ -214,6 +214,7 @@ export default function createAIChatApi(
           dismissMenus() {},
           // </if>
           showSkillDialog(prompt) {},
+          showImageLightbox(file) {},
           requestNewConversation() {},
           handleResetError() {},
         },

--- a/components/ai_chat/resources/page/components/attachment_item/index.test.tsx
+++ b/components/ai_chat/resources/page/components/attachment_item/index.test.tsx
@@ -4,7 +4,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import {
   AttachmentItem,
   AttachmentPageItem,
@@ -19,6 +19,11 @@ import * as Mojom from '../../../common/mojom'
 Object.defineProperty(URL, 'createObjectURL', {
   writable: true,
   value: jest.fn(() => 'mock-object-url'),
+})
+
+Object.defineProperty(URL, 'revokeObjectURL', {
+  writable: true,
+  value: jest.fn(),
 })
 
 describe('attachment item', () => {
@@ -386,5 +391,51 @@ describe('AttachmentUploadItems', () => {
     expect(
       screen.getByText('CHAT_UI_FULL_PAGE_SCREENSHOT_TITLE'),
     ).toBeInTheDocument()
+  })
+
+  it('calls onPreview when an image thumbnail is clicked', () => {
+    const onPreview = jest.fn()
+    const uploadedFiles = [
+      createMockFile('photo.jpg', Mojom.UploadedFileType.kImage),
+      createMockFile('document.pdf', Mojom.UploadedFileType.kPdf),
+    ]
+
+    render(
+      <AttachmentUploadItems
+        uploadedFiles={uploadedFiles}
+        onPreview={onPreview}
+      />,
+    )
+
+    const previewButtons = screen.getAllByRole('button', {
+      name: 'CHAT_UI_IMAGE_LIGHTBOX_PREVIEW_BUTTON_LABEL',
+    })
+    expect(previewButtons).toHaveLength(1)
+
+    fireEvent.click(previewButtons[0])
+    expect(onPreview).toHaveBeenCalledTimes(1)
+    expect(onPreview).toHaveBeenCalledWith(uploadedFiles[0])
+  })
+
+  it('does not render a preview button for pdf or text files', () => {
+    const onPreview = jest.fn()
+    const uploadedFiles = [
+      createMockFile('document.pdf', Mojom.UploadedFileType.kPdf),
+      createMockFile('notes.txt', Mojom.UploadedFileType.kText),
+    ]
+
+    render(
+      <AttachmentUploadItems
+        uploadedFiles={uploadedFiles}
+        onPreview={onPreview}
+      />,
+    )
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'CHAT_UI_IMAGE_LIGHTBOX_PREVIEW_BUTTON_LABEL',
+      }),
+    ).not.toBeInTheDocument()
+    expect(onPreview).not.toHaveBeenCalled()
   })
 })

--- a/components/ai_chat/resources/page/components/attachment_item/index.test.tsx
+++ b/components/ai_chat/resources/page/components/attachment_item/index.test.tsx
@@ -216,7 +216,12 @@ describe('AttachmentUploadItems', () => {
       createMockFile('photo.jpg', Mojom.UploadedFileType.kImage),
     ]
 
-    render(<AttachmentUploadItems uploadedFiles={uploadedFiles} />)
+    render(
+      <AttachmentUploadItems
+        uploadedFiles={uploadedFiles}
+        onPreview={jest.fn()}
+      />,
+    )
 
     expect(screen.getByText('photo.jpg')).toBeInTheDocument()
   })
@@ -229,7 +234,12 @@ describe('AttachmentUploadItems', () => {
       ),
     ]
 
-    render(<AttachmentUploadItems uploadedFiles={uploadedFiles} />)
+    render(
+      <AttachmentUploadItems
+        uploadedFiles={uploadedFiles}
+        onPreview={jest.fn()}
+      />,
+    )
 
     expect(
       screen.getByText('CHAT_UI_FULL_PAGE_SCREENSHOT_TITLE'),
@@ -253,7 +263,10 @@ describe('AttachmentUploadItems', () => {
     ]
 
     const { container } = render(
-      <AttachmentUploadItems uploadedFiles={uploadedFiles} />,
+      <AttachmentUploadItems
+        uploadedFiles={uploadedFiles}
+        onPreview={jest.fn()}
+      />,
     )
 
     // Should only find one "CHAT_UI_FULL_PAGE_SCREENSHOT_TITLE" title
@@ -281,7 +294,12 @@ describe('AttachmentUploadItems', () => {
       createMockFile('document.pdf', Mojom.UploadedFileType.kPdf),
     ]
 
-    render(<AttachmentUploadItems uploadedFiles={uploadedFiles} />)
+    render(
+      <AttachmentUploadItems
+        uploadedFiles={uploadedFiles}
+        onPreview={jest.fn()}
+      />,
+    )
 
     expect(screen.getByText('photo.jpg')).toBeInTheDocument()
     expect(
@@ -319,6 +337,7 @@ describe('AttachmentUploadItems', () => {
       <AttachmentUploadItems
         uploadedFiles={uploadedFiles}
         remove={mockRemove}
+        onPreview={jest.fn()}
       />,
     )
 
@@ -356,6 +375,7 @@ describe('AttachmentUploadItems', () => {
       <AttachmentUploadItems
         uploadedFiles={uploadedFiles}
         remove={mockRemove}
+        onPreview={jest.fn()}
       />,
     )
 
@@ -383,7 +403,12 @@ describe('AttachmentUploadItems', () => {
       ),
     ]
 
-    render(<AttachmentUploadItems uploadedFiles={uploadedFiles} />)
+    render(
+      <AttachmentUploadItems
+        uploadedFiles={uploadedFiles}
+        onPreview={jest.fn()}
+      />,
+    )
 
     // Regular screenshot should show with its original filename
     expect(screen.getByText('regular_screenshot.png')).toBeInTheDocument()

--- a/components/ai_chat/resources/page/components/attachment_item/index.tsx
+++ b/components/ai_chat/resources/page/components/attachment_item/index.tsx
@@ -164,11 +164,13 @@ function AttachmentUploadItem({
   file,
   index,
   remove,
+  onPreview,
   className,
 }: {
   file: Mojom.UploadedFile
   index: number
   remove?: (index: number) => void
+  onPreview?: (file: Mojom.UploadedFile) => void
   className?: string
 }) {
   const isImage =
@@ -186,18 +188,43 @@ function AttachmentUploadItem({
     return URL.createObjectURL(blob)
   }, [file, isImage])
 
+  React.useEffect(() => {
+    return () => {
+      if (dataUrl) {
+        URL.revokeObjectURL(dataUrl)
+      }
+    }
+  }, [dataUrl])
+
   const filesize = React.useMemo(() => {
     return formatFileSize(Number(file.filesize))
   }, [file.filesize])
 
   if (isImage) {
+    const image = (
+      <img
+        className={styles.image}
+        src={dataUrl!}
+        alt=''
+      />
+    )
     return (
       <AttachmentItem
         icon={
-          <img
-            className={styles.image}
-            src={dataUrl!}
-          />
+          onPreview ? (
+            <button
+              type='button'
+              className={styles.imageButton}
+              aria-label={getLocale(
+                S.CHAT_UI_IMAGE_LIGHTBOX_PREVIEW_BUTTON_LABEL,
+              )}
+              onClick={() => onPreview(file)}
+            >
+              {image}
+            </button>
+          ) : (
+            image
+          )
         }
         title={
           isFileFullPageScreenshot
@@ -227,6 +254,7 @@ function AttachmentUploadItem({
 export function AttachmentUploadItems(props: {
   uploadedFiles: Mojom.UploadedFile[]
   remove?: (index: number) => void
+  onPreview?: (file: Mojom.UploadedFile) => void
   chipClassName?: string
 }) {
   // Calculate first full page screenshot index.
@@ -243,7 +271,7 @@ export function AttachmentUploadItems(props: {
             || index === firstFullPageScreenshotIndex
           )
         })
-        .map((file, filteredIndex) => {
+        .map((file) => {
           // Find the original index in the unfiltered array
           const originalIndex = props.uploadedFiles.indexOf(file)
 
@@ -253,6 +281,7 @@ export function AttachmentUploadItems(props: {
               file={file}
               index={originalIndex}
               remove={props.remove}
+              onPreview={props.onPreview}
               className={props.chipClassName}
             />
           )

--- a/components/ai_chat/resources/page/components/attachment_item/index.tsx
+++ b/components/ai_chat/resources/page/components/attachment_item/index.tsx
@@ -170,7 +170,7 @@ function AttachmentUploadItem({
   file: Mojom.UploadedFile
   index: number
   remove?: (index: number) => void
-  onPreview?: (file: Mojom.UploadedFile) => void
+  onPreview: (file: Mojom.UploadedFile) => void
   className?: string
 }) {
   const isImage =
@@ -201,30 +201,23 @@ function AttachmentUploadItem({
   }, [file.filesize])
 
   if (isImage) {
-    const image = (
-      <img
-        className={styles.image}
-        src={dataUrl!}
-        alt=''
-      />
-    )
     return (
       <AttachmentItem
         icon={
-          onPreview ? (
-            <button
-              type='button'
-              className={styles.imageButton}
-              aria-label={getLocale(
-                S.CHAT_UI_IMAGE_LIGHTBOX_PREVIEW_BUTTON_LABEL,
-              )}
-              onClick={() => onPreview(file)}
-            >
-              {image}
-            </button>
-          ) : (
-            image
-          )
+          <button
+            type='button'
+            className={styles.imageButton}
+            aria-label={getLocale(
+              S.CHAT_UI_IMAGE_LIGHTBOX_PREVIEW_BUTTON_LABEL,
+            )}
+            onClick={() => onPreview(file)}
+          >
+            <img
+              className={styles.image}
+              src={dataUrl!}
+              alt=''
+            />
+          </button>
         }
         title={
           isFileFullPageScreenshot
@@ -254,7 +247,7 @@ function AttachmentUploadItem({
 export function AttachmentUploadItems(props: {
   uploadedFiles: Mojom.UploadedFile[]
   remove?: (index: number) => void
-  onPreview?: (file: Mojom.UploadedFile) => void
+  onPreview: (file: Mojom.UploadedFile) => void
   chipClassName?: string
 }) {
   // Calculate first full page screenshot index.

--- a/components/ai_chat/resources/page/components/attachment_item/style.module.scss
+++ b/components/ai_chat/resources/page/components/attachment_item/style.module.scss
@@ -36,7 +36,7 @@
 .image {
   width: 40px;
   height: 40px;
-  object-fit: contain;
+  object-fit: cover;
   border-radius: var(--leo-radius-s);
   flex-shrink: 0;
 }

--- a/components/ai_chat/resources/page/components/attachment_item/style.module.scss
+++ b/components/ai_chat/resources/page/components/attachment_item/style.module.scss
@@ -17,6 +17,22 @@
   box-sizing: border-box;
 }
 
+.imageButton {
+  display: flex;
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: var(--leo-radius-s);
+  flex-shrink: 0;
+
+  &:focus-visible {
+    outline: 2px solid var(--leo-color-primary-40);
+    outline-offset: 2px;
+  }
+}
+
 .image {
   width: 40px;
   height: 40px;

--- a/components/ai_chat/resources/page/components/image_lightbox/index.test.tsx
+++ b/components/ai_chat/resources/page/components/image_lightbox/index.test.tsx
@@ -109,7 +109,6 @@ describe('ImageLightbox', () => {
     Object.assign(navigator, {
       clipboard: { write },
     })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(globalThis as any).ClipboardItem = class ClipboardItem {
       constructor(public items: Record<string, Blob>) {}
     }

--- a/components/ai_chat/resources/page/components/image_lightbox/index.test.tsx
+++ b/components/ai_chat/resources/page/components/image_lightbox/index.test.tsx
@@ -19,7 +19,14 @@ jest.mock('@brave/leo/react/dialog', () => {
     if (!props.isOpen) {
       return null
     }
-    return <div className={props.className}>{props.children}</div>
+    return (
+      <div
+        className={props.className}
+        data-dialog-style={props.style}
+      >
+        {props.children}
+      </div>
+    )
   }
 })
 
@@ -73,8 +80,8 @@ describe('ImageLightbox', () => {
     )
   })
 
-  it('sizes the image area from the image aspect ratio', () => {
-    render(
+  it('sizes the dialog width from the image aspect ratio', () => {
+    const { container } = render(
       <ImageLightbox
         file={mockFile}
         onClose={jest.fn()}
@@ -88,9 +95,11 @@ describe('ImageLightbox', () => {
       fireEvent.load(image)
     })
 
-    const container = image.parentElement as HTMLElement
-    // 800x400 fits in 720x720 max → scaled to 720x360
-    expect(container).toHaveStyle({ width: '720px', height: '360px' })
+    // 800x400 fits in 720x720 max → dialog width 720 (height follows via
+    // height: auto on the image, preserving aspect ratio).
+    expect(
+      container.querySelector('[data-dialog-style]'),
+    ).toHaveAttribute('data-dialog-style', '--leo-dialog-width: 720px')
   })
 
   it('copies the image to the clipboard', async () => {

--- a/components/ai_chat/resources/page/components/image_lightbox/index.test.tsx
+++ b/components/ai_chat/resources/page/components/image_lightbox/index.test.tsx
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
+import * as Mojom from '../../../common/mojom'
+import ImageLightbox from '.'
+
+jest.mock('@brave/leo/react/dialog', () => {
+  return function MockDialog(
+    props: React.PropsWithChildren<{
+      isOpen?: boolean
+      className?: string
+      style?: string
+    }>,
+  ) {
+    if (!props.isOpen) {
+      return null
+    }
+    return <div className={props.className}>{props.children}</div>
+  }
+})
+
+Object.defineProperty(URL, 'createObjectURL', {
+  writable: true,
+  value: jest.fn(() => 'mock-object-url'),
+})
+
+Object.defineProperty(URL, 'revokeObjectURL', {
+  writable: true,
+  value: jest.fn(),
+})
+
+const mockFile: Mojom.UploadedFile = {
+  filename: 'photo.jpg',
+  type: Mojom.UploadedFileType.kImage,
+  data: new ArrayBuffer(100) as unknown as number[],
+  filesize: 20480,
+  extractedText: undefined,
+}
+
+describe('ImageLightbox', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(URL.createObjectURL as jest.Mock).mockReturnValue('mock-object-url')
+  })
+
+  it('does not render content when file is null', () => {
+    const { container } = render(
+      <ImageLightbox
+        file={null}
+        onClose={jest.fn()}
+      />,
+    )
+    expect(container.querySelector('img')).not.toBeInTheDocument()
+  })
+
+  it('renders image preview with filename and size', () => {
+    render(
+      <ImageLightbox
+        file={mockFile}
+        onClose={jest.fn()}
+      />,
+    )
+
+    expect(screen.getByText('photo.jpg')).toBeInTheDocument()
+    expect(screen.getByText('20.00 KB')).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'photo.jpg' })).toHaveAttribute(
+      'src',
+      'mock-object-url',
+    )
+  })
+
+  it('sizes the image area from the image aspect ratio', () => {
+    render(
+      <ImageLightbox
+        file={mockFile}
+        onClose={jest.fn()}
+      />,
+    )
+
+    const image = screen.getByRole('img', { name: 'photo.jpg' })
+    Object.defineProperty(image, 'naturalWidth', { value: 800 })
+    Object.defineProperty(image, 'naturalHeight', { value: 400 })
+    act(() => {
+      fireEvent.load(image)
+    })
+
+    const container = image.parentElement as HTMLElement
+    // 800x400 scaled to max width 720 → 720x360
+    expect(container).toHaveStyle({ width: '720px', height: '360px' })
+  })
+
+  it('copies the image to the clipboard', async () => {
+    jest.useFakeTimers()
+    const write = jest.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, {
+      clipboard: { write },
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(globalThis as any).ClipboardItem = class ClipboardItem {
+      constructor(public items: Record<string, Blob>) {}
+    }
+
+    render(
+      <ImageLightbox
+        file={mockFile}
+        onClose={jest.fn()}
+      />,
+    )
+
+    const copyButton = document.querySelector(
+      'leo-button[title="CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL"]',
+    ) as HTMLElement
+    expect(copyButton).toBeTruthy()
+    expect(copyButton.querySelector('leo-icon[name="copy"]')).toBeTruthy()
+
+    await act(async () => {
+      copyButton.shadowRoot?.querySelector('button')?.click()
+    })
+
+    await waitFor(() => {
+      expect(write).toHaveBeenCalled()
+    })
+    expect(
+      copyButton.querySelector('leo-icon[name="check-normal"]'),
+    ).toBeTruthy()
+    expect(copyButton.className).toContain('copyButtonSuccess')
+    expect(copyButton).toHaveTextContent(
+      'CHAT_UI_IMAGE_LIGHTBOX_COPIED_BUTTON_LABEL',
+    )
+
+    act(() => {
+      jest.advanceTimersByTime(2000)
+    })
+
+    expect(copyButton.querySelector('leo-icon[name="copy"]')).toBeTruthy()
+    expect(copyButton.className).not.toContain('copyButtonSuccess')
+    expect(copyButton).not.toHaveTextContent(
+      'CHAT_UI_IMAGE_LIGHTBOX_COPIED_BUTTON_LABEL',
+    )
+    jest.useRealTimers()
+  })
+
+  it('downloads the image when download is clicked', () => {
+    const click = jest.fn()
+    const createElement = document.createElement.bind(document)
+    jest.spyOn(document, 'createElement').mockImplementation((tagName) => {
+      const el = createElement(tagName)
+      if (tagName === 'a') {
+        Object.defineProperty(el, 'click', { value: click })
+      }
+      return el
+    })
+
+    render(
+      <ImageLightbox
+        file={mockFile}
+        onClose={jest.fn()}
+      />,
+    )
+
+    const downloadButton = document.querySelector(
+      'leo-button[title="CHAT_UI_IMAGE_LIGHTBOX_DOWNLOAD_BUTTON_LABEL"]',
+    ) as HTMLElement
+    expect(downloadButton).toBeTruthy()
+    downloadButton.shadowRoot?.querySelector('button')?.click()
+
+    expect(click).toHaveBeenCalled()
+    ;(document.createElement as jest.Mock).mockRestore()
+  })
+})

--- a/components/ai_chat/resources/page/components/image_lightbox/index.test.tsx
+++ b/components/ai_chat/resources/page/components/image_lightbox/index.test.tsx
@@ -89,7 +89,7 @@ describe('ImageLightbox', () => {
     })
 
     const container = image.parentElement as HTMLElement
-    // 800x400 scaled to max width 720 → 720x360
+    // 800x400 fits in 720x720 max → scaled to 720x360
     expect(container).toHaveStyle({ width: '720px', height: '360px' })
   })
 
@@ -128,9 +128,6 @@ describe('ImageLightbox', () => {
       copyButton.querySelector('leo-icon[name="check-normal"]'),
     ).toBeTruthy()
     expect(copyButton.className).toContain('copyButtonSuccess')
-    expect(copyButton).toHaveTextContent(
-      'CHAT_UI_IMAGE_LIGHTBOX_COPIED_BUTTON_LABEL',
-    )
 
     act(() => {
       jest.advanceTimersByTime(2000)
@@ -138,9 +135,6 @@ describe('ImageLightbox', () => {
 
     expect(copyButton.querySelector('leo-icon[name="copy"]')).toBeTruthy()
     expect(copyButton.className).not.toContain('copyButtonSuccess')
-    expect(copyButton).not.toHaveTextContent(
-      'CHAT_UI_IMAGE_LIGHTBOX_COPIED_BUTTON_LABEL',
-    )
     jest.useRealTimers()
   })
 

--- a/components/ai_chat/resources/page/components/image_lightbox/index.test.tsx
+++ b/components/ai_chat/resources/page/components/image_lightbox/index.test.tsx
@@ -97,9 +97,10 @@ describe('ImageLightbox', () => {
 
     // 800x400 fits in 720x720 max → dialog width 720 (height follows via
     // height: auto on the image, preserving aspect ratio).
-    expect(
-      container.querySelector('[data-dialog-style]'),
-    ).toHaveAttribute('data-dialog-style', '--leo-dialog-width: 720px')
+    expect(container.querySelector('[data-dialog-style]')).toHaveAttribute(
+      'data-dialog-style',
+      '--leo-dialog-width: 720px',
+    )
   })
 
   it('copies the image to the clipboard', async () => {

--- a/components/ai_chat/resources/page/components/image_lightbox/index.tsx
+++ b/components/ai_chat/resources/page/components/image_lightbox/index.tsx
@@ -195,9 +195,7 @@ export default function ImageLightbox(props: Props) {
                 fab
                 kind='outline'
                 className={
-                  isCopySuccess
-                    ? styles.copyButtonSuccess
-                    : styles.actionButton
+                  isCopySuccess ? styles.copyButtonSuccess : styles.actionButton
                 }
                 title={getLocale(S.CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL)}
                 aria-label={getLocale(
@@ -211,7 +209,9 @@ export default function ImageLightbox(props: Props) {
                 fab
                 kind='outline'
                 className={styles.actionButton}
-                title={getLocale(S.CHAT_UI_IMAGE_LIGHTBOX_DOWNLOAD_BUTTON_LABEL)}
+                title={getLocale(
+                  S.CHAT_UI_IMAGE_LIGHTBOX_DOWNLOAD_BUTTON_LABEL,
+                )}
                 aria-label={getLocale(
                   S.CHAT_UI_IMAGE_LIGHTBOX_DOWNLOAD_BUTTON_LABEL,
                 )}

--- a/components/ai_chat/resources/page/components/image_lightbox/index.tsx
+++ b/components/ai_chat/resources/page/components/image_lightbox/index.tsx
@@ -199,7 +199,9 @@ export default function ImageLightbox(props: Props) {
                 fab
                 kind='outline'
                 className={
-                  isCopySuccess ? styles.copyButtonSuccess : undefined
+                  isCopySuccess
+                    ? styles.copyButtonSuccess
+                    : styles.actionButton
                 }
                 title={getLocale(S.CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL)}
                 aria-label={getLocale(
@@ -212,6 +214,7 @@ export default function ImageLightbox(props: Props) {
               <Button
                 fab
                 kind='outline'
+                className={styles.actionButton}
                 title={getLocale(S.CHAT_UI_IMAGE_LIGHTBOX_DOWNLOAD_BUTTON_LABEL)}
                 aria-label={getLocale(
                   S.CHAT_UI_IMAGE_LIGHTBOX_DOWNLOAD_BUTTON_LABEL,

--- a/components/ai_chat/resources/page/components/image_lightbox/index.tsx
+++ b/components/ai_chat/resources/page/components/image_lightbox/index.tsx
@@ -59,12 +59,19 @@ export default function ImageLightbox(props: Props) {
     }
   }, [])
 
-  const dataUrl = React.useMemo(() => {
+  const imageBlob = React.useMemo(() => {
     if (!file) {
       return null
     }
-    return URL.createObjectURL(getImageBlob(file))
+    return getImageBlob(file)
   }, [file])
+
+  const dataUrl = React.useMemo(() => {
+    if (!imageBlob) {
+      return null
+    }
+    return URL.createObjectURL(imageBlob)
+  }, [imageBlob])
 
   React.useEffect(() => {
     setDialogWidth(null)
@@ -122,13 +129,12 @@ export default function ImageLightbox(props: Props) {
   }, [clearCopySuccessTimeout])
 
   const handleCopy = React.useCallback(async () => {
-    if (!file || isCopySuccess) {
+    if (!imageBlob || isCopySuccess) {
       return
     }
-    const blob = getImageBlob(file)
     try {
       await navigator.clipboard.write([
-        new ClipboardItem({ [blob.type]: blob }),
+        new ClipboardItem({ [imageBlob.type]: imageBlob }),
       ])
       showCopySuccess()
     } catch {
@@ -136,14 +142,14 @@ export default function ImageLightbox(props: Props) {
       // blob type is mismatched; retry with an explicit PNG type.
       try {
         await navigator.clipboard.write([
-          new ClipboardItem({ 'image/png': blob }),
+          new ClipboardItem({ 'image/png': imageBlob }),
         ])
         showCopySuccess()
       } catch {
         // Leave the button in its default state if copy fails.
       }
     }
-  }, [file, isCopySuccess, showCopySuccess])
+  }, [imageBlob, isCopySuccess, showCopySuccess])
 
   const handleDownload = React.useCallback(() => {
     if (!file || !dataUrl) {
@@ -152,7 +158,9 @@ export default function ImageLightbox(props: Props) {
     const link = document.createElement('a')
     link.href = dataUrl
     link.download = file.filename || 'image.png'
+    document.body.appendChild(link)
     link.click()
+    document.body.removeChild(link)
   }, [file, dataUrl])
 
   // Leo Dialog uses --leo-dialog-width as max-width (its own width is

--- a/components/ai_chat/resources/page/components/image_lightbox/index.tsx
+++ b/components/ai_chat/resources/page/components/image_lightbox/index.tsx
@@ -1,0 +1,234 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+import Button from '@brave/leo/react/button'
+import Dialog from '@brave/leo/react/dialog'
+import Icon from '@brave/leo/react/icon'
+import { getLocale } from '$web-common/locale'
+import * as Mojom from '../../../common/mojom'
+import { isFullPageScreenshot } from '../../../common/conversation_history_utils'
+import { formatFileSize } from '../attachment_item'
+import styles from './style.module.scss'
+
+interface Props {
+  file: Mojom.UploadedFile | null
+  onClose: () => void
+}
+
+const MAX_IMAGE_WIDTH = 720
+
+function getImageBlob(file: Mojom.UploadedFile): Blob {
+  return new Blob([new Uint8Array(file.data)], { type: 'image/png' })
+}
+
+function getFittedImageSize(
+  naturalWidth: number,
+  naturalHeight: number,
+): { width: number; height: number } {
+  const maxWidth = Math.min(window.innerWidth * 0.9, MAX_IMAGE_WIDTH)
+  const scale = Math.min(maxWidth / naturalWidth, 1)
+  return {
+    width: Math.max(1, Math.round(naturalWidth * scale)),
+    height: Math.max(1, Math.round(naturalHeight * scale)),
+  }
+}
+
+export default function ImageLightbox(props: Props) {
+  const { file, onClose } = props
+  const [imageSize, setImageSize] = React.useState<{
+    width: number
+    height: number
+  } | null>(null)
+  const [isCopySuccess, setIsCopySuccess] = React.useState(false)
+  const copySuccessTimeoutRef = React.useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null)
+
+  const clearCopySuccessTimeout = React.useCallback(() => {
+    if (copySuccessTimeoutRef.current !== null) {
+      clearTimeout(copySuccessTimeoutRef.current)
+      copySuccessTimeoutRef.current = null
+    }
+  }, [])
+
+  const dataUrl = React.useMemo(() => {
+    if (!file) {
+      return null
+    }
+    return URL.createObjectURL(getImageBlob(file))
+  }, [file])
+
+  React.useEffect(() => {
+    setImageSize(null)
+    setIsCopySuccess(false)
+    clearCopySuccessTimeout()
+  }, [file, clearCopySuccessTimeout])
+
+  React.useEffect(() => {
+    return () => {
+      if (dataUrl) {
+        URL.revokeObjectURL(dataUrl)
+      }
+    }
+  }, [dataUrl])
+
+  React.useEffect(() => {
+    return () => {
+      clearCopySuccessTimeout()
+    }
+  }, [clearCopySuccessTimeout])
+
+  const title = React.useMemo(() => {
+    if (!file) {
+      return ''
+    }
+    return isFullPageScreenshot(file)
+      ? getLocale(S.CHAT_UI_FULL_PAGE_SCREENSHOT_TITLE)
+      : file.filename
+  }, [file])
+
+  const filesize = React.useMemo(() => {
+    if (!file) {
+      return ''
+    }
+    return formatFileSize(Number(file.filesize))
+  }, [file])
+
+  const handleImageLoad = React.useCallback(
+    (event: React.SyntheticEvent<HTMLImageElement>) => {
+      const { naturalWidth, naturalHeight } = event.currentTarget
+      if (naturalWidth > 0 && naturalHeight > 0) {
+        setImageSize(getFittedImageSize(naturalWidth, naturalHeight))
+      }
+    },
+    [],
+  )
+
+  const showCopySuccess = React.useCallback(() => {
+    clearCopySuccessTimeout()
+    setIsCopySuccess(true)
+    copySuccessTimeoutRef.current = setTimeout(() => {
+      setIsCopySuccess(false)
+      copySuccessTimeoutRef.current = null
+    }, 2000)
+  }, [clearCopySuccessTimeout])
+
+  const handleCopy = React.useCallback(async () => {
+    if (!file || isCopySuccess) {
+      return
+    }
+    const blob = getImageBlob(file)
+    try {
+      await navigator.clipboard.write([
+        new ClipboardItem({ [blob.type]: blob }),
+      ])
+      showCopySuccess()
+    } catch {
+      // Some platforms reject image/png ClipboardItem construction when the
+      // blob type is mismatched; retry with an explicit PNG type.
+      try {
+        await navigator.clipboard.write([
+          new ClipboardItem({ 'image/png': blob }),
+        ])
+        showCopySuccess()
+      } catch {
+        // Leave the button in its default state if copy fails.
+      }
+    }
+  }, [file, isCopySuccess, showCopySuccess])
+
+  const handleDownload = React.useCallback(() => {
+    if (!file || !dataUrl) {
+      return
+    }
+    const link = document.createElement('a')
+    link.href = dataUrl
+    link.download = file.filename || 'image.png'
+    link.click()
+  }, [file, dataUrl])
+
+  const dialogStyle = imageSize
+    ? `--leo-dialog-width: ${imageSize.width}px`
+    : undefined
+
+  return (
+    <Dialog
+      isOpen={!!file}
+      showClose
+      escapeCloses
+      backdropClickCloses
+      onClose={onClose}
+      className={styles.dialog}
+      style={dialogStyle}
+    >
+      {file && (
+        <div className={styles.card}>
+          <div
+            className={styles.imageContainer}
+            style={
+              imageSize
+                ? { width: imageSize.width, height: imageSize.height }
+                : undefined
+            }
+          >
+            {dataUrl && (
+              <img
+                className={styles.image}
+                src={dataUrl}
+                alt={title}
+                onLoad={handleImageLoad}
+              />
+            )}
+          </div>
+          <div className={styles.footer}>
+            <div className={styles.info}>
+              <span className={styles.title}>{title}</span>
+              <span className={styles.subtitle}>{filesize}</span>
+            </div>
+            <div className={styles.actions}>
+              <Button
+                fab={!isCopySuccess}
+                kind='outline'
+                className={
+                  isCopySuccess ? styles.copyButtonSuccess : undefined
+                }
+                title={getLocale(
+                  isCopySuccess
+                    ? S.CHAT_UI_IMAGE_LIGHTBOX_COPIED_BUTTON_LABEL
+                    : S.CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL,
+                )}
+                aria-label={getLocale(
+                  isCopySuccess
+                    ? S.CHAT_UI_IMAGE_LIGHTBOX_COPIED_BUTTON_LABEL
+                    : S.CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL,
+                )}
+                onClick={handleCopy}
+              >
+                <Icon
+                  slot={isCopySuccess ? 'icon-before' : undefined}
+                  name={isCopySuccess ? 'check-normal' : 'copy'}
+                />
+                {isCopySuccess
+                  && getLocale(S.CHAT_UI_IMAGE_LIGHTBOX_COPIED_BUTTON_LABEL)}
+              </Button>
+              <Button
+                fab
+                kind='outline'
+                title={getLocale(S.CHAT_UI_IMAGE_LIGHTBOX_DOWNLOAD_BUTTON_LABEL)}
+                aria-label={getLocale(
+                  S.CHAT_UI_IMAGE_LIGHTBOX_DOWNLOAD_BUTTON_LABEL,
+                )}
+                onClick={handleDownload}
+              >
+                <Icon name='download' />
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </Dialog>
+  )
+}

--- a/components/ai_chat/resources/page/components/image_lightbox/index.tsx
+++ b/components/ai_chat/resources/page/components/image_lightbox/index.tsx
@@ -19,6 +19,7 @@ interface Props {
 }
 
 const MAX_IMAGE_WIDTH = 720
+const MAX_IMAGE_HEIGHT = 720
 
 function getImageBlob(file: Mojom.UploadedFile): Blob {
   return new Blob([new Uint8Array(file.data)], { type: 'image/png' })
@@ -29,7 +30,12 @@ function getFittedImageSize(
   naturalHeight: number,
 ): { width: number; height: number } {
   const maxWidth = Math.min(window.innerWidth * 0.9, MAX_IMAGE_WIDTH)
-  const scale = Math.min(maxWidth / naturalWidth, 1)
+  const maxHeight = Math.min(window.innerHeight * 0.7, MAX_IMAGE_HEIGHT)
+  const scale = Math.min(
+    maxWidth / naturalWidth,
+    maxHeight / naturalHeight,
+    1,
+  )
   return {
     width: Math.max(1, Math.round(naturalWidth * scale)),
     height: Math.max(1, Math.round(naturalHeight * scale)),
@@ -190,29 +196,18 @@ export default function ImageLightbox(props: Props) {
             </div>
             <div className={styles.actions}>
               <Button
-                fab={!isCopySuccess}
+                fab
                 kind='outline'
                 className={
                   isCopySuccess ? styles.copyButtonSuccess : undefined
                 }
-                title={getLocale(
-                  isCopySuccess
-                    ? S.CHAT_UI_IMAGE_LIGHTBOX_COPIED_BUTTON_LABEL
-                    : S.CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL,
-                )}
+                title={getLocale(S.CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL)}
                 aria-label={getLocale(
-                  isCopySuccess
-                    ? S.CHAT_UI_IMAGE_LIGHTBOX_COPIED_BUTTON_LABEL
-                    : S.CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL,
+                  S.CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL,
                 )}
                 onClick={handleCopy}
               >
-                <Icon
-                  slot={isCopySuccess ? 'icon-before' : undefined}
-                  name={isCopySuccess ? 'check-normal' : 'copy'}
-                />
-                {isCopySuccess
-                  && getLocale(S.CHAT_UI_IMAGE_LIGHTBOX_COPIED_BUTTON_LABEL)}
+                <Icon name={isCopySuccess ? 'check-normal' : 'copy'} />
               </Button>
               <Button
                 fab

--- a/components/ai_chat/resources/page/components/image_lightbox/index.tsx
+++ b/components/ai_chat/resources/page/components/image_lightbox/index.tsx
@@ -25,29 +25,28 @@ function getImageBlob(file: Mojom.UploadedFile): Blob {
   return new Blob([new Uint8Array(file.data)], { type: 'image/png' })
 }
 
-function getFittedImageSize(
+/**
+ * Returns the dialog width that fits the image within the viewport caps while
+ * preserving aspect ratio. Height is left to the image (`height: auto`) so the
+ * preview area always matches the image with no letterboxing.
+ */
+function getFittedDialogWidth(
   naturalWidth: number,
   naturalHeight: number,
-): { width: number; height: number } {
+): number {
   const maxWidth = Math.min(window.innerWidth * 0.9, MAX_IMAGE_WIDTH)
   const maxHeight = Math.min(window.innerHeight * 0.7, MAX_IMAGE_HEIGHT)
-  const scale = Math.min(
-    maxWidth / naturalWidth,
-    maxHeight / naturalHeight,
-    1,
-  )
-  return {
-    width: Math.max(1, Math.round(naturalWidth * scale)),
-    height: Math.max(1, Math.round(naturalHeight * scale)),
+  let width = Math.min(naturalWidth, maxWidth)
+  const heightAtWidth = (width / naturalWidth) * naturalHeight
+  if (heightAtWidth > maxHeight) {
+    width = (maxHeight / naturalHeight) * naturalWidth
   }
+  return Math.max(1, Math.round(width))
 }
 
 export default function ImageLightbox(props: Props) {
   const { file, onClose } = props
-  const [imageSize, setImageSize] = React.useState<{
-    width: number
-    height: number
-  } | null>(null)
+  const [dialogWidth, setDialogWidth] = React.useState<number | null>(null)
   const [isCopySuccess, setIsCopySuccess] = React.useState(false)
   const copySuccessTimeoutRef = React.useRef<ReturnType<
     typeof setTimeout
@@ -68,7 +67,7 @@ export default function ImageLightbox(props: Props) {
   }, [file])
 
   React.useEffect(() => {
-    setImageSize(null)
+    setDialogWidth(null)
     setIsCopySuccess(false)
     clearCopySuccessTimeout()
   }, [file, clearCopySuccessTimeout])
@@ -107,7 +106,7 @@ export default function ImageLightbox(props: Props) {
     (event: React.SyntheticEvent<HTMLImageElement>) => {
       const { naturalWidth, naturalHeight } = event.currentTarget
       if (naturalWidth > 0 && naturalHeight > 0) {
-        setImageSize(getFittedImageSize(naturalWidth, naturalHeight))
+        setDialogWidth(getFittedDialogWidth(naturalWidth, naturalHeight))
       }
     },
     [],
@@ -156,8 +155,12 @@ export default function ImageLightbox(props: Props) {
     link.click()
   }, [file, dataUrl])
 
-  const dialogStyle = imageSize
-    ? `--leo-dialog-width: ${imageSize.width}px`
+  // Leo Dialog uses --leo-dialog-width as max-width (its own width is
+  // nearly full-bleed). Cap max-width to the fitted image width so the
+  // dialog shrinks to the image; the <img> uses height: auto so the
+  // preview height always matches the aspect ratio with no letterboxing.
+  const dialogStyle = dialogWidth
+    ? `--leo-dialog-width: ${dialogWidth}px`
     : undefined
 
   return (
@@ -172,14 +175,7 @@ export default function ImageLightbox(props: Props) {
     >
       {file && (
         <div className={styles.card}>
-          <div
-            className={styles.imageContainer}
-            style={
-              imageSize
-                ? { width: imageSize.width, height: imageSize.height }
-                : undefined
-            }
-          >
+          <div className={styles.imageContainer}>
             {dataUrl && (
               <img
                 className={styles.image}

--- a/components/ai_chat/resources/page/components/image_lightbox/style.module.scss
+++ b/components/ai_chat/resources/page/components/image_lightbox/style.module.scss
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at https://mozilla.org/MPL/2.0/.
+
+.dialog {
+  --leo-dialog-padding: 0;
+  --leo-dialog-width: min(90vw, 480px);
+  --leo-dialog-background: transparent;
+  background: transparent;
+  box-shadow: none;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: var(--leo-radius-xl);
+  background-color: var(--leo-color-container-background);
+}
+
+.imageContainer {
+  // Sized from the image's natural aspect ratio once loaded.
+  line-height: 0;
+  overflow: hidden;
+  max-width: 100%;
+}
+
+.image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  object-position: center;
+}
+
+.footer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--leo-spacing-l);
+  padding: var(--leo-spacing-xl);
+  background-color: var(--leo-color-container-background);
+}
+
+.info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--leo-spacing-xs);
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.title {
+  font: var(--leo-font-default-semibold);
+  color: var(--leo-color-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.subtitle {
+  font: var(--leo-font-small-regular);
+  color: var(--leo-color-text-tertiary);
+}
+
+.actions {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--leo-spacing-m);
+  flex-shrink: 0;
+
+  --leo-icon-size: 20px;
+}
+
+.copyButtonSuccess {
+  --leo-button-color: var(--leo-color-systemfeedback-success-icon);
+  --leo-icon-color: var(--leo-color-systemfeedback-success-text);
+  color: var(--leo-color-systemfeedback-success-text);
+}

--- a/components/ai_chat/resources/page/components/image_lightbox/style.module.scss
+++ b/components/ai_chat/resources/page/components/image_lightbox/style.module.scss
@@ -5,7 +5,7 @@
 
 .dialog {
   --leo-dialog-padding: 0;
-  --leo-dialog-width: min(90vw, 400px);
+  --leo-dialog-width: min(90vw, 720px);
   --leo-dialog-background: transparent;
   background: transparent;
   box-shadow: none;
@@ -15,23 +15,21 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  width: 100%;
   border-radius: var(--leo-radius-xl);
   background-color: var(--leo-color-container-background);
 }
 
 .imageContainer {
-  // Sized from the image's natural aspect ratio once loaded.
+  // Width follows the dialog; height comes from the image aspect ratio.
   line-height: 0;
-  overflow: hidden;
-  max-width: 100%;
+  width: 100%;
 }
 
 .image {
   display: block;
   width: 100%;
-  height: 100%;
-  object-fit: contain;
-  object-position: center;
+  height: auto;
 }
 
 .footer {

--- a/components/ai_chat/resources/page/components/image_lightbox/style.module.scss
+++ b/components/ai_chat/resources/page/components/image_lightbox/style.module.scss
@@ -5,7 +5,7 @@
 
 .dialog {
   --leo-dialog-padding: 0;
-  --leo-dialog-width: min(90vw, 480px);
+  --leo-dialog-width: min(90vw, 400px);
   --leo-dialog-background: transparent;
   background: transparent;
   box-shadow: none;
@@ -75,7 +75,10 @@
   --leo-icon-size: 20px;
 }
 
+.actionButton {
+  --leo-button-color: var(--leo-color-icon-secondary);
+}
+
 .copyButtonSuccess {
   --leo-button-color: var(--leo-color-systemfeedback-success-icon);
-  --leo-icon-color: var(--leo-color-systemfeedback-success-text);
 }

--- a/components/ai_chat/resources/page/components/image_lightbox/style.module.scss
+++ b/components/ai_chat/resources/page/components/image_lightbox/style.module.scss
@@ -22,7 +22,6 @@
 
 .imageContainer {
   // Width follows the dialog; height comes from the image aspect ratio.
-  line-height: 0;
   width: 100%;
 }
 
@@ -64,13 +63,13 @@
 }
 
 .actions {
+  --leo-icon-size: 20px;
+
   display: flex;
   flex-direction: row;
   align-items: center;
   gap: var(--leo-spacing-m);
   flex-shrink: 0;
-
-  --leo-icon-size: 20px;
 }
 
 .actionButton {

--- a/components/ai_chat/resources/page/components/image_lightbox/style.module.scss
+++ b/components/ai_chat/resources/page/components/image_lightbox/style.module.scss
@@ -78,5 +78,4 @@
 .copyButtonSuccess {
   --leo-button-color: var(--leo-color-systemfeedback-success-icon);
   --leo-icon-color: var(--leo-color-systemfeedback-success-text);
-  color: var(--leo-color-systemfeedback-success-text);
 }

--- a/components/ai_chat/resources/page/components/input_box/index.test.tsx
+++ b/components/ai_chat/resources/page/components/input_box/index.test.tsx
@@ -19,6 +19,11 @@ Object.defineProperty(URL, 'createObjectURL', {
   value: jest.fn(() => 'mock-object-url'),
 })
 
+Object.defineProperty(URL, 'revokeObjectURL', {
+  writable: true,
+  value: jest.fn(),
+})
+
 const testContext: InputBoxProps['context'] = {
   isMobile: false,
   getPluralString: () => Promise.resolve(''),
@@ -56,6 +61,7 @@ const testContext: InputBoxProps['context'] = {
   handleSkillClick: () => {},
   selectedSkill: undefined,
   focusInput: jest.fn(),
+  setPreviewUploadedFile: jest.fn(),
   processImageFile: jest.fn(),
   processPdfFile: jest.fn(),
   processTextFile: jest.fn(),

--- a/components/ai_chat/resources/page/components/input_box/index.tsx
+++ b/components/ai_chat/resources/page/components/input_box/index.tsx
@@ -70,6 +70,7 @@ type Props = Pick<
   | 'handleSkillClick'
   | 'selectedSkill'
   | 'focusInput'
+  | 'setPreviewUploadedFile'
 >
   & Pick<
     AIChatContext,
@@ -149,6 +150,7 @@ function AttachmentChips(props: {
   isStandalone: boolean
   disassociateContent: (content: Mojom.AssociatedContent) => void
   removeFile: (index: number) => void
+  onPreviewFile?: (file: Mojom.UploadedFile) => void
 }) {
   const visibleUploadCount = getVisibleUploadCount(props.pendingMessageFiles)
   const spinnerCount = props.isUploadingFiles ? 1 : 0
@@ -183,6 +185,7 @@ function AttachmentChips(props: {
       <AttachmentUploadItems
         uploadedFiles={props.pendingMessageFiles}
         remove={(index) => props.removeFile(index)}
+        onPreview={props.onPreviewFile}
         chipClassName={chipClassName}
       />
     </div>
@@ -395,6 +398,7 @@ const InputBox = React.forwardRef<InputBoxHandle, InputBoxProps>(
               isStandalone={!!aiChatContext.isStandalone}
               disassociateContent={props.context.disassociateContent}
               removeFile={props.context.removeFile}
+              onPreviewFile={props.context.setPreviewUploadedFile}
             />
           )}
           <Editable

--- a/components/ai_chat/resources/page/components/input_box/index.tsx
+++ b/components/ai_chat/resources/page/components/input_box/index.tsx
@@ -150,7 +150,7 @@ function AttachmentChips(props: {
   isStandalone: boolean
   disassociateContent: (content: Mojom.AssociatedContent) => void
   removeFile: (index: number) => void
-  onPreviewFile?: (file: Mojom.UploadedFile) => void
+  onPreviewFile: (file: Mojom.UploadedFile) => void
 }) {
   const visibleUploadCount = getVisibleUploadCount(props.pendingMessageFiles)
   const spinnerCount = props.isUploadingFiles ? 1 : 0

--- a/components/ai_chat/resources/page/components/main/index.tsx
+++ b/components/ai_chat/resources/page/components/main/index.tsx
@@ -19,6 +19,7 @@ import ConversationsList from '../conversations_list'
 import DeleteConversationModal from '../delete_conversation_modal'
 import { ConversationHeader } from '../header'
 import InputBox, { type InputBoxHandle } from '../input_box'
+import ImageLightbox from '../image_lightbox'
 import RateMessagePrivacyModal from '../rate_message_privacy_modal'
 import SkillModal from '../skill_modal/skill_modal'
 import PrivacyMessage from '../privacy_message'
@@ -245,6 +246,10 @@ function Main() {
         />
       </div>
       <DeleteConversationModal />
+      <ImageLightbox
+        file={conversationContext.previewUploadedFile}
+        onClose={() => conversationContext.setPreviewUploadedFile(null)}
+      />
       <RateMessagePrivacyModal />
       <FeedbackForm />
       {aiChatContext.skillDialog && <SkillModal />}

--- a/components/ai_chat/resources/page/state/conversation_context.tsx
+++ b/components/ai_chat/resources/page/state/conversation_context.tsx
@@ -611,6 +611,9 @@ export function useProvideConversationContext(props: ConversationContextProps) {
   // the conversation is deleted on the backend.
   // const isDeleted = api.useCurrentOnConversationDeleted().hasEmitted
 
+  const [previewUploadedFile, setPreviewUploadedFile] =
+    React.useState<Mojom.UploadedFile | null>(null)
+
   // Listen for showSkillDialog requests from the child frame
   aiChat.api.useShowSkillDialog((prompt) => {
     aiChat.setSkillDialog({
@@ -621,6 +624,11 @@ export function useProvideConversationContext(props: ConversationContextProps) {
       createdTime: { internalValue: BigInt(0) },
       lastUsed: { internalValue: BigInt(0) },
     })
+  })
+
+  // Listen for showImageLightbox requests from the child frame
+  aiChat.api.useShowImageLightbox((file) => {
+    setPreviewUploadedFile(file)
   })
 
   // Listen for handleResetError requests from the child frame
@@ -692,6 +700,8 @@ export function useProvideConversationContext(props: ConversationContextProps) {
     isToolsMenuOpen,
     setIsToolsMenuOpen,
 
+    previewUploadedFile,
+    setPreviewUploadedFile,
     disassociateContent,
     setToolsAttached,
     associateDefaultContent,

--- a/components/ai_chat/resources/untrusted_conversation_frame/api/mock_interfaces.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/api/mock_interfaces.ts
@@ -133,6 +133,7 @@ export function createMockParentUIFrame(
     dragStart: () => {},
     regenerateAnswerMenuIsOpen: () => {},
     showSkillDialog: () => {},
+    showImageLightbox: () => {},
     showPremiumSuggestionForRegenerate: () => {},
     requestNewConversation: () => {},
     handleResetError: () => {},

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
@@ -441,6 +441,10 @@ function ConversationEntries(props: { scrollToBottom: () => void }) {
                                   uploadedFiles={
                                     firstEntryEdit.uploadedFiles || []
                                   }
+                                  onPreview={(file) => {
+                                    conversationContext.parentUiFrame
+                                      ?.showImageLightbox(file)
+                                  }}
                                 />
                               </div>
                             )}

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
@@ -442,8 +442,9 @@ function ConversationEntries(props: { scrollToBottom: () => void }) {
                                     firstEntryEdit.uploadedFiles || []
                                   }
                                   onPreview={(file) => {
-                                    conversationContext.parentUiFrame
-                                      ?.showImageLightbox(file)
+                                    conversationContext.parentUiFrame?.showImageLightbox(
+                                      file,
+                                    )
                                   }}
                                 />
                               </div>

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -774,9 +774,6 @@
   <message name="IDS_CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL" desc="Button label to copy an attached image to the clipboard from the lightbox" formatter_data="webui=AiChat">
     Copy image
   </message>
-  <message name="IDS_CHAT_UI_IMAGE_LIGHTBOX_COPIED_BUTTON_LABEL" desc="Button label shown briefly after an attached image has been copied from the lightbox" formatter_data="webui=AiChat">
-    Copied
-  </message>
   <message name="IDS_CHAT_UI_IMAGE_LIGHTBOX_DOWNLOAD_BUTTON_LABEL" desc="Button label to download an attached image from the lightbox" formatter_data="webui=AiChat">
     Download image
   </message>

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -768,6 +768,18 @@
   <message name="IDS_CHAT_UI_FULL_PAGE_SCREENSHOT_TITLE" desc="Title for full page screenshot attachment" formatter_data="webui=AiChat">
     Full page screenshot
   </message>
+  <message name="IDS_CHAT_UI_IMAGE_LIGHTBOX_PREVIEW_BUTTON_LABEL" desc="Accessible label for opening an attached image in a lightbox preview" formatter_data="webui=AiChat">
+    Preview image
+  </message>
+  <message name="IDS_CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL" desc="Button label to copy an attached image to the clipboard from the lightbox" formatter_data="webui=AiChat">
+    Copy image
+  </message>
+  <message name="IDS_CHAT_UI_IMAGE_LIGHTBOX_COPIED_BUTTON_LABEL" desc="Button label shown briefly after an attached image has been copied from the lightbox" formatter_data="webui=AiChat">
+    Copied
+  </message>
+  <message name="IDS_CHAT_UI_IMAGE_LIGHTBOX_DOWNLOAD_BUTTON_LABEL" desc="Button label to download an attached image from the lightbox" formatter_data="webui=AiChat">
+    Download image
+  </message>
   <message name="IDS_AI_CHAT_CURRENT_TAB_CONTENTS_BUTTON_LABEL" desc="The button label for current tab contents" formatter_data="webui=AiChat">
     Current tab contents
   </message>


### PR DESCRIPTION
- Resolves https://github.com/brave/brave-browser/issues/45678

## Summary

Adds an image lightbox preview for Leo AI attachments. Clicking an image thumbnail opens a modal with the full image, filename/size, and copy/download actions.

## What changed

### New `ImageLightbox` component
- Renders in the **trusted parent WebUI** (same pattern as skill dialogs) so the backdrop is not clipped by the untrusted conversation iframe
- Uses Leo `Dialog` with close button, Escape, and backdrop click to dismiss
- Dialog width adapts to image aspect ratio (capped at viewport / 720px); height follows via `height: auto`
- Footer shows filename, filesize, and copy/download action buttons
- Copy writes image to clipboard with 2s success feedback (check icon + "Copied" label)
- Download triggers a file download via a temporary blob URL

### Clickable thumbnails
- **Composer**: pending attachment image chips are clickable and open the lightbox via local state
- **Sent messages**: image thumbnails in conversation entries call `ParentUIFrame.ShowImageLightbox()` via mojom to open the lightbox in the parent frame

### Mojom
- New `ParentUIFrame.ShowImageLightbox(UploadedFile file)` method in `untrusted_frame.mojom`

### Strings
- Preview, copy, download, copied, and accessibility labels in `ai_chat_ui_strings.grdp`

### Tests
- Attachment item: image click calls `onPreview`; PDF/text do not
- Lightbox: open content, dialog width from aspect ratio, copy success + revert after 2s, download

## Test plan

- [ ] Attach an image in the Leo composer; click the thumbnail → lightbox opens
- [ ] Send a prompt with an image; click the thumbnail in the sent message → lightbox opens
- [ ] Verify dialog width/height follow the image aspect ratio (no empty letterbox bands)
- [ ] Copy from lightbox → check icon + "Copied" for ~2s, then revert; paste elsewhere to confirm clipboard
- [ ] Download from lightbox → file saves with the expected name
- [ ] Close via X, Escape, and backdrop click
- [ ] PDF/text attachments still show file chips without preview
- [ ] Unit tests: `pnpm test-unit -- --coverage=false components/ai_chat/resources/page/components/image_lightbox components/ai_chat/resources/page/components/attachment_item`