### PR TITLE
Align ultra-dark tab-strip control icons with toolbar colors

### DIFF
--- a/browser/ui/tabs/brave_tab_color_mixer.cc
+++ b/browser/ui/tabs/brave_tab_color_mixer.cc
@@ -255,11 +255,12 @@ void AddBraveTabThemeColorMixer(ui::ColorProvider* provider,
   postprocessing_mixer[kColorNewTabButtonBackgroundFrameInactive] = {
       ui::kColorFrameInactive};
 
-  // TabStripComboButton / tab search icon (horizontal caret and vertical
-  // toolbar button). Chromium maps these CR color IDs through regular-mixer
-  // ColorId references to kColorTabForegroundInactiveFrameActive, which cannot
-  // see this postprocessing mixer's overrides — so without an explicit recipe
-  // here the icon keeps the regular dark-theme (near-white) color.
+  // Tab-strip control / combo-button icons (tab search, horizontal +,
+  // workspaces, scroll chevrons, vertical-tab toolbar search). Chromium maps
+  // these CR color IDs through regular-mixer ColorId references, which cannot
+  // see this postprocessing mixer's overrides of tab-foreground colors — so
+  // without an explicit recipe here the icons keep the regular dark-theme
+  // (near-white) color. Match toolbar icons instead.
   const SkColor toolbar_icon =
       postprocessing_mixer.GetResultColor(kColorToolbarButtonIcon);
   const SkColor toolbar_icon_inactive =
@@ -283,12 +284,10 @@ void AddBraveTabThemeColorMixer(ui::ColorProvider* provider,
   postprocessing_mixer[kColorBraveVerticalTabSeparator] = {
       nala::kColorPrimitiveNeutral15};
 
-  const SkColor ntb_forground = postprocessing_mixer.GetResultColor(
-      kColorTabForegroundInactiveFrameActive);
-  postprocessing_mixer[kColorBraveVerticalTabNTBIconColor] = {ntb_forground};
-  postprocessing_mixer[kColorBraveVerticalTabNTBTextColor] = {ntb_forground};
+  postprocessing_mixer[kColorBraveVerticalTabNTBIconColor] = {toolbar_icon};
+  postprocessing_mixer[kColorBraveVerticalTabNTBTextColor] = {toolbar_icon};
   postprocessing_mixer[kColorBraveVerticalTabNTBShortcutTextColor] = {
-      ntb_forground};
+      toolbar_icon};
 #endif  // defined(TOOLKIT_VIEWS)
 }
 

--- a/browser/ui/tabs/brave_tab_color_mixer.cc
+++ b/browser/ui/tabs/brave_tab_color_mixer.cc
@@ -255,6 +255,24 @@ void AddBraveTabThemeColorMixer(ui::ColorProvider* provider,
   postprocessing_mixer[kColorNewTabButtonBackgroundFrameInactive] = {
       ui::kColorFrameInactive};
 
+  // TabStripComboButton / tab search icon (horizontal caret and vertical
+  // toolbar button). Chromium maps these CR color IDs through regular-mixer
+  // ColorId references to kColorTabForegroundInactiveFrameActive, which cannot
+  // see this postprocessing mixer's overrides — so without an explicit recipe
+  // here the icon keeps the regular dark-theme (near-white) color.
+  const SkColor toolbar_icon =
+      postprocessing_mixer.GetResultColor(kColorToolbarButtonIcon);
+  const SkColor toolbar_icon_inactive =
+      postprocessing_mixer.GetResultColor(kColorToolbarButtonIconInactive);
+  postprocessing_mixer[kColorNewTabButtonCRForegroundFrameActive] = {
+      toolbar_icon};
+  postprocessing_mixer[kColorNewTabButtonCRForegroundFrameInactive] = {
+      toolbar_icon_inactive};
+  postprocessing_mixer[kColorTabSearchButtonCRForegroundFrameActive] = {
+      toolbar_icon};
+  postprocessing_mixer[kColorTabSearchButtonCRForegroundFrameInactive] = {
+      toolbar_icon_inactive};
+
   // Vertical tabs
   postprocessing_mixer[kColorBraveVerticalTabActiveBackground] =
       darker_theme::ApplyDarknessFromColor(nala::kColorPrimitiveNeutral20);

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip_control_button.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip_control_button.cc
@@ -16,8 +16,19 @@
 #define kColorTabForegroundInactiveFrameActive \
   kColorNewTabButtonCRForegroundFrameActive
 
+// Use the CR background tokens (transparent in Brave via
+// AddBravifiedTabStripColorMixer) so idle tab-strip control buttons —
+// workspaces and scroll chevrons — do not paint a solid frame-colored chip.
+// Matches TabStripComboButton / TabStripFlatEdgeButton.
+#define kColorNewTabButtonBackgroundFrameActive \
+  kColorNewTabButtonCRBackgroundFrameActive
+#define kColorNewTabButtonBackgroundFrameInactive \
+  kColorNewTabButtonCRBackgroundFrameInactive
+
 #include <chrome/browser/ui/views/tabs/tab_strip_control_button.cc>
 
+#undef kColorNewTabButtonBackgroundFrameInactive
+#undef kColorNewTabButtonBackgroundFrameActive
 #undef kColorTabForegroundInactiveFrameActive
 #undef TabStripControlButton
 

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip_control_button.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip_control_button.cc
@@ -9,8 +9,16 @@
 
 #define TabStripControlButton TabStripControlButton_ChromiumImpl
 
+// Use the CR foreground token for the default active icon color so ultra-dark
+// postprocessing of kColorNewTabButtonCRForegroundFrameActive applies to the
+// horizontal new-tab, workspaces, and scroll buttons. Outside darker theme
+// this CR id still aliases to kColorTabForegroundInactiveFrameActive.
+#define kColorTabForegroundInactiveFrameActive \
+  kColorNewTabButtonCRForegroundFrameActive
+
 #include <chrome/browser/ui/views/tabs/tab_strip_control_button.cc>
 
+#undef kColorTabForegroundInactiveFrameActive
 #undef TabStripControlButton
 
 TabStripControlButton::~TabStripControlButton() = default;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57622

In ultra dark theme, several tab-strip / toolbar control icons kept the regular dark (near-white) color instead of matching other toolbar icons (`kColorToolbarButtonIcon` / Neutral50).

Chromium maps the CR foreground color IDs (`kColorTabSearchButtonCRForeground*` / `kColorNewTabButtonCRForeground*`) through regular-mixer `ColorId` references. Those lookups skip postprocessing overrides of tab-foreground colors, so ultra-dark theming never reached the icons.

Separately, horizontal tab-strip control buttons (Spaces, scroll chevrons) painted Chromium’s non-CR new-tab background tokens — an opaque frame-colored rounded rect — even when idle. The combo `+`/search controls already use Brave’s transparent CR background tokens.

## Changes

1. **`brave_tab_color_mixer.cc`** — In the darker-theme postprocessing mixer, set the CR foreground tokens (active/inactive) from `kColorToolbarButtonIcon` / `Inactive`. Also point vertical new-tab icon, label, and shortcut text at the same toolbar icon color.

2. **`tab_strip_control_button.cc`** — Default active foreground uses `kColorNewTabButtonCRForegroundFrameActive` so horizontal new-tab, workspaces, and scroll buttons pick up the ultra-dark override. Outside darker theme this CR id still aliases to `kColorTabForegroundInactiveFrameActive`. Default backgrounds use the CR tokens (`kColorNewTabButtonCRBackgroundFrame*`), which Brave sets to transparent in `AddBravifiedTabStripColorMixer`, so idle Spaces and scroll buttons no longer show a solid chip (hover/press still use the ink drop).

## Icons fixed (ultra dark)

- Tab search (horizontal caret and vertical toolbar search icon)
- Tab groups / Projects combo start button
- Horizontal new tab `+`
- Workspaces
- Horizontal tab-strip scroll chevrons (including disabled)
- Vertical new tab `+` icon, label, and shortcut text

## Idle background fixed

- Horizontal Spaces button (no frame-colored fill when not hovered/pressed)
- Horizontal tab-strip scroll chevrons (same)

## Before
<img width="2088" height="1622" alt="image" src="https://github.com/user-attachments/assets/4069a623-7219-4dbe-ae59-b1bc85f1ed61" />

<img width="2088" height="1622" alt="image" src="https://github.com/user-attachments/assets/306610db-f274-4df9-acd6-a09803cc8fb7" />

## After

<img width="2088" height="1622" alt="image" src="https://github.com/user-attachments/assets/34848174-9c5c-4ce1-bb08-ee545ff9e9af" />

<img width="2088" height="1622" alt="image" src="https://github.com/user-attachments/assets/d954f8c8-3a2e-4c8c-a46c-d67f2b745c4b" />



<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->