### PR TITLE
[iOS] Fix open external app confirmation alert redirect flow affecting 1Password login

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabPolicyDecider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabPolicyDecider.swift
@@ -92,6 +92,7 @@ extension BrowserViewController: TabPolicyDecider {
       tab.externalAppPopupContinuation?.resume(with: .success(false))
       tab.externalAppPopupContinuation = nil
       tab.externalAppPopup = nil
+      tab.isExternalAppAlertPresented = false
     }
 
     // Handle internal:// urls

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabPolicyDecider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabPolicyDecider.swift
@@ -88,10 +88,18 @@ extension BrowserViewController: TabPolicyDecider {
     let isPrivateBrowsing = privateBrowsingManager.isPrivateBrowsing
 
     if tab.isExternalAppAlertPresented == true {
+      // Some external-app schemes may fire the same request back-to-back.
+      // Don't tear down and re-present the alert for a request that matches
+      // the one it's already asking about, otherwise it can dismiss and
+      // presents repeatedly.
+      if tab.externalAppURL == requestURL {
+        return .cancel
+      }
       tab.externalAppPopup?.dismissWithType(dismissType: .noAnimation)
       tab.externalAppPopupContinuation?.resume(with: .success(false))
       tab.externalAppPopupContinuation = nil
       tab.externalAppPopup = nil
+      tab.externalAppURL = nil
       tab.isExternalAppAlertPresented = false
     }
 
@@ -745,6 +753,7 @@ extension BrowserViewController {
 
       view.endEditing(true)
       tab.isExternalAppAlertPresented = true
+      tab.externalAppURL = url
 
       let popup = AlertPopupView(
         imageView: nil,
@@ -769,6 +778,7 @@ extension BrowserViewController {
           openedURLCompletionHandler(false)
           removeTabIfEmpty()
           tab?.isExternalAppAlertPresented = false
+          tab?.externalAppURL = nil
           return .flyDown
         }
       }
@@ -779,6 +789,7 @@ extension BrowserViewController {
         }
         removeTabIfEmpty()
         tab?.isExternalAppAlertPresented = false
+        tab?.externalAppURL = nil
         return .flyDown
       }
       popup.showWithType(showType: .flyUp)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
@@ -189,12 +189,15 @@ class TabBrowserData: NSObject, TabObserver {
   var externalAppAlertCounter = 0
   var isExternalAppAlertSuppressed = false
   var externalAppURLDomain: String?
+  /// The url the currently presented custom url-scheme alert is asking about
+  var externalAppURL: URL?
 
   func resetExternalAlertProperties() {
     externalAppAlertCounter = 0
     isExternalAppAlertPresented = false
     isExternalAppAlertSuppressed = false
     externalAppURLDomain = nil
+    externalAppURL = nil
   }
 
   /// A list of domains that we want to proceed to anyways regardless of any ad-blocking


### PR DESCRIPTION
- Fixes a flaw where we would dismiss the external app confirmation alert, but fail to update our flag tracking if this alert is presented.
- Additionally provides a small UX improvement where we cancel back-to-back requests for the same external app URL, so we don't dismiss & re-present the same alert for each request if the url is unchanged.

- Resolves https://github.com/brave/brave-browser/issues/57440

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

### Testplan
1. In 1Password app, visit Accounts page and go through `Add an Account` flow that uses Google SSO Login
2. When redirected to Brave Browser iOS app, login via Google SSO
3. When prompted to open in 1Password app, tap allow
4. Verify you are logged in successfully