### PR TITLE
[VPN 2.0] Add EndpointClient-based subscriber credential exchange

### DIFF
--- a/browser/brave_vpn/brave_vpn_service_factory.cc
+++ b/browser/brave_vpn/brave_vpn_service_factory.cc
@@ -55,8 +55,12 @@ std::unique_ptr<KeyedService> BuildVpnService_V2(
   auto* profile_prefs = user_prefs::UserPrefs::Get(context);
   brave_vpn::MigrateVPNSettings(profile_prefs, local_state);
 
+  auto* default_storage_partition = context->GetDefaultStoragePartition();
+  auto shared_url_loader_factory =
+      default_storage_partition->GetURLLoaderFactoryForBrowserProcess();
+
   return std::make_unique<v2::BraveVpnServiceImpl>(
-      local_state, profile_prefs,
+      local_state, profile_prefs, shared_url_loader_factory,
       base::BindRepeating(
           [](content::BrowserContext* context) {
             return skus::SkusServiceFactory::GetForContext(context);

--- a/browser/brave_vpn/brave_vpn_service_factory.cc
+++ b/browser/brave_vpn/brave_vpn_service_factory.cc
@@ -55,12 +55,10 @@ std::unique_ptr<KeyedService> BuildVpnService_V2(
   auto* profile_prefs = user_prefs::UserPrefs::Get(context);
   brave_vpn::MigrateVPNSettings(profile_prefs, local_state);
 
-  auto* default_storage_partition = context->GetDefaultStoragePartition();
-  auto shared_url_loader_factory =
-      default_storage_partition->GetURLLoaderFactoryForBrowserProcess();
-
   return std::make_unique<v2::BraveVpnServiceImpl>(
-      local_state, profile_prefs, shared_url_loader_factory,
+      local_state, profile_prefs,
+      context->GetDefaultStoragePartition()
+          ->GetURLLoaderFactoryForBrowserProcess(),
       base::BindRepeating(
           [](content::BrowserContext* context) {
             return skus::SkusServiceFactory::GetForContext(context);

--- a/components/BUILD.gn
+++ b/components/BUILD.gn
@@ -86,6 +86,10 @@ test("brave_components_unittests") {
     ]
   }
 
+  if (enable_brave_vpn_v2) {
+    deps += [ "//brave/components/brave_vpn/browser/v2/api:unit_tests" ]
+  }
+
   if (enable_brave_vpn_v2_apps) {
     deps += [
       "//brave/components/brave_vpn/app/v2/agent:unit_tests",

--- a/components/brave_vpn/browser/v2/BUILD.gn
+++ b/components/brave_vpn/browser/v2/BUILD.gn
@@ -36,11 +36,13 @@ static_library("browser") {
   ]
 
   deps = [
+    "api",
     "//base",
     "//brave/components/brave_vpn/common",
     "//brave/components/resources:strings",
     "//components/prefs",
     "//net",
+    "//services/network/public/cpp",
     "//ui/base",
     "//url",
   ]
@@ -59,6 +61,7 @@ source_set("unit_tests") {
 
   deps = [
     ":browser",
+    "api",
     "//base",
     "//base:i18n",
     "//base/test:test_support",

--- a/components/brave_vpn/browser/v2/BUILD.gn
+++ b/components/brave_vpn/browser/v2/BUILD.gn
@@ -65,6 +65,7 @@ source_set("unit_tests") {
     "//base",
     "//base:i18n",
     "//base/test:test_support",
+    "//brave/components/brave_account/endpoint_client:test_support",
     "//brave/components/brave_vpn/common",
     "//brave/components/brave_vpn/common/mojom",
     "//brave/components/resources:strings",

--- a/components/brave_vpn/browser/v2/api/BUILD.gn
+++ b/components/brave_vpn/browser/v2/api/BUILD.gn
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
+
+assert(enable_brave_vpn_v2)
+
+source_set("api") {
+  sources = [
+    "brave_vpn_api_client.cc",
+    "brave_vpn_api_client.h",
+    "error_body.h",
+    "purchase_endpoints.h",
+  ]
+
+  public_deps = [
+    "//base",
+    "//brave/components/brave_account/endpoint_client",
+    "//brave/components/brave_vpn/common",
+    "//url",
+  ]
+
+  deps = [
+    "//net",
+    "//net/traffic_annotation",
+    "//services/network/public/cpp",
+  ]
+}
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [ "brave_vpn_api_client_unittest.cc" ]
+
+  deps = [
+    ":api",
+    "//base",
+    "//base/test:test_support",
+    "//net",
+    "//services/network:test_support",
+    "//services/network/public/cpp",
+    "//services/network/public/mojom",
+    "//testing/gtest",
+    "//url",
+  ]
+}

--- a/components/brave_vpn/browser/v2/api/BUILD.gn
+++ b/components/brave_vpn/browser/v2/api/BUILD.gn
@@ -38,6 +38,7 @@ source_set("unit_tests") {
     ":api",
     "//base",
     "//base/test:test_support",
+    "//brave/components/brave_account/endpoint_client:test_support",
     "//net",
     "//services/network:test_support",
     "//services/network/public/cpp",

--- a/components/brave_vpn/browser/v2/api/DEPS
+++ b/components/brave_vpn/browser/v2/api/DEPS
@@ -1,0 +1,3 @@
+include_rules = [
+  "+services/network/public/mojom",
+]

--- a/components/brave_vpn/browser/v2/api/DEPS
+++ b/components/brave_vpn/browser/v2/api/DEPS
@@ -1,3 +1,5 @@
-include_rules = [
-  "+services/network/public/mojom",
-]
+specific_include_rules = {
+  ".*_unittest\.cc": [
+    "+services/network/public/mojom",
+  ],
+}

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client.cc
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client.cc
@@ -1,0 +1,127 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h"
+
+#include <utility>
+
+#include "base/functional/bind.h"
+#include "base/functional/callback.h"
+#include "base/types/expected.h"
+#include "brave/components/brave_account/endpoint_client/client.h"
+#include "brave/components/brave_account/endpoint_client/with_headers.h"
+#include "net/base/net_errors.h"
+#include "net/traffic_annotation/network_traffic_annotation.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "services/network/public/cpp/simple_url_loader.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
+
+namespace brave_vpn::v2 {
+
+namespace {
+constexpr char kHeaderBravePaymentsEnvironment[] = "Brave-Payments-Environment";
+
+const net::NetworkTrafficAnnotationTag kTrafficAnnotation =
+    net::DefineNetworkTrafficAnnotation("brave_vpn_api_client", R"(
+      semantics {
+        sender: "Brave VPN Service"
+        description:
+          "This service is used to communicate with Guardian VPN apis"
+          "on behalf of the user interacting with the Brave VPN."
+        trigger:
+          "Triggered by user connecting the Brave VPN."
+        data:
+          "Servers, hosts and credentials for Brave VPN"
+        destination: WEBSITE
+      }
+      policy {
+        cookies_allowed: NO
+        policy_exception_justification:
+          "Not implemented."
+      }
+    )");
+
+// Builds a request with the traffic annotation and retry policy common to all
+// Brave VPN endpoints.
+template <typename Request>
+Request MakeRequest() {
+  Request request;
+  request.network_traffic_annotation_tag =
+      net::MutableNetworkTrafficAnnotationTag(kTrafficAnnotation);
+#if 0
+  // TODO(https://github.com/brave/brave-browser/issues/57112)
+  // Enable retry policy once the PR related to the issue has been merged.
+  request.retry_options = {
+      .max_retries = 1,
+      .retry_mode = network::SimpleURLLoader::RETRY_ON_NETWORK_CHANGE};
+#endif
+  return request;
+}
+
+// Describes a failed response for which no typed body was recovered; i.e. a
+// transport-level or HTTP-level failure rather than a parsed error body.
+template <typename Response>
+std::optional<std::string> MaybeDescribeTransportFailure(
+    const Response& response) {
+  if (response.body) {
+    return std::nullopt;
+  }
+  if (response.net_error != net::OK) {
+    return net::ErrorToString(response.net_error);
+  }
+  if (response.status_code) {
+    return absl::StrFormat("Unexpected HTTP status: %d", *response.status_code);
+  }
+  return "No response received";
+}
+
+}  // namespace
+
+BraveVpnApiClient::BraveVpnApiClient(
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory)
+    : url_loader_factory_(std::move(url_loader_factory)) {}
+
+BraveVpnApiClient::~BraveVpnApiClient() = default;
+
+void BraveVpnApiClient::GetSubscriberCredentialV12(
+    SubscriberCredentialCallback callback,
+    const std::string& skus_credential,
+    const std::string& environment) {
+  using Endpoint = endpoints::GetSubscriberCredentialV12;
+  using Request =
+      brave_account::endpoint_client::WithHeaders<Endpoint::Request>;
+
+  auto request = MakeRequest<Request>();
+  request.body.skus_credential = skus_credential;
+  request.headers.SetHeader(kHeaderBravePaymentsEnvironment, environment);
+
+  brave_account::endpoint_client::Client<Endpoint>::Send(
+      url_loader_factory_, std::move(request),
+      base::BindOnce(&BraveVpnApiClient::OnGetSubscriberCredentialV12Response,
+                     weak_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void BraveVpnApiClient::OnGetSubscriberCredentialV12Response(
+    SubscriberCredentialCallback callback,
+    endpoints::GetSubscriberCredentialV12::Response response) {
+  std::optional<std::string> maybe_transport_error =
+      MaybeDescribeTransportFailure(response);
+  if (maybe_transport_error.has_value()) {
+    std::move(callback).Run(base::unexpected(maybe_transport_error.value()));
+    return;
+  }
+
+  std::move(callback).Run(
+      std::move(*response.body)
+          .transform(
+              [](endpoints::GetSubscriberCredentialV12ResponseBody success) {
+                return std::move(success.subscriber_credential);
+              })
+          .transform_error([](endpoints::VpnErrorBody error) {
+            return std::move(error.error_title);
+          }));
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client.cc
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client.cc
@@ -7,18 +7,26 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
+#include "base/strings/strcat.h"
 #include "base/types/expected.h"
 #include "brave/components/brave_account/endpoint_client/client.h"
 #include "brave/components/brave_account/endpoint_client/with_headers.h"
 #include "net/base/net_errors.h"
+#include "net/http/http_status_code.h"
 #include "net/traffic_annotation/network_traffic_annotation.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "services/network/public/cpp/simple_url_loader.h"
 #include "third_party/abseil-cpp/absl/strings/str_format.h"
 
+using brave_account::endpoint_client::Client;
+using brave_account::endpoint_client::WithHeaders;
+
 namespace brave_vpn::v2 {
+
+using endpoints::GetSubscriberCredentialV12;
 
 namespace {
 constexpr char kHeaderBravePaymentsEnvironment[] = "Brave-Payments-Environment";
@@ -50,38 +58,39 @@ Request MakeRequest() {
   Request request;
   request.network_traffic_annotation_tag =
       net::MutableNetworkTrafficAnnotationTag(kTrafficAnnotation);
-#if 0
-  // TODO(https://github.com/brave/brave-browser/issues/57112)
-  // Enable retry policy once the PR related to the issue has been merged.
   request.retry_options = {
       .max_retries = 1,
       .retry_mode = network::SimpleURLLoader::RETRY_ON_NETWORK_CHANGE};
-#endif
   return request;
 }
 
 // Describes a failed response for which no typed body was recovered; i.e. a
 // transport-level or HTTP-level failure rather than a parsed error body.
 template <typename Response>
-std::optional<std::string> MaybeDescribeTransportFailure(
+std::optional<std::string> MaybeDescribeUnrecoverableResponse(
     const Response& response) {
   if (response.body) {
     return std::nullopt;
   }
-  if (response.net_error != net::OK) {
-    return net::ErrorToString(response.net_error);
-  }
-  if (response.status_code) {
-    return absl::StrFormat("Unexpected HTTP status: %d", *response.status_code);
-  }
-  return "No response received";
+  return response.status_code
+      .transform([](int status_code) {
+        return absl::StrFormat("HTTP %d %s: body missing or failed to parse",
+                               status_code,
+                               net::GetHttpReasonPhrase(status_code));
+      })
+      .value_or(base::StrCat({net::ErrorToString(response.net_error),
+                              response.net_error == net::OK
+                                  ? " (no response headers received)"
+                                  : ""}));
 }
 
 }  // namespace
 
 BraveVpnApiClient::BraveVpnApiClient(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory)
-    : url_loader_factory_(std::move(url_loader_factory)) {}
+    : url_loader_factory_(std::move(url_loader_factory)) {
+  CHECK(url_loader_factory_);
+}
 
 BraveVpnApiClient::~BraveVpnApiClient() = default;
 
@@ -89,15 +98,15 @@ void BraveVpnApiClient::GetSubscriberCredentialV12(
     SubscriberCredentialCallback callback,
     const std::string& skus_credential,
     const std::string& environment) {
-  using Endpoint = endpoints::GetSubscriberCredentialV12;
-  using Request =
-      brave_account::endpoint_client::WithHeaders<Endpoint::Request>;
+  CHECK(!skus_credential.empty());
+  CHECK(!environment.empty());
 
-  auto request = MakeRequest<Request>();
+  auto request =
+      MakeRequest<WithHeaders<GetSubscriberCredentialV12::Request>>();
   request.body.skus_credential = skus_credential;
   request.headers.SetHeader(kHeaderBravePaymentsEnvironment, environment);
 
-  brave_account::endpoint_client::Client<Endpoint>::Send(
+  Client<endpoints::GetSubscriberCredentialV12>::Send(
       url_loader_factory_, std::move(request),
       base::BindOnce(&BraveVpnApiClient::OnGetSubscriberCredentialV12Response,
                      weak_factory_.GetWeakPtr(), std::move(callback)));
@@ -106,17 +115,14 @@ void BraveVpnApiClient::GetSubscriberCredentialV12(
 void BraveVpnApiClient::OnGetSubscriberCredentialV12Response(
     SubscriberCredentialCallback callback,
     endpoints::GetSubscriberCredentialV12::Response response) {
-  std::optional<std::string> maybe_transport_error =
-      MaybeDescribeTransportFailure(response);
-  if (maybe_transport_error.has_value()) {
-    std::move(callback).Run(base::unexpected(maybe_transport_error.value()));
-    return;
+  if (auto unrecoverable = MaybeDescribeUnrecoverableResponse(response)) {
+    return std::move(callback).Run(base::unexpected(*std::move(unrecoverable)));
   }
 
   std::move(callback).Run(
-      std::move(*response.body)
+      std::move(CHECK_DEREF(response.body))
           .transform(
-              [](endpoints::GetSubscriberCredentialV12ResponseBody success) {
+              [](endpoints::GetSubscriberCredentialV12SuccessBody success) {
                 return std::move(success.subscriber_credential);
               })
           .transform_error([](endpoints::VpnErrorBody error) {

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h
@@ -1,0 +1,59 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_BRAVE_VPN_API_CLIENT_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_BRAVE_VPN_API_CLIENT_H_
+
+#include <string>
+
+#include "base/functional/callback_forward.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/memory/weak_ptr.h"
+#include "base/types/expected.h"
+#include "brave/components/brave_vpn/browser/v2/api/purchase_endpoints.h"
+
+namespace network {
+class SharedURLLoaderFactory;
+}  // namespace network
+
+namespace brave_vpn::v2 {
+
+// BraveVpnApiClient issues typed requests to Brave VPN's backend endpoints
+// via Brave Endpoint Client.
+// Callbacks return typed results (base::expected<...>) rather than a raw JSON
+// string paired with a success bool, so callers can distinguish transport/HTTP
+// failures from a structured server-reported error without re-parsing anything
+// themselves.
+class BraveVpnApiClient {
+ public:
+  explicit BraveVpnApiClient(
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
+  BraveVpnApiClient(const BraveVpnApiClient&) = delete;
+  BraveVpnApiClient& operator=(const BraveVpnApiClient&) = delete;
+  virtual ~BraveVpnApiClient();
+
+  // Connect API: GetSubscriberCredentialV12.
+  // Exchanges a SKUS credential for a subscriber credential.
+  // On success: the subscriber credential.
+  // On failure: a user-facing error string (transport/HTTP failure, or the
+  // server's reported error message).
+  using SubscriberCredentialCallback =
+      base::OnceCallback<void(base::expected<std::string, std::string>)>;
+  virtual void GetSubscriberCredentialV12(SubscriberCredentialCallback callback,
+                                          const std::string& skus_credential,
+                                          const std::string& environment);
+
+ private:
+  void OnGetSubscriberCredentialV12Response(
+      SubscriberCredentialCallback callback,
+      endpoints::GetSubscriberCredentialV12::Response response);
+
+  scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
+  base::WeakPtrFactory<BraveVpnApiClient> weak_factory_{this};
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_BRAVE_VPN_API_CLIENT_H_

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client_unittest.cc
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client_unittest.cc
@@ -1,0 +1,125 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h"
+
+#include <string>
+#include <utility>
+
+#include "base/functional/callback.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/test/task_environment.h"
+#include "base/test/test_future.h"
+#include "base/types/expected.h"
+#include "brave/components/brave_vpn/browser/v2/api/purchase_endpoints.h"
+#include "net/base/net_errors.h"
+#include "net/http/http_status_code.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "services/network/public/cpp/url_loader_completion_status.h"
+#include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
+#include "services/network/public/mojom/url_response_head.mojom.h"
+#include "services/network/test/test_url_loader_factory.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
+#include "url/gurl.h"
+
+namespace brave_vpn::v2 {
+namespace {
+constexpr char kTestSkusCredential[] = "test-skus-credential";
+constexpr char kTestSubscriberCredential[] = "test-subscriber-credential";
+constexpr char kTestEnvironment[] = "test-env";
+}  // namespace
+
+class BraveVpnApiClientTest : public testing::Test {
+ public:
+  BraveVpnApiClientTest()
+      : shared_url_loader_factory_(
+            base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
+                &url_loader_factory_)),
+        client_(shared_url_loader_factory_) {}
+
+  // Fires a client API method and blocks until its callback runs, returning the
+  // result the callback was invoked with. Works for any method shaped like
+  //   void Method(base::OnceCallback<void(SomeResultType)> callback, args...)
+  template <typename Class,
+            typename ResultType,
+            typename... MethodArgs,
+            typename... Args>
+  auto CallClientApi(void (Class::*method)(base::OnceCallback<void(ResultType)>,
+                                           MethodArgs...),
+                     Args&&... args) {
+    base::test::TestFuture<ResultType> future;
+    (client_.*method)(future.GetCallback(), std::forward<Args>(args)...);
+    return future.Take();
+  }
+
+ protected:
+  base::test::TaskEnvironment task_environment_;
+  network::TestURLLoaderFactory url_loader_factory_;
+  scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
+  BraveVpnApiClient client_;
+};
+
+// A transport failure surfaces the net-error description, not an HTTP status.
+TEST_F(BraveVpnApiClientTest, TransportErrorReturnsNetErrorString) {
+  url_loader_factory_.AddResponse(
+      endpoints::GetSubscriberCredentialV12::URL(),
+      network::mojom::URLResponseHead::New(),
+      /*content=*/std::string(),
+      network::URLLoaderCompletionStatus(net::ERR_TIMED_OUT));
+
+  const auto result =
+      CallClientApi(&BraveVpnApiClient::GetSubscriberCredentialV12,
+                    kTestSkusCredential, kTestEnvironment);
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error(), net::ErrorToString(net::ERR_TIMED_OUT));
+}
+
+// A non-2xx response whose body is not a parseable error falls back to the HTTP
+// status description (the status_code branch of DescribeTransportFailure).
+TEST_F(BraveVpnApiClientTest, HttpErrorWithUnparseableBodyDescribesStatus) {
+  url_loader_factory_.AddResponse(
+      endpoints::GetSubscriberCredentialV12::URL().spec(), "not json at all",
+      net::HTTP_INTERNAL_SERVER_ERROR);
+
+  const auto result =
+      CallClientApi(&BraveVpnApiClient::GetSubscriberCredentialV12,
+                    kTestSkusCredential, kTestEnvironment);
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error(),
+            absl::StrFormat("Unexpected HTTP status: %d",
+                            static_cast<int>(net::HTTP_INTERNAL_SERVER_ERROR)));
+}
+
+// API-specific tests.
+
+TEST_F(BraveVpnApiClientTest, GetSubscriberCredentialV12_Success) {
+  url_loader_factory_.AddResponse(
+      endpoints::GetSubscriberCredentialV12::URL().spec(),
+      absl::StrFormat(R"({"subscriber-credential":"%s"})",
+                      kTestSubscriberCredential),
+      net::HTTP_OK);
+
+  const auto result =
+      CallClientApi(&BraveVpnApiClient::GetSubscriberCredentialV12,
+                    kTestSkusCredential, kTestEnvironment);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), kTestSubscriberCredential);
+}
+
+TEST_F(BraveVpnApiClientTest, GetSubscriberCredentialV12_RequestError) {
+  url_loader_factory_.AddResponse(
+      endpoints::GetSubscriberCredentialV12::URL().spec(),
+      R"({"error-title":"Token no longer valid.","error-message":"gone"})",
+      net::HTTP_BAD_REQUEST);
+
+  const auto result =
+      CallClientApi(&BraveVpnApiClient::GetSubscriberCredentialV12,
+                    kTestSkusCredential, kTestEnvironment);
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error(), "Token no longer valid.");
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client_unittest.cc
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client_unittest.cc
@@ -9,37 +9,37 @@
 #include <utility>
 
 #include "base/functional/callback.h"
-#include "base/memory/scoped_refptr.h"
 #include "base/test/task_environment.h"
 #include "base/test/test_future.h"
 #include "base/types/expected.h"
+#include "brave/components/brave_account/endpoint_client/test_support.h"
+#include "brave/components/brave_vpn/browser/v2/api/error_body.h"
 #include "brave/components/brave_vpn/browser/v2/api/purchase_endpoints.h"
 #include "net/base/net_errors.h"
 #include "net/http/http_status_code.h"
-#include "services/network/public/cpp/shared_url_loader_factory.h"
-#include "services/network/public/cpp/url_loader_completion_status.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
-#include "services/network/public/mojom/url_response_head.mojom.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/abseil-cpp/absl/strings/str_format.h"
-#include "url/gurl.h"
 
 namespace brave_vpn::v2 {
 namespace {
+using brave_account::endpoint_client::MockResponseFor;
+
 constexpr char kTestSkusCredential[] = "test-skus-credential";
 constexpr char kTestSubscriberCredential[] = "test-subscriber-credential";
 constexpr char kTestEnvironment[] = "test-env";
 }  // namespace
 
-class BraveVpnApiClientTest : public testing::Test {
- public:
-  BraveVpnApiClientTest()
-      : shared_url_loader_factory_(
-            base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
-                &url_loader_factory_)),
-        client_(shared_url_loader_factory_) {}
+struct GetSubscriberCredentialV12TestCase {
+  std::string test_name;
+  endpoints::GetSubscriberCredentialV12::Response response;
+  base::expected<std::string, std::string> expected;
+};
 
+template <typename TestCase>
+class BraveVpnApiClientTest : public testing::TestWithParam<TestCase> {
+ public:
   // Fires a client API method and blocks until its callback runs, returning the
   // result the callback was invoked with. Works for any method shaped like
   //   void Method(base::OnceCallback<void(SomeResultType)> callback, args...)
@@ -58,68 +58,63 @@ class BraveVpnApiClientTest : public testing::Test {
  protected:
   base::test::TaskEnvironment task_environment_;
   network::TestURLLoaderFactory url_loader_factory_;
-  scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
-  BraveVpnApiClient client_;
+  BraveVpnApiClient client_{url_loader_factory_.GetSafeWeakWrapper()};
 };
 
-// A transport failure surfaces the net-error description, not an HTTP status.
-TEST_F(BraveVpnApiClientTest, TransportErrorReturnsNetErrorString) {
-  url_loader_factory_.AddResponse(
-      endpoints::GetSubscriberCredentialV12::URL(),
-      network::mojom::URLResponseHead::New(),
-      /*content=*/std::string(),
-      network::URLLoaderCompletionStatus(net::ERR_TIMED_OUT));
+using BraveVpnApiClientGetSubscriberCredentialV12Test =
+    BraveVpnApiClientTest<GetSubscriberCredentialV12TestCase>;
 
-  const auto result =
-      CallClientApi(&BraveVpnApiClient::GetSubscriberCredentialV12,
-                    kTestSkusCredential, kTestEnvironment);
-  ASSERT_FALSE(result.has_value());
-  EXPECT_EQ(result.error(), net::ErrorToString(net::ERR_TIMED_OUT));
+TEST_P(BraveVpnApiClientGetSubscriberCredentialV12Test, MapsResponseToResult) {
+  const auto& test_case = GetParam();
+  MockResponseFor<endpoints::GetSubscriberCredentialV12>(url_loader_factory_,
+                                                         test_case.response);
+  EXPECT_EQ(CallClientApi(&BraveVpnApiClient::GetSubscriberCredentialV12,
+                          kTestSkusCredential, kTestEnvironment),
+            test_case.expected);
 }
 
-// A non-2xx response whose body is not a parseable error falls back to the HTTP
-// status description (the status_code branch of DescribeTransportFailure).
-TEST_F(BraveVpnApiClientTest, HttpErrorWithUnparseableBodyDescribesStatus) {
-  url_loader_factory_.AddResponse(
-      endpoints::GetSubscriberCredentialV12::URL().spec(), "not json at all",
-      net::HTTP_INTERNAL_SERVER_ERROR);
-
-  const auto result =
-      CallClientApi(&BraveVpnApiClient::GetSubscriberCredentialV12,
-                    kTestSkusCredential, kTestEnvironment);
-  ASSERT_FALSE(result.has_value());
-  EXPECT_EQ(result.error(),
-            absl::StrFormat("Unexpected HTTP status: %d",
-                            static_cast<int>(net::HTTP_INTERNAL_SERVER_ERROR)));
-}
-
-// API-specific tests.
-
-TEST_F(BraveVpnApiClientTest, GetSubscriberCredentialV12_Success) {
-  url_loader_factory_.AddResponse(
-      endpoints::GetSubscriberCredentialV12::URL().spec(),
-      absl::StrFormat(R"({"subscriber-credential":"%s"})",
-                      kTestSubscriberCredential),
-      net::HTTP_OK);
-
-  const auto result =
-      CallClientApi(&BraveVpnApiClient::GetSubscriberCredentialV12,
-                    kTestSkusCredential, kTestEnvironment);
-  ASSERT_TRUE(result.has_value());
-  EXPECT_EQ(result.value(), kTestSubscriberCredential);
-}
-
-TEST_F(BraveVpnApiClientTest, GetSubscriberCredentialV12_RequestError) {
-  url_loader_factory_.AddResponse(
-      endpoints::GetSubscriberCredentialV12::URL().spec(),
-      R"({"error-title":"Token no longer valid.","error-message":"gone"})",
-      net::HTTP_BAD_REQUEST);
-
-  const auto result =
-      CallClientApi(&BraveVpnApiClient::GetSubscriberCredentialV12,
-                    kTestSkusCredential, kTestEnvironment);
-  ASSERT_FALSE(result.has_value());
-  EXPECT_EQ(result.error(), "Token no longer valid.");
-}
+INSTANTIATE_TEST_SUITE_P(
+    BraveVpnApiClientTests,
+    BraveVpnApiClientGetSubscriberCredentialV12Test,
+    testing::Values(
+        // A transport failure surfaces the net-error description, not an HTTP
+        // status.
+        GetSubscriberCredentialV12TestCase{
+            .test_name = "TransportErrorReturnsNetErrorString",
+            .response = {.net_error = net::ERR_TIMED_OUT},
+            .expected =
+                base::unexpected(net::ErrorToString(net::ERR_TIMED_OUT))},
+        // A non-2xx response whose body is not a parseable error falls back to
+        // the HTTP status description (the status_code branch of
+        // MaybeDescribeUnrecoverableResponse).
+        GetSubscriberCredentialV12TestCase{
+            .test_name = "HttpErrorWithUnparseableBodyDescribesStatus",
+            .response = {.net_error = net::OK,
+                         .status_code = net::HTTP_INTERNAL_SERVER_ERROR},
+            .expected = base::unexpected(absl::StrFormat(
+                "HTTP %d %s: body missing or failed to parse",
+                net::HTTP_INTERNAL_SERVER_ERROR,
+                net::GetHttpReasonPhrase(net::HTTP_INTERNAL_SERVER_ERROR)))},
+        // A 2xx response with a parseable success body yields the subscriber
+        // credential.
+        GetSubscriberCredentialV12TestCase{
+            .test_name = "Success",
+            .response = {.net_error = net::OK,
+                         .status_code = net::HTTP_OK,
+                         .body =
+                             endpoints::GetSubscriberCredentialV12SuccessBody{
+                                 .subscriber_credential =
+                                     kTestSubscriberCredential}},
+            .expected = base::ok(kTestSubscriberCredential)},
+        // A non-2xx response with a parseable error body surfaces its title.
+        GetSubscriberCredentialV12TestCase{
+            .test_name = "RequestError",
+            .response = {.net_error = net::OK,
+                         .status_code = net::HTTP_BAD_REQUEST,
+                         .body = base::unexpected(endpoints::VpnErrorBody{
+                             .error_title = "Token no longer valid.",
+                             .error_message = "gone"})},
+            .expected = base::unexpected("Token no longer valid.")}),
+    [](const auto& info) { return info.param.test_name; });
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/api/error_body.h
+++ b/components/brave_vpn/browser/v2/api/error_body.h
@@ -1,0 +1,42 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_ERROR_BODY_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_ERROR_BODY_H_
+
+#include <optional>
+#include <string>
+
+#include "base/values.h"
+
+namespace brave_vpn::v2::endpoints {
+
+inline constexpr char kErrorTitleKey[] = "error-title";
+inline constexpr char kErrorMessageKey[] = "error-message";
+
+// Error body for Guardian VPN endpoints. Per Guardian's API docs, every non-200
+// and non-201 response from both the Connect API and the SGW (per-node) API
+// uses the same shape, so one type covers every endpoint group.
+struct VpnErrorBody {
+  std::string error_title;
+  std::string error_message;
+
+  static std::optional<VpnErrorBody> FromValue(const base::Value& value) {
+    const auto* dict = value.GetIfDict();
+    if (!dict) {
+      return std::nullopt;
+    }
+    const auto* title = dict->FindString(kErrorTitleKey);
+    const auto* message = dict->FindString(kErrorMessageKey);
+    if (!title || !message) {
+      return std::nullopt;
+    }
+    return VpnErrorBody{.error_title = *title, .error_message = *message};
+  }
+};
+
+}  // namespace brave_vpn::v2::endpoints
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_ERROR_BODY_H_

--- a/components/brave_vpn/browser/v2/api/error_body.h
+++ b/components/brave_vpn/browser/v2/api/error_body.h
@@ -35,6 +35,12 @@ struct VpnErrorBody {
     }
     return VpnErrorBody{.error_title = *title, .error_message = *message};
   }
+
+  base::DictValue ToValue() const {
+    return base::DictValue()
+        .Set(kErrorTitleKey, error_title)
+        .Set(kErrorMessageKey, error_message);
+  }
 };
 
 }  // namespace brave_vpn::v2::endpoints

--- a/components/brave_vpn/browser/v2/api/purchase_endpoints.h
+++ b/components/brave_vpn/browser/v2/api/purchase_endpoints.h
@@ -1,0 +1,77 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_PURCHASE_ENDPOINTS_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_PURCHASE_ENDPOINTS_H_
+
+#include <optional>
+#include <string>
+
+#include "base/strings/strcat.h"
+#include "base/values.h"
+#include "brave/components/brave_account/endpoint_client/request_types.h"
+#include "brave/components/brave_account/endpoint_client/response.h"
+#include "brave/components/brave_vpn/browser/v2/api/error_body.h"
+#include "brave/components/brave_vpn/common/brave_vpn_constants.h"
+#include "url/gurl.h"
+#include "url/url_constants.h"
+
+// Purchase/subscription validation endpoints all hit the fixed Guardian account
+// host (kVpnHost).
+
+namespace brave_vpn::v2::endpoints {
+
+inline constexpr char kValidationMethodKey[] = "validation-method";
+inline constexpr char kValidationMethodValue[] = "brave-premium";
+inline constexpr char kSkusCredentialKey[] = "brave-vpn-premium-monthly-pass";
+inline constexpr char kSubscriberCredentialKey[] = "subscriber-credential";
+
+// GetSubscriberCredentialV12 API exchanges a SKUs credential for a subscriber
+// credential.
+struct GetSubscriberCredentialV12RequestBody {
+  std::string validation_method = kValidationMethodValue;
+  std::string skus_credential;
+
+  base::DictValue ToValue() const {
+    return base::DictValue()
+        .Set(kValidationMethodKey, validation_method)
+        .Set(kSkusCredentialKey, skus_credential);
+  }
+};
+
+struct GetSubscriberCredentialV12ResponseBody {
+  std::string subscriber_credential;
+
+  static std::optional<GetSubscriberCredentialV12ResponseBody> FromValue(
+      const base::Value& value) {
+    const auto* dict = value.GetIfDict();
+    if (!dict) {
+      return std::nullopt;
+    }
+    const auto* credential = dict->FindString(kSubscriberCredentialKey);
+    if (!credential) {
+      return std::nullopt;
+    }
+    return GetSubscriberCredentialV12ResponseBody{.subscriber_credential =
+                                                      *credential};
+  }
+};
+
+struct GetSubscriberCredentialV12 {
+  using Request = brave_account::endpoint_client::POST<
+      GetSubscriberCredentialV12RequestBody>;
+  using Response = brave_account::endpoint_client::
+      Response<GetSubscriberCredentialV12ResponseBody, VpnErrorBody>;
+
+  static GURL URL() {
+    return GURL(base::StrCat({url::kHttpsScheme, url::kStandardSchemeSeparator,
+                              kVpnHost}))
+        .Resolve(kCreateSubscriberCredentialV12);
+  }
+};
+
+}  // namespace brave_vpn::v2::endpoints
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_PURCHASE_ENDPOINTS_H_

--- a/components/brave_vpn/browser/v2/api/purchase_endpoints.h
+++ b/components/brave_vpn/browser/v2/api/purchase_endpoints.h
@@ -31,20 +31,19 @@ inline constexpr char kSubscriberCredentialKey[] = "subscriber-credential";
 // GetSubscriberCredentialV12 API exchanges a SKUs credential for a subscriber
 // credential.
 struct GetSubscriberCredentialV12RequestBody {
-  std::string validation_method = kValidationMethodValue;
   std::string skus_credential;
 
   base::DictValue ToValue() const {
     return base::DictValue()
-        .Set(kValidationMethodKey, validation_method)
+        .Set(kValidationMethodKey, kValidationMethodValue)
         .Set(kSkusCredentialKey, skus_credential);
   }
 };
 
-struct GetSubscriberCredentialV12ResponseBody {
+struct GetSubscriberCredentialV12SuccessBody {
   std::string subscriber_credential;
 
-  static std::optional<GetSubscriberCredentialV12ResponseBody> FromValue(
+  static std::optional<GetSubscriberCredentialV12SuccessBody> FromValue(
       const base::Value& value) {
     const auto* dict = value.GetIfDict();
     if (!dict) {
@@ -54,8 +53,13 @@ struct GetSubscriberCredentialV12ResponseBody {
     if (!credential) {
       return std::nullopt;
     }
-    return GetSubscriberCredentialV12ResponseBody{.subscriber_credential =
-                                                      *credential};
+    return GetSubscriberCredentialV12SuccessBody{.subscriber_credential =
+                                                     *credential};
+  }
+
+  base::DictValue ToValue() const {
+    return base::DictValue().Set(kSubscriberCredentialKey,
+                                 subscriber_credential);
   }
 };
 
@@ -63,7 +67,7 @@ struct GetSubscriberCredentialV12 {
   using Request = brave_account::endpoint_client::POST<
       GetSubscriberCredentialV12RequestBody>;
   using Response = brave_account::endpoint_client::
-      Response<GetSubscriberCredentialV12ResponseBody, VpnErrorBody>;
+      Response<GetSubscriberCredentialV12SuccessBody, VpnErrorBody>;
 
   static GURL URL() {
     return GURL(base::StrCat({url::kHttpsScheme, url::kStandardSchemeSeparator,

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl.cc
@@ -16,23 +16,28 @@
 #include "base/notimplemented.h"
 #include "base/sequence_checker.h"
 #include "base/types/to_address.h"
+#include "brave/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h"
 #include "brave/components/brave_vpn/browser/v2/purchased_state_manager.h"
 #include "brave/components/brave_vpn/browser/v2/skus_service_client.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
 
 namespace brave_vpn::v2 {
 
 BraveVpnServiceImpl::BraveVpnServiceImpl(
     PrefService* local_prefs,
     PrefService* profile_prefs,
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     GetSkusServiceCallback skus_service_getter)
     : profile_prefs_(CHECK_DEREF(profile_prefs)),
+      api_client_(
+          std::make_unique<BraveVpnApiClient>(std::move(url_loader_factory))),
       skus_client_(
           std::make_unique<SkusServiceClient>(std::move(skus_service_getter))),
       connection_state_(mojom::ConnectionState::DISCONNECTED) {
   DCHECK(IsBraveVPNFeatureEnabled());
   purchased_state_manager_ = std::make_unique<PurchasedStateManager>(
-      local_prefs, skus_client_.get(),
+      local_prefs, api_client_.get(), skus_client_.get(),
       base::BindRepeating(&BraveVpnServiceImpl::OnPurchasedStateChanged,
                           base::Unretained(this)));
 }
@@ -86,6 +91,7 @@ void BraveVpnServiceImpl::GetAllRegions(GetAllRegionsCallback callback) {
 
 void BraveVpnServiceImpl::Shutdown() {
   purchased_state_manager_.reset();
+  api_client_.reset();
   skus_client_->Reset();
   BraveVpnService::Shutdown();
 }

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl.h
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl.h
@@ -16,17 +16,24 @@
 #include "brave/components/brave_vpn/browser/v2/skus_service_client.h"
 #include "build/build_config.h"
 
+namespace network {
+class SharedURLLoaderFactory;
+}  // namespace network
+
 class PrefService;
 
 namespace brave_vpn::v2 {
 
+class BraveVpnApiClient;
 class PurchasedStateManager;
 
 class BraveVpnServiceImpl : public BraveVpnService {
  public:
-  BraveVpnServiceImpl(PrefService* local_prefs,
-                      PrefService* profile_prefs,
-                      GetSkusServiceCallback skus_service_getter);
+  BraveVpnServiceImpl(
+      PrefService* local_prefs,
+      PrefService* profile_prefs,
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+      GetSkusServiceCallback skus_service_getter);
   ~BraveVpnServiceImpl() override;
 
   BraveVpnServiceImpl(const BraveVpnServiceImpl&) = delete;
@@ -131,6 +138,7 @@ class BraveVpnServiceImpl : public BraveVpnService {
                                std::optional<std::string> description);
 
   const raw_ref<PrefService> profile_prefs_;
+  std::unique_ptr<BraveVpnApiClient> api_client_;
   std::unique_ptr<SkusServiceClient> skus_client_;
   std::unique_ptr<PurchasedStateManager> purchased_state_manager_;
   [[maybe_unused]] mojom::ConnectionState connection_state_;

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl_unittest.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl_unittest.cc
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "base/functional/bind.h"
+#include "base/memory/scoped_refptr.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
 #include "base/test/test_future.h"
@@ -25,6 +26,9 @@
 #include "components/prefs/testing_pref_service.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
+#include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace brave_vpn::v2 {
@@ -43,6 +47,9 @@ class BraveVpnServiceImplTest : public testing::Test {
   void SetUp() override {
     brave_vpn::RegisterLocalStatePrefs(local_pref_service_.registry());
     brave_vpn::RegisterProfilePrefs(profile_pref_service_.registry());
+    shared_url_loader_factory_ =
+        base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
+            &url_loader_factory_);
   }
 
   mojo::PendingRemote<skus::mojom::SkusService> GetSkusService() {
@@ -53,6 +60,7 @@ class BraveVpnServiceImplTest : public testing::Test {
   void CreateService() {
     service_ = std::make_unique<BraveVpnServiceImpl>(
         &local_pref_service_, &profile_pref_service_,
+        shared_url_loader_factory_,
         base::BindRepeating(&BraveVpnServiceImplTest::GetSkusService,
                             base::Unretained(this)));
   }
@@ -64,6 +72,8 @@ class BraveVpnServiceImplTest : public testing::Test {
   base::test::ScopedFeatureList scoped_feature_list_;
   TestingPrefServiceSimple local_pref_service_;
   sync_preferences::TestingPrefServiceSyncable profile_pref_service_;
+  network::TestURLLoaderFactory url_loader_factory_;
+  scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
   skus::FakeSkusService fake_skus_service_;
   int skus_bind_count_ = 0;
   // Declared last so it is destroyed before the prefs and the fake SKUS

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl_unittest.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl_unittest.cc
@@ -10,7 +10,6 @@
 #include <string>
 
 #include "base/functional/bind.h"
-#include "base/memory/scoped_refptr.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
 #include "base/test/test_future.h"
@@ -26,7 +25,6 @@
 #include "components/prefs/testing_pref_service.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
-#include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -47,9 +45,6 @@ class BraveVpnServiceImplTest : public testing::Test {
   void SetUp() override {
     brave_vpn::RegisterLocalStatePrefs(local_pref_service_.registry());
     brave_vpn::RegisterProfilePrefs(profile_pref_service_.registry());
-    shared_url_loader_factory_ =
-        base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
-            &url_loader_factory_);
   }
 
   mojo::PendingRemote<skus::mojom::SkusService> GetSkusService() {
@@ -60,7 +55,7 @@ class BraveVpnServiceImplTest : public testing::Test {
   void CreateService() {
     service_ = std::make_unique<BraveVpnServiceImpl>(
         &local_pref_service_, &profile_pref_service_,
-        shared_url_loader_factory_,
+        url_loader_factory_.GetSafeWeakWrapper(),
         base::BindRepeating(&BraveVpnServiceImplTest::GetSkusService,
                             base::Unretained(this)));
   }
@@ -73,7 +68,6 @@ class BraveVpnServiceImplTest : public testing::Test {
   TestingPrefServiceSimple local_pref_service_;
   sync_preferences::TestingPrefServiceSyncable profile_pref_service_;
   network::TestURLLoaderFactory url_loader_factory_;
-  scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
   skus::FakeSkusService fake_skus_service_;
   int skus_bind_count_ = 0;
   // Declared last so it is destroyed before the prefs and the fake SKUS

--- a/components/brave_vpn/browser/v2/credential_store.cc
+++ b/components/brave_vpn/browser/v2/credential_store.cc
@@ -111,7 +111,7 @@ bool CredentialStore::HasAnyCredential() const {
 }
 
 std::optional<base::Time> CredentialStore::GetExpirationTime() const {
-  if (!HasValidSubscriberCredential()) {
+  if (!HasValidSkusCredential() && !HasValidSubscriberCredential()) {
     return std::nullopt;
   }
   const base::DictValue& dict =

--- a/components/brave_vpn/browser/v2/credential_store.h
+++ b/components/brave_vpn/browser/v2/credential_store.h
@@ -51,9 +51,8 @@ class CredentialStore final {
   // True if anything at all is cached, valid or not.
   bool HasAnyCredential() const;
 
-  // Expiration of the currently cached subscriber credential, used to drive the
-  // refresh timer. Returns nullopt unless a valid subscriber credential is
-  // present.
+  // Expiration of the currently cached credential, used to drive the refresh
+  // timer. Returns nullopt unless any valid credential is present.
   std::optional<base::Time> GetExpirationTime() const;
 
   // Drops the cached credential only. Delegates to the common utility

--- a/components/brave_vpn/browser/v2/credential_store_unittest.cc
+++ b/components/brave_vpn/browser/v2/credential_store_unittest.cc
@@ -79,10 +79,16 @@ TEST_F(CredentialStoreTest, SkusCredentialRoundTripAndLastExpiryStamp) {
   EXPECT_EQ(prefs_.GetTime(prefs::kBraveVPNLastCredentialExpiry), Future());
 }
 
-TEST_F(CredentialStoreTest, ExpirationTimeRequiresSubscriberCredential) {
+TEST_F(CredentialStoreTest, ExpirationTimeRequiresValidCredential) {
+  ASSERT_FALSE(store_.GetExpirationTime().has_value());
+
   store_.SetSkusCredential(kTestSkusCredential, Future());
   EXPECT_TRUE(store_.HasValidSkusCredential());
-  EXPECT_FALSE(store_.GetExpirationTime().has_value());
+  EXPECT_TRUE(store_.GetExpirationTime().has_value());
+
+  store_.SetSubscriberCredential(kTestCredential, Future());
+  EXPECT_TRUE(store_.HasValidSubscriberCredential());
+  EXPECT_TRUE(store_.GetExpirationTime().has_value());
 }
 
 TEST_F(CredentialStoreTest, SettingSubscriberDropsSkus) {

--- a/components/brave_vpn/browser/v2/purchased_state_manager.cc
+++ b/components/brave_vpn/browser/v2/purchased_state_manager.cc
@@ -19,9 +19,12 @@
 #include "base/task/sequenced_task_runner.h"
 #include "base/time/time.h"
 #include "base/timer/timer.h"
+#include "base/types/expected.h"
+#include "brave/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h"
 #include "brave/components/brave_vpn/browser/v2/credential_store.h"
 #include "brave/components/brave_vpn/browser/v2/credential_summary.h"
 #include "brave/components/brave_vpn/browser/v2/skus_service_client.h"
+#include "brave/components/brave_vpn/common/brave_vpn_constants.h"
 #include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
 #include "brave/components/skus/browser/skus_utils.h"
@@ -39,9 +42,11 @@ namespace brave_vpn::v2 {
 
 PurchasedStateManager::PurchasedStateManager(
     PrefService* local_prefs,
+    BraveVpnApiClient* api_client,
     SkusServiceClient* skus_client,
     PurchasedStateChangedCallback callback)
     : local_prefs_(CHECK_DEREF(local_prefs)),
+      api_client_(CHECK_DEREF(api_client)),
       skus_client_(CHECK_DEREF(skus_client)),
       purchased_state_changed_callback_(std::move(callback)),
       credential_store_(std::make_unique<CredentialStore>(local_prefs)) {
@@ -92,15 +97,18 @@ void PurchasedStateManager::Load(const std::string& domain) {
                  "credential";
       BeginLoad(request_environment);
 
-      // TODO(https://github.com/brave/brave-browser/issues/54600)
-      // The API request class is intentionally not wired up yet. Once it is,
-      // this will call GetSubscriberCredentialV12, binding the current loading
-      // sequence into the callback.
-      // NOTE: exchange failures must settle as FAILED, not NOT_PURCHASED (v1
-      // Android uses NOT_PURCHASED). FinishLoad() clears the credential store
-      // on NOT_PURCHASED, which would destroy the cached SKUS credential that
-      // the exchange-retry fast path depends on.
-      NOTIMPLEMENTED();
+      // The cached SKUS credential must have an expiration time, because the
+      // store only retains valid SKUS credentials.
+      std::optional<base::Time> expiration_time =
+          credential_store_->GetExpirationTime();
+      CHECK(expiration_time.has_value());
+
+      // Exchange the cached SKUS credential for a subscriber credential.
+      api_client_->GetSubscriberCredentialV12(
+          base::BindOnce(&PurchasedStateManager::OnGetSubscriberCredential,
+                         weak_factory_.GetWeakPtr(), loading_sequence_, domain,
+                         expiration_time.value()),
+          credential_store_->GetSkusCredential(), loading_environment_);
       return;
     }
   }
@@ -210,16 +218,6 @@ void PurchasedStateManager::FinishLoad(std::string env,
   loading_environment_.clear();
   load_timeout_timer_.Stop();
   SetPurchasedState(env, state, std::move(description));
-
-  // If we know that we're not purchased for the current environment, clear any
-  // cached credentials. This prevents stale credentials from being used in
-  // future loads.
-  if (env == GetCurrentEnvironment() &&
-      (state == mojom::PurchasedState::NOT_PURCHASED ||
-       state == mojom::PurchasedState::SESSION_EXPIRED ||
-       state == mojom::PurchasedState::OUT_OF_CREDENTIALS)) {
-    credential_store_->Clear();
-  }
 
   // A silent (non-current-environment) load ended without committing. If it
   // previously cancelled a visible load, the visible state may be stranded at
@@ -389,15 +387,69 @@ void PurchasedStateManager::OnPrepareCredentialsPresentation(
   local_prefs_->SetTime(prefs::kBraveVPNSessionExpiredDate, {});
 #endif
 
-  // TODO(https://github.com/brave/brave-browser/issues/54600)
-  // The API request class is intentionally not wired up yet. Once it is,
-  // this will call GetSubscriberCredentialV12, binding the current loading
-  // sequence into the callback.
-  // NOTE: exchange failures must settle as FAILED, not NOT_PURCHASED (v1
-  // Android uses NOT_PURCHASED). FinishLoad() clears the credential store on
-  // NOT_PURCHASED, which would destroy the cached SKUS credential that the
-  // exchange-retry fast path depends on.
-  NOTIMPLEMENTED();
+  // Exchange the cached SKUS credential for a subscriber credential.
+  api_client_->GetSubscriberCredentialV12(
+      base::BindOnce(&PurchasedStateManager::OnGetSubscriberCredential,
+                     weak_factory_.GetWeakPtr(), loading_sequence_, domain,
+                     time),
+      credential, loading_environment_);
+}
+
+void PurchasedStateManager::OnGetSubscriberCredential(
+    uint64_t sequence,
+    const std::string& domain,
+    const base::Time& expiration_time,
+    base::expected<std::string, std::string> result) {
+  if (sequence != loading_sequence_) {
+    VLOG(2) << __func__ << ": Ignoring response of a stale load";
+    return;
+  }
+  if (!skus::DomainIsForProduct(domain, skus::GetVpnProductPrefix())) {
+    VLOG(2) << __func__ << ": Called for non-vpn product";
+    return;
+  }
+
+  if (!result.has_value()) {
+    VLOG(1) << __func__ << ": Failed to get subscriber credential ("
+            << result.error() << ")";
+
+    const bool token_no_longer_valid =
+        result.error() == ::brave_vpn::kTokenNoLongerValid;
+
+    // "Token no longer valid" means the credential was already consumed. Make
+    // one more attempt with a fresh SKUS credential (two attempts total).
+    if (token_no_longer_valid) {
+      if (!credential_store_->IsExchangeRetried()) {
+        VLOG(2) << __func__
+                << "Token no longer valid, retrying with fresh SKUS credential";
+        // Set the retried flag before re-requesting so a synchronous callback
+        // won't loop forever.
+        credential_store_->SetExchangeRetried(true);
+        // As we request a new credential, clear the cached value.
+        credential_store_->Clear();
+        RequestCredentialSummary(domain);
+      } else {
+        // The retry also came back invalid: the token is definitively no good.
+        VLOG(2) << __func__ << ": Token no longer valid after retry";
+        FinishLoad(
+            loading_environment_, mojom::PurchasedState::FAILED,
+            l10n_util::GetStringUTF8(IDS_BRAVE_VPN_PURCHASE_TOKEN_NOT_VALID));
+      }
+    } else {
+      // Otherwise it's a transient vendor/network error. The cached credential
+      // will eventually expire and a new one will be fetched.
+      VLOG(2) << __func__ << ": Transient error, will retry later";
+      FinishLoad(loading_environment_, mojom::PurchasedState::FAILED,
+                 l10n_util::GetStringUTF8(
+                     IDS_BRAVE_VPN_PURCHASE_CREDENTIALS_FETCH_FAILED));
+    }
+    return;
+  }
+
+  // Got a valid subscriber credential.
+  credential_store_->SetSubscriberCredential(result.value(), expiration_time);
+  ScheduleSubscriberCredentialRefresh();
+  FinishLoad(loading_environment_, mojom::PurchasedState::PURCHASED);
 }
 
 void PurchasedStateManager::RunPurchasedStateCallback(

--- a/components/brave_vpn/browser/v2/purchased_state_manager.cc
+++ b/components/brave_vpn/browser/v2/purchased_state_manager.cc
@@ -89,26 +89,30 @@ void PurchasedStateManager::Load(const std::string& domain) {
       SetPurchasedState(request_environment, mojom::PurchasedState::PURCHASED);
       return;
     }
-
-    if (credential_store_->HasValidSkusCredential()) {
+    // The valid cached SKUS credential must have an expiration time, because
+    // the store only reports valid credentials. However, both GetSkusCredential
+    // and GetExpirationTime re-evaluate validity against current time, so a
+    // credential expiring between the two reads can make them disagree. We're
+    // checking for both valid credential and expiration time here to avoid
+    // TOCTOU issues.
+    const std::string skus_credential = credential_store_->GetSkusCredential();
+    const std::optional<base::Time> expiration_time =
+        credential_store_->GetExpirationTime();
+    if (!skus_credential.empty() && expiration_time.has_value()) {
       // Previous attempt to exchange the skus credential for a subscriber
       // credential failed. Try again with the cached skus credential.
       VLOG(2) << "Trying to exchange cached skus credential for subscriber "
                  "credential";
       BeginLoad(request_environment);
 
-      // The cached SKUS credential must have an expiration time, because the
-      // store only retains valid SKUS credentials.
-      std::optional<base::Time> expiration_time =
-          credential_store_->GetExpirationTime();
-      CHECK(expiration_time.has_value());
-
-      // Exchange the cached SKUS credential for a subscriber credential.
+      // Exchange the cached SKUS credential for a subscriber credential. The
+      // valid cached SKUS credential must have an expiration time, because the
+      // store only reports valid SKUS credentials.
       api_client_->GetSubscriberCredentialV12(
           base::BindOnce(&PurchasedStateManager::OnGetSubscriberCredential,
                          weak_factory_.GetWeakPtr(), loading_sequence_, domain,
-                         expiration_time.value()),
-          credential_store_->GetSkusCredential(), loading_environment_);
+                         *expiration_time),
+          skus_credential, loading_environment_);
       return;
     }
   }
@@ -402,10 +406,6 @@ void PurchasedStateManager::OnGetSubscriberCredential(
     base::expected<std::string, std::string> result) {
   if (sequence != loading_sequence_) {
     VLOG(2) << __func__ << ": Ignoring response of a stale load";
-    return;
-  }
-  if (!skus::DomainIsForProduct(domain, skus::GetVpnProductPrefix())) {
-    VLOG(2) << __func__ << ": Called for non-vpn product";
     return;
   }
 

--- a/components/brave_vpn/browser/v2/purchased_state_manager.h
+++ b/components/brave_vpn/browser/v2/purchased_state_manager.h
@@ -16,6 +16,7 @@
 #include "base/memory/weak_ptr.h"
 #include "base/time/time.h"
 #include "base/timer/timer.h"
+#include "base/types/expected.h"
 #include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"
 #include "brave/components/skus/common/skus_sdk.mojom-forward.h"
 #include "build/build_config.h"
@@ -23,7 +24,7 @@
 class PrefService;
 
 namespace brave_vpn::v2 {
-
+class BraveVpnApiClient;
 class CredentialStore;
 class SkusServiceClient;
 
@@ -60,6 +61,7 @@ class PurchasedStateManager final {
   static constexpr base::TimeDelta kLoadTimeout = base::Seconds(30);
 
   PurchasedStateManager(PrefService* local_prefs,
+                        BraveVpnApiClient* api_client,
                         SkusServiceClient* skus_client,
                         PurchasedStateChangedCallback callback);
   ~PurchasedStateManager();
@@ -97,6 +99,11 @@ class PurchasedStateManager final {
       uint64_t sequence,
       const std::string& domain,
       skus::mojom::SkusResultPtr credential_as_cookie);
+  void OnGetSubscriberCredential(
+      uint64_t sequence,
+      const std::string& domain,
+      const base::Time& expiration_time,
+      base::expected<std::string, std::string> result);
   void RunPurchasedStateCallback(mojom::PurchasedState state,
                                  std::optional<std::string> description);
   void ScheduleSubscriberCredentialRefresh();
@@ -106,6 +113,7 @@ class PurchasedStateManager final {
 #endif
 
   const raw_ref<PrefService> local_prefs_;
+  const raw_ref<BraveVpnApiClient> api_client_;
   const raw_ref<SkusServiceClient> skus_client_;
   PurchasedStateChangedCallback purchased_state_changed_callback_;
   std::unique_ptr<CredentialStore> credential_store_;

--- a/components/brave_vpn/browser/v2/purchased_state_manager_unittest.cc
+++ b/components/brave_vpn/browser/v2/purchased_state_manager_unittest.cc
@@ -27,9 +27,12 @@
 #include "base/test/test_future.h"
 #include "base/test/values_test_util.h"
 #include "base/time/time.h"
+#include "base/types/expected.h"
 #include "base/values.h"
+#include "brave/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h"
 #include "brave/components/brave_vpn/browser/v2/credential_store.h"
 #include "brave/components/brave_vpn/browser/v2/skus_service_client.h"
+#include "brave/components/brave_vpn/common/brave_vpn_constants.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
@@ -44,14 +47,17 @@
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/testing_pref_service.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
+#include "net/http/http_status_code.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
 #include "ui/base/l10n/l10n_util.h"
 
 namespace brave_vpn::v2 {
 namespace {
-constexpr char kTestCredential[] = "test-credential";
+constexpr char kTestSkusCredential[] = "test-skus-credential";
+constexpr char kTestSubscriberCredential[] = "test-subscriber-credential";
 constexpr char kNonVpnDomain[] = "talk.brave.com";
 
 // Credential-summary payloads for each terminal branch.
@@ -214,6 +220,42 @@ class StateChangeCollector {
   base::OnceClosure quit_closure_;
 };
 
+class FakeBraveVpnApiClient : public BraveVpnApiClient {
+ public:
+  FakeBraveVpnApiClient() : BraveVpnApiClient(nullptr) {}
+  ~FakeBraveVpnApiClient() override = default;
+
+  void GetSubscriberCredentialV12(SubscriberCredentialCallback callback,
+                                  const std::string& skus_credential,
+                                  const std::string& environment) override {
+    ++get_subscriber_credential_calls_;
+    last_skus_credential_ = skus_credential;
+    last_environment_ = environment;
+    pending_callback_ = std::move(callback);
+  }
+
+  int get_subscriber_credential_calls() const {
+    return get_subscriber_credential_calls_;
+  }
+  const std::string& last_skus_credential() const {
+    return last_skus_credential_;
+  }
+  const std::string& last_environment() const { return last_environment_; }
+
+  bool HasPendingExchange() const { return !pending_callback_.is_null(); }
+
+  void ResolveExchange(base::expected<std::string, std::string> result) {
+    ASSERT_FALSE(pending_callback_.is_null());
+    std::move(pending_callback_).Run(std::move(result));
+  }
+
+ private:
+  int get_subscriber_credential_calls_ = 0;
+  std::string last_skus_credential_;
+  std::string last_environment_;
+  SubscriberCredentialCallback pending_callback_;
+};
+
 class FakeSkusServiceClient : public SkusServiceClient {
  public:
   FakeSkusServiceClient()
@@ -267,7 +309,8 @@ class PurchasedStateManagerTest : public testing::Test {
 
   void CreateManager() {
     manager_ = std::make_unique<PurchasedStateManager>(
-        &local_pref_service_, &skus_client_, collector_.GetCallback());
+        &local_pref_service_, &api_client_, &skus_client_,
+        collector_.GetCallback());
   }
 
   // Environment/domain helpers. The "current" environment is whatever the
@@ -310,8 +353,21 @@ class PurchasedStateManagerTest : public testing::Test {
                                                std::move(result));
   }
 
+  void CallOnGetSubscriberCredential(
+      uint64_t sequence,
+      const std::string& domain,
+      const base::Time& expiration_time,
+      base::expected<std::string, std::string> result) {
+    manager_->OnGetSubscriberCredential(sequence, domain, expiration_time,
+                                        std::move(result));
+  }
+
   void SeedSubscriberCredential(base::Time expiration) {
-    credential_store_.SetSubscriberCredential(kTestCredential, expiration);
+    credential_store_.SetSubscriberCredential(kTestSubscriberCredential,
+                                              expiration);
+  }
+  void SeedSkusCredential(base::Time expiration) {
+    credential_store_.SetSkusCredential(kTestSkusCredential, expiration);
   }
   bool HasAnyStoredCredential() const {
     return credential_store_.HasAnyCredential();
@@ -323,6 +379,7 @@ class PurchasedStateManagerTest : public testing::Test {
   TestingPrefServiceSimple local_pref_service_;
   CredentialStore credential_store_{&local_pref_service_};
   StateChangeCollector collector_;
+  FakeBraveVpnApiClient api_client_;
   FakeSkusServiceClient skus_client_;
   std::unique_ptr<PurchasedStateManager> manager_;
 };
@@ -593,28 +650,111 @@ TEST_F(PurchasedStateManagerTest, LateResponseAfterTimeoutIsDropped) {
   EXPECT_EQ(manager_->GetInfo().state, mojom::PurchasedState::FAILED);
 }
 
-// An authoritative non-purchased verdict for the current environment drops
-// the cached credential.
-TEST_F(PurchasedStateManagerTest, FinishLoadClearsCredentialsOnNotPurchased) {
+// The exchange succeeds: the subscriber credential is cached with the SKUS
+// credential's expiry, it replaces the SKUS credential in the shared slot, and
+// the load settles PURCHASED.
+TEST_F(PurchasedStateManagerTest, ExchangeSuccessCachesSubscriberAndPurchases) {
   CreateManager();
-  SeedSubscriberCredential(base::Time::Now() - base::Days(1));
-  ASSERT_TRUE(HasAnyStoredCredential());
-  manager_->Load(CurrentDomain());
+  const base::Time expiry = base::Time::Now() + base::Days(30);
+  SeedSkusCredential(expiry);
+  manager_->Load(
+      CurrentDomain());  // Valid SKUS credential -> exchange fast path.
+  ASSERT_TRUE(api_client_.HasPendingExchange());
+  EXPECT_EQ(api_client_.last_skus_credential(), kTestSkusCredential);
+  EXPECT_EQ(api_client_.last_environment(), CurrentEnvironment());
 
-  CallFinishLoad(CurrentEnvironment(), mojom::PurchasedState::NOT_PURCHASED);
-  EXPECT_FALSE(HasAnyStoredCredential());
+  api_client_.ResolveExchange(base::ok(std::string(kTestSubscriberCredential)));
+
+  EXPECT_TRUE(loading_environment().empty());
+  EXPECT_TRUE(manager_->IsPurchased());
+  EXPECT_EQ(credential_store_.GetSubscriberCredential(),
+            kTestSubscriberCredential);
+  ASSERT_TRUE(credential_store_.GetExpirationTime().has_value());
+  EXPECT_EQ(*credential_store_.GetExpirationTime(),
+            expiry);                                         // Borrowed expiry.
+  EXPECT_FALSE(credential_store_.HasValidSkusCredential());  // Slot replaced.
+  collector_.WaitForChangeCount(2);
+  EXPECT_EQ(collector_.changes()[1].first, mojom::PurchasedState::PURCHASED);
 }
 
-// FAILED is transient, not a verdict: the cached credential survives so the
-// next load can retry with it.
-TEST_F(PurchasedStateManagerTest, FinishLoadPreservesCredentialsOnFailed) {
+// A transient (non-"token no longer valid") exchange error fails the load with
+// a user-facing description but preserves the cached SKUS credential for retry.
+TEST_F(PurchasedStateManagerTest,
+       ExchangeTransientErrorFailsAndPreservesCache) {
   CreateManager();
-  SeedSubscriberCredential(base::Time::Now() - base::Days(1));
-  ASSERT_TRUE(HasAnyStoredCredential());
-  manager_->Load(CurrentDomain());
+  SeedSkusCredential(base::Time::Now() + base::Days(30));
+  manager_->Load(CurrentDomain());  // Valid SKUS credential for the fast path.
+  ASSERT_TRUE(api_client_.HasPendingExchange());
 
-  CallFinishLoad(CurrentEnvironment(), mojom::PurchasedState::FAILED);
-  EXPECT_TRUE(HasAnyStoredCredential());
+  api_client_.ResolveExchange(base::unexpected(std::string("network down")));
+
+  EXPECT_TRUE(loading_environment().empty());
+  EXPECT_EQ(manager_->GetInfo().state, mojom::PurchasedState::FAILED);
+  EXPECT_TRUE(
+      credential_store_.HasValidSkusCredential());  // Preserved for retry.
+  collector_.WaitForChangeCount(2);
+  EXPECT_EQ(collector_.changes()[1].second,
+            l10n_util::GetStringUTF8(
+                IDS_BRAVE_VPN_PURCHASE_CREDENTIALS_FETCH_FAILED));
+}
+
+// "Token no longer valid" triggers exactly one retry: the stale credential is
+// cleared, a fresh summary is requested under the same cycle, and only a second
+// identical error fails the load as TOKEN_NOT_VALID.
+TEST_F(PurchasedStateManagerTest,
+       ExchangeTokenNoLongerValidRetriesOnceThenFails) {
+  CreateManager();
+  SeedSkusCredential(base::Time::Now() + base::Days(30));
+  manager_->Load(CurrentDomain());  // Valid SKUS credential for the fast path.
+  ASSERT_TRUE(api_client_.HasPendingExchange());
+  ASSERT_EQ(skus_client_.credential_summary_calls(),
+            0);  // Fast path skips summary.
+  const uint64_t sequence = loading_sequence();
+
+  // First failure: token consumed. Clears the credential and re-requests a
+  // summary under the same load - it does NOT finish.
+  api_client_.ResolveExchange(
+      base::unexpected(std::string(kTokenNoLongerValid)));
+  EXPECT_FALSE(HasAnyStoredCredential());
+  EXPECT_EQ(skus_client_.credential_summary_calls(), 1);
+  EXPECT_EQ(loading_environment(), CurrentEnvironment());
+  EXPECT_EQ(loading_sequence(), sequence);
+
+  // Drive the retry chain back to a second exchange.
+  CallOnCredentialSummary(loading_sequence(), CurrentDomain(),
+                          SkusOkResult(kValidSummary));
+  CallOnPrepareCredentialsPresentation(
+      loading_sequence(), CurrentDomain(),
+      SkusOkResult(BuildTestCookie(base::Time::Now() + base::Days(30))));
+  ASSERT_TRUE(api_client_.HasPendingExchange());
+
+  // Second identical failure: budget exhausted.
+  api_client_.ResolveExchange(
+      base::unexpected(std::string(kTokenNoLongerValid)));
+
+  EXPECT_TRUE(loading_environment().empty());
+  EXPECT_EQ(manager_->GetInfo().state, mojom::PurchasedState::FAILED);
+  collector_.WaitForChangeCount(2);
+  EXPECT_EQ(collector_.changes()[1].second,
+            l10n_util::GetStringUTF8(IDS_BRAVE_VPN_PURCHASE_TOKEN_NOT_VALID));
+}
+
+// A late exchange response for a cycle that already ended via timeout, is
+// dropped by the sequence check and cannot revive a settled state.
+TEST_F(PurchasedStateManagerTest, StaleExchangeResponseIsDropped) {
+  CreateManager();
+  SeedSkusCredential(base::Time::Now() + base::Days(30));
+  manager_->Load(CurrentDomain());  // Valid SKUS credential for the fast path.
+  ASSERT_TRUE(api_client_.HasPendingExchange());
+
+  task_environment_.FastForwardBy(PurchasedStateManager::kLoadTimeout);
+  ASSERT_EQ(manager_->GetInfo().state, mojom::PurchasedState::FAILED);
+
+  api_client_.ResolveExchange(base::ok(std::string(kTestSubscriberCredential)));
+
+  EXPECT_FALSE(manager_->IsPurchased());
+  EXPECT_FALSE(credential_store_.HasValidSubscriberCredential());
+  EXPECT_EQ(manager_->GetInfo().state, mojom::PurchasedState::FAILED);
 }
 
 // A silent load's verdict must not clear the current environment's credential
@@ -657,8 +797,7 @@ TEST_F(PurchasedStateManagerTest, UnparseableSummaryFailsLoad) {
   EXPECT_EQ(manager_->GetInfo().state, mojom::PurchasedState::FAILED);
 }
 
-TEST_F(PurchasedStateManagerTest,
-       EmptySummaryMeansNotPurchasedAndClearsCredentials) {
+TEST_F(PurchasedStateManagerTest, EmptySummaryMeansNotPurchased) {
   CreateManager();
   SeedSubscriberCredential(base::Time::Now() - base::Days(1));
   ASSERT_TRUE(HasAnyStoredCredential());
@@ -668,7 +807,6 @@ TEST_F(PurchasedStateManagerTest,
                           SkusOkResult(""));
 
   EXPECT_TRUE(loading_environment().empty());
-  EXPECT_FALSE(HasAnyStoredCredential());
   collector_.WaitForChangeCount(2);
   EXPECT_EQ(collector_.changes()[1].first,
             mojom::PurchasedState::NOT_PURCHASED);
@@ -903,7 +1041,7 @@ TEST_F(PurchasedStateManagerTest, CommitClearsSessionExpiredDate) {
 #else  // !BUILDFLAG(IS_ANDROID)
 
 // Android has no session-expired routing: an expired summary is an
-// authoritative non-purchased verdict, so the credential store is cleared.
+// authoritative non-purchased verdict.
 TEST_F(PurchasedStateManagerTest, ExpiredSummaryMeansNotPurchased) {
   CreateManager();
   SeedSubscriberCredential(base::Time::Now() - base::Days(1));
@@ -914,7 +1052,6 @@ TEST_F(PurchasedStateManagerTest, ExpiredSummaryMeansNotPurchased) {
 
   EXPECT_TRUE(loading_environment().empty());
   EXPECT_EQ(manager_->GetInfo().state, mojom::PurchasedState::NOT_PURCHASED);
-  EXPECT_FALSE(HasAnyStoredCredential());
 }
 
 #endif  // !BUILDFLAG(IS_ANDROID)
@@ -922,6 +1059,11 @@ TEST_F(PurchasedStateManagerTest, ExpiredSummaryMeansNotPurchased) {
 class PurchasedStateManagerWithRealSkusServiceTest
     : public PurchasedStateManagerTest {
  public:
+  struct StubHttpsResponse {
+    std::string body;
+    net::HttpStatusCode status = net::HTTP_OK;
+  };
+
   PurchasedStateManagerWithRealSkusServiceTest() : PurchasedStateManagerTest() {
     scoped_feature_list_.InitWithFeatures({skus::features::kSkusFeature}, {});
     skus::RegisterLocalStatePrefs(local_pref_service_.registry());
@@ -938,6 +1080,9 @@ class PurchasedStateManagerWithRealSkusServiceTest
     shared_url_loader_factory_ =
         base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
             &url_loader_factory_);
+    url_loader_factory_.SetInterceptor(base::BindRepeating(
+        &PurchasedStateManagerWithRealSkusServiceTest::Interceptor,
+        base::Unretained(this)));
     skus_service_ = std::make_unique<skus::SkusServiceImpl>(
         &local_pref_service_, url_loader_factory_.GetSafeWeakWrapper());
   }
@@ -972,16 +1117,43 @@ class PurchasedStateManagerWithRealSkusServiceTest
   void CreateManagerWithEmptySkusState() { CreateRealChain(); }
 
   void CreateRealChain() {
+    real_api_client_ = std::make_unique<BraveVpnApiClient>(
+        url_loader_factory_.GetSafeWeakWrapper());
     real_skus_client_ = std::make_unique<SkusServiceClient>(base::BindRepeating(
         &PurchasedStateManagerWithRealSkusServiceTest::GetSkusService,
         base::Unretained(this)));
     manager_ = std::make_unique<PurchasedStateManager>(
-        &local_pref_service_, real_skus_client_.get(),
+        &local_pref_service_, real_api_client_.get(), real_skus_client_.get(),
         collector_.GetCallback());
   }
 
   mojo::PendingRemote<skus::mojom::SkusService> GetSkusService() {
     return skus_service_->MakeRemote();
+  }
+
+  void SetInterceptorResponse(const std::string& response,
+                              net::HttpStatusCode status = net::HTTP_OK) {
+    interceptor_responses_ = {{response, status}};
+    interceptor_response_index_ = 0;
+  }
+
+  // Serve one response per successive intercepted request, in order (one per
+  // exchange attempt). The last entry repeats once the list is exhausted, so a
+  // stray request can't underflow the index.
+  void SetInterceptorResponseSequence(
+      std::vector<StubHttpsResponse> responses) {
+    CHECK(!responses.empty());
+    interceptor_responses_ = std::move(responses);
+    interceptor_response_index_ = 0;
+  }
+
+  void Interceptor(const network::ResourceRequest& request) {
+    url_loader_factory_.ClearResponses();
+    const StubHttpsResponse& response = interceptor_responses_[std::min(
+        interceptor_response_index_, interceptor_responses_.size() - 1)];
+    ++interceptor_response_index_;
+    url_loader_factory_.AddResponse(request.url.spec(), response.body,
+                                    response.status);
   }
 
   void WaitForCommitOrTerminalOutcome(size_t terminal_change_count) {
@@ -1007,8 +1179,11 @@ class PurchasedStateManagerWithRealSkusServiceTest
   base::test::ScopedFeatureList scoped_feature_list_;
   network::TestURLLoaderFactory url_loader_factory_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
+  std::unique_ptr<BraveVpnApiClient> real_api_client_;
   std::unique_ptr<skus::SkusServiceImpl> skus_service_;
   std::unique_ptr<SkusServiceClient> real_skus_client_;
+  std::vector<StubHttpsResponse> interceptor_responses_{{}};
+  size_t interceptor_response_index_ = 0;
 };
 
 // The full chain against the real SKUS: summary JSON parses, the presentation
@@ -1025,8 +1200,8 @@ TEST_F(PurchasedStateManagerWithRealSkusServiceTest,
   EXPECT_TRUE(credential_store_.HasValidSkusCredential());
   EXPECT_FALSE(credential_store_.GetSkusCredential().empty());
   EXPECT_EQ(manager_->GetCurrentEnvironment(), CurrentEnvironment());
-  EXPECT_EQ(loading_environment(), CurrentEnvironment());
-  EXPECT_EQ(manager_->GetInfo().state, mojom::PurchasedState::LOADING);
+  EXPECT_TRUE(loading_environment().empty());
+  EXPECT_EQ(manager_->GetInfo().state, mojom::PurchasedState::FAILED);
 }
 
 // PrepareCredentialsPresentation is idempotent within a credential's validity
@@ -1089,15 +1264,88 @@ TEST_F(PurchasedStateManagerWithRealSkusServiceTest,
   const std::string other_env = OtherEnvironment();
   manager_->Load(OtherDomain());
 
-  // The load is silent, so the first (and only) visible change is the
-  // post-commit LOADING for the new current environment.
-  WaitForCommitOrTerminalOutcome(1);
+  WaitForCommitOrTerminalOutcome(2);  // post-commit LOADING + FAILED.
 
   ASSERT_EQ(url_loader_factory_.NumPending(), 0);
   EXPECT_EQ(manager_->GetCurrentEnvironment(), other_env);
   EXPECT_TRUE(credential_store_.HasValidSkusCredential());
-  EXPECT_EQ(loading_environment(), other_env);
-  EXPECT_EQ(manager_->GetInfo().state, mojom::PurchasedState::LOADING);
+  EXPECT_TRUE(loading_environment().empty());
+  EXPECT_EQ(manager_->GetInfo().state, mojom::PurchasedState::FAILED);
+}
+
+// The full chain with a stubbed, successful exchange settles PURCHASED and
+// caches the subscriber credential end to end.
+TEST_F(PurchasedStateManagerWithRealSkusServiceTest,
+       FullChainExchangeSucceedsPurchased) {
+  CreateManager(CurrentEnvironment());
+  SetInterceptorResponse(absl::StrFormat(R"({"subscriber-credential":"%s"})",
+                                         kTestSubscriberCredential));
+  manager_->Load(CurrentDomain());
+
+  WaitForCommitOrTerminalOutcome(2);  // LOADING + PURCHASED.
+
+  EXPECT_EQ(url_loader_factory_.NumPending(), 0);
+  EXPECT_TRUE(manager_->IsPurchased());
+  EXPECT_EQ(credential_store_.GetSubscriberCredential(),
+            kTestSubscriberCredential);
+  EXPECT_TRUE(loading_environment().empty());
+}
+
+// A "token no longer valid" server error (non-2xx) on every attempt makes the
+// manager retry once against the real SKUS chain, then fail as TOKEN_NOT_VALID
+// on the second identical error.
+TEST_F(PurchasedStateManagerWithRealSkusServiceTest,
+       FullChainTokenNoLongerValidRetriesThenFails) {
+  CreateManager(CurrentEnvironment());
+  SetInterceptorResponse(
+      absl::StrFormat(R"({"error-title":"%s","error-message":"consumed"})",
+                      kTokenNoLongerValid),
+      net::HTTP_BAD_REQUEST);
+  manager_->Load(CurrentDomain());
+
+  // Not WaitForCommitOrTerminalOutcome: the retry rewrites the credential pref
+  // several times (commit, Clear, commit) and its commit-quit would fire
+  // mid-retry, before the second exchange fails. Wait for the terminal
+  // notification instead.
+  collector_.WaitForChangeCount(2);  // LOADING + FAILED (after the retry).
+
+  EXPECT_EQ(url_loader_factory_.NumPending(), 0);
+  EXPECT_EQ(manager_->GetInfo().state, mojom::PurchasedState::FAILED);
+  EXPECT_EQ(manager_->GetInfo().description,
+            l10n_util::GetStringUTF8(IDS_BRAVE_VPN_PURCHASE_TOKEN_NOT_VALID));
+  EXPECT_TRUE(loading_environment().empty());
+}
+
+// Retry recovery against the real SKUS: the first exchange reports the token
+// consumed, so the manager clears the stale credential and re-runs the full
+// summary+presentation chain; the retried exchange succeeds and the load
+// settles PURCHASED. This is the happy retry path end to end.
+TEST_F(PurchasedStateManagerWithRealSkusServiceTest,
+       FullChainTokenNoLongerValidRetrySucceeds) {
+  CreateManager(CurrentEnvironment());
+  SetInterceptorResponseSequence(
+      {// First exchange attempt: token consumed.
+       {absl::StrFormat(R"({"error-title":"%s","error-message":"consumed"})",
+                        kTokenNoLongerValid),
+        net::HTTP_BAD_REQUEST},
+       // Retry attempt: success.
+       {absl::StrFormat(R"({"subscriber-credential":"%s"})",
+                        kTestSubscriberCredential),
+        net::HTTP_OK}});
+  manager_->Load(CurrentDomain());
+
+  // Not WaitForCommitOrTerminalOutcome: the retry rewrites the credential pref
+  // several times (commit, Clear, commit) and its commit-quit would fire
+  // mid-retry, before the second exchange succeeds. Wait for the terminal
+  // notification instead.
+  collector_.WaitForChangeCount(2);  // LOADING + PURCHASED (after the retry).
+
+  EXPECT_EQ(url_loader_factory_.NumPending(), 0);
+  EXPECT_TRUE(manager_->IsPurchased());
+  EXPECT_TRUE(credential_store_.HasValidSubscriberCredential());
+  EXPECT_EQ(credential_store_.GetSubscriberCredential(),
+            kTestSubscriberCredential);
+  EXPECT_TRUE(loading_environment().empty());
 }
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/purchased_state_manager_unittest.cc
+++ b/components/brave_vpn/browser/v2/purchased_state_manager_unittest.cc
@@ -29,6 +29,7 @@
 #include "base/time/time.h"
 #include "base/types/expected.h"
 #include "base/values.h"
+#include "brave/components/brave_account/endpoint_client/test_support.h"
 #include "brave/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h"
 #include "brave/components/brave_vpn/browser/v2/credential_store.h"
 #include "brave/components/brave_vpn/browser/v2/skus_service_client.h"
@@ -48,10 +49,10 @@
 #include "components/prefs/testing_pref_service.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "net/http/http_status_code.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
-#include "third_party/abseil-cpp/absl/strings/str_format.h"
 #include "ui/base/l10n/l10n_util.h"
 
 namespace brave_vpn::v2 {
@@ -222,7 +223,9 @@ class StateChangeCollector {
 
 class FakeBraveVpnApiClient : public BraveVpnApiClient {
  public:
-  FakeBraveVpnApiClient() : BraveVpnApiClient(nullptr) {}
+  FakeBraveVpnApiClient(
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory)
+      : BraveVpnApiClient(std::move(url_loader_factory)) {}
   ~FakeBraveVpnApiClient() override = default;
 
   void GetSubscriberCredentialV12(SubscriberCredentialCallback callback,
@@ -376,10 +379,11 @@ class PurchasedStateManagerTest : public testing::Test {
  protected:
   base::test::TaskEnvironment task_environment_{
       base::test::TaskEnvironment::TimeSource::MOCK_TIME};
+  network::TestURLLoaderFactory url_loader_factory_;
   TestingPrefServiceSimple local_pref_service_;
   CredentialStore credential_store_{&local_pref_service_};
   StateChangeCollector collector_;
-  FakeBraveVpnApiClient api_client_;
+  FakeBraveVpnApiClient api_client_{url_loader_factory_.GetSafeWeakWrapper()};
   FakeSkusServiceClient skus_client_;
   std::unique_ptr<PurchasedStateManager> manager_;
 };
@@ -754,6 +758,7 @@ TEST_F(PurchasedStateManagerTest, StaleExchangeResponseIsDropped) {
 
   EXPECT_FALSE(manager_->IsPurchased());
   EXPECT_FALSE(credential_store_.HasValidSubscriberCredential());
+  EXPECT_TRUE(credential_store_.HasValidSkusCredential());
   EXPECT_EQ(manager_->GetInfo().state, mojom::PurchasedState::FAILED);
 }
 
@@ -1059,11 +1064,6 @@ TEST_F(PurchasedStateManagerTest, ExpiredSummaryMeansNotPurchased) {
 class PurchasedStateManagerWithRealSkusServiceTest
     : public PurchasedStateManagerTest {
  public:
-  struct StubHttpsResponse {
-    std::string body;
-    net::HttpStatusCode status = net::HTTP_OK;
-  };
-
   PurchasedStateManagerWithRealSkusServiceTest() : PurchasedStateManagerTest() {
     scoped_feature_list_.InitWithFeatures({skus::features::kSkusFeature}, {});
     skus::RegisterLocalStatePrefs(local_pref_service_.registry());
@@ -1077,9 +1077,6 @@ class PurchasedStateManagerWithRealSkusServiceTest
     ASSERT_TRUE(base::Time::FromString("2023-01-04", &future_mock_time));
     task_environment_.AdvanceClock(future_mock_time - base::Time::Now());
 
-    shared_url_loader_factory_ =
-        base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
-            &url_loader_factory_);
     url_loader_factory_.SetInterceptor(base::BindRepeating(
         &PurchasedStateManagerWithRealSkusServiceTest::Interceptor,
         base::Unretained(this)));
@@ -1131,29 +1128,29 @@ class PurchasedStateManagerWithRealSkusServiceTest
     return skus_service_->MakeRemote();
   }
 
-  void SetInterceptorResponse(const std::string& response,
-                              net::HttpStatusCode status = net::HTTP_OK) {
-    interceptor_responses_ = {{response, status}};
-    interceptor_response_index_ = 0;
+  void SetExchangeResponse(
+      endpoints::GetSubscriberCredentialV12::Response response) {
+    exchange_responses_.clear();
+    exchange_responses_.push_back(std::move(response));
+    exchange_response_index_ = 0;
   }
 
   // Serve one response per successive intercepted request, in order (one per
   // exchange attempt). The last entry repeats once the list is exhausted, so a
   // stray request can't underflow the index.
-  void SetInterceptorResponseSequence(
-      std::vector<StubHttpsResponse> responses) {
+  void SetExchangeResponseSequence(
+      std::vector<endpoints::GetSubscriberCredentialV12::Response> responses) {
     CHECK(!responses.empty());
-    interceptor_responses_ = std::move(responses);
-    interceptor_response_index_ = 0;
+    exchange_responses_ = std::move(responses);
+    exchange_response_index_ = 0;
   }
 
-  void Interceptor(const network::ResourceRequest& request) {
-    url_loader_factory_.ClearResponses();
-    const StubHttpsResponse& response = interceptor_responses_[std::min(
-        interceptor_response_index_, interceptor_responses_.size() - 1)];
-    ++interceptor_response_index_;
-    url_loader_factory_.AddResponse(request.url.spec(), response.body,
-                                    response.status);
+  void Interceptor(const network::ResourceRequest&) {
+    const size_t i =
+        std::min(exchange_response_index_++, exchange_responses_.size() - 1);
+    brave_account::endpoint_client::MockResponseFor<
+        endpoints::GetSubscriberCredentialV12>(url_loader_factory_,
+                                               exchange_responses_[i]);
   }
 
   void WaitForCommitOrTerminalOutcome(size_t terminal_change_count) {
@@ -1176,14 +1173,27 @@ class PurchasedStateManagerWithRealSkusServiceTest
   }
 
  protected:
+  const endpoints::GetSubscriberCredentialV12::Response
+      kTokenNoLongerValidResponse{
+          .net_error = net::OK,
+          .status_code = net::HTTP_BAD_REQUEST,
+          .body = base::unexpected(endpoints::VpnErrorBody{
+              .error_title = std::string(kTokenNoLongerValid),
+              .error_message = "consumed"})};
+  const endpoints::GetSubscriberCredentialV12::Response
+      kExchangeSuccessResponse{
+          .net_error = net::OK,
+          .status_code = net::HTTP_OK,
+          .body = endpoints::GetSubscriberCredentialV12SuccessBody{
+              .subscriber_credential = std::string(kTestSubscriberCredential)}};
+
   base::test::ScopedFeatureList scoped_feature_list_;
-  network::TestURLLoaderFactory url_loader_factory_;
-  scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
   std::unique_ptr<BraveVpnApiClient> real_api_client_;
   std::unique_ptr<skus::SkusServiceImpl> skus_service_;
   std::unique_ptr<SkusServiceClient> real_skus_client_;
-  std::vector<StubHttpsResponse> interceptor_responses_{{}};
-  size_t interceptor_response_index_ = 0;
+  std::vector<endpoints::GetSubscriberCredentialV12::Response>
+      exchange_responses_{{.net_error = net::OK, .status_code = net::HTTP_OK}};
+  size_t exchange_response_index_ = 0;
 };
 
 // The full chain against the real SKUS: summary JSON parses, the presentation
@@ -1264,6 +1274,10 @@ TEST_F(PurchasedStateManagerWithRealSkusServiceTest,
   const std::string other_env = OtherEnvironment();
   manager_->Load(OtherDomain());
 
+  // The unstubbed exchange (we stub only the SKUS chain here) fails after the
+  // commit, so a FAILED terminal outcome is expected. However, the commit's
+  // effects outlive the failure: the environment switched and the SKUS
+  // credential is cached.
   WaitForCommitOrTerminalOutcome(2);  // post-commit LOADING + FAILED.
 
   ASSERT_EQ(url_loader_factory_.NumPending(), 0);
@@ -1278,8 +1292,7 @@ TEST_F(PurchasedStateManagerWithRealSkusServiceTest,
 TEST_F(PurchasedStateManagerWithRealSkusServiceTest,
        FullChainExchangeSucceedsPurchased) {
   CreateManager(CurrentEnvironment());
-  SetInterceptorResponse(absl::StrFormat(R"({"subscriber-credential":"%s"})",
-                                         kTestSubscriberCredential));
+  SetExchangeResponse(kExchangeSuccessResponse);
   manager_->Load(CurrentDomain());
 
   WaitForCommitOrTerminalOutcome(2);  // LOADING + PURCHASED.
@@ -1297,10 +1310,7 @@ TEST_F(PurchasedStateManagerWithRealSkusServiceTest,
 TEST_F(PurchasedStateManagerWithRealSkusServiceTest,
        FullChainTokenNoLongerValidRetriesThenFails) {
   CreateManager(CurrentEnvironment());
-  SetInterceptorResponse(
-      absl::StrFormat(R"({"error-title":"%s","error-message":"consumed"})",
-                      kTokenNoLongerValid),
-      net::HTTP_BAD_REQUEST);
+  SetExchangeResponse(kTokenNoLongerValidResponse);
   manager_->Load(CurrentDomain());
 
   // Not WaitForCommitOrTerminalOutcome: the retry rewrites the credential pref
@@ -1323,15 +1333,8 @@ TEST_F(PurchasedStateManagerWithRealSkusServiceTest,
 TEST_F(PurchasedStateManagerWithRealSkusServiceTest,
        FullChainTokenNoLongerValidRetrySucceeds) {
   CreateManager(CurrentEnvironment());
-  SetInterceptorResponseSequence(
-      {// First exchange attempt: token consumed.
-       {absl::StrFormat(R"({"error-title":"%s","error-message":"consumed"})",
-                        kTokenNoLongerValid),
-        net::HTTP_BAD_REQUEST},
-       // Retry attempt: success.
-       {absl::StrFormat(R"({"subscriber-credential":"%s"})",
-                        kTestSubscriberCredential),
-        net::HTTP_OK}});
+  SetExchangeResponseSequence(
+      {kTokenNoLongerValidResponse, kExchangeSuccessResponse});
   manager_->Load(CurrentDomain());
 
   // Not WaitForCommitOrTerminalOutcome: the retry rewrites the credential pref

--- a/components/brave_vpn/common/brave_vpn_constants.h
+++ b/components/brave_vpn/common/brave_vpn_constants.h
@@ -69,9 +69,7 @@ inline constexpr char kCredentialSummaryActiveKey[] = "active";
 inline constexpr char kCredentialSummaryRemainingCredentialCountKey[] =
     "remaining_credential_count";
 
-#if !BUILDFLAG(IS_ANDROID)
 inline constexpr char kTokenNoLongerValid[] = "Token No Longer Valid";
-#endif  // !BUILDFLAG(IS_ANDROID)
 
 }  // namespace brave_vpn
 


### PR DESCRIPTION
Introduce the subscriber credential exchange layer to the existing v2's PurchasedStateManager which is based on the EndpointClient infrastructure:

- BraveVpnApiClient: issues typed requests to Brave VPN's backend endpoints via Brave EndpointClient. This PR implements only one API - GetSubscriberCredentialV12 - which is needed for purchase state manager's functionality.
- PurchasedStateManager: implemented the final Guardian API step to fetch the subscriber credential, with one retry; fixed some aggressive credential cache clearing.
- CredentialStore: fixed the shared expiry fetching code to support both subscriber and SKUS credentials.
- All new behaviours are covered with both fake-based and real (intercepted) API call based unit tests.

Implements part of https://github.com/brave/brave-browser/issues/56692

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
