### PR TITLE
Preserve chained WebSocket request header client

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -1258,7 +1258,7 @@ void BraveContentBrowserClient::CreateChromeWebSocket(
         frame, proxy->CreateWebSocketFactory(), url, site_for_cookies,
         user_agent, std::move(handshake_client), std::move(options));
   } else {
-    proxy->Start(std::move(handshake_client));
+    proxy->Start(std::move(handshake_client), std::move(options.header_client));
   }
 }
 void BraveContentBrowserClient::CreateWebSocket(

--- a/browser/net/BUILD.gn
+++ b/browser/net/BUILD.gn
@@ -89,6 +89,7 @@ source_set("unit_tests") {
     "brave_block_safebrowsing_urls_unittest.cc",
     "brave_common_static_redirect_network_delegate_helper_unittest.cc",
     "brave_network_delegate_base_unittest.cc",
+    "brave_proxying_web_socket_unittest.cc",
     "brave_site_hacks_network_delegate_helper_unittest.cc",
     "brave_static_redirect_network_delegate_helper_unittest.cc",
     "brave_system_request_handler_unittest.cc",

--- a/browser/net/brave_proxying_web_socket.cc
+++ b/browser/net/brave_proxying_web_socket.cc
@@ -93,7 +93,13 @@ void BraveProxyingWebSocket<base::WeakPtr>::CreateBraveRequestInfo() {
 template <template <typename> class T>
 void BraveProxyingWebSocket<T>::Start(
     mojo::PendingRemote<network::mojom::WebSocketHandshakeClient>
-        handshake_client) {
+        handshake_client,
+    mojo::PendingRemote<network::mojom::TrustedHeaderClient>
+        trusted_header_client) {
+  if (trusted_header_client) {
+    proxy_trusted_header_client_.Bind(std::move(trusted_header_client));
+  }
+
   forwarding_handshake_client_.Bind(std::move(handshake_client));
   forwarding_handshake_client_.set_disconnect_with_reason_handler(
       base::BindOnce(&BraveProxyingWebSocket::OnMojoConnectionError,
@@ -308,11 +314,10 @@ void BraveProxyingWebSocket<T>::OnBeforeSendHeadersCompleteFromProxy(
     return;
   }
 
-  // update the headers from the proxy
+  // A missing replacement header set means the downstream header client made no
+  // modifications. Preserve the existing headers.
   if (headers) {
     request_.headers = *headers;
-  } else {
-    request_.headers.Clear();
   }
 
   auto continuation =

--- a/browser/net/brave_proxying_web_socket.cc
+++ b/browser/net/brave_proxying_web_socket.cc
@@ -97,6 +97,10 @@ void BraveProxyingWebSocket<T>::Start(
     mojo::PendingRemote<network::mojom::TrustedHeaderClient>
         trusted_header_client) {
   if (trusted_header_client) {
+    // Brave sits in front of Chrome's WebSocket factory. When Chrome does not
+    // install another proxy, this is the downstream trusted-header client, so
+    // bind it before OnBeforeRequestComplete() so its header changes can be
+    // merged into request_ before Brave's OnBeforeStartTransaction handling.
     proxy_trusted_header_client_.Bind(std::move(trusted_header_client));
   }
 

--- a/browser/net/brave_proxying_web_socket.h
+++ b/browser/net/brave_proxying_web_socket.h
@@ -65,7 +65,9 @@ class BraveProxyingWebSocket
       const std::optional<std::string>& user_agent);
 
   void Start(mojo::PendingRemote<network::mojom::WebSocketHandshakeClient>
-                 handshake_client);
+                 handshake_client,
+             mojo::PendingRemote<network::mojom::TrustedHeaderClient>
+                 trusted_header_client = mojo::NullRemote());
 
   content::ContentBrowserClient::WebSocketFactory CreateWebSocketFactory();
   bool proxy_has_extra_headers();

--- a/browser/net/brave_proxying_web_socket_unittest.cc
+++ b/browser/net/brave_proxying_web_socket_unittest.cc
@@ -122,7 +122,6 @@ class BraveProxyingWebSocketTest : public testing::Test {
     downstream_header_client.set_replacement_headers(
         std::move(replacement_headers));
     TestHandshakeClient handshake_client;
-    base::RunLoop run_loop;
 
     auto proxy = CreateProxy(base::BindLambdaForTesting(
         [&](const GURL& url,
@@ -149,13 +148,12 @@ class BraveProxyingWebSocketTest : public testing::Test {
                     EXPECT_EQ(net::OK, result);
                     ASSERT_TRUE(headers);
                     *final_headers = *headers;
-                    run_loop.Quit();
                   }));
         }));
 
     proxy->Start(handshake_client.CreateRemote(),
                  downstream_header_client.CreateRemote());
-    run_loop.Run();
+    task_environment_.RunUntilIdle();
     *downstream_header_client_called =
         downstream_header_client.on_before_send_headers_called();
   }

--- a/browser/net/brave_proxying_web_socket_unittest.cc
+++ b/browser/net/brave_proxying_web_socket_unittest.cc
@@ -24,6 +24,7 @@
 #include "chrome/test/base/testing_profile.h"
 #include "content/public/browser/content_browser_client.h"
 #include "content/public/browser/global_routing_id.h"
+#include "content/public/test/browser_task_environment.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "mojo/public/cpp/bindings/remote.h"
@@ -145,7 +146,7 @@ class BraveProxyingWebSocketTest : public testing::Test {
               base::BindLambdaForTesting(
                   [&](int result,
                       const std::optional<net::HttpRequestHeaders>& headers,
-                      const std::optional<base::Value::Dict>&
+                      std::optional<base::DictValue>
                           extended_net_log_events) {
                     EXPECT_EQ(net::OK, result);
                     ASSERT_TRUE(headers);

--- a/browser/net/brave_proxying_web_socket_unittest.cc
+++ b/browser/net/brave_proxying_web_socket_unittest.cc
@@ -17,6 +17,7 @@
 #include "base/run_loop.h"
 #include "base/test/bind.h"
 #include "base/test/task_environment.h"
+#include "base/test/test_future.h"
 #include "base/values.h"
 #include "brave/browser/net/brave_request_handler.h"
 #include "brave/browser/net/url_context.h"
@@ -122,6 +123,7 @@ class BraveProxyingWebSocketTest : public testing::Test {
     downstream_header_client.set_replacement_headers(
         std::move(replacement_headers));
     TestHandshakeClient handshake_client;
+    base::test::TestFuture<void> headers_processed;
 
     auto proxy = CreateProxy(base::BindLambdaForTesting(
         [&](const GURL& url,
@@ -148,12 +150,13 @@ class BraveProxyingWebSocketTest : public testing::Test {
                     EXPECT_EQ(net::OK, result);
                     ASSERT_TRUE(headers);
                     *final_headers = *headers;
+                    headers_processed.SetValue();
                   }));
         }));
 
     proxy->Start(handshake_client.CreateRemote(),
                  downstream_header_client.CreateRemote());
-    task_environment_.RunUntilIdle();
+    ASSERT_TRUE(headers_processed.Wait());
     *downstream_header_client_called =
         downstream_header_client.on_before_send_headers_called();
   }

--- a/browser/net/brave_proxying_web_socket_unittest.cc
+++ b/browser/net/brave_proxying_web_socket_unittest.cc
@@ -146,8 +146,7 @@ class BraveProxyingWebSocketTest : public testing::Test {
               base::BindLambdaForTesting(
                   [&](int result,
                       const std::optional<net::HttpRequestHeaders>& headers,
-                      std::optional<base::DictValue>
-                          extended_net_log_events) {
+                      std::optional<base::DictValue> extended_net_log_events) {
                     EXPECT_EQ(net::OK, result);
                     ASSERT_TRUE(headers);
                     *final_headers = *headers;

--- a/browser/net/brave_proxying_web_socket_unittest.cc
+++ b/browser/net/brave_proxying_web_socket_unittest.cc
@@ -1,0 +1,194 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/net/brave_proxying_web_socket.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "base/functional/bind.h"
+#include "base/functional/callback.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/run_loop.h"
+#include "base/test/bind.h"
+#include "base/test/task_environment.h"
+#include "base/values.h"
+#include "brave/browser/net/brave_request_handler.h"
+#include "brave/browser/net/url_context.h"
+#include "chrome/test/base/testing_profile.h"
+#include "content/public/browser/content_browser_client.h"
+#include "content/public/browser/global_routing_id.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "net/base/net_errors.h"
+#include "net/http/http_request_headers.h"
+#include "services/network/public/cpp/resource_request.h"
+#include "services/network/public/mojom/network_context.mojom.h"
+#include "services/network/public/mojom/url_response_head.mojom.h"
+#include "services/network/public/mojom/websocket.mojom.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace {
+
+class TestHandshakeClient : public network::mojom::WebSocketHandshakeClient {
+ public:
+  mojo::PendingRemote<network::mojom::WebSocketHandshakeClient> CreateRemote() {
+    return receiver_.BindNewPipeAndPassRemote();
+  }
+
+  void OnOpeningHandshakeStarted(
+      network::mojom::WebSocketHandshakeRequestPtr request) override {}
+  void OnFailure(const std::string& message,
+                 int32_t net_error,
+                 int32_t response_code) override {}
+  void OnConnectionEstablished(
+      mojo::PendingRemote<network::mojom::WebSocket> websocket,
+      mojo::PendingReceiver<network::mojom::WebSocketClient> client_receiver,
+      network::mojom::WebSocketHandshakeResponsePtr response,
+      mojo::ScopedDataPipeConsumerHandle readable,
+      mojo::ScopedDataPipeProducerHandle writable) override {}
+
+ private:
+  mojo::Receiver<network::mojom::WebSocketHandshakeClient> receiver_{this};
+};
+
+class TestTrustedHeaderClient : public network::mojom::TrustedHeaderClient {
+ public:
+  mojo::PendingRemote<network::mojom::TrustedHeaderClient> CreateRemote() {
+    return receiver_.BindNewPipeAndPassRemote();
+  }
+
+  void set_replacement_headers(
+      std::optional<net::HttpRequestHeaders> replacement_headers) {
+    replacement_headers_ = std::move(replacement_headers);
+  }
+
+  bool on_before_send_headers_called() const {
+    return on_before_send_headers_called_;
+  }
+
+  void OnBeforeSendHeaders(const GURL& request_url,
+                           const net::HttpRequestHeaders& headers,
+                           OnBeforeSendHeadersCallback callback) override {
+    on_before_send_headers_called_ = true;
+    observed_headers_ = headers;
+    std::move(callback).Run(net::OK, replacement_headers_, std::nullopt);
+  }
+
+  void OnHeadersReceived(const std::string& headers,
+                         const net::IPEndPoint& remote_endpoint,
+                         const std::optional<net::SSLInfo>& ssl_info,
+                         OnHeadersReceivedCallback callback) override {
+    std::move(callback).Run(net::OK, headers, std::nullopt);
+  }
+
+ private:
+  mojo::Receiver<network::mojom::TrustedHeaderClient> receiver_{this};
+  std::optional<net::HttpRequestHeaders> replacement_headers_;
+  net::HttpRequestHeaders observed_headers_;
+  bool on_before_send_headers_called_ = false;
+};
+
+class BraveProxyingWebSocketTest : public testing::Test {
+ public:
+  BraveProxyingWebSocketTest()
+      : request_handler_(), profile_(TestingProfile::Builder().Build()) {}
+
+ protected:
+  std::unique_ptr<BraveProxyingWebSocket<std::shared_ptr>> CreateProxy(
+      content::ContentBrowserClient::WebSocketFactory factory) {
+    network::ResourceRequest request;
+    request.url = GURL("wss://example.test/socket");
+    request.headers.SetHeader("X-Original", "1");
+
+    return std::make_unique<BraveProxyingWebSocket<std::shared_ptr>>(
+        std::move(factory), request, content::GlobalRenderFrameHostToken(),
+        profile_.get(), base::MakeRefCounted<RequestIDGenerator>(),
+        request_handler_, base::DoNothing());
+  }
+
+  void RunHeaderClientFlow(
+      std::optional<net::HttpRequestHeaders> replacement_headers,
+      net::HttpRequestHeaders* final_headers,
+      bool* downstream_header_client_called) {
+    TestTrustedHeaderClient downstream_header_client;
+    downstream_header_client.set_replacement_headers(
+        std::move(replacement_headers));
+    TestHandshakeClient handshake_client;
+    base::RunLoop run_loop;
+
+    auto proxy = CreateProxy(base::BindLambdaForTesting(
+        [&](const GURL& url,
+            std::vector<network::mojom::HttpHeaderPtr> additional_headers,
+            mojo::PendingRemote<network::mojom::WebSocketHandshakeClient>
+                handshake_client,
+            mojo::PendingRemote<network::mojom::WebSocketAuthenticationHandler>
+                auth_handler,
+            mojo::PendingRemote<network::mojom::TrustedHeaderClient>
+                trusted_header_client) {
+          EXPECT_TRUE(additional_headers.empty());
+          ASSERT_TRUE(trusted_header_client);
+
+          proxy_header_client_.Bind(std::move(trusted_header_client));
+          net::HttpRequestHeaders network_service_headers;
+          network_service_headers.SetHeader("X-Original", "1");
+          proxy_header_client_->OnBeforeSendHeaders(
+              url, network_service_headers,
+              base::BindLambdaForTesting(
+                  [&](int result,
+                      const std::optional<net::HttpRequestHeaders>& headers,
+                      const std::optional<base::Value::Dict>&
+                          extended_net_log_events) {
+                    EXPECT_EQ(net::OK, result);
+                    ASSERT_TRUE(headers);
+                    *final_headers = *headers;
+                    run_loop.Quit();
+                  }));
+        }));
+
+    proxy->Start(handshake_client.CreateRemote(),
+                 downstream_header_client.CreateRemote());
+    run_loop.Run();
+    *downstream_header_client_called =
+        downstream_header_client.on_before_send_headers_called();
+  }
+
+  content::BrowserTaskEnvironment task_environment_;
+  BraveRequestHandler<std::shared_ptr> request_handler_;
+  std::unique_ptr<TestingProfile> profile_;
+  mojo::Remote<network::mojom::TrustedHeaderClient> proxy_header_client_;
+};
+
+TEST_F(BraveProxyingWebSocketTest,
+       StartBindsDownstreamTrustedHeaderClientBeforeHeaderProcessing) {
+  net::HttpRequestHeaders replacement_headers;
+  replacement_headers.SetHeader("X-Downstream", "1");
+
+  net::HttpRequestHeaders final_headers;
+  bool downstream_header_client_called = false;
+  RunHeaderClientFlow(replacement_headers, &final_headers,
+                      &downstream_header_client_called);
+
+  EXPECT_TRUE(downstream_header_client_called);
+  EXPECT_EQ("1", final_headers.GetHeader("X-Downstream").value_or(""));
+}
+
+TEST_F(BraveProxyingWebSocketTest,
+       NullReplacementHeadersPreserveExistingHeaders) {
+  net::HttpRequestHeaders final_headers;
+  bool downstream_header_client_called = false;
+  RunHeaderClientFlow(std::nullopt, &final_headers,
+                      &downstream_header_client_called);
+
+  EXPECT_TRUE(downstream_header_client_called);
+  EXPECT_EQ("1", final_headers.GetHeader("X-Original").value_or(""));
+}
+
+}  // namespace

--- a/browser/net/brave_proxying_web_socket_unittest.cc
+++ b/browser/net/brave_proxying_web_socket_unittest.cc
@@ -178,7 +178,9 @@ TEST_F(BraveProxyingWebSocketTest,
                       &downstream_header_client_called);
 
   EXPECT_TRUE(downstream_header_client_called);
-  EXPECT_EQ("1", final_headers.GetHeader("X-Downstream").value_or(""));
+  const auto downstream_header = final_headers.GetHeader("X-Downstream");
+  ASSERT_TRUE(downstream_header.has_value());
+  EXPECT_EQ("1", *downstream_header);
 }
 
 TEST_F(BraveProxyingWebSocketTest,
@@ -189,7 +191,9 @@ TEST_F(BraveProxyingWebSocketTest,
                       &downstream_header_client_called);
 
   EXPECT_TRUE(downstream_header_client_called);
-  EXPECT_EQ("1", final_headers.GetHeader("X-Original").value_or(""));
+  const auto original_header = final_headers.GetHeader("X-Original");
+  ASSERT_TRUE(original_header.has_value());
+  EXPECT_EQ("1", *original_header);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Fixes two request-header chaining issues in `BraveProxyingWebSocket`:

- Preserve `WebSocketOptions::header_client` in the no-Chrome-proxy path. Previously, if `ChromeContentBrowserClient::WillInterceptWebSocket(frame)` was false, Brave called `Start()` directly and dropped `options.header_client`, so enterprise WebSocket request header injection did not run unless a WebRequest/DNR extension caused Chrome's proxy path to be installed.
- Treat `nullopt` request headers returned by the chained trusted header client as "no modification" instead of "clear every header". Chromium's enterprise header injection client intentionally returns `nullopt` when no policy matches.

## Verification

- `pnpm run presubmit --base master`: `0 Presubmit Messages, 0 Presubmit Warnings, 0 Presubmit ERRORS`.
