### PR TITLE
Fix fullscreen bubble not auto-hiding on Wayland/NVIDIA

### DIFF
--- a/patches/chrome-browser-ui-views-exclusive_access-exclusive_access_bubble_views.cc.patch
+++ b/patches/chrome-browser-ui-views-exclusive_access-exclusive_access_bubble_views.cc.patch
@@ -1,0 +1,10 @@
+diff --git a/chrome/browser/ui/views/exclusive_access/exclusive_access_bubble_views.cc b/chrome/browser/ui/views/exclusive_access/exclusive_access_bubble_views.cc
+--- a/chrome/browser/ui/views/exclusive_access/exclusive_access_bubble_views.cc
++++ b/chrome/browser/ui/views/exclusive_access/exclusive_access_bubble_views.cc
+@@ -462,5 +462,5 @@ void ExclusiveAccessBubbleViews::RunHideCallbackIfNeeded(
+ }
+ 
+ void ExclusiveAccessBubbleViews::OnPresentationTimeout() {
+-  bubble_view_context_->GetExclusiveAccessManager()->ExitExclusiveAccess();
++  Hide();
+ }


### PR DESCRIPTION
## Summary

On Wayland with NVIDIA GPUs, the compositor never fires the presentation callback that the fullscreen bubble relies on to start its auto-hide timer. The watchdog timer then fires  which calls , forcing an immediate fullscreen exit.

## Root Cause

 calls  when the presentation callback doesn't fire. On Wayland/NVIDIA, this callback never fires, so the watchdog immediately exits fullscreen instead of letting the bubble auto-hide.

## Fix

Replace  with  so the bubble hides normally after its timeout instead of forcing a fullscreen exit.

```diff
 void ExclusiveAccessBubbleViews::OnPresentationTimeout() {
-  bubble_view_context_->GetExclusiveAccessManager()->ExitExclusiveAccess();
+  Hide();
 }
```

## Testing

Tested on Arch Linux with Wayland and NVIDIA proprietary drivers. The fullscreen bubble now auto-hides after ~3-4 seconds instead of immediately exiting fullscreen.

## Related Issues

- Fixes #57308
- Fixes #57585