### PR TITLE
[Polkadot] [Wallet] remove CHECKs for nullary results

### DIFF
--- a/components/brave_wallet/browser/polkadot/polkadot_signed_transfer_task.cc
+++ b/components/brave_wallet/browser/polkadot/polkadot_signed_transfer_task.cc
@@ -6,6 +6,7 @@
 #include "brave/components/brave_wallet/browser/polkadot/polkadot_signed_transfer_task.h"
 
 #include "base/containers/to_vector.h"
+#include "base/strings/string_number_conversions.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"
 #include "brave/components/brave_wallet/browser/polkadot/polkadot_substrate_rpc.h"
@@ -101,11 +102,10 @@ void PolkadotSignedTransferTask::OnGetMetadataForSigning(
 void PolkadotSignedTransferTask::OnGetAccountNonce(
     mojom::PolkadotAccountInfoPtr account_info,
     const std::optional<std::string>& error_string) {
-  if (error_string) {
-    return StopWithError(*error_string);
+  if (error_string || !account_info) {
+    return StopWithError(error_string.value_or(WalletInternalErrorMessage()));
   }
 
-  CHECK(account_info);
   account_info_ = std::move(account_info);
 
   MaybeFinalizeSignTransaction();
@@ -114,15 +114,14 @@ void PolkadotSignedTransferTask::OnGetAccountNonce(
 void PolkadotSignedTransferTask::OnGetChainHeader(
     std::optional<PolkadotBlockHeader> header,
     std::optional<std::string> error_string) {
-  if (error_string) {
-    return StopWithError(*error_string);
-  }
-
   // Current behavior of the RPC layer seems to be returning an error when
   // there's no parent hash, so we always fetch it in our case vs polkadot-js
   // which seems to assume very young chains where the parent hash doesn't
   // necessarily exist.
-  CHECK(header);
+  if (error_string || !header.has_value()) {
+    return StopWithError(error_string.value_or(WalletInternalErrorMessage()));
+  }
+
   GetPolkadotRpc()->GetBlockHeader(
       chain_id_, header->parent_hash,
       base::BindOnce(&PolkadotSignedTransferTask::OnGetParentHeader,
@@ -132,11 +131,10 @@ void PolkadotSignedTransferTask::OnGetChainHeader(
 void PolkadotSignedTransferTask::OnGetParentHeader(
     std::optional<PolkadotBlockHeader> header,
     std::optional<std::string> error_string) {
-  if (error_string) {
-    return StopWithError(*error_string);
+  if (error_string || !header.has_value()) {
+    return StopWithError(error_string.value_or(WalletInternalErrorMessage()));
   }
 
-  CHECK(header);
   chain_header_ = std::move(header);
   UpdateSigningHeader();
 }
@@ -144,11 +142,10 @@ void PolkadotSignedTransferTask::OnGetParentHeader(
 void PolkadotSignedTransferTask::OnGetFinalizedHead(
     std::optional<std::array<uint8_t, kPolkadotBlockHashSize>> finalized_hash,
     std::optional<std::string> error_string) {
-  if (error_string) {
-    return StopWithError(*error_string);
+  if (error_string || !finalized_hash.has_value()) {
+    return StopWithError(error_string.value_or(WalletInternalErrorMessage()));
   }
 
-  CHECK(finalized_hash);
   GetPolkadotRpc()->GetBlockHeader(
       chain_id_, *finalized_hash,
       base::BindOnce(&PolkadotSignedTransferTask::OnGetFinalizedBlockHeader,
@@ -158,11 +155,10 @@ void PolkadotSignedTransferTask::OnGetFinalizedHead(
 void PolkadotSignedTransferTask::OnGetFinalizedBlockHeader(
     std::optional<PolkadotBlockHeader> header,
     std::optional<std::string> error_string) {
-  if (error_string) {
-    return StopWithError(*error_string);
+  if (error_string || !header.has_value()) {
+    return StopWithError(error_string.value_or(WalletInternalErrorMessage()));
   }
 
-  CHECK(header);
   finalized_header_ = std::move(header);
   UpdateSigningHeader();
 }
@@ -209,11 +205,10 @@ void PolkadotSignedTransferTask::UpdateSigningHeader() {
 void PolkadotSignedTransferTask::OnGetGenesisHash(
     std::optional<std::array<uint8_t, kPolkadotBlockHashSize>> genesis_hash,
     std::optional<std::string> error_string) {
-  if (error_string) {
-    return StopWithError(*error_string);
+  if (error_string || !genesis_hash.has_value()) {
+    return StopWithError(error_string.value_or(WalletInternalErrorMessage()));
   }
 
-  CHECK(genesis_hash);
   genesis_hash_ = genesis_hash;
   MaybeFinalizeSignTransaction();
 }
@@ -221,11 +216,9 @@ void PolkadotSignedTransferTask::OnGetGenesisHash(
 void PolkadotSignedTransferTask::OnGetRuntimeVersion(
     std::optional<PolkadotRuntimeVersion> runtime_version,
     std::optional<std::string> error_string) {
-  if (error_string) {
-    return StopWithError(*error_string);
+  if (error_string || !runtime_version.has_value()) {
+    return StopWithError(error_string.value_or(WalletInternalErrorMessage()));
   }
-
-  CHECK(runtime_version);
 
   runtime_version_ = runtime_version;
   MaybeFinalizeSignTransaction();

--- a/components/brave_wallet/browser/polkadot/polkadot_test_utils.cc
+++ b/components/brave_wallet/browser/polkadot/polkadot_test_utils.cc
@@ -39,6 +39,12 @@ constexpr std::string_view kDefaultSubmittedExtrinsicHash =
 constexpr std::string_view kRpcErrorResponse =
     R"({"jsonrpc":"2.0","id":1,"error":{"code":1234}})";
 
+// Successful JSON-RPC response carrying a null "result". Substrate nodes can
+// return this (rather than an error) when overloaded, so the RPC layer surfaces
+// it as a std::nullopt value with no error string.
+constexpr std::string_view kNullResultResponse =
+    R"({"jsonrpc":"2.0","id":1,"result":null})";
+
 constexpr std::string_view kDefaultAccountInfoResponse = R"(
   {
     "jsonrpc":"2.0",
@@ -55,6 +61,25 @@ constexpr std::string_view kDefaultAccountInfoResponse = R"(
       }
     ]
   })";
+
+constexpr std::string_view kDefaultChainHead = R"(
+    {
+      "jsonrpc":"2.0",
+      "id":10,
+      "result": {
+        "parentHash": "0x5834828e919dc0eccce83080104cc14f51f81330451bdf74bbc9bc1edba618f2",
+        "number": "0x1c06358",
+        "stateRoot": "0xc7ce642fe3c31724fc2808e179d807e5b0ba38a40eb5c08d98a41bd22eeeb9b5",
+        "extrinsicsRoot": "0xba8c3f44dbde4e14831d61cb349f808f902bf4474112cf45c2c7d92bef4e754e",
+        "digest": {
+          "logs": [
+            "0x0642414245b501030d0000002a92911100000000641ad61d0d848c4b374270406d092e8e5ca294e78ab6ea47d6da8ffe51e207758c49a32cac0d5d1e1ca56e4996b2136f42602debdf22478aff56b359adeadf06912cba0095e5b5abc3d7c0e03d9b628587010e6b44c6f9f40419b16bec4f5204",
+            "0x04424545468403b61c769585188ea959dc10c9434bfa46d57e818c7f17e047c75c42b3b1389c11",
+            "0x0542414245010186630051f53fb7ce6e02d1e020383357327c9e28ebfc399a96a98ad42528290a3f57cd65de0688f232da0b9db4a5007e69da55e2e13146c4f5c60983fc9c138e"
+          ]
+        }
+      }
+    })";
 
 bool IsEmpty(
     const std::array<uint8_t, kPolkadotSubstrateAccountIdSize>& pubkey) {
@@ -318,6 +343,26 @@ void PolkadotMockRpc::RejectRuntimeVersion() {
   reject_runtime_version_ = true;
 }
 
+void PolkadotMockRpc::ReturnNullInitialChainHeader() {
+  null_initial_chain_header_ = true;
+}
+
+void PolkadotMockRpc::ReturnNullParentBlockHeader() {
+  null_parent_block_header_ = true;
+}
+
+void PolkadotMockRpc::ReturnNullFinalizedHead() {
+  null_finalized_head_ = true;
+}
+
+void PolkadotMockRpc::ReturnNullFinalizedBlockHeader() {
+  null_finalized_block_header_ = true;
+}
+
+void PolkadotMockRpc::ReturnNullGenesisBlockHash() {
+  null_genesis_block_hash_ = true;
+}
+
 void PolkadotMockRpc::SetSenderPubKey(
     base::span<uint8_t, kPolkadotSubstrateAccountIdSize> pubkey) {
   base::span(sender_pubkey_).copy_from_nonoverlapping(pubkey);
@@ -359,24 +404,7 @@ void PolkadotMockRpc::AddGetInitialChainHeader() {
   req_res_pairs_.emplace(
       base::test::ParseJsonDict(
           R"({"id":1,"jsonrpc":"2.0","method":"chain_getHeader","params":[]})"),
-      R"(
-            {
-              "jsonrpc":"2.0",
-              "id":10,
-              "result": {
-                "parentHash": "0x5834828e919dc0eccce83080104cc14f51f81330451bdf74bbc9bc1edba618f2",
-                "number": "0x1c06358",
-                "stateRoot": "0xc7ce642fe3c31724fc2808e179d807e5b0ba38a40eb5c08d98a41bd22eeeb9b5",
-                "extrinsicsRoot": "0xba8c3f44dbde4e14831d61cb349f808f902bf4474112cf45c2c7d92bef4e754e",
-                "digest": {
-                  "logs": [
-                    "0x0642414245b501030d0000002a92911100000000641ad61d0d848c4b374270406d092e8e5ca294e78ab6ea47d6da8ffe51e207758c49a32cac0d5d1e1ca56e4996b2136f42602debdf22478aff56b359adeadf06912cba0095e5b5abc3d7c0e03d9b628587010e6b44c6f9f40419b16bec4f5204",
-                    "0x04424545468403b61c769585188ea959dc10c9434bfa46d57e818c7f17e047c75c42b3b1389c11",
-                    "0x0542414245010186630051f53fb7ce6e02d1e020383357327c9e28ebfc399a96a98ad42528290a3f57cd65de0688f232da0b9db4a5007e69da55e2e13146c4f5c60983fc9c138e"
-                  ]
-                }
-              }
-            })");
+      kDefaultChainHead);
 }
 
 void PolkadotMockRpc::AddGetParentBlockHeader() {
@@ -416,6 +444,14 @@ void PolkadotMockRpc::AddGetFinalizedBlockHash() {
         base::test::ParseJsonDict(
             R"({"id":1,"jsonrpc":"2.0","method":"chain_getFinalizedHead","params":[]})"),
         std::string(kRpcErrorResponse));
+    return;
+  }
+
+  if (null_finalized_head_) {
+    req_res_pairs_.emplace(
+        base::test::ParseJsonDict(
+            R"({"id":1,"jsonrpc":"2.0","method":"chain_getFinalizedHead","params":[]})"),
+        std::string(kNullResultResponse));
     return;
   }
 
@@ -491,6 +527,14 @@ void PolkadotMockRpc::AddGetGenesisBlockHash() {
         base::test::ParseJsonDict(
             R"({"id":1,"jsonrpc":"2.0","method":"chain_getBlockHash","params":["00000000"]})"),
         std::string(kRpcErrorResponse));
+    return;
+  }
+
+  if (null_genesis_block_hash_) {
+    req_res_pairs_.emplace(
+        base::test::ParseJsonDict(
+            R"({"id":1,"jsonrpc":"2.0","method":"chain_getBlockHash","params":["00000000"]})"),
+        std::string(kNullResultResponse));
     return;
   }
 
@@ -1062,14 +1106,18 @@ bool PolkadotMockRpc::HandleGetFinalizedBlockHeader(
           return true;
         }
 
+        if (null_initial_chain_header_) {
+          url_loader_factory_->AddResponse(req.url.spec(),
+                                           std::string(kNullResultResponse));
+          return true;
+        }
+
         if (const auto* header = base::FindOrNull(block_header_map_, "")) {
           url_loader_factory_->AddResponse(req.url.spec(), *header);
           return true;
         }
 
-        url_loader_factory_->AddResponse(req.url.spec(),
-                                         finalized_block_header_json_);
-
+        url_loader_factory_->AddResponse(req.url.spec(), kDefaultChainHead);
         return true;
       }
 
@@ -1091,6 +1139,12 @@ bool PolkadotMockRpc::HandleGetFinalizedBlockHeader(
           return true;
         }
 
+        if (null_finalized_block_header_) {
+          url_loader_factory_->AddResponse(req.url.spec(),
+                                           std::string(kNullResultResponse));
+          return true;
+        }
+
         url_loader_factory_->AddResponse(req.url.spec(),
                                          finalized_block_header_json_);
 
@@ -1099,10 +1153,16 @@ bool PolkadotMockRpc::HandleGetFinalizedBlockHeader(
 
       // Any other chain_getHeader with a specific block hash is the current
       // head's parent lookup. The relay-chain req/res pairs serve this
-      // normally; short-circuit with an error when rejecting.
+      // normally; short-circuit with an error/null result when configured.
       if (reject_parent_block_header_) {
         url_loader_factory_->AddResponse(req.url.spec(),
                                          std::string(kRpcErrorResponse));
+        return true;
+      }
+
+      if (null_parent_block_header_) {
+        url_loader_factory_->AddResponse(req.url.spec(),
+                                         std::string(kNullResultResponse));
         return true;
       }
     }

--- a/components/brave_wallet/browser/polkadot/polkadot_test_utils.h
+++ b/components/brave_wallet/browser/polkadot/polkadot_test_utils.h
@@ -68,6 +68,16 @@ struct PolkadotMockRpc {
   void RejectFinalizedBlockHeader();
   void RejectGenesisBlockHash();
   void RejectRuntimeVersion();
+
+  // Respond to an individual step of the signing-payload assembly with a
+  // successful JSON-RPC response whose "result" is null (as Substrate nodes may
+  // do when overloaded) rather than a JSON-RPC error. Configure exactly one
+  // before calling AddReqResPairs() to exercise a specific null-result path.
+  void ReturnNullInitialChainHeader();
+  void ReturnNullParentBlockHeader();
+  void ReturnNullFinalizedHead();
+  void ReturnNullFinalizedBlockHeader();
+  void ReturnNullGenesisBlockHash();
   void SetSenderPubKey(
       base::span<uint8_t, kPolkadotSubstrateAccountIdSize> pubkey);
   void SetExpectedExtrinsic(std::string extrinsic);
@@ -165,6 +175,12 @@ struct PolkadotMockRpc {
   bool reject_finalized_block_header_ = false;
   bool reject_genesis_block_hash_ = false;
   bool reject_runtime_version_ = false;
+
+  bool null_initial_chain_header_ = false;
+  bool null_parent_block_header_ = false;
+  bool null_finalized_head_ = false;
+  bool null_finalized_block_header_ = false;
+  bool null_genesis_block_hash_ = false;
 };
 
 // Build metadata from a known relay/parachain name returned by system_chain.

--- a/components/brave_wallet/browser/polkadot/polkadot_wallet_service_unittest.cc
+++ b/components/brave_wallet/browser/polkadot/polkadot_wallet_service_unittest.cc
@@ -719,6 +719,41 @@ TEST_F(PolkadotWalletServiceUnitTest, SignTransferExtrinsic_NoRuntimeVersion) {
   EXPECT_EQ(signed_extrinsic.error(), WalletInternalErrorMessage());
 }
 
+TEST_F(PolkadotWalletServiceUnitTest,
+       SignTransferExtrinsic_NullChainHeaderResult) {
+  auto signed_extrinsic = SignTransferExtrinsicWithFailedStep(
+      [](PolkadotMockRpc& rpc) { rpc.ReturnNullInitialChainHeader(); });
+  EXPECT_EQ(signed_extrinsic.error(), WalletInternalErrorMessage());
+}
+
+TEST_F(PolkadotWalletServiceUnitTest,
+       SignTransferExtrinsic_NullParentHeaderResult) {
+  auto signed_extrinsic = SignTransferExtrinsicWithFailedStep(
+      [](PolkadotMockRpc& rpc) { rpc.ReturnNullParentBlockHeader(); });
+  EXPECT_EQ(signed_extrinsic.error(), WalletInternalErrorMessage());
+}
+
+TEST_F(PolkadotWalletServiceUnitTest,
+       SignTransferExtrinsic_NullFinalizedHeadResult) {
+  auto signed_extrinsic = SignTransferExtrinsicWithFailedStep(
+      [](PolkadotMockRpc& rpc) { rpc.ReturnNullFinalizedHead(); });
+  EXPECT_EQ(signed_extrinsic.error(), WalletInternalErrorMessage());
+}
+
+TEST_F(PolkadotWalletServiceUnitTest,
+       SignTransferExtrinsic_NullFinalizedBlockHeaderResult) {
+  auto signed_extrinsic = SignTransferExtrinsicWithFailedStep(
+      [](PolkadotMockRpc& rpc) { rpc.ReturnNullFinalizedBlockHeader(); });
+  EXPECT_EQ(signed_extrinsic.error(), WalletInternalErrorMessage());
+}
+
+TEST_F(PolkadotWalletServiceUnitTest,
+       SignTransferExtrinsic_NullGenesisHashResult) {
+  auto signed_extrinsic = SignTransferExtrinsicWithFailedStep(
+      [](PolkadotMockRpc& rpc) { rpc.ReturnNullGenesisBlockHash(); });
+  EXPECT_EQ(signed_extrinsic.error(), WalletInternalErrorMessage());
+}
+
 TEST_F(PolkadotWalletServiceUnitTest, SignAndSendTransaction) {
   // Test the normal happy path where we create a signed extrinsic for the
   // specified account and then author it on the block chain.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->

Remove dangerous usages of CHECK from the PolkadotSignedTransferTask.

Asset Hub Polkadot nodes can intermittently return `"result": null` for valid
queries. An example of this is, we'll make a request for the block header for a
specific blockhash, such as:
```
{"id":10,"jsonrpc":"2.0","method":"chain_getHeader","params":["0d01b491c11307c984a3d84cf7523df1e2c2a5021155f3f2976d8dbcdc3e0765"]}
```
but we will intermittently see either the correct response:
```
{"jsonrpc":"2.0","id":10,"result":{"parentHash":"0x01a64ca06df2340739c779f3f0080ad4d209ecf0b5ac3ad17c21453fe8a6579b","number":"0x11b6f9c","stateRoot":"0x284d8f91b8666708f5641ad9b90fbd8b2d742859d7b4197e46a5dc55c3d7711a","extrinsicsRoot":"0x632e3d97bd304deb647f2720c44a62914680ce4e591f4c6372fe4d0c090ef160","digest":{"logs":["0x06434d4c53100100010c","0x06434d4c530c020001","0x066175726120b8c36e0400000000","0x0452505352901800e8e8d560bf81c5a85e3e2a9773a3cbb465d2f3b0be19d2861e237427c663c29baf07","0x05617572610101e375f636fcc7486ba0cf58781722e58d2fe613ae1dc273c3b1b504b6d427950839ec3d9ea68a0bff158d69966ec9db7e479f9b8a3c40fb3ae23e43fa5f516f0a"]}}}
```

or we will see:
```
{"jsonrpc":"2.0","id":10,"result":null}
```

This is in theory an impossible scenario but RPC nodes behave as they do. We
update the code to remove all usages of CHECK for values derived from the RPC
nodes.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
