### PR TITLE
[Android] Show Brave Delete browsing data from all entry points

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveSettingsLauncherImpl.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSettingsLauncherImpl.java
@@ -5,7 +5,6 @@
 
 package org.chromium.chrome.browser.settings;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -27,37 +26,26 @@ public class BraveSettingsLauncherImpl extends SettingsNavigationImpl {
         super();
     }
 
-    @Override
-    public void startSettings(
-            Context context,
-            @Nullable Class<? extends Fragment> fragment,
-            @Nullable Bundle fragmentArgs) {
-        if (fragment != null) {
-            fragment = substituteFragment(fragment);
-        }
-        super.startSettings(context, fragment, fragmentArgs);
-    }
-
+    // This is the only overload that every startSettings() and createSettingsIntent() variant in
+    // SettingsNavigationImpl funnels into, so overriding it applies the Brave fragment substitution
+    // to all entry points, including the ones that pass a @SettingsFragment enum value instead of a
+    // fragment class (for example Quick Delete's "More options" and the History page's "Delete
+    // browsing data").
     @Override
     public Intent createSettingsIntent(
             Context context,
             @Nullable Class<? extends Fragment> fragment,
-            @Nullable Bundle fragmentArgs) {
+            @Nullable Bundle fragmentArgs,
+            boolean addToBackStack,
+            @Nullable String tag) {
+        // Substitute before calling super: SettingsIntentUtil decides whether the fragment is
+        // standalone by reflecting on the fragment name, so it has to see the Brave class.
         if (fragment != null) {
             fragment = substituteFragment(fragment);
         }
-        Intent intent = super.createSettingsIntent(context, fragment, fragmentArgs);
+        Intent intent =
+                super.createSettingsIntent(context, fragment, fragmentArgs, addToBackStack, tag);
         intent.setClass(context, BraveSettingsActivity.class);
-        if (!(context instanceof Activity)) {
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        }
-        if (fragment != null) {
-            intent.putExtra(SettingsActivity.EXTRA_SHOW_FRAGMENT, fragment.getName());
-        }
-        if (fragmentArgs != null) {
-            intent.putExtra(SettingsActivity.EXTRA_SHOW_FRAGMENT_ARGUMENTS, fragmentArgs);
-        }
         return intent;
     }
 

--- a/android/junit/BUILD.gn
+++ b/android/junit/BUILD.gn
@@ -127,11 +127,15 @@ if (is_android) {
 
   robolectric_library(
       "brave_junit_tests_org.chromium.chrome.browser.settings") {
-    sources = [ "src/org/chromium/chrome/browser/settings/BraveSearchEngineUtilsTest.java" ]
+    sources = [
+      "src/org/chromium/chrome/browser/settings/BraveSearchEngineUtilsTest.java",
+      "src/org/chromium/chrome/browser/settings/BraveSettingsLauncherImplTest.java",
+    ]
 
     deps = [
       "//brave/android/java/org/chromium/chrome/browser/search_engines:java",
       "//chrome/android/junit:chrome_junit_tests_helper",
+      "//chrome/browser/safe_browsing/android:java",
     ]
   }
 

--- a/android/junit/src/org/chromium/chrome/browser/settings/BraveSettingsLauncherImplTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/settings/BraveSettingsLauncherImplTest.java
@@ -1,0 +1,154 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.settings;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.app.Application;
+import android.content.Intent;
+import android.os.Bundle;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.filters.SmallTest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import org.chromium.base.test.BaseRobolectricTestRunner;
+import org.chromium.base.test.util.Features.DisableFeatures;
+import org.chromium.chrome.browser.browsing_data.BraveClearBrowsingDataFragment;
+import org.chromium.chrome.browser.browsing_data.ClearBrowsingDataFragment;
+import org.chromium.chrome.browser.download.settings.BraveDownloadSettings;
+import org.chromium.chrome.browser.download.settings.DownloadSettings;
+import org.chromium.chrome.browser.flags.ChromeFeatureList;
+import org.chromium.chrome.browser.safe_browsing.settings.BraveStandardProtectionSettingsFragment;
+import org.chromium.chrome.browser.safe_browsing.settings.StandardProtectionSettingsFragment;
+import org.chromium.components.browser_ui.settings.SettingsNavigation.SettingsFragment;
+
+/** Tests for {@link BraveSettingsLauncherImpl}. */
+@RunWith(BaseRobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+// Settings fragments are EmbeddableSettingsPages, so SettingsIntentUtil reads this flag while
+// building the intent. Pin it so these tests don't depend on the field trial state.
+@DisableFeatures(ChromeFeatureList.SETTINGS_SINGLE_ACTIVITY)
+public class BraveSettingsLauncherImplTest {
+    private Application mContext;
+    private BraveSettingsLauncherImpl mSettingsNavigation;
+
+    @Before
+    public void setUp() {
+        mContext = ApplicationProvider.getApplicationContext();
+        mSettingsNavigation = new BraveSettingsLauncherImpl();
+    }
+
+    /**
+     * Entry points that pass a {@link SettingsFragment} value instead of a fragment class must
+     * still get the Brave version of the fragment.
+     *
+     * <p>Regression test for https://github.com/brave/brave-browser/issues/57217: Quick Delete's
+     * "More options" (reachable from the tab switcher menu) and the History page's "Delete browsing
+     * data" use this overload, and used to land on the upstream screen, which has no Leo AI option
+     * and no "Clear Brave Ads data" entry.
+     */
+    @Test
+    @SmallTest
+    public void testStartSettingsWithEnumSubstitutesFragment() {
+        mSettingsNavigation.startSettings(mContext, SettingsFragment.CLEAR_BROWSING_DATA);
+
+        Intent intent = shadowOf(mContext).getNextStartedActivity();
+        assertNotNull(intent);
+        assertShowsBraveClearBrowsingData(intent);
+    }
+
+    @Test
+    @SmallTest
+    public void testCreateSettingsIntentWithEnumSubstitutesFragment() {
+        Intent intent =
+                mSettingsNavigation.createSettingsIntent(
+                        mContext, SettingsFragment.CLEAR_BROWSING_DATA, /* fragmentArgs= */ null);
+
+        assertShowsBraveClearBrowsingData(intent);
+    }
+
+    @Test
+    @SmallTest
+    public void testStartSettingsWithFragmentClassSubstitutesFragment() {
+        mSettingsNavigation.startSettings(
+                mContext, ClearBrowsingDataFragment.class, /* fragmentArgs= */ null);
+
+        Intent intent = shadowOf(mContext).getNextStartedActivity();
+        assertNotNull(intent);
+        assertShowsBraveClearBrowsingData(intent);
+    }
+
+    /**
+     * Covers the way {@link org.chromium.chrome.browser.site_settings.BraveSiteSettingsDelegate}
+     * opens the screen: fragment args plus addToBackStack, which travel through overloads that used
+     * to bypass the substitution.
+     */
+    @Test
+    @SmallTest
+    public void testStartSettingsPreservesArgsAndBackStack() {
+        Bundle fragmentArgs = ClearBrowsingDataFragment.createFragmentArgs("referrer");
+
+        mSettingsNavigation.startSettings(
+                mContext,
+                ClearBrowsingDataFragment.class,
+                fragmentArgs,
+                /* addToBackStack= */ true);
+
+        Intent intent = shadowOf(mContext).getNextStartedActivity();
+        assertNotNull(intent);
+        assertShowsBraveClearBrowsingData(intent);
+        assertNotNull(intent.getBundleExtra(SettingsActivity.EXTRA_SHOW_FRAGMENT_ARGUMENTS));
+        assertTrue(intent.getBooleanExtra(SettingsActivity.EXTRA_ADD_TO_BACK_STACK, false));
+    }
+
+    @Test
+    @SmallTest
+    public void testOtherFragmentsAreStillSubstituted() {
+        assertEquals(
+                BraveDownloadSettings.class.getName(),
+                showFragmentName(
+                        mSettingsNavigation.createSettingsIntent(
+                                mContext, DownloadSettings.class)));
+        assertEquals(
+                BraveStandardProtectionSettingsFragment.class.getName(),
+                showFragmentName(
+                        mSettingsNavigation.createSettingsIntent(
+                                mContext, StandardProtectionSettingsFragment.class)));
+    }
+
+    @Test
+    @SmallTest
+    public void testMainSettingsStillOpensBraveSettingsActivity() {
+        Intent intent =
+                mSettingsNavigation.createSettingsIntent(
+                        mContext, SettingsFragment.MAIN, /* fragmentArgs= */ null);
+
+        // MAIN maps to a null fragment, so there is nothing to substitute, but the intent must
+        // still target the Brave settings activity.
+        assertNull(showFragmentName(intent));
+        assertEquals(BraveSettingsActivity.class.getName(), intent.getComponent().getClassName());
+    }
+
+    private void assertShowsBraveClearBrowsingData(Intent intent) {
+        assertEquals(BraveClearBrowsingDataFragment.class.getName(), showFragmentName(intent));
+        // BraveSettingsActivity is what provides the Brave overflow menu, so the substituted
+        // fragment has to be hosted by it rather than by the upstream SettingsActivity.
+        assertEquals(BraveSettingsActivity.class.getName(), intent.getComponent().getClassName());
+    }
+
+    private static String showFragmentName(Intent intent) {
+        return intent.getStringExtra(SettingsActivity.EXTRA_SHOW_FRAGMENT);
+    }
+}


### PR DESCRIPTION
BraveSettingsLauncherImpl only overrode the three-argument startSettings() and createSettingsIntent(), so entry points that pass a @SettingsFragment enum value instead of a fragment class never got the Brave substitution. SettingsNavigationImpl routes those through the four- and five-argument overloads, which were not overridden, so they opened the upstream ClearBrowsingDataFragment inside the upstream SettingsActivity - without the Leo AI option or the "Clear Brave Ads data" entry. This was reachable from the tab switcher menu via Delete browsing data > More options, and also from the History page's Delete browsing data and the omnibox clear-browsing-data action.

Override the five-argument createSettingsIntent() instead, which is the single overload every startSettings()/createSettingsIntent() variant funnels into, and drop the three-argument overrides. Substitution has to happen before the super call because SettingsIntentUtil reflects on the fragment name to decide whether the page is standalone. The flags and extras the old override re-applied afterwards were already set by SettingsIntentUtil.createIntent(), so they go away as dead code.

Add BraveSettingsLauncherImplTest covering the enum overloads, the fragment-class overloads and the remaining substitutions.

Resolves: https://github.com/brave/brave-browser/issues/57217

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
