### PR TITLE
[recipes] Support per-module `PROPERTIES`

### DIFF
--- a/tools/recipes/README.md
+++ b/tools/recipes/README.md
@@ -84,8 +84,9 @@ def RunSteps(api, env_properties):               # ENV_PROPERTIES only
 
 `PROPERTIES` is populated by taking the input property JSON object (from
 `--properties`), removing all keys beginning with `$`, and decoding the rest as
-JSONPB into the `PROPERTIES` message. Keys beginning with `$` are reserved by
-the engine.
+JSONPB into the `PROPERTIES` message. Keys beginning with `$` are reserved: a
+`$<module>` key carries that module's own properties (see
+[Per-module properties](#per-module-properties)).
 
 `ENV_PROPERTIES` is populated by taking the current environment variables,
 capitalizing all keys (`key.upper()`), and decoding that into the
@@ -105,6 +106,77 @@ def GenTests(api):
 
 `api.properties` also accepts top-level keyword arguments as a shorthand, e.g.
 `api.properties(chromium_ref='151.0.7917.1', brave_subrevision=1)`.
+
+### Per-module properties
+
+A recipe _module_ can declare its own `PROPERTIES` (and optionally
+`ENV_PROPERTIES`) too, so it observes typed input without threading it through
+every recipe. Declare the messages in a sibling `.proto`, with the package set
+to the module's namespace (the file name is dropped -- the single-repo analogue
+of upstream's `$repo/module`):
+
+```proto
+// recipe_modules/hello/properties.proto
+syntax = "proto3";
+package recipe_modules.brave.hello;
+
+message InputProperties {
+  string target = 1;
+}
+```
+
+Assign the message as `PROPERTIES` in the module's `__init__.py` (next to
+`DEPS`) and accept it in the api's constructor:
+
+```python
+# recipe_modules/hello/__init__.py
+from PB.recipe_modules.brave.hello.properties import InputProperties
+
+DEPS = ['path', 'step']
+PROPERTIES = InputProperties
+```
+
+```python
+# recipe_modules/hello/api.py
+class HelloApi(RecipeApi):
+    def __init__(self, properties):
+        super().__init__()
+        # DEPS are NOT available yet in __init__ -- only stash the value here.
+        self._target = properties.target or None
+```
+
+The engine passes the bound message(s) positionally, in the same order
+`RunSteps` receives them:
+
+```python
+def __init__(self):                            # neither declared
+def __init__(self, properties):                # PROPERTIES only
+def __init__(self, properties, env_properties): # PROPERTIES and ENV_PROPERTIES
+def __init__(self, env_properties):            # ENV_PROPERTIES only
+```
+
+A module's `PROPERTIES` are **namespaced**: they are decoded from the
+`$<module_name>` block of the input property JSON, keeping per-module input
+separate from the recipe's own top-level properties. So to greet `anya` via the
+`hello` module above:
+
+```sh
+vpython3 tools/recipes/engine.py some/recipe \
+    --properties '{ "$hello": { "target": "anya" } }'
+```
+
+and in tests:
+
+```python
+api.properties(**{'$hello': {'target': 'anya'}})
+```
+
+`ENV_PROPERTIES` on a module works exactly as it does for a recipe (from the
+environment, keys upper-cased). Both decodes ignore unknown fields, and (as with
+recipes) there is no "required" enforcement -- a missing property takes its
+proto default. Per-module properties pair naturally with [Configs](#configs): a
+common pattern is for `get_config_defaults` to feed a property into the config
+schema (the `hello` module does this with `target` -> `TARGET`).
 
 ## Configs
 

--- a/tools/recipes/engine.py
+++ b/tools/recipes/engine.py
@@ -108,6 +108,7 @@ def _load_config_ctx(module_name: str):
     config_path = RECIPES_ROOT / MODULES_PKG / module_name / 'config.py'
     if not config_path.exists():
         return None
+    _ensure_protos()
     from config import ConfigContext  # pylint: disable=import-outside-toplevel
     config_module = importlib.import_module(f'{MODULES_PKG}.{module_name}'
                                             '.config')
@@ -152,8 +153,63 @@ class _Engine:
         # brave-core ref the checkout modules clone. Defaults to `master`;
         # overridable (mainly for testing against a non-master ref).
         self._brave_core_ref: str = brave_core_ref
+        # The run's input property JSON and environment, seeded by
+        # `run_loaded_recipe` before any module is instantiated. A module's
+        # `PROPERTIES`/`ENV_PROPERTIES` are bound from these (see
+        # `_module_property_args`). Empty defaults let tests instantiate a
+        # module directly (without a recipe) -- a module then just sees its
+        # proto defaults.
+        self._properties: dict[str, object] = {}
+        self._environ: Mapping[str, str] = {}
         # module name -> instantiated RecipeApi (one instance per run).
         self._cache: dict[str, RecipeApi] = {}
+
+    def _module_property_args(self, name: str,
+                              package: types.ModuleType) -> list[object]:
+        """Bind a module's declared `PROPERTIES`/`ENV_PROPERTIES` messages.
+
+        Mirrors the recipe-level binding in `_run_steps`, but for a recipe
+        module. A module opts in by declaring `PROPERTIES` and/or
+        `ENV_PROPERTIES` (protobuf message classes) in its `__init__.py`; the
+        engine passes the bound messages positionally to the module's
+        `RecipeApi.__init__`, in the same order `RunSteps` receives them:
+
+            neither                 -> API()
+            PROPERTIES              -> API(properties)
+            PROPERTIES + ENV_PROPS  -> API(properties, env_properties)
+            ENV_PROPERTIES          -> API(env_properties)
+
+        A module's `PROPERTIES` are namespaced: they are read from the
+        `$<module_name>` block of the input property JSON (the single-repo
+        analogue of upstream's `$<repo>/<module>` key), so per-module input is
+        kept separate from the recipe's own top-level properties. `ENV_PROPERTIES`
+        are read from the environment with keys upper-cased. Both decode with
+        unknown fields ignored.
+        """
+        properties_def = getattr(package, 'PROPERTIES', None)
+        env_properties_def = getattr(package, 'ENV_PROPERTIES', None)
+
+        args: list[object] = []
+        if properties_def is not None:
+            if not proto_support.is_message_class(properties_def):
+                raise TypeError(
+                    f"module '{name}' PROPERTIES must be a protobuf message "
+                    f'class; got {properties_def!r}')
+            block = self._properties.get(f'${name}', {})
+            args.append(
+                jsonpb.ParseDict(block,
+                                 properties_def(),
+                                 ignore_unknown_fields=True))
+        if env_properties_def is not None:
+            args.append(
+                jsonpb.ParseDict(
+                    {
+                        k.upper(): v
+                        for k, v in self._environ.items()
+                    },
+                    env_properties_def(),
+                    ignore_unknown_fields=True))
+        return args
 
     def _instantiate_module(self, name: str, chain: list[str]) -> RecipeApi:
         if name in self._cache:
@@ -162,12 +218,15 @@ class _Engine:
             cycle = ' -> '.join(chain + [name])
             raise RuntimeError(f'cyclical DEPS detected: {cycle}')
 
+        # A module's __init__.py/api.py may import its typed PROPERTIES message
+        # from `PB`, so the proto package must exist before we import it.
+        _ensure_protos()
         package = importlib.import_module(f'{MODULES_PKG}.{name}')
         deps = list(getattr(package, 'DEPS', []))
         api_module = importlib.import_module(f'{MODULES_PKG}.{name}.api')
         api_class = _find_api_class(api_module, name)
 
-        inst = api_class()
+        inst = api_class(*self._module_property_args(name, package))
         # Seed engine-provided values (workspace, brave-core ref, and the
         # module's name and config context) so modules can use them. setattr
         # keeps the engine out of the instance's protected members directly.
@@ -207,6 +266,13 @@ class _Engine:
         Splits the import from the run so the test runner can import a recipe
         once (from either `recipes/` or a module's `examples/`) and drive it.
         """
+        # Seed the run's input before instantiating any module, so a module's
+        # PROPERTIES/ENV_PROPERTIES can be bound from it (see
+        # `_module_property_args`). In test mode ENV_PROPERTIES is sourced from
+        # the simulated environment so expectations don't depend on host env.
+        self._properties = properties or {}
+        self._environ = self._test.env if self._test is not None else os.environ
+
         api = RecipeScriptApi()
         for dep_name in getattr(recipe, 'DEPS', []):
             setattr(api, dep_name, self._instantiate_module(dep_name, []))
@@ -215,10 +281,7 @@ class _Engine:
         if run_steps is None:
             raise RuntimeError(f"recipe '{recipe_name}' is missing RunSteps")
 
-        # In test mode, source ENV_PROPERTIES from the simulated environment so
-        # expectations don't depend on the host's env vars.
-        environ = self._test.env if self._test is not None else os.environ
-        return _run_steps(run_steps, api, properties or {}, environ,
+        return _run_steps(run_steps, api, self._properties, self._environ,
                           getattr(recipe, 'PROPERTIES', None),
                           getattr(recipe, 'ENV_PROPERTIES', None))
 

--- a/tools/recipes/recipe_modules/hello/__init__.py
+++ b/tools/recipes/recipe_modules/hello/__init__.py
@@ -2,6 +2,16 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""`hello` module: a worked example of the config system (see README.md)."""
+"""`hello` module: a worked example of the config system (see README.md).
+
+Also demonstrates per-module `PROPERTIES`: the `$hello` block of the input
+property JSON is decoded into `InputProperties` and injected into
+`HelloApi.__init__`, which feeds it to the config system as the `TARGET`
+default.
+"""
+
+from PB.recipe_modules.brave.hello.properties import InputProperties
 
 DEPS = ['path', 'step']
+
+PROPERTIES = InputProperties

--- a/tools/recipes/recipe_modules/hello/api.py
+++ b/tools/recipes/recipe_modules/hello/api.py
@@ -7,11 +7,28 @@
 
 from __future__ import annotations
 
+from PB.recipe_modules.brave.hello.properties import InputProperties
 from recipe_api import RecipeApi
 
 
 class HelloApi(RecipeApi):
     """Greets the configured TARGET, running the configured tool as a step."""
+
+    def __init__(self, properties: InputProperties) -> None:
+        super().__init__()
+        # A module's declared PROPERTIES message is injected here by the engine.
+        # DEPS are NOT yet available in __init__, so we only stash the value.
+        self._target = properties.target or None
+
+    def get_config_defaults(self) -> dict:
+        # Thread the per-module property into the config schema: when a target
+        # was supplied it becomes the default TARGET, otherwise the schema's own
+        # default ('Bob') applies. A per-invocation set_config(TARGET=...) still
+        # overrides this.
+        defaults = {}
+        if self._target is not None:
+            defaults['TARGET'] = self._target
+        return defaults
 
     def greet(self) -> None:
         """Greet `self.c.TARGET`, invoking `self.c.tool` as the step command."""

--- a/tools/recipes/recipe_modules/hello/examples/simple.py
+++ b/tools/recipes/recipe_modules/hello/examples/simple.py
@@ -2,7 +2,11 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Example: the plain default configuration (`default_tool`, TARGET 'Bob')."""
+"""Example: the default config, and a per-module PROPERTIES-driven TARGET.
+
+`bob` uses the schema default TARGET; `anya` supplies the `$hello` module
+property, which `HelloApi.get_config_defaults` feeds in as the TARGET default.
+"""
 
 from __future__ import annotations
 
@@ -13,7 +17,7 @@ DEPS = ['hello']
 
 def RunSteps(api):
     api.hello.set_config('default_tool')
-    api.hello.greet()  # Greets 'Bob' with echo.
+    api.hello.greet()  # Greets the configured target with echo.
 
 
 def GenTests(api):
@@ -21,5 +25,16 @@ def GenTests(api):
         'bob',
         api.post_process(StepCommandRE, 'Greet Admired Individual',
                          [r'.*\becho', 'Hello Bob']),
+        api.post_process(DropExpectation),
+    )
+
+    # The `$hello` block is this module's namespaced PROPERTIES input.
+    yield api.test(
+        'anya',
+        api.properties(**{'$hello': {
+            'target': 'anya'
+        }}),
+        api.post_process(StepCommandRE, 'Greet Admired Individual',
+                         [r'.*\becho', 'Hello anya']),
         api.post_process(DropExpectation),
     )

--- a/tools/recipes/recipe_modules/hello/properties.proto
+++ b/tools/recipes/recipe_modules/hello/properties.proto
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+syntax = "proto3";
+
+// A module's own PROPERTIES proto declares the package as the module's
+// namespace (the file name is dropped), so the message imports from
+// PB.recipe_modules.brave.hello.properties.
+package recipe_modules.brave.hello;
+
+message InputProperties {
+  // Who to greet. Fed into the config system as the `TARGET` default via
+  // HelloApi.get_config_defaults(); empty means "use the schema default".
+  string target = 1;
+}

--- a/tools/recipes/unittests/engine_test.py
+++ b/tools/recipes/unittests/engine_test.py
@@ -183,5 +183,69 @@ class WorkspaceTest(unittest.TestCase):
         self.assertEqual(getattr(module, '_brave_core_ref'), 'master')
 
 
+class ModulePropertiesTest(unittest.TestCase):
+    """The engine binds a module's PROPERTIES/ENV_PROPERTIES into its api.
+
+    Uses the `hello` module (which declares a PROPERTIES message) for the
+    end-to-end paths, and package_rust's compiled messages for the arg-order /
+    env path via `_module_property_args` directly.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        engine._ensure_protos()
+        # pylint: disable=import-outside-toplevel,import-error
+        from PB.recipes.brave.toolchains.rust.package_rust import (
+            EnvProperties, InputProperties)
+        cls.InputProperties = InputProperties
+        cls.EnvProperties = EnvProperties
+
+    def test_properties_bound_from_namespaced_block(self):
+        eng = engine._Engine()
+        eng._properties = {'$hello': {'target': 'Ada'}}
+        hello = eng._instantiate_module('hello', [])
+        self.assertEqual(hello._target, 'Ada')
+
+    def test_absent_block_yields_proto_defaults(self):
+        # No `$hello` block: the message defaults (empty target -> None).
+        hello = engine._Engine()._instantiate_module('hello', [])
+        self.assertIsNone(hello._target)
+
+    def test_top_level_props_do_not_leak_into_module(self):
+        # A non-namespaced top-level property is not a module property.
+        eng = engine._Engine()
+        eng._properties = {'target': 'Zed'}
+        hello = eng._instantiate_module('hello', [])
+        self.assertIsNone(hello._target)
+
+    def test_property_feeds_config_end_to_end(self):
+        eng = engine._Engine()
+        eng._properties = {'$hello': {'target': 'Ada'}}
+        hello = eng._instantiate_module('hello', [])
+        hello.set_config('default_tool')
+        self.assertEqual(hello.c.TARGET, 'Ada')
+
+    def test_arg_order_properties_then_env(self):
+        eng = engine._Engine()
+        eng._properties = {'$fake': {'chromium_ref': 'x'}}
+        eng._environ = {'git_cache': '/c'}  # lower-case: must be upper-cased
+        pkg = types.SimpleNamespace(PROPERTIES=self.InputProperties,
+                                    ENV_PROPERTIES=self.EnvProperties)
+        args = eng._module_property_args('fake', pkg)
+        self.assertEqual(len(args), 2)
+        self.assertEqual(args[0].chromium_ref, 'x')
+        self.assertEqual(args[1].GIT_CACHE, '/c')
+
+    def test_no_defs_means_no_args(self):
+        pkg = types.SimpleNamespace(DEPS=[])
+        self.assertEqual(engine._Engine()._module_property_args('fake', pkg),
+                         [])
+
+    def test_non_message_properties_raises(self):
+        pkg = types.SimpleNamespace(PROPERTIES=dict, DEPS=[])
+        with self.assertRaises(TypeError):
+            engine._Engine()._module_property_args('fake', pkg)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Let a recipe module declare its own `PROPERTIES` (and optionally
`ENV_PROPERTIES`) message.

Bug: https://github.com/brave/brave-browser/issues/56748
