### PR TITLE
[VPN 2.0] Endpoint-based API: GetSubscriberCredential, VerifyPurchaseToken

### DIFF
--- a/components/brave_vpn/browser/v2/api/BUILD.gn
+++ b/components/brave_vpn/browser/v2/api/BUILD.gn
@@ -13,6 +13,7 @@ source_set("api") {
     "brave_vpn_api_client.h",
     "error_body.h",
     "purchase_endpoints.h",
+    "raw_json_response_body.h",
   ]
 
   public_deps = [
@@ -43,6 +44,7 @@ source_set("unit_tests") {
     "//services/network:test_support",
     "//services/network/public/cpp",
     "//services/network/public/mojom",
+    "//testing/gmock",
     "//testing/gtest",
     "//url",
   ]

--- a/components/brave_vpn/browser/v2/api/BUILD.gn
+++ b/components/brave_vpn/browser/v2/api/BUILD.gn
@@ -33,7 +33,10 @@ source_set("api") {
 source_set("unit_tests") {
   testonly = true
 
-  sources = [ "brave_vpn_api_client_unittest.cc" ]
+  sources = [
+    "brave_vpn_api_client_unittest.cc",
+    "purchase_endpoints_unittest.cc",
+  ]
 
   deps = [
     ":api",
@@ -44,7 +47,6 @@ source_set("unit_tests") {
     "//services/network:test_support",
     "//services/network/public/cpp",
     "//services/network/public/mojom",
-    "//testing/gmock",
     "//testing/gtest",
     "//url",
   ]

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client.cc
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client.cc
@@ -5,9 +5,11 @@
 
 #include "brave/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h"
 
+#include <optional>
 #include <utility>
 
 #include "base/check.h"
+#include "base/check_deref.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "base/strings/strcat.h"
@@ -26,10 +28,11 @@ using brave_account::endpoint_client::WithHeaders;
 
 namespace brave_vpn::v2 {
 
+using endpoints::GetSubscriberCredential;
 using endpoints::GetSubscriberCredentialV12;
+using endpoints::VerifyPurchaseToken;
 
 namespace {
-constexpr char kHeaderBravePaymentsEnvironment[] = "Brave-Payments-Environment";
 
 const net::NetworkTrafficAnnotationTag kTrafficAnnotation =
     net::DefineNetworkTrafficAnnotation("brave_vpn_api_client", R"(
@@ -94,6 +97,43 @@ BraveVpnApiClient::BraveVpnApiClient(
 
 BraveVpnApiClient::~BraveVpnApiClient() = default;
 
+void BraveVpnApiClient::GetSubscriberCredential(
+    SubscriberCredentialCallback callback,
+    const std::string& product_type,
+    const std::string& product_id,
+    const std::string& validation_method,
+    const std::string& purchase_token,
+    const std::string& bundle_id) {
+  auto request = MakeRequest<GetSubscriberCredential::Request>();
+  request.body.product_type = product_type;
+  request.body.product_id = product_id;
+  request.body.validation_method = validation_method;
+  request.body.purchase_token = purchase_token;
+  request.body.bundle_id = bundle_id;
+
+  Client<endpoints::GetSubscriberCredential>::Send(
+      url_loader_factory_, std::move(request),
+      base::BindOnce(&BraveVpnApiClient::OnGetSubscriberCredentialResponse,
+                     weak_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void BraveVpnApiClient::OnGetSubscriberCredentialResponse(
+    SubscriberCredentialCallback callback,
+    endpoints::GetSubscriberCredential::Response response) {
+  if (auto unrecoverable = MaybeDescribeUnrecoverableResponse(response)) {
+    return std::move(callback).Run(base::unexpected(*std::move(unrecoverable)));
+  }
+
+  std::move(callback).Run(
+      std::move(CHECK_DEREF(response.body))
+          .transform([](endpoints::GetSubscriberCredentialSuccessBody success) {
+            return std::move(success.subscriber_credential);
+          })
+          .transform_error([](endpoints::VpnErrorBody error) {
+            return std::move(error.error_title);
+          }));
+}
+
 void BraveVpnApiClient::GetSubscriberCredentialV12(
     SubscriberCredentialCallback callback,
     const std::string& skus_credential,
@@ -104,29 +144,47 @@ void BraveVpnApiClient::GetSubscriberCredentialV12(
   auto request =
       MakeRequest<WithHeaders<GetSubscriberCredentialV12::Request>>();
   request.body.skus_credential = skus_credential;
-  request.headers.SetHeader(kHeaderBravePaymentsEnvironment, environment);
+  request.headers.SetHeader(endpoints::kHeaderBravePaymentsEnvironment,
+                            environment);
 
   Client<endpoints::GetSubscriberCredentialV12>::Send(
       url_loader_factory_, std::move(request),
-      base::BindOnce(&BraveVpnApiClient::OnGetSubscriberCredentialV12Response,
+      base::BindOnce(&BraveVpnApiClient::OnGetSubscriberCredentialResponse,
                      weak_factory_.GetWeakPtr(), std::move(callback)));
 }
 
-void BraveVpnApiClient::OnGetSubscriberCredentialV12Response(
-    SubscriberCredentialCallback callback,
-    endpoints::GetSubscriberCredentialV12::Response response) {
+void BraveVpnApiClient::VerifyPurchaseToken(
+    VerifyPurchaseTokenCallback callback,
+    const std::string& purchase_token,
+    const std::string& product_id,
+    const std::string& product_type,
+    const std::string& bundle_id) {
+  auto request = MakeRequest<VerifyPurchaseToken::Request>();
+  request.body.purchase_token = purchase_token;
+  request.body.product_id = product_id;
+  request.body.product_type = product_type;
+  request.body.bundle_id = bundle_id;
+
+  Client<endpoints::VerifyPurchaseToken>::Send(
+      url_loader_factory_, std::move(request),
+      base::BindOnce(&BraveVpnApiClient::OnVerifyPurchaseTokenResponse,
+                     weak_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void BraveVpnApiClient::OnVerifyPurchaseTokenResponse(
+    VerifyPurchaseTokenCallback callback,
+    endpoints::VerifyPurchaseToken::Response response) {
   if (auto unrecoverable = MaybeDescribeUnrecoverableResponse(response)) {
     return std::move(callback).Run(base::unexpected(*std::move(unrecoverable)));
   }
 
   std::move(callback).Run(
       std::move(CHECK_DEREF(response.body))
-          .transform(
-              [](endpoints::GetSubscriberCredentialV12SuccessBody success) {
-                return std::move(success.subscriber_credential);
-              })
-          .transform_error([](endpoints::VpnErrorBody error) {
-            return std::move(error.error_title);
+          .transform([](endpoints::RawJsonResponseBody success) {
+            return std::move(success.json);
+          })
+          .transform_error([](endpoints::RawJsonResponseBody error) {
+            return std::move(error.json);
           }));
 }
 

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h
@@ -34,21 +34,47 @@ class BraveVpnApiClient {
   BraveVpnApiClient& operator=(const BraveVpnApiClient&) = delete;
   virtual ~BraveVpnApiClient();
 
-  // Connect API: GetSubscriberCredentialV12.
-  // Exchanges a SKUS credential for a subscriber credential.
+  // Connect API: GetSubscriberCredential (legacy, store purchase token).
+  // Exchanges store purchase details for a subscriber credential.
   // On success: the subscriber credential.
   // On failure: a user-facing error string (transport/HTTP failure, or the
   // server's reported error message).
   using SubscriberCredentialCallback =
       base::OnceCallback<void(base::expected<std::string, std::string>)>;
+  virtual void GetSubscriberCredential(SubscriberCredentialCallback callback,
+                                       const std::string& product_type,
+                                       const std::string& product_id,
+                                       const std::string& validation_method,
+                                       const std::string& purchase_token,
+                                       const std::string& bundle_id);
+
+  // Connect API: GetSubscriberCredentialV12.
+  // Exchanges a SKUS credential for a subscriber credential.
+  // On success: the subscriber credential.
+  // On failure: a user-facing error string (transport/HTTP failure, or the
+  // server's reported error message).
   virtual void GetSubscriberCredentialV12(SubscriberCredentialCallback callback,
                                           const std::string& skus_credential,
                                           const std::string& environment);
 
+  // Connect API: VerifyPurchaseToken.
+  // Verifies a store purchase token and returns the server's JSON response
+  // verbatim.
+  using VerifyPurchaseTokenCallback =
+      base::OnceCallback<void(base::expected<std::string, std::string>)>;
+  virtual void VerifyPurchaseToken(VerifyPurchaseTokenCallback callback,
+                                   const std::string& purchase_token,
+                                   const std::string& product_id,
+                                   const std::string& product_type,
+                                   const std::string& bundle_id);
+
  private:
-  void OnGetSubscriberCredentialV12Response(
+  void OnGetSubscriberCredentialResponse(
       SubscriberCredentialCallback callback,
-      endpoints::GetSubscriberCredentialV12::Response response);
+      endpoints::GetSubscriberCredential::Response response);
+  void OnVerifyPurchaseTokenResponse(
+      VerifyPurchaseTokenCallback callback,
+      endpoints::VerifyPurchaseToken::Response response);
 
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
   base::WeakPtrFactory<BraveVpnApiClient> weak_factory_{this};

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client_unittest.cc
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client_unittest.cc
@@ -6,39 +6,52 @@
 #include "brave/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h"
 
 #include <string>
+#include <string_view>
+#include <tuple>
 #include <utility>
+#include <vector>
 
+#include "base/containers/extend.h"
 #include "base/functional/callback.h"
+#include "base/test/bind.h"
 #include "base/test/task_environment.h"
 #include "base/test/test_future.h"
 #include "base/types/expected.h"
 #include "brave/components/brave_account/endpoint_client/test_support.h"
 #include "brave/components/brave_vpn/browser/v2/api/error_body.h"
 #include "brave/components/brave_vpn/browser/v2/api/purchase_endpoints.h"
+#include "brave/components/brave_vpn/browser/v2/api/raw_json_response_body.h"
 #include "net/base/net_errors.h"
 #include "net/http/http_status_code.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
+#include "services/network/test/test_utils.h"
+#include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/abseil-cpp/absl/strings/str_format.h"
 
 namespace brave_vpn::v2 {
 namespace {
+using brave_account::endpoint_client::MatchesEndpoint;
 using brave_account::endpoint_client::MockResponseFor;
 
+constexpr char kTestProductType[] = "test-product-type";
+constexpr char kTestProductId[] = "test-product-id";
+constexpr char kTestValidationMethod[] = "test-validation-method";
+constexpr char kTestPurchaseToken[] = "test-purchase-token";
+constexpr char kTestBundleId[] = "test-bundle-id";
 constexpr char kTestSkusCredential[] = "test-skus-credential";
 constexpr char kTestSubscriberCredential[] = "test-subscriber-credential";
 constexpr char kTestEnvironment[] = "test-env";
+
+// Canonical JSON (compact, keys sorted): MockResponseFor re-serializes the
+// body via ToValue() and the client re-parses it via FromValue(), so only
+// already-canonical literals round-trip back to an identical string.
+constexpr char kTestSuccessJson[] = R"({"receipt":"valid"})";
+constexpr char kTestErrorJson[] = R"({"error":"invalid"})";
 }  // namespace
 
-struct GetSubscriberCredentialV12TestCase {
-  std::string test_name;
-  endpoints::GetSubscriberCredentialV12::Response response;
-  base::expected<std::string, std::string> expected;
-};
-
-template <typename TestCase>
-class BraveVpnApiClientTest : public testing::TestWithParam<TestCase> {
+class BraveVpnApiClientTestBase : public testing::Test {
  public:
   // Fires a client API method and blocks until its callback runs, returning the
   // result the callback was invoked with. Works for any method shaped like
@@ -55,10 +68,197 @@ class BraveVpnApiClientTest : public testing::TestWithParam<TestCase> {
     return future.Take();
   }
 
+  // Capture the outgoing request. SetInterceptor is orthogonal to the
+  // AddResponse-style matching MockResponseFor uses, so both fire.
+  void CaptureRequests() {
+    url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
+        [this](const network::ResourceRequest& request) {
+          last_request_ = request;
+          got_request_ = true;
+        }));
+  }
+
  protected:
   base::test::TaskEnvironment task_environment_;
   network::TestURLLoaderFactory url_loader_factory_;
   BraveVpnApiClient client_{url_loader_factory_.GetSafeWeakWrapper()};
+  network::ResourceRequest last_request_;
+  bool got_request_ = false;
+};
+
+TEST_F(BraveVpnApiClientTestBase, GetSubscriberCredentialSerializesRequest) {
+  CaptureRequests();
+  MockResponseFor<endpoints::GetSubscriberCredential>(
+      url_loader_factory_,
+      {.net_error = net::OK,
+       .status_code = net::HTTP_OK,
+       .body = endpoints::GetSubscriberCredentialSuccessBody{
+           .subscriber_credential = "ignored"}});
+
+  std::ignore = CallClientApi(
+      &BraveVpnApiClient::GetSubscriberCredential, kTestProductType,
+      kTestProductId, kTestValidationMethod, kTestPurchaseToken, kTestBundleId);
+
+  ASSERT_TRUE(got_request_);
+  EXPECT_TRUE(
+      MatchesEndpoint<endpoints::GetSubscriberCredential>(last_request_));
+
+  auto body = base::JSONReader::ReadDict(network::GetUploadData(last_request_),
+                                         base::JSON_PARSE_RFC);
+  ASSERT_TRUE(body);
+  EXPECT_EQ(body->size(), 5u);
+  EXPECT_THAT(body->FindString(endpoints::kProductTypeKey),
+              testing::Pointee(std::string(kTestProductType)));
+  EXPECT_THAT(body->FindString(endpoints::kProductIdKey),
+              testing::Pointee(std::string(kTestProductId)));
+  EXPECT_THAT(body->FindString(endpoints::kValidationMethodKey),
+              testing::Pointee(std::string(kTestValidationMethod)));
+  EXPECT_THAT(body->FindString(endpoints::kPurchaseTokenKey),
+              testing::Pointee(std::string(kTestPurchaseToken)));
+  EXPECT_THAT(body->FindString(endpoints::kBundleIdKey),
+              testing::Pointee(std::string(kTestBundleId)));
+}
+
+TEST_F(BraveVpnApiClientTestBase, GetSubscriberCredentialV12SerializesRequest) {
+  CaptureRequests();
+  MockResponseFor<endpoints::GetSubscriberCredentialV12>(
+      url_loader_factory_,
+      {.net_error = net::OK,
+       .status_code = net::HTTP_OK,
+       .body = endpoints::GetSubscriberCredentialSuccessBody{
+           .subscriber_credential = "ignored"}});
+
+  std::ignore = CallClientApi(&BraveVpnApiClient::GetSubscriberCredentialV12,
+                              kTestSkusCredential, kTestEnvironment);
+
+  ASSERT_TRUE(got_request_);
+  EXPECT_TRUE(
+      MatchesEndpoint<endpoints::GetSubscriberCredentialV12>(last_request_));
+
+  auto body = base::JSONReader::ReadDict(network::GetUploadData(last_request_),
+                                         base::JSON_PARSE_RFC);
+  ASSERT_TRUE(body);
+  EXPECT_EQ(body->size(), 2u);
+  EXPECT_THAT(body->FindString(endpoints::kSkusCredentialKey),
+              testing::Pointee(std::string(kTestSkusCredential)));
+  EXPECT_THAT(
+      body->FindString(endpoints::kValidationMethodKey),
+      testing::Pointee(std::string(endpoints::kValidationMethodDefaultValue)));
+  EXPECT_THAT(last_request_.headers.GetHeader(
+                  endpoints::kHeaderBravePaymentsEnvironment),
+              testing::Optional(std::string(kTestEnvironment)));
+}
+
+TEST_F(BraveVpnApiClientTestBase, VerifyPurchaseTokenSerializesRequest) {
+  CaptureRequests();
+  MockResponseFor<endpoints::VerifyPurchaseToken>(
+      url_loader_factory_,
+      {.net_error = net::OK,
+       .status_code = net::HTTP_OK,
+       .body = base::ok(endpoints::RawJsonResponseBody{.json = "{}"})});
+
+  std::ignore =
+      CallClientApi(&BraveVpnApiClient::VerifyPurchaseToken, kTestPurchaseToken,
+                    kTestProductId, kTestProductType, kTestBundleId);
+
+  ASSERT_TRUE(got_request_);
+  EXPECT_TRUE(MatchesEndpoint<endpoints::VerifyPurchaseToken>(last_request_));
+
+  auto body = base::JSONReader::ReadDict(network::GetUploadData(last_request_),
+                                         base::JSON_PARSE_RFC);
+  ASSERT_TRUE(body);
+  EXPECT_EQ(body->size(), 4u);
+  EXPECT_THAT(body->FindString(endpoints::kPurchaseTokenKey),
+              testing::Pointee(std::string(kTestPurchaseToken)));
+  EXPECT_THAT(body->FindString(endpoints::kProductTypeKey),
+              testing::Pointee(std::string(kTestProductType)));
+  EXPECT_THAT(body->FindString(endpoints::kProductIdKey),
+              testing::Pointee(std::string(kTestProductId)));
+  EXPECT_THAT(body->FindString(endpoints::kBundleIdKey),
+              testing::Pointee(std::string(kTestBundleId)));
+}
+
+template <typename TestCase>
+class BraveVpnApiClientTest : public BraveVpnApiClientTestBase,
+                              public testing::WithParamInterface<TestCase> {};
+
+// The two "unrecoverable response" cases are identical for every endpoint.
+template <typename TestCase>
+std::vector<TestCase> WithCommonUnrecoverableCases(
+    std::vector<TestCase> endpoint_specific_cases) {
+  std::vector<TestCase> cases = {
+      // A transport failure surfaces the net-error description, not an HTTP
+      // status.
+      TestCase{
+          .test_name = "TransportErrorReturnsNetErrorString",
+          .response = {.net_error = net::ERR_TIMED_OUT},
+          .expected = base::unexpected(net::ErrorToString(net::ERR_TIMED_OUT))},
+      // A non-2xx response whose body is not a parseable error falls back to
+      // the HTTP status description (the status_code branch of
+      // MaybeDescribeUnrecoverableResponse).
+      TestCase{.test_name = "HttpErrorWithUnparseableBodyDescribesStatus",
+               .response = {.net_error = net::OK,
+                            .status_code = net::HTTP_INTERNAL_SERVER_ERROR},
+               .expected = base::unexpected(absl::StrFormat(
+                   "HTTP %d %s: body missing or failed to parse",
+                   net::HTTP_INTERNAL_SERVER_ERROR,
+                   net::GetHttpReasonPhrase(net::HTTP_INTERNAL_SERVER_ERROR)))},
+  };
+  base::Extend(cases, std::move(endpoint_specific_cases));
+  return cases;
+}
+
+struct GetSubscriberCredentialTestCase {
+  std::string test_name;
+  endpoints::GetSubscriberCredential::Response response;
+  base::expected<std::string, std::string> expected;
+};
+
+using BraveVpnApiClientGetSubscriberCredentialTest =
+    BraveVpnApiClientTest<GetSubscriberCredentialTestCase>;
+
+TEST_P(BraveVpnApiClientGetSubscriberCredentialTest, MapsResponseToResult) {
+  const auto& test_case = GetParam();
+  MockResponseFor<endpoints::GetSubscriberCredential>(url_loader_factory_,
+                                                      test_case.response);
+  EXPECT_EQ(
+      CallClientApi(&BraveVpnApiClient::GetSubscriberCredential,
+                    kTestProductType, kTestProductId, kTestValidationMethod,
+                    kTestPurchaseToken, kTestBundleId),
+      test_case.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BraveVpnApiClientTests,
+    BraveVpnApiClientGetSubscriberCredentialTest,
+    testing::ValuesIn(WithCommonUnrecoverableCases<
+                      GetSubscriberCredentialTestCase>(
+        {// A 2xx response with a parseable success body yields the subscriber
+         // credential.
+         GetSubscriberCredentialTestCase{
+             .test_name = "Success",
+             .response = {.net_error = net::OK,
+                          .status_code = net::HTTP_OK,
+                          .body =
+                              endpoints::GetSubscriberCredentialSuccessBody{
+                                  .subscriber_credential =
+                                      kTestSubscriberCredential}},
+             .expected = base::ok(kTestSubscriberCredential)},
+         // A non-2xx response with a parseable error body surfaces its title.
+         GetSubscriberCredentialTestCase{
+             .test_name = "RequestError",
+             .response = {.net_error = net::OK,
+                          .status_code = net::HTTP_BAD_REQUEST,
+                          .body = base::unexpected(endpoints::VpnErrorBody{
+                              .error_title = "Token no longer valid.",
+                              .error_message = "gone"})},
+             .expected = base::unexpected("Token no longer valid.")}})),
+    [](const auto& info) { return info.param.test_name; });
+
+struct GetSubscriberCredentialV12TestCase {
+  std::string test_name;
+  endpoints::GetSubscriberCredentialV12::Response response;
+  base::expected<std::string, std::string> expected;
 };
 
 using BraveVpnApiClientGetSubscriberCredentialV12Test =
@@ -76,45 +276,71 @@ TEST_P(BraveVpnApiClientGetSubscriberCredentialV12Test, MapsResponseToResult) {
 INSTANTIATE_TEST_SUITE_P(
     BraveVpnApiClientTests,
     BraveVpnApiClientGetSubscriberCredentialV12Test,
-    testing::Values(
-        // A transport failure surfaces the net-error description, not an HTTP
-        // status.
-        GetSubscriberCredentialV12TestCase{
-            .test_name = "TransportErrorReturnsNetErrorString",
-            .response = {.net_error = net::ERR_TIMED_OUT},
-            .expected =
-                base::unexpected(net::ErrorToString(net::ERR_TIMED_OUT))},
-        // A non-2xx response whose body is not a parseable error falls back to
-        // the HTTP status description (the status_code branch of
-        // MaybeDescribeUnrecoverableResponse).
-        GetSubscriberCredentialV12TestCase{
-            .test_name = "HttpErrorWithUnparseableBodyDescribesStatus",
-            .response = {.net_error = net::OK,
-                         .status_code = net::HTTP_INTERNAL_SERVER_ERROR},
-            .expected = base::unexpected(absl::StrFormat(
-                "HTTP %d %s: body missing or failed to parse",
-                net::HTTP_INTERNAL_SERVER_ERROR,
-                net::GetHttpReasonPhrase(net::HTTP_INTERNAL_SERVER_ERROR)))},
-        // A 2xx response with a parseable success body yields the subscriber
-        // credential.
-        GetSubscriberCredentialV12TestCase{
-            .test_name = "Success",
-            .response = {.net_error = net::OK,
-                         .status_code = net::HTTP_OK,
-                         .body =
-                             endpoints::GetSubscriberCredentialV12SuccessBody{
-                                 .subscriber_credential =
-                                     kTestSubscriberCredential}},
-            .expected = base::ok(kTestSubscriberCredential)},
-        // A non-2xx response with a parseable error body surfaces its title.
-        GetSubscriberCredentialV12TestCase{
-            .test_name = "RequestError",
-            .response = {.net_error = net::OK,
-                         .status_code = net::HTTP_BAD_REQUEST,
-                         .body = base::unexpected(endpoints::VpnErrorBody{
-                             .error_title = "Token no longer valid.",
-                             .error_message = "gone"})},
-            .expected = base::unexpected("Token no longer valid.")}),
+    testing::ValuesIn(WithCommonUnrecoverableCases<
+                      GetSubscriberCredentialV12TestCase>(
+        {// A 2xx response with a parseable success body yields the subscriber
+         // credential.
+         GetSubscriberCredentialV12TestCase{
+             .test_name = "Success",
+             .response = {.net_error = net::OK,
+                          .status_code = net::HTTP_OK,
+                          .body =
+                              endpoints::GetSubscriberCredentialSuccessBody{
+                                  .subscriber_credential =
+                                      kTestSubscriberCredential}},
+             .expected = base::ok(kTestSubscriberCredential)},
+         // A non-2xx response with a parseable error body surfaces its title.
+         GetSubscriberCredentialV12TestCase{
+             .test_name = "RequestError",
+             .response = {.net_error = net::OK,
+                          .status_code = net::HTTP_BAD_REQUEST,
+                          .body = base::unexpected(endpoints::VpnErrorBody{
+                              .error_title = "Token no longer valid.",
+                              .error_message = "gone"})},
+             .expected = base::unexpected("Token no longer valid.")}})),
+    [](const auto& info) { return info.param.test_name; });
+
+struct VerifyPurchaseTokenTestCase {
+  std::string test_name;
+  endpoints::VerifyPurchaseToken::Response response;
+  base::expected<std::string, std::string> expected;
+};
+
+using BraveVpnApiClientVerifyPurchaseTokenTest =
+    BraveVpnApiClientTest<VerifyPurchaseTokenTestCase>;
+
+TEST_P(BraveVpnApiClientVerifyPurchaseTokenTest, MapsResponseToResult) {
+  const auto& test_case = GetParam();
+  MockResponseFor<endpoints::VerifyPurchaseToken>(url_loader_factory_,
+                                                  test_case.response);
+  EXPECT_EQ(
+      CallClientApi(&BraveVpnApiClient::VerifyPurchaseToken, kTestPurchaseToken,
+                    kTestProductId, kTestProductType, kTestBundleId),
+      test_case.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BraveVpnApiClientTests,
+    BraveVpnApiClientVerifyPurchaseTokenTest,
+    testing::ValuesIn(WithCommonUnrecoverableCases<VerifyPurchaseTokenTestCase>(
+        {// 2xx body is forwarded verbatim.
+         VerifyPurchaseTokenTestCase{
+             .test_name = "Success",
+             .response = {.net_error = net::OK,
+                          .status_code = net::HTTP_OK,
+                          .body = base::ok(endpoints::RawJsonResponseBody{
+                              .json = kTestSuccessJson})},
+             .expected = base::ok(kTestSuccessJson)},
+         // non-2xx error body is *also* forwarded verbatim (raw on both sides),
+         // not collapsed to a VpnErrorBody title.
+         VerifyPurchaseTokenTestCase{
+             .test_name = "RequestError",
+             .response = {.net_error = net::OK,
+                          .status_code = net::HTTP_BAD_REQUEST,
+                          .body =
+                              base::unexpected(endpoints::RawJsonResponseBody{
+                                  .json = kTestErrorJson})},
+             .expected = base::unexpected(kTestErrorJson)}})),
     [](const auto& info) { return info.param.test_name; });
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client_unittest.cc
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client_unittest.cc
@@ -6,14 +6,11 @@
 #include "brave/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h"
 
 #include <string>
-#include <string_view>
-#include <tuple>
 #include <utility>
 #include <vector>
 
 #include "base/containers/extend.h"
 #include "base/functional/callback.h"
-#include "base/test/bind.h"
 #include "base/test/task_environment.h"
 #include "base/test/test_future.h"
 #include "base/types/expected.h"
@@ -25,14 +22,11 @@
 #include "net/http/http_status_code.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
-#include "services/network/test/test_utils.h"
-#include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/abseil-cpp/absl/strings/str_format.h"
 
 namespace brave_vpn::v2 {
 namespace {
-using brave_account::endpoint_client::MatchesEndpoint;
 using brave_account::endpoint_client::MockResponseFor;
 
 constexpr char kTestProductType[] = "test-product-type";
@@ -51,7 +45,8 @@ constexpr char kTestSuccessJson[] = R"({"receipt":"valid"})";
 constexpr char kTestErrorJson[] = R"({"error":"invalid"})";
 }  // namespace
 
-class BraveVpnApiClientTestBase : public testing::Test {
+template <typename TestCase>
+class BraveVpnApiClientTest : public testing::TestWithParam<TestCase> {
  public:
   // Fires a client API method and blocks until its callback runs, returning the
   // result the callback was invoked with. Works for any method shaped like
@@ -68,119 +63,11 @@ class BraveVpnApiClientTestBase : public testing::Test {
     return future.Take();
   }
 
-  // Capture the outgoing request. SetInterceptor is orthogonal to the
-  // AddResponse-style matching MockResponseFor uses, so both fire.
-  void CaptureRequests() {
-    url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
-        [this](const network::ResourceRequest& request) {
-          last_request_ = request;
-          got_request_ = true;
-        }));
-  }
-
  protected:
   base::test::TaskEnvironment task_environment_;
   network::TestURLLoaderFactory url_loader_factory_;
   BraveVpnApiClient client_{url_loader_factory_.GetSafeWeakWrapper()};
-  network::ResourceRequest last_request_;
-  bool got_request_ = false;
 };
-
-TEST_F(BraveVpnApiClientTestBase, GetSubscriberCredentialSerializesRequest) {
-  CaptureRequests();
-  MockResponseFor<endpoints::GetSubscriberCredential>(
-      url_loader_factory_,
-      {.net_error = net::OK,
-       .status_code = net::HTTP_OK,
-       .body = endpoints::GetSubscriberCredentialSuccessBody{
-           .subscriber_credential = "ignored"}});
-
-  std::ignore = CallClientApi(
-      &BraveVpnApiClient::GetSubscriberCredential, kTestProductType,
-      kTestProductId, kTestValidationMethod, kTestPurchaseToken, kTestBundleId);
-
-  ASSERT_TRUE(got_request_);
-  EXPECT_TRUE(
-      MatchesEndpoint<endpoints::GetSubscriberCredential>(last_request_));
-
-  auto body = base::JSONReader::ReadDict(network::GetUploadData(last_request_),
-                                         base::JSON_PARSE_RFC);
-  ASSERT_TRUE(body);
-  EXPECT_EQ(body->size(), 5u);
-  EXPECT_THAT(body->FindString(endpoints::kProductTypeKey),
-              testing::Pointee(std::string(kTestProductType)));
-  EXPECT_THAT(body->FindString(endpoints::kProductIdKey),
-              testing::Pointee(std::string(kTestProductId)));
-  EXPECT_THAT(body->FindString(endpoints::kValidationMethodKey),
-              testing::Pointee(std::string(kTestValidationMethod)));
-  EXPECT_THAT(body->FindString(endpoints::kPurchaseTokenKey),
-              testing::Pointee(std::string(kTestPurchaseToken)));
-  EXPECT_THAT(body->FindString(endpoints::kBundleIdKey),
-              testing::Pointee(std::string(kTestBundleId)));
-}
-
-TEST_F(BraveVpnApiClientTestBase, GetSubscriberCredentialV12SerializesRequest) {
-  CaptureRequests();
-  MockResponseFor<endpoints::GetSubscriberCredentialV12>(
-      url_loader_factory_,
-      {.net_error = net::OK,
-       .status_code = net::HTTP_OK,
-       .body = endpoints::GetSubscriberCredentialSuccessBody{
-           .subscriber_credential = "ignored"}});
-
-  std::ignore = CallClientApi(&BraveVpnApiClient::GetSubscriberCredentialV12,
-                              kTestSkusCredential, kTestEnvironment);
-
-  ASSERT_TRUE(got_request_);
-  EXPECT_TRUE(
-      MatchesEndpoint<endpoints::GetSubscriberCredentialV12>(last_request_));
-
-  auto body = base::JSONReader::ReadDict(network::GetUploadData(last_request_),
-                                         base::JSON_PARSE_RFC);
-  ASSERT_TRUE(body);
-  EXPECT_EQ(body->size(), 2u);
-  EXPECT_THAT(body->FindString(endpoints::kSkusCredentialKey),
-              testing::Pointee(std::string(kTestSkusCredential)));
-  EXPECT_THAT(
-      body->FindString(endpoints::kValidationMethodKey),
-      testing::Pointee(std::string(endpoints::kValidationMethodDefaultValue)));
-  EXPECT_THAT(last_request_.headers.GetHeader(
-                  endpoints::kHeaderBravePaymentsEnvironment),
-              testing::Optional(std::string(kTestEnvironment)));
-}
-
-TEST_F(BraveVpnApiClientTestBase, VerifyPurchaseTokenSerializesRequest) {
-  CaptureRequests();
-  MockResponseFor<endpoints::VerifyPurchaseToken>(
-      url_loader_factory_,
-      {.net_error = net::OK,
-       .status_code = net::HTTP_OK,
-       .body = base::ok(endpoints::RawJsonResponseBody{.json = "{}"})});
-
-  std::ignore =
-      CallClientApi(&BraveVpnApiClient::VerifyPurchaseToken, kTestPurchaseToken,
-                    kTestProductId, kTestProductType, kTestBundleId);
-
-  ASSERT_TRUE(got_request_);
-  EXPECT_TRUE(MatchesEndpoint<endpoints::VerifyPurchaseToken>(last_request_));
-
-  auto body = base::JSONReader::ReadDict(network::GetUploadData(last_request_),
-                                         base::JSON_PARSE_RFC);
-  ASSERT_TRUE(body);
-  EXPECT_EQ(body->size(), 4u);
-  EXPECT_THAT(body->FindString(endpoints::kPurchaseTokenKey),
-              testing::Pointee(std::string(kTestPurchaseToken)));
-  EXPECT_THAT(body->FindString(endpoints::kProductTypeKey),
-              testing::Pointee(std::string(kTestProductType)));
-  EXPECT_THAT(body->FindString(endpoints::kProductIdKey),
-              testing::Pointee(std::string(kTestProductId)));
-  EXPECT_THAT(body->FindString(endpoints::kBundleIdKey),
-              testing::Pointee(std::string(kTestBundleId)));
-}
-
-template <typename TestCase>
-class BraveVpnApiClientTest : public BraveVpnApiClientTestBase,
-                              public testing::WithParamInterface<TestCase> {};
 
 // The two "unrecoverable response" cases are identical for every endpoint.
 template <typename TestCase>

--- a/components/brave_vpn/browser/v2/api/purchase_endpoints.h
+++ b/components/brave_vpn/browser/v2/api/purchase_endpoints.h
@@ -14,6 +14,7 @@
 #include "brave/components/brave_account/endpoint_client/request_types.h"
 #include "brave/components/brave_account/endpoint_client/response.h"
 #include "brave/components/brave_vpn/browser/v2/api/error_body.h"
+#include "brave/components/brave_vpn/browser/v2/api/raw_json_response_body.h"
 #include "brave/components/brave_vpn/common/brave_vpn_constants.h"
 #include "url/gurl.h"
 #include "url/url_constants.h"
@@ -23,10 +24,36 @@
 
 namespace brave_vpn::v2::endpoints {
 
+inline constexpr char kProductTypeKey[] = "product-type";
+inline constexpr char kProductIdKey[] = "product-id";
+inline constexpr char kPurchaseTokenKey[] = "purchase-token";
+inline constexpr char kBundleIdKey[] = "bundle-id";
 inline constexpr char kValidationMethodKey[] = "validation-method";
-inline constexpr char kValidationMethodValue[] = "brave-premium";
+inline constexpr char kValidationMethodDefaultValue[] = "brave-premium";
 inline constexpr char kSkusCredentialKey[] = "brave-vpn-premium-monthly-pass";
 inline constexpr char kSubscriberCredentialKey[] = "subscriber-credential";
+inline constexpr char kHeaderBravePaymentsEnvironment[] =
+    "Brave-Payments-Environment";
+
+// GetSubscriberCredential API (legacy, store-purchase based) exchanges store
+// purchase details for a subscriber credential. Shares the success/error bodies
+// and URL with the V12 flow; only the request body differs.
+struct GetSubscriberCredentialRequestBody {
+  std::string product_type;
+  std::string product_id;
+  std::string validation_method;
+  std::string purchase_token;
+  std::string bundle_id;
+
+  base::DictValue ToValue() const {
+    return base::DictValue()
+        .Set(kProductTypeKey, product_type)
+        .Set(kProductIdKey, product_id)
+        .Set(kValidationMethodKey, validation_method)
+        .Set(kPurchaseTokenKey, purchase_token)
+        .Set(kBundleIdKey, bundle_id);
+  }
+};
 
 // GetSubscriberCredentialV12 API exchanges a SKUs credential for a subscriber
 // credential.
@@ -35,15 +62,15 @@ struct GetSubscriberCredentialV12RequestBody {
 
   base::DictValue ToValue() const {
     return base::DictValue()
-        .Set(kValidationMethodKey, kValidationMethodValue)
+        .Set(kValidationMethodKey, kValidationMethodDefaultValue)
         .Set(kSkusCredentialKey, skus_credential);
   }
 };
 
-struct GetSubscriberCredentialV12SuccessBody {
+struct GetSubscriberCredentialSuccessBody {
   std::string subscriber_credential;
 
-  static std::optional<GetSubscriberCredentialV12SuccessBody> FromValue(
+  static std::optional<GetSubscriberCredentialSuccessBody> FromValue(
       const base::Value& value) {
     const auto* dict = value.GetIfDict();
     if (!dict) {
@@ -53,8 +80,8 @@ struct GetSubscriberCredentialV12SuccessBody {
     if (!credential) {
       return std::nullopt;
     }
-    return GetSubscriberCredentialV12SuccessBody{.subscriber_credential =
-                                                     *credential};
+    return GetSubscriberCredentialSuccessBody{.subscriber_credential =
+                                                  *credential};
   }
 
   base::DictValue ToValue() const {
@@ -63,16 +90,53 @@ struct GetSubscriberCredentialV12SuccessBody {
   }
 };
 
-struct GetSubscriberCredentialV12 {
-  using Request = brave_account::endpoint_client::POST<
-      GetSubscriberCredentialV12RequestBody>;
+template <typename RequestBody>
+struct GetSubscriberCredentialBase {
+  using Request = brave_account::endpoint_client::POST<RequestBody>;
   using Response = brave_account::endpoint_client::
-      Response<GetSubscriberCredentialV12SuccessBody, VpnErrorBody>;
+      Response<GetSubscriberCredentialSuccessBody, VpnErrorBody>;
 
   static GURL URL() {
     return GURL(base::StrCat({url::kHttpsScheme, url::kStandardSchemeSeparator,
                               kVpnHost}))
         .Resolve(kCreateSubscriberCredentialV12);
+  }
+};
+
+using GetSubscriberCredential =
+    GetSubscriberCredentialBase<GetSubscriberCredentialRequestBody>;
+
+using GetSubscriberCredentialV12 =
+    GetSubscriberCredentialBase<GetSubscriberCredentialV12RequestBody>;
+
+// VerifyPurchaseToken API verifies a store purchase token and returns the
+// server's JSON response verbatim.
+struct VerifyPurchaseTokenRequestBody {
+  std::string purchase_token;
+  std::string product_id;
+  std::string product_type;
+  std::string bundle_id;
+
+  base::DictValue ToValue() const {
+    return base::DictValue()
+        .Set(kPurchaseTokenKey, purchase_token)
+        .Set(kProductIdKey, product_id)
+        .Set(kProductTypeKey, product_type)
+        .Set(kBundleIdKey, bundle_id);
+  }
+};
+
+struct VerifyPurchaseToken {
+  using Request =
+      brave_account::endpoint_client::POST<VerifyPurchaseTokenRequestBody>;
+  using Response =
+      brave_account::endpoint_client::Response<RawJsonResponseBody,
+                                               RawJsonResponseBody>;
+
+  static GURL URL() {
+    return GURL(base::StrCat({url::kHttpsScheme, url::kStandardSchemeSeparator,
+                              kVpnHost}))
+        .Resolve(kVerifyPurchaseToken);
   }
 };
 

--- a/components/brave_vpn/browser/v2/api/purchase_endpoints_unittest.cc
+++ b/components/brave_vpn/browser/v2/api/purchase_endpoints_unittest.cc
@@ -1,0 +1,59 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/api/purchase_endpoints.h"
+
+#include "base/values.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn::v2::endpoints {
+namespace {
+constexpr char kTestProductType[] = "test-product-type";
+constexpr char kTestProductId[] = "test-product-id";
+constexpr char kTestValidationMethod[] = "test-validation-method";
+constexpr char kTestPurchaseToken[] = "test-purchase-token";
+constexpr char kTestBundleId[] = "test-bundle-id";
+constexpr char kTestSkusCredential[] = "test-skus-credential";
+}  // namespace
+
+TEST(PurchaseEndpointsTest, GetSubscriberCredentialRequestBodyToValue) {
+  const GetSubscriberCredentialRequestBody body{
+      .product_type = kTestProductType,
+      .product_id = kTestProductId,
+      .validation_method = kTestValidationMethod,
+      .purchase_token = kTestPurchaseToken,
+      .bundle_id = kTestBundleId};
+  EXPECT_EQ(body.ToValue(),
+            base::DictValue()
+                .Set(kProductTypeKey, kTestProductType)
+                .Set(kProductIdKey, kTestProductId)
+                .Set(kValidationMethodKey, kTestValidationMethod)
+                .Set(kPurchaseTokenKey, kTestPurchaseToken)
+                .Set(kBundleIdKey, kTestBundleId));
+}
+
+TEST(PurchaseEndpointsTest, GetSubscriberCredentialV12RequestBodyToValue) {
+  const GetSubscriberCredentialV12RequestBody body{.skus_credential =
+                                                       kTestSkusCredential};
+  EXPECT_EQ(body.ToValue(),
+            base::DictValue()
+                .Set(kValidationMethodKey, kValidationMethodDefaultValue)
+                .Set(kSkusCredentialKey, kTestSkusCredential));
+}
+
+TEST(PurchaseEndpointsTest, VerifyPurchaseTokenRequestBodyToValue) {
+  const VerifyPurchaseTokenRequestBody body{
+      .purchase_token = kTestPurchaseToken,
+      .product_id = kTestProductId,
+      .product_type = kTestProductType,
+      .bundle_id = kTestBundleId};
+  EXPECT_EQ(body.ToValue(), base::DictValue()
+                                .Set(kPurchaseTokenKey, kTestPurchaseToken)
+                                .Set(kProductIdKey, kTestProductId)
+                                .Set(kProductTypeKey, kTestProductType)
+                                .Set(kBundleIdKey, kTestBundleId));
+}
+
+}  // namespace brave_vpn::v2::endpoints

--- a/components/brave_vpn/browser/v2/api/raw_json_response_body.h
+++ b/components/brave_vpn/browser/v2/api/raw_json_response_body.h
@@ -1,0 +1,40 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_RAW_JSON_RESPONSE_BODY_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_RAW_JSON_RESPONSE_BODY_H_
+
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "base/check_deref.h"
+#include "base/json/json_reader.h"
+#include "base/json/json_writer.h"
+#include "base/values.h"
+
+namespace brave_vpn::v2::endpoints {
+
+// A response body that captures the server's JSON payload verbatim
+// (re-serialized) instead of mapping it to typed fields. For endpoints whose
+// response is opaque to the browser and forwarded elsewhere for interpretation.
+struct RawJsonResponseBody {
+  std::string json;
+
+  static std::optional<RawJsonResponseBody> FromValue(
+      const base::Value& value) {
+    return base::WriteJson(value).transform([](std::string json) {
+      return RawJsonResponseBody{.json = std::move(json)};
+    });
+  }
+
+  base::DictValue ToValue() const {
+    return CHECK_DEREF(base::JSONReader::ReadDict(json, base::JSON_PARSE_RFC));
+  }
+};
+
+}  // namespace brave_vpn::v2::endpoints
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_RAW_JSON_RESPONSE_BODY_H_

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl_android.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl_android.cc
@@ -5,9 +5,27 @@
 
 #include "brave/components/brave_vpn/browser/v2/brave_vpn_service_impl.h"
 
+#include <optional>
+#include <utility>
+
+#include "base/check.h"
+#include "base/functional/bind.h"
 #include "base/notimplemented.h"
+#include "base/types/expected.h"
+#include "brave/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h"
+#include "brave/components/brave_vpn/browser/v2/purchased_state_manager.h"
 
 namespace brave_vpn::v2 {
+namespace {
+// Bridges the endpoint client's typed result to the legacy ResponseCallback
+// contract: value -> (payload, true); error -> (error string, false).
+void RunResponseCallback(BraveVpnServiceImpl::ResponseCallback callback,
+                         base::expected<std::string, std::string> result) {
+  const bool success = result.has_value();
+  std::move(callback).Run(
+      success ? std::move(result).value() : std::move(result).error(), success);
+}
+}  // namespace
 
 void BraveVpnServiceImpl::GetPurchaseToken(GetPurchaseTokenCallback callback) {
   NOTIMPLEMENTED();
@@ -63,7 +81,13 @@ void BraveVpnServiceImpl::VerifyPurchaseToken(ResponseCallback callback,
                                               const std::string& product_id,
                                               const std::string& product_type,
                                               const std::string& bundle_id) {
-  NOTIMPLEMENTED();
+  if (!api_client_) {
+    std::move(callback).Run({}, false);
+    return;
+  }
+  api_client_->VerifyPurchaseToken(
+      base::BindOnce(&RunResponseCallback, std::move(callback)), purchase_token,
+      product_id, product_type, bundle_id);
 }
 
 void BraveVpnServiceImpl::GetSubscriberCredential(
@@ -73,12 +97,23 @@ void BraveVpnServiceImpl::GetSubscriberCredential(
     const std::string& validation_method,
     const std::string& purchase_token,
     const std::string& bundle_id) {
-  NOTIMPLEMENTED();
+  if (!api_client_) {
+    std::move(callback).Run({}, false);
+    return;
+  }
+  api_client_->GetSubscriberCredential(
+      base::BindOnce(&RunResponseCallback, std::move(callback)), product_type,
+      product_id, validation_method, purchase_token, bundle_id);
 }
 
 void BraveVpnServiceImpl::GetSubscriberCredentialV12(
     ResponseCallback callback) {
-  NOTIMPLEMENTED();
+  std::optional<std::string> subscriber_credential =
+      purchased_state_manager_
+          ? purchased_state_manager_->GetSubscriberCredential()
+          : std::nullopt;
+  std::move(callback).Run(subscriber_credential.value_or(""),
+                          subscriber_credential.has_value());
 }
 
 void BraveVpnServiceImpl::RecordAllMetrics() {

--- a/components/brave_vpn/browser/v2/purchased_state_manager.cc
+++ b/components/brave_vpn/browser/v2/purchased_state_manager.cc
@@ -128,6 +128,12 @@ std::string PurchasedStateManager::GetCurrentEnvironment() const {
   return local_prefs_->GetString(prefs::kBraveVPNEnvironment);
 }
 
+std::optional<std::string> PurchasedStateManager::GetSubscriberCredential()
+    const {
+  return credential_store_->GetValidSubscriberCredential().transform(
+      [](const CredentialStore::Credential& data) { return data.value; });
+}
+
 void PurchasedStateManager::SetPurchasedState(
     const std::string& env,
     mojom::PurchasedState state,

--- a/components/brave_vpn/browser/v2/purchased_state_manager.h
+++ b/components/brave_vpn/browser/v2/purchased_state_manager.h
@@ -74,6 +74,7 @@ class PurchasedStateManager final {
   mojom::PurchasedInfo GetInfo() const;
   bool IsPurchased() const;
   std::string GetCurrentEnvironment() const;
+  std::optional<std::string> GetSubscriberCredential() const;
 
   void SetPurchasedState(const std::string& env,
                          mojom::PurchasedState state,

--- a/components/brave_vpn/browser/v2/purchased_state_manager_unittest.cc
+++ b/components/brave_vpn/browser/v2/purchased_state_manager_unittest.cc
@@ -1190,7 +1190,7 @@ class PurchasedStateManagerWithRealSkusServiceTest
       kExchangeSuccessResponse{
           .net_error = net::OK,
           .status_code = net::HTTP_OK,
-          .body = endpoints::GetSubscriberCredentialV12SuccessBody{
+          .body = endpoints::GetSubscriberCredentialSuccessBody{
               .subscriber_credential = std::string(kTestSubscriberCredential)}};
 
   base::test::ScopedFeatureList scoped_feature_list_;


### PR DESCRIPTION
Ported `GetSubscriberCredential` and `VerifyPurchaseToken` to the endpoint client, following the existing GetSubscriberCredentialV12 pattern in BraveVpnApiClient. Plumbed both through BraveVpnServiceImpl, adapting the typed base::expected result back to the legacy (payload, success) ResponseCallback contract.

Implements part of https://github.com/brave/brave-browser/issues/54600



<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
