### PR TITLE
[ZCash] Scan and store Ironwood actions during block sync

### DIFF
--- a/components/brave_wallet/browser/internal/orchard_block_scanner.cc
+++ b/components/brave_wallet/browser/internal/orchard_block_scanner.cc
@@ -8,13 +8,70 @@
 #include "base/threading/thread_restrictions.h"
 #include "brave/components/brave_wallet/browser/zcash/rust/orchard_block_decoder.h"
 #include "brave/components/brave_wallet/browser/zcash/rust/orchard_decoded_blocks_bundle.h"
+#include "brave/components/brave_wallet/common/common_utils.h"
 #include "brave/components/brave_wallet/common/hex_utils.h"
 
 namespace brave_wallet {
 
-OrchardBlockScanner::Result::Result() = default;
+namespace {
 
-OrchardBlockScanner::Result::Result(
+std::optional<std::vector<OrchardNoteSpend>> CollectSpends(
+    const std::vector<zcash::mojom::CompactBlockPtr>& blocks,
+    OrchardPool pool,
+    uint32_t ironwood_activation_height) {
+  std::vector<OrchardNoteSpend> found_spends;
+  for (const auto& block : blocks) {
+    // Keep spend collection consistent with the decoder: ignore pre-activation
+    // blocks for the Ironwood pool.
+    if (pool == OrchardPool::kIronwood &&
+        block->height < ironwood_activation_height) {
+      continue;
+    }
+    for (const auto& tx : block->vtx) {
+      const auto& actions = pool == OrchardPool::kIronwood
+                                ? tx->ironwood_actions
+                                : tx->orchard_actions;
+      for (const auto& action : actions) {
+        if (action->nullifier.size() != kOrchardNullifierSize) {
+          return std::nullopt;
+        }
+        OrchardNoteSpend spend;
+        base::span(spend.nullifier).copy_from(action->nullifier);
+        spend.block_id = block->height;
+        found_spends.push_back(std::move(spend));
+      }
+    }
+  }
+  return found_spends;
+}
+
+base::expected<OrchardBlockScanner::PoolResult, OrchardBlockScanner::ErrorCode>
+BuildPoolResult(std::unique_ptr<orchard::OrchardDecodedBlocksBundle> bundle,
+                const std::vector<zcash::mojom::CompactBlockPtr>& blocks,
+                OrchardPool pool,
+                uint32_t ironwood_activation_height) {
+  if (!bundle) {
+    return base::unexpected(OrchardBlockScanner::ErrorCode::kInputError);
+  }
+  auto notes = bundle->GetDiscoveredNotes();
+  if (!notes) {
+    return base::unexpected(
+        OrchardBlockScanner::ErrorCode::kDiscoveredNotesError);
+  }
+  auto spends = CollectSpends(blocks, pool, ironwood_activation_height);
+  if (!spends) {
+    return base::unexpected(OrchardBlockScanner::ErrorCode::kInputError);
+  }
+  return OrchardBlockScanner::PoolResult(
+      std::move(notes.value()), std::move(spends.value()), std::move(bundle),
+      blocks.back()->height, ToHex(blocks.back()->hash));
+}
+
+}  // namespace
+
+OrchardBlockScanner::PoolResult::PoolResult() = default;
+
+OrchardBlockScanner::PoolResult::PoolResult(
     std::vector<OrchardNote> discovered_notes,
     std::vector<OrchardNoteSpend> spent_notes,
     std::unique_ptr<orchard::OrchardDecodedBlocksBundle> scanned_blocks,
@@ -26,10 +83,17 @@ OrchardBlockScanner::Result::Result(
       latest_scanned_block_id(latest_scanned_block_id),
       latest_scanned_block_hash(latest_scanned_block_hash) {}
 
+OrchardBlockScanner::PoolResult::PoolResult(OrchardBlockScanner::PoolResult&&) =
+    default;
+OrchardBlockScanner::PoolResult& OrchardBlockScanner::PoolResult::operator=(
+    OrchardBlockScanner::PoolResult&&) = default;
+
+OrchardBlockScanner::PoolResult::~PoolResult() = default;
+
+OrchardBlockScanner::Result::Result() = default;
 OrchardBlockScanner::Result::Result(OrchardBlockScanner::Result&&) = default;
 OrchardBlockScanner::Result& OrchardBlockScanner::Result::operator=(
     OrchardBlockScanner::Result&&) = default;
-
 OrchardBlockScanner::Result::~Result() = default;
 
 OrchardBlockScanner::OrchardBlockScanner(const OrchardFullViewKey& fvk)
@@ -39,54 +103,44 @@ OrchardBlockScanner::~OrchardBlockScanner() = default;
 
 base::expected<OrchardBlockScanner::Result, OrchardBlockScanner::ErrorCode>
 OrchardBlockScanner::ScanBlocks(
-    const OrchardTreeState& tree_state,
-    const std::vector<zcash::mojom::CompactBlockPtr>& blocks) {
+    const OrchardTreeState& orchard_tree_state,
+    const std::vector<zcash::mojom::CompactBlockPtr>& blocks,
+    base::optional_ref<const OrchardTreeState> ironwood_tree_state,
+    uint32_t ironwood_activation_height) {
   base::AssertLongCPUWorkAllowed();
-
-  std::unique_ptr<orchard::OrchardDecodedBlocksBundle> result =
-      orchard::OrchardBlockDecoder::DecodeBlocks(fvk_, tree_state, blocks);
-  if (!result) {
-    return base::unexpected(ErrorCode::kInputError);
-  }
-
-  std::optional<std::vector<OrchardNote>> found_notes =
-      result->GetDiscoveredNotes();
-
-  if (!found_notes) {
-    return base::unexpected(ErrorCode::kDiscoveredNotesError);
-  }
-
   if (blocks.empty()) {
     return base::unexpected(ErrorCode::kInputError);
   }
 
-  std::vector<OrchardNoteSpend> found_spends;
+  const bool decode_ironwood =
+      IsZCashIronwoodEnabled() && ironwood_tree_state.has_value();
 
-  uint32_t latest_block_id = blocks.back()->height;
-  std::string latest_block_hash = ToHex(blocks.back()->hash);
+  orchard::OrchardBlockDecoder::Result decoded =
+      orchard::OrchardBlockDecoder::DecodeBlocks(
+          fvk_, orchard_tree_state, blocks,
+          decode_ironwood ? ironwood_tree_state
+                          : base::optional_ref<const OrchardTreeState>(),
+          ironwood_activation_height);
 
-  for (const auto& block : blocks) {
-    for (const auto& tx : block->vtx) {
-      // We only scan orchard actions here
-      for (const auto& orchard_action : tx->orchard_actions) {
-        if (orchard_action->nullifier.size() != kOrchardNullifierSize) {
-          return base::unexpected(ErrorCode::kInputError);
-        }
-
-        // Nullifier is a public information about some note being spent.
-        // Here we are collecting nullifiers from the blocks to check them
-        // later.
-        OrchardNoteSpend spend;
-        base::span(spend.nullifier).copy_from(orchard_action->nullifier);
-        spend.block_id = block->height;
-        found_spends.push_back(std::move(spend));
-      }
-    }
+  auto orchard_result = BuildPoolResult(std::move(decoded.orchard), blocks,
+                                        OrchardPool::kOrchard, 0);
+  if (!orchard_result.has_value()) {
+    return base::unexpected(orchard_result.error());
   }
 
-  return Result({std::move(found_notes.value()), std::move(found_spends),
-                 std::move(result), latest_block_id,
-                 std::move(latest_block_hash)});
+  Result result;
+  result.orchard = std::move(orchard_result.value());
+
+  if (decode_ironwood) {
+    auto ironwood_result =
+        BuildPoolResult(std::move(decoded.ironwood), blocks,
+                        OrchardPool::kIronwood, ironwood_activation_height);
+    if (!ironwood_result.has_value()) {
+      return base::unexpected(ironwood_result.error());
+    }
+    result.ironwood = std::move(ironwood_result.value());
+  }
+  return result;
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/internal/orchard_block_scanner.h
+++ b/components/brave_wallet/browser/internal/orchard_block_scanner.h
@@ -8,11 +8,13 @@
 
 #include <algorithm>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "base/types/expected.h"
+#include "base/types/optional_ref.h"
 #include "brave/components/brave_wallet/browser/internal/orchard_block_scanner.h"
 #include "brave/components/brave_wallet/browser/zcash/rust/orchard_decoded_blocks_bundle.h"
 #include "brave/components/brave_wallet/common/zcash_utils.h"
@@ -26,24 +28,25 @@ class OrchardBlockScanner {
  public:
   enum class ErrorCode { kInputError, kDiscoveredNotesError, kDecoderError };
 
-  struct Result {
-    Result();
-    Result(std::vector<OrchardNote> discovered_notes,
-           std::vector<OrchardNoteSpend> spent_notes,
-           std::unique_ptr<orchard::OrchardDecodedBlocksBundle> scanned_blocks,
-           uint32_t latest_scanned_block_id,
-           const std::string& latest_scanned_block_hash);
-    Result(const Result&) = delete;
-    Result& operator=(const Result&) = delete;
-    Result(Result&&);
-    Result& operator=(Result&&);
-    ~Result();
+  struct PoolResult {
+    PoolResult();
+    PoolResult(
+        std::vector<OrchardNote> discovered_notes,
+        std::vector<OrchardNoteSpend> spent_notes,
+        std::unique_ptr<orchard::OrchardDecodedBlocksBundle> scanned_blocks,
+        uint32_t latest_scanned_block_id,
+        const std::string& latest_scanned_block_hash);
+    PoolResult(const PoolResult&) = delete;
+    PoolResult& operator=(const PoolResult&) = delete;
+    PoolResult(PoolResult&&);
+    PoolResult& operator=(PoolResult&&);
+    ~PoolResult();
 
     // New notes have been discovered.
     std::vector<OrchardNote> discovered_notes;
     // Nullifiers for the previously discovered notes.
     std::vector<OrchardNoteSpend> found_spends;
-    // Decoded blocks bundle to be insterted in the shard tree.
+    // Decoded blocks bundle to be inserted in the shard tree.
     std::unique_ptr<orchard::OrchardDecodedBlocksBundle> scanned_blocks;
     // Latest scanned block height.
     uint32_t latest_scanned_block_id;
@@ -51,14 +54,31 @@ class OrchardBlockScanner {
     std::string latest_scanned_block_hash;
   };
 
+  struct Result {
+    Result();
+    Result(const Result&) = delete;
+    Result& operator=(const Result&) = delete;
+    Result(Result&&);
+    Result& operator=(Result&&);
+    ~Result();
+
+    PoolResult orchard;
+    std::optional<PoolResult> ironwood;
+  };
+
   explicit OrchardBlockScanner(const OrchardFullViewKey& full_view_key);
   virtual ~OrchardBlockScanner();
 
-  // Scans blocks to find incoming notes related to fvk
+  // Scans blocks to find incoming notes related to fvk.
   // Also checks whether existing notes were spent.
   virtual base::expected<Result, OrchardBlockScanner::ErrorCode> ScanBlocks(
-      const OrchardTreeState& tree_state,
-      const std::vector<zcash::mojom::CompactBlockPtr>& blocks);
+      const OrchardTreeState& orchard_tree_state,
+      const std::vector<zcash::mojom::CompactBlockPtr>& blocks,
+      base::optional_ref<const OrchardTreeState> ironwood_tree_state =
+          std::nullopt,
+      // Blocks below this height are excluded from the Ironwood pool. Default 0
+      // keeps existing callers/tests (no cut).
+      uint32_t ironwood_activation_height = 0);
 
  private:
   OrchardFullViewKey fvk_;

--- a/components/brave_wallet/browser/internal/orchard_block_scanner.h
+++ b/components/brave_wallet/browser/internal/orchard_block_scanner.h
@@ -74,11 +74,8 @@ class OrchardBlockScanner {
   virtual base::expected<Result, OrchardBlockScanner::ErrorCode> ScanBlocks(
       const OrchardTreeState& orchard_tree_state,
       const std::vector<zcash::mojom::CompactBlockPtr>& blocks,
-      base::optional_ref<const OrchardTreeState> ironwood_tree_state =
-          std::nullopt,
-      // Blocks below this height are excluded from the Ironwood pool. Default 0
-      // keeps existing callers/tests (no cut).
-      uint32_t ironwood_activation_height = 0);
+      base::optional_ref<const OrchardTreeState> ironwood_tree_state,
+      uint32_t ironwood_activation_height);
 
  private:
   OrchardFullViewKey fvk_;

--- a/components/brave_wallet/browser/internal/orchard_block_scanner_unittest.cc
+++ b/components/brave_wallet/browser/internal/orchard_block_scanner_unittest.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <array>
 #include <initializer_list>
+#include <optional>
 #include <string_view>
 
 #include "base/check.h"
@@ -235,7 +236,8 @@ TEST(OrchardBlockScannerTest, DiscoverNewNotes) {
     blocks.push_back(std::move(block));
   }
 
-  auto result = scanner.ScanBlocks({}, std::move(blocks));
+  auto result =
+      scanner.ScanBlocks({}, std::move(blocks), std::nullopt, 0xFFFFFFFF);
 
   EXPECT_EQ(result.value().orchard.discovered_notes.size(), 4u);
   EXPECT_EQ(result.value().orchard.discovered_notes[0].block_id, 10u);
@@ -289,7 +291,8 @@ TEST(OrchardBlockScannerTest, WrongInput) {
 
     blocks.push_back(std::move(block));
 
-    auto result = scanner.ScanBlocks({}, std::move(blocks));
+    auto result =
+        scanner.ScanBlocks({}, std::move(blocks), std::nullopt, 0xFFFFFFFF);
     EXPECT_FALSE(result.has_value());
   }
 
@@ -318,7 +321,8 @@ TEST(OrchardBlockScannerTest, WrongInput) {
 
     blocks.push_back(std::move(block));
 
-    auto result = scanner.ScanBlocks({}, std::move(blocks));
+    auto result =
+        scanner.ScanBlocks({}, std::move(blocks), std::nullopt, 0xFFFFFFFF);
     EXPECT_FALSE(result.has_value());
   }
 
@@ -348,7 +352,8 @@ TEST(OrchardBlockScannerTest, WrongInput) {
 
     blocks.push_back(std::move(block));
 
-    auto result = scanner.ScanBlocks({}, std::move(blocks));
+    auto result =
+        scanner.ScanBlocks({}, std::move(blocks), std::nullopt, 0xFFFFFFFF);
     EXPECT_FALSE(result.has_value());
   }
 
@@ -377,7 +382,8 @@ TEST(OrchardBlockScannerTest, WrongInput) {
 
     blocks.push_back(std::move(block));
 
-    auto result = scanner.ScanBlocks({}, std::move(blocks));
+    auto result =
+        scanner.ScanBlocks({}, std::move(blocks), std::nullopt, 0xFFFFFFFF);
     EXPECT_FALSE(result.has_value());
   }
 
@@ -406,7 +412,8 @@ TEST(OrchardBlockScannerTest, WrongInput) {
 
     blocks.push_back(std::move(block));
 
-    auto result = scanner.ScanBlocks({}, std::move(blocks));
+    auto result =
+        scanner.ScanBlocks({}, std::move(blocks), std::nullopt, 0xFFFFFFFF);
     EXPECT_FALSE(result.has_value());
   }
 
@@ -433,14 +440,16 @@ TEST(OrchardBlockScannerTest, WrongInput) {
 
     blocks.push_back(std::move(block));
 
-    auto result = scanner.ScanBlocks({}, std::move(blocks));
+    auto result =
+        scanner.ScanBlocks({}, std::move(blocks), std::nullopt, 0xFFFFFFFF);
     EXPECT_FALSE(result.has_value());
   }
 
   // Empty blocks list
   {
     std::vector<zcash::mojom::CompactBlockPtr> blocks;
-    auto result = scanner.ScanBlocks({}, std::move(blocks));
+    auto result =
+        scanner.ScanBlocks({}, std::move(blocks), std::nullopt, 0xFFFFFFFF);
     EXPECT_FALSE(result.has_value());
   }
 }
@@ -530,7 +539,8 @@ TEST(OrchardBlockScanner, FoundKnownNullifiers_SameBatch) {
     blocks.push_back(std::move(block));
   }
 
-  auto result = scanner.ScanBlocks({}, std::move(blocks));
+  auto result =
+      scanner.ScanBlocks({}, std::move(blocks), std::nullopt, 0xFFFFFF);
 
   EXPECT_EQ(result.value().orchard.discovered_notes.size(), 1u);
   EXPECT_EQ(result.value().orchard.discovered_notes[0].block_id, 10u);
@@ -597,7 +607,8 @@ TEST(OrchardBlockScanner, FoundKnownNullifiers) {
 
   OrchardTreeState tree_state;
 
-  auto result = scanner.ScanBlocks(tree_state, std::move(blocks));
+  auto result = scanner.ScanBlocks(tree_state, std::move(blocks), std::nullopt,
+                                   0xFFFFFFFF);
 
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value().orchard.found_spends.size(), 1u);
@@ -634,7 +645,7 @@ TEST(OrchardBlockScannerTest, DiscoverNewIronwoodNotes) {
 
   OrchardTreeState ironwood_tree_state;
   auto result =
-      scanner.ScanBlocks(OrchardTreeState(), blocks, ironwood_tree_state);
+      scanner.ScanBlocks(OrchardTreeState(), blocks, ironwood_tree_state, 0);
 
   ASSERT_TRUE(result.has_value());
   ASSERT_TRUE(result.value().ironwood.has_value());
@@ -711,7 +722,7 @@ TEST(OrchardBlockScannerTest, IronwoodFeatureOff_ResultIsNullopt) {
   auto blocks = BuildBlocksWithIronwoodActions(10u, 3);
 
   auto result =
-      scanner.ScanBlocks(OrchardTreeState(), blocks, ironwood_tree_state);
+      scanner.ScanBlocks(OrchardTreeState(), blocks, ironwood_tree_state, 0);
 
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result.value().ironwood, std::nullopt);
@@ -742,7 +753,7 @@ TEST(OrchardBlockScannerTest, IronwoodFeatureOn_IronwoodResultPopulated) {
   auto blocks = BuildBlocksWithIronwoodActions(10u, kIronwoodActionCount);
 
   auto result =
-      scanner.ScanBlocks(OrchardTreeState(), blocks, ironwood_tree_state);
+      scanner.ScanBlocks(OrchardTreeState(), blocks, ironwood_tree_state, 0);
 
   ASSERT_TRUE(result.has_value());
   ASSERT_TRUE(result.value().ironwood.has_value());

--- a/components/brave_wallet/browser/internal/orchard_block_scanner_unittest.cc
+++ b/components/brave_wallet/browser/internal/orchard_block_scanner_unittest.cc
@@ -6,16 +6,73 @@
 #include "brave/components/brave_wallet/browser/internal/orchard_block_scanner.h"
 
 #include <algorithm>
+#include <array>
+#include <initializer_list>
+#include <string_view>
 
+#include "base/check.h"
+#include "base/test/scoped_feature_list.h"
+#include "brave/components/brave_wallet/browser/bip39.h"
 #include "brave/components/brave_wallet/browser/internal/hd_key_zip32.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_test_utils.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/common_utils.h"
+#include "brave/components/brave_wallet/common/features.h"
 #include "brave/components/brave_wallet/common/hex_utils.h"
 #include "brave/components/services/brave_wallet/public/mojom/zcash_decoder.mojom.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace brave_wallet {
+
+namespace {
+
+OrchardFullViewKey GetTestnetAccount0Fvk() {
+  auto seed = bip39::MnemonicToSeed(
+      "excuse youth title hurt fancy senior olympic coach number spray "
+      "predict before shrug obvious game winner hurry tray load trap garbage "
+      "comic else degree",
+      "");
+  CHECK(seed);
+
+  auto key = HDKeyZip32::GenerateFromSeed(seed.value());
+  CHECK(key);
+  key = key->DeriveHardenedChild(kZip32Purpose);
+  CHECK(key);
+  key = key->DeriveHardenedChild(kTestnetCoinType);
+  CHECK(key);
+  key = key->DeriveHardenedChild(0);
+  CHECK(key);
+  return key->GetFullViewKey();
+}
+
+void AddIronwoodAction(zcash::mojom::CompactTx* tx,
+                       std::string_view nullifier_hex,
+                       std::string_view cmx_hex,
+                       std::string_view ephemeral_key_hex,
+                       std::string_view ciphertext_hex) {
+  auto action = zcash::mojom::CompactOrchardAction::New();
+  action->nullifier = PrefixedHexStringToBytes(nullifier_hex).value();
+  action->cmx = PrefixedHexStringToBytes(cmx_hex).value();
+  action->ephemeral_key = PrefixedHexStringToBytes(ephemeral_key_hex).value();
+  action->ciphertext = PrefixedHexStringToBytes(ciphertext_hex).value();
+  tx->ironwood_actions.push_back(std::move(action));
+}
+
+zcash::mojom::CompactBlockPtr MakeIronwoodBlock(
+    uint32_t height,
+    std::initializer_list<std::array<std::string_view, 8>> txs) {
+  auto block = zcash::mojom::CompactBlock::New();
+  block->height = height;
+  for (const auto& tx_data : txs) {
+    auto tx = zcash::mojom::CompactTx::New();
+    AddIronwoodAction(tx.get(), tx_data[0], tx_data[1], tx_data[2], tx_data[3]);
+    AddIronwoodAction(tx.get(), tx_data[4], tx_data[5], tx_data[6], tx_data[7]);
+    block->vtx.push_back(std::move(tx));
+  }
+  return block;
+}
+
+}  // namespace
 
 TEST(OrchardBlockScannerTest, DiscoverNewNotes) {
   auto scanner = OrchardBlockScanner(OrchardFullViewKey(
@@ -180,19 +237,19 @@ TEST(OrchardBlockScannerTest, DiscoverNewNotes) {
 
   auto result = scanner.ScanBlocks({}, std::move(blocks));
 
-  EXPECT_EQ(result.value().discovered_notes.size(), 4u);
-  EXPECT_EQ(result.value().discovered_notes[0].block_id, 10u);
-  EXPECT_EQ(result.value().discovered_notes[0].amount, 3625561528u);
-  EXPECT_EQ(result.value().discovered_notes[1].block_id, 10u);
-  EXPECT_EQ(result.value().discovered_notes[1].amount, 891903885u);
-  EXPECT_EQ(result.value().discovered_notes[2].block_id, 10u);
-  EXPECT_EQ(result.value().discovered_notes[2].amount, 1881904414u);
-  EXPECT_EQ(result.value().discovered_notes[3].block_id, 11u);
-  EXPECT_EQ(result.value().discovered_notes[3].amount, 2549979667u);
-  EXPECT_EQ(result.value().latest_scanned_block_id, 11u);
-  EXPECT_EQ(result.value().latest_scanned_block_hash, "0xaabb");
+  EXPECT_EQ(result.value().orchard.discovered_notes.size(), 4u);
+  EXPECT_EQ(result.value().orchard.discovered_notes[0].block_id, 10u);
+  EXPECT_EQ(result.value().orchard.discovered_notes[0].amount, 3625561528u);
+  EXPECT_EQ(result.value().orchard.discovered_notes[1].block_id, 10u);
+  EXPECT_EQ(result.value().orchard.discovered_notes[1].amount, 891903885u);
+  EXPECT_EQ(result.value().orchard.discovered_notes[2].block_id, 10u);
+  EXPECT_EQ(result.value().orchard.discovered_notes[2].amount, 1881904414u);
+  EXPECT_EQ(result.value().orchard.discovered_notes[3].block_id, 11u);
+  EXPECT_EQ(result.value().orchard.discovered_notes[3].amount, 2549979667u);
+  EXPECT_EQ(result.value().orchard.latest_scanned_block_id, 11u);
+  EXPECT_EQ(result.value().orchard.latest_scanned_block_hash, "0xaabb");
 
-  EXPECT_EQ(result.value().found_spends.size(), 5u);
+  EXPECT_EQ(result.value().orchard.found_spends.size(), 5u);
 }
 
 TEST(OrchardBlockScannerTest, WrongInput) {
@@ -475,17 +532,18 @@ TEST(OrchardBlockScanner, FoundKnownNullifiers_SameBatch) {
 
   auto result = scanner.ScanBlocks({}, std::move(blocks));
 
-  EXPECT_EQ(result.value().discovered_notes.size(), 1u);
-  EXPECT_EQ(result.value().discovered_notes[0].block_id, 10u);
-  EXPECT_EQ(result.value().discovered_notes[0].amount, 3625561528u);
+  EXPECT_EQ(result.value().orchard.discovered_notes.size(), 1u);
+  EXPECT_EQ(result.value().orchard.discovered_notes[0].block_id, 10u);
+  EXPECT_EQ(result.value().orchard.discovered_notes[0].amount, 3625561528u);
 
-  EXPECT_EQ(result.value().found_spends.size(), 2u);
-  EXPECT_EQ(result.value().found_spends[0].block_id, 10u);
-  EXPECT_EQ(result.value().found_spends[1].block_id, 11u);
+  EXPECT_EQ(result.value().orchard.found_spends.size(), 2u);
+  EXPECT_EQ(result.value().orchard.found_spends[0].block_id, 10u);
+  EXPECT_EQ(result.value().orchard.found_spends[1].block_id, 11u);
 
   EXPECT_EQ(
-      std::vector<uint8_t>(result.value().found_spends[1].nullifier.begin(),
-                           result.value().found_spends[1].nullifier.end()),
+      std::vector<uint8_t>(
+          result.value().orchard.found_spends[1].nullifier.begin(),
+          result.value().orchard.found_spends[1].nullifier.end()),
       PrefixedHexStringToBytes(
           "0x6588cc7fabfab2b2a4baa89d4dfafaa50cc89d22f96d10fb7689461b921ad40d")
           .value());
@@ -533,7 +591,6 @@ TEST(OrchardBlockScanner, FoundKnownNullifiers) {
   note.block_id = 10;
   std::ranges::copy(nullifier_bytes, note.nullifier.begin());
   note.amount = 1;
-  note.note_version = 2;
 
   notes.push_back(note);
   blocks.push_back(std::move(block));
@@ -543,9 +600,190 @@ TEST(OrchardBlockScanner, FoundKnownNullifiers) {
   auto result = scanner.ScanBlocks(tree_state, std::move(blocks));
 
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().found_spends.size(), 1u);
-  EXPECT_EQ(result.value().found_spends[0].nullifier, spend.nullifier);
-  EXPECT_EQ(result.value().discovered_notes.size(), 0u);
+  EXPECT_EQ(result.value().orchard.found_spends.size(), 1u);
+  EXPECT_EQ(result.value().orchard.found_spends[0].nullifier, spend.nullifier);
+  EXPECT_EQ(result.value().orchard.discovered_notes.size(), 0u);
+}
+
+TEST(OrchardBlockScannerTest, DiscoverNewIronwoodNotes) {
+  base::test::ScopedFeatureList features;
+  features.InitAndEnableFeatureWithParameters(
+      features::kBraveWalletZCashFeature,
+      {{"zcash_shielded_transactions_enabled", "true"},
+       {"zcash_ironwood_enabled", "true"}});
+
+  auto scanner = OrchardBlockScanner(GetTestnetAccount0Fvk());
+
+  // Real Ironwood actions from ironwood_output_2.log block height 4192915
+  // (tx[0] with ironwood_actions=2). One action decrypts to this wallet.
+  std::vector<zcash::mojom::CompactBlockPtr> blocks;
+  blocks.push_back(MakeIronwoodBlock(
+      4192915u,
+      {std::array<std::string_view, 8>{
+          "0x1a178bf08e4cdef63c605e088c4cc9fd88309c082d96158d6c0e3fef5b58af1a",
+          "0x9572a165af118d1e2e357ae47029693abd8c84f9ae18c42677b5c829e36c8d19",
+          "0xed27be986554a51f0c131f39df6719fb37ed666f991a7cae4a5bd718e20a7211",
+          "0xc4265db4374f155391318fd2a12209e70f7769e4d5737ed5e58d9bd0215138d6f5"
+          "f5c16651d375f14b824d1ec6657f29cc2fc359",
+          "0x953e4d93616329aa37e22f822add2390245005a21ff6f8ccc450b8b5e1d7c729",
+          "0xbae31185b14c5e960e759a53e5065e8a2dc1afcbd0c86add7b365b4a6e9dbd10",
+          "0xf09c4747b6b12d8b944102b0a464c0779a5521702f50fa2964d931684fe80520",
+          "0x722ca2af84867ab2ba800d35cf7c9487730138a0713431bf7ada7cf6ad7fd21a8e"
+          "f82ec28dd977916208aae518b6592c06e04db0"}}));
+  blocks.back()->hash = {0xaa, 0xbb};
+
+  OrchardTreeState ironwood_tree_state;
+  auto result =
+      scanner.ScanBlocks(OrchardTreeState(), blocks, ironwood_tree_state);
+
+  ASSERT_TRUE(result.has_value());
+  ASSERT_TRUE(result.value().ironwood.has_value());
+  EXPECT_EQ(result.value().ironwood->found_spends.size(), 2u);
+  EXPECT_EQ(result.value().ironwood->discovered_notes.size(), 1u);
+  EXPECT_EQ(result.value().ironwood->discovered_notes[0].block_id, 4192915u);
+  EXPECT_EQ(result.value().ironwood->discovered_notes[0].amount, 100000000u);
+  EXPECT_EQ(result.value().ironwood->latest_scanned_block_id, 4192915u);
+  EXPECT_EQ(result.value().ironwood->latest_scanned_block_hash, "0xaabb");
+  EXPECT_EQ(result.value().orchard.discovered_notes.size(), 0u);
+  EXPECT_EQ(result.value().orchard.found_spends.size(), 0u);
+}
+
+// Builds a block that contains ironwood_actions with valid nullifier sizes.
+// Returns a single block at the given height.
+std::vector<zcash::mojom::CompactBlockPtr> BuildBlocksWithIronwoodActions(
+    uint32_t height,
+    size_t num_ironwood_actions) {
+  auto block = zcash::mojom::CompactBlock::New();
+  block->height = height;
+  block->hash = {0x01, 0x02};
+
+  auto tx = zcash::mojom::CompactTx::New();
+  for (size_t i = 0; i < num_ironwood_actions; i++) {
+    auto action = zcash::mojom::CompactOrchardAction::New();
+    action->nullifier = std::vector<uint8_t>(kOrchardNullifierSize,
+                                             static_cast<uint8_t>(i + 1));
+    action->cmx = std::vector<uint8_t>(kOrchardCmxSize, 0);
+    action->ephemeral_key = std::vector<uint8_t>(kOrchardEphemeralKeySize, 0);
+    action->ciphertext = std::vector<uint8_t>(kOrchardCipherTextSize, 0);
+    tx->ironwood_actions.push_back(std::move(action));
+  }
+  block->vtx.push_back(std::move(tx));
+
+  std::vector<zcash::mojom::CompactBlockPtr> blocks;
+  blocks.push_back(std::move(block));
+  return blocks;
+}
+
+// Builds one block per height in `heights`, each with `actions_per_block`
+// ironwood actions.
+std::vector<zcash::mojom::CompactBlockPtr> BuildIronwoodBlocksAtHeights(
+    const std::vector<uint32_t>& heights,
+    size_t actions_per_block) {
+  std::vector<zcash::mojom::CompactBlockPtr> blocks;
+  for (uint32_t height : heights) {
+    auto single = BuildBlocksWithIronwoodActions(height, actions_per_block);
+    blocks.push_back(std::move(single[0]));
+  }
+  return blocks;
+}
+
+// With the Ironwood feature flag OFF, ironwood_actions in blocks are
+// ignored even when a non-null Ironwood tree state is passed.
+TEST(OrchardBlockScannerTest, IronwoodFeatureOff_ResultIsNullopt) {
+  base::test::ScopedFeatureList features;
+  features.InitAndEnableFeatureWithParameters(
+      features::kBraveWalletZCashFeature,
+      {{"zcash_shielded_transactions_enabled", "true"},
+       {"zcash_ironwood_enabled", "false"}});
+
+  auto scanner = OrchardBlockScanner(OrchardFullViewKey(
+      {0x74, 0x0b, 0xbe, 0x5d, 0x05, 0x80, 0xb2, 0xca, 0xd4, 0x30, 0x18,
+       0x0d, 0x02, 0xcc, 0x12, 0x8b, 0x9a, 0x14, 0x0d, 0x5e, 0x07, 0xc1,
+       0x51, 0x72, 0x1d, 0xc1, 0x6d, 0x25, 0xd4, 0xe2, 0x0f, 0x15, 0x9f,
+       0x2f, 0x82, 0x67, 0x38, 0x94, 0x5a, 0xd0, 0x1f, 0x47, 0xf7, 0x0d,
+       0xb0, 0xc3, 0x67, 0xc2, 0x46, 0xc2, 0x0c, 0x61, 0xff, 0x55, 0x83,
+       0x94, 0x8c, 0x39, 0xde, 0xa9, 0x68, 0xfe, 0xfd, 0x1b, 0x02, 0x1c,
+       0xcf, 0x89, 0x60, 0x4f, 0x5f, 0x7c, 0xc6, 0xe0, 0x34, 0xb3, 0x2d,
+       0x33, 0x89, 0x08, 0xb8, 0x19, 0xfb, 0xe3, 0x25, 0xfe, 0xe6, 0x45,
+       0x8b, 0x56, 0xb4, 0xca, 0x71, 0xa7, 0xe4, 0x3d}));
+
+  OrchardTreeState ironwood_tree_state;
+  auto blocks = BuildBlocksWithIronwoodActions(10u, 3);
+
+  auto result =
+      scanner.ScanBlocks(OrchardTreeState(), blocks, ironwood_tree_state);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().ironwood, std::nullopt);
+}
+
+// With the Ironwood feature flag ON and a non-null Ironwood tree state,
+// ironwood_actions are scanned and the result.ironwood field is populated.
+TEST(OrchardBlockScannerTest, IronwoodFeatureOn_IronwoodResultPopulated) {
+  base::test::ScopedFeatureList features;
+  features.InitAndEnableFeatureWithParameters(
+      features::kBraveWalletZCashFeature,
+      {{"zcash_shielded_transactions_enabled", "true"},
+       {"zcash_ironwood_enabled", "true"}});
+
+  auto scanner = OrchardBlockScanner(OrchardFullViewKey(
+      {0x74, 0x0b, 0xbe, 0x5d, 0x05, 0x80, 0xb2, 0xca, 0xd4, 0x30, 0x18,
+       0x0d, 0x02, 0xcc, 0x12, 0x8b, 0x9a, 0x14, 0x0d, 0x5e, 0x07, 0xc1,
+       0x51, 0x72, 0x1d, 0xc1, 0x6d, 0x25, 0xd4, 0xe2, 0x0f, 0x15, 0x9f,
+       0x2f, 0x82, 0x67, 0x38, 0x94, 0x5a, 0xd0, 0x1f, 0x47, 0xf7, 0x0d,
+       0xb0, 0xc3, 0x67, 0xc2, 0x46, 0xc2, 0x0c, 0x61, 0xff, 0x55, 0x83,
+       0x94, 0x8c, 0x39, 0xde, 0xa9, 0x68, 0xfe, 0xfd, 0x1b, 0x02, 0x1c,
+       0xcf, 0x89, 0x60, 0x4f, 0x5f, 0x7c, 0xc6, 0xe0, 0x34, 0xb3, 0x2d,
+       0x33, 0x89, 0x08, 0xb8, 0x19, 0xfb, 0xe3, 0x25, 0xfe, 0xe6, 0x45,
+       0x8b, 0x56, 0xb4, 0xca, 0x71, 0xa7, 0xe4, 0x3d}));
+
+  OrchardTreeState ironwood_tree_state;
+  constexpr size_t kIronwoodActionCount = 3;
+  auto blocks = BuildBlocksWithIronwoodActions(10u, kIronwoodActionCount);
+
+  auto result =
+      scanner.ScanBlocks(OrchardTreeState(), blocks, ironwood_tree_state);
+
+  ASSERT_TRUE(result.has_value());
+  ASSERT_TRUE(result.value().ironwood.has_value());
+  EXPECT_EQ(result.value().ironwood->found_spends.size(), kIronwoodActionCount);
+}
+
+// Blocks straddling the activation height: only actions at/after activation
+// feed the Ironwood pool.
+TEST(OrchardBlockScannerTest, IronwoodActivationCut) {
+  base::test::ScopedFeatureList features;
+  features.InitAndEnableFeatureWithParameters(
+      features::kBraveWalletZCashFeature,
+      {{"zcash_shielded_transactions_enabled", "true"},
+       {"zcash_ironwood_enabled", "true"}});
+
+  auto scanner = OrchardBlockScanner(OrchardFullViewKey(
+      {0x74, 0x0b, 0xbe, 0x5d, 0x05, 0x80, 0xb2, 0xca, 0xd4, 0x30, 0x18,
+       0x0d, 0x02, 0xcc, 0x12, 0x8b, 0x9a, 0x14, 0x0d, 0x5e, 0x07, 0xc1,
+       0x51, 0x72, 0x1d, 0xc1, 0x6d, 0x25, 0xd4, 0xe2, 0x0f, 0x15, 0x9f,
+       0x2f, 0x82, 0x67, 0x38, 0x94, 0x5a, 0xd0, 0x1f, 0x47, 0xf7, 0x0d,
+       0xb0, 0xc3, 0x67, 0xc2, 0x46, 0xc2, 0x0c, 0x61, 0xff, 0x55, 0x83,
+       0x94, 0x8c, 0x39, 0xde, 0xa9, 0x68, 0xfe, 0xfd, 0x1b, 0x02, 0x1c,
+       0xcf, 0x89, 0x60, 0x4f, 0x5f, 0x7c, 0xc6, 0xe0, 0x34, 0xb3, 0x2d,
+       0x33, 0x89, 0x08, 0xb8, 0x19, 0xfb, 0xe3, 0x25, 0xfe, 0xe6, 0x45,
+       0x8b, 0x56, 0xb4, 0xca, 0x71, 0xa7, 0xe4, 0x3d}));
+
+  constexpr uint32_t kActivation = 100u;
+  // Heights 98, 99 are pre-activation (cut); 100, 101 are kept.
+  auto blocks = BuildIronwoodBlocksAtHeights({98u, 99u, 100u, 101u}, 1);
+
+  OrchardTreeState ironwood_tree_state;
+  auto result = scanner.ScanBlocks(OrchardTreeState(), blocks,
+                                   ironwood_tree_state, kActivation);
+
+  ASSERT_TRUE(result.has_value());
+  ASSERT_TRUE(result.value().ironwood.has_value());
+  // Only the two post-activation blocks (1 action each) are collected.
+  EXPECT_EQ(result.value().ironwood->found_spends.size(), 2u);
+  for (const auto& spend : result.value().ironwood->found_spends) {
+    EXPECT_GE(spend.block_id, kActivation);
+  }
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/internal/orchard_sync_state.cc
+++ b/components/brave_wallet/browser/internal/orchard_sync_state.cc
@@ -11,8 +11,11 @@
 #include "base/check.h"
 #include "base/check_is_test.h"
 #include "base/containers/extend.h"
+#include "base/strings/strcat.h"
+#include "base/strings/string_number_conversions.h"
 #include "base/task/thread_pool.h"
 #include "base/types/expected_macros.h"
+#include "brave/components/brave_wallet/common/common_utils.h"
 #include "brave/components/brave_wallet/common/zcash_utils.h"
 
 namespace brave_wallet {
@@ -53,14 +56,24 @@ OrchardSyncState::~OrchardSyncState() {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 }
 
+// static
+std::string OrchardSyncState::ShardTreeKey(
+    OrchardPool pool,
+    const mojom::AccountIdPtr& account_id) {
+  return base::StrCat({account_id->unique_key, ":",
+                       base::NumberToString(static_cast<int>(pool))});
+}
+
 orchard::OrchardShardTree& OrchardSyncState::GetOrCreateShardTree(
+    OrchardPool pool,
     const mojom::AccountIdPtr& account_id) LIFETIME_BOUND {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (shard_trees_.find(account_id->unique_key) == shard_trees_.end()) {
-    shard_trees_[account_id->unique_key] = orchard::OrchardShardTree::Create(
-        storage_, account_id, OrchardPool::kOrchard);
+  auto key = ShardTreeKey(pool, account_id);
+  if (shard_trees_.find(key) == shard_trees_.end()) {
+    shard_trees_[key] =
+        orchard::OrchardShardTree::Create(storage_, account_id, pool);
   }
-  auto* manager = shard_trees_[account_id->unique_key].get();
+  auto* manager = shard_trees_[key].get();
   CHECK(manager);
   return *manager;
 }
@@ -101,11 +114,19 @@ OrchardSyncState::Rewind(const mojom::AccountIdPtr& account_id,
     if (!tx.has_value()) {
       return base::unexpected(tx.error());
     }
-    if (!GetOrCreateShardTree(account_id)
+    if (!GetOrCreateShardTree(OrchardPool::kOrchard, account_id)
              .TruncateToCheckpoint(rewind_block_height)) {
       return base::unexpected(
           OrchardStorage::Error{OrchardStorage::ErrorCode::kInternalError,
-                                "Failed to truncate tree"});
+                                "Failed to truncate orchard tree"});
+    }
+    if (IsZCashIronwoodEnabled()) {
+      if (!GetOrCreateShardTree(OrchardPool::kIronwood, account_id)
+               .TruncateToCheckpoint(rewind_block_height)) {
+        return base::unexpected(
+            OrchardStorage::Error{OrchardStorage::ErrorCode::kInternalError,
+                                  "Failed to truncate ironwood tree"});
+      }
     }
     auto chain_reorg_result = storage_.HandleChainReorg(
         account_id, rewind_block_height, rewind_block_hash);
@@ -119,9 +140,13 @@ OrchardSyncState::Rewind(const mojom::AccountIdPtr& account_id,
 
 base::expected<std::optional<OrchardSyncState::SpendableNotesBundle>,
                OrchardStorage::Error>
-OrchardSyncState::GetSpendableNotes(const mojom::AccountIdPtr& account_id,
+OrchardSyncState::GetSpendableNotes(OrchardPool pool,
+                                    const mojom::AccountIdPtr& account_id,
                                     const OrchardAddrRawPart& change_address) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (pool == OrchardPool::kIronwood && !IsZCashIronwoodEnabled()) {
+    return std::nullopt;
+  }
   ASSIGN_OR_RETURN(auto account_meta, storage_.GetAccountMeta(account_id));
   if (!account_meta.has_value()) {
     return base::ok(std::nullopt);
@@ -130,12 +155,11 @@ OrchardSyncState::GetSpendableNotes(const mojom::AccountIdPtr& account_id,
   if (!latest_scanned_block_id) {
     return OrchardSyncState::SpendableNotesBundle();
   }
-  ASSIGN_OR_RETURN(auto notes, storage_.GetSpendableNotes(OrchardPool::kOrchard,
-                                                          account_id));
-  ASSIGN_OR_RETURN(auto anchor, storage_.GetMaxCheckpointedHeight(
-                                    OrchardPool::kOrchard, account_id,
-                                    latest_scanned_block_id.value(),
-                                    kZCashInternalAddressMinConfirmations));
+  ASSIGN_OR_RETURN(auto notes, storage_.GetSpendableNotes(pool, account_id));
+  ASSIGN_OR_RETURN(auto anchor,
+                   storage_.GetMaxCheckpointedHeight(
+                       pool, account_id, latest_scanned_block_id.value(),
+                       kZCashInternalAddressMinConfirmations));
 
   SpendableNotesBundle result;
   result.anchor_block_id = anchor;
@@ -165,9 +189,13 @@ OrchardSyncState::GetSpendableNotes(const mojom::AccountIdPtr& account_id,
 }
 
 base::expected<std::vector<OrchardNoteSpend>, OrchardStorage::Error>
-OrchardSyncState::GetNullifiers(const mojom::AccountIdPtr& account_id) {
+OrchardSyncState::GetNullifiers(OrchardPool pool,
+                                const mojom::AccountIdPtr& account_id) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  return storage_.GetNullifiers(OrchardPool::kOrchard, account_id);
+  if (pool == OrchardPool::kIronwood && !IsZCashIronwoodEnabled()) {
+    return std::vector<OrchardNoteSpend>();
+  }
+  return storage_.GetNullifiers(pool, account_id);
 }
 
 base::expected<OrchardStorage::Result, OrchardStorage::Error>
@@ -180,12 +208,12 @@ OrchardSyncState::ApplyScanResults(
   RETURN_IF_ERROR(existing_notes);
 
   std::vector<OrchardNote> notes_to_add =
-      block_scanner_results.discovered_notes;
+      block_scanner_results.orchard.discovered_notes;
   base::Extend(existing_notes.value(), notes_to_add);
 
   std::vector<OrchardNoteSpend> nf_to_add;
 
-  for (const auto& nf : block_scanner_results.found_spends) {
+  for (const auto& nf : block_scanner_results.orchard.found_spends) {
     if (std::ranges::find_if(existing_notes.value(), [&nf](const auto& v) {
           return v.nullifier == nf.nullifier;
         }) != existing_notes.value().end()) {
@@ -199,9 +227,9 @@ OrchardSyncState::ApplyScanResults(
       return base::unexpected(tx.error());
     }
 
-    if (!GetOrCreateShardTree(account_id)
+    if (!GetOrCreateShardTree(OrchardPool::kOrchard, account_id)
              .ApplyScanResults(
-                 std::move(block_scanner_results.scanned_blocks))) {
+                 std::move(block_scanner_results.orchard.scanned_blocks))) {
       return base::unexpected(
           OrchardStorage::Error{OrchardStorage::ErrorCode::kInternalError,
                                 "Failed to insert commitments"});
@@ -209,12 +237,51 @@ OrchardSyncState::ApplyScanResults(
 
     auto update_notes_result = storage_.UpdateNotes(
         OrchardPool::kOrchard, account_id, notes_to_add, std::move(nf_to_add),
-        block_scanner_results.latest_scanned_block_id,
-        block_scanner_results.latest_scanned_block_hash);
+        block_scanner_results.orchard.latest_scanned_block_id,
+        block_scanner_results.orchard.latest_scanned_block_hash);
 
     if (!update_notes_result.has_value() ||
         update_notes_result.value() != OrchardStorage::Result::kSuccess) {
       return update_notes_result;
+    }
+
+    if (block_scanner_results.ironwood.has_value()) {
+      auto& ironwood = block_scanner_results.ironwood.value();
+
+      auto existing_ironwood_notes =
+          storage_.GetSpendableNotes(OrchardPool::kIronwood, account_id);
+      RETURN_IF_ERROR(existing_ironwood_notes);
+
+      std::vector<OrchardNote> ironwood_notes_to_add =
+          ironwood.discovered_notes;
+      base::Extend(existing_ironwood_notes.value(), ironwood_notes_to_add);
+
+      std::vector<OrchardNoteSpend> ironwood_nf_to_add;
+      for (const auto& nf : ironwood.found_spends) {
+        if (std::ranges::find_if(existing_ironwood_notes.value(),
+                                 [&nf](const auto& v) {
+                                   return v.nullifier == nf.nullifier;
+                                 }) != existing_ironwood_notes.value().end()) {
+          ironwood_nf_to_add.push_back(nf);
+        }
+      }
+
+      if (!GetOrCreateShardTree(OrchardPool::kIronwood, account_id)
+               .ApplyScanResults(std::move(ironwood.scanned_blocks))) {
+        return base::unexpected(
+            OrchardStorage::Error{OrchardStorage::ErrorCode::kInternalError,
+                                  "Failed to insert ironwood commitments"});
+      }
+
+      auto update_ironwood_result = storage_.UpdateNotes(
+          OrchardPool::kIronwood, account_id, ironwood_notes_to_add,
+          std::move(ironwood_nf_to_add), ironwood.latest_scanned_block_id,
+          ironwood.latest_scanned_block_hash);
+
+      if (!update_ironwood_result.has_value() ||
+          update_ironwood_result.value() != OrchardStorage::Result::kSuccess) {
+        return update_ironwood_result;
+      }
     }
 
     return tx->Commit();
@@ -244,11 +311,15 @@ OrchardSyncState::ResetAccountSyncState(
 
 base::expected<std::vector<OrchardInput>, OrchardStorage::Error>
 OrchardSyncState::CalculateWitnessForCheckpoint(
+    OrchardPool pool,
     const mojom::AccountIdPtr& account_id,
     const std::vector<OrchardInput>& notes,
     uint32_t checkpoint_position) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  auto& shard_tree = GetOrCreateShardTree(account_id);
+  if (pool == OrchardPool::kIronwood && !IsZCashIronwoodEnabled()) {
+    return std::vector<OrchardInput>();
+  }
+  auto& shard_tree = GetOrCreateShardTree(pool, account_id);
 
   std::vector<OrchardInput> result;
   result.reserve(notes.size());
@@ -267,15 +338,23 @@ OrchardSyncState::CalculateWitnessForCheckpoint(
 }
 
 base::expected<std::optional<uint32_t>, OrchardStorage::Error>
-OrchardSyncState::GetLatestShardIndex(const mojom::AccountIdPtr& account_id) {
+OrchardSyncState::GetLatestShardIndex(OrchardPool pool,
+                                      const mojom::AccountIdPtr& account_id) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  return storage_.GetLatestShardIndex(OrchardPool::kOrchard, account_id);
+  if (pool == OrchardPool::kIronwood && !IsZCashIronwoodEnabled()) {
+    return std::nullopt;
+  }
+  return storage_.GetLatestShardIndex(pool, account_id);
 }
 
 base::expected<std::optional<uint32_t>, OrchardStorage::Error>
-OrchardSyncState::GetMinCheckpointId(const mojom::AccountIdPtr& account_id) {
+OrchardSyncState::GetMinCheckpointId(OrchardPool pool,
+                                     const mojom::AccountIdPtr& account_id) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  return storage_.MinCheckpointId(OrchardPool::kOrchard, account_id);
+  if (pool == OrchardPool::kIronwood && !IsZCashIronwoodEnabled()) {
+    return std::nullopt;
+  }
+  return storage_.MinCheckpointId(pool, account_id);
 }
 
 void OrchardSyncState::ResetDatabase() {
@@ -284,10 +363,11 @@ void OrchardSyncState::ResetDatabase() {
 }
 
 void OrchardSyncState::OverrideShardTreeForTesting(  // IN_TEST
+    OrchardPool pool,
     const mojom::AccountIdPtr& account_id,
     std::unique_ptr<orchard::OrchardShardTree> shard_tree) {
   CHECK_IS_TEST();
-  shard_trees_[account_id->unique_key] = std::move(shard_tree);
+  shard_trees_[ShardTreeKey(pool, account_id)] = std::move(shard_tree);
 }
 
 OrchardStorage& OrchardSyncState::orchard_storage() {

--- a/components/brave_wallet/browser/internal/orchard_sync_state.h
+++ b/components/brave_wallet/browser/internal/orchard_sync_state.h
@@ -69,7 +69,7 @@ class OrchardSyncState {
       const std::string& rewind_block_hash);
 
   base::expected<std::vector<OrchardNoteSpend>, OrchardStorage::Error>
-  GetNullifiers(const mojom::AccountIdPtr& account_id);
+  GetNullifiers(OrchardPool pool, const mojom::AccountIdPtr& account_id);
 
   base::expected<OrchardStorage::Result, OrchardStorage::Error>
   ApplyScanResults(const mojom::AccountIdPtr& account_id,
@@ -78,14 +78,15 @@ class OrchardSyncState {
                    OrchardBlockScanner::Result block_scanner_results);
 
   base::expected<std::optional<uint32_t>, OrchardStorage::Error>
-  GetLatestShardIndex(const mojom::AccountIdPtr& account_id);
+  GetLatestShardIndex(OrchardPool pool, const mojom::AccountIdPtr& account_id);
 
   virtual base::expected<std::optional<uint32_t>, OrchardStorage::Error>
-  GetMinCheckpointId(const mojom::AccountIdPtr& account_id);
+  GetMinCheckpointId(OrchardPool pool, const mojom::AccountIdPtr& account_id);
 
   virtual base::expected<std::optional<SpendableNotesBundle>,
                          OrchardStorage::Error>
-  GetSpendableNotes(const mojom::AccountIdPtr& account_id,
+  GetSpendableNotes(OrchardPool pool,
+                    const mojom::AccountIdPtr& account_id,
                     const OrchardAddrRawPart& change_address);
 
   // Clears sync data related to the account. Updates account birthday if
@@ -98,7 +99,8 @@ class OrchardSyncState {
   void ResetDatabase();
 
   virtual base::expected<std::vector<OrchardInput>, OrchardStorage::Error>
-  CalculateWitnessForCheckpoint(const mojom::AccountIdPtr& account_id,
+  CalculateWitnessForCheckpoint(OrchardPool pool,
+                                const mojom::AccountIdPtr& account_id,
                                 const std::vector<OrchardInput>& notes,
                                 uint32_t checkpoint_position);
 
@@ -107,11 +109,16 @@ class OrchardSyncState {
 
   // Testing
   void OverrideShardTreeForTesting(
+      OrchardPool pool,
       const mojom::AccountIdPtr& account_id,
       std::unique_ptr<orchard::OrchardShardTree> shard_tree);
   OrchardStorage& orchard_storage();
 
+  static std::string ShardTreeKey(OrchardPool pool,
+                                  const mojom::AccountIdPtr& account_id);
+
   orchard::OrchardShardTree& GetOrCreateShardTree(
+      OrchardPool pool,
       const mojom::AccountIdPtr& account_id) LIFETIME_BOUND;
 
   OrchardStorage storage_;

--- a/components/brave_wallet/browser/internal/orchard_sync_state_unittest.cc
+++ b/components/brave_wallet/browser/internal/orchard_sync_state_unittest.cc
@@ -9,10 +9,12 @@
 
 #include "base/files/scoped_temp_dir.h"
 #include "base/strings/string_number_conversions.h"
+#include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_wallet/browser/internal/orchard_storage/orchard_shard_tree_types.h"
 #include "brave/components/brave_wallet/browser/internal/orchard_test_utils.h"
 #include "brave/components/brave_wallet/browser/zcash/rust/orchard_testing_shard_tree.h"
 #include "brave/components/brave_wallet/common/common_utils.h"
+#include "brave/components/brave_wallet/common/features.h"
 #include "brave/components/brave_wallet/common/zcash_utils.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -62,9 +64,13 @@ void OrchardSyncStateTest::SetUp() {
   ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
   sync_state_ = std::make_unique<OrchardSyncState>(temp_dir_.GetPath());
   sync_state_->OverrideShardTreeForTesting(
-      account_id_,
+      OrchardPool::kOrchard, account_id_,
       orchard::CreateShardTreeForTesting(sync_state_->orchard_storage(),
                                          account_id_, OrchardPool::kOrchard));
+  sync_state_->OverrideShardTreeForTesting(
+      OrchardPool::kIronwood, account_id_,
+      orchard::CreateShardTreeForTesting(sync_state_->orchard_storage(),
+                                         account_id_, OrchardPool::kIronwood));
 }
 
 TEST_F(OrchardSyncStateTest, CheckpointsPruned) {
@@ -148,8 +154,8 @@ TEST_F(OrchardSyncStateTest, InsertWithFrontier) {
   OrchardInput input;
   input.note.orchard_commitment_tree_position = 50;
 
-  auto witness_result =
-      sync_state()->CalculateWitnessForCheckpoint(account_id(), {input}, 1);
+  auto witness_result = sync_state()->CalculateWitnessForCheckpoint(
+      OrchardPool::kOrchard, account_id(), {input}, 1);
   EXPECT_TRUE(witness_result.has_value());
   EXPECT_EQ(
       witness_result.value()[0].witness.value(),
@@ -192,8 +198,8 @@ TEST_F(OrchardSyncStateTest, Checkpoint_WithMarked) {
 
   OrchardInput input;
   input.note.orchard_commitment_tree_position = 3;
-  auto witness_result =
-      sync_state()->CalculateWitnessForCheckpoint(account_id(), {input}, 1);
+  auto witness_result = sync_state()->CalculateWitnessForCheckpoint(
+      OrchardPool::kOrchard, account_id(), {input}, 1);
   EXPECT_TRUE(witness_result.has_value());
 
   EXPECT_EQ(
@@ -319,8 +325,8 @@ TEST_F(OrchardSyncStateTest, MaxCheckpoint) {
 TEST_F(OrchardSyncStateTest, GetSpendableNotes_NoRegisteredAccount) {
   OrchardAddrRawPart internal_addr;
   internal_addr.fill(3);
-  auto get_spendable_notes_result =
-      sync_state()->GetSpendableNotes(account_id(), internal_addr);
+  auto get_spendable_notes_result = sync_state()->GetSpendableNotes(
+      OrchardPool::kOrchard, account_id(), internal_addr);
   EXPECT_TRUE(get_spendable_notes_result.has_value());
   EXPECT_FALSE(get_spendable_notes_result.value().has_value());
 }
@@ -353,7 +359,7 @@ TEST_F(OrchardSyncStateTest, GetSpendableNotes_FilterByAddress_And_Anchor) {
 
     auto result = CreateResultForTesting(OrchardTreeState(),
                                          std::move(commitments), 1049, "1049");
-    result.discovered_notes = notes;
+    result.orchard.discovered_notes = notes;
 
     EXPECT_EQ(OrchardStorage::Result::kSuccess,
               sync_state()
@@ -361,8 +367,8 @@ TEST_F(OrchardSyncStateTest, GetSpendableNotes_FilterByAddress_And_Anchor) {
                   .value());
   }
 
-  auto get_spendable_notes_result =
-      sync_state()->GetSpendableNotes(account_id(), internal_addr);
+  auto get_spendable_notes_result = sync_state()->GetSpendableNotes(
+      OrchardPool::kOrchard, account_id(), internal_addr);
   EXPECT_TRUE(get_spendable_notes_result.has_value());
   EXPECT_TRUE(get_spendable_notes_result.value().has_value());
   EXPECT_EQ(get_spendable_notes_result.value()->spendable_notes.size(), 26u);
@@ -392,7 +398,7 @@ TEST_F(OrchardSyncStateTest, GetSpendableNotes_FilterByAddress_External) {
 
     auto result = CreateResultForTesting(OrchardTreeState(),
                                          std::move(commitments), 1049, "1049");
-    result.discovered_notes = notes;
+    result.orchard.discovered_notes = notes;
 
     EXPECT_EQ(OrchardStorage::Result::kSuccess,
               sync_state()
@@ -400,8 +406,8 @@ TEST_F(OrchardSyncStateTest, GetSpendableNotes_FilterByAddress_External) {
                   .value());
   }
 
-  auto get_spendable_notes_result =
-      sync_state()->GetSpendableNotes(account_id(), internal_addr);
+  auto get_spendable_notes_result = sync_state()->GetSpendableNotes(
+      OrchardPool::kOrchard, account_id(), internal_addr);
   EXPECT_TRUE(get_spendable_notes_result.has_value());
   EXPECT_TRUE(get_spendable_notes_result.value().has_value());
   EXPECT_EQ(get_spendable_notes_result.value()->spendable_notes.size(), 40u);
@@ -431,7 +437,7 @@ TEST_F(OrchardSyncStateTest, GetSpendableNotes_FilterByAddress_Internal) {
 
     auto result = CreateResultForTesting(OrchardTreeState(),
                                          std::move(commitments), 1049, "1049");
-    result.discovered_notes = notes;
+    result.orchard.discovered_notes = notes;
 
     EXPECT_EQ(OrchardStorage::Result::kSuccess,
               sync_state()
@@ -439,8 +445,8 @@ TEST_F(OrchardSyncStateTest, GetSpendableNotes_FilterByAddress_Internal) {
                   .value());
   }
 
-  auto get_spendable_notes_result =
-      sync_state()->GetSpendableNotes(account_id(), internal_addr);
+  auto get_spendable_notes_result = sync_state()->GetSpendableNotes(
+      OrchardPool::kOrchard, account_id(), internal_addr);
   EXPECT_TRUE(get_spendable_notes_result.has_value());
   EXPECT_TRUE(get_spendable_notes_result.value().has_value());
   EXPECT_EQ(get_spendable_notes_result.value()->spendable_notes.size(), 46u);
@@ -463,7 +469,7 @@ TEST_F(OrchardSyncStateTest, GetSpendableNotes_NoAnchor) {
       note.addr.fill(2);
       note.nullifier.fill(i - 1000u);
       note.note_version = 2;
-      result.discovered_notes.push_back(note);
+      result.orchard.discovered_notes.push_back(note);
     }
 
     EXPECT_EQ(OrchardStorage::Result::kSuccess,
@@ -472,8 +478,8 @@ TEST_F(OrchardSyncStateTest, GetSpendableNotes_NoAnchor) {
                   .value());
   }
 
-  auto get_spendable_notes_result =
-      sync_state()->GetSpendableNotes(account_id(), internal_addr);
+  auto get_spendable_notes_result = sync_state()->GetSpendableNotes(
+      OrchardPool::kOrchard, account_id(), internal_addr);
   EXPECT_TRUE(get_spendable_notes_result.has_value());
   EXPECT_TRUE(get_spendable_notes_result.value().has_value());
   // Since no checkpoints were added we drop all notes we have.
@@ -508,8 +514,8 @@ TEST_F(OrchardSyncStateTest, NoWitnessOnNonMarked) {
   {
     OrchardInput input;
     input.note.orchard_commitment_tree_position = 2;
-    auto witness_result =
-        sync_state()->CalculateWitnessForCheckpoint(account_id(), {input}, 1);
+    auto witness_result = sync_state()->CalculateWitnessForCheckpoint(
+        OrchardPool::kOrchard, account_id(), {input}, 1);
     EXPECT_FALSE(witness_result.has_value());
   }
 }
@@ -541,8 +547,8 @@ TEST_F(OrchardSyncStateTest, NoWitnessOnWrongCheckpoint) {
   {
     OrchardInput input;
     input.note.orchard_commitment_tree_position = 2;
-    auto witness_result =
-        sync_state()->CalculateWitnessForCheckpoint(account_id(), {input}, 2);
+    auto witness_result = sync_state()->CalculateWitnessForCheckpoint(
+        OrchardPool::kOrchard, account_id(), {input}, 2);
     EXPECT_FALSE(witness_result.has_value());
   }
 }
@@ -578,7 +584,7 @@ TEST_F(OrchardSyncStateTest, Rewind_ToMarkedHeight) {
       note.amount = 10000;
       note.nullifier.fill(1);
       note.note_version = 2;
-      result.discovered_notes.push_back(note);
+      result.orchard.discovered_notes.push_back(note);
     }
     {
       OrchardNote note;
@@ -586,13 +592,13 @@ TEST_F(OrchardSyncStateTest, Rewind_ToMarkedHeight) {
       note.amount = 10000;
       note.nullifier.fill(2);
       note.note_version = 2;
-      result.discovered_notes.push_back(note);
+      result.orchard.discovered_notes.push_back(note);
     }
     {
       OrchardNoteSpend spend;
       spend.block_id = 2;
       spend.nullifier.fill(1);
-      result.found_spends.push_back(spend);
+      result.orchard.found_spends.push_back(spend);
     }
     EXPECT_EQ(OrchardStorage::Result::kSuccess,
               sync_state()
@@ -601,29 +607,29 @@ TEST_F(OrchardSyncStateTest, Rewind_ToMarkedHeight) {
   }
 
   EXPECT_EQ(1u, sync_state()
-                    ->GetSpendableNotes(account_id(), {})
+                    ->GetSpendableNotes(OrchardPool::kOrchard, account_id(), {})
                     .value()
                     ->all_notes.size());
   EXPECT_EQ(2u, sync_state()
-                    ->GetSpendableNotes(account_id(), {})
+                    ->GetSpendableNotes(OrchardPool::kOrchard, account_id(), {})
                     .value()
                     ->all_notes[0]
                     .block_id);
 
   OrchardInput input;
   input.note.orchard_commitment_tree_position = 2;
-  auto expected_witness =
-      sync_state()->CalculateWitnessForCheckpoint(account_id(), {input}, 2);
+  auto expected_witness = sync_state()->CalculateWitnessForCheckpoint(
+      OrchardPool::kOrchard, account_id(), {input}, 2);
 
   EXPECT_EQ(OrchardStorage::Result::kSuccess,
             sync_state()->Rewind(account_id(), 1, "1").value());
 
   EXPECT_EQ(1u, sync_state()
-                    ->GetSpendableNotes(account_id(), {})
+                    ->GetSpendableNotes(OrchardPool::kOrchard, account_id(), {})
                     .value()
                     ->all_notes.size());
   EXPECT_EQ(1u, sync_state()
-                    ->GetSpendableNotes(account_id(), {})
+                    ->GetSpendableNotes(OrchardPool::kOrchard, account_id(), {})
                     .value()
                     ->all_notes[0]
                     .block_id);
@@ -655,7 +661,7 @@ TEST_F(OrchardSyncStateTest, Rewind_ToMarkedHeight) {
       note.amount = 10000;
       note.nullifier.fill(2);
       note.note_version = 2;
-      result.discovered_notes.push_back(note);
+      result.orchard.discovered_notes.push_back(note);
     }
     EXPECT_EQ(OrchardStorage::Result::kSuccess,
               sync_state()
@@ -664,22 +670,22 @@ TEST_F(OrchardSyncStateTest, Rewind_ToMarkedHeight) {
   }
 
   EXPECT_EQ(2u, sync_state()
-                    ->GetSpendableNotes(account_id(), {})
+                    ->GetSpendableNotes(OrchardPool::kOrchard, account_id(), {})
                     .value()
                     ->all_notes.size());
   EXPECT_EQ(1u, sync_state()
-                    ->GetSpendableNotes(account_id(), {})
+                    ->GetSpendableNotes(OrchardPool::kOrchard, account_id(), {})
                     .value()
                     ->all_notes[0]
                     .block_id);
   EXPECT_EQ(2u, sync_state()
-                    ->GetSpendableNotes(account_id(), {})
+                    ->GetSpendableNotes(OrchardPool::kOrchard, account_id(), {})
                     .value()
                     ->all_notes[1]
                     .block_id);
 
-  auto actual_witness =
-      sync_state()->CalculateWitnessForCheckpoint(account_id(), {input}, 2);
+  auto actual_witness = sync_state()->CalculateWitnessForCheckpoint(
+      OrchardPool::kOrchard, account_id(), {input}, 2);
   EXPECT_EQ(expected_witness.value()[0].witness.value(),
             actual_witness.value()[0].witness.value());
 }
@@ -721,7 +727,7 @@ TEST_F(OrchardSyncStateTest, Rewind) {
       note.amount = 10000;
       note.nullifier.fill(1);
       note.note_version = 2;
-      result.discovered_notes.push_back(note);
+      result.orchard.discovered_notes.push_back(note);
     }
     {
       OrchardNote note;
@@ -729,13 +735,13 @@ TEST_F(OrchardSyncStateTest, Rewind) {
       note.amount = 10000;
       note.nullifier.fill(2);
       note.note_version = 2;
-      result.discovered_notes.push_back(note);
+      result.orchard.discovered_notes.push_back(note);
     }
     {
       OrchardNoteSpend spend;
       spend.block_id = 3;
       spend.nullifier.fill(1);
-      result.found_spends.push_back(spend);
+      result.orchard.found_spends.push_back(spend);
     }
 
     EXPECT_EQ(OrchardStorage::Result::kSuccess,
@@ -745,14 +751,14 @@ TEST_F(OrchardSyncStateTest, Rewind) {
   }
 
   EXPECT_EQ(1u, sync_state()
-                    ->GetSpendableNotes(account_id(), {})
+                    ->GetSpendableNotes(OrchardPool::kOrchard, account_id(), {})
                     .value()
                     ->all_notes.size());
   EXPECT_EQ(OrchardStorage::Result::kSuccess,
             sync_state()->Rewind(account_id(), 2, "2").value());
   // Nullifier was deleted so we should have 2 spendable notes now.
   EXPECT_EQ(2u, sync_state()
-                    ->GetSpendableNotes(account_id(), {})
+                    ->GetSpendableNotes(OrchardPool::kOrchard, account_id(), {})
                     .value()
                     ->all_notes.size());
 
@@ -784,16 +790,16 @@ TEST_F(OrchardSyncStateTest, Rewind) {
   {
     OrchardInput input;
     input.note.orchard_commitment_tree_position = 2;
-    auto witness_result =
-        sync_state()->CalculateWitnessForCheckpoint(account_id(), {input}, 2);
+    auto witness_result = sync_state()->CalculateWitnessForCheckpoint(
+        OrchardPool::kOrchard, account_id(), {input}, 2);
     // Since checkpoint #2 was deleted we shouldn't be able to calc witness
     EXPECT_FALSE(witness_result.has_value());
   }
 
   OrchardInput input;
   input.note.orchard_commitment_tree_position = 2;
-  auto witness_result =
-      sync_state()->CalculateWitnessForCheckpoint(account_id(), {input}, 1);
+  auto witness_result = sync_state()->CalculateWitnessForCheckpoint(
+      OrchardPool::kOrchard, account_id(), {input}, 1);
   EXPECT_TRUE(witness_result.has_value());
   EXPECT_EQ(
       witness_result.value()[0].witness.value(),
@@ -863,8 +869,8 @@ TEST_F(OrchardSyncStateTest, SimpleInsert) {
 
   OrchardInput input;
   input.note.orchard_commitment_tree_position = 2;
-  auto witness_result =
-      sync_state()->CalculateWitnessForCheckpoint(account_id(), {input}, 1);
+  auto witness_result = sync_state()->CalculateWitnessForCheckpoint(
+      OrchardPool::kOrchard, account_id(), {input}, 1);
   EXPECT_TRUE(witness_result.has_value());
   EXPECT_EQ(
       witness_result.value()[0].witness.value(),
@@ -879,6 +885,523 @@ TEST_F(OrchardSyncStateTest, SimpleInsert) {
            "4e14563df191a2a65b4b37113b5230680555051b22d74a8e1f1d706f90f3133"
            "b"},
           2));
+}
+
+TEST_F(OrchardSyncStateTest,
+       IronwoodPool_GetSpendableNotes_FilterByAddress_And_Anchor) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kBraveWalletZCashFeature, {{"zcash_ironwood_enabled", "true"}});
+
+  EXPECT_TRUE(sync_state()->RegisterAccount(account_id(), 0u).has_value());
+
+  OrchardAddrRawPart internal_addr;
+  internal_addr.fill(3);
+
+  {
+    std::vector<OrchardCommitment> commitments;
+    std::vector<OrchardNote> notes;
+    for (uint32_t i = 1000; i < 1050; i++) {
+      OrchardNote note;
+      note.amount = 10;
+      note.block_id = i;
+      note.addr.fill(2);
+      note.nullifier.fill(i - 1000u);
+      note.note_version = 2;
+      notes.push_back(note);
+      if (i == 1025) {
+        commitments.push_back(
+            CreateCommitment(CreateMockCommitmentValue(i, 2), true, i));
+      } else {
+        commitments.push_back(CreateCommitment(CreateMockCommitmentValue(i, 2),
+                                               true, std::nullopt));
+      }
+    }
+
+    auto result = CreateResultForTesting(
+        OrchardTreeState(), std::vector<OrchardCommitment>(), 1049, "1049");
+    result.ironwood = CreateIronwoodPoolResultForTesting(
+        OrchardTreeState(), std::move(commitments), 1049, "1049");
+    result.ironwood->discovered_notes = notes;
+
+    EXPECT_EQ(OrchardStorage::Result::kSuccess,
+              sync_state()
+                  ->ApplyScanResults(account_id(), std::move(result))
+                  .value());
+  }
+
+  // Orchard pool is untouched by an ironwood-only scan result.
+  auto orchard_result = sync_state()->GetSpendableNotes(
+      OrchardPool::kOrchard, account_id(), internal_addr);
+  EXPECT_TRUE(orchard_result.has_value());
+  EXPECT_TRUE(orchard_result.value().has_value());
+  EXPECT_EQ(orchard_result.value()->all_notes.size(), 0u);
+
+  auto get_spendable_notes_result = sync_state()->GetSpendableNotes(
+      OrchardPool::kIronwood, account_id(), internal_addr);
+  EXPECT_TRUE(get_spendable_notes_result.has_value());
+  EXPECT_TRUE(get_spendable_notes_result.value().has_value());
+  EXPECT_EQ(get_spendable_notes_result.value()->spendable_notes.size(), 26u);
+  EXPECT_EQ(get_spendable_notes_result.value()->all_notes.size(), 50u);
+}
+
+TEST_F(OrchardSyncStateTest, OrchardAndIronwoodPoolsAreIndependent) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kBraveWalletZCashFeature, {{"zcash_ironwood_enabled", "true"}});
+
+  EXPECT_TRUE(sync_state()->RegisterAccount(account_id(), 0u).has_value());
+
+  OrchardAddrRawPart internal_addr;
+  internal_addr.fill(3);
+
+  std::vector<OrchardCommitment> orchard_commitments;
+  std::vector<OrchardNote> orchard_notes;
+  for (uint32_t i = 1000; i < 1010; i++) {
+    OrchardNote note;
+    note.amount = 10;
+    note.block_id = i;
+    note.addr.fill(2);
+    note.nullifier.fill(i - 1000u);
+    note.note_version = 2;
+    orchard_notes.push_back(note);
+    orchard_commitments.push_back(
+        CreateCommitment(CreateMockCommitmentValue(i, 2), true, i));
+  }
+
+  std::vector<OrchardCommitment> ironwood_commitments;
+  std::vector<OrchardNote> ironwood_notes;
+  for (uint32_t i = 1000; i < 1020; i++) {
+    OrchardNote note;
+    note.amount = 20;
+    note.block_id = i;
+    note.addr.fill(2);
+    note.nullifier.fill(i - 1000u + 50);
+    note.note_version = 2;
+    ironwood_notes.push_back(note);
+    ironwood_commitments.push_back(
+        CreateCommitment(CreateMockCommitmentValue(i, 3), true, i));
+  }
+
+  auto result = CreateResultForTesting(
+      OrchardTreeState(), std::move(orchard_commitments), 1049, "1049");
+  result.orchard.discovered_notes = orchard_notes;
+  result.ironwood = CreateIronwoodPoolResultForTesting(
+      OrchardTreeState(), std::move(ironwood_commitments), 1049, "1049");
+  result.ironwood->discovered_notes = ironwood_notes;
+
+  EXPECT_EQ(
+      OrchardStorage::Result::kSuccess,
+      sync_state()->ApplyScanResults(account_id(), std::move(result)).value());
+
+  auto orchard_result = sync_state()->GetSpendableNotes(
+      OrchardPool::kOrchard, account_id(), internal_addr);
+  ASSERT_TRUE(orchard_result.has_value());
+  ASSERT_TRUE(orchard_result.value().has_value());
+  EXPECT_EQ(orchard_result.value()->all_notes.size(), 10u);
+  for (const auto& note : orchard_result.value()->all_notes) {
+    EXPECT_EQ(note.amount, 10u);
+  }
+
+  auto ironwood_result = sync_state()->GetSpendableNotes(
+      OrchardPool::kIronwood, account_id(), internal_addr);
+  ASSERT_TRUE(ironwood_result.has_value());
+  ASSERT_TRUE(ironwood_result.value().has_value());
+  EXPECT_EQ(ironwood_result.value()->all_notes.size(), 20u);
+  for (const auto& note : ironwood_result.value()->all_notes) {
+    EXPECT_EQ(note.amount, 20u);
+  }
+}
+
+TEST_F(OrchardSyncStateTest, IronwoodPool_SimpleInsertWitness) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kBraveWalletZCashFeature, {{"zcash_ironwood_enabled", "true"}});
+
+  std::vector<OrchardCommitment> commitments;
+
+  commitments.push_back(
+      CreateCommitment(CreateMockCommitmentValue(0, kDefaultCommitmentSeed),
+                       false, std::nullopt));
+  commitments.push_back(
+      CreateCommitment(CreateMockCommitmentValue(1, kDefaultCommitmentSeed),
+                       false, std::nullopt));
+  commitments.push_back(
+      CreateCommitment(CreateMockCommitmentValue(2, kDefaultCommitmentSeed),
+                       true, std::nullopt));
+  commitments.push_back(CreateCommitment(
+      CreateMockCommitmentValue(3, kDefaultCommitmentSeed), false, 1));
+  commitments.push_back(
+      CreateCommitment(CreateMockCommitmentValue(4, kDefaultCommitmentSeed),
+                       false, std::nullopt));
+
+  auto result = CreateResultForTesting(
+      OrchardTreeState(), std::vector<OrchardCommitment>(), 1000, "1000");
+  result.ironwood = CreateIronwoodPoolResultForTesting(
+      OrchardTreeState(), std::move(commitments), 1000, "1000");
+
+  EXPECT_EQ(
+      OrchardStorage::Result::kSuccess,
+      sync_state()->ApplyScanResults(account_id(), std::move(result)).value());
+
+  OrchardInput input;
+  input.note.orchard_commitment_tree_position = 2;
+  // The orchard pool is untouched, so it has no checkpoint #1 to witness
+  // against.
+  EXPECT_FALSE(sync_state()
+                   ->CalculateWitnessForCheckpoint(OrchardPool::kOrchard,
+                                                   account_id(), {input}, 1)
+                   .has_value());
+
+  auto witness_result = sync_state()->CalculateWitnessForCheckpoint(
+      OrchardPool::kIronwood, account_id(), {input}, 1);
+  EXPECT_TRUE(witness_result.has_value());
+  // Same commitments/positions/tree height as the orchard SimpleInsert case,
+  // applied to the independent ironwood shard tree: identical witness.
+  EXPECT_EQ(
+      witness_result.value()[0].witness.value(),
+      CreateWitness(
+          {"f342eb6489f4e5b5a0fb0a4ece48d137dcd5e80011aab4668913f98be2af3311",
+           "d4059d13ddcbe9ec7e6fc99bdf9bfd08b0a678d26e3bf6a734e7688eca669f37",
+           "c7413f4614cd64043abbab7cc1095c9bb104231cea89e2c3e0df83769556d030",
+           "2111fc397753e5fd50ec74816df27d6ada7ed2a9ac3816aab2573c8fac794204",
+           "806afbfeb45c64d4f2384c51eff30764b84599ae56a7ab3d4a46d9ce3aeab431",
+           "873e4157f2c0f0c645e899360069fcc9d2ed9bc11bf59827af0230ed52edab18",
+           "27ab1320953ae1ad70c8c15a1253a0a86fbc8a0aa36a84207293f8a495ffc402",
+           "4e14563df191a2a65b4b37113b5230680555051b22d74a8e1f1d706f90f3133"
+           "b"},
+          2));
+}
+
+TEST_F(OrchardSyncStateTest, Rewind_IronwoodPool_Enabled) {
+  EXPECT_TRUE(sync_state()->RegisterAccount(account_id(), 0u).has_value());
+
+  {
+    std::vector<OrchardCommitment> orchard_commitments;
+    std::vector<OrchardCommitment> ironwood_commitments;
+    for (int i = 0; i < 5; i++) {
+      std::optional<uint32_t> checkpoint =
+          i == 2 ? std::optional<uint32_t>(1) : std::nullopt;
+      orchard_commitments.push_back(
+          CreateCommitment(CreateMockCommitmentValue(i, kDefaultCommitmentSeed),
+                           false, checkpoint));
+      ironwood_commitments.push_back(CreateCommitment(
+          CreateMockCommitmentValue(i, kDefaultCommitmentSeed + 10), false,
+          checkpoint));
+    }
+    auto result = CreateResultForTesting(
+        OrchardTreeState(), std::move(orchard_commitments), 2, "2");
+    result.ironwood = CreateIronwoodPoolResultForTesting(
+        OrchardTreeState(), std::move(ironwood_commitments), 2, "2");
+    EXPECT_EQ(OrchardStorage::Result::kSuccess,
+              sync_state()
+                  ->ApplyScanResults(account_id(), std::move(result))
+                  .value());
+  }
+
+  {
+    OrchardTreeState orchard_tree_state;
+    orchard_tree_state.block_height = 2;
+    orchard_tree_state.tree_size = 5;
+    OrchardTreeState ironwood_tree_state;
+    ironwood_tree_state.block_height = 2;
+    ironwood_tree_state.tree_size = 5;
+
+    std::vector<OrchardCommitment> orchard_commitments;
+    orchard_commitments.push_back(CreateCommitment(
+        CreateMockCommitmentValue(5, kDefaultCommitmentSeed), false, 2u));
+    std::vector<OrchardCommitment> ironwood_commitments;
+    ironwood_commitments.push_back(CreateCommitment(
+        CreateMockCommitmentValue(5, kDefaultCommitmentSeed + 10), false, 2u));
+
+    auto result = CreateResultForTesting(
+        std::move(orchard_tree_state), std::move(orchard_commitments), 4, "4");
+    result.ironwood = CreateIronwoodPoolResultForTesting(
+        std::move(ironwood_tree_state), std::move(ironwood_commitments), 4,
+        "4");
+    EXPECT_EQ(OrchardStorage::Result::kSuccess,
+              sync_state()
+                  ->ApplyScanResults(account_id(), std::move(result))
+                  .value());
+  }
+
+  ASSERT_EQ(
+      2u,
+      storage().CheckpointCount(OrchardPool::kOrchard, account_id()).value());
+  ASSERT_EQ(
+      2u,
+      storage().CheckpointCount(OrchardPool::kIronwood, account_id()).value());
+
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kBraveWalletZCashFeature, {{"zcash_ironwood_enabled", "true"}});
+
+  // TruncateToCheckpoint(2) removes checkpoint #2 (and later), keeping only
+  // checkpoint #1.
+  EXPECT_EQ(OrchardStorage::Result::kSuccess,
+            sync_state()->Rewind(account_id(), 2, "2").value());
+
+  EXPECT_EQ(
+      1u,
+      storage().CheckpointCount(OrchardPool::kOrchard, account_id()).value());
+  // With the feature enabled, Rewind() also truncates the ironwood tree.
+  EXPECT_EQ(
+      1u,
+      storage().CheckpointCount(OrchardPool::kIronwood, account_id()).value());
+}
+
+TEST_F(OrchardSyncStateTest, Rewind_IronwoodPool_Disabled) {
+  EXPECT_TRUE(sync_state()->RegisterAccount(account_id(), 0u).has_value());
+
+  {
+    std::vector<OrchardCommitment> orchard_commitments;
+    std::vector<OrchardCommitment> ironwood_commitments;
+    for (int i = 0; i < 5; i++) {
+      std::optional<uint32_t> checkpoint =
+          i == 2 ? std::optional<uint32_t>(1) : std::nullopt;
+      orchard_commitments.push_back(
+          CreateCommitment(CreateMockCommitmentValue(i, kDefaultCommitmentSeed),
+                           false, checkpoint));
+      ironwood_commitments.push_back(CreateCommitment(
+          CreateMockCommitmentValue(i, kDefaultCommitmentSeed + 10), false,
+          checkpoint));
+    }
+    auto result = CreateResultForTesting(
+        OrchardTreeState(), std::move(orchard_commitments), 2, "2");
+    result.ironwood = CreateIronwoodPoolResultForTesting(
+        OrchardTreeState(), std::move(ironwood_commitments), 2, "2");
+    EXPECT_EQ(OrchardStorage::Result::kSuccess,
+              sync_state()
+                  ->ApplyScanResults(account_id(), std::move(result))
+                  .value());
+  }
+
+  {
+    OrchardTreeState orchard_tree_state;
+    orchard_tree_state.block_height = 2;
+    orchard_tree_state.tree_size = 5;
+    OrchardTreeState ironwood_tree_state;
+    ironwood_tree_state.block_height = 2;
+    ironwood_tree_state.tree_size = 5;
+
+    std::vector<OrchardCommitment> orchard_commitments;
+    orchard_commitments.push_back(CreateCommitment(
+        CreateMockCommitmentValue(5, kDefaultCommitmentSeed), false, 2u));
+    std::vector<OrchardCommitment> ironwood_commitments;
+    ironwood_commitments.push_back(CreateCommitment(
+        CreateMockCommitmentValue(5, kDefaultCommitmentSeed + 10), false, 2u));
+
+    auto result = CreateResultForTesting(
+        std::move(orchard_tree_state), std::move(orchard_commitments), 4, "4");
+    result.ironwood = CreateIronwoodPoolResultForTesting(
+        std::move(ironwood_tree_state), std::move(ironwood_commitments), 4,
+        "4");
+    EXPECT_EQ(OrchardStorage::Result::kSuccess,
+              sync_state()
+                  ->ApplyScanResults(account_id(), std::move(result))
+                  .value());
+  }
+
+  ASSERT_EQ(
+      2u,
+      storage().CheckpointCount(OrchardPool::kOrchard, account_id()).value());
+  ASSERT_EQ(
+      2u,
+      storage().CheckpointCount(OrchardPool::kIronwood, account_id()).value());
+
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kBraveWalletZCashFeature,
+      {{"zcash_ironwood_enabled", "false"}});
+
+  // TruncateToCheckpoint(2) removes checkpoint #2 (and later), keeping only
+  // checkpoint #1.
+  EXPECT_EQ(OrchardStorage::Result::kSuccess,
+            sync_state()->Rewind(account_id(), 2, "2").value());
+
+  EXPECT_EQ(
+      1u,
+      storage().CheckpointCount(OrchardPool::kOrchard, account_id()).value());
+  // With the feature disabled, Rewind() skips truncating the ironwood shard
+  // tree entirely, even though the reorg still happened.
+  EXPECT_EQ(
+      2u,
+      storage().CheckpointCount(OrchardPool::kIronwood, account_id()).value());
+}
+
+// The following tests verify that each OrchardSyncState accessor taking a
+// `pool` argument short-circuits for the Ironwood pool when the feature is
+// disabled, even when real data for that pool already exists in storage.
+
+TEST_F(OrchardSyncStateTest, GetSpendableNotes_IronwoodPool_FeatureDisabled) {
+  EXPECT_TRUE(sync_state()->RegisterAccount(account_id(), 0u).has_value());
+
+  OrchardNote note;
+  note.amount = 20;
+  note.block_id = 1000;
+  note.addr.fill(2);
+  note.nullifier.fill(1);
+  note.note_version = 2;
+
+  auto result = CreateResultForTesting(
+      OrchardTreeState(), std::vector<OrchardCommitment>(), 1000, "1000");
+  result.ironwood = CreateIronwoodPoolResultForTesting(
+      OrchardTreeState(), std::vector<OrchardCommitment>(), 1000, "1000");
+  result.ironwood->discovered_notes = {note};
+
+  EXPECT_EQ(
+      OrchardStorage::Result::kSuccess,
+      sync_state()->ApplyScanResults(account_id(), std::move(result)).value());
+
+  // Confirm the note was actually persisted for the ironwood pool.
+  ASSERT_EQ(1u, storage()
+                    .GetSpendableNotes(OrchardPool::kIronwood, account_id())
+                    .value()
+                    .size());
+
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kBraveWalletZCashFeature,
+      {{"zcash_ironwood_enabled", "false"}});
+
+  OrchardAddrRawPart internal_addr;
+  internal_addr.fill(3);
+  auto ironwood_result = sync_state()->GetSpendableNotes(
+      OrchardPool::kIronwood, account_id(), internal_addr);
+  EXPECT_TRUE(ironwood_result.has_value());
+  EXPECT_FALSE(ironwood_result.value().has_value());
+}
+
+TEST_F(OrchardSyncStateTest, GetNullifiers_IronwoodPool_FeatureDisabled) {
+  EXPECT_TRUE(sync_state()->RegisterAccount(account_id(), 0u).has_value());
+
+  OrchardNoteSpend spend;
+  spend.block_id = 1000;
+  spend.nullifier.fill(7);
+  std::vector<OrchardNoteSpend> spends = {spend};
+  EXPECT_EQ(OrchardStorage::Result::kSuccess,
+            storage()
+                .UpdateNotes(OrchardPool::kIronwood, account_id(),
+                             std::vector<OrchardNote>(), spends, 1000, "1000")
+                .value());
+
+  // Confirm the nullifier was actually persisted for the ironwood pool.
+  ASSERT_EQ(1u, storage()
+                    .GetNullifiers(OrchardPool::kIronwood, account_id())
+                    .value()
+                    .size());
+
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kBraveWalletZCashFeature,
+      {{"zcash_ironwood_enabled", "false"}});
+
+  auto nullifiers_result =
+      sync_state()->GetNullifiers(OrchardPool::kIronwood, account_id());
+  EXPECT_TRUE(nullifiers_result.has_value());
+  EXPECT_TRUE(nullifiers_result.value().empty());
+}
+
+TEST_F(OrchardSyncStateTest,
+       CalculateWitnessForCheckpoint_IronwoodPool_FeatureDisabled) {
+  EXPECT_TRUE(sync_state()->RegisterAccount(account_id(), 0u).has_value());
+
+  std::vector<OrchardCommitment> commitments;
+  commitments.push_back(
+      CreateCommitment(CreateMockCommitmentValue(0, kDefaultCommitmentSeed),
+                       false, std::nullopt));
+  commitments.push_back(
+      CreateCommitment(CreateMockCommitmentValue(1, kDefaultCommitmentSeed),
+                       false, std::nullopt));
+  commitments.push_back(
+      CreateCommitment(CreateMockCommitmentValue(2, kDefaultCommitmentSeed),
+                       true, std::nullopt));
+  commitments.push_back(CreateCommitment(
+      CreateMockCommitmentValue(3, kDefaultCommitmentSeed), false, 1));
+  commitments.push_back(
+      CreateCommitment(CreateMockCommitmentValue(4, kDefaultCommitmentSeed),
+                       false, std::nullopt));
+
+  auto result = CreateResultForTesting(
+      OrchardTreeState(), std::vector<OrchardCommitment>(), 1000, "1000");
+  result.ironwood = CreateIronwoodPoolResultForTesting(
+      OrchardTreeState(), std::move(commitments), 1000, "1000");
+
+  EXPECT_EQ(
+      OrchardStorage::Result::kSuccess,
+      sync_state()->ApplyScanResults(account_id(), std::move(result)).value());
+
+  // Confirm checkpoint #1 was actually persisted for the ironwood pool.
+  ASSERT_EQ(
+      1u,
+      storage().CheckpointCount(OrchardPool::kIronwood, account_id()).value());
+
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kBraveWalletZCashFeature,
+      {{"zcash_ironwood_enabled", "false"}});
+
+  OrchardInput input;
+  input.note.orchard_commitment_tree_position = 2;
+  auto witness_result = sync_state()->CalculateWitnessForCheckpoint(
+      OrchardPool::kIronwood, account_id(), {input}, 1);
+  EXPECT_TRUE(witness_result.has_value());
+  EXPECT_TRUE(witness_result.value().empty());
+}
+
+TEST_F(OrchardSyncStateTest, GetLatestShardIndex_IronwoodPool_FeatureDisabled) {
+  EXPECT_TRUE(sync_state()->RegisterAccount(account_id(), 0u).has_value());
+
+  OrchardShard ironwood_shard;
+  ironwood_shard.address.index = 3;
+  ironwood_shard.address.level = 1;
+  ironwood_shard.shard_data = std::vector<uint8_t>({1, 1, 1, 1});
+  EXPECT_EQ(OrchardStorage::Result::kSuccess,
+            storage()
+                .PutShard(OrchardPool::kIronwood, account_id(), ironwood_shard)
+                .value());
+
+  // Confirm the shard was actually persisted for the ironwood pool.
+  ASSERT_EQ(3u, storage()
+                    .GetLatestShardIndex(OrchardPool::kIronwood, account_id())
+                    .value()
+                    .value());
+
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kBraveWalletZCashFeature,
+      {{"zcash_ironwood_enabled", "false"}});
+
+  auto shard_index_result =
+      sync_state()->GetLatestShardIndex(OrchardPool::kIronwood, account_id());
+  EXPECT_TRUE(shard_index_result.has_value());
+  EXPECT_FALSE(shard_index_result.value().has_value());
+}
+
+TEST_F(OrchardSyncStateTest, GetMinCheckpointId_IronwoodPool_FeatureDisabled) {
+  EXPECT_TRUE(sync_state()->RegisterAccount(account_id(), 0u).has_value());
+
+  EXPECT_EQ(OrchardStorage::Result::kSuccess,
+            storage()
+                .AddCheckpoint(OrchardPool::kIronwood, account_id(), 5,
+                               OrchardCheckpoint(std::nullopt, {}))
+                .value());
+
+  // Confirm the checkpoint was actually persisted for the ironwood pool.
+  ASSERT_EQ(5u, storage()
+                    .MinCheckpointId(OrchardPool::kIronwood, account_id())
+                    .value()
+                    .value());
+
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kBraveWalletZCashFeature,
+      {{"zcash_ironwood_enabled", "false"}});
+
+  auto min_checkpoint_result =
+      sync_state()->GetMinCheckpointId(OrchardPool::kIronwood, account_id());
+  EXPECT_TRUE(min_checkpoint_result.has_value());
+  EXPECT_FALSE(min_checkpoint_result.value().has_value());
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/internal/orchard_test_utils.cc
+++ b/components/brave_wallet/browser/internal/orchard_test_utils.cc
@@ -21,11 +21,26 @@ OrchardBlockScanner::Result CreateResultForTesting(
     builder->AddCommitment(std::move(commitment));
   }
   builder->SetPriorTreeState(std::move(tree_state));
-  return OrchardBlockScanner::Result{{},
-                                     {},
-                                     builder->Complete(),
-                                     latest_scanned_block_id,
-                                     latest_scanned_block_hash};
+  OrchardBlockScanner::Result result;
+  result.orchard = OrchardBlockScanner::PoolResult({}, {}, builder->Complete(),
+                                                   latest_scanned_block_id,
+                                                   latest_scanned_block_hash);
+  return result;
+}
+
+OrchardBlockScanner::PoolResult CreateIronwoodPoolResultForTesting(
+    OrchardTreeState tree_state,
+    std::vector<OrchardCommitment> commitments,
+    uint32_t latest_scanned_block_id,
+    const std::string& latest_scanned_block_hash) {
+  auto builder = orchard::CreateTestingDecodedBundleBuilder();
+  for (auto& commitment : commitments) {
+    builder->AddCommitment(std::move(commitment));
+  }
+  builder->SetPriorTreeState(std::move(tree_state));
+  return OrchardBlockScanner::PoolResult({}, {}, builder->Complete(),
+                                         latest_scanned_block_id,
+                                         latest_scanned_block_hash);
 }
 
 OrchardCommitmentValue CreateMockCommitmentValue(uint32_t position,

--- a/components/brave_wallet/browser/internal/orchard_test_utils.h
+++ b/components/brave_wallet/browser/internal/orchard_test_utils.h
@@ -20,6 +20,12 @@ OrchardBlockScanner::Result CreateResultForTesting(
     uint32_t latest_scanned_block_id,
     const std::string& latest_scanned_block_hash);
 
+OrchardBlockScanner::PoolResult CreateIronwoodPoolResultForTesting(
+    OrchardTreeState tree_state,
+    std::vector<OrchardCommitment> commitments,
+    uint32_t latest_scanned_block_id,
+    const std::string& latest_scanned_block_hash);
+
 OrchardCommitmentValue CreateMockCommitmentValue(uint32_t position,
                                                  uint32_t rseed);
 

--- a/components/brave_wallet/browser/zcash/rust/lib.rs
+++ b/components/brave_wallet/browser/zcash/rust/lib.rs
@@ -17,7 +17,7 @@ use orchard::{
         SpendingKey,
     },
     note::{ExtractedNoteCommitment, NoteVersion, Nullifier, RandomSeed, Rho},
-    note_encryption::{CompactAction, OrchardDomain},
+    note_encryption::{CompactAction, IronwoodDomain, OrchardDomain},
     tree::{MerkleHashOrchard, MerklePath},
     value::NoteValue,
     zip32::{
@@ -40,7 +40,7 @@ use rand::{rngs::OsRng, CryptoRng, Error as OtherError, RngCore};
 
 use brave_wallet::impl_error;
 use std::sync::Arc;
-use zcash_note_encryption::{batch, Domain, ShieldedOutput, COMPACT_NOTE_SIZE};
+use zcash_note_encryption::{batch, BatchDomain, Domain, ShieldedOutput, COMPACT_NOTE_SIZE};
 
 use shardtree::{
     store::{Checkpoint, ShardStore, TreeState},
@@ -380,6 +380,16 @@ mod ffi {
 
         fn batch_decode(
             fvk_bytes: &[u8; 96], // Array size should match kOrchardFullViewKeySize
+            prior_tree_state: CxxOrchardShardTreeState,
+            actions: Vec<CxxOrchardCompactAction>,
+        ) -> Box<CxxOrchardDecodedBlocksBundleResult>;
+
+        // Same as batch_decode but trial-decrypts the actions under the Ironwood
+        // (v3 note plaintext) domain. The resulting bundle feeds a separate
+        // Ironwood commitment tree. fvk array size should match
+        // kOrchardFullViewKeySize.
+        fn batch_decode_ironwood(
+            fvk_bytes: &[u8; 96],
             prior_tree_state: CxxOrchardShardTreeState,
             actions: Vec<CxxOrchardCompactAction>,
         ) -> Box<CxxOrchardDecodedBlocksBundleResult>;
@@ -1080,11 +1090,41 @@ impl ShieldedOutput<OrchardDomain, COMPACT_NOTE_SIZE> for CxxOrchardCompactActio
     }
 }
 
-fn batch_decode(
+// Ironwood compact actions share the exact wire layout of Orchard actions; the
+// only difference is the note-encryption domain (v3 vs v2 plaintext) used to
+// trial-decrypt them. The accessor bodies are therefore identical.
+impl ShieldedOutput<IronwoodDomain, COMPACT_NOTE_SIZE> for CxxOrchardCompactAction {
+    fn ephemeral_key(&self) -> EphemeralKeyBytes {
+        EphemeralKeyBytes(self.ephemeral_key)
+    }
+
+    fn cmstar_bytes(&self) -> [u8; 32] {
+        self.cmx
+    }
+
+    fn enc_ciphertext(&self) -> &[u8; COMPACT_NOTE_SIZE] {
+        &self.enc_cipher_text
+    }
+}
+
+// Decrypts a range of Orchard-shaped compact actions under a single
+// note-encryption domain `D` (either `OrchardDomain` for v2 notes or
+// `IronwoodDomain` for v3 notes). The account's Orchard incoming viewing keys
+// are used for both domains; only the accepted note-plaintext version differs.
+// Every action's cmx is added to the returned commitment list (so the caller's
+// commitment tree stays position-correct), while only actions that
+// trial-decrypt under `D` become discovered notes.
+fn decode_actions<D>(
     fvk_bytes: &[u8; 96],
     prior_tree_state: CxxOrchardShardTreeState,
     actions: Vec<CxxOrchardCompactAction>,
-) -> Box<CxxOrchardDecodedBlocksBundleResult> {
+    for_action: impl Fn(&CompactAction) -> D,
+) -> Box<CxxOrchardDecodedBlocksBundleResult>
+where
+    D: BatchDomain
+        + Domain<Note = orchard::note::Note, IncomingViewingKey = PreparedIncomingViewingKey>,
+    CxxOrchardCompactAction: ShieldedOutput<D, COMPACT_NOTE_SIZE>,
+{
     let fvk = match OrchardFVK::from_bytes(fvk_bytes) {
         Some(fvk) => fvk,
         None => return Box::new(CxxOrchardDecodedBlocksBundleResult::from(Err(Error::FvkError))),
@@ -1095,7 +1135,7 @@ fn batch_decode(
         PreparedIncomingViewingKey::new(&fvk.to_ivk(OrchardScope::Internal)),
     ];
 
-    let input_actions: Result<Vec<(OrchardDomain, CxxOrchardCompactAction)>, Error> = actions
+    let input_actions: Result<Vec<(D, CxxOrchardCompactAction)>, Error> = actions
         .into_iter()
         .map(|v| {
             let nullifier_ctopt = Nullifier::from_bytes(&v.nullifier);
@@ -1117,9 +1157,9 @@ fn batch_decode(
 
             let compact_action =
                 CompactAction::from_parts(nullifier, cmx, ephemeral_key, enc_cipher_text);
-            let orchard_domain = OrchardDomain::for_compact_action(&compact_action);
+            let domain = for_action(&compact_action);
 
-            Ok((orchard_domain, v))
+            Ok((domain, v))
         })
         .collect();
 
@@ -1185,6 +1225,28 @@ fn batch_decode(
         commitments: note_commitments,
         prior_tree_state: prior_tree_state,
     })))
+}
+
+// Scans Orchard (v2) compact actions. Behaviour is unchanged from before the
+// Ironwood refactor.
+fn batch_decode(
+    fvk_bytes: &[u8; 96],
+    prior_tree_state: CxxOrchardShardTreeState,
+    actions: Vec<CxxOrchardCompactAction>,
+) -> Box<CxxOrchardDecodedBlocksBundleResult> {
+    decode_actions(fvk_bytes, prior_tree_state, actions, OrchardDomain::for_compact_action)
+}
+
+// Scans Ironwood (v3) compact actions with the account's Orchard viewing keys.
+// The returned bundle is meant to feed a SEPARATE Ironwood commitment tree;
+// callers must pass only Ironwood actions and the Ironwood prior tree state
+// here.
+fn batch_decode_ironwood(
+    fvk_bytes: &[u8; 96],
+    prior_tree_state: CxxOrchardShardTreeState,
+    actions: Vec<CxxOrchardCompactAction>,
+) -> Box<CxxOrchardDecodedBlocksBundleResult> {
+    decode_actions(fvk_bytes, prior_tree_state, actions, IronwoodDomain::for_compact_action)
 }
 
 impl CxxOrchardDecodedBlocksBundle {

--- a/components/brave_wallet/browser/zcash/rust/orchard_block_decoder.cc
+++ b/components/brave_wallet/browser/zcash/rust/orchard_block_decoder.cc
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/logging.h"
 #include "base/memory/ptr_util.h"
 #include "base/threading/thread_restrictions.h"
 #include "brave/components/brave_wallet/browser/zcash/rust/lib.rs.h"
@@ -18,63 +19,95 @@
 
 namespace brave_wallet::orchard {
 
+OrchardBlockDecoder::Result::Result() = default;
+OrchardBlockDecoder::Result::~Result() = default;
+OrchardBlockDecoder::Result::Result(Result&&) = default;
+OrchardBlockDecoder::Result& OrchardBlockDecoder::Result::operator=(Result&&) =
+    default;
+
 OrchardBlockDecoder::OrchardBlockDecoder() = default;
 OrchardBlockDecoder::~OrchardBlockDecoder() = default;
 
 // static
-std::unique_ptr<OrchardDecodedBlocksBundle> OrchardBlockDecoder::DecodeBlocks(
+std::unique_ptr<OrchardDecodedBlocksBundle> OrchardBlockDecoder::DecodePool(
     const OrchardFullViewKey& fvk,
     const ::brave_wallet::OrchardTreeState& tree_state,
-    const std::vector<::brave_wallet::zcash::mojom::CompactBlockPtr>& blocks) {
-  base::AssertLongCPUWorkAllowed();
-  ::rust::Vec<orchard::CxxOrchardCompactAction> orchard_actions;
+    const std::vector<::brave_wallet::zcash::mojom::CompactBlockPtr>& blocks,
+    ::brave_wallet::OrchardPool pool,
+    uint32_t ironwood_activation_height) {
+  const bool is_ironwood = pool == ::brave_wallet::OrchardPool::kIronwood;
+  ::rust::Vec<orchard::CxxOrchardCompactAction> compact_actions;
   for (const auto& block : blocks) {
-    bool block_has_orchard_action = false;
+    // Ironwood commitments only exist from the activation height onward. Skip
+    // pre-activation blocks so they never contribute to the Ironwood tree.
+    if (is_ironwood && block->height < ironwood_activation_height) {
+      continue;
+    }
+    bool block_has_action = false;
     for (const auto& tx : block->vtx) {
-      for (const auto& orchard_action : tx->orchard_actions) {
-        block_has_orchard_action = true;
-        orchard::CxxOrchardCompactAction orchard_compact_action;
-
-        if (orchard_action->nullifier.size() != kOrchardNullifierSize ||
-            orchard_action->cmx.size() != kOrchardCmxSize ||
-            orchard_action->ephemeral_key.size() != kOrchardEphemeralKeySize ||
-            orchard_action->ciphertext.size() != kOrchardCipherTextSize) {
+      const auto& actions =
+          is_ironwood ? tx->ironwood_actions : tx->orchard_actions;
+      for (const auto& action : actions) {
+        if (action->nullifier.size() != kOrchardNullifierSize ||
+            action->cmx.size() != kOrchardCmxSize ||
+            action->ephemeral_key.size() != kOrchardEphemeralKeySize ||
+            action->ciphertext.size() != kOrchardCipherTextSize) {
           return nullptr;
         }
-
-        orchard_compact_action.block_id = block->height;
-        orchard_compact_action.is_block_last_action = false;
-        base::span(orchard_compact_action.nullifier)
-            .copy_from(orchard_action->nullifier);
-        base::span(orchard_compact_action.cmx).copy_from(orchard_action->cmx);
-        base::span(orchard_compact_action.ephemeral_key)
-            .copy_from(orchard_action->ephemeral_key);
-        base::span(orchard_compact_action.enc_cipher_text)
-            .copy_from(orchard_action->ciphertext);
-
-        orchard_actions.push_back(std::move(orchard_compact_action));
+        block_has_action = true;
+        orchard::CxxOrchardCompactAction c;
+        c.block_id = block->height;
+        c.is_block_last_action = false;
+        base::span(c.nullifier).copy_from(action->nullifier);
+        base::span(c.cmx).copy_from(action->cmx);
+        base::span(c.ephemeral_key).copy_from(action->ephemeral_key);
+        base::span(c.enc_cipher_text).copy_from(action->ciphertext);
+        compact_actions.push_back(std::move(c));
       }
     }
-    if (block_has_orchard_action) {
-      orchard_actions.back().is_block_last_action = true;
+    if (block_has_action) {
+      compact_actions.back().is_block_last_action = true;
     }
   }
 
   CxxOrchardShardTreeState prior_tree_state;
   prior_tree_state.block_height = tree_state.block_height;
   prior_tree_state.tree_size = tree_state.tree_size;
-
   std::ranges::copy(tree_state.frontier,
                     std::back_inserter(prior_tree_state.frontier));
 
-  ::rust::Box<CxxOrchardDecodedBlocksBundleResult> decode_result = batch_decode(
-      fvk, std::move(prior_tree_state), std::move(orchard_actions));
-
+  ::rust::Box<CxxOrchardDecodedBlocksBundleResult> decode_result =
+      is_ironwood ? batch_decode_ironwood(fvk, std::move(prior_tree_state),
+                                          std::move(compact_actions))
+                  : batch_decode(fvk, std::move(prior_tree_state),
+                                 std::move(compact_actions));
   if (decode_result->is_ok()) {
+    auto bundle = decode_result->unwrap();
     return std::make_unique<OrchardDecodedBlocksBundleImpl>(
-        base::PassKey<class OrchardBlockDecoder>(), decode_result->unwrap());
+        base::PassKey<class OrchardBlockDecoder>(), std::move(bundle));
   }
   return nullptr;
+}
+
+// static
+OrchardBlockDecoder::Result OrchardBlockDecoder::DecodeBlocks(
+    const OrchardFullViewKey& fvk,
+    const ::brave_wallet::OrchardTreeState& orchard_tree_state,
+    const std::vector<::brave_wallet::zcash::mojom::CompactBlockPtr>& blocks,
+    base::optional_ref<const ::brave_wallet::OrchardTreeState>
+        ironwood_tree_state,
+    uint32_t ironwood_activation_height) {
+  base::AssertLongCPUWorkAllowed();
+  Result result;
+  // Orchard processes every block; the activation cut does not apply (0).
+  result.orchard =
+      DecodePool(fvk, orchard_tree_state, blocks, OrchardPool::kOrchard, 0);
+  if (ironwood_tree_state.has_value()) {
+    result.ironwood =
+        DecodePool(fvk, *ironwood_tree_state, blocks, OrchardPool::kIronwood,
+                   ironwood_activation_height);
+  }
+  return result;
 }
 
 }  // namespace brave_wallet::orchard

--- a/components/brave_wallet/browser/zcash/rust/orchard_block_decoder.h
+++ b/components/brave_wallet/browser/zcash/rust/orchard_block_decoder.h
@@ -10,21 +10,51 @@
 #include <optional>
 #include <vector>
 
+#include "base/types/optional_ref.h"
 #include "brave/components/brave_wallet/browser/zcash/rust/orchard_decoded_blocks_bundle.h"
+#include "brave/components/brave_wallet/common/zcash_utils.h"
 #include "brave/components/services/brave_wallet/public/mojom/zcash_decoder.mojom.h"
 
 namespace brave_wallet::orchard {
 
 class OrchardBlockDecoder {
  public:
-  static std::unique_ptr<OrchardDecodedBlocksBundle> DecodeBlocks(
+  // Result of decoding one batch of blocks for both pools.
+  struct Result {
+    Result();
+    ~Result();
+    Result(Result&&);
+    Result& operator=(Result&&);
+
+    // Non-null on success. Null means the Orchard decode failed.
+    std::unique_ptr<OrchardDecodedBlocksBundle> orchard;
+    // Null when Ironwood was not requested (or decode failed).
+    std::unique_ptr<OrchardDecodedBlocksBundle> ironwood;
+  };
+
+  static Result DecodeBlocks(
       const OrchardFullViewKey& fvk,
-      const ::brave_wallet::OrchardTreeState& tree_state,
-      const std::vector<::brave_wallet::zcash::mojom::CompactBlockPtr>& blocks);
+      const ::brave_wallet::OrchardTreeState& orchard_tree_state,
+      const std::vector<::brave_wallet::zcash::mojom::CompactBlockPtr>& blocks,
+      base::optional_ref<const ::brave_wallet::OrchardTreeState>
+          ironwood_tree_state = std::nullopt,
+      // Blocks with height < this value are excluded from the Ironwood pool.
+      // Ignored for the Orchard pool. 0 means "no cut".
+      uint32_t ironwood_activation_height = 0);
 
  private:
   OrchardBlockDecoder();
   ~OrchardBlockDecoder();
+
+  // Decodes a single pool. Selects tx->orchard_actions vs tx->ironwood_actions
+  // based on `pool`, then calls the (shared) Rust batch_decode. Must be a
+  // member so it can mint base::PassKey<OrchardBlockDecoder>.
+  static std::unique_ptr<OrchardDecodedBlocksBundle> DecodePool(
+      const OrchardFullViewKey& fvk,
+      const ::brave_wallet::OrchardTreeState& tree_state,
+      const std::vector<::brave_wallet::zcash::mojom::CompactBlockPtr>& blocks,
+      ::brave_wallet::OrchardPool pool,
+      uint32_t ironwood_activation_height);
 };
 
 }  // namespace brave_wallet::orchard

--- a/components/brave_wallet/browser/zcash/zcash_blocks_batch_scan_task_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_blocks_batch_scan_task_unittest.cc
@@ -129,7 +129,8 @@ class ZCashBlocksBatchScanTest : public testing::Test {
                        OrchardStorage::Error>>
         result;
     sync_state_.AsyncCall(&OrchardSyncState::GetSpendableNotes)
-        .WithArgs(account_id_.Clone(), OrchardAddrRawPart({}))
+        .WithArgs(OrchardPool::kOrchard, account_id_.Clone(),
+                  OrchardAddrRawPart({}))
         .Then(base::BindLambdaForTesting(
             [&](base::expected<
                 std::optional<OrchardSyncState::SpendableNotesBundle>,
@@ -154,29 +155,29 @@ class ZCashBlocksBatchScanTest : public testing::Test {
               blocks.back()->height, ToHex(blocks.back()->hash));
           for (const auto& block : blocks) {
             if (block->height == kNu5BlockUpdate + 105) {
-              result.discovered_notes.push_back(
+              result.orchard.discovered_notes.push_back(
                   GenerateMockOrchardNote(account_id, block->height, 1));
             } else if (block->height == kNu5BlockUpdate + 205) {
-              result.discovered_notes.push_back(
+              result.orchard.discovered_notes.push_back(
                   GenerateMockOrchardNote(account_id, block->height, 2));
             } else if (block->height == kNu5BlockUpdate + 305) {
-              result.discovered_notes.push_back(
+              result.orchard.discovered_notes.push_back(
                   GenerateMockOrchardNote(account_id, block->height, 3));
             }
 
             if (block->height == kNu5BlockUpdate + 255) {
-              result.found_spends.push_back(OrchardNoteSpend(
+              result.orchard.found_spends.push_back(OrchardNoteSpend(
                   block->height, {GenerateMockNullifier(account_id, 1)}));
             } else if (block->height == kNu5BlockUpdate + 265) {
-              result.found_spends.push_back(OrchardNoteSpend(
+              result.orchard.found_spends.push_back(OrchardNoteSpend(
                   block->height, {GenerateMockNullifier(account_id, 2)}));
             }
 
             if (block->height == kNu5BlockUpdate + 405) {
-              result.discovered_notes.push_back(
+              result.orchard.discovered_notes.push_back(
                   GenerateMockOrchardNote(account_id, block->height, 4));
             } else if (block->height == kNu5BlockUpdate + 505) {
-              result.discovered_notes.push_back(
+              result.orchard.discovered_notes.push_back(
                   GenerateMockOrchardNote(account_id, block->height, 5));
             }
           }
@@ -290,8 +291,8 @@ TEST_F(ZCashBlocksBatchScanTest, Scan) {
           [&](base::expected<void, ZCashShieldSyncService::Error> result) {
             EXPECT_TRUE(result.has_value());
             auto value = task.TakeResult();
-            EXPECT_EQ(value.discovered_notes.size(), 4u);
-            EXPECT_EQ(value.found_spends.size(), 2u);
+            EXPECT_EQ(value.orchard.discovered_notes.size(), 4u);
+            EXPECT_EQ(value.orchard.found_spends.size(), 2u);
           });
 
   task.Start();
@@ -339,13 +340,13 @@ TEST_F(ZCashBlocksBatchScanTest, Error_PartialDecoding) {
                 blocks.back()->height, ToHex(blocks.back()->hash));
             for (const auto& block : blocks) {
               if (block->height == kNu5BlockUpdate + 105) {
-                result.discovered_notes.push_back(
+                result.orchard.discovered_notes.push_back(
                     GenerateMockOrchardNote(account_id, block->height, 1));
               } else if (block->height == kNu5BlockUpdate + 205) {
-                result.discovered_notes.push_back(
+                result.orchard.discovered_notes.push_back(
                     GenerateMockOrchardNote(account_id, block->height, 2));
               } else if (block->height == kNu5BlockUpdate + 305) {
-                result.discovered_notes.push_back(
+                result.orchard.discovered_notes.push_back(
                     GenerateMockOrchardNote(account_id, block->height, 3));
               }
 

--- a/components/brave_wallet/browser/zcash/zcash_complete_transaction_task.cc
+++ b/components/brave_wallet/browser/zcash/zcash_complete_transaction_task.cc
@@ -172,7 +172,7 @@ void ZCashCompleteTransactionTask::CalculateWitness() {
 
   context_.sync_state
       ->AsyncCall(&OrchardSyncState::CalculateWitnessForCheckpoint)
-      .WithArgs(context_.account_id.Clone(),
+      .WithArgs(OrchardPool::kOrchard, context_.account_id.Clone(),
                 transaction_.v5_part().orchard.inputs,
                 transaction_.v5_part().orchard.anchor_block_height.value())
       .Then(base::BindOnce(

--- a/components/brave_wallet/browser/zcash/zcash_create_orchard_to_orchard_transaction_task.cc
+++ b/components/brave_wallet/browser/zcash/zcash_create_orchard_to_orchard_transaction_task.cc
@@ -76,7 +76,7 @@ void ZCashCreateOrchardToOrchardTransactionTask::GetSpendableNotes() {
     return;
   }
   context_.sync_state->AsyncCall(&OrchardSyncState::GetSpendableNotes)
-      .WithArgs(context_.account_id.Clone(),
+      .WithArgs(OrchardPool::kOrchard, context_.account_id.Clone(),
                 context_.account_internal_addr.value())
       .Then(base::BindOnce(
           &ZCashCreateOrchardToOrchardTransactionTask::OnGetSpendableNotes,

--- a/components/brave_wallet/browser/zcash/zcash_create_orchard_to_orchard_transaction_task_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_create_orchard_to_orchard_transaction_task_unittest.cc
@@ -41,10 +41,11 @@ class MockOrchardSyncState : public OrchardSyncState {
       : OrchardSyncState(path_to_database) {}
   ~MockOrchardSyncState() override {}
 
-  MOCK_METHOD2(
+  MOCK_METHOD3(
       GetSpendableNotes,
       base::expected<std::optional<OrchardSyncState::SpendableNotesBundle>,
                      OrchardStorage::Error>(
+          OrchardPool pool,
           const mojom::AccountIdPtr& account_id,
           const OrchardAddrRawPart& internal_addr));
 };
@@ -130,8 +131,9 @@ class ZCashCreateOrchardToOrchardTransactionTaskTest : public testing::Test {
 };
 
 TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest, TransactionCreated) {
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& addr) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -206,8 +208,9 @@ TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
           .EnsureAccount(mojom::KeyringId::kZCashTestnet, 0)
           ->account_id.Clone();
 
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& addr) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -278,8 +281,9 @@ TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
 
 TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
        TransactionCreated_u64Check) {
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& addr) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -353,8 +357,9 @@ TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
 
 TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
        TransactionCreated_OverflowCheck_FullAmount) {
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& addr) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -406,8 +411,9 @@ TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
 
 TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
        TransactionCreated_OverflowCheck_CustomAmount) {
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& addr) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -459,8 +465,9 @@ TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
 
 TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
        TransactionCreated_MaxAmount) {
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& addr) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -526,8 +533,9 @@ TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
 
 TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
        TransactionCreated_MaxAmount_OverflowCheck) {
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& addr) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -595,8 +603,9 @@ TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
 }
 
 TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest, NotEnoughFunds) {
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& internal_address) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -646,8 +655,9 @@ TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest, NotEnoughFunds) {
 }
 
 TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest, Error) {
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& internal_addr) {
         return base::unexpected(OrchardStorage::Error{
             OrchardStorage::ErrorCode::kConsistencyError, ""});

--- a/components/brave_wallet/browser/zcash/zcash_create_orchard_to_transparent_transaction_task.cc
+++ b/components/brave_wallet/browser/zcash/zcash_create_orchard_to_transparent_transaction_task.cc
@@ -79,7 +79,7 @@ void ZCashCreateOrchardToTransparentTransactionTask::GetSpendableNotes() {
     return;
   }
   context_.sync_state->AsyncCall(&OrchardSyncState::GetSpendableNotes)
-      .WithArgs(context_.account_id.Clone(),
+      .WithArgs(OrchardPool::kOrchard, context_.account_id.Clone(),
                 context_.account_internal_addr.value())
       .Then(base::BindOnce(
           &ZCashCreateOrchardToTransparentTransactionTask::OnGetSpendableNotes,

--- a/components/brave_wallet/browser/zcash/zcash_create_orchard_to_transparent_transaction_task_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_create_orchard_to_transparent_transaction_task_unittest.cc
@@ -47,10 +47,11 @@ class MockOrchardSyncState : public OrchardSyncState {
       : OrchardSyncState(path_to_database) {}
   ~MockOrchardSyncState() override {}
 
-  MOCK_METHOD2(
+  MOCK_METHOD3(
       GetSpendableNotes,
       base::expected<std::optional<OrchardSyncState::SpendableNotesBundle>,
                      OrchardStorage::Error>(
+          OrchardPool pool,
           const mojom::AccountIdPtr& account_id,
           const OrchardAddrRawPart& internal_addr));
 };
@@ -132,8 +133,9 @@ class ZCashCreateOrchardToTransparentTransactionTaskTest
 };
 
 TEST_F(ZCashCreateOrchardToTransparentTransactionTaskTest, TransactionCreated) {
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& addr) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -196,8 +198,9 @@ TEST_F(ZCashCreateOrchardToTransparentTransactionTaskTest, TransactionCreated) {
 
 TEST_F(ZCashCreateOrchardToTransparentTransactionTaskTest,
        TransactionCreated_NoAnchorBlockId) {
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& addr) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -241,8 +244,9 @@ TEST_F(ZCashCreateOrchardToTransparentTransactionTaskTest,
 
 TEST_F(ZCashCreateOrchardToTransparentTransactionTaskTest,
        TransactionCreated_MaxAmount) {
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& addr) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -301,8 +305,9 @@ TEST_F(ZCashCreateOrchardToTransparentTransactionTaskTest,
 
 TEST_F(ZCashCreateOrchardToTransparentTransactionTaskTest,
        TransactionCreated_AllAmount) {
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& addr) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -361,8 +366,9 @@ TEST_F(ZCashCreateOrchardToTransparentTransactionTaskTest,
 
 TEST_F(ZCashCreateOrchardToTransparentTransactionTaskTest,
        TransactionCreated_MaxAmount_OverflowCheck) {
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& addr) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -423,8 +429,9 @@ TEST_F(ZCashCreateOrchardToTransparentTransactionTaskTest,
 
 TEST_F(ZCashCreateOrchardToTransparentTransactionTaskTest,
        TransactionCreated_OverflowCheck_FullAmount) {
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& addr) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -469,8 +476,9 @@ TEST_F(ZCashCreateOrchardToTransparentTransactionTaskTest,
 
 TEST_F(ZCashCreateOrchardToTransparentTransactionTaskTest,
        TransactionCreated_OverflowCheck_CustomAmount) {
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& addr) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -514,8 +522,9 @@ TEST_F(ZCashCreateOrchardToTransparentTransactionTaskTest,
 }
 
 TEST_F(ZCashCreateOrchardToTransparentTransactionTaskTest, NotEnoughFunds) {
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& internal_address) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -558,8 +567,9 @@ TEST_F(ZCashCreateOrchardToTransparentTransactionTaskTest, NotEnoughFunds) {
 }
 
 TEST_F(ZCashCreateOrchardToTransparentTransactionTaskTest, Error) {
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& internal_addr) {
         return base::unexpected(OrchardStorage::Error{
             OrchardStorage::ErrorCode::kConsistencyError, ""});

--- a/components/brave_wallet/browser/zcash/zcash_resolve_balance_task.cc
+++ b/components/brave_wallet/browser/zcash/zcash_resolve_balance_task.cc
@@ -61,7 +61,7 @@ void ZCashResolveBalanceTask::WorkOnTask() {
     if (!spendable_notes_result_) {
       zcash_wallet_service_->sync_state()
           .AsyncCall(&OrchardSyncState::GetSpendableNotes)
-          .WithArgs(context_.account_id.Clone(),
+          .WithArgs(OrchardPool::kOrchard, context_.account_id.Clone(),
                     context_.account_internal_addr.value())
           .Then(base::BindOnce(&ZCashResolveBalanceTask::OnGetSpendableNotes,
                                weak_ptr_factory_.GetWeakPtr()));

--- a/components/brave_wallet/browser/zcash/zcash_scan_blocks_task_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_scan_blocks_task_unittest.cc
@@ -143,7 +143,8 @@ class ZCashScanBlocksTaskTest : public testing::Test {
                        OrchardStorage::Error>>
         result;
     sync_state_.AsyncCall(&OrchardSyncState::GetSpendableNotes)
-        .WithArgs(account_id_.Clone(), OrchardAddrRawPart({}))
+        .WithArgs(OrchardPool::kOrchard, account_id_.Clone(),
+                  OrchardAddrRawPart({}))
         .Then(base::BindLambdaForTesting(
             [&](base::expected<
                 std::optional<OrchardSyncState::SpendableNotesBundle>,
@@ -170,45 +171,45 @@ class ZCashScanBlocksTaskTest : public testing::Test {
           for (const auto& block : blocks) {
             // 3 notes in the blockchain found in the first batch
             if (block->height == kNu5BlockUpdate + 105) {
-              result.discovered_notes.push_back(
+              result.orchard.discovered_notes.push_back(
                   GenerateMockOrchardNote(account_id, block->height, 1));
             } else if (block->height == kNu5BlockUpdate + 205) {
-              result.discovered_notes.push_back(
+              result.orchard.discovered_notes.push_back(
                   GenerateMockOrchardNote(account_id, block->height, 2));
             } else if (block->height == kNu5BlockUpdate + 305) {
-              result.discovered_notes.push_back(
+              result.orchard.discovered_notes.push_back(
                   GenerateMockOrchardNote(account_id, block->height, 3));
             }
 
             // First 2 notes are spent in the second batch
             if (block->height == kNu5BlockUpdate + kExpectedBatchSize + 255) {
-              result.found_spends.push_back(OrchardNoteSpend(
+              result.orchard.found_spends.push_back(OrchardNoteSpend(
                   block->height, {GenerateMockNullifier(account_id, 1)}));
             } else if (block->height ==
                        kNu5BlockUpdate + kExpectedBatchSize + 265) {
-              result.found_spends.push_back(OrchardNoteSpend(
+              result.orchard.found_spends.push_back(OrchardNoteSpend(
                   block->height, {GenerateMockNullifier(account_id, 2)}));
             }
 
             // Another 2 additional notes found in the third batch
             if (block->height ==
                 kNu5BlockUpdate + kExpectedBatchSize * 2 + 105) {
-              result.discovered_notes.push_back(
+              result.orchard.discovered_notes.push_back(
                   GenerateMockOrchardNote(account_id, block->height, 4));
             } else if (block->height ==
                        kNu5BlockUpdate + kExpectedBatchSize * 2 + 205) {
-              result.discovered_notes.push_back(
+              result.orchard.discovered_notes.push_back(
                   GenerateMockOrchardNote(account_id, block->height, 5));
             }
 
             // Another 2 additional notes found far away from 3 previous batches
             if (block->height ==
                 kNu5BlockUpdate + kExpectedBatchSize * 7 + 105) {
-              result.discovered_notes.push_back(
+              result.orchard.discovered_notes.push_back(
                   GenerateMockOrchardNote(account_id, block->height, 6));
             } else if (block->height ==
                        kNu5BlockUpdate + kExpectedBatchSize * 7 + 205) {
-              result.discovered_notes.push_back(
+              result.orchard.discovered_notes.push_back(
                   GenerateMockOrchardNote(account_id, block->height, 7));
             }
           }
@@ -322,7 +323,7 @@ TEST_F(ZCashScanBlocksTaskTest, ScanSingle) {
                 ToHex(blocks[blocks.size() - 1]->hash));
             EXPECT_EQ(blocks.size(), 1u);
             EXPECT_EQ(blocks[0]->height, kNu5BlockUpdate + 1u);
-            result.discovered_notes.push_back(
+            result.orchard.discovered_notes.push_back(
                 GenerateMockOrchardNote(account_id, blocks[0]->height, 1));
             std::move(callback).Run(std::move(result));
           }));

--- a/components/brave_wallet/browser/zcash/zcash_shield_sync_service.cc
+++ b/components/brave_wallet/browser/zcash/zcash_shield_sync_service.cc
@@ -259,7 +259,7 @@ void ZCashShieldSyncService::UpdateSpendableNotes(
   }
   sync_state()
       .AsyncCall(&OrchardSyncState::GetSpendableNotes)
-      .WithArgs(context_.account_id.Clone(),
+      .WithArgs(OrchardPool::kOrchard, context_.account_id.Clone(),
                 context_.account_internal_addr.value())
       .Then(base::BindOnce(&ZCashShieldSyncService::OnGetSpendableNotes,
                            weak_ptr_factory_.GetWeakPtr(),

--- a/components/brave_wallet/browser/zcash/zcash_shield_sync_service.cc
+++ b/components/brave_wallet/browser/zcash/zcash_shield_sync_service.cc
@@ -42,7 +42,8 @@ ZCashShieldSyncService::OrchardBlockScannerProxy::ScanBlocksInBackground(
     OrchardTreeState tree_state,
     std::vector<zcash::mojom::CompactBlockPtr> blocks) {
   OrchardBlockScanner scanner(full_view_key);
-  return scanner.ScanBlocks(tree_state, std::move(blocks));
+  return scanner.ScanBlocks(tree_state, std::move(blocks), std::nullopt,
+                            0xFFFFFFFF);
 }
 
 void ZCashShieldSyncService::OrchardBlockScannerProxy::ScanBlocks(

--- a/components/brave_wallet/browser/zcash/zcash_shield_sync_service_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_shield_sync_service_unittest.cc
@@ -204,8 +204,8 @@ class ZCashShieldSyncServiceTest : public testing::Test {
           OrchardBlockScanner::Result result = CreateResultForTesting(
               std::move(tree_state), std::move(commitments),
               blocks.back()->height, ToHex(blocks.back()->hash));
-          result.discovered_notes = notes;
-          result.found_spends = spends;
+          result.orchard.discovered_notes = notes;
+          result.orchard.found_spends = spends;
           std::move(callback).Run(std::move(result));
         }));
   }
@@ -332,8 +332,8 @@ TEST_F(ZCashShieldSyncServiceTest, ScanBlocks) {
             OrchardBlockScanner::Result result = CreateResultForTesting(
                 std::move(orchard_tree_state), std::move(commitments),
                 blocks.back()->height, ToHex(blocks.back()->hash));
-            result.discovered_notes = notes;
-            result.found_spends = spends;
+            result.orchard.discovered_notes = notes;
+            result.orchard.found_spends = spends;
             std::move(callback).Run(std::move(result));
           })));
 
@@ -401,7 +401,7 @@ TEST_F(ZCashShieldSyncServiceTest, ScanBlocks) {
             OrchardBlockScanner::Result result = CreateResultForTesting(
                 std::move(orchard_tree_state), std::move(commitments),
                 blocks.back()->height, ToHex(blocks.back()->hash));
-            result.discovered_notes = notes;
+            result.orchard.discovered_notes = notes;
             std::move(callback).Run(std::move(result));
           })));
 
@@ -471,8 +471,8 @@ TEST_F(ZCashShieldSyncServiceTest, ScanBlocks) {
             OrchardBlockScanner::Result result = CreateResultForTesting(
                 std::move(tree_state), std::move(commitments),
                 blocks.back()->height, ToHex(blocks.back()->hash));
-            result.discovered_notes = discovered_notes;
-            result.found_spends = found_spends;
+            result.orchard.discovered_notes = discovered_notes;
+            result.orchard.found_spends = found_spends;
             std::move(callback).Run(std::move(result));
           })));
 

--- a/components/brave_wallet/browser/zcash/zcash_verify_chain_state_task.cc
+++ b/components/brave_wallet/browser/zcash/zcash_verify_chain_state_task.cc
@@ -144,7 +144,7 @@ void ZCashVerifyChainStateTask::OnGetChainTipBlock(
 
 void ZCashVerifyChainStateTask::GetMinCheckpointId() {
   context_->sync_state->AsyncCall(&OrchardSyncState::GetMinCheckpointId)
-      .WithArgs(context_->account_id.Clone())
+      .WithArgs(OrchardPool::kOrchard, context_->account_id.Clone())
       .Then(base::BindOnce(&ZCashVerifyChainStateTask::OnGetMinCheckpointId,
                            weak_ptr_factory_.GetWeakPtr()));
 }

--- a/components/brave_wallet/browser/zcash/zcash_verify_chain_state_task_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_verify_chain_state_task_unittest.cc
@@ -55,8 +55,9 @@ class MockOrchardSyncState : public OrchardSyncState {
   using OrchardSyncState::OrchardSyncState;
   ~MockOrchardSyncState() override {}
 
-  MOCK_METHOD1(GetMinCheckpointId,
+  MOCK_METHOD2(GetMinCheckpointId,
                base::expected<std::optional<uint32_t>, OrchardStorage::Error>(
+                   OrchardPool pool,
                    const mojom::AccountIdPtr& account_id));
 
   MOCK_METHOD3(Rewind,
@@ -132,8 +133,9 @@ class ZCashVerifyChainStateTaskTest : public testing::Test {
 };
 
 TEST_F(ZCashVerifyChainStateTaskTest, NoReorg) {
-  ON_CALL(mocked_sync_state(), GetMinCheckpointId(_))
-      .WillByDefault([](const mojom::AccountIdPtr& account_id) {
+  ON_CALL(mocked_sync_state(), GetMinCheckpointId(_, _))
+      .WillByDefault([](OrchardPool pool,
+                        const mojom::AccountIdPtr& account_id) {
         return base::ok(std::optional<uint32_t>(kLatestScannedBlock - 100u));
       });
 
@@ -181,8 +183,9 @@ TEST_F(ZCashVerifyChainStateTaskTest, NoReorg) {
 }
 
 TEST_F(ZCashVerifyChainStateTaskTest, Reorg_ChainTipBeforeLatestScannedBlock) {
-  ON_CALL(mocked_sync_state(), GetMinCheckpointId(_))
-      .WillByDefault([](const mojom::AccountIdPtr& account_id) {
+  ON_CALL(mocked_sync_state(), GetMinCheckpointId(_, _))
+      .WillByDefault([](OrchardPool pool,
+                        const mojom::AccountIdPtr& account_id) {
         return base::ok(std::optional<uint32_t>(kLatestScannedBlock - 100u));
       });
 
@@ -240,8 +243,9 @@ TEST_F(ZCashVerifyChainStateTaskTest, Reorg_ChainTipBeforeLatestScannedBlock) {
 }
 
 TEST_F(ZCashVerifyChainStateTaskTest, Reorg_ChainTipAfterLatestScannedBlock) {
-  ON_CALL(mocked_sync_state(), GetMinCheckpointId(_))
-      .WillByDefault([](const mojom::AccountIdPtr& account_id) {
+  ON_CALL(mocked_sync_state(), GetMinCheckpointId(_, _))
+      .WillByDefault([](OrchardPool pool,
+                        const mojom::AccountIdPtr& account_id) {
         return base::ok(std::optional<uint32_t>(kLatestScannedBlock - 100u));
       });
 
@@ -301,8 +305,9 @@ TEST_F(ZCashVerifyChainStateTaskTest, Reorg_ChainTipAfterLatestScannedBlock) {
 }
 
 TEST_F(ZCashVerifyChainStateTaskTest, Reorg_LatestBlockHashChanged) {
-  ON_CALL(mocked_sync_state(), GetMinCheckpointId(_))
-      .WillByDefault([](const mojom::AccountIdPtr& account_id) {
+  ON_CALL(mocked_sync_state(), GetMinCheckpointId(_, _))
+      .WillByDefault([](OrchardPool pool,
+                        const mojom::AccountIdPtr& account_id) {
         return base::ok(std::optional<uint32_t>(kLatestScannedBlock - 100u));
       });
 
@@ -359,10 +364,11 @@ TEST_F(ZCashVerifyChainStateTaskTest, Reorg_LatestBlockHashChanged) {
 }
 
 TEST_F(ZCashVerifyChainStateTaskTest, Error_CheckpointIdFailed) {
-  ON_CALL(mocked_sync_state(), GetMinCheckpointId(_))
-      .WillByDefault([](const mojom::AccountIdPtr& account_id) {
-        return base::unexpected(OrchardStorage::Error());
-      });
+  ON_CALL(mocked_sync_state(), GetMinCheckpointId(_, _))
+      .WillByDefault(
+          [](OrchardPool pool, const mojom::AccountIdPtr& account_id) {
+            return base::unexpected(OrchardStorage::Error());
+          });
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault([](const std::string& chain_id,
@@ -408,10 +414,11 @@ TEST_F(ZCashVerifyChainStateTaskTest, Error_CheckpointIdFailed) {
 }
 
 TEST_F(ZCashVerifyChainStateTaskTest, Error_NoCheckpointId) {
-  ON_CALL(mocked_sync_state(), GetMinCheckpointId(_))
-      .WillByDefault([](const mojom::AccountIdPtr& account_id) {
-        return base::ok(std::nullopt);
-      });
+  ON_CALL(mocked_sync_state(), GetMinCheckpointId(_, _))
+      .WillByDefault(
+          [](OrchardPool pool, const mojom::AccountIdPtr& account_id) {
+            return base::ok(std::nullopt);
+          });
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault([](const std::string& chain_id,
@@ -457,8 +464,9 @@ TEST_F(ZCashVerifyChainStateTaskTest, Error_NoCheckpointId) {
 }
 
 TEST_F(ZCashVerifyChainStateTaskTest, Error_LatestBlockFailed) {
-  ON_CALL(mocked_sync_state(), GetMinCheckpointId(_))
-      .WillByDefault([](const mojom::AccountIdPtr& account_id) {
+  ON_CALL(mocked_sync_state(), GetMinCheckpointId(_, _))
+      .WillByDefault([](OrchardPool pool,
+                        const mojom::AccountIdPtr& account_id) {
         return base::ok(std::optional<uint32_t>(kLatestScannedBlock - 100u));
       });
 
@@ -512,8 +520,9 @@ TEST_F(ZCashVerifyChainStateTaskTest, Error_LatestBlockFailed) {
 }
 
 TEST_F(ZCashVerifyChainStateTaskTest, Error_TreeStateFailed) {
-  ON_CALL(mocked_sync_state(), GetMinCheckpointId(_))
-      .WillByDefault([](const mojom::AccountIdPtr& account_id) {
+  ON_CALL(mocked_sync_state(), GetMinCheckpointId(_, _))
+      .WillByDefault([](OrchardPool pool,
+                        const mojom::AccountIdPtr& account_id) {
         return base::ok(std::optional<uint32_t>(kLatestScannedBlock - 100u));
       });
 

--- a/components/brave_wallet/browser/zcash/zcash_wallet_service_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_wallet_service_unittest.cc
@@ -125,15 +125,17 @@ class MockOrchardSyncState : public OrchardSyncState {
   using OrchardSyncState::OrchardSyncState;
   ~MockOrchardSyncState() override {}
 
-  MOCK_METHOD2(
+  MOCK_METHOD3(
       GetSpendableNotes,
       base::expected<std::optional<OrchardSyncState::SpendableNotesBundle>,
                      OrchardStorage::Error>(
+          OrchardPool pool,
           const mojom::AccountIdPtr& account_id,
           const OrchardAddrRawPart& internal_addr));
 
-  MOCK_METHOD3(CalculateWitnessForCheckpoint,
+  MOCK_METHOD4(CalculateWitnessForCheckpoint,
                base::expected<std::vector<OrchardInput>, OrchardStorage::Error>(
+                   OrchardPool pool,
                    const mojom::AccountIdPtr& account_id,
                    const std::vector<OrchardInput>& notes,
                    uint32_t checkpoint_position));
@@ -395,8 +397,8 @@ TEST_F(ZCashWalletServiceUnitTest, GetBalanceWithShielded) {
             std::move(callback).Run(std::move(response));
           });
 
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([](OrchardPool pool, const mojom::AccountIdPtr& account_id,
                         const OrchardAddrRawPart& internal_addr) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -496,8 +498,8 @@ TEST_F(ZCashWalletServiceUnitTest, GetBalanceWithShielded_FeatureDisabled) {
 
   OrchardBlockScanner::Result result = CreateResultForTesting(
       OrchardTreeState(), std::vector<OrchardCommitment>(), 50000, "hash50000");
-  result.discovered_notes = std::vector<OrchardNote>({note});
-  result.found_spends = std::vector<OrchardNoteSpend>();
+  result.orchard.discovered_notes = std::vector<OrchardNote>({note});
+  result.orchard.found_spends = std::vector<OrchardNoteSpend>();
 
   zcash_wallet_service_->sync_state()
       .AsyncCall(&OrchardSyncState::ApplyScanResults)
@@ -1837,8 +1839,9 @@ TEST_F(ZCashWalletServiceUnitTest, MAYBE_ShieldFunds) {
         std::move(callback).Run(std::move(tree_state));
       });
 
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& internal_addr) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         return spendable_notes_bundle;
@@ -2595,8 +2598,9 @@ TEST_F(ZCashWalletServiceUnitTest, MAYBE_SendShieldedFunds) {
         std::move(callback).Run(std::move(response));
       });
 
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& internal_addr) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -2645,8 +2649,9 @@ TEST_F(ZCashWalletServiceUnitTest, MAYBE_SendShieldedFunds) {
         return spendable_notes_bundle;
       });
 
-  ON_CALL(mock_orchard_sync_state(), CalculateWitnessForCheckpoint(_, _, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), CalculateWitnessForCheckpoint(_, _, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const std::vector<OrchardInput>& notes,
                          uint32_t checkpoint_position) {
         std::vector<OrchardInput> notes_with_witness = notes;
@@ -3248,8 +3253,9 @@ TEST_F(ZCashWalletServiceUnitTest, MAYBE_UnshieldFunds) {
         std::move(callback).Run(std::move(response));
       });
 
-  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const OrchardAddrRawPart& internal_addr) {
         OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
         {
@@ -3297,8 +3303,9 @@ TEST_F(ZCashWalletServiceUnitTest, MAYBE_UnshieldFunds) {
         spendable_notes_bundle.anchor_block_id = 3373024u;
         return spendable_notes_bundle;
       });
-  ON_CALL(mock_orchard_sync_state(), CalculateWitnessForCheckpoint(_, _, _))
-      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+  ON_CALL(mock_orchard_sync_state(), CalculateWitnessForCheckpoint(_, _, _, _))
+      .WillByDefault([&](OrchardPool pool,
+                         const mojom::AccountIdPtr& account_id,
                          const std::vector<OrchardInput>& notes,
                          uint32_t checkpoint_position) {
         std::vector<OrchardInput> notes_with_witness = notes;


### PR DESCRIPTION
Extends the Rust bridge and orchard_block_decoder to decode Ironwood actions alongside Orchard ones, and updates the Orchard block scanner/sync state to detect and persist discovered Ironwood notes during batch block scanning.

Wiring this into the real sync flow (feature-gated Ironwood tree state computation in ZCashBlocksBatchScanTask/ZCashShieldSyncService) is left for a follow-up change to keep this PR scoped to the decode/scan/storage layer.

Resolves https://github.com/brave/brave-browser/issues/57686

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
