### PR TITLE
[AI Chat] Add `ConversationHistoryView`

### DIFF
--- a/browser/ai_chat/ai_chat_conversation_ui_browsertest_base.cc
+++ b/browser/ai_chat/ai_chat_conversation_ui_browsertest_base.cc
@@ -334,7 +334,7 @@ AIChatConversationUIBrowserTestBase::SetupMockGenerateAssistantResponse(
   }
   expectation.WillOnce(
       [future_ptr](PageContentsMap page_contents,
-                   const EngineConsumer::ConversationHistory& history,
+                   const EngineConsumer::ConversationHistoryView& history,
                    bool is_temporary,
                    const std::vector<base::WeakPtr<Tool>>& provided_tools,
                    std::optional<std::string_view> preferred_tool_name,

--- a/components/ai_chat/core/browser/ai_chat_service_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_service_unittest.cc
@@ -516,7 +516,7 @@ TEST_P(AIChatServiceUnitTest,
   EXPECT_CALL(*engine, GenerateAssistantResponse)
       .WillOnce([&resolve](
                     PageContentsMap page_contents,
-                    const std::vector<mojom::ConversationTurnPtr>& history,
+                    const EngineConsumer::ConversationHistoryView& history,
                     bool is_temporary_chat,
                     const std::vector<base::WeakPtr<Tool>>& tools,
                     std::optional<std::string_view> preferred_tool_name,

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -1332,8 +1332,9 @@ void ConversationHandler::PerformAssistantGeneration() {
   needs_new_entry_ = true;
 
   engine_->GenerateAssistantResponse(
-      associated_content_manager_->GetCachedContentsMap(), chat_history_,
-      IsTemporaryChat(), GetTools(), std::nullopt /* preferred_tool_name */,
+      associated_content_manager_->GetCachedContentsMap(),
+      EngineConsumer::ToHistoryView(chat_history_), IsTemporaryChat(),
+      GetTools(), std::nullopt /* preferred_tool_name */,
       conversation_capabilities_,
       base::BindRepeating(&ConversationHandler::OnEngineCompletionDataReceived,
                           weak_ptr_factory_.GetWeakPtr()),

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -427,10 +427,10 @@ MATCHER_P(LastTurnHasText, expected_text, "") {
   if (arg.empty()) {
     return false;
   }
-  const mojom::ConversationTurnPtr& entry =
-      (arg.back()->edits.has_value() && !arg.back()->edits->empty()
-           ? arg.back()->edits->back()
-           : arg.back());
+  const mojom::ConversationTurn* entry = arg.back();
+  if (entry->edits.has_value() && !entry->edits->empty()) {
+    entry = entry->edits->back().get();
+  }
   return entry->prompt.value_or(entry->text) == expected_text;
 }
 
@@ -2311,7 +2311,7 @@ TEST_F(ConversationHandlerUnitTest, UploadFile) {
   EXPECT_CALL(*engine, GenerateAssistantResponse)
       .WillRepeatedly(
           [](PageContentsMap page_contents,
-             const std::vector<mojom::ConversationTurnPtr>& history,
+             const EngineConsumer::ConversationHistoryView& history,
              bool is_temporary_chat,
              const std::vector<base::WeakPtr<Tool>>& tools,
              std::optional<std::string_view> preferred_tool_name,
@@ -4630,7 +4630,7 @@ TEST_F(ConversationHandlerUnitTest, VisionModelSwitchOnScreenshots) {
   EXPECT_CALL(*engine, GenerateAssistantResponse)
       .WillRepeatedly(
           [](PageContentsMap page_contents,
-             const std::vector<mojom::ConversationTurnPtr>& history,
+             const EngineConsumer::ConversationHistoryView& history,
              bool is_temporary_chat,
              const std::vector<base::WeakPtr<Tool>>& tools,
              std::optional<std::string_view> preferred_tool_name,

--- a/components/ai_chat/core/browser/engine/engine_consumer.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer.cc
@@ -100,22 +100,12 @@ bool EngineConsumer::CanPerformCompletionRequest(
   return true;
 }
 
-void EngineConsumer::GenerateAssistantResponse(
-    PageContentsMap&& page_contents,
-    const ConversationHistory& conversation_history,
-    bool is_temporary_chat,
-    const std::vector<base::WeakPtr<Tool>>& tools,
-    std::optional<std::string_view> preferred_tool_name,
-    const ConversationCapabilitySet& conversation_capabilities,
-    GenerationDataCallback data_received_callback,
-    GenerationCompletedCallback completed_callback) {
-  GenerateAssistantResponse(
-      std::move(page_contents),
-      base::ToVector<const mojom::ConversationTurn*>(
-          conversation_history,
-          [](const mojom::ConversationTurnPtr& turn) { return turn.get(); }),
-      is_temporary_chat, tools, preferred_tool_name, conversation_capabilities,
-      std::move(data_received_callback), std::move(completed_callback));
+// static
+EngineConsumer::ConversationHistoryView EngineConsumer::ToHistoryView(
+    const ConversationHistory& conversation_history) {
+  return base::ToVector<const mojom::ConversationTurn*>(
+      conversation_history,
+      [](const mojom::ConversationTurnPtr& turn) { return turn.get(); });
 }
 
 const std::string& EngineConsumer::GetModelName() const {

--- a/components/ai_chat/core/browser/engine/engine_consumer.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer.cc
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "base/base64.h"
+#include "base/containers/to_vector.h"
 #include "base/json/json_reader.h"
 #include "base/strings/escape.h"
 #include "base/strings/strcat.h"
@@ -54,11 +55,11 @@ EngineConsumer::Error::Error(mojom::APIError api_error,
 
 // static
 std::string EngineConsumer::GetPromptForEntry(
-    const mojom::ConversationTurnPtr& entry) {
-  const mojom::ConversationTurnPtr& prompt_entry =
-      (entry->edits && !entry->edits->empty()) ? entry->edits->back() : entry;
+    const mojom::ConversationTurn& entry) {
+  const mojom::ConversationTurn& prompt_entry =
+      (entry.edits && !entry.edits->empty()) ? *entry.edits->back() : entry;
 
-  return prompt_entry->prompt.value_or(prompt_entry->text);
+  return prompt_entry.prompt.value_or(prompt_entry.text);
 }
 
 // static
@@ -91,12 +92,30 @@ std::string EngineConsumer::GetPdfDataURL(base::span<uint8_t> pdf_data) {
 }
 
 bool EngineConsumer::CanPerformCompletionRequest(
-    const ConversationHistory& conversation_history) const {
+    const ConversationHistoryView& conversation_history) const {
   if (conversation_history.empty()) {
     return false;
   }
 
   return true;
+}
+
+void EngineConsumer::GenerateAssistantResponse(
+    PageContentsMap&& page_contents,
+    const ConversationHistory& conversation_history,
+    bool is_temporary_chat,
+    const std::vector<base::WeakPtr<Tool>>& tools,
+    std::optional<std::string_view> preferred_tool_name,
+    const ConversationCapabilitySet& conversation_capabilities,
+    GenerationDataCallback data_received_callback,
+    GenerationCompletedCallback completed_callback) {
+  GenerateAssistantResponse(
+      std::move(page_contents),
+      base::ToVector<const mojom::ConversationTurn*>(
+          conversation_history,
+          [](const mojom::ConversationTurnPtr& turn) { return turn.get(); }),
+      is_temporary_chat, tools, preferred_tool_name, conversation_capabilities,
+      std::move(data_received_callback), std::move(completed_callback));
 }
 
 const std::string& EngineConsumer::GetModelName() const {

--- a/components/ai_chat/core/browser/engine/engine_consumer.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer.h
@@ -90,12 +90,15 @@ class EngineConsumer {
 
   using ConversationHistory = std::vector<mojom::ConversationTurnPtr>;
 
+  // A non-owning view of conversation history passed to engines.
+  using ConversationHistoryView = std::vector<const mojom::ConversationTurn*>;
+
   using GetSuggestedTopicsCallback = base::OnceCallback<void(
       base::expected<std::vector<std::string>, mojom::APIError>)>;
   using GetFocusTabsCallback = base::OnceCallback<void(
       base::expected<std::vector<std::string>, mojom::APIError>)>;
 
-  static std::string GetPromptForEntry(const mojom::ConversationTurnPtr& entry);
+  static std::string GetPromptForEntry(const mojom::ConversationTurn& entry);
 
   EngineConsumer(ModelService* model_service, PrefService* prefs);
   EngineConsumer(const EngineConsumer&) = delete;
@@ -108,13 +111,23 @@ class EngineConsumer {
 
   virtual void GenerateAssistantResponse(
       PageContentsMap&& page_contents,
-      const ConversationHistory& conversation_history,
+      const ConversationHistoryView& conversation_history,
       bool is_temporary_chat,
       const std::vector<base::WeakPtr<Tool>>& tools,
       std::optional<std::string_view> preferred_tool_name,
       const ConversationCapabilitySet& conversation_capabilities,
       GenerationDataCallback data_received_callback,
       GenerationCompletedCallback completed_callback) = 0;
+
+  void GenerateAssistantResponse(
+      PageContentsMap&& page_contents,
+      const ConversationHistory& conversation_history,
+      bool is_temporary_chat,
+      const std::vector<base::WeakPtr<Tool>>& tools,
+      std::optional<std::string_view> preferred_tool_name,
+      const ConversationCapabilitySet& conversation_capabilities,
+      GenerationDataCallback data_received_callback,
+      GenerationCompletedCallback completed_callback);
 
   virtual void GenerateRewriteSuggestion(
       const std::string& text,
@@ -180,7 +193,7 @@ class EngineConsumer {
   // conversation history. Ex. empty history, or if the last entry is not a
   // human message.
   bool CanPerformCompletionRequest(
-      const ConversationHistory& conversation_history) const;
+      const ConversationHistoryView& conversation_history) const;
 
   void OnConversationTitleGenerated(
       GenerationCompletedCallback completion_callback,

--- a/components/ai_chat/core/browser/engine/engine_consumer.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer.h
@@ -93,6 +93,11 @@ class EngineConsumer {
   // A non-owning view of conversation history passed to engines.
   using ConversationHistoryView = std::vector<const mojom::ConversationTurn*>;
 
+  // Converts an owning conversation history into a non-owning view for use
+  // with engine methods that take ConversationHistoryView.
+  static ConversationHistoryView ToHistoryView(
+      const ConversationHistory& conversation_history);
+
   using GetSuggestedTopicsCallback = base::OnceCallback<void(
       base::expected<std::vector<std::string>, mojom::APIError>)>;
   using GetFocusTabsCallback = base::OnceCallback<void(
@@ -118,16 +123,6 @@ class EngineConsumer {
       const ConversationCapabilitySet& conversation_capabilities,
       GenerationDataCallback data_received_callback,
       GenerationCompletedCallback completed_callback) = 0;
-
-  void GenerateAssistantResponse(
-      PageContentsMap&& page_contents,
-      const ConversationHistory& conversation_history,
-      bool is_temporary_chat,
-      const std::vector<base::WeakPtr<Tool>>& tools,
-      std::optional<std::string_view> preferred_tool_name,
-      const ConversationCapabilitySet& conversation_capabilities,
-      GenerationDataCallback data_received_callback,
-      GenerationCompletedCallback completed_callback);
 
   virtual void GenerateRewriteSuggestion(
       const std::string& text,

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.cc
@@ -73,7 +73,7 @@ void EngineConsumerConversationAPI::OnGenerateQuestionSuggestionsResponse(
 
 void EngineConsumerConversationAPI::GenerateAssistantResponse(
     PageContentsMap&& page_contents,
-    const ConversationHistory& conversation_history,
+    const ConversationHistoryView& conversation_history,
     bool is_temporary_chat,
     const std::vector<base::WeakPtr<Tool>>& tools,
     std::optional<std::string_view> preferred_tool_name,

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.h
@@ -55,7 +55,6 @@ class EngineConsumerConversationAPI : public EngineConsumer {
   ~EngineConsumerConversationAPI() override;
 
   // EngineConsumer
-  using EngineConsumer::GenerateAssistantResponse;
   void GenerateQuestionSuggestions(
       PageContents page_contents,
       SuggestedQuestionsCallback callback) override;

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.h
@@ -55,12 +55,13 @@ class EngineConsumerConversationAPI : public EngineConsumer {
   ~EngineConsumerConversationAPI() override;
 
   // EngineConsumer
+  using EngineConsumer::GenerateAssistantResponse;
   void GenerateQuestionSuggestions(
       PageContents page_contents,
       SuggestedQuestionsCallback callback) override;
   void GenerateAssistantResponse(
       PageContentsMap&& page_contents,
-      const ConversationHistory& conversation_history,
+      const ConversationHistoryView& conversation_history,
       bool is_temporary_chat,
       const std::vector<base::WeakPtr<Tool>>& tools,
       std::optional<std::string_view> preferred_tool_name,

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api_unittest.cc
@@ -223,8 +223,9 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
   history.push_back(std::move(turn));
 
   engine_->GenerateAssistantResponse(
-      {{{"turn-1", {page_content}}}}, history, false, {}, std::nullopt,
-      {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+      {{{"turn-1", {page_content}}}}, EngineConsumer::ToHistoryView(history),
+      false, {}, std::nullopt, {mojom::ConversationCapability::CHAT},
+      base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
   run_loop.Run();
@@ -306,8 +307,9 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
   history.push_back(std::move(turn));
 
   engine_->GenerateAssistantResponse(
-      {{{"turn-1", {page_content_1, page_content_2}}}}, history, false, {},
-      std::nullopt, {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+      {{{"turn-1", {page_content_1, page_content_2}}}},
+      EngineConsumer::ToHistoryView(history), false, {}, std::nullopt,
+      {mojom::ConversationCapability::CHAT}, base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
   run_loop.Run();
@@ -378,8 +380,9 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
   history.push_back(std::move(turn));
 
   engine_->GenerateAssistantResponse(
-      {{{"turn-1", {page_content}}}}, history, false, {}, std::nullopt,
-      {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+      {{{"turn-1", {page_content}}}}, EngineConsumer::ToHistoryView(history),
+      false, {}, std::nullopt, {mojom::ConversationCapability::CHAT},
+      base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
   run_loop.Run();
@@ -481,8 +484,9 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
       });
 
   engine_->GenerateAssistantResponse(
-      {{{"turn-1", {page_content}}}}, history, false, {}, std::nullopt,
-      {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+      {{{"turn-1", {page_content}}}}, EngineConsumer::ToHistoryView(history),
+      false, {}, std::nullopt, {mojom::ConversationCapability::CHAT},
+      base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
   run_loop.Run();
@@ -604,8 +608,9 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
       });
 
   engine_->GenerateAssistantResponse(
-      {{{"turn-1", {page_content}}}}, history, false, {}, std::nullopt,
-      {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+      {{{"turn-1", {page_content}}}}, EngineConsumer::ToHistoryView(history),
+      false, {}, std::nullopt, {mojom::ConversationCapability::CHAT},
+      base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
   run_loop.Run();
@@ -671,8 +676,9 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
   PageContent page_content("This is a sample page content.", false);
 
   engine_->GenerateAssistantResponse(
-      {{{"turn-1", {page_content}}}}, history, false, {}, std::nullopt,
-      {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+      {{{"turn-1", {page_content}}}}, EngineConsumer::ToHistoryView(history),
+      false, {}, std::nullopt, {mojom::ConversationCapability::CHAT},
+      base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
   run_loop.Run();
@@ -764,8 +770,9 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
     base::RunLoop run_loop;
     PageContent page_content("This is a test page content.", false);
     engine_->GenerateAssistantResponse(
-        {{"turn-1", {page_content}}}, std::move(history), false, {},
-        std::nullopt, {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+        {{"turn-1", {page_content}}}, EngineConsumer::ToHistoryView(history),
+        false, {}, std::nullopt, {mojom::ConversationCapability::CHAT},
+        base::DoNothing(),
         base::BindLambdaForTesting(
             [&run_loop](EngineConsumer::GenerationResult) {
               run_loop.Quit();
@@ -849,8 +856,9 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
     base::RunLoop run_loop;
     PageContent page_content("This is a test page content.", false);
     engine_->GenerateAssistantResponse(
-        {{"turn-1", {page_content}}}, std::move(history), false, {},
-        std::nullopt, {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+        {{"turn-1", {page_content}}}, EngineConsumer::ToHistoryView(history),
+        false, {}, std::nullopt, {mojom::ConversationCapability::CHAT},
+        base::DoNothing(),
         base::BindLambdaForTesting(
             [&run_loop](EngineConsumer::GenerationResult) {
               run_loop.Quit();
@@ -937,8 +945,9 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
     base::RunLoop run_loop;
     PageContent page_content("This is a test page content.", false);
     engine_->GenerateAssistantResponse(
-        {{"turn-1", {page_content}}}, std::move(history), false, {},
-        std::nullopt, {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+        {{"turn-1", {page_content}}}, EngineConsumer::ToHistoryView(history),
+        false, {}, std::nullopt, {mojom::ConversationCapability::CHAT},
+        base::DoNothing(),
         base::BindLambdaForTesting(
             [&run_loop](EngineConsumer::GenerationResult) {
               run_loop.Quit();
@@ -1002,8 +1011,9 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
     base::RunLoop run_loop;
     PageContent page_content("This is a test page content.", false);
     engine_->GenerateAssistantResponse(
-        {{"turn-1", {page_content}}}, std::move(history), false, {},
-        std::nullopt, {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+        {{"turn-1", {page_content}}}, EngineConsumer::ToHistoryView(history),
+        false, {}, std::nullopt, {mojom::ConversationCapability::CHAT},
+        base::DoNothing(),
         base::BindLambdaForTesting(
             [&run_loop](EngineConsumer::GenerationResult) {
               run_loop.Quit();
@@ -1072,8 +1082,9 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
     base::RunLoop run_loop;
     PageContent page_content("This is a test page content.", false);
     engine_->GenerateAssistantResponse(
-        {{"turn-1", {page_content}}}, std::move(history), false, {},
-        std::nullopt, {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+        {{"turn-1", {page_content}}}, EngineConsumer::ToHistoryView(history),
+        false, {}, std::nullopt, {mojom::ConversationCapability::CHAT},
+        base::DoNothing(),
         base::BindLambdaForTesting(
             [&run_loop](EngineConsumer::GenerationResult) {
               run_loop.Quit();
@@ -1141,8 +1152,9 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
     base::RunLoop run_loop;
     PageContent page_content("This is a test page content.", false);
     engine_->GenerateAssistantResponse(
-        {{"turn-1", {page_content}}}, std::move(history), false, {},
-        std::nullopt, {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+        {{"turn-1", {page_content}}}, EngineConsumer::ToHistoryView(history),
+        false, {}, std::nullopt, {mojom::ConversationCapability::CHAT},
+        base::DoNothing(),
         base::BindLambdaForTesting(
             [&run_loop](EngineConsumer::GenerationResult) {
               run_loop.Quit();
@@ -1221,7 +1233,7 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
   base::RunLoop run_loop;
   PageContent page_content("This is a test page content.", false);
   engine_->GenerateAssistantResponse(
-      {{"turn-1", {page_content}}}, std::move(history),
+      {{"turn-1", {page_content}}}, EngineConsumer::ToHistoryView(history),
       true,  // is_temporary_chat = true
       {}, std::nullopt, {mojom::ConversationCapability::CHAT},
       base::DoNothing(),
@@ -1268,8 +1280,9 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
   PageContentsMap page_contents{{"turn-1", {page_content}}};
 
   engine_->GenerateAssistantResponse(
-      std::move(page_contents), std::move(history), false, {}, std::nullopt,
-      {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+      std::move(page_contents), EngineConsumer::ToHistoryView(history), false,
+      {}, std::nullopt, {mojom::ConversationCapability::CHAT},
+      base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
   run_loop.Run();
@@ -1289,7 +1302,7 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
   auto history = CreateSampleChatHistory(2);
 
   engine_->GenerateAssistantResponse(
-      {}, std::move(history), false, {}, std::nullopt,
+      {}, EngineConsumer::ToHistoryView(history), false, {}, std::nullopt,
       {mojom::ConversationCapability::CHAT}, base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
@@ -1345,7 +1358,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
   auto history = CreateSampleChatHistory(2);
 
   engine_->GenerateAssistantResponse(
-      {}, std::move(history), false, {mock_tool->GetWeakPtr()}, std::nullopt,
+      {}, EngineConsumer::ToHistoryView(history), false,
+      {mock_tool->GetWeakPtr()}, std::nullopt,
       {mojom::ConversationCapability::CHAT}, base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
@@ -1385,8 +1399,9 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
     turn->uuid = "turn-1";
     history.push_back(std::move(turn));
     mock_engine_consumer->GenerateAssistantResponse(
-        {{{"turn-1", {page_content_1, page_content_2}}}}, history, false, {},
-        std::nullopt, {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+        {{{"turn-1", {page_content_1, page_content_2}}}},
+        EngineConsumer::ToHistoryView(history), false, {}, std::nullopt,
+        {mojom::ConversationCapability::CHAT}, base::DoNothing(),
         base::DoNothing());
     testing::Mock::VerifyAndClearExpectations(mock_engine_consumer.get());
   }
@@ -1447,8 +1462,9 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
   history.push_back(std::move(turn));
 
   engine_->GenerateAssistantResponse(
-      {{"turn-1", {page_content}}}, std::move(history), false, {}, std::nullopt,
-      {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+      {{"turn-1", {page_content}}}, EngineConsumer::ToHistoryView(history),
+      false, {}, std::nullopt, {mojom::ConversationCapability::CHAT},
+      base::DoNothing(),
       base::BindLambdaForTesting(
           [&](EngineConsumer::GenerationResult) { /* handled above */ }));
 
@@ -1497,8 +1513,9 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
   history.push_back(std::move(turn));
 
   engine_->GenerateAssistantResponse(
-      {{"missing-turn", {page_content}}}, std::move(history), false, {},
-      std::nullopt, {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+      {{"missing-turn", {page_content}}},
+      EngineConsumer::ToHistoryView(history), false, {}, std::nullopt,
+      {mojom::ConversationCapability::CHAT}, base::DoNothing(),
       base::BindLambdaForTesting(
           [&](EngineConsumer::GenerationResult) { /* handled above */ }));
 
@@ -1555,9 +1572,9 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
   history.push_back(std::move(turn));
 
   engine_->GenerateAssistantResponse(
-      {{"turn-1", {page_content1, video_content}}}, std::move(history), false,
-      {}, std::nullopt, {mojom::ConversationCapability::CHAT},
-      base::DoNothing(),
+      {{"turn-1", {page_content1, video_content}}},
+      EngineConsumer::ToHistoryView(history), false, {}, std::nullopt,
+      {mojom::ConversationCapability::CHAT}, base::DoNothing(),
       base::BindLambdaForTesting(
           [&](EngineConsumer::GenerationResult) { /* handled above */ }));
 
@@ -1641,7 +1658,7 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
 
   engine_->GenerateAssistantResponse(
       {{"turn-1", {page_content1}}, {"turn-2", {page_content2}}},
-      std::move(history), false, {}, std::nullopt,
+      EngineConsumer::ToHistoryView(history), false, {}, std::nullopt,
       {mojom::ConversationCapability::CHAT}, base::DoNothing(),
       base::BindLambdaForTesting(
           [&](EngineConsumer::GenerationResult) { /* handled above */ }));
@@ -1731,7 +1748,7 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
         engine_->GenerateAssistantResponse(
             {{"turn-1", {page_content_1, page_content_2}},
              {"turn-2", {page_content_3}}},
-            history, false, {}, std::nullopt,
+            EngineConsumer::ToHistoryView(history), false, {}, std::nullopt,
             {mojom::ConversationCapability::CHAT}, base::DoNothing(),
             base::DoNothing());
         run_loop.Run();
@@ -1900,7 +1917,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
       nullptr /* near_verification_status */));
 
   base::test::TestFuture<EngineConsumer::GenerationResult> future;
-  engine_->GenerateAssistantResponse({}, history, false, {}, std::nullopt,
+  engine_->GenerateAssistantResponse({}, EngineConsumer::ToHistoryView(history),
+                                     false, {}, std::nullopt,
                                      {mojom::ConversationCapability::CHAT},
                                      base::DoNothing(), future.GetCallback());
   EXPECT_EQ(future.Take(),
@@ -1999,10 +2017,10 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
   history.push_back(std::move(turn));
 
   base::test::TestFuture<EngineConsumer::GenerationResult> future;
-  engine_->GenerateAssistantResponse({{"turn-1", {page_content}}}, history,
-                                     false, {}, std::nullopt,
-                                     {mojom::ConversationCapability::CHAT},
-                                     base::DoNothing(), future.GetCallback());
+  engine_->GenerateAssistantResponse(
+      {{"turn-1", {page_content}}}, EngineConsumer::ToHistoryView(history),
+      false, {}, std::nullopt, {mojom::ConversationCapability::CHAT},
+      base::DoNothing(), future.GetCallback());
   EXPECT_TRUE(future.Wait());
   testing::Mock::VerifyAndClearExpectations(mock_api_client);
 }
@@ -2142,10 +2160,10 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
   history.push_back(std::move(turn));
 
   base::test::TestFuture<EngineConsumer::GenerationResult> future;
-  engine_->GenerateAssistantResponse({{"turn-1", {page_content}}}, history,
-                                     false, {}, std::nullopt,
-                                     {mojom::ConversationCapability::CHAT},
-                                     base::DoNothing(), future.GetCallback());
+  engine_->GenerateAssistantResponse(
+      {{"turn-1", {page_content}}}, EngineConsumer::ToHistoryView(history),
+      false, {}, std::nullopt, {mojom::ConversationCapability::CHAT},
+      base::DoNothing(), future.GetCallback());
   EXPECT_TRUE(future.Wait());
   testing::Mock::VerifyAndClearExpectations(mock_api_client);
 }
@@ -2222,7 +2240,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
   history.push_back(std::move(turn));
 
   base::test::TestFuture<EngineConsumer::GenerationResult> future;
-  engine_->GenerateAssistantResponse({}, history, false, {}, std::nullopt,
+  engine_->GenerateAssistantResponse({}, EngineConsumer::ToHistoryView(history),
+                                     false, {}, std::nullopt,
                                      {mojom::ConversationCapability::CHAT},
                                      base::DoNothing(), future.GetCallback());
   EXPECT_TRUE(future.Wait());
@@ -2318,10 +2337,10 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
   turn->uploaded_files = Clone(uploaded_files);
   history.push_back(std::move(turn));
 
-  engine_->GenerateAssistantResponse({{"turn-1", {page_content}}}, history,
-                                     false, {}, std::nullopt,
-                                     {mojom::ConversationCapability::CHAT},
-                                     base::DoNothing(), future.GetCallback());
+  engine_->GenerateAssistantResponse(
+      {{"turn-1", {page_content}}}, EngineConsumer::ToHistoryView(history),
+      false, {}, std::nullopt, {mojom::ConversationCapability::CHAT},
+      base::DoNothing(), future.GetCallback());
   EXPECT_TRUE(future.Wait());
   testing::Mock::VerifyAndClearExpectations(mock_api_client);
 }
@@ -2380,8 +2399,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
       });
 
   engine_->GenerateAssistantResponse(
-      {}, conversation_history, false, {}, std::nullopt,
-      {mojom::ConversationCapability::CHAT},
+      {}, EngineConsumer::ToHistoryView(conversation_history), false, {},
+      std::nullopt, {mojom::ConversationCapability::CHAT},
       base::BindRepeating([](EngineConsumer::GenerationResultData) {}),
       future.GetCallback());
 
@@ -2483,7 +2502,7 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
       });
 
   engine_->GenerateAssistantResponse(
-      {}, history, false, {}, std::nullopt,
+      {}, EngineConsumer::ToHistoryView(history), false, {}, std::nullopt,
       {mojom::ConversationCapability::CHAT}, base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
@@ -2614,7 +2633,7 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
       });
 
   engine_->GenerateAssistantResponse(
-      {}, history, false, {}, std::nullopt,
+      {}, EngineConsumer::ToHistoryView(history), false, {}, std::nullopt,
       {mojom::ConversationCapability::CHAT}, base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
@@ -2844,7 +2863,7 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
       });
 
   engine_->GenerateAssistantResponse(
-      {}, history, false, {}, std::nullopt,
+      {}, EngineConsumer::ToHistoryView(history), false, {}, std::nullopt,
       {mojom::ConversationCapability::CHAT}, base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
@@ -2922,7 +2941,7 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
       });
 
   engine_->GenerateAssistantResponse(
-      {}, history, false, {}, std::nullopt,
+      {}, EngineConsumer::ToHistoryView(history), false, {}, std::nullopt,
       {mojom::ConversationCapability::CHAT}, base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
@@ -4169,8 +4188,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
       });
 
   engine_->GenerateAssistantResponse(
-      {}, conversation_history, false, {}, std::nullopt,
-      {mojom::ConversationCapability::CHAT},
+      {}, EngineConsumer::ToHistoryView(conversation_history), false, {},
+      std::nullopt, {mojom::ConversationCapability::CHAT},
       base::BindRepeating([](EngineConsumer::GenerationResultData) {}),
       future.GetCallback());
 
@@ -4213,8 +4232,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
       });
 
   engine_->GenerateAssistantResponse(
-      {}, conversation_history, false, {}, std::nullopt,
-      {mojom::ConversationCapability::CHAT},
+      {}, EngineConsumer::ToHistoryView(conversation_history), false, {},
+      std::nullopt, {mojom::ConversationCapability::CHAT},
       base::BindRepeating([](EngineConsumer::GenerationResultData) {}),
       future.GetCallback());
 

--- a/components/ai_chat/core/browser/engine/engine_consumer_oai.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_oai.cc
@@ -204,7 +204,7 @@ void EngineConsumerOAIRemote::GenerateConversationTitle(
 
 void EngineConsumerOAIRemote::GenerateAssistantResponse(
     PageContentsMap&& page_contents,
-    const ConversationHistory& conversation_history,
+    const ConversationHistoryView& conversation_history,
     bool is_temporary_chat,
     const std::vector<base::WeakPtr<Tool>>& tools,
     std::optional<std::string_view> preferred_tool_name,

--- a/components/ai_chat/core/browser/engine/engine_consumer_oai.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer_oai.h
@@ -51,7 +51,6 @@ class EngineConsumerOAIRemote : public EngineConsumer {
   ~EngineConsumerOAIRemote() override;
 
   // EngineConsumer
-  using EngineConsumer::GenerateAssistantResponse;
   void GenerateQuestionSuggestions(
       PageContents page_contents,
       SuggestedQuestionsCallback callback) override;

--- a/components/ai_chat/core/browser/engine/engine_consumer_oai.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer_oai.h
@@ -51,12 +51,13 @@ class EngineConsumerOAIRemote : public EngineConsumer {
   ~EngineConsumerOAIRemote() override;
 
   // EngineConsumer
+  using EngineConsumer::GenerateAssistantResponse;
   void GenerateQuestionSuggestions(
       PageContents page_contents,
       SuggestedQuestionsCallback callback) override;
   void GenerateAssistantResponse(
       PageContentsMap&& page_contents,
-      const ConversationHistory& conversation_history,
+      const ConversationHistoryView& conversation_history,
       bool is_temporary_chat,
       const std::vector<base::WeakPtr<Tool>>& tools,
       std::optional<std::string_view> preferred_tool_name,

--- a/components/ai_chat/core/browser/engine/engine_consumer_oai_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_oai_unittest.cc
@@ -493,8 +493,9 @@ TEST_F(EngineConsumerOAIUnitTest,
 
   // Initiate the test
   engine_->GenerateAssistantResponse(
-      {{{"turn-1", {page_content}}}}, history, false, {}, std::nullopt,
-      {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+      {{{"turn-1", {page_content}}}}, EngineConsumer::ToHistoryView(history),
+      false, {}, std::nullopt, {mojom::ConversationCapability::CHAT},
+      base::DoNothing(),
       base::BindLambdaForTesting([&run_loop, &assistant_response](
                                      EngineConsumer::GenerationResult result) {
         EXPECT_EQ(result.value(),
@@ -570,7 +571,8 @@ TEST_F(EngineConsumerOAIUnitTest,
             run_loop->Quit();
           });
 
-  engine_->GenerateAssistantResponse({}, history, false, {}, std::nullopt,
+  engine_->GenerateAssistantResponse({}, EngineConsumer::ToHistoryView(history),
+                                     false, {}, std::nullopt,
                                      {mojom::ConversationCapability::CHAT},
                                      base::DoNothing(), base::DoNothing());
 
@@ -654,7 +656,7 @@ TEST_F(EngineConsumerOAIUnitTest,
   }
 
   engine_->GenerateAssistantResponse(
-      {}, history, false, {}, std::nullopt,
+      {}, EngineConsumer::ToHistoryView(history), false, {}, std::nullopt,
       {mojom::ConversationCapability::CHAT}, base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult result) {
@@ -711,8 +713,9 @@ TEST_F(EngineConsumerOAIUnitTest,
           });
 
   engine_->GenerateAssistantResponse(
-      {}, GetHistoryWithModifiedReply(), false, {}, std::nullopt,
-      {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+      {}, EngineConsumer::ToHistoryView(GetHistoryWithModifiedReply()), false,
+      {}, std::nullopt, {mojom::ConversationCapability::CHAT},
+      base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult result) {
             run_loop->Quit();
@@ -748,8 +751,9 @@ TEST_F(EngineConsumerOAIUnitTest, ShouldCallSanitizeInputOnPageContent) {
     history.push_back(std::move(turn));
     mock_engine_consumer->GenerateAssistantResponse(
         {{{history.back()->uuid.value(), {page_content_1, page_content_2}}}},
-        history, false, {}, std::nullopt, {mojom::ConversationCapability::CHAT},
-        base::DoNothing(), base::DoNothing());
+        EngineConsumer::ToHistoryView(history), false, {}, std::nullopt,
+        {mojom::ConversationCapability::CHAT}, base::DoNothing(),
+        base::DoNothing());
     testing::Mock::VerifyAndClearExpectations(mock_engine_consumer.get());
   }
 
@@ -812,7 +816,7 @@ TEST_F(EngineConsumerOAIUnitTest,
           });
 
   engine_->GenerateAssistantResponse(
-      {}, history, false, {}, std::nullopt,
+      {}, EngineConsumer::ToHistoryView(history), false, {}, std::nullopt,
       {mojom::ConversationCapability::CHAT}, base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
@@ -905,7 +909,7 @@ TEST_F(EngineConsumerOAIUnitTest,
           });
 
   engine_->GenerateAssistantResponse(
-      {}, history, false, {}, std::nullopt,
+      {}, EngineConsumer::ToHistoryView(history), false, {}, std::nullopt,
       {mojom::ConversationCapability::CHAT}, base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
@@ -984,7 +988,7 @@ TEST_F(EngineConsumerOAIUnitTest,
           });
 
   engine_->GenerateAssistantResponse(
-      {}, history,
+      {}, EngineConsumer::ToHistoryView(history),
       true,  // is_temporary_chat = true
       {}, std::nullopt, {mojom::ConversationCapability::CHAT},
       base::DoNothing(),
@@ -2121,7 +2125,8 @@ TEST_F(EngineConsumerOAIUnitTest, GenerateAssistantResponse_WithTools) {
       std::nullopt, nullptr));
 
   engine_->GenerateAssistantResponse(
-      {}, history, false, {mock_tool->GetWeakPtr()}, std::nullopt,
+      {}, EngineConsumer::ToHistoryView(history), false,
+      {mock_tool->GetWeakPtr()}, std::nullopt,
       {mojom::ConversationCapability::CHAT}, base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));

--- a/components/ai_chat/core/browser/engine/mock_engine_consumer.h
+++ b/components/ai_chat/core/browser/engine/mock_engine_consumer.h
@@ -30,7 +30,7 @@ class MockEngineConsumer : public EngineConsumer {
   MOCK_METHOD(void,
               GenerateAssistantResponse,
               (PageContentsMap && page_contents,
-               const ConversationHistory& conversation_history,
+               const ConversationHistoryView& conversation_history,
                bool is_temporary_chat,
                const std::vector<base::WeakPtr<Tool>>& tools,
                std::optional<std::string_view> preferred_tool_name,

--- a/components/ai_chat/core/browser/engine/oai_message_utils.cc
+++ b/components/ai_chat/core/browser/engine/oai_message_utils.cc
@@ -157,7 +157,7 @@ std::vector<mojom::ContentBlockPtr> BuildOAIPageContentBlocks(
 
 std::vector<OAIMessage> BuildOAIMessages(
     PageContentsMap&& page_contents,
-    const EngineConsumer::ConversationHistory& conversation_history,
+    const EngineConsumer::ConversationHistoryView& conversation_history,
     PrefService* prefs,
     bool exclude_memory,
     uint32_t remaining_length,
@@ -444,7 +444,7 @@ std::vector<OAIMessage> BuildOAIMessages(
     } else {
       oai_message.content.push_back(
           mojom::ContentBlock::NewTextContentBlock(mojom::TextContentBlock::New(
-              EngineConsumer::GetPromptForEntry(message))));
+              EngineConsumer::GetPromptForEntry(*message))));
     }
 
     // Add the assistant message first
@@ -625,7 +625,7 @@ BuildOAIGenerateConversationTitleMessages(
                                   !assistant_turn->text.empty();
   std::string title_text = use_assistant_text
                                ? assistant_turn->text
-                               : EngineConsumer::GetPromptForEntry(first_turn);
+                               : EngineConsumer::GetPromptForEntry(*first_turn);
 
   // Withdraw the request entirely if we have nothing to summarize. Sending an
   // empty title block wastes a server round-trip and cannot produce a useful

--- a/components/ai_chat/core/browser/engine/oai_message_utils.h
+++ b/components/ai_chat/core/browser/engine/oai_message_utils.h
@@ -41,7 +41,7 @@ struct OAIMessage {
 
 std::vector<OAIMessage> BuildOAIMessages(
     PageContentsMap&& page_contents,
-    const EngineConsumer::ConversationHistory& conversation_history,
+    const EngineConsumer::ConversationHistoryView& conversation_history,
     PrefService* prefs,
     bool exclude_memory,
     uint32_t remaining_length,

--- a/components/ai_chat/core/browser/engine/oai_message_utils_unittest.cc
+++ b/components/ai_chat/core/browser/engine/oai_message_utils_unittest.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "base/containers/to_vector.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "base/test/scoped_feature_list.h"
@@ -39,6 +40,13 @@ struct RewriteActionTestParam {
   std::string expected_payload;  // non-empty for change tones
   std::optional<mojom::SimpleRequestType> expected_simple_request_type;
 };
+
+EngineConsumer::ConversationHistoryView ToHistoryView(
+    const EngineConsumer::ConversationHistory& owning) {
+  return base::ToVector<const mojom::ConversationTurn*>(
+      owning,
+      [](const mojom::ConversationTurnPtr& turn) { return turn.get(); });
+}
 
 // Creates a WebSourcesContentBlock. If any |page_content_sizes| element has
 // a value, the source includes page_content, extra_snippets, and rich_results
@@ -112,8 +120,8 @@ class OAIMessageUtilsTest : public testing::Test {
 
     // Call BuildOAIMessages
     std::vector<OAIMessage> messages =
-        BuildOAIMessages(PageContentsMap(), history, prefs, exclude_memory,
-                         10000, [](std::string&) {});
+        BuildOAIMessages(PageContentsMap(), ToHistoryView(history), prefs,
+                         exclude_memory, 10000, [](std::string&) {});
 
     // Verify: Should have 1 human message with NO memory block
     ASSERT_EQ(messages.size(), 1u);
@@ -270,7 +278,8 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages) {
 
   bool sanitize_input_called = false;
   std::vector<OAIMessage> messages = BuildOAIMessages(
-      std::move(page_contents_map), history, nullptr, true, 10000,
+      std::move(page_contents_map), ToHistoryView(history), nullptr, true,
+      10000,
       [&sanitize_input_called](std::string&) { sanitize_input_called = true; });
 
   EXPECT_TRUE(sanitize_input_called);
@@ -342,8 +351,8 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_ContentTruncation) {
 
   // Set max_length to fit newer content but not both
   std::vector<OAIMessage> messages =
-      BuildOAIMessages(std::move(page_contents_map), history, nullptr, true, 11,
-                       [](std::string&) {});
+      BuildOAIMessages(std::move(page_contents_map), ToHistoryView(history),
+                       nullptr, true, 11, [](std::string&) {});
 
   // Should have 2 messages
   ASSERT_EQ(messages.size(), 2u);
@@ -442,8 +451,8 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_UploadedFiles) {
 
   // Build OAI messages
   std::vector<OAIMessage> messages =
-      BuildOAIMessages(std::move(page_contents_map), history, nullptr, true,
-                       10000, [](std::string&) {});
+      BuildOAIMessages(std::move(page_contents_map), ToHistoryView(history),
+                       nullptr, true, 10000, [](std::string&) {});
 
   // Should have 10 messages (5 human, 5 assistant)
   ASSERT_EQ(messages.size(), 10u);
@@ -567,8 +576,8 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_PdfExtractedTextPreferred) {
 
   PageContentsMap page_contents_map;
   std::vector<OAIMessage> messages =
-      BuildOAIMessages(std::move(page_contents_map), history, nullptr, true,
-                       10000, [](std::string&) {});
+      BuildOAIMessages(std::move(page_contents_map), ToHistoryView(history),
+                       nullptr, true, 10000, [](std::string&) {});
 
   ASSERT_EQ(messages.size(), 2u);
   EXPECT_EQ(messages[0].role, "user");
@@ -604,8 +613,8 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_TextFileExtractedText) {
 
   PageContentsMap page_contents_map;
   std::vector<OAIMessage> messages =
-      BuildOAIMessages(std::move(page_contents_map), history, nullptr, true,
-                       10000, [](std::string&) {});
+      BuildOAIMessages(std::move(page_contents_map), ToHistoryView(history),
+                       nullptr, true, 10000, [](std::string&) {});
 
   ASSERT_EQ(messages.size(), 2u);
   EXPECT_EQ(messages[0].role, "user");
@@ -632,8 +641,8 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_TextFileDefaultFilename) {
 
   PageContentsMap page_contents_map;
   std::vector<OAIMessage> messages =
-      BuildOAIMessages(std::move(page_contents_map), history, nullptr, true,
-                       10000, [](std::string&) {});
+      BuildOAIMessages(std::move(page_contents_map), ToHistoryView(history),
+                       nullptr, true, 10000, [](std::string&) {});
 
   ASSERT_EQ(messages.size(), 2u);
   ASSERT_EQ(messages[0].content.size(), 3u);
@@ -699,8 +708,8 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_Memory) {
 
   // Call BuildOAIMessages
   std::vector<OAIMessage> messages =
-      BuildOAIMessages(std::move(page_contents_map), history, &prefs_, false,
-                       10000, [](std::string&) {});
+      BuildOAIMessages(std::move(page_contents_map), ToHistoryView(history),
+                       &prefs_, false, 10000, [](std::string&) {});
 
   // Should have 3 messages
   ASSERT_EQ(messages.size(), 3u);
@@ -756,8 +765,9 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_Memory_HTMLEscaping) {
   history.pop_back();
 
   // Call BuildOAIMessages
-  std::vector<OAIMessage> messages = BuildOAIMessages(
-      PageContentsMap(), history, &prefs_, false, 10000, [](std::string&) {});
+  std::vector<OAIMessage> messages =
+      BuildOAIMessages(PageContentsMap(), ToHistoryView(history), &prefs_,
+                       false, 10000, [](std::string&) {});
 
   // Should have 1 human message
   ASSERT_EQ(messages.size(), 1u);
@@ -806,8 +816,8 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_Skills) {
 
   // Call BuildOAIMessages
   std::vector<OAIMessage> messages =
-      BuildOAIMessages(std::move(page_contents_map), history, nullptr, false,
-                       10000, [](std::string&) {});
+      BuildOAIMessages(std::move(page_contents_map), ToHistoryView(history),
+                       nullptr, false, 10000, [](std::string&) {});
 
   // Should have 4 OAI messages (2 human + 2 assistant)
   ASSERT_EQ(messages.size(), 4u);
@@ -1330,8 +1340,9 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_StripWebSourcesOutputs) {
     history[1]->events = std::move(events);
   }
 
-  std::vector<OAIMessage> messages = BuildOAIMessages(
-      PageContentsMap(), history, nullptr, true, 100000, [](std::string&) {});
+  std::vector<OAIMessage> messages =
+      BuildOAIMessages(PageContentsMap(), ToHistoryView(history), nullptr, true,
+                       100000, [](std::string&) {});
 
   std::vector<const OAIMessage*> tool_msgs;
   for (const auto& m : messages) {
@@ -1420,8 +1431,9 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_DropLargeToolResults) {
     history[1]->events = std::move(events);
   }
 
-  std::vector<OAIMessage> messages = BuildOAIMessages(
-      PageContentsMap(), history, nullptr, true, 100000, [](std::string&) {});
+  std::vector<OAIMessage> messages =
+      BuildOAIMessages(PageContentsMap(), ToHistoryView(history), nullptr, true,
+                       100000, [](std::string&) {});
 
   std::vector<const OAIMessage*> tool_msgs;
   for (const auto& m : messages) {
@@ -1553,8 +1565,9 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_MixedLargeToolOutputs) {
     history[3]->events = std::move(events);
   }
 
-  std::vector<OAIMessage> messages = BuildOAIMessages(
-      PageContentsMap(), history, nullptr, true, 100000, [](std::string&) {});
+  std::vector<OAIMessage> messages =
+      BuildOAIMessages(PageContentsMap(), ToHistoryView(history), nullptr, true,
+                       100000, [](std::string&) {});
 
   // Collect tool-role messages.
   std::vector<const OAIMessage*> tool_msgs;

--- a/components/ai_chat/core/browser/engine/oai_message_utils_unittest.cc
+++ b/components/ai_chat/core/browser/engine/oai_message_utils_unittest.cc
@@ -41,13 +41,6 @@ struct RewriteActionTestParam {
   std::optional<mojom::SimpleRequestType> expected_simple_request_type;
 };
 
-EngineConsumer::ConversationHistoryView ToHistoryView(
-    const EngineConsumer::ConversationHistory& owning) {
-  return base::ToVector<const mojom::ConversationTurn*>(
-      owning,
-      [](const mojom::ConversationTurnPtr& turn) { return turn.get(); });
-}
-
 // Creates a WebSourcesContentBlock. If any |page_content_sizes| element has
 // a value, the source includes page_content, extra_snippets, and rich_results
 // are populated; otherwise those fields are nullopt/empty (stripped).
@@ -119,9 +112,9 @@ class OAIMessageUtilsTest : public testing::Test {
     history.pop_back();  // Remove assistant turn
 
     // Call BuildOAIMessages
-    std::vector<OAIMessage> messages =
-        BuildOAIMessages(PageContentsMap(), ToHistoryView(history), prefs,
-                         exclude_memory, 10000, [](std::string&) {});
+    std::vector<OAIMessage> messages = BuildOAIMessages(
+        PageContentsMap(), EngineConsumer::ToHistoryView(history), prefs,
+        exclude_memory, 10000, [](std::string&) {});
 
     // Verify: Should have 1 human message with NO memory block
     ASSERT_EQ(messages.size(), 1u);
@@ -278,8 +271,8 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages) {
 
   bool sanitize_input_called = false;
   std::vector<OAIMessage> messages = BuildOAIMessages(
-      std::move(page_contents_map), ToHistoryView(history), nullptr, true,
-      10000,
+      std::move(page_contents_map), EngineConsumer::ToHistoryView(history),
+      nullptr, true, 10000,
       [&sanitize_input_called](std::string&) { sanitize_input_called = true; });
 
   EXPECT_TRUE(sanitize_input_called);
@@ -350,9 +343,9 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_ContentTruncation) {
   history.push_back(std::move(turn2));
 
   // Set max_length to fit newer content but not both
-  std::vector<OAIMessage> messages =
-      BuildOAIMessages(std::move(page_contents_map), ToHistoryView(history),
-                       nullptr, true, 11, [](std::string&) {});
+  std::vector<OAIMessage> messages = BuildOAIMessages(
+      std::move(page_contents_map), EngineConsumer::ToHistoryView(history),
+      nullptr, true, 11, [](std::string&) {});
 
   // Should have 2 messages
   ASSERT_EQ(messages.size(), 2u);
@@ -450,9 +443,9 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_UploadedFiles) {
   history[9]->text = "response4";
 
   // Build OAI messages
-  std::vector<OAIMessage> messages =
-      BuildOAIMessages(std::move(page_contents_map), ToHistoryView(history),
-                       nullptr, true, 10000, [](std::string&) {});
+  std::vector<OAIMessage> messages = BuildOAIMessages(
+      std::move(page_contents_map), EngineConsumer::ToHistoryView(history),
+      nullptr, true, 10000, [](std::string&) {});
 
   // Should have 10 messages (5 human, 5 assistant)
   ASSERT_EQ(messages.size(), 10u);
@@ -575,9 +568,9 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_PdfExtractedTextPreferred) {
   history[0]->uploaded_files = std::move(pdfs);
 
   PageContentsMap page_contents_map;
-  std::vector<OAIMessage> messages =
-      BuildOAIMessages(std::move(page_contents_map), ToHistoryView(history),
-                       nullptr, true, 10000, [](std::string&) {});
+  std::vector<OAIMessage> messages = BuildOAIMessages(
+      std::move(page_contents_map), EngineConsumer::ToHistoryView(history),
+      nullptr, true, 10000, [](std::string&) {});
 
   ASSERT_EQ(messages.size(), 2u);
   EXPECT_EQ(messages[0].role, "user");
@@ -612,9 +605,9 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_TextFileExtractedText) {
   history[0]->uploaded_files = std::move(text_files);
 
   PageContentsMap page_contents_map;
-  std::vector<OAIMessage> messages =
-      BuildOAIMessages(std::move(page_contents_map), ToHistoryView(history),
-                       nullptr, true, 10000, [](std::string&) {});
+  std::vector<OAIMessage> messages = BuildOAIMessages(
+      std::move(page_contents_map), EngineConsumer::ToHistoryView(history),
+      nullptr, true, 10000, [](std::string&) {});
 
   ASSERT_EQ(messages.size(), 2u);
   EXPECT_EQ(messages[0].role, "user");
@@ -640,9 +633,9 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_TextFileDefaultFilename) {
   history[0]->uploaded_files = std::move(text_files);
 
   PageContentsMap page_contents_map;
-  std::vector<OAIMessage> messages =
-      BuildOAIMessages(std::move(page_contents_map), ToHistoryView(history),
-                       nullptr, true, 10000, [](std::string&) {});
+  std::vector<OAIMessage> messages = BuildOAIMessages(
+      std::move(page_contents_map), EngineConsumer::ToHistoryView(history),
+      nullptr, true, 10000, [](std::string&) {});
 
   ASSERT_EQ(messages.size(), 2u);
   ASSERT_EQ(messages[0].content.size(), 3u);
@@ -707,9 +700,9 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_Memory) {
   history[2]->selected_text = "Selected excerpt";
 
   // Call BuildOAIMessages
-  std::vector<OAIMessage> messages =
-      BuildOAIMessages(std::move(page_contents_map), ToHistoryView(history),
-                       &prefs_, false, 10000, [](std::string&) {});
+  std::vector<OAIMessage> messages = BuildOAIMessages(
+      std::move(page_contents_map), EngineConsumer::ToHistoryView(history),
+      &prefs_, false, 10000, [](std::string&) {});
 
   // Should have 3 messages
   ASSERT_EQ(messages.size(), 3u);
@@ -765,9 +758,9 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_Memory_HTMLEscaping) {
   history.pop_back();
 
   // Call BuildOAIMessages
-  std::vector<OAIMessage> messages =
-      BuildOAIMessages(PageContentsMap(), ToHistoryView(history), &prefs_,
-                       false, 10000, [](std::string&) {});
+  std::vector<OAIMessage> messages = BuildOAIMessages(
+      PageContentsMap(), EngineConsumer::ToHistoryView(history), &prefs_, false,
+      10000, [](std::string&) {});
 
   // Should have 1 human message
   ASSERT_EQ(messages.size(), 1u);
@@ -815,9 +808,9 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_Skills) {
   page_contents_map[*history[0]->uuid] = {std::cref(page_content)};
 
   // Call BuildOAIMessages
-  std::vector<OAIMessage> messages =
-      BuildOAIMessages(std::move(page_contents_map), ToHistoryView(history),
-                       nullptr, false, 10000, [](std::string&) {});
+  std::vector<OAIMessage> messages = BuildOAIMessages(
+      std::move(page_contents_map), EngineConsumer::ToHistoryView(history),
+      nullptr, false, 10000, [](std::string&) {});
 
   // Should have 4 OAI messages (2 human + 2 assistant)
   ASSERT_EQ(messages.size(), 4u);
@@ -1340,9 +1333,9 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_StripWebSourcesOutputs) {
     history[1]->events = std::move(events);
   }
 
-  std::vector<OAIMessage> messages =
-      BuildOAIMessages(PageContentsMap(), ToHistoryView(history), nullptr, true,
-                       100000, [](std::string&) {});
+  std::vector<OAIMessage> messages = BuildOAIMessages(
+      PageContentsMap(), EngineConsumer::ToHistoryView(history), nullptr, true,
+      100000, [](std::string&) {});
 
   std::vector<const OAIMessage*> tool_msgs;
   for (const auto& m : messages) {
@@ -1431,9 +1424,9 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_DropLargeToolResults) {
     history[1]->events = std::move(events);
   }
 
-  std::vector<OAIMessage> messages =
-      BuildOAIMessages(PageContentsMap(), ToHistoryView(history), nullptr, true,
-                       100000, [](std::string&) {});
+  std::vector<OAIMessage> messages = BuildOAIMessages(
+      PageContentsMap(), EngineConsumer::ToHistoryView(history), nullptr, true,
+      100000, [](std::string&) {});
 
   std::vector<const OAIMessage*> tool_msgs;
   for (const auto& m : messages) {
@@ -1565,9 +1558,9 @@ TEST_F(OAIMessageUtilsTest, BuildOAIMessages_MixedLargeToolOutputs) {
     history[3]->events = std::move(events);
   }
 
-  std::vector<OAIMessage> messages =
-      BuildOAIMessages(PageContentsMap(), ToHistoryView(history), nullptr, true,
-                       100000, [](std::string&) {});
+  std::vector<OAIMessage> messages = BuildOAIMessages(
+      PageContentsMap(), EngineConsumer::ToHistoryView(history), nullptr, true,
+      100000, [](std::string&) {});
 
   // Collect tool-role messages.
   std::vector<const OAIMessage*> tool_msgs;


### PR DESCRIPTION
Generation requests that happen within threads will require concatenating a subset of entries from the original chat history and the thread messages, to get the full history relevant to the thread. To avoid cloning conversation turns upon every request, this view type will allow the EngineConsumer methods to take either a reference to a vector of owning turn pointers (which we use now) as well as a vector of non-owning pointers. The former will continue to be used for normal conversation generation requests. The latter will be used for thread generation requests.

<!-- Add brave-browser issue below that this PR will resolve -->
https://github.com/brave/brave-browser/issues/57705

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
