### PR TITLE
Switch history embeddings to the native LiteRT embedder

### DIFF
--- a/browser/history_embeddings/BUILD.gn
+++ b/browser/history_embeddings/BUILD.gn
@@ -134,5 +134,7 @@ source_set("history_embeddings") {
     "//chrome/browser:browser_public_dependencies",
     "//chrome/browser/profiles",
     "//components/history_embeddings/core",
+    "//components/optimization_guide/proto:optimization_guide_proto",
+    "//content/public/browser",
   ]
 }

--- a/browser/history_embeddings/README.md
+++ b/browser/history_embeddings/README.md
@@ -7,16 +7,24 @@ Brave's local embedder for history embeddings (semantic history search).
 Upstream Chromium's history embeddings uses `OptimizationGuide` to deliver
 TFLite model files to `ChromePassageEmbeddingsServiceController`, which binds
 its `service_remote_` to a `PassageEmbeddingsService`
-(`services/passage_embeddings/`) running in a separate utility process. The
+(`services/passage_embeddings/`) running in a sandboxed utility process. The
 upstream-owned `SchedulingEmbedder` drives the job queue and calls into that
 service.
 
-Brave replaces only the transport: `BravePassageEmbeddingsServiceController`
-subclasses `PassageEmbeddingsServiceController` and swaps in an in-process
-`BravePassageEmbeddingsService` that hosts a WASM EmbeddingGemma worker inside a
-background WebContents on the guest OTR profile. The upstream
-`SchedulingEmbedder` (priority re-sort, partial-progress resumption,
-performance-scenario awareness) is unchanged.
+Brave keeps that sandboxed-utility architecture but swaps the model and the
+executor: `BravePassageEmbeddingsServiceController` subclasses
+`PassageEmbeddingsServiceController` and launches the real utility via its
+`LitertServiceLauncher`. Inside the utility, a chromium_src override of
+`PassageEmbedderImpl::BuildExecutionTask` runs EmbeddingGemma natively through
+LiteRT's `CompiledModel`
+([`//brave/services/passage_embeddings:litert_model_runner`](../../services/passage_embeddings/))
+instead of upstream's TFLite executor. The upstream `SchedulingEmbedder`
+(priority re-sort, partial-progress resumption, performance-scenario awareness)
+is unchanged.
+
+The EmbeddingGemma model (`model.tflite` plus its SentencePiece tokenizer) is
+delivered by the local AI component updater and resolved from the component's
+`litert/` subdir; Brave does not use the `optimization_guide` TFLite model.
 
 The upstream extraction pipeline is enabled by chromium_src overrides of
 `OptimizationGuideKeyedServiceFactory`, `PageContentAnnotationsServiceFactory`,
@@ -33,92 +41,45 @@ Two prefs gate the feature, via the `IsHistoryEmbeddings*` overrides in
 - **`kBraveHistoryEmbeddingsEnabled`** — per-profile brave://history toggle;
   gates `IsHistoryEmbeddingsEnabledForProfile()`.
 
-The "Tool: On-Device AI" renderer launches only when an embedding service feeds
-the controller. Both such services (`PageEmbeddingsService`,
-`HistoryEmbeddingsService`) refuse to build without
-`PassageEmbedderModelObserverFactory`, so
+The embedder is built only when an embedding service feeds the controller. Both
+such services (`PageEmbeddingsService`, `HistoryEmbeddingsService`) refuse to
+build without `PassageEmbedderModelObserverFactory`, so
 [`chromium_src/.../passage_embedder_model_observer_factory.cc`](../../chromium_src/chrome/browser/passage_embeddings/passage_embedder_model_observer_factory.cc)
 gates that one shared dependency on `IsHistoryEmbeddingsEnabledForProfile()` —
-toggle off ⇒ neither service is built ⇒ no renderer. (Its other upstream gates,
+toggle off ⇒ neither service is built ⇒ no embedder. (Its other upstream gates,
 `kPassageEmbedder`/`kPermissionsAIv4`, are disabled in Brave.) Applied at
 service creation, so changes take effect on restart.
 
-## Why `BindPassageEmbedder` instead of mojo `LoadModels`
-
-Upstream's `mojom::PassageEmbeddingsService::LoadModels` is shaped for
-upstream's embedder: two `ReadOnlyFile` fields (tflite model + sentencepiece
-tokenizer) and a `PassageEmbedderParams` of tflite-specific knobs (thread counts
-per priority, cache size, GPU flag). EmbeddingGemma needs five files (`weights`,
-`weights_dense1`, `weights_dense2`, `tokenizer`, `config`) with different
-semantics, and none of the `PassageEmbedderParams` tuning applies to our WASM
-renderer. There's no clean way to map our inputs onto the upstream struct short
-of patching the mojom.
-
-The mojom also exists to cross a sandbox boundary — upstream runs its
-`PassageEmbeddingsService` in a utility process. `BravePassageEmbeddingsService`
-lives in the browser process, same process as the controller, so the mojo pipe
-adds serialization cost without any isolation benefit.
-
-The only useful piece `LoadModels` would carry for us is the
-`PendingReceiver<PassageEmbedder>` that hooks the controller's
-`embedder_remote_` up to the service. `BindPassageEmbedder(receiver, callback)`
-carries exactly that and nothing more. The renderer's model files are delivered
-separately through `PassageEmbedderFactory::Init` as
-`local_ai::mojom::ModelFiles` (five `BigBuffer` fields), read from the
-component-updater install directory surfaced by `LocalModelsUpdaterState`.
-
-`BravePassageEmbeddingsService` still implements the upstream mojom for
-completeness (its `LoadModels` override forwards to `BindPassageEmbedder` after
-discarding the unused params), but the controller calls `BindPassageEmbedder`
-directly. The base class's `service_remote_` is left unbound; the
-`embedder_remote_` idle handler tears the whole service down so the WASM
-renderer is freed.
-
-## Why fire `EmbedderMetadataUpdated` from the constructor
+## Model delivery + `EmbedderMetadataUpdated`
 
 `SchedulingEmbedder` waits for `EmbedderMetadataUpdated` before it dispatches
-any work. Upstream fires it from `MaybeUpdateModelInfo()` when
-`optimization_guide` delivers model files. Brave has no dynamic model info — our
-metadata is static (`version=1`, `output_size=768`, `threshold=0.45`) and always
-valid — so the controller fires the notification once in its constructor. The
-`chromium_src` include shim declares `BravePassageEmbeddingsServiceController`
-as a `friend class` on the base so we can reach `observer_list_` and
-`embedder_remote_` without touching the upstream header (see
+any work, and the base controller opens the model files the paths point at.
+Brave's model is delivered by the local AI component updater, so the controller
+observes `LocalModelsUpdaterState`: when the EmbeddingGemma component is
+installed, `OnLocalModelsReady` resolves
+`embeddings_model_path_`/`sp_model_path_` from the component's `litert/` subdir
+and fires `EmbedderMetadataUpdated`; `IsModelAvailable()` is true once those
+paths are set. The metadata is otherwise static (`version=2`, `output_size=768`,
+`threshold=0.45`); the version differs from the previous WASM embedder's so
+`SqlDatabase` re-embeds stored history rather than mixing vector spaces.
+
+The `chromium_src` include shim declares
+`BravePassageEmbeddingsServiceController` as a `friend class` on the base so we
+can set the model paths/metadata and reach `observer_list_` without touching the
+upstream header (see
 [`chromium_src/.../passage_embeddings_service_controller.h`](../../chromium_src/components/passage_embeddings/core/passage_embeddings_service_controller.h)).
 
 ## Key Files
 
-- **`brave_passage_embeddings_service.{h,cc}`** — In-process implementation of
-  `passage_embeddings::mojom::PassageEmbeddingsService`. Exposes a direct
-  `BindPassageEmbedder(receiver, model_files, cb)` entry point used by the
-  controller; constructs a `BraveBatchPassageEmbedder` around the supplied
-  files. Also exposes `BindLocalAIReceiver(...)` which the controller forwards
-  to from `UntrustedLocalAIUI::BindInterface` so the WASM page can register its
-  `PassageEmbedderFactory`.
-
-- **`brave_batch_passage_embedder.{h,cc}`** — In-process implementation of
-  `passage_embeddings::mojom::PassageEmbedder` and
-  `local_ai::mojom::LocalAIService`. Owns the full renderer-side lifecycle for a
-  single load: the guest-OTR background WebContents that hosts the WASM worker,
-  the `LocalAIService` receiver set the WASM page uses to register its
-  `PassageEmbedderFactory`, and the `factory->Init` + `factory->Bind` handshake.
-  Initialization is gated on an explicit `LoadPhase`
-  (`kCreatingContents → kAwaitingFactory → kInitializing → kReady`); the model
-  files arrive via the ctor, and Init runs as soon as the renderer registers its
-  factory. Translates upstream's batch mojom to the renderer's
-  one-passage-at-a-time interface, processing passages sequentially so callbacks
-  resolve with embeddings in order.
-
 - **`brave_passage_embeddings_service_controller.{h,cc}`** — Singleton subclass
-  of `PassageEmbeddingsServiceController`. Observes `LocalModelsUpdaterState` so
-  it knows when the EmbeddingGemma component is installed; `IsModelAvailable()`
-  returns true iff the component is present, and `OnLocalModelsReady` fires
-  `EmbedderMetadataUpdated` on observer*list* so SchedulingEmbedder retries.
-  Overrides `MaybeLaunchService()`/`ResetServiceRemote()` to construct/destroy
-  the in-process service, and `GetEmbeddings()` to short-circuit with
-  `kModelUnavailable` when not ready, otherwise post the disk read for the five
-  EmbeddingGemma files and hand them to `service_->BindPassageEmbedder()` once
-  loaded.
+  of `PassageEmbeddingsServiceController`. Provides `LitertServiceLauncher`,
+  which launches the real sandboxed Passage Embeddings utility process. Observes
+  `LocalModelsUpdaterState` and resolves the model paths from the component's
+  `litert/` subdir in `OnLocalModelsReady`, publishes the LiteRT metadata, and
+  swallows `optimization_guide` model updates (`MaybeUpdateModelInfo`) since
+  Brave doesn't use that model. `GetEmbeddings` is the base implementation: the
+  upstream launch + `LoadModels` flow opens the model files and drives the
+  embedder in the utility.
 
 - **`open_tab_search.{h,cc}`** — Standalone util, unrelated to the embedder
   above: it powers on-device "search my open tabs by content".
@@ -127,6 +88,18 @@ as a `friend class` on the base so we can reach `observer_list_` and
   with `HistoryEmbeddingsSearch::Search`. Shared by the tab_search WebUI page
   handler and the semantic tab search chat tool. Builds regardless of
   `enable_local_ai` since it only wraps upstream Chromium APIs.
+
+## The LiteRT embedder
+
+The native embedder lives in
+[`//brave/services/passage_embeddings`](../../services/passage_embeddings/) and
+runs inside the sandboxed utility, wired in by
+[`chromium_src/services/passage_embeddings/passage_embedder_impl.cc`](../../chromium_src/services/passage_embeddings/passage_embedder_impl.cc):
+its `BuildExecutionTask` override builds a `LitertModelRunner` from the loaded
+`.tflite` and wraps it in upstream's `PassageEmbedderExecutor` interface.
+`LitertModelRunner` runs EmbeddingGemma on LiteRT's CPU backend via
+`litert::CompiledModel`. The browser opens the model files and sends them to the
+utility through the standard `LoadModels` mojo call.
 
 ## Related Files
 
@@ -147,10 +120,17 @@ as a `friend class` on the base so we can reach `observer_list_` and
 
 - **`chromium_src/components/passage_embeddings/core/passage_embeddings_service_controller.h`**
   — Chromium_src include shim. Adds `virtual` to
-  `IsModelAvailable`/`GetEmbedderMetadata`/`GetEmbeddings` via `#define`s, and
-  declares `friend class BravePassageEmbeddingsServiceController` by
-  macro-injecting it through the `EmbedderRunning` anchor (same idiom as
+  `IsModelAvailable`/`GetEmbedderMetadata`/`MaybeUpdateModelInfo` via
+  `#define`s, and declares
+  `friend class BravePassageEmbeddingsServiceController` by macro-injecting it
+  through the `EmbedderRunning` anchor (same idiom as
   `chromium_src/ui/android/view_android.h`).
+
+- **`chromium_src/services/passage_embeddings/passage_embedder_impl.cc`** —
+  Injects the LiteRT runner at the top of
+  `PassageEmbedderImpl::BuildExecutionTask` (via a
+  `BRAVE_PASSAGE_EMBEDDER_IMPL_BUILD_EXECUTION_TASK` macro), so the sandboxed
+  utility runs EmbeddingGemma on LiteRT instead of upstream's TFLite executor.
 
 - **`chromium_src/chrome/browser/page_content_annotations/`** — Factory
   overrides for `PageContentAnnotationsService`, `PageContentExtractionService`,
@@ -169,18 +149,14 @@ PageContentAnnotationsWebContentsObserver (upstream)
     → PageContentExtractionService::OnPageContentExtracted
       → PageEmbeddingsService (chunks text into passages)
         → SchedulingEmbedder (upstream; queues, reorders by priority)
-          → BravePassageEmbeddingsServiceController::GetEmbeddings
+          → PassageEmbeddingsServiceController::GetEmbeddings (base)
             → !IsModelAvailable() → kModelUnavailable (SchedulingEmbedder
               retries on the next EmbedderMetadataUpdated)
-            → PostTask: read five EmbeddingGemma files from disk
-              → service_->BindPassageEmbedder(receiver, model_files, cb)
-                → BraveBatchPassageEmbedder created with files in hand;
-                  creates background WebContents and waits for factory
-                  registration
-                  → PassageEmbedderFactory::Init (loads WASM model)
-                    → renderer-side PassageEmbedder bound; embedder_remote_
-                      ready
-            → embedder_remote_->GenerateEmbeddings (subsequent batches)
-              → WASM renderer (EmbeddingGemma, one passage at a time)
-                → HistoryEmbeddingsService (stores passages + embeddings)
+            → LitertServiceLauncher launches the sandboxed utility
+            → LoadModels (browser opens the .tflite + SentencePiece files and
+              sends them to the utility)
+              → PassageEmbedderImpl::BuildExecutionTask (chromium_src override)
+                → LitertModelRunner (EmbeddingGemma on LiteRT's CompiledModel)
+            → GenerateEmbeddings (per batch)
+              → HistoryEmbeddingsService (stores passages + embeddings)
 ```

--- a/browser/history_embeddings/brave_passage_embeddings_service_controller.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service_controller.cc
@@ -10,6 +10,7 @@
 
 #include "base/check.h"
 #include "base/files/file_path.h"
+#include "base/files/file_util.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
 #include "base/no_destructor.h"
@@ -23,28 +24,39 @@
 #include "brave/components/local_ai/core/utils.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/profiles/profile.h"
-#include "components/passage_embeddings/core/passage_embeddings_features.h"
+#include "components/optimization_guide/proto/passage_embeddings_model_metadata.pb.h"
 #include "components/passage_embeddings/core/passage_embeddings_service_launcher.h"
 #include "components/passage_embeddings/core/passage_embeddings_types.h"
+#include "content/public/browser/service_process_host.h"
 #include "mojo/public/cpp/base/big_buffer.h"
-#include "mojo/public/cpp/bindings/callback_helpers.h"
 #include "url/gurl.h"
 
 namespace passage_embeddings {
 
 namespace {
 
-mojom::PassagePriority ToMojom(PassagePriority priority) {
-  switch (priority) {
-    case kUserInitiated:
-      return mojom::PassagePriority::kUserInitiated;
-    case kUrgent:
-      return mojom::PassagePriority::kUrgent;
-    case kPassive:
-    case kLatent:
-      return mojom::PassagePriority::kPassive;
-  }
-}
+// The LiteRT model files ship in the shared EmbeddingGemma component (the same
+// one the WASM embedder uses), under a litert/ subdir of its model dir.
+constexpr char kLitertModelSubdir[] = "litert";
+// Named after optimization guide's convention for the model in a model dir, so
+// the component can later ship a model-info.pb carrying this metadata without
+// publishing the model under a second name.
+constexpr char kLitertModelName[] = "model.tflite";
+constexpr char kSentencePieceModelName[] = "sentencepiece.model";
+// Matches the input window of the model the component ships. The embedder
+// derives the actual window from the model's input tensor, so this only feeds
+// the metadata the controller reports.
+constexpr uint32_t kLitertInputWindowSize = 512;
+constexpr int kLitertOutputSize = 768;
+constexpr double kLitertScoreThreshold = 0.45;
+constexpr int kLitertModelVersion = 2;
+
+// OnBackgroundWebContentsCreated, CreateBackgroundWebContents and
+// LoadLocalModelFilesFromDisk, plus the controller methods tagged "Dead WASM
+// code", are no longer reached now that LiteRT is the only embedder. They are
+// kept to keep this change minimal and are deleted, along with the WASM
+// embedder itself and these comments, in
+// https://github.com/brave/brave-core/pull/38375.
 
 // Completion callback for local_ai::CreateBackgroundWebContents().
 //
@@ -108,22 +120,25 @@ local_ai::mojom::ModelFilesPtr LoadLocalModelFilesFromDisk(
   return model_files;
 }
 
-// `StubServiceLauncher` is provided to `PassageEmbeddingsServiceController`,
-// and is used to spin up a sandboxed process. We pass a stub because we manage
-// the embedding service in-process, and the launcher path is never taken.
-class StubServiceLauncher : public PassageEmbeddingsServiceLauncher {
+// Launches the sandboxed Passage Embeddings utility process, whose LoadModels
+// is chromium_src-overridden to run EmbeddingGemma on LiteRT's CompiledModel
+// inside that process.
+class LitertServiceLauncher : public PassageEmbeddingsServiceLauncher {
  public:
   static PassageEmbeddingsServiceLauncher& Create() {
-    static base::NoDestructor<StubServiceLauncher> launcher;
+    static base::NoDestructor<LitertServiceLauncher> launcher;
     return *launcher;
   }
 
   void LaunchService(mojo::PendingReceiver<mojom::PassageEmbeddingsService>
                          receiver) override {
-    NOTREACHED();
+    content::ServiceProcessHost::Launch<mojom::PassageEmbeddingsService>(
+        std::move(receiver), content::ServiceProcessHost::Options()
+                                 .WithDisplayName("Passage Embeddings Service")
+                                 .Pass());
   }
-  void OnServiceDisconnected(bool is_idle) override { NOTREACHED(); }
-  bool AllowedToLaunch() const override { return false; }
+  void OnServiceDisconnected(bool is_idle) override {}
+  bool AllowedToLaunch() const override { return true; }
 };
 
 }  // namespace
@@ -137,10 +152,19 @@ BravePassageEmbeddingsServiceController::Get() {
 
 BravePassageEmbeddingsServiceController::
     BravePassageEmbeddingsServiceController()
-    : PassageEmbeddingsServiceController(StubServiceLauncher::Create()) {
-  // AddObserver re-fires OnLocalModelsReady synchronously if the
-  // component is already installed; our handler sets model_dir_ready_
-  // and notifies observer_list_ via EmbedderMetadataUpdated.
+    : PassageEmbeddingsServiceController(LitertServiceLauncher::Create()) {
+  // Report the LiteRT model's metadata; the model file paths are resolved
+  // from the component in OnLocalModelsReady once it is installed.
+  optimization_guide::proto::PassageEmbeddingsModelMetadata metadata;
+  metadata.set_input_window_size(kLitertInputWindowSize);
+  metadata.set_output_size(kLitertOutputSize);
+  metadata.set_score_threshold(kLitertScoreThreshold);
+  model_metadata_ = std::move(metadata);
+  model_version_ = kLitertModelVersion;
+
+  // AddObserver re-fires OnLocalModelsReady synchronously if the component is
+  // already installed; our handler resolves the model paths and notifies
+  // observer_list_ once the files are confirmed on disk.
   updater_state_observation_.Observe(
       local_ai::LocalModelsUpdaterState::GetInstance());
 }
@@ -154,6 +178,9 @@ bool BravePassageEmbeddingsServiceController::MaybeUpdateModelInfo(
   return false;
 }
 
+// Dead WASM code (MaybeLaunchService through OnProfileWillBeDestroyed): the
+// in-process WASM service lifecycle, unreached now that LiteRT is the only
+// embedder.
 void BravePassageEmbeddingsServiceController::MaybeLaunchService() {
   if (service_) {
     return;
@@ -202,24 +229,64 @@ void BravePassageEmbeddingsServiceController::OnProfileWillBeDestroyed(
 }
 
 bool BravePassageEmbeddingsServiceController::IsModelAvailable() {
-  // Mirrors upstream's "do we have a model path to load from?" check
-  // — true once LocalModelsUpdaterState reports the component is
-  // installed. SchedulingEmbedder retries on the
-  // EmbedderMetadataUpdated notification fired in OnLocalModelsReady.
-  return model_dir_ready_;
+  // The LiteRT model paths are resolved from the component in
+  // OnLocalModelsReady.
+  return !embeddings_model_path_.empty();
 }
 
 void BravePassageEmbeddingsServiceController::OnLocalModelsReady(
     const base::FilePath& install_dir) {
   model_dir_ready_ = !install_dir.empty();
   if (!model_dir_ready_) {
-    // Component uninstall (or test reset) cleared the dir. Tear the
-    // service down if any so it doesn't outlive the model files.
+    // Component uninstall (or test reset) cleared the dir. Drop the resolved
+    // model paths and tear the service down if any so it doesn't outlive the
+    // model files. (service_ is WASM/candle dead code and is never set now.)
+    embeddings_model_path_ = base::FilePath();
+    sp_model_path_ = base::FilePath();
     if (service_) {
       ResetServiceRemote();
     }
     return;
   }
+  // The LiteRT .tflite + SentencePiece model ship in the EmbeddingGemma
+  // component under a litert/ subdir. They may be absent (an older component,
+  // or the download withheld), so confirm both are on disk before reporting the
+  // model available -- the base-class LoadModels flow opens them
+  // unconditionally and would crash serializing a missing (null) file.
+  const base::FilePath litert_dir =
+      local_ai::LocalModelsUpdaterState::GetInstance()
+          ->GetEmbeddingGemmaModelDir()
+          .AppendASCII(kLitertModelSubdir);
+  const base::FilePath embeddings_model_path =
+      litert_dir.AppendASCII(kLitertModelName);
+  const base::FilePath sp_model_path =
+      litert_dir.AppendASCII(kSentencePieceModelName);
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE,
+      {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
+       base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN},
+      base::BindOnce(
+          [](const base::FilePath& embeddings, const base::FilePath& sp) {
+            return base::PathExists(embeddings) && base::PathExists(sp);
+          },
+          embeddings_model_path, sp_model_path),
+      base::BindOnce(
+          &BravePassageEmbeddingsServiceController::OnLitertModelChecked,
+          base::Unretained(this), embeddings_model_path, sp_model_path));
+}
+
+void BravePassageEmbeddingsServiceController::OnLitertModelChecked(
+    const base::FilePath& embeddings_model_path,
+    const base::FilePath& sp_model_path,
+    bool models_exist) {
+  if (!models_exist) {
+    VLOG(1) << "LiteRT model files missing under "
+            << embeddings_model_path.DirName()
+            << "; passage embeddings disabled until the component ships them";
+    return;
+  }
+  embeddings_model_path_ = embeddings_model_path;
+  sp_model_path_ = sp_model_path;
   // SchedulingEmbedder is the only observer and SubmitWorkToEmbedder()
   // short-circuits if work is already in flight, so re-firing on
   // repeated component-updater notifications is harmless.
@@ -229,58 +296,19 @@ void BravePassageEmbeddingsServiceController::OnLocalModelsReady(
 
 EmbedderMetadata
 BravePassageEmbeddingsServiceController::GetEmbedderMetadata() {
-  return EmbedderMetadata(/*model_version=*/1,
-                          /*output_size=*/768,
-                          /*search_score_threshold=*/0.45);
+  // Report a model_version distinct from the previous WASM embedder's so that
+  // upstream drops the old embeddings rather than mixing vector spaces. On
+  // startup SqlDatabase::InitInternal()
+  // (//components/history_embeddings/core/sql_database.cc) compares this with
+  // the stored model_version and, on a mismatch, clears the embeddings table
+  // and re-embeds the retained passages.
+  return EmbedderMetadata(kLitertModelVersion,
+                          /*output_size=*/kLitertOutputSize,
+                          /*search_score_threshold=*/kLitertScoreThreshold);
 }
 
-void BravePassageEmbeddingsServiceController::GetEmbeddings(
-    std::vector<std::string> passages,
-    PassagePriority priority,
-    GetEmbeddingsResultCallback callback) {
-  if (passages.empty()) {
-    std::move(callback).Run({}, ComputeEmbeddingsStatus::kSuccess);
-    return;
-  }
-
-  if (!IsModelAvailable()) {
-    DVLOG(1) << "GetEmbeddings called before model dir is ready";
-    std::move(callback).Run({}, ComputeEmbeddingsStatus::kModelUnavailable);
-    return;
-  }
-
-  if (!embedder_remote_) {
-    MaybeLaunchService();
-    auto receiver = embedder_remote_.BindNewPipeAndPassReceiver();
-    // When the embedder pipe goes idle or disconnects, tear the whole
-    // service down to free the WASM renderer.
-    embedder_remote_.set_disconnect_handler(base::BindOnce(
-        &BravePassageEmbeddingsServiceController::ResetServiceRemote,
-        base::Unretained(this)));
-    embedder_remote_.set_idle_handler(
-        kEmbedderTimeout.Get(),
-        base::BindRepeating(
-            &BravePassageEmbeddingsServiceController::ResetServiceRemote,
-            base::Unretained(this)));
-    DVLOG(3) << "GetEmbeddings: posting model-file load for new embedder";
-    LoadModelFilesAndBind(std::move(receiver));
-  }
-
-  embedder_remote_->GenerateEmbeddings(
-      std::move(passages), ToMojom(priority),
-      mojo::WrapCallbackWithDefaultInvokeIfNotRun(
-          base::BindOnce(
-              [](GetEmbeddingsResultCallback cb,
-                 std::vector<mojom::PassageEmbeddingsResultPtr> results) {
-                auto status = results.empty()
-                                  ? ComputeEmbeddingsStatus::kExecutionFailure
-                                  : ComputeEmbeddingsStatus::kSuccess;
-                std::move(cb).Run(std::move(results), status);
-              },
-              std::move(callback)),
-          std::vector<mojom::PassageEmbeddingsResultPtr>()));
-}
-
+// Dead WASM code: LoadModelFilesAndBind + OnLocalModelFilesLoaded loaded model
+// files for the in-process WASM embedder.
 void BravePassageEmbeddingsServiceController::LoadModelFilesAndBind(
     mojo::PendingReceiver<mojom::PassageEmbedder> receiver) {
   auto* updater_state = local_ai::LocalModelsUpdaterState::GetInstance();

--- a/browser/history_embeddings/brave_passage_embeddings_service_controller.h
+++ b/browser/history_embeddings/brave_passage_embeddings_service_controller.h
@@ -26,16 +26,14 @@
 
 namespace passage_embeddings {
 
-// Runs the passage embeddings model in-process rather than in a sandboxed
-// utility process, because Brave serves embeddings from its own local AI
-// service.
-//
-// A single instance is shared across profiles, accessed via Get(), to avoid
-// loading the model more than once.
+// Runs EmbeddingGemma through the native LiteRT embedder in the sandboxed
+// passage embeddings utility process. A single instance is shared across
+// profiles, accessed via Get(), to avoid loading the model more than once.
 //
 // Brave does not use the optimization guide tflite model that upstream's
-// embedder relies on, so the model metadata and download paths are overridden
-// to no-ops.
+// embedder relies on; the model is delivered by the local AI component updater
+// (LocalModelsUpdaterState) and its file paths are resolved in
+// OnLocalModelsReady.
 class BravePassageEmbeddingsServiceController
     : public PassageEmbeddingsServiceController,
       public ProfileObserver,
@@ -69,12 +67,8 @@ class BravePassageEmbeddingsServiceController
 
   // PassageEmbeddingsServiceController:
   // Swallow optimization_guide updates. Upstream's PassageEmbedderModelObserver
-  // (created per-profile by PassageEmbedderModelObserverFactory) calls this
-  // whenever the tflite model component changes; the base implementation
-  // clears model paths and resets embedder_remote_ without touching service_,
-  // which leaves the next GetEmbeddings to fail the new embedder against a
-  // still-bound batch_embedder_ on the old service_. We don't use the
-  // upstream model at all, so the notification is noise.
+  // calls this whenever the tflite model component changes; we don't use that
+  // model at all, so the notification is noise.
   bool MaybeUpdateModelInfo(
       base::optional_ref<const optimization_guide::ModelInfo> model_info)
       override;
@@ -86,15 +80,18 @@ class BravePassageEmbeddingsServiceController
 
   bool IsModelAvailable() override;
   EmbedderMetadata GetEmbedderMetadata() override;
-  void GetEmbeddings(std::vector<std::string> passages,
-                     PassagePriority priority,
-                     GetEmbeddingsResultCallback callback) override;
 
   // ProfileObserver:
   void OnProfileWillBeDestroyed(Profile* profile) override;
 
   // local_ai::LocalModelsUpdaterState::Observer:
   void OnLocalModelsReady(const base::FilePath& install_dir) override;
+
+  // Reply for the OnLocalModelsReady existence check: records the LiteRT model
+  // paths and notifies observers only when both files are actually on disk.
+  void OnLitertModelChecked(const base::FilePath& embeddings_model_path,
+                            const base::FilePath& sp_model_path,
+                            bool models_exist);
 
   // Posts the disk read for the five EmbeddingGemma files. Wired to
   // OnLocalModelFilesLoaded; the receiver waits on the mojo pipe until
@@ -112,9 +109,8 @@ class BravePassageEmbeddingsServiceController
                           local_ai::LocalModelsUpdaterState::Observer>
       updater_state_observation_{this};
 
-  // Set true when LocalModelsUpdaterState reports the EmbeddingGemma
-  // component is installed. Required for IsModelAvailable() to return
-  // true.
+  // Whether LocalModelsUpdaterState reports the EmbeddingGemma component as
+  // installed.
   bool model_dir_ready_ = false;
 
   base::WeakPtrFactory<BravePassageEmbeddingsServiceController>

--- a/chromium_src/services/passage_embeddings/passage_embedder_impl.cc
+++ b/chromium_src/services/passage_embeddings/passage_embedder_impl.cc
@@ -1,0 +1,42 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+
+namespace base {
+class File;
+}  // namespace base
+
+namespace passage_embeddings {
+class PassageEmbedderExecutor;
+}  // namespace passage_embeddings
+
+namespace brave_history_embeddings {
+
+// Implemented in //brave/services/passage_embeddings:chromium_impl. Returns
+// null when the LiteRT model is unavailable, or when local AI is disabled.
+std::unique_ptr<passage_embeddings::PassageEmbedderExecutor>
+MaybeCreateLitertExecutor(base::File& embeddings_model_file,
+                          int bos_id,
+                          int eos_id,
+                          int pad_id);
+
+}  // namespace brave_history_embeddings
+
+// Injected at the top of PassageEmbedderImpl::BuildExecutionTask so
+// EmbeddingGemma runs through LiteRT's CompiledModel, falling through to the
+// upstream tflite executor otherwise.
+#define BRAVE_PASSAGE_EMBEDDER_IMPL_BUILD_EXECUTION_TASK           \
+  if (std::unique_ptr<PassageEmbedderExecutor> executor =          \
+          brave_history_embeddings::MaybeCreateLitertExecutor(     \
+              embeddings_model_file_, sp_processor_->bos_id(),     \
+              sp_processor_->eos_id(), sp_processor_->pad_id())) { \
+    executor_ = std::move(executor);                               \
+    return true;                                                   \
+  }
+
+#include <services/passage_embeddings/passage_embedder_impl.cc>
+
+#undef BRAVE_PASSAGE_EMBEDDER_IMPL_BUILD_EXECUTION_TASK

--- a/components/history_embeddings/README.md
+++ b/components/history_embeddings/README.md
@@ -5,13 +5,13 @@ previously visited pages whose content is semantically close to the query, even
 when no keyword matches.
 
 Built on top of Chromium's `history_embeddings` + `passage_embeddings`
-components, but Brave swaps the embedder for a local Rust/Candle WASM model
-(EmbeddingGemma) and disables the upstream visibility filter that depends on
-remote classification.
+components, but Brave swaps the embedder for a local **EmbeddingGemma** model
+run natively through LiteRT, and disables the upstream visibility filter that
+depends on remote classification.
 
 This doc is the big-picture overview of the whole feature — upstream + Brave.
-For the Brave embedder's internals (process model, `BindPassageEmbedder` vs
-`LoadModels`, factory init handshake, file lifecycle), see
+For the Brave embedder's internals (the sandboxed utility, the LiteRT runner,
+component model delivery), see
 [`//brave/browser/history_embeddings/README.md`](../../browser/history_embeddings/README.md).
 
 ## Tunable parameters (defaults)
@@ -92,28 +92,24 @@ nav finishes
                   scheduling_embedder.{h,cc}
    │
    ▼
-[Brave]     BravePassageEmbeddingsServiceController::GetEmbeddings()
-            • verifies the EmbeddingGemma component is installed
-            • reads 5 model files (weights, weights_dense1,
-              weights_dense2, tokenizer, config) off disk
-            • hands them to BravePassageEmbeddingsService
+[Brave]     BravePassageEmbeddingsServiceController (base GetEmbeddings)
+            • resolves the EmbeddingGemma model from the component's litert/
+              subdir (set in OnLocalModelsReady)
+            • launches the sandboxed Passage Embeddings utility via
+              LitertServiceLauncher
+            • opens the .tflite + SentencePiece files and sends them via
+              LoadModels
             └─ //brave/browser/history_embeddings/
                   brave_passage_embeddings_service_controller.{h,cc}
    │
    ▼
-[Brave]     BraveBatchPassageEmbedder spins up a background WebContents
-            on a guest OTR profile pointing at chrome-untrusted://local-ai.
-            That page loads the WASM bundle, instantiates Gemma3Embedder,
-            and registers a PassageEmbedderFactory back over mojo.
-            └─ //brave/browser/history_embeddings/
-                  brave_batch_passage_embedder.{h,cc}
-                  brave_passage_embeddings_service.{h,cc}
-   │
-   ▼
-[WASM]      Gemma3Embedder.ComputeEmbedding(passage) → 768-dim vector
-            (Brave runs this one passage at a time, not batched)
-            └─ //brave/components/local_ai/resources/
-                  candle_embedding_gemma/  (Rust + WASM bundle)
+[utility]   PassageEmbedderImpl::BuildExecutionTask (chromium_src override)
+            builds a LitertModelRunner around the loaded .tflite and runs
+            EmbeddingGemma on LiteRT's CompiledModel → 768-dim vector
+            └─ //brave/services/passage_embeddings/
+                  litert_model_runner.{h,cc}
+            └─ //brave/chromium_src/services/passage_embeddings/
+                  passage_embedder_impl.cc
    │
    ▼
 [browser]   HistoryEmbeddingsService::OnPassagesEmbeddingsComputed()
@@ -175,7 +171,7 @@ HistoryEmbeddingsService::Search(query, time_range, count, ...)
    ├─ reject if query has < 2 words
    │
    ▼
-embed the query through the same WASM pipeline as indexing
+embed the query through the same LiteRT pipeline as indexing
 (priority = UserInitiated, jumps the queue)
    └─ //components/passage_embeddings/core/scheduling_embedder.{h,cc}
        → //brave/browser/history_embeddings/
@@ -294,49 +290,48 @@ semantically but contain most of the query words can still surface.
 
 ## How Brave differs from upstream
 
-| Upstream                                                                  | Brave                                                                                                                                                |
-| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| TFLite model delivered via OptimizationGuide (server fetch)               | Static Rust/Candle **EmbeddingGemma** model delivered via component updater, run as WASM                                                             |
-| Embedder runs in a sandboxed utility process, talks mojo                  | Embedder runs in a **dedicated renderer process** (background WebContents on a guest OTR profile, shown as "Tool: On-Device AI" in the task manager) |
-| PageContentAnnotationsService filters low-visibility pages out of results | Visibility filter bypassed — `SynthesizePassingVisibilityResults()` returns 1.0 for everything                                                       |
-| `kHistoryEmbeddings` / `kPassageEmbedder` enabled by Finch                | Both DISABLED_BY_DEFAULT; user opts in via `chrome://flags`. brave-variations study tunes word-match params for opt-in users (see above)             |
-| `search_score_threshold` from model metadata, fallback 0.9                | Hardcoded **0.45** in `GetEmbedderMetadata()`                                                                                                        |
-| Answerer uses OptimizationGuide-delivered model                           | Same plumbing, but gated behind the flag                                                                                                             |
+| Upstream                                                                  | Brave                                                                                                                                    |
+| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| TFLite model delivered via OptimizationGuide (server fetch)               | **EmbeddingGemma** `.tflite` delivered via component updater, run natively through LiteRT                                                |
+| Embedder runs in a sandboxed utility process, talks mojo                  | Same sandboxed utility; Brave only swaps the executor inside it (LiteRT `CompiledModel` instead of upstream's TFLite executor)           |
+| PageContentAnnotationsService filters low-visibility pages out of results | Visibility filter bypassed — `SynthesizePassingVisibilityResults()` returns 1.0 for everything                                           |
+| `kHistoryEmbeddings` / `kPassageEmbedder` enabled by Finch                | Both DISABLED_BY_DEFAULT; user opts in via `chrome://flags`. brave-variations study tunes word-match params for opt-in users (see above) |
+| `search_score_threshold` from model metadata, fallback 0.9                | Hardcoded **0.45** in `GetEmbedderMetadata()`                                                                                            |
+| Answerer uses OptimizationGuide-delivered model                           | Same plumbing, but gated behind the flag                                                                                                 |
 
 ### Brave-side code
 
 - [`//brave/browser/history_embeddings/`](../../browser/history_embeddings/README.md)
-  — the local embedder: controller, in-process service, batch embedder driving
-  the WASM renderer. See its README for the full breakdown.
+  — the local embedder: the controller that launches the sandboxed utility and
+  resolves the component model. See its README for the full breakdown.
+- `//brave/services/passage_embeddings/` — `LitertModelRunner`, the LiteRT
+  `CompiledModel` execution engine that runs EmbeddingGemma inside the utility.
 - `//brave/browser/history_embeddings/`
   - `brave_history_embeddings_service.{h,cc}` — subclasses upstream's
     `HistoryEmbeddingsService` to short-circuit the visibility step.
 - `//brave/components/history_embeddings/content/`
   - `brave_history_embeddings_helpers.h` —
     `SynthesizePassingVisibilityResults()`.
-- `//brave/components/local_ai/resources/candle_embedding_gemma/` — Rust crate
-  that builds to WASM. Uses `candle-core`, `candle-nn`, `tokenizers`,
-  `safetensors`.
 - `//brave/chromium_src/`
   - Shims that inject `virtual` and `friend` declarations into upstream headers
     so the Brave singleton can subclass cleanly without patches.
-  - Default-disables both feature flags.
-  - Swaps the keyed service factory to instantiate
+  - Injects `LitertModelRunner` into `PassageEmbedderImpl::BuildExecutionTask`
+    so the utility runs EmbeddingGemma on LiteRT.
+  - Default-disables the upstream feature flags; the brave://history toggle opts
+    in. Swaps the keyed service factory to instantiate
     `BraveHistoryEmbeddingsService`.
 
 ### Process model
 
-- Browser-side controller and the mojo `PassageEmbedder` impl live in the
-  browser process — no extra utility process is launched.
-- Actual model execution runs in a **separate renderer process** hosting a
-  background WebContents on a guest OTR profile, pointed at
-  `chrome-untrusted://local-ai`. That process loads the WASM bundle and runs the
-  Candle/Gemma inference; it shows up in Chrome's task manager as "Tool:
-  On-Device AI".
-- Communication between the browser and that renderer is mojo, same as any other
-  renderer.
-- Sandbox: renderer sandbox + `chrome-untrusted` origin (no extension APIs, no
-  privileged bindings).
+- The controller lives in the browser process and launches the sandboxed
+  **Passage Embeddings utility process**, same as upstream.
+- Model execution runs inside that utility: the chromium_src-overridden
+  `PassageEmbedderImpl::BuildExecutionTask` runs EmbeddingGemma on LiteRT's
+  `CompiledModel` (CPU backend).
+- Communication is the standard `PassageEmbeddingsService` mojo interface; the
+  browser opens the model files and passes them via `LoadModels`.
+- Sandbox: the utility runs in the on-device-model service sandbox — no renderer
+  or `chrome-untrusted` origin is involved.
 
 ---
 
@@ -351,6 +346,6 @@ semantically but contain most of the query words can still surface.
 - 0.45 is the entire gate. Tuning it is the most direct lever for
   precision/recall.
 - Visibility is not a factor in Brave — anything indexed can be returned.
-- The query path uses the **same WASM embedder** as indexing, just at
+- The query path uses the **same LiteRT embedder** as indexing, just at
   `UserInitiated` priority. First search after launch can be slow because the
-  WASM page has to load and the model has to deserialize.
+  utility has to launch and compile the model.

--- a/patches/services-passage_embeddings-passage_embedder_impl.cc.patch
+++ b/patches/services-passage_embeddings-passage_embedder_impl.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/services/passage_embeddings/passage_embedder_impl.cc b/services/passage_embeddings/passage_embedder_impl.cc
+index b925fbd4d0f8fff73e426b0d1354e08706ee06b8..2b709cb956db110f96755edde1b343330b859a5f 100644
+--- a/services/passage_embeddings/passage_embedder_impl.cc
++++ b/services/passage_embeddings/passage_embedder_impl.cc
+@@ -146,6 +146,7 @@ bool PassageEmbedderImpl::BuildExecutionTask() {
+   CHECK_NE(current_priority_, mojom::PassagePriority::kUnknown);
+   executor_.reset();
+ 
++  BRAVE_PASSAGE_EMBEDDER_IMPL_BUILD_EXECUTION_TASK
+   std::unique_ptr<tflite::OpResolver> op_resolver;
+   if (execute_for_gemma_) {
+     op_resolver = std::make_unique<GemmaOpResolver>();

--- a/patches/third_party-tflite-BUILD.gn.patch
+++ b/patches/third_party-tflite-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/tflite/BUILD.gn b/third_party/tflite/BUILD.gn
+index a918b05fa880884ae8c59c886ddfca9711969982..d4554431b5f5e6022c916e8584b77bfcb29814f0 100644
+--- a/third_party/tflite/BUILD.gn
++++ b/third_party/tflite/BUILD.gn
+@@ -379,6 +379,7 @@ if (!use_litert_tflite) {
+ 
+     visibility = [
+       ":tflite_benchmark",
++      "//brave/services/passage_embeddings/*",
+       "//components/optimization_guide/internal/*",
+       "//modules/*",
+       "//services/webnn/*",

--- a/services/passage_embeddings/BUILD.gn
+++ b/services/passage_embeddings/BUILD.gn
@@ -1,0 +1,51 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Runs EmbeddingGemma through LiteRT's CompiledModel on the CPU. Knows nothing
+# about //services/passage_embeddings; :chromium_impl adapts it to upstream's
+# PassageEmbedderExecutor interface.
+source_set("litert_model_runner") {
+  sources = [
+    "litert_model_runner.cc",
+    "litert_model_runner.h",
+  ]
+
+  # Exposed as public_deps because the public header includes litert's
+  # CompiledModel/Environment (whose internal includes need litert's config).
+  public_deps = [
+    "//base",
+    "//third_party/litert",
+  ]
+
+  deps = [
+    # No source here includes TFLite, but LiteRT is built with
+    # use_litert_tflite=false, so its runtime links TFLite's op resolver and C
+    # API from here. Matches upstream's other LiteRT consumers
+    # (//services/webnn).
+    "//third_party/tflite",
+    "//third_party/tflite:tflite_builtin_op_resolver",
+  ]
+}
+
+source_set("unit_tests") {
+  testonly = true
+  sources = [ "litert_model_runner_unittest.cc" ]
+
+  # Reaching Init()/Run() needs real models. LiteRT's test data has small ones
+  # covering each shape the runner cares about: int32 input with float output
+  # (scatter_nd), float input (l2_norm) and multi-input (atan2).
+  _testdata = "//third_party/litert/src/litert/test/testdata"
+  data = [
+    "$_testdata/simple_atan2_op.tflite",
+    "$_testdata/simple_l2_norm.tflite",
+    "$_testdata/simple_scatter_nd_op.tflite",
+  ]
+
+  deps = [
+    ":litert_model_runner",
+    "//base",
+    "//testing/gtest",
+  ]
+}

--- a/services/passage_embeddings/BUILD.gn
+++ b/services/passage_embeddings/BUILD.gn
@@ -3,6 +3,28 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/local_ai/buildflags/buildflags.gni")
+
+# Implements the hook the chromium_src passage_embedder_impl.cc override
+# forward-declares.
+source_set("chromium_impl") {
+  deps = [
+    "//base",
+    "//services/passage_embeddings",
+  ]
+
+  # The override calls the hook unconditionally, so a definition is always
+  # linked in. Selecting the source here (rather than guarding the LiteRT
+  # include with a buildflag) keeps the include set matching the deps in every
+  # configuration, which is what gn check verifies.
+  if (enable_local_ai) {
+    sources = [ "litert_executor.cc" ]
+    deps += [ ":litert_model_runner" ]
+  } else {
+    sources = [ "litert_executor_stub.cc" ]
+  }
+}
+
 # Runs EmbeddingGemma through LiteRT's CompiledModel on the CPU. Knows nothing
 # about //services/passage_embeddings; :chromium_impl adapts it to upstream's
 # PassageEmbedderExecutor interface.

--- a/services/passage_embeddings/DEPS
+++ b/services/passage_embeddings/DEPS
@@ -1,0 +1,3 @@
+include_rules = [
+  "+third_party/litert",
+]

--- a/services/passage_embeddings/DEPS
+++ b/services/passage_embeddings/DEPS
@@ -1,3 +1,4 @@
 include_rules = [
+  "+services/passage_embeddings",
   "+third_party/litert",
 ]

--- a/services/passage_embeddings/litert_executor.cc
+++ b/services/passage_embeddings/litert_executor.cc
@@ -1,0 +1,74 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "base/files/file.h"
+#include "base/memory/raw_ref.h"
+#include "base/no_destructor.h"
+#include "brave/services/passage_embeddings/litert_model_runner.h"
+#include "services/passage_embeddings/passage_embedder_executor.h"
+
+namespace brave_history_embeddings {
+
+namespace {
+
+// Adapts the LiteRT runner to upstream's PassageEmbedderExecutor interface.
+class LitertExecutor : public passage_embeddings::PassageEmbedderExecutor {
+ public:
+  LitertExecutor(LitertModelRunner& runner, int bos_id, int eos_id, int pad_id)
+      : runner_(runner), bos_id_(bos_id), eos_id_(eos_id), pad_id_(pad_id) {}
+  ~LitertExecutor() override = default;
+
+  std::optional<passage_embeddings::EmbedderExecutionResult> Execute(
+      const std::vector<int>& raw_tokens) override {
+    // Lay the SentencePiece content ids out for the model's input window using
+    // upstream's Gemma formatter ([bos] + tokens + [eos] + pad).
+    std::vector<int> tokens =
+        passage_embeddings::GemmaModelExecutor::FormatInput(
+            raw_tokens, runner_->window(), bos_id_, eos_id_, pad_id_);
+    std::optional<std::vector<float>> embedding = runner_->Run(tokens);
+    if (!embedding) {
+      return std::nullopt;
+    }
+    passage_embeddings::EmbedderExecutionResult result;
+    result.embeddings = std::move(*embedding);
+    result.signature_length = static_cast<uint32_t>(runner_->window());
+    return result;
+  }
+
+ private:
+  // The process-global runner cached in MaybeCreateLitertExecutor(); outlives
+  // this executor, so a ref is safe.
+  const raw_ref<LitertModelRunner> runner_;
+  const int bos_id_;
+  const int eos_id_;
+  const int pad_id_;
+};
+
+}  // namespace
+
+std::unique_ptr<passage_embeddings::PassageEmbedderExecutor>
+MaybeCreateLitertExecutor(base::File& embeddings_model_file,
+                          int bos_id,
+                          int eos_id,
+                          int pad_id) {
+  // Building a runner compiles the model, and PassageEmbedderImpl rebuilds its
+  // executor on every priority change, so cache one runner per process and hand
+  // out lightweight executors that borrow it. All calls arrive on the service's
+  // single task-runner sequence, so the lazy init needs no locking.
+  static base::NoDestructor<std::unique_ptr<LitertModelRunner>> runner(
+      LitertModelRunner::CreateFromFile(embeddings_model_file));
+  if (!runner->get()) {
+    return nullptr;
+  }
+  return std::make_unique<LitertExecutor>(*runner->get(), bos_id, eos_id,
+                                          pad_id);
+}
+
+}  // namespace brave_history_embeddings

--- a/services/passage_embeddings/litert_executor_stub.cc
+++ b/services/passage_embeddings/litert_executor_stub.cc
@@ -1,0 +1,20 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+
+#include "base/files/file.h"
+#include "services/passage_embeddings/passage_embedder_executor.h"
+
+namespace brave_history_embeddings {
+
+// Null implementation for builds without local AI (Android, Brave Origin). The
+// override calls the hook unconditionally, so a definition must always link.
+std::unique_ptr<passage_embeddings::PassageEmbedderExecutor>
+MaybeCreateLitertExecutor(base::File&, int, int, int) {
+  return nullptr;
+}
+
+}  // namespace brave_history_embeddings

--- a/services/passage_embeddings/litert_model_runner.cc
+++ b/services/passage_embeddings/litert_model_runner.cc
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/services/passage_embeddings/litert_model_runner.h"
+
+#include <type_traits>
+#include <utility>
+
+#include "base/containers/extend.h"
+#include "base/containers/heap_array.h"
+#include "base/logging.h"
+#include "base/memory/ptr_util.h"
+#include "third_party/litert/src/litert/cc/litert_element_type.h"
+#include "third_party/litert/src/litert/cc/litert_environment_options.h"
+#include "third_party/litert/src/litert/cc/litert_layout.h"
+#include "third_party/litert/src/litert/cc/litert_options.h"
+#include "third_party/litert/src/litert/cc/litert_ranked_tensor_type.h"
+#include "third_party/litert/src/litert/cc/litert_tensor_buffer.h"
+
+namespace brave_history_embeddings {
+
+LitertModelRunner::LitertModelRunner() = default;
+
+LitertModelRunner::~LitertModelRunner() = default;
+
+// static
+std::unique_ptr<LitertModelRunner> LitertModelRunner::Create(
+    base::span<const uint8_t> tflite_model) {
+  auto runner = base::WrapUnique(new LitertModelRunner());
+  if (!runner->Init(tflite_model)) {
+    return nullptr;
+  }
+  return runner;
+}
+
+// static
+std::unique_ptr<LitertModelRunner> LitertModelRunner::CreateFromFile(
+    base::File& model_file) {
+  if (!model_file.IsValid()) {
+    return nullptr;
+  }
+  const int64_t length = model_file.GetLength();
+  if (length <= 0) {
+    return nullptr;
+  }
+  auto bytes = base::HeapArray<uint8_t>::WithSize(static_cast<size_t>(length));
+  if (!model_file.ReadAndCheck(0, bytes)) {
+    return nullptr;
+  }
+  return Create(bytes);
+}
+
+bool LitertModelRunner::Init(base::span<const uint8_t> tflite_model) {
+  // The runtime references the model bytes past compilation; keep our own copy.
+  tflite_model_.assign(tflite_model.begin(), tflite_model.end());
+
+  std::vector<litert::EnvironmentOptions::Option> env_options;
+  auto environment = litert::Environment::Create(litert::EnvironmentOptions(
+      litert::Span<const litert::EnvironmentOptions::Option>(
+          env_options.data(), env_options.size())));
+  if (!environment) {
+    LOG(ERROR) << "LiteRT runner: cannot create environment: "
+               << environment.Error().Message();
+    return false;
+  }
+  environment_ = std::move(*environment);
+
+  auto compile_options = litert::Options::Create();
+  if (!compile_options) {
+    return false;
+  }
+  compile_options->SetHardwareAccelerators(litert::HwAccelerators::kCpu);
+
+  auto model = litert::CompiledModel::Create(
+      *environment_,
+      litert::BufferRef<uint8_t>(tflite_model_.data(), tflite_model_.size()),
+      *compile_options);
+  if (!model) {
+    LOG(ERROR) << "LiteRT runner: CompiledModel::Create failed: "
+               << model.Error().Message();
+    return false;
+  }
+  model_ = std::move(*model);
+
+  auto input_buffers = model_->CreateInputBuffers();
+  if (!input_buffers || input_buffers->size() != 1) {
+    return false;
+  }
+  auto input_type = (*input_buffers)[0].TensorType();
+  if (!input_type) {
+    return false;
+  }
+  // Every EmbeddingGemma export takes int32 token ids, and Write() memcpy's
+  // after only a size check, so tokens written into a wider input would
+  // silently be garbage. The model ships via the component updater,
+  // independently of this binary, so reject a mismatched one here rather than
+  // failing every request later.
+  static_assert(std::is_same_v<int, int32_t>);
+  if (input_type->ElementType() != litert::ElementType::Int32) {
+    LOG(ERROR) << "LiteRT runner: model input is not int32";
+    return false;
+  }
+  auto num_elements = input_type->Layout().NumElements();
+  if (!num_elements) {
+    return false;
+  }
+  input_window_size_ = *num_elements;
+  return true;
+}
+
+std::optional<std::vector<float>> LitertModelRunner::Run(
+    base::span<const int> tokens) {
+  // Callers must lay `tokens` out for the model's input window; reject anything
+  // else rather than writing a wrongly-sized buffer.
+  if (tokens.size() != input_window_size_) {
+    return std::nullopt;
+  }
+
+  // CreateInput/OutputBuffers hand back buffers already sized and typed for the
+  // model (host or accelerator memory as the delegate requires); Write/Read
+  // copy through them, so no manual allocation is needed.
+  auto inputs = model_->CreateInputBuffers();
+  auto outputs = model_->CreateOutputBuffers();
+  if (!inputs || !outputs || inputs->size() != 1) {
+    return std::nullopt;
+  }
+
+  // Init() verified the input is int32, so the tokens can be written as-is.
+  if (!(*inputs)[0].Write<int>(
+          litert::Span<const int>(tokens.data(), tokens.size()))) {
+    return std::nullopt;
+  }
+
+  // Synchronous Run waits for accelerator completion internally.
+  if (!model_->Run(*inputs, *outputs)) {
+    return std::nullopt;
+  }
+
+  std::vector<float> embedding;
+  for (litert::TensorBuffer& buf : *outputs) {
+    auto type = buf.TensorType();
+    if (!type || (*type).ElementType() != litert::ElementType::Float32) {
+      continue;
+    }
+    auto packed = buf.PackedSize();
+    if (!packed) {
+      return std::nullopt;
+    }
+    std::vector<float> values(*packed / sizeof(float));
+    if (!buf.Read<float>(litert::Span<float>(values.data(), values.size()))) {
+      return std::nullopt;
+    }
+    base::Extend(embedding, values);
+  }
+  if (embedding.empty()) {
+    return std::nullopt;
+  }
+  return embedding;
+}
+
+}  // namespace brave_history_embeddings

--- a/services/passage_embeddings/litert_model_runner.h
+++ b/services/passage_embeddings/litert_model_runner.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_SERVICES_PASSAGE_EMBEDDINGS_LITERT_MODEL_RUNNER_H_
+#define BRAVE_SERVICES_PASSAGE_EMBEDDINGS_LITERT_MODEL_RUNNER_H_
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "base/containers/span.h"
+#include "base/files/file.h"
+#include "third_party/litert/src/litert/cc/litert_compiled_model.h"
+#include "third_party/litert/src/litert/cc/litert_environment.h"
+
+namespace brave_history_embeddings {
+
+// Runs an embeddings model through LiteRT's CompiledModel on the CPU. This is
+// the execution engine only: it knows nothing about
+// //services/passage_embeddings, which owns tokenization and caching. Callers
+// pass tokens already laid out for the model's input window (e.g. via
+// GemmaModelExecutor::FormatInput); the runner just writes them and runs the
+// model.
+class LitertModelRunner {
+ public:
+  // Builds from the in-memory `.tflite`; nullptr on failure.
+  static std::unique_ptr<LitertModelRunner> Create(
+      base::span<const uint8_t> tflite_model);
+
+  // Reads the `.tflite` out of `model_file` and builds a runner for it, or
+  // returns nullptr if the file or the model is unusable.
+  static std::unique_ptr<LitertModelRunner> CreateFromFile(
+      base::File& model_file);
+
+  ~LitertModelRunner();
+
+  LitertModelRunner(const LitertModelRunner&) = delete;
+  LitertModelRunner& operator=(const LitertModelRunner&) = delete;
+
+  // Runs one window of `tokens` (sized to window()); returns the pooled Float32
+  // embedding, or nullopt on failure.
+  std::optional<std::vector<float>> Run(base::span<const int> tokens);
+
+  // The model's input token window (for reporting and input sizing).
+  size_t window() const { return input_window_size_; }
+
+ private:
+  LitertModelRunner();
+
+  bool Init(base::span<const uint8_t> tflite_model);
+
+  std::vector<uint8_t> tflite_model_;
+  std::optional<litert::Environment> environment_;
+  std::optional<litert::CompiledModel> model_;
+  size_t input_window_size_ = 0;
+};
+
+}  // namespace brave_history_embeddings
+
+#endif  // BRAVE_SERVICES_PASSAGE_EMBEDDINGS_LITERT_MODEL_RUNNER_H_

--- a/services/passage_embeddings/litert_model_runner_unittest.cc
+++ b/services/passage_embeddings/litert_model_runner_unittest.cc
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/services/passage_embeddings/litert_model_runner.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "base/base_paths.h"
+#include "base/containers/span.h"
+#include "base/files/file.h"
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
+#include "base/path_service.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_history_embeddings {
+
+namespace {
+
+constexpr char kTestDataDir[] = "third_party/litert/src/litert/test/testdata/";
+
+// The only LiteRT test model shaped like an embedder: one int32 input, float32
+// output. Stands in for EmbeddingGemma, whose real model is too large to ship
+// as test data.
+constexpr char kInt32InputModel[] = "simple_scatter_nd_op.tflite";
+constexpr size_t kInt32InputModelWindow = 2 * 4;
+
+// Single float32 input -- the layout the runner must refuse, because writing
+// int32 tokens into it would silently produce garbage.
+constexpr char kFloatInputModel[] = "simple_l2_norm.tflite";
+
+// Two inputs; the runner only drives single-input models.
+constexpr char kTwoInputModel[] = "simple_atan2_op.tflite";
+
+// Bytes that are not a valid .tflite flatbuffer.
+std::vector<uint8_t> MalformedModelBytes() {
+  return std::vector<uint8_t>(64, 0xAB);
+}
+
+std::unique_ptr<LitertModelRunner> CreateRunnerForTestModel(
+    const char* model_name) {
+  const base::FilePath root =
+      base::PathService::CheckedGet(base::DIR_SRC_TEST_DATA_ROOT);
+  base::File model_file(root.AppendASCII(kTestDataDir).AppendASCII(model_name),
+                        base::File::FLAG_OPEN | base::File::FLAG_READ);
+  if (!model_file.IsValid()) {
+    return nullptr;
+  }
+  return LitertModelRunner::CreateFromFile(model_file);
+}
+
+}  // namespace
+
+// A missing/withheld model must surface as nullptr rather than crash, so the
+// utility process degrades gracefully when the component ships no valid model.
+TEST(LitertModelRunnerTest, CreateFailsOnEmptyModel) {
+  EXPECT_EQ(nullptr, LitertModelRunner::Create(base::span<const uint8_t>()));
+}
+
+TEST(LitertModelRunnerTest, CreateFailsOnMalformedModel) {
+  EXPECT_EQ(nullptr, LitertModelRunner::Create(MalformedModelBytes()));
+}
+
+// CreateFromFile reads the model from a base::File; an invalid or empty file
+// must fail without reading past the end.
+TEST(LitertModelRunnerTest, CreateFromFileFailsOnInvalidFile) {
+  base::File invalid_file;
+  EXPECT_EQ(nullptr, LitertModelRunner::CreateFromFile(invalid_file));
+}
+
+TEST(LitertModelRunnerTest, CreateFromFileFailsOnMalformedModelFile) {
+  base::ScopedTempDir temp_dir;
+  ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
+  const base::FilePath model_path =
+      temp_dir.GetPath().AppendASCII("model.tflite");
+  ASSERT_TRUE(base::WriteFile(model_path, MalformedModelBytes()));
+
+  base::File model_file(model_path,
+                        base::File::FLAG_OPEN | base::File::FLAG_READ);
+  ASSERT_TRUE(model_file.IsValid());
+  EXPECT_EQ(nullptr, LitertModelRunner::CreateFromFile(model_file));
+}
+
+// Write() only checks that the buffer is large enough, so int32 tokens written
+// into a float32 input would silently succeed with garbage. Rejecting at
+// creation leaves the caller on upstream's tflite executor instead of an
+// embedder that fails every request.
+TEST(LitertModelRunnerTest, CreateFailsOnModelWithNonInt32Input) {
+  EXPECT_EQ(nullptr, CreateRunnerForTestModel(kFloatInputModel));
+}
+
+TEST(LitertModelRunnerTest, CreateFailsOnModelWithMultipleInputs) {
+  EXPECT_EQ(nullptr, CreateRunnerForTestModel(kTwoInputModel));
+}
+
+// The window comes from the model's input tensor; the controller reports it as
+// the embedder's input window size.
+TEST(LitertModelRunnerTest, CreateReportsModelInputWindow) {
+  std::unique_ptr<LitertModelRunner> runner =
+      CreateRunnerForTestModel(kInt32InputModel);
+  ASSERT_TRUE(runner);
+  EXPECT_EQ(kInt32InputModelWindow, runner->window());
+}
+
+TEST(LitertModelRunnerTest, RunReturnsFloatOutputForInt32Model) {
+  std::unique_ptr<LitertModelRunner> runner =
+      CreateRunnerForTestModel(kInt32InputModel);
+  ASSERT_TRUE(runner);
+
+  const std::vector<int> tokens(runner->window(), 0);
+  std::optional<std::vector<float>> output = runner->Run(tokens);
+  ASSERT_TRUE(output.has_value());
+  EXPECT_FALSE(output->empty());
+}
+
+TEST(LitertModelRunnerTest, RunRejectsTokensThatDoNotFillTheWindow) {
+  std::unique_ptr<LitertModelRunner> runner =
+      CreateRunnerForTestModel(kInt32InputModel);
+  ASSERT_TRUE(runner);
+
+  const std::vector<int> tokens(runner->window() - 1, 0);
+  EXPECT_FALSE(runner->Run(tokens).has_value());
+}
+
+}  // namespace brave_history_embeddings

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -404,6 +404,7 @@ test("brave_unit_tests") {
       "//brave/browser/history_embeddings:unit_tests",
       "//brave/browser/local_ai:unit_tests",
       "//brave/browser/speech:unit_tests",
+      "//brave/services/passage_embeddings:unit_tests",
     ]
   }
 

--- a/utility/sources.gni
+++ b/utility/sources.gni
@@ -19,6 +19,7 @@ brave_utility_deps = [
   "//brave/components/brave_rewards/core/buildflags",
   "//brave/components/brave_wallet/common/buildflags",
   "//brave/components/tor/buildflags",
+  "//brave/services/passage_embeddings:chromium_impl",
   "//mojo/public/cpp/bindings",
 ]
 


### PR DESCRIPTION
- Part of https://github.com/brave/brave-browser/issues/57489

Adds a native LiteRT (`litert::CompiledModel`) EmbeddingGemma embedder, runs it in the sandboxed passage embeddings utility (chromium_src `PassageEmbedderImpl::BuildExecutionTask` override), and switches the history-embeddings controller to it — model delivered by the local AI component updater (its `litert/` subdir). `GetEmbedderMetadata` reports a distinct `model_version`, so upstream re-embeds history computed by the previous WASM embedder rather than mixing vector spaces.

LiteRT is fully live here. The WASM/candle embedder is retained in place as dead code (removed in #38375); only two now-unreferenced file-local helpers are dropped so the controller still builds. Docs updated.

**Stack 1/3.** Base: `master`. Followed by #38375, then #38376.
