### PR TITLE
[Local AI] [WebSpeech] Wire the ORT-Web speech worker page to the recognition controller

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -173,7 +173,10 @@
 
 #if BUILDFLAG(ENABLE_LOCAL_AI)
 #include "brave/browser/ui/webui/local_ai/local_ai_ui.h"
+#include "brave/browser/ui/webui/local_ai/on_device_speech_recognition_worker_ui.h"
+#include "brave/components/local_ai/core/features.h"
 #include "brave/components/local_ai/core/local_ai.mojom.h"
+#include "brave/components/local_ai/core/on_device_speech_recognition.mojom.h"
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
@@ -999,6 +1002,11 @@ void BraveContentBrowserClient::RegisterBrowserInterfaceBindersForFrame(
   if (base::FeatureList::IsEnabled(history_embeddings::kHistoryEmbeddings)) {
     content::RegisterWebUIControllerInterfaceBinder<
         local_ai::mojom::LocalAIService, local_ai::UntrustedLocalAIUI>(map);
+  }
+  if (base::FeatureList::IsEnabled(local_ai::kBraveOnDeviceSpeechRecognition)) {
+    content::RegisterWebUIControllerInterfaceBinder<
+        local_ai::mojom::SpeechRecognitionFactoryHost,
+        local_ai::UntrustedOnDeviceSpeechRecognitionWorkerUI>(map);
   }
 #endif
 #if BUILDFLAG(ENABLE_BRAVE_VPN)

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -406,6 +406,7 @@ if (enable_local_ai) {
     "//brave/components/local_ai/core",
     "//brave/components/local_ai/core:features",
     "//brave/components/local_ai/core:mojom",
+    "//brave/components/local_ai/core:speech_recognition_mojom",
   ]
 }
 

--- a/browser/ui/webui/local_ai/BUILD.gn
+++ b/browser/ui/webui/local_ai/BUILD.gn
@@ -18,8 +18,10 @@ source_set("local_ai") {
   deps = [
     "//base",
     "//brave/browser/history_embeddings",
+    "//brave/browser/speech",
     "//brave/components/local_ai/core",
     "//brave/components/local_ai/core:mojom",
+    "//brave/components/local_ai/core:speech_recognition_mojom",
     "//brave/components/local_ai/resources:local_ai_generated",
     "//brave/components/local_ai/resources/candle_embedding_gemma:candle_embedding_module_generated",
     "//brave/components/local_ai/resources/speech_worker:on_device_speech_recognition_worker_generated",

--- a/browser/ui/webui/local_ai/on_device_speech_recognition_worker_ui.cc
+++ b/browser/ui/webui/local_ai/on_device_speech_recognition_worker_ui.cc
@@ -7,6 +7,8 @@
 
 #include <memory>
 
+#include "brave/browser/speech/on_device_speech_recognition_controller.h"
+#include "brave/components/local_ai/core/on_device_speech_recognition.mojom.h"
 #include "brave/components/local_ai/core/url_constants.h"
 #include "brave/components/local_ai/resources/grit/on_device_speech_recognition_worker_generated.h"
 #include "brave/components/local_ai/resources/grit/on_device_speech_recognition_worker_generated_map.h"
@@ -89,6 +91,12 @@ UntrustedOnDeviceSpeechRecognitionWorkerUI::
     ~UntrustedOnDeviceSpeechRecognitionWorkerUI() = default;
 
 WEB_UI_CONTROLLER_TYPE_IMPL(UntrustedOnDeviceSpeechRecognitionWorkerUI)
+
+void UntrustedOnDeviceSpeechRecognitionWorkerUI::BindInterface(
+    mojo::PendingReceiver<mojom::SpeechRecognitionFactoryHost> receiver) {
+  speech::OnDeviceSpeechRecognitionController::Get()->BindFactoryHost(
+      std::move(receiver));
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/browser/ui/webui/local_ai/on_device_speech_recognition_worker_ui.h
+++ b/browser/ui/webui/local_ai/on_device_speech_recognition_worker_ui.h
@@ -8,7 +8,9 @@
 
 #include <memory>
 
+#include "brave/components/local_ai/core/on_device_speech_recognition.mojom-forward.h"
 #include "content/public/browser/webui_config.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "ui/webui/mojo_web_ui_controller.h"
 
 namespace local_ai {
@@ -32,6 +34,9 @@ class UntrustedOnDeviceSpeechRecognitionWorkerUI
   UntrustedOnDeviceSpeechRecognitionWorkerUI& operator=(
       const UntrustedOnDeviceSpeechRecognitionWorkerUI&) = delete;
   ~UntrustedOnDeviceSpeechRecognitionWorkerUI() override;
+
+  void BindInterface(
+      mojo::PendingReceiver<mojom::SpeechRecognitionFactoryHost> receiver);
 
  private:
   WEB_UI_CONTROLLER_TYPE_DECL();

--- a/chromium_src/chrome/browser/ui/webui/chrome_untrusted_web_ui_configs.cc
+++ b/chromium_src/chrome/browser/ui/webui/chrome_untrusted_web_ui_configs.cc
@@ -50,6 +50,8 @@
 
 #if BUILDFLAG(ENABLE_LOCAL_AI)
 #include "brave/browser/ui/webui/local_ai/local_ai_ui.h"
+#include "brave/browser/ui/webui/local_ai/on_device_speech_recognition_worker_ui.h"
+#include "brave/components/local_ai/core/features.h"
 #endif
 
 #define RegisterChromeUntrustedWebUIConfigs \
@@ -79,6 +81,11 @@ void RegisterChromeUntrustedWebUIConfigs() {
   if (base::FeatureList::IsEnabled(history_embeddings::kHistoryEmbeddings)) {
     content::WebUIConfigMap::GetInstance().AddUntrustedWebUIConfig(
         std::make_unique<local_ai::UntrustedLocalAIUIConfig>());
+  }
+  if (base::FeatureList::IsEnabled(local_ai::kBraveOnDeviceSpeechRecognition)) {
+    content::WebUIConfigMap::GetInstance().AddUntrustedWebUIConfig(
+        std::make_unique<
+            local_ai::UntrustedOnDeviceSpeechRecognitionWorkerUIConfig>());
   }
 #endif
 #if !BUILDFLAG(IS_ANDROID)


### PR DESCRIPTION
Part of https://github.com/brave/brave-browser/issues/56487

Gated on kBraveOnDeviceSpeechRecognition:

- Register the worker's untrusted WebUI config so its chrome-untrusted:// URL resolves.
- Allowlist the SpeechRecognitionFactoryHost interface for that page and forward its receiver to the OnDeviceSpeechRecognitionController singleton via BindInterface.
- Add the mojom target and //brave/browser/speech dep to build it.

This enables the worker -> RegisterFactory -> model-load path. It does not yet start recognition; wiring the engine to GetAsrSession() is a follow-up.

