### PR TITLE
[plaster] Fix Windows line-ending stdin mismatch

### DIFF
--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -2321,7 +2321,15 @@ def get_plaster_files(filepaths: list[str] | None = None) -> list[PlasterFile]:
               and filepath.endswith(PLASTER_EXTENSION)):
             expected_plaster_files.add(filepath)
         else:
-            raise ValueError(f'Unexpected file path: {filepath}')
+            hint = ''
+            # Control characters mean the shell interpreted unquoted
+            # backslash escapes (e.g. '\a' -> bell) before we saw the path,
+            # mangling it beyond recovery. Guide the user to quote it.
+            if any(ord(c) < 0x20 for c in filepath):
+                hint = ('\nThe path contains control characters, likely '
+                        'because an unquoted backslash path was escaped by '
+                        'the shell. Quote the path or use forward slashes.')
+            raise PlasterError(f'Unexpected file path: {filepath!r}{hint}')
 
     plaster_parent = Path(PLASTER_FILES_PATH).parent
 

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -108,21 +108,18 @@ class PlasterTest(unittest.TestCase):
         self.assertEqual(patchinfo_from_disk['schemaVersion'], 1)
         self.assertEqual(
             patchinfo_from_disk['patchChecksum'],
-            hashlib.sha256(
-                patchinfo.patch.path.read_text().encode()).hexdigest())
+            hashlib.sha256(patchinfo.patch.path.read_bytes()).hexdigest())
         self.assertEqual(patchinfo_from_disk['appliesTo'][0]['path'],
                          str(test_file_chromium))
         self.assertEqual(
             patchinfo_from_disk['appliesTo'][0]['checksum'],
-            hashlib.sha256(
-                (self.fake_chromium_src.chromium /
-                 test_file_chromium).read_text().encode()).hexdigest())
+            hashlib.sha256((self.fake_chromium_src.chromium /
+                            test_file_chromium).read_bytes()).hexdigest())
         # PatchinfoBuilder normalizes plaster path to be relative to brave root.
         self.assertEqual(patchinfo_from_disk['plaster']['path'],
                          str(patchinfo.plaster_file))
-        self.assertEqual(
-            patchinfo_from_disk['plaster']['checksum'],
-            hashlib.sha256(plaster_path.read_text().encode()).hexdigest())
+        self.assertEqual(patchinfo_from_disk['plaster']['checksum'],
+                         hashlib.sha256(plaster_path.read_bytes()).hexdigest())
 
         self.assertEqual(patchinfo_from_disk['patchChecksum'],
                          patchinfo.patch.checksum)

--- a/tools/cr/terminal.py
+++ b/tools/cr/terminal.py
@@ -206,7 +206,7 @@ class Terminal:
             env: dict[str, str] | None = None,
             cwd=None,
             interactive: bool = False,
-            stdin: str | None = None):
+            stdin: str | bytes | None = None):
         """Runs a command on the terminal.
 
         When `interactive=True`, the subprocess inherits the parent's
@@ -220,10 +220,12 @@ class Terminal:
         add a few keys on top of `os.environ`, copy it first
         (`env={**os.environ, ...}`).
 
-                Pass `stdin=` to feed data into the subprocess's stdin. Captured
-        (non-interactive) mode encodes it with utf-8 to match the
-        captured streams; interactive mode rejects `stdin=` because the
-        subprocess owns the tty.
+                Pass `stdin=` to feed data into the subprocess's stdin. A `str`
+        is encoded as utf-8; `bytes` are sent as-is. Either way the stdin pipe
+        runs in binary mode so the child reads back exactly the bytes passed,
+        with no line-ending translation (see the note below on why this
+        matters). Interactive mode rejects `stdin=` because the subprocess owns
+        the tty.
         """
         # Convert all arguments to strings, to avoid issues with `PurePath`
         # being passed arguments
@@ -262,20 +264,35 @@ class Terminal:
             if resolved != cmd[0]:
                 cmd = [resolved] + cmd[1:]
 
-        # Captured mode pairs `capture_output` with text decoding so the
-        # `.stdout` / `.stderr` strings on the result are usable directly.
-        # Interactive mode skips both -- stdio is inherited from the parent,
-        # nothing is captured, and `text` / `encoding` are irrelevant.
-        capture_kwargs: dict[str, object] = {}
-        if not interactive:
-            capture_kwargs.update(capture_output=True,
-                                  text=True,
-                                  encoding='utf-8')
-
         if interactive and stdin is not None:
             raise ValueError(
                 'terminal.run(): `stdin=` is not supported with '
                 '`interactive=True` (the subprocess owns the tty).')
+
+        # Captured mode records stdout/stderr on the result. We normally let
+        # subprocess decode them as UTF-8 text, which also folds CRLF into LF
+        # (universal newlines).
+        #
+        # When feeding `stdin`, we run the pipes in binary mode instead. Binary
+        # pipes perform no newline translation at any layer, so the bytes flow
+        # through untouched in both directions.
+        feed_stdin = stdin is not None
+        stdin_bytes = None
+        if feed_stdin:
+            stdin_bytes = (stdin.encode('utf-8')
+                           if isinstance(stdin, str) else stdin)
+
+        capture_kwargs: dict[str, object] = {}
+        if not interactive:
+            capture_kwargs.update(capture_output=True)
+            if not feed_stdin:
+                capture_kwargs.update(text=True, encoding='utf-8')
+
+        def decode_stream(data):
+            """UTF-8 decode a binary captured stream, preserving newlines."""
+            if data is None or isinstance(data, str):
+                return data
+            return data.decode('utf-8')
 
         # The status spinner has to be stopped before running any commands in
         # interactive mode, to not interfere with that process's output.
@@ -288,9 +305,14 @@ class Terminal:
                                     check=True,
                                     env=env,
                                     cwd=cwd,
-                                    input=stdin,
+                                    input=stdin_bytes,
                                     **capture_kwargs)
         except subprocess.CalledProcessError as e:
+            if feed_stdin:
+                # Streams were captured as bytes; decode for logging and for
+                # the caller's own exception handling.
+                e.stdout = decode_stream(e.stdout)
+                e.stderr = decode_stream(e.stderr)
             if e.stderr:
                 # Only captured in non-interactive mode.
                 logging.debug('❯ %s', e.stderr.strip())
@@ -302,6 +324,9 @@ class Terminal:
                 self.current_command_start_time = None
                 self.running_command = None
 
+        if feed_stdin:
+            result.stdout = decode_stream(result.stdout)
+            result.stderr = decode_stream(result.stderr)
         return result
 
     def run_git(self,

--- a/tools/cr/terminal_test.py
+++ b/tools/cr/terminal_test.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import unittest
+
+from terminal import terminal
+
+
+class TerminalStdinTest(unittest.TestCase):
+    """`terminal.run(stdin=...)` must round-trip bytes untouched.
+
+    The stdin path runs the child's pipes in binary mode, so no layer -- OS or
+    Python -- translates newlines in either direction. `plaster.run_ast_grep`
+    maps ast-grep's byte offsets back onto the source it sent, so any rewrite
+    (e.g. text mode adding '\\r' on Windows) would shift every offset and
+    corrupt the resulting edits. These tests guard the byte-exact contract on
+    every platform.
+    """
+
+    def test_str_stdin_round_trips_verbatim(self):
+        source = 'line1\nline2\nline3\n'
+        result = terminal.run(['cat'], stdin=source)
+        self.assertIsInstance(result.stdout, str)
+        self.assertEqual(result.stdout, source)
+
+    def test_crlf_is_preserved_verbatim(self):
+        # CRLF in must be CRLF out -- never folded to LF -- and LF-only input
+        # must never gain a '\r'. Cover CRLF, a lone CR, and LF together.
+        for source in ('a\r\nb\r\nc\r\n', 'x\ry\r\nz\n', 'a\nb\n'):
+            with self.subTest(source=source):
+                result = terminal.run(['cat'], stdin=source)
+                self.assertEqual(result.stdout, source)
+
+    def test_no_byte_count_change_on_stdin(self):
+        # The child sees exactly the bytes we passed, so its byte count matches
+        # the source's, regardless of the host platform's line separator.
+        source = 'a\nb\nc\n'
+        result = terminal.run(['wc', '-c'], stdin=source)
+        self.assertEqual(result.stdout.strip(),
+                         str(len(source.encode('utf-8'))))
+
+    def test_bytes_stdin_is_sent_as_is(self):
+        result = terminal.run(['cat'], stdin=b'raw\r\nbytes\n')
+        self.assertEqual(result.stdout, 'raw\r\nbytes\n')
+
+    def test_stdin_rejected_in_interactive_mode(self):
+        with self.assertRaises(ValueError):
+            terminal.run(['cat'], interactive=True, stdin='data')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/cr/test/fake_chromium_repo.py
+++ b/tools/cr/test/fake_chromium_repo.py
@@ -132,6 +132,7 @@ class FakeChromiumRepo:
         """
         path.mkdir(parents=True, exist_ok=True)
         self._run_git_command(['init'], path)
+        self._run_git_command(['config', 'core.autocrlf', 'false'], path)
         (path / 'README.md').write_text(f'# Fake {path.name} repo\n')
         self._run_git_command(['add', 'README.md'], path)
         self._run_git_command(['config', 'user.name', 'Fake User'], path)
@@ -269,7 +270,7 @@ class FakeChromiumRepo:
         """
         file_path = repo_path / relative_path
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        file_path.write_text(content)
+        file_path.write_text(content, newline='\n')
         self._run_git_command(['add', str(file_path)], repo_path)
 
     def delete_file(self, relative_path: str, repo_path: Path) -> None:


### PR DESCRIPTION
The `stdin` was being fed in text-mode pipe, which translates `\n`
line-endings, which was causing the read back to result in mismatches.

This change fix this a few other issues relating to Windows
normalisation.

Bug: https://github.com/brave/brave-browser/issues/45050
