### PR TITLE
[plaster] `after_function_impl` to use the original return type

### DIFF
--- a/patches/chrome-browser-download-bubble-download_display_controller.cc.patch
+++ b/patches/chrome-browser-download-bubble-download_display_controller.cc.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/browser/download/bubble/download_display_controller.cc b/chrome/browser/download/bubble/download_display_controller.cc
-index 55b2d0b11e3ac2d107a4d9371ba41da68a8f64d9..de16430e9f8563901817653f0e43dcced2a58363 100644
+index 55b2d0b11e3ac2d107a4d9371ba41da68a8f64d9..878a267d2786099a5cbffd50ff5fab8b740f81ad 100644
 --- a/chrome/browser/download/bubble/download_display_controller.cc
 +++ b/chrome/browser/download/bubble/download_display_controller.cc
 @@ -272,6 +272,7 @@ void DownloadDisplayController::OpenSecuritySubpage(
  void DownloadDisplayController::UpdateToolbarButtonState(
      const DownloadBubbleDisplayInfo& info,
      const DownloadDisplay::ProgressInfo& progress_info) {
-+  [&]() {
++  [&]() -> void {
    if (info.all_models_size == 0) {
      HideToolbarButton();
      return;

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -1305,8 +1305,11 @@ class AfterFunctionImpl(_AstGrepRewriter):
         inner `_ChromiumImpl`, or to subclassing and calling the base, when you
         want to run code after the upstream body.
 
-        The upstream body becomes `[&]() { ... }();`: a lambda capturing
-        everything (including `this`) by reference and invoked immediately.
+        The upstream body becomes `[&]() -> T { ... }();`: a lambda capturing
+        everything (including `this`) by reference and invoked immediately. `T`
+        is the enclosing function's return type, read from the definition, so a
+        body that returns `{}` still compiles and a `const T&` return is not
+        quietly deduced down to a `T` copy.
 
         Fields:
 
@@ -1315,12 +1318,20 @@ class AfterFunctionImpl(_AstGrepRewriter):
           for a free function.
         - `code` — the statement block to append.
         - `result_var` — optional. For a non-void function, names a variable
-          bound to the wrapped body's return value (`auto <result_var> = [&]()
-          { ... }();`) so the appended `code` can use it. When set, the appended
-          `code` owns the function's final `return`.
+          bound to the wrapped body's return value (`T <result_var> = [&]() ->
+          T { ... }();`) so the appended `code` can use it. When set, the
+          appended `code` owns the function's final `return`.
 
         Each overload sharing the name is one match, so an overloaded method
         needs a matching `count`.
+
+        The return type is taken from the definition as upstream spells it,
+        including a trailing `-> T`. A constructor or destructor has none, so
+        the lambda there returns `void`; pair one with `result_var` and the
+        generated code will not compile.
+
+        This rewriter is not supported with macros (`NOINLINE bool Foo::Bar()`).
+        See `blank_macros_for_ast_parsing` for more details.
 
         Examples:
 
@@ -1352,7 +1363,7 @@ class AfterFunctionImpl(_AstGrepRewriter):
 
         ```cpp
         int OmniboxController::ComputeScore() {
-          auto score = [&]() {
+          int score = [&]() -> int {
           // ... upstream body with its own returns ...
           }();
           return ComputeScore_BraveImpl(score);
@@ -1360,22 +1371,24 @@ class AfterFunctionImpl(_AstGrepRewriter):
         ```
     """
 
-    def __init__(self, *, function_name: str, capture: str, epilogue: str):
+    def __init__(self, *, function_name: str, result_var: str, epilogue: str):
         super().__init__()
         self._function_name = function_name
-        self._capture = capture
+        self._result_var = result_var
         self._epilogue = epilogue
 
     def operations(self, count: int) -> list[Operation]:
-        # Escape backslashes last in both spliced values, since they are spliced
-        # into a `re.sub` replacement where a backslash is special.
+        # Escape backslashes last, since the text is spliced into a `re.sub`
+        # replacement where a backslash is special. `result_var` is empty for a
+        # void wrap, which the op's `when_set` renders as no declaration at
+        # all. The lambda's return type is not passed here: it is a capture the
+        # engine reads off each match.
         epilogue = _indent_yaml(self._epilogue).replace('\\', '\\\\')
-        capture = self._capture.replace('\\', '\\\\')
         return [
             Operation(
                 self.OP_ID, {
                     'function_name': self._function_name,
-                    'capture': capture,
+                    'result_var': self._result_var,
                     'epilogue': epilogue,
                 }, MatchExpectation.from_count(count))
         ]
@@ -1404,21 +1417,21 @@ class AfterFunctionImpl(_AstGrepRewriter):
         if not isinstance(code, str) or not code:
             raise ValueError(f'{cls.NAME} `code` must be a non-empty string '
                              f'(in "{description}")')
-        capture = cls._resolve_capture(body, description)
         return cls(function_name=body['function_name'],
-                   capture=capture,
+                   result_var=cls._resolve_result_var(body, description),
                    epilogue=code)
 
     @classmethod
-    def _resolve_capture(cls, body: dict, description: str) -> str:
-        """Build the `auto <result_var> = ` lead, or empty for a void wrap."""
+    def _resolve_result_var(cls, body: dict, description: str) -> str:
+        """The name to bind the wrapped body's value to, or '' for a void wrap.
+        """
         if 'result_var' not in body:
             return ''
         result_var = body['result_var']
         if not isinstance(result_var, str) or not result_var:
             raise ValueError(f'{cls.NAME} `result_var` must be a non-empty '
                              f'string (in "{description}")')
-        return f'auto {result_var} = '
+        return result_var
 
 
 class RenameClass(_AstGrepRewriter):
@@ -1867,6 +1880,38 @@ def _placeholders(template: str) -> set[str]:
     }
 
 
+# An ast-grep metavariable as written in a rule template (`$RETURN_TYPE`). This
+# mirrors ast-grep's own grammar rather than imposing a house style: a name it
+# does not recognise (`$ret`, `$Ret`) is matched as literal source text, and a
+# leading underscore (`$_`, `$_RET`) means non-capturing. Neither can ever back
+# a capture, so neither belongs here.
+_METAVARIABLE_RE = re.compile(r'\$([A-Z][A-Z0-9_]*)')
+
+
+def _metavariables(template: str) -> set[str]:
+    """The set of named `$METAVARIABLE`s a matcher template binds."""
+    return set(_METAVARIABLE_RE.findall(template))
+
+
+def _is_metavariable(name: str) -> bool:
+    """schema predicate: True if `name` is a metavariable name (no `$`)."""
+    return bool(re.fullmatch(r'[A-Z][A-Z0-9_]*', name))
+
+
+def _is_capture_name(name: str) -> bool:
+    """schema predicate: True if `name` can be a `{placeholder}` field."""
+    return name.isidentifier()
+
+
+def _candidate_metavariables(candidate: dict) -> list[str]:
+    """The metavariables one capture candidate reads (none for a literal)."""
+    if 'text' in candidate:
+        return [candidate['text']]
+    if 'span' in candidate:
+        return list(candidate['span'])
+    return []
+
+
 # Reusable leaf schemas.
 _NON_EMPTY_STR = schema.And(str, len, error='must be a non-empty string')
 _REGEX_STR = schema.And(str,
@@ -1877,16 +1922,53 @@ _OP_ID = schema.And(str,
                     error='op id must be "<lang>.<name>" with a known '
                     'language prefix')
 
-# The "result" block shared by matcher and rewriter ops.
+# The "result" block of a rewriter op: the node kind it replaces.
 _RESULT_SCHEMA = {
     'node': _NON_EMPTY_STR,
+}
+
+_METAVARIABLE = schema.And(str,
+                           _is_metavariable,
+                           error='metavariable must be an upper-case name '
+                           'without its leading "$"')
+
+# One way to derive a capture from a match: the text a single metavariable
+# matched, the source spanning from the start of the first metavariable to the
+# start of the second (for a value no single node covers), or a fixed string
+# for code that binds nothing (only useful last in a candidate list).
+_SPAN_PAIR = schema.And([_METAVARIABLE],
+                        lambda pair: len(pair) == 2,
+                        error='`span` must name exactly two metavariables')
+
+_CAPTURE_CANDIDATE = schema.Or(
+    {'text': _METAVARIABLE},
+    {'span': _SPAN_PAIR},
+    {'literal': _NON_EMPTY_STR},
+    # No braces in this message: the schema library `.format()`s it.
+    error='a capture candidate must have a `text`, `span` or `literal` key')
+
+_CAPTURE_NAME = schema.And(str,
+                           _is_capture_name,
+                           error='capture name must be a valid identifier')
+
+_CAPTURE_CANDIDATES = schema.And(
+    [_CAPTURE_CANDIDATE], len, error='a capture needs at least one candidate')
+
+# The "result" block of a matcher op: the node kind each match is, plus the
+# values it can hand a rewriter. A capture is an ordered candidate list; the
+# first candidate whose metavariables are all bound resolves it.
+_MATCHER_RESULT_SCHEMA = {
+    'node': _NON_EMPTY_STR,
+    schema.Optional('captures'): {
+        _CAPTURE_NAME: _CAPTURE_CANDIDATES
+    },
 }
 
 # A matcher op: a templated ast-grep query plus its result shape. Its inputs
 # are the template's `{placeholder}`s, inferred rather than declared.
 _MATCHER_SCHEMA = {
     'template': _NON_EMPTY_STR,
-    'result': _RESULT_SCHEMA,
+    'result': _MATCHER_RESULT_SCHEMA,
 }
 
 # A rewriter op: locates nodes through a matcher op and edits each via a regex
@@ -1899,6 +1981,9 @@ _REWRITER_SCHEMA = {
     'matcher': _NON_EMPTY_STR,
     'inputs': [str],
     schema.Optional('first_match'): bool,
+    schema.Optional('when_set'): {
+        _NON_EMPTY_STR: _NON_EMPTY_STR
+    },
     'replace': {
         schema.Optional('consume_before'): str,
         schema.Optional('consume_after'): str,
@@ -2014,38 +2099,84 @@ class RewritersEval:
         locates, so the two must agree), and its declared `inputs` must be
         exactly the `{placeholder}`s used across the matcher template and the
         `replace` template -- so the op's advertised interface never drifts from
-        what its templates actually consume.
-        """
-        for op_id, spec in self._rewriters.items():
-            ref = spec['matcher']
-            if ref not in self._matchers:
-                raise RewritersSchemaError(
-                    f'{self._source}: rewriter {op_id!r} references unknown '
-                    f'matcher {ref!r}')
-            matcher = self._matchers[ref]
-            matcher_node = matcher['result']['node']
-            if spec['result']['node'] != matcher_node:
-                raise RewritersSchemaError(
-                    f'{self._source}: rewriter {op_id!r} result node '
-                    f'{spec["result"]["node"]!r} does not match matcher '
-                    f'{ref!r} node {matcher_node!r}')
+        what its templates actually consume. A `replace` template may also name
+        the matcher's captures, which the engine fills per match. Unlike inputs,
+        a capture need not be used (matchers are shared, so a capture one
+        rewriter needs is dead weight to another).
 
-            declared = set(spec['inputs'])
-            replace = spec['replace']
-            used = (_placeholders(matcher['template'])
-                    | _placeholders(replace['replace'])
-                    | _placeholders(replace.get('consume_before', ''))
-                    | _placeholders(replace.get('consume_after', '')))
-            undeclared = sorted(used - declared)
-            if undeclared:
+        Every metavariable a capture reads must be one the matcher's own
+        template binds, so a renamed `$VAR` cannot silently stop resolving.
+        """
+        for op_id, spec in self._matchers.items():
+            self._check_matcher_captures(op_id, spec)
+        for op_id, spec in self._rewriters.items():
+            self._check_rewriter_interface(op_id, spec)
+
+    def _check_matcher_captures(self, op_id: str, spec: dict) -> None:
+        """Every metavariable a capture reads must be bound by the template."""
+        bound = _metavariables(spec['template'])
+        for name, candidates in spec['result'].get('captures', {}).items():
+            read = {
+                metavariable
+                for candidate in candidates
+                for metavariable in _candidate_metavariables(candidate)
+            }
+            unbound = sorted(read - bound)
+            if unbound:
                 raise RewritersSchemaError(
-                    f'{self._source}: rewriter {op_id!r} templates use '
-                    f'undeclared input(s): {", ".join(undeclared)}')
-            unused = sorted(declared - used)
-            if unused:
-                raise RewritersSchemaError(
-                    f'{self._source}: rewriter {op_id!r} declares input(s) '
-                    f'never used in its templates: {", ".join(unused)}')
+                    f'{self._source}: matcher {op_id!r} capture {name!r} '
+                    f'reads metavariable(s) its template never binds: '
+                    f'{", ".join("$" + m for m in unbound)}')
+
+    def _check_rewriter_interface(self, op_id: str, spec: dict) -> None:
+        """A rewriter's matcher, result node and `inputs` must all line up."""
+        ref = spec['matcher']
+        if ref not in self._matchers:
+            raise RewritersSchemaError(
+                f'{self._source}: rewriter {op_id!r} references unknown '
+                f'matcher {ref!r}')
+        matcher = self._matchers[ref]
+        matcher_node = matcher['result']['node']
+        if spec['result']['node'] != matcher_node:
+            raise RewritersSchemaError(
+                f'{self._source}: rewriter {op_id!r} result node '
+                f'{spec["result"]["node"]!r} does not match matcher '
+                f'{ref!r} node {matcher_node!r}')
+
+        declared = set(spec['inputs'])
+        captures = set(matcher['result'].get('captures', {}))
+        shadowed = sorted(declared & captures)
+        if shadowed:
+            raise RewritersSchemaError(
+                f'{self._source}: rewriter {op_id!r} declares input(s) '
+                f'that shadow matcher {ref!r} capture(s): '
+                f'{", ".join(shadowed)}')
+
+        when_set = spec.get('when_set', {})
+        undeclared_optional = sorted(set(when_set) - declared)
+        if undeclared_optional:
+            raise RewritersSchemaError(
+                f'{self._source}: rewriter {op_id!r} marks undeclared '
+                f'input(s) optional in `when_set`: '
+                f'{", ".join(undeclared_optional)}')
+
+        replace = spec['replace']
+        templates = [
+            matcher['template'], replace['replace'],
+            replace.get('consume_before', ''),
+            replace.get('consume_after', ''), *when_set.values()
+        ]
+        used = set().union(*map(_placeholders, templates))
+        undeclared = sorted(used - declared - captures)
+        if undeclared:
+            raise RewritersSchemaError(
+                f'{self._source}: rewriter {op_id!r} templates use '
+                f'undeclared input(s): {", ".join(undeclared)}')
+        unused = sorted(declared - used)
+        if unused:
+            raise RewritersSchemaError(
+                f'{self._source}: rewriter {op_id!r} declares input(s) '
+                f'never used in its templates: {", ".join(unused)}')
 
 
 def _ast_grep_platform_dir() -> str:
@@ -2071,6 +2202,15 @@ class AstGrepError(PlasterError):
     """Raised when the ast-grep binary fails to run a rule."""
 
 
+class AstCaptureError(PlasterError):
+    """Raised when a rewriter needs a capture the matched code cannot supply.
+
+    Not a spec error: the matcher legitimately matched, but none of the
+    capture's candidates resolved for *this* node -- e.g. asking for the return
+    type of a constructor.
+    """
+
+
 @dataclass(frozen=True)
 class AstMatch:
     """The byte range of a single ast-grep match within the scanned source.
@@ -2079,10 +2219,16 @@ class AstMatch:
     is the exclusive offset one past it. The matched text is not stored -- read
     it back from the source (`source[start:end]`) so the bytes have a single
     source of truth, regardless of multi-byte content upstream.
+
+    `metavars` holds the same for each `$NAME` the rule bound, as
+    `name -> (start, end)`. Ranges rather than text for the same reason, and
+    because a capture may be derived from the span *between* two of them.
+    Metavariables under an unmatched `any:` branch are simply absent.
     """
 
     start: int
     length: int
+    metavars: dict[str, tuple[int, int]] = field(default_factory=dict)
 
     @property
     def end(self) -> int:
@@ -2105,6 +2251,17 @@ def _indent_code(text: str, spaces: int) -> str:
     doubled (a backslash is special in a replacement string).
     """
     return _indent_yaml(text, spaces).replace('\\', '\\\\')
+
+
+def _spliced_capture(raw: bytes) -> str:
+    """Normalise captured source for splicing into a `re.sub` replacement.
+
+    A capture is spliced into generated code as a single expression, so runs of
+    whitespace, which a span crossing a multi-line signature will contain, and
+    collapse to single spaces. Backslashes are doubled last, since a backslash
+    is special in a replacement string.
+    """
+    return ' '.join(raw.decode('utf-8').split()).replace('\\', '\\\\')
 
 
 def _leading_indent(source: bytes, pos: int) -> str:
@@ -2149,8 +2306,19 @@ def run_ast_grep(*, language: str, rule_body: str,
             continue
         obj = json.loads(line)
         span = obj['range']['byteOffset']
+        # Only `single` metavariables are read: a `$$$MULTI` binds a node list
+        # with no single range, and `transformed` is an ast-grep-side rewrite
+        # feature plaster does not use.
+        metavars = {
+            name: (var['range']['byteOffset']['start'],
+                   var['range']['byteOffset']['end'])
+            for name, var in obj.get('metaVariables', {}).get('single',
+                                                              {}).items()
+        }
         matches.append(
-            AstMatch(start=span['start'], length=span['end'] - span['start']))
+            AstMatch(start=span['start'],
+                     length=span['end'] - span['start'],
+                     metavars=metavars))
     return matches
 
 
@@ -2247,17 +2415,117 @@ class AstRewriter:
         matches = self._locate(op)
         return matches[0] if matches else None
 
+    def _resolve_captures(self, matcher: dict, match: AstMatch,
+                          needed: set[str], op_id: str) -> dict[str, str]:
+        """The matcher captures in `needed`, resolved against one match.
+
+        Each capture is an ordered candidate list. The first whose
+        metavariables are all bound (and which yields a non-empty value) wins,
+        so a value upstream can spell several ways stays one `{placeholder}`.
+        Text is read from the real source rather than the parse-normalised
+        copy, since blanking preserves offsets but not content.
+
+        A `span` takes everything between the two metavariables' *start*
+        offsets, so whatever separates them lands in the value: it reads the
+        text a node pair brackets rather than any one node's own extent. The
+        second metavariable therefore has to be the token right after the
+        wanted text (trailing whitespace is collapsed away, but a comment
+        sitting in the gap would be kept).
+        """
+        captures = matcher['result'].get('captures', {})
+        source = self._source.encode('utf-8')
+        values = {}
+        for name in sorted(needed):
+            for candidate in captures[name]:
+                if 'literal' in candidate:
+                    # Escaped like any other value: the engine owns splicing
+                    # into the `re.sub` replacement, not the spec author.
+                    values[name] = candidate['literal'].replace('\\', '\\\\')
+                    break
+                if 'text' in candidate:
+                    span = match.metavars.get(candidate['text'])
+                    if span is None:
+                        continue
+                    start, end = span
+                else:
+                    head, tail = candidate['span']
+                    first, last = (match.metavars.get(head),
+                                   match.metavars.get(tail))
+                    if first is None or last is None:
+                        continue
+                    if first[0] > last[0]:
+                        # Both bound but in the wrong order: the span would run
+                        # backwards. Where the grammar binds both, their order
+                        # is fixed, so this is the spec listing them the wrong
+                        # way round -- not a shape the next candidate covers.
+                        raise AstCaptureError(
+                            f'{op_id}: capture `{name}` spans ${head} to '
+                            f'${tail}, but ${tail} comes first in the source; '
+                            f'the candidate lists them in the wrong order')
+                    start, end = first[0], last[0]
+                value = _spliced_capture(source[start:end])
+                if not value:
+                    continue
+                values[name] = value
+                break
+            else:
+                line = source[:match.start].count(b'\n') + 1
+                bound = ', '.join('$' + metavariable
+                                  for metavariable in sorted(match.metavars))
+                raise AstCaptureError(
+                    f'{op_id}: cannot resolve `{name}` for the match at line '
+                    f'{line}; no candidate applies to this code (bound '
+                    f'metavariables: {bound or "none"})')
+        return values
+
+    @staticmethod
+    def _captures_needed(rewriter: dict, matcher: dict,
+                         op: Operation) -> set[str]:
+        """Which of the matcher's captures `op`'s templates actually read.
+
+        An unset optional input's `when_set` template never renders, so nothing
+        it reads is needed. Inputs are fixed for the whole op, so which
+        templates render is settled once rather than per match.
+        """
+        replace = rewriter['replace']
+        when_set = rewriter.get('when_set', {})
+        rendered = [
+            replace['replace'],
+            replace.get('consume_before', ''),
+            replace.get('consume_after', ''),
+            *(template
+              for name, template in when_set.items() if op.inputs.get(name)),
+        ]
+        used = set().union(*map(_placeholders, rendered))
+        return used & matcher['result'].get('captures', {}).keys()
+
+    def _values_for(self, rewriter: dict, matcher: dict, match: AstMatch,
+                    op: Operation, needed: set[str]) -> dict[str, str]:
+        """Everything one match's templates render with: inputs and captures.
+
+        An optional input renders through its `when_set` template, or as
+        nothing when unset. Every such template sees the same unexpanded
+        values, so one optional input cannot depend on another's expansion.
+        """
+        values = op.inputs | self._resolve_captures(matcher, match, needed,
+                                                    op.op_id)
+        return values | {
+            name: (template.format(**values) if values.get(name) else '')
+            for name, template in rewriter.get('when_set', {}).items()
+        }
+
     def run(self, op: Operation) -> int:
         """Run one bound `Operation`, mutate content, return the change count.
 
         Locates nodes via the op's matcher template, applies the op's `replace`
-        regex substitution (with `op.inputs` filled into the replacement
-        template) to each matched node, and splices the results back into the
-        held contents from the end so earlier byte offsets stay valid. Returns
-        the total number of substitutions made.
+        regex substitution (with `op.inputs`, plus any matcher captures the
+        templates name, filled into the replacement template) to each matched
+        node, and splices the results back into the held contents from the end
+        so earlier byte offsets stay valid. Returns the total number of
+        substitutions made.
 
         An op's `replace` may name `consume_before` / `consume_after` tokens
-        (themselves `op.inputs`-formatted) that sit immediately before / after
+        (formatted the same way) that sit immediately before / after
         each matched node; they are folded into the rewritten span when the node
         kind stops short of an adjacent token (e.g. the `:` after an
         access_specifier, or the space before a `final` specifier). An op that
@@ -2265,22 +2533,25 @@ class AstRewriter:
         leaving any later matches untouched.
         """
         rewriter = self._rewriters.rewriter(op.op_id)
+        matcher = self._rewriters.matcher(rewriter['matcher'])
         matches = self._locate(op)
         if rewriter.get('first_match'):
             matches = matches[:1]
 
         replace = rewriter['replace']
         pattern = replace['re_pattern']
-        replacement = replace['replace'].format(**op.inputs)
-        before = replace.get('consume_before',
-                             '').format(**op.inputs).encode('utf-8')
-        after = replace.get('consume_after',
-                            '').format(**op.inputs).encode('utf-8')
+        needed = self._captures_needed(rewriter, matcher, op)
 
         source = self._source.encode('utf-8')
         edits = []
         total = 0
         for match in matches:
+            values = self._values_for(rewriter, matcher, match, op, needed)
+            replacement = replace['replace'].format(**values)
+            before = replace.get('consume_before',
+                                 '').format(**values).encode('utf-8')
+            after = replace.get('consume_after',
+                                '').format(**values).encode('utf-8')
             start = match.start - len(before)
             end = match.end + len(after)
             if (before and source[start:match.start]

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -8,6 +8,7 @@ import unittest
 from pathlib import Path
 import argparse
 import contextlib
+import copy
 import hashlib
 import io
 import json
@@ -1631,6 +1632,20 @@ class RewriterFormsTest(unittest.TestCase):
             source.replace('{\n  Upstream();', '{\n  if (!ok) return;\n'
                            '  Upstream();'))
 
+    def test_preempt_function_impl_constructor(self):
+        # A constructor has no return type, so the matcher's `return_type`
+        # capture cannot resolve for it. This op never asks for that capture,
+        # so the rewrite still applies -- captures are resolved lazily.
+        result = self._apply(
+            'ctor.cc', 'C::C() : x_(1) {\n  Init();\n}\n', 'substitutions:\n'
+            '  - description: skip upstream init when Brave owns it\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::C\n'
+            "      return_if: 'BraveOwnsInit()'\n")
+        self.assertEqual(
+            result, 'C::C() : x_(1) {\n'
+            '  if (BraveOwnsInit()) return;\n  Init();\n}\n')
+
     def test_preempt_function_impl_targets_named_function_only(self):
         # Only the named function's body is touched, not a sibling in the same
         # file.
@@ -2329,7 +2344,8 @@ class RewriterFormsTest(unittest.TestCase):
             '      code: |-\n'
             '        RecordBraveMetric();\n')
         self.assertEqual(
-            result, 'void C::Foo() {\n  [&]() {\n  Upstream();\n  }();\n'
+            result,
+            'void C::Foo() {\n  [&]() -> void {\n  Upstream();\n  }();\n'
             '  RecordBraveMetric();\n}\n')
 
     def test_after_function_impl_captures_result(self):
@@ -2345,8 +2361,99 @@ class RewriterFormsTest(unittest.TestCase):
             '      code: |-\n'
             '        return BraveAdjust(score);\n')
         self.assertEqual(
-            result, 'int C::Compute() {\n  auto score = [&]() {\n'
+            result, 'int C::Compute() {\n  int score = [&]() -> int {\n'
             '  return real_;\n  }();\n  return BraveAdjust(score);\n}\n')
+
+    def test_after_function_impl_reference_return_type(self):
+        # The lambda and the result variable both state the return type exactly
+        # as upstream spells it. `const` leads the type as a separate node and
+        # the `&` hangs off the declarator, so neither is part of the `type`
+        # field -- a naive capture would yield `std::vector<int>`, silently
+        # turning the reference return into a copy.
+        result = self._apply(
+            'append_ref.cc',
+            'const std::vector<int>& C::Items() const {\n  return items_;\n}\n',
+            'substitutions:\n'
+            '  - description: let Brave filter the returned items\n'
+            '    after_function_impl:\n'
+            '      function_name: C::Items\n'
+            '      result_var: items\n'
+            '      code: |-\n'
+            '        return BraveFilter(items);\n')
+        self.assertEqual(
+            result, 'const std::vector<int>& C::Items() const {\n'
+            '  const std::vector<int>& items = [&]()'
+            ' -> const std::vector<int>& {\n'
+            '  return items_;\n  }();\n  return BraveFilter(items);\n}\n')
+
+    def test_after_function_impl_pointer_return_type(self):
+        # The `*` lives on the declarator, not the type field.
+        result = self._apply(
+            'append_ptr.cc', 'Widget* C::GetWidget() {\n  return w_;\n}\n',
+            'substitutions:\n'
+            '  - description: fall back to the Brave widget\n'
+            '    after_function_impl:\n'
+            '      function_name: C::GetWidget\n'
+            '      result_var: widget\n'
+            '      code: |-\n'
+            '        return widget ? widget : BraveWidget();\n')
+        self.assertEqual(
+            result, 'Widget* C::GetWidget() {\n'
+            '  Widget* widget = [&]() -> Widget* {\n'
+            '  return w_;\n  }();\n'
+            '  return widget ? widget : BraveWidget();\n}\n')
+
+    def test_after_function_impl_trailing_return_type(self):
+        # With a trailing return type the `type` field is a bare `auto`, so the
+        # capture takes the trailing type instead -- its first candidate.
+        result = self._apply(
+            'append_trailing.cc',
+            'auto C::Name() -> const char* {\n  return name_;\n}\n',
+            'substitutions:\n'
+            '  - description: let Brave rename\n'
+            '    after_function_impl:\n'
+            '      function_name: C::Name\n'
+            '      result_var: name\n'
+            '      code: |-\n'
+            '        return BraveName(name);\n')
+        self.assertEqual(
+            result, 'auto C::Name() -> const char* {\n'
+            '  const char* name = [&]() -> const char* {\n'
+            '  return name_;\n  }();\n  return BraveName(name);\n}\n')
+
+    def test_after_function_impl_multiline_signature_return_type(self):
+        # A return type split across lines is spliced into generated code as a
+        # single expression, so its whitespace collapses to single spaces.
+        result = self._apply(
+            'append_multiline_sig.cc',
+            'const std::map<int, std::string>&\nC::Map() const {\n'
+            '  return m_;\n}\n', 'substitutions:\n'
+            '  - description: let Brave extend the map\n'
+            '    after_function_impl:\n'
+            '      function_name: C::Map\n'
+            '      result_var: m\n'
+            '      code: |-\n'
+            '        return BraveMap(m);\n')
+        self.assertEqual(
+            result, 'const std::map<int, std::string>&\nC::Map() const {\n'
+            '  const std::map<int, std::string>& m = [&]()'
+            ' -> const std::map<int, std::string>& {\n'
+            '  return m_;\n  }();\n  return BraveMap(m);\n}\n')
+
+    def test_after_function_impl_constructor(self):
+        # A constructor has no return type to read, so the capture falls
+        # through to `void` -- which is what its wrapped body returns.
+        result = self._apply(
+            'append_ctor.cc', 'C::C() : x_(1) {\n  Init();\n}\n',
+            'substitutions:\n'
+            '  - description: run Brave setup after the upstream body\n'
+            '    after_function_impl:\n'
+            '      function_name: C::C\n'
+            '      code: |-\n'
+            '        BraveInit();\n')
+        self.assertEqual(
+            result, 'C::C() : x_(1) {\n  [&]() -> void {\n  Init();\n  }();\n'
+            '  BraveInit();\n}\n')
 
     def test_after_function_impl_wraps_early_returns(self):
         # Every `return` in the upstream body only returns from the lambda, so
@@ -2365,7 +2472,7 @@ class RewriterFormsTest(unittest.TestCase):
             '      code: |-\n'
             '        BraveCleanup();\n')
         self.assertEqual(
-            result, 'void C::Foo() {\n  [&]() {\n'
+            result, 'void C::Foo() {\n  [&]() -> void {\n'
             '  if (!ready_) {\n    return;\n  }\n  Work();\n  }();\n'
             '  BraveCleanup();\n}\n')
 
@@ -2379,7 +2486,8 @@ class RewriterFormsTest(unittest.TestCase):
             '      code: |-\n'
             '        AfterFree(x);\n')
         self.assertEqual(
-            result, 'void FreeFunc(int x) {\n  [&]() {\n  Upstream(x);\n'
+            result,
+            'void FreeFunc(int x) {\n  [&]() -> void {\n  Upstream(x);\n'
             '  }();\n  AfterFree(x);\n}\n')
 
     def test_after_function_impl_multiline_code_indented(self):
@@ -2396,7 +2504,8 @@ class RewriterFormsTest(unittest.TestCase):
             '\n'
             '        Track();\n')
         self.assertEqual(
-            result, 'void C::Foo() {\n  [&]() {\n  Upstream();\n  }();\n'
+            result,
+            'void C::Foo() {\n  [&]() -> void {\n  Upstream();\n  }();\n'
             '  Prepare();\n\n  Track();\n}\n')
 
     def test_after_function_impl_targets_named_function_only(self):
@@ -2412,7 +2521,8 @@ class RewriterFormsTest(unittest.TestCase):
             '        after_b();\n')
         self.assertEqual(
             result, 'void C::A() {\n  a();\n}\n\n'
-            'void C::B() {\n  [&]() {\n  b();\n  }();\n  after_b();\n}\n')
+            'void C::B() {\n  [&]() -> void {\n  b();\n  }();\n'
+            '  after_b();\n}\n')
 
     def test_after_function_impl_overloads_need_count(self):
         result = self._apply(
@@ -2426,9 +2536,10 @@ class RewriterFormsTest(unittest.TestCase):
             '      code: |-\n'
             '        done();\n')
         self.assertEqual(
-            result,
-            'void C::F() {\n  [&]() {\n  a();\n  }();\n  done();\n}\n\n'
-            'void C::F(int x) {\n  [&]() {\n  b();\n  }();\n  done();\n}\n')
+            result, 'void C::F() {\n  [&]() -> void {\n  a();\n  }();\n'
+            '  done();\n}\n\n'
+            'void C::F(int x) {\n  [&]() -> void {\n  b();\n  }();\n'
+            '  done();\n}\n')
 
     def test_after_function_impl_overload_count_mismatch_fails(self):
         with self.assertRaises(plaster.PlasterApplyError):
@@ -3064,6 +3175,156 @@ class RewritersEvalTest(unittest.TestCase):
         self._assert_invalid(lambda spec: spec['ast.rewriter'][
             'cxx.make_virtual'].update({'first_match': 'yes'}))
 
+    # -- matcher captures ---------------------------------------------------
+
+    # The candidate list `_with_capture` gives a capture by default.
+    _RET_CANDIDATES = ({'text': 'RET'}, )
+
+    @staticmethod
+    def _with_capture(spec: dict, candidates=_RET_CANDIDATES) -> dict:
+        """Bind `$RET` in the matcher template and expose it as a capture."""
+        matcher = spec['ast.matcher']['cxx.find_class_method_decl']
+        matcher['template'] += 'has:\n  field: type\n  pattern: $RET\n'
+        matcher['result']['captures'] = {'return_type': list(candidates)}
+        return spec
+
+    def test_rewriter_may_use_matcher_capture(self):
+        # A capture is not an input: the rewriter names it in `replace` without
+        # declaring it, and the engine fills it per match.
+        spec = self._with_capture(self._valid_spec())
+        spec['ast.rewriter']['cxx.make_virtual']['replace']['replace'] = (
+            'virtual {return_type} ')
+        rewriters = plaster.RewritersEval(repr(spec))
+        self.assertEqual(
+            rewriters.matcher('cxx.find_class_method_decl')['result']
+            ['captures']['return_type'], [{
+                'text': 'RET'
+            }])
+
+    def test_matcher_capture_may_go_unused(self):
+        # Matchers are shared, so a capture one rewriter needs is dead weight
+        # to another. Unlike an input, that is not an error.
+        rewriters = plaster.RewritersEval(
+            repr(self._with_capture(self._valid_spec())))
+        self.assertIn(
+            'return_type',
+            rewriters.matcher('cxx.find_class_method_decl')['result']
+            ['captures'])
+
+    def test_matcher_capture_reads_unbound_metavariable(self):
+        # `$NOPE` appears in no template, so the capture could never resolve.
+        self._assert_invalid(
+            lambda s: self._with_capture(s, [{
+                'text': 'NOPE'
+            }]), 'never binds')
+
+    def test_matcher_capture_span_reads_unbound_metavariable(self):
+        self._assert_invalid(
+            lambda s: self._with_capture(s, [{
+                'span': ['RET', 'NOPE']
+            }]), 'never binds')
+
+    def test_matcher_capture_span_needs_two_metavariables(self):
+        self._assert_invalid(
+            lambda s: self._with_capture(s, [{
+                'span': ['RET']
+            }]))
+
+    def test_matcher_capture_needs_a_candidate(self):
+        self._assert_invalid(lambda s: self._with_capture(s, []))
+
+    def test_matcher_capture_candidate_needs_known_kind(self):
+        self._assert_invalid(
+            lambda s: self._with_capture(s, [{
+                'node': 'RET'
+            }]))
+
+    def test_matcher_capture_literal_candidate(self):
+        # A literal reads no metavariable, so it always resolves -- it is the
+        # way to give a capture a fallback for code that binds nothing.
+        rewriters = plaster.RewritersEval(
+            repr(
+                self._with_capture(self._valid_spec(), [{
+                    'text': 'RET'
+                }, {
+                    'literal': 'void'
+                }])))
+        self.assertEqual(
+            rewriters.matcher('cxx.find_class_method_decl')['result']
+            ['captures']['return_type'][-1], {'literal': 'void'})
+
+    def test_matcher_capture_literal_must_be_non_empty(self):
+        self._assert_invalid(
+            lambda s: self._with_capture(s, [{
+                'literal': ''
+            }]))
+
+    def test_matcher_capture_metavariable_must_be_upper_case(self):
+        self._assert_invalid(
+            lambda s: self._with_capture(s, [{
+                'text': 'ret'
+            }]))
+
+    def test_rewriter_input_may_not_shadow_a_capture(self):
+        # If both could fill `{return_type}`, which wins would be invisible at
+        # the call site.
+        def mutate(spec):
+            self._with_capture(spec)
+            rewriter = spec['ast.rewriter']['cxx.make_virtual']
+            rewriter['inputs'].append('return_type')
+            rewriter['replace']['replace'] = 'virtual {return_type} '
+
+        self._assert_invalid(mutate, 'shadow')
+
+    # -- optional inputs (`when_set`) ---------------------------------------
+
+    def test_rewriter_when_set_expands_an_optional_input(self):
+        spec = self._valid_spec()
+        rewriter = spec['ast.rewriter']['cxx.make_virtual']
+        rewriter['inputs'].append('result_var')
+        rewriter['when_set'] = {'result_var': 'auto {result_var} = '}
+        rewriter['replace']['replace'] = '{result_var}virtual '
+        rewriters = plaster.RewritersEval(repr(spec))
+        self.assertEqual(
+            rewriters.rewriter('cxx.make_virtual')['when_set'],
+            {'result_var': 'auto {result_var} = '})
+
+    def test_rewriter_when_set_input_must_be_declared(self):
+        self._assert_invalid(
+            lambda s: s['ast.rewriter']['cxx.make_virtual'].update(
+                {'when_set': {
+                    'nope': 'x'
+                }}), 'undeclared input')
+
+    def test_rewriter_when_set_template_placeholder_must_be_declared(self):
+        # A `when_set` template is rendered like any other, so what it reads
+        # must be a declared input or a capture.
+        def mutate(spec):
+            rewriter = spec['ast.rewriter']['cxx.make_virtual']
+            rewriter['inputs'].append('result_var')
+            rewriter['replace']['replace'] = '{result_var}virtual '
+            rewriter['when_set'] = {'result_var': '{undeclared} '}
+
+        self._assert_invalid(mutate, 'undeclared input')
+
+    def test_rewriter_when_set_template_may_read_a_capture(self):
+
+        def mutate(spec):
+            self._with_capture(spec)
+            rewriter = spec['ast.rewriter']['cxx.make_virtual']
+            rewriter['inputs'].append('result_var')
+            rewriter['when_set'] = {
+                'result_var': '{return_type} {result_var} = '
+            }
+            rewriter['replace']['replace'] = '{result_var}virtual '
+            return spec
+
+        spec = self._valid_spec()
+        mutate(spec)
+        rewriters = plaster.RewritersEval(repr(spec))
+        self.assertIn('result_var',
+                      rewriters.rewriter('cxx.make_virtual')['when_set'])
+
 
 # ast-grep matcher templates used to build synthetic RewritersEval specs for
 # the engine tests below. The shipped rewriters.pyl is empty until the ops that
@@ -3292,6 +3553,59 @@ class RunAstGrepTest(unittest.TestCase):
                                  rule_body='kind: not_a_real_kind',
                                  source='int x;\n')
 
+    # -- metavariables ------------------------------------------------------
+
+    # Binds `$TYPE` and `$NAME` always, and `$QUAL` only when the declaration
+    # leads with a qualifier -- the shape a capture's candidate list relies on.
+    _TYPED_METHOD_RULE = ('kind: field_declaration\n'
+                          'all:\n'
+                          '  - has:\n'
+                          '      field: type\n'
+                          '      pattern: $TYPE\n'
+                          '  - has:\n'
+                          '      kind: function_declarator\n'
+                          '      stopBy: end\n'
+                          '      has:\n'
+                          '        field: declarator\n'
+                          '        pattern: $NAME\n'
+                          '  - any:\n'
+                          '      - has:\n'
+                          '          kind: type_qualifier\n'
+                          '          pattern: $QUAL\n'
+                          '      - not:\n'
+                          '          has:\n'
+                          '            kind: type_qualifier\n')
+
+    _TYPED_SRC = 'class C {\n  const int* Foo();\n  void Bar();\n};\n'
+
+    def _typed_matches(self) -> list[plaster.AstMatch]:
+        return plaster.run_ast_grep(language='cpp',
+                                    rule_body=self._TYPED_METHOD_RULE,
+                                    source=self._TYPED_SRC)
+
+    def test_exposes_metavariable_ranges(self):
+        raw = self._TYPED_SRC.encode('utf-8')
+        qualified = self._typed_matches()[0]
+        text = {
+            name: raw[start:end].decode()
+            for name, (start, end) in qualified.metavars.items()
+        }
+        self.assertEqual(text, {'QUAL': 'const', 'TYPE': 'int', 'NAME': 'Foo'})
+        # The span between two metavariables recovers what no single node
+        # holds: the `*` sits on the declarator, the `const` before the type.
+        start = qualified.metavars['QUAL'][0]
+        self.assertEqual(raw[start:qualified.metavars['NAME'][0]].decode(),
+                         'const int* ')
+
+    def test_omits_unbound_metavariables(self):
+        # `Bar` has no leading qualifier, so `$QUAL`'s `any:` branch never
+        # matched and the metavariable is simply absent.
+        plain = self._typed_matches()[1]
+        self.assertEqual(sorted(plain.metavars), ['NAME', 'TYPE'])
+
+    def test_match_without_metavariables_has_none(self):
+        self.assertEqual(self._find('Foo', self._SRC)[0].metavars, {})
+
 
 class AstRewriterTest(unittest.TestCase):
     """Integration tests for plaster.AstRewriter (real ast-grep binary).
@@ -3422,6 +3736,191 @@ class AstRewriterTest(unittest.TestCase):
             rewriter.run(
                 plaster.Operation('cxx.drop_final', {'class_name': 'C'})), 0)
         self.assertEqual(rewriter.content, 'class C {\n};\n')
+
+
+class AstCaptureTest(unittest.TestCase):
+    """Capture resolution and optional inputs (real ast-grep binary).
+
+    Exercises the engine mechanics in isolation from the shipped ops: a matcher
+    that binds three metavariables, a capture whose candidates fall back
+    through them, and a rewriter with an optional input.
+    """
+
+    # `$NAME` always binds; `$TYPE` only when there is a return type (a
+    # constructor has none) and `$QUAL` only on a qualified declaration.
+    # Constructors parse as `declaration`, regular methods as
+    # `field_declaration`.
+    _RULE = ('any:\n'
+             '  - kind: field_declaration\n'
+             '  - kind: declaration\n'
+             'all:\n'
+             '  - has:\n'
+             '      kind: function_declarator\n'
+             '      stopBy: end\n'
+             '      has:\n'
+             '        field: declarator\n'
+             '        pattern: $NAME\n'
+             '        regex: ^{method_name}$\n'
+             '  - any:\n'
+             '      - has:\n'
+             '          field: type\n'
+             '          pattern: $TYPE\n'
+             '      - not:\n'
+             '          has:\n'
+             '            field: type\n'
+             '            pattern: $_\n'
+             '  - any:\n'
+             '      - has:\n'
+             '          kind: type_qualifier\n'
+             '          pattern: $QUAL\n'
+             '      - not:\n'
+             '          has:\n'
+             '            kind: type_qualifier\n')
+
+    _SPEC = {
+        'ast.matcher': {
+            'cxx.find_typed_method': {
+                'template': _RULE,
+                'result': {
+                    'node': 'field_declaration',
+                    'captures': {
+                        'return_type': [
+                            {
+                                'span': ['QUAL', 'NAME']
+                            },
+                            {
+                                'span': ['TYPE', 'NAME']
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+        'ast.rewriter': {
+            'cxx.annotate': {
+                'matcher': 'cxx.find_typed_method',
+                'inputs': ['method_name', 'note'],
+                'replace': {
+                    're_pattern': '$',
+                    'replace': '  // {note}: {return_type}',
+                },
+                'result': {
+                    'node': 'field_declaration'
+                },
+            },
+            'cxx.annotate_optional': {
+                'matcher': 'cxx.find_typed_method',
+                'inputs': ['method_name', 'prefix'],
+                'when_set': {
+                    'prefix': '{prefix} {return_type} -- ',
+                },
+                'replace': {
+                    're_pattern': '$',
+                    'replace': '  // {prefix}done',
+                },
+                'result': {
+                    'node': 'field_declaration'
+                },
+            },
+        },
+    }
+
+    def _run(self, source: str, op: plaster.Operation) -> str:
+        rewriter = plaster.AstRewriter(plaster.RewritersEval(repr(self._SPEC)),
+                                       source)
+        rewriter.run(op)
+        return rewriter.content
+
+    def _annotate(self, source: str, method_name: str = 'Foo') -> str:
+        return self._run(
+            source,
+            plaster.Operation('cxx.annotate', {
+                'method_name': method_name,
+                'note': 'type'
+            }))
+
+    def test_first_candidate_wins(self):
+        # `$QUAL` binds, so the first span candidate resolves and carries the
+        # qualifier and the `*` that flank the `type` field.
+        result = self._annotate('class C {\n  const int* Foo();\n};\n')
+        self.assertIn('// type: const int*', result)
+
+    def test_falls_back_to_later_candidate(self):
+        # No qualifier, so the first candidate cannot resolve and the second
+        # supplies the value.
+        result = self._annotate('class C {\n  int Foo();\n};\n')
+        self.assertIn('// type: int', result)
+
+    def test_collapses_whitespace_in_a_span(self):
+        result = self._annotate('class C {\n  const std::map<int,\n'
+                                '      std::string>&\n      Foo();\n};\n')
+        self.assertIn('// type: const std::map<int, std::string>&', result)
+
+    def test_reversed_span_raises(self):
+        # Both metavariables bind, but the candidate names them in source order
+        # `NAME`..`TYPE` -- backwards. Falling through to the next candidate
+        # would hide a spec bug behind a value derived some other way, so this
+        # is reported instead.
+        spec = copy.deepcopy(self._SPEC)
+        spec['ast.matcher']['cxx.find_typed_method']['result']['captures'] = {
+            'return_type': [{
+                'span': ['NAME', 'TYPE']
+            }, {
+                'literal': 'void'
+            }],
+        }
+        rewriter = plaster.AstRewriter(plaster.RewritersEval(repr(spec)),
+                                       'class C {\n  int Foo();\n};\n')
+        with self.assertRaises(plaster.AstCaptureError) as ctx:
+            rewriter.run(
+                plaster.Operation('cxx.annotate', {
+                    'method_name': 'Foo',
+                    'note': 'type'
+                }))
+        self.assertIn('spans $NAME to $TYPE', str(ctx.exception))
+        self.assertIn('wrong order', str(ctx.exception))
+
+    def test_unresolvable_capture_raises(self):
+        # A constructor binds neither `$QUAL` nor `$TYPE`, so no candidate
+        # applies and the engine refuses rather than splicing an empty type.
+        with self.assertRaises(plaster.AstCaptureError) as ctx:
+            self._annotate('class C {\n  C();\n};\n', method_name='C')
+        message = str(ctx.exception)
+        self.assertIn('cxx.annotate', message)
+        self.assertIn('cannot resolve `return_type`', message)
+        # The diagnostic locates the match and reports what did bind.
+        self.assertIn('line 2', message)
+        self.assertIn('$NAME', message)
+
+    def test_capture_is_only_resolved_when_a_template_asks(self):
+        # `cxx.annotate_optional` names `return_type` only inside `when_set`,
+        # so with the optional input unset the constructor rewrite succeeds.
+        result = self._run(
+            'class C {\n  C();\n};\n',
+            plaster.Operation('cxx.annotate_optional', {
+                'method_name': 'C',
+                'prefix': ''
+            }))
+        self.assertEqual(result, 'class C {\n  C();  // done\n};\n')
+
+    def test_optional_input_expands_when_set(self):
+        result = self._run(
+            'class C {\n  const int* Foo();\n};\n',
+            plaster.Operation('cxx.annotate_optional', {
+                'method_name': 'Foo',
+                'prefix': 'returns'
+            }))
+        self.assertIn('// returns const int* -- done', result)
+
+    def test_optional_input_renders_empty_when_unset(self):
+        result = self._run(
+            'class C {\n  const int* Foo();\n};\n',
+            plaster.Operation('cxx.annotate_optional', {
+                'method_name': 'Foo',
+                'prefix': ''
+            }))
+        self.assertIn('// done', result)
+        self.assertNotIn('--', result)
 
 
 class _FlatAstGrepRewriter(plaster._AstGrepRewriter):

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -13,14 +13,49 @@
 #       template: ast-grep rule body (the part under `rule:`). Its {placeholder}
 #                 fields are the matcher's inputs; they are inferred from the
 #                 template, not declared.
-#       result:   { node: <tree-sitter kind> } each match is.
+#       result:   what each match yields:
+#                 node:     the <tree-sitter kind> each match is.
+#                 captures: optional { name: [candidate, ...] } of values read
+#                 out of the matched code, which a rewriter using this matcher
+#                 may reference as {name} in its `replace` templates. Each
+#                 candidate derives the value from the metavariables the
+#                 template binds, and the first one whose metavariables are all
+#                 bound wins. A value that upstream can spell more than one
+#                 way is expressed as a list, most specific first:
+#                     { "text": "VAR" }        the text $VAR matched.
+#                     { "span": ["A", "B"] }   the source from the start of $A
+#                                              to the start of $B, for a value
+#                                              no single node covers. It takes
+#                                              whatever lies between them, so
+#                                              $B must be the token right after
+#                                              the wanted text.
+#                     { "literal": "void" }    a fixed string, for code that
+#                                              binds nothing; it always
+#                                              resolves, so it is only useful
+#                                              last.
+#                 Captures are resolved lazily, and only the ones a rendered
+#                 template names are read, so a matcher may offer a capture that
+#                 does not resolve for every node it matches. A capture with no
+#                 applicable candidate is an error naming the op and the line.
+#                 Whitespace in a resolved value is collapsed to single spaces,
+#                 since captures are spliced into generated code as a single
+#                 expression -- so a capture suits a declaration or a type, not
+#                 text whose own spacing matters (a string literal, a comment).
 #
 #   "ast.rewriter" — edits each node a matcher finds:
 #       matcher:  id of the "ast.matcher" op locating the node(s).
 #       inputs:   the interface the rewriter requires, so the template it uses
-#                 can be rendered.
+#                 can be rendered. Distinct from the matcher's captures, which
+#                 the engine supplies per match rather than the caller.
+#       when_set: optional { input: template } making an input optional. When
+#                 the caller passes a non-empty value, {input} renders as that
+#                 template (which may itself read the input, other inputs, and
+#                 captures); when the value is empty, it renders as nothing. It
+#                 is how one op covers a shape with an optional part, instead of
+#                 near-duplicate ops that differ only by a lead or a suffix.
 #       replace:  { re_pattern, replace }, re.sub'd over each match's source;
-#                 `replace` is {input}-formatted first (literal braces: {{ }}).
+#                 `replace` is {input}/{capture}-formatted first (literal
+#                 braces: {{ }}).
 #                 Optional `consume_before` / `consume_after` tokens (also
 #                 {input}-formatted) are folded into the rewritten span when the
 #                 matched node stops short of an adjacent token (e.g. the `:`
@@ -183,20 +218,68 @@ inside:
         # is immune to braces in the parameter list (a `= {}` default argument),
         # a multi-line signature, or an earlier overload. Each overload sharing
         # the name yields its own match.
+        #
+        # `return_type` captures the function's return type exactly as upstream
+        # spells it. No single node holds it: the C++ grammar puts a leading
+        # `const` in a type_qualifier *sibling* of the `type` field, hangs `*`
+        # and `&` off the declarator, and leaves `type` as a bare `auto` when
+        # the real type trails the parameter list. So the candidates read, in
+        # order: a trailing return type; else the source from the leading
+        # qualifier to the name (`const std::vector<int>& Foo::Get`); else the
+        # source from the type to the name (`Widget* Foo::Get`, `bool Foo::Is`).
+        # Each of the three parts is optional in the rule, so a con/destructor
+        # -- which has no `type` field at all -- still matches; for it the
+        # candidates fall through to the literal `void`, which is what a body
+        # wrapped in a lambda there returns.
         "cxx.find_function_body": {
             "template": """\
 kind: compound_statement
 inside:
   kind: function_definition
-  has:
-    kind: function_declarator
-    stopBy: end
-    has:
-      field: declarator
-      regex: ^{function_name}$
+  all:
+    - has:
+        kind: function_declarator
+        stopBy: end
+        all:
+          - has:
+              field: declarator
+              pattern: $FUNCTION
+              regex: ^{function_name}$
+          - any:
+              - has:
+                  kind: trailing_return_type
+                  has:
+                    kind: type_descriptor
+                    pattern: $TRAILING_RETURN_TYPE
+              - not:
+                  has:
+                    kind: trailing_return_type
+    - any:
+        - has:
+            field: type
+            pattern: $RETURN_TYPE
+        - not:
+            has:
+              field: type
+              pattern: $_
+    - any:
+        - has:
+            kind: type_qualifier
+            pattern: $LEADING_QUALIFIER
+        - not:
+            has:
+              kind: type_qualifier
 """,
             "result": {
                 "node": "compound_statement",
+                "captures": {
+                    "return_type": [
+                        {"text": "TRAILING_RETURN_TYPE"},
+                        {"span": ["LEADING_QUALIFIER", "FUNCTION"]},
+                        {"span": ["RETURN_TYPE", "FUNCTION"]},
+                        {"literal": "void"},
+                    ],
+                },
             },
         },
 
@@ -300,18 +383,30 @@ regex: ^{class_name}$
         # compound_statement; a DOTALL `^{ ... }$` capture folds the entire
         # upstream body (`\1`) between a lambda prefix and its `}();`
         # invocation, so the body's own lines are re-emitted verbatim, then
-        # appends `epilogue` as the body's trailing statements.
-        # `capture` is empty (a void wrap: `[&]() {...}();`) or an
-        # `auto <var> =` lead so the epilogue can read the wrapped body's return
-        # value. The caller passes `epilogue` indented to the body level and
-        # both spliced values with backslashes escaped for the `re.sub`
+        # appends `epilogue` as the body's trailing statements. The lambda
+        # states the enclosing function's `return_type` rather than deducing
+        # one, so a body returning `{}` still compiles and a `T&` return is not
+        # quietly deduced to a `T` copy. The caller passes `epilogue` indented
+        # to the body level, with backslashes escaped for the `re.sub`
         # replacement.
+        # `result_var` is optional: when the caller names one, `when_set`
+        # expands it to a declaration binding the wrapped body's value, and
+        # when it is empty the placeholder renders as nothing, leaving a bare
+        # void wrap. The variable is declared with the same `return_type` the
+        # lambda returns, which keeps a reference or pointer return exactly as
+        # upstream declared it (an `auto` lead would decay `const T&` to a `T`
+        # copy).
         "cxx.after_function_impl": {
             "matcher": "cxx.find_function_body",
-            "inputs": ["function_name", "capture", "epilogue"],
+            "inputs": ["function_name", "result_var", "epilogue"],
+            "when_set": {
+                "result_var": "{return_type} {result_var} = ",
+            },
             "replace": {
                 "re_pattern": "(?s)^\\{(.*)\\}$",
-                "replace": "{{\\n  {capture}[&]() {{\\1  }}();\\n{epilogue}\\n}}",
+                "replace":
+                "{{\\n  {result_var}[&]() -> {return_type} "
+                "{{\\1  }}();\\n{epilogue}\\n}}",
             },
             "result": {
                 "node": "compound_statement",


### PR DESCRIPTION
This PR adds support to catpture for an `ast-grep` matcher. These are
additional values that a given matcher can provide if necessary. In this
particular case, we are introducing this functionality to permit us to
capture the return type of a given function matched with
`cxx.find_function_body`.

With this change, we now emit the return for the lambda created by
`after_function_impl`, which solves two problems: The lambda now doesn't
have to deduce the return type from the return statements in the body of
the fucntion, which can lead to build failures if two return statement
have different types, and this also avoids straight deductions for cases
where implicit coversion was the norm before.

Fixed: https://github.com/brave/brave-browser/issues/57583
