### PR TITLE
[plaster] `print_rust_log` 🩹

### DIFF
--- a/chromium_src/base/logging/rust_logger/print_rust_log_ffi.cc
+++ b/chromium_src/base/logging/rust_logger/print_rust_log_ffi.cc
@@ -7,16 +7,11 @@
 
 #include "base/logging.h"
 
-#define print_rust_log print_rust_log_chromium_impl
-#include <base/logging/rust_logger/print_rust_log_ffi.cc>
-#undef print_rust_log
-
 namespace logging::internal {
 
-void print_rust_log(const RustFmtArguments& msg,
-                    const char* file,
-                    int32_t line,
-                    int32_t severity) {
+namespace {
+
+bool ShouldPrintRustLog(int32_t& severity) {
   switch (severity) {
     // Trace and debug logs are set as `LOGGING_INFO`. We also map
     // `LOGGING_WARN` to verbose, to avoid "excessive output" errors in unit
@@ -27,15 +22,14 @@ void print_rust_log(const RustFmtArguments& msg,
       break;
     default:
       // All other cases are handled by the upstream version.
-      print_rust_log_chromium_impl(msg, file, line, severity);
-      return;
+      return true;
   }
 
-  if (!VLOG_IS_ON(-severity)) {
-    return;
-  }
-
-  print_rust_log_chromium_impl(msg, file, line, severity);
+  return VLOG_IS_ON(-severity);
 }
 
+}  // namespace
+
 }  // namespace logging::internal
+
+#include <base/logging/rust_logger/print_rust_log_ffi.cc>

--- a/patches/base-logging-rust_logger-print_rust_log_ffi.cc.patch
+++ b/patches/base-logging-rust_logger-print_rust_log_ffi.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/base/logging/rust_logger/print_rust_log_ffi.cc b/base/logging/rust_logger/print_rust_log_ffi.cc
+index 0d54e6e649a29f1804b06a354d4561f871cf0c7e..62b26b7a53c1c5ece9b56eda2218f29c8882a43c 100644
+--- a/base/logging/rust_logger/print_rust_log_ffi.cc
++++ b/base/logging/rust_logger/print_rust_log_ffi.cc
+@@ -27,6 +27,9 @@ void print_rust_log(const RustFmtArguments& msg,
+                     const char* file,
+                     int32_t line,
+                     int32_t severity) {
++  if (!ShouldPrintRustLog(severity)) {
++    return;
++  }
+   LogMessageRustWrapper wrapper(file, line, severity);
+   msg.format(wrapper);
+ }

--- a/rewrite/base/logging/rust_logger/print_rust_log_ffi.cc.yaml
+++ b/rewrite/base/logging/rust_logger/print_rust_log_ffi.cc.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Consult ShouldPrintRustLog (defined in the chromium_src override) first:
+      it remaps trace/debug severities to verbose and reports whether the
+      message should still fall through to the upstream formatting below.
+    preempt_function_impl:
+      function_name: print_rust_log
+      code: |-
+        if (!ShouldPrintRustLog(severity)) {
+          return;
+        }


### PR DESCRIPTION
This PR migrates `print_rust_log` to use plaster, rather than relying on
`#define` macros.

Bug: https://github.com/brave/brave-browser/issues/45050
