### PR TITLE
[toolchain][deps] Repin Rust/WASM toolchain with `setdep`

### DIFF
--- a/EXTRA_DEPS
+++ b/EXTRA_DEPS
@@ -16,9 +16,7 @@
 #                 * omitted      -- owns its destination (wiped each install).
 #
 # A single-object entry may omit its per-object `condition` and gate on the
-# dep-level one alone. This is a pure literal (parsed as data, not executed),
-# and is repinned textually -- keep it in the format `tools/cr/toolchain.py`'s
-# renderer emits.
+# dep-level one alone.
 
 extra_deps = {
     'src/third_party/rust-toolchain': {

--- a/tools/cr/README.md
+++ b/tools/cr/README.md
@@ -81,16 +81,26 @@ Shared abstractions used by the entry points and tests:
   `install_extra_deps.py sync src/path/to/install/dir`.
 
   Repin an entry in place with the `setdep` subcommand, which rewrites the
-  archive's `object_name`, `sha256sum`, and `size_bytes` while preserving every
-  comment, blank line, and quote style in the `EXTRA_DEPS` file:
+  archive's `object_name`, `sha256sum`, `size_bytes`, and (optionally)
+  `overlayed_on`, while preserving every comment, blank line, and quote style in
+  the `EXTRA_DEPS` file:
 
   ```sh
   install_extra_deps.py setdep \
     -r src/path/to/install/dir@<archive>.tar.xz,<hex sha256>,<size_bytes>
   ```
 
+  For an overlay entry, append the new upstream archive it sits on as a fourth
+  field:
+
+  ```sh
+  install_extra_deps.py setdep \
+    -r src/path/to/install/dir@<archive>.tar.xz,<hex sha256>,<size_bytes>,<upstream archive>
+  ```
+
   Join a multi-object (e.g. per-platform) entry's objects with `?`, in the
-  entry's existing order. Repeat `-r` to repin several entries at once.
+  entry's existing order. Repeat `-r` to repin several entries at once. The
+  object count must match the entry's current count.
 
 ## Subdirectories
 

--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -245,18 +245,18 @@ tools/cr/brockit.py gen-rust-toolchain @latest-canary --watch
 ```
 
 ### `brockit.py update-rust-wasm-toolchain`
-This command repins the Rust/WASM toolchain objects in
-`tools/cr/install_extra_deps.py` to the latest published archives for
-a given Chromium tag's Rust+Clang revision, and commits the change. The tag's
-`tools/rust/update_rust.py` and `tools/clang/scripts/update.py` are read to
-identify the toolchain to pin.
+This command repins the Rust/WASM toolchain objects in `EXTRA_DEPS` to the
+published archive for a given Chromium tag's Rust+Clang revision and Brave
+sub-revision, and commits the change.
 
 ```sh
-tools/cr/brockit.py update-rust-wasm-toolchain --to=150.0.7850.1
+tools/cr/brockit.py update-rust-wasm-toolchain --to=150.0.7850.1 \
+  --brave-subrevision=1
 ```
 
 The `--to` expects a Chromium referecence, and this includes reference labels
-(e.g. `@latest-tag`, etc).
+(e.g. `@latest-tag`, etc). `--brave-subrevision` must name the exact
+sub-revision already published.
 
 Pass `--culprit=<hash>` to reference a specific Chromium commit in the commit
 body. If none is provided, `brockit` uses the last Chromium commit that has
@@ -2258,10 +2258,10 @@ class _RepinToolchainTask(Task):
     def status_message(self) -> str:
         return f'Updating the {self._toolchain.spec.label} toolchain...'
 
-    def execute(self, chromium_ref: str, culprit: str | None):
+    def execute(self, chromium_ref: str, culprit: str | None, **repin_kwargs):
         version = _fetch_chromium_tag(chromium_ref)
         _ensure_chromium_tags(str(version))
-        self._toolchain.repin(version, culprit)
+        self._toolchain.repin(version, culprit, **repin_kwargs)
 
 
 class _GenToolchainTask(Task):
@@ -2645,9 +2645,9 @@ def main():
         parents=[global_parser],
         formatter_class=argparse.RawTextHelpFormatter,
         help='Repins the Rust/WASM toolchain objects in '
-        'tools/cr/install_extra_deps.py to the latest published '
-        'archives for a Chromium tag\'s Rust+Clang revision, and commits the '
-        'change.')
+        'tools/cr/install_extra_deps.py to the published archive for a '
+        'Chromium tag\'s Rust+Clang revision and a given Brave sub-revision, '
+        'and commits the change.')
     update_rust_parser.add_argument(
         '--to',
         required=True,
@@ -2657,6 +2657,12 @@ def main():
             '(e.g. 150.0.7850.1), or one of the @latest-* labels accepted by\n'
             '`lift --to` (e.g. @latest-canary, @latest-m150,\n'
             '@latest-for-branch, @latest-tag).'))
+    update_rust_parser.add_argument(
+        '--brave-subrevision',
+        type=int,
+        required=True,
+        dest='brave_subrevision',
+        help='The published Brave sub-revision to repin')
     update_rust_parser.add_argument(
         '--culprit',
         default=None,
@@ -2730,7 +2736,9 @@ def main():
                 chromium_ref=args.to, culprit=args.culprit)
         if args.command == 'update-rust-wasm-toolchain':
             _RepinToolchainTask(toolchain.RustToolchain()).run(
-                chromium_ref=args.to, culprit=args.culprit)
+                chromium_ref=args.to,
+                culprit=args.culprit,
+                brave_subrevision=args.brave_subrevision)
         gen_toolchains = {
             'gen-rust-toolchain': toolchain.RustToolchain,
             'gen-xcode-toolchain': toolchain.XcodeToolchain,

--- a/tools/cr/install_extra_deps.py
+++ b/tools/cr/install_extra_deps.py
@@ -68,17 +68,30 @@ def _select_object(objects: list[dict],
     return matches[0]
 
 
-# Object keys `setdep` rewrites
-_SETDEP_OBJECT_KEYS = ('object_name', 'sha256sum', 'size_bytes')
+# The optional per-object overlay-base key our own EXTRA_DEPS schema adds on
+# top of upstream's GCS-dep object schema (see the module docstring).
+# `gclient_eval.SetGCS` only knows about upstream's own keys (`object_name`,
+# `sha256sum`, `size_bytes`, `generation`), so `setdep` rewrites this one
+# itself, the same way SetGCS rewrites its own.
+_OVERLAYED_ON_KEY = 'overlayed_on'
+
+# Object keys `setdep` can rewrite: the plain GCS-object triple, always
+# required, plus the optional overlay base.
+_SETDEP_REQUIRED_KEYS = ('object_name', 'sha256sum', 'size_bytes')
+_SETDEP_OBJECT_KEYS = _SETDEP_REQUIRED_KEYS + (_OVERLAYED_ON_KEY, )
 
 
 def _parse_object_spec(spec: str) -> dict[str, str]:
-    """Parse one `object_name,sha256sum,size_bytes` triple from a setdep arg."""
+    """Parse one `object_name,sha256sum,size_bytes[,overlayed_on]` setdep arg.
+    """
     fields = [field.strip() for field in spec.split(',')]
-    if len(fields) != len(_SETDEP_OBJECT_KEYS) or not all(fields):
+    if (len(fields)
+            not in (len(_SETDEP_REQUIRED_KEYS), len(_SETDEP_OBJECT_KEYS))
+            or not all(fields)):
         raise ValueError(
-            f'Object {spec!r} must be `{",".join(_SETDEP_OBJECT_KEYS)}` (all '
-            f'fields required).')
+            f'Object {spec!r} must be `{",".join(_SETDEP_REQUIRED_KEYS)}`, '
+            f'optionally followed by `{_OVERLAYED_ON_KEY}` (no field may be '
+            f'empty).')
     obj = dict(zip(_SETDEP_OBJECT_KEYS, fields))
     if not obj['size_bytes'].isdigit():
         raise ValueError(f'size_bytes must be a non-negative integer, got '
@@ -86,8 +99,24 @@ def _parse_object_spec(spec: str) -> dict[str, str]:
     return obj
 
 
-def _load_editable_extra_deps() -> gclient_eval._NodeDict:
-    """Parse the EXTRA_DEPS file into gclient's token-aware, editable form.
+def format_setdep_revision(path: str, objects: list[dict]) -> str:
+    """Build one `setdep`/`-r` argument from `path`'s current EXTRA_DEPS.
+
+    Renders each object as `object_name,sha256sum,size_bytes`, plus
+    `overlayed_on` when the object has one, joined with `?` in order -- the
+    inverse of `_parse_object_spec`.
+    """
+
+    def render(obj: dict) -> str:
+        keys = (_SETDEP_OBJECT_KEYS
+                if _OVERLAYED_ON_KEY in obj else _SETDEP_REQUIRED_KEYS)
+        return ','.join(str(obj[key]) for key in keys)
+
+    return f'{path}@' + '?'.join(render(obj) for obj in objects)
+
+
+def _load_editable_extra_deps(extra_deps_file: Path) -> gclient_eval._NodeDict:
+    """Parse `extra_deps_file` into gclient's token-aware, editable form.
 
     We drive the tokeniser, capturing every comment, blank line, and quote
     style.
@@ -96,8 +125,8 @@ def _load_editable_extra_deps() -> gclient_eval._NodeDict:
     `deps` mapping, so the table is also exposed under `deps` (sharing the very
     same nodes and tokens) to drive that machinery unchanged.
     """
-    content = EXTRA_DEPS_FILE.read_text(encoding='utf-8')
-    filename = str(EXTRA_DEPS_FILE)
+    content = extra_deps_file.read_text(encoding='utf-8')
+    filename = str(extra_deps_file)
 
     # pylint: disable=protected-access
     tokens = {
@@ -122,35 +151,62 @@ def _load_editable_extra_deps() -> gclient_eval._NodeDict:
     return scope
 
 
-def setdep(revisions: list[str]) -> None:
+def _set_objects(scope: gclient_eval._NodeDict, path: str,
+                 new_objects: list[dict[str, str]]) -> None:
+    """Rewrite one EXTRA_DEPS entry's objects in place, in `scope`'s tokens.
+
+    Delegates `object_name`/`sha256sum`/`size_bytes` to `gclient_eval.SetGCS`,
+    which also enforces the object-count match, then separately rewrites
+    `overlayed_on` for the objects that specify it, since `SetGCS` only knows
+    about upstream's own GCS-dep keys.
+    """
+    gclient_eval.SetGCS(scope, path, new_objects)
+
+    tokens = scope.tokens
+    objects_node = scope['deps'][path].GetNode('objects')
+    for index, object_node in enumerate(objects_node.elts):
+        overlayed_on = new_objects[index].get(_OVERLAYED_ON_KEY)
+        if overlayed_on is None:
+            continue
+        for key, value in zip(object_node.keys, object_node.values):
+            if key.value == _OVERLAYED_ON_KEY:
+                # pylint: disable-next=protected-access
+                gclient_eval._UpdateAstString(tokens, value, overlayed_on)
+                break
+        else:
+            raise ValueError(f'Object {index} of {path!r} has no '
+                             f'{_OVERLAYED_ON_KEY!r} key to update.')
+
+
+def setdep(revisions: list[str], extra_deps_file: Path | None = None) -> None:
     """Repin one or more EXTRA_DEPS entries in place, preserving formatting.
 
     Each `revisions` element is a `DEP@object[?object...]` string (as
     `gclient setdep -r` takes), where every object is an
-    `object_name,sha256sum,size_bytes` triple. The number of objects must match
-    the entry's current object count, and their order is preserved.
+    `object_name,sha256sum,size_bytes` triple, optionally followed by
+    `overlayed_on`. The number of objects must match the entry's current
+    object count, and their order is preserved.
     """
-    scope = _load_editable_extra_deps()
+    extra_deps_file = extra_deps_file or EXTRA_DEPS_FILE
+    scope = _load_editable_extra_deps(extra_deps_file)
     for revision in revisions:
         path, separator, objects_spec = revision.partition('@')
         if not separator or not path or not objects_spec:
             raise ValueError(
                 f'Revision {revision!r} must be of the form `DEP@object,...`.')
-        if path not in EXTRA_DEPS:
+        if path not in scope['extra_deps']:
             raise ValueError(f'Unknown EXTRA_DEPS entry {path!r}. Known '
-                             f'entries: {sorted(EXTRA_DEPS)}.')
+                             f'entries: {sorted(scope["extra_deps"])}.')
         new_objects = [
             _parse_object_spec(obj) for obj in objects_spec.split('?')
         ]
-        # `SetGCS` rewrites the matching string tokens in place, and raises if
-        # the object count does not match the entry's current count.
-        gclient_eval.SetGCS(scope, path, new_objects)
+        _set_objects(scope, path, new_objects)
         _LOG.info('Repinned %s', path)
 
     # `RenderDEPSFile` untokenizes the (now-mutated) tokens back to source, so
     # everything the edit did not touch is byte-for-byte preserved. `newline=''`
     # keeps the file's `\n` line endings intact on every platform.
-    EXTRA_DEPS_FILE.write_text(gclient_eval.RenderDEPSFile(scope),
+    extra_deps_file.write_text(gclient_eval.RenderDEPSFile(scope),
                                encoding='utf-8',
                                newline='')
 
@@ -334,12 +390,13 @@ def main() -> int:
         action='append',
         dest='revisions',
         required=True,
-        metavar='DEP@object_name,sha256sum,size_bytes[?...]',
+        metavar='DEP@object_name,sha256sum,size_bytes[,overlayed_on][?...]',
         help='Repin the EXTRA_DEPS entry DEP to the given object(s). Each '
-        'object is an `object_name,sha256sum,size_bytes` triple; join multiple '
-        'objects with `?`, in the entry\'s existing order. The object count '
-        'must match the entry\'s current count. May be repeated to repin '
-        'several entries in one invocation.')
+        'object is an `object_name,sha256sum,size_bytes` triple, optionally '
+        'followed by `overlayed_on`. Join multiple objects with `?`, in the '
+        'entry\'s existing order. The object count must match the entry\'s '
+        'current count. May be repeated to repin several entries in one '
+        'invocation.')
 
     args = parser.parse_args()
 

--- a/tools/cr/install_extra_deps_test.py
+++ b/tools/cr/install_extra_deps_test.py
@@ -543,6 +543,15 @@ class ParseObjectSpecTest(unittest.TestCase):
                 'size_bytes': '42',
             })
 
+    def test_parses_a_quadruple_with_overlayed_on(self):
+        self.assertEqual(
+            m._parse_object_spec('pkg.tar.gz,abc123,42,upstream/pkg.tar.gz'), {
+                'object_name': 'pkg.tar.gz',
+                'sha256sum': 'abc123',
+                'size_bytes': '42',
+                'overlayed_on': 'upstream/pkg.tar.gz',
+            })
+
     def test_rejects_wrong_field_count(self):
         with self.assertRaises(ValueError):
             m._parse_object_spec('pkg.tar.gz,abc123')
@@ -556,12 +565,66 @@ class ParseObjectSpecTest(unittest.TestCase):
             m._parse_object_spec('pkg.tar.gz,abc123,huge')
 
 
+class FormatSetdepRevisionTest(unittest.TestCase):
+    """Tests for `format_setdep_revision`, the inverse of `_parse_object_spec`.
+    """
+
+    def test_formats_a_single_object_without_overlayed_on(self):
+        self.assertEqual(
+            m.format_setdep_revision('src/path/to/dep', [{
+                'object_name': 'pkg.tar.gz',
+                'sha256sum': 'abc123',
+                'size_bytes': 42,
+            }]), 'src/path/to/dep@pkg.tar.gz,abc123,42')
+
+    def test_formats_multiple_objects_with_overlayed_on(self):
+        objects = [
+            {
+                'object_name': 'linux.tar.xz',
+                'sha256sum': 'linuxsha',
+                'size_bytes': 1,
+                'overlayed_on': 'upstream/linux.tar.xz',
+                'condition': 'host_os == "linux"',
+            },
+            {
+                'object_name': 'win.tar.xz',
+                'sha256sum': 'winsha',
+                'size_bytes': 2,
+                'overlayed_on': 'upstream/win.tar.xz',
+                'condition': 'host_os == "win"',
+            },
+        ]
+        self.assertEqual(
+            m.format_setdep_revision('src/third_party/rust-toolchain',
+                                     objects),
+            'src/third_party/rust-toolchain@'
+            'linux.tar.xz,linuxsha,1,upstream/linux.tar.xz?'
+            'win.tar.xz,winsha,2,upstream/win.tar.xz')
+
+    def test_round_trips_through_parse_object_spec(self):
+        objects = [{
+            'object_name': 'pkg.tar.gz',
+            'sha256sum': 'abc123',
+            'size_bytes': 42,
+            'overlayed_on': 'upstream/pkg.tar.gz',
+        }]
+        revision = m.format_setdep_revision('src/path/to/dep', objects)
+        _, _, objects_spec = revision.partition('@')
+        self.assertEqual(
+            m._parse_object_spec(objects_spec), {
+                'object_name': 'pkg.tar.gz',
+                'sha256sum': 'abc123',
+                'size_bytes': '42',
+                'overlayed_on': 'upstream/pkg.tar.gz',
+            })
+
+
 class SetDepTest(unittest.TestCase):
     """Tests for `setdep`, the comment-preserving EXTRA_DEPS editor.
 
-    Each test points `EXTRA_DEPS_FILE` at a temp fixture and patches the loaded
-    `EXTRA_DEPS` table so path validation matches it, then checks the rendered
-    file byte-for-byte where it matters.
+    Each test points its own temp `EXTRA_DEPS` fixture, passed explicitly via
+    `extra_deps_file`, and checks the rendered file byte-for-byte where it
+    matters.
     """
 
     _SOURCE = '''\
@@ -580,6 +643,16 @@ extra_deps = {
             },
         ],
     },
+    'src/path/to/owned': {
+        'bucket': 'https://downloads.invalid/',
+        'objects': [
+            {
+                'object_name': 'owned-old.tar.gz',
+                'sha256sum': 'ownedoldsha',
+                'size_bytes': 1,
+            },
+        ],
+    },
 }
 '''
 
@@ -588,18 +661,11 @@ extra_deps = {
         self.addCleanup(tmp.cleanup)
         self._path = Path(tmp.name) / 'EXTRA_DEPS'
         self._path.write_text(self._SOURCE, encoding='utf-8')
-        # `setdep` reads/writes the file at `EXTRA_DEPS_FILE` and validates dep
-        # paths against `EXTRA_DEPS`; point both at the fixture. The table's
-        # values are unused (only membership is checked).
-        for patcher in (mock.patch.object(m, 'EXTRA_DEPS_FILE', self._path),
-                        mock.patch.object(m, 'EXTRA_DEPS',
-                                          {'src/path/to/dep': None})):
-            patcher.start()
-            self.addCleanup(patcher.stop)
 
     def test_updates_only_the_object_fields(self):
         """The three object fields change; comments and other keys are kept."""
-        m.setdep(['src/path/to/dep@new.tar.gz,newsha,222'])
+        m.setdep(['src/path/to/dep@new.tar.gz,newsha,222'],
+                 extra_deps_file=self._path)
         result = self._path.read_text(encoding='utf-8')
         self.assertIn("'object_name': 'new.tar.gz',", result)
         self.assertIn("'sha256sum': 'newsha',", result)
@@ -611,18 +677,57 @@ extra_deps = {
         self.assertIn("'overlayed_on': 'upstream/old.tar.gz',", result)
         self.assertIn("'bucket': 'https://downloads.invalid/',", result)
 
+    def test_updates_overlayed_on_when_given(self):
+        """A fourth field rewrites `overlayed_on` alongside the other three."""
+        m.setdep(['src/path/to/dep@new.tar.gz,newsha,222,upstream/new.tar.gz'],
+                 extra_deps_file=self._path)
+        result = self._path.read_text(encoding='utf-8')
+        self.assertIn("'overlayed_on': 'upstream/new.tar.gz',", result)
+        self.assertNotIn('upstream/old.tar.gz', result)
+
+    def test_owned_entry_without_overlayed_on_is_untouched_by_default(self):
+        """An owned entry (no `overlayed_on` in its schema) repins cleanly when
+        the revision omits the field too."""
+        m.setdep(['src/path/to/owned@owned-new.tar.gz,ownednewsha,2'],
+                 extra_deps_file=self._path)
+        result = self._path.read_text(encoding='utf-8')
+        self.assertIn("'object_name': 'owned-new.tar.gz',", result)
+        owned_entry = result[result.index("'src/path/to/owned'"):]
+        self.assertNotIn('overlayed_on', owned_entry)
+
+    def test_overlayed_on_for_an_object_without_the_key_raises(self):
+        """Supplying `overlayed_on` for an object whose schema has no such key
+        is rejected rather than silently dropped."""
+        with self.assertRaises(ValueError):
+            m.setdep([
+                'src/path/to/owned@owned-new.tar.gz,ownednewsha,2,'
+                'upstream/owned-new.tar.gz'
+            ],
+                     extra_deps_file=self._path)
+
     def test_rejects_an_unknown_entry_without_writing(self):
         with self.assertRaises(ValueError):
-            m.setdep(['src/does/not/exist@new.tar.gz,newsha,222'])
+            m.setdep(['src/does/not/exist@new.tar.gz,newsha,222'],
+                     extra_deps_file=self._path)
         self.assertEqual(self._path.read_text(encoding='utf-8'), self._SOURCE)
 
     def test_rejects_an_object_count_mismatch(self):
         with self.assertRaises(ValueError):
-            m.setdep(['src/path/to/dep@a.tar.gz,sa,1?b.tar.gz,sb,2'])
+            m.setdep(['src/path/to/dep@a.tar.gz,sa,1?b.tar.gz,sb,2'],
+                     extra_deps_file=self._path)
 
     def test_rejects_a_malformed_revision(self):
         with self.assertRaises(ValueError):
-            m.setdep(['src/path/to/dep'])  # Missing `@object,...`.
+            m.setdep(['src/path/to/dep'],
+                     extra_deps_file=self._path)  # Missing `@object,...`.
+
+    def test_defaults_to_the_module_extra_deps_file(self):
+        """With no `extra_deps_file` argument, `setdep` reads/writes the real
+        `EXTRA_DEPS_FILE` the module loaded at import time."""
+        with mock.patch.object(m, 'EXTRA_DEPS_FILE', self._path):
+            m.setdep(['src/path/to/dep@new.tar.gz,newsha,222'])
+        self.assertIn("'object_name': 'new.tar.gz',",
+                      self._path.read_text(encoding='utf-8'))
 
 
 if __name__ == '__main__':

--- a/tools/cr/toolchain.py
+++ b/tools/cr/toolchain.py
@@ -7,8 +7,8 @@
 
 from __future__ import annotations
 
-import ast
 from dataclasses import dataclass
+import hashlib
 import os
 import re
 import textwrap
@@ -18,6 +18,7 @@ import requests
 from ci import JenkinsCi
 from exceptions import BadOutcomeException, InvalidInputException
 from git_status import GitStatus
+import install_extra_deps
 import repository
 from terminal import terminal
 from toolchains import build_rust_toolchain, build_xcode_toolchain
@@ -446,9 +447,18 @@ class Toolchain:
 
     # -- repin (in-tree pin + commit), overridden where applicable ----------
 
-    def repin(self, version: Version, culprit: str | None = None) -> None:
-        """Repins the in-tree pin to the published toolchain and commits it."""
-        del version, culprit
+    def repin(self,
+              version: Version,
+              culprit: str | None = None,
+              **kwargs) -> None:
+        """Repins the in-tree pin to the published toolchain and commits it.
+
+        `**kwargs` absorbs toolchain-specific repin arguments (e.g. Rust's
+        `brave_subrevision`) so callers that dispatch generically across
+        toolchains (see `_RepinToolchainTask` in brockit.py) can forward them
+        uniformly.
+        """
+        del version, culprit, kwargs
         raise InvalidInputException(
             f'The {self.spec.label} toolchain has no automated repin.')
 
@@ -515,25 +525,12 @@ class RustToolchain(Toolchain):
                     watch=True,
                     brave_subrevision=self._FIRST_BRAVE_SUBREVISION):
                 return False
-            self.repin(target, culprit)
+            self.repin(target,
+                       culprit,
+                       brave_subrevision=self._FIRST_BRAVE_SUBREVISION)
         except (InvalidInputException, BadOutcomeException):
             return False
         return True
-
-    @staticmethod
-    def _load_extra_deps(source: str) -> tuple[ast.Assign, dict]:
-        """Return the `extra_deps = {...}` assignment node and its dict value.
-
-        The value is read with `ast.literal_eval`, so the file is parsed as
-        data rather than imported.
-        """
-        for node in ast.parse(source).body:
-            if (isinstance(node, ast.Assign) and len(node.targets) == 1
-                    and isinstance(node.targets[0], ast.Name)
-                    and node.targets[0].id == 'extra_deps'):
-                return node, ast.literal_eval(node.value)
-        raise InvalidInputException(
-            'No extra_deps assignment found in the EXTRA_DEPS file.')
 
     @staticmethod
     def _upstream_stem(text: str) -> str:
@@ -562,7 +559,7 @@ class RustToolchain(Toolchain):
                 f'{read("CLANG_REVISION", quoted)}')
 
     @staticmethod
-    def _commit_title(new_entry: dict) -> str:
+    def _commit_title(objects: list[dict]) -> str:
         """Build a commit subject naming the exact toolchain build being pinned.
 
         We build the title to show the new toolchain's relevant details, being
@@ -570,13 +567,13 @@ class RustToolchain(Toolchain):
         trailing `sub` is the upstream rust sub revision (RUST_SUB_REVISION),
         not Brave's respin counter. The result is something like this:
 
-          Rust/WASM toolchain (4c4205163abc-5, llvmorg-23-init-10931-g20b6ec77, sub 5)
+          Rust/WASM toolchain (4c4205163abc-5, llvmorg-23-init-10931-g20b6ec77,
+          sub 5)
 
-        The values in the title are extracted from the tarball's name.
+        The values in the title are extracted from the first object's tarball
+        name.
         """
-        object_name = next(iter(
-            new_entry.values()))['objects'][0]['object_name']
-        name = object_name.removesuffix('.tar.xz')
+        name = objects[0]['object_name'].removesuffix('.tar.xz')
         match = re.search(
             r'rust-toolchain-(?P<rust>[0-9a-f]+)-(?P<sub>\d+)-'
             r'(?P<clang>llvmorg-.+)-(?P<brave>\d+)$', name)
@@ -585,8 +582,40 @@ class RustToolchain(Toolchain):
         return (f'Rust/WASM toolchain ({match["rust"][:12]}-{match["sub"]}, '
                 f'{match["clang"]}, sub {match["sub"]})')
 
-    def repin(self, version: Version, culprit: str | None = None) -> None:
-        """Repins the Rust/WASM `EXTRA_DEPS` entry and commits it."""
+    @staticmethod
+    def _fetch_archive_info(url: str) -> tuple[str, int]:
+        """Download `url` and return its `(sha256sum, size_bytes)`.
+
+        `setdep` values are read straight off the published archive.
+        """
+        digest = hashlib.sha256()
+        size = 0
+        with requests.get(url, stream=True, timeout=60) as response:
+            response.raise_for_status()
+            for chunk in response.iter_content(chunk_size=1 << 20):
+                digest.update(chunk)
+                size += len(chunk)
+        return digest.hexdigest(), size
+
+    # `brave_subrevision` is required here (unlike the base's `**kwargs`
+    # catch-all) since this toolchain has no side index to auto-discover it
+    # from; see the base `repin`'s docstring.
+    # pylint: disable=arguments-differ
+    def repin(self,
+              version: Version,
+              culprit: str | None = None,
+              *,
+              brave_subrevision: int) -> None:
+        """Repins the Rust/WASM `EXTRA_DEPS` entry and commits it.
+
+        `brave_subrevision` must name the exact respin already published for
+        this Chromium tag's Rust+Clang revision (e.g. `1` for a fresh
+        Chromium-version bump, or whatever `gen-rust-toolchain
+        --brave-subrevision` last built) -- there is no side index to
+        auto-discover it from; every object name and its overlay base are
+        derived deterministically and fetched straight from the bucket, like
+        `tools/clang/scripts/sync_deps.py`'s `GetDepsObjectInfo`.
+        """
         self._require_no_staged_files()
 
         ref = str(version)
@@ -594,35 +623,45 @@ class RustToolchain(Toolchain):
                                                       commit=ref)
         upstream_stem = self._upstream_stem(revision_text)
 
-        try:
-            new_entry = build_rust_toolchain.rust_toolchain_extra_dep(
-                upstream_stem)
-        except RuntimeError as e:
-            raise BadOutcomeException(str(e)) from e
+        objects = []
+        platform_conditions = build_rust_toolchain.SUPPORTED_PLATFORM_CONDITIONS
+        for platform_prefix in platform_conditions:
+            object_name = (f'{platform_prefix}-{upstream_stem}-'
+                           f'{brave_subrevision}.tar.xz')
+            url = f'{build_rust_toolchain.TOOLCHAIN_BUCKET_URL}/{object_name}'
+            try:
+                sha256sum, size_bytes = self._fetch_archive_info(url)
+            except requests.RequestException as e:
+                raise BadOutcomeException(
+                    f'Could not fetch published toolchain {url}: {e}') from e
+            host_os = build_rust_toolchain.PLATFORM_PREFIX_TO_CHROMIUM_HOST_OS[
+                platform_prefix]
+            objects.append({
+                'object_name': object_name,
+                'sha256sum': sha256sum,
+                'size_bytes': size_bytes,
+                'overlayed_on': f'{host_os}/{upstream_stem}.tar.xz',
+            })
 
         installer = self.spec.installer
         path = repository.brave.root / installer
-        source = path.read_bytes().decode('utf-8')
-        node, extra_deps = self._load_extra_deps(source)
+        revision = install_extra_deps.format_setdep_revision(
+            build_rust_toolchain.RUST_TOOLCHAIN_DEP_PATH, objects)
 
-        # Replace the rust-toolchain entry (in place, preserving key order),
-        # then re-render the whole extra_deps assignment.
-        extra_deps.update(new_entry)
-        rendered = f'extra_deps = {_render_py_literal(extra_deps)}\n'
-        lines = source.splitlines(keepends=True)
-        new_source = (''.join(lines[:node.lineno - 1]) + rendered +
-                      ''.join(lines[node.end_lineno:]))
+        before = path.read_bytes()
+        try:
+            install_extra_deps.setdep([revision], extra_deps_file=path)
+        except ValueError as e:
+            raise InvalidInputException(str(e)) from e
 
-        if new_source == source:
+        if path.read_bytes() == before:
             terminal.log_task(
                 f'{installer} is already up to date; nothing to commit.')
             return
 
-        path.write_text(new_source, encoding='utf-8', newline='')
-
         commit_hash = self.find_culprit(ref, culprit)
         repository.brave.run_git('add', installer)
-        repository.brave.git_commit(self._commit_title(new_entry),
+        repository.brave.git_commit(self._commit_title(objects),
                                     env={
                                         **os.environ,
                                         'tags': 'toolchain',
@@ -728,6 +767,9 @@ class XcodeToolchain(Toolchain):
         script_path.write_text(content, encoding='utf-8', newline='')
         return True
 
+    # This toolchain takes no extra repin arguments, unlike the base's
+    # `**kwargs` catch-all; see the base `repin`'s docstring.
+    # pylint: disable=arguments-differ
     def repin(self, version: Version, culprit: str | None = None) -> None:
         """Repins `download_hermetic_xcode.py` and commits it."""
         self._require_no_staged_files()
@@ -776,36 +818,3 @@ class WindowsToolchain(Toolchain):
     def __init__(self) -> None:
         super().__init__(
             ToolchainSpec.from_entry('windows', TOOLCHAINS['windows']))
-
-
-def _render_py_literal(value: object, indent: int = 0) -> str:
-    """Render a str/bool/dict/list literal as multi-line Python source.
-
-    Used to re-render the `extra_deps` assignment when repinning. Matches the
-    committed `EXTRA_DEPS` file's layout (4-space indent steps, single-quoted
-    strings, trailing commas) so a repin is a minimal diff.
-    """
-    pad = ' ' * indent
-    child = ' ' * (indent + 4)
-    if isinstance(value, dict):
-        if not value:
-            return '{}'
-        items = ''.join(f'{child}{_render_py_literal(key)}: '
-                        f'{_render_py_literal(val, indent + 4)},\n'
-                        for key, val in value.items())
-        return f'{{\n{items}{pad}}}'
-    if isinstance(value, list):
-        if not value:
-            return '[]'
-        items = ''.join(f'{child}{_render_py_literal(item, indent + 4)},\n'
-                        for item in value)
-        return f'[\n{items}{pad}]'
-    if isinstance(value, bool):
-        return 'True' if value else 'False'
-    if isinstance(value, str):
-        # Single-quoted to match the file. Values here never contain a single
-        # quote or backslash; fall back to repr only defensively.
-        if "'" in value or '\\' in value:
-            return repr(value)
-        return f"'{value}'"
-    return repr(value)

--- a/tools/cr/toolchain_test.py
+++ b/tools/cr/toolchain_test.py
@@ -7,9 +7,8 @@
 
 Layers:
 
-* Pure helpers -- `_render_py_literal`, `RustToolchain._commit_title`,
-  `RustToolchain._load_extra_deps`, `XcodeToolchain._provenance_comment`, and
-  `get_assigned_value`.
+* Pure helpers -- `RustToolchain._commit_title`,
+  `XcodeToolchain._provenance_comment`, and `get_assigned_value`.
 
 * Detection / attribution -- `Toolchain.was_updated`, the unified
   `Toolchain.find_culprit`, `RustToolchain.is_published`, and `Toolchain.check`,
@@ -26,7 +25,6 @@ Layers:
 
 from __future__ import annotations
 
-import ast
 import shutil
 import stat
 import unittest
@@ -49,27 +47,6 @@ CHROMIUM_TAG = '150.0.7850.1'
 # Pure helpers.
 # ---------------------------------------------------------------------------
 
-NEW_ENTRY = {
-    'src/third_party/rust-toolchain': {
-        'bucket': 'https://example.invalid/rust-toolchain-aux/',
-        'condition': 'not rust_force_head_revision',
-        'objects': [
-            {
-                'object_name': 'linux-x64-rust-toolchain-2.tar.xz',
-                'sha256sum': 'newlinuxsha',
-                'size_bytes': 111,
-                'condition': 'host_os == "linux"',
-            },
-            {
-                'object_name': 'win-rust-toolchain-2.tar.xz',
-                'sha256sum': 'newwinsha',
-                'size_bytes': 222,
-                'condition': 'host_os == "win"',
-            },
-        ],
-    },
-}
-
 SAMPLE_INSTALLER = """\
 # Installer module.
 
@@ -89,38 +66,39 @@ extra_deps = {
         'condition': 'not rust_force_head_revision',
         'objects': [
             {
-                'object_name': 'old-linux-1.tar.xz',
+                'object_name': 'old-linux-x64-1.tar.xz',
                 'sha256sum': 'oldlinuxsha',
+                'size_bytes': 1,
+                'overlayed_on': 'Linux_x64/old-upstream.tar.xz',
                 'condition': 'host_os == "linux"',
+            },
+            {
+                'object_name': 'old-mac-arm64-1.tar.xz',
+                'sha256sum': 'oldmacarmsha',
+                'size_bytes': 1,
+                'overlayed_on': 'Mac_arm64/old-upstream.tar.xz',
+                'condition': 'host_os == "mac" and host_cpu == "arm64"',
+            },
+            {
+                'object_name': 'old-mac-1.tar.xz',
+                'sha256sum': 'oldmacsha',
+                'size_bytes': 1,
+                'overlayed_on': 'Mac/old-upstream.tar.xz',
+                'condition': 'host_os == "mac" and host_cpu == "x64"',
+            },
+            {
+                'object_name': 'old-win-1.tar.xz',
+                'sha256sum': 'oldwinsha',
+                'size_bytes': 1,
+                'overlayed_on': 'Win/old-upstream.tar.xz',
+                'condition': 'host_os == "win"',
             },
         ],
     },
 }
 
-
-def untouched():
-    return 1
+OTHER_CONSTANT = 1
 """
-
-
-class RenderLiteralTest(unittest.TestCase):
-    """Tests for `toolchain._render_py_literal`."""
-
-    def test_round_trips(self):
-        self.assertEqual(
-            ast.literal_eval(toolchain._render_py_literal(NEW_ENTRY)),
-            NEW_ENTRY)
-
-    def test_single_quoted_with_embedded_double_quotes(self):
-        rendered = toolchain._render_py_literal(
-            {'condition': 'host_os == "mac" and host_cpu == "arm64"'})
-        self.assertIn(
-            "    'condition': 'host_os == \"mac\" and host_cpu == \"arm64\"',",
-            rendered)
-
-    def test_empty_containers(self):
-        self.assertEqual(toolchain._render_py_literal({}), '{}')
-        self.assertEqual(toolchain._render_py_literal([]), '[]')
 
 
 class GetAssignedValueTest(unittest.TestCase):
@@ -150,44 +128,23 @@ class CommitTitleTest(unittest.TestCase):
     """Tests for `RustToolchain._commit_title`."""
 
     @staticmethod
-    def _entry(object_name: str) -> dict:
-        return {
-            'src/third_party/rust-toolchain': {
-                'objects': [{
-                    'object_name': object_name
-                }],
-            }
-        }
+    def _objects(object_name: str) -> list[dict]:
+        return [{'object_name': object_name}]
 
     def test_title_uses_upstream_rust_sub_revision(self):
         name = ('linux-x64-rust-toolchain-'
                 '4c4205163abcbd08948b3efab796c543ba1ea687-2-'
                 'llvmorg-23-init-10931-g20b6ec66-1.tar.xz')
-        title = toolchain.RustToolchain._commit_title(self._entry(name))
+        title = toolchain.RustToolchain._commit_title(self._objects(name))
         self.assertEqual(
             title, 'Rust/WASM toolchain (4c4205163abc-2, '
             'llvmorg-23-init-10931-g20b6ec66, sub 2)')
 
     def test_unparseable_name_falls_back_to_stem(self):
         title = toolchain.RustToolchain._commit_title(
-            self._entry('linux-x64-rust-toolchain-2.tar.xz'))
+            self._objects('linux-x64-rust-toolchain-2.tar.xz'))
         self.assertEqual(title,
                          'Rust/WASM toolchain linux-x64-rust-toolchain-2')
-
-
-class LoadExtraDepsTest(unittest.TestCase):
-    """Tests for `RustToolchain._load_extra_deps`."""
-
-    def test_returns_node_and_value(self):
-        node, value = toolchain.RustToolchain._load_extra_deps(
-            SAMPLE_INSTALLER)
-        self.assertEqual(node.targets[0].id, 'extra_deps')
-        self.assertIn('src/third_party/rust-toolchain', value)
-        self.assertIn('src/other-dep', value)
-
-    def test_missing_assignment_raises(self):
-        with self.assertRaises(toolchain.InvalidInputException):
-            toolchain.RustToolchain._load_extra_deps('X = 1\n')
 
 
 # Provenance-comment fixtures (shared with the xcode repin test).
@@ -332,14 +289,28 @@ class RustRepinTest(_FakeRepoTest):
 
     INSTALLER = 'EXTRA_DEPS'
 
+    # Matches the revision constants `_seed_rust_revision_bump` writes, via
+    # `RustToolchain._upstream_stem`.
+    UPSTREAM_STEM = 'rust-toolchain-abc123def-2-llvmorg-23-init-10931-g20b6ec66'
+    BRAVE_SUBREVISION = 1
+
+    @staticmethod
+    def _fake_archive_info(url: str) -> tuple[str, int]:
+        """A deterministic stand-in for a real download: derives a fake
+        `(sha256sum, size_bytes)` from the object name in `url`, so each
+        platform's fetched values are distinguishable without any network
+        access."""
+        name = url.rsplit('/', 1)[-1]
+        return f'sha-{name}', len(name)
+
     def setUp(self):
         super().setUp()
         self.rust = toolchain.RustToolchain()
         self._seed_installer()
-        patcher = patch.object(toolchain.build_rust_toolchain,
-                               'rust_toolchain_extra_dep',
-                               return_value=NEW_ENTRY)
-        self.builder = patcher.start()
+        patcher = patch.object(toolchain.RustToolchain,
+                               '_fetch_archive_info',
+                               side_effect=self._fake_archive_info)
+        self.fetch = patcher.start()
         self.addCleanup(patcher.stop)
 
     def _seed_installer(self, content: str = SAMPLE_INSTALLER) -> None:
@@ -370,17 +341,36 @@ class RustRepinTest(_FakeRepoTest):
     def _installer_text(self) -> str:
         return (self.repo.brave / self.INSTALLER).read_bytes().decode('utf-8')
 
+    def _repin(self, culprit: str | None) -> None:
+        self.rust.repin(Version(CHROMIUM_TAG),
+                        culprit=culprit,
+                        brave_subrevision=self.BRAVE_SUBREVISION)
+
     def test_updates_and_commits_with_auto_culprit(self):
         culprit = self._seed_rust_revision_bump()
 
-        self.rust.repin(Version(CHROMIUM_TAG), culprit=None)
+        self._repin(culprit=None)
 
         text = self._installer_text()
-        self.assertIn('linux-x64-rust-toolchain-2.tar.xz', text)
-        self.assertIn('win-rust-toolchain-2.tar.xz', text)
-        self.assertNotIn('old-linux-1.tar.xz', text)
+        linux_name = f'linux-x64-{self.UPSTREAM_STEM}-1.tar.xz'
+        win_name = f'win-{self.UPSTREAM_STEM}-1.tar.xz'
+        self.assertIn(linux_name, text)
+        self.assertIn(win_name, text)
+        self.assertIn(f'sha-{linux_name}', text)
+        self.assertIn(f'sha-{win_name}', text)
+        self.assertNotIn('old-linux-x64-1.tar.xz', text)
+        # The overlay base is repinned alongside the archive itself.
+        self.assertIn(f'Linux_x64/{self.UPSTREAM_STEM}.tar.xz', text)
+        self.assertIn(f'Win/{self.UPSTREAM_STEM}.tar.xz', text)
+        self.assertNotIn('old-upstream.tar.xz', text)
+        # Every platform is fetched straight from the bucket, no side index.
+        self.assertEqual(self.fetch.call_count, 4)
+        self.fetch.assert_any_call(
+            f'{toolchain.build_rust_toolchain.TOOLCHAIN_BUCKET_URL}/'
+            f'{linux_name}')
+        # Everything setdep does not touch survives byte for byte.
         self.assertIn("'src/other-dep'", text)
-        self.assertIn('def untouched():', text)
+        self.assertIn('OTHER_CONSTANT = 1', text)
 
         message = self._last_brave_message()
         subject = message.splitlines()[0]
@@ -399,7 +389,7 @@ class RustRepinTest(_FakeRepoTest):
         culprit = self.repo.commit('Unrelated chromium change',
                                    self.repo.chromium)
 
-        self.rust.repin(Version(CHROMIUM_TAG), culprit=culprit)
+        self._repin(culprit=culprit)
 
         message = self._last_brave_message()
         self.assertIn(
@@ -411,16 +401,22 @@ class RustRepinTest(_FakeRepoTest):
     def test_idempotent_second_run_does_not_commit(self):
         self._seed_rust_revision_bump()
 
-        self.rust.repin(Version(CHROMIUM_TAG), culprit=None)
+        self._repin(culprit=None)
         head_after_first = self._brave_head()
 
-        self.rust.repin(Version(CHROMIUM_TAG), culprit=None)
+        self._repin(culprit=None)
         self.assertEqual(self._brave_head(), head_after_first)
 
     def test_staged_files_block_the_update(self):
         self.repo.write_and_stage_file('staged.txt', 'wip\n', self.repo.brave)
         with self.assertRaises(toolchain.InvalidInputException):
-            self.rust.repin(Version(CHROMIUM_TAG), culprit='deadbeef')
+            self._repin(culprit='deadbeef')
+
+    def test_fetch_failure_raises(self):
+        self._seed_rust_revision_bump()
+        self.fetch.side_effect = toolchain.requests.RequestException('boom')
+        with self.assertRaises(toolchain.BadOutcomeException):
+            self._repin(culprit=None)
 
 
 # Fixtures for the xcode repin test.
@@ -726,7 +722,9 @@ class RecoverTest(unittest.TestCase):
         trigger.assert_called_once_with(self.version,
                                         watch=True,
                                         brave_subrevision=1)
-        repin.assert_called_once_with(self.version, 'culprithash')
+        repin.assert_called_once_with(self.version,
+                                      'culprithash',
+                                      brave_subrevision=1)
 
     def test_failed_build_keeps_advisory(self):
         with patch.object(self.rust, 'trigger', return_value=False), \


### PR DESCRIPTION
This follows the same model in upstream pinning of the rust toolchain.
We check the generated toolchain for the desired URL, and with that we
update our `EXTRA_DEPS` file.

Bug: https://github.com/brave/brave-browser/issues/56723
