### PR TITLE
[CODEOWNERS] Allow `chromium-src-reviewers` approve plaster migrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,8 @@ script/deps.py @brave/deps-reviewers
 package*.json @brave/js-deps-reviewers
 pnpm*.yaml @brave/js-deps-reviewers
 rewrite/ @brave/brave-core-owners
+rewrite/**/*.h.yaml @brave/brave-core-owners @brave/chromium-src-reviewers
+rewrite/**/*.cc.yaml @brave/brave-core-owners @brave/chromium-src-reviewers
 
 # Views
 # Do not add to BRAVE_VIEW_OWNED_BY_CLIENT_PASS_KEY


### PR DESCRIPTION
This change assigns to `@brave/chromium-src-reviewers` ownership over
the cxx plasters. This is being done exclusively so we can reduce the
plaster review bottleneck for the migration away from `#define` macros.

PRs that are unrelated to the migration should still require the
approval of core owners.
