### PR TITLE
[recipes] Adding placeholder support to `step`

### DIFF
--- a/tools/recipes/recipe_modules/brave_core_checkout/__init__.py
+++ b/tools/recipes/recipe_modules/brave_core_checkout/__init__.py
@@ -4,4 +4,4 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """`brave_core_checkout` module: sparse-deploy brave-core subpaths."""
 
-DEPS = ['context', 'path', 'step']
+DEPS = ['context', 'path', 'raw_io', 'step']

--- a/tools/recipes/recipe_modules/brave_core_checkout/api.py
+++ b/tools/recipes/recipe_modules/brave_core_checkout/api.py
@@ -159,8 +159,8 @@ class BraveCoreCheckoutApi(RecipeApi):
             'sparse-checkout list',
             ['git', '-C', str(dest), 'sparse-checkout', 'list'],
             check=False,
-            capture_output=True)
-        if result.returncode != 0 or not result.stdout:
+            stdout=self.m.raw_io.output_text())
+        if result.retcode != 0 or not result.stdout:
             return set()
         return {
             line.strip()

--- a/tools/recipes/recipe_modules/brave_core_checkout/examples/full.py
+++ b/tools/recipes/recipe_modules/brave_core_checkout/examples/full.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import post_process
 
-DEPS = ['brave_core_checkout', 'path', 'step']
+DEPS = ['brave_core_checkout', 'path', 'raw_io', 'step']
 
 
 def RunSteps(api):
@@ -52,8 +52,9 @@ def GenTests(api):
         'already deployed',
         api.path.files('brave-browser/src/brave/third_party/node',
                        'brave-browser/src/brave/tools/cr/bootstrap'),
-        api.step_data('sparse-checkout list',
-                      stdout='third_party/node\ntools/cr\n'),
+        api.step_data(
+            'sparse-checkout list',
+            stdout=api.raw_io.output_text('third_party/node\ntools/cr\n')),
         api.post_process(post_process.DoesNotRun, 'sparse-checkout add'),
         api.post_process(post_process.MustRun, 'npm version'),
         api.post_process(post_process.StatusSuccess),

--- a/tools/recipes/recipe_modules/chromium_checkout/api.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/api.py
@@ -355,7 +355,7 @@ class ChromiumCheckoutApi(RecipeApi):
             'git', 'cache', 'exists', '--quiet', '--cache-dir', git_cache_path,
             url
         ],
-                           capture_output=True).stdout.strip()
+                           stdout=self.m.raw_io.output_text()).stdout.strip()
 
     def _disable_git_gc(self, chromium_src: str | Path) -> None:
         """Disable background gc in *chromium_src*.

--- a/tools/recipes/recipe_modules/chromium_checkout/test_api.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/test_api.py
@@ -38,7 +38,8 @@ class ChromiumCheckoutTestApi(RecipeTestApi):
         Both `clone` and `checkout_ref` run a `git cache exists` step to
         resolve the mirror directory `git cache populate` just fetched into;
         required whenever either of them runs, since the simulated stdout is
-        `None` (not an empty string) unless seeded.
+        an empty string unless seeded.
         """
-        return (self.step_data('git cache exists', stdout=mirror_dir) +
-                self.step_data('git cache exists for ref', stdout=mirror_dir))
+        stdout = self.m.raw_io.output_text(mirror_dir)
+        return (self.step_data('git cache exists', stdout=stdout) +
+                self.step_data('git cache exists for ref', stdout=stdout))

--- a/tools/recipes/recipe_modules/file/__init__.py
+++ b/tools/recipes/recipe_modules/file/__init__.py
@@ -9,4 +9,4 @@ Covers every operation that doesn't need to inject arbitrary file content
 into the step (see `api.py` for what that excludes and why).
 """
 
-DEPS = ['depot_tools', 'step']
+DEPS = ['depot_tools', 'raw_io', 'step']

--- a/tools/recipes/recipe_modules/file/api.py
+++ b/tools/recipes/recipe_modules/file/api.py
@@ -65,7 +65,8 @@ class FileApi(RecipeApi):
         """
         vpython3 = self.m.depot_tools.vpython3()
         result = self.m.step(name, [vpython3, '-u', _FILEUTIL, *args],
-                             capture_output=True)
+                             stdout=self.m.raw_io.output_text(),
+                             stderr=self.m.raw_io.output_text())
         status = (json.loads(result.stderr) if result.stderr else {
             'ok': True,
             'errno_name': '',

--- a/tools/recipes/recipe_modules/file/test_api.py
+++ b/tools/recipes/recipe_modules/file/test_api.py
@@ -27,12 +27,13 @@ class FileTestApi(RecipeTestApi):
 
     def _ok(self, name: str, stdout: str = '') -> TestData:
         return self.step_data(name,
-                              stdout=stdout,
-                              stderr=json.dumps({
-                                  'ok': True,
-                                  'errno_name': '',
-                                  'message': '',
-                              }))
+                              stdout=self.m.raw_io.output_text(stdout),
+                              stderr=self.m.raw_io.output_text(
+                                  json.dumps({
+                                      'ok': True,
+                                      'errno_name': '',
+                                      'message': '',
+                                  })))
 
     def read_text(self, name: str, content: str = '') -> TestData:
         """Seed *name* to succeed, returning *content* as the file's text."""
@@ -72,8 +73,9 @@ class FileTestApi(RecipeTestApi):
               message: str = '') -> TestData:
         """Seed *name* to fail with *errno_name* (and optional *message*)."""
         return self.step_data(name,
-                              stderr=json.dumps({
-                                  'ok': False,
-                                  'errno_name': errno_name,
-                                  'message': message or errno_name,
-                              }))
+                              stderr=self.m.raw_io.output_text(
+                                  json.dumps({
+                                      'ok': False,
+                                      'errno_name': errno_name,
+                                      'message': message or errno_name,
+                                  })))

--- a/tools/recipes/recipe_modules/path/api.py
+++ b/tools/recipes/recipe_modules/path/api.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+import tempfile
 
 from recipe_api import RecipeApi
 
@@ -27,6 +28,10 @@ class _RealFs:  # pragma: no cover - production filesystem backend.
     def mkdir(self, path: str | Path, *, parents: bool,
               exist_ok: bool) -> None:
         Path(path).mkdir(parents=parents, exist_ok=exist_ok)
+
+    def mkdtemp(self, parent: Path, prefix: str) -> Path:
+        parent.mkdir(parents=True, exist_ok=True)
+        return Path(tempfile.mkdtemp(prefix=f'{prefix}_', dir=parent))
 
     def abs(self, path: str | Path) -> Path:
         return Path(path).expanduser().resolve()
@@ -60,6 +65,14 @@ class _SimFs:
         # and implies parents, so these flags don't apply here.
         del parents, exist_ok
         self._test.fs.add_dir(path)
+
+    def mkdtemp(self, parent: Path, prefix: str) -> Path:
+        # Numbered per prefix rather than randomized, so a run that makes
+        # temporary directories still has reproducible expectations.
+        self._test.temp_counter[prefix] += 1
+        path = parent / f'{prefix}_tmp_{self._test.temp_counter[prefix]}'
+        self._test.fs.add_dir(path)
+        return path
 
     def abs(self, path: str | Path) -> Path:
         text = str(path)
@@ -100,6 +113,17 @@ class PathApi(RecipeApi):
         """Build output directory: `<workspace>/out`."""
         return self._workspace / 'out'
 
+    @property
+    def cleanup_dir(self) -> Path:
+        """Scratch directory: `<workspace>/rc`.
+
+        Everything under here is disposable -- treat it as empty at the start of
+        a job and gone afterwards. This is where `mkdtemp` puts the directories
+        it makes, so a step that needs somewhere to write throwaway output has a
+        home for it that nothing else has to clean up.
+        """
+        return self._workspace / 'rc'
+
     # Filesystem seams. The real-vs-simulated choice is made once in
     # `initialise()` by picking a backend. The methods below just delegate, so
     # in test mode recipes probe (and `mkdir` mutates) the simulated filesystem
@@ -134,6 +158,18 @@ class PathApi(RecipeApi):
               exist_ok: bool = True) -> None:
         """Create directory *path* (creating parents by default)."""
         self._fs.mkdir(path, parents=parents, exist_ok=exist_ok)
+
+    def mkdtemp(self, prefix: str = 'tmp') -> Path:
+        """Create a new temporary directory under `cleanup_dir`, and return it.
+
+        Args:
+            prefix: Prepended to the directory's name, to say what it is for.
+
+        In test mode nothing is created on disk and the name is numbered per
+        *prefix* (`<cleanup_dir>/<prefix>_tmp_1`, `_2`, ...) rather than
+        randomized, so expectations stay stable across runs.
+        """
+        return self._fs.mkdtemp(self.cleanup_dir, prefix)
 
     def abs(self, path: str | Path) -> Path:
         """Return an absolute, `~`-expanded, normalized `Path`.

--- a/tools/recipes/recipe_modules/path/examples/full.expected/absent.json
+++ b/tools/recipes/recipe_modules/path/examples/full.expected/absent.json
@@ -21,6 +21,15 @@
     "name": "cache"
   },
   {
+    "cmd": [
+      "echo",
+      "[WORKSPACE]/rc/tmp_tmp_1",
+      "[WORKSPACE]/rc/tmp_tmp_2",
+      "[WORKSPACE]/rc/unpacked_tmp_1"
+    ],
+    "name": "temp dirs"
+  },
+  {
     "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/path/examples/full.expected/seeded.json
+++ b/tools/recipes/recipe_modules/path/examples/full.expected/seeded.json
@@ -28,6 +28,15 @@
     "name": "cache"
   },
   {
+    "cmd": [
+      "echo",
+      "[WORKSPACE]/rc/tmp_tmp_1",
+      "[WORKSPACE]/rc/tmp_tmp_2",
+      "[WORKSPACE]/rc/unpacked_tmp_1"
+    ],
+    "name": "temp dirs"
+  },
+  {
     "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/path/examples/full.py
+++ b/tools/recipes/recipe_modules/path/examples/full.py
@@ -23,6 +23,16 @@ def RunSteps(api):
     api.step('home', ['echo', str(api.path.home())])
     api.step('cache', ['echo', str(api.path.abs('~/cache'))])
 
+    # Temporary directories live under the job's scratch space, and exist for
+    # the rest of the run. Names are numbered per prefix, so two directories
+    # with the same prefix don't collide.
+    first = api.path.mkdtemp()
+    second = api.path.mkdtemp()
+    unpacked = api.path.mkdtemp('unpacked')
+    assert api.path.is_dir(first) and api.path.is_dir(unpacked)
+    assert first.parent == api.path.cleanup_dir, first
+    api.step('temp dirs', ['echo', str(first), str(second), str(unpacked)])
+
 
 def GenTests(api):
     yield api.test(
@@ -35,6 +45,10 @@ def GenTests(api):
         api.post_process(post_process.StepCommandContains, 'home', ['[HOME]']),
         api.post_process(post_process.StepCommandContains, 'cache',
                          ['[HOME]/cache']),
+        api.post_process(post_process.StepCommandContains, 'temp dirs', [
+            '[WORKSPACE]/rc/tmp_tmp_1', '[WORKSPACE]/rc/tmp_tmp_2',
+            '[WORKSPACE]/rc/unpacked_tmp_1'
+        ]),
         api.post_process(post_process.StatusSuccess),
     )
     yield api.test(

--- a/tools/recipes/recipe_modules/raw_io/__init__.py
+++ b/tools/recipes/recipe_modules/raw_io/__init__.py
@@ -2,6 +2,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""`chromium_checkout` module: clone / sync / validate a Chromium src/ tree."""
+"""`raw_io` module: read and write raw data to and from steps."""
 
-DEPS = ['path', 'raw_io', 'step', 'context', 'depot_tools', 'env', 'platform']
+# `path` for the scratch directory `output_dir` places its temporary
+# directories in.
+DEPS = ['path']

--- a/tools/recipes/recipe_modules/raw_io/api.py
+++ b/tools/recipes/recipe_modules/raw_io/api.py
@@ -1,0 +1,370 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""The `raw_io` module API: raw data in and out of steps.
+
+This is the bottom of the placeholder stack: `input`/`input_text` write data to
+a temporary file and hand the step its path; `output`/`output_text` hand the
+step a path to write to and read it back once the step is done. `output_dir`
+does the same for a whole directory of results. Every other module's
+placeholders (`json`, `proto`) are these wearing a codec.
+
+Deliberately not supported: `add_output_log` (mirroring the captured data into a
+step log), which needs step presentation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+import errno
+import os
+from pathlib import Path
+import tempfile
+from typing import Any, Callable
+
+from recipe_api import (InputPlaceholder, OutputPlaceholder, RecipeApi,
+                        returns_placeholder)
+
+# What an output placeholder renders to under simulation. Steps never really run
+# there, so a fixed, obviously-fake path keeps expectations stable (and makes an
+# accidentally-real read easy to spot).
+SIM_TMP_PREFIX = '/path/to/tmp/'
+
+
+class InputDataPlaceholder(InputPlaceholder):
+    """Writes `data` (bytes) to a temp file and renders to its path."""
+
+    def __init__(self,
+                 data: bytes,
+                 suffix: str = '',
+                 name: str | None = None) -> None:
+        self.data = data
+        self.suffix = suffix
+        self._backing_file: str | None = None
+        super().__init__(name=name)
+
+    @property
+    def backing_file(self) -> str | None:
+        return self._backing_file
+
+    def render(self, test) -> list[str]:
+        assert not self._backing_file, 'A placeholder can only be used once'
+        if test.enabled:
+            # Under simulation nothing reads the file, so pretend the data was
+            # passed on the command line: an expectation then shows what the
+            # step was fed rather than an opaque temp path.
+            self._backing_file = self.readable_test_data
+        else:  # pragma: no cover - production placeholder backend.
+            input_fd, self._backing_file = tempfile.mkstemp(suffix=self.suffix)
+            os.close(input_fd)
+            self.write_data(self._backing_file)
+        return [self._backing_file]
+
+    def cleanup(self, test_enabled: bool) -> None:
+        assert self._backing_file is not None
+        if not test_enabled:  # pragma: no cover - production placeholder.
+            _remove(self._backing_file)
+        self._backing_file = None
+
+    def write_data(self, path: str) -> None:  # pragma: no cover - production.
+        Path(path).write_bytes(self.data)
+
+    @property
+    def readable_test_data(self) -> str:
+        return self.data.decode('utf-8', errors='replace')
+
+
+class InputTextPlaceholder(InputDataPlaceholder):
+    """As `InputDataPlaceholder`, but the data is UTF-8 text."""
+
+    def __init__(self,
+                 data: str,
+                 suffix: str = '',
+                 name: str | None = None) -> None:
+        super().__init__(data, suffix, name=name)
+        assert isinstance(data, str)
+
+    def write_data(self, path: str) -> None:  # pragma: no cover - production.
+        Path(path).write_text(self.data, encoding='utf-8', errors='replace')
+
+    @property
+    def readable_test_data(self) -> str:
+        return self.data
+
+
+class OutputDataPlaceholder(OutputPlaceholder):
+    """Renders to a path the step writes to, then reads it back as bytes."""
+
+    def __init__(self,
+                 suffix: str = '',
+                 leak_to: str | Path | None = None,
+                 name: str | None = None) -> None:
+        self.suffix = suffix
+        self.leak_to = leak_to
+        self._backing_file: str | None = None
+        super().__init__(name=name)
+
+    @property
+    def backing_file(self) -> str | None:
+        return self._backing_file
+
+    def render(self, test) -> list[str]:
+        assert not self._backing_file, 'A placeholder can only be used once'
+        if self.leak_to:
+            self._backing_file = str(self.leak_to)
+        elif test.enabled:
+            self._backing_file = SIM_TMP_PREFIX + self.suffix.lstrip('.')
+        else:  # pragma: no cover - production placeholder backend.
+            output_fd, self._backing_file = tempfile.mkstemp(
+                suffix=self.suffix)
+            os.close(output_fd)
+        return [self._backing_file]
+
+    def result(self, test) -> Any:
+        assert self._backing_file
+        if test.enabled:
+            self._backing_file = None
+            # A `leak_to` placeholder seeded with no data simulates a step that
+            # never wrote its output file. Without `leak_to` the backing file is
+            # one this placeholder just created, so it is always there.
+            if self.leak_to and test.data is None:
+                return None
+            return self.read_test_data(test)
+        try:  # pragma: no cover - production placeholder backend.
+            return self.read_data()
+        except OSError as ex:  # pragma: no cover - production placeholder.
+            if ex.errno != errno.ENOENT:
+                raise
+            return None
+        finally:  # pragma: no cover - production placeholder backend.
+            if not self.leak_to:
+                _remove(self._backing_file)
+            self._backing_file = None
+
+    def read_data(self) -> bytes:  # pragma: no cover - production placeholder.
+        return Path(self._backing_file).read_bytes()
+
+    def read_test_data(self, test) -> bytes:
+        data = test.data or b''
+        if not isinstance(data, bytes):
+            raise TypeError(f'test data must be binary data, got {data!r}')
+        return data
+
+
+class OutputTextPlaceholder(OutputDataPlaceholder):
+    """As `OutputDataPlaceholder`, but decodes the data as UTF-8 text."""
+
+    def read_data(self) -> str:  # pragma: no cover - production placeholder.
+        # Any byte that isn't valid UTF-8 becomes U+FFFD rather than an error,
+        # so a step emitting stray bytes doesn't sink the recipe.
+        return Path(self._backing_file).read_text(encoding='utf-8',
+                                                  errors='replace')
+
+    def read_test_data(self, test) -> str:
+        data = test.data or ''
+        if not isinstance(data, str):
+            raise TypeError(f'test data must be text data, got {data!r}')
+        return data
+
+
+class _LazyDirectoryReader(Mapping):
+    """A read-only mapping of relative path -> file content, read on demand.
+
+    What an `output_dir` placeholder hands back. A step can leave behind more
+    output than a recipe will look at (or than fits comfortably in memory), so
+    nothing is read until it is asked for. `del reader[path]` drops a file's
+    content again, and makes further reads of it an error.
+    """
+
+    def __init__(self, paths: Iterator[str], read: Callable[[str],
+                                                            bytes]) -> None:
+        self._paths = set(paths)
+        self._read = read
+        self._content: dict[str, bytes] = {}
+
+    def __getitem__(self, rel_path: str) -> bytes:
+        if rel_path not in self._content:
+            if rel_path not in self._paths:
+                raise KeyError(rel_path)
+            self._content[rel_path] = self._read(rel_path)
+        return self._content[rel_path]
+
+    def __delitem__(self, rel_path: str) -> None:
+        self._paths.discard(rel_path)
+        self._content.pop(rel_path, None)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._paths)
+
+    def __len__(self) -> int:
+        return len(self._paths)
+
+
+class OutputDataDirPlaceholder(OutputPlaceholder):  # pylint: disable=abstract-method
+    """Renders to a directory the step writes into, then reads it back.
+
+    Unlike the other placeholders here this one is not backed by a single file,
+    so it cannot stand in for a step's std handles.
+
+    `backing_file` doesn't apply: `is_file_backed = False` means this
+    placeholder is never treated as a single file.
+    """
+
+    is_file_backed = False
+
+    def __init__(self,
+                 path_api,
+                 leak_to: str | Path | None = None,
+                 name: str | None = None) -> None:
+        self._path_api = path_api
+        self._backing_dir = leak_to
+        self._used = False
+        super().__init__(name=name)
+
+    def render(self, test) -> list[str]:
+        assert not self._used, 'A placeholder can only be used once'
+        self._used = True
+        # Without `leak_to`, a fresh temporary directory under the job's scratch
+        # space. `api.path.mkdtemp` is the seam here, so nothing is created on
+        # disk in test mode and the name stays stable across runs.
+        self._backing_dir = str(self._backing_dir
+                                or self._path_api.mkdtemp('tmp'))
+        if not test.enabled:  # pragma: no cover - production placeholder.
+            os.makedirs(self._backing_dir, exist_ok=True)
+        return [self._backing_dir]
+
+    def result(self, test) -> _LazyDirectoryReader:
+        assert self._used, 'A placeholder has to be rendered before it reads'
+        if test.enabled:
+            data = test.data or {}
+            return _LazyDirectoryReader(iter(data), data.__getitem__)
+        return self._read_backing_dir()  # pragma: no cover - production.
+
+    def _read_backing_dir(self):  # pragma: no cover - production placeholder.
+        paths = set()
+        for dir_path, _dir_names, file_names in os.walk(self._backing_dir):
+            for file_name in file_names:
+                paths.add(
+                    os.path.relpath(os.path.join(dir_path, file_name),
+                                    self._backing_dir))
+
+        def _read(rel_path: str) -> bytes:
+            return Path(self._backing_dir, rel_path).read_bytes()
+
+        return _LazyDirectoryReader(iter(paths), _read)
+
+
+def _remove(path: str) -> None:  # pragma: no cover - production placeholder.
+    """Delete *path*, tolerating its absence."""
+    try:
+        os.remove(path)
+    except OSError as ex:
+        if ex.errno != errno.ENOENT:
+            raise
+
+
+class RawIOApi(RecipeApi):
+    """Placeholders carrying raw bytes (or UTF-8 text) in and out of steps."""
+
+    @returns_placeholder
+    def input(self,
+              data: bytes,
+              suffix: str = '',
+              name: str | None = None) -> InputDataPlaceholder:
+        """A placeholder expanding to the path of a file holding *data*.
+
+        The engine writes *data* to a temporary file, passes its path to the
+        step, and deletes it once the step is done.
+
+        Args:
+            data: The bytes to hand the step. Prefer `input_text` for text.
+            suffix: Suffix for the temporary file's name, when the step cares
+                what its input is called (e.g. `'.py'`).
+            name: Distinguishes this placeholder from others produced by the
+                same method on one step.
+        """
+        if isinstance(data, str):
+            data = data.encode('utf-8', errors='replace')
+        if not isinstance(data, bytes):
+            raise ValueError(f'expected bytes, got {type(data)}: {data!r}')
+        return InputDataPlaceholder(data, suffix, name=name)
+
+    @returns_placeholder
+    def input_text(self,
+                   data: str,
+                   suffix: str = '',
+                   name: str | None = None) -> InputTextPlaceholder:
+        """As `input`, but for UTF-8 text.
+
+        Any character that cannot be encoded as UTF-8 is replaced with U+FFFD.
+        """
+        if isinstance(data, bytes):
+            data = data.decode('utf-8', errors='replace')
+        if not isinstance(data, str):
+            raise ValueError(f'expected text, got {type(data)}: {data!r}')
+        return InputTextPlaceholder(data, suffix, name=name)
+
+    @returns_placeholder
+    def output(self,
+               suffix: str = '',
+               leak_to: str | Path | None = None,
+               name: str | None = None) -> OutputDataPlaceholder:
+        """A placeholder expanding to a path the step is expected to write.
+
+        Once the step is done the engine reads that file back as bytes and
+        files it onto the step's result as `step_result.raw_io.output`. Also
+        usable as a step's `stdout`/`stderr`, in which case its content is the
+        result's `stdout`/`stderr`.
+
+        Args:
+            suffix: Suffix for the temporary file's name, when the step cares
+                what its output is called (e.g. `'.json'`).
+            leak_to: Write to this path instead of a temporary file, and do not
+                delete it afterwards (i.e. "leak" it), so a later step can pick
+                it up.
+            name: Distinguishes this placeholder from others produced by the
+                same method on one step.
+        """
+        return OutputDataPlaceholder(suffix, leak_to, name=name)
+
+    @returns_placeholder
+    def output_text(self,
+                    suffix: str = '',
+                    leak_to: str | Path | None = None,
+                    name: str | None = None) -> OutputTextPlaceholder:
+        """As `output`, but decodes the data the step wrote as UTF-8 text.
+
+        Any byte that isn't valid UTF-8 is replaced with U+FFFD.
+        """
+        return OutputTextPlaceholder(suffix, leak_to, name=name)
+
+    @returns_placeholder
+    def output_dir(self,
+                   leak_to: str | Path | None = None,
+                   name: str | None = None) -> OutputDataDirPlaceholder:
+        """A placeholder expanding to a directory the step writes into.
+
+        Once the step is done, the result filed at
+        `step_result.raw_io.output_dir` is a mapping of path (relative to the
+        directory, with this platform's separator) to that file's bytes. The
+        files are read lazily, on first access, so a step is free to leave more
+        behind than the recipe looks at.
+
+        Args:
+            leak_to: Use this directory instead of a temporary one, and do not
+                delete it afterwards (i.e. "leak" it). Created if absent.
+            name: Distinguishes this placeholder from others produced by the
+                same method on one step.
+
+        Example:
+
+            result = api.step('dump', ['dump_files', api.raw_io.output_dir()])
+
+            # 'some/file' is read right here, and cached from now on.
+            assert result.raw_io.output_dir['some/file'] == b'contents'
+
+            # To hand that memory back (and make further reads an error):
+            del result.raw_io.output_dir['some/file']
+        """
+        return OutputDataDirPlaceholder(self.m.path, leak_to, name=name)

--- a/tools/recipes/recipe_modules/raw_io/examples/__init__.py
+++ b/tools/recipes/recipe_modules/raw_io/examples/__init__.py
@@ -2,6 +2,3 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""`chromium_checkout` module: clone / sync / validate a Chromium src/ tree."""
-
-DEPS = ['path', 'raw_io', 'step', 'context', 'depot_tools', 'env', 'platform']

--- a/tools/recipes/recipe_modules/raw_io/examples/full.expected/basic.json
+++ b/tools/recipes/recipe_modules/raw_io/examples/full.expected/basic.json
@@ -1,0 +1,99 @@
+[
+  {
+    "cmd": [
+      "echo",
+      "Hello World"
+    ],
+    "name": "echo"
+  },
+  {
+    "cmd": [
+      "cat"
+    ],
+    "name": "cat",
+    "stdin": "hello"
+  },
+  {
+    "cmd": [
+      "cat",
+      "hello \ud83d\udca9"
+    ],
+    "name": "cat file"
+  },
+  {
+    "cmd": [
+      "cat"
+    ],
+    "name": "cat bytes",
+    "stdin": "\ufffdhello"
+  },
+  {
+    "cmd": [
+      "cat",
+      "text",
+      "bytes"
+    ],
+    "name": "cat coerced"
+  },
+  {
+    "cmd": [
+      "echo",
+      "huh"
+    ],
+    "name": "automock"
+  },
+  {
+    "cmd": [
+      "sh",
+      "-c",
+      "echo fail 1>&2"
+    ],
+    "name": "automock stderr"
+  },
+  {
+    "cmd": [
+      "write",
+      "/path/to/tmp/txt"
+    ],
+    "name": "write file"
+  },
+  {
+    "cmd": [
+      "write",
+      "/path/to/tmp/",
+      "/path/to/tmp/"
+    ],
+    "name": "write two"
+  },
+  {
+    "cmd": [
+      "write",
+      "[WORKSPACE]/leaked.txt"
+    ],
+    "name": "leak output"
+  },
+  {
+    "cmd": [
+      "write",
+      "[WORKSPACE]/leaked.txt"
+    ],
+    "name": "leak nothing"
+  },
+  {
+    "cmd": [
+      "dump_files",
+      "[WORKSPACE]/rc/tmp_tmp_1"
+    ],
+    "name": "dump files"
+  },
+  {
+    "cmd": [
+      "dump_files",
+      "[WORKSPACE]/out/dumped"
+    ],
+    "name": "dump files to a known place"
+  },
+  {
+    "name": "$result"
+  }
+]

--- a/tools/recipes/recipe_modules/raw_io/examples/full.py
+++ b/tools/recipes/recipe_modules/raw_io/examples/full.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipe exercising the `raw_io` module's input/output placeholders."""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['path', 'raw_io', 'step']
+
+
+def RunSteps(api):
+    # Read a command's stdout and stderr.
+    result = api.step('echo', ['echo', 'Hello World'],
+                      stdout=api.raw_io.output_text(),
+                      stderr=api.raw_io.output_text())
+    assert result.stdout == 'Hello World\n', result.stdout
+    assert result.stderr == '', result.stderr
+
+    # Feed a command's stdin, and read what it writes back.
+    result = api.step('cat', ['cat'],
+                      stdin=api.raw_io.input_text('hello'),
+                      stdout=api.raw_io.output_text('.out'))
+    assert result.stdout == 'hello', result.stdout
+
+    # The same data as a command-line argument instead: the placeholder becomes
+    # the path of a file holding it.
+    result = api.step('cat file',
+                      ['cat', api.raw_io.input_text('hello 💩')],
+                      stdout=api.raw_io.output_text('.out'))
+    assert result.stdout == 'hello 💩', result.stdout
+
+    # `\xe2` is not valid UTF-8, so it has to travel as bytes.
+    result = api.step('cat bytes', ['cat'],
+                      stdin=api.raw_io.input(b'\xe2hello'),
+                      stdout=api.raw_io.output())
+    assert result.stdout == b'\xe2hello', result.stdout
+
+    # `input` takes text (encoding it) and `input_text` takes bytes (decoding
+    # them), for callers that don't get to choose which they have.
+    api.step(
+        'cat coerced',
+        ['cat',
+         api.raw_io.input('text'),
+         api.raw_io.input_text(b'bytes')])
+
+    # A step can carry its own default simulated output, so the common case
+    # needs nothing seeded per test.
+    result = api.step(
+        'automock', ['echo', 'huh'],
+        stdout=api.raw_io.output_text('.out'),
+        step_test_data=lambda: api.raw_io.test_api.stream_output_text('huh\n'))
+    assert result.stdout == 'huh\n', result.stdout
+
+    result = api.step('automock stderr', ['sh', '-c', 'echo fail 1>&2'],
+                      stderr=api.raw_io.output('.err'),
+                      step_test_data=lambda: api.raw_io.test_api.stream_output(
+                          b'fail\n', 'stderr'))
+    assert result.stderr == b'fail\n', result.stderr
+
+    # An output placeholder in the command line is filed onto the result under
+    # the module and method that produced it.
+    result = api.step('write file', ['write', api.raw_io.output_text('.txt')])
+    assert result.raw_io.output_text == 'written', result.raw_io.output_text
+
+    # Several placeholders from one method are told apart by name.
+    result = api.step('write two', [
+        'write',
+        api.raw_io.output_text(name='a'),
+        api.raw_io.output_text(name='b')
+    ])
+    assert result.raw_io.output_texts == {
+        'a': 'first',
+        'b': 'second'
+    }, result.raw_io.output_texts
+
+    # `leak_to` writes to a known path and leaves it there, so a later step can
+    # pick it up.
+    leaked = api.path.workspace / 'leaked.txt'
+    result = api.step(
+        'leak output',
+        ['write', api.raw_io.output_text(leak_to=leaked)])
+    assert result.raw_io.output_text == 'leaked', result.raw_io.output_text
+
+    # A leaked file the step never wrote reads back as None rather than raising.
+    result = api.step(
+        'leak nothing',
+        ['write',
+         api.raw_io.output_text(leak_to=leaked, name='missing')])
+    assert result.raw_io.output_text is None, result.raw_io.output_text
+
+    # `output_dir` collects a whole directory of results. The step is handed a
+    # fresh temporary directory under the job's scratch space.
+    result = api.step('dump files', ['dump_files', api.raw_io.output_dir()])
+    outdir = result.raw_io.output_dir
+    assert set(outdir) == {'some/file', 'other_file'}, set(outdir)
+    assert len(outdir) == 2, len(outdir)
+    # Each file is read on first access, and cached from then on.
+    assert outdir['some/file'] == b'cool contents', outdir['some/file']
+    assert outdir['some/file'] == b'cool contents'
+    assert outdir['other_file'] == b'whatever', outdir['other_file']
+    assert 'not_here' not in outdir
+
+    # Deleting an entry hands its memory back and makes further reads an error.
+    del outdir['some/file']
+    assert 'some/file' not in outdir
+    assert outdir.get('some/file') is None
+
+    # `leak_to` works here too, for a directory a later step needs.
+    result = api.step(
+        'dump files to a known place',
+        ['dump_files',
+         api.raw_io.output_dir(leak_to=api.path.out / 'dumped')])
+    assert dict(result.raw_io.output_dir) == {'report': b'all good'}
+
+
+def GenTests(api):
+    yield api.test(
+        'basic',
+        api.step_data('echo',
+                      stdout=api.raw_io.output_text('Hello World\n'),
+                      stderr=api.raw_io.output_text('')),
+        api.step_data('cat', stdout=api.raw_io.output_text('hello')),
+        api.step_data('cat file', stdout=api.raw_io.output_text('hello 💩')),
+        api.step_data('cat bytes', stdout=api.raw_io.output(b'\xe2hello')),
+        api.step_data('write file', api.raw_io.output_text('written')),
+        api.step_data(
+            'write two',
+            api.raw_io.output_text('first', name='a'),
+            api.raw_io.output_text('second', name='b'),
+        ),
+        api.step_data('leak output', api.raw_io.output_text('leaked')),
+        api.step_data('leak nothing',
+                      api.raw_io.backing_file_missing(name='missing')),
+        api.step_data(
+            'dump files',
+            api.raw_io.output_dir({
+                'some/file': b'cool contents',
+                'other_file': b'whatever',
+            })),
+        api.step_data('dump files to a known place',
+                      api.raw_io.output_dir({'report': b'all good'})),
+        api.post_process(post_process.StatusSuccess),
+    )
+    # `output_text` also accepts (and decodes) bytes, for tests that don't get
+    # to choose which they have.
+    yield api.test(
+        'bytes seeded as text',
+        api.step_data('echo',
+                      stdout=api.raw_io.output_text(b'Hello World\n'),
+                      stderr=api.raw_io.output_text('')),
+        api.step_data('cat', stdout=api.raw_io.output_text('hello')),
+        api.step_data('cat file', stdout=api.raw_io.output_text('hello 💩')),
+        api.step_data('cat bytes', stdout=api.raw_io.output(b'\xe2hello')),
+        api.step_data('write file', api.raw_io.output_text('written')),
+        api.step_data(
+            'write two',
+            api.raw_io.output_text('first', name='a'),
+            api.raw_io.output_text('second', name='b'),
+        ),
+        api.step_data('leak output', api.raw_io.output_text('leaked')),
+        api.step_data('leak nothing',
+                      api.raw_io.backing_file_missing(name='missing')),
+        api.step_data(
+            'dump files',
+            api.raw_io.output_dir({
+                'some/file': b'cool contents',
+                'other_file': b'whatever',
+            })),
+        api.step_data('dump files to a known place',
+                      api.raw_io.output_dir({'report': b'all good'})),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )

--- a/tools/recipes/recipe_modules/raw_io/test_api.py
+++ b/tools/recipes/recipe_modules/raw_io/test_api.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Test API for `raw_io`: seed what an output placeholder hands back.
+
+`api.raw_io.output_text('hello')` is a fragment for `api.step_data`, either as
+one of its positional arguments (seeding an `api.raw_io.output_text()` in the
+step's command) or as its `stdout=`/`stderr=` (seeding the step's std handle):
+
+    api.step_data('greet', api.raw_io.output_text('hello'))
+    api.step_data('greet', stdout=api.raw_io.output_text('hello\\n'))
+
+`stream_output`/`stream_output_text` build the same thing in one call, for a
+step's own `step_test_data=` default.
+
+Input placeholders need no helpers: what they carry into a step comes from the
+recipe, not from the test.
+"""
+
+from __future__ import annotations
+
+from recipe_test_api import (RecipeTestApi, StepTestData,
+                             placeholder_step_data)
+
+
+class RawIOTestApi(RecipeTestApi):
+    """Seed the simulated data of a `raw_io` output placeholder."""
+
+    @placeholder_step_data
+    def output(self,
+               data: bytes | str | None,
+               retcode: int | None = None,
+               name: str | None = None):
+        """Seed an `api.raw_io.output()` placeholder with *data* (bytes)."""
+        if isinstance(data, str):
+            data = data.encode('utf-8')
+        if not isinstance(data, (type(None), bytes)):
+            raise ValueError(f'expected bytes, got {type(data)}: {data!r}')
+        return data, retcode, name
+
+    @placeholder_step_data
+    def output_text(self,
+                    data: str | bytes | None,
+                    retcode: int | None = None,
+                    name: str | None = None):
+        """Seed an `api.raw_io.output_text()` placeholder with *data* (text)."""
+        if isinstance(data, bytes):
+            data = data.decode('utf-8')
+        if not isinstance(data, (type(None), str)):
+            raise ValueError(f'expected text, got {type(data)}: {data!r}')
+        return data, retcode, name
+
+    def stream_output(self,
+                      data: bytes | str | None,
+                      stream: str = 'stdout',
+                      retcode: int | None = None,
+                      name: str | None = None) -> StepTestData:
+        """Seed *data* as the step's `stdout` (or `stderr`), as bytes."""
+        return self._stream_output(self.output(data,
+                                               retcode=retcode,
+                                               name=name),
+                                   stream=stream,
+                                   retcode=retcode)
+
+    def stream_output_text(self,
+                           data: str | bytes | None,
+                           stream: str = 'stdout',
+                           retcode: int | None = None,
+                           name: str | None = None) -> StepTestData:
+        """Seed *data* as the step's `stdout` (or `stderr`), as text."""
+        return self._stream_output(self.output_text(data,
+                                                    retcode=retcode,
+                                                    name=name),
+                                   stream=stream,
+                                   retcode=retcode)
+
+    @staticmethod
+    def _stream_output(placeholder_data: StepTestData,
+                       stream: str,
+                       retcode: int | None = None) -> StepTestData:
+        assert stream in ('stdout', 'stderr')
+        fragment = StepTestData()
+        setattr(fragment, stream, placeholder_data.unwrap_placeholder())
+        if retcode:
+            fragment.retcode = retcode
+        return fragment
+
+    @placeholder_step_data
+    def output_dir(self,
+                   files: dict[str, bytes],
+                   retcode: int | None = None,
+                   name: str | None = None):
+        """Seed the files an `api.raw_io.output_dir()` placeholder finds.
+
+        *files* maps a path relative to the directory to that file's bytes. Use
+        the separator of the platform the test is targeting, since that is what
+        the recipe will see.
+
+        Example:
+
+            api.step_data('dump', api.raw_io.output_dir({
+                'some/file': b'contents of some/file',
+            }))
+        """
+        if not isinstance(files, dict):
+            raise ValueError(f'expected a dict, got {type(files)}: {files!r}')
+        for key, value in files.items():
+            if not isinstance(key, str):
+                raise ValueError(f'expected a path, got {type(key)}: {key!r}')
+            if not isinstance(value, bytes):
+                raise ValueError(f'expected bytes for {key!r}, got '
+                                 f'{type(value)}: {value!r}')
+        return files, retcode, name
+
+    @placeholder_step_data('output')
+    def backing_file_missing(self,
+                             retcode: int | None = None,
+                             name: str | None = None):
+        """Seed an output placeholder as if the step never wrote its file.
+
+        Only meaningful for a placeholder created with `leak_to`; without it the
+        engine creates the backing file itself, so it is always there.
+        """
+        # `None` data is what tells a placeholder to behave, under simulation,
+        # as though its backing file were absent.
+        return None, retcode, name

--- a/tools/recipes/recipe_modules/raw_io/tests/__init__.py
+++ b/tools/recipes/recipe_modules/raw_io/tests/__init__.py
@@ -2,6 +2,3 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""`chromium_checkout` module: clone / sync / validate a Chromium src/ tree."""
-
-DEPS = ['path', 'raw_io', 'step', 'context', 'depot_tools', 'env', 'platform']

--- a/tools/recipes/recipe_modules/raw_io/tests/errors.py
+++ b/tools/recipes/recipe_modules/raw_io/tests/errors.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `raw_io`'s rejection of data (and test data) of the wrong type.
+
+A seeded `MODE` env var selects which mistake to make. Each one aborts the
+recipe, which is the point: a placeholder handed something it cannot carry is a
+bug in the recipe (or in the test), not a step failure to recover from.
+"""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['env', 'raw_io', 'step']
+
+# Each mode, and the stdout placeholder the step should use for it.
+MODES = {
+    # `input` carries bytes (or text it can encode), not arbitrary objects.
+    'input_not_bytes': None,
+    # Likewise `input_text` carries text, or bytes it can decode.
+    'input_text_not_text': None,
+    # A placeholder's name is what tells several of them apart, so it has to be
+    # a string.
+    'bad_placeholder_name': None,
+    # A text placeholder seeded with bytes (and vice versa): the test data and
+    # the placeholder disagree about what the step produces.
+    'text_placeholder_given_bytes': 'output_text',
+    'bytes_placeholder_given_text': 'output',
+    # A step's own default simulated data has to be of the right type too.
+    'output_test_data_not_bytes': 'output',
+    'output_text_test_data_not_text': 'output_text',
+    # An `output_dir` placeholder stands for a directory, not a file, so it
+    # cannot be a step's stdout.
+    'output_dir_on_stdout': None,
+    # ... and its test data is a mapping of relative path to bytes.
+    'output_dir_test_data_not_a_dict': None,
+    'output_dir_test_data_bad_path': None,
+    'output_dir_test_data_not_bytes': None,
+}
+
+# The test data each `output_dir_test_data_*` mode feeds the placeholder.
+BAD_OUTPUT_DIR_DATA = {
+    'output_dir_test_data_not_a_dict': ['some/file'],
+    'output_dir_test_data_bad_path': {
+        1: b'contents'
+    },
+    'output_dir_test_data_not_bytes': {
+        'some/file': 'text, not bytes'
+    },
+}
+
+
+def RunSteps(api):
+    mode = api.env.get('MODE')
+    if mode == 'input_not_bytes':
+        api.step('cat', ['cat', api.raw_io.input(123)])
+    elif mode == 'input_text_not_text':
+        api.step('cat', ['cat', api.raw_io.input_text(123)])
+    elif mode == 'bad_placeholder_name':
+        api.step('cat', ['cat', api.raw_io.output_text(name=123)])
+    elif mode == 'output_test_data_not_bytes':
+        api.step('cat', ['cat'],
+                 stdout=api.raw_io.output(),
+                 step_test_data=lambda: api.raw_io.test_api.output(123))
+    elif mode == 'output_text_test_data_not_text':
+        api.step('cat', ['cat'],
+                 stdout=api.raw_io.output_text(),
+                 step_test_data=lambda: api.raw_io.test_api.output_text(123))
+    elif mode == 'output_dir_on_stdout':
+        api.step('cat', ['cat'], stdout=api.raw_io.output_dir())
+    elif mode in BAD_OUTPUT_DIR_DATA:
+        api.step('dump', ['dump_files', api.raw_io.output_dir()],
+                 step_test_data=lambda: api.raw_io.test_api.output_dir(
+                     BAD_OUTPUT_DIR_DATA[mode]))
+    else:
+        api.step('cat', ['cat'], stdout=getattr(api.raw_io, MODES[mode])())
+
+
+def GenTests(api):
+    mismatched = {
+        'text_placeholder_given_bytes': api.raw_io.output(b'bytes'),
+        'bytes_placeholder_given_text': api.raw_io.output_text('text'),
+    }
+    for mode in MODES:
+        yield api.test(
+            mode,
+            api.env.set('MODE', mode),
+            *([api.step_data('cat', stdout=mismatched[mode])]
+              if mode in mismatched else []),
+            api.post_process(post_process.StatusException),
+            api.post_process(post_process.DropExpectation),
+            status='EXCEPTION',
+        )

--- a/tools/recipes/recipe_modules/raw_io/tests/streams.py
+++ b/tools/recipes/recipe_modules/raw_io/tests/streams.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `raw_io`'s stream helpers seeding a retcode alongside output.
+
+A step's own default simulated data can say the step failed, and still say what
+it wrote on its way out -- which is how a recipe that inspects a failing
+command's output gets tested.
+"""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['raw_io', 'step']
+
+
+def RunSteps(api):
+    result = api.step('failing command', ['do-thing'],
+                      check=False,
+                      stdout=api.raw_io.output(),
+                      step_test_data=lambda: api.raw_io.test_api.stream_output(
+                          'nope\n', retcode=3))
+    assert result.retcode == 3, result.retcode
+    assert result.stdout == b'nope\n', result.stdout
+
+
+def GenTests(api):
+    yield api.test(
+        'basic',
+        api.post_process(post_process.StepFailure, 'failing command'),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )

--- a/tools/recipes/recipe_modules/step/api.py
+++ b/tools/recipes/recipe_modules/step/api.py
@@ -6,12 +6,15 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 import logging
 from pathlib import Path
 import subprocess
 
-from recipe_api import RecipeApi
+from recipe_api import (InputPlaceholder, OutputPlaceholder, Placeholder,
+                        RecipeApi)
+from recipe_test_api import PlaceholderTestData, StepTestData
+from step_data import StepData
 
 
 class StepApi(RecipeApi):
@@ -30,6 +33,11 @@ class StepApi(RecipeApi):
     (`with api.context(...)`): the step inherits `context.cwd` and applies
     `context.env` / `env_prefixes` / `env_suffixes`. Explicit `cwd` / `env`
     arguments, when given, layer on top of that ambient state.
+
+    A step's command may contain placeholders (see `recipe_api.Placeholder`),
+    and its `stdin`/`stdout`/`stderr` may each be one. This module renders them
+    into real arguments before the step runs and collects their results into the
+    `StepData` it returns afterwards.
     """
 
     def __init__(self) -> None:
@@ -52,35 +60,78 @@ class StepApi(RecipeApi):
         return self._prod_runner
 
     def __call__(
-            self,
-            name: str,
-            cmd: Sequence[str | Path],
-            *,
-            cwd: str | Path | None = None,
-            env: Mapping[str, str] | None = None,
-            check: bool = True,
-            capture_output: bool = False) -> subprocess.CompletedProcess[str]:
+        self,
+        name: str,
+        cmd: Sequence[str | Path | Placeholder],
+        *,
+        cwd: str | Path | None = None,
+        env: Mapping[str, str] | None = None,
+        check: bool = True,
+        stdin: InputPlaceholder | None = None,
+        stdout: OutputPlaceholder | None = None,
+        stderr: OutputPlaceholder | None = None,
+        step_test_data: Callable[[], StepTestData] | None = None,
+    ) -> StepData:
         """Run *cmd* as the step named *name*.
 
         Args:
             name: Human-readable step name, logged before the command runs.
             cmd: The program and its arguments as a sequence; each element is
-                stringified (so `Path` objects are fine).
+                either a `Placeholder` (rendered into arguments just before the
+                step runs) or stringified (so `Path` objects are fine).
             cwd: Working directory override for the subprocess; defaults to
                 `context.cwd` (and, when neither is set, the engine's cwd).
             env: Whole-variable environment overrides layered on top of
                 `context.env` (the explicit value wins per key).
             check: Raise `CalledProcessError` on non-zero exit when True.
-            capture_output: Capture stdout/stderr (as text) instead of
-                inheriting the parent's streams.
+            stdin: An input placeholder whose data is fed to the command, e.g.
+                `api.json.input({'k': 'v'})`.
+            stdout: An output placeholder capturing the command's standard
+                output, e.g. `api.raw_io.output_text()`. Its result is the
+                returned `StepData`'s `stdout`. Left unset, the command
+                inherits this process's stdout.
+            stderr: As *stdout*, for standard error.
+            step_test_data: A zero-argument callable returning the
+                `StepTestData` this step should default to under simulation, so
+                the common case needs no per-test seeding, e.g.
+                `lambda: api.raw_io.stream_output_text('hello\\n')`. A test can
+                add to it with `api.step_data` or discard it with
+                `api.override_step_data`.
 
         Returns:
-            The `subprocess.CompletedProcess` for the invocation.
+            The `StepData` for the invocation: its retcode, the results of its
+            `stdout`/`stderr` placeholders, and one attribute per output
+            placeholder in *cmd*.
 
         Raises:
             subprocess.CalledProcessError: If `check` and the process fails.
             RuntimeError: On Windows, if the command cannot be resolved.
         """
+        runner = self._runner()
+        test_data = runner.step_test_data(name, step_test_data)
+
+        # A placeholder's simulated data is looked up once and reused, so
+        # rendering and reading a result back agree on what was seeded.
+        placeholder_tests: dict[tuple[str, str, str | None],
+                                PlaceholderTestData] = {}
+
+        def _test_for(placeholder: Placeholder) -> PlaceholderTestData:
+            key = (*placeholder.namespaces, placeholder.name)
+            if key not in placeholder_tests:
+                placeholder_tests[key] = test_data.pop_placeholder(*key)
+            return placeholder_tests[key]
+
+        rendered_cmd: list[str] = []
+        cmd_placeholders: list[Placeholder] = []
+        for arg in cmd:
+            if isinstance(arg, Placeholder):
+                rendered_cmd.extend(arg.render(_test_for(arg)))
+                cmd_placeholders.append(arg)
+            else:
+                rendered_cmd.append(str(arg))
+
+        handles = _render_handles(stdin, stdout, stderr, test_data)
+
         # Draw cwd/env from the ambient context, letting explicit arguments
         # override. The env overrides and the path prefix/suffix affixes are
         # carried separately so the runner can compose them (production) or
@@ -89,13 +140,69 @@ class StepApi(RecipeApi):
         env_overrides = {**context.env, **(env or {})}
         step = {
             'name': name,
-            'cmd': [str(arg) for arg in cmd],
+            'cmd': rendered_cmd,
             'cwd': cwd if cwd is not None else context.cwd,
+            'stdin': handles['stdin'],
             'env': env_overrides or None,
             'env_prefixes': context.env_prefixes,
             'env_suffixes': context.env_suffixes,
         }
-        logging.info('[step] %s\n >>>> %s', name, ' '.join(step['cmd']))
-        return self._runner().run(step,
-                                  check=check,
-                                  capture_output=capture_output)
+        logging.info('[step] %s\n >>>> %s', name, ' '.join(rendered_cmd))
+        retcode = runner.run(step, handles)
+
+        # Resolve placeholders before reporting a failure, so that a failing
+        # step still cleans up its input files and still reports whatever
+        # output it did produce.
+        result = StepData(name, retcode)
+        for placeholder in cmd_placeholders:
+            placeholder_test = _test_for(placeholder)
+            if isinstance(placeholder, InputPlaceholder):
+                placeholder.cleanup(placeholder_test.enabled)
+            else:
+                result.assign_placeholder(placeholder,
+                                          placeholder.result(placeholder_test))
+        if stdin is not None:
+            stdin.cleanup(test_data.stdin.enabled)
+        if stdout is not None:
+            result.stdout = stdout.result(test_data.stdout)
+        if stderr is not None:
+            result.stderr = stderr.result(test_data.stderr)
+        result.finalize()
+
+        if check and retcode != 0:
+            raise subprocess.CalledProcessError(retcode,
+                                                rendered_cmd,
+                                                output=result.stdout,
+                                                stderr=result.stderr)
+        return result
+
+
+def _render_handles(stdin: InputPlaceholder | None,
+                    stdout: OutputPlaceholder | None,
+                    stderr: OutputPlaceholder | None,
+                    test_data) -> dict[str, str | None]:
+    """Render the step's std handle placeholders to their backing files.
+
+    A handle with no placeholder maps to `None`, meaning "inherit this
+    process's".
+    """
+    handles: dict[str, str | None] = {}
+    for handle, placeholder, expected in (('stdin', stdin, InputPlaceholder),
+                                          ('stdout', stdout,
+                                           OutputPlaceholder),
+                                          ('stderr', stderr,
+                                           OutputPlaceholder)):
+        if placeholder is None:
+            handles[handle] = None
+            continue
+        if not isinstance(placeholder, expected):
+            raise ValueError(
+                f"a step's {handle} must be an {expected.__name__}; got "
+                f'{placeholder!r}')
+        if not placeholder.is_file_backed:
+            raise ValueError(
+                f"a step's {handle} must be backed by a single file; "
+                f'{placeholder!r} is not')
+        placeholder.render(getattr(test_data, handle))
+        handles[handle] = placeholder.backing_file
+    return handles

--- a/tools/recipes/recipe_modules/step/test_api.py
+++ b/tools/recipes/recipe_modules/step/test_api.py
@@ -11,18 +11,14 @@ to other `api.step.*` fragments.
 
 from __future__ import annotations
 
-from recipe_test_api import RecipeTestApi, TestData
+from typing import Any
+
+from recipe_test_api import RecipeTestApi, StepTestData, TestData
 
 
 class StepTestApi(RecipeTestApi):
-    """Seed the simulated result (retcode / captured output) of a step."""
+    """Seed the simulated result (retcode / placeholder data) of a step."""
 
-    def data(self,
-             name: str,
-             retcode: int = 0,
-             stdout: str | None = None,
-             stderr: str | None = None) -> TestData:
-        return self.step_data(name,
-                              retcode=retcode,
-                              stdout=stdout,
-                              stderr=stderr)
+    def data(self, name: str, *data: StepTestData, **kwargs: Any) -> TestData:
+        """See `api.step_data`."""
+        return self.step_data(name, *data, **kwargs)

--- a/tools/recipes/recipe_modules/step/tests/__init__.py
+++ b/tools/recipes/recipe_modules/step/tests/__init__.py
@@ -2,6 +2,3 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""`chromium_checkout` module: clone / sync / validate a Chromium src/ tree."""
-
-DEPS = ['path', 'raw_io', 'step', 'context', 'depot_tools', 'env', 'platform']

--- a/tools/recipes/recipe_modules/step/tests/handles.py
+++ b/tools/recipes/recipe_modules/step/tests/handles.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `step`'s validation of the placeholders on its std handles.
+
+A handle only accepts a placeholder pointing the right way: data goes *into*
+`stdin` and comes *out of* `stdout`/`stderr`. A seeded `MODE` env var selects
+which way to get it wrong; each one aborts the recipe.
+"""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['env', 'raw_io', 'step']
+
+
+def RunSteps(api):
+    if api.env.get('MODE') == 'output_on_stdin':
+        api.step('cat', ['cat'], stdin=api.raw_io.output_text())
+    else:
+        api.step('cat', ['cat'], stdout=api.raw_io.input_text('hello'))
+
+
+def GenTests(api):
+    for mode in ('output_on_stdin', 'input_on_stdout'):
+        yield api.test(
+            mode,
+            api.env.set('MODE', mode),
+            api.post_process(post_process.StatusException),
+            api.post_process(post_process.DropExpectation),
+            status='EXCEPTION',
+        )

--- a/tools/recipes/recipe_test_api.py
+++ b/tools/recipes/recipe_test_api.py
@@ -21,13 +21,13 @@ injected as `api.<module>`, so a recipe writes, e.g.:
 
 Each `api.*` call returns a `TestData` *fragment*; `api.test(name, *fragments)`
 folds them together (via `TestData.__add__`) into the case the engine runs.
-
-Notable simplification: no output placeholders.
 """
 
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Callable
+import functools
 import inspect
 from typing import Any, NamedTuple
 
@@ -37,40 +37,171 @@ from google.protobuf.message import Message as PBMessage
 from recipe_api import ModuleInjectionSite
 
 
-class StepTestData:
-    """Simulated result for a single step: retcode and captured output.
+class BaseTestData:
+    """Common base for the simulated-data containers below.
 
-    Seeded in `GenTests` via `api.step_data(name, ...)`. During simulation the
-    `step` module returns a `CompletedProcess` built from this, and raises
-    `CalledProcessError` when the step is `check`ed and `retcode` is non-zero.
+    Its one job is the `enabled` flag: production code paths get a
+    `DisabledTestData`, whose `enabled` is False, so a placeholder can tell
+    "I am being simulated" from "I am really running" without the modules
+    having to branch on test mode themselves.
     """
 
-    def __init__(self,
-                 retcode: int | None = None,
-                 stdout: str | None = None,
-                 stderr: str | None = None) -> None:
-        # `retcode` is kept optional internally so merging can tell "unset" from
-        # an explicit 0; `.retcode` exposes the effective value (0 when unset).
-        self._retcode = retcode
-        self.stdout = stdout
-        self.stderr = stderr
+    def __init__(self, enabled: bool = True) -> None:
+        self._enabled = enabled
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+
+class PlaceholderTestData(BaseTestData):
+    """The simulated data for one placeholder on one step.
+
+    `data` is whatever the placeholder's `result()` should hand back (a
+    `None` means "pretend the backing file wasn't there"), and `name` matches
+    the placeholder's caller-chosen name, so
+    `api.json.output(..., name='cfg')` seeds only the `cfg` placeholder.
+    """
+
+    def __init__(self, data: Any = None, name: str | None = None) -> None:
+        super().__init__()
+        self.data = data
+        self.name = name
+
+    def __repr__(self) -> str:
+        if self.name is None:
+            return f'PlaceholderTestData(DEFAULT, {self.data!r})'
+        return f'PlaceholderTestData({self.name!r}, {self.data!r})'
+
+
+class StepTestData(BaseTestData):
+    """Simulated result for a single step: retcode plus placeholder data.
+
+    Seeded in `GenTests` via `api.step_data(name, ...)`, or by a step's own
+    `step_test_data=` default. During simulation the `step` module builds the
+    step's `StepData` from this, and raises `CalledProcessError` when the step
+    is `check`ed and `retcode` is non-zero.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # (module, method, placeholder name) -> PlaceholderTestData, for the
+        # output placeholders in the step's command.
+        self.placeholder_data: dict[tuple[str, str, str | None],
+                                    PlaceholderTestData] = {}
+        # When True this fragment replaces (rather than merges into) whatever
+        # came before it -- see `api.override_step_data`.
+        self.override = False
+        # `retcode` is kept optional internally so merging can tell "unset"
+        # from an explicit 0; `.retcode` exposes the effective value.
+        self._retcode: int | None = None
+        self._stdout: PlaceholderTestData | None = None
+        self._stderr: PlaceholderTestData | None = None
+
+    def __add__(self, other: StepTestData) -> StepTestData:
+        """Merge two fragments into a new one.
+
+        Placeholder data is last-set-wins per key, and so are the std handles.
+        Two fragments setting *different* retcodes for one step is a mistake in
+        the test rather than something to silently resolve. An `override`
+        fragment discards everything to its left.
+        """
+        base = StepTestData() if other.override else self
+        merged = StepTestData()
+        merged.override = other.override
+        merged.placeholder_data = {
+            **base.placeholder_data,
+            **other.placeholder_data
+        }
+        merged._stdout = other._stdout or base._stdout
+        merged._stderr = other._stderr or base._stderr
+        merged._retcode = base._retcode
+        if other._retcode is not None:
+            if (merged._retcode is not None
+                    and merged._retcode != other._retcode):
+                raise ValueError('Conflicting retcode values: '
+                                 f'{merged._retcode} and {other._retcode}')
+            merged._retcode = other._retcode
+        return merged
+
+    def unwrap_placeholder(self) -> PlaceholderTestData:
+        """Return this fragment's single placeholder datum.
+
+        Used to reuse an output placeholder's test data as a step's `stdout`
+        or `stderr`, e.g. `api.raw_io.stream_output_text('hi')`.
+        """
+        if len(self.placeholder_data) != 1:
+            raise ValueError('Cannot unwrap step test data holding '
+                             f'{len(self.placeholder_data)} placeholders')
+        return next(iter(self.placeholder_data.values()))
+
+    def pop_placeholder(self, module: str, method: str,
+                        name: str | None) -> PlaceholderTestData:
+        """Take the datum seeded for one placeholder (empty if none was)."""
+        return self.placeholder_data.pop((module, method, name),
+                                         PlaceholderTestData())
 
     @property
     def retcode(self) -> int:
         return self._retcode or 0
 
-    def __add__(self, other: StepTestData) -> StepTestData:
-        """Merge two fragments.
+    @retcode.setter
+    def retcode(self, value: int | None) -> None:
+        self._retcode = value
 
-        A non-zero retcode from either side wins (0 is the unset default, so a
-        later success fragment doesn't clobber an earlier failure); captured
-        output is last-set-wins.
-        """
-        return StepTestData(
-            retcode=other._retcode or self._retcode,
-            stdout=other.stdout if other.stdout is not None else self.stdout,
-            stderr=other.stderr if other.stderr is not None else self.stderr,
-        )
+    @property
+    def stdout(self) -> PlaceholderTestData:
+        return self._stdout or PlaceholderTestData()
+
+    @stdout.setter
+    def stdout(self, value: PlaceholderTestData) -> None:
+        assert isinstance(value, PlaceholderTestData)
+        self._stdout = value
+
+    @property
+    def stderr(self) -> PlaceholderTestData:
+        return self._stderr or PlaceholderTestData()
+
+    @stderr.setter
+    def stderr(self, value: PlaceholderTestData) -> None:
+        assert isinstance(value, PlaceholderTestData)
+        self._stderr = value
+
+    @property
+    def stdin(self) -> PlaceholderTestData:
+        # An input placeholder has nothing to hand back, so there is nothing to
+        # seed either; this exists so the `step` module can treat all three
+        # handles alike.
+        return PlaceholderTestData()
+
+    def __repr__(self) -> str:
+        return ('StepTestData(%r)' % {
+            'placeholder_data': self.placeholder_data,
+            'stdout': self._stdout,
+            'stderr': self._stderr,
+            'retcode': self._retcode,
+            'override': self.override,
+        })
+
+
+class DisabledTestData(BaseTestData):
+    """Stand-in for simulated data on the production path.
+
+    Every lookup answers with itself, and `enabled` is False all the way down,
+    so a placeholder rendering for a real step sees "no test data" no matter
+    what it asks for.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(False)
+
+    def __getattr__(self, name: str) -> DisabledTestData:
+        return self
+
+    def pop_placeholder(self, module: str, method: str,
+                        name: str | None) -> DisabledTestData:
+        del module, method, name
+        return self
 
 
 class PostprocessHookContext(NamedTuple):
@@ -102,8 +233,10 @@ class TestData:
         # `api.properties.environ(...)`; folded into the run's environment so
         # the engine can decode it into the recipe's ENV_PROPERTIES message.
         self.environ: dict[str, str] = {}
-        # Per-step simulated results, keyed by step name.
-        self.step_data: dict[str, StepTestData] = {}
+        # Per-step simulated results, keyed by step name. A defaultdict so a
+        # fragment builder can set one field (a retcode, say) on a step that
+        # has no data yet.
+        self.step_data: dict[str, StepTestData] = defaultdict(StepTestData)
         # Per-module seed values consumed to build the run's TestContext
         # (e.g. mod_data['platform'] = {'name': 'mac'}).
         self.mod_data: dict[str, dict[str, Any]] = {}
@@ -127,7 +260,7 @@ class TestData:
         merged.properties = {**self.properties, **other.properties}
         merged.environ = {**self.environ, **other.environ}
         merged.mod_data = _merge_mod_data(self.mod_data, other.mod_data)
-        merged.step_data = dict(self.step_data)
+        merged.step_data.update(self.step_data)
         for step_name, data in other.step_data.items():
             existing = merged.step_data.get(step_name)
             merged.step_data[step_name] = (existing +
@@ -140,6 +273,27 @@ class TestData:
         merged.brave_core_ref = (other.brave_core_ref if other.brave_core_ref
                                  != 'master' else self.brave_core_ref)
         return merged
+
+    def get_step_test_data(
+            self, step_name: str,
+            step_test_data_fn: Callable[[], StepTestData]) -> StepTestData:
+        """The simulated data for the step named *step_name*.
+
+        `step_test_data_fn` builds the step's own default data (its
+        `step_test_data=` argument), which whatever this case seeded for the
+        step is then merged on top of -- so a test can leave the default alone,
+        add to it, or replace it wholesale with `api.override_step_data`.
+
+        Note that step names are not deduplicated by this engine, so a recipe
+        that runs the same step twice sees the seeded data both times.
+        """
+        step_test_data = step_test_data_fn()
+        if step_name in self.step_data:
+            try:
+                step_test_data += self.step_data[step_name]
+            except ValueError as ex:
+                raise ValueError(f'in step {step_name!r}: {ex}') from ex
+        return step_test_data
 
 
 def _merge_mod_data(a: dict[str, dict], b: dict[str, dict]) -> dict[str, dict]:
@@ -224,6 +378,67 @@ class _PropertiesTestApi:
         return data
 
 
+def _placeholder_step_data(func, placeholder_name: str | None = None):
+
+    @functools.wraps(func)
+    def inner(self, *args, **kwargs):
+        data = func(self, *args, **kwargs)
+        if isinstance(data, StepTestData):
+            # The method delegated to another `placeholder_step_data` one;
+            # adopt its single datum (and retcode) as this one's.
+            placeholder_data = data.unwrap_placeholder()
+            retcode = data.retcode if data.retcode else None
+        else:
+            value, retcode, name = data
+            placeholder_data = PlaceholderTestData(data=value, name=name)
+
+        fragment = StepTestData()
+        method = placeholder_name or func.__name__
+        fragment.placeholder_data[(
+            self._module,
+            method,  # pylint: disable=protected-access
+            placeholder_data.name)] = placeholder_data
+        fragment.retcode = retcode
+        return fragment
+
+    return inner
+
+
+def placeholder_step_data(func_or_name):
+    """Decorate a module `TEST_API` method to seed one output placeholder.
+
+    A decorated method returns the plain
+    `(<placeholder data>, <retcode or None>, <name or None>)` triple, and this
+    wraps it into the `StepTestData` fragment `api.step_data` expects, keyed by
+    the module and method name so it lines up with the matching
+    `returns_placeholder` method on the module's `api.py`. So for the `json`
+    module:
+
+        class JsonTestApi(RecipeTestApi):
+            @placeholder_step_data
+            def output(self, data, retcode=None, name=None):
+                return json.dumps(data), retcode, name
+
+    `api.json.output({'passed': 791})` then seeds the data an
+    `api.json.output()` placeholder hands back.
+
+    A decorated method may also return the result of calling another decorated
+    method, to reuse its data under this method's name.
+
+    Decorate as `@placeholder_step_data('other_name')` to seed the placeholder
+    produced by a *differently* named api method -- that is how, e.g.,
+    `api.json.invalid(...)` seeds an `api.json.output()` placeholder.
+    """
+    if isinstance(func_or_name, str):
+        if not func_or_name:
+            raise ValueError('placeholder_step_data needs a non-empty name')
+        return lambda func: _placeholder_step_data(func, func_or_name)
+    if not callable(func_or_name):
+        raise ValueError('Expected either a function or a string; got '
+                         f'{func_or_name!r}')
+    return _placeholder_step_data(func_or_name)
+
+
 class RecipeTestApi:
     """Root test API (passed to `GenTests`) and base for module `TEST_API`s.
 
@@ -267,15 +482,64 @@ class RecipeTestApi:
 
     @staticmethod
     def step_data(name: str,
-                  retcode: int = 0,
-                  stdout: str | None = None,
-                  stderr: str | None = None) -> TestData:
-        """A fragment seeding the simulated result of the step named *name*."""
-        data = TestData()
-        data.step_data[name] = StepTestData(retcode=retcode,
-                                            stdout=stdout,
-                                            stderr=stderr)
-        return data
+                  *data: StepTestData,
+                  retcode: int | None = None,
+                  stdout: StepTestData | None = None,
+                  stderr: StepTestData | None = None,
+                  override: bool = False) -> TestData:
+        """A fragment seeding the simulated result of the step named *name*.
+
+        Args:
+            name: The name of the step being seeded.
+            data: Zero or more `StepTestData` fragments, each supplying one
+                output placeholder's data (and possibly a retcode) -- e.g.
+                `api.json.output({'ok': True})`.
+            retcode: The step's exit code. Overrides any retcode carried by
+                *data*; unset means the step exits 0.
+            stdout: A `StepTestData` holding a single placeholder datum, used
+                as the step's standard output -- e.g.
+                `stdout=api.raw_io.output_text('hello')`.
+            stderr: As *stdout*, for standard error.
+            override: Discard whatever was seeded for this step so far
+                (including the step's own `step_test_data=` default) instead of
+                merging into it.
+
+        Example:
+
+            yield api.test(
+                'winning',
+                api.step_data('run tests', api.json.output({'passed': 791})),
+                api.step_data('flaky', retcode=1),
+                api.step_data('greet', stdout=api.raw_io.output_text('hi\\n')),
+            )
+        """
+        fragment = TestData()
+        step = fragment.step_data[name]
+        for datum in data:
+            if not isinstance(datum, StepTestData):
+                raise ValueError(
+                    f'api.step_data({name!r}, ...) takes step test data '
+                    f'fragments. Got: {datum!r} (type {type(datum)!r})')
+            step += datum
+        if retcode is not None:
+            step.retcode = retcode
+        if stdout is not None:
+            step.stdout = stdout.unwrap_placeholder()
+        if stderr is not None:
+            step.stderr = stderr.unwrap_placeholder()
+        step.override = override
+        fragment.step_data[name] = step
+        return fragment
+
+    @staticmethod
+    def override_step_data(name: str, *data: StepTestData,
+                           **kwargs: Any) -> TestData:
+        """Like `step_data`, but replaces this step's data rather than adding.
+
+        Use this to drop a step's own `step_test_data=` default (or an earlier
+        fragment's data) instead of merging on top of it.
+        """
+        return RecipeTestApi.step_data(name, *data, override=True, **kwargs)
 
     @staticmethod
     def brave_core_ref(ref: str) -> TestData:

--- a/tools/recipes/simulation.py
+++ b/tools/recipes/simulation.py
@@ -13,8 +13,11 @@ Holds everything needed to run a recipe with zero real side effects:
     read/mutate it instead of the real machine.
   * `SubprocessStepRunner` / `SimulationStepRunner`: the two `step`
     back-ends. Production shells out (with the Windows resolution that used to
-    live in `StepApi`); simulation records an ordered step list and returns
-    canned results.
+    live in `StepApi`) and redirects the step's std handles at the files its
+    placeholders rendered to; simulation records an ordered step list, runs
+    nothing, and hands back the canned retcode. Both also answer the `step`
+    module's request for a step's simulated data -- production with a
+    `DisabledTestData`, so placeholders know they are running for real.
   * expectation helpers: `stabilize` (machine paths -> `[WORKSPACE]`/`[HOME]`
     tokens), `build_steps`, and `apply_post_process`.
 
@@ -25,7 +28,8 @@ steps here for post-processing and serialization.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections import Counter
+from collections.abc import Callable, Iterable
 import copy
 import inspect
 from pathlib import Path, PurePosixPath
@@ -36,7 +40,8 @@ from typing import Any
 from check import Check, Checker, PostProcessError, VerifySubset
 from engine_env import merge_envs
 import post_process as pp
-from recipe_test_api import PostprocessHookContext, StepTestData, TestData
+from recipe_test_api import (DisabledTestData, PostprocessHookContext,
+                             StepTestData, TestData)
 
 # Fixed synthetic locations used in test mode. They are never touched on disk;
 # they exist only so module-derived paths are deterministic, and are rewritten
@@ -110,9 +115,18 @@ class SubprocessStepRunner:
     `StepApi.__call__`, so the API layer no longer touches the OS directly.
     """
 
-    def run(self, step: dict, *, check: bool,
-            capture_output: bool) -> subprocess.CompletedProcess:
-        import os  # Local imports: only the prod path needs these.
+    def step_test_data(
+        self, name: str, step_test_data_fn: Callable[[], StepTestData] | None
+    ) -> DisabledTestData:
+        """Nothing is simulated here: every lookup answers "not simulated"."""
+        del name, step_test_data_fn
+        return DisabledTestData()
+
+    def run(
+        self, step: dict, handles: dict[str, str | None]
+    ) -> int:  # pragma: no cover - production step backend.
+        import contextlib  # Local imports: only the prod path needs these.
+        import os
         import platform
         import shutil
 
@@ -135,38 +149,66 @@ class SubprocessStepRunner:
         if overrides or prefixes or suffixes:
             env = merge_envs(os.environ, overrides or {}, prefixes or {},
                              suffixes or {}, os.pathsep)
-        return subprocess.run(cmd,
-                              cwd=step.get('cwd'),
-                              env=env,
-                              check=check,
-                              capture_output=capture_output,
-                              text=True)
+
+        # Point the child's std handles at the files the step's placeholders
+        # rendered to. A handle with no placeholder is left inherited, so a
+        # step's output still reaches the build log by default.
+        with contextlib.ExitStack() as stack:
+
+            def _open(handle: str, mode: str):
+                path = handles.get(handle)
+                if path is None:
+                    return None
+                return stack.enter_context(open(path, mode))
+
+            return subprocess.run(cmd,
+                                  cwd=step.get('cwd'),
+                                  env=env,
+                                  check=False,
+                                  stdin=_open('stdin', 'rb'),
+                                  stdout=_open('stdout', 'wb'),
+                                  stderr=_open('stderr', 'wb')).returncode
 
 
 class SimulationStepRunner:
-    """Simulation step back-end: record the step, return canned data.
+    """Simulation step back-end: record the step, return the canned retcode.
 
     No subprocess ever runs. Each `run` appends a step dict to `recorded_steps`
-    (the ordered stream the expectation is built from) and returns a
-    `CompletedProcess` seeded from the step's `StepTestData`. When the step is
-    `check`ed and its seeded retcode is non-zero, it raises the genuine
-    `subprocess.CalledProcessError` so module `except CalledProcessError` arms
-    and the recipe's failure path behave exactly as in production.
+    (the ordered stream the expectation is built from). The step's simulated
+    data -- its retcode and its placeholders' contents -- is handed to the
+    `step` module by `step_test_data`, which merges what the test case seeded
+    for the step on top of the step's own `step_test_data=` default.
     """
 
-    def __init__(self,
-                 step_data: dict[str, StepTestData] | None = None) -> None:
-        self._step_data = step_data or {}
+    def __init__(self, test_data: TestData | None = None) -> None:
+        self._test_data = test_data if test_data is not None else TestData()
+        # step name -> the data handed out for it, so `run` can read back the
+        # retcode the case seeded without the `step` module passing it along.
+        self._used_steps: dict[str, StepTestData] = {}
         self.recorded_steps: list[dict] = []
 
-    def run(self, step: dict, *, check: bool,
-            capture_output: bool) -> subprocess.CompletedProcess:
-        data = self._step_data.get(step['name'], StepTestData())
-        cmd = [str(arg) for arg in step['cmd']]
+    def step_test_data(
+            self, name: str, step_test_data_fn: Callable[[], StepTestData]
+        | None) -> StepTestData:
+        """The simulated data for the step named *name*."""
+        data = self._test_data.get_step_test_data(
+            name, step_test_data_fn or StepTestData)
+        self._used_steps[name] = data
+        return data
 
-        record: dict[str, Any] = {'name': step['name'], 'cmd': cmd}
+    def run(self, step: dict, handles: dict[str, str | None]) -> int:
+        # The std handles' backing files are of no interest to the expectation
+        # (they are temporary, and their contents come from the test data),
+        # except for stdin: what a step is fed is worth recording.
+        del handles
+        record: dict[str, Any] = {
+            'name': step['name'],
+            'cmd': [str(arg) for arg in step['cmd']],
+        }
         if step.get('cwd'):
             record['cwd'] = str(step['cwd'])
+        if step.get('stdin') is not None:
+            record['stdin'] = str(step['stdin'])
         if step.get('env'):
             # A `None` value means "remove this variable"; preserve it (rather
             # than stringifying to 'None') so it renders as null.
@@ -180,25 +222,11 @@ class SimulationStepRunner:
                     k: [str(v) for v in values]
                     for k, values in step[affix].items()
                 }
-        if data.retcode:
-            record['retcode'] = data.retcode
+        retcode = self._used_steps[step['name']].retcode
+        if retcode:
+            record['retcode'] = retcode
         self.recorded_steps.append(record)
-
-        # Mirror subprocess: captured output is only available when the caller
-        # asked to capture it; otherwise the child inherited the parent streams
-        # and `stdout`/`stderr` come back as None.
-        stdout = data.stdout if capture_output else None
-        stderr = data.stderr if capture_output else None
-
-        if check and data.retcode != 0:
-            raise subprocess.CalledProcessError(data.retcode,
-                                                cmd,
-                                                output=stdout,
-                                                stderr=stderr)
-        return subprocess.CompletedProcess(cmd,
-                                           data.retcode,
-                                           stdout=stdout,
-                                           stderr=stderr)
+        return retcode
 
 
 class TestContext:
@@ -212,13 +240,16 @@ class TestContext:
                  dirs: Iterable[str | Path] = (),
                  which_map: dict[str, str] | None = None,
                  home: str | Path = SIM_HOME,
-                 step_data: dict[str, StepTestData] | None = None) -> None:
+                 test_data: TestData | None = None) -> None:
         self.platform = platform
         self.env = dict(env or {})
         self.fs = SimFS(files, dirs)
         self.which_map = dict(which_map or {})
         self.home = Path(str(home))
-        self.step_runner = SimulationStepRunner(step_data)
+        # Per-prefix counter behind `api.path.mkdtemp`, so a run's temporary
+        # directories get stable, ordered names instead of random ones.
+        self.temp_counter: Counter[str] = Counter()
+        self.step_runner = SimulationStepRunner(test_data)
 
     @classmethod
     def from_test_data(cls, test_data: TestData) -> TestContext:
@@ -238,7 +269,7 @@ class TestContext:
             which_map=dict(env_seed.get('which', {})),
             files=[_resolve_seed(p) for p in path_seed.get('files', [])],
             dirs=[_resolve_seed(p) for p in path_seed.get('dirs', [])],
-            step_data=test_data.step_data,
+            test_data=test_data,
         )
 
 
@@ -274,6 +305,8 @@ def build_steps(runner: SimulationStepRunner, failure: dict | None,
         }
         if 'cwd' in step:
             entry['cwd'] = stabilize(step['cwd'], context)
+        if 'stdin' in step:
+            entry['stdin'] = stabilize(step['stdin'], context)
         if 'env' in step:
             entry['env'] = {
                 k: (None if v is None else stabilize(v, context))

--- a/tools/recipes/unittests/recipe_test_api_test.py
+++ b/tools/recipes/unittests/recipe_test_api_test.py
@@ -12,21 +12,173 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # pylint: disable=wrong-import-position
-from recipe_test_api import RecipeTestApi, StepTestData, TestData
+from recipe_test_api import (DisabledTestData, PlaceholderTestData,
+                             RecipeTestApi, StepTestData, TestData,
+                             placeholder_step_data)
+
+
+def _step_test_data(retcode=None, **placeholders):
+    """A StepTestData carrying *placeholders* (by name) and a retcode."""
+    data = StepTestData()
+    for name, value in placeholders.items():
+        data.placeholder_data[('mod', 'output',
+                               name)] = PlaceholderTestData(data=value,
+                                                            name=name)
+    data.retcode = retcode
+    return data
 
 
 class StepTestDataTest(unittest.TestCase):
     """StepTestData merges with explicitly-set fields on the right winning."""
 
-    def test_retcode_and_output_override(self):
-        base = StepTestData(retcode=0, stdout='a')
-        override = StepTestData(retcode=2)
-        merged = base + override
-        self.assertEqual(merged.retcode, 2)
-        self.assertEqual(merged.stdout, 'a')  # not overridden -> kept
+    def test_placeholder_data_merges_per_key(self):
+        merged = _step_test_data(a='first') + _step_test_data(b='second')
+        self.assertEqual(
+            {
+                key[2]: datum.data
+                for key, datum in merged.placeholder_data.items()
+            }, {
+                'a': 'first',
+                'b': 'second'
+            })
 
-    def test_unset_retcode_defaults_to_zero(self):
+    def test_later_placeholder_datum_wins(self):
+        merged = _step_test_data(a='first') + _step_test_data(a='second')
+        self.assertEqual(
+            merged.pop_placeholder('mod', 'output', 'a').data, 'second')
+
+    def test_retcode_carries_and_unset_defaults_to_zero(self):
         self.assertEqual(StepTestData().retcode, 0)
+        merged = _step_test_data(a='x') + _step_test_data(retcode=2)
+        self.assertEqual(merged.retcode, 2)
+        # The left side's placeholder datum survives.
+        self.assertEqual(
+            merged.pop_placeholder('mod', 'output', 'a').data, 'x')
+
+    def test_conflicting_retcodes_raise(self):
+        with self.assertRaises(ValueError):
+            _ = _step_test_data(retcode=1) + _step_test_data(retcode=2)
+
+    def test_override_discards_what_came_before(self):
+        override = _step_test_data(b='second')
+        override.override = True
+        merged = _step_test_data(a='first', retcode=1) + override
+        self.assertEqual(list(merged.placeholder_data),
+                         [('mod', 'output', 'b')])
+        self.assertEqual(merged.retcode, 0)
+
+    def test_std_handles_default_to_an_empty_datum(self):
+        data = StepTestData()
+        # Unseeded handles still answer, so a placeholder can always ask.
+        for handle in (data.stdin, data.stdout, data.stderr):
+            self.assertIsNone(handle.data)
+            self.assertTrue(handle.enabled)
+
+    def test_unwrap_placeholder_requires_exactly_one(self):
+        self.assertEqual(_step_test_data(a='x').unwrap_placeholder().data, 'x')
+        with self.assertRaises(ValueError):
+            _step_test_data(a='x', b='y').unwrap_placeholder()
+
+
+class PlaceholderStepDataTest(unittest.TestCase):
+    """The decorator wraps a plain triple into a keyed StepTestData."""
+
+    # `functools.wraps` (in `placeholder_step_data`) leaves pylint inferring a
+    # decorated method's return type from the *undecorated* function body, so
+    # it sees the `(value, retcode, name)` tuple `output`/`invalid`/`delegating`
+    # return rather than the `StepTestData` the decorator actually returns.
+    # pylint: disable=no-member
+
+    class FakeTestApi(RecipeTestApi):
+
+        @placeholder_step_data
+        def output(self, data, retcode=None, name=None):
+            return f'data({data})', retcode, name
+
+        @placeholder_step_data('output')
+        def invalid(self, retcode=None, name=None):
+            return 'garbage', retcode, name
+
+        @placeholder_step_data
+        def delegating(self, retcode=None, name=None):
+            return self.output('hammer time', retcode=retcode, name=name)
+
+    def setUp(self):
+        self.api = self.FakeTestApi(module='mod')
+
+    def test_keyed_by_module_method_and_name(self):
+        data = self.api.output('hello', name='cool')
+        self.assertEqual(list(data.placeholder_data),
+                         [('mod', 'output', 'cool')])
+        self.assertEqual(data.placeholder_data[('mod', 'output', 'cool')].data,
+                         'data(hello)')
+
+    def test_retcode_is_carried(self):
+        self.assertEqual(self.api.output('hello', retcode=50).retcode, 50)
+
+    def test_alternate_name_targets_another_method(self):
+        # `invalid` seeds the placeholder `output` produces.
+        self.assertEqual(list(self.api.invalid().placeholder_data),
+                         [('mod', 'output', None)])
+
+    def test_delegating_method_adopts_the_inner_datum(self):
+        data = self.api.delegating(retcode=50, name='other')
+        self.assertEqual(list(data.placeholder_data),
+                         [('mod', 'delegating', 'other')])
+        self.assertEqual(data.unwrap_placeholder().data, 'data(hammer time)')
+        self.assertEqual(data.retcode, 50)
+
+    def test_bad_decorator_arguments_raise(self):
+        with self.assertRaises(ValueError):
+            placeholder_step_data('')
+        with self.assertRaises(ValueError):
+            placeholder_step_data(123)
+
+
+class DisabledTestDataTest(unittest.TestCase):
+    """The production stand-in answers everything with itself, disabled."""
+
+    def test_every_lookup_is_disabled(self):
+        data = DisabledTestData()
+        self.assertFalse(data.enabled)
+        self.assertFalse(data.stdout.enabled)
+        self.assertFalse(data.pop_placeholder('mod', 'output', None).enabled)
+
+
+class StepTestDataLookupTest(unittest.TestCase):
+    """A step's data merges its own default with what the case seeded."""
+
+    def test_default_is_merged_under_the_seeded_data(self):
+        case = TestData('case') + RecipeTestApi.step_data(
+            's', _step_test_data(a='seeded'))
+        data = case.get_step_test_data('s',
+                                       lambda: _step_test_data(b='default'))
+        self.assertEqual(
+            data.pop_placeholder('mod', 'output', 'a').data, 'seeded')
+        self.assertEqual(
+            data.pop_placeholder('mod', 'output', 'b').data, 'default')
+
+    def test_override_discards_the_default(self):
+        case = TestData('case') + RecipeTestApi.override_step_data(
+            's', _step_test_data(a='seeded'))
+        data = case.get_step_test_data('s',
+                                       lambda: _step_test_data(b='default'))
+        self.assertIsNone(data.pop_placeholder('mod', 'output', 'b').data)
+
+    def test_a_repeated_step_name_sees_the_data_each_time(self):
+        # Step names are not deduplicated by this engine, so seeded data has to
+        # survive being handed out more than once.
+        case = TestData('case') + RecipeTestApi.step_data(
+            's', _step_test_data(a='seeded'))
+        for _ in range(2):
+            data = case.get_step_test_data('s', StepTestData)
+            self.assertEqual(
+                data.pop_placeholder('mod', 'output', 'a').data, 'seeded')
+
+    def test_conflicting_retcodes_name_the_step(self):
+        case = TestData('case') + RecipeTestApi.step_data('s', retcode=1)
+        with self.assertRaisesRegex(ValueError, "in step 's'"):
+            case.get_step_test_data('s', lambda: _step_test_data(retcode=2))
 
 
 class TestDataMergeTest(unittest.TestCase):
@@ -49,9 +201,10 @@ class TestDataMergeTest(unittest.TestCase):
 
     def test_step_data_merges_per_step(self):
         merged = (RecipeTestApi.step_data('s', retcode=1) +
-                  RecipeTestApi.step_data('s', stdout='out'))
+                  RecipeTestApi.step_data(
+                      's', stdout=_step_test_data(out='written')))
         self.assertEqual(merged.step_data['s'].retcode, 1)
-        self.assertEqual(merged.step_data['s'].stdout, 'out')
+        self.assertEqual(merged.step_data['s'].stdout.data, 'written')
 
     def test_hooks_concatenate(self):
         merged = (RecipeTestApi.post_process(lambda c, s: None) +

--- a/tools/recipes/unittests/simulation_test.py
+++ b/tools/recipes/unittests/simulation_test.py
@@ -6,7 +6,6 @@
 """Tests for the simulation runtime: SimFS, step runner, and expectations."""
 
 import os
-import subprocess
 import sys
 import unittest
 
@@ -37,43 +36,72 @@ class SimFSTest(unittest.TestCase):
         self.assertTrue(fs.is_dir('/b/s/out'))
 
 
+def _run(runner, step):
+    """Hand *runner* a step, as the `step` module would."""
+    runner.step_test_data(step['name'], None)
+    return runner.run(step, {'stdin': None, 'stdout': None, 'stderr': None})
+
+
 class SimulationStepRunnerTest(unittest.TestCase):
 
-    def test_records_and_returns_completed_process(self):
+    def test_records_the_step_and_returns_its_retcode(self):
         runner = simulation.SimulationStepRunner()
-        result = runner.run({
+        self.assertEqual(_run(runner, {
             'name': 'go',
             'cmd': ['echo', 'hi']
-        },
-                            check=True,
-                            capture_output=False)
-        self.assertIsInstance(result, subprocess.CompletedProcess)
-        self.assertEqual(result.returncode, 0)
-        self.assertEqual(runner.recorded_steps[0]['name'], 'go')
+        }), 0)
+        self.assertEqual(runner.recorded_steps[0], {
+            'name': 'go',
+            'cmd': ['echo', 'hi']
+        })
 
-    def test_checked_failure_raises_and_records_retcode(self):
+    def test_seeded_retcode_is_returned_and_recorded(self):
         runner = simulation.SimulationStepRunner(
-            {'go': StepTestData(retcode=1)})
-        with self.assertRaises(subprocess.CalledProcessError):
-            runner.run({
-                'name': 'go',
-                'cmd': ['false']
-            },
-                       check=True,
-                       capture_output=False)
-        # The failing step is still recorded (before the raise).
+            TestData() + RecipeTestApi.step_data('go', retcode=1))
+        self.assertEqual(_run(runner, {'name': 'go', 'cmd': ['false']}), 1)
         self.assertEqual(runner.recorded_steps[0]['retcode'], 1)
 
-    def test_unchecked_failure_does_not_raise(self):
-        runner = simulation.SimulationStepRunner(
-            {'go': StepTestData(retcode=1)})
-        result = runner.run({
+    def test_stdin_is_recorded_but_the_other_handles_are_not(self):
+        runner = simulation.SimulationStepRunner()
+        runner.step_test_data('cat', None)
+        runner.run({
+            'name': 'cat',
+            'cmd': ['cat'],
+            'stdin': 'fed to the step'
+        }, {
+            'stdin': 'fed to the step',
+            'stdout': '/path/to/tmp/',
+            'stderr': None
+        })
+        self.assertEqual(runner.recorded_steps[0], {
+            'name': 'cat',
+            'cmd': ['cat'],
+            'stdin': 'fed to the step'
+        })
+
+    def test_a_steps_own_default_data_is_used(self):
+        runner = simulation.SimulationStepRunner()
+
+        def default():
+            data = StepTestData()
+            data.retcode = 7
+            return data
+
+        runner.step_test_data('go', default)
+        self.assertEqual(runner.run({
             'name': 'go',
-            'cmd': ['false']
-        },
-                            check=False,
-                            capture_output=False)
-        self.assertEqual(result.returncode, 1)
+            'cmd': ['do-thing']
+        }, {}), 7)
+
+
+class SubprocessStepRunnerTest(unittest.TestCase):
+
+    def test_nothing_is_simulated(self):
+        # The production runner reports "not simulated" for every lookup, so a
+        # placeholder rendering for a real step touches the real filesystem.
+        data = simulation.SubprocessStepRunner().step_test_data('go', None)
+        self.assertFalse(data.enabled)
+        self.assertFalse(data.stdout.enabled)
 
 
 class TestContextTest(unittest.TestCase):
@@ -117,12 +145,7 @@ class ExpectationTest(unittest.TestCase):
 
     def test_build_steps_success_result(self):
         runner = simulation.SimulationStepRunner()
-        runner.run({
-            'name': 'a',
-            'cmd': ['/b/s/out/tool']
-        },
-                   check=True,
-                   capture_output=False)
+        _run(runner, {'name': 'a', 'cmd': ['/b/s/out/tool']})
         steps = simulation.build_steps(runner, None, simulation.TestContext())
         self.assertEqual(steps['a']['cmd'], ['[WORKSPACE]/out/tool'])
         # A successful run's $result carries no failure key.


### PR DESCRIPTION
This is a follow up to:
https://github.com/brave/brave-core/pull/38614

This change adds the derived placeholder classes to be used along with
steps.

* `step`'s `__call__` now renders `stdin`/`stdout`/`stderr` (and any
  placeholder in `cmd`) and returns a `StepData` instead of a plain
  `subprocess.CompletedProcess`, so a step can hand back more than a
  retcode.
* `recipe_test_api.py`'s `StepTestData`/`PlaceholderTestData` are
  rewritten to seed those placeholders under simulation, and
  `simulation.py`'s two step runners are updated to match (production
  redirects the real std handles at a placeholder's file; simulation
  hands the `step` module the seeded data instead of building a
  `CompletedProcess` itself).
* `raw_io` is the first concrete placeholder module (bytes/text in and
  out of a step, plus a whole output directory)

Bug: https://github.com/brave/brave-browser/issues/56748
