### PR TITLE
[VPN 2.0] Refresh VPN subscriber credential on expiry

### DIFF
--- a/components/brave_vpn/browser/v2/credential_store_unittest.cc
+++ b/components/brave_vpn/browser/v2/credential_store_unittest.cc
@@ -7,7 +7,6 @@
 
 #include <optional>
 #include <string>
-#include <string_view>
 #include <utility>
 
 #include "base/json/values_util.h"

--- a/components/brave_vpn/browser/v2/purchased_state_manager.cc
+++ b/components/brave_vpn/browser/v2/purchased_state_manager.cc
@@ -15,7 +15,6 @@
 #include "base/functional/bind.h"
 #include "base/location.h"
 #include "base/logging.h"
-#include "base/notimplemented.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/time/time.h"
 #include "base/timer/timer.h"
@@ -79,13 +78,14 @@ void PurchasedStateManager::Load(const std::string& domain) {
   // environment must authorize with SKUS from scratch.
   const std::string current_environment = GetCurrentEnvironment();
   if (current_environment == request_environment) {
-    if (credential_store_->GetValidSubscriberCredential().has_value()) {
+    if (std::optional<CredentialStore::Credential> cached_credential =
+            credential_store_->GetValidSubscriberCredential()) {
       // Already purchased. Serving from cache settles the visible state
       // immediately, so any in-flight load for another environment is cancelled
       // rather than left to finish against a state that just changed under it.
       VLOG(2) << "Already have valid subscriber credential, scheduling refresh";
       CancelPendingLoad();
-      ScheduleSubscriberCredentialRefresh();
+      ScheduleSubscriberCredentialRefresh(cached_credential->expiration);
       SetPurchasedState(request_environment, mojom::PurchasedState::PURCHASED);
       return;
     }
@@ -163,29 +163,21 @@ void PurchasedStateManager::SetPurchasedState(
 }
 
 void PurchasedStateManager::CheckInitialState() {
-  if (credential_store_->GetValidSubscriberCredential().has_value()) {
-    // Have a valid subscriber credential, so we are purchased. Schedule a
-    // refresh of the credential before it expires.
-    VLOG(2) << "Have valid subscriber credential, scheduling refresh";
-    ScheduleSubscriberCredentialRefresh();
-    SetPurchasedState(GetCurrentEnvironment(),
-                      mojom::PurchasedState::PURCHASED);
-  } else if (credential_store_->GetValidSkusCredential().has_value()) {
-    // There is a cached SKUS credential - exchange it for a subscriber
-    // credential upfront.
-    VLOG(2) << "Reloading purchased state due to cached SKUS credential";
-    Reload();
-  } else {
-    // A stored subscriber credential may have been invalidated while we were
-    // not running. Always clear whatever is cached; if something stale was
-    // present, reload the state.
-    const bool has_stale_credential = credential_store_->HasAnyCredential();
-    credential_store_->Clear();
-    if (has_stale_credential) {
-      VLOG(2) << "Reloading purchased state due to stale credential";
-      Reload();
-    }
+  // A stored subscriber credential might have been invalidated while we were
+  // not running. If nothing (even stale) is present, don't attempt to load
+  // the state.
+  if (!credential_store_->HasAnyCredential()) {
+    return;
   }
+  // Always clear cached stale credentials.
+  if (!credential_store_->GetValidSubscriberCredential() &&
+      !credential_store_->GetValidSkusCredential()) {
+    credential_store_->Clear();
+  }
+
+  // Load the state for the current environment; it will set the right purchased
+  // state, taking fast paths wherever possible.
+  Reload();
 }
 
 void PurchasedStateManager::BeginLoad(std::string env) {
@@ -450,7 +442,7 @@ void PurchasedStateManager::OnGetSubscriberCredential(
       .value = result.value(),
       .expiration = expiration_time,
   });
-  ScheduleSubscriberCredentialRefresh();
+  ScheduleSubscriberCredentialRefresh(expiration_time);
   FinishLoad(loading_environment_, mojom::PurchasedState::PURCHASED);
 }
 
@@ -460,8 +452,36 @@ void PurchasedStateManager::RunPurchasedStateCallback(
   purchased_state_changed_callback_.Run(state, std::move(description));
 }
 
-void PurchasedStateManager::ScheduleSubscriberCredentialRefresh() {
-  NOTIMPLEMENTED();
+void PurchasedStateManager::ScheduleSubscriberCredentialRefresh(
+    const base::Time& expiration_time) {
+  // We're scheduling a refresh at expiration, not earlier, because subscriber
+  // credential itself outlives SKUS expiry, so the refresh happens before the
+  // credential actually dies.
+  const base::TimeDelta delta = expiration_time - base::Time::Now();
+  VLOG(2) << "Schedule subscriber credential refresh after " << delta;
+  subscriber_credential_refresh_timer_.Start(
+      FROM_HERE, delta,
+      base::BindOnce(&PurchasedStateManager::RefreshSubscriberCredential,
+                     base::Unretained(this)));
+}
+
+void PurchasedStateManager::RefreshSubscriberCredential() {
+  VLOG(2) << "Refreshing subscriber credential...";
+
+  if (!loading_environment_.empty()) {
+    // A load for the CURRENT environment already owns resolution of the visible
+    // state: it reschedules the refresh on success, and on failure leaves none
+    // intentionally (recovery is manual). A silent load for ANOTHER environment
+    // does not touch the current environment, so it cannot settle the refresh -
+    // but the failure is fairly soft: we end up in a stale state that fixes
+    // itself on the next UI interaction.
+    VLOG(2) << "Load in flight, skipping refresh";
+    return;
+  }
+
+  // Clear the cached credential to get a new subscriber credential.
+  credential_store_->Clear();
+  Reload();
 }
 
 #if !BUILDFLAG(IS_ANDROID)

--- a/components/brave_vpn/browser/v2/purchased_state_manager.h
+++ b/components/brave_vpn/browser/v2/purchased_state_manager.h
@@ -107,7 +107,8 @@ class PurchasedStateManager final {
       base::expected<std::string, std::string> result);
   void RunPurchasedStateCallback(mojom::PurchasedState state,
                                  std::optional<std::string> description);
-  void ScheduleSubscriberCredentialRefresh();
+  void ScheduleSubscriberCredentialRefresh(const base::Time& expiration_time);
+  void RefreshSubscriberCredential();
 
 #if !BUILDFLAG(IS_ANDROID)
   void UpdatePurchasedStateForSessionExpired();
@@ -122,6 +123,7 @@ class PurchasedStateManager final {
   std::string loading_environment_;
   uint64_t loading_sequence_ = 0;
   base::OneShotTimer load_timeout_timer_;
+  base::OneShotTimer subscriber_credential_refresh_timer_;
   base::WeakPtrFactory<PurchasedStateManager> weak_factory_{this};
 };
 

--- a/components/brave_vpn/browser/v2/purchased_state_manager_unittest.cc
+++ b/components/brave_vpn/browser/v2/purchased_state_manager_unittest.cc
@@ -9,7 +9,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -383,6 +382,13 @@ class PurchasedStateManagerTest : public testing::Test {
     return credential_store_.HasAnyCredential();
   }
 
+  bool RefreshScheduled() const {
+    return manager_->subscriber_credential_refresh_timer_.IsRunning();
+  }
+  base::TimeDelta RefreshDelay() const {
+    return manager_->subscriber_credential_refresh_timer_.GetCurrentDelay();
+  }
+
  protected:
   base::test::TaskEnvironment task_environment_{
       base::test::TaskEnvironment::TimeSource::MOCK_TIME};
@@ -421,9 +427,20 @@ TEST_F(PurchasedStateManagerTest, InitialStateWithValidCredentialIsPurchased) {
   // State is settled synchronously at construction, and the notification is
   // delivered asynchronously.
   EXPECT_TRUE(manager_->IsPurchased());
+  EXPECT_TRUE(RefreshScheduled());
   EXPECT_EQ(skus_client_.credential_summary_calls(), 0);
   collector_.WaitForChangeCount(1);
   EXPECT_EQ(collector_.changes()[0].first, mojom::PurchasedState::PURCHASED);
+}
+
+TEST_F(PurchasedStateManagerTest, InitialStateWithSkusCredentialExchanges) {
+  SeedSkusCredential(base::Time::Now() + base::Days(30));
+  CreateManager();
+
+  EXPECT_TRUE(credential_store_.GetValidSkusCredential().has_value());
+  EXPECT_TRUE(api_client_.HasPendingExchange());
+  EXPECT_EQ(skus_client_.credential_summary_calls(), 0);
+  EXPECT_EQ(loading_environment(), CurrentEnvironment());
 }
 
 TEST_F(PurchasedStateManagerTest, InitialStateClearsStaleCredential) {
@@ -516,6 +533,7 @@ TEST_F(PurchasedStateManagerTest, CachedCredentialFastPathCancelsSilentLoad) {
   EXPECT_TRUE(loading_environment().empty());
   EXPECT_GT(loading_sequence(), silent_sequence);
   EXPECT_TRUE(manager_->IsPurchased());
+  EXPECT_TRUE(RefreshScheduled());
   EXPECT_EQ(skus_client_.credential_summary_calls(), 1);
 }
 
@@ -1066,6 +1084,73 @@ TEST_F(PurchasedStateManagerTest, ExpiredSummaryMeansNotPurchased) {
 }
 
 #endif  // !BUILDFLAG(IS_ANDROID)
+
+// Success schedules a refresh, at expiry today; firing it clears the cache and
+// re-resolves from scratch (a full summary round-trip, visible as LOADING).
+TEST_F(PurchasedStateManagerTest, SuccessSchedulesRefreshThatReresolves) {
+  CreateManager();
+  const base::Time expiry = base::Time::Now() + base::Days(30);
+  SeedSkusCredential(expiry);
+  manager_->Load(CurrentDomain());
+
+  api_client_.ResolveExchange(base::ok(std::string(kTestSubscriberCredential)));
+  ASSERT_TRUE(manager_->IsPurchased());
+  EXPECT_TRUE(RefreshScheduled());
+  EXPECT_EQ(RefreshDelay(), expiry - base::Time::Now());
+
+  task_environment_.FastForwardBy(base::Days(30) - base::Seconds(1));
+  EXPECT_TRUE(HasAnyStoredCredential());
+  task_environment_.FastForwardBy(base::Seconds(1));
+  EXPECT_FALSE(HasAnyStoredCredential());
+
+  EXPECT_EQ(skus_client_.credential_summary_calls(), 1);
+  EXPECT_EQ(manager_->GetInfo().state, mojom::PurchasedState::LOADING);
+}
+
+// A transient error during the refresh leaves the user un-purchased with
+// nothing scheduled to recover. This is intended behavior: the refresh can be
+// manually triggered by a user in the UI.
+TEST_F(PurchasedStateManagerTest,
+       RefreshTransientFailureDoesntScheduleRecovery) {
+  CreateManager();
+  SeedSkusCredential(base::Time::Now() + base::Days(30));
+  manager_->Load(CurrentDomain());
+
+  api_client_.ResolveExchange(base::ok(std::string(kTestSubscriberCredential)));
+  ASSERT_TRUE(manager_->IsPurchased());
+
+  task_environment_.FastForwardBy(base::Days(30));
+  CallOnCredentialSummary(loading_sequence(), CurrentDomain(),
+                          SkusTransportError());
+  EXPECT_EQ(manager_->GetInfo().state, mojom::PurchasedState::FAILED);
+  EXPECT_FALSE(RefreshScheduled());
+}
+
+// A load for the new environment makes the refresh yield to it entirely: no
+// clear, no reload, and no re-armed refresh either.
+TEST_F(PurchasedStateManagerTest, RefreshSkippedForEnvironmentLoad) {
+  SeedSubscriberCredential(base::Time::Now() +
+                           PurchasedStateManager::kLoadTimeout / 2);
+  CreateManager();  // PURCHASED + refresh armed at expiry.
+  ASSERT_TRUE(RefreshScheduled());
+
+  // Drop the cached credential so a current-environment Load() resolves through
+  // the async chain instead of the fast path, leaving a load in flight while
+  // the refresh (armed at construction) is still pending.
+  credential_store_.Clear();
+  manager_->Load(CurrentDomain());
+  ASSERT_EQ(loading_environment(), CurrentEnvironment());
+  ASSERT_EQ(skus_client_.credential_summary_calls(), 1);
+  const uint64_t in_flight_sequence = loading_sequence();
+
+  task_environment_.FastForwardBy(PurchasedStateManager::kLoadTimeout / 2);
+
+  // Yielded: the in-flight load is untouched and nothing was re-armed.
+  EXPECT_EQ(loading_environment(), CurrentEnvironment());
+  EXPECT_EQ(loading_sequence(), in_flight_sequence);
+  EXPECT_EQ(skus_client_.credential_summary_calls(), 1);
+  EXPECT_FALSE(RefreshScheduled());
+}
 
 class PurchasedStateManagerWithRealSkusServiceTest
     : public PurchasedStateManagerTest {


### PR DESCRIPTION
Schedule a one-shot timer whenever a subscriber credential is cached:
- at startup;
- on a successful exchange;
- on the cached-credential fast path.

The refresh call clears the credential and re-runs the reload chain when the subscriber credential expires, so an active subscription keeps a live credential without user action. Unsuccessful refresh doesn't retry automatically and relies on a regular UI action initiated by a user.

The change also simplifies CheckInitialState logic, thus removing one of the potential `ScheduleSubscriberCredentialRefresh` call sites.

Resolves https://github.com/brave/brave-browser/issues/56692

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
