### PR TITLE
[AI Chat]: Use site origin rather than URL for tool names to reduce Bedrock tool name length errors

### DIFF
--- a/browser/ai_chat/web_mcp_browsertest.cc
+++ b/browser/ai_chat/web_mcp_browsertest.cc
@@ -177,21 +177,20 @@ IN_PROC_BROWSER_TEST_F(WebMcpBrowserTest,
   auto tools = RefreshAndGetTools(manager);
   ASSERT_EQ(2u, tools.size());
 
-  // Names are prefixed with the sanitized host and path
-  // ("a.com/web_mcp_tools.html" → "a_com_web_mcp_tools_html") to disambiguate
-  // page-defined tools across origins and pages.
+  // Names are prefixed with the sanitized host ("a.com" → "a_com"). Only the
+  // host is used (not the full path) to keep the name within Bedrock's 64-char
+  // tool-name limit.
   std::set<std::string> tool_names;
   for (const auto& tool : tools) {
     ASSERT_TRUE(tool);
     tool_names.insert(std::string(tool->Name()));
   }
   EXPECT_THAT(tool_names,
-              ::testing::UnorderedElementsAre("a_com_web_mcp_tools_html_echo",
-                                              "a_com_web_mcp_tools_html_ping"));
+              ::testing::UnorderedElementsAre("a_com_echo", "a_com_ping"));
 
   // Sanity check on metadata for the richer tool.
   for (const auto& tool : tools) {
-    if (tool->Name() == "a_com_web_mcp_tools_html_echo") {
+    if (tool->Name() == "a_com_echo") {
       // The description embeds the full page URL and the page-provided
       // description.
       std::string description(tool->Description());

--- a/components/ai_chat/content/browser/associated_web_contents_content_unittest.cc
+++ b/components/ai_chat/content/browser/associated_web_contents_content_unittest.cc
@@ -706,17 +706,16 @@ TEST_P(AssociatedWebContentsContentUnitTest,
   base::test::TestFuture<std::vector<std::unique_ptr<Tool>>> future;
   GetContentTools(future.GetCallback());
   auto tools = future.Take();
-  // ScriptTool prefixes names with the sanitized host and path
-  // ("https://www.example.com/" → "www_example_com_") and embeds the host plus
+  // ScriptTool prefixes names with the sanitized host
+  // ("https://www.example.com" → "www_example_com") and embeds the host plus
   // the page-provided description in the description so the LLM has the
-  // website-attribution context. The path is included so tools with the same
-  // name on different pages of the same host don't collapse; here the root path
-  // "/" sanitizes to an extra underscore.
+  // website-attribution context. Only the host is used (not the full path) to
+  // keep the name within Bedrock's 64-char tool-name limit.
   ASSERT_EQ(2u, tools.size());
-  EXPECT_EQ(tools[0]->Name(), "www_example_com__search");
+  EXPECT_EQ(tools[0]->Name(), "www_example_com_search");
   EXPECT_NE(std::string(tools[0]->Description()).find("Search the page"),
             std::string::npos);
-  EXPECT_EQ(tools[1]->Name(), "www_example_com__summarize");
+  EXPECT_EQ(tools[1]->Name(), "www_example_com_summarize");
   EXPECT_NE(std::string(tools[1]->Description()).find("Summarize the article"),
             std::string::npos);
 }

--- a/components/ai_chat/content/browser/content_tool.cc
+++ b/components/ai_chat/content/browser/content_tool.cc
@@ -32,10 +32,9 @@ ContentTool::ContentTool(const blink::mojom::ScriptTool& script_tool,
     : rfh_(std::move(rfh)), internal_tool_name_(script_tool.name) {
   const GURL& url = rfh_.AsRenderFrameHostIfValid()->GetLastCommittedURL();
 
-  // Name of the ContentTool is {host}{path}_tool_name. The path is included
-  // (not just the host) so that tools with the same name registered on
-  // different pages of the same host don't collapse to the same tool name.
-  name_ = base::StrCat({url.host(), url.path(), "_", script_tool.name});
+  // Name of the ContentTool is {host}_tool_name. Only the host is used (not the
+  // full path) to keep the name within Bedrock's 64-char tool-name limit.
+  name_ = base::StrCat({url.host(), "_", script_tool.name});
 
   // Toolnames only allow alphanumeric characters and underscores.
   std::replace_if(

--- a/components/ai_chat/content/browser/content_tool_unittest.cc
+++ b/components/ai_chat/content/browser/content_tool_unittest.cc
@@ -29,10 +29,9 @@ namespace {
 
 constexpr char kTestUrl[] = "https://example.com/page";
 constexpr char kTestHost[] = "example.com";
-// "example.com/page" (host + path) with non-alnum/underscore characters
-// replaced by '_'. The path is part of the name so tools with the same name on
-// different pages of the same host don't collapse.
-constexpr char kTestHostPathSanitized[] = "example_com_page";
+// "example.com" (host only) with non-alnum/underscore characters replaced
+// by '_'.
+constexpr char kTestHostSanitized[] = "example_com";
 
 blink::mojom::ScriptToolPtr MakeScriptTool(
     const std::string& name,
@@ -134,18 +133,18 @@ class ContentToolTest : public content::RenderViewHostTestHarness {
 TEST_F(ContentToolTest, NamePrefixesHostAndSanitizes) {
   auto mojo_tool = MakeScriptTool("highlight", "Highlight the page");
   ContentTool tool(*mojo_tool, weak_document());
-  // Name format is "{sanitized-host}{sanitized-path}_{tool-name}". The dot in
-  // the host and the slash in the path are replaced with underscores because
-  // tool names only allow alphanumeric characters and underscores.
+  // Name format is "{sanitized-host}_{tool-name}". The dot in the host is
+  // replaced with an underscore because tool names only allow alphanumeric
+  // characters and underscores.
   EXPECT_EQ(tool.Name(),
-            std::string(kTestHostPathSanitized) + std::string("_highlight"));
+            std::string(kTestHostSanitized) + std::string("_highlight"));
 }
 
 TEST_F(ContentToolTest, NameSanitizesDisallowedCharactersInToolName) {
   auto mojo_tool = MakeScriptTool("do-thing.now!", "");
   ContentTool tool(*mojo_tool, weak_document());
-  EXPECT_EQ(tool.Name(), std::string(kTestHostPathSanitized) +
-                             std::string("_do_thing_now_"));
+  EXPECT_EQ(tool.Name(),
+            std::string(kTestHostSanitized) + std::string("_do_thing_now_"));
 }
 
 TEST_F(ContentToolTest, DescriptionIncludesHostAndOriginalMetadata) {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Series https://github.com/brave/brave-browser/issues/55232

Bedrock has a 64 char limit on toolnames: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolSpecification.html

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
