### PR TITLE
[storybook]: Fix Storybook variables/icon loading

### DIFF
--- a/components/brave_news/browser/resources/sidebar.tsx
+++ b/components/brave_news/browser/resources/sidebar.tsx
@@ -16,8 +16,6 @@ import getBraveNewsController from './shared/api'
 import { BraveNewsContextProvider, useBraveNews } from './shared/Context'
 import './strings'
 
-setIconBasePath('//resources/brave-icons')
-
 const Root = styled(Variables)`
   /* Consumed by SidebarMenu to position its slide-out beneath the header. */
   --bn-top-bar-height: 56px;
@@ -83,6 +81,11 @@ export function Sidebar() {
 // module import-safe for Storybook, which renders <Sidebar /> directly.
 const root = document.getElementById('root')
 if (root) {
+  // Note: must stay inside the guard. The icon base path is global and applies
+  // retroactively to every mounted icon, so setting it on import would break
+  // icons for Storybook, which can't load `//resources` URLs.
+  setIconBasePath('//resources/brave-icons')
+
   createRoot(root).render(
     <StyledComponentsProvider>
       <BraveNewsContextProvider openArticlesInNewTab={false}>

--- a/components/brave_shields/resources/panel/components/ad-block-only-mode-controls-content/index.tsx
+++ b/components/brave_shields/resources/panel/components/ad-block-only-mode-controls-content/index.tsx
@@ -6,7 +6,7 @@
 import * as React from 'react'
 import Alert from '@brave/leo/react/alert'
 import Button from '@brave/leo/react/button'
-import Icon, { setIconBasePath } from '@brave/leo/react/icon'
+import Icon from '@brave/leo/react/icon'
 import getPanelBrowserAPI from '../../api/panel_browser_api'
 import { getLocale } from '$web-common/locale'
 import { GlobalSettings } from "../advanced-controls-content"
@@ -18,8 +18,6 @@ import {
   HeaderDescription,
 } from './style'
 import styles from '../alerts.module.scss'
-
-setIconBasePath('chrome://resources/brave-icons')
 
 const onSettingsClick = () => {
   chrome.tabs.create({ url: 'chrome://settings/shields', active: true })

--- a/web/storybook/preview.tsx
+++ b/web/storybook/preview.tsx
@@ -11,6 +11,12 @@ import { getString } from './locale'
 import ThemeProvider from '$web-common/BraveCoreThemeProvider'
 import StyledComponentsProvider from '$web-common/StyledComponentsProvider'
 
+// Nala design tokens (the `--leo-*` custom properties). In the browser these
+// come from `chrome://resources/brave/css/nala.css`, which Storybook can't
+// load, so pull in the static token stylesheet globally here. It defines both
+// the light and dark values, keyed off `prefers-color-scheme`.
+import '@brave/leo/tokens/css/variables.css'
+
 // Fonts
 import '../../ui/webui/resources/fonts/poppins.css'
 import '../../ui/webui/resources/fonts/manrope.css'
@@ -21,6 +27,12 @@ import '../../ui/webui/resources/fonts/inter.css'
 // somewhere deep. The icons will be hosted in the relative path of the
 // storybook. Let's find the relative path we're at, and give that to
 // Nala icons.
+//
+// Note: the base path is global and is applied retroactively to every mounted
+// icon, so the *last* caller wins. Page entry points set it to a `chrome://`
+// path that can't be loaded on the web, so they must only do so when actually
+// mounting the page - never at module scope, where merely importing them from a
+// story would clobber this.
 if (!document.location.pathname.endsWith('/iframe.html')) {
   // Perhaps storybook was upgraded and this changed?
   console.error(


### PR DESCRIPTION
This PR fixes a bug where Storybook wasn't loading Nala variables, and where icon paths would get broken after loading certain stories.

<!-- Add brave-browser issue below that this PR will resolve -->
<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
