### PR TITLE
[recipes] Allow shallow Chromium in re-checkouts

### DIFF
--- a/tools/recipes/recipe_modules/chromium_checkout/api.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/api.py
@@ -278,16 +278,27 @@ class ChromiumCheckoutApi(RecipeApi):
             ['git', 'remote', 'set-url', '--push', 'origin', CHROMIUM_URL],
             cwd=chromium_src)
 
+        # `--depth` here (not just on the `populate` above) matters whenever
+        # *chromium_src* is already shallow at a different commit than the
+        # mirror's current one for this ref (e.g. re-checking out a branch
+        # after it moved on): a plain `git fetch` tries to extend the
+        # existing shallow history and fails outright ("did not send all
+        # necessary objects") once the mirror can no longer connect the two.
+        # Passing `--depth` here instead negotiates a fresh, self-contained
+        # shallow window for the requested ref, which doesn't depend on that
+        # connection at all.
+        depth_args = ['--depth', str(depth)] if depth else []
         if is_tag:
             # Chromium release tag (e.g. `150.0.7850.1`): fetch it as a tag so
             # it lands at `refs/tags/<ref>` in the local repo.
             self.m.step('fetch tag', [
-                'git', 'fetch', '--no-tags', 'origin',
+                'git', 'fetch', *depth_args, '--no-tags', 'origin',
                 f'refs/tags/{ref}:refs/tags/{ref}'
             ],
                         cwd=chromium_src)
         else:
-            self.m.step('fetch ref', ['git', 'fetch', 'origin', ref],
+            self.m.step('fetch ref',
+                        ['git', 'fetch', *depth_args, 'origin', ref],
                         cwd=chromium_src)
 
         # A manual `git checkout --force` rather than `gclient sync -r <ref>`

--- a/tools/recipes/recipe_modules/chromium_checkout/tests/depth.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/tests/depth.py
@@ -2,30 +2,67 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Test for `ensure_checkout`'s optional `depth` -- threaded down into
-`git cache populate --depth` for a shallower shared mirror.
+"""Test for `ensure_checkout`'s optional `depth` -- threaded down into both
+`git cache populate --depth` (for a shallower shared mirror) and the actual
+`git fetch --depth` that lands the requested ref in `chromium_src` (so
+re-checking out a moved branch negotiates a fresh shallow window instead of
+trying, and failing, to extend the existing one).
 """
 
 from __future__ import annotations
 
 import post_process
 
-DEPS = ['chromium_checkout']
+DEPS = ['chromium_checkout', 'env']
 
 
 def RunSteps(api):
-    api.chromium_checkout.ensure_checkout(ref='151.0.7917.1', depth=1)
+    ref = api.env.get('REF')
+    depth = api.env.get('DEPTH')
+    api.chromium_checkout.ensure_checkout(ref=ref,
+                                          depth=int(depth) if depth else None)
 
 
 def GenTests(api):
     yield api.test(
-        'shallow',
+        'shallow tag',
+        api.env.set('REF', '151.0.7917.1'),
+        api.env.set('DEPTH', '1'),
         api.chromium_checkout.with_git_cache(),
         api.chromium_checkout.git_cache_populated(),
         api.post_process(post_process.StepCommandContains,
                          'git cache populate', ['--depth', '1']),
         api.post_process(post_process.StepCommandContains,
                          'git cache populate for ref', ['--depth', '1']),
+        api.post_process(post_process.StepCommandContains, 'fetch tag',
+                         ['--depth', '1']),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )
+    yield api.test(
+        'shallow branch',
+        api.env.set('REF', 'main'),
+        api.env.set('DEPTH', '1'),
+        api.chromium_checkout.with_git_cache(),
+        api.chromium_checkout.git_cache_populated(),
+        api.post_process(post_process.StepCommandContains,
+                         'git cache populate', ['--depth', '1']),
+        api.post_process(post_process.StepCommandContains,
+                         'git cache populate for ref', ['--depth', '1']),
+        api.post_process(post_process.StepCommandContains, 'fetch ref',
+                         ['--depth', '1']),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )
+    # Without an explicit `depth`, neither the mirror populate nor the actual
+    # fetch is depth-limited.
+    yield api.test(
+        'no depth requested',
+        api.env.set('REF', 'main'),
+        api.chromium_checkout.with_git_cache(),
+        api.chromium_checkout.git_cache_populated(),
+        api.post_process(post_process.StepCommandRE, 'fetch ref',
+                         ['git', 'fetch', 'origin', 'main']),
         api.post_process(post_process.StatusSuccess),
         api.post_process(post_process.DropExpectation),
     )

--- a/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
@@ -206,6 +206,8 @@
     "cmd": [
       "git",
       "fetch",
+      "--depth",
+      "1",
       "--no-tags",
       "origin",
       "refs/tags/151.0.7917.1:refs/tags/151.0.7917.1"

--- a/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/linux.json
+++ b/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/linux.json
@@ -206,6 +206,8 @@
     "cmd": [
       "git",
       "fetch",
+      "--depth",
+      "1",
       "--no-tags",
       "origin",
       "refs/tags/151.0.7917.1:refs/tags/151.0.7917.1"


### PR DESCRIPTION
This PR adds further support for reuse of shallow clones of Chromium.
When it comes to checking out branches, the branch head tends to move,
and the recipes module needs to be capable of handling that.

This fix makes sure we have the correct ref with the correct depth when
doing a shallow clone update.

Bug: https://github.com/brave/brave-browser/issues/56748
