### PR TITLE
[Sync] [AI Chat] (7 of n) Add AI Chat sync deserialization

### DIFF
--- a/chromium_src/components/sync/protocol/proto_visitors.h
+++ b/chromium_src/components/sync/protocol/proto_visitors.h
@@ -36,7 +36,7 @@ VISIT(brave_fields);
       const sync_pb::AIChatConversationSpecifics_Entry& proto) {           \
     VISIT(uuid);                                                           \
     VISIT(conversation_uuid);                                              \
-    VISIT(date_unix_epoch_micros);                                         \
+    VISIT(created_time_windows_epoch_micros);                              \
     VISIT(entry_text);                                                     \
     VISIT(prompt);                                                         \
     VISIT(character_type);                                                 \
@@ -74,7 +74,6 @@ VISIT(brave_fields);
     VISIT(extracted_text);                                                 \
   }                                                                        \
   VISIT_PROTO_FIELDS(const sync_pb::AIChatEntryEventProto& proto) {        \
-    VISIT(event_order);                                                    \
     VISIT(completion);                                                     \
     VISIT(search_queries);                                                 \
     VISIT(web_sources);                                                    \

--- a/components/ai_chat/core/browser/DEPS
+++ b/components/ai_chat/core/browser/DEPS
@@ -23,6 +23,7 @@ include_rules = [
   "+tensorflow_lite_support/cc/task/core/proto",
   "+tensorflow_lite_support/cc/task/processor/proto",
   "+tensorflow_lite_support/cc/task/text/proto",
+  "+third_party/protobuf/src/google/protobuf",
   "+third_party/re2/src/re2",
   "+third_party/skia/include",
   "+third_party/zlib/google",

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
@@ -325,6 +325,31 @@ void WriteEntryFields(const mojom::ConversationTurn& entry,
 
 // --- Download helpers: sync proto → mojom ---
 
+// Decodes a repeated AIChatCompressibleString field into strings, skipping any
+// entry with no usable value (omitted-for-sync, empty, or undecodable).
+std::vector<std::string> ReadCompressibleStrings(
+    const google::protobuf::RepeatedPtrField<sync_pb::AIChatCompressibleString>&
+        strings) {
+  std::vector<std::string> out;
+  out.reserve(strings.size());
+  for (const auto& string : strings) {
+    if (auto decoded = ReadCompressibleString(string)) {
+      out.push_back(std::move(*decoded));
+    }
+  }
+  return out;
+}
+
+// Coerces a serialized integer enum value to a known mojom enumerator, falling
+// back to the default enumerator when the sender used a value this client does
+// not recognize (forward-compat or corrupt remote data). Keeps an out-of-range
+// value from reaching a mojo pipe, where it would fail validation.
+template <typename Enum>
+Enum ToKnownEnumValue(int value) {
+  const auto enum_value = static_cast<Enum>(value);
+  return mojom::IsKnownEnumValue(enum_value) ? enum_value : Enum();
+}
+
 mojom::WebSourcePtr ProtoToWebSource(const sync_pb::AIChatWebSource& proto) {
   auto source = mojom::WebSource::New();
   source->title = proto.title();
@@ -334,12 +359,8 @@ mojom::WebSourcePtr ProtoToWebSource(const sync_pb::AIChatWebSource& proto) {
   if (proto.has_favicon_url()) {
     source->favicon_url = GURL(proto.favicon_url());
   }
-  if (proto.has_page_content()) {
-    if (auto pc = ReadCompressibleString(proto.page_content())) {
-      source->page_content = std::move(*pc);
-    }
-  }
-  if (proto.extra_snippets_size() > 0) {
+  source->page_content = ReadCompressibleString(proto.page_content());
+  if (!proto.extra_snippets().empty()) {
     source->extra_snippets = base::ToVector(proto.extra_snippets());
   }
   return source;
@@ -349,13 +370,8 @@ mojom::WebSourcesContentBlockPtr ProtoToWebSourcesContentBlock(
     const sync_pb::AIChatWebSourcesContentBlock& proto) {
   auto block = mojom::WebSourcesContentBlock::New();
   block->sources = base::ToVector(proto.sources(), &ProtoToWebSource);
-  block->queries.append_range(proto.queries());
-  block->rich_results.reserve(proto.rich_results_size());
-  for (const auto& rr : proto.rich_results()) {
-    if (auto value = ReadCompressibleString(rr)) {
-      block->rich_results.push_back(std::move(*value));
-    }
-  }
+  block->queries = base::ToVector(proto.queries());
+  block->rich_results = ReadCompressibleStrings(proto.rich_results());
   return block;
 }
 
@@ -364,46 +380,45 @@ mojom::ToolUseEventPtr ProtoToToolUse(
   auto tool_use = mojom::ToolUseEvent::New();
   tool_use->tool_name = proto.tool_name();
   tool_use->id = proto.id();
-  if (proto.has_arguments_json()) {
-    if (auto args = ReadCompressibleString(proto.arguments_json())) {
-      tool_use->arguments_json = std::move(*args);
-    }
-  }
+  tool_use->arguments_json =
+      ReadCompressibleString(proto.arguments_json()).value_or(std::string());
   tool_use->is_server_result = proto.is_server_result();
-  if (proto.output_size() > 0) {
+  if (!proto.output().empty()) {
     std::vector<mojom::ContentBlockPtr> blocks;
     blocks.reserve(proto.output_size());
+    // No default case: adding a new content-block variant must be an explicit
+    // decision here rather than silently dropping it.
     for (const auto& block_proto : proto.output()) {
-      mojom::ContentBlockPtr block;
-      if (block_proto.has_text_content_block()) {
-        auto text = mojom::TextContentBlock::New();
-        if (auto value = ReadCompressibleString(
-                block_proto.text_content_block().text())) {
-          text->text = std::move(*value);
-        }
-        block = mojom::ContentBlock::NewTextContentBlock(std::move(text));
-      } else if (block_proto.has_image_content_block()) {
-        auto image = mojom::ImageContentBlock::New();
-        image->image_url = GURL(block_proto.image_content_block().image_url());
-        block = mojom::ContentBlock::NewImageContentBlock(std::move(image));
-      } else if (block_proto.has_web_sources_content_block()) {
-        block = mojom::ContentBlock::NewWebSourcesContentBlock(
-            ProtoToWebSourcesContentBlock(
-                block_proto.web_sources_content_block()));
-      } else {
-        continue;
+      switch (block_proto.content_case()) {
+        case sync_pb::AIChatContentBlock::kTextContentBlock:
+          blocks.push_back(mojom::ContentBlock::NewTextContentBlock(
+              mojom::TextContentBlock::New(
+                  ReadCompressibleString(
+                      block_proto.text_content_block().text())
+                      .value_or(std::string()))));
+          break;
+        case sync_pb::AIChatContentBlock::kImageContentBlock:
+          blocks.push_back(mojom::ContentBlock::NewImageContentBlock(
+              mojom::ImageContentBlock::New(
+                  GURL(block_proto.image_content_block().image_url()))));
+          break;
+        case sync_pb::AIChatContentBlock::kWebSourcesContentBlock:
+          blocks.push_back(mojom::ContentBlock::NewWebSourcesContentBlock(
+              ProtoToWebSourcesContentBlock(
+                  block_proto.web_sources_content_block())));
+          break;
+        case sync_pb::AIChatContentBlock::CONTENT_NOT_SET:
+          break;
       }
-      blocks.push_back(std::move(block));
     }
     tool_use->output = std::move(blocks);
   }
-  if (proto.artifacts_size() > 0) {
+  if (!proto.artifacts().empty()) {
     tool_use->artifacts = base::ToVector(proto.artifacts(), [](const auto& a) {
       auto artifact = mojom::ToolArtifact::New();
       artifact->type = a.type();
-      if (auto value = ReadCompressibleString(a.content_json())) {
-        artifact->content_json = std::move(*value);
-      }
+      artifact->content_json =
+          ReadCompressibleString(a.content_json()).value_or(std::string());
       return artifact;
     });
   }
@@ -413,40 +428,27 @@ mojom::ToolUseEventPtr ProtoToToolUse(
 mojom::ConversationEntryEventPtr ProtoToEntryEvent(
     const sync_pb::AIChatEntryEventProto& proto) {
   if (proto.has_completion()) {
-    auto completion = mojom::CompletionEvent::New();
-    if (auto value = ReadCompressibleString(proto.completion())) {
-      completion->completion = std::move(*value);
-    }
     return mojom::ConversationEntryEvent::NewCompletionEvent(
-        std::move(completion));
+        mojom::CompletionEvent::New(ReadCompressibleString(proto.completion())
+                                        .value_or(std::string())));
   }
   if (proto.has_search_queries()) {
-    auto event = mojom::SearchQueriesEvent::New();
-    event->search_queries.append_range(proto.search_queries().queries());
     return mojom::ConversationEntryEvent::NewSearchQueriesEvent(
-        std::move(event));
+        mojom::SearchQueriesEvent::New(
+            base::ToVector(proto.search_queries().queries())));
   }
   if (proto.has_web_sources()) {
-    auto event = mojom::WebSourcesEvent::New();
-    event->sources =
-        base::ToVector(proto.web_sources().sources(), &ProtoToWebSource);
-    event->rich_results.reserve(proto.web_sources().rich_results_size());
-    for (const auto& rr : proto.web_sources().rich_results()) {
-      if (auto value = ReadCompressibleString(rr)) {
-        event->rich_results.push_back(std::move(*value));
-      }
-    }
-    return mojom::ConversationEntryEvent::NewSourcesEvent(std::move(event));
+    return mojom::ConversationEntryEvent::NewSourcesEvent(
+        mojom::WebSourcesEvent::New(
+            base::ToVector(proto.web_sources().sources(), &ProtoToWebSource),
+            ReadCompressibleStrings(proto.web_sources().rich_results())));
   }
   if (proto.has_inline_search()) {
-    auto event = mojom::InlineSearchEvent::New();
-    event->query = proto.inline_search().query();
-    if (auto value =
-            ReadCompressibleString(proto.inline_search().results_json())) {
-      event->results_json = std::move(*value);
-    }
     return mojom::ConversationEntryEvent::NewInlineSearchEvent(
-        std::move(event));
+        mojom::InlineSearchEvent::New(
+            proto.inline_search().query(),
+            ReadCompressibleString(proto.inline_search().results_json())
+                .value_or(std::string())));
   }
   if (proto.has_tool_use()) {
     return mojom::ConversationEntryEvent::NewToolUseEvent(
@@ -464,7 +466,8 @@ mojom::AssociatedContentPtr ProtoToAssociatedContent(
   if (proto.has_url()) {
     content->url = GURL(proto.url());
   }
-  content->content_type = static_cast<mojom::ContentType>(proto.content_type());
+  content->content_type =
+      ToKnownEnumValue<mojom::ContentType>(proto.content_type());
   content->content_used_percentage = proto.content_used_percentage();
   content->conversation_turn_uuid = entry_uuid;
   return content;
@@ -477,18 +480,14 @@ mojom::UploadedFilePtr ProtoToUploadedFile(
     file->filename = proto.filename();
   }
   file->filesize = proto.filesize();
-  file->type = static_cast<mojom::UploadedFileType>(proto.type());
+  file->type = ToKnownEnumValue<mojom::UploadedFileType>(proto.type());
   // Only populate bytes when the sender actually shipped them. When the sender
   // omitted them (the oneof holds omitted_data_hash instead), leave |data|
   // empty so the caller can restore any existing local bytes.
   if (proto.has_data()) {
     file->data = base::ToVector(base::as_byte_span(proto.data()));
   }
-  if (proto.has_extracted_text()) {
-    if (auto value = ReadCompressibleString(proto.extracted_text())) {
-      file->extracted_text = std::move(*value);
-    }
-  }
+  file->extracted_text = ReadCompressibleString(proto.extracted_text());
   return file;
 }
 
@@ -617,8 +616,8 @@ mojom::ConversationTurnPtr SpecificsToEntry(
     entry->prompt = proto.prompt();
   }
   entry->character_type =
-      static_cast<mojom::CharacterType>(proto.character_type());
-  entry->action_type = static_cast<mojom::ActionType>(proto.action_type());
+      ToKnownEnumValue<mojom::CharacterType>(proto.character_type());
+  entry->action_type = ToKnownEnumValue<mojom::ActionType>(proto.action_type());
   if (proto.has_selected_text()) {
     entry->selected_text = proto.selected_text();
   }
@@ -626,12 +625,11 @@ mojom::ConversationTurnPtr SpecificsToEntry(
     entry->model_key = proto.model_key();
   }
 
-  if (proto.events_size() > 0) {
+  if (!proto.events().empty()) {
     std::vector<mojom::ConversationEntryEventPtr> events;
     events.reserve(proto.events_size());
     for (const auto& event_proto : proto.events()) {
-      auto event = ProtoToEntryEvent(event_proto);
-      if (event) {
+      if (auto event = ProtoToEntryEvent(event_proto)) {
         events.push_back(std::move(event));
       }
     }
@@ -641,7 +639,7 @@ mojom::ConversationTurnPtr SpecificsToEntry(
   ReadAssociatedContentFromEntry(proto, associated_content,
                                  associated_content_texts);
 
-  if (proto.uploaded_files_size() > 0) {
+  if (!proto.uploaded_files().empty()) {
     entry->uploaded_files =
         base::ToVector(proto.uploaded_files(), &ProtoToUploadedFile);
   }

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
@@ -15,6 +15,8 @@
 
 #include "base/containers/flat_map.h"
 #include "base/containers/map_util.h"
+#include "base/containers/span.h"
+#include "base/containers/to_vector.h"
 #include "base/hash/hash.h"
 #include "base/logging.h"
 #include "base/notreached.h"
@@ -138,9 +140,8 @@ void WriteWebSource(const mojom::WebSource& source,
                             proto->mutable_page_content());
   }
   if (source.extra_snippets) {
-    for (const auto& snippet : *source.extra_snippets) {
-      proto->add_extra_snippets(snippet);
-    }
+    proto->mutable_extra_snippets()->Assign(source.extra_snippets->begin(),
+                                            source.extra_snippets->end());
   }
 }
 
@@ -149,9 +150,7 @@ void WriteWebSourcesContentBlock(const mojom::WebSourcesContentBlock& block,
   for (const auto& source : block.sources) {
     WriteWebSource(*source, proto->add_sources());
   }
-  for (const auto& q : block.queries) {
-    proto->add_queries(q);
-  }
+  proto->mutable_queries()->Assign(block.queries.begin(), block.queries.end());
   for (const auto& rr : block.rich_results) {
     WriteCompressibleString(rr, proto->add_rich_results());
   }
@@ -240,11 +239,12 @@ void WriteEvent(const mojom::ConversationEntryEvent& event,
       WriteCompressibleString(event.get_completion_event()->completion,
                               proto->mutable_completion());
       break;
-    case mojom::ConversationEntryEvent::Tag::kSearchQueriesEvent:
-      for (const auto& q : event.get_search_queries_event()->search_queries) {
-        proto->mutable_search_queries()->add_queries(q);
-      }
+    case mojom::ConversationEntryEvent::Tag::kSearchQueriesEvent: {
+      const auto& queries = event.get_search_queries_event()->search_queries;
+      proto->mutable_search_queries()->mutable_queries()->Assign(
+          queries.begin(), queries.end());
       break;
+    }
     case mojom::ConversationEntryEvent::Tag::kSourcesEvent: {
       auto* ws = proto->mutable_web_sources();
       const auto& sources_event = event.get_sources_event();
@@ -340,12 +340,7 @@ mojom::WebSourcePtr ProtoToWebSource(const sync_pb::AIChatWebSource& proto) {
     }
   }
   if (proto.extra_snippets_size() > 0) {
-    std::vector<std::string> snippets;
-    snippets.reserve(proto.extra_snippets_size());
-    for (const auto& snippet : proto.extra_snippets()) {
-      snippets.push_back(snippet);
-    }
-    source->extra_snippets = std::move(snippets);
+    source->extra_snippets = base::ToVector(proto.extra_snippets());
   }
   return source;
 }
@@ -353,12 +348,9 @@ mojom::WebSourcePtr ProtoToWebSource(const sync_pb::AIChatWebSource& proto) {
 mojom::WebSourcesContentBlockPtr ProtoToWebSourcesContentBlock(
     const sync_pb::AIChatWebSourcesContentBlock& proto) {
   auto block = mojom::WebSourcesContentBlock::New();
-  for (const auto& source : proto.sources()) {
-    block->sources.push_back(ProtoToWebSource(source));
-  }
-  for (const auto& q : proto.queries()) {
-    block->queries.push_back(q);
-  }
+  block->sources = base::ToVector(proto.sources(), &ProtoToWebSource);
+  block->queries.append_range(proto.queries());
+  block->rich_results.reserve(proto.rich_results_size());
   for (const auto& rr : proto.rich_results()) {
     if (auto value = ReadCompressibleString(rr)) {
       block->rich_results.push_back(std::move(*value));
@@ -406,17 +398,14 @@ mojom::ToolUseEventPtr ProtoToToolUse(
     tool_use->output = std::move(blocks);
   }
   if (proto.artifacts_size() > 0) {
-    std::vector<mojom::ToolArtifactPtr> artifacts;
-    artifacts.reserve(proto.artifacts_size());
-    for (const auto& a : proto.artifacts()) {
+    tool_use->artifacts = base::ToVector(proto.artifacts(), [](const auto& a) {
       auto artifact = mojom::ToolArtifact::New();
       artifact->type = a.type();
       if (auto value = ReadCompressibleString(a.content_json())) {
         artifact->content_json = std::move(*value);
       }
-      artifacts.push_back(std::move(artifact));
-    }
-    tool_use->artifacts = std::move(artifacts);
+      return artifact;
+    });
   }
   return tool_use;
 }
@@ -433,17 +422,15 @@ mojom::ConversationEntryEventPtr ProtoToEntryEvent(
   }
   if (proto.has_search_queries()) {
     auto event = mojom::SearchQueriesEvent::New();
-    for (const auto& q : proto.search_queries().queries()) {
-      event->search_queries.push_back(q);
-    }
+    event->search_queries.append_range(proto.search_queries().queries());
     return mojom::ConversationEntryEvent::NewSearchQueriesEvent(
         std::move(event));
   }
   if (proto.has_web_sources()) {
     auto event = mojom::WebSourcesEvent::New();
-    for (const auto& source : proto.web_sources().sources()) {
-      event->sources.push_back(ProtoToWebSource(source));
-    }
+    event->sources =
+        base::ToVector(proto.web_sources().sources(), &ProtoToWebSource);
+    event->rich_results.reserve(proto.web_sources().rich_results_size());
     for (const auto& rr : proto.web_sources().rich_results()) {
       if (auto value = ReadCompressibleString(rr)) {
         event->rich_results.push_back(std::move(*value));
@@ -495,8 +482,7 @@ mojom::UploadedFilePtr ProtoToUploadedFile(
   // omitted them (the oneof holds omitted_data_hash instead), leave |data|
   // empty so the caller can restore any existing local bytes.
   if (proto.has_data()) {
-    const std::string& bytes = proto.data();
-    file->data.assign(bytes.begin(), bytes.end());
+    file->data = base::ToVector(base::as_byte_span(proto.data()));
   }
   if (proto.has_extracted_text()) {
     if (auto value = ReadCompressibleString(proto.extracted_text())) {
@@ -513,13 +499,10 @@ mojom::UploadedFilePtr ProtoToUploadedFile(
 // caller preserves any existing local text.
 void ReadAssociatedContentFromEntry(
     const sync_pb::AIChatConversationSpecifics_Entry& proto,
-    std::vector<mojom::AssociatedContentPtr>* associated_content,
+    std::vector<mojom::AssociatedContentPtr>& associated_content,
     base::flat_map<std::string, std::string>* associated_content_texts) {
-  if (!associated_content) {
-    return;
-  }
   for (const auto& content_proto : proto.associated_content()) {
-    associated_content->push_back(
+    associated_content.push_back(
         ProtoToAssociatedContent(content_proto, proto.uuid()));
     if (associated_content_texts && content_proto.has_last_contents()) {
       if (auto value = ReadCompressibleString(content_proto.last_contents())) {
@@ -619,7 +602,7 @@ mojom::ConversationPtr SpecificsToConversationMetadata(
 
 mojom::ConversationTurnPtr SpecificsToEntry(
     const sync_pb::AIChatConversationSpecifics& specifics,
-    std::vector<mojom::AssociatedContentPtr>* associated_content,
+    std::vector<mojom::AssociatedContentPtr>& associated_content,
     base::flat_map<std::string, std::string>* associated_content_texts) {
   if (!specifics.has_entry()) {
     return nullptr;
@@ -659,12 +642,8 @@ mojom::ConversationTurnPtr SpecificsToEntry(
                                  associated_content_texts);
 
   if (proto.uploaded_files_size() > 0) {
-    std::vector<mojom::UploadedFilePtr> files;
-    files.reserve(proto.uploaded_files_size());
-    for (const auto& file_proto : proto.uploaded_files()) {
-      files.push_back(ProtoToUploadedFile(file_proto));
-    }
-    entry->uploaded_files = std::move(files);
+    entry->uploaded_files =
+        base::ToVector(proto.uploaded_files(), &ProtoToUploadedFile);
   }
 
   if (proto.has_skill()) {

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
@@ -26,10 +26,13 @@
 #include "base/system/sys_info.h"
 #include "base/time/time.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
+#include "brave/components/ai_chat/core/common/mojom/common.mojom-shared.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
 #include "brave/components/sync/protocol/ai_chat_specifics.pb.h"
 #include "components/sync/protocol/entity_data.h"
 #include "components/sync/protocol/entity_specifics.pb.h"
+#include "mojo/public/cpp/bindings/enum_utils.h"
+#include "third_party/protobuf/src/google/protobuf/repeated_ptr_field.h"
 #include "third_party/zlib/google/compression_utils.h"
 #include "url/gurl.h"
 
@@ -340,16 +343,6 @@ std::vector<std::string> ReadCompressibleStrings(
   return out;
 }
 
-// Coerces a serialized integer enum value to a known mojom enumerator, falling
-// back to the default enumerator when the sender used a value this client does
-// not recognize (forward-compat or corrupt remote data). Keeps an out-of-range
-// value from reaching a mojo pipe, where it would fail validation.
-template <typename Enum>
-Enum ToKnownEnumValue(int value) {
-  const auto enum_value = static_cast<Enum>(value);
-  return mojom::IsKnownEnumValue(enum_value) ? enum_value : Enum();
-}
-
 mojom::WebSourcePtr ProtoToWebSource(const sync_pb::AIChatWebSource& proto) {
   auto source = mojom::WebSource::New();
   source->title = proto.title();
@@ -467,7 +460,8 @@ mojom::AssociatedContentPtr ProtoToAssociatedContent(
     content->url = GURL(proto.url());
   }
   content->content_type =
-      ToKnownEnumValue<mojom::ContentType>(proto.content_type());
+      mojo::ConvertIntToMojoEnum<mojom::ContentType>(proto.content_type())
+          .value_or(mojom::ContentType::PageContent);
   content->content_used_percentage = proto.content_used_percentage();
   content->conversation_turn_uuid = entry_uuid;
   return content;
@@ -480,7 +474,8 @@ mojom::UploadedFilePtr ProtoToUploadedFile(
     file->filename = proto.filename();
   }
   file->filesize = proto.filesize();
-  file->type = ToKnownEnumValue<mojom::UploadedFileType>(proto.type());
+  file->type = mojo::ConvertIntToMojoEnum<mojom::UploadedFileType>(proto.type())
+                   .value_or(mojom::UploadedFileType::kText);
   // Only populate bytes when the sender actually shipped them. When the sender
   // omitted them (the oneof holds omitted_data_hash instead), leave |data|
   // empty so the caller can restore any existing local bytes.
@@ -616,8 +611,11 @@ mojom::ConversationTurnPtr SpecificsToEntry(
     entry->prompt = proto.prompt();
   }
   entry->character_type =
-      ToKnownEnumValue<mojom::CharacterType>(proto.character_type());
-  entry->action_type = ToKnownEnumValue<mojom::ActionType>(proto.action_type());
+      mojo::ConvertIntToMojoEnum<mojom::CharacterType>(proto.character_type())
+          .value_or(mojom::CharacterType::HUMAN);
+  entry->action_type =
+      mojo::ConvertIntToMojoEnum<mojom::ActionType>(proto.action_type())
+          .value_or(mojom::ActionType::UNSPECIFIED);
   if (proto.has_selected_text()) {
     entry->selected_text = proto.selected_text();
   }

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
@@ -283,7 +283,7 @@ void WriteEntryFields(const mojom::ConversationTurn& entry,
   if (entry.uuid) {
     proto->set_uuid(*entry.uuid);
   }
-  proto->set_date_unix_epoch_micros(
+  proto->set_created_time_windows_epoch_micros(
       entry.created_time.ToDeltaSinceWindowsEpoch().InMicroseconds());
   proto->set_entry_text(entry.text);
   if (entry.prompt) {
@@ -299,10 +299,9 @@ void WriteEntryFields(const mojom::ConversationTurn& entry,
   }
 
   if (entry.events) {
-    for (int order = 0; const auto& event : *entry.events) {
-      auto* event_proto = proto->add_events();
-      event_proto->set_event_order(order++);
-      WriteEvent(*event, event_proto);
+    // Event order is preserved by the repeated field's ordering.
+    for (const auto& event : *entry.events) {
+      WriteEvent(*event, proto->add_events());
     }
   }
 
@@ -321,6 +320,212 @@ void WriteEntryFields(const mojom::ConversationTurn& entry,
   if (entry.near_verification_status) {
     proto->mutable_near_verification_status()->set_verified(
         entry.near_verification_status->verified);
+  }
+}
+
+// --- Download helpers: sync proto → mojom ---
+
+mojom::WebSourcePtr ProtoToWebSource(const sync_pb::AIChatWebSource& proto) {
+  auto source = mojom::WebSource::New();
+  source->title = proto.title();
+  if (proto.has_url()) {
+    source->url = GURL(proto.url());
+  }
+  if (proto.has_favicon_url()) {
+    source->favicon_url = GURL(proto.favicon_url());
+  }
+  if (proto.has_page_content()) {
+    if (auto pc = ReadCompressibleString(proto.page_content())) {
+      source->page_content = std::move(*pc);
+    }
+  }
+  if (proto.extra_snippets_size() > 0) {
+    std::vector<std::string> snippets;
+    snippets.reserve(proto.extra_snippets_size());
+    for (const auto& snippet : proto.extra_snippets()) {
+      snippets.push_back(snippet);
+    }
+    source->extra_snippets = std::move(snippets);
+  }
+  return source;
+}
+
+mojom::WebSourcesContentBlockPtr ProtoToWebSourcesContentBlock(
+    const sync_pb::AIChatWebSourcesContentBlock& proto) {
+  auto block = mojom::WebSourcesContentBlock::New();
+  for (const auto& source : proto.sources()) {
+    block->sources.push_back(ProtoToWebSource(source));
+  }
+  for (const auto& q : proto.queries()) {
+    block->queries.push_back(q);
+  }
+  for (const auto& rr : proto.rich_results()) {
+    if (auto value = ReadCompressibleString(rr)) {
+      block->rich_results.push_back(std::move(*value));
+    }
+  }
+  return block;
+}
+
+mojom::ToolUseEventPtr ProtoToToolUse(
+    const sync_pb::AIChatToolUseEvent& proto) {
+  auto tool_use = mojom::ToolUseEvent::New();
+  tool_use->tool_name = proto.tool_name();
+  tool_use->id = proto.id();
+  if (proto.has_arguments_json()) {
+    if (auto args = ReadCompressibleString(proto.arguments_json())) {
+      tool_use->arguments_json = std::move(*args);
+    }
+  }
+  tool_use->is_server_result = proto.is_server_result();
+  if (proto.output_size() > 0) {
+    std::vector<mojom::ContentBlockPtr> blocks;
+    blocks.reserve(proto.output_size());
+    for (const auto& block_proto : proto.output()) {
+      mojom::ContentBlockPtr block;
+      if (block_proto.has_text_content_block()) {
+        auto text = mojom::TextContentBlock::New();
+        if (auto value = ReadCompressibleString(
+                block_proto.text_content_block().text())) {
+          text->text = std::move(*value);
+        }
+        block = mojom::ContentBlock::NewTextContentBlock(std::move(text));
+      } else if (block_proto.has_image_content_block()) {
+        auto image = mojom::ImageContentBlock::New();
+        image->image_url = GURL(block_proto.image_content_block().image_url());
+        block = mojom::ContentBlock::NewImageContentBlock(std::move(image));
+      } else if (block_proto.has_web_sources_content_block()) {
+        block = mojom::ContentBlock::NewWebSourcesContentBlock(
+            ProtoToWebSourcesContentBlock(
+                block_proto.web_sources_content_block()));
+      } else {
+        continue;
+      }
+      blocks.push_back(std::move(block));
+    }
+    tool_use->output = std::move(blocks);
+  }
+  if (proto.artifacts_size() > 0) {
+    std::vector<mojom::ToolArtifactPtr> artifacts;
+    artifacts.reserve(proto.artifacts_size());
+    for (const auto& a : proto.artifacts()) {
+      auto artifact = mojom::ToolArtifact::New();
+      artifact->type = a.type();
+      if (auto value = ReadCompressibleString(a.content_json())) {
+        artifact->content_json = std::move(*value);
+      }
+      artifacts.push_back(std::move(artifact));
+    }
+    tool_use->artifacts = std::move(artifacts);
+  }
+  return tool_use;
+}
+
+mojom::ConversationEntryEventPtr ProtoToEntryEvent(
+    const sync_pb::AIChatEntryEventProto& proto) {
+  if (proto.has_completion()) {
+    auto completion = mojom::CompletionEvent::New();
+    if (auto value = ReadCompressibleString(proto.completion())) {
+      completion->completion = std::move(*value);
+    }
+    return mojom::ConversationEntryEvent::NewCompletionEvent(
+        std::move(completion));
+  }
+  if (proto.has_search_queries()) {
+    auto event = mojom::SearchQueriesEvent::New();
+    for (const auto& q : proto.search_queries().queries()) {
+      event->search_queries.push_back(q);
+    }
+    return mojom::ConversationEntryEvent::NewSearchQueriesEvent(
+        std::move(event));
+  }
+  if (proto.has_web_sources()) {
+    auto event = mojom::WebSourcesEvent::New();
+    for (const auto& source : proto.web_sources().sources()) {
+      event->sources.push_back(ProtoToWebSource(source));
+    }
+    for (const auto& rr : proto.web_sources().rich_results()) {
+      if (auto value = ReadCompressibleString(rr)) {
+        event->rich_results.push_back(std::move(*value));
+      }
+    }
+    return mojom::ConversationEntryEvent::NewSourcesEvent(std::move(event));
+  }
+  if (proto.has_inline_search()) {
+    auto event = mojom::InlineSearchEvent::New();
+    event->query = proto.inline_search().query();
+    if (auto value =
+            ReadCompressibleString(proto.inline_search().results_json())) {
+      event->results_json = std::move(*value);
+    }
+    return mojom::ConversationEntryEvent::NewInlineSearchEvent(
+        std::move(event));
+  }
+  if (proto.has_tool_use()) {
+    return mojom::ConversationEntryEvent::NewToolUseEvent(
+        ProtoToToolUse(proto.tool_use()));
+  }
+  return nullptr;
+}
+
+mojom::AssociatedContentPtr ProtoToAssociatedContent(
+    const sync_pb::AIChatAssociatedContentProto& proto,
+    const std::string& entry_uuid) {
+  auto content = mojom::AssociatedContent::New();
+  content->uuid = proto.uuid();
+  content->title = proto.title();
+  if (proto.has_url()) {
+    content->url = GURL(proto.url());
+  }
+  content->content_type = static_cast<mojom::ContentType>(proto.content_type());
+  content->content_used_percentage = proto.content_used_percentage();
+  content->conversation_turn_uuid = entry_uuid;
+  return content;
+}
+
+mojom::UploadedFilePtr ProtoToUploadedFile(
+    const sync_pb::AIChatUploadedFile& proto) {
+  auto file = mojom::UploadedFile::New();
+  if (proto.has_filename()) {
+    file->filename = proto.filename();
+  }
+  file->filesize = proto.filesize();
+  file->type = static_cast<mojom::UploadedFileType>(proto.type());
+  // Only populate bytes when the sender actually shipped them. When the sender
+  // omitted them (the oneof holds omitted_data_hash instead), leave |data|
+  // empty so the caller can restore any existing local bytes.
+  if (proto.has_data()) {
+    const std::string& bytes = proto.data();
+    file->data.assign(bytes.begin(), bytes.end());
+  }
+  if (proto.has_extracted_text()) {
+    if (auto value = ReadCompressibleString(proto.extracted_text())) {
+      file->extracted_text = std::move(*value);
+    }
+  }
+  return file;
+}
+
+// Populates |associated_content| from the entry's associated_content field
+// (each tagged with the entry UUID) and, when provided, |associated_content_
+// texts| with the last_contents value for each AC the sender included. An AC
+// with omitted last_contents is intentionally left out of the texts map so the
+// caller preserves any existing local text.
+void ReadAssociatedContentFromEntry(
+    const sync_pb::AIChatConversationSpecifics_Entry& proto,
+    std::vector<mojom::AssociatedContentPtr>* associated_content,
+    base::flat_map<std::string, std::string>* associated_content_texts) {
+  if (!associated_content) {
+    return;
+  }
+  for (const auto& content_proto : proto.associated_content()) {
+    associated_content->push_back(
+        ProtoToAssociatedContent(content_proto, proto.uuid()));
+    if (associated_content_texts && content_proto.has_last_contents()) {
+      if (auto value = ReadCompressibleString(content_proto.last_contents())) {
+        (*associated_content_texts)[content_proto.uuid()] = std::move(*value);
+      }
+    }
   }
 }
 
@@ -368,7 +573,7 @@ sync_pb::AIChatConversationSpecifics EntryToSpecifics(
   if (entry.uuid) {
     entry_proto->set_uuid(*entry.uuid);
   }
-  entry_proto->set_date_unix_epoch_micros(
+  entry_proto->set_created_time_windows_epoch_micros(
       entry.created_time.ToDeltaSinceWindowsEpoch().InMicroseconds());
 
   // Filter associated content to items tied to this entry only. Associated
@@ -392,6 +597,85 @@ sync_pb::AIChatConversationSpecifics EntryToSpecifics(
   }
 
   return specifics;
+}
+
+mojom::ConversationPtr SpecificsToConversationMetadata(
+    const sync_pb::AIChatConversationSpecifics& specifics) {
+  if (!specifics.has_conversation()) {
+    return nullptr;
+  }
+  const auto& meta = specifics.conversation();
+  auto conversation = mojom::Conversation::New();
+  conversation->uuid = meta.uuid();
+  conversation->title = meta.title();
+  if (meta.has_model_key()) {
+    conversation->model_key = meta.model_key();
+  }
+  conversation->total_tokens = meta.total_tokens();
+  conversation->trimmed_tokens = meta.trimmed_tokens();
+  conversation->has_content = true;
+  return conversation;
+}
+
+mojom::ConversationTurnPtr SpecificsToEntry(
+    const sync_pb::AIChatConversationSpecifics& specifics,
+    std::vector<mojom::AssociatedContentPtr>* associated_content,
+    base::flat_map<std::string, std::string>* associated_content_texts) {
+  if (!specifics.has_entry()) {
+    return nullptr;
+  }
+  const auto& proto = specifics.entry();
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = proto.uuid();
+  entry->created_time = base::Time::FromDeltaSinceWindowsEpoch(
+      base::Microseconds(proto.created_time_windows_epoch_micros()));
+  entry->text = proto.entry_text();
+  if (proto.has_prompt()) {
+    entry->prompt = proto.prompt();
+  }
+  entry->character_type =
+      static_cast<mojom::CharacterType>(proto.character_type());
+  entry->action_type = static_cast<mojom::ActionType>(proto.action_type());
+  if (proto.has_selected_text()) {
+    entry->selected_text = proto.selected_text();
+  }
+  if (proto.has_model_key()) {
+    entry->model_key = proto.model_key();
+  }
+
+  if (proto.events_size() > 0) {
+    std::vector<mojom::ConversationEntryEventPtr> events;
+    events.reserve(proto.events_size());
+    for (const auto& event_proto : proto.events()) {
+      auto event = ProtoToEntryEvent(event_proto);
+      if (event) {
+        events.push_back(std::move(event));
+      }
+    }
+    entry->events = std::move(events);
+  }
+
+  ReadAssociatedContentFromEntry(proto, associated_content,
+                                 associated_content_texts);
+
+  if (proto.uploaded_files_size() > 0) {
+    std::vector<mojom::UploadedFilePtr> files;
+    files.reserve(proto.uploaded_files_size());
+    for (const auto& file_proto : proto.uploaded_files()) {
+      files.push_back(ProtoToUploadedFile(file_proto));
+    }
+    entry->uploaded_files = std::move(files);
+  }
+
+  if (proto.has_skill()) {
+    entry->skill = mojom::SkillEntry::New(proto.skill().shortcut(),
+                                          proto.skill().prompt());
+  }
+  if (proto.has_near_verification_status()) {
+    entry->near_verification_status = mojom::NEARVerificationStatus::New(
+        proto.near_verification_status().verified());
+  }
+  return entry;
 }
 
 std::unique_ptr<syncer::EntityData> CreateEntityDataFromSpecifics(

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
@@ -401,7 +401,8 @@ mojom::ToolUseEventPtr ProtoToToolUse(
                   block_proto.web_sources_content_block())));
           break;
         case sync_pb::AIChatContentBlock::CONTENT_NOT_SET:
-          break;
+          // Variant not known by this client or not set
+          return nullptr;
       }
     }
     tool_use->output = std::move(blocks);
@@ -420,34 +421,33 @@ mojom::ToolUseEventPtr ProtoToToolUse(
 
 mojom::ConversationEntryEventPtr ProtoToEntryEvent(
     const sync_pb::AIChatEntryEventProto& proto) {
-  if (proto.has_completion()) {
-    return mojom::ConversationEntryEvent::NewCompletionEvent(
-        mojom::CompletionEvent::New(ReadCompressibleString(proto.completion())
-                                        .value_or(std::string())));
+  switch (proto.event_case()) {
+    case sync_pb::AIChatEntryEventProto::kCompletion:
+      return mojom::ConversationEntryEvent::NewCompletionEvent(
+          mojom::CompletionEvent::New(ReadCompressibleString(proto.completion())
+                                          .value_or(std::string())));
+    case sync_pb::AIChatEntryEventProto::kSearchQueries:
+      return mojom::ConversationEntryEvent::NewSearchQueriesEvent(
+          mojom::SearchQueriesEvent::New(
+              base::ToVector(proto.search_queries().queries())));
+    case sync_pb::AIChatEntryEventProto::kWebSources:
+      return mojom::ConversationEntryEvent::NewSourcesEvent(
+          mojom::WebSourcesEvent::New(
+              base::ToVector(proto.web_sources().sources(), &ProtoToWebSource),
+              ReadCompressibleStrings(proto.web_sources().rich_results())));
+    case sync_pb::AIChatEntryEventProto::kInlineSearch:
+      return mojom::ConversationEntryEvent::NewInlineSearchEvent(
+          mojom::InlineSearchEvent::New(
+              proto.inline_search().query(),
+              ReadCompressibleString(proto.inline_search().results_json())
+                  .value_or(std::string())));
+    case sync_pb::AIChatEntryEventProto::kToolUse:
+      return mojom::ConversationEntryEvent::NewToolUseEvent(
+          ProtoToToolUse(proto.tool_use()));
+    case sync_pb::AIChatEntryEventProto::EVENT_NOT_SET:
+      // Variant not known by this client or not set
+      return nullptr;
   }
-  if (proto.has_search_queries()) {
-    return mojom::ConversationEntryEvent::NewSearchQueriesEvent(
-        mojom::SearchQueriesEvent::New(
-            base::ToVector(proto.search_queries().queries())));
-  }
-  if (proto.has_web_sources()) {
-    return mojom::ConversationEntryEvent::NewSourcesEvent(
-        mojom::WebSourcesEvent::New(
-            base::ToVector(proto.web_sources().sources(), &ProtoToWebSource),
-            ReadCompressibleStrings(proto.web_sources().rich_results())));
-  }
-  if (proto.has_inline_search()) {
-    return mojom::ConversationEntryEvent::NewInlineSearchEvent(
-        mojom::InlineSearchEvent::New(
-            proto.inline_search().query(),
-            ReadCompressibleString(proto.inline_search().results_json())
-                .value_or(std::string())));
-  }
-  if (proto.has_tool_use()) {
-    return mojom::ConversationEntryEvent::NewToolUseEvent(
-        ProtoToToolUse(proto.tool_use()));
-  }
-  return nullptr;
 }
 
 mojom::AssociatedContentPtr ProtoToAssociatedContent(
@@ -459,9 +459,14 @@ mojom::AssociatedContentPtr ProtoToAssociatedContent(
   if (proto.has_url()) {
     content->url = GURL(proto.url());
   }
-  content->content_type =
-      mojo::ConvertIntToMojoEnum<mojom::ContentType>(proto.content_type())
-          .value_or(mojom::ContentType::PageContent);
+  auto content_type =
+      mojo::ConvertIntToMojoEnum<mojom::ContentType>(proto.content_type());
+  if (!content_type) {
+    DVLOG(1) << "Rejecting associated content with unknown content_type "
+             << proto.content_type();
+    return nullptr;
+  }
+  content->content_type = content_type.value();
   content->content_used_percentage = proto.content_used_percentage();
   content->conversation_turn_uuid = entry_uuid;
   return content;
@@ -474,8 +479,12 @@ mojom::UploadedFilePtr ProtoToUploadedFile(
     file->filename = proto.filename();
   }
   file->filesize = proto.filesize();
-  file->type = mojo::ConvertIntToMojoEnum<mojom::UploadedFileType>(proto.type())
-                   .value_or(mojom::UploadedFileType::kText);
+  auto type = mojo::ConvertIntToMojoEnum<mojom::UploadedFileType>(proto.type());
+  if (!type) {
+    DVLOG(1) << "Rejecting uploaded file with unknown type " << proto.type();
+    return nullptr;
+  }
+  file->type = type.value();
   // Only populate bytes when the sender actually shipped them. When the sender
   // omitted them (the oneof holds omitted_data_hash instead), leave |data|
   // empty so the caller can restore any existing local bytes.
@@ -491,19 +500,25 @@ mojom::UploadedFilePtr ProtoToUploadedFile(
 // texts| with the last_contents value for each AC the sender included. An AC
 // with omitted last_contents is intentionally left out of the texts map so the
 // caller preserves any existing local text.
-void ReadAssociatedContentFromEntry(
+bool ReadAssociatedContentFromEntry(
     const sync_pb::AIChatConversationSpecifics_Entry& proto,
     std::vector<mojom::AssociatedContentPtr>& associated_content,
     base::flat_map<std::string, std::string>* associated_content_texts) {
   for (const auto& content_proto : proto.associated_content()) {
-    associated_content.push_back(
-        ProtoToAssociatedContent(content_proto, proto.uuid()));
+    mojom::AssociatedContentPtr content_item =
+        ProtoToAssociatedContent(content_proto, proto.uuid());
+    if (!content_item) {
+      // If the associated content failed to decode, reject the entire entry.
+      return false;
+    }
+    associated_content.push_back(std::move(content_item));
     if (associated_content_texts && content_proto.has_last_contents()) {
       if (auto value = ReadCompressibleString(content_proto.last_contents())) {
         (*associated_content_texts)[content_proto.uuid()] = std::move(*value);
       }
     }
   }
+  return true;
 }
 
 }  // namespace
@@ -610,12 +625,23 @@ mojom::ConversationTurnPtr SpecificsToEntry(
   if (proto.has_prompt()) {
     entry->prompt = proto.prompt();
   }
-  entry->character_type =
-      mojo::ConvertIntToMojoEnum<mojom::CharacterType>(proto.character_type())
-          .value_or(mojom::CharacterType::HUMAN);
-  entry->action_type =
-      mojo::ConvertIntToMojoEnum<mojom::ActionType>(proto.action_type())
-          .value_or(mojom::ActionType::UNSPECIFIED);
+  auto character_type =
+      mojo::ConvertIntToMojoEnum<mojom::CharacterType>(proto.character_type());
+  if (!character_type) {
+    DVLOG(1) << "Rejecting entry with unknown character_type "
+             << proto.character_type();
+    return nullptr;
+  }
+  entry->character_type = character_type.value();
+  auto action_type =
+      mojo::ConvertIntToMojoEnum<mojom::ActionType>(proto.action_type());
+  if (!action_type) {
+    DVLOG(1) << "Rejecting entry with unknown action_type "
+             << proto.action_type();
+    return nullptr;
+  }
+  entry->action_type = action_type.value();
+
   if (proto.has_selected_text()) {
     entry->selected_text = proto.selected_text();
   }
@@ -627,19 +653,29 @@ mojom::ConversationTurnPtr SpecificsToEntry(
     std::vector<mojom::ConversationEntryEventPtr> events;
     events.reserve(proto.events_size());
     for (const auto& event_proto : proto.events()) {
-      if (auto event = ProtoToEntryEvent(event_proto)) {
-        events.push_back(std::move(event));
+      auto event = ProtoToEntryEvent(event_proto);
+      if (!event) {
+        return nullptr;
       }
+      events.push_back(std::move(event));
     }
     entry->events = std::move(events);
   }
 
-  ReadAssociatedContentFromEntry(proto, associated_content,
-                                 associated_content_texts);
+  if (!ReadAssociatedContentFromEntry(proto, associated_content,
+                                      associated_content_texts)) {
+    return nullptr;
+  }
 
   if (!proto.uploaded_files().empty()) {
     entry->uploaded_files =
         base::ToVector(proto.uploaded_files(), &ProtoToUploadedFile);
+    // If any are nullptr (failed to decode), reject the entire entry.
+    if (std::any_of(entry->uploaded_files->begin(),
+                    entry->uploaded_files->end(),
+                    [](const auto& file) { return !file; })) {
+      return nullptr;
+    }
   }
 
   if (proto.has_skill()) {

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h
@@ -93,6 +93,23 @@ sync_pb::AIChatConversationSpecifics EntryToSpecifics(
     const base::flat_map<std::string, std::string>& associated_content_texts =
         {});
 
+// Reverses ConversationMetadataToSpecifics. The returned Conversation has no
+// entries or associated content (those are carried by Entry records).
+mojom::ConversationPtr SpecificsToConversationMetadata(
+    const sync_pb::AIChatConversationSpecifics& specifics);
+
+// Reverses EntryToSpecifics. |associated_content| is populated from the
+// entry's associated_content field, each tagged with this entry's UUID via
+// |conversation_turn_uuid|. When non-null, |associated_content_texts|
+// receives the last_contents value for each AC where the sender provided
+// one; absent map entries mean the caller should preserve any existing
+// local text (forward-compat or truncated-for-sync).
+mojom::ConversationTurnPtr SpecificsToEntry(
+    const sync_pb::AIChatConversationSpecifics& specifics,
+    std::vector<mojom::AssociatedContentPtr>* associated_content,
+    base::flat_map<std::string, std::string>* associated_content_texts =
+        nullptr);
+
 // Wraps an AIChatConversationSpecifics in EntityData for change_processor()
 // to consume. Sets the entity name to a human-readable string.
 std::unique_ptr<syncer::EntityData> CreateEntityDataFromSpecifics(

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h
@@ -106,7 +106,7 @@ mojom::ConversationPtr SpecificsToConversationMetadata(
 // local text (forward-compat or truncated-for-sync).
 mojom::ConversationTurnPtr SpecificsToEntry(
     const sync_pb::AIChatConversationSpecifics& specifics,
-    std::vector<mojom::AssociatedContentPtr>* associated_content,
+    std::vector<mojom::AssociatedContentPtr>& associated_content,
     base::flat_map<std::string, std::string>* associated_content_texts =
         nullptr);
 

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions_unittest.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions_unittest.cc
@@ -10,9 +10,12 @@
 #include <string>
 #include <vector>
 
+#include "base/containers/flat_map.h"
 #include "base/hash/hash.h"
+#include "base/location.h"
 #include "base/numerics/byte_conversions.h"
 #include "base/time/time.h"
+#include "brave/components/ai_chat/core/browser/test_utils.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
 #include "brave/components/sync/protocol/ai_chat_specifics.pb.h"
@@ -218,7 +221,7 @@ TEST(AIChatSyncConversionsTest, EntryToSpecificsMapsFields) {
             static_cast<int32_t>(mojom::CharacterType::HUMAN));
   EXPECT_EQ(proto.action_type(),
             static_cast<int32_t>(mojom::ActionType::QUERY));
-  EXPECT_EQ(proto.date_unix_epoch_micros(), 42);
+  EXPECT_EQ(proto.created_time_windows_epoch_micros(), 42);
 }
 
 TEST(AIChatSyncConversionsTest,
@@ -268,7 +271,7 @@ TEST(AIChatSyncConversionsTest,
   const auto& proto = specifics.entry();
   // Identity: from the original turn.
   EXPECT_EQ(proto.uuid(), "entry-1");
-  EXPECT_EQ(proto.date_unix_epoch_micros(), 42);
+  EXPECT_EQ(proto.created_time_windows_epoch_micros(), 42);
   // Content: from the most recent edit, not the original or intermediate edit.
   EXPECT_EQ(proto.entry_text(), "latest edit");
   EXPECT_EQ(proto.model_key(), "edited-model");
@@ -560,6 +563,570 @@ TEST(AIChatSyncConversionsTest, EntryToSpecificsOmitsAbsentSkillAndNear) {
   ASSERT_TRUE(specifics.has_entry());
   EXPECT_FALSE(specifics.entry().has_skill());
   EXPECT_FALSE(specifics.entry().has_near_verification_status());
+}
+
+TEST(AIChatSyncConversionsTest, ConversationMetadataRoundTrip) {
+  // Built with the positional constructor on purpose: a new mojom::Conversation
+  // field forces a compile error here, so the author must decide whether it
+  // should be synced (and the round-trip assertion below then enforces it).
+  auto original = mojom::Conversation::New(
+      "conv-123" /* uuid */, "Test conversation" /* title */,
+      base::Time() /* updated_time (not synced) */,
+      false /* has_content (not synced) */, "claude-opus" /* model_key */,
+      4096u /* total_tokens */, 256u /* trimmed_tokens */,
+      false /* temporary (not synced) */,
+      std::vector<mojom::AssociatedContentPtr>() /* associated_content */);
+
+  auto rebuilt = SpecificsToConversationMetadata(
+      ConversationMetadataToSpecifics(*original));
+  ASSERT_TRUE(rebuilt);
+
+  // Compares every synced field; non-persisted fields (e.g. has_content, which
+  // the receiver infers) are excluded by the helper.
+  ExpectConversationEquals(FROM_HERE, rebuilt, original,
+                           /*compare_non_persisted_fields=*/false);
+}
+
+TEST(AIChatSyncConversionsTest, ConversationMetadataRoundTripUnsetModelKey) {
+  auto original = mojom::Conversation::New();
+  original->uuid = "conv-min";
+  original->title = "Minimal";
+
+  auto rebuilt = SpecificsToConversationMetadata(
+      ConversationMetadataToSpecifics(*original));
+  ASSERT_TRUE(rebuilt);
+  EXPECT_FALSE(rebuilt->model_key.has_value());
+  ExpectConversationEquals(FROM_HERE, rebuilt, original,
+                           /*compare_non_persisted_fields=*/false);
+}
+
+TEST(AIChatSyncConversionsTest, EntryRoundTripBasic) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-1";
+  entry->created_time = base::Time::Now();
+  entry->text = "What is the capital of France?";
+  entry->prompt = "Be concise.";
+  entry->character_type = mojom::CharacterType::HUMAN;
+  entry->action_type = mojom::ActionType::QUERY;
+  entry->selected_text = "France";
+  entry->model_key = "claude-opus";
+
+  std::vector<mojom::AssociatedContentPtr> rebuilt_content;
+  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
+                                  &rebuilt_content);
+  ASSERT_TRUE(rebuilt);
+  ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
+  EXPECT_TRUE(rebuilt_content.empty());
+}
+
+// Populates every field of ConversationTurn (and every nested synced struct)
+// using positional constructors on purpose: adding a field to any of these
+// mojom structs forces a compile error here, so the author must populate it
+// and decide whether it should be synced. The round-trip assertions then
+// enforce that decision -- a newly-synced field must survive the round trip,
+// while an intentionally-unsynced one must be excluded (like |edits|).
+TEST(AIChatSyncConversionsTest, EntryRoundTripAllFields) {
+  // One event of every synced variant, each built positionally.
+  std::vector<mojom::ConversationEntryEventPtr> events;
+  events.push_back(mojom::ConversationEntryEvent::NewCompletionEvent(
+      mojom::CompletionEvent::New("the completion")));
+  events.push_back(mojom::ConversationEntryEvent::NewSearchQueriesEvent(
+      mojom::SearchQueriesEvent::New(
+          std::vector<std::string>{"query one", "query two"})));
+
+  std::vector<mojom::WebSourcePtr> event_sources;
+  event_sources.push_back(mojom::WebSource::New(
+      "Source" /* title */, GURL("https://example.com/source") /* url */,
+      GURL("https://example.com/source.ico") /* favicon_url */,
+      "source page content" /* page_content */,
+      std::vector<std::string>{"snippet"} /* extra_snippets */));
+  events.push_back(mojom::ConversationEntryEvent::NewSourcesEvent(
+      mojom::WebSourcesEvent::New(
+          std::move(event_sources) /* sources */,
+          std::vector<std::string>{"{\"rich\":1}"} /* rich_results */)));
+
+  events.push_back(mojom::ConversationEntryEvent::NewInlineSearchEvent(
+      mojom::InlineSearchEvent::New("inline query" /* query */,
+                                    "{\"results\":1}" /* results_json */)));
+
+  // Tool use, exercising every synced content-block variant and an artifact.
+  std::vector<mojom::ContentBlockPtr> output;
+  output.push_back(mojom::ContentBlock::NewTextContentBlock(
+      mojom::TextContentBlock::New("text output")));
+  output.push_back(mojom::ContentBlock::NewImageContentBlock(
+      mojom::ImageContentBlock::New(GURL("https://example.com/image.png"))));
+  std::vector<mojom::WebSourcePtr> block_sources;
+  block_sources.push_back(mojom::WebSource::New(
+      "Block Source" /* title */, GURL("https://example.com/block") /* url */,
+      GURL("https://example.com/block.ico") /* favicon_url */,
+      "block page content" /* page_content */,
+      std::vector<std::string>{"block snippet"} /* extra_snippets */));
+  output.push_back(mojom::ContentBlock::NewWebSourcesContentBlock(
+      mojom::WebSourcesContentBlock::New(
+          std::move(block_sources) /* sources */,
+          std::vector<std::string>{"block query"} /* queries */,
+          std::vector<std::string>{"{\"block\":1}"} /* rich_results */)));
+
+  std::vector<mojom::ToolArtifactPtr> artifacts;
+  artifacts.push_back(mojom::ToolArtifact::New(
+      std::nullopt /* id (not synced) */, "line_chart" /* type */,
+      "[1,2,3]" /* content_json */));
+
+  events.push_back(
+      mojom::ConversationEntryEvent::NewToolUseEvent(mojom::ToolUseEvent::New(
+          "tool" /* tool_name */, "tool-id" /* id */,
+          "{\"arg\":1}" /* arguments_json */, std::move(output) /* output */,
+          std::move(artifacts) /* artifacts */,
+          nullptr /* permission_challenge (not synced) */,
+          true /* is_server_result */)));
+
+  // Uploaded files: one with inline bytes, one with extracted text.
+  std::vector<mojom::UploadedFilePtr> uploaded_files;
+  uploaded_files.push_back(mojom::UploadedFile::New(
+      "image.png" /* filename */, 5u /* filesize */,
+      std::vector<uint8_t>{1, 2, 3, 4, 5} /* data */,
+      mojom::UploadedFileType::kImage, std::nullopt /* extracted_text */));
+  uploaded_files.push_back(mojom::UploadedFile::New(
+      "doc.pdf" /* filename */, 0u /* filesize */,
+      std::vector<uint8_t>{} /* data */, mojom::UploadedFileType::kPdf,
+      "extracted text" /* extracted_text */));
+
+  auto entry = mojom::ConversationTurn::New(
+      "entry-all" /* uuid */, mojom::CharacterType::ASSISTANT,
+      mojom::ActionType::RESPONSE, "entry text" /* text */,
+      "the prompt" /* prompt */, "selected text" /* selected_text */,
+      std::move(events) /* events */, base::Time::Now() /* created_time */,
+      std::nullopt /* edits (not synced) */,
+      std::move(uploaded_files) /* uploaded_files */,
+      mojom::SkillEntry::New("/skill", "skill prompt") /* skill */,
+      false /* from_brave_search_SERP (not synced) */,
+      "model-key" /* model_key */,
+      mojom::NEARVerificationStatus::New(true) /* near_verification_status */);
+
+  // Associated content is carried alongside the entry; its extracted text
+  // rides in the texts map keyed by AC uuid.
+  std::vector<mojom::AssociatedContentPtr> associated_content;
+  associated_content.push_back(mojom::AssociatedContent::New(
+      "ac-uuid" /* uuid */, mojom::ContentType::PageContent,
+      "AC title" /* title */, 0 /* content_id (not synced) */,
+      GURL("https://example.com/ac") /* url */,
+      42 /* content_used_percentage */,
+      "entry-all" /* conversation_turn_uuid */,
+      false /* tools_attached (not synced) */));
+
+  base::flat_map<std::string, std::string> texts;
+  texts["ac-uuid"] = "associated content extracted text";
+
+  std::vector<mojom::AssociatedContentPtr> rebuilt_content;
+  base::flat_map<std::string, std::string> rebuilt_texts;
+  auto rebuilt = SpecificsToEntry(
+      EntryToSpecifics("conv-all", *entry, associated_content, texts),
+      &rebuilt_content, &rebuilt_texts);
+  ASSERT_TRUE(rebuilt);
+  ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
+  ExpectAssociatedContentEquals(FROM_HERE, rebuilt_content, associated_content,
+                                /*compare_non_persisted_fields=*/false);
+  EXPECT_EQ(rebuilt_texts,
+            (base::flat_map<std::string, std::string>{
+                {"ac-uuid", "associated content extracted text"}}));
+}
+
+TEST(AIChatSyncConversionsTest, EntryRoundTripCompletionEvent) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-completion";
+  entry->created_time = base::Time::Now();
+  entry->character_type = mojom::CharacterType::ASSISTANT;
+  entry->action_type = mojom::ActionType::RESPONSE;
+
+  std::vector<mojom::ConversationEntryEventPtr> events;
+  auto completion = mojom::CompletionEvent::New();
+  completion->completion = "Paris.";
+  events.push_back(
+      mojom::ConversationEntryEvent::NewCompletionEvent(std::move(completion)));
+  entry->events = std::move(events);
+
+  std::vector<mojom::AssociatedContentPtr> rebuilt_content;
+  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
+                                  &rebuilt_content);
+  ASSERT_TRUE(rebuilt);
+  ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
+}
+
+TEST(AIChatSyncConversionsTest, EntryRoundTripSearchQueriesEvent) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-queries";
+  entry->created_time = base::Time::Now();
+  entry->character_type = mojom::CharacterType::ASSISTANT;
+  entry->action_type = mojom::ActionType::RESPONSE;
+
+  std::vector<mojom::ConversationEntryEventPtr> events;
+  auto sq = mojom::SearchQueriesEvent::New();
+  sq->search_queries = {"capital of France", "Paris facts"};
+  events.push_back(
+      mojom::ConversationEntryEvent::NewSearchQueriesEvent(std::move(sq)));
+  entry->events = std::move(events);
+
+  std::vector<mojom::AssociatedContentPtr> rebuilt_content;
+  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
+                                  &rebuilt_content);
+  ASSERT_TRUE(rebuilt);
+  ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
+}
+
+TEST(AIChatSyncConversionsTest, EntryRoundTripWebSourcesEvent) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-web";
+  entry->created_time = base::Time::Now();
+  entry->character_type = mojom::CharacterType::ASSISTANT;
+  entry->action_type = mojom::ActionType::RESPONSE;
+
+  auto source = mojom::WebSource::New();
+  source->title = "Paris";
+  source->url = GURL("https://en.wikipedia.org/wiki/Paris");
+  source->favicon_url = GURL("https://en.wikipedia.org/favicon.ico");
+  source->page_content = "Paris is the capital of France.";
+  source->extra_snippets = std::vector<std::string>{"Snippet A", "Snippet B"};
+
+  auto sources_event = mojom::WebSourcesEvent::New();
+  sources_event->sources.push_back(std::move(source));
+  sources_event->rich_results = {"{\"x\":1}"};
+
+  std::vector<mojom::ConversationEntryEventPtr> events;
+  events.push_back(
+      mojom::ConversationEntryEvent::NewSourcesEvent(std::move(sources_event)));
+  entry->events = std::move(events);
+
+  std::vector<mojom::AssociatedContentPtr> rebuilt_content;
+  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
+                                  &rebuilt_content);
+  ASSERT_TRUE(rebuilt);
+  ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
+}
+
+TEST(AIChatSyncConversionsTest, EntryRoundTripToolUseEvent) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-tool";
+  entry->created_time = base::Time::Now();
+  entry->character_type = mojom::CharacterType::ASSISTANT;
+  entry->action_type = mojom::ActionType::RESPONSE;
+
+  auto tool_use = mojom::ToolUseEvent::New();
+  tool_use->tool_name = "search";
+  tool_use->id = "tool-1";
+  tool_use->arguments_json = "{\"q\":\"test\"}";
+  tool_use->is_server_result = true;
+
+  std::vector<mojom::ContentBlockPtr> output;
+  auto text = mojom::TextContentBlock::New();
+  text->text = "result";
+  output.push_back(mojom::ContentBlock::NewTextContentBlock(std::move(text)));
+  tool_use->output = std::move(output);
+
+  std::vector<mojom::ConversationEntryEventPtr> events;
+  events.push_back(
+      mojom::ConversationEntryEvent::NewToolUseEvent(std::move(tool_use)));
+  entry->events = std::move(events);
+
+  std::vector<mojom::AssociatedContentPtr> rebuilt_content;
+  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
+                                  &rebuilt_content);
+  ASSERT_TRUE(rebuilt);
+  ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
+}
+
+TEST(AIChatSyncConversionsTest, EntryRoundTripToolUseArtifacts) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-artifacts";
+  entry->created_time = base::Time::Now();
+  entry->character_type = mojom::CharacterType::ASSISTANT;
+  entry->action_type = mojom::ActionType::RESPONSE;
+
+  auto tool_use = mojom::ToolUseEvent::New();
+  tool_use->tool_name = "chart";
+  tool_use->id = "tool-artifact";
+  tool_use->arguments_json = "{}";
+  std::vector<mojom::ToolArtifactPtr> artifacts;
+  // |id| is a local identifier and is intentionally not synced, so leave it
+  // unset to keep the round trip an identity.
+  artifacts.push_back(
+      mojom::ToolArtifact::New(std::nullopt, "line_chart", "[1,2,3]"));
+  tool_use->artifacts = std::move(artifacts);
+
+  std::vector<mojom::ConversationEntryEventPtr> events;
+  events.push_back(
+      mojom::ConversationEntryEvent::NewToolUseEvent(std::move(tool_use)));
+  entry->events = std::move(events);
+
+  std::vector<mojom::AssociatedContentPtr> rebuilt_content;
+  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
+                                  &rebuilt_content);
+  ASSERT_TRUE(rebuilt);
+  ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
+}
+
+TEST(AIChatSyncConversionsTest, EntryRoundTripImageContentBlock) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-image";
+  entry->created_time = base::Time::Now();
+  entry->character_type = mojom::CharacterType::ASSISTANT;
+  entry->action_type = mojom::ActionType::RESPONSE;
+
+  auto image = mojom::ImageContentBlock::New();
+  image->image_url = GURL("https://example.com/screenshot.png");
+  std::vector<mojom::ContentBlockPtr> output;
+  output.push_back(mojom::ContentBlock::NewImageContentBlock(std::move(image)));
+
+  auto tool_use = mojom::ToolUseEvent::New();
+  tool_use->tool_name = "screenshot";
+  tool_use->id = "tool-image";
+  tool_use->arguments_json = "{}";
+  tool_use->output = std::move(output);
+
+  std::vector<mojom::ConversationEntryEventPtr> events;
+  events.push_back(
+      mojom::ConversationEntryEvent::NewToolUseEvent(std::move(tool_use)));
+  entry->events = std::move(events);
+
+  std::vector<mojom::AssociatedContentPtr> rebuilt_content;
+  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
+                                  &rebuilt_content);
+  ASSERT_TRUE(rebuilt);
+  ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
+}
+
+TEST(AIChatSyncConversionsTest, EntryRoundTripInlineSearchEvent) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-inline";
+  entry->created_time = base::Time::Now();
+  entry->character_type = mojom::CharacterType::ASSISTANT;
+  entry->action_type = mojom::ActionType::RESPONSE;
+
+  auto inline_search = mojom::InlineSearchEvent::New();
+  inline_search->query = "weather today";
+  inline_search->results_json = R"({"temp":72})";
+  std::vector<mojom::ConversationEntryEventPtr> events;
+  events.push_back(mojom::ConversationEntryEvent::NewInlineSearchEvent(
+      std::move(inline_search)));
+  entry->events = std::move(events);
+
+  std::vector<mojom::AssociatedContentPtr> rebuilt_content;
+  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
+                                  &rebuilt_content);
+  ASSERT_TRUE(rebuilt);
+  ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
+}
+
+TEST(AIChatSyncConversionsTest,
+     EntryRoundTripAssociatedContentFilteredByEntry) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-with-content";
+  entry->created_time = base::Time::Now();
+  entry->character_type = mojom::CharacterType::HUMAN;
+  entry->action_type = mojom::ActionType::QUERY;
+
+  auto mine = mojom::AssociatedContent::New();
+  mine->uuid = "content-mine";
+  mine->title = "Mine";
+  mine->url = GURL("https://example.com/mine");
+  mine->content_type = mojom::ContentType::PageContent;
+  mine->content_used_percentage = 75;
+  mine->conversation_turn_uuid = "entry-with-content";
+
+  auto other = mojom::AssociatedContent::New();
+  other->uuid = "content-other";
+  other->title = "Other";
+  other->url = GURL("https://example.com/other");
+  other->content_type = mojom::ContentType::PageContent;
+  other->content_used_percentage = 50;
+  other->conversation_turn_uuid = "different-entry";
+
+  // Only |mine| (tied to this entry) survives the round trip.
+  std::vector<mojom::AssociatedContentPtr> expected_content;
+  expected_content.push_back(mine->Clone());
+
+  std::vector<mojom::AssociatedContentPtr> all_content;
+  all_content.push_back(std::move(mine));
+  all_content.push_back(std::move(other));
+
+  std::vector<mojom::AssociatedContentPtr> rebuilt_content;
+  auto rebuilt = SpecificsToEntry(
+      EntryToSpecifics("conv-1", *entry, all_content), &rebuilt_content);
+  ASSERT_TRUE(rebuilt);
+  ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
+  ExpectAssociatedContentEquals(FROM_HERE, rebuilt_content, expected_content,
+                                /*compare_non_persisted_fields=*/false);
+}
+
+TEST(AIChatSyncConversionsTest,
+     SpecificsToConversationReturnsNullForWrongKind) {
+  sync_pb::AIChatConversationSpecifics specifics;
+  specifics.mutable_entry()->set_uuid("e1");
+  EXPECT_FALSE(SpecificsToConversationMetadata(specifics));
+}
+
+TEST(AIChatSyncConversionsTest, SpecificsToEntryReturnsNullForWrongKind) {
+  sync_pb::AIChatConversationSpecifics specifics;
+  specifics.mutable_conversation()->set_uuid("c1");
+  std::vector<mojom::AssociatedContentPtr> content;
+  EXPECT_FALSE(SpecificsToEntry(specifics, &content));
+}
+
+TEST(AIChatSyncConversionsTest, EntryRoundTripUploadedFiles) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-files";
+  entry->created_time = base::Time::Now();
+  entry->character_type = mojom::CharacterType::HUMAN;
+  entry->action_type = mojom::ActionType::QUERY;
+
+  std::vector<mojom::UploadedFilePtr> files;
+  auto img = mojom::UploadedFile::New();
+  img->filename = "cat.jpg";
+  img->filesize = 5;
+  img->type = mojom::UploadedFileType::kImage;
+  img->data = {0x89, 0x50, 0x4e, 0x47, 0x0a};
+  files.push_back(std::move(img));
+
+  auto pdf = mojom::UploadedFile::New();
+  pdf->filename = "spec.pdf";
+  pdf->filesize = 0;
+  pdf->type = mojom::UploadedFileType::kPdf;
+  pdf->extracted_text = std::string(2048, 'x');  // Triggers gzip.
+  files.push_back(std::move(pdf));
+
+  entry->uploaded_files = std::move(files);
+
+  auto specifics = EntryToSpecifics("conv-1", *entry, {});
+  ASSERT_TRUE(specifics.has_entry());
+  ASSERT_EQ(specifics.entry().uploaded_files_size(), 2);
+  // Raw bytes are inlined for the image; the large extracted text is gzipped.
+  EXPECT_TRUE(specifics.entry().uploaded_files(0).has_data());
+  EXPECT_FALSE(specifics.entry().uploaded_files(0).has_omitted_data_hash());
+  EXPECT_TRUE(
+      specifics.entry().uploaded_files(1).extracted_text().has_gzipped());
+
+  std::vector<mojom::AssociatedContentPtr> rebuilt_content;
+  auto rebuilt = SpecificsToEntry(specifics, &rebuilt_content);
+  ASSERT_TRUE(rebuilt);
+  ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
+}
+
+TEST(AIChatSyncConversionsTest, EntryRoundTripWebSourcesContentBlock) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-tool-ws";
+  entry->created_time = base::Time::Now();
+  entry->character_type = mojom::CharacterType::ASSISTANT;
+  entry->action_type = mojom::ActionType::RESPONSE;
+
+  auto ws_block = mojom::WebSourcesContentBlock::New();
+  auto source = mojom::WebSource::New();
+  source->title = "MDN";
+  source->url = GURL("https://developer.mozilla.org/");
+  source->page_content = "Web docs.";
+  ws_block->sources.push_back(std::move(source));
+  ws_block->queries = {"mdn web docs"};
+  ws_block->rich_results = {"{\"a\":1}"};
+
+  std::vector<mojom::ContentBlockPtr> output;
+  output.push_back(
+      mojom::ContentBlock::NewWebSourcesContentBlock(std::move(ws_block)));
+
+  auto tool_use = mojom::ToolUseEvent::New();
+  tool_use->tool_name = "search";
+  tool_use->id = "tool-2";
+  tool_use->arguments_json = "{}";
+  tool_use->output = std::move(output);
+
+  std::vector<mojom::ConversationEntryEventPtr> events;
+  events.push_back(
+      mojom::ConversationEntryEvent::NewToolUseEvent(std::move(tool_use)));
+  entry->events = std::move(events);
+
+  auto specifics = EntryToSpecifics("conv-1", *entry, {});
+  ASSERT_EQ(specifics.entry().events(0).tool_use().output_size(), 1);
+  EXPECT_TRUE(specifics.entry()
+                  .events(0)
+                  .tool_use()
+                  .output(0)
+                  .has_web_sources_content_block());
+
+  std::vector<mojom::AssociatedContentPtr> rebuilt_content;
+  auto rebuilt = SpecificsToEntry(specifics, &rebuilt_content);
+  ASSERT_TRUE(rebuilt);
+  ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
+}
+
+TEST(AIChatSyncConversionsTest, EntryRoundTripAssociatedContentText) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-ac";
+  entry->created_time = base::Time::Now();
+  entry->character_type = mojom::CharacterType::HUMAN;
+  entry->action_type = mojom::ActionType::QUERY;
+
+  auto ac = mojom::AssociatedContent::New();
+  ac->uuid = "ac-1";
+  ac->title = "Page";
+  ac->url = GURL("https://example.com/");
+  ac->content_type = mojom::ContentType::PageContent;
+  ac->content_used_percentage = 100;
+  ac->conversation_turn_uuid = "entry-ac";
+  std::vector<mojom::AssociatedContentPtr> expected_content;
+  expected_content.push_back(ac->Clone());
+
+  std::vector<mojom::AssociatedContentPtr> all_content;
+  all_content.push_back(std::move(ac));
+
+  // Highly-compressible text so gzip kicks in (validates the encoding path).
+  const std::string content_text(4096, 'P');
+  base::flat_map<std::string, std::string> texts;
+  texts["ac-1"] = content_text;
+
+  auto specifics = EntryToSpecifics("conv-1", *entry, all_content, texts);
+  ASSERT_EQ(specifics.entry().associated_content_size(), 1);
+  ASSERT_TRUE(specifics.entry().associated_content(0).has_last_contents());
+  EXPECT_TRUE(
+      specifics.entry().associated_content(0).last_contents().has_gzipped());
+
+  std::vector<mojom::AssociatedContentPtr> rebuilt_content;
+  base::flat_map<std::string, std::string> rebuilt_texts;
+  auto rebuilt = SpecificsToEntry(specifics, &rebuilt_content, &rebuilt_texts);
+  ASSERT_TRUE(rebuilt);
+  ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
+  ExpectAssociatedContentEquals(FROM_HERE, rebuilt_content, expected_content,
+                                /*compare_non_persisted_fields=*/false);
+  EXPECT_EQ(rebuilt_texts,
+            (base::flat_map<std::string, std::string>{{"ac-1", content_text}}));
+}
+
+TEST(AIChatSyncConversionsTest, EntryRoundTripSkillAndNearVerification) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-skill";
+  entry->created_time = base::Time::Now();
+  entry->character_type = mojom::CharacterType::HUMAN;
+  entry->action_type = mojom::ActionType::QUERY;
+  entry->skill = mojom::SkillEntry::New("/summarize", "Summarize this page");
+  entry->near_verification_status = mojom::NEARVerificationStatus::New(true);
+
+  std::vector<mojom::AssociatedContentPtr> rebuilt_content;
+  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
+                                  &rebuilt_content);
+  ASSERT_TRUE(rebuilt);
+  ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
+}
+
+TEST(AIChatSyncConversionsTest, EntryRoundTripWithoutSkillOrNear) {
+  auto entry = mojom::ConversationTurn::New();
+  entry->uuid = "entry-plain";
+  entry->created_time = base::Time::Now();
+  entry->character_type = mojom::CharacterType::HUMAN;
+  entry->action_type = mojom::ActionType::QUERY;
+
+  std::vector<mojom::AssociatedContentPtr> rebuilt_content;
+  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
+                                  &rebuilt_content);
+  ASSERT_TRUE(rebuilt);
+  ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
+  EXPECT_FALSE(rebuilt->skill);
+  EXPECT_FALSE(rebuilt->near_verification_status);
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions_unittest.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions_unittest.cc
@@ -612,8 +612,8 @@ TEST(AIChatSyncConversionsTest, EntryRoundTripBasic) {
   entry->model_key = "claude-opus";
 
   std::vector<mojom::AssociatedContentPtr> rebuilt_content;
-  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
-                                  &rebuilt_content);
+  auto rebuilt =
+      SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}), rebuilt_content);
   ASSERT_TRUE(rebuilt);
   ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
   EXPECT_TRUE(rebuilt_content.empty());
@@ -721,7 +721,7 @@ TEST(AIChatSyncConversionsTest, EntryRoundTripAllFields) {
   base::flat_map<std::string, std::string> rebuilt_texts;
   auto rebuilt = SpecificsToEntry(
       EntryToSpecifics("conv-all", *entry, associated_content, texts),
-      &rebuilt_content, &rebuilt_texts);
+      rebuilt_content, &rebuilt_texts);
   ASSERT_TRUE(rebuilt);
   ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
   ExpectAssociatedContentEquals(FROM_HERE, rebuilt_content, associated_content,
@@ -746,8 +746,8 @@ TEST(AIChatSyncConversionsTest, EntryRoundTripCompletionEvent) {
   entry->events = std::move(events);
 
   std::vector<mojom::AssociatedContentPtr> rebuilt_content;
-  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
-                                  &rebuilt_content);
+  auto rebuilt =
+      SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}), rebuilt_content);
   ASSERT_TRUE(rebuilt);
   ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
 }
@@ -767,8 +767,8 @@ TEST(AIChatSyncConversionsTest, EntryRoundTripSearchQueriesEvent) {
   entry->events = std::move(events);
 
   std::vector<mojom::AssociatedContentPtr> rebuilt_content;
-  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
-                                  &rebuilt_content);
+  auto rebuilt =
+      SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}), rebuilt_content);
   ASSERT_TRUE(rebuilt);
   ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
 }
@@ -797,8 +797,8 @@ TEST(AIChatSyncConversionsTest, EntryRoundTripWebSourcesEvent) {
   entry->events = std::move(events);
 
   std::vector<mojom::AssociatedContentPtr> rebuilt_content;
-  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
-                                  &rebuilt_content);
+  auto rebuilt =
+      SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}), rebuilt_content);
   ASSERT_TRUE(rebuilt);
   ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
 }
@@ -828,8 +828,8 @@ TEST(AIChatSyncConversionsTest, EntryRoundTripToolUseEvent) {
   entry->events = std::move(events);
 
   std::vector<mojom::AssociatedContentPtr> rebuilt_content;
-  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
-                                  &rebuilt_content);
+  auto rebuilt =
+      SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}), rebuilt_content);
   ASSERT_TRUE(rebuilt);
   ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
 }
@@ -858,8 +858,8 @@ TEST(AIChatSyncConversionsTest, EntryRoundTripToolUseArtifacts) {
   entry->events = std::move(events);
 
   std::vector<mojom::AssociatedContentPtr> rebuilt_content;
-  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
-                                  &rebuilt_content);
+  auto rebuilt =
+      SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}), rebuilt_content);
   ASSERT_TRUE(rebuilt);
   ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
 }
@@ -888,8 +888,8 @@ TEST(AIChatSyncConversionsTest, EntryRoundTripImageContentBlock) {
   entry->events = std::move(events);
 
   std::vector<mojom::AssociatedContentPtr> rebuilt_content;
-  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
-                                  &rebuilt_content);
+  auto rebuilt =
+      SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}), rebuilt_content);
   ASSERT_TRUE(rebuilt);
   ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
 }
@@ -910,8 +910,8 @@ TEST(AIChatSyncConversionsTest, EntryRoundTripInlineSearchEvent) {
   entry->events = std::move(events);
 
   std::vector<mojom::AssociatedContentPtr> rebuilt_content;
-  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
-                                  &rebuilt_content);
+  auto rebuilt =
+      SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}), rebuilt_content);
   ASSERT_TRUE(rebuilt);
   ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
 }
@@ -950,7 +950,7 @@ TEST(AIChatSyncConversionsTest,
 
   std::vector<mojom::AssociatedContentPtr> rebuilt_content;
   auto rebuilt = SpecificsToEntry(
-      EntryToSpecifics("conv-1", *entry, all_content), &rebuilt_content);
+      EntryToSpecifics("conv-1", *entry, all_content), rebuilt_content);
   ASSERT_TRUE(rebuilt);
   ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
   ExpectAssociatedContentEquals(FROM_HERE, rebuilt_content, expected_content,
@@ -968,7 +968,7 @@ TEST(AIChatSyncConversionsTest, SpecificsToEntryReturnsNullForWrongKind) {
   sync_pb::AIChatConversationSpecifics specifics;
   specifics.mutable_conversation()->set_uuid("c1");
   std::vector<mojom::AssociatedContentPtr> content;
-  EXPECT_FALSE(SpecificsToEntry(specifics, &content));
+  EXPECT_FALSE(SpecificsToEntry(specifics, content));
 }
 
 TEST(AIChatSyncConversionsTest, EntryRoundTripUploadedFiles) {
@@ -1005,7 +1005,7 @@ TEST(AIChatSyncConversionsTest, EntryRoundTripUploadedFiles) {
       specifics.entry().uploaded_files(1).extracted_text().has_gzipped());
 
   std::vector<mojom::AssociatedContentPtr> rebuilt_content;
-  auto rebuilt = SpecificsToEntry(specifics, &rebuilt_content);
+  auto rebuilt = SpecificsToEntry(specifics, rebuilt_content);
   ASSERT_TRUE(rebuilt);
   ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
 }
@@ -1050,7 +1050,7 @@ TEST(AIChatSyncConversionsTest, EntryRoundTripWebSourcesContentBlock) {
                   .has_web_sources_content_block());
 
   std::vector<mojom::AssociatedContentPtr> rebuilt_content;
-  auto rebuilt = SpecificsToEntry(specifics, &rebuilt_content);
+  auto rebuilt = SpecificsToEntry(specifics, rebuilt_content);
   ASSERT_TRUE(rebuilt);
   ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
 }
@@ -1088,7 +1088,7 @@ TEST(AIChatSyncConversionsTest, EntryRoundTripAssociatedContentText) {
 
   std::vector<mojom::AssociatedContentPtr> rebuilt_content;
   base::flat_map<std::string, std::string> rebuilt_texts;
-  auto rebuilt = SpecificsToEntry(specifics, &rebuilt_content, &rebuilt_texts);
+  auto rebuilt = SpecificsToEntry(specifics, rebuilt_content, &rebuilt_texts);
   ASSERT_TRUE(rebuilt);
   ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
   ExpectAssociatedContentEquals(FROM_HERE, rebuilt_content, expected_content,
@@ -1107,8 +1107,8 @@ TEST(AIChatSyncConversionsTest, EntryRoundTripSkillAndNearVerification) {
   entry->near_verification_status = mojom::NEARVerificationStatus::New(true);
 
   std::vector<mojom::AssociatedContentPtr> rebuilt_content;
-  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
-                                  &rebuilt_content);
+  auto rebuilt =
+      SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}), rebuilt_content);
   ASSERT_TRUE(rebuilt);
   ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
 }
@@ -1121,8 +1121,8 @@ TEST(AIChatSyncConversionsTest, EntryRoundTripWithoutSkillOrNear) {
   entry->action_type = mojom::ActionType::QUERY;
 
   std::vector<mojom::AssociatedContentPtr> rebuilt_content;
-  auto rebuilt = SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}),
-                                  &rebuilt_content);
+  auto rebuilt =
+      SpecificsToEntry(EntryToSpecifics("conv-1", *entry, {}), rebuilt_content);
   ASSERT_TRUE(rebuilt);
   ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
   EXPECT_FALSE(rebuilt->skill);

--- a/components/ai_chat/core/browser/test_utils.cc
+++ b/components/ai_chat/core/browser/test_utils.cc
@@ -64,9 +64,11 @@ void ExpectConversationEquals(base::Location location,
     // has_content is not persisted
     a->has_content = false;
     b->has_content = false;
-    // Date is not persisted
-    a->updated_time = base::Time::Now();
-    b->updated_time = base::Time::Now();
+    // Date is not persisted. Use a single timestamp for both so the clones
+    // compare equal regardless of any clock tick between the assignments.
+    const base::Time now = base::Time::Now();
+    a->updated_time = now;
+    b->updated_time = now;
     // content_id is not persisted
     for (auto& content : a->associated_content) {
       content->content_id = 0;

--- a/components/sync/protocol/ai_chat_specifics.proto
+++ b/components/sync/protocol/ai_chat_specifics.proto
@@ -80,7 +80,9 @@ message AIChatConversationSpecifics {
     optional string uuid = 1;
     // UUID of the conversation this entry belongs to.
     optional string conversation_uuid = 2;
-    optional int64 date_unix_epoch_micros = 3;
+    // Microseconds since the Windows epoch (1601). Mirrors
+    // mojom::ConversationTurn::created_time.
+    optional int64 created_time_windows_epoch_micros = 3;
     optional string entry_text = 4;
     // Optional user-invisible override prompt sent to the AI engine.
     optional string prompt = 5;
@@ -164,15 +166,15 @@ message AIChatUploadedFile {
   optional AIChatCompressibleString extracted_text = 6;
 }
 
-// An event within a conversation entry.
+// An event within a conversation entry. Events are ordered by their position
+// in the repeated |events| field of the parent Entry.
 message AIChatEntryEventProto {
-  optional int32 event_order = 1;
   oneof event {
-    AIChatCompressibleString completion = 2;
-    AIChatSearchQueriesEvent search_queries = 3;
-    AIChatWebSourcesEvent web_sources = 4;
-    AIChatInlineSearchEvent inline_search = 5;
-    AIChatToolUseEvent tool_use = 6;
+    AIChatCompressibleString completion = 1;
+    AIChatSearchQueriesEvent search_queries = 2;
+    AIChatWebSourcesEvent web_sources = 3;
+    AIChatInlineSearchEvent inline_search = 4;
+    AIChatToolUseEvent tool_use = 5;
   }
 }
 


### PR DESCRIPTION
Reverses the serialization, rebuilding mojom `Conversation`/`ConversationTurn` (with events, associated content, and uploaded files) from `AIChatConversationSpecifics` and reading `AIChatCompressibleString` fields back (gunzip; preserve-local on the truncated-for-sync sentinel).

- `SpecificsToConversationMetadata` / `SpecificsToEntry` + `ProtoTo*` helpers for each event/content/file variant.
- Round-trip unit tests for every entry field, event, content, and file type, plus the wrong-kind null cases.


Spec:
- https://github.com/brave/brave-core/blob/aichat-sync-flow/docs/aichat-sync.md

Based on:
- https://github.com/brave/brave-core/pull/35028
- https://github.com/brave/brave-core/pull/35242
- https://github.com/brave/brave-core/pull/37537
- https://github.com/brave/brave-core/pull/37539
- https://github.com/brave/brave-core/pull/37540
- https://github.com/brave/brave-core/pull/38192
- https://github.com/brave/go-sync/pull/427 (server)

Series:
- https://github.com/brave/brave-browser/issues/53978