### PR TITLE
Forward Early Hints through Brave proxy

### DIFF
--- a/browser/net/brave_proxying_url_loader_factory.cc
+++ b/browser/net/brave_proxying_url_loader_factory.cc
@@ -274,7 +274,9 @@ void BraveProxyingURLLoaderFactory<T>::InProgressRequest::SetPriority(
 
 template <template <typename> class T>
 void BraveProxyingURLLoaderFactory<T>::InProgressRequest::OnReceiveEarlyHints(
-    network::mojom::EarlyHintsPtr early_hints) {}
+    network::mojom::EarlyHintsPtr early_hints) {
+  target_client_->OnReceiveEarlyHints(std::move(early_hints));
+}
 
 template <template <typename> class T>
 void BraveProxyingURLLoaderFactory<T>::InProgressRequest::OnReceiveResponse(


### PR DESCRIPTION
## Summary

Forwards `URLLoaderClient::OnReceiveEarlyHints` through `BraveProxyingURLLoaderFactory` to the original client.

Brave's proxy had an empty `OnReceiveEarlyHints()` override, which dropped every HTTP 103 Early Hints notification for requests using this proxy. Chromium's `WebRequestProxyingURLLoaderFactory` forwards the callback, and Brave should preserve the same behavior so Early Hints preloads are not lost.

## Verification

- `pnpm run presubmit --base master`: `0 Presubmit Messages, 0 Presubmit Warnings, 0 Presubmit ERRORS`.

Note: a direct object build in this local checkout was blocked by an unrelated generated Chromium tree/patch state (`chrome/browser/google/BUILD.gn` imports a missing generated Brave `sources.gni`; `apply_patches` also fails on unrelated WebUI patches). This PR changes only `browser/net/brave_proxying_url_loader_factory.cc`, and presubmit is clean.

Resolves https://github.com/brave/brave-browser/issues/57534
