### PR TITLE
[PSST] Add prefs observer to refresh omnibar icon state

### DIFF
--- a/browser/psst/psst_settings_service_factory.cc
+++ b/browser/psst/psst_settings_service_factory.cc
@@ -46,5 +46,6 @@ PsstSettingsServiceFactory::BuildServiceInstanceForBrowserContext(
     content::BrowserContext* context) const {
   auto* profile = Profile::FromBrowserContext(context);
   auto* map = HostContentSettingsMapFactory::GetForProfile(profile);
-  return std::make_unique<psst::PsstSettingsService>(CHECK_DEREF(map));
+  return std::make_unique<psst::PsstSettingsService>(CHECK_DEREF(map),
+                                                     profile->GetPrefs());
 }

--- a/browser/psst/psst_tab_web_contents_observer.cc
+++ b/browser/psst/psst_tab_web_contents_observer.cc
@@ -159,9 +159,13 @@ PsstTabWebContentsObserver::PsstTabWebContentsObserver(
     : tabs::ContentsObservingTabFeature(tab),
       registry_(registry),
       psst_settings_service_(psst_settings_service),
-      ui_delegate_(std::move(ui_delegate)) {}
+      ui_delegate_(std::move(ui_delegate)) {
+  psst_settings_service_->AddObserver(this);
+}
 
-PsstTabWebContentsObserver::~PsstTabWebContentsObserver() = default;
+PsstTabWebContentsObserver::~PsstTabWebContentsObserver() {
+  psst_settings_service_->RemoveObserver(this);
+}
 
 PsstTabWebContentsObserver::PsstUiDelegate*
 PsstTabWebContentsObserver::GetPsstUiDelegate() const {
@@ -173,9 +177,7 @@ PsstTabWebContentsObserver::AsWeakPtr() {
 }
 
 void PsstTabWebContentsObserver::PrimaryPageChanged(content::Page& page) {
-  script_injector_remote_.reset();
-  page_weak_factory_.InvalidateWeakPtrs();
-  should_process_current_page_ = false;
+  CancelInFlightFlow();
 }
 
 void PsstTabWebContentsObserver::DidFinishNavigation(
@@ -355,6 +357,19 @@ void PsstTabWebContentsObserver::SetInjectAsyncScriptCallback(
     InjectScriptAsyncCallback inject_async_script_callback) {
   CHECK(!inject_async_script_callback.is_null());
   inject_async_script_callback_ = std::move(inject_async_script_callback);
+}
+
+void PsstTabWebContentsObserver::CancelInFlightFlow() {
+  script_injector_remote_.reset();
+  page_weak_factory_.InvalidateWeakPtrs();
+  should_process_current_page_ = false;
+}
+
+void PsstTabWebContentsObserver::OnPsstEnableChange(bool new_value) {
+  if (new_value) {
+    return;
+  }
+  CancelInFlightFlow();
 }
 
 }  // namespace psst

--- a/browser/psst/psst_tab_web_contents_observer.cc
+++ b/browser/psst/psst_tab_web_contents_observer.cc
@@ -90,10 +90,10 @@ PsstTabWebContentsObserver::MaybeCreateForWebContents(
     tabs::TabInterface& tab,
     content::BrowserContext* browser_context,
     std::unique_ptr<PsstUiDelegate> ui_delegate,
-    PrefService* prefs,
+    PsstSettingsService* psst_settings_service,
     const int32_t world_id) {
   CHECK(browser_context);
-  CHECK(prefs);
+  CHECK(psst_settings_service);
   CHECK(ui_delegate);
 
   if (browser_context->IsOffTheRecord() ||
@@ -103,7 +103,8 @@ PsstTabWebContentsObserver::MaybeCreateForWebContents(
 
   auto observer = base::WrapUnique<PsstTabWebContentsObserver>(
       new PsstTabWebContentsObserver(tab, PsstRuleRegistry::GetInstance(),
-                                     prefs, std::move(ui_delegate)));
+                                     psst_settings_service,
+                                     std::move(ui_delegate)));
 
   auto inject_script_callback = base::BindRepeating(
       [](base::WeakPtr<PsstTabWebContentsObserver> self, int32_t world_id,
@@ -153,11 +154,11 @@ PsstTabWebContentsObserver::MaybeCreateForWebContents(
 PsstTabWebContentsObserver::PsstTabWebContentsObserver(
     tabs::TabInterface& tab,
     PsstRuleRegistry* registry,
-    PrefService* prefs,
+    PsstSettingsService* psst_settings_service,
     std::unique_ptr<PsstUiDelegate> ui_delegate)
     : tabs::ContentsObservingTabFeature(tab),
       registry_(registry),
-      prefs_(prefs),
+      psst_settings_service_(psst_settings_service),
       ui_delegate_(std::move(ui_delegate)) {}
 
 PsstTabWebContentsObserver::~PsstTabWebContentsObserver() = default;
@@ -187,7 +188,7 @@ void PsstTabWebContentsObserver::DidFinishNavigation(
   should_process_current_page_ =
       handle->GetURL().SchemeIsHTTPOrHTTPS() &&
       handle->GetRestoreType() != content::RestoreType::kRestored &&
-      prefs_->GetBoolean(prefs::kPsstEnabled);
+      psst_settings_service_->IsPsstEnabled();
 }
 
 void PsstTabWebContentsObserver::DocumentOnLoadCompletedInPrimaryMainFrame() {

--- a/browser/psst/psst_tab_web_contents_observer.h
+++ b/browser/psst/psst_tab_web_contents_observer.h
@@ -27,7 +27,7 @@ class MatchedRule;
 class PsstRuleRegistry;
 
 class PsstTabWebContentsObserver : public tabs::ContentsObservingTabFeature,
-                                   public PsstSettingsService::Observer {
+                                   public PsstSettingsService::PrefObserver {
  public:
   using InsertScriptInPageCallback = base::OnceCallback<void(base::Value)>;
   using InsertScriptInPageTimeoutCallback =

--- a/browser/psst/psst_tab_web_contents_observer.h
+++ b/browser/psst/psst_tab_web_contents_observer.h
@@ -26,7 +26,8 @@ namespace psst {
 class MatchedRule;
 class PsstRuleRegistry;
 
-class PsstTabWebContentsObserver : public tabs::ContentsObservingTabFeature {
+class PsstTabWebContentsObserver : public tabs::ContentsObservingTabFeature,
+                                   public PsstSettingsService::Observer {
  public:
   using InsertScriptInPageCallback = base::OnceCallback<void(base::Value)>;
   using InsertScriptInPageTimeoutCallback =
@@ -108,6 +109,10 @@ class PsstTabWebContentsObserver : public tabs::ContentsObservingTabFeature {
   void SetInjectScriptCallback(InjectScriptCallback inject_script_callback);
   void SetInjectAsyncScriptCallback(
       InjectScriptAsyncCallback inject_async_script_callback);
+  void CancelInFlightFlow();
+
+  // PsstSettingsService::Observer
+  void OnPsstEnableChange(bool new_value) override;
 
   const raw_ptr<PsstRuleRegistry> registry_;
   const raw_ptr<PsstSettingsService> psst_settings_service_ = nullptr;

--- a/browser/psst/psst_tab_web_contents_observer.h
+++ b/browser/psst/psst_tab_web_contents_observer.h
@@ -21,8 +21,6 @@
 #include "chrome/browser/ui/tabs/contents_observing_tab_feature.h"
 #include "mojo/public/cpp/bindings/associated_remote.h"
 
-class PrefService;
-
 namespace psst {
 
 class MatchedRule;

--- a/browser/psst/psst_tab_web_contents_observer.h
+++ b/browser/psst/psst_tab_web_contents_observer.h
@@ -13,6 +13,7 @@
 #include "base/memory/weak_ptr.h"
 #include "base/timer/timer.h"
 #include "base/values.h"
+#include "brave/components/psst/core/browser/psst_settings_service.h"
 #include "brave/components/psst/core/common/psst_metadata_schema.h"
 #include "brave/components/psst/core/common/psst_script_responses.h"
 #include "brave/components/psst/core/common/psst_ui_common.mojom-shared.h"
@@ -67,7 +68,7 @@ class PsstTabWebContentsObserver : public tabs::ContentsObservingTabFeature {
       tabs::TabInterface& tab,
       content::BrowserContext* browser_context,
       std::unique_ptr<PsstUiDelegate> ui_delegate,
-      PrefService* prefs,
+      PsstSettingsService* psst_settings_service,
       const int32_t world_id);
 
   ~PsstTabWebContentsObserver() override;
@@ -83,7 +84,7 @@ class PsstTabWebContentsObserver : public tabs::ContentsObservingTabFeature {
 
   PsstTabWebContentsObserver(tabs::TabInterface& tab,
                              PsstRuleRegistry* registry,
-                             PrefService* prefs,
+                             PsstSettingsService* psst_settings_service,
                              std::unique_ptr<PsstUiDelegate> ui_delegate);
 
   void InsertUserScript(std::unique_ptr<MatchedRule> rule);
@@ -111,7 +112,7 @@ class PsstTabWebContentsObserver : public tabs::ContentsObservingTabFeature {
       InjectScriptAsyncCallback inject_async_script_callback);
 
   const raw_ptr<PsstRuleRegistry> registry_;
-  const raw_ptr<PrefService> prefs_;
+  const raw_ptr<PsstSettingsService> psst_settings_service_ = nullptr;
   InjectScriptCallback inject_script_callback_;
   mojo::AssociatedRemote<script_injector::mojom::ScriptInjector>
       script_injector_remote_;

--- a/browser/psst/psst_tab_web_contents_observer_browsertest.cc
+++ b/browser/psst/psst_tab_web_contents_observer_browsertest.cc
@@ -813,9 +813,10 @@ IN_PROC_BROWSER_TEST_F(PsstTabWebContentsObserverBrowserTest,
   ASSERT_TRUE(confirm_delegate);
   EXPECT_EQ(confirm_delegate->GetIdentifier(),
             infobars::InfoBarDelegate::BRAVE_PSST_INFOBAR_DELEGATE);
+  // Dismissing the infobar disables PSST, which in turn removes the infobar.
   confirm_delegate->InfoBarDismissed();
-  manager->RemoveInfoBar(psst_infobar);
   ASSERT_TRUE(infobar_observer.WaitForInfobarRemoved());
+  EXPECT_FALSE(GetPsstInfobar(manager));
 
   // Wait for console message only from user script
   ASSERT_TRUE(console_observer.Wait());

--- a/browser/psst/psst_tab_web_contents_observer_browsertest.cc
+++ b/browser/psst/psst_tab_web_contents_observer_browsertest.cc
@@ -622,6 +622,23 @@ class PsstTabWebContentsObserverBrowserTest : public PlatformBrowserTest {
         kActionShowPsstIcon);
   }
 
+  // Navigates to `url` and waits for the PSST icon to appear in the location
+  // bar.
+  void NavigateAndWaitForPsstIconVisible(const GURL& url) {
+    IconLabelBubbleView* const psst_view = GetPsstPageActionView();
+    ASSERT_TRUE(psst_view);
+    // The icon starts hidden and only appears as a result of the navigation.
+    ASSERT_FALSE(psst_view->GetVisible());
+
+    ASSERT_TRUE(content::NavigateToURL(web_contents(), url));
+
+    // The icon appears once the PSST user script detects a matching rule.
+    ASSERT_TRUE(base::test::RunUntil([&]() {
+      views::test::RunScheduledLayout(psst_view);
+      return psst_view->GetVisible();
+    }));
+  }
+
   // Navigates to `url`, waits for the PSST icon to appear in the location bar,
   // then clicks it with the specified `event_flags` to open its context menu
   // and waits for the menu to appear, or opens the consent dialog and waits
@@ -633,22 +650,15 @@ class PsstTabWebContentsObserverBrowserTest : public PlatformBrowserTest {
       content::WebContents** dialog_wc_out = nullptr) {
     ASSERT_TRUE(event_flags == ui::EF_RIGHT_MOUSE_BUTTON ||
                 event_flags == ui::EF_LEFT_MOUSE_BUTTON);
-    IconLabelBubbleView* const psst_view = GetPsstPageActionView();
-    ASSERT_TRUE(psst_view);
-    // The icon starts hidden and only appears as a result of the navigation.
-    ASSERT_FALSE(psst_view->GetVisible());
 
     actions::ActionItem* const action =
         actions::ActionManager::Get().FindAction(kActionShowPsstIcon);
     ASSERT_TRUE(action);
 
-    ASSERT_TRUE(content::NavigateToURL(web_contents(), url));
+    ASSERT_NO_FATAL_FAILURE(NavigateAndWaitForPsstIconVisible(url));
 
-    // The icon appears once the PSST user script detects a matching rule.
-    ASSERT_TRUE(base::test::RunUntil([&]() {
-      views::test::RunScheduledLayout(psst_view);
-      return psst_view->GetVisible();
-    }));
+    IconLabelBubbleView* const psst_view = GetPsstPageActionView();
+    ASSERT_TRUE(psst_view);
     ASSERT_FALSE(action->GetIsShowingBubble());
 
     // Start observing for the consent dialog's WebContents before clicking, so
@@ -951,6 +961,23 @@ IN_PROC_BROWSER_TEST_F(PsstTabWebContentsObserverBrowserTest,
 
   // PSST is disabled globally.
   EXPECT_FALSE(GetPrefs()->GetBoolean(prefs::kPsstEnabled));
+}
+
+// The PSST icon appears in the location bar after navigating to a matching
+// site, and turning off the PSST pref while the page stays loaded hides the
+// icon.
+IN_PROC_BROWSER_TEST_F(PsstTabWebContentsObserverBrowserTest,
+                       LocationBarIconHiddenWhenPsstPrefDisabled) {
+  GetPrefs()->SetBoolean(prefs::kPsstEnabled, true);
+  ASSERT_TRUE(GetPrefs()->GetBoolean(prefs::kPsstEnabled));
+
+  const GURL url = GetEmbeddedTestServer().GetURL("a.test", "/a_test_0.html");
+  ASSERT_NO_FATAL_FAILURE(NavigateAndWaitForPsstIconVisible(url));
+
+  // Disabling PSST refreshes the icon state without a navigation.
+  GetPrefs()->SetBoolean(prefs::kPsstEnabled, false);
+
+  ASSERT_NO_FATAL_FAILURE(WaitForPsstIconHidden());
 }
 
 IN_PROC_BROWSER_TEST_F(PsstTabWebContentsObserverBrowserTest,

--- a/browser/psst/psst_tab_web_contents_observer_unittest.cc
+++ b/browser/psst/psst_tab_web_contents_observer_unittest.cc
@@ -23,6 +23,7 @@
 #include "base/test/test_future.h"
 #include "base/time/time.h"
 #include "base/values.h"
+#include "brave/browser/psst/psst_settings_service_factory.h"
 #include "brave/components/psst/core/browser/pref_names.h"
 #include "brave/components/psst/core/browser/psst_rule_registry.h"
 #include "brave/components/psst/core/common/features.h"
@@ -221,8 +222,12 @@ class PsstTabWebContentsObserverUnitTestBase
     ON_CALL(mock_tab, GetContents())
         .WillByDefault(testing::Return(web_contents()));
 
+    psst_settings_service_ =
+        PsstSettingsServiceFactory::GetInstance()->GetForProfile(profile());
+
     psst_web_contents_observer_ = base::WrapUnique<PsstTabWebContentsObserver>(
-        new PsstTabWebContentsObserver(mock_tab, rule_registry_.get(), &prefs_,
+        new PsstTabWebContentsObserver(mock_tab, rule_registry_.get(),
+                                       psst_settings_service_,
                                        std::move(ui_delegate)));
     psst_web_contents_observer_->SetInjectScriptCallback(
         inject_script_callback_.Get());
@@ -231,12 +236,13 @@ class PsstTabWebContentsObserverUnitTestBase
   }
 
   void TearDown() override {
-    ChromeRenderViewHostTestHarness::TearDown();
     ui_delegate_ = nullptr;
+    psst_web_contents_observer_.reset();
+    psst_settings_service_ = nullptr;
+    ChromeRenderViewHostTestHarness::TearDown();
   }
 
   MockPsstRuleRegistry& psst_rule_registry() { return *rule_registry_.get(); }
-  PrefService* prefs() { return &prefs_; }
 
   MatchedRule* CreateMatchedRule(const std::string& user_script,
                                  const std::string& policy_script,
@@ -258,6 +264,10 @@ class PsstTabWebContentsObserverUnitTestBase
 
   tabs::MockTabInterface& mock_tab_interface() { return mock_tab; }
 
+  PsstSettingsService* psst_settings_service() {
+    return psst_settings_service_;
+  }
+
  protected:
   base::test::ScopedFeatureList feature_list_;
 
@@ -270,6 +280,7 @@ class PsstTabWebContentsObserverUnitTestBase
   std::unique_ptr<MockPsstRuleRegistry> rule_registry_;
   std::unique_ptr<PsstTabWebContentsObserver> psst_web_contents_observer_;
   sync_preferences::TestingPrefServiceSyncable prefs_;
+  raw_ptr<PsstSettingsService> psst_settings_service_;
   tabs::MockTabInterface mock_tab;
 };
 
@@ -293,7 +304,7 @@ class PsstTabWebContentsObserverUnitTest
 TEST_F(PsstTabWebContentsObserverUnitTest, CreateForRegularBrowserContext) {
   EXPECT_NE(PsstTabWebContentsObserver::MaybeCreateForWebContents(
                 mock_tab_interface(), browser_context(),
-                std::make_unique<MockUiDelegate>(), prefs(), 2),
+                std::make_unique<MockUiDelegate>(), psst_settings_service(), 2),
             nullptr);
 }
 
@@ -307,7 +318,7 @@ TEST_F(PsstTabWebContentsObserverUnitTest,
 
   EXPECT_EQ(PsstTabWebContentsObserver::MaybeCreateForWebContents(
                 mock_tab_interface(), otr_profile,
-                std::make_unique<MockUiDelegate>(), prefs(), 2),
+                std::make_unique<MockUiDelegate>(), psst_settings_service(), 2),
             nullptr);
 }
 
@@ -633,7 +644,7 @@ TEST_F(PsstTabWebContentsObserverUnitTest, DefaultPrefEnabledShouldProcess) {
 }
 
 TEST_F(PsstTabWebContentsObserverUnitTest, PrefDisabledDontProcess) {
-  prefs()->SetBoolean(prefs::kPsstEnabled, false);
+  psst_settings_service()->SetPsstEnabled(false);
   EXPECT_CALL(psst_rule_registry(), CheckIfMatch(url_, _)).Times(0);
   DocumentOnLoadObserver observer(web_contents());
   content::NavigationSimulator::NavigateAndCommitFromBrowser(web_contents(),
@@ -1190,7 +1201,7 @@ class PsstTabWebContentsObserverFeatureDisabledUnitTest
 TEST_F(PsstTabWebContentsObserverFeatureDisabledUnitTest, DontCreate) {
   EXPECT_EQ(PsstTabWebContentsObserver::MaybeCreateForWebContents(
                 mock_tab_interface(), browser_context(),
-                std::make_unique<MockUiDelegate>(), prefs(), 2),
+                std::make_unique<MockUiDelegate>(), psst_settings_service(), 2),
             nullptr);
 }
 

--- a/browser/psst/psst_ui_delegate_impl.cc
+++ b/browser/psst/psst_ui_delegate_impl.cc
@@ -7,6 +7,7 @@
 
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
+#include "base/logging.h"
 #include "brave/components/psst/core/browser/pref_names.h"
 #include "brave/components/psst/core/common/psst_metadata_schema.h"
 #include "components/prefs/pref_service.h"
@@ -29,8 +30,11 @@ PsstUiDelegateImpl::PsstUiDelegateImpl(
   CHECK(psst_settings_service_);
   CHECK(ui_presenter_);
   CHECK(prefs_);
+  psst_settings_service_->AddObserver(this);
 }
-PsstUiDelegateImpl::~PsstUiDelegateImpl() = default;
+PsstUiDelegateImpl::~PsstUiDelegateImpl() {
+  psst_settings_service_->RemoveObserver(this);
+}
 
 void PsstUiDelegateImpl::Show(
     url::Origin origin,
@@ -167,7 +171,7 @@ void PsstUiDelegateImpl::OnUserAcceptedInfobar(const bool is_accepted) {
     ui_presenter_->ShowConsentDialog();
   } else {
     // Disable PSST if user declined the infobar
-    prefs_->SetBoolean(prefs::kPsstEnabled, false);
+    psst_settings_service_->SetPsstEnabled(false);
   }
 }
 
@@ -184,8 +188,20 @@ void PsstUiDelegateImpl::OnDontShowForThisSite() {
 }
 
 void PsstUiDelegateImpl::OnDisablePrivacySettingsTuning() {
-  prefs_->SetBoolean(prefs::kPsstEnabled, false);
+  psst_settings_service_->SetPsstEnabled(false);
   ui_presenter_->HideInfoBar();
+  ui_presenter_->SetLocationBarIconStatus(LocationBarIconStatus::kHidden,
+                                          base::NullCallback(),
+                                          base::NullCallback());
+}
+
+void PsstUiDelegateImpl::OnPsstEnableChange(bool new_value) {
+  if (new_value) {
+    return;
+  }
+
+  ui_presenter_->HideInfoBar();
+  ui_presenter_->HideConsentDialog();
   ui_presenter_->SetLocationBarIconStatus(LocationBarIconStatus::kHidden,
                                           base::NullCallback(),
                                           base::NullCallback());

--- a/browser/psst/psst_ui_delegate_impl.h
+++ b/browser/psst/psst_ui_delegate_impl.h
@@ -23,7 +23,7 @@ class PrefService;
 namespace psst {
 
 class PsstUiDelegateImpl : public PsstTabWebContentsObserver::PsstUiDelegate,
-                           public PsstSettingsService::Observer {
+                           public PsstSettingsService::PrefObserver {
  public:
   class Observer : public base::CheckedObserver {
    public:

--- a/browser/psst/psst_ui_delegate_impl.h
+++ b/browser/psst/psst_ui_delegate_impl.h
@@ -22,7 +22,8 @@ class PrefService;
 
 namespace psst {
 
-class PsstUiDelegateImpl : public PsstTabWebContentsObserver::PsstUiDelegate {
+class PsstUiDelegateImpl : public PsstTabWebContentsObserver::PsstUiDelegate,
+                           public PsstSettingsService::Observer {
  public:
   class Observer : public base::CheckedObserver {
    public:
@@ -64,6 +65,7 @@ class PsstUiDelegateImpl : public PsstTabWebContentsObserver::PsstUiDelegate {
   void OnUserAcceptedInfobar(const bool is_accepted);
   void OnDontShowForThisSite();
   void OnDisablePrivacySettingsTuning();
+  void OnPsstEnableChange(bool new_value) override;
 
   std::unique_ptr<PsstUiPresenter> ui_presenter_;
   std::optional<PsstWebsiteSettings> dialog_data_;

--- a/browser/psst/psst_ui_desktop_presenter.cc
+++ b/browser/psst/psst_ui_desktop_presenter.cc
@@ -225,6 +225,14 @@ void PsstUiDesktopPresenter::ShowConsentDialog() {
   dialog_delegate_ = OpenPsstDialog(web_contents_.get());
 }
 
+void PsstUiDesktopPresenter::HideConsentDialog() {
+  if (!dialog_delegate_) {
+    return;
+  }
+
+  dialog_delegate_->CloseDialog();
+}
+
 bool PsstUiDesktopPresenter::IsDialogShown() const {
   if (!dialog_delegate_) {
     return false;

--- a/browser/psst/psst_ui_desktop_presenter.h
+++ b/browser/psst/psst_ui_desktop_presenter.h
@@ -71,6 +71,8 @@ class PsstUiDesktopPresenter
 
   void ShowConsentDialog() override;
 
+  void HideConsentDialog() override;
+
   bool IsDialogShown() const override;
 
  private:

--- a/browser/psst/psst_ui_presenter.h
+++ b/browser/psst/psst_ui_presenter.h
@@ -32,6 +32,7 @@ class PsstUiPresenter {
   virtual void ShowInfoBar(InfoBarCallback on_accept_callback) = 0;
   virtual void HideInfoBar() = 0;
   virtual void ShowConsentDialog() = 0;
+  virtual void HideConsentDialog() = 0;
   virtual bool IsDialogShown() const = 0;
 };
 

--- a/browser/ui/tabs/brave_tab_features.cc
+++ b/browser/ui/tabs/brave_tab_features.cc
@@ -82,16 +82,17 @@ void BraveTabFeatures::Init(TabInterface& tab, Profile* profile) {
     psst_action_controller_ =
         std::make_unique<page_actions::PsstActionController>(
             tab, *page_action_controller());
+    auto* psst_settings_service =
+        PsstSettingsServiceFactory::GetForProfile(profile);
     psst_web_contents_observer_ =
         psst::PsstTabWebContentsObserver::MaybeCreateForWebContents(
             tab, profile,
             std::make_unique<psst::PsstUiDelegateImpl>(
-                PsstSettingsServiceFactory::GetForProfile(profile),
-                profile->GetPrefs(),
+                psst_settings_service, profile->GetPrefs(),
                 std::make_unique<psst::PsstUiDesktopPresenter>(
                     tab.GetContents()->GetWeakPtr(),
                     psst_action_controller_->AsWeakPtr())),
-            profile->GetPrefs(), ISOLATED_WORLD_ID_BRAVE_INTERNAL);
+            psst_settings_service, ISOLATED_WORLD_ID_BRAVE_INTERNAL);
   }
 #endif
 

--- a/components/psst/core/browser/psst_settings_service.cc
+++ b/components/psst/core/browser/psst_settings_service.cc
@@ -56,11 +56,11 @@ PsstSettingsService::PsstSettingsService(
 
 PsstSettingsService::~PsstSettingsService() = default;
 
-void PsstSettingsService::AddObserver(Observer* observer) {
+void PsstSettingsService::AddObserver(PrefObserver* observer) {
   observers_.AddObserver(observer);
 }
 
-void PsstSettingsService::RemoveObserver(Observer* observer) {
+void PsstSettingsService::RemoveObserver(PrefObserver* observer) {
   observers_.RemoveObserver(observer);
 }
 
@@ -137,7 +137,7 @@ void PsstSettingsService::SetPsstEnabled(bool enabled) {
 
 void PsstSettingsService::OnPreferenceChanged(const std::string& pref_name) {
   if (pref_name == prefs::kPsstEnabled) {
-    observers_.Notify(&Observer::OnPsstEnableChange, IsPsstEnabled());
+    observers_.Notify(&PrefObserver::OnPsstEnableChange, IsPsstEnabled());
     return;
   }
 }

--- a/components/psst/core/browser/psst_settings_service.cc
+++ b/components/psst/core/browser/psst_settings_service.cc
@@ -5,7 +5,10 @@
 
 #include "brave/components/psst/core/browser/psst_settings_service.h"
 
+#include "base/check.h"
+#include "base/functional/bind.h"
 #include "brave/components/psst/core/browser/pref_names.h"
+#include "components/prefs/pref_service.h"
 #include "url/gurl.h"
 
 namespace psst {

--- a/components/psst/core/browser/psst_settings_service.cc
+++ b/components/psst/core/browser/psst_settings_service.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/psst/core/browser/psst_settings_service.h"
 
+#include "brave/components/psst/core/browser/pref_names.h"
 #include "url/gurl.h"
 
 namespace psst {
@@ -38,10 +39,27 @@ base::DictValue CreatePsstSettingsObject(PsstWebsiteSettings psst_metadata) {
 }  // namespace
 
 PsstSettingsService::PsstSettingsService(
-    HostContentSettingsMap& host_content_settings_map)
-    : host_content_settings_map_(host_content_settings_map) {}
+    HostContentSettingsMap& host_content_settings_map,
+    PrefService* prefs)
+    : host_content_settings_map_(host_content_settings_map), prefs_(prefs) {
+  CHECK(prefs_);
+
+  pref_change_registrar_.Init(prefs_);
+  pref_change_registrar_.Add(
+      prefs::kPsstEnabled,
+      base::BindRepeating(&PsstSettingsService::OnPreferenceChanged,
+                          weak_ptr_factory_.GetWeakPtr()));
+}
 
 PsstSettingsService::~PsstSettingsService() = default;
+
+void PsstSettingsService::AddObserver(Observer* observer) {
+  observers_.AddObserver(observer);
+}
+
+void PsstSettingsService::RemoveObserver(Observer* observer) {
+  observers_.RemoveObserver(observer);
+}
 
 std::optional<PsstWebsiteSettings> PsstSettingsService::GetPsstWebsiteSettings(
     const url::Origin& origin,
@@ -103,6 +121,21 @@ void PsstSettingsService::SetPsstWebsiteSettings(
         origin.GetURL(), origin.GetURL(), ContentSettingsType::BRAVE_PSST,
         base::Value(base::DictValue().Set(
             user_id, CreatePsstSettingsObject(std::move(psst_metadata)))));
+  }
+}
+
+bool PsstSettingsService::IsPsstEnabled() const {
+  return prefs_->GetBoolean(prefs::kPsstEnabled);
+}
+
+void PsstSettingsService::SetPsstEnabled(bool enabled) {
+  prefs_->SetBoolean(prefs::kPsstEnabled, enabled);
+}
+
+void PsstSettingsService::OnPreferenceChanged(const std::string& pref_name) {
+  if (pref_name == prefs::kPsstEnabled) {
+    observers_.Notify(&Observer::OnPsstEnableChange, IsPsstEnabled());
+    return;
   }
 }
 

--- a/components/psst/core/browser/psst_settings_service.h
+++ b/components/psst/core/browser/psst_settings_service.h
@@ -6,13 +6,19 @@
 #ifndef BRAVE_COMPONENTS_PSST_CORE_BROWSER_PSST_SETTINGS_SERVICE_H_
 #define BRAVE_COMPONENTS_PSST_CORE_BROWSER_PSST_SETTINGS_SERVICE_H_
 
+#include <string>
+
+#include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ref.h"
 #include "base/memory/weak_ptr.h"
+#include "base/observer_list.h"
 #include "brave/components/psst/core/common/psst_metadata_schema.h"
 #include "components/content_settings/core/browser/host_content_settings_map.h"
 #include "components/keyed_service/core/keyed_service.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "url/origin.h"
+
+class PrefService;
 
 namespace psst {
 

--- a/components/psst/core/browser/psst_settings_service.h
+++ b/components/psst/core/browser/psst_settings_service.h
@@ -24,12 +24,12 @@ namespace psst {
 
 class PsstSettingsService : public KeyedService {
  public:
-  class Observer : public base::CheckedObserver {
+  class PrefObserver : public base::CheckedObserver {
    public:
     virtual void OnPsstEnableChange(bool new_value) {}
 
    protected:
-    ~Observer() override = default;
+    ~PrefObserver() override = default;
   };
 
   explicit PsstSettingsService(
@@ -37,8 +37,8 @@ class PsstSettingsService : public KeyedService {
       PrefService* prefs);
   ~PsstSettingsService() override;
 
-  void AddObserver(Observer* observer);
-  void RemoveObserver(Observer* observer);
+  void AddObserver(PrefObserver* observer);
+  void RemoveObserver(PrefObserver* observer);
 
   // Saves the PSST metadata for the (origin, user_id) pair with the given
   // details.
@@ -65,7 +65,7 @@ class PsstSettingsService : public KeyedService {
   const raw_ref<HostContentSettingsMap>
       host_content_settings_map_;         // NOT OWNED
   raw_ptr<PrefService> prefs_ = nullptr;  // NOT OWNED
-  base::ObserverList<Observer> observers_;
+  base::ObserverList<PrefObserver> observers_;
   PrefChangeRegistrar pref_change_registrar_;
   base::WeakPtrFactory<PsstSettingsService> weak_ptr_factory_{this};
 };

--- a/components/psst/core/browser/psst_settings_service.h
+++ b/components/psst/core/browser/psst_settings_service.h
@@ -7,18 +7,32 @@
 #define BRAVE_COMPONENTS_PSST_CORE_BROWSER_PSST_SETTINGS_SERVICE_H_
 
 #include "base/memory/raw_ref.h"
+#include "base/memory/weak_ptr.h"
 #include "brave/components/psst/core/common/psst_metadata_schema.h"
 #include "components/content_settings/core/browser/host_content_settings_map.h"
 #include "components/keyed_service/core/keyed_service.h"
+#include "components/prefs/pref_change_registrar.h"
 #include "url/origin.h"
 
 namespace psst {
 
 class PsstSettingsService : public KeyedService {
  public:
+  class Observer : public base::CheckedObserver {
+   public:
+    virtual void OnPsstEnableChange(bool new_value) {}
+
+   protected:
+    ~Observer() override = default;
+  };
+
   explicit PsstSettingsService(
-      HostContentSettingsMap& host_content_settings_map);
+      HostContentSettingsMap& host_content_settings_map,
+      PrefService* prefs);
   ~PsstSettingsService() override;
+
+  void AddObserver(Observer* observer);
+  void RemoveObserver(Observer* observer);
 
   // Saves the PSST metadata for the (origin, user_id) pair with the given
   // details.
@@ -36,9 +50,18 @@ class PsstSettingsService : public KeyedService {
   void SetPsstWebsiteSettings(const url::Origin& origin,
                               PsstWebsiteSettings psst_metadata);
 
+  bool IsPsstEnabled() const;
+  void SetPsstEnabled(bool enabled);
+
  private:
+  void OnPreferenceChanged(const std::string& pref_name);
+
   const raw_ref<HostContentSettingsMap>
-      host_content_settings_map_;  // NOT OWNED
+      host_content_settings_map_;         // NOT OWNED
+  raw_ptr<PrefService> prefs_ = nullptr;  // NOT OWNED
+  base::ObserverList<Observer> observers_;
+  PrefChangeRegistrar pref_change_registrar_;
+  base::WeakPtrFactory<PsstSettingsService> weak_ptr_factory_{this};
 };
 
 }  // namespace psst


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57687

Fixes the problem when PSST omnibar icon stays visible even if you switch off the PSST toggle

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
