### PR TITLE
[recipes] Clone Chromium from git-cache

### DIFF
--- a/tools/recipes/recipe_modules/chromium_checkout/__init__.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/__init__.py
@@ -4,4 +4,4 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """`chromium_checkout` module: clone / sync / validate a Chromium src/ tree."""
 
-DEPS = ['path', 'step', 'depot_tools', 'env', 'platform']
+DEPS = ['path', 'step', 'context', 'depot_tools', 'env', 'platform']

--- a/tools/recipes/recipe_modules/chromium_checkout/api.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/api.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+import contextlib
+import functools
 import logging
 from pathlib import Path
 import re
@@ -23,15 +25,51 @@ WIN_HERMETIC_TOOLCHAIN_BASE_URL = (
     'https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-'
     '2.on.aws/windows-hermetic-toolchain/')
 
+# The URL for Chromium's googlesource.
+CHROMIUM_URL = 'https://chromium.googlesource.com/chromium/src.git'
+
 
 class ChromiumCheckoutApi(RecipeApi):
     """Clones, syncs, and validates a Chromium `src/` checkout."""
 
+    @contextlib.contextmanager
+    def chromium_layout(self):
+        """Context manager entered before any Chromium checkout operation.
+
+        Responsible for basic environment initialization.
+        """
+        with self.m.context(
+                env=
+            {
+                # CHROME_HEADLESS makes sure that running `gclient
+                # runhooks` and other tools don't require user
+                # interaction.
+                'CHROME_HEADLESS': '1',
+            }):
+            yield
+
+    def _with_chromium_layout(fn):
+        """Decorator applying `chromium_layout()` to a bound
+        `ChromiumCheckoutApi` method.
+
+        INTERNAL: decorates `ChromiumCheckoutApi` member functions only; do
+        not use outside this class/module.
+        """
+
+        @functools.wraps(fn)
+        def inner(self, *args, **kwargs):
+            with self.chromium_layout():
+                return fn(self, *args, **kwargs)
+
+        return inner
+
+    @_with_chromium_layout
     def ensure_checkout(self,
                         *,
                         chromium_src: str | Path | None = None,
                         ref: str | None = None,
-                        git_cache: str | Path | None = None) -> Path:
+                        git_cache: str | Path | None = None,
+                        depth: int | None = None) -> Path:
         """Guarantee a Chromium checkout at *chromium_src*, optionally on *ref*.
 
         Clones a fresh checkout if *chromium_src* is not already a valid
@@ -44,6 +82,9 @@ class ChromiumCheckoutApi(RecipeApi):
             git_cache: Optional explicit git cache directory. When given it sets
                 `GIT_CACHE_PATH`; otherwise an existing `GIT_CACHE_PATH` in the
                 environment is used as-is.
+            depth: Optional history depth for the shared git-cache mirror (see
+                `clone`/`checkout_ref`). `None` fetches full history, matching
+                `git cache populate`'s own default.
 
         Returns:
             The resolved absolute `src/` path.
@@ -56,18 +97,18 @@ class ChromiumCheckoutApi(RecipeApi):
             self.set_git_cache(git_cache or None)
         self.validate_git_cache()
 
-        # depot_tools provides `fetch`/`gclient`, needed whether we clone or
-        # operate on an existing checkout.
+        # depot_tools provides `fetch`/`gclient`/`git cache`, needed whether we
+        # clone or operate on an existing checkout.
         self.m.depot_tools.ensure_on_path()
 
         # No valid checkout yet -> clone one.
         if not self.has_valid_checkout(chromium_src):
             logging.info('Chromium src not found at %s, cloning...',
                          chromium_src)
-            self.clone(chromium_src)
+            self.clone(chromium_src, depth=depth)
 
         if ref:
-            self.checkout_ref(chromium_src, ref)
+            self.checkout_ref(chromium_src, ref, depth=depth)
         return chromium_src
 
     def validate_git_cache(self) -> str:
@@ -154,14 +195,53 @@ class ChromiumCheckoutApi(RecipeApi):
             return False
         return True
 
-    def clone(self, chromium_src: str | Path) -> None:
-        """Clone a fresh Chromium checkout at *chromium_src* via `fetch`."""
+    def clone(self,
+              chromium_src: str | Path,
+              *,
+              depth: int | None = None) -> None:
+        """Clone a fresh Chromium checkout at *chromium_src*.
+
+        Rather than a plain network clone, `git cache populate` fetches into
+        a persistent, shared bare mirror under `GIT_CACHE_PATH` (reused across
+        every checkout and build on this machine, not just this one), and the
+        working checkout is a `--local --shared` clone of it, so re-cloning is
+        disk I/O rather than a repeat of the same network fetch.
+        """
         chromium_src = Path(chromium_src)
         self.m.path.mkdir(chromium_src.parent)
-        self.m.step('fetch chromium', ['fetch', '--nohooks', 'chromium'],
+
+        # Writes the `.gclient` solution file so `gclient sync` (for DEPS, in
+        # `checkout_ref`) knows about the `src` solution once it exists below.
+        self.m.step('gclient config', [
+            'gclient', 'config', '--name', 'src', '--unmanaged', CHROMIUM_URL
+        ],
                     cwd=chromium_src.parent)
 
-    def checkout_ref(self, chromium_src: str | Path, ref: str) -> None:
+        git_cache_path = self.validate_git_cache()
+        mirror_dir = self._populate_git_cache(
+            git_cache_path,
+            CHROMIUM_URL,
+            depth=depth,
+            populate_step='git cache populate',
+            exists_step='git cache exists')
+        # `--local --shared`: a same-volume, hardlink-sharing clone of the
+        # mirror, effectively free compared to a network clone. `origin` ends up
+        # pointing at `mirror_dir` (the clone source), which is exactly what we
+        # want for `checkout_ref`'s subsequent fetches to stay local too.
+        self.m.step('clone from git cache', [
+            'git', 'clone', '--no-checkout', '--local', '--shared', mirror_dir,
+            chromium_src
+        ])
+        self._disable_git_gc(chromium_src)
+        self.m.step('checkout origin/HEAD',
+                    ['git', 'checkout', '--force', 'origin/HEAD', '--'],
+                    cwd=chromium_src)
+
+    def checkout_ref(self,
+                     chromium_src: str | Path,
+                     ref: str,
+                     *,
+                     depth: int | None = None) -> None:
         """Check out *ref* in *chromium_src* and resync dependencies."""
         chromium_src = Path(chromium_src)
         logging.info('Checking out Chromium ref %s', ref)
@@ -171,7 +251,34 @@ class ChromiumCheckoutApi(RecipeApi):
             self.m.env.set('DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL',
                            WIN_HERMETIC_TOOLCHAIN_BASE_URL)
 
-        if re.fullmatch(r'\d+\.\d+\.\d+\.\d+', ref):
+        is_tag = bool(re.fullmatch(r'\d+\.\d+\.\d+\.\d+', ref))
+
+        git_cache_path = self.validate_git_cache()
+        # The mirror's default `refs/heads/*` fetch already covers branches;
+        # tags need an explicit ref, since fetching every tag chromium/src has
+        # ever had would be far more expensive than the one we actually want.
+        mirror_dir = self._populate_git_cache(
+            git_cache_path,
+            CHROMIUM_URL,
+            ref=f'refs/tags/{ref}' if is_tag else None,
+            depth=depth,
+            populate_step='git cache populate for ref',
+            exists_step='git cache exists for ref')
+
+        # `chromium_src` may already exist from a prior run (or from before
+        # this checkout started using a git cache mirror at all), so point
+        # `origin` at the mirror unconditionally rather than assuming `clone`
+        # already did it. Everything below then runs as local disk I/O instead
+        # of talking to the real remote.
+        self.m.step('point origin at git cache',
+                    ['git', 'remote', 'set-url', 'origin', mirror_dir],
+                    cwd=chromium_src)
+        self.m.step(
+            'restore origin push url',
+            ['git', 'remote', 'set-url', '--push', 'origin', CHROMIUM_URL],
+            cwd=chromium_src)
+
+        if is_tag:
             # Chromium release tag (e.g. `150.0.7850.1`): fetch it as a tag so
             # it lands at `refs/tags/<ref>` in the local repo.
             self.m.step('fetch tag', [
@@ -191,3 +298,61 @@ class ChromiumCheckoutApi(RecipeApi):
                     cwd=chromium_src)
         self.m.step('gclient sync', ['gclient', 'sync', '--force', '-D'],
                     cwd=chromium_src)
+
+    def _populate_git_cache(self,
+                            git_cache_path: str | Path,
+                            url: str,
+                            *,
+                            ref: str | None = None,
+                            depth: int | None = None,
+                            populate_step: str,
+                            exists_step: str) -> str:
+        """Populate (or refresh) the shared bare mirror for *url*.
+
+        `git cache populate` fetches into a persistent bare mirror under
+        `GIT_CACHE_PATH`, which is reused across every checkout and build on
+        this machine, rather than the working checkout talking to the remote
+        directly. `--no-fetch-tags` skips chromium/src's huge tag history. The
+        mirror's default `refs/heads/*` fetch already covers branches, so a
+        specific tag *ref* is fetched precisely via `--ref` instead of ever
+        needing the full tag catalog.
+
+        Args:
+            git_cache_path: `GIT_CACHE_PATH` (the `--cache-dir` for `git
+                cache`).
+            url: The repo to mirror.
+            ref: An additional fully-qualified ref (e.g. `refs/tags/<tag>`) to
+                fetch into the mirror, beyond its default `refs/heads/*`.
+            depth: Optional history depth; `None` fetches full history.
+            populate_step: Step name for the `git cache populate` call.
+            exists_step: Step name for the `git cache exists` call.
+
+        Returns:
+            The absolute path to the mirror directory.
+        """
+        populate_cmd = [
+            'git', 'cache', 'populate', '--cache-dir', git_cache_path, url,
+            '--reset-fetch-config', '--no-fetch-tags'
+        ]
+        if ref:
+            populate_cmd.extend(['--ref', ref])
+        if depth:
+            populate_cmd.extend(['--depth', str(depth)])
+        self.m.step(populate_step, populate_cmd)
+
+        return self.m.step(exists_step, [
+            'git', 'cache', 'exists', '--quiet', '--cache-dir', git_cache_path,
+            url
+        ],
+                           capture_output=True).stdout.strip()
+
+    def _disable_git_gc(self, chromium_src: str | Path) -> None:
+        """Disable background gc in *chromium_src*.
+
+        A shared, long-lived checkout can have several tools touching it
+        around the same time, and an auto-triggered `git gc` racing with them
+        (or being killed midway) can corrupt the repo.
+        """
+        for key in ('gc.auto', 'gc.autodetach', 'gc.autopacklimit'):
+            self.m.step(f'git config {key}=0', ['git', 'config', key, '0'],
+                        cwd=chromium_src)

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/existing_branch.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/existing_branch.json
@@ -8,12 +8,18 @@
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
     ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "clone depot_tools"
   },
   {
     "cmd": [
       "gclient"
     ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "verify gclient"
   },
   {
@@ -25,7 +31,70 @@
       "chrome/VERSION"
     ],
     "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "check chrome/VERSION"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "populate",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git",
+      "--reset-fetch-config",
+      "--no-fetch-tags"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate for ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache exists for ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "remote",
+      "set-url",
+      "origin",
+      "/b/cache/chromium.googlesource.com-chromium-src"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "point origin at git cache"
+  },
+  {
+    "cmd": [
+      "git",
+      "remote",
+      "set-url",
+      "--push",
+      "origin",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "restore origin push url"
   },
   {
     "cmd": [
@@ -35,6 +104,9 @@
       "main"
     ],
     "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "fetch ref"
   },
   {
@@ -45,6 +117,9 @@
       "FETCH_HEAD"
     ],
     "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "checkout FETCH_HEAD"
   },
   {
@@ -55,6 +130,9 @@
       "-D"
     ],
     "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "gclient sync"
   },
   {

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/fresh_tag.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/fresh_tag.json
@@ -8,22 +8,195 @@
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
     ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "clone depot_tools"
   },
   {
     "cmd": [
       "gclient"
     ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "verify gclient"
   },
   {
     "cmd": [
-      "fetch",
-      "--nohooks",
-      "chromium"
+      "gclient",
+      "config",
+      "--name",
+      "src",
+      "--unmanaged",
+      "https://chromium.googlesource.com/chromium/src.git"
     ],
     "cwd": "[WORKSPACE]/brave-browser",
-    "name": "fetch chromium"
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "gclient config"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "populate",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git",
+      "--reset-fetch-config",
+      "--no-fetch-tags"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache exists"
+  },
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--no-checkout",
+      "--local",
+      "--shared",
+      "/b/cache/chromium.googlesource.com-chromium-src",
+      "[WORKSPACE]/brave-browser/src"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "clone from git cache"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.auto",
+      "0"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git config gc.auto=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autodetach",
+      "0"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git config gc.autodetach=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autopacklimit",
+      "0"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git config gc.autopacklimit=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "checkout",
+      "--force",
+      "origin/HEAD",
+      "--"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "checkout origin/HEAD"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "populate",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git",
+      "--reset-fetch-config",
+      "--no-fetch-tags",
+      "--ref",
+      "refs/tags/151.0.7917.1"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate for ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache exists for ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "remote",
+      "set-url",
+      "origin",
+      "/b/cache/chromium.googlesource.com-chromium-src"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "point origin at git cache"
+  },
+  {
+    "cmd": [
+      "git",
+      "remote",
+      "set-url",
+      "--push",
+      "origin",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "restore origin push url"
   },
   {
     "cmd": [
@@ -34,6 +207,9 @@
       "refs/tags/151.0.7917.1:refs/tags/151.0.7917.1"
     ],
     "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "fetch tag"
   },
   {
@@ -44,6 +220,9 @@
       "FETCH_HEAD"
     ],
     "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "checkout FETCH_HEAD"
   },
   {
@@ -54,6 +233,9 @@
       "-D"
     ],
     "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "gclient sync"
   },
   {

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_hermetic_toolchain.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_hermetic_toolchain.json
@@ -8,12 +8,18 @@
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
     ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "clone depot_tools"
   },
   {
     "cmd": [
       "gclient"
     ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "verify gclient"
   },
   {
@@ -25,7 +31,70 @@
       "chrome/VERSION"
     ],
     "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "check chrome/VERSION"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "populate",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git",
+      "--reset-fetch-config",
+      "--no-fetch-tags"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate for ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache exists for ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "remote",
+      "set-url",
+      "origin",
+      "/b/cache/chromium.googlesource.com-chromium-src"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "point origin at git cache"
+  },
+  {
+    "cmd": [
+      "git",
+      "remote",
+      "set-url",
+      "--push",
+      "origin",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "restore origin push url"
   },
   {
     "cmd": [
@@ -35,6 +104,9 @@
       "main"
     ],
     "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "fetch ref"
   },
   {
@@ -45,6 +117,9 @@
       "FETCH_HEAD"
     ],
     "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "checkout FETCH_HEAD"
   },
   {
@@ -55,6 +130,9 @@
       "-D"
     ],
     "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "gclient sync"
   },
   {

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.py
@@ -25,14 +25,23 @@ def RunSteps(api, properties):
 
 
 def GenTests(api):
-    # No existing checkout -> clone, then check out a release tag.
+    # No existing checkout -> clone via a shared git-cache mirror, then check
+    # out a release tag (also fetched into the mirror first).
     yield api.test(
         'fresh tag',
         api.chromium_checkout.with_git_cache(),
+        api.chromium_checkout.git_cache_populated(),
         api.properties(chromium_ref='151.0.7917.1'),
-        api.post_process(post_process.MustRun, 'fetch chromium'),
+        api.post_process(post_process.MustRun, 'gclient config'),
+        api.post_process(post_process.MustRun, 'git cache populate'),
+        api.post_process(post_process.MustRun, 'clone from git cache'),
+        api.post_process(post_process.MustRun, 'checkout origin/HEAD'),
+        api.post_process(post_process.MustRun, 'git cache populate for ref'),
         api.post_process(post_process.MustRun, 'fetch tag'),
         api.post_process(post_process.MustRun, 'gclient sync'),
+        api.post_process(post_process.StepCommandContains,
+                         'git cache populate for ref',
+                         ['--ref', 'refs/tags/151.0.7917.1']),
         api.post_process(post_process.StatusSuccess),
     )
     # Existing checkout (chrome/VERSION present) + a branch ref -> no clone,
@@ -41,9 +50,12 @@ def GenTests(api):
         'existing branch',
         api.chromium_checkout.with_git_cache(),
         api.chromium_checkout.existing_checkout(),
+        api.chromium_checkout.git_cache_populated(),
         api.properties(chromium_ref='main'),
         api.post_process(post_process.MustRun, 'check chrome/VERSION'),
-        api.post_process(post_process.DoesNotRun, 'fetch chromium'),
+        api.post_process(post_process.DoesNotRun, 'gclient config'),
+        api.post_process(post_process.DoesNotRun, 'clone from git cache'),
+        api.post_process(post_process.MustRun, 'point origin at git cache'),
         api.post_process(post_process.MustRun, 'fetch ref'),
         api.post_process(post_process.StatusSuccess),
     )
@@ -61,6 +73,7 @@ def GenTests(api):
         api.platform.name('win'),
         api.chromium_checkout.with_git_cache(),
         api.chromium_checkout.existing_checkout(),
+        api.chromium_checkout.git_cache_populated(),
         api.properties(chromium_ref='main'),
         api.post_process(post_process.MustRun, 'win toolchain env'),
         api.post_process(

--- a/tools/recipes/recipe_modules/chromium_checkout/test_api.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/test_api.py
@@ -17,6 +17,9 @@ from recipe_test_api import RecipeTestApi, TestData
 # Default simulated git cache directory.
 _GIT_CACHE = '/b/cache'
 
+# Default simulated mirror directory `git cache exists` resolves to.
+_MIRROR_DIR = '/b/cache/chromium.googlesource.com-chromium-src'
+
 
 class ChromiumCheckoutTestApi(RecipeTestApi):
     """Seed the simulated state `chromium_checkout.ensure_checkout` requires."""
@@ -28,3 +31,14 @@ class ChromiumCheckoutTestApi(RecipeTestApi):
     def existing_checkout(self) -> TestData:
         """Simulate a valid existing checkout (`chrome/VERSION` present)."""
         return self.m.path.files('brave-browser/src/chrome/VERSION')
+
+    def git_cache_populated(self, mirror_dir: str = _MIRROR_DIR) -> TestData:
+        """Seed `clone`/`checkout_ref`'s `git cache exists` lookups.
+
+        Both `clone` and `checkout_ref` run a `git cache exists` step to
+        resolve the mirror directory `git cache populate` just fetched into;
+        required whenever either of them runs, since the simulated stdout is
+        `None` (not an empty string) unless seeded.
+        """
+        return (self.step_data('git cache exists', stdout=mirror_dir) +
+                self.step_data('git cache exists for ref', stdout=mirror_dir))

--- a/tools/recipes/recipe_modules/chromium_checkout/tests/depth.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/tests/depth.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Test for `ensure_checkout`'s optional `depth` -- threaded down into
+`git cache populate --depth` for a shallower shared mirror.
+"""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['chromium_checkout']
+
+
+def RunSteps(api):
+    api.chromium_checkout.ensure_checkout(ref='151.0.7917.1', depth=1)
+
+
+def GenTests(api):
+    yield api.test(
+        'shallow',
+        api.chromium_checkout.with_git_cache(),
+        api.chromium_checkout.git_cache_populated(),
+        api.post_process(post_process.StepCommandContains,
+                         'git cache populate', ['--depth', '1']),
+        api.post_process(post_process.StepCommandContains,
+                         'git cache populate for ref', ['--depth', '1']),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )

--- a/tools/recipes/recipe_modules/chromium_checkout/tests/git_cache.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/tests/git_cache.py
@@ -40,6 +40,7 @@ def GenTests(api):
         api.path.dirs('/b/cache'),
         api.path.files('brave-browser/src/chrome/VERSION'),
         api.env.on_path('gclient', '/dt/gclient'),
+        api.chromium_checkout.git_cache_populated(),
         api.post_process(post_process.StatusSuccess),
         api.post_process(post_process.DropExpectation),
     )
@@ -84,10 +85,12 @@ def GenTests(api):
         api.env.set('MODE', 'invalid_checkout'),
         api.chromium_checkout.with_git_cache(),
         api.chromium_checkout.existing_checkout(),
+        api.chromium_checkout.git_cache_populated(),
         api.env.on_path('gclient', '/dt/gclient'),
         api.step.data('check chrome/VERSION', retcode=1),
         api.post_process(post_process.MustRun, 'check chrome/VERSION'),
-        api.post_process(post_process.MustRun, 'fetch chromium'),
+        api.post_process(post_process.MustRun, 'gclient config'),
+        api.post_process(post_process.MustRun, 'clone from git cache'),
         api.post_process(post_process.StatusSuccess),
         api.post_process(post_process.DropExpectation),
     )

--- a/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
@@ -8,22 +8,199 @@
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
     ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "clone depot_tools"
   },
   {
     "cmd": [
       "gclient"
     ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "verify gclient"
   },
   {
     "cmd": [
-      "fetch",
-      "--nohooks",
-      "chromium"
+      "gclient",
+      "config",
+      "--name",
+      "src",
+      "--unmanaged",
+      "https://chromium.googlesource.com/chromium/src.git"
     ],
     "cwd": "[WORKSPACE]/brave-browser",
-    "name": "fetch chromium"
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "gclient config"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "populate",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git",
+      "--reset-fetch-config",
+      "--no-fetch-tags",
+      "--depth",
+      "1"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache exists"
+  },
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--no-checkout",
+      "--local",
+      "--shared",
+      "/b/cache/chromium.googlesource.com-chromium-src",
+      "[WORKSPACE]/brave-browser/src"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "clone from git cache"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.auto",
+      "0"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git config gc.auto=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autodetach",
+      "0"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git config gc.autodetach=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autopacklimit",
+      "0"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git config gc.autopacklimit=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "checkout",
+      "--force",
+      "origin/HEAD",
+      "--"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "checkout origin/HEAD"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "populate",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git",
+      "--reset-fetch-config",
+      "--no-fetch-tags",
+      "--ref",
+      "refs/tags/151.0.7917.1",
+      "--depth",
+      "1"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate for ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache exists for ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "remote",
+      "set-url",
+      "origin",
+      "/b/cache/chromium.googlesource.com-chromium-src"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "point origin at git cache"
+  },
+  {
+    "cmd": [
+      "git",
+      "remote",
+      "set-url",
+      "--push",
+      "origin",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "restore origin push url"
   },
   {
     "cmd": [
@@ -34,6 +211,9 @@
       "refs/tags/151.0.7917.1:refs/tags/151.0.7917.1"
     ],
     "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "fetch tag"
   },
   {
@@ -44,6 +224,9 @@
       "FETCH_HEAD"
     ],
     "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "checkout FETCH_HEAD"
   },
   {
@@ -54,6 +237,9 @@
       "-D"
     ],
     "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "gclient sync"
   },
   {

--- a/tools/recipes/recipes/toolchains/rust/package_rust.py
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.py
@@ -26,7 +26,8 @@ def RunSteps(api: RecipeScriptApi, properties: InputProperties,
              env_properties: EnvProperties) -> None:
     chromium_src = api.chromium_checkout.ensure_checkout(
         ref=properties.chromium_ref,
-        git_cache=env_properties.GIT_CACHE or None)
+        git_cache=env_properties.GIT_CACHE or None,
+        depth=1)
 
     brave_core_root = api.brave_core_checkout.deploy('tools/cr/toolchains')
 
@@ -52,13 +53,18 @@ def GenTests(api):
     yield api.test(
         'linux',
         api.chromium_checkout.with_git_cache(),
+        api.chromium_checkout.git_cache_populated(),
         api.brave_core_checkout.deployed('tools/cr/toolchains'),
         api.properties(brave_subrevision=1, chromium_ref='151.0.7917.1'),
-        api.post_process(post_process.MustRun, 'fetch chromium'),
+        api.post_process(post_process.MustRun, 'clone from git cache'),
         api.post_process(post_process.MustRun, 'fetch tag'),
         api.post_process(post_process.MustRun, 'build rust toolchain'),
         api.post_process(post_process.StepCommandContains,
                          'build rust toolchain', ['--brave-subrevision', '1']),
+        api.post_process(post_process.StepCommandContains,
+                         'git cache populate', ['--depth', '1']),
+        api.post_process(post_process.StepCommandContains,
+                         'git cache populate for ref', ['--depth', '1']),
         api.post_process(post_process.StatusSuccess),
     )
     # Without a git cache, the checkout refuses to run.

--- a/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/linux.json
+++ b/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/linux.json
@@ -8,22 +8,199 @@
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
     ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "clone depot_tools"
   },
   {
     "cmd": [
       "gclient"
     ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "verify gclient"
   },
   {
     "cmd": [
-      "fetch",
-      "--nohooks",
-      "chromium"
+      "gclient",
+      "config",
+      "--name",
+      "src",
+      "--unmanaged",
+      "https://chromium.googlesource.com/chromium/src.git"
     ],
     "cwd": "[WORKSPACE]/brave-browser",
-    "name": "fetch chromium"
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "gclient config"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "populate",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git",
+      "--reset-fetch-config",
+      "--no-fetch-tags",
+      "--depth",
+      "1"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache exists"
+  },
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--no-checkout",
+      "--local",
+      "--shared",
+      "/b/cache/chromium.googlesource.com-chromium-src",
+      "[WORKSPACE]/brave-browser/src"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "clone from git cache"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.auto",
+      "0"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git config gc.auto=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autodetach",
+      "0"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git config gc.autodetach=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autopacklimit",
+      "0"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git config gc.autopacklimit=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "checkout",
+      "--force",
+      "origin/HEAD",
+      "--"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "checkout origin/HEAD"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "populate",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git",
+      "--reset-fetch-config",
+      "--no-fetch-tags",
+      "--ref",
+      "refs/tags/151.0.7917.1",
+      "--depth",
+      "1"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate for ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache exists for ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "remote",
+      "set-url",
+      "origin",
+      "/b/cache/chromium.googlesource.com-chromium-src"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "point origin at git cache"
+  },
+  {
+    "cmd": [
+      "git",
+      "remote",
+      "set-url",
+      "--push",
+      "origin",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "restore origin push url"
   },
   {
     "cmd": [
@@ -34,6 +211,9 @@
       "refs/tags/151.0.7917.1:refs/tags/151.0.7917.1"
     ],
     "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "fetch tag"
   },
   {
@@ -44,6 +224,9 @@
       "FETCH_HEAD"
     ],
     "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "checkout FETCH_HEAD"
   },
   {
@@ -54,6 +237,9 @@
       "-D"
     ],
     "cwd": "[WORKSPACE]/brave-browser/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
     "name": "gclient sync"
   },
   {

--- a/tools/recipes/recipes/tools/ast_grep/package_ast_grep.py
+++ b/tools/recipes/recipes/tools/ast_grep/package_ast_grep.py
@@ -26,7 +26,8 @@ def RunSteps(api: RecipeScriptApi, properties: InputProperties,
              env_properties: EnvProperties) -> None:
     api.chromium_checkout.ensure_checkout(ref=properties.chromium_ref,
                                           git_cache=env_properties.GIT_CACHE
-                                          or None)
+                                          or None,
+                                          depth=1)
 
     brave_root = api.brave_core_checkout.deploy([
         'third_party/ast-grep',
@@ -48,10 +49,15 @@ def GenTests(api):
     yield api.test(
         'linux',
         api.chromium_checkout.with_git_cache(),
+        api.chromium_checkout.git_cache_populated(),
         api.brave_core_checkout.deployed('third_party/ast-grep',
                                          'tools/cr/toolchains'),
         api.properties(chromium_ref='151.0.7917.1'),
-        api.post_process(post_process.MustRun, 'fetch chromium'),
+        api.post_process(post_process.MustRun, 'clone from git cache'),
         api.post_process(post_process.MustRun, 'package ast-grep'),
+        api.post_process(post_process.StepCommandContains,
+                         'git cache populate', ['--depth', '1']),
+        api.post_process(post_process.StepCommandContains,
+                         'git cache populate for ref', ['--depth', '1']),
         api.post_process(post_process.StatusSuccess),
     )


### PR DESCRIPTION
`chromium_checkout.clone()`/`checkout_ref()` used to fetch straight
from chromium.googlesource.com on every run: `fetch chromium` for the
initial clone, then a raw `git fetch origin <ref>` to move to the
requested tag/branch. Although these operations are backed by git
cache, they were not as efficient as they could have been.

We now make sure to first do `git cache populate`: this provides us
with a persistent, shared bare mirror under `GIT_CACHE_PATH`,
incrementally fetched (not re-cloned) on every call. The actual working
checkout is then a `--local --shared` clone of (or local fetch from)
that mirror, so repeated runs against different refs on the same
machine become local disk I/O instead of a repeat network fetch.
`--no-fetch-tags` keeps the mirror from pulling chromium/src's entire
tag history, whilst `checkout_ref` fetches the one tag it needs into
the mirror via `--ref refs/tags/<tag>`, precisely and every time (so a
newly-published tag is never stale). `origin` is repointed at the
mirror unconditionally in `checkout_ref`, so this also self-heals an
existing checkout from before this change.

Background gc is disabled on a fresh clone (`gc.auto`/`gc.autodetach`/
`gc.autopacklimit`), since a shared long-lived checkout can have
several tools touching it around the same time.

This hopefully will make cloning Chromium in the bots cheaper.

Finally, `chromium_checkout` gained a `chromium_layout()` context
manager that sets `CHROME_HEADLESS=1` for every step it runs, so
`gclient runhooks` and friends never block on interactive prompts.

Bug: https://github.com/brave/brave-browser/issues/56748
