### PR TITLE
[CodeHealth] Remove `DistillStates` nested namespace

### DIFF
--- a/browser/speedreader/speedreader_browsertest.cc
+++ b/browser/speedreader/speedreader_browsertest.cc
@@ -187,8 +187,7 @@ class SpeedReaderBrowserTest : public InProcessBrowserTest {
       th = tab_helper();
     }
     if (!base::test::RunUntil([th]() {
-          return speedreader::DistillStates::IsDistilled(
-              th->PageDistillState());
+          return speedreader::IsDistilled(th->PageDistillState());
         })) {
       return false;
     }
@@ -201,8 +200,7 @@ class SpeedReaderBrowserTest : public InProcessBrowserTest {
       th = tab_helper();
     }
     if (!base::test::RunUntil([th]() {
-          return speedreader::DistillStates::IsDistillable(
-              th->PageDistillState());
+          return speedreader::IsDistillable(th->PageDistillState());
         })) {
       return false;
     }
@@ -215,8 +213,7 @@ class SpeedReaderBrowserTest : public InProcessBrowserTest {
       th = tab_helper();
     }
     if (!base::test::RunUntil([th]() {
-          return speedreader::DistillStates::IsViewOriginal(
-              th->PageDistillState());
+          return speedreader::IsViewOriginal(th->PageDistillState());
         })) {
       return false;
     }
@@ -225,8 +222,8 @@ class SpeedReaderBrowserTest : public InProcessBrowserTest {
   }
 
   bool ClickReaderButton() {
-    const auto was_distilled = speedreader::DistillStates::IsDistilled(
-        tab_helper()->PageDistillState());
+    const auto was_distilled =
+        speedreader::IsDistilled(tab_helper()->PageDistillState());
     browser()->command_controller()->ExecuteCommand(
         IDC_SPEEDREADER_ICON_ONCLICK);
     if (!was_distilled) {
@@ -307,43 +304,36 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, PRE_RestoreSpeedreaderPage) {
   EnableSpeedreaderAllowedForAllSites();
   NavigateToPageSynchronously(kTestPageReadable,
                               WindowOpenDisposition::CURRENT_TAB);
-  EXPECT_TRUE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
 }
 
 IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, RestoreSpeedreaderPage) {
   browser()->tab_strip_model()->ActivateTabAt(0);
   ASSERT_TRUE(WaitDistilled());
-  EXPECT_TRUE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
 }
 
 IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, NavigationNostickTest) {
   EnableSpeedreaderAllowedForAllSites();
   NavigateToPageSynchronously(kTestPageSimple);
-  EXPECT_FALSE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_FALSE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
   NavigateToPageSynchronously(kTestPageReadable,
                               WindowOpenDisposition::CURRENT_TAB);
-  EXPECT_TRUE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
 
   // Ensure distill state doesn't stick when we back-navigate from a readable
   // page to a non-readable one.
   GoBack(browser());
-  EXPECT_FALSE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_FALSE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
 }
 
 IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, DisableSiteWorks) {
   EnableSpeedreaderAllowedForAllSites();
   NavigateToPageSynchronously(kTestPageReadable);
-  EXPECT_TRUE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
   speedreader_service()->SetEnabledForSite(ActiveWebContents(), false);
   EXPECT_TRUE(WaitForLoadStop(ActiveWebContents()));
-  EXPECT_FALSE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_FALSE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
 }
 
 // I assume that the periodic fails of this test are related to issues/36355, I
@@ -471,16 +461,14 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, ClickingOnReaderButton) {
   NavigateToPageSynchronously(kTestPageReadable);
   EXPECT_TRUE(GetReaderButton()->GetVisible());
 
-  EXPECT_FALSE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_FALSE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
 
   histogram_tester_.ExpectTotalCount(
       speedreader::kSpeedreaderPageViewsHistogramName, 0);
 
   ASSERT_TRUE(ClickReaderButton());
   EXPECT_TRUE(GetReaderButton()->GetVisible());
-  EXPECT_TRUE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
   EXPECT_TRUE(GetReaderButton()->GetVisible());
 
   histogram_tester_.ExpectTotalCount(
@@ -488,8 +476,7 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, ClickingOnReaderButton) {
 
   ASSERT_TRUE(ClickReaderButton());
   EXPECT_TRUE(GetReaderButton()->GetVisible());
-  EXPECT_TRUE(speedreader::DistillStates::IsViewOriginal(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsViewOriginal(tab_helper()->PageDistillState()));
 
   EXPECT_FALSE(speedreader_service()->IsAllowedForAllReadableSites());
 }
@@ -500,8 +487,7 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, OnDemandReader) {
   NavigateToPageSynchronously(kTestPageReadable);
   EXPECT_TRUE(GetReaderButton()->GetVisible());
 
-  EXPECT_TRUE(speedreader::DistillStates::IsDistillable(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistillable(tab_helper()->PageDistillState()));
   // Change content on the page.
   static constexpr char kChangeContent[] =
       R"js(
@@ -512,8 +498,7 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, OnDemandReader) {
                               content::EXECUTE_SCRIPT_DEFAULT_OPTIONS));
   ASSERT_TRUE(ClickReaderButton());
 
-  EXPECT_TRUE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
 
   // Check title on the distilled page.
   static constexpr char kCheckContent[] =
@@ -546,13 +531,11 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, SpeedreaderPrefDisabled) {
   NavigateToPageSynchronously(kTestPageReadable);
 
   EXPECT_FALSE(GetReaderButton()->GetVisible());
-  EXPECT_FALSE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_FALSE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
   EnableSpeedreaderAllowedForAllSites();
   content::WaitForLoadStop(ActiveWebContents());
   EXPECT_FALSE(GetReaderButton()->GetVisible());
-  EXPECT_FALSE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_FALSE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
 }
 
 IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, EnableDisableSpeedreaderA) {
@@ -560,20 +543,16 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, EnableDisableSpeedreaderA) {
   NavigateToPageSynchronously(kTestPageReadable);
 
   EXPECT_TRUE(GetReaderButton()->GetVisible());
-  EXPECT_TRUE(speedreader::DistillStates::IsDistillable(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistillable(tab_helper()->PageDistillState()));
   EnableSpeedreaderAllowedForAllSites();
   ASSERT_TRUE(WaitDistilled());
   EXPECT_TRUE(GetReaderButton()->GetVisible());
-  EXPECT_TRUE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
   DisableSpeedreaderForAllSites();
   ASSERT_TRUE(WaitOriginal());
   EXPECT_TRUE(GetReaderButton()->GetVisible());
-  EXPECT_TRUE(speedreader::DistillStates::IsDistillable(
-      tab_helper()->PageDistillState()));
-  EXPECT_TRUE(speedreader::DistillStates::IsViewOriginal(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistillable(tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsViewOriginal(tab_helper()->PageDistillState()));
 }
 
 IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, EnableDisableSpeedreaderB) {
@@ -581,20 +560,16 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, EnableDisableSpeedreaderB) {
   ASSERT_TRUE(ClickReaderButton());
   ASSERT_TRUE(WaitDistilled());
   EXPECT_TRUE(GetReaderButton()->GetVisible());
-  EXPECT_TRUE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
   EnableSpeedreaderAllowedForAllSites();
   ASSERT_TRUE(WaitDistilled());
   EXPECT_TRUE(GetReaderButton()->GetVisible());
-  EXPECT_TRUE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
   DisableSpeedreaderForAllSites();
   ASSERT_TRUE(WaitOriginal());
   EXPECT_TRUE(GetReaderButton()->GetVisible());
-  EXPECT_TRUE(speedreader::DistillStates::IsDistillable(
-      tab_helper()->PageDistillState()));
-  EXPECT_TRUE(speedreader::DistillStates::IsViewOriginal(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistillable(tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsViewOriginal(tab_helper()->PageDistillState()));
 }
 
 IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, TogglingSiteSpeedreader) {
@@ -603,14 +578,12 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, TogglingSiteSpeedreader) {
 
   for (int i = 0; i < 2; ++i) {
     EXPECT_TRUE(WaitForLoadStop(ActiveWebContents()));
-    EXPECT_TRUE(speedreader::DistillStates::IsDistilled(
-        tab_helper()->PageDistillState()));
+    EXPECT_TRUE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
     EXPECT_TRUE(GetReaderButton()->GetVisible());
 
     speedreader_service()->SetEnabledForSite(ActiveWebContents(), false);
     EXPECT_TRUE(WaitForLoadStop(ActiveWebContents()));
-    EXPECT_TRUE(speedreader::DistillStates::IsViewOriginal(
-        tab_helper()->PageDistillState()));
+    EXPECT_TRUE(speedreader::IsViewOriginal(tab_helper()->PageDistillState()));
     EXPECT_TRUE(GetReaderButton()->GetVisible());
 
     speedreader_service()->SetEnabledForSite(ActiveWebContents(), true);
@@ -630,25 +603,19 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, ReloadContent) {
   auto* tab_helper_2 =
       speedreader::SpeedreaderTabHelper::FromWebContents(contents_2);
 
-  EXPECT_TRUE(speedreader::DistillStates::IsDistilled(
-      tab_helper_1->PageDistillState()));
-  EXPECT_TRUE(speedreader::DistillStates::IsDistilled(
-      tab_helper_2->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistilled(tab_helper_1->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistilled(tab_helper_2->PageDistillState()));
 
   speedreader_service()->SetEnabledForSite(tab_helper_1->web_contents(), false);
   content::WaitForLoadStop(contents_1);
-  EXPECT_TRUE(speedreader::DistillStates::IsViewOriginal(
-      tab_helper_1->PageDistillState()));
-  EXPECT_TRUE(speedreader::DistillStates::IsDistilled(
-      tab_helper_2->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsViewOriginal(tab_helper_1->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistilled(tab_helper_2->PageDistillState()));
 
   contents_2->GetController().Reload(content::ReloadType::NORMAL, false);
   content::WaitForLoadStop(contents_2);
 
-  EXPECT_TRUE(speedreader::DistillStates::IsViewOriginal(
-      tab_helper_1->PageDistillState()));
-  EXPECT_TRUE(speedreader::DistillStates::IsViewOriginal(
-      tab_helper_2->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsViewOriginal(tab_helper_1->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsViewOriginal(tab_helper_2->PageDistillState()));
 }
 
 IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, ShowOriginalPage) {
@@ -706,15 +673,13 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, ShowOriginalPage) {
   content::WaitForLoadStop(web_contents);
   auto* tab_helper =
       speedreader::SpeedreaderTabHelper::FromWebContents(web_contents);
-  EXPECT_TRUE(speedreader::DistillStates::IsDistillable(
-      tab_helper->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistillable(tab_helper->PageDistillState()));
   EXPECT_TRUE(speedreader_service()->IsAllowedForSite(web_contents));
 
   // Click on speedreader button
   ASSERT_TRUE(ClickReaderButton());
   content::WaitForLoadStop(web_contents);
-  EXPECT_TRUE(
-      speedreader::DistillStates::IsDistilled(tab_helper->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistilled(tab_helper->PageDistillState()));
 }
 
 IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, ShowOriginalPageOnUnreadable) {
@@ -996,8 +961,7 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, ErrorPage) {
   // Navigate to the non-automatic distillable page.
   NavigateToPageSynchronously(kTestPageReadableOnUnreadablePath,
                               WindowOpenDisposition::CURRENT_TAB);
-  EXPECT_TRUE(speedreader::DistillStates::IsViewOriginal(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsViewOriginal(tab_helper()->PageDistillState()));
   ASSERT_TRUE(WaitDistillable(tab_helper()));
   EXPECT_TRUE(GetReaderButton()->GetVisible());
 
@@ -1006,8 +970,7 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, ErrorPage) {
                               WindowOpenDisposition::CURRENT_TAB);
   ASSERT_TRUE(WaitDistilled());
   EXPECT_TRUE(GetReaderButton()->GetVisible());
-  EXPECT_TRUE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
 }
 
 IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, Csp) {
@@ -1103,13 +1066,11 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest,
 
   EXPECT_TRUE(GetReaderButton()->GetVisible());
 
-  EXPECT_TRUE(speedreader::DistillStates::IsDistillable(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistillable(tab_helper()->PageDistillState()));
 
   ASSERT_TRUE(ClickReaderButton());
 
-  EXPECT_TRUE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
 
   // Enable speedreader for site explicitly.
   speedreader_service()->SetEnabledForSite(ActiveWebContents(), true);
@@ -1117,13 +1078,11 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest,
                                               false);
   ASSERT_TRUE(WaitDistilled());
 
-  EXPECT_TRUE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
 
   // Go to home page.
   NavigateToPageSynchronously("/", WindowOpenDisposition::CURRENT_TAB);
-  EXPECT_TRUE(speedreader::DistillStates::IsViewOriginal(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsViewOriginal(tab_helper()->PageDistillState()));
 }
 
 // Test toolbar's rounded corners is updated when split view is toggled.
@@ -1136,8 +1095,7 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, ToolbarWithRoundedCorners) {
   EXPECT_EQ(0, tab_strip_model->active_index());
   NavigateToPageSynchronously(kTestPageReadable,
                               WindowOpenDisposition::CURRENT_TAB);
-  EXPECT_TRUE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
 
   const bool rounded_contents =
       browser()->profile()->GetPrefs()->GetBoolean(kWebViewRoundedCorners);
@@ -1149,12 +1107,10 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, ToolbarWithRoundedCorners) {
                       split_tabs::SplitTabCreatedSource::kTabContextMenu);
 
   // Tab at 1 is newly created tab with split view and it's not distilled.
-  EXPECT_FALSE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_FALSE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
 
   tab_strip_model->ActivateTabAt(0);
-  EXPECT_TRUE(speedreader::DistillStates::IsDistilled(
-      tab_helper()->PageDistillState()));
+  EXPECT_TRUE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
   EXPECT_FALSE(browser_view->reader_mode_toolbar()->rounded_corners_.IsEmpty());
 
   auto* active_tab = tab_strip_model->GetActiveTab();
@@ -1226,12 +1182,10 @@ class SpeedReaderContentSpoofBrowserTest : public SpeedReaderBrowserTest {
                         content::EXECUTE_SCRIPT_DEFAULT_OPTIONS,
                         ISOLATED_WORLD_ID_BRAVE_INTERNAL)
             .ExtractBool());
-    EXPECT_FALSE(speedreader::DistillStates::IsDistilled(
-        tab_helper()->PageDistillState()));
+    EXPECT_FALSE(speedreader::IsDistilled(tab_helper()->PageDistillState()));
     // The pending distillation is dropped together with the content, so
     // speedreader is not stuck in the distilling state either.
-    EXPECT_TRUE(speedreader::DistillStates::IsViewOriginal(
-        tab_helper()->PageDistillState()));
+    EXPECT_TRUE(speedreader::IsViewOriginal(tab_helper()->PageDistillState()));
   }
 
  private:

--- a/browser/ui/speedreader/speedreader_tab_helper.cc
+++ b/browser/ui/speedreader/speedreader_tab_helper.cc
@@ -151,18 +151,17 @@ base::WeakPtr<SpeedreaderTabHelper> SpeedreaderTabHelper::GetWeakPtr() {
 }
 
 void SpeedreaderTabHelper::ProcessIconClick() {
-  if (DistillStates::IsViewOriginal(distill_state_)) {
-    const auto& vo = std::get<DistillStates::ViewOriginal>(distill_state_);
+  if (IsViewOriginal(distill_state_)) {
+    const auto& vo = std::get<ViewOriginal>(distill_state_);
     if (!vo.was_auto_distilled ||
         !speedreader_service_->IsAllowedForSite(web_contents())) {
       GetDistilledHTML(
           base::BindOnce(&SpeedreaderTabHelper::OnGetDocumentSource,
                          weak_factory_.GetWeakPtr()));
     } else {
-      TransitStateTo(DistillStates::Distilling(
-          DistillStates::Distilling::Reason::kAutomatic));
+      TransitStateTo(Distilling(Distilling::Reason::kAutomatic));
     }
-  } else if (DistillStates::IsDistilled(distill_state_)) {
+  } else if (IsDistilled(distill_state_)) {
     OnShowOriginalPage();
   }
 }
@@ -181,9 +180,9 @@ bool SpeedreaderTabHelper::MaybeUpdateCachedState(
 
   const DistillState state = SpeedreaderExtendedInfoHandler::GetCachedMode(
       entry, &speedreader_service_.get());
-  if (DistillStates::IsDistilled(state)) {
+  if (IsDistilled(state)) {
     if (handle->IsServedFromBackForwardCache() ||
-        DistillStates::IsDistilledAutomatically(state)) {
+        IsDistilledAutomatically(state)) {
       distill_state_ = state;
       return true;
     }
@@ -228,10 +227,10 @@ void SpeedreaderTabHelper::HideSpeedreaderBubble() {
 }
 
 void SpeedreaderTabHelper::OnShowOriginalPage() {
-  if (!DistillStates::IsDistilled(distill_state_)) {
+  if (!IsDistilled(distill_state_)) {
     return;
   }
-  TransitStateTo(DistillStates::ViewOriginal());
+  TransitStateTo(ViewOriginal());
 }
 
 void SpeedreaderTabHelper::OnTtsPlayPause(int paragraph_index) {
@@ -288,20 +287,18 @@ void SpeedreaderTabHelper::ProcessNavigation(
   if (finish_navigation) {
     if (navigation_handle->IsErrorPage() ||
         web_contents()->GetPrimaryMainFrame()->IsErrorDocument()) {
-      TransitStateTo(
-          DistillStates::ViewOriginal(
-              DistillStates::ViewOriginal::Reason::kNotDistillable, false),
-          true);
+      TransitStateTo(ViewOriginal(ViewOriginal::Reason::kNotDistillable, false),
+                     true);
     }
     return;
   }
 
-  if (DistillStates::IsDistilling(distill_state_)) {
+  if (IsDistilling(distill_state_)) {
     // State will be determined in OnDistillComplete.
     return;
   }
-  if (DistillStates::IsDistillReverting(distill_state_)) {
-    TransitStateTo(DistillStates::ViewOriginal(), true);
+  if (IsDistillReverting(distill_state_)) {
+    TransitStateTo(ViewOriginal(), true);
     return;
   }
 
@@ -313,11 +310,11 @@ void SpeedreaderTabHelper::ProcessNavigation(
   const bool enabled_for_site =
       speedreader_service_->IsAllowedForSite(navigation_handle->GetURL());
 
-  const auto reason =
-      url_looks_readable ? DistillStates::ViewOriginal::Reason::kNone
-                         : DistillStates::ViewOriginal::Reason::kNotDistillable;
-  TransitStateTo(DistillStates::DistillReverting(reason, false), true);
-  TransitStateTo(DistillStates::ViewOriginal(), true);
+  const auto reason = url_looks_readable
+                          ? ViewOriginal::Reason::kNone
+                          : ViewOriginal::Reason::kNotDistillable;
+  TransitStateTo(DistillReverting(reason, false), true);
+  TransitStateTo(ViewOriginal(), true);
 
   if (enabled_for_site) {
     // Check if url is pointed to the homepage, basically these pages aren't
@@ -332,17 +329,15 @@ void SpeedreaderTabHelper::ProcessNavigation(
         speedreader_service_->IsEnabledForSite(navigation_handle->GetURL());
     if (url_looks_readable || explicit_enabled_for_size) {
       // Speedreader enabled for this page.
-      TransitStateTo(DistillStates::Distilling(
-                         DistillStates::Distilling::Reason::kAutomatic),
-                     true);
+      TransitStateTo(Distilling(Distilling::Reason::kAutomatic), true);
     }
   }
 }
 
 void SpeedreaderTabHelper::UpdateUI() {
-  if (DistillStates::IsDistilled(distill_state_)) {
+  if (IsDistilled(distill_state_)) {
     UpdateState(State::kDistilled);
-  } else if (DistillStates::IsDistillable(distill_state_)) {
+  } else if (IsDistillable(distill_state_)) {
     UpdateState(State::kDistillable);
   } else {
     UpdateState(State::kNotDistillable);
@@ -366,12 +361,12 @@ void SpeedreaderTabHelper::ReadyToCommitNavigation(
     return;
   }
 
-  const bool is_distilled = DistillStates::IsDistilled(PageDistillState());
+  const bool is_distilled = IsDistilled(PageDistillState());
 
   blink::web_pref::WebPreferences prefs =
       web_contents()->GetOrCreateWebPreferences();
   if (prefs.page_in_reader_mode != is_distilled) {
-    prefs.page_in_reader_mode = DistillStates::IsDistilled(PageDistillState());
+    prefs.page_in_reader_mode = IsDistilled(PageDistillState());
     web_contents()->SetWebPreferences(prefs);
   }
 }
@@ -401,7 +396,7 @@ void SpeedreaderTabHelper::DidStopLoading() {
 void SpeedreaderTabHelper::DOMContentLoaded(
     content::RenderFrameHost* render_frame_host) {
   if (!render_frame_host->IsInPrimaryMainFrame() ||
-      !DistillStates::IsDistilled(distill_state_)) {
+      !IsDistilled(distill_state_)) {
     return;
   }
   UpdateUI();
@@ -443,8 +438,7 @@ void SpeedreaderTabHelper::WebContentsDestroyed() {
 }
 
 bool SpeedreaderTabHelper::IsPageDistillationAllowed() {
-  return DistillStates::IsDistilling(distill_state_) ||
-         DistillStates::IsDistilled(distill_state_);
+  return IsDistilling(distill_state_) || IsDistilled(distill_state_);
 }
 
 bool SpeedreaderTabHelper::IsPageContentPresent() {
@@ -457,7 +451,7 @@ std::string SpeedreaderTabHelper::TakePageContent() {
 
 void SpeedreaderTabHelper::OnDistillComplete(DistillationResult result) {
   // Perform a state transition
-  Transit(distill_state_, DistillStates::Distilled(result));
+  Transit(distill_state_, Distilled(result));
   if (result == DistillationResult::kSuccess) {
     speedreader_service_->metrics().RecordPageView();
   }
@@ -471,7 +465,7 @@ void SpeedreaderTabHelper::OnDistilledDocumentSent() {
   // This is done by mocking a pinch gesture on Android,
   // see chrome/android/java/src/org/chromium/chrome/browser/ZoomController.java
   // and ui/android/event_forwarder.cc
-  if (DistillStates::IsDistilled(distill_state_)) {
+  if (IsDistilled(distill_state_)) {
     ui::ViewAndroid* view = web_contents()->GetNativeView();
     int64_t time_ms = base::TimeTicks::Now().ToUptimeMillis();
     SendGestureEvent(view, ui::GESTURE_EVENT_TYPE_PINCH_BEGIN, time_ms, 0.f);
@@ -482,7 +476,7 @@ void SpeedreaderTabHelper::OnDistilledDocumentSent() {
 }
 
 void SpeedreaderTabHelper::OnReadingStart(content::WebContents* web_contents) {
-  if (!speedreader::DistillStates::IsDistilled(distill_state_)) {
+  if (!speedreader::IsDistilled(distill_state_)) {
     return;
   }
 
@@ -505,7 +499,7 @@ void SpeedreaderTabHelper::OnReadingProgress(content::WebContents* web_contents,
                                              int paragraph_index,
                                              int char_index,
                                              int length) {
-  if (!speedreader::DistillStates::IsDistilled(distill_state_) ||
+  if (!speedreader::IsDistilled(distill_state_) ||
       web_contents != this->web_contents()) {
     return;
   }
@@ -530,10 +524,9 @@ void SpeedreaderTabHelper::OnSiteEnableSettingChanged(
   }
 
   if (enabled_on_site) {
-    TransitStateTo(DistillStates::Distilling(
-        DistillStates::Distilled::Reason::kAutomatic));
+    TransitStateTo(Distilling(Distilled::Reason::kAutomatic));
   } else {
-    TransitStateTo(DistillStates::ViewOriginal());
+    TransitStateTo(ViewOriginal());
   }
   HideSpeedreaderBubble();
 }
@@ -549,7 +542,7 @@ void SpeedreaderTabHelper::OnAllSitesEnableSettingChanged(
 
 void SpeedreaderTabHelper::OnAppearanceSettingsChanged(
     const mojom::AppearanceSettings& view_settings) {
-  if (!speedreader::DistillStates::IsDistilled(distill_state_)) {
+  if (!speedreader::IsDistilled(distill_state_)) {
     return;
   }
 
@@ -564,11 +557,9 @@ void SpeedreaderTabHelper::OnAppearanceSettingsChanged(
 
 void SpeedreaderTabHelper::OnResult(
     const dom_distiller::DistillabilityResult& result) {
-  if (DistillStates::IsNotDistillable(distill_state_) &&
-      result.is_distillable) {
-    TransitStateTo(DistillStates::DistillReverting(
-        DistillStates::DistillReverting::Reason::kNone, false));
-    TransitStateTo(DistillStates::ViewOriginal());
+  if (IsNotDistillable(distill_state_) && result.is_distillable) {
+    TransitStateTo(DistillReverting(DistillReverting::Reason::kNone, false));
+    TransitStateTo(ViewOriginal());
   }
 }
 
@@ -597,15 +588,13 @@ void SpeedreaderTabHelper::SetDocumentAttribute(const std::string& attribute,
 
 void SpeedreaderTabHelper::OnGetDocumentSource(bool success, std::string html) {
   if (!success || html.empty()) {
-    TransitStateTo(DistillStates::DistillReverting(
-        DistillStates::DistillReverting::Reason::kError, false));
-    TransitStateTo(DistillStates::ViewOriginal());
+    TransitStateTo(DistillReverting(DistillReverting::Reason::kError, false));
+    TransitStateTo(ViewOriginal());
     return;
   }
 
   single_show_content_ = std::move(html);
-  TransitStateTo(
-      DistillStates::Distilling(DistillStates::Distilling::Reason::kManual));
+  TransitStateTo(Distilling(Distilling::Reason::kManual));
 }
 
 void SpeedreaderTabHelper::TransitStateTo(const DistillState& desired_state,

--- a/browser/ui/speedreader/speedreader_tab_helper.h
+++ b/browser/ui/speedreader/speedreader_tab_helper.h
@@ -184,7 +184,7 @@ class SpeedreaderTabHelper
 
   std::string single_show_content_;
 
-  DistillState distill_state_{DistillStates::ViewOriginal()};
+  DistillState distill_state_{ViewOriginal()};
 
   raw_ref<SpeedreaderService> speedreader_service_;
 

--- a/browser/ui/views/brave_actions/brave_shields_action_controller.cc
+++ b/browser/ui/views/brave_actions/brave_shields_action_controller.cc
@@ -239,8 +239,7 @@ bool BraveShieldsActionController::IsPageInReaderMode(
 #if BUILDFLAG(ENABLE_SPEEDREADER)
   if (auto* speedreader_tab_helper =
           speedreader::SpeedreaderTabHelper::FromWebContents(web_contents)) {
-    return speedreader::DistillStates::IsDistilled(
-        speedreader_tab_helper->PageDistillState());
+    return speedreader::IsDistilled(speedreader_tab_helper->PageDistillState());
   }
 #endif
   return false;

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -618,7 +618,7 @@ void BraveBrowserView::UpdateReaderModeToolbar() {
     }
     if (auto* th =
             speedreader::SpeedreaderTabHelper::FromWebContents(web_contents)) {
-      return speedreader::DistillStates::IsDistilled(th->PageDistillState());
+      return speedreader::IsDistilled(th->PageDistillState());
     }
     return false;
   };

--- a/browser/ui/views/speedreader/reader_mode_bubble.cc
+++ b/browser/ui/views/speedreader/reader_mode_bubble.cc
@@ -142,7 +142,7 @@ void ReaderModeBubble::Init() {
       DistillState state = tab_helper_->PageDistillState();
       if (IsDistilledAutomatically(state)) {
         site_toggle_->SetIsOn(true);
-      } else if (DistillStates::IsDistillable(state)) {
+      } else if (IsDistillable(state)) {
         site_toggle_->SetIsOn(false);
       }
     }

--- a/browser/ui/views/speedreader/speedreader_icon_view.cc
+++ b/browser/ui/views/speedreader/speedreader_icon_view.cc
@@ -54,8 +54,7 @@ void SpeedreaderIconView::UpdateImpl() {
   }
 
   const auto state = GetDistillState();
-  if (!speedreader::DistillStates::IsDistilled(state) &&
-      !speedreader::DistillStates::IsDistillable(state)) {
+  if (!speedreader::IsDistilled(state) && !speedreader::IsDistillable(state)) {
     SetVisible(false);
     return;
   }
@@ -66,7 +65,7 @@ void SpeedreaderIconView::UpdateImpl() {
   }
 
   if (const ui::ColorProvider* color_provider = GetColorProvider()) {
-    if (speedreader::DistillStates::IsDistilled(state)) {
+    if (speedreader::IsDistilled(state)) {
       const SkColor icon_color_active =
           color_provider->GetColor(kColorSpeedreaderIcon);
       SetIconColor(icon_color_active);
@@ -106,7 +105,7 @@ const gfx::VectorIcon& SpeedreaderIconView::GetVectorIcon() const {
 
 std::u16string SpeedreaderIconView::GetTextForTooltipAndAccessibleName() const {
   const auto state = GetDistillState();
-  const int id = (speedreader::DistillStates::IsDistilled(state))
+  const int id = (speedreader::IsDistilled(state))
                      ? IDS_SPEEDREADER_ICON_TURN_OFF_READER_MODE
                      : IDS_SPEEDREADER_ICON_TURN_ON_READER_MODE;
   return l10n_util::GetStringUTF16(id);

--- a/components/speedreader/speedreader_extended_info_handler.cc
+++ b/components/speedreader/speedreader_extended_info_handler.cc
@@ -45,9 +45,9 @@ void SpeedreaderExtendedInfoHandler::PersistMode(
     DistillState state) {
   DCHECK(entry);
   std::unique_ptr<SpeedreaderNavigationData> data;
-  if (DistillStates::IsDistilledAutomatically(state)) {
+  if (IsDistilledAutomatically(state)) {
     data = std::make_unique<SpeedreaderNavigationData>(kPageSavedDistilled);
-  } else if (DistillStates::IsDistilled(state)) {
+  } else if (IsDistilled(state)) {
     data =
         std::make_unique<SpeedreaderNavigationData>(kPageSavedDistilledManual);
   }
@@ -66,13 +66,11 @@ DistillState SpeedreaderExtendedInfoHandler::GetCachedMode(
     return {};
   }
   if (data->value == kPageSavedDistilled) {
-    return DistillStates::Distilled(
-        DistillStates::Distilled::Reason::kAutomatic,
-        DistillationResult::kSuccess);
+    return Distilled(Distilled::Reason::kAutomatic,
+                     DistillationResult::kSuccess);
   }
 
-  return DistillStates::Distilled(DistillStates::Distilled::Reason::kManual,
-                                  DistillationResult::kSuccess);
+  return Distilled(Distilled::Reason::kManual, DistillationResult::kSuccess);
 }
 
 // static

--- a/components/speedreader/speedreader_util.cc
+++ b/components/speedreader/speedreader_util.cc
@@ -21,8 +21,6 @@
 
 namespace speedreader {
 
-namespace DistillStates {
-
 ViewOriginal::ViewOriginal() = default;
 
 ViewOriginal::ViewOriginal(ViewOriginal::Reason reason, bool was_auto_distilled)
@@ -49,43 +47,41 @@ DistillReverting::DistillReverting(const Distilled& state,
                                    DistillReverting::Reason reason)
     : ViewOriginal(reason, state.reason == Distilled::Reason::kAutomatic) {}
 
-bool IsViewOriginal(const State& state) {
+bool IsViewOriginal(const DistillState& state) {
   return std::holds_alternative<ViewOriginal>(state);
 }
 
-bool IsDistilling(const State& state) {
+bool IsDistilling(const DistillState& state) {
   return std::holds_alternative<Distilling>(state);
 }
 
-bool IsDistilled(const State& state) {
+bool IsDistilled(const DistillState& state) {
   return std::holds_alternative<Distilled>(state);
 }
 
-bool IsDistillReverting(const State& state) {
+bool IsDistillReverting(const DistillState& state) {
   return std::holds_alternative<DistillReverting>(state);
 }
 
-bool IsNotDistillable(const State& state) {
-  return IsViewOriginal(state) &&
-         std::get<DistillStates::ViewOriginal>(state).reason ==
-             DistillStates::ViewOriginal::Reason::kNotDistillable;
+bool IsNotDistillable(const DistillState& state) {
+  return IsViewOriginal(state) && std::get<ViewOriginal>(state).reason ==
+                                      ViewOriginal::Reason::kNotDistillable;
 }
 
-bool IsDistillable(const State& state) {
-  return IsViewOriginal(state) &&
-         std::get<DistillStates::ViewOriginal>(state).reason !=
-             DistillStates::ViewOriginal::Reason::kNotDistillable;
+bool IsDistillable(const DistillState& state) {
+  return IsViewOriginal(state) && std::get<ViewOriginal>(state).reason !=
+                                      ViewOriginal::Reason::kNotDistillable;
 }
 
-bool IsDistilledAutomatically(const State& state) {
+bool IsDistilledAutomatically(const DistillState& state) {
   if (const auto* d = std::get_if<Distilled>(&state)) {
     return d->reason == Distilled::Reason::kAutomatic;
   }
   return false;
 }
 
-bool Transit(State& state, const State& desired) {
-  if (std::holds_alternative<None>(state)) {
+bool Transit(DistillState& state, const DistillState& desired) {
+  if (std::holds_alternative<std::monostate>(state)) {
     state = desired;
     return false;
   }
@@ -151,8 +147,6 @@ bool Transit(State& state, const State& desired) {
 
   NOTREACHED();
 }
-
-}  // namespace DistillStates
 
 void DistillPage(const GURL& url,
                  std::string body,

--- a/components/speedreader/speedreader_util.h
+++ b/components/speedreader/speedreader_util.h
@@ -23,10 +23,6 @@ enum class DistillationResult : int {
   kFail,
 };
 
-namespace DistillStates {
-
-using None = std::monostate;
-
 struct DistillReverting;
 
 struct ViewOriginal {
@@ -71,28 +67,24 @@ struct DistillReverting : ViewOriginal {
   DistillReverting(const Distilled& state, Reason reason);
 };
 
-using State = std::variant<DistillStates::None,
-                           DistillStates::ViewOriginal,
-                           DistillStates::Distilling,
-                           DistillStates::Distilled,
-                           DistillStates::DistillReverting>;
+using DistillState = std::variant<std::monostate,
+                                  ViewOriginal,
+                                  Distilling,
+                                  Distilled,
+                                  DistillReverting>;
 
-bool IsViewOriginal(const State& state);
-bool IsDistilling(const State& state);
-bool IsDistilled(const State& state);
-bool IsDistillReverting(const State& state);
+bool IsViewOriginal(const DistillState& state);
+bool IsDistilling(const DistillState& state);
+bool IsDistilled(const DistillState& state);
+bool IsDistillReverting(const DistillState& state);
 
-bool IsNotDistillable(const State& state);
-bool IsDistillable(const State& state);
-bool IsDistilledAutomatically(const State& state);
+bool IsNotDistillable(const DistillState& state);
+bool IsDistillable(const DistillState& state);
+bool IsDistilledAutomatically(const DistillState& state);
 
 // Performs the transition from |state| to |desired|, returns true if transition
 // requires page reload.
-bool Transit(State& state, const State& desired);
-
-}  // namespace DistillStates
-
-using DistillState = DistillStates::State;
+bool Transit(DistillState& state, const DistillState& desired);
 
 using DistillationResultCallback =
     base::OnceCallback<void(DistillationResult result,

--- a/docs/best-practices/testing-async.md
+++ b/docs/best-practices/testing-async.md
@@ -146,7 +146,7 @@ tests:
 
 ```cpp
 ASSERT_TRUE(base::test::RunUntil([th]() {
-  return speedreader::DistillStates::IsDistilled(th->PageDistillState());
+  return speedreader::IsDistilled(th->PageDistillState());
 }));
 ```
 


### PR DESCRIPTION
This namespace in `speedreader` is not quite necessary, and we should
keep to the upstream recommendation in this case:

https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++-dos-and-donts.md#named-namespaces

In summary, minimize use of nested namespaces, as they do not improve
encapsulation. It is also of notice that this namespace is using
PascalCase, rather than snake_case, which is against the style guide.
