### PR TITLE
Migrate into VerticalTabController: vertical_tab_utils

### DIFF
--- a/browser/ui/brave_browser_command_controller_browsertest.cc
+++ b/browser/ui/brave_browser_command_controller_browsertest.cc
@@ -16,6 +16,7 @@
 #include "brave/browser/ui/browser_commands.h"
 #include "brave/browser/ui/focus_mode/focus_mode_controller.h"
 #include "brave/browser/ui/focus_mode/focus_mode_features.h"
+#include "brave/browser/ui/tabs/public/vertical_tab_controller.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_account/features.h"
@@ -717,15 +718,16 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerTest,
                        BraveCommandsToggleVerticalTabs) {
   auto* command_controller = browser()->command_controller();
   EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_TOGGLE_VERTICAL_TABS));
-  ASSERT_FALSE(tabs::utils::ShouldShowBraveVerticalTabs(browser()));
+  auto* vtc = VerticalTabController::FromBrowser(browser());
+  ASSERT_FALSE(vtc->ShouldShowBraveVerticalTabs());
 
   // Enable Vertical tabs
   command_controller->ExecuteCommand(IDC_TOGGLE_VERTICAL_TABS);
-  ASSERT_TRUE(tabs::utils::ShouldShowBraveVerticalTabs(browser()));
+  ASSERT_TRUE(vtc->ShouldShowBraveVerticalTabs());
 
   // Toggle back
   command_controller->ExecuteCommand(IDC_TOGGLE_VERTICAL_TABS);
-  ASSERT_FALSE(tabs::utils::ShouldShowBraveVerticalTabs(browser()));
+  ASSERT_FALSE(vtc->ShouldShowBraveVerticalTabs());
 }
 
 #if BUILDFLAG(IS_MAC)
@@ -754,8 +756,7 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerTest,
 class BraveBrowserCommandControllerWithSideBySideTest
     : public BraveBrowserCommandControllerTest {
  public:
-  BraveBrowserCommandControllerWithSideBySideTest() {
-  }
+  BraveBrowserCommandControllerWithSideBySideTest() {}
   ~BraveBrowserCommandControllerWithSideBySideTest() override = default;
 
   TabStripModel* tab_strip_model() { return browser()->tab_strip_model(); }

--- a/browser/ui/views/tabs/vertical_tab_utils.cc
+++ b/browser/ui/views/tabs/vertical_tab_utils.cc
@@ -5,95 +5,17 @@
 
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 
-#include "base/check.h"
-#include "base/check_is_test.h"
-#include "base/command_line.h"
 #include "base/numerics/safe_conversions.h"
 #include "brave/browser/ui/focus_mode/focus_mode_utils.h"
-#include "brave/browser/ui/tabs/brave_tab_prefs.h"
-#include "brave/browser/ui/tabs/public/switches.h"
 #include "build/build_config.h"
 #include "chrome/app/chrome_command_ids.h"
-#include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_command_controller.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
-#include "chrome/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/views/frame/browser_frame_view.h"
 #include "chrome/browser/ui/views/frame/browser_widget.h"
-#include "components/prefs/pref_service.h"
 
 namespace tabs::utils {
-
-bool SupportsBraveVerticalTabs(const BrowserWindowInterface* browser) {
-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kDisableVerticalTabsSwitch)) {
-    return false;
-  }
-
-  if (tabs::IsVerticalTabsFeatureEnabled()) {
-    // In case that Chromium's vertical tabs feature is enabled, we should not
-    // show Brave's vertical tabs.
-    return false;
-  }
-
-  if (!browser) {
-    // During unit tests, |browser| can be null.
-    CHECK_IS_TEST();
-    return false;
-  }
-
-  return browser->GetType() == BrowserWindowInterface::TYPE_NORMAL;
-}
-
-bool ShouldShowBraveVerticalTabs(const BrowserWindowInterface* browser) {
-  if (!SupportsBraveVerticalTabs(browser)) {
-    return false;
-  }
-
-  if (!browser->GetProfile()) {
-    // During unit tests, profile can be null.
-    CHECK_IS_TEST();
-    return false;
-  }
-
-  return browser->GetProfile()->GetPrefs()->GetBoolean(
-      brave_tabs::kVerticalTabsEnabled);
-}
-
-bool ShouldShowWindowTitleForVerticalTabs(
-    const BrowserWindowInterface* browser) {
-  if (!ShouldShowBraveVerticalTabs(browser)) {
-    return false;
-  }
-
-  if (IsFocusModeEnabled(browser)) {
-    return false;
-  }
-
-  return browser->GetProfile()->GetPrefs()->GetBoolean(
-      brave_tabs::kVerticalTabsShowTitleOnWindow);
-}
-
-bool IsFloatingVerticalTabsEnabled(const BrowserWindowInterface* browser) {
-  if (!ShouldShowBraveVerticalTabs(browser)) {
-    return false;
-  }
-
-  if (ShouldHideVerticalTabsCompletelyWhenCollapsed(browser)) {
-    // In this case, we should support floating mode regardless of the setting
-    // of kVerticalTabsFloatingEnabled.
-    return true;
-  }
-
-  return browser->GetProfile()->GetPrefs()->GetBoolean(
-      brave_tabs::kVerticalTabsFloatingEnabled);
-}
-
-bool IsVerticalTabOnRight(const BrowserWindowInterface* browser) {
-  return browser->GetProfile()->GetPrefs()->GetBoolean(
-      brave_tabs::kVerticalTabsOnRight);
-}
 
 std::pair<int, int> GetLeadingTrailingCaptionButtonWidth(
     const BrowserWidget* frame) {
@@ -113,13 +35,6 @@ std::pair<int, int> GetLeadingTrailingCaptionButtonWidth(
 #else
 #error "not handled platform"
 #endif
-}
-
-bool ShouldHideVerticalTabsCompletelyWhenCollapsed(
-    const BrowserWindowInterface* browser) {
-  return base::FeatureList::IsEnabled(tabs::kBraveVerticalTabHideCompletely) &&
-         browser->GetProfile()->GetPrefs()->GetBoolean(
-             brave_tabs::kVerticalTabsHideCompletelyWhenCollapsed);
 }
 
 bool IsVerticalTabToggleEnabled(BrowserWindowInterface* browser) {

--- a/browser/ui/views/tabs/vertical_tab_utils.h
+++ b/browser/ui/views/tabs/vertical_tab_utils.h
@@ -11,30 +11,13 @@
 class BrowserWidget;
 class BrowserWindowInterface;
 
+// Note that this utils file is directly included by //brave/browser/ui/
+// which allows circular dependency between //brave/browser/ui/ and
+// //chrome/browser/ui/. So this file should only contain code
+// related to vertical tabs and have no choices of including any header
+// from //chrome/browser/ui/. If it doesn't have any circular dependency to the
+// target, it should be put in VerticalTabController instead.
 namespace tabs::utils {
-
-// Returns true if the current |browser| might ever support vertical tabs.
-bool SupportsBraveVerticalTabs(const BrowserWindowInterface* browser);
-
-// Returns true when users chose to use vertical tabs
-bool ShouldShowBraveVerticalTabs(const BrowserWindowInterface* browser);
-
-// Returns true when we should show window title on window frame when vertical
-// tab strip is enabled.
-bool ShouldShowWindowTitleForVerticalTabs(
-    const BrowserWindowInterface* browser);
-
-// Returns true if we should trigger floating vertical tab strip on mouse over.
-bool IsFloatingVerticalTabsEnabled(const BrowserWindowInterface* browser);
-
-bool IsVerticalTabOnRight(const BrowserWindowInterface* browser);
-
-// Returns true if we should hide vertical tab completely when collapsed. In
-// this case vertical tab strip will be almost a few pixels wide vertical bar
-// when collapsed. And will expand to show tab icons when mouse is over the bar
-// regardless of the setting of kVerticalTabsFloatingEnabled.
-bool ShouldHideVerticalTabsCompletelyWhenCollapsed(
-    const BrowserWindowInterface* browser);
 
 // Returns true when the vertical tab toggle should be enabled.
 bool IsVerticalTabToggleEnabled(BrowserWindowInterface* browser);

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -186,6 +186,14 @@ void SetBraveButtonFlexBehavior(views::View* btn) {
   btn->SetProperty(views::kFlexBehaviorKey, kBraveButtonFlex);
 }
 
+bool SupportsBraveVerticalTabs(BrowserWindowInterface* browser) {
+  if (!browser) {
+    return false;
+  }
+  auto* vtc = VerticalTabController::FromBrowser(browser);
+  return vtc && vtc->SupportsBraveVerticalTabs();
+}
+
 }  // namespace
 
 class BraveToolbarView::LayoutGuard {
@@ -282,7 +290,7 @@ void BraveToolbarView::Init() {
       base::BindRepeating(&BraveToolbarView::OnCompactModePrefChanged,
                           base::Unretained(this)));
 
-  if (tabs::utils::SupportsBraveVerticalTabs(browser_)) {
+  if (SupportsBraveVerticalTabs(browser_)) {
     show_vertical_tabs_.Init(brave_tabs::kVerticalTabsEnabled,
                              profile->GetPrefs(),
                              base::BindRepeating(
@@ -327,7 +335,7 @@ void BraveToolbarView::Init() {
   };
 
   // Add vertical tab toggle button to the left of the back button.
-  if (tabs::utils::SupportsBraveVerticalTabs(browser_)) {
+  if (SupportsBraveVerticalTabs(browser_)) {
     auto back_button_index = GetIndexOf(back_);
     vertical_tab_toggle_ =
         AddChildViewAt(std::make_unique<ToolbarButton>(base::BindRepeating(
@@ -435,7 +443,7 @@ void BraveToolbarView::Init() {
     ReorderChildView(avatar_button, *GetIndexOf(app_menu_button_) - 1);
   }
 
-  if (tabs::utils::SupportsBraveVerticalTabs(browser_)) {
+  if (SupportsBraveVerticalTabs(browser_)) {
     UpdateVerticalTabTogglePlacement();
   }
 
@@ -562,8 +570,12 @@ void BraveToolbarView::UpdateHorizontalPadding() {
   // shown, or when the top container is hosted in the Focus Mode top overlay.
   // In the latter case, upstream's "top container reparented" layout branch
   // takes care of the insets.
-  if (!tabs::utils::ShouldShowBraveVerticalTabs(browser()) ||
-      tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser()) ||
+  auto* vtc = VerticalTabController::FromBrowser(browser_);
+  const bool should_show_vertical_tabs =
+      vtc && vtc->ShouldShowBraveVerticalTabs();
+  const bool should_show_title_bar_for_vertical_tabs =
+      vtc && vtc->ShouldShowWindowTitleForVerticalTabs();
+  if (!should_show_vertical_tabs || should_show_title_bar_for_vertical_tabs ||
       IsFocusModeOverlayActive()) {
     SetBorder(nullptr);
     return;
@@ -740,8 +752,9 @@ void BraveToolbarView::UpdateVerticalTabTogglePlacement() {
   // (logical index 0 renders on the visual right). To keep the toggle on the
   // same physical side as the strip, invert the placement choice when the UI
   // is RTL.
+  auto* vtc = VerticalTabController::FromBrowser(browser_);
   const bool place_near_app_menu =
-      tabs::utils::IsVerticalTabOnRight(browser_) != base::i18n::IsRTL();
+      vtc && vtc->IsVerticalTabOnRight() != base::i18n::IsRTL();
 
   size_t target_idx = 0;
   if (place_near_app_menu) {
@@ -875,7 +888,8 @@ void BraveToolbarView::UpdateComboButtonState() {
     return;
   }
 
-  combo_button_->SetVisible(tabs::utils::ShouldShowBraveVerticalTabs(browser_));
+  auto* vtc = VerticalTabController::FromBrowser(browser_);
+  combo_button_->SetVisible(vtc && vtc->ShouldShowBraveVerticalTabs());
 }
 
 bool BraveToolbarView::IsFocusModeOverlayActive() const {

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1027,6 +1027,7 @@ test("brave_browser_tests") {
     "//brave/browser/test:browser_tests",
     "//brave/browser/themes",
     "//brave/browser/ui:browser_tests",
+    "//brave/browser/ui/tabs:tabs_public",
     "//brave/browser/ui/tabs/test:browser_tests",
     "//brave/browser/ui/views/tabs:browser_tests",
     "//brave/browser/ui/webui:browser_tests",


### PR DESCRIPTION
Retire utility functions in vertical_tab_utils.h and move them into VerticalTabController.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/51112
Resovles https://github.com/brave/brave-browser/issues/56390

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
