### PR TITLE
Update Customize NTP dialog design

### DIFF
--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.style.ts
@@ -3,7 +3,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { color, font } from '@brave/leo/tokens/css/variables'
+import {
+  color,
+  effect,
+  font,
+  icon,
+  radius,
+  spacing,
+} from '@brave/leo/tokens/css/variables'
 import { scoped } from '$web-common/scoped_css'
 
 export const style = scoped.css`
@@ -22,85 +29,77 @@ export const style = scoped.css`
   }
 
   .background-options {
-    padding: 16px;
-    margin-bottom: 8px;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 16px;
+    padding: ${spacing['2Xl']};
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: ${spacing.xl};
 
-    button {
+    > button,
+    .background-option > button:first-child {
       display: flex;
       flex-direction: column;
-      gap: 8px;
+      width: 100%;
+      gap: ${spacing.m};
+      padding-bottom: ${spacing.m};
     }
   }
 
   .preview {
-    background: var(--preview-background, ${color.container.highlight});
+    position: relative;
+    background: var(--preview-background, ${color.page.background});
     background-size: cover;
     background-repeat: no-repeat;
     background-position: center center;
-    border-radius: 10px;
-    width: 198px;
-    height: 156px;
+    border-radius: ${radius.m};
+    border: solid 1px ${color.divider.faint};
+    width: 100%;
+    height: auto;
+    aspect-ratio: 4 / 3;
+
+    &:has(.selected-marker) {
+      box-shadow: ${effect.elevation['01']};
+    }
   }
 
   .background-option {
     position: relative;
     text-align: center;
 
-    &:hover .remove-image {
+    &:hover .remove-image,
+    &:focus-within .remove-image {
       visibility: visible;
     }
   }
 
-  .allow-remove:hover .selected-marker {
-    visibility: hidden;
-  }
-
   .remove-image {
-    --leo-icon-size: 24px;
+    --leo-icon-color: ${color.icon.default};
+    --leo-icon-size: ${icon.m};
 
     position: absolute;
-    inset-block-start: 10px;
-    inset-inline-end: 10px;
-    background-color: #fff;
-    border-radius: 50%;
-    box-shadow: rgba(0, 0, 0, 0.5) 0px 0px 5px;
-    padding: 6px;
+    inset-block-start: ${spacing.m};
+    inset-inline-end: ${spacing.m};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: ${icon.l};
+    height: ${icon.l};
+    background-color: ${color.white};
+    border-radius: ${radius.full};
+    padding: 0;
     visibility: hidden;
-
-    &:hover {
-      color: ${color.icon.interactive};
-    }
   }
 
   .upload {
-    --leo-icon-size: 36px;
-    --leo-progressring-size: 36px;
+    --leo-icon-size: 24px;
+    --leo-progressring-size: 24px;
 
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    gap: 16px;
-    border: solid 2px ${color.divider.subtle};
+    gap: ${spacing.xl};
+    border: solid 2px ${color.divider.faint};
     font: ${font.small.regular};
   }
 
-  h4 {
-    padding: 16px 16px 0;
-
-    button {
-      --leo-icon-size: 20px;
-
-      display: flex;
-      align-items: center;
-      gap: 4px;
-
-      &:hover {
-        color: ${color.text.interactive};
-      }
-    }
-  }
 `

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.style.ts
@@ -11,6 +11,7 @@ import {
   radius,
   spacing,
 } from '@brave/leo/tokens/css/variables'
+
 import { scoped } from '$web-common/scoped_css'
 
 export const style = scoped.css`
@@ -19,7 +20,7 @@ export const style = scoped.css`
     flex-direction: column;
   }
 
-  label .subtext {
+  .label .subtext {
     font: ${font.small.regular};
     color: ${color.text.secondary};
 
@@ -33,15 +34,6 @@ export const style = scoped.css`
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: ${spacing.xl};
-
-    > button,
-    .background-option > button:first-child {
-      display: flex;
-      flex-direction: column;
-      width: 100%;
-      gap: ${spacing.m};
-      padding-bottom: ${spacing.m};
-    }
   }
 
   .preview {
@@ -56,7 +48,7 @@ export const style = scoped.css`
     height: auto;
     aspect-ratio: 4 / 3;
 
-    &:has(.selected-marker) {
+    &.selected {
       box-shadow: ${effect.elevation['01']};
     }
   }
@@ -65,9 +57,19 @@ export const style = scoped.css`
     position: relative;
     text-align: center;
 
-    &:hover .remove-image,
-    &:focus-within .remove-image {
-      visibility: visible;
+    > button:first-child {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      gap: ${spacing.m};
+      padding-bottom: ${spacing.m};
+    }
+
+    &:hover,
+    &:focus-within {
+      .remove-image {
+        visibility: visible;
+      }
     }
   }
 
@@ -85,7 +87,6 @@ export const style = scoped.css`
     height: ${icon.l};
     background-color: ${color.white};
     border-radius: ${radius.full};
-    padding: 0;
     visibility: hidden;
   }
 
@@ -101,5 +102,4 @@ export const style = scoped.css`
     border: solid 2px ${color.divider.faint};
     font: ${font.small.regular};
   }
-
 `

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.tsx
@@ -29,7 +29,12 @@ import {
 
 import { style } from './background_panel.style'
 
-export function BackgroundPanel() {
+interface Props {
+  panelType: SelectedBackgroundType | null
+  onPanelTypeChange: (type: SelectedBackgroundType | null) => void
+}
+
+export function BackgroundPanel(props: Props) {
   const actions = useBackgroundActions()
 
   const backgroundsEnabled = useBackgroundState((s) => s.backgroundsEnabled)
@@ -45,8 +50,6 @@ export function BackgroundPanel() {
   const rewardsFeatureEnabled = useRewardsState((s) => s.rewardsFeatureEnabled)
   const rewardsEnabled = useRewardsState((s) => s.rewardsEnabled)
 
-  const [panelType, setPanelType] =
-    React.useState<SelectedBackgroundType | null>(null)
   const [uploading, setUploading] = React.useState(false)
 
   React.useEffect(() => {
@@ -54,7 +57,7 @@ export function BackgroundPanel() {
   }, [selectedBackground, customBackgrounds])
 
   function setPanel(type?: SelectedBackgroundType) {
-    setPanelType(type ?? null)
+    props.onPanelTypeChange(type ?? null)
   }
 
   function getTypePreviewValue(type: SelectedBackgroundType) {
@@ -134,17 +137,16 @@ export function BackgroundPanel() {
     }
   }
 
-  if (panelType !== null) {
+  if (props.panelType !== null) {
     return (
       <div data-css-scope={style.scope}>
         <BackgroundTypePanel
-          backgroundType={panelType}
+          backgroundType={props.panelType}
           renderUploadOption={() => (
             <button onClick={showCustomBackgroundChooser}>
               {renderUploadPreview()}
             </button>
           )}
-          onClose={() => setPanel()}
         />
       </div>
     )
@@ -198,12 +200,6 @@ export function BackgroundPanel() {
         <>
           <div className='background-options'>
             <div className='background-option'>
-              <button onClick={onCustomPreviewClick}>
-                {renderTypePreview(SelectedBackgroundType.kCustom)}
-                {getString(S.NEW_TAB_CUSTOM_BACKGROUND_LABEL)}
-              </button>
-            </div>
-            <div className='background-option'>
               <button
                 onClick={() => {
                   actions.selectBackground(SelectedBackgroundType.kBrave, '')
@@ -211,6 +207,12 @@ export function BackgroundPanel() {
               >
                 {renderTypePreview(SelectedBackgroundType.kBrave)}
                 {getString(S.NEW_TAB_BRAVE_BACKGROUND_LABEL)}
+              </button>
+            </div>
+            <div className='background-option'>
+              <button onClick={onCustomPreviewClick}>
+                {renderTypePreview(SelectedBackgroundType.kCustom)}
+                {getString(S.NEW_TAB_CUSTOM_BACKGROUND_LABEL)}
               </button>
             </div>
             <div className='background-option'>

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.tsx
@@ -16,8 +16,10 @@ import { useRewardsState } from '../../context/rewards_context'
 import { getString } from '../../lib/strings'
 import { inlineCSSVars } from '../../lib/inline_css_vars'
 import { BackgroundTypePanel } from './background_type_panel'
+import { SettingsPanel } from './settings_panel'
 import { Link } from '../common/link'
 import { formatString } from '$web-common/formatString'
+import classnames from '$web-common/classnames'
 import { settingsURL } from '../../../../../components/brave_rewards/resources/shared/lib/rewards_urls'
 
 import {
@@ -29,12 +31,7 @@ import {
 
 import { style } from './background_panel.style'
 
-interface Props {
-  panelType: SelectedBackgroundType | null
-  onPanelTypeChange: (type: SelectedBackgroundType | null) => void
-}
-
-export function BackgroundPanel(props: Props) {
+export function BackgroundPanel() {
   const actions = useBackgroundActions()
 
   const backgroundsEnabled = useBackgroundState((s) => s.backgroundsEnabled)
@@ -50,15 +47,13 @@ export function BackgroundPanel(props: Props) {
   const rewardsFeatureEnabled = useRewardsState((s) => s.rewardsFeatureEnabled)
   const rewardsEnabled = useRewardsState((s) => s.rewardsEnabled)
 
+  const [panelType, setPanelType] =
+    React.useState<SelectedBackgroundType | null>(null)
   const [uploading, setUploading] = React.useState(false)
 
   React.useEffect(() => {
     setUploading(false)
   }, [selectedBackground, customBackgrounds])
-
-  function setPanel(type?: SelectedBackgroundType) {
-    props.onPanelTypeChange(type ?? null)
-  }
 
   function getTypePreviewValue(type: SelectedBackgroundType) {
     const isSelectedType = type === selectedBackground.type
@@ -102,9 +97,10 @@ export function BackgroundPanel(props: Props) {
     ) {
       return renderUploadPreview()
     }
+    const selected = type === selectedBackground.type
     return (
       <div
-        className='preview'
+        className={classnames({ preview: true, selected })}
         style={inlineCSSVars({
           '--preview-background': backgroundCSSValue(
             type,
@@ -112,7 +108,7 @@ export function BackgroundPanel(props: Props) {
           ),
         })}
       >
-        {type === selectedBackground.type && (
+        {selected && (
           <span className='selected-marker'>
             <Icon name='check-normal' />
           </span>
@@ -133,27 +129,47 @@ export function BackgroundPanel(props: Props) {
     if (customBackgrounds.length === 0) {
       showCustomBackgroundChooser()
     } else {
-      setPanel(SelectedBackgroundType.kCustom)
+      setPanelType(SelectedBackgroundType.kCustom)
     }
   }
 
-  if (props.panelType !== null) {
+  function subPanelTitle(type: SelectedBackgroundType) {
+    switch (type) {
+      case SelectedBackgroundType.kCustom:
+        return getString(S.NEW_TAB_CUSTOM_BACKGROUND_LABEL)
+      case SelectedBackgroundType.kGradient:
+        return getString(S.NEW_TAB_GRADIENT_BACKGROUND_LABEL)
+      case SelectedBackgroundType.kSolid:
+        return getString(S.NEW_TAB_SOLID_BACKGROUND_LABEL)
+      default:
+        return ''
+    }
+  }
+
+  if (panelType !== null) {
     return (
-      <div data-css-scope={style.scope}>
+      <SettingsPanel
+        cssScope={style.scope}
+        title={subPanelTitle(panelType)}
+        onBack={() => setPanelType(null)}
+      >
         <BackgroundTypePanel
-          backgroundType={props.panelType}
+          backgroundType={panelType}
           renderUploadOption={() => (
             <button onClick={showCustomBackgroundChooser}>
               {renderUploadPreview()}
             </button>
           )}
         />
-      </div>
+      </SettingsPanel>
     )
   }
 
   return (
-    <div data-css-scope={style.scope}>
+    <SettingsPanel
+      cssScope={style.scope}
+      title={getString(S.NEW_TAB_BACKGROUND_SETTINGS_TITLE)}
+    >
       <Toggle
         className='toggle-row'
         size='small'
@@ -176,22 +192,25 @@ export function BackgroundPanel(props: Props) {
           }}
         >
           <span className='label'>
-            {getString(S.NEW_TAB_SHOW_SPONSORED_IMAGES_LABEL)}
-            <div className='subtext'>
-              {!rewardsEnabled
-                && formatString(
-                  getString(S.NEW_TAB_SHOW_SPONSORED_IMAGES_EARNING_TEXT),
-                  {
-                    $1: (content) => (
-                      <Link
-                        url={settingsURL}
-                        openInNewTab
-                      >
-                        {content}
-                      </Link>
-                    ),
-                  },
-                )}
+            <div>
+              {getString(S.NEW_TAB_SHOW_SPONSORED_IMAGES_LABEL)}
+              {!rewardsEnabled && (
+                <div className='subtext'>
+                  {formatString(
+                    getString(S.NEW_TAB_SHOW_SPONSORED_IMAGES_EARNING_TEXT),
+                    {
+                      $1: (content) => (
+                        <Link
+                          url={settingsURL}
+                          openInNewTab
+                        >
+                          {content}
+                        </Link>
+                      ),
+                    },
+                  )}
+                </div>
+              )}
             </div>
           </span>
         </Toggle>
@@ -216,14 +235,16 @@ export function BackgroundPanel(props: Props) {
               </button>
             </div>
             <div className='background-option'>
-              <button onClick={() => setPanel(SelectedBackgroundType.kSolid)}>
+              <button
+                onClick={() => setPanelType(SelectedBackgroundType.kSolid)}
+              >
                 {renderTypePreview(SelectedBackgroundType.kSolid)}
                 {getString(S.NEW_TAB_SOLID_BACKGROUND_LABEL)}
               </button>
             </div>
             <div className='background-option'>
               <button
-                onClick={() => setPanel(SelectedBackgroundType.kGradient)}
+                onClick={() => setPanelType(SelectedBackgroundType.kGradient)}
               >
                 {renderTypePreview(SelectedBackgroundType.kGradient)}
                 {getString(S.NEW_TAB_GRADIENT_BACKGROUND_LABEL)}
@@ -232,6 +253,6 @@ export function BackgroundPanel(props: Props) {
           </div>
         </>
       )}
-    </div>
+    </SettingsPanel>
   )
 }

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_type_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_type_panel.tsx
@@ -27,7 +27,6 @@ import {
 interface Props {
   backgroundType: SelectedBackgroundType
   renderUploadOption: () => React.ReactNode
-  onClose: () => void
 }
 
 export function BackgroundTypePanel(props: Props) {
@@ -38,19 +37,6 @@ export function BackgroundTypePanel(props: Props) {
   const currentBackground = useCurrentBackground()
 
   const type = props.backgroundType
-
-  function panelTitle() {
-    switch (type) {
-      case SelectedBackgroundType.kCustom:
-        return getString(S.NEW_TAB_CUSTOM_BACKGROUND_LABEL)
-      case SelectedBackgroundType.kGradient:
-        return getString(S.NEW_TAB_GRADIENT_BACKGROUND_LABEL)
-      case SelectedBackgroundType.kSolid:
-        return getString(S.NEW_TAB_SOLID_BACKGROUND_LABEL)
-      default:
-        return ''
-    }
-  }
 
   function panelValues() {
     switch (type) {
@@ -86,12 +72,6 @@ export function BackgroundTypePanel(props: Props) {
 
   return (
     <>
-      <h4>
-        <button onClick={props.onClose}>
-          <Icon name='arrow-left' />
-          {panelTitle()}
-        </button>
-      </h4>
       <div className='control-row'>
         <label>{getString(S.NEW_TAB_RANDOMIZE_BACKGROUND_LABEL)}</label>
         <Toggle
@@ -104,6 +84,7 @@ export function BackgroundTypePanel(props: Props) {
         />
       </div>
       <div className='background-options'>
+        {type === SelectedBackgroundType.kCustom && props.renderUploadOption()}
         {values.map((value) => {
           const isSelected =
             selectedBackground.type === type
@@ -148,7 +129,6 @@ export function BackgroundTypePanel(props: Props) {
             </div>
           )
         })}
-        {type === SelectedBackgroundType.kCustom && props.renderUploadOption()}
       </div>
     </>
   )

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_type_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_type_panel.tsx
@@ -9,7 +9,6 @@ import Toggle from '@brave/leo/react/toggle'
 
 import { getString } from '../../lib/strings'
 import { inlineCSSVars } from '../../lib/inline_css_vars'
-import classNames from '$web-common/classnames'
 
 import {
   SelectedBackgroundType,
@@ -84,7 +83,9 @@ export function BackgroundTypePanel(props: Props) {
         />
       </div>
       <div className='background-options'>
-        {type === SelectedBackgroundType.kCustom && props.renderUploadOption()}
+        {type === SelectedBackgroundType.kCustom && (
+          <div className='background-option'>{props.renderUploadOption()}</div>
+        )}
         {values.map((value) => {
           const isSelected =
             selectedBackground.type === type
@@ -93,10 +94,7 @@ export function BackgroundTypePanel(props: Props) {
           return (
             <div
               key={value}
-              className={classNames({
-                'background-option': true,
-                'can-remove': type === SelectedBackgroundType.kCustom,
-              })}
+              className='background-option'
             >
               <button
                 onClick={() => {

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/clock_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/clock_panel.tsx
@@ -10,6 +10,7 @@ import Toggle from '@brave/leo/react/toggle'
 import { useNewTabState, useNewTabActions } from '../../context/new_tab_context'
 import { ClockFormat } from '../../state/new_tab_store'
 import { getString } from '../../lib/strings'
+import { SettingsPanel } from './settings_panel'
 import { formatString } from '$web-common/formatString'
 
 import { style } from './clock_panel.style'
@@ -41,7 +42,10 @@ export function ClockPanel() {
   }
 
   return (
-    <div data-css-scope={style.scope}>
+    <SettingsPanel
+      cssScope={style.scope}
+      title={getString(S.NEW_TAB_CLOCK_SETTINGS_TITLE)}
+    >
       <Toggle
         className='toggle-row'
         size='small'
@@ -67,6 +71,6 @@ export function ClockPanel() {
           {renderFormatOption(ClockFormat.k24)}
         </DropDown>
       </div>
-    </div>
+    </SettingsPanel>
   )
 }

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/search_panel.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/search_panel.style.ts
@@ -3,7 +3,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { color, font } from '@brave/leo/tokens/css/variables'
+import {
+  color,
+  font,
+  icon,
+  radius,
+  spacing,
+} from '@brave/leo/tokens/css/variables'
 import { scoped } from '$web-common/scoped_css'
 
 export const style = scoped.css`
@@ -12,19 +18,44 @@ export const style = scoped.css`
     flex-direction: column;
   }
 
+  .toggle-row .label {
+    --leo-icon-size: ${icon.m};
+
+    display: flex;
+    align-items: center;
+    gap: ${spacing.xl};
+    color: ${color.text.primary};
+  }
+
   .search-engines {
-    padding: 24px;
+    display: flex;
+    flex-direction: column;
+
+    > h4 {
+      padding: ${spacing['2Xl']};
+    }
   }
 
   .search-engine-list {
     --leo-checkbox-flex-direction: row-reverse;
-    --leo-checkbox-label-gap: 16px;
-    --leo-icon-size: 20px;
+    --leo-checkbox-label-gap: ${spacing.xl};
+    --leo-icon-size: ${icon.s};
 
-    padding: 24px 0;
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    margin: 0 ${spacing.xl};
+    overflow: hidden;
+    border: solid 1px ${color.divider.subtle};
+    border-radius: ${radius.m};
+  }
+
+  .search-engine {
+    padding: ${spacing.l} ${spacing.xl};
+    border-bottom: solid 1px ${color.divider.subtle};
+
+    &:last-child {
+      border-bottom: none;
+    }
   }
 
   .engine-name {
@@ -32,8 +63,8 @@ export const style = scoped.css`
   }
 
   .engine-icon {
-    width: 20px;
-    height: 20px;
+    width: ${icon.s};
+    height: ${icon.s};
   }
 
   h4 {
@@ -46,12 +77,15 @@ export const style = scoped.css`
   }
 
   .customize-link {
-    --leo-icon-size: 20px;
+    --leo-icon-size: ${icon.m};
 
-    margin-top: 16px;
-    display: inline-flex;
+    display: flex;
     align-items: center;
-    gap: 8px;
+    justify-content: space-between;
+    gap: ${spacing.m};
+    width: 100%;
+    padding: ${spacing.xl} ${spacing['2Xl']};
+    box-sizing: border-box;
     text-decoration: none;
     color: ${color.text.primary};
   }

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/search_panel.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/search_panel.style.ts
@@ -10,21 +10,13 @@ import {
   radius,
   spacing,
 } from '@brave/leo/tokens/css/variables'
+
 import { scoped } from '$web-common/scoped_css'
 
 export const style = scoped.css`
   & {
     display: flex;
     flex-direction: column;
-  }
-
-  .toggle-row .label {
-    --leo-icon-size: ${icon.m};
-
-    display: flex;
-    align-items: center;
-    gap: ${spacing.xl};
-    color: ${color.text.primary};
   }
 
   .search-engines {
@@ -44,16 +36,15 @@ export const style = scoped.css`
     display: flex;
     flex-direction: column;
     margin: 0 ${spacing.xl};
-    overflow: hidden;
     border: solid 1px ${color.divider.subtle};
     border-radius: ${radius.m};
-  }
 
-  .search-engine {
-    padding: ${spacing.l} ${spacing.xl};
-    border-bottom: solid 1px ${color.divider.subtle};
+    > * {
+      padding: ${spacing.l} ${spacing.xl};
+      border-bottom: solid 1px ${color.divider.subtle};
+    }
 
-    &:last-child {
+    > :last-child {
       border-bottom: none;
     }
   }
@@ -71,11 +62,6 @@ export const style = scoped.css`
     font: ${font.default.semibold};
   }
 
-  .divider {
-    height: 1px;
-    background: ${color.divider.subtle};
-  }
-
   .customize-link {
     --leo-icon-size: ${icon.m};
 
@@ -85,7 +71,6 @@ export const style = scoped.css`
     gap: ${spacing.m};
     width: 100%;
     padding: ${spacing.xl} ${spacing['2Xl']};
-    box-sizing: border-box;
     text-decoration: none;
     color: ${color.text.primary};
   }

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/search_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/search_panel.tsx
@@ -36,7 +36,8 @@ export function SearchPanel() {
         }}
       >
         <span className='label'>
-          {getString(S.NEW_TAB_SHOW_SEARCH_BOX_LABEL)}
+          <Icon name='search' />
+          <span>{getString(S.NEW_TAB_SHOW_SEARCH_BOX_LABEL)}</span>
         </span>
       </Toggle>
       {aiChatInputEnabled && (
@@ -49,7 +50,8 @@ export function SearchPanel() {
           }}
         >
           <span className='label'>
-            {getString(S.NEW_TAB_SHOW_CHAT_INPUT_LABEL)}
+            <Icon name='product-brave-leo' />
+            <span>{getString(S.NEW_TAB_SHOW_CHAT_INPUT_LABEL)}</span>
           </span>
         </Toggle>
       )}
@@ -60,6 +62,7 @@ export function SearchPanel() {
             {searchEngines.map((engine) => (
               <Checkbox
                 key={engine.host}
+                className='search-engine'
                 checked={enabledSearchEngines.has(engine.host)}
                 onChange={({ checked }) => {
                   actions.setSearchEngineEnabled(engine.host, checked)

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/search_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/search_panel.tsx
@@ -12,6 +12,7 @@ import { useSearchState, useSearchActions } from '../../context/search_context'
 import { useNewTabState } from '../../context/new_tab_context'
 import { getString } from '../../lib/strings'
 import { EngineIcon } from '../search/engine_icon'
+import { SettingsPanel } from './settings_panel'
 import { Link } from '../common/link'
 
 import { style } from './search_panel.style'
@@ -26,7 +27,14 @@ export function SearchPanel() {
   const aiChatInputEnabled = useNewTabState((s) => s.aiChatInputEnabled)
 
   return (
-    <div data-css-scope={style.scope}>
+    <SettingsPanel
+      cssScope={style.scope}
+      title={
+        aiChatInputEnabled
+          ? getString(S.NEW_TAB_SEARCH_AND_CHAT_SETTINGS_TITLE)
+          : getString(S.NEW_TAB_SEARCH_SETTINGS_TITLE)
+      }
+    >
       <Toggle
         className='toggle-row'
         size='small'
@@ -37,7 +45,7 @@ export function SearchPanel() {
       >
         <span className='label'>
           <Icon name='search' />
-          <span>{getString(S.NEW_TAB_SHOW_SEARCH_BOX_LABEL)}</span>
+          {getString(S.NEW_TAB_SHOW_SEARCH_BOX_LABEL)}
         </span>
       </Toggle>
       {aiChatInputEnabled && (
@@ -51,7 +59,7 @@ export function SearchPanel() {
         >
           <span className='label'>
             <Icon name='product-brave-leo' />
-            <span>{getString(S.NEW_TAB_SHOW_CHAT_INPUT_LABEL)}</span>
+            {getString(S.NEW_TAB_SHOW_CHAT_INPUT_LABEL)}
           </span>
         </Toggle>
       )}
@@ -62,7 +70,6 @@ export function SearchPanel() {
             {searchEngines.map((engine) => (
               <Checkbox
                 key={engine.host}
-                className='search-engine'
                 checked={enabledSearchEngines.has(engine.host)}
                 onChange={({ checked }) => {
                   actions.setSearchEngineEnabled(engine.host, checked)
@@ -84,6 +91,6 @@ export function SearchPanel() {
           </div>
         </div>
       )}
-    </div>
+    </SettingsPanel>
   )
 }

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/settings_modal.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/settings_modal.style.ts
@@ -3,67 +3,131 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { color, effect } from '@brave/leo/tokens/css/variables'
+import {
+  color,
+  effect,
+  font,
+  icon,
+  radius,
+  spacing,
+} from '@brave/leo/tokens/css/variables'
 import { scoped } from '$web-common/scoped_css'
 
 export const style = scoped.css`
   & {
-    --leo-dialog-width: 720px;
+    --leo-dialog-width: 860px;
     --leo-dialog-padding: 0;
-    --leo-dialog-background: ${color.container.background};
+    --leo-dialog-background: transparent;
+    --leo-dialog-border-radius: 0;
+    /* The dialog is now just a transparent frame; its own elevation would
+       paint a shadow around empty space. Leo exposes no shadow variable. */
+    --leo-effect-elevation-05: none;
 
     height: 0;
   }
 
-  h3 {
-    padding: 24px;
-    border-bottom: solid 1px ${color.divider.subtle};
+  .dialog-frame {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: ${spacing.m};
   }
 
-  .panel-body {
+  .close {
+    --leo-button-color: ${color.white};
+    color: ${color.white};
+  }
+
+  .panel {
+    width: 100%;
+    max-height: 800px;
     display: flex;
+    overflow: hidden;
+    border-radius: ${radius.xl};
+    background: ${color.container.background};
+    box-shadow: ${effect.elevation['05']};
   }
 
   nav {
-    flex: 0 0 220px;
+    flex: 0 0 228px;
+    padding-bottom: ${spacing['2Xl']};
     white-space: nowrap;
-    margin-top: 24px;
+  }
+
+  h3 {
+    padding: ${spacing['2Xl']};
+    font: ${font.heading.h4};
+    color: ${color.text.primary};
   }
 
   section {
     flex: 1 1 auto;
-    padding: 16px;
-    height: 400px;
-    overflow: auto;
+    min-width: 0;
+    min-height: 0;
+    padding: ${spacing.m} ${spacing.m} ${spacing.m} 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  section > .content {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
     overscroll-behavior: contain;
     scrollbar-width: thin;
+    padding: ${spacing['4Xl']};
+    border-radius: ${radius.xl};
     background: ${color.page.background};
 
-    > * {
-      background: ${color.container.background};
-      box-shadow: ${effect.elevation['01']};
-      border-radius: 8px;
+    > h4 {
+      padding-bottom: ${spacing.xl};
+      color: ${color.text.primary};
     }
+
+  }
+
+  .section-title {
+    --leo-icon-size: ${icon.m};
+
+    display: flex;
+    align-items: center;
+    gap: ${spacing.s};
+    color: inherit;
+    font: inherit;
+  }
+
+  .settings-group {
+    width: 100%;
+    overflow: hidden;
+    background: ${color.container.background};
+    box-shadow: ${effect.elevation['01']};
+    border-radius: ${radius.xl};
   }
 `
 
 style.passthrough.css`
   .selected-marker {
-    --leo-icon-color: #fff;
-    --leo-icon-size: 24px;
+    --leo-icon-color: ${color.white};
+    --leo-icon-size: ${icon.xs};
 
     position: absolute;
-    inset-block-start: 10px;
-    inset-inline-end: 10px;
+    inset-block-end: ${spacing.m};
+    inset-inline-end: ${spacing.m};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: ${icon.l};
+    height: ${icon.l};
     background: ${color.icon.interactive};
-    border-radius: 50%;
-    padding: 6px;
+    border: 2px solid ${color.white};
+    border-radius: ${radius.full};
+    box-sizing: border-box;
   }
 
 
   .control-row,
   .toggle-row {
-    padding: 24px;
+    padding: ${spacing.l} ${spacing['2Xl']};
     border-bottom: solid 1px ${color.divider.subtle};
 
     &:last-child {
@@ -74,7 +138,7 @@ style.passthrough.css`
   .control-row {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: ${spacing.m};
 
     label {
       flex: 1 1 auto;

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/settings_modal.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/settings_modal.style.ts
@@ -3,153 +3,56 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import {
-  color,
-  effect,
-  font,
-  icon,
-  radius,
-  spacing,
-} from '@brave/leo/tokens/css/variables'
+import { color, radius, spacing } from '@brave/leo/tokens/css/variables'
 import { scoped } from '$web-common/scoped_css'
 
 export const style = scoped.css`
   & {
     --leo-dialog-width: 860px;
     --leo-dialog-padding: 0;
-    --leo-dialog-background: transparent;
-    --leo-dialog-border-radius: 0;
-    /* The dialog is now just a transparent frame; its own elevation would
-       paint a shadow around empty space. Leo exposes no shadow variable. */
-    --leo-effect-elevation-05: none;
+    --leo-dialog-background: ${color.container.background};
 
     height: 0;
   }
 
-  .dialog-frame {
+  .panel-body {
     display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: ${spacing.m};
-  }
-
-  .close {
-    --leo-button-color: ${color.white};
-    color: ${color.white};
-  }
-
-  .panel {
-    width: 100%;
-    max-height: 800px;
-    display: flex;
-    overflow: hidden;
-    border-radius: ${radius.xl};
-    background: ${color.container.background};
-    box-shadow: ${effect.elevation['05']};
+    max-height: calc(100vh - ${spacing['4Xl']});
   }
 
   nav {
     flex: 0 0 228px;
-    padding-bottom: ${spacing['2Xl']};
+    display: flex;
+    flex-direction: column;
+    gap: ${spacing['2Xl']};
+    padding: ${spacing['2Xl']} 0;
     white-space: nowrap;
   }
 
-  h3 {
-    padding: ${spacing['2Xl']};
-    font: ${font.heading.h4};
+  h4 {
     color: ${color.text.primary};
+    padding: 0 ${spacing['2Xl']};
   }
 
   section {
     flex: 1 1 auto;
-    min-width: 0;
     min-height: 0;
     padding: ${spacing.m} ${spacing.m} ${spacing.m} 0;
-    display: flex;
-    flex-direction: column;
-  }
-
-  section > .content {
-    flex: 1 1 auto;
-    min-height: 0;
-    overflow-y: auto;
+    overflow: auto;
     overscroll-behavior: contain;
     scrollbar-width: thin;
-    padding: ${spacing['4Xl']};
-    border-radius: ${radius.xl};
-    background: ${color.page.background};
+    display: flex;
+    flex-direction: column;
 
-    > h4 {
-      padding-bottom: ${spacing.xl};
-      color: ${color.text.primary};
+    .panel-body[data-resizing] & {
+      overflow: hidden;
     }
 
-  }
-
-  .section-title {
-    --leo-icon-size: ${icon.m};
-
-    display: flex;
-    align-items: center;
-    gap: ${spacing.s};
-    color: inherit;
-    font: inherit;
-  }
-
-  .settings-group {
-    width: 100%;
-    overflow: hidden;
-    background: ${color.container.background};
-    box-shadow: ${effect.elevation['01']};
-    border-radius: ${radius.xl};
-  }
-`
-
-style.passthrough.css`
-  .selected-marker {
-    --leo-icon-color: ${color.white};
-    --leo-icon-size: ${icon.xs};
-
-    position: absolute;
-    inset-block-end: ${spacing.m};
-    inset-inline-end: ${spacing.m};
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: ${icon.l};
-    height: ${icon.l};
-    background: ${color.icon.interactive};
-    border: 2px solid ${color.white};
-    border-radius: ${radius.full};
-    box-sizing: border-box;
-  }
-
-
-  .control-row,
-  .toggle-row {
-    padding: ${spacing.l} ${spacing['2Xl']};
-    border-bottom: solid 1px ${color.divider.subtle};
-
-    &:last-child {
-      border-bottom: none;
-    }
-  }
-
-  .control-row {
-    display: flex;
-    align-items: center;
-    gap: ${spacing.m};
-
-    label {
-      flex: 1 1 auto;
-    }
-  }
-
-  .toggle-row {
-    --leo-toggle-label-flex-direction: row-reverse;
-
-    .label {
-      flex: 1 1 auto;
+    > * {
+      flex-grow: 1;
+      padding: ${spacing['4Xl']};
+      border-radius: ${radius.xl};
+      background: ${color.page.background};
     }
   }
 `

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/settings_modal.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/settings_modal.tsx
@@ -4,6 +4,7 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react'
+import Button from '@brave/leo/react/button'
 import Dialog from '@brave/leo/react/dialog'
 import Icon from '@brave/leo/react/icon'
 import Navigation from '@brave/leo/react/navigation'
@@ -13,6 +14,7 @@ import { useBraveNews } from '../../../../../components/brave_news/browser/resou
 
 import { useNewTabState } from '../../context/new_tab_context'
 import { useSearchState } from '../../context/search_context'
+import { SelectedBackgroundType } from '../../state/background_store'
 import { BackgroundPanel } from './background_panel'
 import { SearchPanel } from './search_panel'
 import { TopSitesPanel } from './top_sites_panel'
@@ -38,6 +40,8 @@ interface Props {
 
 export function SettingsModal(props: Props) {
   const braveNews = useBraveNews()
+  const panelRef = React.useRef<HTMLDivElement>(null)
+  const previousPanelHeight = React.useRef<number | null>(null)
   const searchFeatureEnabled = useSearchState((s) => s.searchFeatureEnabled)
   const aiChatInputEnabled = useNewTabState((s) => s.aiChatInputEnabled)
   const newsFeatureEnabled = useNewTabState((s) => s.newsFeatureEnabled)
@@ -45,17 +49,58 @@ export function SettingsModal(props: Props) {
   const [currentView, setCurrentView] = React.useState<SettingsView>(
     props.initialView || 'background',
   )
+  const [backgroundPanelType, setBackgroundPanelType] =
+    React.useState<SelectedBackgroundType | null>(null)
+
+  React.useLayoutEffect(() => {
+    const panel = panelRef.current
+    const previousHeight = previousPanelHeight.current
+    if (
+      !panel
+      || previousHeight === null
+      || matchMedia('(prefers-reduced-motion: reduce)').matches
+    ) {
+      return
+    }
+
+    const nextHeight = panel.getBoundingClientRect().height
+    if (Math.abs(previousHeight - nextHeight) < 1) {
+      return
+    }
+
+    panel.getAnimations().forEach((animation) => animation.cancel())
+    panel.animate(
+      [{ height: `${previousHeight}px` }, { height: `${nextHeight}px` }],
+      {
+        duration: 180,
+        easing: 'ease-out',
+      },
+    )
+  }, [currentView, backgroundPanelType])
 
   React.useEffect(() => {
     if (props.isOpen) {
+      setBackgroundPanelType(null)
       if (props.initialView === 'news') {
         braveNews.setCustomizePage('news')
         setCurrentView('background')
       } else {
         setCurrentView(props.initialView ?? 'background')
       }
+    } else {
+      previousPanelHeight.current = null
     }
   }, [props.isOpen, props.initialView])
+
+  function capturePanelHeight() {
+    previousPanelHeight.current =
+      panelRef.current?.getBoundingClientRect().height ?? null
+  }
+
+  function changeBackgroundPanelType(type: SelectedBackgroundType | null) {
+    capturePanelHeight()
+    setBackgroundPanelType(type)
+  }
 
   function shouldShowView(view: SettingsView) {
     switch (view) {
@@ -74,7 +119,12 @@ export function SettingsModal(props: Props) {
     }
     switch (currentView) {
       case 'background':
-        return <BackgroundPanel />
+        return (
+          <BackgroundPanel
+            panelType={backgroundPanelType}
+            onPanelTypeChange={changeBackgroundPanelType}
+          />
+        )
       case 'search':
         return <SearchPanel />
       case 'top-sites':
@@ -124,6 +174,19 @@ export function SettingsModal(props: Props) {
     }
   }
 
+  function getSectionTitle() {
+    switch (backgroundPanelType) {
+      case SelectedBackgroundType.kCustom:
+        return getString(S.NEW_TAB_CUSTOM_BACKGROUND_LABEL)
+      case SelectedBackgroundType.kGradient:
+        return getString(S.NEW_TAB_GRADIENT_BACKGROUND_LABEL)
+      case SelectedBackgroundType.kSolid:
+        return getString(S.NEW_TAB_SOLID_BACKGROUND_LABEL)
+      default:
+        return getNavItemText(currentView)
+    }
+  }
+
   function renderNavItem(view: SettingsView) {
     if (!shouldShowView(view)) {
       return null
@@ -135,6 +198,8 @@ export function SettingsModal(props: Props) {
           if (view === 'news') {
             braveNews.setCustomizePage('news')
           } else {
+            capturePanelHeight()
+            setBackgroundPanelType(null)
             setCurrentView(view)
           }
         }}
@@ -149,25 +214,52 @@ export function SettingsModal(props: Props) {
     <div data-css-scope={style.scope}>
       <Dialog
         isOpen={props.isOpen}
-        showClose
         onClose={() => props.onClose()}
         backdropClickCloses={!braveNews.customizePage}
       >
-        <h3>{getString(S.NEW_TAB_SETTINGS_TITLE)}</h3>
-        <div className='panel-body'>
-          <nav>
-            <Navigation>
-              {renderNavItem('background')}
-              {renderNavItem('search')}
-              {renderNavItem('top-sites')}
-              {renderNavItem('news')}
-              {renderNavItem('clock')}
-              {renderNavItem('widgets')}
-            </Navigation>
-          </nav>
-          <section>
-            <div>{renderPanel()}</div>
-          </section>
+        <div className='dialog-frame'>
+          <Button
+            className='close'
+            kind='plain-faint'
+            fab
+            onClick={props.onClose}
+          >
+            <Icon name='close' />
+          </Button>
+          <div
+            className='panel'
+            ref={panelRef}
+          >
+            <nav>
+              <h3>{getString(S.NEW_TAB_SETTINGS_TITLE)}</h3>
+              <Navigation>
+                {renderNavItem('background')}
+                {renderNavItem('search')}
+                {renderNavItem('top-sites')}
+                {renderNavItem('news')}
+                {renderNavItem('clock')}
+                {renderNavItem('widgets')}
+              </Navigation>
+            </nav>
+            <section>
+              <div className='content'>
+                <h4>
+                  {backgroundPanelType === null ? (
+                    getSectionTitle()
+                  ) : (
+                    <button
+                      className='section-title'
+                      onClick={() => changeBackgroundPanelType(null)}
+                    >
+                      <Icon name='arrow-left' />
+                      {getSectionTitle()}
+                    </button>
+                  )}
+                </h4>
+                <div className='settings-group'>{renderPanel()}</div>
+              </div>
+            </section>
+          </div>
         </div>
       </Dialog>
     </div>

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/settings_modal.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/settings_modal.tsx
@@ -4,7 +4,6 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react'
-import Button from '@brave/leo/react/button'
 import Dialog from '@brave/leo/react/dialog'
 import Icon from '@brave/leo/react/icon'
 import Navigation from '@brave/leo/react/navigation'
@@ -14,13 +13,13 @@ import { useBraveNews } from '../../../../../components/brave_news/browser/resou
 
 import { useNewTabState } from '../../context/new_tab_context'
 import { useSearchState } from '../../context/search_context'
-import { SelectedBackgroundType } from '../../state/background_store'
 import { BackgroundPanel } from './background_panel'
 import { SearchPanel } from './search_panel'
 import { TopSitesPanel } from './top_sites_panel'
 import { ClockPanel } from './clock_panel'
 import { WidgetsPanel } from './widgets_panel'
 import { getString } from '../../lib/strings'
+import { useAnimatedResize } from '../../lib/animated_resize'
 
 import { style } from './settings_modal.style'
 
@@ -40,8 +39,7 @@ interface Props {
 
 export function SettingsModal(props: Props) {
   const braveNews = useBraveNews()
-  const panelRef = React.useRef<HTMLDivElement>(null)
-  const previousPanelHeight = React.useRef<number | null>(null)
+  const panelBodyRef = React.useRef<HTMLDivElement>(null)
   const searchFeatureEnabled = useSearchState((s) => s.searchFeatureEnabled)
   const aiChatInputEnabled = useNewTabState((s) => s.aiChatInputEnabled)
   const newsFeatureEnabled = useNewTabState((s) => s.newsFeatureEnabled)
@@ -49,58 +47,19 @@ export function SettingsModal(props: Props) {
   const [currentView, setCurrentView] = React.useState<SettingsView>(
     props.initialView || 'background',
   )
-  const [backgroundPanelType, setBackgroundPanelType] =
-    React.useState<SelectedBackgroundType | null>(null)
 
-  React.useLayoutEffect(() => {
-    const panel = panelRef.current
-    const previousHeight = previousPanelHeight.current
-    if (
-      !panel
-      || previousHeight === null
-      || matchMedia('(prefers-reduced-motion: reduce)').matches
-    ) {
-      return
-    }
-
-    const nextHeight = panel.getBoundingClientRect().height
-    if (Math.abs(previousHeight - nextHeight) < 1) {
-      return
-    }
-
-    panel.getAnimations().forEach((animation) => animation.cancel())
-    panel.animate(
-      [{ height: `${previousHeight}px` }, { height: `${nextHeight}px` }],
-      {
-        duration: 180,
-        easing: 'ease-out',
-      },
-    )
-  }, [currentView, backgroundPanelType])
+  useAnimatedResize(panelBodyRef)
 
   React.useEffect(() => {
     if (props.isOpen) {
-      setBackgroundPanelType(null)
       if (props.initialView === 'news') {
         braveNews.setCustomizePage('news')
         setCurrentView('background')
       } else {
         setCurrentView(props.initialView ?? 'background')
       }
-    } else {
-      previousPanelHeight.current = null
     }
   }, [props.isOpen, props.initialView])
-
-  function capturePanelHeight() {
-    previousPanelHeight.current =
-      panelRef.current?.getBoundingClientRect().height ?? null
-  }
-
-  function changeBackgroundPanelType(type: SelectedBackgroundType | null) {
-    capturePanelHeight()
-    setBackgroundPanelType(type)
-  }
 
   function shouldShowView(view: SettingsView) {
     switch (view) {
@@ -114,17 +73,12 @@ export function SettingsModal(props: Props) {
   }
 
   function renderPanel() {
-    if (!shouldShowView(currentView)) {
+    if (!props.isOpen || !shouldShowView(currentView)) {
       return null
     }
     switch (currentView) {
       case 'background':
-        return (
-          <BackgroundPanel
-            panelType={backgroundPanelType}
-            onPanelTypeChange={changeBackgroundPanelType}
-          />
-        )
+        return <BackgroundPanel />
       case 'search':
         return <SearchPanel />
       case 'top-sites':
@@ -174,19 +128,6 @@ export function SettingsModal(props: Props) {
     }
   }
 
-  function getSectionTitle() {
-    switch (backgroundPanelType) {
-      case SelectedBackgroundType.kCustom:
-        return getString(S.NEW_TAB_CUSTOM_BACKGROUND_LABEL)
-      case SelectedBackgroundType.kGradient:
-        return getString(S.NEW_TAB_GRADIENT_BACKGROUND_LABEL)
-      case SelectedBackgroundType.kSolid:
-        return getString(S.NEW_TAB_SOLID_BACKGROUND_LABEL)
-      default:
-        return getNavItemText(currentView)
-    }
-  }
-
   function renderNavItem(view: SettingsView) {
     if (!shouldShowView(view)) {
       return null
@@ -198,8 +139,6 @@ export function SettingsModal(props: Props) {
           if (view === 'news') {
             braveNews.setCustomizePage('news')
           } else {
-            capturePanelHeight()
-            setBackgroundPanelType(null)
             setCurrentView(view)
           }
         }}
@@ -214,52 +153,28 @@ export function SettingsModal(props: Props) {
     <div data-css-scope={style.scope}>
       <Dialog
         isOpen={props.isOpen}
+        showClose
         onClose={() => props.onClose()}
-        backdropClickCloses={!braveNews.customizePage}
+        backdropClickCloses={false}
       >
-        <div className='dialog-frame'>
-          <Button
-            className='close'
-            kind='plain-faint'
-            fab
-            onClick={props.onClose}
-          >
-            <Icon name='close' />
-          </Button>
-          <div
-            className='panel'
-            ref={panelRef}
-          >
-            <nav>
-              <h3>{getString(S.NEW_TAB_SETTINGS_TITLE)}</h3>
-              <Navigation>
-                {renderNavItem('background')}
-                {renderNavItem('search')}
-                {renderNavItem('top-sites')}
-                {renderNavItem('news')}
-                {renderNavItem('clock')}
-                {renderNavItem('widgets')}
-              </Navigation>
-            </nav>
-            <section>
-              <div className='content'>
-                <h4>
-                  {backgroundPanelType === null ? (
-                    getSectionTitle()
-                  ) : (
-                    <button
-                      className='section-title'
-                      onClick={() => changeBackgroundPanelType(null)}
-                    >
-                      <Icon name='arrow-left' />
-                      {getSectionTitle()}
-                    </button>
-                  )}
-                </h4>
-                <div className='settings-group'>{renderPanel()}</div>
-              </div>
-            </section>
-          </div>
+        <div
+          className='panel-body'
+          ref={panelBodyRef}
+        >
+          <nav>
+            <h4>{getString(S.NEW_TAB_SETTINGS_TITLE)}</h4>
+            <Navigation>
+              {renderNavItem('background')}
+              {renderNavItem('search')}
+              {renderNavItem('top-sites')}
+              {renderNavItem('news')}
+              {renderNavItem('clock')}
+              {renderNavItem('widgets')}
+            </Navigation>
+          </nav>
+          <section>
+            <div>{renderPanel()}</div>
+          </section>
         </div>
       </Dialog>
     </div>

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/settings_panel.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/settings_panel.style.ts
@@ -1,0 +1,91 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import {
+  color,
+  effect,
+  icon,
+  radius,
+  spacing,
+} from '@brave/leo/tokens/css/variables'
+
+import { scoped } from '$web-common/scoped_css'
+
+export const style = scoped.css`
+  h4 {
+    padding-bottom: ${spacing.xl};
+    color: ${color.text.primary};
+  }
+
+  .title {
+    --leo-icon-size: ${icon.m};
+
+    display: flex;
+    align-items: center;
+    gap: ${spacing.s};
+    color: inherit;
+    font: inherit;
+  }
+
+  .content {
+    background: ${color.container.background};
+    box-shadow: ${effect.elevation['01']};
+    border-radius: ${radius.xl};
+  }
+`
+
+style.passthrough.css`
+  .selected-marker {
+    --leo-icon-color: ${color.white};
+    --leo-icon-size: ${icon.xs};
+
+    position: absolute;
+    inset-block-end: ${spacing.m};
+    inset-inline-end: ${spacing.m};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: ${icon.l};
+    height: ${icon.l};
+    background: ${color.icon.interactive};
+    border: 2px solid ${color.white};
+    border-radius: ${radius.full};
+  }
+
+  .control-row,
+  .toggle-row {
+    padding: ${spacing.l} ${spacing['2Xl']};
+    border-bottom: solid 1px ${color.divider.subtle};
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  .control-row {
+    display: flex;
+    align-items: center;
+    gap: ${spacing.m};
+
+    label {
+      flex: 1 1 auto;
+    }
+  }
+
+  .toggle-row {
+    --leo-toggle-label-flex-direction: row-reverse;
+    --leo-toggle-label-gap: ${spacing.xl};
+
+    .label {
+      --leo-icon-size: ${icon.m};
+
+      flex: 1 1 auto;
+      display: flex;
+      align-items: center;
+      gap: ${spacing.xl};
+      color: ${color.text.primary};
+    }
+  }
+`

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/settings_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/settings_panel.tsx
@@ -1,0 +1,42 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+import Icon from '@brave/leo/react/icon'
+
+import { style } from './settings_panel.style'
+
+interface Props {
+  title: string
+  cssScope: string
+  onBack?: () => void
+  children: React.ReactNode
+}
+
+// A titled group of settings displayed within the settings modal. Supply
+// `onBack` when the panel was opened from another panel, in order to display
+// the title as a back button.
+export function SettingsPanel(props: Props) {
+  return (
+    <div data-css-scope={style.scope}>
+      <h4>
+        {props.onBack ? (
+          <button
+            className='title'
+            onClick={props.onBack}
+          >
+            <Icon name='arrow-left' />
+            {props.title}
+          </button>
+        ) : (
+          props.title
+        )}
+      </h4>
+      <div className='content'>
+        <div data-css-scope={props.cssScope}>{props.children}</div>
+      </div>
+    </div>
+  )
+}

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.tsx
@@ -13,6 +13,7 @@ import {
   useTopSitesActions,
 } from '../../context/top_sites_context'
 import { getString } from '../../lib/strings'
+import { SettingsPanel } from './settings_panel'
 import classNames from '$web-common/classnames'
 
 import { style } from './top_sites_panel.style'
@@ -36,7 +37,10 @@ export function TopSitesPanel() {
   }
 
   return (
-    <div data-css-scope={style.scope}>
+    <SettingsPanel
+      cssScope={style.scope}
+      title={getString(S.NEW_TAB_TOP_SITES_SETTINGS_TITLE)}
+    >
       <Toggle
         className='toggle-row'
         size='small'
@@ -97,6 +101,6 @@ export function TopSitesPanel() {
           </button>
         </div>
       )}
-    </div>
+    </SettingsPanel>
   )
 }

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/widgets_panel.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/widgets_panel.style.ts
@@ -3,11 +3,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { color, icon, spacing } from '@brave/leo/tokens/css/variables'
 import { scoped } from '$web-common/scoped_css'
 
 export const style = scoped.css`
   & {
     display: flex;
     flex-direction: column;
+  }
+
+  .toggle-row .label {
+    --leo-icon-size: ${icon.m};
+
+    display: flex;
+    align-items: center;
+    gap: ${spacing.xl};
+    color: ${color.text.primary};
   }
 `

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/widgets_panel.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/widgets_panel.style.ts
@@ -3,21 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { color, icon, spacing } from '@brave/leo/tokens/css/variables'
 import { scoped } from '$web-common/scoped_css'
 
 export const style = scoped.css`
   & {
     display: flex;
     flex-direction: column;
-  }
-
-  .toggle-row .label {
-    --leo-icon-size: ${icon.m};
-
-    display: flex;
-    align-items: center;
-    gap: ${spacing.xl};
-    color: ${color.text.primary};
   }
 `

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/widgets_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/widgets_panel.tsx
@@ -4,6 +4,7 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react'
+import Icon from '@brave/leo/react/icon'
 import Toggle from '@brave/leo/react/toggle'
 
 import { useBraveNews } from '../../../../../components/brave_news/browser/resources/shared/Context'
@@ -43,7 +44,10 @@ export function WidgetsPanel() {
           newTabActions.setShowShieldsStats(checked)
         }}
       >
-        <span className='label'>{getString(S.NEW_TAB_SHOW_STATS_LABEL)}</span>
+        <span className='label'>
+          <Icon name='shield-done' />
+          <span>{getString(S.NEW_TAB_SHOW_STATS_LABEL)}</span>
+        </span>
       </Toggle>
       {vpnFeatureEnabled && (
         <Toggle
@@ -55,7 +59,8 @@ export function WidgetsPanel() {
           }}
         >
           <span className='label'>
-            {getString(S.NEW_TAB_SHOW_VPN_WIDGET_LABEL)}
+            <Icon name='product-vpn' />
+            <span>{getString(S.NEW_TAB_SHOW_VPN_WIDGET_LABEL)}</span>
           </span>
         </Toggle>
       )}
@@ -69,7 +74,8 @@ export function WidgetsPanel() {
           }}
         >
           <span className='label'>
-            {getString(S.NEW_TAB_SHOW_REWARDS_WIDGET_LABEL)}
+            <Icon name='product-bat-outline' />
+            <span>{getString(S.NEW_TAB_SHOW_REWARDS_WIDGET_LABEL)}</span>
           </span>
         </Toggle>
       )}
@@ -83,7 +89,8 @@ export function WidgetsPanel() {
           }}
         >
           <span className='label'>
-            {getString(S.NEW_TAB_SHOW_TALK_WIDGET_LABEL)}
+            <Icon name='product-brave-talk' />
+            <span>{getString(S.NEW_TAB_SHOW_TALK_WIDGET_LABEL)}</span>
           </span>
         </Toggle>
       )}
@@ -97,7 +104,8 @@ export function WidgetsPanel() {
           }}
         >
           <span className='label'>
-            {getString(S.NEW_TAB_SHOW_NEWS_WIDGET_LABEL)}
+            <Icon name='product-brave-news' />
+            <span>{getString(S.NEW_TAB_SHOW_NEWS_WIDGET_LABEL)}</span>
           </span>
         </Toggle>
       )}

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/widgets_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/widgets_panel.tsx
@@ -16,6 +16,7 @@ import {
   useRewardsActions,
 } from '../../context/rewards_context'
 import { useVpnState, useVpnActions } from '../../context/vpn_context'
+import { SettingsPanel } from './settings_panel'
 
 import { style } from './widgets_panel.style'
 
@@ -35,7 +36,10 @@ export function WidgetsPanel() {
   const showVpnWidget = useVpnState((s) => s.showVpnWidget)
 
   return (
-    <div data-css-scope={style.scope}>
+    <SettingsPanel
+      cssScope={style.scope}
+      title={getString(S.NEW_TAB_WIDGET_SETTINGS_TITLE)}
+    >
       <Toggle
         className='toggle-row'
         size='small'
@@ -46,7 +50,7 @@ export function WidgetsPanel() {
       >
         <span className='label'>
           <Icon name='shield-done' />
-          <span>{getString(S.NEW_TAB_SHOW_STATS_LABEL)}</span>
+          {getString(S.NEW_TAB_SHOW_STATS_LABEL)}
         </span>
       </Toggle>
       {vpnFeatureEnabled && (
@@ -60,7 +64,7 @@ export function WidgetsPanel() {
         >
           <span className='label'>
             <Icon name='product-vpn' />
-            <span>{getString(S.NEW_TAB_SHOW_VPN_WIDGET_LABEL)}</span>
+            {getString(S.NEW_TAB_SHOW_VPN_WIDGET_LABEL)}
           </span>
         </Toggle>
       )}
@@ -75,7 +79,7 @@ export function WidgetsPanel() {
         >
           <span className='label'>
             <Icon name='product-bat-outline' />
-            <span>{getString(S.NEW_TAB_SHOW_REWARDS_WIDGET_LABEL)}</span>
+            {getString(S.NEW_TAB_SHOW_REWARDS_WIDGET_LABEL)}
           </span>
         </Toggle>
       )}
@@ -90,7 +94,7 @@ export function WidgetsPanel() {
         >
           <span className='label'>
             <Icon name='product-brave-talk' />
-            <span>{getString(S.NEW_TAB_SHOW_TALK_WIDGET_LABEL)}</span>
+            {getString(S.NEW_TAB_SHOW_TALK_WIDGET_LABEL)}
           </span>
         </Toggle>
       )}
@@ -105,10 +109,10 @@ export function WidgetsPanel() {
         >
           <span className='label'>
             <Icon name='product-brave-news' />
-            <span>{getString(S.NEW_TAB_SHOW_NEWS_WIDGET_LABEL)}</span>
+            {getString(S.NEW_TAB_SHOW_NEWS_WIDGET_LABEL)}
           </span>
         </Toggle>
       )}
-    </div>
+    </SettingsPanel>
   )
 }

--- a/browser/resources/brave_new_tab_page_refresh/lib/animated_resize.ts
+++ b/browser/resources/brave_new_tab_page_refresh/lib/animated_resize.ts
@@ -1,0 +1,74 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+
+const resizingAttribute = 'data-resizing'
+
+const animationOptions: KeyframeAnimationOptions = {
+  duration: 180,
+  easing: 'ease-out',
+}
+
+function prefersReducedMotion() {
+  return matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+// Animates the height of an element when its content causes it to resize. The
+// element carries a "data-resizing" attribute while the animation is running,
+// which can be used to hide content that would otherwise overflow. Showing or
+// hiding the element is not animated.
+export function useAnimatedResize(ref: React.RefObject<HTMLElement | null>) {
+  React.useEffect(() => {
+    const elem = ref.current
+    if (!elem) {
+      return
+    }
+
+    let animation: Animation | null = null
+    let height = elem.offsetHeight
+
+    function onResize() {
+      // The running animation is itself a source of resize notifications.
+      if (animation || !elem) {
+        return
+      }
+
+      const previousHeight = height
+      height = elem.offsetHeight
+
+      if (
+        previousHeight === 0
+        || height === 0
+        || previousHeight === height
+        || prefersReducedMotion()
+      ) {
+        return
+      }
+
+      animation = elem.animate(
+        [{ height: `${previousHeight}px` }, { height: `${height}px` }],
+        animationOptions,
+      )
+
+      elem.setAttribute(resizingAttribute, '')
+
+      animation.onfinish = () => {
+        animation = null
+        elem.removeAttribute(resizingAttribute)
+        onResize()
+      }
+    }
+
+    const observer = new ResizeObserver(onResize)
+    observer.observe(elem)
+
+    return () => {
+      observer.disconnect()
+      animation?.cancel()
+      elem.removeAttribute(resizingAttribute)
+    }
+  }, [ref])
+}

--- a/components/resources/brave_new_tab_page_strings.grdp
+++ b/components/resources/brave_new_tab_page_strings.grdp
@@ -226,7 +226,7 @@
   </message>
 
   <message name="IDS_NEW_TAB_SETTINGS_TITLE" desc="Title for settings dialog" formatter_data="webui=BraveNewTabPage">
-    Customize New Tab Page
+    Customize
   </message>
 
   <message name="IDS_NEW_TAB_SHOW_BACKGROUNDS_LABEL" desc="Text for settings background option" formatter_data="webui=BraveNewTabPage">


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57685

## Summary

Updates the desktop New Tab Page Customize dialog to match the new design and improve its layout, sizing, navigation, and controls.

### Dialog shell

- Renames the dialog title from **Customize New Tab Page** to **Customize**.
- Increases the dialog width from 720px to 860px.
- Makes the height content-driven with an 800px maximum and internal scrolling for taller sections.
- Animates height changes when switching sections and background sub-sections, while respecting `prefers-reduced-motion`.
- Moves the close button outside and above the dialog at the top-right.
- Moves the Customize title into the 228px navigation sidebar.
- Adds the inset page-background content area, section heading, rounded settings group, and updated elevation.
- Uses Nala/Leo tokens for colors, spacing, radii, icons, typography, and elevation where available.

### Background images

- Changes background choices to a two-column grid with consistent 4:3 previews.
- Reorders the choices to Brave backgrounds, Use your own, Solid colors, and Gradients.
- Moves the selected check badge to the bottom-right and adds `elevation-01` to selected previews.
- Updates the custom-background remove button to match the design and show on hover or keyboard focus.
- Places **Upload from device** first in the custom-background picker.
- Moves internal titles and their back arrow out of the settings group so they replace the main section title.
- Updates preview, upload, border, spacing, and selection styling.

### Search and AI

- Adds Search and Leo icons to the widget toggle rows.
- Restyles enabled search engines as an inset, bordered list with consistent compact rows and favicon sizing.
- Makes each complete search-engine row, including its padding, clickable to toggle the checkbox.
- Restyles **Customize available engines** as a full-width footer row with a right-aligned external-link icon.

### Cards

- Adds Nala icons to every Cards toggle:
  - Brave Stats: `shield-done`
  - Brave VPN: `product-vpn`
  - Brave Rewards: `product-bat-outline`
  - Brave Talk: `product-brave-talk`
  - Brave News: `product-brave-news`

## Important note

The Brave News customization section is intentionally unchanged because it is separate content and will be handled independently.

## Testing

- `pnpm run build --target=brave/browser/resources/brave_new_tab_page_refresh:resources`
- Manually checked the updated Customize dialog and section layouts on `brave://newtab`.

## Results

<img width="913" height="795" alt="Background images section" src="https://github.com/user-attachments/assets/1574a9b8-8759-403a-b644-2ca11ddff34a" />

<img width="903" height="837" alt="Custom backgrounds section" src="https://github.com/user-attachments/assets/06f18a81-47c0-492c-b1ec-7008418f7341" />

<img width="902" height="738" alt="Search and AI section" src="https://github.com/user-attachments/assets/1f6759f4-946a-4b17-b7bc-871b71792e63" />

<img width="906" height="546" alt="Top sites section" src="https://github.com/user-attachments/assets/c5c73cdb-85b7-46bf-99cc-bef64cc6d0ea" />

<img width="895" height="405" alt="Clock section" src="https://github.com/user-attachments/assets/0c6c4753-0f78-4838-af4e-70c527a17233" />

<img width="903" height="426" alt="Cards section" src="https://github.com/user-attachments/assets/9202d7c5-e322-4a99-9972-c465d4c7a444" />

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->