### PR TITLE
Best practices: broaden chromium_src Brave-dependency guidance (CSRC-019)

### DIFF
--- a/docs/best-practices/chromium-src-overrides.md
+++ b/docs/best-practices/chromium-src-overrides.md
@@ -291,23 +291,80 @@ gn check out/Default
 
 <a id="CSRC-019"></a>
 
-## ❌ chromium_src Must Not Depend on Brave Component Targets
+## ❌ chromium_src Should Avoid Depending on Brave Targets
 
-**The chromium_src layer must never have GN dependencies on
-`//brave/components/` targets.** This prevents patch churn when upstream
-modularizes targets. Use forward declarations in chromium_src with
-implementations resolved at link time from other targets via `sources.gni`.
+**A chromium_src override should avoid adding a GN dependency on, or a direct
+`#include` of, any downstream `//brave/...` target** (`//brave/components/...`,
+`//brave/browser/...`, `//brave/chrome/...`, etc.). The override is compiled as
+part of the upstream target, so pulling a Brave target into it creates an
+upstream → Brave dependency that breaks whenever upstream modularizes, grows the
+patched target's dependency graph, and forces us to patch Brave deps into the
+upstream GN config.
+
+Prefer keeping the override minimal: **forward-declare a free function** (or
+factory) in the override and call it, put the `#include`, implementation, and
+implementation dependencies in a dedicated Brave target such as
+`//brave/browser/ui/window_feature_controller:chromium_impl`, and add that impl
+target as a dependency of the relevant top-level Brave target (for example,
+`//brave/browser:core`). That way the override itself includes no Brave header
+and the upstream target does not need a patched dependency on Brave
+implementation details.
 
 ```cpp
-// ❌ WRONG - direct include from chromium_src to brave component
-// chromium_src/chrome/browser/policy/profile_policy_connector.cc
-#include "brave/components/brave_policy/brave_browser_policy_provider.h"
+// ❌ WRONG - chromium_src override includes/depends on a Brave target
+// chromium_src/chrome/browser/ui/window_feature_controller/window_feature_controller.cc
+#include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 
-// ✅ CORRECT - forward declare, implement in component, link via sources.gni
-// chromium_src/chrome/browser/policy/profile_policy_connector.cc
-std::unique_ptr<policy::ConfigurationPolicyProvider>
-CreateBraveBrowserPolicyProvider();
-// Implementation lives in brave/components/brave_policy/
+bool WindowFeatureController::UsesImmersiveFullscreenMode() const {
+  if (tabs::utils::ShouldUseImmersiveFullscreen(browser_)) {
+    return true;
+  }
+  return WindowFeatureController::UsesImmersiveFullscreenMode_ChromiumImpl();
+}
+
+// ✅ CORRECT - forward-declare a free function; the include + implementation
+// live in a dedicated Brave target, e.g.
+// //brave/browser/ui/window_feature_controller:chromium_impl
+// chromium_src/chrome/browser/ui/window_feature_controller/window_feature_controller.cc
+std::optional<bool> BraveUsesImmersiveFullscreenMode(bool disabled_at_startup,
+                                                     Browser* browser);
+
+bool WindowFeatureController::UsesImmersiveFullscreenMode() const {
+  if (auto result =
+          BraveUsesImmersiveFullscreenMode(disabled_at_startup_, browser_)) {
+    return *result;
+  }
+  return WindowFeatureController::UsesImmersiveFullscreenMode_ChromiumImpl();
+}
+```
+
+The GN wiring follows the same rule: **do not patch upstream GN to pull in a
+Brave dependency variable just to satisfy a `chromium_src` override.** Put the
+implementation source and its dependencies in a dedicated Brave target instead.
+
+```gn
+# ❌ WRONG - patching the upstream target to depend on Brave implementation deps
+# chrome/browser/ui/window_feature_controller/BUILD.gn (patched upstream file)
+deps += brave_browser_ui_window_feature_controller_deps
+
+# ✅ CORRECT - implementation + deps live in a Brave target
+# brave/browser/ui/window_feature_controller/BUILD.gn
+source_set("chromium_impl") {
+  sources = [
+    "window_feature_controller.cc",
+  ]
+  deps = [
+    # Appropriate implementation dependencies go here.
+  ]
+}
+
+# ✅ CORRECT - the relevant top-level Brave target depends on the impl target
+# brave/browser/BUILD.gn
+source_set("core") {
+  deps += [
+    "//brave/browser/ui/window_feature_controller:chromium_impl",
+  ]
+}
 ```
 
 ---

--- a/docs/best-practices/chromium-src-overrides.md
+++ b/docs/best-practices/chromium-src-overrides.md
@@ -313,10 +313,10 @@ same binary as the upstream target. The override itself should include no Brave
 header and the upstream target should not need a patched dependency on Brave
 implementation details.
 
-**Wrong: the override includes Brave implementation details and the upstream GN
-file is patched to know about those Brave dependencies.**
+**BAD:**
 
 ```cpp
+// ❌ WRONG - the override includes Brave implementation details
 // chromium_src/chrome/browser/ui/window_feature_controller/window_feature_controller.cc
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 
@@ -329,6 +329,7 @@ bool WindowFeatureController::UsesImmersiveFullscreenMode() const {
 ```
 
 ```diff
+# ❌ WRONG - the upstream GN file knows about Brave implementation dependencies
 # chrome/browser/ui/window_feature_controller/BUILD.gn (patched upstream file)
  source_set("window_feature_controller") {
    sources = [
@@ -344,10 +345,10 @@ bool WindowFeatureController::UsesImmersiveFullscreenMode() const {
  }
 ```
 
-**Correct: the override only calls a forward-declared hook, and the Brave
-implementation target owns the Brave include and dependency wiring.**
+**GOOD:**
 
 ```cpp
+// ✅ CORRECT - the override calls a forward-declared hook
 // chromium_src/chrome/browser/ui/window_feature_controller/window_feature_controller.cc
 class Browser;
 
@@ -376,6 +377,7 @@ std::optional<bool> BraveUsesImmersiveFullscreenMode(bool disabled_at_startup,
 ```
 
 ```gn
+# ✅ CORRECT - a Brave target owns the include and dependency wiring
 # brave/browser/ui/window_feature_controller/BUILD.gn
 source_set("chromium_impl") {
   sources = [

--- a/docs/best-practices/chromium-src-overrides.md
+++ b/docs/best-practices/chromium-src-overrides.md
@@ -302,11 +302,16 @@ patched target's dependency graph, and forces us to patch Brave deps into the
 upstream GN config.
 
 Prefer keeping the override minimal: **forward-declare a free function** (or
-factory) in the override and call it. Put the `#include`, implementation, and
-implementation dependencies together in a dedicated Brave target, then make the
-relevant top-level Brave target depend on that implementation target. The
-override itself should include no Brave header and the upstream target should
-not need a patched dependency on Brave implementation details.
+factory) in the override and call it. Put the hook implementation in a matching
+Brave source file outside `chromium_src` (for example,
+`brave/browser/ui/window_feature_controller/window_feature_controller.cc`) and
+put that source in a dedicated Brave target in the same directory. That target
+owns the Brave `#include` and its implementation dependencies. Finally, make the
+relevant existing top-level Brave target (for example, `//brave/browser:core`)
+depend on the dedicated implementation target so the hook is linked into the
+same binary as the upstream target. The override itself should include no Brave
+header and the upstream target should not need a patched dependency on Brave
+implementation details.
 
 **Wrong: the override includes Brave implementation details and the upstream GN
 file is patched to know about those Brave dependencies.**

--- a/docs/best-practices/chromium-src-overrides.md
+++ b/docs/best-practices/chromium-src-overrides.md
@@ -308,8 +308,10 @@ relevant top-level Brave target depend on that implementation target. The
 override itself should include no Brave header and the upstream target should
 not need a patched dependency on Brave implementation details.
 
+**Wrong: the override includes Brave implementation details and the upstream GN
+file is patched to know about those Brave dependencies.**
+
 ```cpp
-// ❌ WRONG - chromium_src override includes/depends on a Brave target
 // chromium_src/chrome/browser/ui/window_feature_controller/window_feature_controller.cc
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 
@@ -321,8 +323,17 @@ bool WindowFeatureController::UsesImmersiveFullscreenMode() const {
 }
 ```
 
+```gn
+# chrome/browser/ui/window_feature_controller/BUILD.gn (patched upstream file)
+deps += [
+  "//brave/browser/ui/views/tabs",
+]
+```
+
+**Correct: the override only calls a forward-declared hook, and the Brave
+implementation target owns the Brave include and dependency wiring.**
+
 ```cpp
-// ✅ CORRECT - chromium_src only forward-declares and calls the hook
 // chromium_src/chrome/browser/ui/window_feature_controller/window_feature_controller.cc
 std::optional<bool> BraveUsesImmersiveFullscreenMode(bool disabled_at_startup,
                                                      Browser* browser);
@@ -334,13 +345,7 @@ bool WindowFeatureController::UsesImmersiveFullscreenMode() const {
   }
   return WindowFeatureController::UsesImmersiveFullscreenMode_ChromiumImpl();
 }
-```
 
-Keep the implementation `.cc` and its GN wiring together under `//brave/...` so
-reviewers can see the implementation and dependencies as one logical change.
-
-```cpp
-// ✅ CORRECT - Brave implementation owns Brave includes and dependencies
 // brave/browser/ui/window_feature_controller/window_feature_controller.cc
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 
@@ -355,7 +360,6 @@ std::optional<bool> BraveUsesImmersiveFullscreenMode(bool disabled_at_startup,
 ```
 
 ```gn
-# ✅ CORRECT - implementation + deps live beside the Brave implementation
 # brave/browser/ui/window_feature_controller/BUILD.gn
 source_set("chromium_impl") {
   sources = [
@@ -366,22 +370,12 @@ source_set("chromium_impl") {
   ]
 }
 
-# ✅ CORRECT - the relevant top-level Brave target depends on the impl target
 # brave/browser/BUILD.gn
 source_set("core") {
   deps += [
     "//brave/browser/ui/window_feature_controller:chromium_impl",
   ]
 }
-```
-
-Do **not** patch upstream GN to pull in a Brave dependency variable just to
-satisfy a `chromium_src` override.
-
-```gn
-# ❌ WRONG - patching the upstream target to depend on Brave implementation deps
-# chrome/browser/ui/window_feature_controller/BUILD.gn (patched upstream file)
-deps += brave_browser_ui_window_feature_controller_deps
 ```
 
 ---

--- a/docs/best-practices/chromium-src-overrides.md
+++ b/docs/best-practices/chromium-src-overrides.md
@@ -323,11 +323,16 @@ bool WindowFeatureController::UsesImmersiveFullscreenMode() const {
 }
 ```
 
-```gn
+```diff
 # chrome/browser/ui/window_feature_controller/BUILD.gn (patched upstream file)
-deps += [
-  "//brave/browser/ui/views/tabs",
-]
+ source_set("window_feature_controller") {
+   sources = [
+     "window_feature_controller.cc",
+   ]
++  deps += [
++    "//brave/browser/ui/views/tabs",
++  ]
+ }
 ```
 
 **Correct: the override only calls a forward-declared hook, and the Brave
@@ -335,6 +340,8 @@ implementation target owns the Brave include and dependency wiring.**
 
 ```cpp
 // chromium_src/chrome/browser/ui/window_feature_controller/window_feature_controller.cc
+class Browser;
+
 std::optional<bool> BraveUsesImmersiveFullscreenMode(bool disabled_at_startup,
                                                      Browser* browser);
 
@@ -372,6 +379,7 @@ source_set("chromium_impl") {
 
 # brave/browser/BUILD.gn
 source_set("core") {
+  ...
   deps += [
     "//brave/browser/ui/window_feature_controller:chromium_impl",
   ]

--- a/docs/best-practices/chromium-src-overrides.md
+++ b/docs/best-practices/chromium-src-overrides.md
@@ -302,13 +302,11 @@ patched target's dependency graph, and forces us to patch Brave deps into the
 upstream GN config.
 
 Prefer keeping the override minimal: **forward-declare a free function** (or
-factory) in the override and call it, put the `#include`, implementation, and
-implementation dependencies in a dedicated Brave target such as
-`//brave/browser/ui/window_feature_controller:chromium_impl`, and add that impl
-target as a dependency of the relevant top-level Brave target (for example,
-`//brave/browser:core`). That way the override itself includes no Brave header
-and the upstream target does not need a patched dependency on Brave
-implementation details.
+factory) in the override and call it. Put the `#include`, implementation, and
+implementation dependencies together in a dedicated Brave target, then make the
+relevant top-level Brave target depend on that implementation target. The
+override itself should include no Brave header and the upstream target should
+not need a patched dependency on Brave implementation details.
 
 ```cpp
 // ❌ WRONG - chromium_src override includes/depends on a Brave target
@@ -321,10 +319,10 @@ bool WindowFeatureController::UsesImmersiveFullscreenMode() const {
   }
   return WindowFeatureController::UsesImmersiveFullscreenMode_ChromiumImpl();
 }
+```
 
-// ✅ CORRECT - forward-declare a free function; the include + implementation
-// live in a dedicated Brave target, e.g.
-// //brave/browser/ui/window_feature_controller:chromium_impl
+```cpp
+// ✅ CORRECT - chromium_src only forward-declares and calls the hook
 // chromium_src/chrome/browser/ui/window_feature_controller/window_feature_controller.cc
 std::optional<bool> BraveUsesImmersiveFullscreenMode(bool disabled_at_startup,
                                                      Browser* browser);
@@ -338,23 +336,33 @@ bool WindowFeatureController::UsesImmersiveFullscreenMode() const {
 }
 ```
 
-The GN wiring follows the same rule: **do not patch upstream GN to pull in a
-Brave dependency variable just to satisfy a `chromium_src` override.** Put the
-implementation source and its dependencies in a dedicated Brave target instead.
+Keep the implementation `.cc` and its GN wiring together under `//brave/...` so
+reviewers can see the implementation and dependencies as one logical change.
+
+```cpp
+// ✅ CORRECT - Brave implementation owns Brave includes and dependencies
+// brave/browser/ui/window_feature_controller/window_feature_controller.cc
+#include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
+
+std::optional<bool> BraveUsesImmersiveFullscreenMode(bool disabled_at_startup,
+                                                     Browser* browser) {
+  if (!disabled_at_startup &&
+      tabs::utils::ShouldUseImmersiveFullscreen(browser)) {
+    return true;
+  }
+  return std::nullopt;
+}
+```
 
 ```gn
-# ❌ WRONG - patching the upstream target to depend on Brave implementation deps
-# chrome/browser/ui/window_feature_controller/BUILD.gn (patched upstream file)
-deps += brave_browser_ui_window_feature_controller_deps
-
-# ✅ CORRECT - implementation + deps live in a Brave target
+# ✅ CORRECT - implementation + deps live beside the Brave implementation
 # brave/browser/ui/window_feature_controller/BUILD.gn
 source_set("chromium_impl") {
   sources = [
     "window_feature_controller.cc",
   ]
   deps = [
-    # Appropriate implementation dependencies go here.
+    "//brave/browser/ui/views/tabs",
   ]
 }
 
@@ -365,6 +373,15 @@ source_set("core") {
     "//brave/browser/ui/window_feature_controller:chromium_impl",
   ]
 }
+```
+
+Do **not** patch upstream GN to pull in a Brave dependency variable just to
+satisfy a `chromium_src` override.
+
+```gn
+# ❌ WRONG - patching the upstream target to depend on Brave implementation deps
+# chrome/browser/ui/window_feature_controller/BUILD.gn (patched upstream file)
+deps += brave_browser_ui_window_feature_controller_deps
 ```
 
 ---

--- a/docs/best-practices/chromium-src-overrides.md
+++ b/docs/best-practices/chromium-src-overrides.md
@@ -327,11 +327,15 @@ bool WindowFeatureController::UsesImmersiveFullscreenMode() const {
 # chrome/browser/ui/window_feature_controller/BUILD.gn (patched upstream file)
  source_set("window_feature_controller") {
    sources = [
+     ...
      "window_feature_controller.cc",
++    ...
    ]
-+  deps += [
-+    "//brave/browser/ui/views/tabs",
-+  ]
+
+   deps = [
+     ...
+   ]
++  deps += [ "//brave/browser/ui/views/tabs" ]
  }
 ```
 


### PR DESCRIPTION
## Summary

Updates **CSRC-019** in the chromium_src best-practices doc so it would catch
the dependency issue raised in review on #38278.

Changes:
- **Broadened scope:** previously the rule only mentioned `//brave/components/`,
  so it did not flag a `chromium_src` override taking a dependency on a
  `//brave/browser/...` target. It now covers **any** downstream `//brave/...`
  target (components, browser, chrome, ...).
- **Softened wording:** "must never" → "should avoid".
- **Clarified the pattern:** forward-declare a free function in the override and
  keep the `#include` + implementation in the relevant top-level Brave target
  (e.g. `//brave/browser`), which is already linked into the upstream target, so
  the override includes no Brave header.

## Context

Prompted by review feedback on
https://github.com/brave/brave-core/pull/38278#discussion_r3639171690 (finish
the forward-declare split; the override should forward-declare a free function).

## Verification

- `presubmit` (via pnpm): `0 Presubmit Messages, 0 Presubmit Warnings, 0
  Presubmit ERRORS`.
- `CSRC-019` anchor unchanged; no other best-practice IDs touched.
- Docs-only change; no code/build impact.
