### PR TITLE
[ads] Raise database raze threshold and drop old migration paths

### DIFF
--- a/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_database_table.cc
+++ b/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_database_table.cc
@@ -223,49 +223,6 @@ void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 }
 
-void MigrateToV36(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  Execute(mojom_db_transaction, R"(
-      CREATE TABLE confirmation_queue (
-        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-        transaction_id TEXT NOT NULL,
-        creative_instance_id TEXT NOT NULL,
-        type TEXT NOT NULL,
-        ad_type TEXT NOT NULL,
-        created_at TIMESTAMP NOT NULL,
-        token TEXT,
-        blinded_token TEXT,
-        unblinded_token TEXT,
-        public_key TEXT,
-        signature TEXT,
-        credential_base64url TEXT,
-        user_data TEXT NOT NULL,
-        process_at TIMESTAMP NOT NULL,
-        retry_count INTEGER DEFAULT 0
-      ))");
-
-  // Optimize database query for `GetAll, and `GetNext`.
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"confirmation_queue",
-                   /*columns=*/{"process_at"});
-}
-
-void MigrateToV38(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // The conversion queue is deprecated since all confirmations are now being
-  // added to the confirmation queue.
-  DropTable(mojom_db_transaction, "conversion_queue");
-}
-
-void MigrateToV43(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // Optimize database query for `Delete`, and `Retry`.
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"confirmation_queue",
-                   /*columns=*/{"transaction_id"});
-}
-
 }  // namespace
 
 ConfirmationQueue::ConfirmationQueue() : batch_size_(kDefaultBatchSize) {}
@@ -478,21 +435,6 @@ void ConfirmationQueue::Migrate(
   CHECK(mojom_db_transaction);
 
   switch (to_version) {
-    case 36: {
-      MigrateToV36(mojom_db_transaction);
-      break;
-    }
-
-    case 38: {
-      MigrateToV38(mojom_db_transaction);
-      break;
-    }
-
-    case 43: {
-      MigrateToV43(mojom_db_transaction);
-      break;
-    }
-
     default: {
       // No migration needed.
       break;

--- a/components/brave_ads/core/internal/account/deposits/deposits_database_table.cc
+++ b/components/brave_ads/core/internal/account/deposits/deposits_database_table.cc
@@ -92,18 +92,6 @@ std::string BuildInsertSql(const mojom::DBActionInfoPtr& mojom_db_action,
       {kTableName, BuildBindColumnPlaceholder(/*column_count=*/3)}, nullptr);
 }
 
-void MigrateToV43(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // Optimize database query for `GetForCreativeInstanceId`.
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"deposits",
-                   /*columns=*/{"creative_instance_id"});
-
-  // Optimize database query for `PurgeExpired`.
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"deposits",
-                   /*columns=*/{"expire_at"});
-}
-
 void MigrateToV57(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
   CHECK(mojom_db_transaction);
 
@@ -203,11 +191,6 @@ void Deposits::Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
   CHECK(mojom_db_transaction);
 
   switch (to_version) {
-    case 43: {
-      MigrateToV43(mojom_db_transaction);
-      break;
-    }
-
     case 57: {
       MigrateToV57(mojom_db_transaction);
       break;

--- a/components/brave_ads/core/internal/account/transactions/transactions_database_table.cc
+++ b/components/brave_ads/core/internal/account/transactions/transactions_database_table.cc
@@ -106,60 +106,6 @@ void GetCallback(
   std::move(callback).Run(/*success=*/true, transactions);
 }
 
-void MigrateToV35(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // Optimize database query for `GetForDateRange`.
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"transactions",
-                   /*columns=*/{"created_at"});
-}
-
-void MigrateToV40(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // Delete legacy transactions with an undefined `creative_instance_id`,
-  // `segment`, `ad_type`, or `confirmation_type`.
-  Execute(mojom_db_transaction, R"(
-      DELETE FROM
-        transactions
-      WHERE
-        COALESCE(creative_instance_id, '') = ''
-        OR COALESCE(segment, '') = ''
-        OR COALESCE(ad_type, '') = ''
-        OR COALESCE(confirmation_type, '') = '')");
-
-  // Create a temporary table:
-  //   - with a new `creative_instance_id` column constraint.
-  //   - with a new `segment` column constraint.
-  //   - with a new `reconciled_at` default value.
-  Execute(mojom_db_transaction, R"(
-      CREATE TABLE transactions_temp (
-        id TEXT NOT NULL PRIMARY KEY ON CONFLICT REPLACE,
-        created_at TIMESTAMP NOT NULL,
-        creative_instance_id TEXT NOT NULL,
-        value DOUBLE NOT NULL,
-        segment TEXT NOT NULL,
-        ad_type TEXT NOT NULL,
-        confirmation_type TEXT NOT NULL,
-        reconciled_at TIMESTAMP DEFAULT 0
-      ))");
-
-  // Copy legacy columns to the temporary table, drop the legacy table,
-  // rename the temporary table and create an index.
-  const std::vector<std::string> columns = {
-      "id",      "created_at", "creative_instance_id", "value",
-      "segment", "ad_type",    "confirmation_type",    "reconciled_at"};
-
-  CopyTableColumns(mojom_db_transaction, "transactions", "transactions_temp",
-                   columns, /*should_drop=*/true);
-
-  RenameTable(mojom_db_transaction, "transactions_temp", "transactions");
-
-  // Optimize database query for `GetForDateRange`.
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"transactions",
-                   /*columns=*/{"created_at"});
-}
-
 std::string BuildInsertSql(const mojom::DBActionInfoPtr& mojom_db_action,
                            const TransactionList& transactions) {
   CHECK(mojom_db_action);
@@ -192,18 +138,6 @@ void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
   mojom_db_action->type = mojom::DBActionInfo::Type::kExecuteWithBindings;
   mojom_db_action->sql = BuildInsertSql(mojom_db_action, transactions);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
-}
-
-void MigrateToV43(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // Optimize database query for `Reconcile`.
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"transactions",
-                   /*columns=*/{"reconciled_at"});
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"transactions",
-                   /*columns=*/{"id"});
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"transactions",
-                   /*columns=*/{"creative_instance_id"});
 }
 
 void MigrateToV57(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
@@ -366,21 +300,6 @@ void Transactions::Migrate(
   CHECK(mojom_db_transaction);
 
   switch (to_version) {
-    case 35: {
-      MigrateToV35(mojom_db_transaction);
-      break;
-    }
-
-    case 40: {
-      MigrateToV40(mojom_db_transaction);
-      break;
-    }
-
-    case 43: {
-      MigrateToV43(mojom_db_transaction);
-      break;
-    }
-
     case 57: {
       MigrateToV57(mojom_db_transaction);
       break;

--- a/components/brave_ads/core/internal/creatives/campaigns_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/campaigns_database_table.cc
@@ -167,11 +167,6 @@ void Campaigns::Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
   CHECK(mojom_db_transaction);
 
   switch (to_version) {
-    case 48: {
-      MigrateToV48(mojom_db_transaction);
-      break;
-    }
-
     case 52: {
       MigrateToV52(mojom_db_transaction);
       break;
@@ -185,27 +180,6 @@ void Campaigns::Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-
-void Campaigns::MigrateToV48(
-    const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // It is safe to recreate the table because it will be repopulated after
-  // downloading the catalog post-migration. However, after this migration, we
-  // should not drop the table as it will store catalog and non-catalog ad units
-  // and maintain relationships with other tables.
-  DropTable(mojom_db_transaction, "campaigns");
-  Execute(mojom_db_transaction, R"(
-      CREATE TABLE campaigns (
-        id TEXT NOT NULL PRIMARY KEY ON CONFLICT REPLACE,
-        start_at TIMESTAMP NOT NULL,
-        end_at TIMESTAMP NOT NULL,
-        daily_cap INTEGER DEFAULT 0 NOT NULL,
-        advertiser_id TEXT NOT NULL,
-        priority INTEGER NOT NULL DEFAULT 0,
-        ptr DOUBLE NOT NULL DEFAULT 1
-      ))");
-}
 
 void Campaigns::MigrateToV52(
     const mojom::DBTransactionInfoPtr& mojom_db_transaction) {

--- a/components/brave_ads/core/internal/creatives/campaigns_database_table.h
+++ b/components/brave_ads/core/internal/creatives/campaigns_database_table.h
@@ -30,7 +30,6 @@ class Campaigns final : public TableInterface {
                int to_version) override;
 
  private:
-  void MigrateToV48(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
   void MigrateToV52(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 };
 

--- a/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table.cc
@@ -96,24 +96,6 @@ void GetCallback(
   std::move(callback).Run(/*success=*/true, creative_set_conversions);
 }
 
-void MigrateToV35(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // Optimize database query for `GetUnexpired`.
-  CreateTableIndex(mojom_db_transaction,
-                   /*table_name=*/"creative_set_conversions",
-                   /*columns=*/{"expire_at"});
-}
-
-void MigrateToV43(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // Optimize database query for `database::table::AdEvents`.
-  CreateTableIndex(mojom_db_transaction,
-                   /*table_name=*/"creative_set_conversions",
-                   /*columns=*/{"creative_set_id"});
-}
-
 std::string BuildInsertSql(
     const mojom::DBActionInfoPtr& mojom_db_action,
     const CreativeSetConversionList& creative_set_conversions) {
@@ -306,16 +288,6 @@ void CreativeSetConversions::Migrate(
   CHECK(mojom_db_transaction);
 
   switch (to_version) {
-    case 35: {
-      MigrateToV35(mojom_db_transaction);
-      break;
-    }
-
-    case 43: {
-      MigrateToV43(mojom_db_transaction);
-      break;
-    }
-
     case 55: {
       MigrateToV55(mojom_db_transaction);
       break;

--- a/components/brave_ads/core/internal/creatives/creative_ads_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/creative_ads_database_table.cc
@@ -13,10 +13,8 @@
 #include "base/functional/bind.h"
 #include "base/location.h"
 #include "base/strings/string_util.h"
-#include "brave/components/brave_ads/core/internal/common/database/database_table_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_transaction_util.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
-#include "brave/components/brave_ads/core/internal/creatives/condition_matchers_database_table_util.h"
 #include "brave/components/brave_ads/core/internal/creatives/creative_ads_database_table_util.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 
@@ -162,11 +160,6 @@ void CreativeAds::Migrate(
   CHECK(mojom_db_transaction);
 
   switch (to_version) {
-    case 48: {
-      MigrateToV48(mojom_db_transaction);
-      break;
-    }
-
     case 54: {
       MigrateToV54(mojom_db_transaction);
       break;
@@ -180,30 +173,6 @@ void CreativeAds::Migrate(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-
-void CreativeAds::MigrateToV48(
-    const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // It is safe to recreate the table because it will be repopulated after
-  // downloading the catalog post-migration. However, after this migration, we
-  // should not drop the table as it will store catalog and non-catalog ad units
-  // and maintain relationships with other tables.
-  DropTable(mojom_db_transaction, "creative_ads");
-  Execute(mojom_db_transaction, R"(
-      CREATE TABLE creative_ads (
-        creative_instance_id TEXT NOT NULL PRIMARY KEY ON CONFLICT REPLACE,
-        creative_set_id TEXT NOT NULL,
-        per_day INTEGER NOT NULL DEFAULT 0,
-        per_week INTEGER NOT NULL DEFAULT 0,
-        per_month INTEGER NOT NULL DEFAULT 0,
-        total_max INTEGER NOT NULL DEFAULT 0,
-        value DOUBLE NOT NULL DEFAULT 0,
-        split_test_group TEXT,
-        condition_matchers TEXT NOT NULL,
-        target_url TEXT NOT NULL
-      ))");
-}
 
 void CreativeAds::MigrateToV54(
     const mojom::DBTransactionInfoPtr& mojom_db_transaction) {

--- a/components/brave_ads/core/internal/creatives/creative_ads_database_table.h
+++ b/components/brave_ads/core/internal/creatives/creative_ads_database_table.h
@@ -31,7 +31,6 @@ class CreativeAds final : public TableInterface {
                int to_version) override;
 
  private:
-  void MigrateToV48(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
   void MigrateToV54(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 };
 

--- a/components/brave_ads/core/internal/creatives/dayparts_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/dayparts_database_table.cc
@@ -6,7 +6,6 @@
 #include "brave/components/brave_ads/core/internal/creatives/dayparts_database_table.h"
 
 #include "base/check.h"
-#include "brave/components/brave_ads/core/internal/common/database/database_table_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_transaction_util.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 
@@ -36,42 +35,11 @@ void Dayparts::Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
   CHECK(mojom_db_transaction);
 
   switch (to_version) {
-    case 48: {
-      MigrateToV48(mojom_db_transaction);
-      break;
-    }
-
     default: {
       // No migration needed.
       break;
     }
   }
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
-void Dayparts::MigrateToV48(
-    const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // It is safe to recreate the table because it will be repopulated after
-  // downloading the catalog post-migration. However, after this migration, we
-  // should not drop the table as it will store catalog and non-catalog ad units
-  // and maintain relationships with other tables.
-  DropTable(mojom_db_transaction, "dayparts");
-  Execute(mojom_db_transaction, R"(
-      CREATE TABLE dayparts (
-        campaign_id TEXT NOT NULL,
-        days_of_week TEXT NOT NULL,
-        start_minute INT NOT NULL,
-        end_minute INT NOT NULL,
-        PRIMARY KEY (
-          campaign_id,
-          days_of_week,
-          start_minute,
-          end_minute
-        ) ON CONFLICT REPLACE
-      ))");
 }
 
 }  // namespace brave_ads::database::table

--- a/components/brave_ads/core/internal/creatives/dayparts_database_table.h
+++ b/components/brave_ads/core/internal/creatives/dayparts_database_table.h
@@ -17,9 +17,6 @@ class Dayparts final : public TableInterface {
   void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
   void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
-
- private:
-  void MigrateToV48(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 };
 
 }  // namespace brave_ads::database::table

--- a/components/brave_ads/core/internal/creatives/geo_targets_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/geo_targets_database_table.cc
@@ -6,7 +6,6 @@
 #include "brave/components/brave_ads/core/internal/creatives/geo_targets_database_table.h"
 
 #include "base/check.h"
-#include "brave/components/brave_ads/core/internal/common/database/database_table_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_transaction_util.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 
@@ -34,38 +33,11 @@ void GeoTargets::Migrate(
   CHECK(mojom_db_transaction);
 
   switch (to_version) {
-    case 48: {
-      MigrateToV48(mojom_db_transaction);
-      break;
-    }
-
     default: {
       // No migration needed.
       break;
     }
   }
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
-void GeoTargets::MigrateToV48(
-    const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // It is safe to recreate the table because it will be repopulated after
-  // downloading the catalog post-migration. However, after this migration, we
-  // should not drop the table as it will store catalog and non-catalog ad units
-  // and maintain relationships with other tables.
-  DropTable(mojom_db_transaction, "geo_targets");
-  Execute(mojom_db_transaction, R"(
-      CREATE TABLE geo_targets (
-        campaign_id TEXT NOT NULL,
-        geo_target TEXT NOT NULL,
-        PRIMARY KEY (
-          campaign_id,
-          geo_target
-        ) ON CONFLICT REPLACE
-      ))");
 }
 
 }  // namespace brave_ads::database::table

--- a/components/brave_ads/core/internal/creatives/geo_targets_database_table.h
+++ b/components/brave_ads/core/internal/creatives/geo_targets_database_table.h
@@ -17,9 +17,6 @@ class GeoTargets final : public TableInterface {
   void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
   void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
-
- private:
-  void MigrateToV48(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 };
 
 }  // namespace brave_ads::database::table

--- a/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_database_table.cc
@@ -19,7 +19,6 @@
 #include "brave/components/brave_ads/core/internal/common/algorithm/split_vector_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_column_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_statement_util.h"
-#include "brave/components/brave_ads/core/internal/common/database/database_table_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_transaction_util.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
 #include "brave/components/brave_ads/core/internal/common/time/time_util.h"
@@ -519,78 +518,11 @@ void CreativeNewTabPageAds::Migrate(
   CHECK(mojom_db_transaction);
 
   switch (to_version) {
-    case 48: {
-      MigrateToV48(mojom_db_transaction);
-      break;
-    }
-
-    case 49: {
-      MigrateToV49(mojom_db_transaction);
-      break;
-    }
-
     default: {
       // No migration needed.
       break;
     }
   }
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
-void CreativeNewTabPageAds::MigrateToV48(
-    const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // Wallpapers table has been deprecated.
-  DropTable(mojom_db_transaction, "creative_new_tab_page_ad_wallpapers");
-
-  // It is safe to recreate the table because it will be repopulated after
-  // downloading the component resource post-migration. However, after this
-  // migration, we should not drop the table as it is needed to maintain
-  // relationships with other tables.
-  DropTable(mojom_db_transaction, "creative_new_tab_page_ads");
-
-  Execute(mojom_db_transaction, R"(
-      CREATE TABLE creative_new_tab_page_ads (
-        creative_instance_id TEXT NOT NULL PRIMARY KEY ON CONFLICT REPLACE,
-        creative_set_id TEXT NOT NULL,
-        campaign_id TEXT NOT NULL,
-        company_name TEXT NOT NULL,
-        alt TEXT NOT NULL
-      );)");
-}
-
-void CreativeNewTabPageAds::MigrateToV49(
-    const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // Create a temporary table:
-  //   - with a new `type` column constraint. The default value for existing
-  //     rows is 'image', which will be corrected when the new tab page ads are
-  //     updated.
-  Execute(mojom_db_transaction, R"(
-      CREATE TABLE creative_new_tab_page_ads_temp (
-        creative_instance_id TEXT NOT NULL PRIMARY KEY ON CONFLICT REPLACE,
-        creative_set_id TEXT NOT NULL,
-        campaign_id TEXT NOT NULL,
-        type TEXT NOT NULL DEFAULT 'image',
-        company_name TEXT NOT NULL,
-        alt TEXT NOT NULL
-      ))");
-
-  // Copy legacy columns to the temporary table, drop the legacy table and
-  // rename the temporary table.
-  const std::vector<std::string> columns = {"creative_instance_id",
-                                            "creative_set_id", "campaign_id",
-                                            "company_name", "alt"};
-
-  CopyTableColumns(mojom_db_transaction, "creative_new_tab_page_ads",
-                   "creative_new_tab_page_ads_temp", columns,
-                   /*should_drop=*/true);
-
-  RenameTable(mojom_db_transaction, "creative_new_tab_page_ads_temp",
-              "creative_new_tab_page_ads");
 }
 
 }  // namespace brave_ads::database::table

--- a/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_database_table.h
+++ b/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_database_table.h
@@ -61,9 +61,6 @@ class CreativeNewTabPageAds final : public TableInterface {
                int to_version) override;
 
  private:
-  void MigrateToV48(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
-  void MigrateToV49(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
-
   int batch_size_;
 
   Campaigns campaigns_database_table_;

--- a/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_table.cc
@@ -19,7 +19,6 @@
 #include "brave/components/brave_ads/core/internal/common/algorithm/split_vector_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_column_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_statement_util.h"
-#include "brave/components/brave_ads/core/internal/common/database/database_table_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_transaction_util.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
 #include "brave/components/brave_ads/core/internal/common/time/time_util.h"
@@ -358,41 +357,11 @@ void CreativeNotificationAds::Migrate(
   CHECK(mojom_db_transaction);
 
   switch (to_version) {
-    case 48: {
-      MigrateToV48(mojom_db_transaction);
-      break;
-    }
-
     default: {
       // No migration needed.
       break;
     }
   }
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
-void CreativeNotificationAds::MigrateToV48(
-    const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // Embeddings are deprecated.
-  DropTable(mojom_db_transaction, "embeddings");
-  DropTable(mojom_db_transaction, "text_embedding_html_events");
-
-  // It is safe to recreate the table because it will be repopulated after
-  // downloading the catalog post-migration. However, after this migration, we
-  // should not drop the table as it will store catalog and non-catalog ad units
-  // and maintain relationships with other tables.
-  DropTable(mojom_db_transaction, "creative_ad_notifications");
-  Execute(mojom_db_transaction, R"(
-      CREATE TABLE creative_ad_notifications (
-        creative_instance_id TEXT NOT NULL PRIMARY KEY ON CONFLICT REPLACE,
-        creative_set_id TEXT NOT NULL,
-        campaign_id TEXT NOT NULL,
-        title TEXT NOT NULL,
-        body TEXT NOT NULL
-      ))");
 }
 
 }  // namespace brave_ads::database::table

--- a/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_table.h
+++ b/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_table.h
@@ -50,8 +50,6 @@ class CreativeNotificationAds final : public TableInterface {
                int to_version) override;
 
  private:
-  void MigrateToV48(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
-
   int batch_size_;
 
   Campaigns campaigns_database_table_;

--- a/components/brave_ads/core/internal/creatives/segments_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/segments_database_table.cc
@@ -6,7 +6,6 @@
 #include "brave/components/brave_ads/core/internal/creatives/segments_database_table.h"
 
 #include "base/check.h"
-#include "brave/components/brave_ads/core/internal/common/database/database_table_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_transaction_util.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 
@@ -32,38 +31,11 @@ void Segments::Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
   CHECK(mojom_db_transaction);
 
   switch (to_version) {
-    case 48: {
-      MigrateToV48(mojom_db_transaction);
-      break;
-    }
-
     default: {
       // No migration needed.
       break;
     }
   }
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
-void Segments::MigrateToV48(
-    const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // It is safe to recreate the table because it will be repopulated after
-  // downloading the catalog post-migration. However, after this migration, we
-  // should not drop the table as it will store catalog and non-catalog ad units
-  // and maintain relationships with other tables.
-  DropTable(mojom_db_transaction, "segments");
-  Execute(mojom_db_transaction, R"(
-      CREATE TABLE segments (
-        creative_set_id TEXT NOT NULL,
-        segment TEXT NOT NULL,
-        PRIMARY KEY (
-          creative_set_id,
-          segment
-        ) ON CONFLICT REPLACE
-      ))");
 }
 
 }  // namespace brave_ads::database::table

--- a/components/brave_ads/core/internal/creatives/segments_database_table.h
+++ b/components/brave_ads/core/internal/creatives/segments_database_table.h
@@ -17,9 +17,6 @@ class Segments final : public TableInterface {
   void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
   void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
-
- private:
-  void MigrateToV48(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 };
 
 }  // namespace brave_ads::database::table

--- a/components/brave_ads/core/internal/history/ad_history_database_table.cc
+++ b/components/brave_ads/core/internal/history/ad_history_database_table.cc
@@ -116,42 +116,6 @@ void GetCallback(
   std::move(callback).Run(std::move(ad_history));
 }
 
-void MigrateToV42(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  Execute(mojom_db_transaction, R"(
-      CREATE TABLE ad_history (
-        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-        created_at TIMESTAMP NOT NULL,
-        type TEXT NOT NULL,
-        confirmation_type TEXT NOT NULL,
-        placement_id TEXT NOT NULL,
-        creative_instance_id TEXT NOT NULL,
-        creative_set_id TEXT NOT NULL,
-        campaign_id TEXT NOT NULL,
-        advertiser_id TEXT NOT NULL,
-        segment TEXT NOT NULL,
-        title TEXT NOT NULL,
-        description TEXT NOT NULL,
-        target_url TEXT NOT NULL
-      ))");
-
-  // Optimize database query for `GetForDateRange`,
-  // `GetHighestRankedPlacementsForDateRange`, and `PurgeExpired`.
-  CreateTableIndex(mojom_db_transaction,
-                   /*table_name=*/"ad_history", /*columns=*/{"created_at"});
-
-  // Optimize database query for `GetHighestRankedPlacementsForDateRange`.
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"ad_history",
-                   /*columns=*/{"confirmation_type"});
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"ad_history",
-                   /*columns=*/{"placement_id"});
-
-  // Optimize database query for `GetForCreativeInstanceId`.
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"ad_history",
-                   /*columns=*/{"creative_instance_id"});
-}
-
 std::string BuildInsertSql(const mojom::DBActionInfoPtr& mojom_db_action,
                            const AdHistoryList& ad_history) {
   CHECK(mojom_db_action);
@@ -461,11 +425,6 @@ void AdHistory::Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
   CHECK(mojom_db_transaction);
 
   switch (to_version) {
-    case 42: {
-      MigrateToV42(mojom_db_transaction);
-      break;
-    }
-
     default: {
       // No migration needed.
       break;

--- a/components/brave_ads/core/internal/legacy_migration/database/database_constants.h
+++ b/components/brave_ads/core/internal/legacy_migration/database/database_constants.h
@@ -12,10 +12,13 @@ inline constexpr int kVersionNumber = 58;
 inline constexpr int kCompatibleVersionNumber = 58;
 
 // If the database version number is less than or equal to this value, the
-// database will be razed and recreated during migration. This should be updated
-// to match CR versions of the browser that no longer refill confirmation
-// tokens.
-inline constexpr int kRazeDatabaseThresholdVersionNumber = 32;
+// database will be razed and recreated during migration rather than migrated
+// incrementally. Recreation uses `Create`, which builds the current schema
+// directly and skips `Migrate` entirely, so `threshold + 1`'s migration is
+// unreachable too. Versions at or below this threshold are over a year old,
+// so their per-table migration code has been removed; raise this value again
+// once the next batch of migration paths turns a year old.
+inline constexpr int kRazeDatabaseThresholdVersionNumber = 50;
 
 }  // namespace brave_ads::database
 

--- a/components/brave_ads/core/internal/legacy_migration/database/database_migration.cc
+++ b/components/brave_ads/core/internal/legacy_migration/database/database_migration.cc
@@ -34,19 +34,6 @@ namespace brave_ads::database {
 
 namespace {
 
-void MigrateToV44(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // Normally, whether or not the database supports `auto_vacuum` must be
-  // configured before the database file is actually created. However, when not
-  // in write-ahead log mode, the `auto_vacuum` properties of an existing
-  // database may be changed by using the `auto_vacuum` pragmas and then
-  // immediately VACUUMing the database.
-
-  Execute(mojom_db_transaction, "PRAGMA auto_vacuum = FULL;");
-  Vacuum(mojom_db_transaction);
-}
-
 void MigrateToV53(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
   CHECK(mojom_db_transaction);
 
@@ -91,11 +78,6 @@ void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
   CHECK(mojom_db_transaction);
 
   switch (to_version) {
-    case 44: {
-      MigrateToV44(mojom_db_transaction);
-      break;
-    }
-
     case 53: {
       MigrateToV53(mojom_db_transaction);
       break;

--- a/components/brave_ads/core/internal/user_engagement/ad_events/ad_events_database_table.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/ad_events_database_table.cc
@@ -106,122 +106,6 @@ void GetCallback(
   std::move(callback).Run(/*success=*/true, ad_events);
 }
 
-void MigrateToV35(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  DropTableIndex(mojom_db_transaction, "ad_events_created_at_index");
-
-  // Optimize database query for `GetUnexpired`.
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"ad_events",
-                   /*columns=*/{"created_at"});
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"ad_events",
-                   /*columns=*/{"type", "created_at"});
-}
-
-void MigrateToV41(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // Remove non-clicked search result ad events for users who have not joined
-  // Brave Rewards.
-  if (!UserHasJoinedBraveRewards()) {
-    Execute(mojom_db_transaction, R"(
-        DELETE FROM
-          ad_events
-        WHERE
-          type == 'search_result_ad'
-          AND confirmation_type != 'click')");
-  }
-}
-
-void MigrateToV43(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  DropTableIndex(mojom_db_transaction, "ad_events_type_creative_set_id_index");
-
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"ad_events",
-                   /*columns=*/{"type"});
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"ad_events",
-                   /*columns=*/{"confirmation_type"});
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"ad_events",
-                   /*columns=*/{"creative_set_id"});
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"ad_events",
-                   /*columns=*/{"placement_id"});
-}
-
-void MigrateToV50(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // Delete legacy ad events with an undefined `placement_id`, `campaign_id`,
-  // `creative_set_id`, or `creative_instance_id`.
-  Execute(mojom_db_transaction, R"(
-      DELETE FROM
-        ad_events
-      WHERE
-        COALESCE(placement_id, '') = ''
-        OR COALESCE(campaign_id, '') = ''
-        OR COALESCE(creative_set_id, '') = ''
-        OR COALESCE(creative_instance_id, '') = ''
-        OR created_at IS NULL)");
-
-  // Create a temporary table:
-  //   - with a new `target_url` column with a default value of
-  //     'https://brave.com/brave-ads/'.
-  Execute(mojom_db_transaction, R"(
-      CREATE TABLE ad_events_temp (
-        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-        placement_id TEXT NOT NULL,
-        type TEXT,
-        confirmation_type TEXT,
-        campaign_id TEXT NOT NULL,
-        creative_set_id TEXT NOT NULL,
-        creative_instance_id TEXT NOT NULL,
-        advertiser_id TEXT,
-        segment TEXT,
-        target_url TEXT NOT NULL DEFAULT 'https://brave.com/brave-ads/',
-        created_at TIMESTAMP NOT NULL
-      ))");
-
-  // Copy legacy columns to the temporary table, drop the legacy table and
-  // rename the temporary table.
-  const std::vector<std::string> columns = {
-      "placement_id",      "type",
-      "confirmation_type", "campaign_id",
-      "creative_set_id",   "creative_instance_id",
-      "advertiser_id",     "segment",
-      "created_at"};
-
-  CopyTableColumns(mojom_db_transaction, "ad_events", "ad_events_temp", columns,
-                   /*should_drop=*/true);
-
-  RenameTable(mojom_db_transaction, "ad_events_temp", "ad_events");
-
-  // Optimize database query for `GetUnexpired`, and `PurgeExpired` from
-  // schema 35.
-  CreateTableIndex(mojom_db_transaction, "ad_events",
-                   /*columns=*/{"created_at"});
-
-  // Optimize database query for `GetUnexpired`, and `PurgeExpired` from
-  // schema 43.
-  CreateTableIndex(mojom_db_transaction, "ad_events",
-                   /*columns=*/{"creative_set_id"});
-
-  // Optimize database query for `GetUnexpired`, and `PurgeOrphaned` from
-  // schema 43.
-  CreateTableIndex(mojom_db_transaction, "ad_events",
-                   /*columns=*/{"type"});
-
-  // Optimize database query for `PurgeOrphaned`, and `PurgeAllOrphaned` from
-  // schema 43.
-  CreateTableIndex(mojom_db_transaction, "ad_events",
-                   /*columns=*/{"confirmation_type"});
-  CreateTableIndex(mojom_db_transaction, "ad_events",
-                   /*columns=*/{"placement_id"});
-
-  // Optimize database query for `IsFirstTime` from schema 50.
-  CreateTableIndex(mojom_db_transaction, /*table_name=*/"ad_events",
-                   /*columns=*/{"campaign_id", "confirmation_type"});
-}
-
 std::string BuildInsertSql(const mojom::DBActionInfoPtr& mojom_db_action,
                            const AdEventList& ad_events) {
   CHECK(mojom_db_action);
@@ -256,18 +140,6 @@ void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
   mojom_db_action->type = mojom::DBActionInfo::Type::kExecuteWithBindings;
   mojom_db_action->sql = BuildInsertSql(mojom_db_action, ad_events);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
-}
-
-void MigrateToV51(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
-  CHECK(mojom_db_transaction);
-
-  // Optimize database query for `GetVirtualPrefs` from schema 51.
-  CreateTableIndex(mojom_db_transaction, "ad_events",
-                   /*columns=*/{"creative_set_id", "confirmation_type"});
-  CreateTableIndex(mojom_db_transaction, "ad_events",
-                   /*columns=*/{"creative_instance_id", "confirmation_type"});
-  CreateTableIndex(mojom_db_transaction, "ad_events",
-                   /*columns=*/{"advertiser_id", "confirmation_type"});
 }
 
 }  // namespace
@@ -781,31 +653,6 @@ void AdEvents::Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
   CHECK(mojom_db_transaction);
 
   switch (to_version) {
-    case 35: {
-      MigrateToV35(mojom_db_transaction);
-      break;
-    }
-
-    case 41: {
-      MigrateToV41(mojom_db_transaction);
-      break;
-    }
-
-    case 43: {
-      MigrateToV43(mojom_db_transaction);
-      break;
-    }
-
-    case 50: {
-      MigrateToV50(mojom_db_transaction);
-      break;
-    }
-
-    case 51: {
-      MigrateToV51(mojom_db_transaction);
-      break;
-    }
-
     default: {
       // No migration needed.
       break;


### PR DESCRIPTION
Raises kRazeDatabaseThresholdVersionNumber from 32 to 50, so any database on schema 50 or below is razed and recreated rather than migrated incrementally. This makes the per-table migration code for those old versions unreachable, so it has been removed. Version 51's migration case is also unreachable by construction: any database that would need it (from_version == 50) gets razed instead, so its migration code has been removed too, not just versions below it. Schema 51 was released on June 11, 2025 in 139.1.81.75.

Part of https://github.com/brave/brave-browser/issues/57572

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
