### PR TITLE
[ads] Show confirmation toast when clearing Brave Ads data in settings

### DIFF
--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -872,6 +872,12 @@
   <message name="IDS_SETTINGS_CLEAR_BRAVE_ADS_DATA" desc="The label for the link to clear 'Brave Ads' data">
     Clear Brave Ads data...
   </message>
+  <message name="IDS_SETTINGS_CLEAR_BRAVE_ADS_DATA_TOAST_LABEL" desc="The label for the toast shown after Brave Ads data is cleared">
+    Brave Ads data cleared
+  </message>
+  <message name="IDS_SETTINGS_CLEAR_BRAVE_ADS_DATA_ERROR_TOAST_LABEL" desc="The label for the toast shown when clearing Brave Ads data fails">
+    Couldn't clear Brave Ads data. Try again.
+  </message>
   <message name="IDS_SETTINGS_RESET_REWARDS_DATA" desc="The label for opening rewards manage wallet dialog">
     Reset Brave Rewards data...
   </message>

--- a/browser/resources/settings/brave_clear_browsing_data_dialog/brave_clear_browsing_data_dialog_behavior.ts
+++ b/browser/resources/settings/brave_clear_browsing_data_dialog/brave_clear_browsing_data_dialog_behavior.ts
@@ -45,6 +45,8 @@ export class BraveSettingsClearBrowsingDataDialogElement
   private clearDataBrowserProxy_: BraveClearBrowsingDataDialogBrowserProxy =
     BraveClearBrowsingDataDialogBrowserProxyImpl.getInstance()
 
+  private isClearingBraveAdsData_ = false
+
   constructor() {
     super()
 
@@ -217,9 +219,31 @@ export class BraveSettingsClearBrowsingDataDialogElement
   /**
    * Clears Brave Ads data.
    */
-  private clearBraveAdsData_ = (e: Event) => {
+  private clearBraveAdsData_ = async (e: Event) => {
     e.preventDefault()
-    this.clearDataBrowserProxy_.clearBraveAdsData()
-    this.$.deleteBrowsingDataDialog.close()
+
+    if (this.isClearingBraveAdsData_) {
+      return
+    }
+    this.isClearingBraveAdsData_ = true
+
+    const success = await this.clearDataBrowserProxy_.clearBraveAdsData()
+
+    this.isClearingBraveAdsData_ = false
+
+    this.dispatchEvent(new CustomEvent('browsing-data-deleted', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        deletionConfirmationText: loadTimeData.getString(
+          success
+            ? 'clearBraveAdsDataToastLabel'
+            : 'clearBraveAdsDataErrorToastLabel')
+      }
+    }))
+
+    if (this.$.deleteBrowsingDataDialog.open) {
+      this.$.deleteBrowsingDataDialog.close()
+    }
   }
 }

--- a/browser/resources/settings/brave_clear_browsing_data_dialog/brave_clear_browsing_data_dialog_proxy.ts
+++ b/browser/resources/settings/brave_clear_browsing_data_dialog/brave_clear_browsing_data_dialog_proxy.ts
@@ -7,7 +7,7 @@
 
  export interface BraveClearBrowsingDataDialogBrowserProxy {
   getBraveRewardsEnabled: () => Promise<boolean>
-  clearBraveAdsData: () => void
+  clearBraveAdsData: () => Promise<boolean>
  }
 
  export class BraveClearBrowsingDataDialogBrowserProxyImpl
@@ -18,7 +18,7 @@
   }
 
   clearBraveAdsData() {
-    chrome.send('clearBraveAdsData')
+    return sendWithPromise<boolean>('clearBraveAdsData')
   }
 
   static getInstance(): BraveClearBrowsingDataDialogBrowserProxyImpl {

--- a/browser/ui/webui/settings/brave_clear_browsing_data_handler.cc
+++ b/browser/ui/webui/settings/brave_clear_browsing_data_handler.cc
@@ -5,10 +5,11 @@
 
 #include "brave/browser/ui/webui/settings/brave_clear_browsing_data_handler.h"
 
+#include <utility>
+
 #include "base/check.h"
 #include "base/check_op.h"
 #include "base/functional/bind.h"
-#include "base/functional/callback_helpers.h"
 #include "base/values.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
 #include "chrome/browser/profiles/profile.h"
@@ -67,11 +68,33 @@ void BraveClearBrowsingDataHandler::HandleGetBraveRewardsEnabled(
 
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
 void BraveClearBrowsingDataHandler::HandleClearBraveAdsData(
-    const base::ListValue& /*args*/) {
-  if (auto* ads_service =
-          brave_ads::AdsServiceFactory::GetForProfile(profile_)) {
-    ads_service->ClearData(/*intentional*/ base::DoNothing());
+    const base::ListValue& args) {
+  CHECK_EQ(args.size(), 1U);
+
+  AllowJavascript();
+
+  base::Value callback_id = args[0].Clone();
+
+  auto* const ads_service =
+      brave_ads::AdsServiceFactory::GetForProfile(profile_);
+  if (!ads_service) {
+    OnClearBraveAdsDataComplete(std::move(callback_id), /*success=*/false);
+    return;
   }
+
+  ads_service->ClearData(base::BindOnce(
+      &BraveClearBrowsingDataHandler::OnClearBraveAdsDataComplete,
+      weak_ptr_factory_.GetWeakPtr(), std::move(callback_id)));
+}
+
+void BraveClearBrowsingDataHandler::OnClearBraveAdsDataComplete(
+    base::Value callback_id,
+    bool success) {
+  if (!IsJavascriptAllowed()) {
+    return;
+  }
+
+  ResolveJavascriptCallback(callback_id, base::Value(success));
 }
 #endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 

--- a/browser/ui/webui/settings/brave_clear_browsing_data_handler.h
+++ b/browser/ui/webui/settings/brave_clear_browsing_data_handler.h
@@ -6,11 +6,17 @@
 #ifndef BRAVE_BROWSER_UI_WEBUI_SETTINGS_BRAVE_CLEAR_BROWSING_DATA_HANDLER_H_
 #define BRAVE_BROWSER_UI_WEBUI_SETTINGS_BRAVE_CLEAR_BROWSING_DATA_HANDLER_H_
 
+#include "base/memory/weak_ptr.h"
 #include "brave/components/brave_ads/buildflags/buildflags.h"
 #include "chrome/browser/ui/webui/settings/settings_clear_browsing_data_handler.h"
 #include "components/prefs/pref_change_registrar.h"
 
 class Profile;
+
+namespace base {
+class ListValue;
+class Value;
+}  // namespace base
 
 namespace settings {
 
@@ -32,6 +38,7 @@ class BraveClearBrowsingDataHandler : public ClearBrowsingDataHandler {
 
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
   void HandleClearBraveAdsData(const base::ListValue& args);
+  void OnClearBraveAdsDataComplete(base::Value callback_id, bool success);
 #endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 
   void OnRewardsEnabledPreferenceChanged();
@@ -39,6 +46,10 @@ class BraveClearBrowsingDataHandler : public ClearBrowsingDataHandler {
   raw_ptr<Profile> profile_ = nullptr;
 
   PrefChangeRegistrar pref_change_registrar_;
+
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+  base::WeakPtrFactory<BraveClearBrowsingDataHandler> weak_ptr_factory_{this};
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 };
 
 }  // namespace settings

--- a/browser/ui/webui/settings/brave_clear_browsing_data_handler_unittest.cc
+++ b/browser/ui/webui/settings/brave_clear_browsing_data_handler_unittest.cc
@@ -6,8 +6,11 @@
 #include "brave/browser/ui/webui/settings/brave_clear_browsing_data_handler.h"
 
 #include <memory>
+#include <string>
+#include <utility>
 
 #include "base/test/bind.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/values.h"
 #include "brave/browser/brave_ads/ads_service_factory.h"
 #include "brave/components/brave_ads/core/browser/service/test/ads_service_mock.h"
@@ -69,8 +72,31 @@ class TestingBraveClearBrowsingDataHandler
   size_t javascript_allowed_count_ = 0;
 };
 
+void VerifyAdsDataClearedResponseExpectation(content::TestWebUI& test_web_ui,
+                                             const std::string& callback_id,
+                                             bool expected_success) {
+  const content::TestWebUI::CallData& call_data =
+      *test_web_ui.call_data().back();
+  EXPECT_EQ("cr.webUIResponse", call_data.function_name());
+  EXPECT_EQ(callback_id, call_data.arg1()->GetString());
+  EXPECT_TRUE(/*resolved*/ call_data.arg2()->GetBool());
+  EXPECT_EQ(expected_success, /*success*/ call_data.arg3()->GetBool());
+}
+
 class BraveClearBrowsingDataHandlerTest : public testing::Test {
  protected:
+  brave_ads::AdsServiceMock* SetUpAdsServiceMock() {
+    brave_ads::AdsServiceFactory::GetInstance()->SetTestingFactory(
+        profile_.get(),
+        base::BindLambdaForTesting([](content::BrowserContext* /*context*/)
+                                       -> std::unique_ptr<KeyedService> {
+          return std::make_unique<brave_ads::AdsServiceMock>();
+        }));
+
+    return static_cast<brave_ads::AdsServiceMock*>(
+        brave_ads::AdsServiceFactory::GetForProfile(profile_.get()));
+  }
+
   content::BrowserTaskEnvironment browser_task_environment_;
 
   std::unique_ptr<TestingProfile> profile_ = TestingProfile::Builder().Build();
@@ -85,14 +111,14 @@ TEST_F(BraveClearBrowsingDataHandlerTest,
 
   // Act
   handler.HandleGetBraveRewardsEnabled(
-      /*args=*/base::ListValue().Append(/*callback_id*/ "foo"));
+      /*args=*/base::ListValue().Append(/*callback_id=*/"foo"));
 
   // Assert
   EXPECT_EQ(1U, handler.javascript_allowed_count());
   const content::TestWebUI::CallData& call_data =
       *handler.test_web_ui()->call_data().back();
   EXPECT_EQ("cr.webUIResponse", call_data.function_name());
-  EXPECT_EQ(/*callback_id*/ "foo", call_data.arg1()->GetString());
+  EXPECT_EQ(/*callback_id=*/"foo", call_data.arg1()->GetString());
   EXPECT_TRUE(/*resolved*/ call_data.arg2()->GetBool());
   EXPECT_FALSE(/*rewards_enabled*/ call_data.arg3()->GetBool());
 }
@@ -106,46 +132,124 @@ TEST_F(BraveClearBrowsingDataHandlerTest,
 
   // Act
   handler.HandleGetBraveRewardsEnabled(
-      /*args=*/base::ListValue().Append(/*callback_id*/ "foo"));
+      /*args=*/base::ListValue().Append(/*callback_id=*/"foo"));
 
   // Assert
   EXPECT_EQ(1U, handler.javascript_allowed_count());
   const content::TestWebUI::CallData& call_data =
       *handler.test_web_ui()->call_data().back();
   EXPECT_EQ("cr.webUIResponse", call_data.function_name());
-  EXPECT_EQ(/*callback_id*/ "foo", call_data.arg1()->GetString());
+  EXPECT_EQ(/*callback_id=*/"foo", call_data.arg1()->GetString());
   EXPECT_TRUE(/*resolved*/ call_data.arg2()->GetBool());
   EXPECT_TRUE(/*rewards_enabled*/ call_data.arg3()->GetBool());
 }
 
 TEST_F(BraveClearBrowsingDataHandlerTest,
-       HandleClearBraveAdsDataWithNullServiceDoesNotCrash) {
+       HandleClearBraveAdsDataResolvesWithFailureWhenServiceIsNull) {
   // Arrange
   TestingBraveClearBrowsingDataHandler handler(profile_.get());
 
-  // Act & Assert
-  handler.HandleClearBraveAdsData(/*args=*/{});
+  // Act
+  handler.HandleClearBraveAdsData(
+      /*args=*/base::ListValue().Append(/*callback_id=*/"foo"));
+
+  // Assert
+  EXPECT_EQ(1U, handler.javascript_allowed_count());
+  VerifyAdsDataClearedResponseExpectation(*handler.test_web_ui(),
+                                          /*callback_id=*/"foo",
+                                          /*expected_success=*/false);
 }
 
 TEST_F(BraveClearBrowsingDataHandlerTest,
-       HandleClearBraveAdsDataCallsClearDataOnAdsService) {
+       HandleClearBraveAdsDataResolvesWithSuccessWhenClearingSucceeds) {
   // Arrange
-  brave_ads::AdsServiceFactory::GetInstance()->SetTestingFactory(
-      profile_.get(),
-      base::BindLambdaForTesting([](content::BrowserContext* /*context*/)
-                                     -> std::unique_ptr<KeyedService> {
-        return std::make_unique<brave_ads::AdsServiceMock>();
-      }));
-
-  auto* const ads_service_mock = static_cast<brave_ads::AdsServiceMock*>(
-      brave_ads::AdsServiceFactory::GetForProfile(profile_.get()));
+  brave_ads::AdsServiceMock* const ads_service_mock = SetUpAdsServiceMock();
 
   TestingBraveClearBrowsingDataHandler handler(profile_.get());
 
-  EXPECT_CALL(*ads_service_mock, ClearData);
+  EXPECT_CALL(*ads_service_mock, ClearData)
+      .WillOnce(base::test::RunOnceCallback<0>(/*success=*/true));
 
   // Act
-  handler.HandleClearBraveAdsData(/*args=*/{});
+  handler.HandleClearBraveAdsData(
+      /*args=*/base::ListValue().Append(/*callback_id=*/"foo"));
+
+  // Assert
+  EXPECT_EQ(1U, handler.javascript_allowed_count());
+  VerifyAdsDataClearedResponseExpectation(*handler.test_web_ui(),
+                                          /*callback_id=*/"foo",
+                                          /*expected_success=*/true);
+}
+
+TEST_F(BraveClearBrowsingDataHandlerTest,
+       HandleClearBraveAdsDataResolvesWithFailureWhenClearingFails) {
+  // Arrange
+  brave_ads::AdsServiceMock* const ads_service_mock = SetUpAdsServiceMock();
+
+  TestingBraveClearBrowsingDataHandler handler(profile_.get());
+
+  EXPECT_CALL(*ads_service_mock, ClearData)
+      .WillOnce(base::test::RunOnceCallback<0>(/*success=*/false));
+
+  // Act
+  handler.HandleClearBraveAdsData(
+      /*args=*/base::ListValue().Append(/*callback_id=*/"foo"));
+
+  // Assert
+  EXPECT_EQ(1U, handler.javascript_allowed_count());
+  VerifyAdsDataClearedResponseExpectation(*handler.test_web_ui(),
+                                          /*callback_id=*/"foo",
+                                          /*expected_success=*/false);
+}
+
+TEST_F(
+    BraveClearBrowsingDataHandlerTest,
+    HandleClearBraveAdsDataDoesNotCrashWhenHandlerDestroyedBeforeClearingCompletes) {
+  // Arrange
+  brave_ads::AdsServiceMock* const ads_service_mock = SetUpAdsServiceMock();
+
+  brave_ads::ResultCallback captured_callback;
+  EXPECT_CALL(*ads_service_mock, ClearData)
+      .WillOnce([&captured_callback](brave_ads::ResultCallback callback) {
+        captured_callback = std::move(callback);
+      });
+
+  auto handler =
+      std::make_unique<TestingBraveClearBrowsingDataHandler>(profile_.get());
+  handler->HandleClearBraveAdsData(
+      /*args=*/base::ListValue().Append(/*callback_id=*/"foo"));
+  ASSERT_TRUE(captured_callback);
+
+  // Act
+  handler.reset();
+
+  // Assert
+  std::move(captured_callback).Run(/*success=*/true);
+}
+
+TEST_F(BraveClearBrowsingDataHandlerTest,
+       HandleClearBraveAdsDataDoesNotResolveAfterJavascriptDisallowed) {
+  // Arrange
+  brave_ads::AdsServiceMock* const ads_service_mock = SetUpAdsServiceMock();
+
+  brave_ads::ResultCallback captured_callback;
+  EXPECT_CALL(*ads_service_mock, ClearData)
+      .WillOnce([&captured_callback](brave_ads::ResultCallback callback) {
+        captured_callback = std::move(callback);
+      });
+
+  TestingBraveClearBrowsingDataHandler handler(profile_.get());
+  handler.HandleClearBraveAdsData(
+      /*args=*/base::ListValue().Append(/*callback_id=*/"foo"));
+  ASSERT_TRUE(captured_callback);
+
+  handler.DisallowJavascript();
+
+  // Act
+  std::move(captured_callback).Run(/*success=*/true);
+
+  // Assert
+  EXPECT_TRUE(handler.test_web_ui()->call_data().empty());
 }
 
 TEST_F(BraveClearBrowsingDataHandlerTest,

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -840,6 +840,10 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
 
       // Delete browsing data settings
       {"clearBraveAdsData", IDS_SETTINGS_CLEAR_BRAVE_ADS_DATA},
+      {"clearBraveAdsDataToastLabel",
+       IDS_SETTINGS_CLEAR_BRAVE_ADS_DATA_TOAST_LABEL},
+      {"clearBraveAdsDataErrorToastLabel",
+       IDS_SETTINGS_CLEAR_BRAVE_ADS_DATA_ERROR_TOAST_LABEL},
       {"resetRewardsData", IDS_SETTINGS_RESET_REWARDS_DATA},
 
       // Misc (TODO: Organize this)

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -1041,8 +1041,10 @@ void AdsServiceImpl::ShutdownAds(ResultCallback callback) {
   // Use `weak_ptr_factory_` because `bat_ads_service_weak_ptr_factory_` is
   // invalidated to cancel pending startups; this callback must always fire.
   bat_ads_associated_remote_->Shutdown(
-      base::BindOnce(&AdsServiceImpl::ShutdownAdsCallback,
-                     weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
+      mojo::WrapCallbackWithDefaultInvokeIfNotRun(
+          base::BindOnce(&AdsServiceImpl::ShutdownAdsCallback,
+                         weak_ptr_factory_.GetWeakPtr(), std::move(callback)),
+          /*success=*/false));
 }
 
 void AdsServiceImpl::ShutdownAdsCallback(ResultCallback callback,

--- a/components/brave_ads/browser/ads_service_impl_unittest.cc
+++ b/components/brave_ads/browser/ads_service_impl_unittest.cc
@@ -15,6 +15,7 @@
 #include "base/test/run_until.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
+#include "base/test/test_future.h"
 #include "base/time/time.h"
 #include "base/values.h"
 #include "brave/components/brave_ads/browser/test/fake_ads_service_delegate.h"
@@ -124,6 +125,10 @@ class BraveAdsAdsServiceImplTest : public testing::Test {
   }
 
   void Shutdown() { ads_service_->Shutdown(); }
+
+  void ClearData(ResultCallback callback) {
+    ads_service_->ClearData(std::move(callback));
+  }
 
   void NotifyBrowserWillShutdown() {
     shutdown_monitor_->NotifyAppTerminating();
@@ -737,5 +742,23 @@ TEST_F(BraveAdsAdsServiceImplTest,
                         base::Value(true));
 }
 #endif  // !BUILDFLAG(IS_ANDROID)
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       ClearDataReportsFailureWhenBatAdsDisconnectsDuringShutdown) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  bat_ads_service_factory_->set_simulate_shutdown_disconnect();
+  Startup();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
+
+  base::test::TestFuture<bool> test_future;
+
+  // Act
+  ClearData(test_future.GetCallback());
+
+  // Assert
+  EXPECT_FALSE(test_future.Get());
+}
 
 }  // namespace brave_ads

--- a/components/brave_ads/browser/test/fake_bat_ads.cc
+++ b/components/brave_ads/browser/test/fake_bat_ads.cc
@@ -17,9 +17,11 @@
 namespace brave_ads::test {
 
 FakeBatAds::FakeBatAds(base::RepeatingClosure initialize_callback,
-                       bool simulate_initialization_failure)
+                       bool simulate_initialization_failure,
+                       bool simulate_shutdown_disconnect)
     : initialize_callback_(std::move(initialize_callback)),
-      simulate_initialization_failure_(simulate_initialization_failure) {}
+      simulate_initialization_failure_(simulate_initialization_failure),
+      simulate_shutdown_disconnect_(simulate_shutdown_disconnect) {}
 
 FakeBatAds::~FakeBatAds() = default;
 
@@ -39,6 +41,14 @@ void FakeBatAds::Initialize(brave_ads::mojom::WalletInfoPtr /*mojom_wallet*/,
 }
 
 void FakeBatAds::Shutdown(ShutdownCallback callback) {
+  if (simulate_shutdown_disconnect_) {
+    // Simulate the bat ads utility process disconnecting mid-shutdown by
+    // severing the pipe instead of replying, dropping `callback` without
+    // running it.
+    bat_ads_associated_receiver_.reset();
+    return;
+  }
+
   std::move(callback).Run(/*success=*/true);
 }
 

--- a/components/brave_ads/browser/test/fake_bat_ads.h
+++ b/components/brave_ads/browser/test/fake_bat_ads.h
@@ -27,9 +27,13 @@ namespace brave_ads::test {
 // all other methods are no-ops.
 class FakeBatAds : public bat_ads::mojom::BatAds {
  public:
-  // `initialize_callback` is called when `Initialize` succeeds.
+  // `initialize_callback` is called when `Initialize` succeeds. When
+  // `simulate_shutdown_disconnect` is true, `Shutdown` severs the pipe
+  // instead of replying, simulating the bat ads utility process
+  // disconnecting mid-shutdown.
   FakeBatAds(base::RepeatingClosure initialize_callback,
-             bool simulate_initialization_failure);
+             bool simulate_initialization_failure,
+             bool simulate_shutdown_disconnect);
 
   FakeBatAds(const FakeBatAds&) = delete;
   FakeBatAds& operator=(const FakeBatAds&) = delete;
@@ -101,6 +105,7 @@ class FakeBatAds : public bat_ads::mojom::BatAds {
  private:
   base::RepeatingClosure initialize_callback_;
   bool simulate_initialization_failure_;
+  bool simulate_shutdown_disconnect_;
 
   mojo::AssociatedReceiver<bat_ads::mojom::BatAds> bat_ads_associated_receiver_{
       this};

--- a/components/brave_ads/browser/test/fake_bat_ads_service.cc
+++ b/components/brave_ads/browser/test/fake_bat_ads_service.cc
@@ -17,10 +17,12 @@ namespace brave_ads::test {
 
 FakeBatAdsService::FakeBatAdsService(base::RepeatingClosure initialize_callback,
                                      base::RepeatingClosure shutdown_callback,
-                                     bool simulate_initialization_failure)
+                                     bool simulate_initialization_failure,
+                                     bool simulate_shutdown_disconnect)
     : shutdown_callback_(std::move(shutdown_callback)),
       bat_ads_(std::move(initialize_callback),
-               simulate_initialization_failure) {}
+               simulate_initialization_failure,
+               simulate_shutdown_disconnect) {}
 
 FakeBatAdsService::~FakeBatAdsService() = default;
 

--- a/components/brave_ads/browser/test/fake_bat_ads_service.h
+++ b/components/brave_ads/browser/test/fake_bat_ads_service.h
@@ -29,7 +29,8 @@ class FakeBatAdsService : public bat_ads::mojom::BatAdsService {
  public:
   FakeBatAdsService(base::RepeatingClosure initialize_callback,
                     base::RepeatingClosure shutdown_callback,
-                    bool simulate_initialization_failure);
+                    bool simulate_initialization_failure,
+                    bool simulate_shutdown_disconnect);
 
   FakeBatAdsService(const FakeBatAdsService&) = delete;
   FakeBatAdsService& operator=(const FakeBatAdsService&) = delete;

--- a/components/brave_ads/browser/test/fake_bat_ads_service_factory.cc
+++ b/components/brave_ads/browser/test/fake_bat_ads_service_factory.cc
@@ -59,7 +59,7 @@ mojo::Remote<bat_ads::mojom::BatAdsService> FakeBatAdsServiceFactory::Launch()
                           base::Unretained(this)),
       base::BindRepeating(&FakeBatAdsServiceFactory::OnShutdown,
                           base::Unretained(this)),
-      simulate_initialization_failure_);
+      simulate_initialization_failure_, simulate_shutdown_disconnect_);
   bat_ads_service_->BindReceiver(
       bat_ads_service_remote.BindNewPipeAndPassReceiver());
 

--- a/components/brave_ads/browser/test/fake_bat_ads_service_factory.h
+++ b/components/brave_ads/browser/test/fake_bat_ads_service_factory.h
@@ -44,6 +44,12 @@ class FakeBatAdsServiceFactory : public BatAdsServiceFactory {
     simulate_initialization_failure_ = true;
   }
 
+  // Causes subsequently launched services to disconnect instead of replying
+  // when `Shutdown` is called.
+  void set_simulate_shutdown_disconnect() {
+    simulate_shutdown_disconnect_ = true;
+  }
+
   // BatAdsServiceFactory:
   mojo::Remote<bat_ads::mojom::BatAdsService> Launch() const override;
 
@@ -62,6 +68,7 @@ class FakeBatAdsServiceFactory : public BatAdsServiceFactory {
   mutable size_t shutdown_count_ = 0;
 
   bool simulate_initialization_failure_ = false;
+  bool simulate_shutdown_disconnect_ = false;
 
   // Owns the service implementation so the receiver stays alive for as long
   // as the `mojo::Remote` returned by `Launch` is in use.


### PR DESCRIPTION
Clicking "Clear Brave Ads data..." in brave://settings/clearBrowserData closed the dialog with no feedback, discarding AdsService::ClearData's result via base::DoNothing(). The dialog's click handler now awaits the clearing result and reuses Chromium's existing browsing-data-deleted toast bridge already wired into the privacy settings page, so no new UI plumbing is needed. The WebUI handler resolves the JS callback with the actual result instead of discarding it, guarded by a WeakPtrFactory against the handler being destroyed mid-flight. Also wraps AdsServiceImpl::ShutdownAds's mojo callback with WrapCallbackWithDefaultInvokeIfNotRun, matching sibling methods, since this feedback path now depends on that callback always firing.

<!-- Add brave-browser issue below that this PR will resolve -->

- Resolves https://github.com/brave/brave-browser/issues/46546
- Resolves https://github.com/brave/brave-browser/issues/46140

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
