### PR TITLE
[ads] Open iOS static NTT target links in their app if installed

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDelegate.swift
@@ -363,15 +363,9 @@ extension BrowserViewController: TabDelegate {
     _ tab: some TabState,
     shouldBlockUniversalLinksForRequest request: URLRequest
   ) -> Bool {
-    func isYouTubeLoad() -> Bool {
-      guard let domain = request.mainDocumentURL?.baseDomain else {
-        return false
-      }
-      let domainsWithUniversalLinks: Set<String> = ["youtube.com", "youtu.be"]
-      return domainsWithUniversalLinks.contains(domain)
-    }
+    let isYouTubeLoad = request.mainDocumentURL?.isYouTubeURL ?? false
     if tab.isPrivate || !Preferences.General.followUniversalLinks.value
-      || (Preferences.General.keepYouTubeInBrave.value && isYouTubeLoad())
+      || (Preferences.General.keepYouTubeInBrave.value && isYouTubeLoad)
     {
       return true
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
@@ -936,11 +936,34 @@ class NewTabPageViewController: UIViewController {
 
   private func tappedSponsorButton(_ logo: NTPSponsoredImageLogo) {
     UIImpactFeedbackGenerator(style: .medium).vibrate()
-    if let url = logo.destinationURL {
-      delegate?.navigateToInput(url.absoluteString, inNewTab: false, switchingToPrivateMode: false)
+    reportSponsoredBackgroundEvent(.clicked)
+
+    guard let url = logo.destinationURL else { return }
+    if url.scheme != "https"
+      || !Preferences.General.followUniversalLinks.value
+      || (Preferences.General.keepYouTubeInBrave.value && url.isYouTubeURL)
+    {
+      delegate?.navigateToInput(
+        url.absoluteString,
+        inNewTab: false,
+        switchingToPrivateMode: false
+      )
+      return
     }
 
-    reportSponsoredBackgroundEvent(.clicked)
+    // Try to open the destination URL as a universal link in case there is
+    // an installed app configured to open it. Fall back to loading the URL
+    // in the browser if no app opened it.
+    UIApplication.shared.open(url, options: [.universalLinksOnly: true]) {
+      [weak self] didOpen in
+      if !didOpen {
+        self?.delegate?.navigateToInput(
+          url.absoluteString,
+          inNewTab: false,
+          switchingToPrivateMode: false
+        )
+      }
+    }
   }
 
   private func handleFavoriteAction(favorite: Favorite, action: BookmarksAction) {

--- a/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
+++ b/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
@@ -247,6 +247,13 @@ extension URL {
     return baseDomain.replacingOccurrences(of: ".\(publicSuffix)", with: "")
   }
 
+  /// Checks if the URL is a YouTube URL.
+  public var isYouTubeURL: Bool {
+    guard let baseDomain else { return false }
+    let youTubeDomains: Set<String> = ["youtube.com", "youtu.be"]
+    return youTubeDomains.contains(baseDomain)
+  }
+
   // Check if the website is supporting showing Add To playlist toast
   public var isPlaylistSupportedSiteURL: Bool {
     let urlHost = self.host ?? self.hostSLD

--- a/ios/brave-ios/Tests/BraveSharedTests/URLExtensionTests.swift
+++ b/ios/brave-ios/Tests/BraveSharedTests/URLExtensionTests.swift
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import BraveShared
 import Foundation
 import Shared
 import WebKit
@@ -278,6 +279,36 @@ class URLExtensionTests: XCTestCase {
     XCTAssertEqual(URL(string: "https://otap.co")?.baseDomain, "otap.co")
     XCTAssertEqual(URL(string: "https://test.otap.co")?.baseDomain, "test.otap.co")
     XCTAssertEqual(URL(string: "https://one.two.otap.co")?.baseDomain, "one.two.otap.co")
+  }
+
+  func testIsYouTubeURL() {
+    let youTubeURLs = [
+      "https://youtube.com",
+      "https://www.youtube.com",
+      "https://m.youtube.com",
+      "https://youtu.be",
+      "https://youtube.com/watch?v=1234567",
+      "https://www.youtube.com/watch?v=1234567",
+      "https://m.youtube.com/watch?v=1234567",
+      "https://youtu.be/1234567",
+      "http://youtube.com",
+      "http://www.youtube.com",
+      "http://m.youtube.com",
+      "http://youtu.be",
+    ]
+
+    let nonYouTubeURLs = [
+      "https://brave.com",
+      "https://notyoutube.com",
+      "https://youtube.com.com",
+      "https://youtube.evil.com",
+      "https://youtu.be.be",
+      "https://youtu.evil.be",
+      "about:blank",
+    ]
+
+    youTubeURLs.forEach { XCTAssertTrue(URL(string: $0)!.isYouTubeURL, $0) }
+    nonYouTubeURLs.forEach { XCTAssertFalse(URL(string: $0)!.isYouTubeURL, $0) }
   }
 
   func testNewTabPageURL() {


### PR DESCRIPTION
The PR adds the ability for a static NTT on iOS to open the target link URL as a universal link in its own app if such an app is installed. If there is no app configured to open such links, the URL is loaded in the browser. If `Allow universal links to open in external apps` setting is off, then the target URL is always loaded in the browser. If target URL is YouTube and `Open YouTube links in Brave` setting is on, then the target URL is loaded in the browser.

Security/privacy review: https://github.com/brave/reviews/issues/2326

## Test plan

### Test case 1

1. Setup static NTT campaign with amazon target URL on staging (example of such campaign is `Amazon Image NTT for iOS - KY only`  https://ads-admin.bravesoftware.com/campaigns/2bb1f90f-b32a-453e-ac8c-c4cd9ac6e46a)
2. Install Brave browser on iOS without Amazon app installed
3. Start Brave browser on iOS with staging component server
4. Trigger NTT
5. Tap CTA button
 EXPECTATION: amazon web page is opened in browser.
6. Install Amazon app on iOS device
7. Restart the Browser
8. Trigger NTT
9. Tap CTA button
 EXPECTATION: Amazon app is opened.
10. Toggle off `Allow universal links to open in external apps` setting
3. Trigger NTT
4. Tap CTA button
 EXPECTATION: amazon web page is opened in browser.

### Test case 2

1. Install Brave browser on iOS without Amazon app installed
2. Start Brave browser
3. Do some search request to make SERP contain amazon links
4. Tap Amazon link
 EXPECTATION: amazon web page is opened in browser.
5. Install amazon app on iOS device
6. Do some search request to make SERP contain amazon links
7. Tap Amazon link
 EXPECTATION: Amazon app is opened.
8. Toggle off `Allow universal links to open in external apps` setting
9. Do some search request to make SERP contain amazon links
5. Tap Amazon link
 EXPECTATION: amazon web page is opened in browser.

### Test case 3

1. Install Brave browser on iOS without YouTube app installed
2. Start Brave browser
3. Do some search request to make SERP contain YouTube links
4. Tap YouTube link
 EXPECTATION: YouTube web page is opened in browser.
5. Install YouTube app on iOS device
6. Do some search request to make SERP contain YouTube links
7. Tap YouTube link
  EXPECTATION: YouTube web page is opened in browser.
8. Toggle off `Open YouTube links in Brave` setting
9. Do some search request to make SERP contain YouTube links
10. Tap YouTube link
  EXPECTATION: YouTube app is opened
8. Toggle off `Allow universal links to open in external apps` setting
9. Do some search request to make SERP contain YouTube links
5. Tap YouTube link
 EXPECTATION: YouTube web page is opened in browser.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/57180

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
