### PR TITLE
Use request_initiator() in BraveRequestInfo and Adblock

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -1402,6 +1402,24 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, FrameSourceURL) {
   EXPECT_EQ(profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 }
 
+// Sandboxed iframes by default have an opaque request_initiator.
+// Requests from them must still be checked by adblock.
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, SandboxedIframeRequestsBlocked) {
+  UpdateAdBlockInstanceWithRules("adbanner.js");
+
+  NavigateToURL(embedded_test_server()->GetURL("a.com", kAdBlockTestPage));
+  ASSERT_EQ(true, EvalJs(web_contents(),
+                         "addFrame('/blocking.html', 'allow-scripts')"));
+
+  content::RenderFrameHost* frame = ChildFrameAt(web_contents(), 0);
+  ASSERT_TRUE(frame->GetLastCommittedOrigin().opaque());
+
+  EXPECT_EQ(true, EvalJs(frame,
+                         "setExpectations(0, 0, 0, 1);"
+                         "xhr('adbanner.js')"));
+  EXPECT_EQ(profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
+}
+
 IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
                        SocialMediaBlockingPrefsToggleLists) {
   // kTwitterEmbedListConstants UUID (enabled by default)

--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -1402,8 +1402,8 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, FrameSourceURL) {
   EXPECT_EQ(profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 }
 
-// Sandboxed iframes by default have an opaque request_initiator.
-// Requests from them must still be checked by adblock.
+// The requests from sandboxed iframes also must be checked by adblock
+// even though they have an opaque request_initiator.
 IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, SandboxedIframeRequestsBlocked) {
   UpdateAdBlockInstanceWithRules("adbanner.js");
 

--- a/browser/net/brave_ad_block_csp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_csp_network_delegate_helper.cc
@@ -24,26 +24,14 @@
 namespace brave {
 
 std::optional<std::string> GetCspDirectivesOnTaskRunner(
-    const GURL& initiator_url,
+    const std::optional<url::Origin>& request_initiator,
     const GURL& request_url,
     blink::mojom::ResourceType resource_type,
     const std::string& method,
     std::optional<std::string> original_csp,
     brave_shields::AdBlockEngineWrapper* engine_wrapper) {
-  std::string source_host;
-  if (initiator_url.is_valid() && !initiator_url.host().empty()) {
-    source_host = initiator_url.host();
-  } else if (request_url.is_valid()) {
-    // Top-level document requests do not have a valid initiator URL, and
-    // requests from special schemes like file:// do not have host parts, so we
-    // use the request URL as the initiator.
-    source_host = request_url.host();
-  } else {
-    return std::nullopt;
-  }
-
   std::optional<std::string> csp_directives = engine_wrapper->GetCspDirectives(
-      request_url, resource_type, source_host, method);
+      request_url, resource_type, request_initiator, method);
 
   brave_shields::MergeCspDirectiveInto(original_csp, &csp_directives);
   return csp_directives;
@@ -95,7 +83,7 @@ int OnHeadersReceived_AdBlockCspWork(
 
     auto* ad_block_service = g_brave_browser_process->ad_block_service();
     ad_block_service->AsyncCallAndReplyWithResult<std::optional<std::string>>(
-        base::BindOnce(&GetCspDirectivesOnTaskRunner, ctx->initiator_url(),
+        base::BindOnce(&GetCspDirectivesOnTaskRunner, ctx->request_initiator(),
                        ctx->request_url(), ctx->resource_type(), ctx->method(),
                        std::move(original_csp)),
         base::BindOnce(&OnReceiveCspDirectives, next_callback,

--- a/browser/net/brave_ad_block_csp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_csp_network_delegate_helper.cc
@@ -24,14 +24,26 @@
 namespace brave {
 
 std::optional<std::string> GetCspDirectivesOnTaskRunner(
-    const std::optional<url::Origin>& request_initiator,
+    const GURL& initiator_url,
     const GURL& request_url,
     blink::mojom::ResourceType resource_type,
     const std::string& method,
     std::optional<std::string> original_csp,
     brave_shields::AdBlockEngineWrapper* engine_wrapper) {
+  std::string source_host;
+  if (initiator_url.is_valid() && !initiator_url.host().empty()) {
+    source_host = initiator_url.host();
+  } else if (request_url.is_valid()) {
+    // Top-level document requests do not have a valid initiator URL, and
+    // requests from special schemes like file:// do not have host parts, so we
+    // use the request URL as the initiator.
+    source_host = request_url.host();
+  } else {
+    return std::nullopt;
+  }
+
   std::optional<std::string> csp_directives = engine_wrapper->GetCspDirectives(
-      request_url, resource_type, request_initiator, method);
+      request_url, resource_type, source_host, method);
 
   brave_shields::MergeCspDirectiveInto(original_csp, &csp_directives);
   return csp_directives;
@@ -82,8 +94,10 @@ int OnHeadersReceived_AdBlockCspWork(
     (*override_response_headers)->RemoveHeader("Content-Security-Policy");
 
     auto* ad_block_service = g_brave_browser_process->ad_block_service();
+    const GURL initiator_url =
+        ctx->request_initiator().value_or(url::Origin()).GetURL();
     ad_block_service->AsyncCallAndReplyWithResult<std::optional<std::string>>(
-        base::BindOnce(&GetCspDirectivesOnTaskRunner, ctx->request_initiator(),
+        base::BindOnce(&GetCspDirectivesOnTaskRunner, initiator_url,
                        ctx->request_url(), ctx->resource_type(), ctx->method(),
                        std::move(original_csp)),
         base::BindOnce(&OnReceiveCspDirectives, next_callback,

--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -63,7 +63,7 @@ struct EngineFlags {
 };
 
 struct ShouldBlockRequestParams {
-  GURL initiator_url;
+  url::Origin request_initiator;
   GURL request_url;
   blink::mojom::ResourceType resource_type =
       BraveRequestInfo::kInvalidResourceType;
@@ -205,10 +205,8 @@ ShouldBlockRequestResult ShouldBlockRequestOnTaskRunner(
   ShouldBlockRequestResult result;
   result.engine_flags = previous_result;
 
-  if (!input.initiator_url.is_valid()) {
-    return result;
-  }
-  const std::string source_host = std::string(input.initiator_url.host());
+  // Can be empty if the request initiator is opaque.
+  const std::string source_host = std::string(input.request_initiator.host());
 
   GURL url_to_check;
   if (canonical_url.has_value()) {
@@ -218,13 +216,13 @@ ShouldBlockRequestResult ShouldBlockRequestOnTaskRunner(
   }
 
   bool force_aggressive = SameDomainOrHost(
-      input.initiator_url,
       url::Origin::CreateFromNormalizedTuple("https", "youtube.com", 443),
+      input.request_initiator,
       net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES);
 
   SCOPED_UMA_HISTOGRAM_TIMER("Brave.Adblock.ShouldBlockRequest");
   auto adblock_result = engine_wrapper->ShouldStartRequest(
-      url_to_check, input.resource_type, source_host, input.method,
+      url_to_check, input.resource_type, input.request_initiator, input.method,
       input.aggressive_blocking || force_aggressive,
       previous_result.did_match_rule, previous_result.did_match_exception,
       previous_result.did_match_important);
@@ -315,7 +313,7 @@ void UseCnameResult(const ResponseCallback& next_callback,
                     std::optional<std::string> cname) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
-  if (!ctx) {
+  if (!ctx || !ctx->request_initiator()) {
     next_callback.Run();
     return;
   }
@@ -327,7 +325,7 @@ void UseCnameResult(const ResponseCallback& next_callback,
     const GURL canonical_url =
         ctx->request_url().ReplaceComponents(replacements);
 
-    ShouldBlockRequestParams input{ctx->initiator_url(),
+    ShouldBlockRequestParams input{*ctx->request_initiator(),
                                    ctx->request_url(),
                                    ctx->resource_type(),
                                    ctx->aggressive_blocking(),
@@ -400,7 +398,7 @@ void OnBeforeURLRequestAdBlockTP(const ResponseCallback& next_callback,
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
   DCHECK_NE(ctx->request_identifier(), 0UL);
   DCHECK(!ctx->request_url().is_empty());
-  DCHECK(!ctx->initiator_url().is_empty());
+  CHECK(ctx->request_initiator());
 
   // DNS queries won't be routed through Tor or proxies, so we need to
   // skip requests in those contexts.
@@ -418,15 +416,13 @@ void OnBeforeURLRequestAdBlockTP(const ResponseCallback& next_callback,
           brave_shields::features::kBraveAdblockDefault1pBlocking) &&
       should_check_uncloaked && !ctx->aggressive_blocking() &&
       SameDomainOrHost(
-          ctx->request_url(),
-          url::Origin::CreateFromNormalizedTuple(
-              "https", std::string(ctx->initiator_url().host()), 80),
+          ctx->request_url(), *ctx->request_initiator(),
           net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES)) {
     should_check_uncloaked = false;
   }
 
   ShouldBlockRequestParams input{
-      ctx->initiator_url(),       ctx->request_url(), ctx->resource_type(),
+      *ctx->request_initiator(),  ctx->request_url(), ctx->resource_type(),
       ctx->aggressive_blocking(), ctx->method(),      ctx->render_frame_token(),
       ctx->devtools_request_id()};
   auto* ad_block_service = g_brave_browser_process->ad_block_service();
@@ -442,10 +438,15 @@ int OnBeforeURLRequest_AdBlockTPPreWork(const ResponseCallback& next_callback,
                                         T<BraveRequestInfo> ctx) {
   // If the following info isn't available, then proper content settings can't
   // be looked up, so do nothing.
-  if (ctx->request_url().is_empty() || ctx->initiator_url().is_empty() ||
-      !ctx->initiator_url().has_host() || !ctx->allow_brave_shields() ||
+  if (ctx->request_url().is_empty() || !ctx->allow_brave_shields() ||
       ctx->allow_ads() ||
       ctx->resource_type() == BraveRequestInfo::kInvalidResourceType) {
+    return net::OK;
+  }
+
+  const auto request_initiator = ctx->request_initiator();
+  if (!request_initiator) {
+    // Skip browser-initiated requests.
     return net::OK;
   }
 
@@ -458,7 +459,7 @@ int OnBeforeURLRequest_AdBlockTPPreWork(const ResponseCallback& next_callback,
 
   // Also, until a better solution is available, we explicitly allow any
   // request from an extension.
-  if (ctx->initiator_url().SchemeIs(kChromeExtensionScheme) &&
+  if (request_initiator->scheme() == kChromeExtensionScheme &&
       !base::FeatureList::IsEnabled(
           ::brave_shields::features::kBraveExtensionNetworkBlocking)) {
     return net::OK;

--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -205,9 +205,6 @@ ShouldBlockRequestResult ShouldBlockRequestOnTaskRunner(
   ShouldBlockRequestResult result;
   result.engine_flags = previous_result;
 
-  // Can be empty if the request initiator is opaque.
-  const std::string source_host = std::string(input.request_initiator.host());
-
   GURL url_to_check;
   if (canonical_url.has_value()) {
     url_to_check = *canonical_url;
@@ -256,6 +253,9 @@ ShouldBlockRequestResult ShouldBlockRequestOnTaskRunner(
       (result.blocked_by == kAdBlocked || previous_result.did_match_exception);
 
   if (should_report_to_devtools) {
+    // Can be empty if the request initiator is opaque.
+    const std::string source_host = std::string(input.request_initiator.host());
+
     content::devtools_instrumentation::AdblockInfo info;
     info.request_url = input.request_url;
     info.checked_url = url_to_check;

--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -213,8 +213,8 @@ ShouldBlockRequestResult ShouldBlockRequestOnTaskRunner(
   }
 
   bool force_aggressive = SameDomainOrHost(
-      url::Origin::CreateFromNormalizedTuple("https", "youtube.com", 443),
       input.request_initiator,
+      url::Origin::CreateFromNormalizedTuple("https", "youtube.com", 443),
       net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES);
 
   SCOPED_UMA_HISTOGRAM_TIMER("Brave.Adblock.ShouldBlockRequest");
@@ -438,15 +438,9 @@ int OnBeforeURLRequest_AdBlockTPPreWork(const ResponseCallback& next_callback,
                                         T<BraveRequestInfo> ctx) {
   // If the following info isn't available, then proper content settings can't
   // be looked up, so do nothing.
-  if (ctx->request_url().is_empty() || !ctx->allow_brave_shields() ||
-      ctx->allow_ads() ||
+  if (ctx->request_url().is_empty() || !ctx->request_initiator() ||
+      !ctx->allow_brave_shields() || ctx->allow_ads() ||
       ctx->resource_type() == BraveRequestInfo::kInvalidResourceType) {
-    return net::OK;
-  }
-
-  const auto request_initiator = ctx->request_initiator();
-  if (!request_initiator) {
-    // Skip browser-initiated requests.
     return net::OK;
   }
 
@@ -459,7 +453,7 @@ int OnBeforeURLRequest_AdBlockTPPreWork(const ResponseCallback& next_callback,
 
   // Also, until a better solution is available, we explicitly allow any
   // request from an extension.
-  if (request_initiator->scheme() == kChromeExtensionScheme &&
+  if (ctx->request_initiator()->scheme() == kChromeExtensionScheme &&
       !base::FeatureList::IsEnabled(
           ::brave_shields::features::kBraveExtensionNetworkBlocking)) {
     return net::OK;

--- a/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
@@ -205,10 +205,14 @@ class BraveAdBlockTPNetworkDelegateHelperTest : public testing::Test {
 using PtrStrategies = testing::Types<SharedPtrStrategy, WeakPtrStrategy>;
 TYPED_TEST_SUITE(BraveAdBlockTPNetworkDelegateHelperTest, PtrStrategies);
 
-TYPED_TEST(BraveAdBlockTPNetworkDelegateHelperTest, NoInitiatorURL) {
-  const GURL url("https://bradhatesprimes.brave.com/composite_numbers_ftw");
+// Browser-initiated requests omit request_initiator and must not be checked.
+TYPED_TEST(BraveAdBlockTPNetworkDelegateHelperTest, NoInitiator) {
+  this->ResetAdblockInstance("||brave.com/test.txt");
+
+  const GURL url("https://brave.com/test.txt");
   auto request_info = this->MakeRequest(url);
   request_info->set_resource_type(blink::mojom::ResourceType::kScript);
+  ASSERT_EQ(request_info->request_initiator(), std::nullopt);
 
   EXPECT_FALSE(this->CheckRequest(request_info));
   EXPECT_EQ(request_info->blocked_by(), brave::kNotBlocked);
@@ -268,6 +272,39 @@ TYPED_TEST(BraveAdBlockTPNetworkDelegateHelperTest, SimpleBlocking) {
   // It's unclear whether or not this is a Tor request, so no DNS queries are
   // made (`browser_context` is `nullptr`).
   EXPECT_EQ(0ULL, this->host_resolver_->num_resolve());
+}
+
+// Opaque initiators (e.g. sandboxed iframe / about:srcdoc) are present and must
+// still be checked. The requests from opaque origins are always treated as
+// third-party.
+TYPED_TEST(BraveAdBlockTPNetworkDelegateHelperTest, OpaqueInitiator) {
+  const GURL url("https://brave.com/test.txt");
+  const url::Origin opaque_initiator =
+      url::Origin::Create(GURL("https://brave.com")).DeriveNewOpaqueOrigin();
+  ASSERT_TRUE(opaque_initiator.opaque());
+
+  {
+    this->ResetAdblockInstance("||brave.com/test.txt");
+
+    auto request_info = this->MakeRequest(url);
+    request_info->set_resource_type(blink::mojom::ResourceType::kScript);
+    request_info->set_request_initiator(opaque_initiator);
+
+    EXPECT_TRUE(this->CheckRequest(request_info));
+    EXPECT_EQ(request_info->blocked_by(), brave::kAdBlocked);
+  }
+
+  {
+    // Apply only to first-party requests.
+    this->ResetAdblockInstance("||brave.com/test.txt$~third-party");
+
+    auto request_info = this->MakeRequest(url);
+    request_info->set_resource_type(blink::mojom::ResourceType::kScript);
+    request_info->set_request_initiator(opaque_initiator);
+
+    EXPECT_TRUE(this->CheckRequest(request_info));
+    EXPECT_EQ(request_info->blocked_by(), brave::kNotBlocked);
+  }
 }
 
 TYPED_TEST(BraveAdBlockTPNetworkDelegateHelperTest, Default1pException) {

--- a/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
@@ -35,6 +35,7 @@
 #include "net/log/net_log.h"
 #include "services/network/host_resolver.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "url/origin.h"
 
 using brave::ResponseCallback;
 using brave_component_updater::BraveComponent;
@@ -216,7 +217,8 @@ TYPED_TEST(BraveAdBlockTPNetworkDelegateHelperTest, NoInitiatorURL) {
 
 TYPED_TEST(BraveAdBlockTPNetworkDelegateHelperTest, EmptyRequestURL) {
   auto request_info = this->MakeRequest(GURL());
-  request_info->set_initiator_url(GURL("https://example.com"));
+  request_info->set_request_initiator(
+      url::Origin::Create(GURL("https://example.com")));
   request_info->set_resource_type(blink::mojom::ResourceType::kScript);
 
   EXPECT_FALSE(this->CheckRequest(request_info));
@@ -227,8 +229,8 @@ TYPED_TEST(BraveAdBlockTPNetworkDelegateHelperTest, EmptyRequestURL) {
 TYPED_TEST(BraveAdBlockTPNetworkDelegateHelperTest, DevToolURL) {
   const GURL url("devtools://devtools/");
   auto request_info = this->MakeRequest(url);
-  request_info->set_initiator_url(
-      GURL("devtools://devtools/bundled/root/root.js"));
+  request_info->set_request_initiator(
+      url::Origin::Create(GURL("devtools://devtools/bundled/root/root.js")));
   request_info->set_resource_type(blink::mojom::ResourceType::kScript);
 
   EXPECT_FALSE(this->CheckRequest(request_info));
@@ -241,7 +243,8 @@ TYPED_TEST(BraveAdBlockTPNetworkDelegateHelperTest, RequestDataURL) {
       "data:image/gif;base64,R0lGODlhAQABAIAAAP///"
       "wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==");
   auto request_info = this->MakeRequest(url);
-  request_info->set_initiator_url(GURL("https://example.com"));
+  request_info->set_request_initiator(
+      url::Origin::Create(GURL("https://example.com")));
   request_info->set_resource_type(blink::mojom::ResourceType::kImage);
 
   EXPECT_FALSE(this->CheckRequest(request_info));
@@ -256,7 +259,8 @@ TYPED_TEST(BraveAdBlockTPNetworkDelegateHelperTest, SimpleBlocking) {
   auto request_info = this->MakeRequest(url);
   request_info->set_request_identifier(1);
   request_info->set_resource_type(blink::mojom::ResourceType::kScript);
-  request_info->set_initiator_url(GURL("https://bravesoftware.com"));
+  request_info->set_request_initiator(
+      url::Origin::Create(GURL("https://bravesoftware.com")));
 
   EXPECT_TRUE(this->CheckRequest(request_info));
   EXPECT_EQ(request_info->blocked_by(), brave::kAdBlocked);
@@ -273,7 +277,8 @@ TYPED_TEST(BraveAdBlockTPNetworkDelegateHelperTest, Default1pException) {
   auto request_info = this->MakeRequest(url);
   request_info->set_request_identifier(1);
   request_info->set_resource_type(blink::mojom::ResourceType::kScript);
-  request_info->set_initiator_url(GURL("https://brave.com"));
+  request_info->set_request_initiator(
+      url::Origin::Create(GURL("https://brave.com")));
 
   EXPECT_TRUE(this->CheckRequest(request_info));
   EXPECT_EQ(request_info->blocked_by(), brave::kNotBlocked);
@@ -288,7 +293,8 @@ TYPED_TEST(BraveAdBlockTPNetworkDelegateHelperTest, AggressiveNo1pException) {
   auto request_info = this->MakeRequest(url);
   request_info->set_request_identifier(1);
   request_info->set_resource_type(blink::mojom::ResourceType::kScript);
-  request_info->set_initiator_url(GURL("https://brave.com"));
+  request_info->set_request_initiator(
+      url::Origin::Create(GURL("https://brave.com")));
   request_info->set_aggressive_blocking(true);
 
   EXPECT_TRUE(this->CheckRequest(request_info));

--- a/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
@@ -274,9 +274,8 @@ TYPED_TEST(BraveAdBlockTPNetworkDelegateHelperTest, SimpleBlocking) {
   EXPECT_EQ(0ULL, this->host_resolver_->num_resolve());
 }
 
-// Opaque initiators (e.g. sandboxed iframe / about:srcdoc) are present and must
-// still be checked. The requests from opaque origins are always treated as
-// third-party.
+// The request from opaque origins (e.g. sandboxed about:blank iframe)
+// also must be processed by adblock and treated as third-party.
 TYPED_TEST(BraveAdBlockTPNetworkDelegateHelperTest, OpaqueInitiator) {
   const GURL url("https://brave.com/test.txt");
   const url::Origin opaque_initiator =

--- a/browser/net/brave_reduce_language_network_delegate_helper.cc
+++ b/browser/net/brave_reduce_language_network_delegate_helper.cc
@@ -28,6 +28,7 @@
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/browser_context.h"
 #include "net/base/net_errors.h"
+#include "url/origin.h"
 
 #if BUILDFLAG(ENABLE_CONTAINERS)
 #include "brave/components/containers/content/browser/storage_partition_utils.h"
@@ -101,7 +102,7 @@ int OnBeforeStartTransaction_ReduceLanguageWork(
   DCHECK(content_settings);
   GURL origin_url(ctx->tab_origin());
   if (origin_url.is_empty()) {
-    origin_url = ctx->initiator_url();
+    origin_url = ctx->request_initiator().value_or(url::Origin()).GetURL();
   }
   if (origin_url.is_empty()) {
     return net::OK;

--- a/browser/net/brave_site_hacks_network_delegate_helper.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper.cc
@@ -77,7 +77,7 @@ int OnBeforeURLRequest_SiteHacksWork(const ResponseCallback& next_callback,
   if (ctx->allow_brave_shields() &&
       IsTrackingQueryParametersFilteringEnabled(ctx)) {
     auto filtered_url = query_filter::MaybeApplyQueryStringFilter(
-        ctx->initiator_url(), ctx->redirect_source(), ctx->request_url(),
+        ctx->request_initiator(), ctx->redirect_source(), ctx->request_url(),
         ctx->method(), ctx->internal_redirect());
 
     if (filtered_url.has_value()) {

--- a/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
@@ -219,8 +219,8 @@ TYPED_TEST(BraveSiteHacksNetworkDelegateHelperTest, QueryStringUntouched) {
        "https://example.com/Unsubscribe.html?fake_param=abc&mkt_tok=123"});
   for (const auto& url : urls) {
     auto brave_request_info = this->MakeRequest(GURL(url));
-    brave_request_info->set_initiator_url(
-        GURL("https://example.net"));  // cross-site
+    brave_request_info->set_request_initiator(
+        url::Origin::Create(GURL("https://example.net")));  // cross-site
     brave_request_info->set_method("GET");
     int rc = brave::OnBeforeURLRequest_SiteHacksWork(ResponseCallback(),
                                                      brave_request_info);
@@ -240,7 +240,8 @@ TYPED_TEST(BraveSiteHacksNetworkDelegateHelperTest, QueryStringExempted) {
 
   for (const auto& initiator : initiators) {
     auto brave_request_info = this->MakeRequest(tracking_url);
-    brave_request_info->set_initiator_url(GURL(initiator));
+    brave_request_info->set_request_initiator(
+        url::Origin::Create(GURL(initiator)));
     brave_request_info->set_method("GET");
     int rc = brave::OnBeforeURLRequest_SiteHacksWork(ResponseCallback(),
                                                      brave_request_info);
@@ -252,8 +253,8 @@ TYPED_TEST(BraveSiteHacksNetworkDelegateHelperTest, QueryStringExempted) {
   // Internal redirect
   {
     auto brave_request_info = this->MakeRequest(tracking_url);
-    brave_request_info->set_initiator_url(
-        GURL("https://example.net"));  // cross-site
+    brave_request_info->set_request_initiator(
+        url::Origin::Create(GURL("https://example.net")));  // cross-site
     brave_request_info->set_method("GET");
     brave_request_info->set_internal_redirect(true);
     brave_request_info->set_redirect_source(
@@ -268,8 +269,8 @@ TYPED_TEST(BraveSiteHacksNetworkDelegateHelperTest, QueryStringExempted) {
   // POST requests
   {
     auto brave_request_info = this->MakeRequest(tracking_url);
-    brave_request_info->set_initiator_url(
-        GURL("https://example.net"));  // cross-site
+    brave_request_info->set_request_initiator(
+        url::Origin::Create(GURL("https://example.net")));  // cross-site
     brave_request_info->set_method("POST");
     brave_request_info->set_redirect_source(
         GURL("https://example.org"));  // cross-site
@@ -283,8 +284,8 @@ TYPED_TEST(BraveSiteHacksNetworkDelegateHelperTest, QueryStringExempted) {
   // Same-site redirect
   {
     auto brave_request_info = this->MakeRequest(tracking_url);
-    brave_request_info->set_initiator_url(
-        GURL("https://example.net"));  // cross-site
+    brave_request_info->set_request_initiator(
+        url::Origin::Create(GURL("https://example.net")));  // cross-site
     brave_request_info->set_method("GET");
     brave_request_info->set_redirect_source(
         GURL("https://sub.example.com"));  // same-site
@@ -336,8 +337,8 @@ TYPED_TEST(BraveSiteHacksNetworkDelegateHelperTest, QueryStringFiltered) {
         "https://example.com/?foo=bar"}});
   for (const auto& pair : urls) {
     auto brave_request_info = this->MakeRequest(GURL(pair.first));
-    brave_request_info->set_initiator_url(
-        GURL("https://example.net"));  // cross-site
+    brave_request_info->set_request_initiator(
+        url::Origin::Create(GURL("https://example.net")));  // cross-site
     brave_request_info->set_method("GET");
     int rc = brave::OnBeforeURLRequest_SiteHacksWork(ResponseCallback(),
                                                      brave_request_info);
@@ -349,8 +350,8 @@ TYPED_TEST(BraveSiteHacksNetworkDelegateHelperTest, QueryStringFiltered) {
   {
     auto brave_request_info =
         this->MakeRequest(GURL("https://example.com/?fbclid=1"));
-    brave_request_info->set_initiator_url(
-        GURL("https://example.com"));  // same-origin
+    brave_request_info->set_request_initiator(
+        url::Origin::Create(GURL("https://example.com")));  // same-origin
     brave_request_info->set_method("GET");
     brave_request_info->set_redirect_source(
         GURL("https://example.net"));  // cross-site
@@ -364,7 +365,7 @@ TYPED_TEST(BraveSiteHacksNetworkDelegateHelperTest, QueryStringFiltered) {
   {
     auto brave_request_info =
         this->MakeRequest(GURL("https://example.com/?fbclid=2"));
-    brave_request_info->set_initiator_url(GURL());
+    brave_request_info->set_request_initiator(std::nullopt);
     brave_request_info->set_method("GET");
     int rc = brave::OnBeforeURLRequest_SiteHacksWork(ResponseCallback(),
                                                      brave_request_info);
@@ -381,7 +382,8 @@ TYPED_TEST(BraveSiteHacksNetworkDelegateHelperTest,
 
   auto brave_request_info =
       this->MakeRequest(GURL("https://example.com/?fbclid=1"));
-  brave_request_info->set_initiator_url(GURL("https://example.net"));
+  brave_request_info->set_request_initiator(
+      url::Origin::Create(GURL("https://example.net")));
   brave_request_info->set_method("GET");
   int rc = brave::OnBeforeURLRequest_SiteHacksWork(ResponseCallback(),
                                                    brave_request_info);
@@ -400,7 +402,8 @@ TYPED_TEST(BraveSiteHacksNetworkDelegateHelperTest,
 
   auto brave_request_info =
       this->MakeRequest(GURL("https://example.com/?fbclid=1"));
-  brave_request_info->set_initiator_url(GURL("https://example.net"));
+  brave_request_info->set_request_initiator(
+      url::Origin::Create(GURL("https://example.net")));
   brave_request_info->set_method("GET");
   int rc = brave::OnBeforeURLRequest_SiteHacksWork(ResponseCallback(),
                                                    brave_request_info);
@@ -419,7 +422,8 @@ TYPED_TEST(BraveSiteHacksNetworkDelegateHelperTest,
 
   auto brave_request_info =
       this->MakeRequest(GURL("https://example.com/?fbclid=1"));
-  brave_request_info->set_initiator_url(GURL("https://example.net"));
+  brave_request_info->set_request_initiator(
+      url::Origin::Create(GURL("https://example.net")));
   brave_request_info->set_method("GET");
   brave_request_info->set_allow_brave_shields(false);
   int rc = brave::OnBeforeURLRequest_SiteHacksWork(ResponseCallback(),
@@ -437,7 +441,8 @@ TYPED_TEST(BraveSiteHacksNetworkDelegateHelperTest,
 
   auto brave_request_info =
       this->MakeRequest(GURL("https://example.com/?fbclid=1"));
-  brave_request_info->set_initiator_url(GURL("https://example.net"));
+  brave_request_info->set_request_initiator(
+      url::Origin::Create(GURL("https://example.net")));
   brave_request_info->set_method("GET");
   int rc = brave::OnBeforeURLRequest_SiteHacksWork(ResponseCallback(),
                                                    brave_request_info);

--- a/browser/net/search_ads_header_network_delegate_helper.cc
+++ b/browser/net/search_ads_header_network_delegate_helper.cc
@@ -55,7 +55,7 @@ int OnBeforeStartTransaction_SearchAdsHeader(
   // - and all of the following are true:
   //   - The current tab is not in a Private browser window.
   //   - `request_url` host is allowed.
-  //   - `tab_origin` or `initiator_url` host is allowed.
+  //   - `tab_origin` or `request_initiator` host is allowed.
 
   // The header should not be set if any one of the following are true. (to
   // allow search ads):
@@ -63,13 +63,14 @@ int OnBeforeStartTransaction_SearchAdsHeader(
   // - Rewards is disabled.
   // - Rewards is enabled and not connected, and opted-in to search ads.
   // - `request_url` host is disallowed.
-  // - `tab_origin` and `initiator_url` hosts are disallowed.
+  // - `tab_origin` and `request_initiator` hosts are disallowed.
 
   Profile* profile = Profile::FromBrowserContext(request->browser_context());
   if (ShouldSetHeaderForProfile(profile) &&
       brave_search::IsAllowedHost(request->request_url()) &&
       (brave_search::IsAllowedHost(request->tab_origin()) ||
-       brave_search::IsAllowedHost(request->initiator_url()))) {
+       brave_search::IsAllowedHost(
+           request->request_initiator().value_or(url::Origin()).GetURL()))) {
     headers->SetHeader(kSearchAdsHeader, kSearchAdsDisabledValue);
     request->mutable_modified_headers().insert(kSearchAdsHeader);
   }

--- a/browser/net/search_ads_header_network_delegate_helper_unittest.cc
+++ b/browser/net/search_ads_header_network_delegate_helper_unittest.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/net/search_ads_header_network_delegate_helper.h"
 
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <utility>
 
@@ -25,6 +26,7 @@
 #include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/blink/public/mojom/loader/resource_load_info.mojom-data-view.h"
 #include "url/gurl.h"
+#include "url/origin.h"
 
 #if BUILDFLAG(IS_ANDROID)
 #include "brave/components/brave_rewards/core/features.h"
@@ -106,7 +108,8 @@ class SearchAdsHeaderDelegateHelperTest : public testing::Test {
       auto request = std::make_shared<BraveRequestInfo>(GURL(url));
       request->set_request_url(GURL(kBraveSearchTabUrl));
       request->set_tab_origin(GURL(kBraveSearchTabUrl));
-      request->set_initiator_url(GURL(kBraveSearchTabUrl));
+      request->set_request_initiator(
+          url::Origin::Create(GURL(kBraveSearchTabUrl)));
       request->set_resource_type(blink::mojom::ResourceType::kMainFrame);
       request->set_browser_context(profile);
       return request;
@@ -115,7 +118,8 @@ class SearchAdsHeaderDelegateHelperTest : public testing::Test {
       owned_request_ = std::make_unique<BraveRequestInfo>(GURL(url));
       owned_request_->set_request_url(GURL(kBraveSearchTabUrl));
       owned_request_->set_tab_origin(GURL(kBraveSearchTabUrl));
-      owned_request_->set_initiator_url(GURL(kBraveSearchTabUrl));
+      owned_request_->set_request_initiator(
+          url::Origin::Create(GURL(kBraveSearchTabUrl)));
       owned_request_->set_resource_type(blink::mojom::ResourceType::kMainFrame);
       owned_request_->set_browser_context(profile);
       return owned_request_->AsWeakPtr();
@@ -201,7 +205,7 @@ TYPED_TEST(SearchAdsHeaderDelegateHelperTest,
 
   auto request =
       this->MakeRequest(kBraveSearchRequestUrl, this->profile_.get());
-  request->set_initiator_url(GURL());
+  request->set_request_initiator(std::nullopt);
   this->VerifyMissingHeaderExpectation(request);
 }
 
@@ -213,7 +217,7 @@ TYPED_TEST(
   auto request =
       this->MakeRequest(kBraveSearchRequestUrl, this->profile_.get());
   request->set_tab_origin(GURL());
-  request->set_initiator_url(GURL());
+  request->set_request_initiator(std::nullopt);
   this->VerifyMissingHeaderExpectation(request);
 }
 
@@ -233,7 +237,8 @@ TYPED_TEST(SearchAdsHeaderDelegateHelperTest,
 
   auto request =
       this->MakeRequest(kBraveSearchRequestUrl, this->profile_.get());
-  request->set_initiator_url(GURL(kNonBraveSearchTabUrl));
+  request->set_request_initiator(
+      url::Origin::Create(GURL(kNonBraveSearchTabUrl)));
   this->VerifyMissingHeaderExpectation(request);
 }
 

--- a/browser/net/url_context.cc
+++ b/browser/net/url_context.cc
@@ -93,14 +93,15 @@ void BraveRequestInfo::set_tab_url(const GURL& value) {
   tab_url_ = value;
 }
 
-const GURL& BraveRequestInfo::initiator_url() const {
+const std::optional<url::Origin>& BraveRequestInfo::request_initiator() const {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  return initiator_url_;
+  return request_initiator_;
 }
 
-void BraveRequestInfo::set_initiator_url(const GURL& value) {
+void BraveRequestInfo::set_request_initiator(
+    const std::optional<url::Origin>& value) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  initiator_url_ = value;
+  request_initiator_ = value;
 }
 
 bool BraveRequestInfo::internal_redirect() const {
@@ -429,9 +430,7 @@ std::unique_ptr<brave::BraveRequestInfo> BraveRequestInfo::MakeCTX(
   ctx->set_request_identifier(request_identifier);
   ctx->set_method(request.method);
   ctx->set_request_url(request.url);
-  // TODO(iefremov): Replace GURL with Origin
-  ctx->set_initiator_url(
-      request.request_initiator.value_or(url::Origin()).GetURL());
+  ctx->set_request_initiator(request.request_initiator);
 
   ctx->set_referrer(request.referrer);
   ctx->set_referrer_policy(request.referrer_policy);

--- a/browser/net/url_context.h
+++ b/browser/net/url_context.h
@@ -22,6 +22,7 @@
 #include "net/url_request/referrer_policy.h"
 #include "third_party/blink/public/mojom/loader/resource_load_info.mojom-shared.h"
 #include "url/gurl.h"
+#include "url/origin.h"
 
 template <template <typename> class T>
 class BraveRequestHandler;
@@ -82,8 +83,8 @@ class BraveRequestInfo {
   const GURL& tab_url() const;
   void set_tab_url(const GURL& value);
 
-  const GURL& initiator_url() const;
-  void set_initiator_url(const GURL& value);
+  const std::optional<url::Origin>& request_initiator() const;
+  void set_request_initiator(const std::optional<url::Origin>& value);
 
   bool internal_redirect() const;
   void set_internal_redirect(bool value);
@@ -206,7 +207,7 @@ class BraveRequestInfo {
   GURL request_url_;
   GURL tab_origin_;
   GURL tab_url_;
-  GURL initiator_url_;
+  std::optional<url::Origin> request_initiator_;
 
   bool internal_redirect_ = false;
   GURL redirect_source_;

--- a/components/brave_shields/content/browser/ad_block_engine.cc
+++ b/components/brave_shields/content/browser/ad_block_engine.cc
@@ -107,20 +107,18 @@ AdBlockEngine::~AdBlockEngine() = default;
 adblock::BlockerResult AdBlockEngine::ShouldStartRequest(
     const GURL& url,
     blink::mojom::ResourceType resource_type,
-    const std::string& tab_host,
+    const url::Origin& request_initiator,
     const std::string& method,
     bool previously_matched_rule,
     bool previously_matched_exception,
     bool previously_matched_important) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   // Determine third-party here so the library doesn't need to figure it out.
-  // CreateFromNormalizedTuple is needed because SameDomainOrHost needs
-  // a URL or origin and not a string to a host name.
-  bool is_third_party = !SameDomainOrHost(
-      url, url::Origin::CreateFromNormalizedTuple("https", tab_host, 80),
-      INCLUDE_PRIVATE_REGISTRIES);
+  bool is_third_party =
+      !SameDomainOrHost(url, request_initiator, INCLUDE_PRIVATE_REGISTRIES);
+  const auto initiator_hostname = request_initiator.host();
   return ad_block_client_->matches(
-      url.spec(), std::string(url.host()), tab_host,
+      url.spec(), std::string(url.host()), initiator_hostname,
       ResourceTypeToString(resource_type), is_third_party, method,
       // Checking normal rules is skipped if a normal rule or exception rule was
       // found previously
@@ -132,17 +130,24 @@ adblock::BlockerResult AdBlockEngine::ShouldStartRequest(
 std::optional<std::string> AdBlockEngine::GetCspDirectives(
     const GURL& url,
     blink::mojom::ResourceType resource_type,
-    const std::string& tab_host,
+    const std::optional<url::Origin>& request_initiator,
     const std::string& method) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   // Determine third-party here so the library doesn't need to figure it out.
-  // CreateFromNormalizedTuple is needed because SameDomainOrHost needs
-  // a URL or origin and not a string to a host name.
-  bool is_third_party = !SameDomainOrHost(
-      url, url::Origin::CreateFromNormalizedTuple("https", tab_host, 80),
-      INCLUDE_PRIVATE_REGISTRIES);
+  bool is_third_party =
+      request_initiator &&
+      !SameDomainOrHost(url, *request_initiator, INCLUDE_PRIVATE_REGISTRIES);
+
+  // Top-level document requests do not have a valid initiator URL, and
+  // requests from special schemes like file:// do not have host parts, so we
+  // use the request URL as the initiator.
+  const std::string_view initiator_host =
+      request_initiator && !request_initiator->host().empty()
+          ? request_initiator->host()
+          : url.host();
+
   auto result = ad_block_client_->get_csp_directives(
-      url.spec(), std::string(url.host()), tab_host,
+      url.spec(), std::string(url.host()), std::string(initiator_host),
       ResourceTypeToString(resource_type), is_third_party, method);
 
   if (result.empty()) {

--- a/components/brave_shields/content/browser/ad_block_engine.cc
+++ b/components/brave_shields/content/browser/ad_block_engine.cc
@@ -139,7 +139,6 @@ std::optional<std::string> AdBlockEngine::GetCspDirectives(
   bool is_third_party = !SameDomainOrHost(
       url, url::Origin::CreateFromNormalizedTuple("https", tab_host, 80),
       INCLUDE_PRIVATE_REGISTRIES);
-
   auto result = ad_block_client_->get_csp_directives(
       url.spec(), std::string(url.host()), tab_host,
       ResourceTypeToString(resource_type), is_third_party, method);

--- a/components/brave_shields/content/browser/ad_block_engine.cc
+++ b/components/brave_shields/content/browser/ad_block_engine.cc
@@ -130,24 +130,18 @@ adblock::BlockerResult AdBlockEngine::ShouldStartRequest(
 std::optional<std::string> AdBlockEngine::GetCspDirectives(
     const GURL& url,
     blink::mojom::ResourceType resource_type,
-    const std::optional<url::Origin>& request_initiator,
+    const std::string& tab_host,
     const std::string& method) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   // Determine third-party here so the library doesn't need to figure it out.
-  bool is_third_party =
-      request_initiator &&
-      !SameDomainOrHost(url, *request_initiator, INCLUDE_PRIVATE_REGISTRIES);
-
-  // Top-level document requests do not have a valid initiator URL, and
-  // requests from special schemes like file:// do not have host parts, so we
-  // use the request URL as the initiator.
-  const std::string_view initiator_host =
-      request_initiator && !request_initiator->host().empty()
-          ? request_initiator->host()
-          : url.host();
+  // CreateFromNormalizedTuple is needed because SameDomainOrHost needs
+  // a URL or origin and not a string to a host name.
+  bool is_third_party = !SameDomainOrHost(
+      url, url::Origin::CreateFromNormalizedTuple("https", tab_host, 80),
+      INCLUDE_PRIVATE_REGISTRIES);
 
   auto result = ad_block_client_->get_csp_directives(
-      url.spec(), std::string(url.host()), std::string(initiator_host),
+      url.spec(), std::string(url.host()), tab_host,
       ResourceTypeToString(resource_type), is_third_party, method);
 
   if (result.empty()) {

--- a/components/brave_shields/content/browser/ad_block_engine.h
+++ b/components/brave_shields/content/browser/ad_block_engine.h
@@ -22,6 +22,7 @@
 #include "third_party/blink/public/mojom/loader/resource_load_info.mojom-shared.h"
 #include "third_party/rust/cxx/v1/cxx.h"
 #include "url/gurl.h"
+#include "url/origin.h"
 
 using brave_component_updater::DATFileDataBuffer;
 
@@ -43,7 +44,7 @@ class AdBlockEngine {
   adblock::BlockerResult ShouldStartRequest(
       const GURL& url,
       blink::mojom::ResourceType resource_type,
-      const std::string& tab_host,
+      const url::Origin& request_initiator,
       const std::string& method,
       bool previously_matched_rule,
       bool previously_matched_exception,
@@ -51,7 +52,7 @@ class AdBlockEngine {
   std::optional<std::string> GetCspDirectives(
       const GURL& url,
       blink::mojom::ResourceType resource_type,
-      const std::string& tab_host,
+      const std::optional<url::Origin>& request_initiator,
       const std::string& method);
   void UseResources(const adblock::BraveCoreResourceStorage& storage);
 

--- a/components/brave_shields/content/browser/ad_block_engine.h
+++ b/components/brave_shields/content/browser/ad_block_engine.h
@@ -52,7 +52,7 @@ class AdBlockEngine {
   std::optional<std::string> GetCspDirectives(
       const GURL& url,
       blink::mojom::ResourceType resource_type,
-      const std::optional<url::Origin>& request_initiator,
+      const std::string& tab_host,
       const std::string& method);
   void UseResources(const adblock::BraveCoreResourceStorage& storage);
 

--- a/components/brave_shields/content/browser/ad_block_engine_wrapper.cc
+++ b/components/brave_shields/content/browser/ad_block_engine_wrapper.cc
@@ -55,7 +55,7 @@ std::unique_ptr<AdBlockEngineWrapper> AdBlockEngineWrapper::Create() {
 adblock::BlockerResult AdBlockEngineWrapper::ShouldStartRequest(
     const GURL& url,
     blink::mojom::ResourceType resource_type,
-    const std::string& tab_host,
+    const url::Origin& request_initiator,
     const std::string& method,
     bool aggressive_blocking,
     bool previously_matched_rule,
@@ -65,7 +65,7 @@ adblock::BlockerResult AdBlockEngineWrapper::ShouldStartRequest(
   TRACE_EVENT("brave.adblock", "ShouldStartRequest", "url", url);
 
   adblock::BlockerResult fp_result = default_engine_->ShouldStartRequest(
-      url, resource_type, tab_host, method, previously_matched_rule,
+      url, resource_type, request_initiator, method, previously_matched_rule,
       previously_matched_exception, previously_matched_important);
 
   // removeparam results from the default engine are always ignored
@@ -75,7 +75,7 @@ adblock::BlockerResult AdBlockEngineWrapper::ShouldStartRequest(
       base::FeatureList::IsEnabled(
           brave_shields::features::kBraveAdblockDefault1pBlocking) ||
       !SameDomainOrHost(
-          url, url::Origin::CreateFromNormalizedTuple("https", tab_host, 80),
+          url, request_initiator,
           net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES)) {
     if (fp_result.important) {
       return fp_result;
@@ -90,7 +90,7 @@ adblock::BlockerResult AdBlockEngineWrapper::ShouldStartRequest(
                          ? GURL(std::string(fp_result.rewritten_url.value))
                          : url;
   auto result = additional_filters_engine_->ShouldStartRequest(
-      request_url, resource_type, tab_host, method,
+      request_url, resource_type, request_initiator, method,
       previously_matched_rule | fp_result.matched,
       previously_matched_exception | fp_result.has_exception,
       previously_matched_important | fp_result.important);
@@ -148,15 +148,15 @@ DATFileDataBuffer AdBlockEngineWrapper::Serialize(bool is_default_engine) {
 std::optional<std::string> AdBlockEngineWrapper::GetCspDirectives(
     const GURL& url,
     blink::mojom::ResourceType resource_type,
-    const std::string& tab_host,
+    const std::optional<url::Origin>& request_initiator,
     const std::string& method) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   TRACE_EVENT("brave.adblock", "GetCspDirectives", "url", url);
-  auto csp_directives =
-      default_engine_->GetCspDirectives(url, resource_type, tab_host, method);
+  auto csp_directives = default_engine_->GetCspDirectives(
+      url, resource_type, request_initiator, method);
 
   const auto additional_csp = additional_filters_engine_->GetCspDirectives(
-      url, resource_type, tab_host, method);
+      url, resource_type, request_initiator, method);
   MergeCspDirectiveInto(additional_csp, &csp_directives);
 
   return csp_directives;

--- a/components/brave_shields/content/browser/ad_block_engine_wrapper.cc
+++ b/components/brave_shields/content/browser/ad_block_engine_wrapper.cc
@@ -148,15 +148,15 @@ DATFileDataBuffer AdBlockEngineWrapper::Serialize(bool is_default_engine) {
 std::optional<std::string> AdBlockEngineWrapper::GetCspDirectives(
     const GURL& url,
     blink::mojom::ResourceType resource_type,
-    const std::optional<url::Origin>& request_initiator,
+    const std::string& tab_host,
     const std::string& method) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   TRACE_EVENT("brave.adblock", "GetCspDirectives", "url", url);
-  auto csp_directives = default_engine_->GetCspDirectives(
-      url, resource_type, request_initiator, method);
+  auto csp_directives =
+      default_engine_->GetCspDirectives(url, resource_type, tab_host, method);
 
   const auto additional_csp = additional_filters_engine_->GetCspDirectives(
-      url, resource_type, request_initiator, method);
+      url, resource_type, tab_host, method);
   MergeCspDirectiveInto(additional_csp, &csp_directives);
 
   return csp_directives;

--- a/components/brave_shields/content/browser/ad_block_engine_wrapper.h
+++ b/components/brave_shields/content/browser/ad_block_engine_wrapper.h
@@ -22,6 +22,7 @@
 #include "brave/components/brave_shields/core/common/adblock/rs/src/lib.rs.h"
 #include "third_party/blink/public/mojom/loader/resource_load_info.mojom-shared.h"
 #include "url/gurl.h"
+#include "url/origin.h"
 
 namespace brave_shields {
 
@@ -42,7 +43,7 @@ class AdBlockEngineWrapper {
   adblock::BlockerResult ShouldStartRequest(
       const GURL& url,
       blink::mojom::ResourceType resource_type,
-      const std::string& tab_host,
+      const url::Origin& request_initiator,
       const std::string& method,
       bool aggressive_blocking,
       bool previously_matched_rule,
@@ -62,7 +63,7 @@ class AdBlockEngineWrapper {
   std::optional<std::string> GetCspDirectives(
       const GURL& url,
       blink::mojom::ResourceType resource_type,
-      const std::string& tab_host,
+      const std::optional<url::Origin>& request_initiator,
       const std::string& method);
 
   void UseResources(const adblock::BraveCoreResourceStorage& storage);

--- a/components/brave_shields/content/browser/ad_block_engine_wrapper.h
+++ b/components/brave_shields/content/browser/ad_block_engine_wrapper.h
@@ -63,7 +63,7 @@ class AdBlockEngineWrapper {
   std::optional<std::string> GetCspDirectives(
       const GURL& url,
       blink::mojom::ResourceType resource_type,
-      const std::optional<url::Origin>& request_initiator,
+      const std::string& tab_host,
       const std::string& method);
 
   void UseResources(const adblock::BraveCoreResourceStorage& storage);

--- a/components/brave_shields/content/browser/domain_block_navigation_throttle.cc
+++ b/components/brave_shields/content/browser/domain_block_navigation_throttle.cc
@@ -37,6 +37,7 @@
 #include "content/public/browser/web_contents_user_data.h"
 #include "net/base/net_errors.h"
 #include "url/gurl.h"
+#include "url/origin.h"
 
 namespace brave_shields {
 
@@ -65,7 +66,7 @@ ShouldBlockDomainOnTaskRunner(
   // necessary.
   bool aggressive_for_engine = true;
   auto result = engine_wrapper->ShouldStartRequest(
-      url, blink::mojom::ResourceType::kMainFrame, std::string(url.host()),
+      url, blink::mojom::ResourceType::kMainFrame, url::Origin::Create(url),
       "GET", aggressive_for_engine, false, false, false);
 
   block_result.should_block =

--- a/components/brave_shields/content/test/ad_block_service_unittest.cc
+++ b/components/brave_shields/content/test/ad_block_service_unittest.cc
@@ -58,8 +58,9 @@ adblock::BlockerResult ShouldStartRequest(AdBlockService* service,
                 ? wrapper->default_engine_for_testing()
                 : wrapper->additional_filters_engine_for_testing();
         out = block_engine.ShouldStartRequest(
-            GURL(url), blink::mojom::ResourceType::kScript, "test.com", "GET",
-            false, false, false);
+            GURL(url), blink::mojom::ResourceType::kScript,
+            url::Origin::Create(GURL("https://test.com")), "GET", false, false,
+            false);
         run_loop.Quit();
       }));
   run_loop.Run();

--- a/components/brave_shields/core/common/adblock/rs/src/engine.rs
+++ b/components/brave_shields/core/common/adblock/rs/src/engine.rs
@@ -131,7 +131,7 @@ impl Engine {
         &self,
         url: &CxxString,
         hostname: &CxxString,
-        source_hostname: &CxxString,
+        initiator_hostname: &CxxString,
         request_type: &CxxString,
         third_party_request: bool,
         method: &CxxString,
@@ -145,7 +145,7 @@ impl Engine {
                 &adblock::request::Request::preparsed(
                     url.to_str().unwrap(),
                     hostname.to_str().unwrap(),
-                    source_hostname.to_str().unwrap(),
+                    initiator_hostname.to_str().unwrap(),
                     request_type.to_str().unwrap(),
                     third_party_request,
                     method.to_str().unwrap_or_default(),

--- a/components/brave_shields/core/common/adblock/rs/src/lib.rs
+++ b/components/brave_shields/core/common/adblock/rs/src/lib.rs
@@ -67,7 +67,7 @@ mod ffi {
             &self,
             url: &CxxString,
             hostname: &CxxString,
-            source_hostname: &CxxString,
+            initiator_hostname: &CxxString,
             request_type: &CxxString,
             third_party_request: bool,
             method: &CxxString,

--- a/components/query_filter/browser/utils.cc
+++ b/components/query_filter/browser/utils.cc
@@ -140,7 +140,7 @@ std::optional<GURL> ApplyQueryFilter(const GURL& original_url) {
 }
 
 std::optional<GURL> MaybeApplyQueryStringFilter(
-    const GURL& initiator_url,
+    const std::optional<url::Origin>& request_initiator,
     const GURL& redirect_source_url,
     const GURL& request_url,
     const std::string& request_method,
@@ -171,9 +171,9 @@ std::optional<GURL> MaybeApplyQueryStringFilter(
       // Same-site redirects are exempted.
       return std::nullopt;
     }
-  } else if (initiator_url.is_valid() &&
+  } else if (request_initiator.has_value() &&
              net::registry_controlled_domains::SameDomainOrHost(
-                 initiator_url, request_url,
+                 request_url, *request_initiator,
                  net::registry_controlled_domains::
                      INCLUDE_PRIVATE_REGISTRIES)) {
     // Same-site requests are exempted.

--- a/components/query_filter/browser/utils.h
+++ b/components/query_filter/browser/utils.h
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "url/gurl.h"
+#include "url/origin.h"
 
 namespace query_filter {
 std::optional<GURL> ApplyQueryFilter(const GURL& original_url);
@@ -17,16 +18,16 @@ std::optional<GURL> ApplyQueryFilter(const GURL& original_url);
 // This function will return a new url stripping known tracking query params.
 // If nothing is to be stripped, a null value is returned.
 //
-// `initiator_url` specifies the origin initiating the resource request.
-// If there were redirects, this is the url prior to any redirects.
+// `request_initiator` specifies the origin initiating the resource request.
+// If there were redirects, this is the origin prior to any redirects.
 // `redirect_source_url` specifies the url that we are currently navigating
 // from, including any redirects that might have happened. `request_url`
 // specifies where we are navigating to. `request_method` indicates the HTTP
-// method of the request. `internal_redirect` indicates wether or not this is an
-// internal redirect or not. This function returns the url we should redirect to
-// or a `std::nullopt` value if nothing is changed.
+// method of the request. `internal_redirect` indicates whether or not this is
+// an internal redirect or not. This function returns the url we should redirect
+// to or a `std::nullopt` value if nothing is changed.
 std::optional<GURL> MaybeApplyQueryStringFilter(
-    const GURL& initiator_url,
+    const std::optional<url::Origin>& request_initiator,
     const GURL& redirect_source_url,
     const GURL& request_url,
     const std::string& request_method,

--- a/components/query_filter/browser/utils_unittest.cc
+++ b/components/query_filter/browser/utils_unittest.cc
@@ -14,6 +14,12 @@
 #include "testing/gtest/include/gtest/gtest.h"
 #include "url/gurl.h"
 
+namespace {
+url::Origin CreateOrigin(std::string_view url) {
+  return url::Origin::Create(GURL(url));
+}
+}  // namespace
+
 class BraveQueryFilter_ComponentEnabled : public testing::Test {
  public:
   void SetUp() override {
@@ -49,94 +55,94 @@ TEST_F(BraveQueryFilter_ComponentEnabled, FilterQueryTrackers) {
   // Expect filtering `gclid` param when cross origin `initiator_url`
   // and `redirect_source_url`
   EXPECT_EQ(query_filter::MaybeApplyQueryStringFilter(
-                GURL("https://brave.com"), GURL("https://brave.com"),
+                CreateOrigin("https://brave.com"), GURL("https://brave.com"),
                 GURL("https://test.com/?gclid=123"), "GET", false),
             GURL("https://test.com/"));
   // Expect filtering `gclid` param when cross origin `redirect_source_url`
   // and same origin `initiator_url`
   EXPECT_EQ(query_filter::MaybeApplyQueryStringFilter(
-                GURL("https://test.com"), GURL("https://brave.com"),
+                CreateOrigin("https://test.com"), GURL("https://brave.com"),
                 GURL("https://test.com/?gclid=123"), "GET", false),
             GURL("https://test.com/"));
   // Expect filtering `fbclid` param when cross origin `initiator_url`
   // and invalid `redirect_source_url`
   EXPECT_EQ(query_filter::MaybeApplyQueryStringFilter(
-                GURL("https://brave.com"), GURL(),
+                CreateOrigin("https://brave.com"), GURL(),
                 GURL("https://test.com/?fbclid=123"), "GET", false),
             GURL("https://test.com/"));
   // Expect filtering `fbclid` param when cross origin `initiator_url`
   // and invalid `redirect_source_url`
   // (even though `internal_redirect=true`)
   EXPECT_EQ(query_filter::MaybeApplyQueryStringFilter(
-                GURL("https://brave.com"), GURL(),
+                CreateOrigin("https://brave.com"), GURL(),
                 GURL("https://test.com/?fbclid=123"), "GET", false),
             GURL("https://test.com/"));
   // Expect filtering `fbclid` param when cross origin `initiator_url`
   // and invalid `redirect_source_url` even though `internal_redirect` == true
   EXPECT_EQ(query_filter::MaybeApplyQueryStringFilter(
-                GURL("https://brave.com"), GURL(),
+                CreateOrigin("https://brave.com"), GURL(),
                 GURL("https://test.com/?fbclid=123"), "GET", false),
             GURL("https://test.com/"));
   // Expect filtering `mkt_tok` param when cross origin `redirect_source_url`
   // and invalid `initiator_url`
   EXPECT_EQ(query_filter::MaybeApplyQueryStringFilter(
-                GURL(), GURL("https://brave.com"),
+                std::nullopt, GURL("https://brave.com"),
                 GURL("https://test.com/?mkt_tok=123"), "GET", false),
             GURL("https://test.com/"));
   // Test filtering `gclid` param and leaving other params
   EXPECT_EQ(
       query_filter::MaybeApplyQueryStringFilter(
-          GURL("https://brave.com"), GURL(),
+          CreateOrigin("https://brave.com"), GURL(),
           GURL("https://test.com/?gclid=123&unsubscribe=123"), "GET", false),
       GURL("https://test.com/?unsubscribe=123"));
   // Test filtering `gclid` param and leaving other params
   EXPECT_EQ(
       query_filter::MaybeApplyQueryStringFilter(
-          GURL(), GURL("https://brave.com"),
+          std::nullopt, GURL("https://brave.com"),
           GURL("https://test.com/?gclid=123&Unsubscribe=123"), "GET", false),
       GURL("https://test.com/?Unsubscribe=123"));
   // Test nil when nothing is needed to be filtered
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://brave.com"), GURL("https://brave.com"),
+      CreateOrigin("https://brave.com"), GURL("https://brave.com"),
       GURL("https://test.com/"), "GET", false));
   // Test nothing is filtered with invalid request url
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://brave.com"), GURL("https://brave.com"), GURL(), "GET",
-      false));
+      CreateOrigin("https://brave.com"), GURL("https://brave.com"), GURL(),
+      "GET", false));
   // Only `GET` requests are filtered
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://brave.com"), GURL("https://brave.com"),
+      CreateOrigin("https://brave.com"), GURL("https://brave.com"),
       GURL("https://test.com/?gclid=123"), "POST", false));
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://brave.com"), GURL("https://brave.com"),
+      CreateOrigin("https://brave.com"), GURL("https://brave.com"),
       GURL("https://test.com/?gclid=123"), "PATH", false));
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://brave.com"), GURL("https://brave.com"),
+      CreateOrigin("https://brave.com"), GURL("https://brave.com"),
       GURL("https://test.com/?gclid=123"), "HEAD", false));
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://brave.com"), GURL("https://brave.com"),
+      CreateOrigin("https://brave.com"), GURL("https://brave.com"),
       GURL("https://test.com/?gclid=123"), "PUT", false));
   // Test nothing is filtered with same origin `initiator_url`
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://test.com"), GURL(), GURL("https://test.com/?gclid=123"),
-      "GET", false));
+      CreateOrigin("https://test.com"), GURL(),
+      GURL("https://test.com/?gclid=123"), "GET", false));
   // Test nothing is filtered with same origin `redirect_source_url`
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL(), GURL("https://test.com"), GURL("https://test.com/?gclid=123"),
-      "GET", false));
+      std::nullopt, GURL("https://test.com"),
+      GURL("https://test.com/?gclid=123"), "GET", false));
   // Test nothing is filtered with same origin `redirect_source_url`
   // and cross origin `initiator_url`
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://brave.com"), GURL("https://test.com"),
+      CreateOrigin("https://brave.com"), GURL("https://test.com"),
       GURL("https://test.com/?gclid=123"), "GET", false));
   // Test nothing is filtered with `internal_redirect=true`
   // (even though `redirect_source_url` and `initiator_url` are cross origin)
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://brave.com"), GURL("https://brave.com"),
+      CreateOrigin("https://brave.com"), GURL("https://brave.com"),
       GURL("https://test.com/?gclid=123"), "GET", true));
   // Don't filter exempted hostnames
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://brave.com"), GURL(),
+      CreateOrigin("https://brave.com"), GURL(),
       GURL("https://urldefense.com/v3/__https://www.portainer.io/hs/"
            "preferences-center/en/"
            "direct?utm_campaign=XNF&utm_source=hs_automation&_hsenc=p2&_hsmi="
@@ -190,65 +196,65 @@ TEST_F(BraveQueryFilter_ComponentEnabled, ScopedQueryTrackingTest) {
 
   // Normal case for a parameter that's not on the list
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://brave.com"), GURL(), GURL("https://twitter.com/?t=123"),
-      "GET", false));
+      CreateOrigin("https://brave.com"), GURL(),
+      GURL("https://twitter.com/?t=123"), "GET", false));
 
   // Normal case with a single domain
   EXPECT_EQ(query_filter::MaybeApplyQueryStringFilter(
-                GURL("https://brave.com"), GURL(),
+                CreateOrigin("https://brave.com"), GURL(),
                 GURL("https://instagram.com/?igshid=123"), "GET", false),
             GURL("https://instagram.com/"));
   EXPECT_EQ(query_filter::MaybeApplyQueryStringFilter(
-                GURL("https://brave.com"), GURL(),
+                CreateOrigin("https://brave.com"), GURL(),
                 GURL("http://www.instagram.com/?igshid=123"), "GET", false),
             GURL("http://www.instagram.com/"));
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://brave.com"), GURL(),
+      CreateOrigin("https://brave.com"), GURL(),
       GURL("https://example.com/?igshid=123"), "GET", false));
 
   // Normal case with more than one domain
   EXPECT_EQ(query_filter::MaybeApplyQueryStringFilter(
-                GURL("https://brave.com"), GURL(),
+                CreateOrigin("https://brave.com"), GURL(),
                 GURL("https://twitter.com/?ref_src=123"), "GET", false),
             GURL("https://twitter.com/"));
   EXPECT_EQ(query_filter::MaybeApplyQueryStringFilter(
-                GURL("https://brave.com"), GURL(),
+                CreateOrigin("https://brave.com"), GURL(),
                 GURL("https://x.com/?ref_src=123"), "GET", false),
             GURL("https://x.com/"));
   EXPECT_EQ(query_filter::MaybeApplyQueryStringFilter(
-                GURL("https://brave.com"), GURL(),
+                CreateOrigin("https://brave.com"), GURL(),
                 GURL("https://y.com/?ref_src=123"), "GET", false),
             GURL("https://y.com/"));
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://brave.com"), GURL(), GURL("https://z.com/?ref_src=123"),
-      "GET", false));
+      CreateOrigin("https://brave.com"), GURL(),
+      GURL("https://z.com/?ref_src=123"), "GET", false));
 
   // Edge cases
   EXPECT_EQ(query_filter::MaybeApplyQueryStringFilter(
-                GURL("https://example.com"), GURL(),
+                CreateOrigin("https://example.com"), GURL(),
                 GURL("https://brave.com/?sample1=123"), "GET", false),
             GURL("https://brave.com/"));
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://brave.com"), GURL(),
+      CreateOrigin("https://brave.com"), GURL(),
       GURL("https://example.com/?sample1=123"), "GET", false));
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://example.com"), GURL(),
+      CreateOrigin("https://example.com"), GURL(),
       GURL("https://brave.com/?sample2=123"), "GET", false));
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://example.com"), GURL(),
+      CreateOrigin("https://example.com"), GURL(),
       GURL("https://brave.com/?sample3=123"), "GET", false));
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://example.com"), GURL(),
+      CreateOrigin("https://example.com"), GURL(),
       GURL("https://brave.com/?sample4=123"), "GET", false));
 
   EXPECT_EQ(query_filter::MaybeApplyQueryStringFilter(
-                GURL("https://google.com"), GURL(),
+                CreateOrigin("https://google.com"), GURL(),
                 GURL("https://mobile.facebook.com/?evil=666"), "GET", false),
             GURL("https://mobile.facebook.com/"));
   // theshining.com is part of the exclude list for the evil param. So, we
   // shouldn't be stripping it away.
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://google.com"), GURL(),
+      CreateOrigin("https://google.com"), GURL(),
       GURL("https://theshining.com/?evil=123"), "GET", false));
 }
 
@@ -256,42 +262,42 @@ TEST_F(BraveQueryFilter_ComponentEnabled, ConditionalFilteringTest) {
   // `ck_subscriber_id` param gets removed when `unsubscribe` not present in
   // url.
   EXPECT_EQ(query_filter::MaybeApplyQueryStringFilter(
-                GURL(), GURL("https://brave.com"),
+                std::nullopt, GURL("https://brave.com"),
                 GURL("https://test.com/?ck_subscriber_id=123"), "GET", false),
             GURL("https://test.com/"));
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL(), GURL("https://brave.com"),
+      std::nullopt, GURL("https://brave.com"),
       GURL("https://unsubscribe.com/?ck_subscriber_id=123"), "GET", false));
 
   // `h_sid` param gets removed when /email/ not present in url.
   EXPECT_EQ(query_filter::MaybeApplyQueryStringFilter(
-                GURL(), GURL("https://brave.com"),
+                std::nullopt, GURL("https://brave.com"),
                 GURL("https://test.com/?h_sid=123"), "GET", false),
             GURL("https://test.com/"));
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL(), GURL("https://brave.com"),
+      std::nullopt, GURL("https://brave.com"),
       GURL("https://test.com/email/?h_sid=123"), "GET", false));
 
   // `h_slt` param gets removed when /email/ not present in url.
   EXPECT_EQ(query_filter::MaybeApplyQueryStringFilter(
-                GURL(), GURL("https://brave.com"),
+                std::nullopt, GURL("https://brave.com"),
                 GURL("https://test.com/?h_slt=123"), "GET", false),
             GURL("https://test.com/"));
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL(), GURL("https://brave.com"),
+      std::nullopt, GURL("https://brave.com"),
       GURL("https://test.com/email/?h_slt=123"), "GET", false));
 
   // `mkt_tok` param gets removed when `unsubscribe` or `emailWebView` not
   // present in url.
   EXPECT_EQ(query_filter::MaybeApplyQueryStringFilter(
-                GURL(), GURL("https://brave.com"),
+                std::nullopt, GURL("https://brave.com"),
                 GURL("https://test.com/?mkt_tok=123"), "GET", false),
             GURL("https://test.com/"));
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL(), GURL("https://brave.com"),
+      std::nullopt, GURL("https://brave.com"),
       GURL("https://Unsubscribe.com/?mkt_tok=123"), "GET", false));
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL(), GURL("https://brave.com"),
+      std::nullopt, GURL("https://brave.com"),
       GURL("https://test.com/emailWebview?mkt_tok=123"), "GET", false));
 }
 
@@ -300,7 +306,7 @@ TEST_F(BraveQueryFilter_ComponentEnabled, ConditionalFilteringWithoutAnyRules) {
   ResetRules();
 
   EXPECT_EQ(query_filter::MaybeApplyQueryStringFilter(
-                GURL(), GURL("https://brave.com"),
+                std::nullopt, GURL("https://brave.com"),
                 GURL("https://test.com/?mkt_tok=123"), "GET", false),
             GURL("https://test.com/"));
 }
@@ -323,11 +329,11 @@ class BraveQueryFilter_ComponentDisabled : public testing::Test {
 
 TEST_F(BraveQueryFilter_ComponentDisabled, NoStrippingOccurs) {
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL("https://brave.com"), GURL("https://brave.com"),
+      CreateOrigin("https://brave.com"), GURL("https://brave.com"),
       GURL("https://test.com/?gclid=123"), "GET", false));
 
   // Conditional filtering also fails.
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
-      GURL(), GURL("https://brave.com"), GURL("https://test.com/?mkt_tok=123"),
-      "GET", false));
+      std::nullopt, GURL("https://brave.com"),
+      GURL("https://test.com/?mkt_tok=123"), "GET", false));
 }

--- a/ios/browser/api/query_filter/utils.mm
+++ b/ios/browser/api/query_filter/utils.mm
@@ -5,10 +5,13 @@
 
 #include "brave/ios/browser/api/query_filter/utils.h"
 
+#include <optional>
+
 #include "base/strings/sys_string_conversions.h"
 #include "brave/components/query_filter/browser/utils.h"
 #import "net/base/apple/url_conversions.h"
 #include "url/gurl.h"
+#include "url/origin.h"
 
 #if !defined(__has_feature) || !__has_feature(objc_arc)
 #error "This file requires ARC support."
@@ -27,12 +30,12 @@
                                  isInternalRedirect:(BOOL)isInternalRedirect {
   // Create new fake gurls because thats what
   // `query_filter::MaybeApplyQueryStringFilter` expects
-  GURL initiatorGURL;
   GURL redirectSourceGurl;
+  std::optional<url::Origin> request_initiator;
 
   // Set the actual initiator and redirect source urls if we have them
   if (initiatorURL != nil) {
-    initiatorGURL = net::GURLWithNSURL(initiatorURL);
+    request_initiator = url::Origin::Create(net::GURLWithNSURL(initiatorURL));
   }
   if (redirectSourceURL != nil) {
     redirectSourceGurl = net::GURLWithNSURL(redirectSourceURL);
@@ -42,7 +45,7 @@
   const auto method = base::SysNSStringToUTF8(requestMethod);
 
   auto filteredGURL = query_filter::MaybeApplyQueryStringFilter(
-      initiatorGURL, redirectSourceGurl, requestGurl, method,
+      request_initiator, redirectSourceGurl, requestGurl, method,
       isInternalRedirect);
 
   if (!filteredGURL.has_value()) {

--- a/test/data/blocking.html
+++ b/test/data/blocking.html
@@ -67,10 +67,14 @@ function addImage(src) {
   });
 }
 
-// Adds an iframe to the DOM with the specified src
-function addFrame(src) {
+// Adds an iframe to the DOM with the specified src. Optional `sandbox` sets the
+// iframe sandbox attribute (e.g. 'allow-scripts' for an opaque origin).
+function addFrame(src, sandbox) {
   return new Promise(resolve => {
     const frame = document.createElement('iframe')
+    if (sandbox) {
+      frame.setAttribute('sandbox', sandbox)
+    }
     frame.src = src
     frame.className = 'adFrame'
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/28491

The PR:
* updates the code to use `url::Origin` for storing request_initiator in `BraveRequestInfo`
* makes processing `request_initiator == opaque origin` requests in adblock, but continue to skip browser-initiated (`request_initiator == std::nullopt`) 
* adds tests to verify new behavior, including checking sandboxed iframes.
* renames some params to make it clear we works with request_initiator origin or host, not with a full URL (like frame or tab URL)

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
