### PR TITLE
[deps] Simplify mac `updater` deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ patches/**/*.patchinfo
 /third_party/ast-grep-intermediate/
 /third_party/ast-grep-src/
 /third_party/ast-grep/ast-grep-*
+/third_party/updater/mac/
 *.xcodeproj
 !/ios/brave-ios/App/*.xcodeproj
 *.swp

--- a/DEPS
+++ b/DEPS
@@ -83,8 +83,7 @@ hooks = [
     'condition': 'checkout_mac',
     'action': ['vpython3', 'build/download_dep.py',
                'omaha4/BraveUpdater-143.1.87.74.zip',
-               '//brave/third_party/updater/mac',
-               'BraveUpdater.app/'],
+               '//brave/third_party/updater/mac'],
   },
   {
     'name': 'update_pip',

--- a/third_party/updater/.gitignore
+++ b/third_party/updater/.gitignore
@@ -1,6 +1,0 @@
-# It would be nice to have file mac/.gitignore with entries `BraveUpdater.app/`
-# and `.url`. But the `DownloadAndUnpack` function we are using deletes the
-# destination directory, `mac/`, and thus also `mac/.gitignore`. We therefore
-# maintain the .gitignore entries here:
-mac/BraveUpdater.app/
-mac/.url


### PR DESCRIPTION
This change is being done in preparation to move this particular hook
download to be handled by `EXTRA_DEPS`. We remove the unzip filter, as
this is only filtering a single file, `.install`, which is just 413kb.

This change also deletes the `.gitignore` in `updater` entirely, as we
should be ignoring everything related to this package, as we do in other
cases like this.

Bug: https://github.com/brave/brave-browser/issues/56723
