### PR TITLE
Enhance password generator to include all printable ASCII symbols

### DIFF
--- a/patches/components-password_manager-core-browser-generation-password_generator.cc.patch
+++ b/patches/components-password_manager-core-browser-generation-password_generator.cc.patch
@@ -5,7 +5,7 @@ diff --git a/components/password_manager/core/browser/generation/password_genera
      "abcdefghijkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ";
  constexpr char kDigits[] = "23456789";
 -constexpr char kSymbols[] = "-_.:!";
-+constexpr char kSymbols[] = "-_.:!@#$%^&*()+=?";
++constexpr char kSymbols[] = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~";
  
  // Returns a default password requirements specification that requires:
 @@ -74,8 +74,8 @@ PasswordRequirementsSpec BuildDefaultSpec() {

--- a/patches/components-password_manager-core-browser-generation-password_generator.cc.patch
+++ b/patches/components-password_manager-core-browser-generation-password_generator.cc.patch
@@ -1,0 +1,19 @@
+diff --git a/components/password_manager/core/browser/generation/password_generator.cc b/components/password_manager/core/browser/generation/password_generator.cc
+--- a/components/password_manager/core/browser/generation/password_generator.cc
++++ b/components/password_manager/core/browser/generation/password_generator.cc
+@@ -39,7 +39,7 @@ constexpr char kAlphabeticChars[] =
+     "abcdefghijkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ";
+ constexpr char kDigits[] = "23456789";
+-constexpr char kSymbols[] = "-_.:!";
++constexpr char kSymbols[] = "-_.:!@#$%^&*()+=?";
+ 
+ // Returns a default password requirements specification that requires:
+@@ -74,8 +74,8 @@ PasswordRequirementsSpec BuildDefaultSpec() {
+ 
+   spec.mutable_symbols()->set_character_set(kSymbols);
+-  spec.mutable_symbols()->set_min(0);
+-  spec.mutable_symbols()->set_max(0);
++  spec.mutable_symbols()->set_min(1);
++  spec.mutable_symbols()->set_max(std::numeric_limits<int32_t>::max());
+   return spec;
+ }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves
This pull request updates the password generation logic to strengthen the default password requirements and expand the set of allowed symbols. The main changes are:

**Password Generation Policy Updates:**

* The allowed symbol set in `kSymbols` was expanded to include a wider range of special characters, improving password complexity.
* The default password requirements now require at least one symbol (previously zero), and set the maximum number of symbols to the largest possible integer, rather than zero, ensuring symbols are always present and not artificially limited.
<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
