### PR TITLE
[deps] Migrate `build/download_dep.py` to `EXTRA_DEPS`

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -82,17 +82,19 @@ hooks = [
     'name': 'download_sparkle',
     'pattern': '.',
     'condition': 'checkout_mac and download_prebuilt_sparkle',
-    'action': ['vpython3', 'build/download_dep.py',
-               'sparkle/sparkle-1.24.4.tar.gz',
-               '//build/mac_files/sparkle_binaries'],
+    'action': ['vpython3',
+               'tools/cr/install_extra_deps.py',
+               'sync',
+               'src/build/mac_files/sparkle_binaries']
   },
   {
     'name': 'download_omaha4',
     'pattern': '.',
     'condition': 'checkout_mac',
-    'action': ['vpython3', 'build/download_dep.py',
-               'omaha4/BraveUpdater-143.1.87.74.zip',
-               '//brave/third_party/updater/mac'],
+    'action': ['vpython3',
+               'tools/cr/install_extra_deps.py',
+               'sync',
+               'src/brave/third_party/updater/mac']
   },
   {
     'name': 'update_pip',
@@ -118,17 +120,19 @@ hooks = [
     'name': 'wireguard_nt',
     'pattern': '.',
     'condition': 'checkout_win',
-    'action': ['vpython3', 'build/download_dep.py',
-               'brave-vpn-wireguard-dlls/brave-vpn-wireguard-nt-dlls-0.10.1.zip',
-               '//brave/third_party/brave-vpn-wireguard-nt-dlls'],
+    'action': ['vpython3',
+               'tools/cr/install_extra_deps.py',
+               'sync',
+               'src/brave/third_party/brave-vpn-wireguard-nt-dlls']
   },
   {
     'name': 'wireguard_tunnel',
     'pattern': '.',
     'condition': 'checkout_win',
-    'action': ['vpython3', 'build/download_dep.py',
-               'brave-vpn-wireguard-dlls/brave-vpn-wireguard-tunnel-dlls-v0.5.3.zip',
-               '//brave/third_party/brave-vpn-wireguard-tunnel-dlls'],
+    'action': ['vpython3',
+               'tools/cr/install_extra_deps.py',
+               'sync',
+               'src/brave/third_party/brave-vpn-wireguard-tunnel-dlls']
   },
   {
     'name': 'download_wintun',

--- a/EXTRA_DEPS
+++ b/EXTRA_DEPS
@@ -151,4 +151,44 @@ extra_deps = {
             },
         ],
     },
+    'src/build/mac_files/sparkle_binaries': {
+        'bucket': 'https://brave-build-deps-public.s3.brave.com/sparkle/',
+        'objects': [
+            {
+                'object_name': 'sparkle-1.24.4.tar.gz',
+                'sha256sum': '45fbd10cda63195cf2dfd32bc6bfe24c550cd00d419fc5039052507c6d9986f7',
+                'size_bytes': 1404428,
+            },
+        ],
+    },
+    'src/brave/third_party/updater/mac': {
+        'bucket': 'https://brave-build-deps-public.s3.brave.com/omaha4/',
+        'objects': [
+            {
+                'object_name': 'BraveUpdater-143.1.87.74.zip',
+                'sha256sum': 'ca3255dca4dd0e197a6f1a2d57456d0ce33ac4f62c95664a7c32671397fe00a6',
+                'size_bytes': 10989909,
+            },
+        ],
+    },
+    'src/brave/third_party/brave-vpn-wireguard-nt-dlls': {
+        'bucket': 'https://brave-build-deps-public.s3.brave.com/brave-vpn-wireguard-dlls/',
+        'objects': [
+            {
+                'object_name': 'brave-vpn-wireguard-nt-dlls-0.10.1.zip',
+                'sha256sum': '31ed28a2b7178d51ece415bfc2fdde546ed76325b4153067204524e3c37a5326',
+                'size_bytes': 1309246,
+            },
+        ],
+    },
+    'src/brave/third_party/brave-vpn-wireguard-tunnel-dlls': {
+        'bucket': 'https://brave-build-deps-public.s3.brave.com/brave-vpn-wireguard-dlls/',
+        'objects': [
+            {
+                'object_name': 'brave-vpn-wireguard-tunnel-dlls-v0.5.3.zip',
+                'sha256sum': '316db78a5a090e013f980b7068e3a1182e18da10e14159b7f5ef80699ce79c98',
+                'size_bytes': 3593760,
+            },
+        ],
+    },
 }


### PR DESCRIPTION
This change migrates all downloads being done during sync by
`build/download_dep.py` to `EXTRA_DEPS`

Bug: https://github.com/brave/brave-browser/issues/56723
