### PR TITLE
Keep Brave proxy target factory alive for pending requests

### DIFF
--- a/browser/net/brave_proxying_url_loader_factory.cc
+++ b/browser/net/brave_proxying_url_loader_factory.cc
@@ -793,10 +793,6 @@ void BraveProxyingURLLoaderFactory<T>::OnTargetFactoryError() {
 
 template <template <typename> class T>
 void BraveProxyingURLLoaderFactory<T>::OnProxyBindingError() {
-  if (proxy_receivers_.empty()) {
-    target_factory_.reset();
-  }
-
   MaybeRemoveProxy();
 }
 
@@ -812,9 +808,12 @@ void BraveProxyingURLLoaderFactory<T>::RemoveRequest(
 
 template <template <typename> class T>
 void BraveProxyingURLLoaderFactory<T>::MaybeRemoveProxy() {
-  // Even if all URLLoaderFactory pipes connected to this object have been
-  // closed it has to stay alive until all active requests have completed.
-  if (target_factory_.is_bound() || !requests_.empty()) {
+  // We can delete this factory only when there are no active requests and no
+  // remaining URLLoaderFactory receivers. Active requests may be waiting on
+  // asynchronous Shields callbacks; keep |target_factory_| alive so they can
+  // resume and create their target URLLoader even after the last factory
+  // receiver disconnects.
+  if (!requests_.empty() || !proxy_receivers_.empty()) {
     return;
   }
 


### PR DESCRIPTION
## Summary

Keeps `BraveProxyingURLLoaderFactory::target_factory_` alive after the last factory receiver disconnects while there are still active requests.

Requests can be paused while waiting for asynchronous Shields callbacks. Before this change, `OnProxyBindingError()` reset `target_factory_` as soon as the last receiver disconnected, even if `requests_` was non-empty. When a paused request later resumed, `ContinueToStartRequest()` could no longer create the target loader and the request was stranded.

This matches the current lifetime model in Chromium's `WebRequestProxyingURLLoaderFactory`: remove the proxy only once there are no requests and no future requests can arrive.

## Verification

- `pnpm run presubmit --base master`: `0 Presubmit Messages, 0 Presubmit Warnings, 0 Presubmit ERRORS`.

Note: a direct object build in this local checkout was blocked by an unrelated generated Chromium tree/patch state (`chrome/browser/google/BUILD.gn` imports a missing generated Brave `sources.gni`; `apply_patches` also fails on unrelated WebUI patches). This PR changes only `browser/net/brave_proxying_url_loader_factory.cc`, and presubmit is clean.

Resolves https://github.com/brave/brave-browser/issues/57533
