### PR TITLE
[deps] `TarballInstaller` to preserve mode bits with zips

### DIFF
--- a/tools/cr/tarball_installer.py
+++ b/tools/cr/tarball_installer.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 import hashlib
 import json
 import shutil
+import subprocess
 import sys
 import tarfile
 import tempfile
@@ -223,10 +224,7 @@ class TarballInstaller:
         `tar.getnames()`), recorded in the `_content_names` sidecar.
         """
         if zipfile.is_zipfile(archive_path):
-            with zipfile.ZipFile(archive_path) as archive:
-                names = archive.namelist()
-                archive.extractall(path=self.dest_dir)
-                return names
+            return self._extract_zip(archive_path)
         with tarfile.open(archive_path, mode='r:*') as tar:
             names = tar.getnames()
             # The `filter='data'` extraction guard (PEP 706) only exists on
@@ -239,6 +237,33 @@ class TarballInstaller:
             else:
                 tar.extractall(path=self.dest_dir)
             return names
+
+    def _extract_zip(self, archive_path: Path) -> list[str]:
+        """Extract a zip archive into `dest_dir`, keeping modes and symlinks.
+
+        `zipfile.extractall` ignores the Unix permission bits zip stores in
+        the high 16 bits of `external_attr` and writes symlink entries out as
+        plain files holding the link target as text, silently turning an
+        executable or a symlink into neither. Shelling out to `unzip`
+        restores both, the same way `script/lib/util.extract_zip` does; on
+        Windows neither concept applies to the extracted tree, so `zipfile`
+        is kept there (and `unzip` may not even be on PATH).
+        """
+        with zipfile.ZipFile(archive_path) as archive:
+            names = archive.namelist()
+            if sys.platform == 'win32':
+                archive.extractall(path=self.dest_dir)
+                return names
+        # `unzip -d` only creates a single missing directory level, unlike
+        # `zipfile.extractall`, which makes the whole path -- so make sure
+        # `dest_dir` (freshly wiped for an owned dep) exists first.
+        self.dest_dir.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ['unzip', '-o', '-q',
+             str(archive_path), '-d',
+             str(self.dest_dir)],
+            check=True)
+        return names
 
     def _write_sidecars(self, member_names: list[str]) -> None:
         """Write the sidecar set, each with a `.stamp` tail."""

--- a/tools/cr/tarball_installer_test.py
+++ b/tools/cr/tarball_installer_test.py
@@ -16,6 +16,7 @@ import contextlib
 import hashlib
 import io
 import json
+import os
 import sys
 import tarfile
 import tempfile
@@ -50,6 +51,19 @@ def _make_zip(members: list[tuple[str, bytes]]):
     with zipfile.ZipFile(buf, 'w') as archive:
         for name, content in members:
             archive.writestr(name, content)
+    return buf.getvalue()
+
+
+def _make_zip_with_unix_modes(members: list[tuple[str, bytes, int]]):
+    """A zip whose entries carry the given Unix `st_mode` (e.g. `0o100755`
+    for an executable file, `0o120777` for a symlink), packed into the high
+    16 bits of `external_attr` the way `zip`/`unzip` do."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as archive:
+        for name, content, mode in members:
+            info = zipfile.ZipInfo(name)
+            info.external_attr = mode << 16
+            archive.writestr(info, content)
     return buf.getvalue()
 
 
@@ -139,6 +153,35 @@ class TarballInstallerTest(unittest.TestCase):
         self.assertTrue(installer.install(self._download(data)))
         self.assertEqual((self.dest / 'node.exe').read_bytes(), b'MZ')
         self.assertEqual((self.dest / 'LICENSE').read_bytes(), b'mpl')
+
+    @unittest.skipIf(sys.platform == 'win32', 'unzip is not used on Windows')
+    def test_install_extracts_zip_preserves_mode_bits_and_symlinks(self):
+        # `zipfile.extractall` drops the Unix permission bits zip stores in
+        # `external_attr` and writes symlinks out as regular files holding the
+        # link target as text -- exactly what BraveUpdater-*.zip needs kept
+        # (mode-0755 executables plus a `ksadmin` symlink) for the updater
+        # bundle to still run after extraction.
+        data = _make_zip_with_unix_modes([
+            ('bin/tool', b'#!/bin/sh\n', 0o100755),
+            ('bin/link', b'tool', 0o120777),
+        ])
+        installer = self._installer(data, object_name='pkg.zip')
+        self.assertTrue(installer.install(self._download(data)))
+        tool = self.dest / 'bin/tool'
+        link = self.dest / 'bin/link'
+        self.assertTrue(os.access(tool, os.X_OK))
+        self.assertTrue(link.is_symlink())
+        self.assertEqual(os.readlink(link), 'tool')
+
+    def test_install_extracts_zip_creates_missing_nested_dest(self):
+        # `unzip -d` (unlike `zipfile.extractall`) only creates a single
+        # missing directory level, so a `dest_dir` nested under parents that
+        # don't exist yet must be created before `unzip` runs.
+        self.dest = self.root / 'nested' / 'missing' / 'dest'
+        data = _make_zip([('f', b'x')])
+        installer = self._installer(data, object_name='pkg.zip')
+        self.assertTrue(installer.install(self._download(data)))
+        self.assertEqual((self.dest / 'f').read_bytes(), b'x')
 
     def test_install_is_idempotent(self):
         data = _make_tar([('f', b'x')])


### PR DESCRIPTION
`zipfile.extractall` ignores Unix permission bits the zip stores. This
is a hindrance to mirgate some uses we have of `build/download_dep.py`
over to `EXTRA_DEPS`.

Shell out to `unzip` on POSIX to restore both, the same way
`script/lib/util.extract_zip` already did before this dep moved to
`TarballInstaller`. `zipfile` is kept for Windows, where neither
concept applies. `unzip -d` only creates a single missing directory
level (unlike `zipfile.extractall`), so `dest_dir` is created upfront.

Bug: https://github.com/brave/brave-browser/issues/56723
