### PR TITLE
Fix vertical tab hover expansion triggering on covered/background windows

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -208,6 +208,35 @@ class BraveBrowserView::BrowserWindowMouseEventHandler
   // ui::EventObserver overrides:
   void OnEvent(const ui::Event& event) override {
     if (event.type() == ui::EventType::kMouseMoved) {
+      const gfx::PointF point_in_screen(
+          display::Screen::Get()->GetCursorScreenPoint());
+
+      gfx::NativeWindow window_under_cursor =
+          display::Screen::Get()->GetWindowAtScreenPoint(
+              gfx::ToFlooredPoint(point_in_screen));
+
+      if (window_under_cursor) {
+        views::Widget* top_level_widget =
+            views::Widget::GetTopLevelWidgetForNativeView(window_under_cursor);
+
+        bool is_our_widget = (top_level_widget == browser_view_->GetWidget());
+
+#if BUILDFLAG(IS_MAC)
+        if (!is_our_widget && browser_view_->immersive_mode_controller() &&
+            browser_view_->immersive_mode_controller()->IsEnabled()) {
+          views::Widget* overlay_widget =
+              browser_view_->immersive_mode_controller()->overlay_widget();
+          if (overlay_widget && top_level_widget == overlay_widget) {
+            is_our_widget = true;
+          }
+        }
+#endif
+
+        if (!is_our_widget) {
+          return;
+        }
+      }
+
       browser_view_->HandleBrowserWindowMouseEvent(*event.AsMouseEvent());
       return;
     }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves [brave/brave-browser#57681](https://github.com/brave/brave-browser/issues/57681)

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Description
Fixes an issue where hovering over the left edge of a foreground window/profile incorrectly expands the vertical tab strip of an overlapping background browser window.

### Context & Fix
`BrowserWindowMouseEventHandler` uses an application-wide event monitor (`views::EventMonitor::CreateApplicationMonitor`) to listen for mouse move events across all windows. Previously, every `BraveBrowserView` instance received all `kMouseMoved` events and evaluated screen coordinates against its own layout bounds without checking whether its window was the top-most window under the cursor.

This fix updates `BrowserWindowMouseEventHandler::OnEvent` to look up the native window under the cursor (`display::Screen::Get()->GetWindowAtScreenPoint()`) and verify that its top-level widget matches `browser_view_->GetWidget()`. If the native window under the cursor belongs to a different window, the mouse event is ignored.

## Test Plan / QA Steps
1. Open two browser windows (or two separate profiles).
2. Enable vertical tabs with float/expand on hover in Window A.
3. Disable vertical tabs in Window B.
4. Overlap or maximize both windows with Window B in the foreground.
5. Move the cursor to the left edge of the screen over Window B.
6. Verify Window A's vertical tabs do not expand while in the background.
7. Place Window A and Window B side-by-side. Hover over Window A's left edge to verify vertical tabs still expand on hover when inactive.
