### PR TITLE
Fix race where playlist item is downloaded twice

### DIFF
--- a/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
@@ -24,6 +24,9 @@ public class PlaylistManager: NSObject {
   private let cacheManager = PlaylistDownloadManager()
   private var frc = PlaylistItem.frc()
   private var didRestoreSession = false
+  /// In-flight download work keyed by item id. Holds the `Task` doing mime-type probing (which eventually kicks off the URLSession download)
+  /// so duplicate requests are rejected and cancellation stops probe work that hasn't reached `cacheManager` yet.
+  @MainActor private var pendingDownloadTasks = [String: (id: UUID, task: Task<Void, Never>)]()
 
   private var _playbackTask: Task<Void, Error>?
 
@@ -241,7 +244,10 @@ public class PlaylistManager: NSObject {
   }
 
   public func cacheState(for itemId: String) async -> PlaylistDownloadManager.CacheState {
-    if cacheManager.downloadTask(for: itemId) != nil {
+    let isInProgress = await MainActor.run {
+      pendingDownloadTasks[itemId] != nil || cacheManager.downloadTask(for: itemId) != nil
+    }
+    if isInProgress {
       return .inProgress
     }
 
@@ -334,35 +340,68 @@ public class PlaylistManager: NSObject {
     guard
       FeatureList.kPlaylistOfflineCacheEnabled.enabled
         || FeatureList.kPlaylistCacheFirstEnabled.enabled,
-      cacheManager.downloadTask(for: item.tagId) == nil,
       let assetUrl = URL(string: item.src)
     else { return }
-    Task {
-      if assetUrl.scheme == "data" {
-        DispatchQueue.main.async {
-          self.cacheManager.downloadDataAsset(assetUrl, for: item)
-        }
-        return
+
+    let itemId = item.tagId
+    Task { @MainActor in
+      guard pendingDownloadTasks[itemId] == nil,
+        cacheManager.downloadTask(for: itemId) == nil
+      else { return }
+
+      let registrationId = UUID()
+      let downloadTask = Task { [weak self] in
+        guard let self else { return }
+        await self.downloadItem(
+          item,
+          assetUrl: assetUrl,
+          itemId: itemId,
+          registrationId: registrationId
+        )
       }
+      pendingDownloadTasks[itemId] = (registrationId, downloadTask)
+    }
+  }
 
-      let mimeType = await PlaylistMediaStreamer.getMimeType(assetUrl)
-      guard let mimeType = mimeType?.lowercased() else { return }
+  private func downloadItem(
+    _ item: PlaylistInfo,
+    assetUrl: URL,
+    itemId: String,
+    registrationId: UUID
+  ) async {
+    defer {
+      Task { @MainActor in
+        if pendingDownloadTasks[itemId]?.id == registrationId {
+          pendingDownloadTasks.removeValue(forKey: itemId)
+        }
+      }
+    }
 
+    if assetUrl.scheme == "data" {
+      await MainActor.run {
+        self.cacheManager.downloadDataAsset(assetUrl, for: item)
+      }
+      return
+    }
+
+    let mimeType = await PlaylistMediaStreamer.getMimeType(assetUrl)
+    guard let mimeType = mimeType?.lowercased() else { return }
+
+    await MainActor.run {
       if mimeType.contains("x-mpegurl") || mimeType.contains("application/vnd.apple.mpegurl")
         || mimeType.contains("mpegurl")
       {
-        DispatchQueue.main.async {
-          self.cacheManager.downloadHLSAsset(assetUrl, for: item)
-        }
+        self.cacheManager.downloadHLSAsset(assetUrl, for: item)
       } else {
-        DispatchQueue.main.async {
-          self.cacheManager.downloadFileAsset(assetUrl, for: item)
-        }
+        self.cacheManager.downloadFileAsset(assetUrl, for: item)
       }
     }
   }
 
+  @MainActor
   public func cancelDownload(itemId: String) {
+    pendingDownloadTasks[itemId]?.task.cancel()
+    pendingDownloadTasks.removeValue(forKey: itemId)
     cacheManager.cancelDownload(itemId: itemId)
   }
 

--- a/ios/brave-ios/Sources/Playlist/PlaylistMediaStreamer.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistMediaStreamer.swift
@@ -64,7 +64,8 @@ public class PlaylistMediaStreamer {
     // Cache-first: the stored URL is still valid, so `streamingFallback` (which would otherwise kick off caching via `autoDownload`)
     // isn't reached. Start a background cache here so the item is available locally next time. Gated on the kPlaylistCacheFirstEnabled
     // flag so the kPlaylistOfflineCacheEnabled offline-cache path  is unaffected.
-    if FeatureList.kPlaylistCacheFirstEnabled.enabled {
+    // Skip if a download is already pending or in progress (e.g. triggered when the item was added).
+    if FeatureList.kPlaylistCacheFirstEnabled.enabled, cacheState == .invalid {
       PlaylistManager.shared.autoDownload(item: item)
     }
 


### PR DESCRIPTION
## Summary
This PR fixes a bug on iOS where saving a video or audio to Playlist and then opening it to play could result in a double cache for the same item.

Playlist now keeps track of each in-progress download so the same item isn’t saved twice. If you delete an item or cancel a download while it’s still starting, that download is actually stopped instead of continuing in the background.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/57523

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
