### PR TITLE
[ads] Only show sponsored site tiles when relevant

### DIFF
--- a/browser/resources/brave_new_tab_page_refresh/components/top_sites/top_sites_grid.test.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/top_sites/top_sites_grid.test.tsx
@@ -294,11 +294,12 @@ describe('TopSitesGrid onDrop', () => {
   it('should snap to the start when dropped on a sponsored site', () => {
     const topSiteA = createTopSite('https://foo.com')
     const topSiteB = createTopSite('https://bar.com')
+    const topSiteC = createTopSite('https://baz.com')
     const sponsoredSite = createSponsoredSite('https://baz.com')
     const setTopSitePosition = jest.fn()
     renderGrid(
       {
-        topSites: [topSiteA, topSiteB],
+        topSites: [topSiteA, topSiteB, topSiteC],
         sponsoredSites: [sponsoredSite],
       },
       { setTopSitePosition },
@@ -329,11 +330,12 @@ describe('TopSitesGrid onDrop', () => {
 
   it('should not reorder when the dragged tile is a sponsored site', () => {
     const topSiteA = createTopSite('https://foo.com')
+    const topSiteB = createTopSite('https://bar.com')
     const sponsoredSite = createSponsoredSite('https://bar.com')
     const setTopSitePosition = jest.fn()
     renderGrid(
       {
-        topSites: [topSiteA],
+        topSites: [topSiteA, topSiteB],
         sponsoredSites: [sponsoredSite],
       },
       { setTopSitePosition },

--- a/browser/resources/brave_new_tab_page_refresh/components/top_sites/top_sites_grid_items.test.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/top_sites/top_sites_grid_items.test.tsx
@@ -149,9 +149,10 @@ describe('useTopSitesGridItems', () => {
   it('should place sponsored sites ahead of top sites, each carrying its original index', () => {
     const topSiteA = createTopSite('https://foo.com')
     const topSiteB = createTopSite('https://qux.com')
+    const topSiteC = createTopSite('https://baz.com')
     const sponsoredSite = createSponsoredSite('https://baz.com')
     const store = createStore({
-      topSites: [topSiteA, topSiteB],
+      topSites: [topSiteA, topSiteB, topSiteC],
       sponsoredSites: [sponsoredSite],
     })
 
@@ -165,6 +166,58 @@ describe('useTopSitesGridItems', () => {
       { type: 'top-site', site: topSiteA, index: 0 },
       { type: 'top-site', site: topSiteB, index: 1 },
     ])
+  })
+
+  it('should show only the sponsored sites that match a top site when there are multiple', () => {
+    const matchedTopSite = createTopSite('https://bar.com')
+    const relevantSponsoredSite = createSponsoredSite('https://bar.com')
+    const irrelevantSponsoredSite = createSponsoredSite('https://foo.com')
+    const store = createStore({
+      topSites: [matchedTopSite],
+      sponsoredSites: [relevantSponsoredSite, irrelevantSponsoredSite],
+    })
+
+    const { result } = renderHook(
+      () => useTopSitesGridItems({ canAddSite: false }),
+      { wrapper: createWrapper(store) },
+    )
+
+    expect(result.current).toEqual([
+      { type: 'sponsored-site', site: relevantSponsoredSite },
+    ])
+  })
+
+  it('should not show a sponsored site with an unparsable target URL', () => {
+    const topSite = createTopSite('https://bar.com')
+    const sponsoredSite = createSponsoredSite('not-a-url')
+    const store = createStore({
+      topSites: [topSite],
+      sponsoredSites: [sponsoredSite],
+    })
+
+    const { result } = renderHook(
+      () => useTopSitesGridItems({ canAddSite: false }),
+      { wrapper: createWrapper(store) },
+    )
+
+    expect(result.current).toEqual([
+      { type: 'top-site', site: topSite, index: 0 },
+    ])
+  })
+
+  it('should not show any sponsored sites when there are no top sites at all', () => {
+    const sponsoredSite = createSponsoredSite('https://baz.com')
+    const store = createStore({
+      topSites: [],
+      sponsoredSites: [sponsoredSite],
+    })
+
+    const { result } = renderHook(
+      () => useTopSitesGridItems({ canAddSite: false }),
+      { wrapper: createWrapper(store) },
+    )
+
+    expect(result.current).toEqual([])
   })
 
   it('should omit a top site deduplicated against a sponsored site, preserving remaining indices', () => {

--- a/browser/resources/brave_new_tab_page_refresh/components/top_sites/top_sites_grid_items.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/top_sites/top_sites_grid_items.ts
@@ -37,12 +37,16 @@ export function buildGridItems(
   sponsoredSites: SponsoredSite[],
   canAddSite: boolean,
 ): GridItem[] {
-  const deduplicatedTopSites = topSitesWithoutSponsoredSiteDuplicates(
+  const relevantSponsoredSites = sponsoredSitesMatchingTopSites(
     topSites,
     sponsoredSites,
   )
+  const deduplicatedTopSites = topSitesWithoutSponsoredSiteDuplicates(
+    topSites,
+    relevantSponsoredSites,
+  )
   const items: GridItem[] = [
-    ...sponsoredSites.map(
+    ...relevantSponsoredSites.map(
       (site): GridItem => ({ type: 'sponsored-site', site }),
     ),
     // `index` is the site's position in the full (non-deduplicated) top
@@ -62,6 +66,34 @@ export function buildGridItems(
   return items
 }
 
+// The exact hostname of a sponsored site's target, with any leading "www."
+// stripped so a top site on either the www or non-www variant still matches.
+// Returns null for an unparsable `targetUrl` (e.g. malformed ad server data),
+// which callers treat as never matching any top site.
+function advertiserDomain(sponsoredSite: SponsoredSite): string | null {
+  try {
+    const hostname = new URL(sponsoredSite.targetUrl).hostname
+    return hostname.startsWith('www.') ? hostname.slice(4) : hostname
+  } catch {
+    return null
+  }
+}
+
+function sponsoredSitesMatchingTopSites(
+  topSites: TopSite[],
+  sponsoredSites: SponsoredSite[],
+): SponsoredSite[] {
+  return sponsoredSites.filter((sponsoredSite) => {
+    const domain = advertiserDomain(sponsoredSite)
+    return (
+      domain !== null
+      && topSites.some((topSite) =>
+        matchesAdvertiserDomain(topSite.url, domain),
+      )
+    )
+  })
+}
+
 export function topSitesWithoutSponsoredSiteDuplicates(
   topSites: TopSite[],
   sponsoredSites: SponsoredSite[],
@@ -70,15 +102,12 @@ export function topSitesWithoutSponsoredSiteDuplicates(
     return topSites
   }
 
-  // The exact hostname of each sponsored site's target, with any leading "www."
-  // stripped so a top site on either the www or non-www variant still matches.
   // This is intentionally exact: a top site on an unrelated subdomain (e.g.
   // `aws.amazon.com` when the sponsored site targets `amazon.com`) is a
   // distinct destination and should not be deduped away.
-  const advertiserDomains = sponsoredSites.map((sponsoredSite) => {
-    const hostname = new URL(sponsoredSite.targetUrl).hostname
-    return hostname.startsWith('www.') ? hostname.slice(4) : hostname
-  })
+  const advertiserDomains = sponsoredSites
+    .map(advertiserDomain)
+    .filter((domain): domain is string => domain !== null)
   return topSites.filter(
     (topSite) =>
       // A top site with a search query is a specific page the user visited, not
@@ -100,12 +129,10 @@ export function topSitesWithoutSponsoredSiteDuplicates(
 // sponsored site targeting `aws.amazon.com` only dedupes `aws.amazon.com` or
 // `www.aws.amazon.com`, not the parent `amazon.com` and not other unrelated
 // subdomains.
-function matchesAdvertiserDomain(topSiteUrl: string, advertiserDomain: string) {
+function matchesAdvertiserDomain(topSiteUrl: string, domain: string) {
   try {
     const hostname = new URL(topSiteUrl).hostname
-    return (
-      hostname === advertiserDomain || hostname === `www.${advertiserDomain}`
-    )
+    return hostname === domain || hostname === `www.${domain}`
   } catch {
     return false
   }


### PR DESCRIPTION
A sponsored site tile is only shown when its advertiser domain also matches an existing top site, either in Frequently Visited or in the user's favourites. Showing a sponsored tile with no such match is not useful to the user, since it is not tied to anything they have visited or chosen. When a match exists, the matching top site tile is suppressed so the same destination is not shown twice.

Part of https://github.com/brave/brave-browser/issues/57461

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
