### PR TITLE
Extract inline workflow scripts and add GitHub Actions lint CI

### DIFF
--- a/.github/workflows/compare-chromium-versions.yml
+++ b/.github/workflows/compare-chromium-versions.yml
@@ -15,41 +15,11 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github/workflows/scripts
+        if: github.event.pull_request.head.repo.full_name == github.repository
       - name: Check if CI and merge are allowed based on the Chromium version in the target branch
         if: github.event.pull_request.head.repo.full_name == github.repository
-        run: |
-          shopt -s inherit_errexit
-          set -eEo pipefail
-
-          chromium_ver() { gh api -H "Accept: application/vnd.github.raw+json" "https://api.github.com/repos/${GITHUB_REPOSITORY:?}/contents/package.json?ref=${1:?}"|jq -r .config.projects.chrome.tag; }
-          status() { echo "::${1:?}::${2:?}"; echo "$2" >>"${GITHUB_STEP_SUMMARY:?}"; }
-          has_label() { gh pr view "${PR_NUMBER:?}" -R "${GITHUB_REPOSITORY:?}" --json labels -q '.labels[].name'|grep -qxF chromium-version-mismatch; }
-          label() { gh pr edit "${PR_NUMBER:?}" -R "${GITHUB_REPOSITORY:?}" "--${1:?}-label" chromium-version-mismatch >/dev/null; }
-
-          pr_ver="$(chromium_ver "${PR_SHA:?}")"
-          target_ver="$(chromium_ver "${GITHUB_BASE_REF:?}")"
-
-          comment() { gh pr comment "${PR_NUMBER:?}" -R "${GITHUB_REPOSITORY:?}" -b "Chromium major version is behind target branch ($pr_ver vs $target_ver). Please rebase."; }
-          success() { status notice "${1:?}: CI ✅ | Merge ✅"; label remove; }
-
-          failure() {
-              case "${1:?}" in
-                  runci) ci=✅; label remove;;
-                  *) has_label || comment; ci=🚫; label add;;
-              esac
-              status error "${2:?}: CI $ci | Merge 🚫"
-              status error "Please rebase."
-              exit 2
-          }
-
-          echo "::notice::PR branch: ${pr_ver:?}, target branch: ${target_ver:?}"
-
-          if [[ "$pr_ver" == "$target_ver" ]]; then
-              success "Chromium version full match"
-          elif [[ "$(sort -V <<<"$target_ver"$'\n'"$pr_ver"|tail -n1)" == "$pr_ver" ]]; then
-              success "Chromium version is newer in the PR"
-          elif [[ "${pr_ver%%.*}" == "${target_ver%%.*}" ]]; then
-              success "Chromium major version match"
-          else
-              failure blockci "Chromium version mismatch"
-          fi
+        run: bash .github/workflows/scripts/compare-chromium-versions.sh

--- a/.github/workflows/lint-github-actions.yml
+++ b/.github/workflows/lint-github-actions.yml
@@ -1,0 +1,44 @@
+name: Lint GitHub Actions
+
+on:
+  pull_request:
+    paths:
+      - .github/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github/workflows
+      - uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
+
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github/workflows/scripts
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run shellcheck
+        run: shellcheck -x -S warning .github/workflows/scripts/*.sh
+
+# Note: JavaScript files placed under .github/workflows/scripts/ (e.g. consumed by
+# actions/github-script) are linted by the repository-wide ESLint configuration
+# (`npm run eslint`, see eslint.config.js) and PRESUBMIT CheckESLint under
+# PRESUBMIT_ALL_BRAVE. This workflow lints workflow YAML (actionlint) and shell
+# scripts (shellcheck) only.

--- a/.github/workflows/propagate-labels.yml
+++ b/.github/workflows/propagate-labels.yml
@@ -18,27 +18,11 @@ jobs:
     name: propagate labels
     runs-on: ubuntu-slim
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github/workflows/scripts
       - name: propagate labels
-        run: |
-          set -xeEo pipefail
-          shopt -s inherit_errexit
-
-          pr_number="${{ github.event.pull_request.number }}"
-          read -ra relevant_pr_labels <<<"$(gh pr view -R "$GITHUB_REPOSITORY" "$pr_number" --json labels -q ".labels[].name"|\
-            grep -E "${LABELS// /|}"|tr '\n' '\t')"
-
-          if [[ "${relevant_pr_labels[*]}" ]]; then
-            read -ra pr_issues <<<"$(gh api graphql -q ".data.repository.pullRequest.closingIssuesReferences.edges[].node.url" -f query="{
-              repository(owner: \"${GITHUB_REPOSITORY_OWNER:?}\", name: \"${GITHUB_REPOSITORY##*/}\") {
-                pullRequest(number: ${pr_number:?}) { closingIssuesReferences (first: 100) { edges { node { url } } } }
-              } }"|tr '\n' '\t')"
-
-            for label in "${relevant_pr_labels[@]}"; do
-              for issue in "${pr_issues[@]}"; do
-                if [[ "$(gh label list -R "$(echo "${issue:?}"|cut -d/ -f4-5)" -S "${label:?}" \
-                    --json name -q ".[]|select(.name==\"$label\").name")" ]]; then
-                  gh issue edit "$issue" --add-label "$label"
-                fi
-              done
-            done
-          fi
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: bash .github/workflows/scripts/propagate-labels.sh

--- a/.github/workflows/rerun-compare-chromium-versions.yml
+++ b/.github/workflows/rerun-compare-chromium-versions.yml
@@ -27,35 +27,9 @@ jobs:
       # TODO: This is the sha where the PR branched off, so not really what we want, but there seems to be no easy way to get the last pre-merge sha without a checkout
       TARGET_SHA: ${{ github.event.pull_request.base.sha }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github/workflows/scripts
       - name: If a major Chromium bump was merged, rerun compare-chromium-versions in all PRs targeting the same branch
-        run: |
-          shopt -s inherit_errexit
-          set -eEo pipefail
-
-          chromium_ver() {
-              gh api -H "Accept: application/vnd.github.raw+json" "https://api.github.com/repos/${GITHUB_REPOSITORY:?}/contents/package.json?ref=${1:?}"|jq -r .config.projects.chrome.tag
-          }
-
-          pr_ver="$(chromium_ver "${PR_SHA:?}")"
-          target_ver="$(chromium_ver "${TARGET_SHA:?}")"
-
-          echo "::notice::PR branch: ${GITHUB_HEAD_REF:?} (${pr_ver:?}), target branch: ${GITHUB_BASE_REF:?} (${target_ver:?})"
-
-          if [[ "${pr_ver%%.*}" != "${target_ver%%.*}" ]]; then
-              echo "::notice::Rerunning compare-chromium-versions in PRs targeting ${GITHUB_BASE_REF:?}"
-              while read -r pr_number head_sha; do
-                  run_id="$(gh api "/repos/$GITHUB_REPOSITORY/actions/workflows/compare-chromium-versions.yml/runs?head_sha=${head_sha:?}" -q '.workflow_runs[0].id')"
-                  pr_url="https://github.com/brave/brave-core/pull/${pr_number:?}"
-                  if [[ "$run_id" ]]; then
-                      echo "Rerunning $run_id for $pr_url"
-                      # TODO: Workflows older than 30 days will fail to rerun (by design), let's filter them out (using `|| true` for now)
-                      # https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/re-running-workflows-and-jobs
-                      gh -R "$GITHUB_REPOSITORY" run rerun "$run_id" || true
-                  else
-                      echo "No run found for $pr_url"
-                  fi
-                  sleep 1
-              done < <(gh -R "$GITHUB_REPOSITORY" pr list --limit 1000 --state open --base "$GITHUB_BASE_REF" --json number,headRefOid -q '.[]|"\(.number)\t\(.headRefOid)"')
-          else
-              echo "::notice::Chromium major versions match, nothing to do"
-          fi
+        run: bash .github/workflows/scripts/rerun-compare-chromium-versions.sh

--- a/.github/workflows/scripts/compare-chromium-versions.sh
+++ b/.github/workflows/scripts/compare-chromium-versions.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -eEo pipefail
+shopt -s inherit_errexit
+
+chromium_ver() {
+  gh api -H "Accept: application/vnd.github.raw+json" \
+    "https://api.github.com/repos/${GITHUB_REPOSITORY:?}/contents/package.json?ref=${1:?}" |
+    jq -r .config.projects.chrome.tag
+}
+
+status() {
+  echo "::${1:?}::${2:?}"
+  echo "$2" >>"${GITHUB_STEP_SUMMARY:?}"
+}
+
+has_label() {
+  gh pr view "${PR_NUMBER:?}" -R "${GITHUB_REPOSITORY:?}" --json labels -q '.labels[].name' |
+    grep -qxF chromium-version-mismatch
+}
+
+label() {
+  gh pr edit "${PR_NUMBER:?}" -R "${GITHUB_REPOSITORY:?}" "--${1:?}-label" chromium-version-mismatch >/dev/null
+}
+
+pr_ver="$(chromium_ver "${PR_SHA:?}")"
+target_ver="$(chromium_ver "${GITHUB_BASE_REF:?}")"
+
+comment() {
+  gh pr comment "${PR_NUMBER:?}" -R "${GITHUB_REPOSITORY:?}" \
+    -b "Chromium major version is behind target branch ($pr_ver vs $target_ver). Please rebase."
+}
+
+success() {
+  status notice "${1:?}: CI ✅ | Merge ✅"
+  label remove
+}
+
+failure() {
+  local ci
+  case "${1:?}" in
+    runci) ci=✅; label remove ;;
+    *) has_label || comment; ci=🚫; label add ;;
+  esac
+  status error "${2:?}: CI $ci | Merge 🚫"
+  status error "Please rebase."
+  exit 2
+}
+
+echo "::notice::PR branch: ${pr_ver:?}, target branch: ${target_ver:?}"
+
+if [[ "$pr_ver" == "$target_ver" ]]; then
+  success "Chromium version full match"
+elif [[ "$(sort -V <<<"$target_ver"$'\n'"$pr_ver" | tail -n1)" == "$pr_ver" ]]; then
+  success "Chromium version is newer in the PR"
+elif [[ "${pr_ver%%.*}" == "${target_ver%%.*}" ]]; then
+  success "Chromium major version match"
+else
+  failure blockci "Chromium version mismatch"
+fi

--- a/.github/workflows/scripts/propagate-labels.sh
+++ b/.github/workflows/scripts/propagate-labels.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -xeEo pipefail
+shopt -s inherit_errexit
+
+pr_number="${PR_NUMBER:?}"
+
+read -ra relevant_pr_labels <<<"$(gh pr view -R "${GITHUB_REPOSITORY:?}" "$pr_number" \
+  --json labels -q ".labels[].name" | grep -E "${LABELS// /|}" | tr '\n' '\t')"
+
+if [[ "${relevant_pr_labels[*]}" ]]; then
+  read -ra pr_issues <<<"$(gh api graphql -q \
+    ".data.repository.pullRequest.closingIssuesReferences.edges[].node.url" -f query="{
+      repository(owner: \"${GITHUB_REPOSITORY_OWNER:?}\", name: \"${GITHUB_REPOSITORY##*/}\") {
+        pullRequest(number: ${pr_number:?}) { closingIssuesReferences (first: 100) { edges { node { url } } } }
+      } }" | tr '\n' '\t')"
+
+  for label in "${relevant_pr_labels[@]}"; do
+    for issue in "${pr_issues[@]}"; do
+      if [[ "$(gh label list -R "$(echo "${issue:?}" | cut -d/ -f4-5)" \
+        -S "${label:?}" --json name -q ".[]|select(.name==\"$label\").name")" ]]; then
+        gh issue edit "$issue" --add-label "$label"
+      fi
+    done
+  done
+fi

--- a/.github/workflows/scripts/rerun-compare-chromium-versions.sh
+++ b/.github/workflows/scripts/rerun-compare-chromium-versions.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -eEo pipefail
+shopt -s inherit_errexit
+
+chromium_ver() {
+  gh api -H "Accept: application/vnd.github.raw+json" \
+    "https://api.github.com/repos/${GITHUB_REPOSITORY:?}/contents/package.json?ref=${1:?}" |
+    jq -r .config.projects.chrome.tag
+}
+
+pr_ver="$(chromium_ver "${PR_SHA:?}")"
+target_ver="$(chromium_ver "${TARGET_SHA:?}")"
+
+echo "::notice::PR branch: ${GITHUB_HEAD_REF:?} (${pr_ver:?}), target branch: ${GITHUB_BASE_REF:?} (${target_ver:?})"
+
+if [[ "${pr_ver%%.*}" != "${target_ver%%.*}" ]]; then
+  echo "::notice::Rerunning compare-chromium-versions in PRs targeting ${GITHUB_BASE_REF:?}"
+  while read -r pr_number head_sha; do
+    run_id="$(gh api "/repos/$GITHUB_REPOSITORY/actions/workflows/compare-chromium-versions.yml/runs?head_sha=${head_sha:?}" -q '.workflow_runs[0].id')"
+    pr_url="https://github.com/brave/brave-core/pull/${pr_number:?}"
+    if [[ -n "$run_id" ]]; then
+      echo "Rerunning $run_id for $pr_url"
+      # TODO: Workflows older than 30 days will fail to rerun (by design), let's filter them out (using `|| true` for now)
+      # https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/re-running-workflows-and-jobs
+      gh -R "$GITHUB_REPOSITORY" run rerun "$run_id" || true
+    else
+      echo "No run found for $pr_url"
+    fi
+    sleep 1
+  done < <(gh -R "$GITHUB_REPOSITORY" pr list --limit 1000 --state open --base "$GITHUB_BASE_REF" \
+    --json number,headRefOid -q '.[]|"\(.number)\t\(.headRefOid)"')
+else
+  echo "::notice::Chromium major versions match, nothing to do"
+fi

--- a/.github/workflows/scripts/socket-fix-open-pr.sh
+++ b/.github/workflows/scripts/socket-fix-open-pr.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -eEo pipefail
+shopt -s inherit_errexit
+
+if [ -z "$(git status --porcelain)" ]; then
+  echo "::error::No changes produced by socket fix."
+  exit 1
+fi
+
+BRANCH="socket-fix/$(echo "$GHSA_IDS" | tr ', ' '-' | tr -s '-' | cut -c1-60)"
+HEAD_SHA=$(gh api "/repos/${GITHUB_REPOSITORY}/git/refs/heads/master" -q '.object.sha')
+
+if gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/$BRANCH" -q .ref > /dev/null 2>&1; then
+  gh api --method PATCH "/repos/${GITHUB_REPOSITORY}/git/refs/heads/$BRANCH" \
+    --field sha="$HEAD_SHA" --field force=true
+else
+  gh api --method POST /repos/${GITHUB_REPOSITORY}/git/refs \
+    --field ref="refs/heads/$BRANCH" --field sha="$HEAD_SHA"
+fi
+
+TREE_JSON="[]"
+while IFS= read -r -d $'\0' line; do
+  XY="${line:0:2}"
+  FILE="${line:3}"
+  # For rename/copy entries the old path follows as the next NUL entry;
+  # emit a deletion for it so the source path is removed from the tree.
+  if [[ "${XY:0:1}" =~ [RC] ]]; then
+    IFS= read -r -d $'\0' _old_path
+    if [[ "${XY:0:1}" == "R" ]]; then
+      TREE_JSON=$(jq --arg path "$_old_path" \
+        '. += [{"path": $path, "mode": "100644", "type": "blob", "sha": null}]' \
+        <<< "$TREE_JSON")
+    fi
+  fi
+  if [[ "${XY:1:1}" == "D" ]]; then
+    TREE_JSON=$(jq --arg path "$FILE" \
+      '. += [{"path": $path, "mode": "100644", "type": "blob", "sha": null}]' \
+      <<< "$TREE_JSON")
+  else
+    MODE=$(git ls-files -s -- "$FILE" | awk 'NR==1 { print $1 }')
+    [[ -z "$MODE" ]] && MODE="100644"
+    if [[ "$MODE" == "120000" ]]; then
+      BLOB_SHA=$(gh api --method POST /repos/${GITHUB_REPOSITORY}/git/blobs \
+        --field content=@<(printf '%s' "$(readlink -- "$FILE")" | base64 -w 0) \
+        --field encoding=base64 \
+        -q .sha)
+    else
+      BLOB_SHA=$(gh api --method POST /repos/${GITHUB_REPOSITORY}/git/blobs \
+        --field content=@<(base64 -w 0 -- "$FILE") \
+        --field encoding=base64 \
+        -q .sha)
+    fi
+    TREE_JSON=$(jq --arg path "$FILE" --arg mode "$MODE" --arg sha "$BLOB_SHA" \
+      '. += [{"path": $path, "mode": $mode, "type": "blob", "sha": $sha}]' \
+      <<< "$TREE_JSON")
+  fi
+done < <(git status --porcelain=v1 -z)
+
+BASE_TREE=$(gh api /repos/${GITHUB_REPOSITORY}/git/commits/"$HEAD_SHA" -q .tree.sha)
+
+NEW_TREE_SHA=$(jq -n \
+  --arg base_tree "$BASE_TREE" \
+  --argjson tree "$TREE_JSON" \
+  '{"base_tree": $base_tree, "tree": $tree}' | \
+  gh api --method POST /repos/${GITHUB_REPOSITORY}/git/trees --input - -q .sha)
+
+NEW_COMMIT_SHA=$(jq -n \
+  --arg tree "$NEW_TREE_SHA" \
+  --arg parent "$HEAD_SHA" \
+  '{"message": "fix: address security advisories", "tree": $tree, "parents": [$parent]}' | \
+  gh api --method POST /repos/${GITHUB_REPOSITORY}/git/commits --input - -q .sha)
+
+gh api --method PATCH /repos/${GITHUB_REPOSITORY}/git/refs/heads/"$BRANCH" \
+  --field sha="$NEW_COMMIT_SHA"
+
+BODY="Addresses: $GHSA_IDS"
+IFS=',' read -ra LINKS <<< "$ISSUE_LINK"
+for link in "${LINKS[@]}"; do
+  BODY="$BODY"$'\n\n'"closes ${link// /}"
+done
+if [[ -n "$WDP_REF" ]]; then
+  WDP_PR=$(gh api "repos/brave/web-discovery-project/commits/$WDP_REF/pulls" -q '.[0].html_url' 2>/dev/null || true)
+  [[ -n "$WDP_PR" ]] && BODY="$BODY"$'\n\n'"WDP: $WDP_PR"
+fi
+if [[ -n "$LEO_REF" ]]; then
+  LEO_PR=$(gh api "repos/brave/leo/commits/$LEO_REF/pulls" -q '.[0].html_url' 2>/dev/null || true)
+  [[ -n "$LEO_PR" ]] && BODY="$BODY"$'\n\n'"Leo: $LEO_PR"
+fi
+if ! gh pr list --repo "${GITHUB_REPOSITORY}" --head "$BRANCH" --json number -q '.[].number' | grep -q .; then
+  gh pr create \
+    --repo "${GITHUB_REPOSITORY}" \
+    --title "fix: address security advisories" \
+    --body "$BODY" \
+    --head "$BRANCH" \
+    --base master \
+    --label "CI/skip" \
+    --label "security"
+fi

--- a/.github/workflows/scripts/socket-fix-run.sh
+++ b/.github/workflows/scripts/socket-fix-run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -eEo pipefail
+
+if ! [[ "$GHSA_IDS" =~ ^GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}(,[[:space:]]?GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4})*$ ]]; then
+  echo "::error::GHSA_IDS contains invalid entries. Expected format: GHSA-xxxx-xxxx-xxxx (comma or comma-space separated)"
+  exit 1
+fi
+
+IFS=',' read -ra IDS <<< "$GHSA_IDS"
+for id in "${IDS[@]}"; do
+  FLAGS+=(--id "${id// /}")
+done
+
+socket config set defaultOrg "brave"
+socket fix . "${FLAGS[@]}"

--- a/.github/workflows/scripts/socket-fix-update-leo.sh
+++ b/.github/workflows/scripts/socket-fix-update-leo.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -eEo pipefail
+
+[[ "$LEO_REF" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::Invalid leo_ref: must be a 40-char hex SHA"; exit 1; }
+sed -i -E "s|(\"@brave/leo\"[^#]*#)[0-9a-f]{40}|\1${LEO_REF}|" package.json
+grep -q "$LEO_REF" package.json || { echo "::error::Failed to update Leo hash in package.json"; exit 1; }

--- a/.github/workflows/scripts/socket-fix-update-wdp.sh
+++ b/.github/workflows/scripts/socket-fix-update-wdp.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -eEo pipefail
+
+[[ "$WDP_REF" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::Invalid wdp_ref: must be a 40-char hex SHA"; exit 1; }
+sed -i -E "s|(\"vendor/web-discovery-project\"[^@]*@)[0-9a-f]{40}|\1${WDP_REF}|" DEPS
+grep -q "$WDP_REF" DEPS || { echo "::error::Failed to update WDP hash in DEPS"; exit 1; }

--- a/.github/workflows/scripts/sync-pr-from-fork.sh
+++ b/.github/workflows/scripts/sync-pr-from-fork.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -x
+
+git config user.name brave-builds
+git config user.email devops@brave.com
+git config push.default simple
+
+if ! grep -qix '[0-9a-f]\{40,40\}' <<<"$COMMIT_HASH"; then
+  echo "Provide a full commit hash; got: $COMMIT_HASH"
+  exit 1
+fi
+
+pr_number="${PR_NUMBER:-"$(gh pr list --search "$COMMIT_HASH" --json number -q '.[].number')"}"
+gh_pr_view=$(gh pr view "${pr_number:?}" --json baseRefName,headRefName,headRepository,headRepositoryOwner,id,isCrossRepository,url)
+
+JQ=(jq -e -r)
+baseRefName=$("${JQ[@]}" ".baseRefName" <<<"$gh_pr_view")
+headRefName=$("${JQ[@]}" ".headRefName" <<<"$gh_pr_view")
+headRepositoryName=$("${JQ[@]}" ".headRepository.name" <<<"$gh_pr_view")
+headRepositoryOwnerLogin=$("${JQ[@]}" ".headRepositoryOwner.login" <<<"$gh_pr_view")
+isCrossRepository=$("${JQ[@]}" ".isCrossRepository" <<<"$gh_pr_view")
+
+[[ "$isCrossRepository" = "true" ]] || { echo "PR is not cross repo. Exiting!"; exit 1; }
+
+git remote add contributor "https://github.com/$headRepositoryOwnerLogin/$headRepositoryName.git" || :
+contribHeadRefName="contributor-$headRepositoryOwnerLogin-$headRefName"
+git fetch --no-tags contributor +"$headRefName":"$contribHeadRefName"
+# Note we are checking out the provided commit hash instead of the pr-branch to avoid race condition
+# The author could have commited malicious code between the last review and the execution of this workflow
+git checkout "$COMMIT_HASH"
+git push -f origin HEAD:"refs/heads/$contribHeadRefName"
+
+existing_prs=$(gh pr list -H "$contribHeadRefName" --json number)
+if [[ "$existing_prs" = "[]" ]]; then
+  gh pr create \
+    --draft \
+    --base "$baseRefName" \
+    --head "$contribHeadRefName" \
+    --title "CI run for contributor PR #$pr_number" \
+    --body \
+"## Description
+This PR is created to run CI on the changes proposed in PR #$pr_number by @$headRepositoryOwnerLogin.
+
+**This PR should not be merged.**"
+fi

--- a/.github/workflows/scripts/update-dep.sh
+++ b/.github/workflows/scripts/update-dep.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -eEo pipefail
+shopt -s inherit_errexit
+
+SED="sed"
+
+get_dep_url() {
+  sed -n '/deps = {/, /^}/p' DEPS | sed 's/deps = //' |
+    python3 -c "import sys, ast; d=ast.literal_eval(sys.stdin.read()); dep=d[\"$1\"]; print(dep) if isinstance(dep, str) else print(dep.get(\"url\"))"
+}
+
+get_dep_repo() {
+  echo "$1" | grep -Po '(?<=github.com\/).*?(?=\.git)?(?=@)' | sed 's/\.git//'
+}
+
+# Inputs
+DEP="${DEP:?}"
+DEPREF="${DEPREF:-}"
+
+[[ "${DEP:?}" =~ ^[a-zA-Z/-]+$ ]] || { echo "Input dependency validation failed"; exit 1; }
+if [[ -z "${DEPREF}" ]]; then
+  echo "Attempting to guess ref hash"
+  DEP_REPO=$(get_dep_repo "$(get_dep_url "$DEP")")
+  gh api /repos/"${DEP_REPO}"/commits/master -q .sha > /tmp/DEPREF || gh api /repos/"${DEP_REPO}"/commits/main -q .sha > /tmp/DEPREF
+  DEPREF=$(</tmp/DEPREF)
+fi
+[[ "${DEPREF:?}" =~ ^[a-z0-9]+$ ]] || { echo "Dependency reference validation failed"; exit 1; }
+if grep -q "$DEPREF" DEPS; then
+  echo "Dependency reference already exists in DEPS. Cannot continue"
+  exit 1
+fi
+
+# readarray -t milestones < <(gh api /repos/${GITHUB_REPOSITORY:?}/milestones -q ".[] | .title" | grep -Fv Closed)
+# branches=( "${milestones[@]/*Nightly/master}" )
+# branches=( "${branches[@]/ -*/}" )
+# echo "Branches to operate on: ${branches[*]}"
+# For now, forcing branches to only master
+branches=(master)
+for branch in "${branches[@]}"; do
+  git switch "$branch"
+  # Current dep URL on this branch (before bump) — used for compare link in PR body
+  DEP_URL=$(get_dep_url "$DEP")
+  DEP_REPO=$(get_dep_repo "$DEP_URL")
+  OLD_REF="${DEP_URL##*@}"
+
+  pr_branch="update-dep-${branch}-${DEP}-${DEPREF}"
+  if git rev-parse --verify "$pr_branch" 2>/dev/null; then continue; fi # Skip duplicate
+  git switch -c "$pr_branch"
+  "$SED" -i -e "s,^\(\s*\"$DEP\"\s*:\s*\"https.*\)@[^\"]*\",\1@$DEPREF\"," \
+            -e "/^\s*\"${DEP//\//\\/}\"\s*:\s*{/,/@/ s/@[^\"]*/@$DEPREF/" DEPS
+  git push -u origin "$pr_branch"
+  gh api \
+    --method PUT "/repos/${GITHUB_REPOSITORY}/contents/DEPS" \
+    --field message="Update dependency ${DEP}@${DEPREF}" \
+    --field content=@<(base64 -i DEPS) \
+    --field encoding=base64 \
+    --field branch="$pr_branch" \
+    --field sha="$(git rev-parse "$pr_branch:DEPS")"
+  git restore DEPS
+  git pull
+  PR_BODY="https://github.com/${DEP_REPO}/compare/${OLD_REF}...${DEPREF}"
+  gh pr create --base "${branch}" -t "Update dependency ${DEP}@${DEPREF}" -b "${PR_BODY}" -l "CI/run-audit-deps"
+done

--- a/.github/workflows/socket-fix.yml
+++ b/.github/workflows/socket-fix.yml
@@ -39,19 +39,13 @@ jobs:
         if: inputs.wdp_ref != ''
         env:
           WDP_REF: ${{ inputs.wdp_ref }}
-        run: |
-          [[ "$WDP_REF" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::Invalid wdp_ref: must be a 40-char hex SHA"; exit 1; }
-          sed -i -E "s|(\"vendor/web-discovery-project\"[^@]*@)[0-9a-f]{40}|\1${WDP_REF}|" DEPS
-          grep -q "$WDP_REF" DEPS || { echo "::error::Failed to update WDP hash in DEPS"; exit 1; }
+        run: bash .github/workflows/scripts/socket-fix-update-wdp.sh
 
       - name: Update Leo in package.json
         if: inputs.leo_ref != ''
         env:
           LEO_REF: ${{ inputs.leo_ref }}
-        run: |
-          [[ "$LEO_REF" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::Invalid leo_ref: must be a 40-char hex SHA"; exit 1; }
-          sed -i -E "s|(\"@brave/leo\"[^#]*#)[0-9a-f]{40}|\1${LEO_REF}|" package.json
-          grep -q "$LEO_REF" package.json || { echo "::error::Failed to update Leo hash in package.json"; exit 1; }
+        run: bash .github/workflows/scripts/socket-fix-update-leo.sh
 
       - name: Install Socket CLI
         run: npm install -g @socketsecurity/cli
@@ -62,15 +56,7 @@ jobs:
           SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
           SOCKET_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI: ''
-        run: |
-          if ! [[ "$GHSA_IDS" =~ ^GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}(,[[:space:]]?GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4})*$ ]]; then
-            echo "::error::GHSA_IDS contains invalid entries. Expected format: GHSA-xxxx-xxxx-xxxx (comma or comma-space separated)"
-            exit 1
-          fi
-          IFS=',' read -ra IDS <<< "$GHSA_IDS"
-          for id in "${IDS[@]}"; do FLAGS+=(--id "${id// /}"); done
-          socket config set defaultOrg "brave"
-          socket fix . "${FLAGS[@]}"
+        run: bash .github/workflows/scripts/socket-fix-run.sh
 
       - name: Open Pull Request
         env:
@@ -79,101 +65,5 @@ jobs:
           ISSUE_LINK: ${{ inputs.issue_link }}
           WDP_REF: ${{ inputs.wdp_ref }}
           LEO_REF: ${{ inputs.leo_ref }}
-        run: |
-          shopt -s inherit_errexit
-          set -eEo pipefail
+        run: bash .github/workflows/scripts/socket-fix-open-pr.sh
 
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "::error::No changes produced by socket fix."
-            exit 1
-          fi
-
-          BRANCH="socket-fix/$(echo "$GHSA_IDS" | tr ', ' '-' | tr -s '-' | cut -c1-60)"
-          HEAD_SHA=$(gh api "/repos/${GITHUB_REPOSITORY}/git/refs/heads/master" -q '.object.sha')
-
-          if gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/$BRANCH" -q .ref > /dev/null 2>&1; then
-            gh api --method PATCH "/repos/${GITHUB_REPOSITORY}/git/refs/heads/$BRANCH" \
-              --field sha="$HEAD_SHA" --field force=true
-          else
-            gh api --method POST /repos/${GITHUB_REPOSITORY}/git/refs \
-              --field ref="refs/heads/$BRANCH" --field sha="$HEAD_SHA"
-          fi
-
-          TREE_JSON="[]"
-          while IFS= read -r -d $'\0' line; do
-            XY="${line:0:2}"
-            FILE="${line:3}"
-            # For rename/copy entries the old path follows as the next NUL entry;
-            # emit a deletion for it so the source path is removed from the tree.
-            if [[ "${XY:0:1}" =~ [RC] ]]; then
-              IFS= read -r -d $'\0' _old_path
-              if [[ "${XY:0:1}" == "R" ]]; then
-                TREE_JSON=$(jq --arg path "$_old_path" \
-                  '. += [{"path": $path, "mode": "100644", "type": "blob", "sha": null}]' \
-                  <<< "$TREE_JSON")
-              fi
-            fi
-            if [[ "${XY:1:1}" == "D" ]]; then
-              TREE_JSON=$(jq --arg path "$FILE" \
-                '. += [{"path": $path, "mode": "100644", "type": "blob", "sha": null}]' \
-                <<< "$TREE_JSON")
-            else
-              MODE=$(git ls-files -s -- "$FILE" | awk 'NR==1 { print $1 }')
-              [[ -z "$MODE" ]] && MODE="100644"
-              if [[ "$MODE" == "120000" ]]; then
-                BLOB_SHA=$(gh api --method POST /repos/${GITHUB_REPOSITORY}/git/blobs \
-                  --field content=@<(printf '%s' "$(readlink -- "$FILE")" | base64 -w 0) \
-                  --field encoding=base64 \
-                  -q .sha)
-              else
-                BLOB_SHA=$(gh api --method POST /repos/${GITHUB_REPOSITORY}/git/blobs \
-                  --field content=@<(base64 -w 0 -- "$FILE") \
-                  --field encoding=base64 \
-                  -q .sha)
-              fi
-              TREE_JSON=$(jq --arg path "$FILE" --arg mode "$MODE" --arg sha "$BLOB_SHA" \
-                '. += [{"path": $path, "mode": $mode, "type": "blob", "sha": $sha}]' \
-                <<< "$TREE_JSON")
-            fi
-          done < <(git status --porcelain=v1 -z)
-
-          BASE_TREE=$(gh api /repos/${GITHUB_REPOSITORY}/git/commits/"$HEAD_SHA" -q .tree.sha)
-
-          NEW_TREE_SHA=$(jq -n \
-            --arg base_tree "$BASE_TREE" \
-            --argjson tree "$TREE_JSON" \
-            '{"base_tree": $base_tree, "tree": $tree}' | \
-            gh api --method POST /repos/${GITHUB_REPOSITORY}/git/trees --input - -q .sha)
-
-          NEW_COMMIT_SHA=$(jq -n \
-            --arg tree "$NEW_TREE_SHA" \
-            --arg parent "$HEAD_SHA" \
-            '{"message": "fix: address security advisories", "tree": $tree, "parents": [$parent]}' | \
-            gh api --method POST /repos/${GITHUB_REPOSITORY}/git/commits --input - -q .sha)
-
-          gh api --method PATCH /repos/${GITHUB_REPOSITORY}/git/refs/heads/"$BRANCH" \
-            --field sha="$NEW_COMMIT_SHA"
-
-          BODY="Addresses: $GHSA_IDS"
-          IFS=',' read -ra LINKS <<< "$ISSUE_LINK"
-          for link in "${LINKS[@]}"; do
-            BODY="$BODY"$'\n\n'"closes ${link// /}"
-          done
-          if [[ -n "$WDP_REF" ]]; then
-            WDP_PR=$(gh api "repos/brave/web-discovery-project/commits/$WDP_REF/pulls" -q '.[0].html_url' 2>/dev/null || true)
-            [[ -n "$WDP_PR" ]] && BODY="$BODY"$'\n\n'"WDP: $WDP_PR"
-          fi
-          if [[ -n "$LEO_REF" ]]; then
-            LEO_PR=$(gh api "repos/brave/leo/commits/$LEO_REF/pulls" -q '.[0].html_url' 2>/dev/null || true)
-            [[ -n "$LEO_PR" ]] && BODY="$BODY"$'\n\n'"Leo: $LEO_PR"
-          fi
-          if ! gh pr list --repo "${GITHUB_REPOSITORY}" --head "$BRANCH" --json number -q '.[].number' | grep -q .; then
-            gh pr create \
-              --repo "${GITHUB_REPOSITORY}" \
-              --title "fix: address security advisories" \
-              --body "$BODY" \
-              --head "$BRANCH" \
-              --base master \
-              --label "CI/skip" \
-              --label "security"
-          fi

--- a/.github/workflows/sync-pr-from-fork.yml
+++ b/.github/workflows/sync-pr-from-fork.yml
@@ -23,56 +23,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Git
-        run: |
-          git config user.name brave-builds
-          git config user.email devops@brave.com
-          git config push.default simple
-
       - name: Sync and rebase PR from fork
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           PR_NUMBER: ${{ inputs.PR_NUMBER }}
           COMMIT_HASH: ${{ inputs.COMMIT_HASH }}
-        run: |
-          set -x
-
-          if ! grep -qix '[0-9a-f]\{40,40\}' <<<"$COMMIT_HASH"; then
-            echo "Provide a full commit hash; got: $COMMIT_HASH"
-            exit 1
-          fi
-
-          pr_number="${PR_NUMBER:-"$(gh pr list --search "$COMMIT_HASH" --json number -q '.[].number')"}"
-          gh_pr_view=$(gh pr view "${pr_number:?}" --json baseRefName,headRefName,headRepository,headRepositoryOwner,id,isCrossRepository,url)
-
-          JQ="jq -e -r"
-          baseRefName=$($JQ ".baseRefName" <<<"$gh_pr_view")
-          headRefName=$($JQ ".headRefName" <<<"$gh_pr_view")
-          headRepositoryName=$($JQ ".headRepository.name" <<<"$gh_pr_view")
-          headRepositoryOwnerLogin=$($JQ ".headRepositoryOwner.login" <<<"$gh_pr_view")
-          isCrossRepository=$($JQ ".isCrossRepository" <<<"$gh_pr_view")
-          url=$($JQ ".url" <<<"$gh_pr_view")
-
-          [[ "$isCrossRepository" = "true" ]] || { echo "PR is not cross repo. Exiting!"; exit 1; }
-
-          git remote add contributor "https://github.com/$headRepositoryOwnerLogin/$headRepositoryName.git" || :
-          contribHeadRefName="contributor-$headRepositoryOwnerLogin-$headRefName"
-          git fetch --no-tags contributor +"$headRefName":"$contribHeadRefName"
-          # Note we are checking out the provided commit hash instead of the pr-branch to avoid race condition
-          # The author could have commited malicious code between the last review and the execution of this workflow
-          git checkout "$COMMIT_HASH"
-          git push -f origin HEAD:"refs/heads/$contribHeadRefName"
-
-          existing_prs=$(gh pr list -H "$contribHeadRefName" --json number)
-          if [[ "$existing_prs" = "[]" ]]; then
-            gh pr create \
-              --draft \
-              --base "$baseRefName" \
-              --head "$contribHeadRefName" \
-              --title "CI run for contributor PR #$pr_number" \
-              --body \
-          "## Description
-          This PR is created to run CI on the changes proposed in PR #$pr_number by @$headRepositoryOwnerLogin.
-
-          **This PR should not be merged.**"
-          fi
+        run: bash .github/workflows/scripts/sync-pr-from-fork.sh

--- a/.github/workflows/update-dep.yml
+++ b/.github/workflows/update-dep.yml
@@ -34,64 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Update dependency
-        run: |
-          shopt -s inherit_errexit
-          set -eEo pipefail
-
-          SED=sed
-
-          get_dep_url() {
-            sed -n '/deps = {/, /^}/p' DEPS | sed 's/deps = //' |
-              python3 -c "import sys, ast; d=ast.literal_eval(sys.stdin.read()); dep=d[\"$1\"]; print(dep) if isinstance(dep, str) else print(dep.get(\"url\"))"
-          }
-
-          get_dep_repo() {
-            echo "$1" | grep -Po '(?<=github.com\/).*?(?=\.git)?(?=@)' | sed 's/\.git//'
-          }
-
-          # Inputs
-          DEP="${{ inputs.dep }}"
-          DEPREF="${{ inputs.ref }}"
-
-          [[ "${DEP:?}" =~ ^[a-zA-Z/-]+$ ]] || { echo "Input dependency validation failed"; exit 1; }
-          if [[ -z "${DEPREF}" ]]; then
-            echo "Attempting to guess ref hash"
-            DEP_REPO=$(get_dep_repo "$(get_dep_url "$DEP")")
-            gh api /repos/"${DEP_REPO}"/commits/master -q .sha > /tmp/DEPREF || gh api /repos/"${DEP_REPO}"/commits/main -q .sha > /tmp/DEPREF
-            DEPREF=$(</tmp/DEPREF)
-          fi
-          [[ "${DEPREF:?}" =~ ^[a-z0-9]+$ ]] || { echo "Dependency reference validation failed"; exit 1; }
-          ! $(grep -q "$DEPREF" DEPS) || { echo "Dependency reference already exists in DEPS. Cannot continue"; exit 1; }
-
-          # readarray -t milestones < <(gh api /repos/${GITHUB_REPOSITORY:?}/milestones -q ".[] | .title" | grep -Fv Closed)
-          # branches=( "${milestones[@]/*Nightly/master}" )
-          # branches=( "${branches[@]/ -*/}" )
-          # echo "Branches to operate on: ${branches[*]}"
-          # For now, forcing branches to only master
-          branches=(master)
-          for branch in "${branches[@]}"
-          do
-            git switch "$branch"
-            # Current dep URL on this branch (before bump) — used for compare link in PR body
-            DEP_URL=$(get_dep_url "$DEP")
-            DEP_REPO=$(get_dep_repo "$DEP_URL")
-            OLD_REF="${DEP_URL##*@}"
-
-            pr_branch="update-dep-${branch}-${DEP}-${DEPREF}"
-            if git rev-parse --verify "$pr_branch" 2>/dev/null; then continue; fi # Skip duplicate
-            git switch -c "$pr_branch"
-            "$SED" -i -e "s,^\(\s*\"$DEP\"\s*:\s*\"https.*\)@[^\"]*\",\1@$DEPREF\"," \
-                      -e "/^\s*\"${DEP//\//\\/}\"\s*:\s*{/,/@/ s/@[^\"]*/@$DEPREF/" DEPS
-            git push -u origin "$pr_branch"
-            gh api \
-                --method PUT "/repos/${GITHUB_REPOSITORY}/contents/DEPS" \
-                --field message="Update dependency ${DEP}@${DEPREF}" \
-                --field content=@<(base64 -i DEPS) \
-                --field encoding=base64 \
-                --field branch="$pr_branch" \
-                --field sha="$(git rev-parse "$pr_branch:DEPS")"
-            git restore DEPS
-            git pull
-            PR_BODY="https://github.com/${DEP_REPO}/compare/${OLD_REF}...${DEPREF}"
-            gh pr create --base "${branch}" -t "Update dependency ${DEP}@${DEPREF}" -b "${PR_BODY}" -l "CI/run-audit-deps"
-          done
+        env:
+          DEP: ${{ inputs.dep }}
+          DEPREF: ${{ inputs.ref }}
+        run: bash .github/workflows/scripts/update-dep.sh


### PR DESCRIPTION
## Summary

Follows review feedback on #37911 ([review comment](https://github.com/brave/brave-core/pull/37911#pullrequestreview-4674754978)): move workflow scripts into `.github/workflows/scripts/` and lint them regularly from the YAML.

Closes brave/brave-browser#57667

## Changes

- Extract inline bash `run:` blocks from 6 workflows into `.github/workflows/scripts/*.sh`, invoked as `bash .github/workflows/scripts/<name>.sh`:
  - `compare-chromium-versions.yml`
  - `propagate-labels.yml`
  - `rerun-compare-chromium-versions.yml`
  - `socket-fix.yml` (4 blocks: update-wdp, update-leo, run, open-pr)
  - `sync-pr-from-fork.yml` (folded setup-git in)
  - `update-dep.yml`
- Move all `${{ }}` interpolations into step `env:` so scripts read only environment variables — closes template-injection surface (`update-dep.yml`, `propagate-labels.yml`).
- Add `.github/workflows/lint-github-actions.yml` running `actionlint` (workflow YAML) + `shellcheck` (scripts) on PRs touching `.github/**`.
- Add sparse `actions/checkout` to the 3 workflows that previously had no checkout (compare-chromium-versions, propagate-labels, rerun-compare-chromium-versions).

## Notes

- No `actions/github-script` inline JS remains on master (the trigger workflow from #37911 was removed in #38378). Future JS scripts under `scripts/` are covered by the repo-wide ESLint config (`eslint.config.js` globs `.github`, MPL header rule) and PRESUBMIT `CheckESLint`; documented in the lint workflow.
- Behavior identical; shellcheck-clean (`-S warning`), actionlint-clean, `bash -n` clean. Minor shellcheck fixes applied without logic change (removed unused `url` var in sync script, quoted `SED="sed"`, fixed `! $(grep ...)` in update-dep).

## Verification

- `actionlint .github/workflows/*.yml` → exit 0
- `shellcheck -x -S warning .github/workflows/scripts/*.sh` → clean
- `bash -n` on all scripts → ok

## Checklist

- [x] Workflows extract scripts to `.github/workflows/scripts/`
- [x] Lint CI added (actionlint + shellcheck)
- [x] Template interpolations moved to `env:`
- [x] No behavior change