### PR TITLE
[AI Chat] Move full page to side panel when a link within a conversation opens a tab

### DIFF
--- a/browser/ai_chat/ai_chat_sidepanel_behavior_browsertest.cc
+++ b/browser/ai_chat/ai_chat_sidepanel_behavior_browsertest.cc
@@ -36,6 +36,7 @@
 #include "content/public/browser/web_ui.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
 #include "printing/buildflags/buildflags.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/blink/public/mojom/window_features/window_features.mojom.h"
@@ -361,6 +362,71 @@ IN_PROC_BROWSER_TEST_P(AIChatGlobalSidePanelBrowserTest,
             nullptr);
   ASSERT_EQ(side_panel->GetContentParentView()->children().size(), 1u);
   EXPECT_EQ(GetAttachedSidePanelWebContents(browser()), leo_contents);
+}
+
+// End-to-end forward move: conversation links are plain `<a target="_blank">`
+// anchors, so following one opens a new foreground tab through the browser's
+// normal new-window path with no AI Chat handler involved.
+// `AIChatFullPageLinkObserver` watches for that and moves the full-page
+// conversation into the side panel, so the linked page takes its place instead
+// of covering it. Where the transfer doesn't apply the link still opens and AI
+// Chat stays a full tab. The click is made in the WebUI's main frame: the
+// conversation renders its links in an iframe of the same `WebContents`, and
+// the browser-side signal the observer watches is identical either way.
+IN_PROC_BROWSER_TEST_P(AIChatGlobalSidePanelBrowserTest,
+                       LinkOpeningNewTabMovesFullPageChatToSidePanel) {
+  ASSERT_TRUE(embedded_test_server()->Start());
+
+  auto* tab_strip = browser()->tab_strip_model();
+
+  // Open the full-page AI Chat conversation in a new tab, keeping the original
+  // tab so the tab strip stays valid after AI Chat is detached.
+  ASSERT_TRUE(ui_test_utils::NavigateToURLWithDisposition(
+      browser(), GURL(kAIChatUIURL), WindowOpenDisposition::NEW_FOREGROUND_TAB,
+      ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP));
+  content::WebContents* leo_contents = tab_strip->GetActiveWebContents();
+  ASSERT_TRUE(leo_contents);
+
+  const int initial_tab_count = tab_strip->count();
+
+  // Follow a link the way the conversation renders it.
+  const GURL link_url = embedded_test_server()->GetURL("/title1.html");
+  ASSERT_TRUE(content::ExecJs(
+      leo_contents,
+      content::JsReplace("const link = document.createElement('a');"
+                         "link.href = $1;"
+                         "link.target = '_blank';"
+                         "link.rel = 'noopener noreferrer';"
+                         "document.body.appendChild(link);"
+                         "link.click();",
+                         link_url)));
+
+  // The transfer requires both the move feature and the global side panel.
+  if (!(IsMoveToSidePanelEnabled() && IsGlobalFlagEnabled())) {
+    // The link opens in a tab of its own and AI Chat stays a full tab.
+    ASSERT_TRUE(base::test::RunUntil(
+        [&]() { return tab_strip->count() == initial_tab_count + 1; }));
+    EXPECT_NE(tab_strip->GetIndexOfWebContents(leo_contents),
+              TabStripModel::kNoTab);
+    EXPECT_FALSE(IsSidePanelOpen(browser()));
+    return;
+  }
+
+  // The side panel now shows and hosts the *same* live WebContents (no reload /
+  // no fresh contents). Only this end state can be waited on: the link's tab is
+  // inserted and AI Chat is detached back-to-back, so the tab strip is never
+  // observed holding both.
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return IsSidePanelOpen(browser()) &&
+           GetAttachedSidePanelWebContents(browser()) == leo_contents;
+  }));
+
+  // The link's tab took AI Chat's place: it is the active tab, and the tab
+  // count is unchanged because AI Chat left the strip as the link's tab joined.
+  EXPECT_EQ(tab_strip->GetIndexOfWebContents(leo_contents),
+            TabStripModel::kNoTab);
+  EXPECT_EQ(tab_strip->count(), initial_tab_count);
+  EXPECT_EQ(tab_strip->GetActiveWebContents()->GetVisibleURL(), link_url);
 }
 
 // The forward move only applies to a full-page AI Chat. When AI Chat is already

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -216,9 +216,11 @@ source_set("ui") {
 
   if (enable_ai_chat) {
     # Compiled on all platforms: the desktop side panel implementations live in
-    # //brave/browser/ui/views/side_panel/ai_chat, while this file provides the
+    # //brave/browser/ui/views/side_panel/ai_chat, while these files provide the
     # non-views (e.g. Android) fallbacks, so callers stay platform-agnostic.
     sources += [
+      "side_panel/ai_chat/ai_chat_full_page_link_observer.cc",
+      "side_panel/ai_chat/ai_chat_full_page_link_observer.h",
       "side_panel/ai_chat/ai_chat_side_panel_utils.cc",
       "side_panel/ai_chat/ai_chat_side_panel_utils.h",
     ]

--- a/browser/ui/side_panel/ai_chat/ai_chat_full_page_link_observer.cc
+++ b/browser/ui/side_panel/ai_chat/ai_chat_full_page_link_observer.cc
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/side_panel/ai_chat/ai_chat_full_page_link_observer.h"
+
+#include "base/functional/bind.h"
+#include "base/location.h"
+#include "base/task/sequenced_task_runner.h"
+#include "brave/browser/ui/side_panel/ai_chat/ai_chat_side_panel_utils.h"
+#include "content/public/browser/web_contents.h"
+
+namespace ai_chat {
+
+AIChatFullPageLinkObserver::AIChatFullPageLinkObserver(
+    content::WebContents* web_contents)
+    : content::WebContentsObserver(web_contents) {}
+
+AIChatFullPageLinkObserver::~AIChatFullPageLinkObserver() = default;
+
+void AIChatFullPageLinkObserver::DidOpenRequestedURL(
+    content::WebContents* new_contents,
+    content::RenderFrameHost* source_render_frame_host,
+    const GURL& url,
+    const content::Referrer& referrer,
+    WindowOpenDisposition disposition,
+    ui::PageTransition transition,
+    bool started_from_context_menu,
+    bool renderer_initiated) {
+  // Only a link the page followed on the user's behalf takes the conversation's
+  // place. A background tab (modifier-click), a new window and a popup all
+  // leave the conversation visible where it is, so they must not move it, and
+  // neither should a browser-driven open such as a context menu item.
+  if (!renderer_initiated || started_from_context_menu ||
+      disposition != WindowOpenDisposition::NEW_FOREGROUND_TAB) {
+    return;
+  }
+
+  // `new_contents` is not in the tab strip yet: this runs while it is still
+  // being created, and the insertion positions and activates it against AI
+  // Chat's tab. Detaching that tab now would pull it out from under the
+  // insertion, and the in-flight window would be handed to the side panel's
+  // delegate (which navigates the active tab instead of opening one). Let the
+  // new tab land first and move once this open has finished.
+  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+      FROM_HERE,
+      base::BindOnce(&AIChatFullPageLinkObserver::MoveConversationToSidePanel,
+                     weak_ptr_factory_.GetWeakPtr()));
+}
+
+void AIChatFullPageLinkObserver::MoveConversationToSidePanel() {
+  if (!web_contents()) {
+    return;
+  }
+
+  // No-op unless the feature is enabled and this conversation is a full-page
+  // tab in a window whose side panel is global.
+  MaybeMoveFullPageChatToSidePanel(web_contents());
+}
+
+}  // namespace ai_chat

--- a/browser/ui/side_panel/ai_chat/ai_chat_full_page_link_observer.h
+++ b/browser/ui/side_panel/ai_chat/ai_chat_full_page_link_observer.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_BROWSER_UI_SIDE_PANEL_AI_CHAT_AI_CHAT_FULL_PAGE_LINK_OBSERVER_H_
+#define BRAVE_BROWSER_UI_SIDE_PANEL_AI_CHAT_AI_CHAT_FULL_PAGE_LINK_OBSERVER_H_
+
+#include "base/memory/weak_ptr.h"
+#include "content/public/browser/web_contents_observer.h"
+#include "ui/base/page_transition_types.h"
+#include "ui/base/window_open_disposition.h"
+
+class GURL;
+
+namespace content {
+class RenderFrameHost;
+class WebContents;
+}  // namespace content
+
+namespace ai_chat {
+
+// Moves a full-page AI Chat conversation into the side panel when a link in it
+// opens a new foreground tab, so the linked page takes the conversation's place
+// rather than covering it.
+//
+// Conversation links are plain `<a target="_blank">` anchors, so the browser
+// opens them through its normal new-window path without any AI Chat handler
+// being involved. `DidOpenRequestedURL` is the browser-side signal that one was
+// followed. Links AI Chat opens itself (`AIChatUIHandler::OpenURL` and friends)
+// are browser-initiated and never reach here, so they keep moving the
+// conversation from their own call sites.
+//
+// This observes AI Chat's `WebContents` wherever it is hosted; the move is a
+// no-op while the conversation is in the side panel already (and on platforms
+// with no side panel), so the observer does not need to track which surface
+// hosts it.
+class AIChatFullPageLinkObserver : public content::WebContentsObserver {
+ public:
+  explicit AIChatFullPageLinkObserver(content::WebContents* web_contents);
+  AIChatFullPageLinkObserver(const AIChatFullPageLinkObserver&) = delete;
+  AIChatFullPageLinkObserver& operator=(const AIChatFullPageLinkObserver&) =
+      delete;
+  ~AIChatFullPageLinkObserver() override;
+
+ private:
+  // content::WebContentsObserver:
+  void DidOpenRequestedURL(content::WebContents* new_contents,
+                           content::RenderFrameHost* source_render_frame_host,
+                           const GURL& url,
+                           const content::Referrer& referrer,
+                           WindowOpenDisposition disposition,
+                           ui::PageTransition transition,
+                           bool started_from_context_menu,
+                           bool renderer_initiated) override;
+
+  void MoveConversationToSidePanel();
+
+  base::WeakPtrFactory<AIChatFullPageLinkObserver> weak_ptr_factory_{this};
+};
+
+}  // namespace ai_chat
+
+#endif  // BRAVE_BROWSER_UI_SIDE_PANEL_AI_CHAT_AI_CHAT_FULL_PAGE_LINK_OBSERVER_H_

--- a/browser/ui/side_panel/ai_chat/ai_chat_side_panel_utils.h
+++ b/browser/ui/side_panel/ai_chat/ai_chat_side_panel_utils.h
@@ -20,11 +20,13 @@ Browser* GetBrowserForWebContents(content::WebContents* web_contents);
 void ClosePanel(content::WebContents* web_contents);
 
 // Forward (tab -> side panel): when `ai_chat_web_contents` is a full browser
-// tab and the `kAIChatMoveFullPageToSidePanel` feature is enabled, opens
-// `link_url` in a tab at AI Chat's position and moves the live AI Chat
-// `WebContents` into the side panel. Returns true if the click was handled this
-// way (the caller must then NOT open `link_url` itself). Desktop only; the
-// definition lives in the toolkit_views translation unit.
+// tab and the `kAIChatMoveFullPageToSidePanel` feature is enabled, moves the
+// live AI Chat `WebContents` into the side panel (preserving state). Returns
+// true if the conversation was moved. Opening the link that prompted the move
+// is the caller's separate responsibility - see `AIChatFullPageLinkObserver`
+// for anchor clicks, which the browser opens itself, and
+// `AIChatUIPageHandler::OpenURLInNewTab` for links AI Chat opens over Mojo.
+// Desktop only; the definition lives in the toolkit_views translation unit.
 bool MaybeMoveFullPageChatToSidePanel(
     content::WebContents* ai_chat_web_contents);
 

--- a/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_utils_views.cc
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_utils_views.cc
@@ -116,12 +116,14 @@ bool MaybeMoveFullPageChatToSidePanel(
 
   const tabs::TabHandle ai_chat_handle = ai_chat_tab->GetHandle();
 
-  // Capture the full-page contents' rect (in browser/widget coordinates) before
-  // detaching, so the side panel can animate the conversation in from where it
-  // currently sits. This must happen before `DetachWebContents`, which orphans
-  // the contents' native view and leaves it unable to report an on-screen rect.
-  // AI Chat is the active tab at this point (its own link was just clicked), so
-  // the active contents web view hosts it.
+  // Capture the content area's rect (in browser/widget coordinates) before
+  // detaching, so the side panel can animate the conversation in from where the
+  // full page sits. The active contents web view spans that area whichever tab
+  // is active, which is what matters here: AI Chat is still the active tab when
+  // it moves from a Mojo link handler, while the link's new tab has just been
+  // activated when it moves from `AIChatFullPageLinkObserver`. This must happen
+  // before `DetachWebContents`, which orphans the contents' native view and
+  // leaves it unable to report an on-screen rect.
   gfx::Rect starting_bounds;
   if (BrowserElementsViews* elements = BrowserElementsViews::From(browser)) {
     if (views::WebView* contents_web_view =

--- a/browser/ui/webui/ai_chat/ai_chat_ui.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.cc
@@ -14,6 +14,7 @@
 #include "base/feature_list.h"
 #include "brave/browser/ai_chat/ai_chat_service_factory.h"
 #include "brave/browser/ai_chat/tab_tracker_service_factory.h"
+#include "brave/browser/ui/side_panel/ai_chat/ai_chat_full_page_link_observer.h"
 #include "brave/browser/ui/side_panel/ai_chat/ai_chat_side_panel_utils.h"
 #include "brave/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h"
 #include "brave/browser/ui/webui/brave_webui_source.h"
@@ -133,6 +134,16 @@ AIChatUI::AIChatUI(content::WebUI* web_ui)
   content::URLDataSource::Add(profile_,
                               std::make_unique<ThemeSource>(profile_));
 #endif
+
+  // Links in a conversation are plain anchors, so the browser opens them
+  // without going through any AI Chat handler. Watch for that so a full-page
+  // conversation can move into the side panel and let the link take its place.
+  if (base::FeatureList::IsEnabled(
+          ai_chat::features::kAIChatMoveFullPageToSidePanel)) {
+    full_page_link_observer_ =
+        std::make_unique<ai_chat::AIChatFullPageLinkObserver>(
+            web_ui->GetWebContents());
+  }
 }
 
 AIChatUI::~AIChatUI() = default;

--- a/browser/ui/webui/ai_chat/ai_chat_ui.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.h
@@ -28,6 +28,7 @@
 #endif  // #if !BUILDFLAG(IS_ANDROID)
 
 namespace ai_chat {
+class AIChatFullPageLinkObserver;
 class AIChatUIPageHandlerBrowserTest;
 class BookmarksPageHandler;
 }  // namespace ai_chat
@@ -71,6 +72,11 @@ class AIChatUI : public ui::MojoWebUIController {
   std::unique_ptr<ai_chat::AIChatUIPageHandler> page_handler_;
   std::unique_ptr<ai_chat::BookmarksPageHandler> bookmarks_page_handler_;
   std::unique_ptr<ai_chat::HistoryUIHandler> history_ui_handler_;
+
+  // Moves a full-page conversation into the side panel when a link in it opens
+  // a new tab. Only created when `kAIChatMoveFullPageToSidePanel` is enabled,
+  // so the feature stays inert while it is off.
+  std::unique_ptr<ai_chat::AIChatFullPageLinkObserver> full_page_link_observer_;
 
   base::WeakPtr<TopChromeWebUIController::Embedder> embedder_;
   raw_ptr<Profile> profile_ = nullptr;

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -423,11 +423,12 @@ void AIChatUIPageHandler::OpenURL(const GURL& url) {
     return;
   }
 
-  // A frontend link was clicked inside the conversation. If AI Chat is a full
-  // browser tab, move the live conversation into the side panel and open the
-  // link in a tab in its place. No-op unless the feature is enabled and AI
-  // Chat is a full tab; internal chrome/UI links use OpenURLInNewTab directly
-  // and never reach here.
+  // A link in the AI Chat UI was clicked. If AI Chat is a full browser tab,
+  // move the live conversation into the side panel and open the link in a tab
+  // in its place. No-op unless the feature is enabled and AI Chat is a full
+  // tab. Neither the links AI Chat opens itself (`GoPremium` and friends, which
+  // use OpenURLInNewTab directly) nor the anchors a conversation renders (which
+  // the browser opens, and `AIChatFullPageLinkObserver` moves for) reach here.
   ai_chat::MaybeMoveFullPageChatToSidePanel(owner_web_contents_);
 
   OpenURLInNewTab(url);

--- a/browser/ui/webui/ai_chat/ai_chat_untrusted_conversation_ui.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_untrusted_conversation_ui.cc
@@ -270,7 +270,9 @@ class UIHandler : public ai_chat::mojom::UntrustedUIHandler {
     }
     // If AI Chat is a full browser tab, move the live conversation into the
     // side panel. No-op unless the feature is enabled and AI Chat is a full
-    // tab.
+    // tab. This covers the links the conversation asks us to open over Mojo;
+    // links it renders as anchors are opened by the browser itself and move the
+    // conversation via `AIChatFullPageLinkObserver`.
     ai_chat::MaybeMoveFullPageChatToSidePanel(web_ui_->GetWebContents());
 #if !BUILDFLAG(IS_ANDROID)
     Browser* browser =


### PR DESCRIPTION
Conversation links are now plain `<a target="_blank">` anchors rather than Mojo calls, so the browser opens them itself and the full-page to side panel move lost its trigger for everything except the links AI Chat still opens over Mojo (web source citations, search, premium).

Observe the AI Chat `WebContents` instead: `AIChatFullPageLinkObserver` moves the live conversation into the side panel when `DidOpenRequestedURL` reports a renderer-initiated new foreground tab, which content notifies for both new-window paths. Modifier clicks, new windows, popups and context menu opens leave the conversation where it is, and the move is deferred with a `PostTask` so the link's tab is inserted before AI Chat leaves the tab strip.

Only created when `kAIChatMoveFullPageToSidePanel` is enabled.

Series
- https://github.com/brave/brave-browser/issues/57047

Based on:
- https://github.com/brave/brave-core/pull/37913
- https://github.com/brave/brave-core/pull/37994
- https://github.com/brave/brave-core/pull/38113
- https://github.com/brave/brave-core/pull/38319