### PR TITLE
Refactor original initiator handling in BraveRequestInfo

### DIFF
--- a/browser/net/brave_proxying_url_loader_factory.cc
+++ b/browser/net/brave_proxying_url_loader_factory.cc
@@ -181,11 +181,9 @@ void BraveProxyingURLLoaderFactory<T>::InProgressRequest::UpdateRequestInfo() {
 template <>
 void BraveProxyingURLLoaderFactory<
     std::shared_ptr>::InProgressRequest::CreateBraveRequestInfo() {
-  network::ResourceRequest request_for_info = request_;
-  request_for_info.request_initiator = original_initiator_;
   ctx_ = brave::BraveRequestInfo::MakeCTX(
-      request_for_info, render_frame_token_, request_id_, browser_context_,
-      ctx_.get(), factory_->url_loader_factory_type_,
+      request_, render_frame_token_, request_id_, browser_context_, ctx_.get(),
+      original_initiator_, factory_->url_loader_factory_type_,
       factory_->request_initiator_, factory_->isolation_info_);
 }
 
@@ -195,11 +193,9 @@ void BraveProxyingURLLoaderFactory<
   if (ctx_) {
     factory_->request_handler_->OnURLRequestDestroyed(ctx_);
   }
-  network::ResourceRequest request_for_info = request_;
-  request_for_info.request_initiator = original_initiator_;
   ctx_owned_ = brave::BraveRequestInfo::MakeCTX(
-      request_for_info, render_frame_token_, request_id_, browser_context_,
-      ctx_owned_.get(), factory_->url_loader_factory_type_,
+      request_, render_frame_token_, request_id_, browser_context_,
+      ctx_owned_.get(), original_initiator_, factory_->url_loader_factory_type_,
       factory_->request_initiator_, factory_->isolation_info_);
   ctx_ = ctx_owned_->AsWeakPtr();
 }

--- a/browser/net/brave_proxying_url_loader_factory_unittest.cc
+++ b/browser/net/brave_proxying_url_loader_factory_unittest.cc
@@ -9,6 +9,7 @@
 #include <optional>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
@@ -187,6 +188,59 @@ TEST_F(BraveProxyingURLLoaderFactoryTest,
   EXPECT_TRUE(redirected_request_initiator->opaque());
   EXPECT_NE(initiator, *redirected_request_initiator);
   EXPECT_EQ(net::OK, client.completion_status().error_code);
+}
+
+TEST_F(BraveProxyingURLLoaderFactoryTest,
+       PreservesOriginalInitiatorForHandlerAfterBraveRedirect) {
+  // Although the outgoing network request's initiator is tainted to an opaque
+  // origin after a cross-origin Brave redirect (as verified by
+  // TaintsInitiatorOnCrossOriginBraveRedirect), the BraveRequestInfo handed to
+  // the request handler for the redirected request must still carry the real,
+  // original initiator so Shields/adblock can attribute the request to the true
+  // initiator. Using the outgoing request's initiator here would instead expose
+  // the opaque tainted origin to the handler.
+  const GURL request_url("https://redirect-source.example/resource");
+  const GURL redirected_url("https://redirect-target.example/resource");
+  ASSERT_TRUE(request_url.is_valid()) << request_url;
+  ASSERT_TRUE(redirected_url.is_valid()) << redirected_url;
+  const url::Origin initiator =
+      url::Origin::Create(GURL("https://initiator.example"));
+  ASSERT_FALSE(initiator.opaque()) << initiator;
+
+  request_handler_->SetRedirect(request_url, redirected_url);
+  test_factory_.AddResponse(redirected_url.spec(), "ok");
+
+  auto factory = CreateFactory();
+  network::TestURLLoaderClient client;
+  mojo::Remote<network::mojom::URLLoader> loader;
+  CreateLoaderAndStart(factory, loader, CreateRequest(request_url, initiator),
+                       client);
+
+  client.RunUntilRedirectReceived();
+  loader->FollowRedirect({}, std::nullopt);
+  client.RunUntilComplete();
+
+  EXPECT_EQ(net::OK, client.completion_status().error_code)
+      << "Request URL: " << request_url
+      << ", redirected URL: " << redirected_url;
+
+  bool saw_redirected_request = false;
+  std::optional<url::Origin> initiator_for_redirected;
+  for (const auto& observation : request_handler_->observations()) {
+    if (observation.first == redirected_url) {
+      saw_redirected_request = true;
+      initiator_for_redirected = observation.second;
+    }
+  }
+  ASSERT_TRUE(saw_redirected_request)
+      << "No handler observation for " << redirected_url;
+  ASSERT_TRUE(initiator_for_redirected.has_value())
+      << "Missing initiator for " << redirected_url;
+  EXPECT_FALSE(initiator_for_redirected->opaque())
+      << "Redirected URL: " << redirected_url
+      << ", initiator: " << *initiator_for_redirected;
+  EXPECT_EQ(initiator, *initiator_for_redirected)
+      << "Redirected URL: " << redirected_url;
 }
 
 }  // namespace

--- a/browser/net/url_context.cc
+++ b/browser/net/url_context.cc
@@ -456,6 +456,7 @@ std::unique_ptr<brave::BraveRequestInfo> BraveRequestInfo::MakeCTX(
     uint64_t request_identifier,
     content::BrowserContext* browser_context,
     brave::BraveRequestInfo* old_ctx,
+    base::optional_ref<const url::Origin> original_request_initiator,
     std::optional<content::ContentBrowserClient::URLLoaderFactoryType>
         url_loader_factory_type,
     base::optional_ref<const url::Origin> factory_request_initiator,
@@ -467,7 +468,9 @@ std::unique_ptr<brave::BraveRequestInfo> BraveRequestInfo::MakeCTX(
   const bool use_factory_context =
       url_loader_factory_type &&
       ShouldUseFactoryURLLoaderContext(*url_loader_factory_type);
-  std::optional<url::Origin> request_initiator = request.request_initiator;
+  std::optional<url::Origin> request_initiator =
+      original_request_initiator ? *original_request_initiator
+                                 : request.request_initiator;
   if (!request_initiator && use_factory_context && factory_request_initiator) {
     request_initiator = *factory_request_initiator;
   }

--- a/browser/net/url_context.h
+++ b/browser/net/url_context.h
@@ -186,12 +186,18 @@ class BraveRequestInfo {
   const std::optional<std::string>& devtools_request_id() const;
   void set_devtools_request_id(const std::optional<std::string>& value);
 
+  // Builds request context using |original_request_initiator| when provided;
+  // otherwise uses |request.request_initiator|, with
+  // |factory_request_initiator| as a worker-factory fallback when neither is
+  // available.
   static std::unique_ptr<brave::BraveRequestInfo> MakeCTX(
       const network::ResourceRequest& request,
       content::GlobalRenderFrameHostToken render_frame_token,
       uint64_t request_identifier,
       content::BrowserContext* browser_context,
       brave::BraveRequestInfo* old_ctx,
+      base::optional_ref<const url::Origin> original_request_initiator =
+          std::nullopt,
       std::optional<content::ContentBrowserClient::URLLoaderFactoryType>
           url_loader_factory_type = std::nullopt,
       base::optional_ref<const url::Origin> factory_request_initiator =

--- a/browser/net/url_context_unittest.cc
+++ b/browser/net/url_context_unittest.cc
@@ -50,7 +50,7 @@ TEST_F(BraveRequestInfoTest,
 
   auto ctx = BraveRequestInfo::MakeCTX(
       request, content::GlobalRenderFrameHostToken(), 1, &profile,
-      /*old_ctx=*/nullptr,
+      /*old_ctx=*/nullptr, /*original_request_initiator=*/std::nullopt,
       content::ContentBrowserClient::URLLoaderFactoryType::kWorkerSubResource,
       factory_initiator, factory_isolation_info);
 
@@ -59,6 +59,46 @@ TEST_F(BraveRequestInfoTest,
   EXPECT_EQ(factory_top_frame_origin.GetURL(), ctx->tab_origin());
   EXPECT_EQ(ctx->network_anonymization_key(),
             factory_isolation_info.network_anonymization_key());
+}
+
+// The request intentionally omits both initiator sources available after
+// construction so only the worker factory initiator can populate the context.
+TEST_F(BraveRequestInfoTest, WorkerRequestFallsBackToFactoryInitiator) {
+  TestingProfile profile;
+  network::ResourceRequest request;
+  request.url = GURL("https://worker.example/fetch");
+  ASSERT_FALSE(request.request_initiator);
+
+  const url::Origin factory_initiator =
+      url::Origin::Create(GURL("https://factory-initiator.example"));
+
+  auto ctx = BraveRequestInfo::MakeCTX(
+      request, content::GlobalRenderFrameHostToken(), 1, &profile,
+      /*old_ctx=*/nullptr, /*original_request_initiator=*/std::nullopt,
+      content::ContentBrowserClient::URLLoaderFactoryType::kWorkerSubResource,
+      factory_initiator);
+
+  ASSERT_TRUE(ctx->request_initiator());
+  EXPECT_EQ(factory_initiator, *ctx->request_initiator());
+}
+
+TEST_F(BraveRequestInfoTest, OriginalInitiatorOverridesRequestInitiator) {
+  TestingProfile profile;
+  const url::Origin original_request_initiator =
+      url::Origin::Create(GURL("https://original-initiator.example"));
+  network::ResourceRequest request;
+  request.url = GURL("https://document.example/fetch");
+  request.request_initiator =
+      url::Origin::Create(GURL("https://request-initiator.example"));
+
+  auto ctx = BraveRequestInfo::MakeCTX(
+      request, content::GlobalRenderFrameHostToken(), 1, &profile,
+      /*old_ctx=*/nullptr, original_request_initiator);
+
+  ASSERT_TRUE(ctx->request_initiator()) << "Request URL: " << request.url;
+  EXPECT_EQ(original_request_initiator, *ctx->request_initiator())
+      << "Request URL: " << request.url
+      << ", request initiator: " << *request.request_initiator;
 }
 
 TEST_F(BraveRequestInfoTest, RequestContextOverridesFactoryContext) {
@@ -81,7 +121,7 @@ TEST_F(BraveRequestInfoTest, RequestContextOverridesFactoryContext) {
 
   auto ctx = BraveRequestInfo::MakeCTX(
       request, content::GlobalRenderFrameHostToken(), 1, &profile,
-      /*old_ctx=*/nullptr,
+      /*old_ctx=*/nullptr, /*original_request_initiator=*/std::nullopt,
       content::ContentBrowserClient::URLLoaderFactoryType::kWorkerSubResource,
       factory_initiator, MakeIsolationInfo(factory_top_frame_origin));
 
@@ -107,7 +147,7 @@ TEST_F(BraveRequestInfoTest,
 
   auto ctx = BraveRequestInfo::MakeCTX(
       request, content::GlobalRenderFrameHostToken(), 1, &profile,
-      /*old_ctx=*/nullptr,
+      /*old_ctx=*/nullptr, /*original_request_initiator=*/std::nullopt,
       content::ContentBrowserClient::URLLoaderFactoryType::kDocumentSubResource,
       factory_initiator, MakeIsolationInfo(factory_top_frame_origin));
 


### PR DESCRIPTION
## Summary

This is a refactoring of existing original-initiator handling, not a behavior change.

Before this PR, `BraveProxyingURLLoaderFactory` copied `ResourceRequest` and overwrote the copy's `request_initiator` with its captured `original_initiator_` before calling `BraveRequestInfo::MakeCTX`. This PR passes that captured initiator explicitly to `MakeCTX` instead, centralizing the initiator-selection logic in `BraveRequestInfo` without changing its effective precedence:

1. captured original request initiator;
2. current `request.request_initiator` when no captured original exists;
3. worker URL-loader factory initiator when neither request initiator is available.

The outgoing request remains unchanged, including Chromium's cross-origin redirect tainting behavior.

## Test coverage

- `PreservesOriginalInitiatorForHandlerAfterBraveRedirect` verifies the handler context receives the captured original initiator after a Brave redirect.
- `TaintsInitiatorOnCrossOriginBraveRedirect` verifies the outgoing request initiator remains opaque after a cross-origin redirect.
- `OriginalInitiatorOverridesRequestInitiator` verifies explicit original-initiator precedence in `MakeCTX`.
- `WorkerRequestFallsBackToFactoryInitiator` verifies worker requests retain the existing factory-initiator fallback.

## Validation

- `git diff --check`: passed on the final squashed diff.
- Earlier validation of the same implementation and tests passed formatting, `gn_check`, presubmit with 0 messages / 0 warnings / 0 errors, the `brave_unit_tests` build, and all 11 focused request-info / URL-loader / WebSocket tests.
- A final rerun after squash was blocked before command execution because the protected shared Chromium checkout contained unrelated untracked/generated files; the final squash did not change the source diff.
- Final implementation review: no validated findings.

Follow-up to https://github.com/brave/brave-browser/issues/57537
