### PR TITLE
[iOS] Decouple LinkPreviewViewController from BrowserViewController

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDelegate.swift
@@ -181,7 +181,13 @@ extension BrowserViewController: TabDelegate {
 
     let linkPreview: UIContextMenuContentPreviewProvider? = { [unowned self, weak tab] in
       guard let tab else { return nil }
-      return LinkPreviewViewController(url: url, for: tab, browserController: self)
+      return LinkPreviewViewController(
+        url: url,
+        for: tab,
+        policyDecider: self,
+        tabDelegate: self,
+        downloadDelegate: self
+      )
     }
 
     let linkPreviewProvider = Preferences.General.enableLinkPreview.value ? linkPreview : nil

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/LinkPreviewViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/LinkPreviewViewController.swift
@@ -15,12 +15,22 @@ class LinkPreviewViewController: UIViewController {
   private let url: URL
   private weak var parentTab: (any TabState)?
   private var currentTab: (any TabState)?
-  private weak var browserController: BrowserViewController?
+  private weak var policyDecider: (any TabPolicyDecider)?
+  private weak var tabDelegate: (any TabDelegate)?
+  private weak var downloadDelegate: (any TabDownloadDelegate)?
 
-  init(url: URL, for tab: some TabState, browserController: BrowserViewController) {
+  init(
+    url: URL,
+    for tab: some TabState,
+    policyDecider: (any TabPolicyDecider)?,
+    tabDelegate: any TabDelegate,
+    downloadDelegate: (any TabDownloadDelegate)?
+  ) {
     self.url = url
     self.parentTab = tab
-    self.browserController = browserController
+    self.policyDecider = policyDecider
+    self.tabDelegate = tabDelegate
+    self.downloadDelegate = downloadDelegate
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -28,7 +38,7 @@ class LinkPreviewViewController: UIViewController {
   required init?(coder aDecoder: NSCoder) { fatalError() }
 
   override func viewDidLoad() {
-    guard let browserController, let parentTab else {
+    guard let parentTab else {
       return
     }
 
@@ -42,15 +52,17 @@ class LinkPreviewViewController: UIViewController {
       with: .init(profile: parentTab.profile, initialConfiguration: initialConfiguration)
     )
     tab.createWebView()
-    tab.addPolicyDecider(browserController)
+    if let policyDecider {
+      tab.addPolicyDecider(policyDecider)
+    }
     let braveShieldsTabHelper: BraveShieldsTabHelper = .init(
       tab: tab,
       braveShieldsSettings: BraveShieldsSettingsServiceFactory.get(profile: tab.profile)
     )
     tab.braveShieldsHelper = braveShieldsTabHelper
     tab.addPolicyDecider(braveShieldsTabHelper)
-    tab.delegate = browserController
-    tab.downloadDelegate = browserController
+    tab.delegate = tabDelegate
+    tab.downloadDelegate = downloadDelegate
     tab.webViewProxy?.scrollView?.layer.masksToBounds = true
     tab.isVisible = true
     self.currentTab = tab
@@ -80,8 +92,8 @@ class LinkPreviewViewController: UIViewController {
   }
 
   deinit {
-    if let browserController {
-      currentTab?.removePolicyDecider(browserController)
+    if let policyDecider {
+      currentTab?.removePolicyDecider(policyDecider)
     }
     self.currentTab = nil
   }


### PR DESCRIPTION
 Replace the `browserController: BrowserViewController` parameter with explicit `policyDecider`, `tabDelegate`, and `downloadDelegate` dependencies so the preview can be hosted by QuickViewController.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
