### PR TITLE
[Android] Fix Private NTP crashes on system UI mode changes

### DIFF
--- a/android/java/org/chromium/chrome/browser/omnibox/BraveLocationBarMediator.java
+++ b/android/java/org/chromium/chrome/browser/omnibox/BraveLocationBarMediator.java
@@ -150,14 +150,11 @@ public class BraveLocationBarMediator extends LocationBarMediator {
 
     @Override
     public void onResumeWithNative() {
-        if (mTemplateUrlServiceSupplier.get() != null
-                && !mTemplateUrlServiceSupplier.get().isLoaded()) {
-            mTemplateUrlServiceSupplier
-                    .get()
-                    .runWhenLoaded(
-                            () -> {
-                                super.onResumeWithNative();
-                            });
+        @Nullable TemplateUrlService templateUrlService = mTemplateUrlServiceSupplier.get();
+        if (templateUrlService != null
+                && templateUrlService.hasNativeService()
+                && !templateUrlService.isLoaded()) {
+            templateUrlService.runWhenLoaded(() -> super.onResumeWithNative());
             return;
         }
         super.onResumeWithNative();

--- a/android/javatests/org/chromium/chrome/browser/PrivateTabSystemUiModeChangeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/PrivateTabSystemUiModeChangeTest.java
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package org.chromium.chrome.browser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.res.Configuration;
+
+import androidx.test.filters.MediumTest;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.runner.lifecycle.Stage;
+import androidx.test.uiautomator.UiDevice;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.chromium.base.test.util.ApplicationTestUtils;
+import org.chromium.base.test.util.CommandLineFlags;
+import org.chromium.base.test.util.CriteriaHelper;
+import org.chromium.base.test.util.DoNotBatch;
+import org.chromium.base.test.util.Features.DisableFeatures;
+import org.chromium.chrome.browser.flags.ChromeFeatureList;
+import org.chromium.chrome.browser.flags.ChromeSwitches;
+import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
+import org.chromium.chrome.test.ChromeTabbedActivityTestRule;
+
+import java.io.IOException;
+
+/** Regression tests for private-tab crashes during system UI mode changes. */
+@RunWith(ChromeJUnit4ClassRunner.class)
+@CommandLineFlags.Add({ChromeSwitches.DISABLE_FIRST_RUN_EXPERIENCE})
+@DisableFeatures(ChromeFeatureList.ANDROID_OPEN_INCOGNITO_AS_WINDOW)
+@DoNotBatch(
+        reason =
+                "Changes device-wide night mode and battery saver state, and recreates"
+                        + " ChromeTabbedActivity.")
+public class PrivateTabSystemUiModeChangeTest {
+    private static final String NIGHT_MODE_COMMAND = "cmd uimode night";
+    private static final String NIGHT_MODE_PREFIX = "Night mode: ";
+    private static final String NIGHT_MODE_ENABLED = "yes";
+    private static final String NIGHT_MODE_DISABLED = "no";
+    private static final String BATTERY_SAVER_MODE_COMMAND = "cmd power set-mode ";
+    private static final String BATTERY_SAVER_MODE_SETTING = "settings get global low_power";
+    private static final String BATTERY_SAVER_MODE_ENABLED = "1";
+    private static final String BATTERY_SAVER_MODE_DISABLED = "0";
+    private static final String UI_MODE_DUMP_COMMAND = "dumpsys uimode";
+    private static final String CURRENT_UI_MODE_PREFIX = "mCurUiMode=0x";
+
+    @Rule
+    public final ChromeTabbedActivityTestRule mActivityTestRule =
+            new ChromeTabbedActivityTestRule();
+
+    private UiDevice mDevice;
+    private String mInitialNightMode;
+    private String mInitialBatterySaverMode;
+
+    @Before
+    public void setUp() throws IOException {
+        mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+        mInitialNightMode = getNightMode();
+        mInitialBatterySaverMode = getBatterySaverMode();
+        prepareSystemUiModeBaseline();
+
+        mActivityTestRule.startMainActivityOnBlankPage();
+        assertTrue(mActivityTestRule.newIncognitoTabFromMenu().isIncognito());
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        try {
+            if (mInitialBatterySaverMode != null
+                    && !getBatterySaverMode().equals(mInitialBatterySaverMode)) {
+                setBatterySaverMode(mInitialBatterySaverMode);
+            }
+        } finally {
+            // Restore night mode even if battery-saver restoration fails.
+            if (mInitialNightMode != null && !getNightMode().equals(mInitialNightMode)) {
+                setNightMode(mInitialNightMode);
+            }
+        }
+    }
+
+    @Test
+    @MediumTest
+    public void testPrivateTabDoesNotCrashAfterSystemNightModeChange() throws IOException {
+        recreateActivityForNightMode(NIGHT_MODE_ENABLED);
+        waitForActivityTab();
+
+        assertTrue(mActivityTestRule.newIncognitoTabFromMenu().isIncognito());
+
+        recreateActivityForNightMode(NIGHT_MODE_DISABLED);
+        waitForActivityTab();
+    }
+
+    @Test
+    @MediumTest
+    public void testPrivateTabDoesNotCrashAfterBatterySaverModeChange() throws IOException {
+        recreateActivityForBatterySaverMode(BATTERY_SAVER_MODE_ENABLED);
+        // The real system configuration change triggers the activity recreation under test.
+        assertTrue(
+                "Battery saver did not switch the system UI mode to night",
+                isSystemNightModeEnabled());
+        waitForActivityTab();
+
+        assertTrue(mActivityTestRule.newIncognitoTabFromMenu().isIncognito());
+
+        recreateActivityForBatterySaverMode(BATTERY_SAVER_MODE_DISABLED);
+        assertFalse(
+                "Battery saver did not restore the system UI mode to light",
+                isSystemNightModeEnabled());
+        waitForActivityTab();
+    }
+
+    private void recreateActivityForNightMode(String nightMode) {
+        ChromeTabbedActivity recreatedActivity =
+                ApplicationTestUtils.waitForActivityWithClass(
+                        ChromeTabbedActivity.class,
+                        Stage.RESUMED,
+                        /* uiThreadTrigger= */ null,
+                        () -> {
+                            try {
+                                setNightMode(nightMode);
+                            } catch (IOException e) {
+                                throw new AssertionError(
+                                        "Could not change the system night mode", e);
+                            }
+                        });
+        mActivityTestRule.setActivity(recreatedActivity);
+    }
+
+    private void recreateActivityForBatterySaverMode(String batterySaverMode) {
+        ChromeTabbedActivity recreatedActivity =
+                ApplicationTestUtils.waitForActivityWithClass(
+                        ChromeTabbedActivity.class,
+                        Stage.RESUMED,
+                        /* uiThreadTrigger= */ null,
+                        () -> {
+                            try {
+                                setBatterySaverMode(batterySaverMode);
+                            } catch (IOException e) {
+                                throw new AssertionError(
+                                        "Could not change the battery saver mode", e);
+                            }
+                        });
+        mActivityTestRule.setActivity(recreatedActivity);
+    }
+
+    private void waitForActivityTab() {
+        CriteriaHelper.pollUiThread(() -> mActivityTestRule.getActivityTab() != null);
+    }
+
+    private String getNightMode() throws IOException {
+        String output = mDevice.executeShellCommand(NIGHT_MODE_COMMAND).trim();
+        if (!output.startsWith(NIGHT_MODE_PREFIX)) {
+            throw new AssertionError("Unexpected system night mode output: " + output);
+        }
+        return output.substring(NIGHT_MODE_PREFIX.length());
+    }
+
+    private void setNightMode(String nightMode) throws IOException {
+        mDevice.executeShellCommand(NIGHT_MODE_COMMAND + " " + nightMode);
+        assertEquals(nightMode, getNightMode());
+    }
+
+    private String getBatterySaverMode() throws IOException {
+        String batterySaverMode = mDevice.executeShellCommand(BATTERY_SAVER_MODE_SETTING).trim();
+        if (!batterySaverMode.equals(BATTERY_SAVER_MODE_ENABLED)
+                && !batterySaverMode.equals(BATTERY_SAVER_MODE_DISABLED)) {
+            throw new AssertionError("Unexpected battery saver mode: " + batterySaverMode);
+        }
+        return batterySaverMode;
+    }
+
+    private void setBatterySaverMode(String batterySaverMode) throws IOException {
+        mDevice.executeShellCommand(BATTERY_SAVER_MODE_COMMAND + batterySaverMode);
+        assertEquals(batterySaverMode, getBatterySaverMode());
+    }
+
+    private void prepareSystemUiModeBaseline() throws IOException {
+        setBatterySaverMode(BATTERY_SAVER_MODE_DISABLED);
+        setNightMode(NIGHT_MODE_DISABLED);
+        assertFalse("Could not prepare a light system UI mode", isSystemNightModeEnabled());
+    }
+
+    private boolean isSystemNightModeEnabled() throws IOException {
+        String uiModeDump = mDevice.executeShellCommand(UI_MODE_DUMP_COMMAND);
+        int start = uiModeDump.indexOf(CURRENT_UI_MODE_PREFIX);
+        if (start == -1) {
+            throw new AssertionError("Could not find the current UI mode in: " + uiModeDump);
+        }
+        start += CURRENT_UI_MODE_PREFIX.length();
+        int end = start;
+        while (end < uiModeDump.length() && Character.digit(uiModeDump.charAt(end), 16) != -1) {
+            end++;
+        }
+        int currentUiMode = Integer.parseInt(uiModeDump.substring(start, end), 16);
+        return (currentUiMode & Configuration.UI_MODE_NIGHT_MASK)
+                == Configuration.UI_MODE_NIGHT_YES;
+    }
+}

--- a/android/javatests/org/chromium/chrome/browser/PrivateTabSystemUiModeChangeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/PrivateTabSystemUiModeChangeTest.java
@@ -51,6 +51,8 @@ public class PrivateTabSystemUiModeChangeTest {
     private static final String BATTERY_SAVER_MODE_SETTING = "settings get global low_power";
     private static final String BATTERY_SAVER_MODE_ENABLED = "1";
     private static final String BATTERY_SAVER_MODE_DISABLED = "0";
+    private static final String BATTERY_UNPLUG_COMMAND = "cmd battery unplug";
+    private static final String BATTERY_RESET_COMMAND = "cmd battery reset";
     private static final String UI_MODE_DUMP_COMMAND = "dumpsys uimode";
     private static final String CURRENT_UI_MODE_PREFIX = "mCurUiMode=0x";
 
@@ -61,6 +63,7 @@ public class PrivateTabSystemUiModeChangeTest {
     private UiDevice mDevice;
     private String mInitialNightMode;
     private String mInitialBatterySaverMode;
+    private boolean mBatteryUnpluggedForTest;
 
     @Before
     public void setUp() throws IOException {
@@ -75,15 +78,23 @@ public class PrivateTabSystemUiModeChangeTest {
 
     @After
     public void tearDown() throws IOException {
+        // Restore Battery Saver before resetting simulated battery state: Android rejects enabling it
+        // while the device reports external power.
         try {
             if (mInitialBatterySaverMode != null
                     && !getBatterySaverMode().equals(mInitialBatterySaverMode)) {
                 setBatterySaverMode(mInitialBatterySaverMode);
             }
         } finally {
-            // Restore night mode even if battery-saver restoration fails.
-            if (mInitialNightMode != null && !getNightMode().equals(mInitialNightMode)) {
-                setNightMode(mInitialNightMode);
+            try {
+                if (mBatteryUnpluggedForTest) {
+                    mDevice.executeShellCommand(BATTERY_RESET_COMMAND);
+                }
+            } finally {
+                // Restore night mode even if Battery Saver or battery-state restoration fails.
+                if (mInitialNightMode != null && !getNightMode().equals(mInitialNightMode)) {
+                    setNightMode(mInitialNightMode);
+                }
             }
         }
     }
@@ -103,6 +114,10 @@ public class PrivateTabSystemUiModeChangeTest {
     @Test
     @MediumTest
     public void testPrivateTabDoesNotCrashAfterBatterySaverModeChange() throws IOException {
+        // Battery Saver cannot be enabled while the device reports external power.
+        mDevice.executeShellCommand(BATTERY_UNPLUG_COMMAND);
+        mBatteryUnpluggedForTest = true;
+
         recreateActivityForBatterySaverMode(BATTERY_SAVER_MODE_ENABLED);
         // The real system configuration change triggers the activity recreation under test.
         assertTrue(

--- a/android/javatests/org/chromium/chrome/browser/PrivateTabSystemUiModeChangeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/PrivateTabSystemUiModeChangeTest.java
@@ -78,8 +78,8 @@ public class PrivateTabSystemUiModeChangeTest {
 
     @After
     public void tearDown() throws IOException {
-        // Restore Battery Saver before resetting simulated battery state: Android rejects enabling it
-        // while the device reports external power.
+        // Restore Battery Saver before resetting simulated battery state: Android rejects enabling
+        // it while the device reports external power.
         try {
             if (mInitialBatterySaverMode != null
                     && !getBatterySaverMode().equals(mInitialBatterySaverMode)) {

--- a/patches/chrome-browser-ui-android-omnibox-java-src-org-chromium-chrome-browser-omnibox-fusebox-FuseboxCoordinator.java.patch
+++ b/patches/chrome-browser-ui-android-omnibox-java-src-org-chromium-chrome-browser-omnibox-fusebox-FuseboxCoordinator.java.patch
@@ -1,0 +1,14 @@
+diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/fusebox/FuseboxCoordinator.java b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/fusebox/FuseboxCoordinator.java
+index 9c071d2c00570bdac3359b9f561af32bbe0082e1..6b11119f8970f8c645a7a11e862ffff23b9a1dd4 100644
+--- a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/fusebox/FuseboxCoordinator.java
++++ b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/fusebox/FuseboxCoordinator.java
+@@ -457,6 +457,9 @@ public class FuseboxCoordinator implements TemplateUrlServiceObserver {
+     // TemplateUrlServiceObserver
+     @Override
+     public void onTemplateURLServiceChanged() {
++        if (!mTemplateUrlService.hasNativeService()) {
++            return;
++        }
+         boolean isDseGoogle = mTemplateUrlService.isDefaultSearchEngineGoogle();
+         if (isDseGoogle == mDefaultSearchEngineIsGoogle) return;
+         mDefaultSearchEngineIsGoogle = isDseGoogle;

--- a/patches/chrome-browser-ui-android-omnibox-java-src-org-chromium-chrome-browser-omnibox-geo-GeolocationHeader.java.patch
+++ b/patches/chrome-browser-ui-android-omnibox-java-src-org-chromium-chrome-browser-omnibox-geo-GeolocationHeader.java.patch
@@ -1,0 +1,14 @@
+diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/geo/GeolocationHeader.java b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/geo/GeolocationHeader.java
+index b7dc84e7decbcc7444d3c3d13240a15554d9b233..b5705dd2d4d631fbed17271507007efa3210c6e2 100644
+--- a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/geo/GeolocationHeader.java
++++ b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/geo/GeolocationHeader.java
+@@ -211,6 +211,9 @@ public class GeolocationHeader {
+ 
+     private static @HeaderState int geoHeaderStateForDse(
+             Profile profile, TemplateUrlService templateService) {
++        if (!templateService.hasNativeService()) {
++            return HeaderState.UNSUITABLE_URL;
++        }
+         return geoHeaderStateForUrl(
+                 profile, templateService, templateService.getUrlForSearchQuery(DUMMY_URL_QUERY));
+     }

--- a/patches/components-search_engines-android-java-src-org-chromium-components-search_engines-TemplateUrlService.java.patch
+++ b/patches/components-search_engines-android-java-src-org-chromium-components-search_engines-TemplateUrlService.java.patch
@@ -1,0 +1,20 @@
+diff --git a/components/search_engines/android/java/src/org/chromium/components/search_engines/TemplateUrlService.java b/components/search_engines/android/java/src/org/chromium/components/search_engines/TemplateUrlService.java
+index be9153aad2317f6efd343c227f7ca5d05d3a969a..52cb1d1113cf7470589a612c35f304acf1c8dc7f 100644
+--- a/components/search_engines/android/java/src/org/chromium/components/search_engines/TemplateUrlService.java
++++ b/components/search_engines/android/java/src/org/chromium/components/search_engines/TemplateUrlService.java
+@@ -60,6 +60,15 @@ public class TemplateUrlService {
+     private void clearNativePtr() {
+         mNativeTemplateUrlServiceAndroid = 0;
+     }
++    /**
++     * Returns whether the native service is available for JNI calls.
++     *
++     * The Java wrapper can outlive native teardown during activity
++     * recreation. This does not indicate whether {@link #isLoaded()} returns true.
++     */
++    public boolean hasNativeService() {
++        return mNativeTemplateUrlServiceAndroid != 0;
++    }
+ 
+     public boolean isLoaded() {
+         ThreadUtils.assertOnUiThread();

--- a/patches/components-search_engines-android-java-src-org-chromium-components-search_engines-TemplateUrlService.java.patch
+++ b/patches/components-search_engines-android-java-src-org-chromium-components-search_engines-TemplateUrlService.java.patch
@@ -1,11 +1,11 @@
 diff --git a/components/search_engines/android/java/src/org/chromium/components/search_engines/TemplateUrlService.java b/components/search_engines/android/java/src/org/chromium/components/search_engines/TemplateUrlService.java
-index be9153aad2317f6efd343c227f7ca5d05d3a969a..52cb1d1113cf7470589a612c35f304acf1c8dc7f 100644
+index be9153aad2317f6efd343c227f7ca5d05d3a969a..fd6d3caf8fbdab4acee87accd5a76b24bd112b54 100644
 --- a/components/search_engines/android/java/src/org/chromium/components/search_engines/TemplateUrlService.java
 +++ b/components/search_engines/android/java/src/org/chromium/components/search_engines/TemplateUrlService.java
-@@ -60,6 +60,15 @@ public class TemplateUrlService {
-     private void clearNativePtr() {
-         mNativeTemplateUrlServiceAndroid = 0;
-     }
+@@ -30,6 +30,15 @@ import java.util.List;
+  */
+ @NullMarked
+ public class TemplateUrlService {
 +    /**
 +     * Returns whether the native service is available for JNI calls.
 +     *
@@ -15,6 +15,6 @@ index be9153aad2317f6efd343c227f7ca5d05d3a969a..52cb1d1113cf7470589a612c35f304ac
 +    public boolean hasNativeService() {
 +        return mNativeTemplateUrlServiceAndroid != 0;
 +    }
- 
-     public boolean isLoaded() {
-         ThreadUtils.assertOnUiThread();
+     /** This listener will be notified when template url service is done loading. */
+     public interface LoadListener {
+         void onTemplateUrlServiceLoaded();

--- a/rewrite/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/fusebox/FuseboxCoordinator.java.yaml
+++ b/rewrite/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/fusebox/FuseboxCoordinator.java.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Do not update Fusebox's default-search-engine state when
+      TemplateUrlService has no native object.
+
+      Android can recreate an activity while this Java object remains after
+      native code clears its pointer. Return before calling JNI.
+    count: 1
+    regex:
+      re_pattern:
+        '(    @Override\n    public void onTemplateURLServiceChanged\(\)
+        \{\n)(        boolean isDseGoogle =
+        mTemplateUrlService\.isDefaultSearchEngineGoogle\(\);)'
+      replace: |-
+        \1        if (!mTemplateUrlService.hasNativeService()) {
+                    return;
+                }
+        \2

--- a/rewrite/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/fusebox/FuseboxCoordinator.java.yaml
+++ b/rewrite/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/fusebox/FuseboxCoordinator.java.yaml
@@ -12,12 +12,9 @@ substitutions:
       native code clears its pointer. Return before calling JNI.
     count: 1
     regex:
-      re_pattern:
-        '(    @Override\n    public void onTemplateURLServiceChanged\(\)
-        \{\n)(        boolean isDseGoogle =
-        mTemplateUrlService\.isDefaultSearchEngineGoogle\(\);)'
+      re_pattern: '(public void onTemplateURLServiceChanged\(\)\s*\{)'
       replace: |-
-        \1        if (!mTemplateUrlService.hasNativeService()) {
+        \1
+                if (!mTemplateUrlService.hasNativeService()) {
                     return;
                 }
-        \2

--- a/rewrite/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/geo/GeolocationHeader.java.yaml
+++ b/rewrite/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/geo/GeolocationHeader.java.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Do not calculate the location header for the default search engine when
+      TemplateUrlService has no native object.
+
+      Android can recreate an activity while this Java object remains after
+      native code clears its pointer. Return UNSUITABLE_URL before calling JNI.
+    count: 1
+    regex:
+      re_pattern:
+        '(    private static @HeaderState int
+        geoHeaderStateForDse\(\n            Profile profile, TemplateUrlService
+        templateService\) \{\n)(        return geoHeaderStateForUrl\()'
+      replace: |-
+        \1        if (!templateService.hasNativeService()) {
+                    return HeaderState.UNSUITABLE_URL;
+                }
+        \2

--- a/rewrite/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/geo/GeolocationHeader.java.yaml
+++ b/rewrite/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/geo/GeolocationHeader.java.yaml
@@ -12,12 +12,9 @@ substitutions:
       native code clears its pointer. Return UNSUITABLE_URL before calling JNI.
     count: 1
     regex:
-      re_pattern:
-        '(    private static @HeaderState int
-        geoHeaderStateForDse\(\n            Profile profile, TemplateUrlService
-        templateService\) \{\n)(        return geoHeaderStateForUrl\()'
+      re_pattern: '(geoHeaderStateForDse\s*\([^)]*\)\s*\{)'
       replace: |-
-        \1        if (!templateService.hasNativeService()) {
+        \1
+                if (!templateService.hasNativeService()) {
                     return HeaderState.UNSUITABLE_URL;
                 }
-        \2

--- a/rewrite/components/search_engines/android/java/src/org/chromium/components/search_engines/TemplateUrlService.java.yaml
+++ b/rewrite/components/search_engines/android/java/src/org/chromium/components/search_engines/TemplateUrlService.java.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Let callers check whether TemplateUrlService still has its native object.
+
+      Android can recreate an activity while this Java object remains after
+      native code clears its pointer. Callers must check before they call JNI.
+    count: 1
+    regex:
+      re_pattern:
+        '(    private void clearNativePtr\(\)
+        \{\n        mNativeTemplateUrlServiceAndroid =
+        0;\n    \}\n)(\n    public boolean isLoaded\(\) \{)'
+      replace: |-
+        \1    /**
+             * Returns whether the native service is available for JNI calls.
+             *
+             * The Java wrapper can outlive native teardown during activity
+             * recreation. This does not indicate whether {@link #isLoaded()} returns true.
+             */
+            public boolean hasNativeService() {
+                return mNativeTemplateUrlServiceAndroid != 0;
+            }
+        \2

--- a/rewrite/components/search_engines/android/java/src/org/chromium/components/search_engines/TemplateUrlService.java.yaml
+++ b/rewrite/components/search_engines/android/java/src/org/chromium/components/search_engines/TemplateUrlService.java.yaml
@@ -5,18 +5,16 @@
 
 substitutions:
   - description: |
-      Let callers check whether TemplateUrlService still has its native object.
+      Expose whether TemplateUrlService still has its native object.
 
       Android can recreate an activity while this Java object remains after
       native code clears its pointer. Callers must check before they call JNI.
     count: 1
     regex:
-      re_pattern:
-        '(    private void clearNativePtr\(\)
-        \{\n        mNativeTemplateUrlServiceAndroid =
-        0;\n    \}\n)(\n    public boolean isLoaded\(\) \{)'
+      re_pattern: '(public class TemplateUrlService\s*\{)'
       replace: |-
-        \1    /**
+        \1
+            /**
              * Returns whether the native service is available for JNI calls.
              *
              * The Java wrapper can outlive native teardown during activity
@@ -25,4 +23,3 @@ substitutions:
             public boolean hasNativeService() {
                 return mNativeTemplateUrlServiceAndroid != 0;
             }
-        \2

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1612,6 +1612,7 @@ if (is_android) {
     sources = [
       "//brave/android/javatests/org/chromium/chrome/browser/BraveSafetyNetThreatsPrioritiesTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/BytecodeTest.java",
+      "//brave/android/javatests/org/chromium/chrome/browser/PrivateTabSystemUiModeChangeTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/autofill/options/BraveAutofillOptionsFragmentTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/autofill/settings/BraveAutofillPaymentMethodsFragmentTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/homepage/settings/BraveHomepageSettingsTest.java",
@@ -1738,7 +1739,9 @@ if (is_android) {
       "//third_party/androidx:androidx_lifecycle_lifecycle_common_java",
       "//third_party/androidx:androidx_preference_preference_java",
       "//third_party/androidx:androidx_recyclerview_recyclerview_java",
+      "//third_party/androidx:androidx_test_monitor_java",
       "//third_party/androidx:androidx_test_runner_java",
+      "//third_party/androidx:androidx_test_uiautomator_uiautomator_java",
       "//third_party/hamcrest:hamcrest_core_java",
       "//third_party/hamcrest:hamcrest_library_java",
       "//third_party/junit",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/53960
- Resolves https://github.com/brave/brave-browser/issues/49692
- See also https://github.com/brave/brave-core/pull/28448 / https://github.com/brave/brave-browser/issues/45127

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Overview

Changing the system UI mode can recreate `ChromeTabbedActivity` while a private tab is open, leaving the old activity holding a Java `TemplateUrlService` whose native `TemplateUrlServiceAndroid` counterpart has been destroyed.

When `TemplateUrlServiceAndroid` is destroyed, it calls [`clearNativePtr()`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/components/search_engines/android/java/src/org/chromium/components/search_engines/TemplateUrlService.java#60), which sets `mNativeTemplateUrlServiceAndroid` to `0`. 

JNI-backed methods such as [`isLoaded()`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/components/search_engines/android/java/src/org/chromium/components/search_engines/TemplateUrlService.java#64), [`isDefaultSearchEngineGoogle()`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/components/search_engines/android/java/src/org/chromium/components/search_engines/TemplateUrlService.java#207), and [`getUrlForSearchQuery()`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/components/search_engines/android/java/src/org/chromium/components/search_engines/TemplateUrlService.java#293) require a non-zero native pointer. 

Calling any of these methods on a `TemplateUrlService` instance after `clearNativePtr()` runs will cause a crash.

This PR:

1. Adds `TemplateUrlService.hasNativeService()` to check whether a `TemplateUrlService` instance currently has its native service.
2. Guards the three affected call paths:
   - `BraveLocationBarMediator` resumes normally instead of waiting for the destroyed service to load.
   - `FuseboxCoordinator` skips its default-search-engine update.
   - `GeolocationHeader` treats the search URL as unsuitable and does not request location data.

## Testing

Adds `PrivateTabSystemUiModeChangeTest`, which covers activity recreation while a private tab is open for:

- system night-mode changes
- battery-saver-mode changes

Temporarily reverting `5e87289f51e55c3ff5b1390568a1a8059957b555` makes both tests fail. Restoring it makes both tests pass.


## Use of patches via plaster

@AlexeyBarabash mentioned in a DM the goal is to move from bytecode patches to plaster. If this requires modifications, please let me know what needs changing.

## Screenshots

Toggling system dark theme (https://github.com/brave/brave-browser/issues/53960):

[private-ntp-toggle-dark-theme.webm](https://github.com/user-attachments/assets/e133d181-4617-4214-bb21-6361fc08cc55)


Toggling battery saver on (from light mode) (https://github.com/brave/brave-browser/issues/53960):

[private-ntp-enable-battery-saver.webm](https://github.com/user-attachments/assets/3aa3fcda-e56c-44ea-b564-ac916445d3ef)



