### PR TITLE
[iOS] Rename P3A Opt-In onboarding step

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Callout.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Callout.swift
@@ -65,7 +65,7 @@ extension BrowserViewController {
         p3aUtils: braveCore.p3aUtils,
         attributionManager: attributionManager
       ),
-      steps: [.p3aOptIn],
+      steps: [.metricsOptIn],
       showSplashScreen: false,
       showDismissButton: false
     ).then {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Onboarding.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Onboarding.swift
@@ -236,7 +236,7 @@ extension BrowserViewController {
       steps.insert(.defaultBrowsing, at: 0)
     }
     if !braveCore.p3aUtils.isP3APreferenceManaged {
-      steps.append(.p3aOptIn)
+      steps.append(.metricsOptIn)
     }
 
     let controller = OnboardingController(

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/RetentionPreferencesDebugMenuViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/RetentionPreferencesDebugMenuViewController.swift
@@ -114,7 +114,7 @@ private struct OnboardingRepresentable: UIViewControllerRepresentable {
     }
     steps.append(.blockInterruptions)
     if !p3aUtilities.isP3APreferenceManaged {
-      steps.append(.p3aOptIn)
+      steps.append(.metricsOptIn)
     }
     return OnboardingController(environment: env, steps: steps)
   }

--- a/ios/brave-ios/Sources/Onboarding/WelcomeFocus/MetricsOptInOnboardingStep.swift
+++ b/ios/brave-ios/Sources/Onboarding/WelcomeFocus/MetricsOptInOnboardingStep.swift
@@ -9,7 +9,7 @@ import SafariServices
 import Strings
 import SwiftUI
 
-struct P3AOptInGraphicsView: View {
+struct MetricsOptInGraphicsView: View {
   @Environment(\.onboardingEnvironment.p3aUtils) private var p3aUtils
   @State private var isDisplayingP3AHelp = false
   @State private var isP3AEnabled: Bool = false
@@ -55,7 +55,7 @@ struct P3AOptInGraphicsView: View {
   }
 }
 
-struct P3AOptInActionsView: View {
+struct MetricsOptInActionsView: View {
   var continueHandler: () -> Void
 
   @Environment(\.onboardingEnvironment.p3aUtils) private var p3aUtils
@@ -87,8 +87,8 @@ private struct FocusSafariControllerView: UIViewControllerRepresentable {
   func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {}
 }
 
-public struct P3AOptInOnboardingStep: OnboardingStep {
-  public var id: String = "p3a-opt-in"
+public struct MetricsOptInOnboardingStep: OnboardingStep {
+  public var id: String = "metrics-opt-in"
   public func makeTitle() -> some View {
     OnboardingTitleView(
       title: Strings.FocusOnboarding.p3aScreenTitle,
@@ -96,19 +96,19 @@ public struct P3AOptInOnboardingStep: OnboardingStep {
     )
   }
   public func makeGraphic() -> some View {
-    P3AOptInGraphicsView()
+    MetricsOptInGraphicsView()
   }
   public func makeActions(continueHandler: @escaping () -> Void) -> some View {
-    P3AOptInActionsView(continueHandler: continueHandler)
+    MetricsOptInActionsView(continueHandler: continueHandler)
   }
 }
 
-extension OnboardingStep where Self == P3AOptInOnboardingStep {
-  public static var p3aOptIn: Self { .init() }
+extension OnboardingStep where Self == MetricsOptInOnboardingStep {
+  public static var metricsOptIn: Self { .init() }
 }
 
 #if DEBUG
 #Preview {
-  OnboardingStepView(step: .p3aOptIn)
+  OnboardingStepView(step: .metricsOptIn)
 }
 #endif

--- a/ios/brave-ios/Sources/Onboarding/WelcomeFocus/OnboardingStep.swift
+++ b/ios/brave-ios/Sources/Onboarding/WelcomeFocus/OnboardingStep.swift
@@ -42,7 +42,7 @@ extension [any OnboardingStep] {
     if AddToDockEligibility.isEligible {
       steps.append(.addToDock)
     }
-    steps.append(contentsOf: [.blockInterruptions, .p3aOptIn])
+    steps.append(contentsOf: [.blockInterruptions, .metricsOptIn])
     return steps
   }
   /// A subset of steps if the user is already the default browser on first launch
@@ -51,7 +51,7 @@ extension [any OnboardingStep] {
     if AddToDockEligibility.isEligible {
       steps.append(.addToDock)
     }
-    steps.append(contentsOf: [.blockInterruptions, .p3aOptIn])
+    steps.append(contentsOf: [.blockInterruptions, .metricsOptIn])
     return steps
   }
 }

--- a/ios/brave-ios/Sources/Onboarding/WelcomeFocus/OnboardingStepView.swift
+++ b/ios/brave-ios/Sources/Onboarding/WelcomeFocus/OnboardingStepView.swift
@@ -155,6 +155,6 @@ struct OnboardingStepView: View {
 
 #if DEBUG
 #Preview {
-  OnboardingStepView(step: .p3aOptIn)
+  OnboardingStepView(step: .metricsOptIn)
 }
 #endif


### PR DESCRIPTION
Renames the file and associated types to prepare for adding crash reporting opt-in to this step

No behaviour changes