### PR TITLE
[Android] Fix Search in Settings tests for hidden Developer options

### DIFF
--- a/android/javatests/org/chromium/chrome/browser/settings/BraveSettingsSearchTest.java
+++ b/android/javatests/org/chromium/chrome/browser/settings/BraveSettingsSearchTest.java
@@ -45,6 +45,7 @@ import org.chromium.brave.browser.customize_menu.CustomizeBraveMenu;
 import org.chromium.brave.browser.customize_menu.MenuItemData;
 import org.chromium.chrome.browser.BraveRewardsPolicy;
 import org.chromium.chrome.browser.flags.ChromeSwitches;
+import org.chromium.chrome.browser.tracing.settings.DeveloperSettings;
 import org.chromium.chrome.browser.widget.quickactionsearchandbookmark.utils.BraveSearchWidgetUtils;
 import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
 import org.chromium.chrome.test.R;
@@ -200,9 +201,9 @@ public class BraveSettingsSearchTest {
         // assertSearchResult("Rate Brave");
 
         // About section
-
-        clearAndTypeIntoSearch("Developer options");
-        assertSearchResult("Developer options");
+        // "Developer options" visibility depends on channel/pref, so it is covered separately by
+        // testDeveloperOptionsSearchable_WhenEnabled and
+        // testDeveloperOptionsNotSearchable_WhenDisabled.
 
         clearAndTypeIntoSearch("About Brave");
         assertSearchResult("About Brave");
@@ -988,6 +989,10 @@ public class BraveSettingsSearchTest {
     @SmallTest
     @Feature({"Preferences"})
     public void testDeveloperOptionsSettingsAreSearchable() {
+        // Developer options are hidden by default on Beta/Stable channels (they must be unlocked by
+        // tapping the build number). Force them on so the sub-screen is indexed regardless of
+        // channel.
+        DeveloperSettings.setIsEnabledForTests(true);
         mSettingsActivityTestRule.startSettingsActivity();
 
         typeIntoSearch("Tracing");
@@ -1004,6 +1009,36 @@ public class BraveSettingsSearchTest {
 
         clearAndTypeIntoSearch("Show Safe Browsing errors");
         assertSearchResult("Show Safe Browsing errors");
+    }
+
+    /**
+     * Verifies that the main-settings "Developer options" entry is searchable when developer
+     * options are enabled (always the case on Dev/Nightly, and after unlocking on Beta/Stable).
+     */
+    @Test
+    @SmallTest
+    @Feature({"Preferences"})
+    public void testDeveloperOptionsSearchable_WhenEnabled() {
+        DeveloperSettings.setIsEnabledForTests(true);
+        mSettingsActivityTestRule.startSettingsActivity();
+
+        typeIntoSearch("Developer options");
+        assertSearchResult("Developer options");
+    }
+
+    /**
+     * Verifies the counterpart: when developer options are disabled (the default on Beta/Stable),
+     * the "Developer options" entry is not indexed and cannot be found in search.
+     */
+    @Test
+    @SmallTest
+    @Feature({"Preferences"})
+    public void testDeveloperOptionsNotSearchable_WhenDisabled() {
+        DeveloperSettings.setIsEnabledForTests(false);
+        mSettingsActivityTestRule.startSettingsActivity();
+
+        typeIntoSearch("Developer options");
+        assertSearchResultEmpty();
     }
 
     /**


### PR DESCRIPTION
`Developer options` are hidden by default on `Beta`/`Stable` channels, so the "Developer options" main-settings entry and its sub-screen are removed from the Settings search index. The affected tests implicitly assumed the `Dev`/`Nightly` behavior where developer options are always available, so they failed once `1.94.x` moved to the `Beta` channel.

Force the developer-options state explicitly via
`DeveloperSettings.setIsEnabledForTests()` so the tests are channel independent, and split the channel-dependent `"Developer options"` assertion out of `testBraveMainSettingsAreSearchable` into dedicated enabled/disabled tests.

This PR should be uplifted to Beta to unblock CI and releases.

Resolves https://github.com/brave/brave-browser/issues/57458
Resolves https://github.com/brave/brave-browser/issues/57459
<!-- Add brave-browser issue below that this PR will resolve -->

  No production code changes — only test code.

  ## Test Plan

  - Build `brave_java_unit_tests` on the **Release** channel (matching the failing
    CI config):
    `npm run build Release --target_os=android --target_arch=x64 --target=brave_java_unit_tests`
  - Run: `npm run test brave_java_unit_tests Release --target_os=android --target_arch=x64`
  - Confirm green: `testBraveMainSettingsAreSearchable`,
    `testDeveloperOptionsSettingsAreSearchable`,
    `testDeveloperOptionsSearchable_WhenEnabled`,
    `testDeveloperOptionsNotSearchable_WhenDisabled`.


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
