### PR TITLE
Add commands for opening new tabs in containers

### DIFF
--- a/app/brave_command_ids.h
+++ b/app/brave_command_ids.h
@@ -170,6 +170,17 @@
 // acceleratable so users can assign it a custom keyboard shortcut.
 #define IDC_BLOCK_ELEMENTS 56470
 
+// Brave Containers: Open a new tab directly in the nth container.
+#define IDC_NEW_TAB_IN_CONTAINER_1 56471
+#define IDC_NEW_TAB_IN_CONTAINER_2 56472
+#define IDC_NEW_TAB_IN_CONTAINER_3 56473
+#define IDC_NEW_TAB_IN_CONTAINER_4 56474
+#define IDC_NEW_TAB_IN_CONTAINER_5 56475
+#define IDC_NEW_TAB_IN_CONTAINER_6 56476
+#define IDC_NEW_TAB_IN_CONTAINER_7 56477
+#define IDC_NEW_TAB_IN_CONTAINER_8 56478
+#define IDC_NEW_TAB_IN_CONTAINER_9 56479
+
 #define IDC_BRAVE_COMMANDS_LAST 57000
 
 #endif  // BRAVE_APP_BRAVE_COMMAND_IDS_H_

--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -370,14 +370,14 @@ void BraveBrowserCommandController::InitBraveCommandState() {
 #endif
 
 #if BUILDFLAG(ENABLE_CONTAINERS)
-  auto* containers_service = 
-	ContainersServiceFactory::GetForProfile(browser_->profile());
+  auto* containers_service =
+      ContainersServiceFactory::GetForProfile(browser_->profile());
 
   UpdateCommandEnabled(IDC_NEW_TEMPORARY_CONTAINER,
-		       containers_service != nullptr);
+                       containers_service != nullptr);
 
-  for (int id = IDC_NEW_TAB_IN_CONTAINER_1;
-      id <= IDC_NEW_TAB_IN_CONTAINER_9; ++id){
+  for (int id = IDC_NEW_TAB_IN_CONTAINER_1; id <= IDC_NEW_TAB_IN_CONTAINER_9;
+       ++id) {
     UpdateCommandEnabled(id, containers_service != nullptr);
   }
 #endif
@@ -816,30 +816,27 @@ bool BraveBrowserCommandController::ExecuteBraveCommandWithDisposition(
     case IDC_NEW_TAB_IN_CONTAINER_7:
     case IDC_NEW_TAB_IN_CONTAINER_8:
     case IDC_NEW_TAB_IN_CONTAINER_9: {
+      int index = id - IDC_NEW_TAB_IN_CONTAINER_1;
 
-       int index = id - IDC_NEW_TAB_IN_CONTAINER_1;
+      auto* containers_service =
+          ContainersServiceFactory::GetForProfile(browser_->profile());
 
-       auto* containers_service =
-	  ContainersServiceFactory::GetForProfile(browser_->profile());
-
-       if (!containers_service) {
-         break;
-       }
-
-       auto containers = containers_service->GetContainers();
-
-       if (index >= static_cast<int>(containers.size())) {
-	 break;
-       }
-
-       brave::OpenUrlInContainer(
-	   base::to_address(browser_),
-	   browser_->GetNewTabURL(),
-	   containers[index],
-	   /*is_link=*/false);
-
-       break;
+      if (!containers_service) {
+        break;
       }
+
+      auto containers = containers_service->GetContainers();
+
+      if (index >= static_cast<int>(containers.size())) {
+        break;
+      }
+
+      brave::OpenUrlInContainer(base::to_address(browser_),
+                                browser_->GetNewTabURL(), containers[index],
+                                /*is_link=*/false);
+
+      break;
+    }
 
     case IDC_NEW_TEMPORARY_CONTAINER:
       brave::CreateTemporaryContainerAndOpenUrl(base::to_address(browser_),

--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -370,9 +370,16 @@ void BraveBrowserCommandController::InitBraveCommandState() {
 #endif
 
 #if BUILDFLAG(ENABLE_CONTAINERS)
-  UpdateCommandEnabled(
-      IDC_NEW_TEMPORARY_CONTAINER,
-      ContainersServiceFactory::GetForProfile(browser_->profile()));
+  auto* containers_service = 
+	ContainersServiceFactory::GetForProfile(browser_->profile());
+
+  UpdateCommandEnabled(IDC_NEW_TEMPORARY_CONTAINER,
+		       containers_service != nullptr);
+
+  for (int id = IDC_NEW_TAB_IN_CONTAINER_1;
+      id <= IDC_NEW_TAB_IN_CONTAINER_9; ++id){
+    UpdateCommandEnabled(id, containers_service != nullptr);
+  }
 #endif
 
   if (browser_->is_type_normal()) {
@@ -800,6 +807,40 @@ bool BraveBrowserCommandController::ExecuteBraveCommandWithDisposition(
       break;
 #endif
 #if BUILDFLAG(ENABLE_CONTAINERS)
+    case IDC_NEW_TAB_IN_CONTAINER_1:
+    case IDC_NEW_TAB_IN_CONTAINER_2:
+    case IDC_NEW_TAB_IN_CONTAINER_3:
+    case IDC_NEW_TAB_IN_CONTAINER_4:
+    case IDC_NEW_TAB_IN_CONTAINER_5:
+    case IDC_NEW_TAB_IN_CONTAINER_6:
+    case IDC_NEW_TAB_IN_CONTAINER_7:
+    case IDC_NEW_TAB_IN_CONTAINER_8:
+    case IDC_NEW_TAB_IN_CONTAINER_9: {
+
+       int index = id - IDC_NEW_TAB_IN_CONTAINER_1;
+
+       auto* containers_service =
+	  ContainersServiceFactory::GetForProfile(browser_->profile());
+
+       if (!containers_service) {
+         break;
+       }
+
+       auto containers = containers_service->GetContainers();
+
+       if (index >= static_cast<int>(containers.size())) {
+	 break;
+       }
+
+       brave::OpenUrlInContainer(
+	   base::to_address(browser_),
+	   browser_->GetNewTabURL(),
+	   containers[index],
+	   /*is_link=*/false);
+
+       break;
+      }
+
     case IDC_NEW_TEMPORARY_CONTAINER:
       brave::CreateTemporaryContainerAndOpenUrl(base::to_address(browser_),
                                                 browser_->GetNewTabURL(),

--- a/components/resources/commands.grdp
+++ b/components/resources/commands.grdp
@@ -598,4 +598,40 @@
   <message name="IDS_IDC_NEW_TEMPORARY_CONTAINER" desc="Label for the command that opens the current URL in a new local-only temporary container.">
     New temporary container
   </message>
+  
+  <message name="IDS_IDC_NEW_TAB_IN_CONTAINER_1" desc="Label for the command that opens a new tab in container 1.">
+    New tab in container 1
+  </message>
+
+  <message name="IDS_IDC_NEW_TAB_IN_CONTAINER_2" desc="Label for the command that opens a new tab in container 2.">      
+    New tab in container 2
+  </message>
+
+ <message name="IDS_IDC_NEW_TAB_IN_CONTAINER_3" desc="Label for the command that opens a new tab in container 3.">      
+    New tab in container 3
+  </message>
+
+ <message name="IDS_IDC_NEW_TAB_IN_CONTAINER_4" desc="Label for the command that opens a new tab in container 4.">      
+    New tab in container 4
+  </message>
+
+ <message name="IDS_IDC_NEW_TAB_IN_CONTAINER_5" desc="Label for the command that opens a new tab in container 5.">      
+    New tab in container 5
+  </message>
+
+ <message name="IDS_IDC_NEW_TAB_IN_CONTAINER_6" desc="Label for the command that opens a new tab in container 6.">      
+    New tab in container 6
+  </message>
+
+ <message name="IDS_IDC_NEW_TAB_IN_CONTAINER_7" desc="Label for the command that opens a new tab in container 7.">      
+    New tab in container 7
+  </message>
+
+ <message name="IDS_IDC_NEW_TAB_IN_CONTAINER_8" desc="Label for the command that opens a new tab in container 8.">      
+    New tab in container 8
+  </message>
+
+ <message name="IDS_IDC_NEW_TAB_IN_CONTAINER_9" desc="Label for the command that opens a new tab in container 9.">      
+    New tab in container 9
+  </message>
 </grit-part>


### PR DESCRIPTION
Part of https://github.com/brave/brave-browser/issues/56745

## Summary

Adds browser commands for opening new tabs in specific containers.

## Changes

- Added command IDs for opening new tabs in containers.
- Registered the commands in the browser command controller.
- Added the corresponding command resources.