### PR TITLE
[AI Chat] Prepare new NTP search box for day zero experiment

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -29,6 +29,7 @@
 #include "brave/browser/brave_search/backup_results_service_factory.h"
 #include "brave/browser/brave_shields/brave_shields_settings_service_factory.h"
 #include "brave/browser/brave_shields/brave_shields_web_contents_observer.h"
+#include "brave/browser/brave_stats/first_run_util.h"
 #include "brave/browser/cosmetic_filters/cosmetic_filters_tab_helper.h"
 #include "brave/browser/debounce/debounce_service_factory.h"
 #include "brave/browser/ephemeral_storage/ephemeral_storage_service_factory.h"
@@ -757,7 +758,9 @@ void BraveContentBrowserClient::RegisterTrustedWebUIInterfaceBrokers(
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
   if (ai_chat::features::IsAIChatEnabled() &&
-      ai_chat::features::IsShowAIChatInputOnNewTabPageEnabled()) {
+      ai_chat::features::IsShowAIChatInputOnNewTabPageEnabled(
+          g_browser_process->local_state(),
+          brave_stats::IsFirstRun(g_browser_process->local_state()))) {
     ntp_refresh_registration.Add<ai_chat::mojom::AIChatUIHandler>()
         .Add<ai_chat::mojom::Service>()
         .Add<ai_chat::mojom::TabTrackerService>()

--- a/browser/brave_stats/BUILD.gn
+++ b/browser/brave_stats/BUILD.gn
@@ -15,14 +15,26 @@ buildflag_header("buildflags") {
   ]
 }
 
+source_set("first_run_util") {
+  sources = [
+    "//brave/browser/brave_stats/first_run_util.cc",
+    "//brave/browser/brave_stats/first_run_util.h",
+  ]
+
+  deps = [
+    "//base",
+    "//brave/components/constants",
+    "//chrome/browser/first_run",
+    "//components/prefs",
+  ]
+}
+
 source_set("brave_stats") {
   sources = [
     "//brave/browser/brave_stats/brave_stats_updater_params.cc",
     "//brave/browser/brave_stats/brave_stats_updater_params.h",
     "//brave/browser/brave_stats/features.cc",
     "//brave/browser/brave_stats/features.h",
-    "//brave/browser/brave_stats/first_run_util.cc",
-    "//brave/browser/brave_stats/first_run_util.h",
     "//brave/browser/brave_stats/switches.h",
   ]
 
@@ -35,6 +47,7 @@ source_set("brave_stats") {
 
   public_deps = [
     "//brave/browser/brave_stats:buildflags",
+    "//brave/browser/brave_stats:first_run_util",
     "//brave/components/brave_stats/browser",
   ]
 

--- a/browser/ui/webui/BUILD.gn
+++ b/browser/ui/webui/BUILD.gn
@@ -5,6 +5,7 @@
 
 import("//brave/browser/updater/buildflags.gni")
 import("//brave/build/config.gni")
+import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
 
 source_set("browser_tests") {
   testonly = true
@@ -34,9 +35,15 @@ source_set("browser_tests") {
     ]
 
     deps += [
+      "//brave/components/ai_chat/core/common/buildflags",
+      "//brave/components/brave_search/common",
       "//chrome/browser/ui/webui/searchbox",
       "//chrome/browser/ui/webui/searchbox:searchbox_test_utils",
     ]
+
+    if (enable_ai_chat) {
+      deps += [ "//brave/components/ai_chat/core/common" ]
+    }
   }
 }
 

--- a/browser/ui/webui/brave_new_tab_page_refresh/BUILD.gn
+++ b/browser/ui/webui/brave_new_tab_page_refresh/BUILD.gn
@@ -52,6 +52,7 @@ source_set("brave_new_tab_page_refresh") {
   deps = [
     ":mojom",
     "//brave/browser:browser_process",
+    "//brave/browser/brave_stats:first_run_util",
     "//brave/browser/misc_metrics",
     "//brave/browser/ntp_background",
     "//brave/browser/resources/brave_new_tab_page_refresh:generated_resources",

--- a/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page_ui.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page_ui.cc
@@ -40,6 +40,7 @@
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/browser/ai_chat/ai_chat_service_factory.h"
 #include "brave/browser/ai_chat/tab_tracker_service_factory.h"
+#include "brave/browser/brave_stats/first_run_util.h"
 #include "brave/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_service.h"
 #include "brave/components/ai_chat/core/browser/bookmarks_page_handler.h"
@@ -226,7 +227,9 @@ BraveNewTabPageUI::GetContextualSessionHandle() {
 #if BUILDFLAG(ENABLE_AI_CHAT)
 void BraveNewTabPageUI::BindInterface(
     mojo::PendingReceiver<ai_chat::mojom::AIChatUIHandler> receiver) {
-  CHECK(ai_chat::features::IsShowAIChatInputOnNewTabPageEnabled());
+  CHECK(ai_chat::features::IsShowAIChatInputOnNewTabPageEnabled(
+      g_browser_process->local_state(),
+      brave_stats::IsFirstRun(g_browser_process->local_state())));
   auto* profile = Profile::FromWebUI(web_ui());
   if (!ai_chat::AIChatServiceFactory::GetForBrowserContext(profile)) {
     return;
@@ -237,7 +240,9 @@ void BraveNewTabPageUI::BindInterface(
 
 void BraveNewTabPageUI::BindInterface(
     mojo::PendingReceiver<ai_chat::mojom::Service> receiver) {
-  CHECK(ai_chat::features::IsShowAIChatInputOnNewTabPageEnabled());
+  CHECK(ai_chat::features::IsShowAIChatInputOnNewTabPageEnabled(
+      g_browser_process->local_state(),
+      brave_stats::IsFirstRun(g_browser_process->local_state())));
   auto* profile = Profile::FromWebUI(web_ui());
   auto* service = ai_chat::AIChatServiceFactory::GetForBrowserContext(profile);
   if (!service) {
@@ -248,7 +253,9 @@ void BraveNewTabPageUI::BindInterface(
 
 void BraveNewTabPageUI::BindInterface(
     mojo::PendingReceiver<ai_chat::mojom::TabTrackerService> pending_receiver) {
-  CHECK(ai_chat::features::IsShowAIChatInputOnNewTabPageEnabled());
+  CHECK(ai_chat::features::IsShowAIChatInputOnNewTabPageEnabled(
+      g_browser_process->local_state(),
+      brave_stats::IsFirstRun(g_browser_process->local_state())));
   auto* profile = Profile::FromWebUI(web_ui());
   auto* service =
       ai_chat::TabTrackerServiceFactory::GetForBrowserContext(profile);
@@ -261,7 +268,9 @@ void BraveNewTabPageUI::BindInterface(
 void BraveNewTabPageUI::BindInterface(
     mojo::PendingReceiver<ai_chat::mojom::BookmarksPageHandler>
         pending_receiver) {
-  CHECK(ai_chat::features::IsShowAIChatInputOnNewTabPageEnabled());
+  CHECK(ai_chat::features::IsShowAIChatInputOnNewTabPageEnabled(
+      g_browser_process->local_state(),
+      brave_stats::IsFirstRun(g_browser_process->local_state())));
   auto* profile = Profile::FromWebUI(web_ui());
   bookmarks_page_handler_ = std::make_unique<ai_chat::BookmarksPageHandler>(
       BookmarkModelFactory::GetForBrowserContext(profile),
@@ -270,7 +279,9 @@ void BraveNewTabPageUI::BindInterface(
 
 void BraveNewTabPageUI::BindInterface(
     mojo::PendingReceiver<ai_chat::mojom::HistoryUIHandler> pending_receiver) {
-  CHECK(ai_chat::features::IsShowAIChatInputOnNewTabPageEnabled());
+  CHECK(ai_chat::features::IsShowAIChatInputOnNewTabPageEnabled(
+      g_browser_process->local_state(),
+      brave_stats::IsFirstRun(g_browser_process->local_state())));
   auto* profile = Profile::FromWebUI(web_ui());
   history_ui_handler_ = std::make_unique<ai_chat::HistoryUIHandler>(
       std::move(pending_receiver),

--- a/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_initializer.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_initializer.cc
@@ -27,6 +27,7 @@
 #include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/ntp_background_images/browser/features.h"
 #include "brave/components/ntp_background_images/browser/ntp_custom_images_source.h"
+#include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/regional_capabilities/regional_capabilities_service_factory.h"
 #include "chrome/browser/themes/theme_syncable_service.h"
@@ -52,6 +53,7 @@
 #include "ui/webui/webui_util.h"
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
+#include "brave/browser/brave_stats/first_run_util.h"
 #include "brave/components/ai_chat/core/browser/utils.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #endif
@@ -252,7 +254,9 @@ void NewTabPageInitializer::AddLoadTimeValues() {
 #if BUILDFLAG(ENABLE_AI_CHAT)
   ai_chat_input_enabled =
       ai_chat::IsAIChatEnabled(profile->GetPrefs()) &&
-      ai_chat::features::IsShowAIChatInputOnNewTabPageEnabled();
+      ai_chat::features::IsShowAIChatInputOnNewTabPageEnabled(
+          g_browser_process->local_state(),
+          brave_stats::IsFirstRun(g_browser_process->local_state()));
 
   // Required by Brave AI Chat UI.
   source_->AddBoolean("isMobile", false);

--- a/browser/ui/webui/searchbox/brave_realbox_handler_browsertest.cc
+++ b/browser/ui/webui/searchbox/brave_realbox_handler_browsertest.cc
@@ -4,10 +4,14 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "base/test/bind.h"
+#include "base/test/scoped_feature_list.h"
 #include "base/time/time.h"
+#include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_search/common/features.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/search_engines/template_url_service_factory.h"
 #include "chrome/browser/ui/browser.h"
@@ -29,6 +33,15 @@
 #include "testing/gtest/include/gtest/gtest.h"
 #include "ui/base/page_transition_types.h"
 #include "ui/base/window_open_disposition.h"
+
+#if BUILDFLAG(ENABLE_AI_CHAT)
+#include "brave/components/ai_chat/core/common/features.h"
+#endif
+
+struct NewTabSourceTestParams {
+  const std::string source;
+  const std::optional<base::test::FeatureRef> enabled_feature;
+};
 
 class BraveRealboxHandlerTest : public InProcessBrowserTest {
  public:
@@ -75,16 +88,46 @@ class BraveRealboxHandlerTest : public InProcessBrowserTest {
   }
 };
 
-IN_PROC_BROWSER_TEST_F(BraveRealboxHandlerTest, BraveSearchUsesNewTabSource) {
+class BraveRealboxHandlerSourceTest
+    : public BraveRealboxHandlerTest,
+      public testing::WithParamInterface<NewTabSourceTestParams> {
+ public:
+  BraveRealboxHandlerSourceTest() {
+    if (GetParam().enabled_feature) {
+      scoped_feature_list_.InitWithFeatures({*GetParam().enabled_feature}, {});
+    }
+  }
+
+ protected:
+  base::test::ScopedFeatureList scoped_feature_list_;
+};
+
+IN_PROC_BROWSER_TEST_P(BraveRealboxHandlerSourceTest,
+                       BraveSearchUsesNewTabSource) {
   EXPECT_EQ(GURL("about:blank"), contents()->GetVisibleURL());
   EXPECT_TRUE(VerifyTemplateURLServiceLoad());
 
   OnAutocompleteAccept(
       GURL("https://search.brave.com/search?q=hello+world&source=desktop"),
       u":br");
-  EXPECT_EQ(GURL("https://search.brave.com/search?q=hello+world&source=newtab"),
+  EXPECT_EQ(GURL("https://search.brave.com/search?q=hello+world&source=" +
+                 GetParam().source),
             contents()->GetLastCommittedURL());
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    BraveRealboxHandlerSourceTest,
+    testing::Values(
+        NewTabSourceTestParams{"newtab", std::nullopt},
+        NewTabSourceTestParams{"newtab_v1",
+                               brave_search::features::kSearchNewTabV1Source}
+#if BUILDFLAG(ENABLE_AI_CHAT)
+        ,
+        NewTabSourceTestParams{"newtab_v2",
+                               ai_chat::features::kShowAIChatInputOnNewTabPage}
+#endif
+        ));
 
 IN_PROC_BROWSER_TEST_F(BraveRealboxHandlerTest,
                        BraveSearchNoKeywordIsUnaffected) {

--- a/chromium_src/chrome/browser/ui/webui/cr_components/searchbox/DEPS
+++ b/chromium_src/chrome/browser/ui/webui/cr_components/searchbox/DEPS
@@ -1,3 +1,5 @@
 include_rules = [
+    "+brave/components/ai_chat/core/common",
+    "+brave/components/brave_search",
     "+brave/components/search_engines",
 ]

--- a/chromium_src/chrome/browser/ui/webui/cr_components/searchbox/searchbox_omnibox_client.cc
+++ b/chromium_src/chrome/browser/ui/webui/cr_components/searchbox/searchbox_omnibox_client.cc
@@ -5,12 +5,22 @@
 
 #include "chrome/browser/ui/webui/cr_components/searchbox/searchbox_omnibox_client.h"
 
+#include <string_view>
+
+#include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_search/common/features.h"
 #include "brave/components/search_engines/brave_prepopulated_engines.h"
 #include "components/omnibox/browser/autocomplete_input.h"
 #include "components/omnibox/browser/autocomplete_match.h"
 #include "components/search_engines/template_url_service.h"
 #include "content/public/browser/page_navigator.h"
 #include "net/base/url_util.h"
+
+#if BUILDFLAG(ENABLE_AI_CHAT)
+#include "brave/browser/brave_stats/first_run_util.h"
+#include "brave/components/ai_chat/core/common/features.h"
+#include "chrome/browser/browser_process.h"
+#endif
 
 namespace {
 
@@ -33,8 +43,19 @@ content::OpenURLParams MaybeOverrideURLParams(
   if (template_url &&
       template_url->prepopulate_id() ==
           TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_BRAVE) {
+    std::string_view source = "newtab";
+    if (brave_search::features::IsSearchNewTabV1SourceEnabled()) {
+      source = "newtab_v1";
+    }
+#if BUILDFLAG(ENABLE_AI_CHAT)
+    auto* local_state = g_browser_process->local_state();
+    if (ai_chat::features::IsShowAIChatInputOnNewTabPageEnabled(
+            local_state, brave_stats::IsFirstRun(local_state))) {
+      source = "newtab_v2";
+    }
+#endif
     params.url =
-        net::AppendOrReplaceQueryParameter(params.url, "source", "newtab");
+        net::AppendOrReplaceQueryParameter(params.url, "source", source);
   }
 
   return params;

--- a/chromium_src/chrome/browser/ui/webui/cr_components/searchbox/sources.gni
+++ b/chromium_src/chrome/browser/ui/webui/cr_components/searchbox/sources.gni
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
+
+brave_chromium_src_chrome_browser_ui_webui_cr_components_searchbox_deps = [
+  "//brave/components/ai_chat/core/common/buildflags",
+  "//brave/components/brave_search/common",
+]
+
+if (enable_ai_chat) {
+  brave_chromium_src_chrome_browser_ui_webui_cr_components_searchbox_deps += [
+    "//brave/browser/brave_stats:first_run_util",
+    "//brave/components/ai_chat/core/common",
+  ]
+}

--- a/components/ai_chat/core/common/features.cc
+++ b/components/ai_chat/core/common/features.cc
@@ -7,12 +7,15 @@
 
 #include <string>
 
+#include "base/check.h"
 #include "base/feature_list.h"
 #include "base/metrics/field_trial_params.h"
 #include "base/time/time.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/ai_chat/core/common/constants.h"
+#include "brave/components/ai_chat/core/common/pref_names.h"
 #include "build/build_config.h"
+#include "components/prefs/pref_service.h"
 
 namespace ai_chat::features {
 
@@ -203,8 +206,28 @@ bool IsAIChatWebUIEnabled() {
 
 BASE_FEATURE(kShowAIChatInputOnNewTabPage, base::FEATURE_DISABLED_BY_DEFAULT);
 
-bool IsShowAIChatInputOnNewTabPageEnabled() {
-  return base::FeatureList::IsEnabled(features::kShowAIChatInputOnNewTabPage);
+const base::FeatureParam<bool> kShowAIChatInputOnNewTabPageDayZero{
+    &kShowAIChatInputOnNewTabPage, "day_zero", false};
+
+bool IsShowAIChatInputOnNewTabPageEnabled(PrefService* local_state,
+                                          bool is_first_run) {
+  CHECK(local_state);
+  // If feature was enabled via day zero experiment at install time, leave
+  // the feature enabled forever.
+  if (local_state->GetBoolean(ai_chat::prefs::kNtpInputDayZeroEnabled)) {
+    return true;
+  }
+  if (!base::FeatureList::IsEnabled(features::kShowAIChatInputOnNewTabPage)) {
+    return false;
+  }
+  if (kShowAIChatInputOnNewTabPageDayZero.Get()) {
+    if (!is_first_run) {
+      // Existing users are not included in the day zero study.
+      return false;
+    }
+    local_state->SetBoolean(ai_chat::prefs::kNtpInputDayZeroEnabled, true);
+  }
+  return true;
 }
 
 BASE_FEATURE(kAIChatDeepResearch,

--- a/components/ai_chat/core/common/features.h
+++ b/components/ai_chat/core/common/features.h
@@ -16,6 +16,8 @@
 
 static_assert(BUILDFLAG(ENABLE_AI_CHAT));
 
+class PrefService;
+
 namespace ai_chat::features {
 
 COMPONENT_EXPORT(AI_CHAT_COMMON) BASE_DECLARE_FEATURE(kAIChat);
@@ -175,7 +177,9 @@ COMPONENT_EXPORT(AI_CHAT_COMMON) bool IsAIChatWebUIEnabled();
 
 COMPONENT_EXPORT(AI_CHAT_COMMON)
 BASE_DECLARE_FEATURE(kShowAIChatInputOnNewTabPage);
-COMPONENT_EXPORT(AI_CHAT_COMMON) bool IsShowAIChatInputOnNewTabPageEnabled();
+COMPONENT_EXPORT(AI_CHAT_COMMON)
+bool IsShowAIChatInputOnNewTabPageEnabled(PrefService* local_state,
+                                          bool is_first_run);
 
 COMPONENT_EXPORT(AI_CHAT_COMMON)
 BASE_DECLARE_FEATURE(kAIChatDeepResearch);

--- a/components/ai_chat/core/common/pref_names.cc
+++ b/components/ai_chat/core/common/pref_names.cc
@@ -64,6 +64,7 @@ void RegisterProfilePrefsForMigration(PrefRegistrySimple* registry) {
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
   // Added 11/2023
   registry->RegisterDictionaryPref(kBraveChatPremiumCredentialCache);
+  registry->RegisterBooleanPref(kNtpInputDayZeroEnabled, false);
 }
 
 }  // namespace ai_chat::prefs

--- a/components/ai_chat/core/common/pref_names.h
+++ b/components/ai_chat/core/common/pref_names.h
@@ -123,6 +123,9 @@ inline constexpr char kBraveAIChatTabOrganizationEnabled[] =
 inline constexpr char kBraveAIChatTabOrganizationModelKey[] =
     "brave.ai_chat.tab_organization_model_key";
 
+inline constexpr char kNtpInputDayZeroEnabled[] =
+    "brave.ai_chat.ntp_input_day_zero_enabled";
+
 inline constexpr char kBraveAIChatUserCustomizationEnabled[] =
     "brave.ai_chat.user_customization_enabled";
 inline constexpr char kBraveAIChatUserCustomizations[] =

--- a/components/brave_search/common/features.cc
+++ b/components/brave_search/common/features.cc
@@ -98,4 +98,10 @@ const base::FeatureParam<std::string> kBackupResultsRendererLanguages{
 const base::FeatureParam<std::string> kBackupResultsLanguagesHeader{
     &kBackupResults, "languages_header", ""};
 
+BASE_FEATURE(kSearchNewTabV1Source, base::FEATURE_DISABLED_BY_DEFAULT);
+
+bool IsSearchNewTabV1SourceEnabled() {
+  return base::FeatureList::IsEnabled(kSearchNewTabV1Source);
+}
+
 }  // namespace brave_search::features

--- a/components/brave_search/common/features.h
+++ b/components/brave_search/common/features.h
@@ -93,6 +93,9 @@ extern const base::FeatureParam<std::string> kBackupResultsRendererLanguages;
 // Same value format as kBackupResultsRendererLanguages.
 extern const base::FeatureParam<std::string> kBackupResultsLanguagesHeader;
 
+BASE_DECLARE_FEATURE(kSearchNewTabV1Source);
+bool IsSearchNewTabV1SourceEnabled();
+
 }  // namespace features
 }  // namespace brave_search
 

--- a/patches/chrome-browser-ui-webui-cr_components-searchbox-BUILD.gn.patch
+++ b/patches/chrome-browser-ui-webui-cr_components-searchbox-BUILD.gn.patch
@@ -1,0 +1,11 @@
+diff --git a/chrome/browser/ui/webui/cr_components/searchbox/BUILD.gn b/chrome/browser/ui/webui/cr_components/searchbox/BUILD.gn
+index 744166a0c828e931188bb863663e5d5e147e84f9..922ca2acecf4fa823415cce4f4ff0519b2ac139c 100644
+--- a/chrome/browser/ui/webui/cr_components/searchbox/BUILD.gn
++++ b/chrome/browser/ui/webui/cr_components/searchbox/BUILD.gn
+@@ -112,4 +112,6 @@ source_set("searchbox_impl") {
+       "//components/contextual_search/footprints/internal",
+     ]
+   }
++  import("//brave/chromium_src/chrome/browser/ui/webui/cr_components/searchbox/sources.gni")
++  deps += brave_chromium_src_chrome_browser_ui_webui_cr_components_searchbox_deps
+ }

--- a/rewrite/chrome/browser/ui/webui/cr_components/searchbox/BUILD.gn.yaml
+++ b/rewrite/chrome/browser/ui/webui/cr_components/searchbox/BUILD.gn.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: Brave additions to `source_set("searchbox_impl")`.
+    regex:
+      re_pattern: '(source_set\("searchbox_impl"\).*?)\n\}'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          import("//brave/chromium_src/chrome/browser/ui/webui/cr_components/searchbox/sources.gni")
+          deps += brave_chromium_src_chrome_browser_ui_webui_cr_components_searchbox_deps
+        }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57701

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

## Test plan

0. Start with fresh profile and `--enable-features="ShowAIChatInputOnNewTabPage"` switch.
1. Ensure new widget shows on NTP. Make a query, ensure URL source query param is `newtab_v2`.
2. Close browser, start again with `--disable-features="ShowAIChatInputOnNewTabPage"`. Ensure old widget shows on NTP. Make a query, ensure source param is `newtab`.
3. Start with fresh profile and `--enable-features="ShowAIChatInputOnNewTabPage:day_zero/true"` switch.
4. Repeat step 1.
5. Close browser, start again with `--disable-features="ShowAIChatInputOnNewTabPage"`
6. Repeat step 1.
7. Start with fresh profile and `--enable-features="SearchNewTabV1Source" --disable-features="ShowAIChatInputOnNewTabPage"` switch.
8. Close browser, start again without switch. Ensure old widget shows on NTP. Make a query, ensure source param is `newtab_v1`.
9. Start browser with fresh profile and with `--disable-features="ShowAIChatInputOnNewTabPage"`. Close browser and restart with `--enable-features="ShowAIChatInputOnNewTabPage:day_zero/true"`. Ensure the new widget is not present.