### PR TITLE
[AI Chat] Move existing side panel conversation WebContents to a full-page Tab

### DIFF
--- a/browser/ai_chat/ai_chat_sidepanel_behavior_browsertest.cc
+++ b/browser/ai_chat/ai_chat_sidepanel_behavior_browsertest.cc
@@ -522,9 +522,10 @@ IN_PROC_BROWSER_TEST_P(AIChatGlobalSidePanelBrowserTest,
 // tab and the panel is left untouched.
 IN_PROC_BROWSER_TEST_P(AIChatGlobalSidePanelBrowserTest,
                        ReverseMovesSidePanelChatToFullPageTab) {
-  // Show the AI Chat side panel and read the *attached* contents. Avoid
-  // `GetWebContentsForTest`, which re-runs the entry factory and would register
-  // a throwaway (unattached) chat view as the active one.
+  // Show the AI Chat side panel and read the *attached* contents (the live
+  // panel conversation the reverse move operates on). Avoid
+  // `GetWebContentsForTest`, which re-runs the entry factory and returns a
+  // fresh, unattached contents rather than the one hosted in the panel.
   auto* coordinator = SidePanelCoordinator::From(browser());
   ASSERT_TRUE(coordinator);
   coordinator->Show(SidePanelEntry::Id::kChatUI);

--- a/browser/ai_chat/ai_chat_sidepanel_behavior_browsertest.cc
+++ b/browser/ai_chat/ai_chat_sidepanel_behavior_browsertest.cc
@@ -515,6 +515,113 @@ IN_PROC_BROWSER_TEST_P(AIChatGlobalSidePanelBrowserTest,
   EXPECT_TRUE(status_bubble_url().is_empty());
 }
 
+// The reverse move takes the live AI Chat conversation hosted in the (global)
+// side panel and moves it into a full-page tab (preserving state), then closes
+// the panel. It only engages with the move feature and the global side panel
+// both enabled; otherwise the caller falls back to opening a fresh full-page
+// tab and the panel is left untouched.
+IN_PROC_BROWSER_TEST_P(AIChatGlobalSidePanelBrowserTest,
+                       ReverseMovesSidePanelChatToFullPageTab) {
+  // Show the AI Chat side panel and read the *attached* contents. Avoid
+  // `GetWebContentsForTest`, which re-runs the entry factory and would register
+  // a throwaway (unattached) chat view as the active one.
+  auto* coordinator = SidePanelCoordinator::From(browser());
+  ASSERT_TRUE(coordinator);
+  coordinator->Show(SidePanelEntry::Id::kChatUI);
+
+  content::WebContents* panel_contents = nullptr;
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    panel_contents = GetAttachedSidePanelWebContents(browser());
+    return IsSidePanelOpen(browser()) && panel_contents != nullptr;
+  }));
+
+  auto* tab_strip = browser()->tab_strip_model();
+  const int initial_tab_count = tab_strip->count();
+
+  // The transfer requires both the move feature and the global side panel.
+  const bool expect_transfer =
+      IsMoveToSidePanelEnabled() && IsGlobalFlagEnabled();
+
+  const bool handled = ai_chat::MaybeMoveSidePanelChatToTab(panel_contents);
+
+  if (!expect_transfer) {
+    // No transfer: the conversation stays in the side panel.
+    EXPECT_FALSE(handled);
+    EXPECT_TRUE(IsSidePanelOpen(browser()));
+    EXPECT_EQ(tab_strip->count(), initial_tab_count);
+    return;
+  }
+
+  EXPECT_TRUE(handled);
+
+  // The same live conversation contents is now a full-page foreground tab (no
+  // reload / no fresh contents).
+  EXPECT_EQ(tab_strip->GetActiveWebContents(), panel_contents);
+  EXPECT_NE(tab_strip->GetIndexOfWebContents(panel_contents),
+            TabStripModel::kNoTab);
+  EXPECT_EQ(tab_strip->count(), initial_tab_count + 1);
+
+  // The side panel has closed to avoid showing the same conversation twice.
+  ASSERT_TRUE(
+      base::test::RunUntil([&]() { return !IsSidePanelOpen(browser()); }));
+}
+
+// The reverse move only applies to a side-panel-hosted conversation. A
+// full-page AI Chat tab has no side-panel chat view to move, so the helper is a
+// no-op regardless of the feature flags and the caller opens a fresh full-page
+// tab as before.
+IN_PROC_BROWSER_TEST_P(AIChatGlobalSidePanelBrowserTest,
+                       ReverseMoveIsNoOpForFullPageChat) {
+  auto* tab_strip = browser()->tab_strip_model();
+  ASSERT_TRUE(ui_test_utils::NavigateToURLWithDisposition(
+      browser(), GURL(kAIChatUIURL), WindowOpenDisposition::NEW_FOREGROUND_TAB,
+      ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP));
+  content::WebContents* leo_contents = tab_strip->GetActiveWebContents();
+  ASSERT_TRUE(leo_contents);
+  const int leo_index = tab_strip->GetIndexOfWebContents(leo_contents);
+
+  EXPECT_FALSE(ai_chat::MaybeMoveSidePanelChatToTab(leo_contents));
+
+  // AI Chat is untouched: still a full-page tab at the same position.
+  EXPECT_EQ(tab_strip->GetIndexOfWebContents(leo_contents), leo_index);
+}
+
+// Round trip: a full-page conversation moved into the side panel (forward) can
+// be moved back out to a full-page tab (reverse) as the SAME live WebContents.
+// This verifies the reverse works on a moved-in conversation (whose tab
+// associations were re-established when the panel adopted it) and that neither
+// direction reloads the contents.
+IN_PROC_BROWSER_TEST_P(AIChatGlobalSidePanelBrowserTest,
+                       ForwardThenReverseRoundTripsSameContents) {
+  if (!(IsMoveToSidePanelEnabled() && IsGlobalFlagEnabled())) {
+    GTEST_SKIP() << "The transfer only happens with move + global enabled.";
+  }
+
+  auto* tab_strip = browser()->tab_strip_model();
+  ASSERT_TRUE(ui_test_utils::NavigateToURLWithDisposition(
+      browser(), GURL(kAIChatUIURL), WindowOpenDisposition::NEW_FOREGROUND_TAB,
+      ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP));
+  content::WebContents* leo_contents = tab_strip->GetActiveWebContents();
+  ASSERT_TRUE(leo_contents);
+
+  // Forward: full page -> side panel.
+  ASSERT_TRUE(ai_chat::MaybeMoveFullPageChatToSidePanel(leo_contents));
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return IsSidePanelOpen(browser()) &&
+           GetAttachedSidePanelWebContents(browser()) == leo_contents;
+  }));
+  EXPECT_EQ(tab_strip->GetIndexOfWebContents(leo_contents),
+            TabStripModel::kNoTab);
+
+  // Reverse: side panel -> full page, as the same live contents.
+  ASSERT_TRUE(ai_chat::MaybeMoveSidePanelChatToTab(leo_contents));
+  EXPECT_EQ(tab_strip->GetActiveWebContents(), leo_contents);
+  EXPECT_NE(tab_strip->GetIndexOfWebContents(leo_contents),
+            TabStripModel::kNoTab);
+  ASSERT_TRUE(
+      base::test::RunUntil([&]() { return !IsSidePanelOpen(browser()); }));
+}
+
 INSTANTIATE_TEST_SUITE_P(
     ,
     AIChatGlobalSidePanelBrowserTest,

--- a/browser/ui/side_panel/ai_chat/ai_chat_side_panel_utils.cc
+++ b/browser/ui/side_panel/ai_chat/ai_chat_side_panel_utils.cc
@@ -33,6 +33,10 @@ bool MaybeMoveFullPageChatToSidePanel(
     content::WebContents* ai_chat_web_contents) {
   return false;
 }
+
+bool MaybeMoveSidePanelChatToTab(content::WebContents* ai_chat_web_contents) {
+  return false;
+}
 #endif
 
 bool ShouldSidePanelBeGlobal(Profile* profile) {

--- a/browser/ui/side_panel/ai_chat/ai_chat_side_panel_utils.h
+++ b/browser/ui/side_panel/ai_chat/ai_chat_side_panel_utils.h
@@ -28,6 +28,16 @@ void ClosePanel(content::WebContents* web_contents);
 bool MaybeMoveFullPageChatToSidePanel(
     content::WebContents* ai_chat_web_contents);
 
+// Reverse (side panel -> tab): when `ai_chat_web_contents` is the live AI Chat
+// conversation hosted in the global side panel, moves that live `WebContents`
+// into a new full-page tab (preserving state) and closes the panel. Returns
+// true if the switch was handled this way (the caller must then NOT open a
+// fresh full-page tab). No-op (returns false) unless the
+// `kAIChatMoveFullPageToSidePanel` feature is enabled, the side panel is the
+// global standalone AI Chat, and it is the one being shown. Desktop only; the
+// definition lives in the toolkit_views translation unit.
+bool MaybeMoveSidePanelChatToTab(content::WebContents* ai_chat_web_contents);
+
 // Closes the side panel only if the AI Chat entry is the one currently being
 // shown. Used when moving a conversation to a full-page tab, where leaving the
 // now-duplicate AI Chat side panel open would be confusing.

--- a/browser/ui/views/side_panel/ai_chat/BUILD.gn
+++ b/browser/ui/views/side_panel/ai_chat/BUILD.gn
@@ -39,6 +39,7 @@ source_set("ai_chat") {
     "//chrome/browser:file_select_helper",
     "//chrome/browser/profiles",
     "//chrome/browser/tab_list",
+    "//chrome/browser/ui:browser_element_identifiers",
     "//chrome/browser/ui/browser_window",
     "//chrome/browser/ui/navigator",
     "//chrome/browser/ui/side_panel",

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.cc
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.cc
@@ -79,17 +79,38 @@ std::unique_ptr<views::View> AIChatMovableSidePanelWebView::CreateView(
 
   auto web_view = std::make_unique<AIChatMovableSidePanelWebView>(profile);
 
-  // When a full-page AI Chat is being moved into the side panel, adopt that
-  // live `WebContents` instead of creating a fresh one, so the conversation's
-  // renderer/scroll/Mojo state is preserved.
-  AIChatSidePanelTabTransferBridge* transfer_controller =
+  AIChatSidePanelTabTransferBridge* transfer_bridge =
       scope.GetBrowserWindowInterface()
           .GetFeatures()
           .ai_chat_side_panel_tab_transfer_bridge();
-  web_view->AdoptWebContents(
-      transfer_controller && transfer_controller->HasPendingTransfer()
-          ? transfer_controller->TakePendingContents()
-          : CreateFreshAIChatContents(profile, is_tab_associated, scope));
+
+  if (transfer_bridge && transfer_bridge->HasPendingTransfer()) {
+    // A full-page AI Chat is being moved into the side panel: adopt that live
+    // `WebContents` instead of creating a fresh one, so the conversation's
+    // renderer/scroll/Mojo state is preserved.
+    std::unique_ptr<content::WebContents> moved_in =
+        transfer_bridge->TakePendingContents();
+    // The contents' tab associations were torn down when it was detached from
+    // the tab strip, which leaves a stale tab tracker in the webui embedding
+    // context. Re-establish the browser-window association (mirroring
+    // `ContextualTasksSidePanelCoordinator::SetBrowserWindowInterface`) so
+    // links and modal dialogs still resolve the hosting window while it is
+    // panel-hosted, and so the reverse move can later hand it back to a tab.
+    webui::SetTabInterface(moved_in.get(), nullptr);
+    webui::SetBrowserWindowInterface(moved_in.get(),
+                                     &scope.GetBrowserWindowInterface());
+    web_view->AdoptWebContents(std::move(moved_in));
+  } else {
+    web_view->AdoptWebContents(
+        CreateFreshAIChatContents(profile, is_tab_associated, scope));
+  }
+
+  // Register as the window's live AI Chat side panel view so the reverse move
+  // (side panel -> tab) can find and release this view's contents. The bridge
+  // observes the view and clears the registration when it is destroyed.
+  if (transfer_bridge) {
+    transfer_bridge->SetActiveChatView(web_view.get());
+  }
   return web_view;
 }
 
@@ -135,6 +156,14 @@ void AIChatMovableSidePanelWebView::AdoptWebContents(
     std::unique_ptr<content::WebContents> web_contents) {
   owned_web_contents_ = std::move(web_contents);
   SetWebContents(owned_web_contents_.get());
+}
+
+std::unique_ptr<content::WebContents>
+AIChatMovableSidePanelWebView::ReleaseWebContents() {
+  // Detach the contents from the view (hides it and drops the modal-dialog
+  // manager) without destroying it, then relinquish ownership.
+  SetWebContents(nullptr);
+  return std::move(owned_web_contents_);
 }
 
 void AIChatMovableSidePanelWebView::SetWebContents(

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.cc
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.cc
@@ -33,6 +33,7 @@
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_contents_delegate.h"
 #include "extensions/buildflags/buildflags.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/base/page_transition_types.h"
 #include "ui/base/window_open_disposition.h"
 #include "ui/compositor/layer.h"
@@ -105,12 +106,6 @@ std::unique_ptr<views::View> AIChatMovableSidePanelWebView::CreateView(
         CreateFreshAIChatContents(profile, is_tab_associated, scope));
   }
 
-  // Register as the window's live AI Chat side panel view so the reverse move
-  // (side panel -> tab) can find and release this view's contents. The bridge
-  // observes the view and clears the registration when it is destroyed.
-  if (transfer_bridge) {
-    transfer_bridge->SetActiveChatView(web_view.get());
-  }
   return web_view;
 }
 
@@ -301,3 +296,6 @@ void AIChatMovableSidePanelWebView::DetachWebContentsModalDialogManager(
     dialog_manager->SetDelegate(nullptr);
   }
 }
+
+BEGIN_METADATA(AIChatMovableSidePanelWebView)
+END_METADATA

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.h
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.h
@@ -66,6 +66,12 @@ class AIChatMovableSidePanelWebView
   // Takes ownership of `web_contents` and displays it in this view.
   void AdoptWebContents(std::unique_ptr<content::WebContents> web_contents);
 
+  // Relinquishes ownership of the hosted `WebContents`, detaching it from this
+  // view without destroying it. Used by the reverse transfer (side panel ->
+  // tab) so the live conversation can be re-inserted into a browser tab.
+  // Returns null when the view is not currently hosting any contents.
+  std::unique_ptr<content::WebContents> ReleaseWebContents();
+
   // views::WebView:
   void SetWebContents(content::WebContents* web_contents) override;
 

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.h
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.h
@@ -9,6 +9,7 @@
 #include <memory>
 
 #include "components/web_modal/web_contents_modal_dialog_manager_delegate.h"
+#include "ui/base/metadata/metadata_header_macros.h"
 #include "ui/views/controls/webview/unhandled_keyboard_event_handler.h"
 #include "ui/views/controls/webview/webview.h"
 #include "url/gurl.h"
@@ -48,6 +49,8 @@ class StatusBubbleViews;
 class AIChatMovableSidePanelWebView
     : public views::WebView,
       public web_modal::WebContentsModalDialogManagerDelegate {
+  METADATA_HEADER(AIChatMovableSidePanelWebView, views::WebView)
+
  public:
   // Factory used by `AIChatSidePanelWebView::CreateView` when the feature is
   // enabled. If `is_tab_associated` is true the panel tracks the active tab's

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_tab_transfer_bridge.cc
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_tab_transfer_bridge.cc
@@ -10,7 +10,6 @@
 #include "base/check.h"
 #include "brave/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.h"
 #include "brave/components/ai_chat/core/common/ai_chat_urls.h"
-#include "chrome/browser/ui/browser_element_identifiers.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 #include "chrome/browser/ui/navigator/browser_navigator.h"
 #include "chrome/browser/ui/navigator/browser_navigator_params.h"
@@ -18,7 +17,8 @@
 #include "chrome/browser/ui/side_panel/side_panel_enums.h"
 #include "chrome/browser/ui/side_panel/side_panel_registry.h"
 #include "chrome/browser/ui/side_panel/side_panel_ui.h"
-#include "chrome/browser/ui/views/interaction/browser_elements_views.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/side_panel/side_panel.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h"
 #include "chrome/browser/ui/webui/webui_embedding_context.h"
 #include "components/tabs/public/tab_interface.h"
@@ -27,7 +27,6 @@
 #include "ui/base/page_transition_types.h"
 #include "ui/base/window_open_disposition.h"
 #include "ui/gfx/geometry/rect.h"
-#include "ui/views/view.h"
 #include "ui/views/view_utils.h"
 #include "ui/views/widget/widget.h"
 
@@ -124,25 +123,19 @@ void AIChatSidePanelTabTransferBridge::ClearChatEntryCache() {
 
 bool AIChatSidePanelTabTransferBridge::MoveSidePanelContentsToTab(
     content::WebContents* side_panel_contents) {
-  // Only the live conversation currently hosted in the side panel can be moved.
-  // Find the movable AI Chat view by its shared id: resolve the `SidePanel` via
-  // `BrowserElementsViews` (mirrors the private
-  // `SidePanelCoordinator::GetSidePanel()` lookup) to reach the window, then
-  // search from the window's root view. The root view (not the `SidePanel`
-  // subtree) is used because the flash-free forward animation (`ShowFrom`)
-  // transiently reparents the panel content to the browser view while it
-  // animates in; searching the root finds the view whether it is animating or
-  // settled. Returns null when AI Chat is not the side panel's live entry.
-  AIChatMovableSidePanelWebView* chat_view = nullptr;
-  BrowserElementsViews* elements = BrowserElementsViews::From(browser_);
-  views::View* side_panel =
-      elements ? elements->GetView(kSidePanelElementId) : nullptr;
-  views::Widget* widget = side_panel ? side_panel->GetWidget() : nullptr;
-  if (widget) {
+  BrowserView* browser_view = BrowserView::GetBrowserViewForBrowser(browser_);
+  // If the Side Panel is still animating in then it won't yet be parented to
+  // the SidePanel and we need to find it on the BrowserView instead.
+  AIChatMovableSidePanelWebView* chat_view =
+      views::AsViewClass<AIChatMovableSidePanelWebView>(
+          browser_view->GetSidePanelAnimationContent());
+
+  if (!chat_view) {
     chat_view = views::AsViewClass<AIChatMovableSidePanelWebView>(
-        widget->GetRootView()->GetViewByID(
+        browser_view->side_panel()->GetViewByID(
             SidePanelWebUIView::kSidePanelWebViewId));
   }
+
   // Bail if there is no live movable chat view, or it hosts some other
   // contents.
   if (!chat_view || chat_view->web_contents() != side_panel_contents) {
@@ -152,8 +145,8 @@ bool AIChatSidePanelTabTransferBridge::MoveSidePanelContentsToTab(
   // A tab-associated (contextual) conversation follows the active tab and
   // carries `/tab` semantics that don't belong in a standalone full-page tab;
   // leave it to the caller's fresh-tab path.
-  if (ai_chat::ConversationUUIDFromURL(
-          side_panel_contents->GetLastCommittedURL()) == "tab") {
+  if (ai_chat::TabAssociatedConversationUrl().EqualsIgnoringRef(
+          side_panel_contents->GetLastCommittedURL())) {
     return false;
   }
 

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_tab_transfer_bridge.cc
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_tab_transfer_bridge.cc
@@ -44,10 +44,7 @@ AIChatSidePanelTabTransferBridge::AIChatSidePanelTabTransferBridge(
   CHECK(browser_);
 }
 
-AIChatSidePanelTabTransferBridge::~AIChatSidePanelTabTransferBridge() {
-  // Stop observing the active view (if any) before this bridge goes away.
-  SetActiveChatView(nullptr);
-}
+AIChatSidePanelTabTransferBridge::~AIChatSidePanelTabTransferBridge() = default;
 
 void AIChatSidePanelTabTransferBridge::TransferFullPageContentsToSidePanel(
     std::unique_ptr<content::WebContents> web_contents,
@@ -122,15 +119,14 @@ void AIChatSidePanelTabTransferBridge::ClearChatEntryCache() {
 
 void AIChatSidePanelTabTransferBridge::SetActiveChatView(
     AIChatMovableSidePanelWebView* view) {
-  if (active_chat_view_ == view) {
+  if (chat_view_observation_.GetSource() == view) {
     return;
   }
-  if (active_chat_view_) {
-    active_chat_view_->RemoveObserver(this);
-  }
-  active_chat_view_ = view;
-  if (active_chat_view_) {
-    active_chat_view_->AddObserver(this);
+  // `Observe()` requires no current source, so reset first when switching
+  // views.
+  chat_view_observation_.Reset();
+  if (view) {
+    chat_view_observation_.Observe(view);
   }
 }
 
@@ -139,8 +135,8 @@ bool AIChatSidePanelTabTransferBridge::MoveSidePanelContentsToTab(
   // Only the live conversation currently hosted in the side panel can be moved.
   // If there is no active movable chat view, or the caller is some other
   // contents, there is nothing to move.
-  if (!active_chat_view_ ||
-      active_chat_view_->web_contents() != side_panel_contents) {
+  AIChatMovableSidePanelWebView* chat_view = active_chat_view();
+  if (!chat_view || chat_view->web_contents() != side_panel_contents) {
     return false;
   }
 
@@ -159,7 +155,7 @@ bool AIChatSidePanelTabTransferBridge::MoveSidePanelContentsToTab(
 
   // Take the live contents out of the view (not destroyed, not reloaded).
   std::unique_ptr<content::WebContents> web_contents =
-      active_chat_view_->ReleaseWebContents();
+      chat_view->ReleaseWebContents();
   CHECK(web_contents);
 
   // Restore the associations the contents needs as a tab, mirroring
@@ -192,7 +188,8 @@ bool AIChatSidePanelTabTransferBridge::MoveSidePanelContentsToTab(
 
 void AIChatSidePanelTabTransferBridge::OnViewIsDeleting(
     views::View* observed_view) {
-  if (observed_view == active_chat_view_) {
-    SetActiveChatView(nullptr);
-  }
+  // The active chat view is the only view observed, so stop observing it before
+  // it is destroyed (the observation holds the back-pointer to it).
+  CHECK(observed_view == active_chat_view());
+  chat_view_observation_.Reset();
 }

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_tab_transfer_bridge.cc
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_tab_transfer_bridge.cc
@@ -10,6 +10,7 @@
 #include "base/check.h"
 #include "brave/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.h"
 #include "brave/components/ai_chat/core/common/ai_chat_urls.h"
+#include "chrome/browser/ui/browser_element_identifiers.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 #include "chrome/browser/ui/navigator/browser_navigator.h"
 #include "chrome/browser/ui/navigator/browser_navigator_params.h"
@@ -17,6 +18,8 @@
 #include "chrome/browser/ui/side_panel/side_panel_enums.h"
 #include "chrome/browser/ui/side_panel/side_panel_registry.h"
 #include "chrome/browser/ui/side_panel/side_panel_ui.h"
+#include "chrome/browser/ui/views/interaction/browser_elements_views.h"
+#include "chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h"
 #include "chrome/browser/ui/webui/webui_embedding_context.h"
 #include "components/tabs/public/tab_interface.h"
 #include "content/public/browser/web_contents.h"
@@ -25,6 +28,8 @@
 #include "ui/base/window_open_disposition.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/views/view.h"
+#include "ui/views/view_utils.h"
+#include "ui/views/widget/widget.h"
 
 #if BUILDFLAG(ENABLE_EXTENSIONS_CORE)
 #include "extensions/browser/view_type_utils.h"
@@ -117,25 +122,29 @@ void AIChatSidePanelTabTransferBridge::ClearChatEntryCache() {
   }
 }
 
-void AIChatSidePanelTabTransferBridge::SetActiveChatView(
-    AIChatMovableSidePanelWebView* view) {
-  if (chat_view_observation_.GetSource() == view) {
-    return;
-  }
-  // `Observe()` requires no current source, so reset first when switching
-  // views.
-  chat_view_observation_.Reset();
-  if (view) {
-    chat_view_observation_.Observe(view);
-  }
-}
-
 bool AIChatSidePanelTabTransferBridge::MoveSidePanelContentsToTab(
     content::WebContents* side_panel_contents) {
   // Only the live conversation currently hosted in the side panel can be moved.
-  // If there is no active movable chat view, or the caller is some other
-  // contents, there is nothing to move.
-  AIChatMovableSidePanelWebView* chat_view = active_chat_view();
+  // Find the movable AI Chat view by its shared id: resolve the `SidePanel` via
+  // `BrowserElementsViews` (mirrors the private
+  // `SidePanelCoordinator::GetSidePanel()` lookup) to reach the window, then
+  // search from the window's root view. The root view (not the `SidePanel`
+  // subtree) is used because the flash-free forward animation (`ShowFrom`)
+  // transiently reparents the panel content to the browser view while it
+  // animates in; searching the root finds the view whether it is animating or
+  // settled. Returns null when AI Chat is not the side panel's live entry.
+  AIChatMovableSidePanelWebView* chat_view = nullptr;
+  BrowserElementsViews* elements = BrowserElementsViews::From(browser_);
+  views::View* side_panel =
+      elements ? elements->GetView(kSidePanelElementId) : nullptr;
+  views::Widget* widget = side_panel ? side_panel->GetWidget() : nullptr;
+  if (widget) {
+    chat_view = views::AsViewClass<AIChatMovableSidePanelWebView>(
+        widget->GetRootView()->GetViewByID(
+            SidePanelWebUIView::kSidePanelWebViewId));
+  }
+  // Bail if there is no live movable chat view, or it hosts some other
+  // contents.
   if (!chat_view || chat_view->web_contents() != side_panel_contents) {
     return false;
   }
@@ -172,9 +181,8 @@ bool AIChatSidePanelTabTransferBridge::MoveSidePanelContentsToTab(
   // that the browser and tab associations are never set at the same time.
   webui::SetBrowserWindowInterface(web_contents.get(), nullptr);
 
-  // Insert the live contents into a new foreground tab. The
-  // `BrowserWindowInterface*` + `unique_ptr<WebContents>` ctor keeps this
-  // `Browser*`-free; `Navigate` re-runs the idempotent `AttachTabHelpers`.
+  // Insert the live contents into a new foreground tab; `Navigate` re-runs the
+  // idempotent `AttachTabHelpers`.
   NavigateParams params(browser_, std::move(web_contents));
   params.disposition = WindowOpenDisposition::NEW_FOREGROUND_TAB;
   params.transition = ui::PAGE_TRANSITION_LINK;
@@ -184,12 +192,4 @@ bool AIChatSidePanelTabTransferBridge::MoveSidePanelContentsToTab(
   // is torn down on close, but its owned contents was already released.
   side_panel_ui->Close();
   return true;
-}
-
-void AIChatSidePanelTabTransferBridge::OnViewIsDeleting(
-    views::View* observed_view) {
-  // The active chat view is the only view observed, so stop observing it before
-  // it is destroyed (the observation holds the back-pointer to it).
-  CHECK(observed_view == active_chat_view());
-  chat_view_observation_.Reset();
 }

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_tab_transfer_bridge.cc
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_tab_transfer_bridge.cc
@@ -8,14 +8,27 @@
 #include <utility>
 
 #include "base/check.h"
+#include "brave/browser/ui/views/side_panel/ai_chat/ai_chat_movable_side_panel_web_view.h"
+#include "brave/components/ai_chat/core/common/ai_chat_urls.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
+#include "chrome/browser/ui/navigator/browser_navigator.h"
+#include "chrome/browser/ui/navigator/browser_navigator_params.h"
 #include "chrome/browser/ui/side_panel/side_panel_entry.h"
 #include "chrome/browser/ui/side_panel/side_panel_enums.h"
 #include "chrome/browser/ui/side_panel/side_panel_registry.h"
 #include "chrome/browser/ui/side_panel/side_panel_ui.h"
+#include "chrome/browser/ui/webui/webui_embedding_context.h"
 #include "components/tabs/public/tab_interface.h"
 #include "content/public/browser/web_contents.h"
+#include "extensions/buildflags/buildflags.h"
+#include "ui/base/page_transition_types.h"
+#include "ui/base/window_open_disposition.h"
 #include "ui/gfx/geometry/rect.h"
+#include "ui/views/view.h"
+
+#if BUILDFLAG(ENABLE_EXTENSIONS_CORE)
+#include "extensions/browser/view_type_utils.h"
+#endif
 
 namespace {
 
@@ -31,7 +44,10 @@ AIChatSidePanelTabTransferBridge::AIChatSidePanelTabTransferBridge(
   CHECK(browser_);
 }
 
-AIChatSidePanelTabTransferBridge::~AIChatSidePanelTabTransferBridge() = default;
+AIChatSidePanelTabTransferBridge::~AIChatSidePanelTabTransferBridge() {
+  // Stop observing the active view (if any) before this bridge goes away.
+  SetActiveChatView(nullptr);
+}
 
 void AIChatSidePanelTabTransferBridge::TransferFullPageContentsToSidePanel(
     std::unique_ptr<content::WebContents> web_contents,
@@ -101,5 +117,82 @@ void AIChatSidePanelTabTransferBridge::ClearChatEntryCache() {
         entry->ClearCachedView();
       }
     }
+  }
+}
+
+void AIChatSidePanelTabTransferBridge::SetActiveChatView(
+    AIChatMovableSidePanelWebView* view) {
+  if (active_chat_view_ == view) {
+    return;
+  }
+  if (active_chat_view_) {
+    active_chat_view_->RemoveObserver(this);
+  }
+  active_chat_view_ = view;
+  if (active_chat_view_) {
+    active_chat_view_->AddObserver(this);
+  }
+}
+
+bool AIChatSidePanelTabTransferBridge::MoveSidePanelContentsToTab(
+    content::WebContents* side_panel_contents) {
+  // Only the live conversation currently hosted in the side panel can be moved.
+  // If there is no active movable chat view, or the caller is some other
+  // contents, there is nothing to move.
+  if (!active_chat_view_ ||
+      active_chat_view_->web_contents() != side_panel_contents) {
+    return false;
+  }
+
+  // A tab-associated (contextual) conversation follows the active tab and
+  // carries `/tab` semantics that don't belong in a standalone full-page tab;
+  // leave it to the caller's fresh-tab path.
+  if (ai_chat::ConversationUUIDFromURL(
+          side_panel_contents->GetLastCommittedURL()) == "tab") {
+    return false;
+  }
+
+  // The bridge is only created for normal windows, which always have a side
+  // panel UI.
+  SidePanelUI* side_panel_ui = SidePanelUI::From(browser_);
+  CHECK(side_panel_ui);
+
+  // Take the live contents out of the view (not destroyed, not reloaded).
+  std::unique_ptr<content::WebContents> web_contents =
+      active_chat_view_->ReleaseWebContents();
+  CHECK(web_contents);
+
+  // Restore the associations the contents needs as a tab, mirroring
+  // `ContextualTasksSidePanelCoordinator::DetachWebContentsForTask`.
+#if BUILDFLAG(ENABLE_EXTENSIONS_CORE)
+  // Back to a tab-hosted view type (the movable view set `kComponent`).
+  extensions::SetViewType(web_contents.get(),
+                          extensions::mojom::ViewType::kTabContents);
+#endif
+  // The movable view is no longer a valid delegate once the contents leaves it.
+  web_contents->SetDelegate(nullptr);
+  // Drop the panel's browser-window association. Tab insertion re-establishes
+  // the tab (and its window) association; the webui embedding context CHECKs
+  // that the browser and tab associations are never set at the same time.
+  webui::SetBrowserWindowInterface(web_contents.get(), nullptr);
+
+  // Insert the live contents into a new foreground tab. The
+  // `BrowserWindowInterface*` + `unique_ptr<WebContents>` ctor keeps this
+  // `Browser*`-free; `Navigate` re-runs the idempotent `AttachTabHelpers`.
+  NavigateParams params(browser_, std::move(web_contents));
+  params.disposition = WindowOpenDisposition::NEW_FOREGROUND_TAB;
+  params.transition = ui::PAGE_TRANSITION_LINK;
+  Navigate(&params);
+
+  // The conversation now lives in a tab; close the (now-empty) panel. Its view
+  // is torn down on close, but its owned contents was already released.
+  side_panel_ui->Close();
+  return true;
+}
+
+void AIChatSidePanelTabTransferBridge::OnViewIsDeleting(
+    views::View* observed_view) {
+  if (observed_view == active_chat_view_) {
+    SetActiveChatView(nullptr);
   }
 }

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_tab_transfer_bridge.h
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_tab_transfer_bridge.h
@@ -9,10 +9,7 @@
 #include <memory>
 
 #include "base/memory/raw_ptr.h"
-#include "base/scoped_observation.h"
-#include "ui/views/view_observer.h"
 
-class AIChatMovableSidePanelWebView;
 class BrowserWindowInterface;
 
 namespace content {
@@ -23,24 +20,20 @@ namespace gfx {
 class Rect;
 }  // namespace gfx
 
-namespace views {
-class View;
-}  // namespace views
-
 // Window-scoped controller (owned by `BrowserWindowFeatures`) that moves the
 // live AI Chat `WebContents` between a browser tab and the side panel when the
 // `kAIChatMoveFullPageToSidePanel` feature is enabled. It is intentionally
 // small: it does not own the steady-state side panel contents (the
 // `AIChatMovableSidePanelWebView` does) — only the transient hand-off used
 // while a transfer is in-flight.
-class AIChatSidePanelTabTransferBridge : public views::ViewObserver {
+class AIChatSidePanelTabTransferBridge {
  public:
   explicit AIChatSidePanelTabTransferBridge(BrowserWindowInterface* browser);
   AIChatSidePanelTabTransferBridge(const AIChatSidePanelTabTransferBridge&) =
       delete;
   AIChatSidePanelTabTransferBridge& operator=(
       const AIChatSidePanelTabTransferBridge&) = delete;
-  ~AIChatSidePanelTabTransferBridge() override;
+  ~AIChatSidePanelTabTransferBridge();
 
   // Forward (tab -> side panel). Takes ownership of the live AI Chat
   // `web_contents` (already detached from the tab strip by the caller) and
@@ -60,15 +53,6 @@ class AIChatSidePanelTabTransferBridge : public views::ViewObserver {
   // factory). Returns null when there is no pending transfer.
   std::unique_ptr<content::WebContents> TakePendingContents();
 
-  // Tracks the live movable AI Chat side panel view (self-registered by
-  // `AIChatMovableSidePanelWebView::CreateView`). Pass null to clear. The
-  // bridge observes the view and clears the registration automatically when the
-  // view is destroyed. The reverse move uses it to reach the panel's contents.
-  void SetActiveChatView(AIChatMovableSidePanelWebView* view);
-  AIChatMovableSidePanelWebView* active_chat_view() {
-    return chat_view_observation_.GetSource();
-  }
-
   // Reverse (side panel -> tab). Moves the live AI Chat `side_panel_contents`
   // out of the side panel and into a new full-page tab (preserving state), then
   // closes the panel. Returns true when it moved the contents; false (leaving
@@ -76,9 +60,6 @@ class AIChatSidePanelTabTransferBridge : public views::ViewObserver {
   // conversation or is a tab-associated (contextual) conversation, in which
   // case the caller opens a fresh full-page tab instead.
   bool MoveSidePanelContentsToTab(content::WebContents* side_panel_contents);
-
-  // views::ViewObserver:
-  void OnViewIsDeleting(views::View* observed_view) override;
 
  private:
   // Clears any cached AI Chat side panel view (in both the window-scoped and
@@ -92,14 +73,6 @@ class AIChatSidePanelTabTransferBridge : public views::ViewObserver {
   // `TransferFullPageContentsToSidePanel` and consumed by the side panel view
   // factory via `TakePendingContents`.
   std::unique_ptr<content::WebContents> pending_web_contents_;
-
-  // Tracks the live movable AI Chat side panel view for this window (null when
-  // AI Chat is not movably hosted in the side panel). The scoped observation is
-  // the single source of truth for the active view: it holds the back-pointer
-  // and stops observing when the view is destroyed, so the pointer can never
-  // dangle and the bridge needs no manual teardown.
-  base::ScopedObservation<AIChatMovableSidePanelWebView, views::ViewObserver>
-      chat_view_observation_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_AI_CHAT_AI_CHAT_SIDE_PANEL_TAB_TRANSFER_BRIDGE_H_

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_tab_transfer_bridge.h
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_tab_transfer_bridge.h
@@ -9,7 +9,9 @@
 #include <memory>
 
 #include "base/memory/raw_ptr.h"
+#include "ui/views/view_observer.h"
 
+class AIChatMovableSidePanelWebView;
 class BrowserWindowInterface;
 
 namespace content {
@@ -20,20 +22,24 @@ namespace gfx {
 class Rect;
 }  // namespace gfx
 
+namespace views {
+class View;
+}  // namespace views
+
 // Window-scoped controller (owned by `BrowserWindowFeatures`) that moves the
 // live AI Chat `WebContents` between a browser tab and the side panel when the
 // `kAIChatMoveFullPageToSidePanel` feature is enabled. It is intentionally
 // small: it does not own the steady-state side panel contents (the
 // `AIChatMovableSidePanelWebView` does) — only the transient hand-off used
 // while a transfer is in-flight.
-class AIChatSidePanelTabTransferBridge {
+class AIChatSidePanelTabTransferBridge : public views::ViewObserver {
  public:
   explicit AIChatSidePanelTabTransferBridge(BrowserWindowInterface* browser);
   AIChatSidePanelTabTransferBridge(const AIChatSidePanelTabTransferBridge&) =
       delete;
   AIChatSidePanelTabTransferBridge& operator=(
       const AIChatSidePanelTabTransferBridge&) = delete;
-  ~AIChatSidePanelTabTransferBridge();
+  ~AIChatSidePanelTabTransferBridge() override;
 
   // Forward (tab -> side panel). Takes ownership of the live AI Chat
   // `web_contents` (already detached from the tab strip by the caller) and
@@ -53,6 +59,26 @@ class AIChatSidePanelTabTransferBridge {
   // factory). Returns null when there is no pending transfer.
   std::unique_ptr<content::WebContents> TakePendingContents();
 
+  // Tracks the live movable AI Chat side panel view (self-registered by
+  // `AIChatMovableSidePanelWebView::CreateView`). Pass null to clear. The
+  // bridge observes the view and clears the registration automatically when the
+  // view is destroyed. The reverse move uses it to reach the panel's contents.
+  void SetActiveChatView(AIChatMovableSidePanelWebView* view);
+  AIChatMovableSidePanelWebView* active_chat_view() {
+    return active_chat_view_;
+  }
+
+  // Reverse (side panel -> tab). Moves the live AI Chat `side_panel_contents`
+  // out of the side panel and into a new full-page tab (preserving state), then
+  // closes the panel. Returns true when it moved the contents; false (leaving
+  // everything untouched) when `side_panel_contents` is not the live panel
+  // conversation or is a tab-associated (contextual) conversation, in which
+  // case the caller opens a fresh full-page tab instead.
+  bool MoveSidePanelContentsToTab(content::WebContents* side_panel_contents);
+
+  // views::ViewObserver:
+  void OnViewIsDeleting(views::View* observed_view) override;
+
  private:
   // Clears any cached AI Chat side panel view (in both the window-scoped and
   // active tab-scoped registries) so the entry factory is guaranteed to run
@@ -65,6 +91,11 @@ class AIChatSidePanelTabTransferBridge {
   // `TransferFullPageContentsToSidePanel` and consumed by the side panel view
   // factory via `TakePendingContents`.
   std::unique_ptr<content::WebContents> pending_web_contents_;
+
+  // The live movable AI Chat side panel view for this window, or null when AI
+  // Chat is not (movably) hosted in the side panel. Observed for destruction so
+  // this back-pointer never dangles.
+  raw_ptr<AIChatMovableSidePanelWebView> active_chat_view_ = nullptr;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_AI_CHAT_AI_CHAT_SIDE_PANEL_TAB_TRANSFER_BRIDGE_H_

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_tab_transfer_bridge.h
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_tab_transfer_bridge.h
@@ -9,6 +9,7 @@
 #include <memory>
 
 #include "base/memory/raw_ptr.h"
+#include "base/scoped_observation.h"
 #include "ui/views/view_observer.h"
 
 class AIChatMovableSidePanelWebView;
@@ -65,7 +66,7 @@ class AIChatSidePanelTabTransferBridge : public views::ViewObserver {
   // view is destroyed. The reverse move uses it to reach the panel's contents.
   void SetActiveChatView(AIChatMovableSidePanelWebView* view);
   AIChatMovableSidePanelWebView* active_chat_view() {
-    return active_chat_view_;
+    return chat_view_observation_.GetSource();
   }
 
   // Reverse (side panel -> tab). Moves the live AI Chat `side_panel_contents`
@@ -92,10 +93,13 @@ class AIChatSidePanelTabTransferBridge : public views::ViewObserver {
   // factory via `TakePendingContents`.
   std::unique_ptr<content::WebContents> pending_web_contents_;
 
-  // The live movable AI Chat side panel view for this window, or null when AI
-  // Chat is not (movably) hosted in the side panel. Observed for destruction so
-  // this back-pointer never dangles.
-  raw_ptr<AIChatMovableSidePanelWebView> active_chat_view_ = nullptr;
+  // Tracks the live movable AI Chat side panel view for this window (null when
+  // AI Chat is not movably hosted in the side panel). The scoped observation is
+  // the single source of truth for the active view: it holds the back-pointer
+  // and stops observing when the view is destroyed, so the pointer can never
+  // dangle and the bridge needs no manual teardown.
+  base::ScopedObservation<AIChatMovableSidePanelWebView, views::ViewObserver>
+      chat_view_observation_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_AI_CHAT_AI_CHAT_SIDE_PANEL_TAB_TRANSFER_BRIDGE_H_

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_utils_views.cc
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_utils_views.cc
@@ -169,7 +169,8 @@ bool MaybeMoveSidePanelChatToTab(content::WebContents* ai_chat_web_contents) {
   AIChatSidePanelTabTransferBridge* transfer_bridge =
       browser->GetFeatures().ai_chat_side_panel_tab_transfer_bridge();
   if (!transfer_bridge) {
-    // Flag off, or a window type that has no bridge.
+    // The feature is enabled (checked above), so this is a window type that has
+    // no bridge (e.g. not a normal browser window).
     return false;
   }
 

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_utils_views.cc
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_utils_views.cc
@@ -18,6 +18,7 @@
 #include "chrome/browser/ui/side_panel/side_panel_ui.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/interaction/browser_elements_views.h"
+#include "chrome/browser/ui/webui/webui_embedding_context.h"
 #include "components/tabs/public/tab_interface.h"
 #include "content/public/browser/web_contents.h"
 #include "ui/gfx/geometry/rect.h"
@@ -141,6 +142,38 @@ bool MaybeMoveFullPageChatToSidePanel(
   transfer_controller->TransferFullPageContentsToSidePanel(
       std::move(ai_chat_contents), starting_bounds);
   return true;
+}
+
+bool MaybeMoveSidePanelChatToTab(content::WebContents* ai_chat_web_contents) {
+  if (!base::FeatureList::IsEnabled(features::kAIChatMoveFullPageToSidePanel)) {
+    return false;
+  }
+
+  // A side-panel-hosted AI Chat keeps its browser-window association while
+  // hosted (see `AIChatMovableSidePanelWebView`), so resolve the window from
+  // the contents without a `Browser*`.
+  BrowserWindowInterface* browser =
+      webui::GetBrowserWindowInterface(ai_chat_web_contents);
+  if (!browser) {
+    return false;
+  }
+
+  // Symmetric with the forward move: only the global (window-scoped) side panel
+  // transfers. A tab-scoped panel is tied to the tab it opened on, so moving
+  // the conversation out and closing the panel there is not the standalone case
+  // we support; leave it to the caller's fresh-tab path.
+  if (!ShouldSidePanelBeGlobal(browser->GetProfile())) {
+    return false;
+  }
+
+  AIChatSidePanelTabTransferBridge* transfer_bridge =
+      browser->GetFeatures().ai_chat_side_panel_tab_transfer_bridge();
+  if (!transfer_bridge) {
+    // Flag off, or a window type that has no bridge.
+    return false;
+  }
+
+  return transfer_bridge->MoveSidePanelContentsToTab(ai_chat_web_contents);
 }
 
 }  // namespace ai_chat

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -392,7 +392,7 @@ void AIChatUIPageHandler::OpenConversationFullPage(
   // move that live `WebContents` into a full-page tab, preserving its state,
   // instead of navigating a fresh one. No-op unless the feature is enabled and
   // the side panel is the standalone global AI Chat; otherwise fall through to
-  // opening a fresh full-page tab below.
+  // the fresh full-page tab navigation.
   if (ai_chat::MaybeMoveSidePanelChatToTab(owner_web_contents_)) {
     return;
   }

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -387,6 +387,16 @@ void AIChatUIPageHandler::OpenConversationFullPage(
   if (ai_chat_metrics_) {
     ai_chat_metrics_->RecordFullPageSwitch();
   }
+
+  // If this conversation is the live AI Chat hosted in the (global) side panel,
+  // move that live `WebContents` into a full-page tab, preserving its state,
+  // instead of navigating a fresh one. No-op unless the feature is enabled and
+  // the side panel is the standalone global AI Chat; otherwise fall through to
+  // opening a fresh full-page tab below.
+  if (ai_chat::MaybeMoveSidePanelChatToTab(owner_web_contents_)) {
+    return;
+  }
+
   NavigateParams params(profile_, ConversationUrl(conversation_uuid),
                         ui::PAGE_TRANSITION_TYPED);
   params.disposition = WindowOpenDisposition::NEW_FOREGROUND_TAB;


### PR DESCRIPTION
Preserve page state and scroll position instead of the current re-navigation to the conversation's URL.

Implements the reverse of the tab <-> side panel transfer: when the user opens the current side-panel AI Chat conversation as a full page (OpenConversationFullPage), move the live WebContents into a new tab instead of navigating a fresh one, preserving renderer/scroll/Mojo state. Falls back to a fresh full-page tab when it is not the live global side-panel conversation.

The bridge now tracks the live movable side panel view (self-registered by CreateView, cleared via ViewObserver) so MoveSidePanelContentsToTab can release its contents, restore the tab associations (kTabContents view type, null delegate, drop the panel's browser-window association), insert it with NavigateParams, and close the panel.

CreateView now also re-establishes the browser-window association on a moved-in contents (whose tab associations were torn down on detach, leaving a stale tab tracker), mirroring ContextualTasksSidePanelCoordinator. This keeps modal dialogs / links anchored to the window while panel-hosted and lets a forward-then-reverse round trip preserve the same live contents.

Gated behind kAIChatMoveFullPageToSidePanel (default-off) and the global side panel; tab-associated (/tab) conversations fall back to a fresh tab.

<!-- Add brave-browser issue below that this PR will resolve -->
Series
- https://github.com/brave/brave-browser/issues/57047

Based on:
- https://github.com/brave/brave-core/pull/37913
- https://github.com/brave/brave-core/pull/37994
- https://github.com/brave/brave-core/pull/38113

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
