### PR TITLE
Indent and stack tree-tab children when dragging vertical tabs

### DIFF
--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
@@ -22,10 +22,41 @@
 #include "chrome/browser/ui/views/tabs/tab_strip_layout.h"
 #include "chrome/browser/ui/views/tabs/tab_width_constraints.h"
 #include "ui/gfx/geometry/rect.h"
+#include "ui/views/view.h"
+#include "ui/views/view_utils.h"
 
 namespace tabs {
 
 namespace {
+
+// Computes the horizontal offset to apply to a tab at |level| within a tree
+// whose height is |tree_height|, given |available_width_for_tab| and
+// |tab_minimum_width|. Shared between the static vertical layout and the
+// dragged-views layout so indentation looks the same in both states.
+int CalculateNestingOffset(int available_width_for_tab,
+                           int tab_minimum_width,
+                           int level,
+                           int tree_height) {
+  const int available_width_for_tree =
+      available_width_for_tab - tab_minimum_width;
+  const int clamped_available_width_for_tree =
+      std::max(0, available_width_for_tree);
+  const int tree_levels = std::max(1, tree_height + 1);
+  const int even_offset_per_level =
+      clamped_available_width_for_tree / tree_levels;
+
+  // Fallback should be based on tree-wide capacity, not the current node's
+  // level, to avoid threshold jumps at specific depths.
+  const bool should_use_narrow_offset =
+      even_offset_per_level < kBaseOffsetPerLevel;
+  const int offset_per_level = should_use_narrow_offset
+                                   ? std::max(1, even_offset_per_level)
+                                   : kBaseOffsetPerLevel;
+
+  int offset = offset_per_level * level;
+  // This ensures that the tab is always at least the minimum width.
+  return std::clamp(offset, 0, clamped_available_width_for_tree);
+}
 
 void CalculateVerticalLayout(const std::vector<TabWidthConstraints>& tabs,
                              std::optional<int> width,
@@ -79,24 +110,8 @@ void CalculateVerticalLayout(const std::vector<TabWidthConstraints>& tabs,
       // and width of the tab to fit the nesting level.
       const int tab_minimum_width = tab.size_info().min_inactive_width;
       const int tree_height = tab.state().nesting_info().tree_height;
-      const int available_width_for_tree = rect.width() - tab_minimum_width;
-      const int clamped_available_width_for_tree =
-          std::max(0, available_width_for_tree);
-      const int tree_levels = std::max(1, tree_height + 1);
-      const int even_offset_per_level =
-          clamped_available_width_for_tree / tree_levels;
-
-      // Fallback should be based on tree-wide capacity, not the current node's
-      // level, to avoid threshold jumps at specific depths.
-      const bool should_use_narrow_offset =
-          even_offset_per_level < kBaseOffsetPerLevel;
-      const int offset_per_level = should_use_narrow_offset
-                                       ? std::max(1, even_offset_per_level)
-                                       : kBaseOffsetPerLevel;
-
-      int offset = offset_per_level * level;
-      // This ensures that the tab is always at least the minimum width.
-      offset = std::clamp(offset, 0, clamped_available_width_for_tree);
+      const int offset = CalculateNestingOffset(rect.width(), tab_minimum_width,
+                                                level, tree_height);
 
       rect.set_x(offset + rect.x());
       rect.set_width(rect.width() - offset);
@@ -232,17 +247,22 @@ std::pair<std::vector<gfx::Rect>, LayoutDomain> CalculateVerticalTabBounds(
 
 std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
     const std::vector<TabSlotView*>& views,
-    TabStrip* tab_strip) {
-  const bool is_vertical_tabs_floating =
-      static_cast<BraveTabStrip*>(tab_strip)->IsVerticalTabsFloating();
+    int drag_area_width,
+    bool is_vertical_tabs_floating) {
+  // Fan-out offset between successively stacked pinned tabs.
+  constexpr int kStackedOffset = 4;
+  // Vertical gap between a tree-tab parent and its nested children so a
+  // dragged subtree renders as a compact, overlapping pile instead of a
+  // fully spaced list. Taller than kStackedOffset so the pile still reads
+  // as a visible stack rather than nearly-flush tabs.
+  constexpr int kNestedTabStackedOffset = 12;
 
   std::vector<gfx::Rect> bounds;
   int x = 0;
   int y = 0;
-  for (const TabSlotView* view : views) {
-    auto width = tab_strip->GetDragContext()
-                     ->GetPositioningDelegate()
-                     ->GetTabDragAreaWidth();
+  for (size_t i = 0; i < views.size(); ++i) {
+    const TabSlotView* view = views[i];
+    int width = drag_area_width;
     const int height = view->height();
     const bool is_slot_tab =
         view->GetTabSlotViewType() == TabSlotView::ViewType::kTab;
@@ -251,7 +271,6 @@ std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
           static_cast<const Tab*>(view)->data().pinned) {
         // In case it's a pinned tab, lay out them horizontally
         bounds.emplace_back(x, y, tabs::kVerticalTabMinWidth, height);
-        constexpr int kStackedOffset = 4;
         x += kStackedOffset;
         continue;
       }
@@ -262,12 +281,55 @@ std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
         width -= x * 2;
       }
     }
-    bounds.emplace_back(x, y, width, height);
 
-    // unpinned dragged tabs are laid out vertically.
-    y += height + kVerticalTabsSpacing;
+    int tab_x = x;
+    const auto nesting_info = view->GetTabNestingInfo();
+    if (nesting_info.level) {
+      // Indent nested (tree) tabs the same way the static vertical layout
+      // does, so the dragged pile still communicates the tab hierarchy.
+      const int offset =
+          CalculateNestingOffset(width, tabs::kVerticalTabMinWidth,
+                                 nesting_info.level, nesting_info.tree_height);
+      tab_x += offset;
+      width -= offset;
+    }
+
+    bounds.emplace_back(tab_x, y, width, height);
+
+    // Unpinned dragged tabs are laid out vertically. If the next tab is a
+    // tree-tab child, stack it tightly under this one (partial overlap) to
+    // keep the dragged subtree compact; otherwise use normal spacing.
+    const bool next_is_nested_child =
+        i + 1 < views.size() && views[i + 1]->GetTabNestingInfo().level > 0;
+    y += next_is_nested_child ? kNestedTabStackedOffset
+                              : height + kVerticalTabsSpacing;
   }
+
   return bounds;
+}
+
+std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
+    const std::vector<TabSlotView*>& views,
+    TabStrip* tab_strip) {
+  const bool is_vertical_tabs_floating =
+      static_cast<BraveTabStrip*>(tab_strip)->IsVerticalTabsFloating();
+  const int drag_area_width = tab_strip->GetDragContext()
+                                  ->GetPositioningDelegate()
+                                  ->GetTabDragAreaWidth();
+  return CalculateBoundsForVerticalDraggedViews(views, drag_area_width,
+                                                is_vertical_tabs_floating);
+}
+
+void ReorderDraggedViewsForStacking(views::View* parent,
+                                    const std::vector<TabSlotView*>& views) {
+  for (size_t i = views.size(); i-- > 0;) {
+    TabSlotView* view = views[i];
+    if (view->GetTabSlotViewType() == TabSlotView::ViewType::kTab &&
+        views::AsViewClass<Tab>(view)->data().pinned) {
+      continue;
+    }
+    parent->ReorderChildView(view, parent->children().size() - 1);
+  }
 }
 
 void UpdateInsertionIndexForVerticalTabs(

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
@@ -251,11 +251,6 @@ std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
     bool is_vertical_tabs_floating) {
   // Fan-out offset between successively stacked pinned tabs.
   constexpr int kStackedOffset = 4;
-  // Vertical gap between a tree-tab parent and its nested children so a
-  // dragged subtree renders as a compact, overlapping pile instead of a
-  // fully spaced list. Taller than kStackedOffset so the pile still reads
-  // as a visible stack rather than nearly-flush tabs.
-  constexpr int kNestedTabStackedOffset = 12;
 
   std::vector<gfx::Rect> bounds;
   int x = 0;
@@ -312,7 +307,7 @@ std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
     const std::vector<TabSlotView*>& views,
     TabStrip* tab_strip) {
   const bool is_vertical_tabs_floating =
-      static_cast<BraveTabStrip*>(tab_strip)->IsVerticalTabsFloating();
+      views::AsViewClass<BraveTabStrip>(tab_strip)->IsVerticalTabsFloating();
   const int drag_area_width = tab_strip->GetDragContext()
                                   ->GetPositioningDelegate()
                                   ->GetTabDragAreaWidth();
@@ -322,12 +317,14 @@ std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
 
 void ReorderDraggedViewsForStacking(views::View* parent,
                                     const std::vector<TabSlotView*>& views) {
-  for (size_t i = views.size(); i-- > 0;) {
-    TabSlotView* view = views[i];
+  for (TabSlotView* view : base::Reversed(views)) {
     if (view->GetTabSlotViewType() == TabSlotView::ViewType::kTab &&
         views::AsViewClass<Tab>(view)->data().pinned) {
-      continue;
+      // As can't drag pinned tabs and unpinned tabs together, we don't need to
+      // continue.
+      return;
     }
+
     parent->ReorderChildView(view, parent->children().size() - 1);
   }
 }

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.h
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.h
@@ -39,6 +39,12 @@ inline constexpr int kPinnedUnpinnedSeparatorHeight = 1;
 // The base offset per level for vertical tabs in tree tabs
 inline constexpr int kBaseOffsetPerLevel = 20;
 
+// Vertical gap between a tree-tab parent and its nested children so a
+// dragged subtree renders as a compact, overlapping pile instead of a
+// fully spaced list. Taller than kStackedOffset so the pile still reads
+// as a visible stack rather than nearly-flush tabs.
+inline constexpr int kNestedTabStackedOffset = 12;
+
 int GetTabCornerRadius(const Tab& tab);
 
 void CalculatePinnedTabsBoundsInGrid(

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.h
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.h
@@ -16,6 +16,10 @@ namespace gfx {
 class Rect;
 }  // namespace gfx
 
+namespace views {
+class View;
+}  // namespace views
+
 class Tab;
 class TabStripLayoutHelper;
 class TabWidthConstraints;
@@ -47,9 +51,26 @@ std::pair<std::vector<gfx::Rect>, LayoutDomain> CalculateVerticalTabBounds(
     std::optional<int> width,
     bool should_layout_pinned_tabs_in_grid);
 
+// Core layout for a vertical-tabs drag pile, given the already-resolved drag
+// area width and floating state. Exposed separately from the TabStrip*
+// overload below so it can be unit tested without a live TabStrip.
+std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
+    const std::vector<TabSlotView*>& views,
+    int drag_area_width,
+    bool is_vertical_tabs_floating);
+
 std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
     const std::vector<TabSlotView*>& views,
     TabStrip* tab_strip);
+
+// `views` must already be children of `parent`. Reorders them so that
+// `views[0]` ends up painted on top of the rest of the pile and each
+// subsequent entry stacks progressively behind the previous one, matching
+// the compact overlapping pile CalculateBoundsForVerticalDraggedViews
+// computes bounds for. Pinned tabs are left untouched since they fan out
+// horizontally instead of stacking.
+void ReorderDraggedViewsForStacking(views::View* parent,
+                                    const std::vector<TabSlotView*>& views);
 
 void UpdateInsertionIndexForVerticalTabs(
     const gfx::Rect& dragged_bounds,

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper_unittest.cc
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper_unittest.cc
@@ -532,6 +532,7 @@ TEST_F(CalculateBoundsForVerticalDraggedViewsTest,
   // The nested child is stacked tightly under its parent: it starts before
   // the parent's bottom edge (partial overlap), instead of the normal
   // height + kVerticalTabsSpacing gap.
+  EXPECT_EQ(bounds[1].y(), bounds[0].y() + tabs::kNestedTabStackedOffset);
   EXPECT_LT(bounds[1].y(), bounds[0].bottom());
 
   // Once the nested subtree ends, normal spacing resumes.
@@ -559,31 +560,6 @@ TEST_F(ReorderDraggedViewsForStackingTest, FirstDraggedViewEndsUpOnTop) {
   // dragged view, ends up at the bottom.
   ASSERT_EQ(3u, parent.children().size());
   EXPECT_EQ(0u, *parent.GetIndexOf(c));
-  EXPECT_EQ(1u, *parent.GetIndexOf(b));
-  EXPECT_EQ(2u, *parent.GetIndexOf(a));
-}
-
-TEST_F(ReorderDraggedViewsForStackingTest, SkipsPinnedTabs) {
-  FakeTabSlotController controller;
-  views::View parent;
-  auto pinned_tab_owned =
-      std::make_unique<BraveTab>(tabs::TabHandle(1), &controller);
-  tabs::TabData data;
-  data.pinned = true;
-  pinned_tab_owned->SetDataForTesting(std::move(data));
-  BraveTab* pinned_tab = parent.AddChildView(std::move(pinned_tab_owned));
-
-  BraveTab* a = parent.AddChildView(
-      std::make_unique<BraveTab>(tabs::TabHandle(2), &controller));
-  BraveTab* b = parent.AddChildView(
-      std::make_unique<BraveTab>(tabs::TabHandle(3), &controller));
-
-  ReorderDraggedViewsForStacking(&parent, {pinned_tab, a, b});
-
-  // The pinned tab is left at its original position; only `a` and `b` get
-  // reordered relative to each other.
-  ASSERT_EQ(3u, parent.children().size());
-  EXPECT_EQ(0u, *parent.GetIndexOf(pinned_tab));
   EXPECT_EQ(1u, *parent.GetIndexOf(b));
   EXPECT_EQ(2u, *parent.GetIndexOf(a));
 }

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper_unittest.cc
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper_unittest.cc
@@ -11,12 +11,18 @@
 
 #include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
+#include "brave/browser/ui/views/tabs/brave_tab.h"
 #include "chrome/browser/ui/tabs/tab_types.h"
+#include "chrome/browser/ui/views/tabs/fake_tab_slot_controller.h"
 #include "chrome/browser/ui/views/tabs/tab_layout_state.h"
 #include "chrome/browser/ui/views/tabs/tab_strip_layout_types.h"
 #include "chrome/browser/ui/views/tabs/tab_width_constraints.h"
+#include "chrome/test/views/chrome_views_test_base.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "ui/base/metadata/metadata_header_macros.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/gfx/geometry/rect.h"
+#include "ui/views/view.h"
 
 namespace tabs {
 
@@ -41,6 +47,26 @@ TabWidthConstraints MakeTabConstraints(TabPinned pinned,
   constraints.set_is_tab_in_group(in_group);
   return constraints;
 }
+
+// A BraveTab whose GetTabNestingInfo() is directly settable, so tests can
+// exercise tree-tab indentation/stacking without wiring up a real tree-tab
+// node graph.
+class TestBraveTab : public BraveTab {
+  METADATA_HEADER(TestBraveTab, BraveTab)
+
+ public:
+  TestBraveTab(tabs::TabHandle handle, TabSlotController* controller)
+      : BraveTab(handle, controller) {}
+
+  void set_nesting_info(TabNestingInfo info) { nesting_info_ = info; }
+  TabNestingInfo GetTabNestingInfo() const override { return nesting_info_; }
+
+ private:
+  TabNestingInfo nesting_info_;
+};
+
+BEGIN_METADATA(TestBraveTab)
+END_METADATA
 
 }  // namespace
 
@@ -430,6 +456,148 @@ TEST(BraveTabStripLayoutHelperUnitTest,
   ASSERT_EQ(1u, bounds.size());
   EXPECT_EQ(kMarginForVerticalTabContainers + 4, bounds[0].x());
   EXPECT_EQ(constraints.size_info().min_inactive_width, bounds[0].width());
+}
+
+// Tests for CalculateBoundsForVerticalDraggedViews
+
+class CalculateBoundsForVerticalDraggedViewsTest : public ChromeViewsTestBase {
+};
+
+TEST_F(CalculateBoundsForVerticalDraggedViewsTest,
+       IndentsNestedChildRelativeToParent) {
+  FakeTabSlotController controller;
+  views::View parent;
+
+  TestBraveTab* root = parent.AddChildView(
+      std::make_unique<TestBraveTab>(tabs::TabHandle(1), &controller));
+  root->SetBoundsRect({0, 0, 0, kVerticalTabHeight});
+  root->set_nesting_info({.tree_height = 1, .level = 0});
+
+  TestBraveTab* child = parent.AddChildView(
+      std::make_unique<TestBraveTab>(tabs::TabHandle(2), &controller));
+  child->SetBoundsRect({0, 0, 0, kVerticalTabHeight});
+  child->set_nesting_info({.tree_height = 1, .level = 1});
+
+  // With this width, level, and tree_height, even_offset_per_level =
+  // (200 - kVerticalTabMinWidth) / (tree_height + 1) = (200 - 32) / 2 = 84,
+  // which is >= kBaseOffsetPerLevel, so the offset is exactly
+  // kBaseOffsetPerLevel * level = 20 (same formula as
+  // CalculateVerticalTabBounds_NestingUsesBaseOffsetWhenEnoughSpace above).
+  constexpr int kDragAreaWidth = 200;
+  constexpr int kExpectedOffset = kBaseOffsetPerLevel;
+
+  std::vector<TabSlotView*> views = {root, child};
+  std::vector<gfx::Rect> bounds = CalculateBoundsForVerticalDraggedViews(
+      views, kDragAreaWidth, /*is_vertical_tabs_floating=*/false);
+
+  ASSERT_EQ(2u, bounds.size());
+
+  // The root (level 0) isn't indented and spans the full drag area width.
+  EXPECT_EQ(0, bounds[0].x());
+  EXPECT_EQ(kDragAreaWidth, bounds[0].width());
+
+  // The nested child is indented (and narrowed) relative to its parent, the
+  // same way tabs are indented in the static (non-dragging) layout.
+  EXPECT_EQ(bounds[0].x() + kExpectedOffset, bounds[1].x());
+  EXPECT_EQ(bounds[0].width() - kExpectedOffset, bounds[1].width());
+}
+
+TEST_F(CalculateBoundsForVerticalDraggedViewsTest,
+       StacksNestedChildTightlyThenResumesNormalSpacing) {
+  FakeTabSlotController controller;
+  views::View parent;
+
+  TestBraveTab* root = parent.AddChildView(
+      std::make_unique<TestBraveTab>(tabs::TabHandle(1), &controller));
+  root->SetBoundsRect({0, 0, 0, kVerticalTabHeight});
+  root->set_nesting_info({.tree_height = 1, .level = 0});
+
+  TestBraveTab* child = parent.AddChildView(
+      std::make_unique<TestBraveTab>(tabs::TabHandle(2), &controller));
+  child->SetBoundsRect({0, 0, 0, kVerticalTabHeight});
+  child->set_nesting_info({.tree_height = 1, .level = 1});
+
+  // Not nested: the subtree has ended, so this should get normal spacing.
+  TestBraveTab* sibling = parent.AddChildView(
+      std::make_unique<TestBraveTab>(tabs::TabHandle(3), &controller));
+  sibling->SetBoundsRect({0, 0, 0, kVerticalTabHeight});
+  sibling->set_nesting_info({});
+
+  std::vector<TabSlotView*> views = {root, child, sibling};
+  std::vector<gfx::Rect> bounds = CalculateBoundsForVerticalDraggedViews(
+      views, /*drag_area_width=*/200, /*is_vertical_tabs_floating=*/false);
+
+  ASSERT_EQ(3u, bounds.size());
+
+  // The nested child is stacked tightly under its parent: it starts before
+  // the parent's bottom edge (partial overlap), instead of the normal
+  // height + kVerticalTabsSpacing gap.
+  EXPECT_LT(bounds[1].y(), bounds[0].bottom());
+
+  // Once the nested subtree ends, normal spacing resumes.
+  EXPECT_EQ(kVerticalTabsSpacing, bounds[2].y() - bounds[1].bottom());
+}
+
+// Tests for ReorderDraggedViewsForStacking
+
+class ReorderDraggedViewsForStackingTest : public ChromeViewsTestBase {};
+
+TEST_F(ReorderDraggedViewsForStackingTest, FirstDraggedViewEndsUpOnTop) {
+  FakeTabSlotController controller;
+  views::View parent;
+  BraveTab* a = parent.AddChildView(
+      std::make_unique<BraveTab>(tabs::TabHandle(1), &controller));
+  BraveTab* b = parent.AddChildView(
+      std::make_unique<BraveTab>(tabs::TabHandle(2), &controller));
+  BraveTab* c = parent.AddChildView(
+      std::make_unique<BraveTab>(tabs::TabHandle(3), &controller));
+
+  ReorderDraggedViewsForStacking(&parent, {a, b, c});
+
+  // `a` is the first dragged view, so it should end up with the highest
+  // child index (painted last, i.e. on top of the pile). `c`, the last
+  // dragged view, ends up at the bottom.
+  ASSERT_EQ(3u, parent.children().size());
+  EXPECT_EQ(0u, *parent.GetIndexOf(c));
+  EXPECT_EQ(1u, *parent.GetIndexOf(b));
+  EXPECT_EQ(2u, *parent.GetIndexOf(a));
+}
+
+TEST_F(ReorderDraggedViewsForStackingTest, SkipsPinnedTabs) {
+  FakeTabSlotController controller;
+  views::View parent;
+  auto pinned_tab_owned =
+      std::make_unique<BraveTab>(tabs::TabHandle(1), &controller);
+  tabs::TabData data;
+  data.pinned = true;
+  pinned_tab_owned->SetDataForTesting(std::move(data));
+  BraveTab* pinned_tab = parent.AddChildView(std::move(pinned_tab_owned));
+
+  BraveTab* a = parent.AddChildView(
+      std::make_unique<BraveTab>(tabs::TabHandle(2), &controller));
+  BraveTab* b = parent.AddChildView(
+      std::make_unique<BraveTab>(tabs::TabHandle(3), &controller));
+
+  ReorderDraggedViewsForStacking(&parent, {pinned_tab, a, b});
+
+  // The pinned tab is left at its original position; only `a` and `b` get
+  // reordered relative to each other.
+  ASSERT_EQ(3u, parent.children().size());
+  EXPECT_EQ(0u, *parent.GetIndexOf(pinned_tab));
+  EXPECT_EQ(1u, *parent.GetIndexOf(b));
+  EXPECT_EQ(2u, *parent.GetIndexOf(a));
+}
+
+TEST_F(ReorderDraggedViewsForStackingTest, SingleViewStaysInPlace) {
+  FakeTabSlotController controller;
+  views::View parent;
+  BraveTab* a = parent.AddChildView(
+      std::make_unique<BraveTab>(tabs::TabHandle(1), &controller));
+
+  ReorderDraggedViewsForStacking(&parent, {a});
+
+  ASSERT_EQ(1u, parent.children().size());
+  EXPECT_EQ(0u, *parent.GetIndexOf(a));
 }
 
 }  // namespace tabs

--- a/browser/ui/views/tabs/dragging/tab_drag_controller.cc
+++ b/browser/ui/views/tabs/dragging/tab_drag_controller.cc
@@ -18,6 +18,7 @@
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_container_view.h"
 #include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h"
+#include "brave/browser/ui/views/tabs/brave_tab_strip_layout_helper.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/tabs/features.h"
@@ -82,6 +83,17 @@ void BraveTabDragController::StartDraggingTabsSession(
       offset_from_first_dragged_view_.y());
   dragging_tabs_session_->set_is_showing_vertical_tabs(
       is_showing_vertical_tabs_);
+
+  // Vertical tabs can render a dragged tree-tab subtree as a partially
+  // overlapping stack (see CalculateBoundsForVerticalDraggedViews). Children
+  // added later paint on top by default (see
+  // TabDragContextImpl::PaintChildren / ZOrderableTabContainerElement), which
+  // would otherwise let the last dragged view cover all the others. Fix the
+  // paint order once here rather than on every drag layout pass.
+  if (is_showing_vertical_tabs_) {
+    tabs::ReorderDraggedViewsForStacking(attached_context_,
+                                         drag_data_.attached_views());
+  }
 }
 
 void BraveTabDragController::DetachAndAttachToNewContext(


### PR DESCRIPTION
Vertical tabs with tree-tab nesting didn't reflect hierarchy while being dragged: CalculateBoundsForVerticalDraggedViews laid out every dragged tab with full spacing and no indentation, and the drag pile painted later tabs on top of earlier ones, hiding the compact stack.

- Extract CalculateNestingOffset from CalculateVerticalLayout and reuse it in CalculateBoundsForVerticalDraggedViews so dragged tree-tab children are indented the same way as in the static layout.
- Stack nested children tightly (kNestedTabStackedOffset) instead of full height + spacing, so a dragged subtree renders as a compact, partially overlapping pile.
- Fix paint order for the pile: extract ReorderDraggedViewsForStacking and call it once from BraveTabDragController::StartDraggingTabsSession (at drag-session start/reattach) so the first dragged view stays on top and later ones stack behind it, instead of on every drag layout pass. Pinned tabs and the active-tab-always-on-top rule are left untouched.
- Add unit tests for the nesting-offset refactor and the new stacking reorder logic in brave_tab_strip_layout_helper_unittest.cc.

<!-- Add brave-browser issue below that this PR will resolve -->
- part of https://github.com/brave/brave-browser/issues/57228

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
