### PR TITLE
Avoid cloning response headers when STP has nothing to remove

### DIFF
--- a/browser/net/brave_stp_util.cc
+++ b/browser/net/brave_stp_util.cc
@@ -39,10 +39,10 @@ void RemoveTrackableSecurityHeadersForThirdParty(
     }
   }
   if (!has_trackable_security_header) {
-    // Avoid cloning and reparsing the raw response headers for the common case
-    // where there is nothing for STP to remove. Without this guard every
-    // third-party response would pay that cost even when the header list is
-    // already safe to pass through unchanged.
+    // Leave the headers untouched when there are no STP-managed headers to
+    // remove. This preserves any non-trackable headers by keeping the existing
+    // response header object in place instead of cloning/reparsing it just to
+    // remove nothing.
     return;
   }
 

--- a/browser/net/brave_stp_util.cc
+++ b/browser/net/brave_stp_util.cc
@@ -28,6 +28,20 @@ void RemoveTrackableSecurityHeadersForThirdParty(
     return;
   }
 
+  const net::HttpResponseHeaders* headers =
+      override_response_headers->get() ? override_response_headers->get()
+                                       : original_response_headers;
+  bool has_trackable_security_header = false;
+  for (auto header : kTrackableSecurityHeaders) {
+    if (headers->HasHeader(std::string(header))) {
+      has_trackable_security_header = true;
+      break;
+    }
+  }
+  if (!has_trackable_security_header) {
+    return;
+  }
+
   if (!override_response_headers->get()) {
     *override_response_headers =
         new net::HttpResponseHeaders(original_response_headers->raw_headers());

--- a/browser/net/brave_stp_util.cc
+++ b/browser/net/brave_stp_util.cc
@@ -39,6 +39,10 @@ void RemoveTrackableSecurityHeadersForThirdParty(
     }
   }
   if (!has_trackable_security_header) {
+    // Avoid cloning and reparsing the raw response headers for the common case
+    // where there is nothing for STP to remove. Without this guard every
+    // third-party response would pay that cost even when the header list is
+    // already safe to pass through unchanged.
     return;
   }
 


### PR DESCRIPTION
## Summary

Avoids cloning response headers in `RemoveTrackableSecurityHeadersForThirdParty()` unless one of the tracked security headers is actually present.

Previously every third-party response could populate `override_headers_` even when none of the tracked headers existed. That made `BraveProxyingURLLoaderFactory` replace/reparse response headers on the UI thread unnecessarily.

## Verification

- `pnpm run presubmit --base master`: `0 Presubmit Messages, 0 Presubmit Warnings, 0 Presubmit ERRORS`.

Resolves https://github.com/brave/brave-browser/issues/57536
