### PR TITLE
Fix vertical tabs/sidebar hover-expand affecting all windows

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -191,10 +191,15 @@ class BraveBrowserView::BrowserWindowMouseEventHandler
     auto* widget = browser_view_->GetWidget();
     CHECK(widget && widget->GetNativeWindow());
 
-    // Use application monitor to get events when browser widget is inactive
-    // while application is active. This can happen in fullscreen and other
-    // overlay widget is focused. (ex, immersive mode on macOS)
-    monitor_ = views::EventMonitor::CreateApplicationMonitor(
+    // Use a window-scoped monitor so that mouse moves in other browser
+    // windows don't get handled here. An application-wide monitor was used
+    // previously to also get events when the browser widget is inactive
+    // while an overlay widget is focused (ex, immersive mode on macOS), but
+    // that observes mouse moves across *all* browser windows in the process,
+    // causing hover-expand (vertical tabs/sidebar) to trigger in every open
+    // window instead of just the one being hovered. See AddOverlayWidget()
+    // for how the overlay-widget case is handled instead.
+    monitor_ = views::EventMonitor::CreateWindowMonitor(
         this, widget->GetNativeWindow(), {ui::EventType::kMouseMoved});
   }
 
@@ -204,6 +209,18 @@ class BraveBrowserView::BrowserWindowMouseEventHandler
       delete;
   BrowserWindowMouseEventHandler& operator=(
       const BrowserWindowMouseEventHandler&) = delete;
+
+  // Adds a window-scoped monitor for an overlay widget belonging to this same
+  // browser window (ex, immersive-fullscreen overlay widgets on macOS), so
+  // that hover-expand keeps working while the overlay widget is focused
+  // instead of the main browser widget.
+  void AddOverlayWidget(views::Widget* overlay_widget) {
+    if (!overlay_widget || !overlay_widget->GetNativeWindow()) {
+      return;
+    }
+    overlay_monitors_.push_back(views::EventMonitor::CreateWindowMonitor(
+        this, overlay_widget->GetNativeWindow(), {ui::EventType::kMouseMoved}));
+  }
 
  private:
   // ui::EventObserver overrides:
@@ -216,6 +233,7 @@ class BraveBrowserView::BrowserWindowMouseEventHandler
 
   raw_ptr<BraveBrowserView> browser_view_ = nullptr;
   std::unique_ptr<views::EventMonitor> monitor_;
+  std::vector<std::unique_ptr<views::EventMonitor>> overlay_monitors_;
 };
 
 class BraveBrowserView::TabCyclingEventHandler : public ui::EventObserver,
@@ -802,6 +820,22 @@ void BraveBrowserView::RemovedFromWidget() {
   focus_mode_observation_.Reset();
   BrowserView::RemovedFromWidget();
 }
+
+#if BUILDFLAG(IS_MAC)
+views::View* BraveBrowserView::CreateMacOverlayView() {
+  auto* overlay_view = BrowserView::CreateMacOverlayView();
+
+  // Hover-expand (vertical tabs/sidebar) needs mouse events while the overlay
+  // widget is focused instead of this window's main widget (ex, immersive
+  // fullscreen). `browser_window_mouse_event_handler_` normally only monitors
+  // the main widget, so add the overlay widgets it created above too.
+  CHECK(browser_window_mouse_event_handler_);
+  browser_window_mouse_event_handler_->AddOverlayWidget(overlay_widget());
+  browser_window_mouse_event_handler_->AddOverlayWidget(tab_overlay_widget());
+
+  return overlay_view;
+}
+#endif
 
 bool BraveBrowserView::ShowBraveHelpBubbleView(const std::string& text) {
   if (page_info::features::IsShowBraveShieldsInPageInfoEnabled()) {

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -205,6 +205,10 @@ class BraveBrowserView : public BrowserView,
   BraveShieldsToolbarButton* GetPwaShieldsToolbarButton();
 #endif
 
+#if BUILDFLAG(IS_MAC)
+  views::View* CreateMacOverlayView() override;
+#endif
+
  private:
   class TabCyclingEventHandler;
   class BrowserWindowMouseEventHandler;

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view.h
@@ -40,17 +40,7 @@
 #define ShouldDrawTabStrokes virtual ShouldDrawTabStrokes
 #define GetFrameElementInfo virtual GetFrameElementInfo
 
-#if BUILDFLAG(IS_MAC)
-#define CreateMacOverlayView     \
-  CreateMacOverlayView_Unused(); \
-  virtual views::View* CreateMacOverlayView
-#endif
-
 #include <chrome/browser/ui/views/frame/browser_view.h>  // IWYU pragma: export
-
-#if BUILDFLAG(IS_MAC)
-#undef CreateMacOverlayView
-#endif
 
 #undef GetFrameElementInfo
 #undef ReparentTopContainerForEndOfImmersive

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view.h
@@ -12,9 +12,9 @@
 #include "chrome/browser/ui/exclusive_access/exclusive_access_context.h"
 #include "chrome/browser/ui/views/frame/shadow_overlay_view.h"
 
-#define BrowserViewLayoutDelegateImplOld                        \
-  BrowserViewLayoutDelegateImplOld;                             \
-  friend class BraveBrowserView;                                \
+#define BrowserViewLayoutDelegateImplOld \
+  BrowserViewLayoutDelegateImplOld;      \
+  friend class BraveBrowserView;         \
   virtual bool IsWebPanelContents(content::WebContents* contents)
 
 #define BrowserWindow BraveBrowserWindow
@@ -40,7 +40,17 @@
 #define ShouldDrawTabStrokes virtual ShouldDrawTabStrokes
 #define GetFrameElementInfo virtual GetFrameElementInfo
 
+#if BUILDFLAG(IS_MAC)
+#define CreateMacOverlayView     \
+  CreateMacOverlayView_Unused(); \
+  virtual views::View* CreateMacOverlayView
+#endif
+
 #include <chrome/browser/ui/views/frame/browser_view.h>  // IWYU pragma: export
+
+#if BUILDFLAG(IS_MAC)
+#undef CreateMacOverlayView
+#endif
 
 #undef GetFrameElementInfo
 #undef ReparentTopContainerForEndOfImmersive

--- a/patches/chrome-browser-ui-views-frame-browser_view.h.patch
+++ b/patches/chrome-browser-ui-views-frame-browser_view.h.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/views/frame/browser_view.h b/chrome/browser/ui/views/frame/browser_view.h
+index c6bcc529f1cc1842be2285fb8b880e00cbde4309..4e9f2d801baad7c459683522a65256ef5df9b5ba 100644
+--- a/chrome/browser/ui/views/frame/browser_view.h
++++ b/chrome/browser/ui/views/frame/browser_view.h
+@@ -676,7 +676,7 @@ class BrowserView : public BrowserWindow,
+   views::ClientView* CreateClientView(views::Widget* widget) override;
+   views::View* CreateOverlayView() override;
+ #if BUILDFLAG(IS_MAC)
+-  views::View* CreateMacOverlayView();
++  virtual views::View* CreateMacOverlayView();
+ #endif
+   void OnWindowBeginUserBoundsChange() override;
+   void OnWindowEndUserBoundsChange() override;

--- a/rewrite/chrome/browser/ui/views/frame/browser_view.h.yaml
+++ b/rewrite/chrome/browser/ui/views/frame/browser_view.h.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: Make the CreateMacOverlayView virtual for subclassing.
+    make_virtual:
+      class_name: BrowserView
+      method_name: 'CreateMacOverlayView'


### PR DESCRIPTION
Commit c369640b6930 switched the hover-detection mouse monitor from a window-scoped monitor to an application-wide one, to keep hover-expand working while a macOS immersive-fullscreen overlay widget is focused instead of the main browser widget. But an application-wide monitor observes mouse moves across every browser window in the process, so hovering one window's sidebar/vertical-tab hot corner also triggered hover-expand in every other open window.

Revert to a window-scoped monitor for the main widget, and separately add window-scoped monitors for the macOS immersive-fullscreen overlay widgets (which are distinct NSWindows) so that case still works without observing unrelated windows.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/56842

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
