### PR TITLE
[AI Chat] Enable kAIChatMoveFullPageToSidePanel by default

### DIFF
--- a/components/ai_chat/core/common/features.cc
+++ b/components/ai_chat/core/common/features.cc
@@ -100,7 +100,7 @@ bool IsAIChatGlobalSidePanelEverywhereEnabled() {
       features::kAIChatGlobalSidePanelEverywhere);
 }
 
-BASE_FEATURE(kAIChatMoveFullPageToSidePanel, base::FEATURE_DISABLED_BY_DEFAULT);
+BASE_FEATURE(kAIChatMoveFullPageToSidePanel, base::FEATURE_ENABLED_BY_DEFAULT);
 
 BASE_FEATURE(kCustomSiteDistillerScripts, base::FEATURE_ENABLED_BY_DEFAULT);
 

--- a/components/ai_chat/core/common/features.h
+++ b/components/ai_chat/core/common/features.h
@@ -105,7 +105,8 @@ bool IsAIChatGlobalSidePanelEverywhereEnabled();
 // Moves the full-page AI Chat conversation into the side panel when an
 // in-conversation link is clicked, and back into a tab when opening the
 // conversation full-page, transferring the live WebContents to preserve state.
-// Desktop only; disabled by default.
+// Desktop only.
+// https://github.com/brave/brave-browser/issues/57047
 COMPONENT_EXPORT(AI_CHAT_COMMON)
 BASE_DECLARE_FEATURE(kAIChatMoveFullPageToSidePanel);
 


### PR DESCRIPTION
Now that the full functionality has landed, we can enable this feature.

Series
- https://github.com/brave/brave-browser/issues/57047
