### PR TITLE
Adjusts Widevine install prompt with correct origin.

### DIFF
--- a/browser/brave_drm_tab_helper.cc
+++ b/browser/brave_drm_tab_helper.cc
@@ -17,10 +17,12 @@
 #include "chrome/browser/browser_process_impl.h"
 #include "chrome/browser/profiles/profile.h"
 #include "components/permissions/permission_request_manager.h"
+#include "components/permissions/permission_util.h"
 #include "components/prefs/pref_service.h"
 #include "components/update_client/crx_update_item.h"
 #include "content/public/browser/navigation_controller.h"
 #include "content/public/browser/navigation_handle.h"
+#include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"
 
 #if !BUILDFLAG(IS_ANDROID)
@@ -33,6 +35,23 @@
 using component_updater::ComponentUpdateService;
 
 namespace {
+
+// The permission prompt renders this with
+// url_formatter::FormatUrlForSecurityDisplay(), i.e. scheme/host/port only.
+// Prefer the frame's origin: an about:blank or srcdoc subframe inherits a
+// meaningful origin while its URL would display as "about:blank". Fall back to
+// the frame's URL for a sandboxed subframe, whose opaque origin would otherwise
+// leave the prompt naming no site at all. Two levels cover everything reachable
+// here, because requestMediaKeySystemAccess() is gated on a secure context.
+GURL GetRequestingOriginForPrompt(content::RenderFrameHost* requesting_frame) {
+  GURL origin = permissions::PermissionUtil::GetLastCommittedOriginAsURL(
+      requesting_frame);
+  if (origin.is_empty()) {
+    origin = requesting_frame->GetLastCommittedURL().DeprecatedGetOriginAsURL();
+  }
+  return origin;
+}
+
 #if !BUILDFLAG(IS_ANDROID)
 bool IsAlreadyRegistered(ComponentUpdateService* cus) {
   return std::ranges::contains(cus->GetComponentIDs(), kWidevineComponentId);
@@ -119,6 +138,22 @@ void BraveDrmTabHelper::DidStartNavigation(
 }
 
 void BraveDrmTabHelper::OnWidevineKeySystemAccessRequest() {
+  OnWidevineKeySystemAccessRequestForFrame(
+      brave_drm_receivers_.GetCurrentTargetFrame());
+}
+
+void BraveDrmTabHelper::OnWidevineKeySystemAccessRequestForFrame(
+    content::RenderFrameHost* requesting_frame) {
+  CHECK(requesting_frame);
+
+  // A frame that is prerendering, in the back/forward cache or pending deletion
+  // must not drive UI or this tab's Widevine state: the prompt (and the
+  // component update follow-up in OnEvent()) would otherwise be attributed to
+  // whatever page is currently committed in this tab.
+  if (!requesting_frame->IsActive()) {
+    return;
+  }
+
   is_widevine_requested_ = true;
 #if BUILDFLAG(IS_ANDROID)
   bool for_restart = true;
@@ -132,10 +167,10 @@ void BraveDrmTabHelper::OnWidevineKeySystemAccessRequest() {
         Profile::FromBrowserContext(web_contents()->GetBrowserContext())
             ->GetPrefs();
     permissions::PermissionRequestManager::FromWebContents(web_contents())
-        ->AddRequest(
-            web_contents()->GetPrimaryMainFrame(),
-            std::make_unique<WidevinePermissionRequest>(
-                prefs, web_contents()->GetLastCommittedURL(), for_restart));
+        ->AddRequest(requesting_frame,
+                     std::make_unique<WidevinePermissionRequest>(
+                         prefs, GetRequestingOriginForPrompt(requesting_frame),
+                         for_restart));
   }
 }
 

--- a/browser/brave_drm_tab_helper.h
+++ b/browser/brave_drm_tab_helper.h
@@ -9,6 +9,7 @@
 #include "base/scoped_observation.h"
 #include "brave/components/brave_drm/brave_drm.mojom.h"
 #include "components/component_updater/component_updater_service.h"
+#include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_frame_host_receiver_set.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "content/public/browser/web_contents_user_data.h"
@@ -33,8 +34,17 @@ class BraveDrmTabHelper final
   void DidStartNavigation(
       content::NavigationHandle* navigation_handle) override;
 
-  // blink::mojom::BraveDRM
+  // brave_drm::mojom::BraveDRM
+  // Must only be called while a BraveDRM message is being dispatched, as it
+  // resolves the sending frame from `brave_drm_receivers_` and forwards to the
+  // method below.
   void OnWidevineKeySystemAccessRequest() override;
+
+  // Handles a Widevine key system access request originating from
+  // `requesting_frame`. Exposed so that tests can drive this helper without a
+  // renderer dispatching a mojo message.
+  void OnWidevineKeySystemAccessRequestForFrame(
+      content::RenderFrameHost* requesting_frame);
 
   // component_updater::ComponentUpdateService::Observer
   void OnEvent(const update_client::CrxUpdateItem& item) override;

--- a/browser/widevine/widevine_permission_android_unittest.cc
+++ b/browser/widevine/widevine_permission_android_unittest.cc
@@ -52,6 +52,14 @@ class WidevinePermissionAndroidTest : public ChromeRenderViewHostTestHarness {
     brave_drm_tab_helper()->DidStartNavigation(&test_handle);
   }
 
+  // BraveDrmTabHelper::OnWidevineKeySystemAccessRequest() can only resolve the
+  // requesting frame while a mojo message is being dispatched, so tests that
+  // don't go through the renderer name the frame explicitly.
+  void SimulateWidevineKeySystemAccessRequest() {
+    brave_drm_tab_helper()->OnWidevineKeySystemAccessRequestForFrame(
+        web_contents()->GetPrimaryMainFrame());
+  }
+
  protected:
   void SetUp() override {
     ChromeRenderViewHostTestHarness::SetUp();
@@ -102,7 +110,7 @@ TEST_F(WidevinePermissionAndroidTest, BraveDrmTabHelperTest) {
   permissions::PermissionRequestManager* manager = permission_request_manager();
   EXPECT_FALSE(brave_drm_tab_helper()->ShouldShowWidevineOptIn());
 
-  brave_drm_tab_helper()->OnWidevineKeySystemAccessRequest();
+  SimulateWidevineKeySystemAccessRequest();
   base::RunLoop().RunUntilIdle();
   EXPECT_TRUE(brave_drm_tab_helper()->ShouldShowWidevineOptIn());
 
@@ -112,7 +120,7 @@ TEST_F(WidevinePermissionAndroidTest, BraveDrmTabHelperTest) {
   // After navigation
   SimulateNavigation();
   EXPECT_FALSE(brave_drm_tab_helper()->ShouldShowWidevineOptIn());
-  brave_drm_tab_helper()->OnWidevineKeySystemAccessRequest();
+  SimulateWidevineKeySystemAccessRequest();
   base::RunLoop().RunUntilIdle();
   EXPECT_TRUE(brave_drm_tab_helper()->ShouldShowWidevineOptIn());
 
@@ -143,7 +151,7 @@ TEST_F(WidevinePermissionAndroidTest, WidevinePermissionRequestTest) {
   permissions::PermissionRequestManager* manager = permission_request_manager();
 
   // Accept
-  brave_drm_tab_helper()->OnWidevineKeySystemAccessRequest();
+  SimulateWidevineKeySystemAccessRequest();
   base::RunLoop().RunUntilIdle();
 
   EXPECT_TRUE(manager->has_pending_requests() &&
@@ -155,7 +163,7 @@ TEST_F(WidevinePermissionAndroidTest, WidevinePermissionRequestTest) {
   // Deny
   local_state()->SetBoolean(kWidevineEnabled, false);
   SimulateNavigation();
-  brave_drm_tab_helper()->OnWidevineKeySystemAccessRequest();
+  SimulateWidevineKeySystemAccessRequest();
   base::RunLoop().RunUntilIdle();
 
   EXPECT_TRUE(manager->has_pending_requests() &&
@@ -165,7 +173,7 @@ TEST_F(WidevinePermissionAndroidTest, WidevinePermissionRequestTest) {
 
   // Cancel
   SimulateNavigation();
-  brave_drm_tab_helper()->OnWidevineKeySystemAccessRequest();
+  SimulateWidevineKeySystemAccessRequest();
   base::RunLoop().RunUntilIdle();
 
   EXPECT_TRUE(manager->has_pending_requests() &&

--- a/browser/widevine/widevine_permission_request_browsertest.cc
+++ b/browser/widevine/widevine_permission_request_browsertest.cc
@@ -26,8 +26,11 @@
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
 #include "chrome/test/permissions/permission_request_manager_test_api.h"
+#include "components/permissions/permission_request.h"
+#include "components/permissions/request_type.h"
 #include "components/prefs/pref_service.h"
 #include "components/update_client/crx_update_item.h"
+#include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
@@ -88,6 +91,14 @@ class WidevinePermissionRequestBrowserTest
     return BraveDrmTabHelper::FromWebContents(GetActiveWebContents());
   }
 
+  // BraveDrmTabHelper::OnWidevineKeySystemAccessRequest() can only resolve the
+  // requesting frame while a mojo message is being dispatched, so tests that
+  // don't go through the renderer name the frame explicitly.
+  void SimulateWidevineKeySystemAccessRequest() {
+    GetBraveDrmTabHelper()->OnWidevineKeySystemAccessRequestForFrame(
+        GetActiveWebContents()->GetPrimaryMainFrame());
+  }
+
   TestObserver observer;
   std::unique_ptr<test::PermissionRequestManagerTestApi> test_api_;
 };
@@ -95,16 +106,15 @@ class WidevinePermissionRequestBrowserTest
 IN_PROC_BROWSER_TEST_F(WidevinePermissionRequestBrowserTest, VisibilityTest) {
   GetPermissionRequestManager()->set_auto_response_for_test(
       permissions::PermissionRequestManager::DISMISS);
-  auto* drm_tab_helper = GetBraveDrmTabHelper();
 
   // Check permission bubble is visible.
-  drm_tab_helper->OnWidevineKeySystemAccessRequest();
+  SimulateWidevineKeySystemAccessRequest();
   content::RunAllTasksUntilIdle();
   EXPECT_TRUE(observer.bubble_added_);
 
   // Check permission is not requested again for same site.
   observer.bubble_added_ = false;
-  drm_tab_helper->OnWidevineKeySystemAccessRequest();
+  SimulateWidevineKeySystemAccessRequest();
   content::RunAllTasksUntilIdle();
   EXPECT_FALSE(observer.bubble_added_);
 
@@ -112,7 +122,7 @@ IN_PROC_BROWSER_TEST_F(WidevinePermissionRequestBrowserTest, VisibilityTest) {
   observer.bubble_added_ = false;
   EXPECT_TRUE(content::NavigateToURL(GetActiveWebContents(),
                                      GURL("chrome://newtab/")));
-  drm_tab_helper->OnWidevineKeySystemAccessRequest();
+  SimulateWidevineKeySystemAccessRequest();
   content::RunAllTasksUntilIdle();
   EXPECT_TRUE(observer.bubble_added_);
 
@@ -123,7 +133,7 @@ IN_PROC_BROWSER_TEST_F(WidevinePermissionRequestBrowserTest, VisibilityTest) {
       ->SetBoolean(kAskEnableWidvine, false);
   EXPECT_TRUE(content::NavigateToURL(GetActiveWebContents(),
                                      GURL("chrome://newtab/")));
-  drm_tab_helper->OnWidevineKeySystemAccessRequest();
+  SimulateWidevineKeySystemAccessRequest();
   content::RunAllTasksUntilIdle();
   EXPECT_FALSE(observer.bubble_added_);
 
@@ -134,7 +144,7 @@ IN_PROC_BROWSER_TEST_F(WidevinePermissionRequestBrowserTest, VisibilityTest) {
       ->SetBoolean(kAskEnableWidvine, true);
   EXPECT_TRUE(content::NavigateToURL(GetActiveWebContents(),
                                      GURL("chrome://newtab/")));
-  drm_tab_helper->OnWidevineKeySystemAccessRequest();
+  SimulateWidevineKeySystemAccessRequest();
   content::RunAllTasksUntilIdle();
   EXPECT_TRUE(observer.bubble_added_);
 }
@@ -144,7 +154,7 @@ IN_PROC_BROWSER_TEST_F(WidevinePermissionRequestBrowserTest, BubbleTest) {
   auto* permission_request_manager =
       GetPermissionRequestManager();
   EXPECT_FALSE(permission_request_manager->IsRequestInProgress());
-  GetBraveDrmTabHelper()->OnWidevineKeySystemAccessRequest();
+  SimulateWidevineKeySystemAccessRequest();
   content::RunAllTasksUntilIdle();
   EXPECT_TRUE(permission_request_manager->IsRequestInProgress());
 
@@ -169,8 +179,7 @@ IN_PROC_BROWSER_TEST_F(WidevinePermissionRequestBrowserTest,
 
   GetPermissionRequestManager()->set_auto_response_for_test(
       permissions::PermissionRequestManager::ACCEPT_ALL);
-  auto* drm_tab_helper = GetBraveDrmTabHelper();
-  drm_tab_helper->OnWidevineKeySystemAccessRequest();
+  SimulateWidevineKeySystemAccessRequest();
   content::RunAllTasksUntilIdle();
 
   // After we allow, opted in pref should be true
@@ -179,7 +188,7 @@ IN_PROC_BROWSER_TEST_F(WidevinePermissionRequestBrowserTest,
 
   // Reset observer and check permission bubble isn't created again.
   observer.bubble_added_ = false;
-  drm_tab_helper->OnWidevineKeySystemAccessRequest();
+  SimulateWidevineKeySystemAccessRequest();
   content::RunAllTasksUntilIdle();
   EXPECT_FALSE(observer.bubble_added_);
 }
@@ -194,7 +203,7 @@ IN_PROC_BROWSER_TEST_F(WidevinePermissionRequestBrowserTest,
   permission_request_manager->set_auto_response_for_test(
       permissions::PermissionRequestManager::ACCEPT_ALL);
 
-  GetBraveDrmTabHelper()->OnWidevineKeySystemAccessRequest();
+  SimulateWidevineKeySystemAccessRequest();
   content::RunAllTasksUntilIdle();
 
   WidevinePermissionRequest::is_test_ = true;
@@ -316,4 +325,57 @@ IN_PROC_BROWSER_TEST_F(ScriptTriggerWidevinePermissionRequestBrowserTest,
               content::EvalJsResult::ErrorIs(testing::Eq(js_error)));
   content::RunAllTasksUntilIdle();
   EXPECT_TRUE(IsPermissionBubbleShown());
+}
+
+// A request from a cross-origin subframe must be attributed to that subframe's
+// origin, not to the top level page.
+IN_PROC_BROWSER_TEST_F(ScriptTriggerWidevinePermissionRequestBrowserTest,
+                       PermissionIsAttributedToRequestingSubframeOrigin) {
+  const GURL main_url = https_server_.GetURL("a.com", "/simple.html");
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), main_url));
+  EXPECT_FALSE(IsPermissionBubbleShown());
+
+  // `encrypted-media` has a default allowlist of `self`, so without the
+  // `allow` grant requestMediaKeySystemAccess() throws a SecurityError before
+  // Brave is ever notified. The attribute is set before the frame is inserted
+  // because the container policy is computed when the frame navigates.
+  const GURL subframe_url = https_server_.GetURL("b.com", "/simple.html");
+  const std::string add_subframe_js = R"(
+      new Promise(resolve => {
+        const iframe = document.createElement('iframe');
+        iframe.setAttribute('allow', 'encrypted-media');
+        iframe.src = $1;
+        iframe.onload = () => resolve();
+        document.body.appendChild(iframe);
+      }))";
+  ASSERT_TRUE(content::ExecJs(
+      active_contents(), content::JsReplace(add_subframe_js, subframe_url)));
+
+  content::RenderFrameHost* subframe =
+      content::ChildFrameAt(active_contents()->GetPrimaryMainFrame(), 0);
+  ASSERT_TRUE(subframe);
+  ASSERT_EQ(subframe_url.DeprecatedGetOriginAsURL(),
+            subframe->GetLastCommittedOrigin().GetURL());
+
+  // Whether the promise resolves depends on whether a CDM is available, which
+  // varies by platform and build config. Brave is notified synchronously inside
+  // requestMediaKeySystemAccess() either way, so swallow the rejection rather
+  // than asserting on it. A synchronous throw still fails the test, which is
+  // what should happen if the permissions policy grant above stops working.
+  ASSERT_TRUE(content::ExecJs(subframe, R"(
+      var config = [{initDataTypes: ['cenc']}];
+      navigator.requestMediaKeySystemAccess('com.widevine.alpha', config)
+          .catch(() => {});)"));
+  content::RunAllTasksUntilIdle();
+
+  ASSERT_TRUE(IsPermissionBubbleShown());
+  const auto& requests = GetPermissionRequestManager()->Requests();
+  ASSERT_EQ(1u, requests.size());
+  EXPECT_EQ(permissions::RequestType::kWidevine, requests[0]->request_type());
+  EXPECT_EQ(subframe_url.DeprecatedGetOriginAsURL(),
+            requests[0]->requesting_origin());
+  // Spelled out separately because the top level origin is the specific wrong
+  // answer this test exists to catch: the helper used to pass the tab's URL.
+  EXPECT_NE(main_url.DeprecatedGetOriginAsURL(),
+            requests[0]->requesting_origin());
 }


### PR DESCRIPTION
This is AI-assisted, so I'd appreciate some eyes on this @goodov @boocmp. Thanks!

<!-- Add brave-browser issue below that this PR will resolve -->

- Resolves https://github.com/brave/brave-browser/issues/57649
- Resolves https://github.com/brave/internal/issues/1849 

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
