### PR TITLE
[iOS] handle `contextMenuConfigurationForLinkURL` in QuickViewController

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -153,12 +153,16 @@ extension BrowserViewController: TabManagerDelegate {
         profile: tab.profile,
         syncAPI: profileController.syncAPI,
         sendTabAPI: profileController.sendTabAPI,
-        onOpenInNewTab: { [weak self] request in
+        onOpenInNewTab: { [weak self] request, isPrivateMode in
           guard let self else { return }
           self.tabManager.addTabAndSelect(
             request,
-            isPrivate: self.privateBrowsingManager.isPrivateBrowsing
+            isPrivate: isPrivateMode
           )
+        },
+        onOpenInNewWindow: { [weak self] url, isPrivateMode in
+          guard let self else { return }
+          self.openInNewWindow(url: url, isPrivate: isPrivateMode)
         },
         onAttachTab: { [weak self] tab in
           guard let self else { return }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
@@ -32,7 +32,8 @@ class QuickViewController: UIViewController {
     manager.isPrivateBrowsing = profile.isOffTheRecord
     return manager
   }()
-  private let onOpenInNewTab: ((URLRequest) -> Void)?
+  private let onOpenInNewTab: ((URLRequest, Bool) -> Void)?
+  private let onOpenInNewWindow: ((URL, Bool) -> Void)?
   private let onAttachTab: ((any TabState) -> Void)?
 
   init(
@@ -40,7 +41,8 @@ class QuickViewController: UIViewController {
     profile: any Profile,
     syncAPI: BraveSyncAPI,
     sendTabAPI: BraveSendTabAPI,
-    onOpenInNewTab: ((URLRequest) -> Void)?,
+    onOpenInNewTab: ((URLRequest, Bool) -> Void)?,
+    onOpenInNewWindow: ((URL, Bool) -> Void)?,
     onAttachTab: ((any TabState) -> Void)?
   ) {
     self.url = url
@@ -52,6 +54,7 @@ class QuickViewController: UIViewController {
       isPrivate: profile.isOffTheRecord
     )
     self.onOpenInNewTab = onOpenInNewTab
+    self.onOpenInNewWindow = onOpenInNewWindow
     self.onAttachTab = onAttachTab
     super.init(nibName: nil, bundle: nil)
     modalPresentationStyle = .fullScreen
@@ -382,6 +385,15 @@ class QuickViewController: UIViewController {
       $0.bottom.equalTo(toolbarHostingController.view.snp.top)
     }
   }
+
+  private func openNewTab(with request: URLRequest, inPrivateMode: Bool) {
+    dismiss(animated: true) { [weak self] in
+      guard let self else { return }
+      self.currentTab?.removeObserver(self.toolbarViewModel)
+      self.currentTab?.removeObserver(self)
+      self.onOpenInNewTab?(request, inPrivateMode)
+    }
+  }
 }
 
 // MARK: - TabDelegate
@@ -397,7 +409,7 @@ extension QuickViewController: TabDelegate {
       currentTab.removeObserver(self.toolbarViewModel)
       currentTab.removeObserver(self)
       self.onAttachTab?(currentTab)
-      self.onOpenInNewTab?(request)
+      self.onOpenInNewTab?(request, profile.isOffTheRecord)
     }
     return nil
   }
@@ -406,6 +418,179 @@ extension QuickViewController: TabDelegate {
     if tab.visibleURL?.isInternalURL(for: .readermode) != true {
       hideReaderModeBar()
     }
+  }
+
+  func tab(
+    _ tab: some TabState,
+    contextMenuConfigurationForLinkURL linkURL: URL?
+  ) async -> UIContextMenuConfiguration? {
+    guard let url = linkURL, url.isWebPage() else {
+      return UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: nil)
+    }
+
+    let actionProvider: UIContextMenuActionProvider = { [weak self] _ -> UIMenu? in
+      guard let self else { return nil }
+      var actions = [UIAction]()
+
+      if let currentTab = self.currentTab {
+        let isPrivate = currentTab.isPrivate
+
+        if !isPrivate {
+          let openNewTabAction = UIAction(
+            title: Strings.openNewTabButtonTitle,
+            image: UIImage(braveSystemNamed: "leo.browser.mobile-tab-new")
+          ) { [weak self] _ in
+            self?.openNewTab(with: URLRequest(url: url), inPrivateMode: false)
+          }
+
+          openNewTabAction.accessibilityLabel = "linkContextMenu.openInNewTab"
+          actions.append(openNewTabAction)
+        }
+
+        let openNewPrivateTabAction = UIAction(
+          title: Strings.openNewPrivateTabButtonTitle,
+          image: UIImage(braveSystemNamed: "leo.product.private-window")
+        ) { [weak self] _ in
+          guard let self else { return }
+          if !isPrivate, Preferences.Privacy.privateBrowsingLock.value {
+            self.askForLocalAuthentication { [weak self] success, error in
+              if success {
+                self?.openNewTab(with: URLRequest(url: url), inPrivateMode: true)
+              }
+            }
+          } else {
+            self.openNewTab(with: URLRequest(url: url), inPrivateMode: true)
+          }
+        }
+        openNewPrivateTabAction.accessibilityLabel = "linkContextMenu.openInNewPrivateTab"
+
+        actions.append(openNewPrivateTabAction)
+
+        if UIApplication.shared.supportsMultipleScenes {
+          if !isPrivate {
+            let openNewWindowAction = UIAction(
+              title: Strings.openInNewWindowTitle,
+              image: UIImage(braveSystemNamed: "leo.window.tab-new")
+            ) { [weak self] _ in
+              self?.onOpenInNewWindow?(url, false)
+            }
+
+            openNewWindowAction.accessibilityLabel = "linkContextMenu.openInNewWindow"
+            actions.append(openNewWindowAction)
+          }
+
+          let openNewPrivateWindowAction = UIAction(
+            title: Strings.openInNewPrivateWindowTitle,
+            image: UIImage(braveSystemNamed: "leo.window.tab-private")
+          ) { [weak self] _ in
+            guard let self else { return }
+            if !isPrivate, Preferences.Privacy.privateBrowsingLock.value {
+              self.askForLocalAuthentication { [weak self] success, error in
+                if success {
+                  self?.onOpenInNewWindow?(url, true)
+                }
+              }
+            } else {
+              self.onOpenInNewWindow?(url, true)
+            }
+          }
+
+          openNewPrivateWindowAction.accessibilityLabel = "linkContextMenu.openInNewPrivateWindow"
+          actions.append(openNewPrivateWindowAction)
+        }
+
+        let copyAction = UIAction(
+          title: Strings.copyLinkActionTitle,
+          image: UIImage(braveSystemNamed: "leo.copy"),
+          handler: UIAction.deferredActionHandler { _ in
+            UIPasteboard.general.url = url as URL
+          }
+        )
+        copyAction.accessibilityLabel = "linkContextMenu.copyLink"
+        actions.append(copyAction)
+
+        let copyCleanLinkAction = UIAction(
+          title: Strings.copyCleanLink,
+          image: UIImage(braveSystemNamed: "leo.copy.clean"),
+          handler: UIAction.deferredActionHandler { _ in
+            let service = URLSanitizerServiceFactory.get(privateMode: currentTab.isPrivate)
+            let cleanedURL = service?.sanitize(url: url) ?? url
+            UIPasteboard.general.url = cleanedURL
+          }
+        )
+        copyCleanLinkAction.accessibilityLabel = "linkContextMenu.copyCleanLink"
+        actions.append(copyCleanLinkAction)
+
+        let shareAction = UIAction(
+          title: Strings.shareLinkActionTitle,
+          image: UIImage(braveSystemNamed: "leo.share.macos")
+        ) { [weak self] _ in
+          guard let self else { return }
+          let anchorView = self.toolbarHostingController.rootView.shareBackgroundView.uiView
+          self.presentShareActivity(
+            url: url,
+            tab: currentTab,
+            syncAPI: self.syncAPI,
+            sendTabAPI: self.sendTabAPI,
+            feedDataSource: nil,
+            isBraveNewsAvailable: false,
+            source: .init(
+              view: anchorView,
+              rect: anchorView.bounds,
+              arrowDirection: .any
+            ),
+            callbacks: .init(
+              onToggleReaderMode: { [weak self] in
+                self?.currentTab?.readerMode?.toggleReaderMode()
+              },
+              onShowSubmitReport: { [weak self] url in
+                self?.showSubmitReportView(for: url)
+              }
+            )
+          )
+        }
+        shareAction.accessibilityLabel = "linkContextMenu.share"
+        actions.append(shareAction)
+
+        let linkPreview = Preferences.General.enableLinkPreview.value
+
+        let linkPreviewTitle =
+          linkPreview ? Strings.hideLinkPreviewsActionTitle : Strings.showLinkPreviewsActionTitle
+        let linkPreviewAction = UIAction(
+          title: linkPreviewTitle,
+          image: UIImage(braveSystemNamed: linkPreview ? "leo.eye.off" : "leo.eye.on")
+        ) { _ in
+          Preferences.General.enableLinkPreview.value.toggle()
+        }
+
+        actions.append(linkPreviewAction)
+      }
+
+      let formattedURL = URLFormatter.formatURL(
+        url.absoluteString,
+        formatTypes: [.omitDefaults, .omitTrivialSubdomains],
+        unescapeOptions: .normal
+      )
+      return UIMenu(title: formattedURL, children: actions)
+    }
+
+    let linkPreview: UIContextMenuContentPreviewProvider? = { [unowned self, weak tab] in
+      guard let tab else { return nil }
+      return LinkPreviewViewController(
+        url: url,
+        for: tab,
+        policyDecider: currentTab?.detachedPrivacyHelper,
+        tabDelegate: self,
+        downloadDelegate: nil
+      )
+    }
+
+    let linkPreviewProvider = Preferences.General.enableLinkPreview.value ? linkPreview : nil
+    return UIContextMenuConfiguration(
+      identifier: nil,
+      previewProvider: linkPreviewProvider,
+      actionProvider: actionProvider
+    )
   }
 }
 


### PR DESCRIPTION
Implement contextMenuConfigurationForLinkURL in QuickViewController to support opening links in new/private tabs and windows and other more actions. 

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57296

<img width=40% alt="simulator_screenshot_37D1BC48-570D-4600-B925-9058B8B999F9" src="https://github.com/user-attachments/assets/23cd84ce-6656-46f5-a2a7-50527800568d" />


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
