### PR TITLE
ImageLightbox: truncate long filenames and polish preview chrome

### DIFF
--- a/components/ai_chat/resources/page/components/image_lightbox/index.tsx
+++ b/components/ai_chat/resources/page/components/image_lightbox/index.tsx
@@ -210,9 +210,7 @@ export default function ImageLightbox(props: Props) {
                 fab
                 kind='outline'
                 className={
-                  isCopySuccess
-                    ? styles.copyButtonSuccess
-                    : styles.actionButton
+                  isCopySuccess ? styles.copyButtonSuccess : styles.actionButton
                 }
                 title={getLocale(S.CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL)}
                 aria-label={getLocale(

--- a/components/ai_chat/resources/page/components/image_lightbox/index.tsx
+++ b/components/ai_chat/resources/page/components/image_lightbox/index.tsx
@@ -174,7 +174,6 @@ export default function ImageLightbox(props: Props) {
   return (
     <Dialog
       isOpen={!!file}
-      showClose
       escapeCloses
       backdropClickCloses
       onClose={onClose}
@@ -182,51 +181,72 @@ export default function ImageLightbox(props: Props) {
       style={dialogStyle}
     >
       {file && (
-        <div className={styles.card}>
-          <div className={styles.imageContainer}>
-            {dataUrl && (
-              <img
-                className={styles.image}
-                src={dataUrl}
-                alt={title}
-                onLoad={handleImageLoad}
-              />
-            )}
-          </div>
-          <div className={styles.footer}>
-            <div className={styles.info}>
-              <span className={styles.title}>{title}</span>
-              <span className={styles.subtitle}>{filesize}</span>
+        <div className={styles.wrapper}>
+          <Button
+            fab
+            kind='plain-faint'
+            className={styles.closeButton}
+            title={getLocale(S.CHAT_UI_LABEL_CLOSE)}
+            aria-label={getLocale(S.CHAT_UI_LABEL_CLOSE)}
+            onClick={onClose}
+          >
+            <Icon name='close' />
+          </Button>
+          <div className={styles.card}>
+            <div className={styles.imageContainer}>
+              {dataUrl && (
+                <img
+                  className={styles.image}
+                  src={dataUrl}
+                  alt={title}
+                  onLoad={handleImageLoad}
+                />
+              )}
             </div>
-            <div className={styles.actions}>
-              <Button
-                fab
-                kind='outline'
-                className={
-                  isCopySuccess ? styles.copyButtonSuccess : styles.actionButton
-                }
-                title={getLocale(S.CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL)}
-                aria-label={getLocale(
-                  S.CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL,
-                )}
-                onClick={handleCopy}
-              >
-                <Icon name={isCopySuccess ? 'check-normal' : 'copy'} />
-              </Button>
-              <Button
-                fab
-                kind='outline'
-                className={styles.actionButton}
-                title={getLocale(
-                  S.CHAT_UI_IMAGE_LIGHTBOX_DOWNLOAD_BUTTON_LABEL,
-                )}
-                aria-label={getLocale(
-                  S.CHAT_UI_IMAGE_LIGHTBOX_DOWNLOAD_BUTTON_LABEL,
-                )}
-                onClick={handleDownload}
-              >
-                <Icon name='download' />
-              </Button>
+            <div className={styles.footer}>
+              <div className={styles.info}>
+                <div className={styles.forEllipsis}>
+                  <span
+                    className={styles.title}
+                    title={title}
+                  >
+                    {title}
+                  </span>
+                </div>
+                <span className={styles.subtitle}>{filesize}</span>
+              </div>
+              <div className={styles.actions}>
+                <Button
+                  fab
+                  kind='outline'
+                  className={
+                    isCopySuccess
+                      ? styles.copyButtonSuccess
+                      : styles.actionButton
+                  }
+                  title={getLocale(S.CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL)}
+                  aria-label={getLocale(
+                    S.CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL,
+                  )}
+                  onClick={handleCopy}
+                >
+                  <Icon name={isCopySuccess ? 'check-normal' : 'copy'} />
+                </Button>
+                <Button
+                  fab
+                  kind='outline'
+                  className={styles.actionButton}
+                  title={getLocale(
+                    S.CHAT_UI_IMAGE_LIGHTBOX_DOWNLOAD_BUTTON_LABEL,
+                  )}
+                  aria-label={getLocale(
+                    S.CHAT_UI_IMAGE_LIGHTBOX_DOWNLOAD_BUTTON_LABEL,
+                  )}
+                  onClick={handleDownload}
+                >
+                  <Icon name='download' />
+                </Button>
+              </div>
             </div>
           </div>
         </div>

--- a/components/ai_chat/resources/page/components/image_lightbox/index.tsx
+++ b/components/ai_chat/resources/page/components/image_lightbox/index.tsx
@@ -174,6 +174,7 @@ export default function ImageLightbox(props: Props) {
   return (
     <Dialog
       isOpen={!!file}
+      showClose
       escapeCloses
       backdropClickCloses
       onClose={onClose}
@@ -181,72 +182,60 @@ export default function ImageLightbox(props: Props) {
       style={dialogStyle}
     >
       {file && (
-        <div className={styles.wrapper}>
-          <Button
-            fab
-            kind='plain-faint'
-            className={styles.closeButton}
-            title={getLocale(S.CHAT_UI_LABEL_CLOSE)}
-            aria-label={getLocale(S.CHAT_UI_LABEL_CLOSE)}
-            onClick={onClose}
-          >
-            <Icon name='close' />
-          </Button>
-          <div className={styles.card}>
-            <div className={styles.imageContainer}>
-              {dataUrl && (
-                <img
-                  className={styles.image}
-                  src={dataUrl}
-                  alt={title}
-                  onLoad={handleImageLoad}
-                />
-              )}
+        <div className={styles.card}>
+          <div className={styles.imageContainer}>
+            {dataUrl && (
+              <img
+                className={styles.image}
+                src={dataUrl}
+                alt={title}
+                onLoad={handleImageLoad}
+              />
+            )}
+          </div>
+          <div className={styles.footer}>
+            <div className={styles.info}>
+              <div className={styles.forEllipsis}>
+                <span
+                  className={styles.title}
+                  title={title}
+                >
+                  {title}
+                </span>
+              </div>
+              <span className={styles.subtitle}>{filesize}</span>
             </div>
-            <div className={styles.footer}>
-              <div className={styles.info}>
-                <div className={styles.forEllipsis}>
-                  <span
-                    className={styles.title}
-                    title={title}
-                  >
-                    {title}
-                  </span>
-                </div>
-                <span className={styles.subtitle}>{filesize}</span>
-              </div>
-              <div className={styles.actions}>
-                <Button
-                  fab
-                  kind='outline'
-                  className={
-                    isCopySuccess
-                      ? styles.copyButtonSuccess
-                      : styles.actionButton
-                  }
-                  title={getLocale(S.CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL)}
-                  aria-label={getLocale(
-                    S.CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL,
-                  )}
-                  onClick={handleCopy}
-                >
-                  <Icon name={isCopySuccess ? 'check-normal' : 'copy'} />
-                </Button>
-                <Button
-                  fab
-                  kind='outline'
-                  className={styles.actionButton}
-                  title={getLocale(
-                    S.CHAT_UI_IMAGE_LIGHTBOX_DOWNLOAD_BUTTON_LABEL,
-                  )}
-                  aria-label={getLocale(
-                    S.CHAT_UI_IMAGE_LIGHTBOX_DOWNLOAD_BUTTON_LABEL,
-                  )}
-                  onClick={handleDownload}
-                >
-                  <Icon name='download' />
-                </Button>
-              </div>
+            <div className={styles.actions}>
+              <Button
+                fab
+                kind='outline'
+                className={
+                  isCopySuccess
+                    ? styles.copyButtonSuccess
+                    : styles.actionButton
+                }
+                title={getLocale(S.CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL)}
+                aria-label={getLocale(
+                  S.CHAT_UI_IMAGE_LIGHTBOX_COPY_BUTTON_LABEL,
+                )}
+                onClick={handleCopy}
+              >
+                <Icon name={isCopySuccess ? 'check-normal' : 'copy'} />
+              </Button>
+              <Button
+                fab
+                kind='outline'
+                className={styles.actionButton}
+                title={getLocale(
+                  S.CHAT_UI_IMAGE_LIGHTBOX_DOWNLOAD_BUTTON_LABEL,
+                )}
+                aria-label={getLocale(
+                  S.CHAT_UI_IMAGE_LIGHTBOX_DOWNLOAD_BUTTON_LABEL,
+                )}
+                onClick={handleDownload}
+              >
+                <Icon name='download' />
+              </Button>
             </div>
           </div>
         </div>

--- a/components/ai_chat/resources/page/components/image_lightbox/style.module.scss
+++ b/components/ai_chat/resources/page/components/image_lightbox/style.module.scss
@@ -33,6 +33,7 @@
 
 .closeButton {
   --leo-icon-color: var(--leo-color-icon-default);
+  --leo-button-color: var(--leo-color-icon-default);
 
   align-self: flex-end;
   flex-shrink: 0;

--- a/components/ai_chat/resources/page/components/image_lightbox/style.module.scss
+++ b/components/ai_chat/resources/page/components/image_lightbox/style.module.scss
@@ -39,6 +39,7 @@
   width: 100%;
   min-width: 0;
   overflow: hidden;
+  background-color: var(--leo-color-black);
 }
 
 .image {

--- a/components/ai_chat/resources/page/components/image_lightbox/style.module.scss
+++ b/components/ai_chat/resources/page/components/image_lightbox/style.module.scss
@@ -9,6 +9,34 @@
   --leo-dialog-background: transparent;
   background: transparent;
   box-shadow: none;
+  overflow: visible;
+
+  // Leo Dialog is a web component; className lands on the host. Pin the
+  // slotted content width so a long filename cannot expand the dialog past
+  // --leo-dialog-width (which is only applied as max-width inside the
+  // shadow tree).
+  & > * {
+    width: min(var(--leo-dialog-width), 100%);
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+  }
+}
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  // 8px gap between the close control and the top of the card.
+  gap: var(--leo-spacing-m);
+  overflow: hidden;
+}
+
+.closeButton {
+  --leo-icon-color: var(--leo-color-icon-default);
+
+  align-self: flex-end;
+  flex-shrink: 0;
+  color: var(--leo-color-white);
 }
 
 .card {
@@ -16,6 +44,7 @@
   flex-direction: column;
   overflow: hidden;
   width: 100%;
+  min-width: 0;
   border-radius: var(--leo-radius-xl);
   background-color: var(--leo-color-container-background);
 }
@@ -23,6 +52,8 @@
 .imageContainer {
   // Width follows the dialog; height comes from the image aspect ratio.
   width: 100%;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .image {
@@ -39,14 +70,27 @@
   gap: var(--leo-spacing-l);
   padding: var(--leo-spacing-xl);
   background-color: var(--leo-color-container-background);
+  min-width: 0;
+  width: 100%;
+  overflow: hidden;
+  box-sizing: border-box;
 }
 
 .info {
   display: flex;
+  flex: 1 1 auto;
   flex-direction: column;
   gap: var(--leo-spacing-xs);
   min-width: 0;
-  flex: 1 1 auto;
+  overflow: hidden;
+}
+
+// Same pattern as attachment_item: a grid wrapper is needed for reliable
+// text-overflow ellipsis inside flex layouts.
+.forEllipsis {
+  display: grid;
+  width: 100%;
+  min-width: 0;
 }
 
 .title {

--- a/components/ai_chat/resources/page/components/image_lightbox/style.module.scss
+++ b/components/ai_chat/resources/page/components/image_lightbox/style.module.scss
@@ -7,9 +7,10 @@
   --leo-dialog-padding: 0;
   --leo-dialog-width: min(90vw, 720px);
   --leo-dialog-background: transparent;
+  // Colors the built-in showClose plain-faint button (inherits into shadow DOM).
+  --leo-button-color: var(--leo-color-white);
   background: transparent;
   box-shadow: none;
-  overflow: visible;
 
   // Leo Dialog is a web component; className lands on the host. Pin the
   // slotted content width so a long filename cannot expand the dialog past
@@ -21,23 +22,6 @@
     min-width: 0;
     box-sizing: border-box;
   }
-}
-
-.wrapper {
-  display: flex;
-  flex-direction: column;
-  // 8px gap between the close control and the top of the card.
-  gap: var(--leo-spacing-m);
-  overflow: hidden;
-}
-
-.closeButton {
-  --leo-icon-color: var(--leo-color-icon-default);
-  --leo-button-color: var(--leo-color-icon-default);
-
-  align-self: flex-end;
-  flex-shrink: 0;
-  color: var(--leo-color-white);
 }
 
 .card {


### PR DESCRIPTION
## Summary
- Truncate long image filenames in the Leo AI Chat image lightbox with an ellipsis so they no longer expand the dialog past its fitted width
- Pin slotted content width to `--leo-dialog-width` and use a `forEllipsis` grid (same pattern as attachment items) so truncation works inside Leo Dialog's web component / flex layout
- Keep Leo Dialog's built-in close control (`showClose`), colored white via `--leo-button-color: var(--leo-color-white)`
- Give the image preview area a black background (`--leo-color-black`)

- Resolves https://github.com/brave/brave-browser/issues/57692

## Result


<img width="441" height="427" alt="image" src="https://github.com/user-attachments/assets/78304312-f79f-425c-ba19-068cf76b5e8c" />


## Test plan
- [ ] Open Leo AI Chat and upload an image with a **short** filename
  - [ ] Lightbox opens and shows the full filename
  - [ ] Image preview sits on a black background
  - [ ] Image, filesize, copy, and download controls look correct
- [ ] Upload an image with a **very long** filename (e.g. `tobias-van-schneider-88137-unsplash.jpg` or longer)
  - [ ] Filename truncates with an ellipsis and does **not** widen the dialog past the image width
  - [ ] Hovering the truncated title shows the full filename in a tooltip
  - [ ] Copy and download buttons remain fully visible and usable
- [ ] Close button
  - [ ] Built-in Dialog close (X) appears and is white
  - [ ] Clicking X closes the lightbox
  - [ ] Escape and backdrop click still close the lightbox
- [ ] Copy / download
  - [ ] Copy shows the success (check) state briefly, then returns to the copy icon
  - [ ] Download saves the image with the original filename
- [ ] Also verify with a full-page screenshot attachment (localized title) and with a narrow/small image so the dialog is image-sized