### PR TITLE
[plaster] Adding `add_enum_entries`

### DIFF
--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -139,6 +139,7 @@ introduce more rewriters. These are the ones we have supported for now.
 | `rename_class`          | AST  | Renames a C++ class.                              |
 | `add_to_protected`      | AST  | Adds a member to a class `protected:` section.    |
 | `add_to_public`         | AST  | Appends a member to a class `public:` section.    |
+| `add_enum_entries`      | AST  | Appends entries to the end of a C++ enum.         |
 
 Use `plaster --help` to discover rewriters and read their full docs:
 

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -1700,11 +1700,256 @@ class AddToPublic(_AstGrepRewriter):
         return cls(class_name=body['class_name'], code=body['code'])
 
 
+class AddEnumEntries(_AstGrepRewriter):
+    """Append entries to a C++ enum, keeping its max-value entry last."""
+
+    NAME: Final = 'add_enum_entries'
+    # Two ops share the work (see `apply`); this names the language and a
+    # representative op for the base's helpers.
+    OP_ID: Final = 'cxx.insert_enum_entries_before_max_value'
+    SUMMARY: Final = 'Append entries to an enum, re-pointing its max value.'
+    # Authored in Markdown; `Help` renders it with rich.
+    HELP: Final = r"""
+        Appends entries to an enum.
+
+        This rewriter appends entries at the end of an enum. When `max_value` is
+        provided, the keys are appended just before the max-value entry. If the
+        max-value entry has a value assigned to it, the last appended entry is
+        assigned as the new max-value.
+
+        Fields:
+
+        - `enum_name` — the enum to extend (can be `enum` or `enum class`).
+        - `entries` — the entry to add, or a list of them, in the order they
+          should appear. Each is an entry name, optionally with an `= value` of
+          its own (`kBraveMaxValue = kBraveCardano`).
+        - `max_value` — optional: the name of the entry that must stay last.
+          Omit it for an enum that ends in an ordinary entry.
+
+        The insertion happens exactly once, so `count` is always 1. Declaring a
+        `max_value` that is not the enum's last entry is an error, rather than
+        an insertion in the wrong place.
+
+        Examples:
+
+        ```yaml
+        substitutions:
+          - description: Add the Brave properties, keeping kMaxValue last.
+            add_enum_entries:
+              enum_name: Property
+              max_value: kMaxValue
+              entries:
+                - kAlwaysShowLabel
+                - kOverrideChipColors
+                - kOverrideBorder
+
+          - description: Add ECDSA_SHA384 so downstream switches handle it.
+            add_enum_entries:
+              enum_name: SignatureAlgorithm
+              entries: ECDSA_SHA384
+        ```
+
+        The first entry turns this upstream enum:
+
+        ```cpp
+        enum class Property {
+          // ... upstream entries ...
+          kOverrideBackgroundColor,
+          kMaxValue = kOverrideBackgroundColor,
+        };
+        ```
+
+        into:
+
+        ```cpp
+        enum class Property {
+          // ... upstream entries ...
+          kOverrideBackgroundColor,
+          kAlwaysShowLabel,
+          kOverrideChipColors,
+          kOverrideBorder,
+          kMaxValue = kOverrideBorder,
+        };
+        ```
+    """
+
+    # The two placements: before the declared max-value entry, or after the
+    # enum's current last entry when no `max_value` is declared.
+    _INSERT_BEFORE_MAX_VALUE: Final = 'cxx.insert_enum_entries_before_max_value'
+    _APPEND_AFTER_LAST: Final = 'cxx.append_enum_entries_after_last'
+
+    # One entry as authored: a name, optionally with an `= value`. A comma or a
+    # newline would take the shape of the emitted list out of our hands.
+    _ENTRY_RE: Final = re.compile(r'\w+(?:\s*=\s*[^,\n]+)?')
+
+    # The name leading an entry, as authored or as read back from the source.
+    _ENTRY_NAME_RE: Final = re.compile(r'\s*(\w+)')
+
+    # The separator following an entry, with any spacing before it.
+    _SEPARATOR_RE: Final = re.compile(rb'[ \t]*,')
+
+    @classmethod
+    def validate_count(cls, count: int, description: str) -> None:
+        # The insertion happens once, in whichever placement applies, so a
+        # `count:` other than 1 is meaningless here.
+        if count != 1:
+            raise ValueError(f'{cls.NAME} inserts exactly once and does not '
+                             f'accept a count other than 1 '
+                             f'(in "{description}")')
+
+    def __init__(self, *, enum_name: str, entries: list[str],
+                 max_value: str | None):
+        super().__init__()
+        self._enum_name = enum_name
+        self._entries = entries
+        self._max_value = max_value
+
+    def apply(self,
+              contents: str,
+              *,
+              count: int,
+              description: str,
+              blank_for_parse: bool = False) -> tuple[str, list[str]]:
+        # The insertion happens exactly once, either above the declared
+        # max-value entry or after the enum's current last entry. Both
+        # placements anchor on that last entry, so the new entries take its
+        # column, and a trailing comment in the body never displaces them.
+        del count
+        engine = AstRewriter(RewritersEval.load(),
+                             contents,
+                             blank_for_parse=blank_for_parse)
+        source = contents.encode('utf-8')
+        enum_inputs = {'enum_name': self._enum_name}
+
+        last = engine.first_match(
+            Operation(self._INSERT_BEFORE_MAX_VALUE, enum_inputs))
+        # A missing anchor leaves the run to report the count shortfall.
+        last_text = source[last.start:last.end].decode('utf-8') if last else ''
+        indent = _leading_indent(source, last.start) if last else ''
+
+        if self._max_value is not None:
+            name = self._entry_name(last_text)
+            if last is not None and name != self._max_value:
+                return contents, [
+                    f'Enum `{self._enum_name}` ends in `{name}`, not in the '
+                    f'declared `max_value` entry `{self._max_value}` '
+                    f'(in "{description}")'
+                ]
+            op = Operation(
+                self._INSERT_BEFORE_MAX_VALUE, {
+                    'enum_name': self._enum_name,
+                    'entries': self._entry_block(indent, indent_first=False),
+                    'indent': indent,
+                    'value': self._repointed_entry(last_text),
+                }, MatchExpectation.exactly(1))
+        else:
+            op = Operation(
+                self._APPEND_AFTER_LAST, {
+                    'enum_name': self._enum_name,
+                    'entries': self._entry_block(indent, indent_first=True),
+                    'comma': self._separator(source, last.end) if last else '',
+                }, MatchExpectation.exactly(1))
+        changes = engine.run(op)
+        error = op.expectation.error_for(changes)
+        return engine.content, [error] if error else []
+
+    def _entry_block(self, indent: str, *, indent_first: bool) -> str:
+        """The entries as `<entry>,` lines at `indent`, ready to splice in.
+
+        `indent_first` opens the first line at `indent` too; it is off where the
+        block starts at the column the matched entry already sits at. Escapes
+        backslashes, since the text is spliced into a `re.sub` replacement where
+        a backslash is special.
+        """
+        block = (indent if indent_first else '') + f',\n{indent}'.join(
+            self._entries) + ','
+        return block.replace('\\', '\\\\')
+
+    def _repointed_entry(self, last_text: str) -> str:
+        """The entry the max value is re-pointed at, or '' where it keeps none.
+
+        An entry carrying no value of its own takes the one that follows on from
+        whatever precedes it, so inserting entries above it moves it along by
+        itself, and the op's `when_set` leaves it alone for an empty value. One
+        that does carry a value has to be re-pointed, or it would keep covering
+        the upstream entries alone.
+        """
+        if '=' not in last_text:
+            return ''
+        return self._entry_name(self._entries[-1])
+
+    @classmethod
+    def _entry_name(cls, text: str) -> str | None:
+        """The entry name leading `text`, or None where it holds no name."""
+        match = cls._ENTRY_NAME_RE.match(text)
+        return match.group(1) if match else None
+
+    @classmethod
+    def _is_entry_name(cls, value: object) -> bool:
+        """True where `value` is a bare entry name, e.g. `kMaxValue`."""
+        return isinstance(value, str) and cls._entry_name(value) == value
+
+    @classmethod
+    def _separator(cls, source: bytes, pos: int) -> str:
+        """The separator following the entry ending at `pos`, or '' for none.
+
+        Returned as the source's own text, spacing included, so a placement can
+        fold it into the span it rewrites rather than leave a comma dangling
+        after the appended entries.
+        """
+        match = cls._SEPARATOR_RE.match(source, pos)
+        return match.group().decode('utf-8') if match else ''
+
+    @classmethod
+    def parse(cls, body: object, *, description: str) -> AddEnumEntries:
+        """Validate the body, accepting one entry or a list of them."""
+        if not isinstance(body, dict):
+            raise ValueError(
+                f'"{cls.NAME}" must be a mapping (in "{description}")')
+        allowed = {'enum_name', 'entries', 'max_value'}
+        unknown = sorted(set(body) - allowed)
+        if unknown:
+            raise ValueError(
+                f'Unrecognised {cls.NAME} arg(s): '
+                f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
+        missing = sorted({'enum_name', 'entries'} - set(body))
+        if missing:
+            raise ValueError(f'{cls.NAME} requires arg(s): '
+                             f'{", ".join(missing)} (in "{description}")')
+        if not isinstance(body['enum_name'], str) or not body['enum_name']:
+            raise ValueError(f'{cls.NAME} `enum_name` must be a non-empty '
+                             f'string (in "{description}")')
+        max_value = body.get('max_value')
+        if max_value is not None and not cls._is_entry_name(max_value):
+            raise ValueError(f'{cls.NAME} `max_value` must be an entry name '
+                             f'(in "{description}")')
+        return cls(enum_name=body['enum_name'],
+                   entries=cls._parse_entries(body['entries'], description),
+                   max_value=max_value)
+
+    @classmethod
+    def _parse_entries(cls, value: object, description: str) -> list[str]:
+        """Normalise `entries` to a non-empty list of entries, as authored."""
+        entries = [value] if isinstance(value, str) else value
+        if not (isinstance(entries, list) and entries
+                and all(isinstance(entry, str) for entry in entries)):
+            raise ValueError(
+                f'{cls.NAME} `entries` must be a string or a non-empty list of '
+                f'strings (in "{description}")')
+        for entry in entries:
+            if not cls._ENTRY_RE.fullmatch(entry):
+                raise ValueError(
+                    f'{cls.NAME} `entries` items must be an entry name, '
+                    f'optionally with an `= value`, and carry no trailing '
+                    f'comma: {entry!r} (in "{description}")')
+        return list(entries)
+
+
 _REWRITERS: MappingProxyType[str, type[Rewriter]] = MappingProxyType({
     rewriter.NAME: rewriter
     for rewriter in (Regex, MakeVirtual, AddFriend, DropFinal,
                      PreemptFunctionImpl, AfterFunctionImpl, RenameClass,
-                     AddToProtected, AddToPublic)
+                     AddToProtected, AddToPublic, AddEnumEntries)
 })
 
 

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -2330,6 +2330,355 @@ class RewriterFormsTest(unittest.TestCase):
             '    virtual void A();\n    virtual void B();\n\n'
             '   private:\n    int x_;\n  };\n};\n')
 
+    # -- add_enum_entries op (real ast-grep binary) --------------------------
+    #
+    # The sources below are cut down from the upstream enums our `rewrite/`
+    # plasters extend today, so each case shows the rewriter covering one of
+    # them.
+
+    def test_add_enum_entries_repoints_the_max_value(self):
+        # chrome/browser/ui/page_action/page_action_model.h: the entries are
+        # appended to the nested `Property` enum, at its own column, and
+        # kMaxValue is re-pointed at the last one so PropertySet's EnumSet range
+        # covers them.
+        result = self._apply(
+            'enum_property.h', 'class PageActionModelInterface {\n public:\n'
+            '  enum class Property {\n'
+            '    kShowRequested,\n'
+            '    kOverrideBackgroundColor,\n'
+            '    kMaxValue = kOverrideBackgroundColor,\n'
+            '  };\n};\n', 'substitutions:\n'
+            '  - description: add the Brave properties\n'
+            '    add_enum_entries:\n'
+            '      enum_name: Property\n'
+            '      max_value: kMaxValue\n'
+            '      entries:\n'
+            '        - kAlwaysShowLabel\n'
+            '        - kOverrideChipColors\n'
+            '        - kOverrideBorder\n')
+        self.assertEqual(
+            result, 'class PageActionModelInterface {\n public:\n'
+            '  enum class Property {\n'
+            '    kShowRequested,\n'
+            '    kOverrideBackgroundColor,\n'
+            '    kAlwaysShowLabel,\n'
+            '    kOverrideChipColors,\n'
+            '    kOverrideBorder,\n'
+            '    kMaxValue = kOverrideBorder,\n'
+            '  };\n};\n')
+
+    def test_add_enum_entries_repoints_a_max_value_of_any_name(self):
+        # components/sync/base/user_selectable_type.h: the max value is spelled
+        # kLastType, and carries no trailing comma of its own -- neither matters
+        # to the insertion, which re-emits the entry in place.
+        result = self._apply(
+            'enum_last_type.h', 'enum class UserSelectableType {\n'
+            '  kBookmarks,\n'
+            '  kFirstType = kBookmarks,\n'
+            '\n'
+            '  kCookies,\n'
+            '  kLastType = kCookies\n'
+            '};\n', 'substitutions:\n'
+            '  - description: append kAIChat as the new kLastType\n'
+            '    add_enum_entries:\n'
+            '      enum_name: UserSelectableType\n'
+            '      max_value: kLastType\n'
+            '      entries: kAIChat\n')
+        self.assertEqual(
+            result, 'enum class UserSelectableType {\n'
+            '  kBookmarks,\n'
+            '  kFirstType = kBookmarks,\n'
+            '\n'
+            '  kCookies,\n'
+            '  kAIChat,\n'
+            '  kLastType = kAIChat\n'
+            '};\n')
+
+    def test_add_enum_entries_accepts_entries_carrying_values(self):
+        # components/permissions/request_type.h: the Brave entries include
+        # aliases of their own. The max value is re-pointed at the last entry
+        # added -- kBraveMaxValue, which its alias makes equal to kBraveCardano.
+        result = self._apply(
+            'enum_request_type.h', 'enum class RequestType {\n'
+            '  kStorageAccess,\n'
+            '  kWindowManagement,\n'
+            '  kMaxValue = kWindowManagement,\n'
+            '};\n', 'substitutions:\n'
+            '  - description: append the Brave request types\n'
+            '    add_enum_entries:\n'
+            '      enum_name: RequestType\n'
+            '      max_value: kMaxValue\n'
+            '      entries:\n'
+            '        - kWidevine\n'
+            '        - kBraveCardano\n'
+            '        - kBraveMinValue = kWidevine\n'
+            '        - kBraveMaxValue = kBraveCardano\n')
+        self.assertEqual(
+            result, 'enum class RequestType {\n'
+            '  kStorageAccess,\n'
+            '  kWindowManagement,\n'
+            '  kWidevine,\n'
+            '  kBraveCardano,\n'
+            '  kBraveMinValue = kWidevine,\n'
+            '  kBraveMaxValue = kBraveCardano,\n'
+            '  kMaxValue = kBraveMaxValue,\n'
+            '};\n')
+
+    def test_add_enum_entries_leaves_a_valueless_max_value_alone(self):
+        # An entry that carries no value of its own follows on from whatever
+        # precedes it, so inserting before it already moves it along; it is
+        # re-emitted untouched rather than pointed at the new last key.
+        result = self._apply(
+            'enum_count.h', 'enum class Kind {\n'
+            '  kA,\n'
+            '  kCount,\n'
+            '};\n', 'substitutions:\n'
+            '  - description: add kB before the count\n'
+            '    add_enum_entries:\n'
+            '      enum_name: Kind\n'
+            '      max_value: kCount\n'
+            '      entries: kB\n')
+        self.assertEqual(
+            result, 'enum class Kind {\n'
+            '  kA,\n'
+            '  kB,\n'
+            '  kCount,\n'
+            '};\n')
+
+    def test_add_enum_entries_appends_without_a_max_value(self):
+        # crypto/signature_verifier.h: an unscoped enum with no max-value entry,
+        # so the entries simply follow the last one. The comment above that entry
+        # is not where the insertion goes.
+        result = self._apply(
+            'enum_signature.h', 'class SignatureVerifier {\n public:\n'
+            '  enum SignatureAlgorithm {\n'
+            '    RSA_PKCS1_SHA1,\n'
+            '    // This is RSA-PSS with SHA-256 as both signing hash and MGF-1\n'
+            '    // hash.\n'
+            '    RSA_PSS_SHA256,\n'
+            '  };\n};\n', 'substitutions:\n'
+            '  - description: add ECDSA_SHA384 for downstream switches\n'
+            '    add_enum_entries:\n'
+            '      enum_name: SignatureAlgorithm\n'
+            '      entries: ECDSA_SHA384\n')
+        self.assertEqual(
+            result, 'class SignatureVerifier {\n public:\n'
+            '  enum SignatureAlgorithm {\n'
+            '    RSA_PKCS1_SHA1,\n'
+            '    // This is RSA-PSS with SHA-256 as both signing hash and MGF-1\n'
+            '    // hash.\n'
+            '    RSA_PSS_SHA256,\n'
+            '    ECDSA_SHA384,\n'
+            '  };\n};\n')
+
+    def test_add_enum_entries_appends_without_a_max_value_or_a_separator(self):
+        # The same enum, with the trailing comma its last entry is free to omit
+        # while nothing follows it. Appending after that entry adds the comma the
+        # new key now requires, and the comment above is still not the anchor.
+        result = self._apply(
+            'enum_signature_bare.h', 'class SignatureVerifier {\n public:\n'
+            '  enum SignatureAlgorithm {\n'
+            '    RSA_PKCS1_SHA1,\n'
+            '    // This is RSA-PSS with SHA-256 as both signing hash and MGF-1\n'
+            '    // hash.\n'
+            '    RSA_PSS_SHA256\n'
+            '  };\n};\n', 'substitutions:\n'
+            '  - description: add ECDSA_SHA384 for downstream switches\n'
+            '    add_enum_entries:\n'
+            '      enum_name: SignatureAlgorithm\n'
+            '      entries: ECDSA_SHA384\n')
+        self.assertEqual(
+            result, 'class SignatureVerifier {\n public:\n'
+            '  enum SignatureAlgorithm {\n'
+            '    RSA_PKCS1_SHA1,\n'
+            '    // This is RSA-PSS with SHA-256 as both signing hash and MGF-1\n'
+            '    // hash.\n'
+            '    RSA_PSS_SHA256,\n'
+            '    ECDSA_SHA384,\n'
+            '  };\n};\n')
+
+    def test_add_enum_entries_ignores_a_comment_after_the_last_entry(self):
+        # A comment trailing the last entry is not an entry: the entries still go
+        # after that entry, where a match on the body's closing brace would put
+        # them after the comment instead.
+        result = self._apply(
+            'enum_trailing_comment.h', 'enum class OriginFilter {\n'
+            '  kPublic = 0,\n'
+            '  kValidTestOriginForTesting,\n'
+            '  // NOTE(crbug.com/481255908): Remove the placeholder filter.\n'
+            '};\n', 'substitutions:\n'
+            '  - description: add the Brave origins\n'
+            '    add_enum_entries:\n'
+            '      enum_name: OriginFilter\n'
+            '      entries:\n'
+            '        - kBraveSearch\n'
+            '        - kBraveTalk\n')
+        self.assertEqual(
+            result, 'enum class OriginFilter {\n'
+            '  kPublic = 0,\n'
+            '  kValidTestOriginForTesting,\n'
+            '  kBraveSearch,\n'
+            '  kBraveTalk,\n'
+            '  // NOTE(crbug.com/481255908): Remove the placeholder filter.\n'
+            '};\n')
+
+    def test_add_enum_entries_separates_a_bare_last_entry(self):
+        # The upstream last entry carries no comma, since nothing followed it.
+        # Appending after it adds the one the new entries now require.
+        result = self._apply(
+            'enum_bare_last.h', 'enum class Kind {\n'
+            '  kA,\n'
+            '  kB\n'
+            '};\n', 'substitutions:\n'
+            '  - description: append two kinds\n'
+            '    add_enum_entries:\n'
+            '      enum_name: Kind\n'
+            '      entries:\n'
+            '        - kC\n'
+            '        - kD\n')
+        self.assertEqual(
+            result, 'enum class Kind {\n'
+            '  kA,\n'
+            '  kB,\n'
+            '  kC,\n'
+            '  kD,\n'
+            '};\n')
+
+    def test_add_enum_entries_scoped_to_named_enum(self):
+        # Only the named enum is extended; a sibling enum is left alone.
+        result = self._apply(
+            'enum_scope.h', 'enum class Kind {\n  kA,\n};\n\n'
+            'enum class Other {\n  kA,\n};\n', 'substitutions:\n'
+            '  - description: add only to Kind\n'
+            '    add_enum_entries:\n'
+            '      enum_name: Kind\n'
+            '      entries: kB\n')
+        self.assertEqual(
+            result, 'enum class Kind {\n  kA,\n  kB,\n};\n\n'
+            'enum class Other {\n  kA,\n};\n')
+
+    def test_add_enum_entries_extends_an_enum_with_a_base_clause(self):
+        # An underlying type on the enum head does not get in the way of the
+        # body's entries.
+        result = self._apply(
+            'enum_base.h', 'enum class Kind : int {\n  kA,\n};\n',
+            'substitutions:\n'
+            '  - description: add kB\n'
+            '    add_enum_entries:\n'
+            '      enum_name: Kind\n'
+            '      entries: kB\n')
+        self.assertEqual(result, 'enum class Kind : int {\n  kA,\n  kB,\n};\n')
+
+    def test_add_enum_entries_two_enums_of_the_same_name_fail(self):
+        # Two enums share the name, so which one to extend is ambiguous: the
+        # count check flags it rather than extending both.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'enum_ambiguous.h', 'enum class Kind {\n  kA,\n};\n'
+                'class C {\n public:\n  enum class Kind {\n    kX,\n  };\n};\n',
+                'substitutions:\n'
+                '  - description: ambiguous enum name\n'
+                '    add_enum_entries:\n'
+                '      enum_name: Kind\n'
+                '      entries: kB\n')
+
+    def test_add_enum_entries_max_value_not_last_fails(self):
+        # The declared max value is no longer the enum's last entry, so the
+        # premise of the insertion no longer holds. The error names the entry
+        # that is last, so the next reader knows what changed upstream.
+        with self.assertRaises(plaster.PlasterApplyError) as ctx:
+            self._apply(
+                'enum_moved_max_value.h', 'enum class Kind {\n'
+                '  kA,\n'
+                '  kMaxValue = kA,\n'
+                '  kExtra,\n'
+                '};\n', 'substitutions:\n'
+                '  - description: the max value is not last anymore\n'
+                '    add_enum_entries:\n'
+                '      enum_name: Kind\n'
+                '      max_value: kMaxValue\n'
+                '      entries: kB\n')
+        self.assertIn(
+            'Enum `Kind` ends in `kExtra`, not in the declared `max_value` '
+            'entry `kMaxValue`', str(ctx.exception))
+
+    def test_add_enum_entries_absent_enum_fails(self):
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'enum_absent.h', 'enum class Kind {\n  kA,\n};\n',
+                'substitutions:\n'
+                '  - description: no such enum\n'
+                '    add_enum_entries:\n'
+                '      enum_name: Missing\n'
+                '      entries: kB\n')
+
+    def test_add_enum_entries_empty_enum_fails(self):
+        # There is no last entry to anchor on.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'enum_empty.h', 'enum class Kind {};\n', 'substitutions:\n'
+                '  - description: nothing to append to\n'
+                '    add_enum_entries:\n'
+                '      enum_name: Kind\n'
+                '      entries: kB\n')
+
+    def test_add_enum_entries_unknown_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: typo arg\n'
+            '    add_enum_entries:\n'
+            '      enum_name: Kind\n'
+            '      key: kB\n', 'Unrecognised add_enum_entries arg')
+
+    def test_add_enum_entries_missing_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: missing entries\n'
+            '    add_enum_entries:\n'
+            '      enum_name: Kind\n', 'add_enum_entries requires arg')
+
+    def test_add_enum_entries_empty_entry_list_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: no entries to add\n'
+            '    add_enum_entries:\n'
+            '      enum_name: Kind\n'
+            '      entries: []\n',
+            'add_enum_entries `entries` must be a string or a '
+            'non-empty list of strings')
+
+    def test_add_enum_entries_entry_with_trailing_comma_rejected(self):
+        # The separators are the rewriter's to add, so an authored one is a
+        # mistake rather than something to pass through.
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: comma in the key\n'
+            '    add_enum_entries:\n'
+            '      enum_name: Kind\n'
+            "      entries: 'kB,'\n",
+            'add_enum_entries `entries` items must be an '
+            'entry name')
+
+    def test_add_enum_entries_max_value_must_name_an_entry(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: the max value is not a name\n'
+            '    add_enum_entries:\n'
+            '      enum_name: Kind\n'
+            '      max_value: kMaxValue = kA\n'
+            '      entries: kB\n',
+            'add_enum_entries `max_value` must be an entry name')
+
+    def test_add_enum_entries_count_other_than_one_rejected(self):
+        # It always adds the entries once, so any other count is a config error.
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: bogus count\n'
+            '    count: 2\n'
+            '    add_enum_entries:\n'
+            '      enum_name: Kind\n'
+            '      entries: kB\n', 'does not accept a count other than 1')
+
     # -- after_function_impl op (real ast-grep binary) -------------------------
 
     def test_after_function_impl_void(self):

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -283,6 +283,33 @@ inside:
             },
         },
 
+        # The last entry of the enum named `enum_name`: the final `enumerator`
+        # among the ones its body holds. `ofRule` narrows what `nthChild`
+        # counts to entries alone, so a comment sitting after the last entry, or
+        # anywhere else in the body, does not displace it. Anchoring on the
+        # entry, rather than on the body's closing brace, also means the match
+        # never depends on where that brace sits.
+        "cxx.find_last_enum_entry": {
+            "template": """\
+kind: enumerator
+nthChild:
+  position: 1
+  reverse: true
+  ofRule:
+    kind: enumerator
+inside:
+  kind: enumerator_list
+  inside:
+    kind: enum_specifier
+    has:
+      field: name
+      regex: ^{enum_name}$
+""",
+            "result": {
+                "node": "enumerator",
+            },
+        },
+
         # Every identifier-family token whose text is exactly `class_name`:
         # type positions (type_identifier), the `Class::` qualifier
         # (namespace_identifier), the ctor/dtor name and bare uses (identifier),
@@ -497,6 +524,52 @@ regex: ^{class_name}$
             },
             "result": {
                 "node": "field_declaration_list",
+            },
+        },
+
+        # The enum's max-value entry, the last one, which the caller has already
+        # established is the declared one, replaced by `entries` followed by
+        # that entry itself, its name (`\1`) re-emitted so the match's own
+        # spelling carries over. `entries` arrives with its first line
+        # unindented, the match starting at the column the entry already sits
+        # at, and `indent` opens every line after it.
+        # `value` is optional: when the caller names the entry to re-point at,
+        # `when_set` expands it to the value this one now takes, and when it is
+        # empty the placeholder renders as nothing, which is what an entry
+        # carrying no value of its own needs, since it simply follows on from
+        # whatever was inserted above it.
+        "cxx.insert_enum_entries_before_max_value": {
+            "matcher": "cxx.find_last_enum_entry",
+            "inputs": ["enum_name", "entries", "indent", "value"],
+            "when_set": {
+                "value": " = {value}",
+            },
+            "replace": {
+                "re_pattern": "(?s)^(\\w+).*$",
+                "replace": "{entries}\\n{indent}\\1{value}",
+            },
+            "result": {
+                "node": "enumerator",
+            },
+        },
+
+        # `entries` appended after the enum's last entry, which is re-emitted
+        # (`\1`) with the separator the new entries now require. `comma` is the
+        # separator the source already has, if any: it is folded into the
+        # rewritten span so it cannot be left dangling after the appended
+        # entries, and is empty for a last entry that carries none (the closing
+        # brace allows it). `entries` arrives fully indented, as it opens a
+        # line of its own.
+        "cxx.append_enum_entries_after_last": {
+            "matcher": "cxx.find_last_enum_entry",
+            "inputs": ["enum_name", "entries", "comma"],
+            "replace": {
+                "consume_after": "{comma}",
+                "re_pattern": "(?s)^(.*)$",
+                "replace": "\\1,\\n{entries}",
+            },
+            "result": {
+                "node": "enumerator",
             },
         },
     },


### PR DESCRIPTION
This is a modest rewriter to permit the addition of enum keys at the end
of enum types. For now this iteration does not attempt to handle all
possible uses, but it does address the most common one in C++: adding at
the end and correct the max-value key.

Fixed: https://github.com/brave/brave-browser/issues/57593
