### PR TITLE
[recipes] Add the `json` module

### DIFF
--- a/tools/recipes/recipe_modules/json/__init__.py
+++ b/tools/recipes/recipe_modules/json/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""`json` module: produce and consume JSON to and from steps."""
+
+DEPS = ['raw_io']

--- a/tools/recipes/recipe_modules/json/api.py
+++ b/tools/recipes/recipe_modules/json/api.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""The `json` module API: JSON in and out of steps.
+
+Return codes are a poor channel for anything richer than "did it work", so the
+usual way for a step to report back is to write JSON. `api.json.output()` gives
+the step a path to write, and hands the parsed result back on the step's result
+as `step_result.json.output`; `api.json.input(data)` goes the other way.
+
+Deliberately not supported: `add_json_log` (mirroring the parsed JSON into a
+step log), which needs step presentation.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+from pathlib import Path
+from typing import Any
+
+from google.protobuf import json_format as jsonpb
+from google.protobuf import struct_pb2
+
+from recipe_api import OutputPlaceholder, RecipeApi, returns_placeholder
+
+# JSON is meant to be read by whoever debugs a build, so anything encoded here
+# gets the same treatment: stable key order and a real indent.
+_INDENT = 2
+
+# Beyond this magnitude a JSON number can't round-trip through a float, so a
+# whole float in range is safe to hand back as the int it plainly is.
+MIN_SAFE_INTEGER = -((2**53) - 1)
+MAX_SAFE_INTEGER = (2**53) - 1
+
+
+def _default_serializer(obj: Any):
+    """Make the types recipes pass around routinely JSON-serializable."""
+    if isinstance(obj, Path):
+        return str(obj)
+    if isinstance(obj, struct_pb2.Struct):
+        # A proto Struct has exactly one sensible JSON form, so coercing it
+        # keeps code that serializes plain dicts working for Structs too. Other
+        # message types are deliberately left out: how a message becomes JSON
+        # is a choice (field name capitalization, and so on), so those go
+        # through the `proto` module instead.
+        return jsonpb.MessageToDict(obj)
+    raise TypeError(f'{obj!r} is not JSON serializable')
+
+
+@functools.wraps(json.dumps)
+def dumps(*args, **kwargs) -> str:
+    """Works like `json.dumps`, sorting keys and handling recipe types."""
+    kwargs.setdefault('sort_keys', True)
+    kwargs.setdefault('default', _default_serializer)
+    return json.dumps(*args, **kwargs)
+
+
+def fix_json_object(obj: Any) -> Any:
+    """Replace whole, in-range floats in *obj* with the ints they represent.
+
+    JSON has one number type, so a producer's `1` may arrive as `1.0`. Turning
+    those back into ints keeps a recipe from having to defend against it (and
+    keeps expectations from depending on which side of the wire wrote them).
+    """
+    if isinstance(obj, list):
+        return [fix_json_object(item) for item in obj]
+    if isinstance(obj, float):
+        if obj.is_integer() and MIN_SAFE_INTEGER <= obj <= MAX_SAFE_INTEGER:
+            return int(obj)
+        return obj
+    if isinstance(obj, dict):
+        return {
+            fix_json_object(key): fix_json_object(value)
+            for key, value in obj.items()
+        }
+    return obj
+
+
+@functools.wraps(json.loads)
+def loads(data: str, **kwargs) -> Any:
+    """Works like `json.loads`, but see `fix_json_object` for the difference."""
+    return fix_json_object(json.loads(data, **kwargs))
+
+
+class JsonOutputPlaceholder(OutputPlaceholder):
+    """Renders to a path the step writes JSON to, then parses it back.
+
+    This is a `raw_io.output_text` placeholder with a `json.loads` on the end:
+    the step sees an ordinary file path (e.g. `/tmp/tmp4lp1qM`), and by the time
+    the recipe sees the result it is a parsed Python value. A file the step
+    never wrote, or wrote something that isn't JSON to, results in `None` rather
+    than an exception, so a recipe can decide for itself how much it cares.
+    """
+
+    def __init__(self,
+                 api,
+                 name: str | None = None,
+                 leak_to: str | Path | None = None) -> None:
+        self.raw = api.m.raw_io.output_text('.json', leak_to=leak_to)
+        super().__init__(name=name)
+
+    @property
+    def backing_file(self) -> str | None:
+        return self.raw.backing_file
+
+    def render(self, test) -> list[str]:
+        return self.raw.render(test)
+
+    def result(self, test) -> Any:
+        raw_data = self.raw.result(test)
+        if raw_data is None:
+            return None
+        try:
+            return loads(raw_data)
+        except ValueError:
+            return None
+
+
+class JsonApi(RecipeApi):
+    """Encode and decode JSON, and carry it in and out of steps."""
+
+    @staticmethod
+    def dumps(*args, **kwargs) -> str:
+        """Works like `json.dumps`.
+
+        Dictionary keys are sorted by default (pass `sort_keys=False` to keep
+        insertion order), and `Path`/proto `Struct` values serialize sensibly.
+        """
+        return dumps(*args, **kwargs)
+
+    @staticmethod
+    def loads(data: str, **kwargs) -> Any:
+        """Works like `json.loads`, but whole in-range floats become ints."""
+        return loads(data, **kwargs)
+
+    @returns_placeholder
+    def input(self, data: Any, sort_keys: bool = True):
+        """A placeholder expanding to the path of a file holding *data* as JSON.
+
+        Args:
+            data: A JSON-serializable value to hand the step.
+            sort_keys: Sort dictionary keys. On by default so the rendered JSON
+                (and any expectation quoting it) is stable; turn it off when the
+                step cares about the original order.
+        """
+        return self.m.raw_io.input_text(
+            self.dumps(data, indent=_INDENT, sort_keys=sort_keys), '.json')
+
+    @returns_placeholder
+    def output(self,
+               name: str | None = None,
+               leak_to: str | Path | None = None) -> JsonOutputPlaceholder:
+        """A placeholder expanding to a path the step writes JSON to.
+
+        Once the step is done, the engine parses that file and files the result
+        onto the step's result as `step_result.json.output`. Also usable as a
+        step's `stdout`/`stderr`, in which case the parsed value is the result's
+        `stdout`/`stderr`.
+
+        Args:
+            name: Distinguishes this placeholder from others produced by the
+                same method on one step. With a name, the result is also at
+                `step_result.json.outputs[name]`.
+            leak_to: Write to this path instead of a temporary file, and do not
+                delete it afterwards (i.e. "leak" it), so a later step can pick
+                it up.
+        """
+        return JsonOutputPlaceholder(self, name=name, leak_to=leak_to)

--- a/tools/recipes/recipe_modules/json/examples/__init__.py
+++ b/tools/recipes/recipe_modules/json/examples/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tools/recipes/recipe_modules/json/examples/full.expected/basic.json
+++ b/tools/recipes/recipe_modules/json/examples/full.expected/basic.json
@@ -1,0 +1,62 @@
+[
+  {
+    "cmd": [
+      "echo",
+      "[1, 2, 3]"
+    ],
+    "name": "echo list"
+  },
+  {
+    "cmd": [
+      "echo",
+      "[2, 3, 4]"
+    ],
+    "name": "echo more"
+  },
+  {
+    "cmd": [
+      "run_tests",
+      "/path/to/tmp/json"
+    ],
+    "name": "run tests"
+  },
+  {
+    "cmd": [
+      "run_tests",
+      "/path/to/tmp/json",
+      "/path/to/tmp/json"
+    ],
+    "name": "run more tests"
+  },
+  {
+    "cmd": [
+      "cat",
+      "{\n  \"x\": 1,\n  \"y\": 2\n}"
+    ],
+    "name": "cat config"
+  },
+  {
+    "cmd": [
+      "cat",
+      "{\n  \"y\": 2,\n  \"x\": 1\n}"
+    ],
+    "name": "cat unsorted config"
+  },
+  {
+    "cmd": [
+      "write",
+      "/path/to/tmp/json"
+    ],
+    "name": "write garbage"
+  },
+  {
+    "cmd": [
+      "write",
+      "[WORKSPACE]/out.json"
+    ],
+    "name": "write nothing"
+  },
+  {
+    "name": "$result"
+  }
+]

--- a/tools/recipes/recipe_modules/json/examples/full.py
+++ b/tools/recipes/recipe_modules/json/examples/full.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipe exercising the `json` module's placeholders and encoding."""
+
+from __future__ import annotations
+
+from google.protobuf import struct_pb2
+
+import post_process
+
+DEPS = ['json', 'path', 'step']
+
+
+def RunSteps(api):
+    # Read a step's stdout as JSON: the value comes back parsed.
+    result = api.step('echo list', ['echo', '[1, 2, 3]'],
+                      stdout=api.json.output())
+    assert result.stdout == [1, 2, 3], result.stdout
+
+    # A step can carry its own default simulated output, so the common case
+    # needs nothing seeded per test.
+    result = api.step(
+        'echo more', ['echo', '[2, 3, 4]'],
+        stdout=api.json.output(),
+        step_test_data=lambda: api.json.test_api.output_stream([2, 3, 4]))
+    assert result.stdout == [2, 3, 4], result.stdout
+
+    # An output placeholder in the command line is filed onto the result under
+    # the module and method that produced it.
+    result = api.step('run tests', ['run_tests', api.json.output()])
+    assert result.json.output == {'passed': 791}, result.json.output
+
+    # Several placeholders from one method are told apart by name.
+    result = api.step('run more tests', [
+        'run_tests',
+        api.json.output(name='fast'),
+        api.json.output(name='slow')
+    ])
+    assert result.json.outputs == {
+        'fast': [1, 2, 3],
+        'slow': ['x', 'y']
+    }, result.json.outputs
+
+    # `input` goes the other way: the placeholder becomes the path of a file
+    # holding the rendered JSON.
+    config = {'y': 2, 'x': 1}
+    api.step('cat config', ['cat', api.json.input(config)])
+    # ... and with insertion order preserved, for a step that cares.
+    api.step('cat unsorted config',
+             ['cat', api.json.input(config, sort_keys=False)])
+
+    # A step that writes something that isn't JSON, or nothing at all, results
+    # in None rather than an exception.
+    result = api.step('write garbage', ['write', api.json.output()])
+    assert result.json.output is None, result.json.output
+    result = api.step(
+        'write nothing',
+        ['write',
+         api.json.output(leak_to=api.path.workspace / 'out.json')])
+    assert result.json.output is None, result.json.output
+
+    # Encoding: `dumps` handles the types recipes pass around routinely; other
+    # types raise `TypeError`, same as stdlib's `json.dumps` (see
+    # `recipe_modules/json/tests/errors.py`).
+    assert api.json.dumps(api.path.workspace) == '"/b/s"'
+    assert api.json.dumps(
+        struct_pb2.Struct(fields={'foo': struct_pb2.Value(
+            string_value='bar')})) == ('{"foo": "bar"}')
+
+    # Decoding: a whole float that arrived where an int was meant comes back as
+    # an int, at any depth.
+    assert api.json.loads('[1.0, 2.5, {"a": 3.0}, "s"]') == [
+        1, 2.5, {
+            'a': 3
+        }, 's'
+    ]
+    # ... but not one too large to have been an int in the first place.
+    assert api.json.loads('[1e300]') == [1e300]
+
+
+def GenTests(api):
+    yield api.test(
+        'basic',
+        # `api.json.loads`/`dumps` on the test api are the same functions the
+        # module offers, for building the text a step is meant to have written.
+        api.step_data('echo list',
+                      stdout=api.json.output(
+                          api.json.loads('[1.0, 2.0, 3.0]'))),
+        api.step_data('run tests', api.json.output({'passed': 791})),
+        api.step_data(
+            'run more tests',
+            api.json.output([1, 2, 3], name='fast'),
+            api.json.output(['x', 'y'], name='slow'),
+        ),
+        api.step_data(
+            'write garbage',
+            # Valid JSON with its last character chopped off.
+            api.json.invalid(api.json.dumps({'passed': 791})[:-1])),
+        api.step_data('write nothing', api.json.backing_file_missing()),
+        api.post_process(post_process.StatusSuccess),
+    )
+    # A step's default simulated output can be replaced outright.
+    yield api.test(
+        'override default',
+        # `api.json.loads`/`dumps` on the test api are the same functions the
+        # module offers, for building the text a step is meant to have written.
+        api.step_data('echo list',
+                      stdout=api.json.output(
+                          api.json.loads('[1.0, 2.0, 3.0]'))),
+        api.override_step_data('echo more', stdout=api.json.output([2, 3, 4])),
+        api.step_data('run tests', api.json.output({'passed': 791})),
+        api.step_data(
+            'run more tests',
+            api.json.output([1, 2, 3], name='fast'),
+            api.json.output(['x', 'y'], name='slow'),
+        ),
+        api.step_data(
+            'write garbage',
+            # Valid JSON with its last character chopped off.
+            api.json.invalid(api.json.dumps({'passed': 791})[:-1])),
+        api.step_data('write nothing', api.json.backing_file_missing()),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )

--- a/tools/recipes/recipe_modules/json/test_api.py
+++ b/tools/recipes/recipe_modules/json/test_api.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Test API for `json`: seed what a JSON output placeholder hands back.
+
+`api.json.output({'passed': 791})` is a fragment for `api.step_data`, either as
+one of its positional arguments (seeding an `api.json.output()` in the step's
+command) or as its `stdout=`/`stderr=` (seeding the step's std handle):
+
+    api.step_data('run tests', api.json.output({'passed': 791}))
+    api.step_data('run tests', stdout=api.json.output({'passed': 791}))
+
+`output_stream` builds the latter in one call, for a step's own
+`step_test_data=` default.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from recipe_test_api import (RecipeTestApi, StepTestData,
+                             placeholder_step_data)
+
+from .api import dumps, loads
+
+
+class JsonTestApi(RecipeTestApi):
+    """Seed the simulated data of a `json` output placeholder."""
+
+    @staticmethod
+    def dumps(*args, **kwargs) -> str:
+        """Same as `api.json.dumps`."""
+        return dumps(*args, **kwargs)
+
+    @staticmethod
+    def loads(data: str, **kwargs) -> Any:
+        """Same as `api.json.loads`."""
+        return loads(data, **kwargs)
+
+    @placeholder_step_data
+    def output(self,
+               data: Any,
+               retcode: int | None = None,
+               name: str | None = None):
+        """Seed an `api.json.output()` placeholder to return *data*.
+
+        *data* is an ordinary Python value (dict, list, str, int, ...); the step
+        is simulated as having written it out as JSON.
+        """
+        return json.dumps(data, indent=2, sort_keys=True), retcode, name
+
+    @placeholder_step_data('output')
+    def invalid(self,
+                raw_data: str,
+                retcode: int | None = None,
+                name: str | None = None):
+        """Seed an `api.json.output()` placeholder with text that isn't JSON.
+
+        For exercising what a recipe does when a step writes garbage: the
+        placeholder's result is then `None`.
+        """
+        return raw_data, retcode, name
+
+    @placeholder_step_data('output')
+    def backing_file_missing(self,
+                             retcode: int | None = None,
+                             name: str | None = None):
+        """Seed an output placeholder as if the step never wrote its file.
+
+        Only meaningful for a placeholder created with `leak_to`; without it the
+        engine creates the backing file itself, so it is always there.
+        """
+        return None, retcode, name
+
+    def output_stream(self,
+                      data: Any,
+                      stream: str = 'stdout',
+                      retcode: int | None = None,
+                      name: str | None = None) -> StepTestData:
+        """Seed *data* as the JSON on the step's `stdout` (or `stderr`)."""
+        assert stream in ('stdout', 'stderr')
+        fragment = StepTestData()
+        # `functools.wraps` (in `placeholder_step_data`) leaves pylint
+        # inferring `output`'s return type from its undecorated body (a plain
+        # tuple), rather than the `StepTestData` the decorator actually
+        # returns.
+        placeholder_data = self.output(data, retcode=retcode, name=name)
+        setattr(fragment, stream, placeholder_data.unwrap_placeholder())  # pylint: disable=no-member
+        if retcode:
+            fragment.retcode = retcode
+        return fragment

--- a/tools/recipes/recipe_modules/json/tests/__init__.py
+++ b/tools/recipes/recipe_modules/json/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tools/recipes/recipe_modules/json/tests/errors.py
+++ b/tools/recipes/recipe_modules/json/tests/errors.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `json`'s rejection of values `dumps` cannot encode.
+
+`dumps` raises `TypeError`, same as stdlib's `json.dumps`, for a type it (and
+`_default_serializer`) doesn't know how to turn into JSON. That is a bug in the
+recipe, not a step failure to recover from, so it aborts the recipe rather than
+returning some fallback value.
+"""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['json']
+
+
+def RunSteps(api):
+    api.json.dumps({'set': {'a', 'b'}})
+
+
+def GenTests(api):
+    yield api.test(
+        'not_serializable',
+        api.post_process(post_process.StatusException),
+        api.post_process(post_process.DropExpectation),
+        status='EXCEPTION',
+    )

--- a/tools/recipes/recipe_modules/json/tests/streams.py
+++ b/tools/recipes/recipe_modules/json/tests/streams.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `json.output_stream` seeding a retcode alongside the JSON.
+
+A step's own default simulated data can say the step failed, and still say what
+JSON it wrote on its way out -- which is how a recipe that inspects a failing
+command's report gets tested.
+"""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['json', 'step']
+
+
+def RunSteps(api):
+    result = api.step('run tests', ['run_tests'],
+                      check=False,
+                      stdout=api.json.output(),
+                      step_test_data=lambda: api.json.test_api.output_stream(
+                          {'failed': ['a', 'b']}, retcode=1))
+    assert result.retcode == 1, result.retcode
+    assert result.stdout == {'failed': ['a', 'b']}, result.stdout
+
+
+def GenTests(api):
+    yield api.test(
+        'basic',
+        api.post_process(post_process.StepFailure, 'run tests'),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )


### PR DESCRIPTION
This change adds `json`, the first module built on top of `raw_io`. This
means that `api.json.output()`/`input()` are `raw_io` placeholders
wearing a JSON codec, so a result doesn't need to be parsed out of
straight text.

Beyond the placeholder pair, the module carries `dumps`/`loads` as the
one blessed way to turn recipe values into JSON text and back --
`dumps` sorts keys and knows how to serialize a `Path` and a proto
`Struct`, and `fix_json_object` repairs the whole-float-for-int
round-trip JSON forces on any producer that wasn't Python. Nothing
else in this stack calls `json.dumps` directly for that reason.

Bug: https://github.com/brave/brave-browser/issues/56748
