### PR TITLE
[ads] Fixes Do not classify iOS page content for same document navigations

### DIFF
--- a/ios/browser/brave_ads/BUILD.gn
+++ b/ios/browser/brave_ads/BUILD.gn
@@ -51,3 +51,26 @@ optimize_ts("ads_media_reporting_js") {
 
   deps = [ "//ios/web/public/js_messaging:util_scripts" ]
 }
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [ "ads_tab_helper_unittest.mm" ]
+
+  deps = [
+    ":brave_ads",
+    "//base/test:test_support",
+    "//brave/components/brave_ads/core/browser/service:test_support",
+    "//brave/components/brave_ads/core/public:headers",
+    "//brave/components/brave_rewards/core",
+    "//ios/chrome/browser/shared/model/profile/test",
+    "//ios/chrome/test:test_support",
+    "//ios/web/public/test",
+    "//ios/web/public/test/fakes",
+    "//net",
+    "//testing/gmock",
+    "//testing/gtest",
+    "//ui/base",
+    "//url",
+  ]
+}

--- a/ios/browser/brave_ads/ads_tab_helper.h
+++ b/ios/browser/brave_ads/ads_tab_helper.h
@@ -76,6 +76,8 @@ class AdsTabHelper : public web::WebStateUserData<AdsTabHelper>,
   std::optional<int> http_status_code_;
   bool was_restored_ = false;
   bool is_new_navigation_ = false;
+  bool is_same_document_navigation_ = false;
+  bool has_page_loaded_ = false;
   bool is_web_state_visible_ = false;
 
   base::WeakPtrFactory<AdsTabHelper> weak_factory_{this};

--- a/ios/browser/brave_ads/ads_tab_helper.mm
+++ b/ios/browser/brave_ads/ads_tab_helper.mm
@@ -98,6 +98,7 @@ void AdsTabHelper::DidStartNavigation(
     web::NavigationContext* navigation_context) {
   redirect_chain_.clear();
   http_status_code_.reset();
+  is_same_document_navigation_ = false;
 
   if (web::NavigationManager* navigation_manager =
           web_state->GetNavigationManager()) {
@@ -119,6 +120,14 @@ void AdsTabHelper::DidFinishNavigation(
     web::NavigationContext* navigation_context) {
   if (!navigation_context->HasCommitted()) {
     return;
+  }
+
+  // Computed before the error page check below, so that `has_page_loaded_`
+  // is reset for a new document even if it fails to load, rather than
+  // keeping a stale value from whatever document was previously loaded.
+  is_same_document_navigation_ = navigation_context->IsSameDocument();
+  if (!is_same_document_navigation_) {
+    has_page_loaded_ = false;
   }
 
   if (net::HttpResponseHeaders* headers =
@@ -150,9 +159,11 @@ void AdsTabHelper::DidFinishNavigation(
 
   MaybeNotifyTabDidLoad();
 
-  if (navigation_context->IsSameDocument()) {
-    // Set `was_restored_` to `false` so that listeners are notified of tab
-    // changes after the tab is restored.
+  // Only reset `was_restored_` once the current document has finished
+  // loading, so that listeners are not notified of tab changes for a
+  // same-document navigation that occurs while the tab is still being
+  // restored.
+  if (is_same_document_navigation_ && has_page_loaded_) {
     was_restored_ = false;
   }
 }
@@ -160,6 +171,8 @@ void AdsTabHelper::DidFinishNavigation(
 void AdsTabHelper::PageLoaded(
     web::WebState* web_state,
     web::PageLoadCompletionStatus load_completion_status) {
+  has_page_loaded_ = true;
+
   MaybeNotifyTabTextContentDidChange();
 
   // Set `was_restored_` to `false` so that listeners are notified of tab
@@ -212,11 +225,15 @@ void AdsTabHelper::OnVisibilityChanged(bool is_visible) {
 bool AdsTabHelper::ShouldNotifyTabContentDidChange() const {
   // Don't notify about content changes if the ads service is not available, the
   // tab was restored, was a previously committed navigation, the web contents
-  // are still loading, or an error page was displayed. `http_status_code_` can
-  // be `std::nullopt` if the navigation never finishes, which can occur if the
-  // user constantly refreshes the page, or if the committed navigation was a
-  // network error page.
-  return !was_restored_ && is_new_navigation_ && !redirect_chain_.empty() &&
+  // are still loading, was a same-document navigation, or an error page was
+  // displayed. `http_status_code_` can be `std::nullopt` if the navigation
+  // never finishes, which can occur if the user constantly refreshes the page,
+  // or if the committed navigation was a network error page.
+  //
+  // Unlike desktop, `PageLoaded` also fires for same-document navigations, so
+  // this must be checked explicitly here.
+  return !was_restored_ && is_new_navigation_ &&
+         !is_same_document_navigation_ && !redirect_chain_.empty() &&
          http_status_code_ && !IsHttpErrorStatusCode(*http_status_code_);
 }
 

--- a/ios/browser/brave_ads/ads_tab_helper_unittest.mm
+++ b/ios/browser/brave_ads/ads_tab_helper_unittest.mm
@@ -1,0 +1,407 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/brave_ads/ads_tab_helper.h"
+
+#include <memory>
+
+#include "base/check.h"
+#include "base/memory/raw_ptr.h"
+#include "base/task/single_thread_task_runner.h"
+#include "base/test/test_future.h"
+#include "base/values.h"
+#include "brave/components/brave_ads/core/browser/service/test/ads_service_mock.h"
+#include "brave/components/brave_ads/core/public/prefs/pref_names.h"
+#include "brave/components/brave_rewards/core/pref_names.h"
+#include "components/prefs/pref_service.h"
+#include "ios/chrome/browser/shared/model/profile/test/test_profile_ios.h"
+#include "ios/web/public/test/fakes/fake_navigation_context.h"
+#include "ios/web/public/test/fakes/fake_navigation_manager.h"
+#include "ios/web/public/test/fakes/fake_web_frame.h"
+#include "ios/web/public/test/fakes/fake_web_frames_manager.h"
+#include "ios/web/public/test/fakes/fake_web_state.h"
+#include "ios/web/public/test/web_task_environment.h"
+#include "ios/web/public/web_state_observer.h"
+#include "net/http/http_response_headers.h"
+#include "net/http/http_status_code.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "testing/platform_test.h"
+#include "ui/base/page_transition_types.h"
+#include "url/gurl.h"
+
+namespace brave_ads {
+
+namespace {
+
+constexpr char kInnerText[] = "Inner text";
+
+class NavigationBuilder final {
+ public:
+  NavigationBuilder(web::FakeWebState& web_state, const GURL& url)
+      : web_state_(web_state) {
+    navigation_context_.SetUrl(url);
+  }
+
+  NavigationBuilder(const NavigationBuilder&) = delete;
+  NavigationBuilder& operator=(const NavigationBuilder&) = delete;
+
+  ~NavigationBuilder() = default;
+
+  NavigationBuilder& WithPageTransition(ui::PageTransition page_transition) {
+    navigation_context_.SetPageTransition(page_transition);
+    return *this;
+  }
+
+  NavigationBuilder& WithIsSameDocument(bool is_same_document) {
+    navigation_context_.SetIsSameDocument(is_same_document);
+    return *this;
+  }
+
+  NavigationBuilder& WithResponseHeaders(
+      scoped_refptr<net::HttpResponseHeaders> headers) {
+    navigation_context_.SetResponseHeaders(std::move(headers));
+    return *this;
+  }
+
+  NavigationBuilder& WithError(NSError* error) {
+    navigation_context_.SetError(error);
+    return *this;
+  }
+
+  void Simulate() {
+    navigation_context_.SetHasCommitted(true);
+    web_state_->OnNavigationStarted(&navigation_context_);
+    web_state_->OnNavigationFinished(&navigation_context_);
+  }
+
+ private:
+  raw_ref<web::FakeWebState> web_state_;
+  web::FakeNavigationContext navigation_context_;
+};
+
+// Adds support for simulating a native session restore, which
+// `web::FakeNavigationManager` does not expose a setter for.
+class FakeNavigationManagerWithRestore final
+    : public web::FakeNavigationManager {
+ public:
+  bool IsNativeRestoreInProgress() const override { return is_restoring_; }
+
+  void SetNativeRestoreInProgress(bool is_restoring) {
+    is_restoring_ = is_restoring;
+  }
+
+ private:
+  bool is_restoring_ = false;
+};
+
+}  // namespace
+
+class AdsTabHelperTest : public PlatformTest {
+ public:
+  AdsTabHelperTest() {
+    profile_ = TestProfileIOS::Builder().Build();
+
+    profile_->GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, true);
+    profile_->GetPrefs()->SetBoolean(prefs::kOptedInToNotificationAds, true);
+
+    web_state_ = std::make_unique<web::FakeWebState>();
+    web_state_->SetBrowserState(profile_.get());
+
+    auto web_frames_manager = std::make_unique<web::FakeWebFramesManager>();
+    web_frames_manager_ = web_frames_manager.get();
+    web_state_->SetWebFramesManager(web::ContentWorld::kIsolatedWorld,
+                                    std::move(web_frames_manager));
+
+    auto main_web_frame = web::FakeWebFrame::CreateMainWebFrame();
+    main_web_frame_ = main_web_frame.get();
+    web_frames_manager_->AddWebFrame(std::move(main_web_frame));
+
+    auto navigation_manager =
+        std::make_unique<FakeNavigationManagerWithRestore>();
+    navigation_manager_ = navigation_manager.get();
+    web_state_->SetNavigationManager(std::move(navigation_manager));
+
+    AdsTabHelper::CreateForWebState(web_state_.get(), &ads_service_mock_);
+  }
+
+  AdsTabHelperTest(const AdsTabHelperTest&) = delete;
+  AdsTabHelperTest& operator=(const AdsTabHelperTest&) = delete;
+
+  ~AdsTabHelperTest() override = default;
+
+  void DisableBraveRewards() {
+    profile_->GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, false);
+  }
+
+  void OptOutOfNotificationAds() {
+    profile_->GetPrefs()->SetBoolean(prefs::kOptedInToNotificationAds, false);
+  }
+
+  NavigationBuilder Navigation(const GURL& url) {
+    return NavigationBuilder(*web_state_, url);
+  }
+
+  // Waits for the frame's already-posted callback to run first.
+  void SimulatePageLoad(const std::string& inner_text) {
+    page_load_js_result_ = base::Value(inner_text);
+    main_web_frame_->AddResultForExecutedJs(&page_load_js_result_,
+                                            u"document?.body?.innerText");
+    web_state_->OnPageLoaded(web::PageLoadCompletionStatus::SUCCESS);
+
+    base::test::TestFuture<void> test_future;
+    base::SingleThreadTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE, test_future.GetCallback());
+    ASSERT_TRUE(test_future.Wait());
+  }
+
+  void SimulateVisibilityChanged(bool is_visible) {
+    if (is_visible) {
+      web_state_->WasShown();
+    } else {
+      web_state_->WasHidden();
+    }
+  }
+
+  void SimulateCloseTab() { web_state_.reset(); }
+
+  AdsServiceMock& ads_service_mock() { return ads_service_mock_; }
+
+  FakeNavigationManagerWithRestore& navigation_manager() {
+    CHECK(navigation_manager_);
+    return *navigation_manager_;
+  }
+
+ private:
+  web::WebTaskEnvironment task_environment_;
+  std::unique_ptr<TestProfileIOS> profile_;
+  // Declared before `web_state_` so it outlives it: destroying `web_state_`,
+  // whether via `SimulateCloseTab` or fixture teardown, notifies
+  // `AdsTabHelper`, which calls into this mock.
+  AdsServiceMock ads_service_mock_;
+  std::unique_ptr<web::FakeWebState> web_state_;
+  raw_ptr<web::FakeWebFramesManager> web_frames_manager_;
+  raw_ptr<web::FakeWebFrame> main_web_frame_;
+  raw_ptr<FakeNavigationManagerWithRestore> navigation_manager_;
+  // The frame keeps a pointer to this, so it must outlive `SimulatePageLoad`.
+  base::Value page_load_js_result_;
+};
+
+TEST_F(AdsTabHelperTest, NotifyTabDidChange) {
+  EXPECT_CALL(ads_service_mock(),
+              NotifyTabDidChange(/*tab_id=*/testing::_,
+                                 /*redirect_chain=*/testing::_,
+                                 /*is_new_navigation=*/true,
+                                 /*is_restoring=*/false,
+                                 /*is_visible=*/testing::_));
+  Navigation(GURL("https://brave.com")).Simulate();
+}
+
+TEST_F(AdsTabHelperTest, NotifyTabDidChangeIfTabWasRestored) {
+  navigation_manager().SetNativeRestoreInProgress(true);
+  EXPECT_CALL(ads_service_mock(),
+              NotifyTabDidChange(/*tab_id=*/testing::_,
+                                 /*redirect_chain=*/testing::_,
+                                 /*is_new_navigation=*/testing::_,
+                                 /*is_restoring=*/true,
+                                 /*is_visible=*/testing::_));
+
+  Navigation(GURL("https://brave.com")).Simulate();
+}
+
+TEST_F(
+    AdsTabHelperTest,
+    NotifyTabDidChangeIfTabWasRestoredForSameDocumentNavigationBeforePageLoaded) {
+  navigation_manager().SetNativeRestoreInProgress(true);
+  Navigation(GURL("https://brave.com")).Simulate();
+  Navigation(GURL("https://brave.com#anchor"))
+      .WithIsSameDocument(true)
+      .Simulate();
+  EXPECT_CALL(ads_service_mock(),
+              NotifyTabDidChange(/*tab_id=*/testing::_,
+                                 /*redirect_chain=*/testing::_,
+                                 /*is_new_navigation=*/testing::_,
+                                 /*is_restoring=*/true,
+                                 /*is_visible=*/testing::_));
+
+  SimulateVisibilityChanged(true);
+}
+
+TEST_F(
+    AdsTabHelperTest,
+    NotifyTabDidChangeIfTabWasNotRestoredForSameDocumentNavigationAfterPageLoaded) {
+  navigation_manager().SetNativeRestoreInProgress(true);
+  Navigation(GURL("https://brave.com")).Simulate();
+  SimulatePageLoad(kInnerText);
+  Navigation(GURL("https://brave.com#anchor"))
+      .WithIsSameDocument(true)
+      .Simulate();
+  EXPECT_CALL(ads_service_mock(),
+              NotifyTabDidChange(/*tab_id=*/testing::_,
+                                 /*redirect_chain=*/testing::_,
+                                 /*is_new_navigation=*/testing::_,
+                                 /*is_restoring=*/false,
+                                 /*is_visible=*/testing::_));
+
+  SimulateVisibilityChanged(true);
+}
+
+TEST_F(
+    AdsTabHelperTest,
+    NotifyTabDidChangeIfTabWasRestoredForSameDocumentNavigationAfterErrorPage) {
+  Navigation(GURL("https://brave.com")).Simulate();
+  SimulatePageLoad(kInnerText);
+  navigation_manager().SetNativeRestoreInProgress(true);
+  NSError* error = [NSError errorWithDomain:@"test" code:-1 userInfo:nil];
+  Navigation(GURL("https://brave.com/error")).WithError(error).Simulate();
+  Navigation(GURL("https://brave.com/error#anchor"))
+      .WithIsSameDocument(true)
+      .Simulate();
+  EXPECT_CALL(ads_service_mock(),
+              NotifyTabDidChange(/*tab_id=*/testing::_,
+                                 /*redirect_chain=*/testing::_,
+                                 /*is_new_navigation=*/testing::_,
+                                 /*is_restoring=*/true,
+                                 /*is_visible=*/testing::_));
+
+  SimulateVisibilityChanged(true);
+}
+
+TEST_F(AdsTabHelperTest, NotifyTabDidLoadForHttpSuccessfulResponsePage) {
+  EXPECT_CALL(ads_service_mock(),
+              NotifyTabDidLoad(/*tab_id=*/testing::_, net::HTTP_OK));
+  Navigation(GURL("https://brave.com")).Simulate();
+}
+
+TEST_F(AdsTabHelperTest, NotifyTabDidLoadForHttpClientErrorResponsePage) {
+  EXPECT_CALL(ads_service_mock(),
+              NotifyTabDidLoad(/*tab_id=*/testing::_, net::HTTP_NOT_FOUND));
+  Navigation(GURL("https://brave.com"))
+      .WithResponseHeaders(net::HttpResponseHeaders::TryToCreate(
+          "HTTP/1.1 404 Not Found\r\n\r\n"))
+      .Simulate();
+}
+
+TEST_F(AdsTabHelperTest, NotifyTabDidLoadForHttpServerErrorResponsePage) {
+  EXPECT_CALL(
+      ads_service_mock(),
+      NotifyTabDidLoad(/*tab_id=*/testing::_, net::HTTP_INTERNAL_SERVER_ERROR));
+  Navigation(GURL("https://brave.com"))
+      .WithResponseHeaders(net::HttpResponseHeaders::TryToCreate(
+          "HTTP/1.1 500 Internal Server Error\r\n\r\n"))
+      .Simulate();
+}
+
+TEST_F(AdsTabHelperTest, DoNotNotifyTabDidLoadForNetErrorPage) {
+  NSError* error = [NSError errorWithDomain:@"test" code:-1 userInfo:nil];
+  EXPECT_CALL(ads_service_mock(), NotifyTabDidLoad).Times(0);
+  EXPECT_CALL(ads_service_mock(), NotifyTabDidFailToLoad);
+
+  Navigation(GURL("https://brave.com")).WithError(error).Simulate();
+}
+
+TEST_F(AdsTabHelperTest,
+       NotifyTabTextContentDidChangeForRewardsUserOptedInToNotificationAds) {
+  Navigation(GURL("https://brave.com")).Simulate();
+  EXPECT_CALL(ads_service_mock(),
+              NotifyTabTextContentDidChange(/*tab_id=*/testing::_,
+                                            /*redirect_chain=*/testing::_,
+                                            /*text=*/kInnerText));
+  SimulatePageLoad(kInnerText);
+}
+
+TEST_F(AdsTabHelperTest, DoNotNotifyTabTextContentDidChangeForNonRewardsUser) {
+  DisableBraveRewards();
+  Navigation(GURL("https://brave.com")).Simulate();
+  EXPECT_CALL(ads_service_mock(), NotifyTabTextContentDidChange).Times(0);
+  SimulatePageLoad(kInnerText);
+}
+
+TEST_F(
+    AdsTabHelperTest,
+    DoNotNotifyTabTextContentDidChangeForNonRewardsUserAndOptedOutOfNotificationAds) {
+  DisableBraveRewards();
+  OptOutOfNotificationAds();
+  Navigation(GURL("https://brave.com")).Simulate();
+  EXPECT_CALL(ads_service_mock(), NotifyTabTextContentDidChange).Times(0);
+  SimulatePageLoad(kInnerText);
+}
+
+TEST_F(
+    AdsTabHelperTest,
+    DoNotNotifyTabTextContentDidChangeForRewardsUserOptedOutOfNotificationAds) {
+  OptOutOfNotificationAds();
+  Navigation(GURL("https://brave.com")).Simulate();
+  EXPECT_CALL(ads_service_mock(), NotifyTabTextContentDidChange).Times(0);
+  SimulatePageLoad(kInnerText);
+}
+
+TEST_F(AdsTabHelperTest, DoNotNotifyTabTextContentDidChangeIfTabWasRestored) {
+  navigation_manager().SetNativeRestoreInProgress(true);
+  Navigation(GURL("https://brave.com")).Simulate();
+  EXPECT_CALL(ads_service_mock(), NotifyTabTextContentDidChange).Times(0);
+  SimulatePageLoad(kInnerText);
+}
+
+TEST_F(AdsTabHelperTest,
+       DoNotNotifyTabTextContentDidChangeForSameDocumentNavigation) {
+  Navigation(GURL("https://brave.com")).Simulate();
+  SimulatePageLoad(kInnerText);
+  EXPECT_CALL(ads_service_mock(), NotifyTabTextContentDidChange).Times(0);
+
+  Navigation(GURL("https://brave.com#anchor"))
+      .WithIsSameDocument(true)
+      .Simulate();
+  SimulatePageLoad(kInnerText);
+}
+
+TEST_F(AdsTabHelperTest,
+       DoNotNotifyTabTextContentDidChangeForPreviouslyCommittedNavigation) {
+  Navigation(GURL("https://brave.com")).Simulate();
+  SimulatePageLoad(kInnerText);
+  EXPECT_CALL(ads_service_mock(), NotifyTabTextContentDidChange).Times(0);
+
+  Navigation(GURL("https://brave.com"))
+      .WithPageTransition(ui::PAGE_TRANSITION_FORWARD_BACK)
+      .Simulate();
+  SimulatePageLoad(kInnerText);
+
+  Navigation(GURL("https://brave.com"))
+      .WithPageTransition(ui::PAGE_TRANSITION_FORWARD_BACK)
+      .Simulate();
+  SimulatePageLoad(kInnerText);
+
+  Navigation(GURL("https://brave.com"))
+      .WithPageTransition(ui::PAGE_TRANSITION_RELOAD)
+      .Simulate();
+  SimulatePageLoad(kInnerText);
+}
+
+TEST_F(AdsTabHelperTest,
+       DoNotNotifyTabTextContentDidChangeForHttpClientErrorResponsePage) {
+  EXPECT_CALL(ads_service_mock(), NotifyTabTextContentDidChange).Times(0);
+  Navigation(GURL("https://brave.com"))
+      .WithResponseHeaders(net::HttpResponseHeaders::TryToCreate(
+          "HTTP/1.1 404 Not Found\r\n\r\n"))
+      .Simulate();
+  SimulatePageLoad(kInnerText);
+}
+
+TEST_F(AdsTabHelperTest,
+       DoNotNotifyTabTextContentDidChangeForHttpServerErrorResponsePage) {
+  EXPECT_CALL(ads_service_mock(), NotifyTabTextContentDidChange).Times(0);
+  Navigation(GURL("https://brave.com"))
+      .WithResponseHeaders(net::HttpResponseHeaders::TryToCreate(
+          "HTTP/1.1 500 Internal Server Error\r\n\r\n"))
+      .Simulate();
+  SimulatePageLoad(kInnerText);
+}
+
+TEST_F(AdsTabHelperTest, NotifyDidCloseTab) {
+  EXPECT_CALL(ads_service_mock(), NotifyDidCloseTab);
+  SimulateCloseTab();
+}
+
+}  // namespace brave_ads

--- a/ios/testing/BUILD.gn
+++ b/ios/testing/BUILD.gn
@@ -25,6 +25,7 @@ test("ios_brave_unit_tests") {
 
     # Unit tests
     ":legacy_unit_tests",
+    "//brave/ios/browser/brave_ads:unit_tests",
     "//brave/ios/browser/brave_shields:unit_tests",
     "//brave/ios/browser/brave_shields/request_blocking:unit_tests",
     "//brave/ios/browser/serp_metrics:unit_tests",


### PR DESCRIPTION
iOS reclassified page content on every same document navigation, such as an anchor link tap, because its page load callback fires in cases where desktop's equivalent callback does not. This caused unnecessary reclassification work and inconsistent behavior compared to desktop and Android. Added test coverage matching desktop's equivalent tests, since none existed for this class on iOS before, and confirmed the new same document test fails without this change and passes with it.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/39700

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
