### PR TITLE
[Android] Keep only 1 instance of NTP SI infobar at a moment (uplift to 1.93.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabTakeoverInfobar.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabTakeoverInfobar.java
@@ -47,18 +47,38 @@ public class BraveNewTabTakeoverInfobar {
         WindowAndroid windowAndroid = webContents.getTopLevelNativeWindow();
         if (windowAndroid == null) return;
         SnackbarManager snackbarManager = SnackbarManagerProvider.from(windowAndroid);
-        if (snackbarManager == null) return;
+        if (!(snackbarManager instanceof BraveSnackbarManager)) return;
+        BraveSnackbarManager braveSnackbarManager = (BraveSnackbarManager) snackbarManager;
 
-        recordInfobarWasDisplayed();
+        // Bail out if the snackbar cannot be shown right now (e.g. the activity is not in the
+        // foreground); leave the counter untouched so a later NTP can retry.
+        if (!braveSnackbarManager.canShowSnackbar()) return;
+
+        // Only ever show one New Tab Takeover notice at a time across all tabs. The notice lives at
+        // the window level while each NTP owns its own BraveNewTabTakeoverInfobar, so without this
+        // guard every new NTP would queue another one; closing the visible one would then merely
+        // reveal the next, making the close button appear broken. The (window-scoped) manager
+        // remembers the live notice, so we ask it instead of tracking that state ourselves.
+        if (braveSnackbarManager.hasNewTabTakeoverInfobar()) {
+            return;
+        }
 
         SnackbarController controller =
                 new SnackbarController() {
                     @Override
                     public void onAction(@Nullable Object actionData) {
+                        braveSnackbarManager.clearNewTabTakeoverInfobar();
                         // Pressing `Learn more` opens the support page and stops the notice from
                         // showing again.
                         suppressInfobar();
                         TabUtils.openUrlInNewTab(/* isIncognito= */ false, LEARN_MORE_URL);
+                    }
+
+                    @Override
+                    public void onDismissNoAction(@Nullable Object actionData) {
+                        // Single choke point for every non-action dismissal: close button, swipe,
+                        // replacement, queue overflow, and the activity stop/destroy clears.
+                        braveSnackbarManager.clearNewTabTakeoverInfobar();
                     }
                 };
 
@@ -73,21 +93,21 @@ public class BraveNewTabTakeoverInfobar {
                         .setAction(actionLabel, /* actionData= */ null)
                         .setDefaultLines(false);
 
-        snackbarManager.showSnackbar(snackbar);
+        braveSnackbarManager.showNewTabTakeoverInfobar(snackbar);
+        recordInfobarWasDisplayed();
 
         // Move the long action label onto its own line below the message, with a trailing close
         // button. Like the old infobar, closing dismisses the snackbar and suppresses future
         // displays so the notice is not shown again.
-        if (snackbarManager instanceof BraveSnackbarManager) {
-            BraveSnackbarManager braveSnackbarManager = (BraveSnackbarManager) snackbarManager;
-            braveSnackbarManager.setActionBelowMessage(
-                    R.drawable.ic_close,
-                    activity.getString(R.string.close),
-                    () -> {
-                        suppressInfobar();
-                        braveSnackbarManager.dismissSnackbars(controller);
-                    });
-        }
+        braveSnackbarManager.setActionBelowMessage(
+                R.drawable.ic_close,
+                activity.getString(R.string.close),
+                () -> {
+                    suppressInfobar();
+                    // Dismissing invokes controller.onDismissNoAction(), which releases the
+                    // remembered notice from the manager.
+                    braveSnackbarManager.dismissSnackbars(controller);
+                });
     }
 
     private boolean shouldDisplayInfobar() {

--- a/android/junit/BUILD.gn
+++ b/android/junit/BUILD.gn
@@ -260,6 +260,16 @@ if (is_android) {
     ]
   }
 
+  robolectric_library(
+      "brave_junit_tests_org.chromium.chrome.browser.ui.messages.snackbar") {
+    sources = [ "src/org/chromium/chrome/browser/ui/messages/snackbar/BraveSnackbarManagerNewTabTakeoverTest.java" ]
+
+    deps = [
+      "//chrome/android:chrome_java",
+      "//chrome/android/junit:chrome_junit_tests_helper",
+    ]
+  }
+
   robolectric_library("brave_junit_tests_org.chromium.chrome.browser.media") {
     sources = [
       "src/org/chromium/chrome/browser/media/BraveFullscreenVideoPictureInPictureControllerTest.java",

--- a/android/junit/src/org/chromium/chrome/browser/ui/messages/snackbar/BraveSnackbarManagerNewTabTakeoverTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/ui/messages/snackbar/BraveSnackbarManagerNewTabTakeoverTest.java
@@ -1,0 +1,103 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.ui.messages.snackbar;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import android.widget.FrameLayout;
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.robolectric.annotation.Config;
+
+import org.chromium.base.test.BaseRobolectricTestRunner;
+import org.chromium.base.test.util.CommandLineFlags;
+import org.chromium.chrome.browser.ChromeTabbedActivity;
+import org.chromium.chrome.browser.flags.ChromeSwitches;
+import org.chromium.chrome.browser.ui.messages.snackbar.SnackbarManager.SnackbarController;
+
+/**
+ * Unit tests for the New Tab Takeover dedup bookkeeping in {@link BraveSnackbarManager}. Each NTP
+ * tab creates its own notice but they share the window's manager, so the manager must report a
+ * single outstanding notice and release it once dismissed.
+ */
+@RunWith(BaseRobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+@CommandLineFlags.Add({
+    ChromeSwitches.DISABLE_FIRST_RUN_EXPERIENCE,
+    ChromeSwitches.DISABLE_NATIVE_INITIALIZATION
+})
+public class BraveSnackbarManagerNewTabTakeoverTest {
+    @Rule
+    public ActivityScenarioRule<ChromeTabbedActivity> mActivityScenarioRule =
+            new ActivityScenarioRule<>(ChromeTabbedActivity.class);
+
+    @Rule public final MockitoRule mMockitoRule = MockitoJUnit.rule();
+
+    private BraveSnackbarManager mManager;
+
+    @Before
+    public void setUp() {
+        mActivityScenarioRule.getScenario().onActivity(this::onActivity);
+    }
+
+    private void onActivity(ChromeTabbedActivity activity) {
+        // Spy so showSnackbar() is a no-op: these tests exercise only the dedup bookkeeping, not
+        // the real snackbar view inflation/animation.
+        mManager =
+                spy(
+                        new BraveSnackbarManager(
+                                activity,
+                                new FrameLayout(activity),
+                                /* windowAndroid= */ null,
+                                /* additionalBottomMarginPxSupplier= */ null,
+                                /* modalDialogManager= */ null));
+        doNothing().when(mManager).showSnackbar(any());
+    }
+
+    private static Snackbar makeNotice() {
+        return Snackbar.make(
+                        "New Tab Takeover",
+                        new SnackbarController() {},
+                        Snackbar.TYPE_PERSISTENT,
+                        Snackbar.UMA_UNKNOWN)
+                .setAction("Learn more", /* actionData= */ null);
+    }
+
+    @Test
+    public void noNoticeOutstandingInitially() {
+        assertFalse(mManager.hasNewTabTakeoverInfobar());
+    }
+
+    @Test
+    public void showMarksNoticeOutstandingAndDisplaysIt() {
+        Snackbar snackbar = makeNotice();
+        mManager.showNewTabTakeoverInfobar(snackbar);
+
+        assertTrue(mManager.hasNewTabTakeoverInfobar());
+        verify(mManager).showSnackbar(snackbar);
+    }
+
+    @Test
+    public void clearReleasesOutstandingNotice() {
+        mManager.showNewTabTakeoverInfobar(makeNotice());
+        assertTrue(mManager.hasNewTabTakeoverInfobar());
+
+        mManager.clearNewTabTakeoverInfobar();
+        assertFalse(mManager.hasNewTabTakeoverInfobar());
+    }
+}

--- a/browser/ui/messages/android/java/src/org/chromium/chrome/browser/ui/messages/snackbar/BraveSnackbarManager.java
+++ b/browser/ui/messages/android/java/src/org/chromium/chrome/browser/ui/messages/snackbar/BraveSnackbarManager.java
@@ -26,6 +26,15 @@ public class BraveSnackbarManager extends SnackbarManager {
 
     private @Nullable Runnable mPendingClickCallback;
 
+    // The single New Tab Takeover notice currently outstanding in this (window-scoped) manager, or
+    // null when none is showing or queued. Each NTP tab creates its own BraveNewTabTakeoverInfobar
+    // but they share this manager, so remembering the live notice here lets a later NTP detect it
+    // and avoid enqueueing a duplicate. It is released from the notice's SnackbarController on
+    // every
+    // dismissal path, and is naturally gone when this manager (and its activity) is destroyed, so
+    // unlike a static flag it cannot leak across sessions or get stuck set.
+    private @Nullable Snackbar mNewTabTakeoverInfobar;
+
     public BraveSnackbarManager(
             Activity activity,
             ViewGroup snackbarParentView,
@@ -45,6 +54,26 @@ public class BraveSnackbarManager extends SnackbarManager {
         super.showSnackbar(snackbar);
 
         tryMakeSnackbarClickable();
+    }
+
+    /** Returns whether a New Tab Takeover notice is currently outstanding (showing or queued). */
+    public boolean hasNewTabTakeoverInfobar() {
+        return mNewTabTakeoverInfobar != null;
+    }
+
+    /**
+     * Shows the given New Tab Takeover notice and remembers it as the single outstanding one (see
+     * {@link #hasNewTabTakeoverInfobar()}). The caller must release it via {@link
+     * #clearNewTabTakeoverInfobar()} from the notice's controller when it is dismissed.
+     */
+    public void showNewTabTakeoverInfobar(Snackbar snackbar) {
+        mNewTabTakeoverInfobar = snackbar;
+        showSnackbar(snackbar);
+    }
+
+    /** Releases the remembered New Tab Takeover notice once it has been dismissed. */
+    public void clearNewTabTakeoverInfobar() {
+        mNewTabTakeoverInfobar = null;
     }
 
     /**

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1750,6 +1750,7 @@ if (is_android) {
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.tasks",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.toolbar",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.ui",
+      "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.ui.messages.snackbar",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.vpn",
       "//brave/browser/customize_menu/android:junit",
       "//brave/browser/first_run/android:junit",


### PR DESCRIPTION
Uplift of #38358
Resolves https://github.com/brave/brave-browser/issues/57448

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.