### PR TITLE
fix: recover queued legacy tokens

### DIFF
--- a/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_database_table_unittest.cc
+++ b/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_database_table_unittest.cc
@@ -7,6 +7,7 @@
 
 #include "base/test/test_future.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/confirmation_info.h"
+#include "brave/components/brave_ads/core/internal/account/confirmations/confirmations_util.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/queue/queue_item/confirmation_queue_item_builder.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/queue/queue_item/confirmation_queue_item_info.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/queue/queue_item/confirmation_queue_item_util.h"
@@ -16,6 +17,7 @@
 #include "brave/components/brave_ads/core/internal/account/confirmations/user_data_builder/test/confirmation_user_data_builder_test_util.h"
 #include "brave/components/brave_ads/core/internal/account/tokens/confirmation_tokens/test/confirmation_tokens_test_util.h"
 #include "brave/components/brave_ads/core/internal/account/tokens/test/token_generator_test_util.h"
+#include "brave/components/brave_ads/core/internal/common/challenge_bypass_ristretto/unblinded_token.h"
 #include "brave/components/brave_ads/core/internal/common/random/test/scoped_rand_time_delta_with_jitter_for_testing.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/common/test/time_test_util.h"
@@ -73,6 +75,52 @@ TEST_F(BraveAdsConfirmationQueueDatabaseTableTest, SaveConfirmationQueueItems) {
   const auto [success, got_items] = test_future.Take();
   EXPECT_TRUE(success);
   EXPECT_EQ(confirmation_queue_items, got_items);
+}
+
+TEST_F(BraveAdsConfirmationQueueDatabaseTableTest,
+       GetLegacyRewardConfirmationRecoversNonRfcDerivation) {
+  // Arrange
+  test::MockTokenGenerator(/*count=*/1);
+  test::RefillConfirmationTokens(/*count=*/1);
+
+  std::optional<ConfirmationInfo> confirmation =
+      test::BuildRewardConfirmationWithoutDynamicUserData(
+          /*use_random_uuids=*/false);
+  ASSERT_TRUE(confirmation);
+  ASSERT_TRUE(confirmation->reward);
+
+  // Simulate a confirmation queued by a pre-RFC build: a legacy-derived
+  // unblinded token with a matching legacy credential. The `rfc` flag is not
+  // persisted in the queue, so on read it defaults to the RFC 9497 derivation.
+  const std::optional<std::string> unblinded_token_base64 =
+      confirmation->reward->unblinded_token.EncodeBase64();
+  ASSERT_TRUE(unblinded_token_base64);
+  confirmation->reward->unblinded_token =
+      cbr::UnblindedToken(*unblinded_token_base64, /*rfc=*/false);
+  const std::optional<std::string> credential_base64url =
+      BuildRewardCredential(*confirmation);
+  ASSERT_TRUE(credential_base64url);
+  confirmation->reward->credential_base64url = *credential_base64url;
+  ASSERT_TRUE(IsValid(*confirmation));
+
+  test::SaveConfirmationQueueItems(
+      test::BuildConfirmationQueueItems(*confirmation, /*count=*/1));
+
+  // Act
+  base::test::TestFuture<bool, ConfirmationQueueItemList> test_future;
+  database_table_.GetAll(
+      test_future.GetCallback<bool, const ConfirmationQueueItemList&>());
+  const auto [success, got_items] = test_future.Take();
+
+  // Assert
+  ASSERT_TRUE(success);
+  ASSERT_EQ(1U, got_items.size());
+  ASSERT_TRUE(got_items.front().confirmation.reward);
+  // The legacy derivation must be recovered so the confirmation still verifies
+  // and can be processed, instead of validating as invalid and crashing on
+  // `CHECK(IsValid(...))` during queue processing.
+  EXPECT_FALSE(got_items.front().confirmation.reward->unblinded_token.rfc());
+  EXPECT_TRUE(IsValid(got_items.front().confirmation));
 }
 
 TEST_F(BraveAdsConfirmationQueueDatabaseTableTest,

--- a/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_database_table_util.cc
+++ b/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_database_table_util.cc
@@ -11,6 +11,7 @@
 #include "base/json/json_reader.h"
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/confirmation_type.h"
+#include "brave/components/brave_ads/core/internal/account/confirmations/confirmations_util.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/queue/queue_item/confirmation_queue_item_info.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/reward/reward_info.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_type.h"
@@ -86,6 +87,15 @@ ConfirmationQueueItemInfo ConfirmationQueueItemFromMojomRow(
   }
 
   confirmation_queue_item.retry_count = ColumnInt(mojom_db_row, 13);
+
+  // Confirmations queued before RFC support was added use the legacy
+  // derivation. Recover them from the stored credentials so such
+  // confirmations still verify and redeem.
+  if (confirmation_queue_item.confirmation.reward &&
+      !IsValid(confirmation_queue_item.confirmation)) {
+    confirmation_queue_item.confirmation.reward->unblinded_token =
+        cbr::UnblindedToken(unblinded_token, /*rfc=*/false);
+  }
 
   return confirmation_queue_item;
 }


### PR DESCRIPTION
- Resolves brave/brave-browser#57577

Summary

Fixes a startup crash loop that occurs when upgrading from a build that predates the RFC 9497 verification-key derivation (e.g. 1.92.x) to one that supports it (1.95.x) while the ads confirmation queue is not empty.

Problem

`cbr::UnblindedToken` selects its verification-key derivation via an rfc flag that defaults to the RFC 9497 derivation. That flag is not persisted in the `confirmation_queue` table. Therefore, a reward confirmation queued by an older build whose token and credential were produced with the legacy derivation is read back with `rfc = true. IsValid()` → `Verify()` then derives the RFC verification key and checks it against the legacy stored credential. The mismatch makes `IsValid()` return false, and `ProcessQueueItem()` / `RebuildConfirmationDynamicUserData()` abort on `CHECK(IsValid(confirmation))`. The queued item is never redeemed or removed.

Fix

When reading a reward confirmation from the queue, if it does not validate under the default (RFC) derivation, reconstruct its unblinded token with the legacy derivation (`rfc = false`) recovered from the stored credential. Legacy confirmations then validate, are rebuilt and redeemed via the legacy path, and drain from the queue normally. Confirmations queued by RFC-capable builds validate under the default derivation and are untouched.

Testing

- Unit test: added `BraveAdsConfirmationQueueDatabaseTableTest.GetLegacyRewardConfirmationRecoversNonRfcDerivation`, which persists a legacy-derivation reward confirmation to the queue (the rfc flag is dropped on write, as older rows have it) and asserts that on read the legacy derivation is recovered and the confirmation is valid. Fails without the fix, passes with it.

Checklist

- [x] Added unit test covering the legacy-confirmation read/recover path (incl. the crash edge case).
- [x] Added comments explaining why the recovery is needed on the read path.
- [x] No third-party/schema changes; change is limited to the ads confirmation-queue read path.
- [ ] npm run test brave_unit_tests / npm run presubmit / npm run gn_check locally.
- [ ] git rebase master if needed.