### PR TITLE
[recipes] Adding placeholder protocol and `StepData`

### DIFF
--- a/tools/recipes/engine.py
+++ b/tools/recipes/engine.py
@@ -33,6 +33,7 @@ from google.protobuf import json_format as jsonpb
 
 import proto_support
 from recipe_api import RecipeApi
+from recipe_test_api import RecipeTestApi
 
 # Root of the recipes tree (this file's directory). Recipe modules live under
 # `recipe_modules/<name>/` and recipes under `recipes/<name>.py`.
@@ -95,6 +96,65 @@ def _find_api_class(api_module: types.ModuleType,
             f"recipe module '{module_name}' must define exactly one RecipeApi "
             f'subclass in api.py; found {len(classes)}')
     return classes[0]
+
+
+def _find_test_api_class(test_module: types.ModuleType,
+                         module_name: str) -> type[RecipeTestApi]:
+    """Return the single `RecipeTestApi` subclass in *test_module*, if any."""
+    classes = [
+        value for value in vars(test_module).values()
+        if isinstance(value, type) and issubclass(value, RecipeTestApi) and
+        value is not RecipeTestApi and value.__module__ == test_module.__name__
+    ]
+    if len(classes) > 1:
+        raise RuntimeError(
+            f"recipe module '{module_name}' defines {len(classes)} "
+            'RecipeTestApi subclasses in test_api.py; expected at most one')
+    return classes[0] if classes else RecipeTestApi
+
+
+def instantiate_test_module(name: str, chain: list[str],
+                            cache: dict[str, RecipeTestApi]) -> RecipeTestApi:
+    """Instantiate a module's TEST_API, wiring its DEPS onto `.m` (cached).
+
+    Every run builds these, not just simulated ones: a module reaches its own
+    test api as `self.test_api` to describe what its steps should return under
+    simulation (`step_test_data=`), so the attribute has to be there in
+    production too.
+    """
+    if name in cache:
+        return cache[name]
+    if name in chain:
+        cycle = ' -> '.join(chain + [name])
+        raise RuntimeError(f'cyclical DEPS detected: {cycle}')
+
+    _ensure_protos()
+    package = importlib.import_module(f'{MODULES_PKG}.{name}')
+    deps = list(getattr(package, 'DEPS', []))
+
+    if (RECIPES_ROOT / MODULES_PKG / name / 'test_api.py').exists():
+        test_module = importlib.import_module(f'{MODULES_PKG}.{name}.test_api')
+        api_class = _find_test_api_class(test_module, name)
+    else:
+        # Modules without a test_api.py contribute the base api (no helpers).
+        api_class = RecipeTestApi
+
+    inst = api_class(module=name)
+    for dep_name in deps:
+        setattr(inst.m, dep_name,
+                instantiate_test_module(dep_name, chain + [name], cache))
+    setattr(inst.m, name, inst)
+    cache[name] = inst
+    return inst
+
+
+def build_root_test_api(deps: list[str]) -> RecipeTestApi:
+    """Build the `api` passed to `GenTests`, with each DEP injected by name."""
+    root = RecipeTestApi(module=None)
+    cache: dict[str, RecipeTestApi] = {}
+    for dep_name in deps:
+        setattr(root, dep_name, instantiate_test_module(dep_name, [], cache))
+    return root
 
 
 def _load_config_ctx(module_name: str):
@@ -163,6 +223,9 @@ class _Engine:
         self._environ: Mapping[str, str] = {}
         # module name -> instantiated RecipeApi (one instance per run).
         self._cache: dict[str, RecipeApi] = {}
+        # module name -> instantiated RecipeTestApi, attached to each module as
+        # its `test_api` (see `instantiate_test_module`).
+        self._test_api_cache: dict[str, RecipeTestApi] = {}
 
     def _module_property_args(self, name: str,
                               package: types.ModuleType) -> list[object]:
@@ -234,6 +297,7 @@ class _Engine:
         setattr(inst, '_brave_core_ref', self._brave_core_ref)
         setattr(inst, '_module_name', name)
         setattr(inst, '_config_ctx', _load_config_ctx(name))
+        inst.test_api = instantiate_test_module(name, [], self._test_api_cache)
         for dep_name in deps:
             setattr(inst.m, dep_name,
                     self._instantiate_module(dep_name, chain + [name]))

--- a/tools/recipes/recipe_api.py
+++ b/tools/recipes/recipe_api.py
@@ -2,18 +2,27 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Base class for Brave recipe modules.
+"""Base class for Brave recipe modules, plus the step placeholder protocol.
 
 A deliberately tiny base class. Every recipe module exposes exactly one
 `RecipeApi` subclass (in its `api.py`). After constructing it, the engine attaches the
 module's resolved `DEPS` onto `self.m`, which is the "module injection site",
 so a module reaches each dependency as `self.m.<dep_name>` (and itself as
 `self.m.<own_name>`).
+
+This is also where the `Placeholder` hierarchy lives. A placeholder stands in
+for a file that a step reads from or writes to: a module hands one to
+`api.step(...)`, the engine renders it into real command-line arguments just
+before the step runs, and (for outputs) reads the data back afterwards. See the
+"Getting data back from a step" section of README.md.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
+import functools
 from pathlib import Path
+from typing import Any
 
 
 class ModuleInjectionSite:
@@ -30,6 +39,135 @@ class ModuleInjectionSite:
         # dynamic, so accessing an injected dep is not flagged as no-member.)
         raise AttributeError(
             f'{name!r} is not a declared dependency (add it to DEPS?)')
+
+
+class Placeholder:
+    """Base class for a step's command-line placeholders. Not used directly.
+
+    A placeholder is a stand-in for a file that only exists for the duration of
+    a step. Put one in a step's `cmd` (or pass it as the step's `stdin` /
+    `stdout` / `stderr`) and the engine will:
+
+      1. call `render()` just before the step runs, replacing the placeholder
+         with whatever command-line arguments it returns (usually a single
+         path), and
+      2. once the step is done, call `cleanup()` on an `InputPlaceholder`, or
+         `result()` on an `OutputPlaceholder` to read the data back.
+
+    Every placeholder has a `namespaces` pair, with the name of the module that
+    produced it and the name of the method that returned it, e.g.
+    `('json', 'output')` for `api.json.output()`. The `returns_placeholder`
+    decorator fills that in, and the engine uses it to file an output
+    placeholder's result onto the step's result as
+    `step_result.json.output`. A placeholder may additionally carry a
+    caller-chosen `name`, to tell several placeholders from the same method
+    apart (see `step_data.StepData`).
+    """
+
+    # Whether this placeholder stands for a single file, and so can be a step's
+    # `stdin`/`stdout`/`stderr`. False for the ones that stand for something
+    # else, like a whole directory of results.
+    is_file_backed = True
+
+    def __init__(self, name: str | None = None) -> None:
+        if name is not None and not isinstance(name, str):
+            raise ValueError('Expected a string name for a placeholder, but '
+                             f'got {name!r}')
+        self.name = name
+        # (module name, method name); filled in by `returns_placeholder`.
+        self.namespaces: tuple[str, str] | None = None
+
+    @property
+    def backing_file(self) -> str:
+        """The path of the file holding (or receiving) the data.
+
+        Only valid once `render` has been called. This is what the engine
+        redirects a step's std handle to when the placeholder is passed as
+        `stdin`/`stdout`/`stderr`.
+        """
+        raise NotImplementedError
+
+    def render(self, test) -> list[str]:
+        """Return the command-line arguments this placeholder expands to.
+
+        *test* is the `PlaceholderTestData` for this placeholder; when
+        `test.enabled` the placeholder must not touch the real filesystem.
+        """
+        raise NotImplementedError
+
+    @property
+    def label(self) -> str:
+        """A human-readable `<module>.<method>[<name>]` label."""
+        module, method = self.namespaces
+        if self.name is None:
+            return f'{module}.{method}'
+        return f'{module}.{method}[{self.name}]'
+
+    def __repr__(self) -> str:
+        namespaced = ('<unnamespaced>'
+                      if self.namespaces is None else self.label)
+        return f'{type(self).__name__}({namespaced})'
+
+
+class InputPlaceholder(Placeholder):
+    """A placeholder carrying data *into* a step. Not used directly."""
+
+    # Abstract base: concrete subclasses implement `render`/`backing_file`.
+    # pylint: disable=abstract-method
+
+    def cleanup(self, test_enabled: bool) -> None:
+        """Called once the step has finished, to drop the backing file."""
+
+
+class OutputPlaceholder(Placeholder):
+    """A placeholder carrying data *out of* a step. Not used directly."""
+
+    # Abstract base: concrete subclasses implement `render`/`backing_file`.
+    # pylint: disable=abstract-method
+
+    def result(self, test) -> Any:
+        """Called once the step has finished; the return value is the result.
+
+        The engine files it onto the step's `StepData` under this
+        placeholder's namespaces (so `api.json.output()`'s result shows up as
+        `step_result.json.output`).
+        """
+
+
+def _returns_placeholder(func: Callable[..., Placeholder],
+                         alternate_name: str | None = None):
+
+    @functools.wraps(func)
+    def inner(self, *args, **kwargs):
+        placeholder = func(self, *args, **kwargs)
+        assert isinstance(placeholder, Placeholder), (
+            f'{func.__name__} is decorated with returns_placeholder but '
+            f'returned {placeholder!r}')
+        placeholder.namespaces = (
+            self._module_name,
+            alternate_name  # pylint: disable=protected-access
+            or func.__name__)
+        return placeholder
+
+    return inner
+
+
+def returns_placeholder(func_or_name):
+    """Decorate a placeholder-returning `RecipeApi` method to namespace it.
+
+    The namespace defaults to `(<module name>, <method name>)`, which is what
+    the engine files an output placeholder's result under. Decorate as
+    `@returns_placeholder('other_name')` to substitute a different method name,
+    so several methods can produce placeholders that land in the same place.
+    """
+    if isinstance(func_or_name, str):
+        if not func_or_name:
+            raise ValueError('returns_placeholder needs a non-empty name')
+        return lambda func: _returns_placeholder(func, func_or_name)
+    if not callable(func_or_name):
+        raise ValueError('Expected either a function or a string; got '
+                         f'{func_or_name!r}')
+    return _returns_placeholder(func_or_name)
 
 
 class RecipeApi:
@@ -50,8 +188,14 @@ class RecipeApi:
         # touch the real machine. When set, they read/mutate this instead. Its
         # presence (`self._test is not None`) is the sole test-mode flag.
         self._test = None
-        # The module's name, seeded by the engine (used in config error text).
+        # The module's name, seeded by the engine (used in config error text
+        # and to namespace the placeholders this module hands out).
         self._module_name: str = type(self).__name__
+        # This module's own `TEST_API` instance (from its `test_api.py`), seeded
+        # by the engine, or None if the module has no test api. Modules use it
+        # to build the default simulated data for the steps they run, e.g.
+        # `step_test_data=self.test_api.errno`.
+        self.test_api = None
         # The module's configuration context (the `ConfigContext` from its
         # `config.py`), seeded by the engine, or None if the module has no
         # config. See `set_config`/`make_config`/`apply_config` below and the

--- a/tools/recipes/recipe_test_runner.py
+++ b/tools/recipes/recipe_test_runner.py
@@ -37,67 +37,10 @@ from typing import TYPE_CHECKING
 
 import engine
 import simulation
-from recipe_test_api import RecipeTestApi, TestData
+from recipe_test_api import TestData
 
 if TYPE_CHECKING:
     import coverage
-
-# -- TEST_API discovery & injection (mirrors engine's DEPS resolution) --------
-
-
-def _find_test_api_class(module, name: str) -> type[RecipeTestApi]:
-    """Return the single `RecipeTestApi` subclass in *module*, if any."""
-    classes = [
-        value for value in vars(module).values()
-        if isinstance(value, type) and issubclass(value, RecipeTestApi)
-        and value is not RecipeTestApi and value.__module__ == module.__name__
-    ]
-    if len(classes) > 1:
-        raise RuntimeError(
-            f"recipe module '{name}' defines {len(classes)} RecipeTestApi "
-            f'subclasses in test_api.py; expected at most one')
-    return classes[0] if classes else RecipeTestApi
-
-
-def _instantiate_test_module(name: str, chain: list[str],
-                             cache: dict[str, RecipeTestApi]) -> RecipeTestApi:
-    """Instantiate a module's TEST_API, wiring its DEPS onto `.m` (cached)."""
-    if name in cache:
-        return cache[name]
-    if name in chain:
-        cycle = ' -> '.join(chain + [name])
-        raise RuntimeError(f'cyclical DEPS detected: {cycle}')
-
-    package = importlib.import_module(f'{engine.MODULES_PKG}.{name}')
-    deps = list(getattr(package, 'DEPS', []))
-
-    test_api_path = (engine.RECIPES_ROOT / engine.MODULES_PKG / name /
-                     'test_api.py')
-    if test_api_path.exists():
-        test_module = importlib.import_module(
-            f'{engine.MODULES_PKG}.{name}.test_api')
-        api_class = _find_test_api_class(test_module, name)
-    else:
-        # Modules without a test_api.py contribute the base api (no helpers).
-        api_class = RecipeTestApi
-
-    inst = api_class(module=name)
-    for dep_name in deps:
-        setattr(inst.m, dep_name,
-                _instantiate_test_module(dep_name, chain + [name], cache))
-    setattr(inst.m, name, inst)
-    cache[name] = inst
-    return inst
-
-
-def _build_root_test_api(deps: list[str]) -> RecipeTestApi:
-    """Build the `api` passed to `GenTests`, with each DEP injected by name."""
-    root = RecipeTestApi(module=None)
-    cache: dict[str, RecipeTestApi] = {}
-    for dep_name in deps:
-        setattr(root, dep_name, _instantiate_test_module(dep_name, [], cache))
-    return root
-
 
 # -- Recipe discovery ---------------------------------------------------------
 
@@ -401,7 +344,8 @@ def run_tests(train: bool = False,
     start = time.monotonic()
     seen_all: set[Path] = set()
     for recipe_id, recipe in _testable_recipes():
-        root_api = _build_root_test_api(list(getattr(recipe, 'DEPS', [])))
+        root_api = engine.build_root_test_api(list(getattr(recipe, 'DEPS',
+                                                           [])))
         seen: set[Path] = set()
         for test_data in recipe.GenTests(root_api):
             case_id = f'{recipe_id}.{test_data.name}'

--- a/tools/recipes/step_data.py
+++ b/tools/recipes/step_data.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""`StepData`: what `api.step(...)` hands back.
+
+Besides the step's `retcode` (and the results of its `stdout`/`stderr`
+placeholders, if it had any), a `StepData` grows an attribute per output
+placeholder the step's command contained, filed under that placeholder's
+namespaces. So a step run as:
+
+    step_result = api.step('run tests', [script, api.json.output()])
+
+comes back with `step_result.json.output` holding the parsed JSON the script
+wrote.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from recipe_api import Placeholder
+
+# Distinguishes "no result staged" from a placeholder whose result is None.
+_UNSET = object()
+
+
+class _PlaceholderNamespace:
+    """One tier of a placeholder namespace on a `StepData` (e.g. `.json`).
+
+    Holds the results filed under it as plain attributes, and raises a helpful
+    `AttributeError` for anything else -- a step that didn't pass
+    `api.json.output()` has no `step_result.json.output` to read.
+    """
+
+    def __init__(self, step_name: str, namespace: str) -> None:
+        # Set through __dict__ because __setattr__ below consults `_frozen`,
+        # which doesn't exist yet.
+        self.__dict__['_step_name'] = step_name
+        self.__dict__['_namespace'] = namespace
+        self.__dict__['_frozen'] = False
+
+    def __getattr__(self, name: str):
+        raise AttributeError(
+            f'StepData({self._step_name!r}).{self._namespace} has no attribute '
+            f'{name!r}.')
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if self.__dict__.get('_frozen'):
+            raise AttributeError(
+                f'Cannot assign to StepData({self._step_name!r})'
+                f'.{self._namespace}.{name}.')
+        self.__dict__[name] = value
+
+    def _freeze(self) -> None:
+        self.__dict__['_frozen'] = True
+
+
+class StepData:
+    """The result of running one step.
+
+    The always-present members are:
+
+      * `name`: the step's name.
+      * `retcode`: the command's exit code.
+      * `stdout` / `stderr`: the result of the step's `stdout`/`stderr`
+        placeholder, or `None` when the step didn't redirect that handle.
+
+    On top of those, each output placeholder in the step's command contributes
+    one attribute, addressed by the placeholder's namespaces (its module and
+    method name) and, optionally, the caller-chosen placeholder `name`:
+
+      * An unnamed placeholder is filed at `<module>.<method>`. Two unnamed
+        placeholders from the same method on one step is an error.
+      * A named placeholder is filed at `<module>.<method>s[name]` (note the
+        plural).
+      * If exactly one placeholder from a method has a name, and none is
+        unnamed, its result is *also* filed at `<module>.<method>`.
+
+    So `api.step('...', [script, api.json.output()])` yields
+    `step_result.json.output`, while
+    `api.step('...', [script, api.json.output(name='a'),
+    api.json.output(name='b')])` yields `step_result.json.outputs['a']` and
+    `['b']`.
+    """
+
+    def __init__(self, name: str, retcode: int) -> None:
+        self.name = name
+        self.retcode = retcode
+        # Results of the step's std handle placeholders, if it had any. Set by
+        # the `step` module once the step is done.
+        self.stdout: Any = None
+        self.stderr: Any = None
+        # namespaces -> {placeholder name or None: result}, filled in by
+        # `assign_placeholder` and turned into real attributes by `finalize`.
+        self._staged: dict[tuple[str, str], dict[str | None, Any]] = {}
+        self._frozen = False
+
+    def assign_placeholder(self, placeholder: Placeholder,
+                           result: Any) -> None:
+        """Stage one output placeholder's *result*, to be filed by `finalize`."""
+        if self._frozen:
+            raise ValueError(
+                f'Cannot assign placeholder {placeholder.label!r} on the '
+                f'finalized result of step {self.name!r}')
+        by_name = self._staged.setdefault(placeholder.namespaces, {})
+        if placeholder.name in by_name:
+            raise ValueError(
+                f'Step {self.name!r} has two {placeholder.label!r} '
+                'placeholders. Give them distinct names.')
+        by_name[placeholder.name] = result
+
+    def finalize(self) -> None:
+        """File every staged placeholder result, then stop accepting writes."""
+        if self._frozen:
+            return
+        for namespace, by_name in self._staged.items():
+            by_name = dict(by_name)
+            default = by_name.pop(None, _UNSET)
+            if default is _UNSET and len(by_name) == 1:
+                # Exactly one named placeholder, and nothing unnamed: it is
+                # also reachable without its name.
+                default = next(iter(by_name.values()))
+            if default is not _UNSET:
+                self._set(namespace, default)
+            if by_name:
+                module, method = namespace
+                self._set((module, method + 's'), by_name)
+        self._staged = {}
+        for value in self.__dict__.values():
+            if isinstance(value, _PlaceholderNamespace):
+                value._freeze()  # pylint: disable=protected-access
+        self._frozen = True
+
+    def _set(self, namespace: tuple[str, str], value: Any) -> None:
+        """Set `self.<module>.<method> = value`, creating the tier as needed."""
+        module, method = namespace
+        tier = self.__dict__.get(module)
+        if not isinstance(tier, _PlaceholderNamespace):
+            tier = _PlaceholderNamespace(self.name, module)
+            setattr(self, module, tier)
+        setattr(tier, method, value)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if self.__dict__.get('_frozen'):
+            raise ValueError(
+                f'Cannot assign to {name!r} on the finalized result of step '
+                f'{self.name!r}')
+        object.__setattr__(self, name, value)
+
+    def __getattr__(self, name: str):
+        step_name = self.__dict__.get('name')
+        raise AttributeError(
+            f'The result of step {step_name!r} has no attribute {name!r}.')

--- a/tools/recipes/unittests/engine_test.py
+++ b/tools/recipes/unittests/engine_test.py
@@ -20,8 +20,10 @@ from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-import engine  # pylint: disable=wrong-import-position
-from recipe_api import RecipeApi  # pylint: disable=wrong-import-position
+# pylint: disable=wrong-import-position
+import engine
+from recipe_api import RecipeApi
+from recipe_test_api import RecipeTestApi
 
 
 class DepsResolutionTest(unittest.TestCase):
@@ -40,6 +42,77 @@ class DepsResolutionTest(unittest.TestCase):
         dt = eng._instantiate_module('depot_tools', [])
         # chromium_checkout and depot_tools share one `step` instance.
         self.assertIs(cc.m.step, dt.m.step)
+
+
+class TestApiInjectionTest(unittest.TestCase):
+    """Every module is given its own TEST_API, in production runs too.
+
+    A module reaches it as `self.test_api` to describe what its steps should
+    return under simulation (`step_test_data=`), so it has to be there whether
+    or not the run is simulated.
+    """
+
+    def test_module_gets_its_own_test_api(self):
+        cc = engine._Engine()._instantiate_module('chromium_checkout', [])
+        self.assertIsInstance(cc.test_api, RecipeTestApi)
+        # It is the chromium_checkout test api, not the base class.
+        self.assertTrue(hasattr(cc.test_api, 'with_git_cache'))
+
+    def test_module_without_a_test_api_gets_the_base(self):
+        context = engine._Engine()._instantiate_module('context', [])
+        self.assertIs(type(context.test_api), RecipeTestApi)
+
+    def test_deps_are_wired_onto_m(self):
+        cache = {}
+        cc = engine.instantiate_test_module('chromium_checkout', [], cache)
+        # chromium_checkout's DEPS test apis are reachable via .m.
+        self.assertTrue(hasattr(cc.m, 'env'))
+        self.assertTrue(hasattr(cc.m, 'path'))
+        # Cached instances are shared.
+        self.assertIs(engine.instantiate_test_module('path', [], cache),
+                      cc.m.path)
+
+    def test_root_api_exposes_dep_helpers(self):
+        root = engine.build_root_test_api(['platform', 'step'])
+        # api.platform.name(...) and api.step.data(...) resolve to the module
+        # test apis.
+        self.assertEqual(
+            root.platform.name('mac').mod_data['platform']['name'], 'mac')
+        self.assertIn('s', root.step.data('s', retcode=2).step_data)
+
+
+class FindTestApiClassTest(unittest.TestCase):
+    """_find_test_api_class allows at most one RecipeTestApi subclass."""
+
+    def test_defaults_to_base_when_absent(self):
+        module = types.ModuleType('fake')
+        self.assertIs(engine._find_test_api_class(module, 'fake'),
+                      RecipeTestApi)
+
+    def test_finds_the_single_subclass(self):
+        module = types.ModuleType('fake')
+
+        class MyTestApi(RecipeTestApi):
+            pass
+
+        MyTestApi.__module__ = 'fake'
+        module.MyTestApi = MyTestApi
+        self.assertIs(engine._find_test_api_class(module, 'fake'), MyTestApi)
+
+    def test_two_classes_raises(self):
+        module = types.ModuleType('fake')
+
+        class TestApiA(RecipeTestApi):
+            pass
+
+        class TestApiB(RecipeTestApi):
+            pass
+
+        TestApiA.__module__ = TestApiB.__module__ = 'fake'
+        module.TestApiA = TestApiA
+        module.TestApiB = TestApiB
+        with self.assertRaises(RuntimeError):
+            engine._find_test_api_class(module, 'fake')
 
 
 class FindApiClassTest(unittest.TestCase):

--- a/tools/recipes/unittests/recipe_api_test.py
+++ b/tools/recipes/unittests/recipe_api_test.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for the RecipeApi base class and the placeholder protocol."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# pylint: disable=wrong-import-position
+from recipe_api import (InputPlaceholder, OutputPlaceholder, Placeholder,
+                        RecipeApi, returns_placeholder)
+
+
+class FakeApi(RecipeApi):
+    """A module api handing out placeholders, as a real one would."""
+
+    @returns_placeholder
+    def output(self, name=None):
+        return OutputPlaceholder(name=name)
+
+    @returns_placeholder('output')
+    def leaky_output(self):
+        """Produces the same placeholder `output` does, under its name."""
+        return OutputPlaceholder()
+
+    @returns_placeholder
+    def not_a_placeholder(self):
+        return 'nope'
+
+
+def _api(module_name='fake'):
+    api = FakeApi()
+    # The engine seeds the module's registered name; placeholders are
+    # namespaced with it.
+    setattr(api, '_module_name', module_name)
+    return api
+
+
+class ReturnsPlaceholderTest(unittest.TestCase):
+
+    def test_namespaces_are_the_module_and_method(self):
+        self.assertEqual(_api().output().namespaces, ('fake', 'output'))
+
+    def test_alternate_name_substitutes_the_method(self):
+        self.assertEqual(_api().leaky_output().namespaces, ('fake', 'output'))
+
+    def test_the_placeholder_name_is_carried_through(self):
+        self.assertEqual(_api().output(name='cfg').name, 'cfg')
+
+    def test_docstring_and_name_are_preserved(self):
+        self.assertEqual(FakeApi.leaky_output.__name__, 'leaky_output')
+        self.assertIn('same placeholder', FakeApi.leaky_output.__doc__)
+
+    def test_a_method_that_returns_something_else_is_a_bug(self):
+        with self.assertRaises(AssertionError):
+            _api().not_a_placeholder()
+
+    def test_bad_decorator_arguments_raise(self):
+        with self.assertRaises(ValueError):
+            returns_placeholder('')
+        with self.assertRaises(ValueError):
+            returns_placeholder(123)
+
+
+class PlaceholderTest(unittest.TestCase):
+
+    def test_a_non_string_name_is_rejected(self):
+        # The name is what tells several placeholders apart on one step.
+        with self.assertRaises(ValueError):
+            Placeholder(name=123)
+
+    def test_the_base_class_renders_nothing(self):
+        # Subclasses supply both; the base exists to be implemented.
+        placeholder = Placeholder()
+        with self.assertRaises(NotImplementedError):
+            _ = placeholder.backing_file
+        with self.assertRaises(NotImplementedError):
+            placeholder.render(None)
+
+    def test_placeholders_stand_for_a_file_by_default(self):
+        # Only the ones standing for something else (a whole directory) opt out,
+        # and those are rejected on a step's std handles.
+        self.assertTrue(Placeholder().is_file_backed)
+
+    def test_input_and_output_hooks_default_to_doing_nothing(self):
+        # A placeholder with no file to clean up, or no data to report, doesn't
+        # have to say so.
+        self.assertIsNone(InputPlaceholder().cleanup(True))
+        self.assertIsNone(OutputPlaceholder().result(None))
+
+
+class ModuleInjectionTest(unittest.TestCase):
+
+    def test_an_undeclared_dependency_says_so(self):
+        with self.assertRaisesRegex(AttributeError, 'DEPS'):
+            _ = RecipeApi().m.nope
+
+    def test_test_api_is_unset_until_the_engine_seeds_it(self):
+        self.assertIsNone(RecipeApi().test_api)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/recipes/unittests/recipe_test_runner_test.py
+++ b/tools/recipes/unittests/recipe_test_runner_test.py
@@ -3,60 +3,22 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Tests for the test runner's TEST_API discovery/DI and recipe discovery."""
+"""Tests for the test runner's recipe discovery.
+
+TEST_API discovery and injection live in `engine` (every run builds them, not
+just simulated ones), and are tested in `engine_test.py`.
+"""
 
 # White-box tests exercising runner internals; protected access is intentional.
 # pylint: disable=protected-access
 
 import os
 import sys
-import types
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-# pylint: disable=wrong-import-position
-import recipe_test_runner as runner
-from recipe_test_api import RecipeTestApi
-
-
-class FindTestApiClassTest(unittest.TestCase):
-
-    def test_defaults_to_base_when_absent(self):
-        module = types.ModuleType('fake')
-        self.assertIs(runner._find_test_api_class(module, 'fake'),
-                      RecipeTestApi)
-
-    def test_finds_the_single_subclass(self):
-        module = types.ModuleType('fake')
-
-        class MyTestApi(RecipeTestApi):
-            pass
-
-        MyTestApi.__module__ = 'fake'
-        module.MyTestApi = MyTestApi
-        self.assertIs(runner._find_test_api_class(module, 'fake'), MyTestApi)
-
-
-class TestApiInjectionTest(unittest.TestCase):
-
-    def test_deps_are_wired_onto_m(self):
-        cache = {}
-        cc = runner._instantiate_test_module('chromium_checkout', [], cache)
-        # chromium_checkout's DEPS test apis are reachable via .m.
-        self.assertTrue(hasattr(cc.m, 'env'))
-        self.assertTrue(hasattr(cc.m, 'path'))
-        # Cached instances are shared.
-        self.assertIs(runner._instantiate_test_module('path', [], cache),
-                      cc.m.path)
-
-    def test_root_api_exposes_dep_helpers(self):
-        root = runner._build_root_test_api(['platform', 'step'])
-        # api.platform.name(...) and api.step.data(...) resolve to the module
-        # test apis.
-        self.assertEqual(
-            root.platform.name('mac').mod_data['platform']['name'], 'mac')
-        self.assertIn('s', root.step.data('s', retcode=2).step_data)
+import recipe_test_runner as runner  # pylint: disable=wrong-import-position
 
 
 class DiscoveryTest(unittest.TestCase):

--- a/tools/recipes/unittests/step_data_test.py
+++ b/tools/recipes/unittests/step_data_test.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for how StepData files placeholder results onto a step's result."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# pylint: disable=wrong-import-position
+from recipe_api import OutputPlaceholder
+from step_data import StepData
+
+
+def _placeholder(method='output', name=None, module='json'):
+    """An output placeholder namespaced as the engine would namespace it."""
+    placeholder = OutputPlaceholder(name=name)
+    placeholder.namespaces = (module, method)
+    return placeholder
+
+
+def _finalized(*assignments):
+    """A finalized StepData with (placeholder, result) pairs assigned."""
+    data = StepData('a step', 0)
+    for placeholder, result in assignments:
+        data.assign_placeholder(placeholder, result)
+    data.finalize()
+    return data
+
+
+class PlaceholderFilingTest(unittest.TestCase):
+
+    def test_unnamed_placeholder_lands_under_its_namespaces(self):
+        data = _finalized((_placeholder(), {'passed': 791}))
+        self.assertEqual(data.json.output, {'passed': 791})
+
+    def test_named_placeholders_land_under_the_plural(self):
+        data = _finalized((_placeholder(name='a'), 1),
+                          (_placeholder(name='b'), 2))
+        self.assertEqual(data.json.outputs, {'a': 1, 'b': 2})
+        # With more than one name and nothing unnamed, there is no default.
+        with self.assertRaises(AttributeError):
+            _ = data.json.output
+
+    def test_a_lone_named_placeholder_is_also_the_default(self):
+        data = _finalized((_placeholder(name='only'), 'value'))
+        self.assertEqual(data.json.outputs, {'only': 'value'})
+        self.assertEqual(data.json.output, 'value')
+
+    def test_an_unnamed_placeholder_wins_the_default(self):
+        data = _finalized((_placeholder(name='a'), 'named'),
+                          (_placeholder(), 'unnamed'))
+        self.assertEqual(data.json.output, 'unnamed')
+        self.assertEqual(data.json.outputs, {'a': 'named'})
+
+    def test_methods_and_modules_are_kept_apart(self):
+        data = _finalized((_placeholder(), 'json output'),
+                          (_placeholder(method='input'), 'json input'),
+                          (_placeholder(module='raw_io'), 'raw_io output'))
+        self.assertEqual(data.json.output, 'json output')
+        self.assertEqual(data.json.input, 'json input')
+        self.assertEqual(data.raw_io.output, 'raw_io output')
+
+    def test_a_none_result_is_still_filed(self):
+        # A placeholder whose file the step never wrote reports None, which is a
+        # result like any other -- not an absent attribute.
+        data = _finalized((_placeholder(), None))
+        self.assertIsNone(data.json.output)
+
+    def test_finalize_is_idempotent(self):
+        data = _finalized((_placeholder(), 'value'))
+        data.finalize()
+        self.assertEqual(data.json.output, 'value')
+
+
+class ErrorMessageTest(unittest.TestCase):
+
+    def test_unknown_namespace_names_the_step(self):
+        data = _finalized()
+        with self.assertRaisesRegex(AttributeError, "'a step'.*'json'"):
+            _ = data.json
+
+    def test_unknown_attribute_names_the_namespace(self):
+        data = _finalized((_placeholder(), 'value'))
+        with self.assertRaisesRegex(AttributeError,
+                                    r"'a step'\)\.json.*'nope'"):
+            _ = data.json.nope
+
+    def test_two_indistinguishable_placeholders_raise(self):
+        data = StepData('a step', 0)
+        data.assign_placeholder(_placeholder(), 'first')
+        with self.assertRaisesRegex(ValueError, 'distinct names'):
+            data.assign_placeholder(_placeholder(), 'second')
+
+
+class FinalizedTest(unittest.TestCase):
+    """A finalized result is read-only, so a recipe can't rewrite history."""
+
+    def test_assigning_a_placeholder_after_finalize_raises(self):
+        data = _finalized()
+        with self.assertRaises(ValueError):
+            data.assign_placeholder(_placeholder(), 'value')
+
+    def test_assigning_an_attribute_after_finalize_raises(self):
+        data = _finalized()
+        with self.assertRaises(ValueError):
+            data.retcode = 1
+
+    def test_assigning_inside_a_namespace_after_finalize_raises(self):
+        data = _finalized((_placeholder(), 'value'))
+        with self.assertRaises(AttributeError):
+            data.json.output = 'other'
+
+
+class AlwaysPresentMembersTest(unittest.TestCase):
+
+    def test_name_retcode_and_handles(self):
+        data = StepData('a step', 3)
+        self.assertEqual(data.name, 'a step')
+        self.assertEqual(data.retcode, 3)
+        # Unset until the step's stdout/stderr placeholders report back.
+        self.assertIsNone(data.stdout)
+        self.assertIsNone(data.stderr)
+
+
+class PlaceholderLabelTest(unittest.TestCase):
+
+    def test_label_reflects_the_name(self):
+        self.assertEqual(_placeholder().label, 'json.output')
+        self.assertEqual(_placeholder(name='cfg').label, 'json.output[cfg]')
+
+    def test_repr_survives_an_unnamespaced_placeholder(self):
+        self.assertEqual(repr(OutputPlaceholder()),
+                         'OutputPlaceholder(<unnamespaced>)')
+        self.assertEqual(repr(_placeholder(name='cfg')),
+                         'OutputPlaceholder(json.output[cfg])')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is the first PR to introduce support for structured data to be
handed back through the step machinery.

This PR adds the base classes
`Placeholder`/`InputPlaceholder`/`OutputPlaceholder` that will server as
foundation to build on top. `StepData` is also being introduced, as a
result object which we use to fill in with the placeholders.

Bug: https://github.com/brave/brave-browser/issues/56748
