### PR TITLE
[ads] Add a hover delay to the sponsored site tile tooltip

### DIFF
--- a/browser/resources/brave_new_tab_page_refresh/components/top_sites/sponsored_site_tile.test.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/top_sites/sponsored_site_tile.test.tsx
@@ -22,6 +22,14 @@ function getTileLink() {
   return document.querySelector<HTMLAnchorElement>('a.top-site-tile')!
 }
 
+// The Leo tooltip web component receives its props as plain JS properties
+// set directly on the element, not as HTML attributes.
+function getTooltipElement() {
+  return document.querySelector('leo-tooltip') as
+    | (HTMLElement & { mouseenterDelay?: number; mouseleaveTimeout?: number })
+    | null
+}
+
 function createSite(overrides: Partial<SponsoredSite> = {}): SponsoredSite {
   return {
     relativeImageUrl: 'chrome://branded-wallpaper/sponsored-images/foo',
@@ -86,6 +94,26 @@ describe('SponsoredSitesTile', () => {
       expect(getTileLink()).toHaveAttribute('href', expectedHref)
     },
   )
+
+  it('should open its tooltip on a delay rather than immediately on hover', () => {
+    render(
+      <SponsoredSitesTile
+        site={createSite()}
+        onContextMenu={() => {}}
+      />,
+    )
+    expect(getTooltipElement()?.mouseenterDelay).toBe(200)
+  })
+
+  it('should close its tooltip immediately when the pointer leaves', () => {
+    render(
+      <SponsoredSitesTile
+        site={createSite()}
+        onContextMenu={() => {}}
+      />,
+    )
+    expect(getTooltipElement()?.mouseleaveTimeout).toBe(0)
+  })
 
   it('should not be draggable', () => {
     render(

--- a/browser/resources/brave_new_tab_page_refresh/components/top_sites/sponsored_site_tile.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/top_sites/sponsored_site_tile.tsx
@@ -15,6 +15,9 @@ import { formatString } from '$web-common/formatString'
 import { getString } from '../../lib/strings'
 import { Link } from '../common/link'
 
+const tooltipHideDelay = 0
+const tooltipShowDelay = 200
+
 interface Props {
   site: SponsoredSite
   onContextMenu: (event: React.MouseEvent) => void
@@ -28,6 +31,8 @@ export function SponsoredSitesTile(props: Props) {
       mode='default'
       placement='bottom'
       positionStrategy='fixed'
+      mouseleaveTimeout={tooltipHideDelay}
+      mouseenterDelay={tooltipShowDelay}
     >
       <a
         className='top-site-tile'


### PR DESCRIPTION
The tooltip now waits briefly after the pointer stops over the tile before appearing, matching how other tooltips behave. Previously it appeared immediately on hover, which felt out of place next to those.

Part of https://github.com/brave/brave-browser/issues/57461

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
