### PR TITLE
Android phone rotation sync settings

### DIFF
--- a/android/java/brave-res/layout/brave_sync_layout.xml
+++ b/android/java/brave-res/layout/brave_sync_layout.xml
@@ -29,7 +29,7 @@
                android:layout_height="0px"
                android:layout_weight="3"
                app:srcCompat="@drawable/brave_sync"
-               android:scaleType="center"
+               android:scaleType="centerInside"
                android:contentDescription="@null" />
 
            <TextView android:id="@+id/brave_sync_text_initial"

--- a/android/java/brave-res/layout/brave_sync_layout.xml
+++ b/android/java/brave-res/layout/brave_sync_layout.xml
@@ -156,6 +156,10 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     app:srcCompat="@drawable/brave_sync_btn_mobile"
+                    android:scaleType="centerInside"
+                    android:paddingTop="12dp"
+                    android:paddingBottom="44dp"
+                    android:paddingHorizontal="12dp"
                     android:contentDescription="@string/brave_sync_btn_mobile"
                     android:background="@drawable/brave_sync_image_btn" />
 

--- a/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
@@ -131,6 +131,10 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
     private Dialog mPlayServicesErrorDialog;
     private TabLayout mTabLayout;
 
+    // One-shot listener used to re-apply the wide-display layout correction once the fragment root
+    // gets its post-rotation size (see correctWideDisplayLayoutAfterRotation).
+    private View.OnLayoutChangeListener mRotationLayoutListener;
+
     // Below enum is matching the values of GetDeviceTypeString() in brave_device_info.cc
     public enum DeviceType {
         UNKNOWN("unknown"),
@@ -203,9 +207,7 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
      *
      * <p>We correct this after the rotation layout pass settles: apply the padding computed from
      * screenWidthDp (already updated for the new orientation), force a re-layout, and rebuild the
-     * device list so the dynamically-added rows are re-measured against the correct width. This
-     * runs from a posted runnable (not from within a layout pass) so the forced re-layout is
-     * honored.
+     * device list so the dynamically-added rows are re-measured against the correct width.
      *
      * <p>Since cr151 the Multi-column Settings feature (default-on) hosts this fragment in a narrow
      * detail pane rather than full screen. In that mode the screenWidthDp-based centering padding
@@ -213,17 +215,47 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
      * so we skip it and let the pane constrain the width - mirroring upstream WideDisplayPadding,
      * which does not attach a ViewResizer when {@link
      * SettingsActivity#isTwoColumnSettingsVisible()}.
+     *
+     * <p>This also affects phones: when the landscape window is wide enough the multi-column
+     * SlidingPaneLayout keeps both panes visible (a narrow detail pane), which is why the issue
+     * does not reproduce with 3-button navigation - the extra nav-bar width keeps the pane below
+     * the two-column threshold. The detail pane re-measures on its own schedule after a rotation,
+     * so the correction is applied from a one-shot OnLayoutChangeListener once the root actually
+     * receives its new size.
      */
     private void correctWideDisplayLayoutAfterRotation() {
-        // Post twice so this runs after the framework's rotation layout pass and the ViewResizer
-        // have finished, guaranteeing our padding is the final value and the forced re-layout is
-        // not swallowed by being called during a layout pass.
-        PostTask.postTask(
-                TaskTraits.UI_USER_VISIBLE,
-                () ->
-                        PostTask.postTask(
-                                TaskTraits.UI_USER_VISIBLE,
-                                this::applyWideDisplayLayoutCorrection));
+        // The fragment root re-measures on its own schedule after a rotation. In Multi-column
+        // Settings it lives in a SlidingPaneLayout detail pane whose size settles a frame or two
+        // after onConfigurationChanged, so reading it synchronously here would give a stale
+        // (previous-orientation) size and leave the fillViewport weighted content (e.g. the Sync
+        // graphic) at its old height. Re-apply the correction from a one-shot
+        // OnLayoutChangeListener
+        // once the root actually receives its new size, so we measure against the final
+        // orientation.
+        if (getView() == null) {
+            return;
+        }
+        View root = getView().findViewById(R.id.brave_sync_layout);
+        if (root == null) {
+            return;
+        }
+        // root persists across rotations; ensure only one listener is attached.
+        if (mRotationLayoutListener != null) {
+            root.removeOnLayoutChangeListener(mRotationLayoutListener);
+        }
+        mRotationLayoutListener =
+                (v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> {
+                    boolean sizeChanged =
+                            (right - left) != (oldRight - oldLeft)
+                                    || (bottom - top) != (oldBottom - oldTop);
+                    if (!sizeChanged) {
+                        return;
+                    }
+                    v.removeOnLayoutChangeListener(mRotationLayoutListener);
+                    mRotationLayoutListener = null;
+                    applyWideDisplayLayoutCorrection();
+                };
+        root.addOnLayoutChangeListener(mRotationLayoutListener);
     }
 
     private void applyWideDisplayLayoutCorrection() {
@@ -255,10 +287,37 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
         }
         root.setPadding(padding, root.getPaddingTop(), padding, root.getPaddingBottom());
         ViewUtils.requestLayout(root, "BraveSyncScreensPreference.correctWideDisplayLayout");
+        // Re-measure the currently visible sub-screen against the corrected size. The initial and
+        // other sub-screens use a fillViewport ScrollView with weighted children (e.g. the Sync
+        // graphic), whose heights depend on the viewport size and must be recomputed after a
+        // rotation; requestLayout on the visible ScrollView forces that.
+        View visibleScrollView = getVisibleSyncScrollView();
+        if (visibleScrollView != null) {
+            ViewUtils.requestLayout(
+                    visibleScrollView, "BraveSyncScreensPreference.correctVisibleScrollView");
+        }
         // Rebuild the device rows so they re-measure against the corrected content width.
         if (mScrollViewSyncDone != null && View.VISIBLE == mScrollViewSyncDone.getVisibility()) {
             onDevicesAvailable();
         }
+    }
+
+    private View getVisibleSyncScrollView() {
+        View[] scrollViews = {
+            mScrollViewSyncInitial,
+            mScrollViewSyncChainCode,
+            mScrollViewSyncStartChain,
+            mScrollViewAddMobileDevice,
+            mScrollViewAddLaptop,
+            mScrollViewEnterCodeWords,
+            mScrollViewSyncDone
+        };
+        for (View scrollView : scrollViews) {
+            if (scrollView != null && View.VISIBLE == scrollView.getVisibility()) {
+                return scrollView;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
@@ -5,6 +5,8 @@
 
 package org.chromium.chrome.browser.settings;
 
+import static org.chromium.build.NullUtil.assertNonNull;
+
 import android.Manifest;
 import android.app.Activity;
 import android.app.Dialog;
@@ -130,6 +132,7 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
     private AlertDialog mFinalWarningDialog;
     private Dialog mPlayServicesErrorDialog;
     private TabLayout mTabLayout;
+    private View mRootView;
 
     // One-shot listener used to re-apply the wide-display layout correction once the fragment root
     // gets its post-rotation size (see correctWideDisplayLayoutAfterRotation).
@@ -235,13 +238,9 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
         if (getView() == null) {
             return;
         }
-        View root = getView().findViewById(R.id.brave_sync_layout);
-        if (root == null) {
-            return;
-        }
         // root persists across rotations; ensure only one listener is attached.
         if (mRotationLayoutListener != null) {
-            root.removeOnLayoutChangeListener(mRotationLayoutListener);
+            mRootView.removeOnLayoutChangeListener(mRotationLayoutListener);
         }
         mRotationLayoutListener =
                 (v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> {
@@ -255,19 +254,11 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
                     mRotationLayoutListener = null;
                     applyWideDisplayLayoutCorrection();
                 };
-        root.addOnLayoutChangeListener(mRotationLayoutListener);
+        mRootView.addOnLayoutChangeListener(mRotationLayoutListener);
     }
 
     private void applyWideDisplayLayoutCorrection() {
-        // PostTask does not track the fragment/view lifecycle (unlike View.post), so guard against
-        // the fragment being torn down between posting and execution.
-        if (getActivity() == null || getView() == null) {
-            return;
-        }
-        View root = getView().findViewById(R.id.brave_sync_layout);
-        if (root == null) {
-            return;
-        }
+        assertNonNull(mRootView);
         int screenWidthDp = getResources().getConfiguration().screenWidthDp;
         int padding = 0;
         // In Multi-column Settings mode this fragment lives in a narrow detail pane, which already
@@ -285,8 +276,9 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
                     Math.round((excessWidthDp / 2.f) * getResources().getDisplayMetrics().density);
             padding = Math.max(minWidePadding, paddingPx);
         }
-        root.setPadding(padding, root.getPaddingTop(), padding, root.getPaddingBottom());
-        ViewUtils.requestLayout(root, "BraveSyncScreensPreference.correctWideDisplayLayout");
+        mRootView.setPadding(
+                padding, mRootView.getPaddingTop(), padding, mRootView.getPaddingBottom());
+        ViewUtils.requestLayout(mRootView, "BraveSyncScreensPreference.correctWideDisplayLayout");
         // Re-measure the currently visible sub-screen against the corrected size. The initial and
         // other sub-screens use a fillViewport ScrollView with weighted children (e.g. the Sync
         // graphic), whose heights depend on the viewport size and must be recomputed after a
@@ -339,6 +331,15 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
         requireActivity()
                 .getOnBackPressedDispatcher()
                 .addCallback(getViewLifecycleOwner(), mBackPressedCallback);
+    }
+
+    @Override
+    public void onDestroyView() {
+        if (mRotationLayoutListener != null) {
+            mRootView.removeOnLayoutChangeListener(mRotationLayoutListener);
+            mRotationLayoutListener = null;
+        }
+        super.onDestroyView();
     }
 
     private boolean ensureCameraPermission() {
@@ -630,6 +631,8 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
 
         mLayoutMobile = getView().findViewById(R.id.brave_sync_frame_mobile);
         mLayoutLaptop = getView().findViewById(R.id.brave_sync_frame_laptop);
+
+        mRootView = getView().findViewById(R.id.brave_sync_layout);
 
         setAppropriateView();
 


### PR DESCRIPTION
On the phone with enabled gesture navigation - browser settings are switched to multicolumn mode.
Adjustment for sync screen was required. Recalculation is done once per rotation at `onLayoutChangeListener` for the root view. Also fixed add mobile device image and brave-sync image to match reduced area on the phone in two column mode.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57600



https://github.com/user-attachments/assets/21e89a1c-43d9-41a3-8391-65b81a576dd4



<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
