### PR TITLE
[PSST] Add support of the renderer initiated navigations

### DIFF
--- a/browser/psst/psst_tab_web_contents_observer.cc
+++ b/browser/psst/psst_tab_web_contents_observer.cc
@@ -11,7 +11,6 @@
 #include "base/functional/bind.h"
 #include "base/json/json_writer.h"
 #include "base/strings/strcat.h"
-#include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"
 #include "base/timer/timer.h"
@@ -23,7 +22,6 @@
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/navigation_controller.h"
-#include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/navigation_handle.h"
 #include "content/public/browser/page.h"
 #include "content/public/browser/web_contents.h"
@@ -34,18 +32,11 @@ namespace psst {
 namespace {
 
 constexpr base::TimeDelta kScriptTimeout = base::Seconds(15);
-const char kShouldProcessKey[] = "should_process_key";
 
 const char kUserScriptResultTasksPropName[] = "tasks";
 const char kUserScriptResultTaskItemUidPropName[] = "uid";
 const char kUserScriptResultInitialExecutionPropName[] = "initial_execution";
-
-struct PsstNavigationData : public base::SupportsUserData::Data {
- public:
-  explicit PsstNavigationData(int id) : id(id) {}
-
-  int id;
-};
+const int kUnsetScriptVersion = -1;
 
 // Adds the dictionary of parameters returned by the user.js script to the
 // policy.js script, before it is executed. In case when parameters dictionary
@@ -183,63 +174,56 @@ PsstTabWebContentsObserver::AsWeakPtr() {
 
 void PsstTabWebContentsObserver::PrimaryPageChanged(content::Page& page) {
   script_injector_remote_.reset();
+  ++current_page_id_;
+  should_process_current_page_ = false;
 }
 
 void PsstTabWebContentsObserver::DidFinishNavigation(
     content::NavigationHandle* handle) {
   if (!handle->IsInPrimaryMainFrame() || !handle->HasCommitted() ||
-      !handle->GetURL().SchemeIsHTTPOrHTTPS()) {
+      handle->IsSameDocument()) {
     return;
   }
 
-  auto* entry = handle->GetNavigationEntry();
-  if (!entry || handle->IsSameDocument() ||
-      handle->GetRestoreType() == content::RestoreType::kRestored ||
-      !prefs_->GetBoolean(prefs::kPsstEnabled)) {
-    return;
-  } else {
-    entry->SetUserData(kShouldProcessKey, std::make_unique<PsstNavigationData>(
-                                              entry->GetUniqueID()));
-  }
+  should_process_current_page_ =
+      handle->GetURL().SchemeIsHTTPOrHTTPS() &&
+      handle->GetRestoreType() != content::RestoreType::kRestored &&
+      prefs_->GetBoolean(prefs::kPsstEnabled);
 }
 
 void PsstTabWebContentsObserver::DocumentOnLoadCompletedInPrimaryMainFrame() {
-  int id =
-      web_contents()->GetController().GetLastCommittedEntry()->GetUniqueID();
-  if (!ShouldInsertScriptForPage(id)) {
+  if (!should_process_current_page_) {
     return;
   }
 
   registry_->CheckIfMatch(
       web_contents()->GetLastCommittedURL(),
       base::BindOnce(&PsstTabWebContentsObserver::InsertUserScript,
-                     weak_factory_.GetWeakPtr(), id));
+                     weak_factory_.GetWeakPtr(), current_page_id_));
 }
 
-bool PsstTabWebContentsObserver::ShouldInsertScriptForPage(int id) {
-  auto* entry = web_contents()->GetController().GetLastCommittedEntry();
-  auto* data = entry->GetUserData(kShouldProcessKey);
-  return data && static_cast<PsstNavigationData*>(data)->id == id;
+bool PsstTabWebContentsObserver::ShouldInsertScriptForPage(int page_id) {
+  return page_id == current_page_id_;
 }
 
 void PsstTabWebContentsObserver::InsertUserScript(
-    int id,
+    int page_id,
     std::unique_ptr<MatchedRule> rule) {
-  if (!rule || !ShouldInsertScriptForPage(id)) {
+  if (!rule || !ShouldInsertScriptForPage(page_id)) {
     return;
   }
   const std::string user_script = rule->user_script();
   RunWithTimeout(
-      id, user_script, false,
+      page_id, user_script, false,
       base::BindOnce(&PsstTabWebContentsObserver::OnUserScriptResult,
-                     weak_factory_.GetWeakPtr(), id, std::move(rule)));
+                     weak_factory_.GetWeakPtr(), page_id, std::move(rule)));
 }
 
 void PsstTabWebContentsObserver::OnUserScriptResult(
-    int id,
+    int page_id,
     std::unique_ptr<MatchedRule> rule,
     base::Value user_script_result) {
-  if (!ShouldInsertScriptForPage(id)) {
+  if (!ShouldInsertScriptForPage(page_id)) {
     return;
   }
 
@@ -279,7 +263,7 @@ void PsstTabWebContentsObserver::OnUserScriptResult(
     // If user accepted the consent dialog and it is not the initial iteration
     // (i.e. it is not the first applied PSST setting), we don't need to
     // show the dialog again.
-    OnUserAcceptedPsstSettings(id, false, std::move(rule),
+    OnUserAcceptedPsstSettings(page_id, false, std::move(rule),
                                user_script_result.Clone(),
                                psst_settings->uids_to_perform);
     return;
@@ -289,7 +273,8 @@ void PsstTabWebContentsObserver::OnUserScriptResult(
   if (!psst_settings) {
     psst_settings.emplace();
     psst_settings->consent_status = ConsentStatus::kAsk;
-    psst_settings->script_version = rule->version();
+    // Use not existed version to guarantee that will be shown icon with red dot 
+    psst_settings->script_version = kUnsetScriptVersion;
     psst_settings->user_id = user_script_result_parsed->user_id;
   }
 
@@ -298,35 +283,35 @@ void PsstTabWebContentsObserver::OnUserScriptResult(
       std::move(origin), std::move(*psst_settings), rule_version,
       std::move(user_script_result_parsed),
       base::BindOnce(&PsstTabWebContentsObserver::OnUserAcceptedPsstSettings,
-                     weak_factory_.GetWeakPtr(), id, true, std::move(rule),
+                     weak_factory_.GetWeakPtr(), page_id, true, std::move(rule),
                      std::move(user_script_result)));
 }
 
 void PsstTabWebContentsObserver::OnUserAcceptedPsstSettings(
-    int id,
+    int page_id,
     bool is_initial,
     std::unique_ptr<MatchedRule> rule,
     base::Value user_script_result,
     const std::vector<std::string>& perform_for_uids) {
-  if (!ShouldInsertScriptForPage(id)) {
+  if (!ShouldInsertScriptForPage(page_id)) {
     return;
   }
   auto user_script_result_dict = std::move(user_script_result).TakeDict();
-  PrepareParametersForPolicyExecution(id, user_script_result_dict,
+  PrepareParametersForPolicyExecution(page_id, user_script_result_dict,
                                       perform_for_uids, is_initial);
   RunWithTimeout(
-      id,
+      page_id,
       MaybeAddParamsToScript(std::move(rule),
                              std::move(user_script_result_dict)),
       true,
       base::BindOnce(&PsstTabWebContentsObserver::OnPolicyScriptResult,
-                     weak_factory_.GetWeakPtr(), id));
+                     weak_factory_.GetWeakPtr(), page_id));
 }
 
 void PsstTabWebContentsObserver::OnPolicyScriptResult(
-    int nav_entry_id,
+    int page_id,
     base::Value script_result) {
-  if (!ShouldInsertScriptForPage(nav_entry_id)) {
+  if (!ShouldInsertScriptForPage(page_id)) {
     return;
   }
 
@@ -359,14 +344,14 @@ void PsstTabWebContentsObserver::OnPolicyScriptResult(
 }
 
 void PsstTabWebContentsObserver::RunWithTimeout(
-    const int last_committed_entry_id,
+    const int page_id,
     const std::string& script,
     bool is_async,
     InsertScriptInPageCallback callback) {
   timeout_timer_.Start(
       FROM_HERE, kScriptTimeout,
       base::BindOnce(&PsstTabWebContentsObserver::OnScriptTimeout,
-                     weak_factory_.GetWeakPtr(), last_committed_entry_id));
+                     weak_factory_.GetWeakPtr(), page_id));
   if (is_async) {
     inject_async_script_callback_.Run(script, std::move(callback));
   } else {

--- a/browser/psst/psst_tab_web_contents_observer.cc
+++ b/browser/psst/psst_tab_web_contents_observer.cc
@@ -273,7 +273,7 @@ void PsstTabWebContentsObserver::OnUserScriptResult(
   if (!psst_settings) {
     psst_settings.emplace();
     psst_settings->consent_status = ConsentStatus::kAsk;
-    // Use not existed version to guarantee that will be shown icon with red dot 
+    // Use not existed version to guarantee that will be shown icon with red dot
     psst_settings->script_version = kUnsetScriptVersion;
     psst_settings->user_id = user_script_result_parsed->user_id;
   }

--- a/browser/psst/psst_tab_web_contents_observer.cc
+++ b/browser/psst/psst_tab_web_contents_observer.cc
@@ -65,7 +65,6 @@ std::string MaybeAddParamsToScript(std::unique_ptr<MatchedRule> rule,
 }
 
 void PrepareParametersForPolicyExecution(
-    int navigation_id,
     base::DictValue& user_script_result,
     const std::vector<std::string>& perform_for_uids,
     const bool is_initial) {
@@ -174,7 +173,7 @@ PsstTabWebContentsObserver::AsWeakPtr() {
 
 void PsstTabWebContentsObserver::PrimaryPageChanged(content::Page& page) {
   script_injector_remote_.reset();
-  ++current_page_id_;
+  page_weak_factory_.InvalidateWeakPtrs();
   should_process_current_page_ = false;
 }
 
@@ -199,34 +198,24 @@ void PsstTabWebContentsObserver::DocumentOnLoadCompletedInPrimaryMainFrame() {
   registry_->CheckIfMatch(
       web_contents()->GetLastCommittedURL(),
       base::BindOnce(&PsstTabWebContentsObserver::InsertUserScript,
-                     weak_factory_.GetWeakPtr(), current_page_id_));
-}
-
-bool PsstTabWebContentsObserver::ShouldInsertScriptForPage(int page_id) {
-  return page_id == current_page_id_;
+                     page_weak_factory_.GetWeakPtr()));
 }
 
 void PsstTabWebContentsObserver::InsertUserScript(
-    int page_id,
     std::unique_ptr<MatchedRule> rule) {
-  if (!rule || !ShouldInsertScriptForPage(page_id)) {
+  if (!rule) {
     return;
   }
   const std::string user_script = rule->user_script();
   RunWithTimeout(
-      page_id, user_script, false,
+      user_script, false,
       base::BindOnce(&PsstTabWebContentsObserver::OnUserScriptResult,
-                     weak_factory_.GetWeakPtr(), page_id, std::move(rule)));
+                     page_weak_factory_.GetWeakPtr(), std::move(rule)));
 }
 
 void PsstTabWebContentsObserver::OnUserScriptResult(
-    int page_id,
     std::unique_ptr<MatchedRule> rule,
     base::Value user_script_result) {
-  if (!ShouldInsertScriptForPage(page_id)) {
-    return;
-  }
-
   timeout_timer_.Stop();
 
   // We should break the flow in case of policy script is not available or user
@@ -263,7 +252,7 @@ void PsstTabWebContentsObserver::OnUserScriptResult(
     // If user accepted the consent dialog and it is not the initial iteration
     // (i.e. it is not the first applied PSST setting), we don't need to
     // show the dialog again.
-    OnUserAcceptedPsstSettings(page_id, false, std::move(rule),
+    OnUserAcceptedPsstSettings(false, std::move(rule),
                                user_script_result.Clone(),
                                psst_settings->uids_to_perform);
     return;
@@ -283,38 +272,28 @@ void PsstTabWebContentsObserver::OnUserScriptResult(
       std::move(origin), std::move(*psst_settings), rule_version,
       std::move(user_script_result_parsed),
       base::BindOnce(&PsstTabWebContentsObserver::OnUserAcceptedPsstSettings,
-                     weak_factory_.GetWeakPtr(), page_id, true, std::move(rule),
+                     page_weak_factory_.GetWeakPtr(), true, std::move(rule),
                      std::move(user_script_result)));
 }
 
 void PsstTabWebContentsObserver::OnUserAcceptedPsstSettings(
-    int page_id,
     bool is_initial,
     std::unique_ptr<MatchedRule> rule,
     base::Value user_script_result,
     const std::vector<std::string>& perform_for_uids) {
-  if (!ShouldInsertScriptForPage(page_id)) {
-    return;
-  }
   auto user_script_result_dict = std::move(user_script_result).TakeDict();
-  PrepareParametersForPolicyExecution(page_id, user_script_result_dict,
-                                      perform_for_uids, is_initial);
+  PrepareParametersForPolicyExecution(user_script_result_dict, perform_for_uids,
+                                      is_initial);
   RunWithTimeout(
-      page_id,
       MaybeAddParamsToScript(std::move(rule),
                              std::move(user_script_result_dict)),
       true,
       base::BindOnce(&PsstTabWebContentsObserver::OnPolicyScriptResult,
-                     weak_factory_.GetWeakPtr(), page_id));
+                     weak_factory_.GetWeakPtr()));
 }
 
 void PsstTabWebContentsObserver::OnPolicyScriptResult(
-    int page_id,
     base::Value script_result) {
-  if (!ShouldInsertScriptForPage(page_id)) {
-    return;
-  }
-
   timeout_timer_.Stop();
   const auto script_result_parsed =
       PolicyScriptResult::FromValue(script_result);
@@ -344,14 +323,13 @@ void PsstTabWebContentsObserver::OnPolicyScriptResult(
 }
 
 void PsstTabWebContentsObserver::RunWithTimeout(
-    const int page_id,
     const std::string& script,
     bool is_async,
     InsertScriptInPageCallback callback) {
   timeout_timer_.Start(
       FROM_HERE, kScriptTimeout,
       base::BindOnce(&PsstTabWebContentsObserver::OnScriptTimeout,
-                     weak_factory_.GetWeakPtr(), page_id));
+                     page_weak_factory_.GetWeakPtr()));
   if (is_async) {
     inject_async_script_callback_.Run(script, std::move(callback));
   } else {
@@ -359,13 +337,9 @@ void PsstTabWebContentsObserver::RunWithTimeout(
   }
 }
 
-void PsstTabWebContentsObserver::OnScriptTimeout(int id) {
-  if (!ShouldInsertScriptForPage(id)) {
-    return;
-  }
-
+void PsstTabWebContentsObserver::OnScriptTimeout() {
   // Make sure any in-progress script that returns after the timeout is a no-op
-  weak_factory_.InvalidateWeakPtrs();
+  page_weak_factory_.InvalidateWeakPtrs();
 
   ui_delegate_->UpdateTasks(100, {}, mojom::PsstStatus::kFailed);
 }

--- a/browser/psst/psst_tab_web_contents_observer.cc
+++ b/browser/psst/psst_tab_web_contents_observer.cc
@@ -262,7 +262,7 @@ void PsstTabWebContentsObserver::OnUserScriptResult(
   if (!psst_settings) {
     psst_settings.emplace();
     psst_settings->consent_status = ConsentStatus::kAsk;
-    // Use not existed version to guarantee that will be shown icon with red dot
+    // Use a non-existent version to guarantee the icon is shown with a red dot.
     psst_settings->script_version = kUnsetScriptVersion;
     psst_settings->user_id = user_script_result_parsed->user_id;
   }

--- a/browser/psst/psst_tab_web_contents_observer.cc
+++ b/browser/psst/psst_tab_web_contents_observer.cc
@@ -289,7 +289,7 @@ void PsstTabWebContentsObserver::OnUserAcceptedPsstSettings(
                              std::move(user_script_result_dict)),
       true,
       base::BindOnce(&PsstTabWebContentsObserver::OnPolicyScriptResult,
-                     weak_factory_.GetWeakPtr()));
+                     page_weak_factory_.GetWeakPtr()));
 }
 
 void PsstTabWebContentsObserver::OnPolicyScriptResult(

--- a/browser/psst/psst_tab_web_contents_observer.cc
+++ b/browser/psst/psst_tab_web_contents_observer.cc
@@ -36,7 +36,7 @@ constexpr base::TimeDelta kScriptTimeout = base::Seconds(15);
 const char kUserScriptResultTasksPropName[] = "tasks";
 const char kUserScriptResultTaskItemUidPropName[] = "uid";
 const char kUserScriptResultInitialExecutionPropName[] = "initial_execution";
-const int kUnsetScriptVersion = -1;
+constexpr int kUnsetScriptVersion = -1;
 
 // Adds the dictionary of parameters returned by the user.js script to the
 // policy.js script, before it is executed. In case when parameters dictionary

--- a/browser/psst/psst_tab_web_contents_observer.h
+++ b/browser/psst/psst_tab_web_contents_observer.h
@@ -86,24 +86,20 @@ class PsstTabWebContentsObserver : public tabs::ContentsObservingTabFeature {
                              PrefService* prefs,
                              std::unique_ptr<PsstUiDelegate> ui_delegate);
 
-  bool ShouldInsertScriptForPage(int page_id);
-  void InsertUserScript(int page_id, std::unique_ptr<MatchedRule> rule);
+  void InsertUserScript(std::unique_ptr<MatchedRule> rule);
 
-  void OnUserScriptResult(int page_id,
-                          std::unique_ptr<MatchedRule> rule,
+  void OnUserScriptResult(std::unique_ptr<MatchedRule> rule,
                           base::Value script_result);
   void OnUserAcceptedPsstSettings(
-      int page_id,
       bool is_initial,
       std::unique_ptr<MatchedRule> rule,
       base::Value user_script_result,
       const std::vector<std::string>& perform_for_uids);
-  void OnPolicyScriptResult(int page_id, base::Value script_result);
-  void RunWithTimeout(const int page_id,
-                      const std::string& script,
+  void OnPolicyScriptResult(base::Value script_result);
+  void RunWithTimeout(const std::string& script,
                       bool is_async,
                       InsertScriptInPageCallback callback);
-  void OnScriptTimeout(int id);
+  void OnScriptTimeout();
 
   // content::WebContentsObserver overrides
   void DocumentOnLoadCompletedInPrimaryMainFrame() override;
@@ -123,14 +119,16 @@ class PsstTabWebContentsObserver : public tabs::ContentsObservingTabFeature {
   std::unique_ptr<PsstUiDelegate> ui_delegate_;
   base::OneShotTimer timeout_timer_;
 
-  // Counter for the current primary page. Async script
-  // callbacks capture the value current at dispatch time; a mismatch means the
-  // page changed underneath and the callback must be dropped.
-  int current_page_id_ = 0;
-
   // Whether the currently committed primary page is eligible for PSST
   // processing. Recomputed on every cross-document primary main frame commit.
   bool should_process_current_page_ = false;
+
+  // Weak pointers scoped to the lifetime of the current primary document. Every
+  // step of the PSST flow (rule lookup, script results, consent callback,
+  // timeout) is bound to this factory, which is invalidated whenever the
+  // document is replaced. That makes stale callbacks no-ops by construction, so
+  // no step has to validate that its page is still current.
+  base::WeakPtrFactory<PsstTabWebContentsObserver> page_weak_factory_{this};
 
   base::WeakPtrFactory<PsstTabWebContentsObserver> weak_factory_{this};
 };

--- a/browser/psst/psst_tab_web_contents_observer.h
+++ b/browser/psst/psst_tab_web_contents_observer.h
@@ -86,20 +86,20 @@ class PsstTabWebContentsObserver : public tabs::ContentsObservingTabFeature {
                              PrefService* prefs,
                              std::unique_ptr<PsstUiDelegate> ui_delegate);
 
-  bool ShouldInsertScriptForPage(int id);
-  void InsertUserScript(int id, std::unique_ptr<MatchedRule> rule);
+  bool ShouldInsertScriptForPage(int page_id);
+  void InsertUserScript(int page_id, std::unique_ptr<MatchedRule> rule);
 
-  void OnUserScriptResult(int id,
+  void OnUserScriptResult(int page_id,
                           std::unique_ptr<MatchedRule> rule,
                           base::Value script_result);
   void OnUserAcceptedPsstSettings(
-      int id,
+      int page_id,
       bool is_initial,
       std::unique_ptr<MatchedRule> rule,
       base::Value user_script_result,
       const std::vector<std::string>& perform_for_uids);
-  void OnPolicyScriptResult(int nav_entry_id, base::Value script_result);
-  void RunWithTimeout(const int last_committed_entry_id,
+  void OnPolicyScriptResult(int page_id, base::Value script_result);
+  void RunWithTimeout(const int page_id,
                       const std::string& script,
                       bool is_async,
                       InsertScriptInPageCallback callback);
@@ -122,6 +122,16 @@ class PsstTabWebContentsObserver : public tabs::ContentsObservingTabFeature {
   InjectScriptAsyncCallback inject_async_script_callback_;
   std::unique_ptr<PsstUiDelegate> ui_delegate_;
   base::OneShotTimer timeout_timer_;
+
+  // Counter for the current primary page. Async script
+  // callbacks capture the value current at dispatch time; a mismatch means the
+  // page changed underneath and the callback must be dropped.
+  int current_page_id_ = 0;
+
+  // Whether the currently committed primary page is eligible for PSST
+  // processing. Recomputed on every cross-document primary main frame commit.
+  bool should_process_current_page_ = false;
+
   base::WeakPtrFactory<PsstTabWebContentsObserver> weak_factory_{this};
 };
 

--- a/browser/psst/psst_tab_web_contents_observer_unittest.cc
+++ b/browser/psst/psst_tab_web_contents_observer_unittest.cc
@@ -651,7 +651,7 @@ TEST_F(PsstTabWebContentsObserverUnitTest,
   const std::vector<std::string> expected_uids_to_perform = {"1"};
   EXPECT_CALL(ui_delegate(),
               Show(url::Origin::Create(url_),
-                   PsstWebsiteSettingsEq(ConsentStatus::kAsk, 1, user_id_,
+                   PsstWebsiteSettingsEq(ConsentStatus::kAsk, -1, user_id_,
                                          std::vector<std::string>()),
                    1, _, _))
       .WillOnce(ShowCallback(&user_accept_psst_settings_future,
@@ -764,7 +764,7 @@ TEST_F(PsstTabWebContentsObserverUnitTest,
   const std::vector<std::string> expected_uids_to_perform = {"1"};
   EXPECT_CALL(ui_delegate(),
               Show(url::Origin::Create(url_),
-                   PsstWebsiteSettingsEq(ConsentStatus::kAsk, 1, user_id_,
+                   PsstWebsiteSettingsEq(ConsentStatus::kAsk, -1, user_id_,
                                          std::vector<std::string>()),
                    1, _, _))
       .WillOnce(ShowCallback(&user_accept_psst_settings_future,
@@ -852,7 +852,7 @@ TEST_F(PsstTabWebContentsObserverUnitTest, UiDelegateUpdateTasksCalled) {
   const std::vector<std::string> expected_uids_to_perform = {"1"};
   EXPECT_CALL(ui_delegate(),
               Show(url::Origin::Create(url_),
-                   PsstWebsiteSettingsEq(ConsentStatus::kAsk, 1, user_id_,
+                   PsstWebsiteSettingsEq(ConsentStatus::kAsk, -1, user_id_,
                                          std::vector<std::string>()),
                    1, _, _))
       .WillOnce(ShowCallback(&user_accept_psst_settings_future,
@@ -975,9 +975,9 @@ TEST_F(PsstTabWebContentsObserverUnitTest,
                                             .Set("url", "https://example1.com")
                                             .Set("description", "settings"))));
 
-  ON_CALL(ui_delegate(),
+  EXPECT_CALL(ui_delegate(),
           GetPsstWebsiteSettings(url::Origin::Create(url_), user_id_))
-      .WillByDefault([&settings](const url::Origin&, const std::string&) {
+      .WillOnce([&settings](const url::Origin&, const std::string&) {
         return settings.Clone();
       });
 

--- a/browser/psst/psst_tab_web_contents_observer_unittest.cc
+++ b/browser/psst/psst_tab_web_contents_observer_unittest.cc
@@ -113,6 +113,12 @@ ACTION_P(CheckIfMatchFailsCallback, loop) {
   loop->Quit();
 }
 
+ACTION(CheckIfMatchWithoutRule) {
+  std::move(
+      const_cast<base::OnceCallback<void(std::unique_ptr<MatchedRule>)>&>(arg1))
+      .Run(nullptr);
+}
+
 // testing::InvokeArgument<N> does not work with base::OnceCallback, so we
 // define our own gMock action to run the 2nd argument.
 ACTION_P(InsertScriptInPageCallback, future, value) {
@@ -127,6 +133,13 @@ ACTION_P(InsertPolicyScriptInPageCallback, future, value) {
       const_cast<PsstTabWebContentsObserver::InsertScriptInPageCallback&>(arg1))
       .Run(value.Clone());
   future->SetValue(value.Clone());
+}
+
+// Captures the script result callback instead of running it, so that the test
+// can decide when (and after which navigations) it is invoked.
+ACTION_P(HoldInsertScriptInPageCallback, holder) {
+  *holder = std::move(
+      const_cast<PsstTabWebContentsObserver::InsertScriptInPageCallback&>(arg1));
 }
 
 ACTION_P(ShowCallback, future, urls_to_skip) {
@@ -400,6 +413,132 @@ TEST_F(PsstTabWebContentsObserverUnitTest,
 
   second_nav_check_loop.Run();
   EXPECT_EQ(base::Value(), second_nav_user_script_insert_future.Take());
+}
+
+// The user script runs asynchronously in the renderer, so its result can come
+// back after the user has already navigated elsewhere. The result must be
+// dropped: no UI update and no policy script injection into the new page.
+TEST_F(PsstTabWebContentsObserverUnitTest,
+       UserScriptResultArrivingAfterNavigationIsDropped) {
+  const GURL second_navigation_url("https://example2.com");
+
+  base::RunLoop first_nav_check_loop;
+  base::RunLoop second_nav_check_loop;
+  EXPECT_CALL(psst_rule_registry(), CheckIfMatch(url_, _))
+      .WillOnce(CheckIfMatchCallback(
+          &first_nav_check_loop,
+          CreateMatchedRule(user_script_, policy_script_)));
+  // The second page has no matching rule, so it starts no flow of its own and
+  // anything observed afterwards can only come from the stale first flow.
+  EXPECT_CALL(psst_rule_registry(), CheckIfMatch(second_navigation_url, _))
+      .WillOnce(CheckIfMatchFailsCallback(&second_nav_check_loop));
+
+  // Hold the user script result until after the second navigation commits.
+  PsstTabWebContentsObserver::InsertScriptInPageCallback
+      held_user_script_callback;
+  EXPECT_CALL(inject_script_callback(), Run(user_script_, _))
+      .WillOnce(HoldInsertScriptInPageCallback(&held_user_script_callback));
+
+  // The stale result must not reach the UI or trigger the policy script.
+  EXPECT_CALL(ui_delegate(), GetPsstWebsiteSettings).Times(0);
+  EXPECT_CALL(ui_delegate(), Show).Times(0);
+  EXPECT_CALL(ui_delegate(), UpdateTasks).Times(0);
+  EXPECT_CALL(inject_async_script_callback(), Run).Times(0);
+
+  {
+    DocumentOnLoadObserver observer(web_contents());
+    content::NavigationSimulator::NavigateAndCommitFromBrowser(web_contents(),
+                                                               url_);
+    observer.Wait();
+  }
+  first_nav_check_loop.Run();
+  ASSERT_FALSE(held_user_script_callback.is_null());
+
+  {
+    DocumentOnLoadObserver observer(web_contents());
+    content::NavigationSimulator::NavigateAndCommitFromBrowser(
+        web_contents(), second_navigation_url);
+    observer.Wait();
+  }
+  second_nav_check_loop.Run();
+
+  // A result that would otherwise drive the whole flow: it has a user id and
+  // tasks, so on a still-current page it would show the consent dialog and run
+  // the policy script.
+  std::move(held_user_script_callback)
+      .Run(base::Value(
+          base::DictValue()
+              .Set("initial_execution", true)
+              .Set("user_id", user_id_)
+              .Set("site_name", "example")
+              .Set("tasks", base::ListValue().Append(
+                                base::DictValue()
+                                    .Set("uid", "1")
+                                    .Set("url", url_.spec())
+                                    .Set("description", "settings")))));
+}
+
+// A back navigation re-commits an already visited entry as a new page, so a
+// user script result held from that entry's earlier visit is still stale and
+// must be dropped.
+TEST_F(PsstTabWebContentsObserverUnitTest,
+       UserScriptResultArrivingAfterBackNavigationToSameEntryIsDropped) {
+  const GURL second_navigation_url("https://example2.com");
+
+  base::RunLoop first_nav_check_loop;
+  base::RunLoop second_nav_check_loop;
+  // The back navigation may or may not reach DocumentOnLoadCompleted in the
+  // test harness, so no run loop is tied to a rule check for it. What matters
+  // for this test is only that the back navigation commits.
+  EXPECT_CALL(psst_rule_registry(), CheckIfMatch(url_, _))
+      .WillOnce(CheckIfMatchCallback(
+          &first_nav_check_loop,
+          CreateMatchedRule(user_script_, policy_script_)))
+      .WillRepeatedly(CheckIfMatchWithoutRule());
+  EXPECT_CALL(psst_rule_registry(), CheckIfMatch(second_navigation_url, _))
+      .WillOnce(CheckIfMatchFailsCallback(&second_nav_check_loop));
+
+  PsstTabWebContentsObserver::InsertScriptInPageCallback
+      held_user_script_callback;
+  EXPECT_CALL(inject_script_callback(), Run(user_script_, _))
+      .WillOnce(HoldInsertScriptInPageCallback(&held_user_script_callback));
+
+  EXPECT_CALL(ui_delegate(), GetPsstWebsiteSettings).Times(0);
+  EXPECT_CALL(ui_delegate(), Show).Times(0);
+  EXPECT_CALL(ui_delegate(), UpdateTasks).Times(0);
+  EXPECT_CALL(inject_async_script_callback(), Run).Times(0);
+
+  {
+    DocumentOnLoadObserver observer(web_contents());
+    content::NavigationSimulator::NavigateAndCommitFromBrowser(web_contents(),
+                                                               url_);
+    observer.Wait();
+  }
+  first_nav_check_loop.Run();
+  ASSERT_FALSE(held_user_script_callback.is_null());
+
+  {
+    DocumentOnLoadObserver observer(web_contents());
+    content::NavigationSimulator::NavigateAndCommitFromBrowser(
+        web_contents(), second_navigation_url);
+    observer.Wait();
+  }
+  second_nav_check_loop.Run();
+
+  content::NavigationSimulator::GoBack(web_contents());
+  ASSERT_EQ(url_, web_contents()->GetLastCommittedURL());
+
+  std::move(held_user_script_callback)
+      .Run(base::Value(
+          base::DictValue()
+              .Set("initial_execution", true)
+              .Set("user_id", user_id_)
+              .Set("site_name", "example")
+              .Set("tasks", base::ListValue().Append(
+                                base::DictValue()
+                                    .Set("uid", "1")
+                                    .Set("url", url_.spec())
+                                    .Set("description", "settings")))));
 }
 
 TEST_F(PsstTabWebContentsObserverUnitTest, ShouldProcessRedirectsNavigations) {

--- a/browser/psst/psst_tab_web_contents_observer_unittest.cc
+++ b/browser/psst/psst_tab_web_contents_observer_unittest.cc
@@ -139,7 +139,8 @@ ACTION_P(InsertPolicyScriptInPageCallback, future, value) {
 // can decide when (and after which navigations) it is invoked.
 ACTION_P(HoldInsertScriptInPageCallback, holder) {
   *holder = std::move(
-      const_cast<PsstTabWebContentsObserver::InsertScriptInPageCallback&>(arg1));
+      const_cast<PsstTabWebContentsObserver::InsertScriptInPageCallback&>(
+          arg1));
 }
 
 ACTION_P(ShowCallback, future, urls_to_skip) {
@@ -491,9 +492,9 @@ TEST_F(PsstTabWebContentsObserverUnitTest,
   // test harness, so no run loop is tied to a rule check for it. What matters
   // for this test is only that the back navigation commits.
   EXPECT_CALL(psst_rule_registry(), CheckIfMatch(url_, _))
-      .WillOnce(CheckIfMatchCallback(
-          &first_nav_check_loop,
-          CreateMatchedRule(user_script_, policy_script_)))
+      .WillOnce(
+          CheckIfMatchCallback(&first_nav_check_loop,
+                               CreateMatchedRule(user_script_, policy_script_)))
       .WillRepeatedly(CheckIfMatchWithoutRule());
   EXPECT_CALL(psst_rule_registry(), CheckIfMatch(second_navigation_url, _))
       .WillOnce(CheckIfMatchFailsCallback(&second_nav_check_loop));
@@ -1115,7 +1116,7 @@ TEST_F(PsstTabWebContentsObserverUnitTest,
                                             .Set("description", "settings"))));
 
   EXPECT_CALL(ui_delegate(),
-          GetPsstWebsiteSettings(url::Origin::Create(url_), user_id_))
+              GetPsstWebsiteSettings(url::Origin::Create(url_), user_id_))
       .WillOnce([&settings](const url::Origin&, const std::string&) {
         return settings.Clone();
       });

--- a/components/psst/README.md
+++ b/components/psst/README.md
@@ -32,7 +32,7 @@ https://docs.google.com/document/d/1ccnBWBV_KkknZpZYxcOXTwtfIiaSzeLS5dMd08N2pbs/
    - takes the first URL (URL_1) and marks it as current;
    - navigates to that URL;
    - returns the progress and applied tasks list to the back-end:
-     `PsstTabWebContentsObserver::OnPolicyScriptResult(int nav_entry_id,base::Value script_result)`</br>
+     `PsstTabWebContentsObserver::OnPolicyScriptResult(base::Value script_result)`</br>
      where after deserialization and validation, we update the flow's status on
      the consent dialog, by calling the UI delegate's method:</br>
      `UpdateTasks(long progress,const std::vector<PolicyTask>& applied_tasks)`</br>
@@ -70,13 +70,12 @@ seconds):
 
 ```
 void PsstTabWebContentsObserver::RunWithTimeout(
-    const int last_committed_entry_id,
     const std::string& script,
     InsertScriptInPageCallback callback) {
   timeout_timer_.Start(
       FROM_HERE, kScriptTimeout,
       base::BindOnce(&PsstTabWebContentsObserver::OnScriptTimeout,
-                     weak_factory_.GetWeakPtr(), last_committed_entry_id));
+                     page_weak_factory_.GetWeakPtr()));
   inject_script_callback_.Run(script, std::move(callback));
 }
 
@@ -89,7 +88,7 @@ script result once it executes;
 
 The `PsstTabWebContentsObserver::OnScriptTimeout` is special timeout handler,
 which stops the other script execution result handlers by calling the
-`weak_factory_.InvalidateWeakPtrs();`
+`page_weak_factory_.InvalidateWeakPtrs();`
 
 # PSST CRX Component
 
@@ -98,7 +97,7 @@ Contains set of rules and scripts for small number of very popular sites
 open source (similar to https://github.com/brave/adblock-lists), and shipped
 daily to users.
 
-- Component ID: `lhhcaamjbmbijmjbnnodjaknblkiagon`
+- Component ID: `bchfnigamfmpeanhekjggkphjfobpipo`
 - Component version: `1`
 
 ### Component's folder structure:

--- a/components/psst/resources/ui/components/PsstProgressModal.tsx
+++ b/components/psst/resources/ui/components/PsstProgressModal.tsx
@@ -80,8 +80,6 @@ export const PsstProgressModal = () => {
     return hasFailures ? SettingState.Failed : SettingState.Completed
   })()
 
-  console.log('[PsstProgressModal] commonState:', SettingState[commonState], optionsStatuses)
-
   const { performPrivacyTuning } = api.usePerformPrivacyTuning()
 
   const siteName = siteData ? siteData.siteName : ''
@@ -102,7 +100,6 @@ export const PsstProgressModal = () => {
 
   // Handle request status updates
   api.useOnSetRequestStatus((requestUid, requestError) => {
-    console.log('[PsstProgressModal] useOnSetRequestStatus:', requestUid, requestError)
     updateAllMatchingOptionsStatuses((prevOptionsStatuses) => {
       if (!prevOptionsStatuses) return prevOptionsStatuses
 
@@ -223,7 +220,8 @@ export const PsstProgressModal = () => {
         }}
         onItemChecked={handleSettingItemCheck}
       />
-      {(commonState !== SettingState.Completed && commonState !== SettingState.Failed) ? (
+      {commonState !== SettingState.Completed
+      && commonState !== SettingState.Failed ? (
         <RightAlignedItem>
           <PsstDlgButton
             kind='outline'

--- a/components/psst/resources/ui/components/PsstProgressModal.tsx
+++ b/components/psst/resources/ui/components/PsstProgressModal.tsx
@@ -80,6 +80,8 @@ export const PsstProgressModal = () => {
     return hasFailures ? SettingState.Failed : SettingState.Completed
   })()
 
+  console.log('[PsstProgressModal] commonState:', SettingState[commonState], optionsStatuses)
+
   const { performPrivacyTuning } = api.usePerformPrivacyTuning()
 
   const siteName = siteData ? siteData.siteName : ''
@@ -100,6 +102,7 @@ export const PsstProgressModal = () => {
 
   // Handle request status updates
   api.useOnSetRequestStatus((requestUid, requestError) => {
+    console.log('[PsstProgressModal] useOnSetRequestStatus:', requestUid, requestError)
     updateAllMatchingOptionsStatuses((prevOptionsStatuses) => {
       if (!prevOptionsStatuses) return prevOptionsStatuses
 
@@ -220,7 +223,7 @@ export const PsstProgressModal = () => {
         }}
         onItemChecked={handleSettingItemCheck}
       />
-      {commonState !== SettingState.Failed ? (
+      {(commonState !== SettingState.Completed && commonState !== SettingState.Failed) ? (
         <RightAlignedItem>
           <PsstDlgButton
             kind='outline'
@@ -243,15 +246,17 @@ export const PsstProgressModal = () => {
         </RightAlignedItem>
       ) : (
         <RightAlignedItem>
-          <PsstDlgButton
-            kind='outline'
-            size='medium'
-            isDisabled={isInProgress}
-            isLoading={isInProgress}
-            onClick={api.reportFailedContent}
-          >
-            {getLocale(S.PSST_COMPLETE_CONSENT_DIALOG_REPORT_FAILED)}
-          </PsstDlgButton>
+          {commonState !== SettingState.Completed && (
+            <PsstDlgButton
+              kind='outline'
+              size='medium'
+              isDisabled={isInProgress}
+              isLoading={isInProgress}
+              onClick={api.reportFailedContent}
+            >
+              {getLocale(S.PSST_COMPLETE_CONSENT_DIALOG_REPORT_FAILED)}
+            </PsstDlgButton>
+          )}
           <PsstDlgButton
             kind='filled'
             size='medium'


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57651

Adds PSST support for renderer-initiated navigations, and replaces the per-NavigationEntry bookkeeping with observer-owned state, and fixes small related UI issue.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
