### PR TITLE
[Android] Dynamic colors setting to tint preference icons

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -364,6 +364,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveSettingsActivity.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveSettingsIntentUtil.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveSettingsLauncherImpl.java",
+  "../../brave/android/java/org/chromium/chrome/browser/settings/BraveSettingsPreferenceGroupAdapter.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveShredPreference.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveShredPreferencesFragment.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveStatsPreferences.java",

--- a/android/java/org/chromium/chrome/browser/browsing_data/BraveClearBrowsingDataFragment.java
+++ b/android/java/org/chromium/chrome/browser/browsing_data/BraveClearBrowsingDataFragment.java
@@ -9,14 +9,21 @@ import android.os.Bundle;
 import android.text.SpannableString;
 import android.view.View;
 
+import androidx.preference.PreferenceGroupAdapter;
+import androidx.preference.PreferenceScreen;
+import androidx.preference.PreferenceViewHolder;
+
 import org.chromium.base.Callback;
+import org.chromium.build.annotations.NonNull;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.BraveAdsNativeHelper;
 import org.chromium.chrome.browser.BraveRewardsHelper;
 import org.chromium.chrome.browser.app.BraveActivity;
 import org.chromium.chrome.browser.brave_leo.BraveLeoMojomHelper;
 import org.chromium.chrome.browser.profiles.Profile;
+import org.chromium.chrome.browser.theme.BraveDynamicColors;
 import org.chromium.chrome.browser.util.TabUtils;
+import org.chromium.components.browser_ui.settings.BraveSettingsIconTintUtils;
 import org.chromium.components.browser_ui.settings.ClickableSpansTextMessagePreference;
 import org.chromium.components.browser_ui.settings.SpinnerPreference;
 import org.chromium.ui.text.ChromeClickableSpan;
@@ -25,6 +32,19 @@ import org.chromium.ui.text.SpanApplier.SpanInfo;
 
 public class BraveClearBrowsingDataFragment extends ClearBrowsingDataFragment {
     ClearBrowsingDataCheckBoxPreference mClearAIChatDataCheckBoxPreference;
+
+    @Override
+    protected @NonNull PreferenceGroupAdapter onCreateAdapter(
+            @NonNull PreferenceScreen preferenceScreen) {
+        return new PreferenceGroupAdapter(preferenceScreen) {
+            @Override
+            public void onBindViewHolder(@NonNull PreferenceViewHolder holder, int position) {
+                super.onBindViewHolder(holder, position);
+                BraveSettingsIconTintUtils.applyIconTint(
+                        holder, BraveDynamicColors.isDynamicColorsEnabled());
+            }
+        };
+    }
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {

--- a/android/java/org/chromium/chrome/browser/browsing_data/BraveClearBrowsingDataFragment.java
+++ b/android/java/org/chromium/chrome/browser/browsing_data/BraveClearBrowsingDataFragment.java
@@ -11,7 +11,6 @@ import android.view.View;
 
 import androidx.preference.PreferenceGroupAdapter;
 import androidx.preference.PreferenceScreen;
-import androidx.preference.PreferenceViewHolder;
 
 import org.chromium.base.Callback;
 import org.chromium.build.annotations.NonNull;
@@ -21,9 +20,8 @@ import org.chromium.chrome.browser.BraveRewardsHelper;
 import org.chromium.chrome.browser.app.BraveActivity;
 import org.chromium.chrome.browser.brave_leo.BraveLeoMojomHelper;
 import org.chromium.chrome.browser.profiles.Profile;
-import org.chromium.chrome.browser.theme.BraveDynamicColors;
+import org.chromium.chrome.browser.settings.BraveSettingsPreferenceGroupAdapter;
 import org.chromium.chrome.browser.util.TabUtils;
-import org.chromium.components.browser_ui.settings.BraveSettingsIconTintUtils;
 import org.chromium.components.browser_ui.settings.ClickableSpansTextMessagePreference;
 import org.chromium.components.browser_ui.settings.SpinnerPreference;
 import org.chromium.ui.text.ChromeClickableSpan;
@@ -36,14 +34,7 @@ public class BraveClearBrowsingDataFragment extends ClearBrowsingDataFragment {
     @Override
     protected @NonNull PreferenceGroupAdapter onCreateAdapter(
             @NonNull PreferenceScreen preferenceScreen) {
-        return new PreferenceGroupAdapter(preferenceScreen) {
-            @Override
-            public void onBindViewHolder(@NonNull PreferenceViewHolder holder, int position) {
-                super.onBindViewHolder(holder, position);
-                BraveSettingsIconTintUtils.applyIconTint(
-                        holder, BraveDynamicColors.isDynamicColorsEnabled());
-            }
-        };
+        return new BraveSettingsPreferenceGroupAdapter(preferenceScreen);
     }
 
     @Override

--- a/android/java/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
+++ b/android/java/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
@@ -30,7 +30,6 @@ import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceGroup;
 import androidx.preference.PreferenceGroupAdapter;
 import androidx.preference.PreferenceScreen;
-import androidx.preference.PreferenceViewHolder;
 
 import org.chromium.base.DeviceInfo;
 import org.chromium.base.metrics.RecordHistogram;
@@ -48,13 +47,12 @@ import org.chromium.chrome.browser.password_manager.BravePasswordManagerHelper;
 import org.chromium.chrome.browser.password_manager.ManagePasswordsReferrer;
 import org.chromium.chrome.browser.preferences.Pref;
 import org.chromium.chrome.browser.profiles.Profile;
+import org.chromium.chrome.browser.settings.BraveSettingsPreferenceGroupAdapter;
 import org.chromium.chrome.browser.settings.ChromeBaseSettingsFragment;
 import org.chromium.chrome.browser.settings.ChromeManagedPreferenceDelegate;
 import org.chromium.chrome.browser.settings.MainSettings;
 import org.chromium.chrome.browser.settings.search.ChromeBaseSearchIndexProvider;
-import org.chromium.chrome.browser.theme.BraveDynamicColors;
 import org.chromium.chrome.browser.ui.favicon.FaviconHelper;
-import org.chromium.components.browser_ui.settings.BraveSettingsIconTintUtils;
 import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
 import org.chromium.components.browser_ui.settings.SearchUtils;
 import org.chromium.components.browser_ui.settings.SearchViewProvider;
@@ -141,14 +139,7 @@ public class PasswordSettings extends ChromeBaseSettingsFragment
     @Override
     protected @NonNull PreferenceGroupAdapter onCreateAdapter(
             @NonNull PreferenceScreen preferenceScreen) {
-        return new PreferenceGroupAdapter(preferenceScreen) {
-            @Override
-            public void onBindViewHolder(@NonNull PreferenceViewHolder holder, int position) {
-                super.onBindViewHolder(holder, position);
-                BraveSettingsIconTintUtils.applyIconTint(
-                        holder, BraveDynamicColors.isDynamicColorsEnabled());
-            }
-        };
+        return new BraveSettingsPreferenceGroupAdapter(preferenceScreen);
     }
 
     public ExportFlow getExportFlowForTesting() {

--- a/android/java/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
+++ b/android/java/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
@@ -139,7 +139,12 @@ public class PasswordSettings extends ChromeBaseSettingsFragment
     @Override
     protected @NonNull PreferenceGroupAdapter onCreateAdapter(
             @NonNull PreferenceScreen preferenceScreen) {
-        return new BraveSettingsPreferenceGroupAdapter(preferenceScreen);
+        return new BraveSettingsPreferenceGroupAdapter(preferenceScreen) {
+            @Override
+            protected boolean shouldClearIconTint(@NonNull Preference preference) {
+                return preference instanceof PasswordEntryPreference;
+            }
+        };
     }
 
     public ExportFlow getExportFlowForTesting() {

--- a/android/java/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
+++ b/android/java/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
@@ -28,6 +28,9 @@ import androidx.fragment.app.FragmentManager;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceGroup;
+import androidx.preference.PreferenceGroupAdapter;
+import androidx.preference.PreferenceScreen;
+import androidx.preference.PreferenceViewHolder;
 
 import org.chromium.base.DeviceInfo;
 import org.chromium.base.metrics.RecordHistogram;
@@ -37,6 +40,7 @@ import org.chromium.base.supplier.SettableMonotonicObservableSupplier;
 import org.chromium.build.annotations.EnsuresNonNull;
 import org.chromium.build.annotations.Initializer;
 import org.chromium.build.annotations.MonotonicNonNull;
+import org.chromium.build.annotations.NonNull;
 import org.chromium.build.annotations.NullMarked;
 import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.R;
@@ -48,7 +52,9 @@ import org.chromium.chrome.browser.settings.ChromeBaseSettingsFragment;
 import org.chromium.chrome.browser.settings.ChromeManagedPreferenceDelegate;
 import org.chromium.chrome.browser.settings.MainSettings;
 import org.chromium.chrome.browser.settings.search.ChromeBaseSearchIndexProvider;
+import org.chromium.chrome.browser.theme.BraveDynamicColors;
 import org.chromium.chrome.browser.ui.favicon.FaviconHelper;
+import org.chromium.components.browser_ui.settings.BraveSettingsIconTintUtils;
 import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
 import org.chromium.components.browser_ui.settings.SearchUtils;
 import org.chromium.components.browser_ui.settings.SearchViewProvider;
@@ -131,6 +137,19 @@ public class PasswordSettings extends ChromeBaseSettingsFragment
     private final ImportFlow mImportFlow = new ImportFlow();
 
     private @MonotonicNonNull SearchViewProvider.Observer mSearchViewObserver;
+
+    @Override
+    protected @NonNull PreferenceGroupAdapter onCreateAdapter(
+            @NonNull PreferenceScreen preferenceScreen) {
+        return new PreferenceGroupAdapter(preferenceScreen) {
+            @Override
+            public void onBindViewHolder(@NonNull PreferenceViewHolder holder, int position) {
+                super.onBindViewHolder(holder, position);
+                BraveSettingsIconTintUtils.applyIconTint(
+                        holder, BraveDynamicColors.isDynamicColorsEnabled());
+            }
+        };
+    }
 
     public ExportFlow getExportFlowForTesting() {
         return mExportFlow;

--- a/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
@@ -10,11 +10,14 @@ import android.os.Build;
 import android.os.Bundle;
 
 import androidx.preference.Preference;
+import androidx.preference.PreferenceGroupAdapter;
+import androidx.preference.PreferenceScreen;
 
 import org.chromium.base.BraveFeatureList;
 import org.chromium.base.BravePreferenceKeys;
 import org.chromium.base.ContextUtils;
 import org.chromium.brave.browser.customize_menu.CustomizeBraveMenu;
+import org.chromium.build.annotations.NonNull;
 import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.BraveFeatureUtil;
@@ -69,6 +72,12 @@ public class AppearancePreferences extends AppearanceSettingsFragment
     /* package */ static final String PREF_BRAVE_CUSTOMIZE_MENU = "brave_customize_menu";
 
     private BraveRewardsNativeWorker mBraveRewardsNativeWorker;
+
+    @Override
+    protected @NonNull PreferenceGroupAdapter onCreateAdapter(
+            @NonNull PreferenceScreen preferenceScreen) {
+        return new BraveSettingsPreferenceGroupAdapter(preferenceScreen);
+    }
 
     @Override
     public void onCreatePreferences(@Nullable Bundle savedInstanceState, @Nullable String rootKey) {

--- a/android/java/org/chromium/chrome/browser/settings/BravePreferenceFragment.java
+++ b/android/java/org/chromium/chrome/browser/settings/BravePreferenceFragment.java
@@ -5,6 +5,7 @@
 
 package org.chromium.chrome.browser.settings;
 
+import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -15,8 +16,11 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 
 import androidx.preference.Preference;
+import androidx.preference.PreferenceGroupAdapter;
+import androidx.preference.PreferenceScreen;
 
 import org.chromium.base.ContextUtils;
+import org.chromium.build.annotations.NonNull;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.BraveRewardsNativeWorker;
 import org.chromium.chrome.browser.ChromeTabbedActivity;
@@ -26,6 +30,12 @@ public abstract class BravePreferenceFragment extends ChromeBaseSettingsFragment
     protected static final int STORAGE_PERMISSION_EXPORT_REQUEST_CODE = 8000;
     protected static final int STORAGE_PERMISSION_IMPORT_REQUEST_CODE =
             STORAGE_PERMISSION_EXPORT_REQUEST_CODE + 1;
+
+    @Override
+    protected @NonNull PreferenceGroupAdapter onCreateAdapter(
+            @NonNull PreferenceScreen preferenceScreen) {
+        return new BraveSettingsPreferenceGroupAdapter(preferenceScreen);
+    }
 
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
@@ -71,13 +81,15 @@ public abstract class BravePreferenceFragment extends ChromeBaseSettingsFragment
     protected boolean isStoragePermissionGranted(boolean isExport) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             Context context = ContextUtils.getApplicationContext();
-            if (context.checkSelfPermission(
-                    android.Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
+            if (context.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    == PackageManager.PERMISSION_GRANTED) {
                 return true;
             } else {
                 requestPermissions(
-                        new String[] { android.Manifest.permission.WRITE_EXTERNAL_STORAGE },
-                        isExport ? STORAGE_PERMISSION_EXPORT_REQUEST_CODE : STORAGE_PERMISSION_IMPORT_REQUEST_CODE);
+                        new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                        isExport
+                                ? STORAGE_PERMISSION_EXPORT_REQUEST_CODE
+                                : STORAGE_PERMISSION_IMPORT_REQUEST_CODE);
                 return false;
             }
         }

--- a/android/java/org/chromium/chrome/browser/settings/BraveSettingsPreferenceGroupAdapter.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSettingsPreferenceGroupAdapter.java
@@ -29,7 +29,8 @@ public class BraveSettingsPreferenceGroupAdapter extends PreferenceGroupAdapter 
         if (preference != null && shouldClearIconTint(preference)) {
             BraveSettingsIconTintUtils.clearIconTint(holder);
         } else {
-            BraveSettingsIconTintUtils.applyIconTint(holder, BraveDynamicColors.isDynamicColorsEnabled());
+            BraveSettingsIconTintUtils.applyIconTint(
+                    holder, BraveDynamicColors.isDynamicColorsEnabled());
         }
     }
 

--- a/android/java/org/chromium/chrome/browser/settings/BraveSettingsPreferenceGroupAdapter.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSettingsPreferenceGroupAdapter.java
@@ -15,8 +15,8 @@ import org.chromium.chrome.browser.theme.BraveDynamicColors;
 import org.chromium.components.browser_ui.settings.BraveSettingsIconTintUtils;
 
 @NullMarked
-class BraveSettingsPreferenceGroupAdapter extends PreferenceGroupAdapter {
-    BraveSettingsPreferenceGroupAdapter(PreferenceScreen preferenceScreen) {
+public class BraveSettingsPreferenceGroupAdapter extends PreferenceGroupAdapter {
+    public BraveSettingsPreferenceGroupAdapter(PreferenceScreen preferenceScreen) {
         super(preferenceScreen);
     }
 

--- a/android/java/org/chromium/chrome/browser/settings/BraveSettingsPreferenceGroupAdapter.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSettingsPreferenceGroupAdapter.java
@@ -5,27 +5,24 @@
 
 package org.chromium.chrome.browser.settings;
 
-import android.content.Context;
-import android.util.AttributeSet;
-
+import androidx.preference.PreferenceGroupAdapter;
+import androidx.preference.PreferenceScreen;
 import androidx.preference.PreferenceViewHolder;
 
+import org.chromium.build.annotations.NonNull;
 import org.chromium.build.annotations.NullMarked;
-import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.browser.theme.BraveDynamicColors;
 import org.chromium.components.browser_ui.settings.BraveSettingsIconTintUtils;
-import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
 
-/** A Brave switch preference that tints its icon for enabled and disabled states. */
 @NullMarked
-public class BraveTintedIconSwitchPreference extends ChromeSwitchPreference {
-    public BraveTintedIconSwitchPreference(Context context, @Nullable AttributeSet attrs) {
-        super(context, attrs);
+class BraveSettingsPreferenceGroupAdapter extends PreferenceGroupAdapter {
+    BraveSettingsPreferenceGroupAdapter(PreferenceScreen preferenceScreen) {
+        super(preferenceScreen);
     }
 
     @Override
-    public void onBindViewHolder(PreferenceViewHolder holder) {
-        super.onBindViewHolder(holder);
+    public void onBindViewHolder(@NonNull PreferenceViewHolder holder, int position) {
+        super.onBindViewHolder(holder, position);
         BraveSettingsIconTintUtils.applyIconTint(
                 holder, BraveDynamicColors.isDynamicColorsEnabled());
     }

--- a/android/java/org/chromium/chrome/browser/settings/BraveSettingsPreferenceGroupAdapter.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSettingsPreferenceGroupAdapter.java
@@ -5,12 +5,14 @@
 
 package org.chromium.chrome.browser.settings;
 
+import androidx.preference.Preference;
 import androidx.preference.PreferenceGroupAdapter;
 import androidx.preference.PreferenceScreen;
 import androidx.preference.PreferenceViewHolder;
 
 import org.chromium.build.annotations.NonNull;
 import org.chromium.build.annotations.NullMarked;
+import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.browser.theme.BraveDynamicColors;
 import org.chromium.components.browser_ui.settings.BraveSettingsIconTintUtils;
 
@@ -23,7 +25,16 @@ public class BraveSettingsPreferenceGroupAdapter extends PreferenceGroupAdapter 
     @Override
     public void onBindViewHolder(@NonNull PreferenceViewHolder holder, int position) {
         super.onBindViewHolder(holder, position);
-        BraveSettingsIconTintUtils.applyIconTint(
-                holder, BraveDynamicColors.isDynamicColorsEnabled());
+        @Nullable Preference preference = getItem(position);
+        if (preference != null && shouldClearIconTint(preference)) {
+            BraveSettingsIconTintUtils.clearIconTint(holder);
+        } else {
+            BraveSettingsIconTintUtils.applyIconTint(holder, BraveDynamicColors.isDynamicColorsEnabled());
+        }
+    }
+
+    /** Returns whether the adapter must clear tint from this preference's icon. */
+    protected boolean shouldClearIconTint(@NonNull Preference preference) {
+        return false;
     }
 }

--- a/android/junit/BUILD.gn
+++ b/android/junit/BUILD.gn
@@ -131,10 +131,12 @@ if (is_android) {
     sources = [
       "src/org/chromium/chrome/browser/settings/BraveSearchEngineUtilsTest.java",
       "src/org/chromium/chrome/browser/settings/BraveSettingsLauncherImplTest.java",
+      "src/org/chromium/components/browser_ui/settings/BraveSettingsIconTintUtilsTest.java",
     ]
 
     deps = [
       "//brave/android/java/org/chromium/chrome/browser/search_engines:java",
+      "//brave/components/browser_ui/settings/android:java",
       "//chrome/android/junit:chrome_junit_tests_helper",
       "//chrome/browser/safe_browsing/android:java",
     ]

--- a/android/junit/src/org/chromium/components/browser_ui/settings/BraveSettingsIconTintUtilsTest.java
+++ b/android/junit/src/org/chromium/components/browser_ui/settings/BraveSettingsIconTintUtilsTest.java
@@ -7,8 +7,8 @@ package org.chromium.components.browser_ui.settings;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 import android.content.Context;
 import android.content.ContextWrapper;
@@ -67,7 +67,8 @@ public class BraveSettingsIconTintUtilsTest {
     @Test
     public void testClearIconTint_removesPreviouslyAppliedTint() {
         Context context =
-                new DefaultTintContext(ApplicationProvider.getApplicationContext(), createDefaultTint());
+                new DefaultTintContext(
+                        ApplicationProvider.getApplicationContext(), createDefaultTint());
         TintCapturingImageView icon = new TintCapturingImageView(context);
         BraveSettingsIconTintUtils.applyIconTint(icon, false);
         icon.setColorFilter(0xffaabbcc);

--- a/android/junit/src/org/chromium/components/browser_ui/settings/BraveSettingsIconTintUtilsTest.java
+++ b/android/junit/src/org/chromium/components/browser_ui/settings/BraveSettingsIconTintUtilsTest.java
@@ -1,0 +1,139 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.components.browser_ui.settings;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.res.ColorStateList;
+import android.content.res.Resources;
+import android.os.Build;
+import android.view.ContextThemeWrapper;
+import android.widget.ImageView;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import org.chromium.base.test.BaseRobolectricTestRunner;
+import org.chromium.components.browser_ui.styles.R;
+import org.chromium.components.browser_ui.styles.SemanticColorUtils;
+
+/** Unit tests for {@link BraveSettingsIconTintUtils}. */
+@RunWith(BaseRobolectricTestRunner.class)
+@Config(manifest = Config.NONE, sdk = Build.VERSION_CODES.S)
+public class BraveSettingsIconTintUtilsTest {
+    private static final int[] DISABLED_STATE_SET = new int[] {-android.R.attr.state_enabled};
+    private static final int[] ENABLED_STATE_SET = new int[] {android.R.attr.state_enabled};
+    private static final int[] DEFAULT_STATE_SET = new int[] {};
+
+    @Test
+    public void testApplyIconTint_dynamicColorsDisabled_usesDefaultTint() {
+        assertUsesDefaultTint();
+    }
+
+    @Test
+    public void testApplyIconTint_dynamicColorsEnabled_preservesDisabledTint() {
+        ColorStateList defaultTint = createDefaultTint();
+        Context context =
+                new DefaultTintContext(
+                        new ContextThemeWrapper(
+                                ApplicationProvider.getApplicationContext(),
+                                R.style.Theme_MaterialComponents_DayNight),
+                        defaultTint);
+        TintCapturingImageView icon = new TintCapturingImageView(context);
+
+        BraveSettingsIconTintUtils.applyIconTint(icon, true);
+
+        ColorStateList actualTint = icon.getCapturedTint();
+        assertNotNull(actualTint);
+        assertEquals(
+                defaultTint.getColorForState(DISABLED_STATE_SET, defaultTint.getDefaultColor()),
+                actualTint.getColorForState(DISABLED_STATE_SET, actualTint.getDefaultColor()));
+        assertEquals(
+                SemanticColorUtils.getDefaultIconColorAccent1(context),
+                actualTint.getColorForState(ENABLED_STATE_SET, actualTint.getDefaultColor()));
+    }
+
+    private void assertUsesDefaultTint() {
+        ColorStateList expectedTint = createDefaultTint();
+        Context context =
+                new DefaultTintContext(ApplicationProvider.getApplicationContext(), expectedTint);
+        TintCapturingImageView icon = new TintCapturingImageView(context);
+
+        BraveSettingsIconTintUtils.applyIconTint(icon, false);
+
+        assertSame(expectedTint, icon.getCapturedTint());
+    }
+
+    private static ColorStateList createDefaultTint() {
+        return new ColorStateList(
+                new int[][] {DISABLED_STATE_SET, DEFAULT_STATE_SET},
+                new int[] {0xffaabbcc, 0xff112233});
+    }
+
+    private static class DefaultTintContext extends ContextWrapper {
+        private final Resources mResources;
+
+        DefaultTintContext(Context base, ColorStateList defaultTint) {
+            super(base);
+            mResources = new DefaultTintResources(base.getResources(), defaultTint);
+        }
+
+        @Override
+        public Resources getResources() {
+            return mResources;
+        }
+    }
+
+    private static class DefaultTintResources extends Resources {
+        private final ColorStateList mDefaultTint;
+
+        DefaultTintResources(Resources base, ColorStateList defaultTint) {
+            super(base.getAssets(), base.getDisplayMetrics(), base.getConfiguration());
+            mDefaultTint = defaultTint;
+        }
+
+        @Override
+        public ColorStateList getColorStateList(int resId) {
+            if (resId == R.color.default_icon_color_tint_list) {
+                return mDefaultTint;
+            }
+            return super.getColorStateList(resId);
+        }
+
+        @Override
+        public ColorStateList getColorStateList(int resId, Theme theme) {
+            if (resId == R.color.default_icon_color_tint_list) {
+                return mDefaultTint;
+            }
+            return super.getColorStateList(resId, theme);
+        }
+    }
+
+    private static class TintCapturingImageView extends ImageView {
+        private ColorStateList mTint;
+
+        TintCapturingImageView(Context context) {
+            super(context);
+        }
+
+        @Override
+        public void setImageTintList(ColorStateList tint) {
+            super.setImageTintList(tint);
+            mTint = tint;
+        }
+
+        ColorStateList getCapturedTint() {
+            return mTint;
+        }
+    }
+}

--- a/android/junit/src/org/chromium/components/browser_ui/settings/BraveSettingsIconTintUtilsTest.java
+++ b/android/junit/src/org/chromium/components/browser_ui/settings/BraveSettingsIconTintUtilsTest.java
@@ -8,6 +8,7 @@ package org.chromium.components.browser_ui.settings;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNull;
 
 import android.content.Context;
 import android.content.ContextWrapper;
@@ -61,6 +62,23 @@ public class BraveSettingsIconTintUtilsTest {
         assertEquals(
                 SemanticColorUtils.getDefaultIconColorAccent1(context),
                 actualTint.getColorForState(ENABLED_STATE_SET, actualTint.getDefaultColor()));
+    }
+
+    @Test
+    public void testClearIconTint_removesPreviouslyAppliedTint() {
+        Context context =
+                new DefaultTintContext(ApplicationProvider.getApplicationContext(), createDefaultTint());
+        TintCapturingImageView icon = new TintCapturingImageView(context);
+        BraveSettingsIconTintUtils.applyIconTint(icon, false);
+        icon.setColorFilter(0xffaabbcc);
+
+        assertNotNull(icon.getCapturedTint());
+        assertNotNull(icon.getColorFilter());
+
+        BraveSettingsIconTintUtils.clearIconTint(icon);
+
+        assertNull(icon.getCapturedTint());
+        assertNull(icon.getColorFilter());
     }
 
     private void assertUsesDefaultTint() {

--- a/browser/autofill/android/BUILD.gn
+++ b/browser/autofill/android/BUILD.gn
@@ -26,6 +26,8 @@ android_library("options_java") {
   deps = [
     ":options_java_resources",
     "//brave/browser/android/preferences:pref_names_java",
+    "//brave/browser/ui/android/theme:dynamic_colors_java",
+    "//brave/components/browser_ui/settings/android:java",
     "//build/android:build_java",
     "//chrome/browser/autofill/android:java",
     "//chrome/browser/profiles/android:java",

--- a/browser/autofill/android/java/src/org/chromium/chrome/browser/autofill/options/BraveAutofillOptionsFragmentBase.java
+++ b/browser/autofill/android/java/src/org/chromium/chrome/browser/autofill/options/BraveAutofillOptionsFragmentBase.java
@@ -21,6 +21,8 @@ import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.browser.autofill.brave.R;
 import org.chromium.chrome.browser.preferences.BravePref;
 import org.chromium.chrome.browser.settings.ChromeBaseSettingsFragment;
+import org.chromium.chrome.browser.theme.BraveDynamicColors;
+import org.chromium.components.browser_ui.settings.BraveSettingsIconTintUtils;
 import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
 import org.chromium.components.user_prefs.UserPrefs;
 
@@ -123,6 +125,8 @@ public abstract class BraveAutofillOptionsFragmentBase extends ChromeBaseSetting
         @Override
         public void onBindViewHolder(PreferenceViewHolder holder) {
             super.onBindViewHolder(holder);
+            BraveSettingsIconTintUtils.applyIconTint(
+                    holder, BraveDynamicColors.isDynamicColorsEnabled());
 
             View iconFrame =
                     holder.findViewById(

--- a/components/browser_ui/settings/android/BUILD.gn
+++ b/components/browser_ui/settings/android/BUILD.gn
@@ -7,6 +7,7 @@ import("//build/config/android/rules.gni")
 
 android_library("java") {
   sources = [
+    "java/src/org/chromium/components/browser_ui/settings/BraveSettingsIconTintUtils.java",
     "java/src/org/chromium/components/browser_ui/settings/BraveSettingsUtils.java",
     "widget/java/src/org/chromium/components/browser_ui/settings/brave_tricks/checkbox_to_switch/ChromeBaseCheckBoxPreference.java",
   ]
@@ -14,6 +15,7 @@ android_library("java") {
   deps = [
     "//build/android:build_java",
     "//components/browser_ui/settings/android:java",
+    "//components/browser_ui/styles/android:java",
     "//third_party/androidx:androidx_preference_preference_java",
   ]
 }

--- a/components/browser_ui/settings/android/java/src/org/chromium/components/browser_ui/settings/BraveSettingsIconTintUtils.java
+++ b/components/browser_ui/settings/android/java/src/org/chromium/components/browser_ui/settings/BraveSettingsIconTintUtils.java
@@ -1,0 +1,69 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.components.browser_ui.settings;
+
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.view.View;
+import android.widget.ImageView;
+
+import androidx.preference.PreferenceViewHolder;
+
+import org.chromium.build.annotations.NullMarked;
+import org.chromium.build.annotations.Nullable;
+import org.chromium.components.browser_ui.styles.SemanticColorUtils;
+
+@NullMarked
+public final class BraveSettingsIconTintUtils {
+    private static final int[] DISABLED_STATE_SET = new int[] {-android.R.attr.state_enabled};
+    private static final int[] DEFAULT_STATE_SET = new int[] {};
+    private static final int DEFAULT_ICON_COLOR_TINT_LIST =
+            org.chromium.components.browser_ui.styles.R.color.default_icon_color_tint_list;
+
+    private BraveSettingsIconTintUtils() {}
+
+    /**
+     * Applies an icon tint to the standard preference icon in {@code holder}.
+     *
+     * <p>When {@code dynamicColorsEnabled} is true, the enabled-state color uses the current
+     * Dynamic Colors accent. Otherwise, this applies the default resource tint.
+     */
+    public static void applyIconTint(PreferenceViewHolder holder, boolean dynamicColorsEnabled) {
+        applyIconTint(holder.findViewById(android.R.id.icon), dynamicColorsEnabled);
+    }
+
+    /**
+     * Applies an icon tint to {@code view} when it is an {@link ImageView}.
+     *
+     * <p>When {@code dynamicColorsEnabled} is true, the enabled-state color uses the current
+     * Dynamic Colors accent. Otherwise, this applies the default resource tint. Non-image views are
+     * unchanged.
+     */
+    public static void applyIconTint(@Nullable View view, boolean dynamicColorsEnabled) {
+        if (view instanceof ImageView icon) {
+            Context context = icon.getContext();
+            ColorStateList defaultIconTint =
+                    context.getColorStateList(DEFAULT_ICON_COLOR_TINT_LIST);
+            ColorStateList iconTint =
+                    dynamicColorsEnabled
+                            ? createDynamicColorsIconTint(context, defaultIconTint)
+                            : defaultIconTint;
+            icon.setImageTintList(iconTint);
+        }
+    }
+
+    private static ColorStateList createDynamicColorsIconTint(
+            Context context, ColorStateList defaultIconTint) {
+        int disabledColor =
+                defaultIconTint.getColorForState(
+                        DISABLED_STATE_SET, defaultIconTint.getDefaultColor());
+        int enabledColor = SemanticColorUtils.getDefaultIconColorAccent1(context);
+
+        return new ColorStateList(
+                new int[][] {DISABLED_STATE_SET, DEFAULT_STATE_SET},
+                new int[] {disabledColor, enabledColor});
+    }
+}

--- a/components/browser_ui/settings/android/java/src/org/chromium/components/browser_ui/settings/BraveSettingsIconTintUtils.java
+++ b/components/browser_ui/settings/android/java/src/org/chromium/components/browser_ui/settings/BraveSettingsIconTintUtils.java
@@ -35,6 +35,11 @@ public final class BraveSettingsIconTintUtils {
         applyIconTint(holder.findViewById(android.R.id.icon), dynamicColorsEnabled);
     }
 
+    /** Clears an icon tint from the standard preference icon in {@code holder}. */
+    public static void clearIconTint(PreferenceViewHolder holder) {
+        clearIconTint(holder.findViewById(android.R.id.icon));
+    }
+
     /**
      * Applies an icon tint to {@code view} when it is an {@link ImageView}.
      *
@@ -52,6 +57,14 @@ public final class BraveSettingsIconTintUtils {
                             ? createDynamicColorsIconTint(context, defaultIconTint)
                             : defaultIconTint;
             icon.setImageTintList(iconTint);
+        }
+    }
+
+    /** Clears an icon tint from {@code view} when it is an {@link ImageView}. */
+    public static void clearIconTint(@Nullable View view) {
+        if (view instanceof ImageView icon) {
+            icon.setImageTintList(null);
+            icon.clearColorFilter();
         }
     }
 

--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-settings-search-SettingsSearchCoordinator.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-settings-search-SettingsSearchCoordinator.java.patch
@@ -1,0 +1,21 @@
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/search/SettingsSearchCoordinator.java b/chrome/android/java/src/org/chromium/chrome/browser/settings/search/SettingsSearchCoordinator.java
+index 89c6d58897b21cbfc1f2b9831f65e9617a80c7d7..9738f200c8f577977f11620d1e3547aac3170563 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/settings/search/SettingsSearchCoordinator.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/settings/search/SettingsSearchCoordinator.java
+@@ -4,6 +4,8 @@
+ 
+ package org.chromium.chrome.browser.settings.search;
+ 
++import org.chromium.chrome.browser.theme.BraveDynamicColors;
++import org.chromium.components.browser_ui.settings.BraveSettingsIconTintUtils;
+ import static androidx.annotation.VisibleForTesting.PRIVATE;
+ 
+ import static org.chromium.base.CallbackUtils.emptyRunnable;
+@@ -272,6 +274,7 @@ public class SettingsSearchCoordinator
+                 searchBox.findViewById(R.id.search_icon),
+                 mActivity.getString(R.string.search_in_settings_hint));
+ 
++        BraveSettingsIconTintUtils.applyIconTint(searchBox.findViewById(R.id.search_icon), BraveDynamicColors.isDynamicColorsEnabled());
+         View query = mActivity.findViewById(R.id.search_query_container);
+         Drawable bg = ContextCompat.getDrawable(mActivity, R.drawable.pill_background);
+         int tint = SemanticColorUtils.getSettingsContainerBackgroundColor(mActivity);

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/settings/search/SettingsSearchCoordinator.java.yaml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/settings/search/SettingsSearchCoordinator.java.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description:
+      'Add Brave imports beneath the Settings search package declaration.'
+    regex:
+      re_pattern: '^(package [^;]+;\n)'
+      re_flags: [MULTILINE]
+      replace: |-
+        \1
+        import org.chromium.chrome.browser.theme.BraveDynamicColors;
+        import org.chromium.components.browser_ui.settings.BraveSettingsIconTintUtils;
+
+  - description: |
+      Apply the Dynamic Colors tint to the Settings search icon before the
+      search query view is initialized.
+    regex:
+      re_pattern:
+        '(initializeSearchUi\s*\([^)]*\)\s*\{.*?)(^[ \t]*)(View query =
+        mActivity\.findViewById\(R\.id\.search_query_container\);)'
+      re_flags: [DOTALL, MULTILINE]
+      replace: |-
+        \1\2BraveSettingsIconTintUtils.applyIconTint(searchBox.findViewById(R.id.search_icon), BraveDynamicColors.isDynamicColorsEnabled());
+        \2\3


### PR DESCRIPTION


<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57054

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

## Changes

**Android: tint Settings preference icons** (88b0487ac344e3c88aad38aed6cbd1de15f12245)
- add `BraveSettingsIconTintUtils` with `applyIconTint()` methods
- add `BraveSettingsPreferenceGroupAdapter`
- update various preference fragments to apply icon tint to preference icons via `applyIconTint()` or `BraveSettingsPreferenceGroupAdapter`
- patch upstream SettingsSearchCoordinator to use `applyIconTint()`

## Screenshots


`Dynamic colors` on|`Dynamic colors` off
--|--
<img width="802" height="1846" alt="dynamic_colors_on" src="https://github.com/user-attachments/assets/2aabe255-ec88-4f88-b123-6bf3e292e60b" />|<img width="794" height="1842" alt="dynamic_colors_off" src="https://github.com/user-attachments/assets/c3371fe5-7b2f-4680-b3ca-61a61fa52aa9" />







