### PR TITLE
[iOS] Fix open external app confirmation alert redirect flow affecting 1Password login (uplift to 1.93.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabPolicyDecider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabPolicyDecider.swift
@@ -88,10 +88,19 @@ extension BrowserViewController: TabPolicyDecider {
     let isPrivateBrowsing = privateBrowsingManager.isPrivateBrowsing
 
     if tab.isExternalAppAlertPresented == true {
+      // Some external-app schemes may fire the same request back-to-back.
+      // Don't tear down and re-present the alert for a request that matches
+      // the one it's already asking about, otherwise it can dismiss and
+      // presents repeatedly.
+      if tab.externalAppURL == requestURL {
+        return .cancel
+      }
       tab.externalAppPopup?.dismissWithType(dismissType: .noAnimation)
       tab.externalAppPopupContinuation?.resume(with: .success(false))
       tab.externalAppPopupContinuation = nil
       tab.externalAppPopup = nil
+      tab.externalAppURL = nil
+      tab.isExternalAppAlertPresented = false
     }
 
     // Handle internal:// urls
@@ -743,6 +752,7 @@ extension BrowserViewController {
 
       view.endEditing(true)
       tab.isExternalAppAlertPresented = true
+      tab.externalAppURL = url
 
       let popup = AlertPopupView(
         imageView: nil,
@@ -767,6 +777,7 @@ extension BrowserViewController {
           openedURLCompletionHandler(false)
           removeTabIfEmpty()
           tab?.isExternalAppAlertPresented = false
+          tab?.externalAppURL = nil
           return .flyDown
         }
       }
@@ -777,6 +788,7 @@ extension BrowserViewController {
         }
         removeTabIfEmpty()
         tab?.isExternalAppAlertPresented = false
+        tab?.externalAppURL = nil
         return .flyDown
       }
       popup.showWithType(showType: .flyUp)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
@@ -228,12 +228,15 @@ class TabBrowserData: NSObject, TabObserver {
   var externalAppAlertCounter = 0
   var isExternalAppAlertSuppressed = false
   var externalAppURLDomain: String?
+  /// The url the currently presented custom url-scheme alert is asking about
+  var externalAppURL: URL?
 
   func resetExternalAlertProperties() {
     externalAppAlertCounter = 0
     isExternalAppAlertPresented = false
     isExternalAppAlertSuppressed = false
     externalAppURLDomain = nil
+    externalAppURL = nil
   }
 
   /// A list of domains that we want to proceed to anyways regardless of any ad-blocking


### PR DESCRIPTION
Uplift of #38406
Resolves https://github.com/brave/brave-browser/issues/57440

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.