### PR TITLE
Harden Brave WebSocket auth proxy handling

### DIFF
--- a/browser/net/brave_proxying_web_socket.cc
+++ b/browser/net/brave_proxying_web_socket.cc
@@ -236,6 +236,10 @@ void BraveProxyingWebSocket<T>::OnAuthRequired(
     const scoped_refptr<net::HttpResponseHeaders>& headers,
     const net::IPEndPoint& remote_endpoint,
     OnAuthRequiredCallback callback) {
+  if (!proxy_auth_handler_.is_bound()) {
+    std::move(callback).Run(std::nullopt);
+    return;
+  }
   proxy_auth_handler_->OnAuthRequired(auth_info, headers, remote_endpoint,
                                       std::move(callback));
 }
@@ -431,6 +435,7 @@ void BraveProxyingWebSocket<T>::OnHeadersReceivedComplete(int error_code) {
 template <template <typename> class T>
 void BraveProxyingWebSocket<T>::PauseIncomingMethodCallProcessing() {
   receiver_as_handshake_client_.Pause();
+  receiver_as_auth_handler_.Pause();
   if (proxy_has_extra_headers()) {
     receiver_as_header_client_.Pause();
   }
@@ -439,6 +444,7 @@ void BraveProxyingWebSocket<T>::PauseIncomingMethodCallProcessing() {
 template <template <typename> class T>
 void BraveProxyingWebSocket<T>::ResumeIncomingMethodCallProcessing() {
   receiver_as_handshake_client_.Resume();
+  receiver_as_auth_handler_.Resume();
   if (proxy_has_extra_headers()) {
     receiver_as_header_client_.Resume();
   }

--- a/browser/net/brave_proxying_web_socket.cc
+++ b/browser/net/brave_proxying_web_socket.cc
@@ -236,6 +236,11 @@ void BraveProxyingWebSocket<T>::OnAuthRequired(
     const scoped_refptr<net::HttpResponseHeaders>& headers,
     const net::IPEndPoint& remote_endpoint,
     OnAuthRequiredCallback callback) {
+  if (!callback) {
+    OnError(net::ERR_FAILED);
+    return;
+  }
+
   if (!proxy_auth_handler_.is_bound()) {
     std::move(callback).Run(std::nullopt);
     return;


### PR DESCRIPTION
## Summary

Fixes two authentication-handling issues in `BraveProxyingWebSocket`:

- Pause `receiver_as_auth_handler_` together with the handshake and trusted-header receivers while async response-header processing is in flight, matching Chromium's `WebRequestProxyingWebSocket` and preventing auth callbacks from racing header processing.
- If `OnAuthRequired()` is reached without a downstream auth handler, return `nullopt` credentials instead of dereferencing an unbound remote. This matches the network service behavior when no auth handler is supplied.

## Verification

- `pnpm run presubmit --base master`: `0 Presubmit Messages, 0 Presubmit Warnings, 0 Presubmit ERRORS`.
