### PR TITLE
[AI Chat] combined screenshot attachment item sums all file sizes

### DIFF
--- a/components/ai_chat/resources/page/components/attachment_item/index.test.tsx
+++ b/components/ai_chat/resources/page/components/attachment_item/index.test.tsx
@@ -199,6 +199,8 @@ describe('formatFileSize', () => {
   })
 })
 
+const MOCK_FILE_SIZE = 100
+
 describe('AttachmentUploadItems', () => {
   const createMockFile = (
     filename: string,
@@ -206,8 +208,8 @@ describe('AttachmentUploadItems', () => {
   ): Mojom.UploadedFile => ({
     filename,
     type,
-    data: new ArrayBuffer(100),
-    filesize: BigInt(100),
+    data: new Array(MOCK_FILE_SIZE).fill(0),
+    filesize: MOCK_FILE_SIZE,
     extractedText: undefined,
   })
 
@@ -278,6 +280,11 @@ describe('AttachmentUploadItems', () => {
     // Should only have one image rendered
     const images = container.querySelectorAll('img')
     expect(images).toHaveLength(1)
+
+    // Should sum the filesizes
+    const expectedFileSize = 300
+    const subtitle = container.querySelector('[data-key=subtitle]')
+    expect(subtitle).toHaveTextContent(expectedFileSize.toString())
   })
 
   it('renders mixed file types correctly', () => {
@@ -294,7 +301,7 @@ describe('AttachmentUploadItems', () => {
       createMockFile('document.pdf', Mojom.UploadedFileType.kPdf),
     ]
 
-    render(
+    const { container } = render(
       <AttachmentUploadItems
         uploadedFiles={uploadedFiles}
         onPreview={jest.fn()}
@@ -312,6 +319,12 @@ describe('AttachmentUploadItems', () => {
       'CHAT_UI_FULL_PAGE_SCREENSHOT_TITLE',
     )
     expect(screenshotTitles).toHaveLength(1)
+
+    const fileSizeElements = container.querySelectorAll('[data-key=subtitle]')
+    expect(fileSizeElements).toHaveLength(3) // photo, screenshot, pdf
+    expect(fileSizeElements[0]).toHaveTextContent('100') // photo
+    expect(fileSizeElements[1]).toHaveTextContent('200') // screenshot
+    expect(fileSizeElements[2]).toHaveTextContent('100') // pdf
   })
 
   it('removes all full page screenshots when screenshot thumbnail remove is clicked', () => {

--- a/components/ai_chat/resources/page/components/attachment_item/index.tsx
+++ b/components/ai_chat/resources/page/components/attachment_item/index.tsx
@@ -250,9 +250,19 @@ export function AttachmentUploadItems(props: {
   onPreview: (file: Mojom.UploadedFile) => void
   chipClassName?: string
 }) {
-  // Calculate first full page screenshot index.
-  const firstFullPageScreenshotIndex =
-    props.uploadedFiles.findIndex(isFullPageScreenshot)
+  // We're only going to show 1 item for full-page screenshot,
+  // so find the index of the first one and sum the filesizes for accuracy
+  // of the context impact.
+  let firstFullPageScreenshotIndex = -1
+  let totalFullPageScreenshotFilesizes = 0
+  props.uploadedFiles.forEach((file, index) => {
+    if (isFullPageScreenshot(file)) {
+      if (firstFullPageScreenshotIndex === -1) {
+        firstFullPageScreenshotIndex = index
+      }
+      totalFullPageScreenshotFilesizes += file.filesize
+    }
+  })
 
   return (
     <>
@@ -267,6 +277,10 @@ export function AttachmentUploadItems(props: {
         .map((file) => {
           // Find the original index in the unfiltered array
           const originalIndex = props.uploadedFiles.indexOf(file)
+
+          if (isFullPageScreenshot(file)) {
+            file = { ...file, filesize: totalFullPageScreenshotFilesizes }
+          }
 
           return (
             <AttachmentUploadItem


### PR DESCRIPTION
For full-page screenshots, we only show a single attachment item even if the screenshot is split in to multiple files. However, we only show the filesize of the first image. This fixes that by summing all the visible + hidden full-page screenshots

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57676

-----------------------------

### Before
<img width="409" height="190" alt="image" src="https://github.com/user-attachments/assets/ed9c3fa3-d485-45bc-8ef4-77062ce986a8" />

### After
<img width="437" height="244" alt="image" src="https://github.com/user-attachments/assets/d5295f36-7d3a-477c-8973-d6b2748f9c09" />
