### PR TITLE
[AI Chat] Sharing - include metadata for associated content

### DIFF
--- a/browser/ui/webui/ai_chat/BUILD.gn
+++ b/browser/ui/webui/ai_chat/BUILD.gn
@@ -47,6 +47,7 @@ source_set("ai_chat") {
     "//chrome/browser/ui/webui:favicon_source",
     "//components/favicon/core",
     "//components/favicon_base",
+    "//components/keyed_service/core",
     "//components/prefs",
     "//components/strings:components_strings",
     "//components/user_prefs",
@@ -54,6 +55,7 @@ source_set("ai_chat") {
     "//pdf:buildflags",
     "//printing",
     "//services/data_decoder/public/cpp",
+    "//ui/base",
     "//ui/gfx/codec",
     "//ui/webui",
   ]
@@ -98,6 +100,7 @@ source_set("unit_tests") {
     "//brave/components/ai_chat/core/browser",
     "//brave/components/ai_chat/core/common",
     "//brave/components/ai_chat/core/common/mojom",
+    "//chrome/browser/favicon",
     "//chrome/test:test_support",
     "//content/test:test_support",
     "//pdf:buildflags",

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -14,6 +14,7 @@
 
 #include "base/barrier_callback.h"
 #include "base/check.h"
+#include "base/containers/span.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_forward.h"
 #include "base/strings/utf_string_conversions.h"
@@ -29,6 +30,7 @@
 #include "brave/components/ai_chat/core/browser/utils.h"
 #include "brave/components/ai_chat/core/common/ai_chat_urls.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/ai_chat/core/common/constants.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
@@ -39,7 +41,9 @@
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/singleton_tabs.h"
 #include "components/favicon/core/favicon_service.h"
+#include "components/favicon_base/favicon_types.h"
 #include "components/grit/brave_components_webui_strings.h"
+#include "components/keyed_service/core/service_access_type.h"
 #include "components/tabs/public/tab_interface.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/navigation_controller.h"
@@ -54,6 +58,7 @@
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/page_transition_types.h"
+#include "ui/base/webui/web_ui_util.h"
 #include "ui/gfx/codec/png_codec.h"
 #include "ui/gfx/geometry/size.h"
 
@@ -180,6 +185,18 @@ void ProcessImageData(
       data_decoder, image_data, data_decoder::mojom::ImageCodec::kDefault, true,
       data_decoder::kDefaultMaxSizeInBytes, gfx::Size(),
       base::BindOnce(&OnImageDecoded, std::move(callback)));
+}
+
+void OnFaviconRawBitmapAvailable(
+    mojom::AIChatUIHandler::GetFaviconDataURLCallback callback,
+    const favicon_base::FaviconRawBitmapResult& result) {
+  if (!result.is_valid()) {
+    std::move(callback).Run(std::nullopt);
+    return;
+  }
+  // Favicons are always stored as PNG (see FaviconSource::GetMimeType).
+  std::move(callback).Run(
+      webui::GetPngDataUrl(base::span<const uint8_t>(*result.bitmap_data)));
 }
 
 }  // namespace
@@ -360,6 +377,26 @@ void AIChatUIPageHandler::GetPluralString(const std::string& key,
                                 &webui::LocalizedString::name);
   CHECK(iter != webui::kAiChatStrings.end());
   std::move(callback).Run(l10n_util::GetPluralStringFUTF8(iter->id, count));
+}
+
+void AIChatUIPageHandler::GetFaviconDataURL(
+    const GURL& page_url,
+    GetFaviconDataURLCallback callback) {
+  favicon::FaviconService* favicon_service =
+      FaviconServiceFactory::GetForProfile(profile_,
+                                           ServiceAccessType::EXPLICIT_ACCESS);
+  if (!favicon_service) {
+    std::move(callback).Run(std::nullopt);
+    return;
+  }
+
+  favicon_service->GetRawFaviconForPageURL(
+      page_url, {favicon_base::IconType::kFavicon}, kFaviconDataURLSizeInPixels,
+      // Matches what the UI displays, which comes from the local-storage-only
+      // path of FaviconSource (see FaviconSource::StartDataRequest).
+      /*fallback_to_host=*/true,
+      base::BindOnce(&OnFaviconRawBitmapAvailable, std::move(callback)),
+      &favicon_task_tracker_);
 }
 
 void AIChatUIPageHandler::OpenAIChatSettings() {

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
@@ -105,6 +105,8 @@ class AIChatUIPageHandler : public mojom::AIChatUIHandler,
   void GetPluralString(const std::string& key,
                        int32_t count,
                        GetPluralStringCallback callback) override;
+  void GetFaviconDataURL(const GURL& page_url,
+                         GetFaviconDataURLCallback callback) override;
   void CloseUI() override;
   void SetChatUI(mojo::PendingRemote<mojom::ChatUI> chat_ui,
                  SetChatUICallback callback) override;
@@ -194,6 +196,9 @@ class AIChatUIPageHandler : public mojom::AIChatUIHandler,
 
   // DataDecoder instance for processing image data
   data_decoder::DataDecoder data_decoder_;
+
+  // Tracks in-progress favicon lookups so they are cancelled with `this`.
+  base::CancelableTaskTracker favicon_task_tracker_;
 
   // Active file extractors (owned until extraction completes)
   std::vector<std::unique_ptr<FileTextExtractorBase>> extractors_;

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler_unittest.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler_unittest.cc
@@ -6,12 +6,18 @@
 #include "brave/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h"
 
 #include <memory>
+#include <optional>
 #include <string>
+#include <string_view>
+#include <vector>
 
+#include "base/base64.h"
 #include "base/memory/raw_ptr.h"
+#include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/test_future.h"
+#include "base/time/time.h"
 #include "brave/browser/ai_chat/ai_chat_service_factory.h"
 #include "brave/browser/brave_shields/brave_shields_web_contents_observer.h"
 #include "brave/browser/ephemeral_storage/ephemeral_storage_tab_helper.h"
@@ -19,18 +25,28 @@
 #include "brave/components/ai_chat/content/browser/associated_url_content.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_service.h"
 #include "brave/components/ai_chat/core/browser/conversation_handler.h"
+#include "brave/components/ai_chat/core/common/constants.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
 #include "build/build_config.h"
+#include "chrome/browser/favicon/favicon_service_factory.h"
+#include "chrome/browser/history/history_service_factory.h"
 #include "chrome/test/base/chrome_render_view_host_test_harness.h"
+#include "components/favicon/core/favicon_service.h"
+#include "components/favicon_base/favicon_types.h"
+#include "components/history/core/browser/history_service.h"
+#include "components/history/core/browser/history_types.h"
+#include "components/keyed_service/core/service_access_type.h"
 #include "content/public/test/web_contents_tester.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "pdf/buildflags.h"
 #include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/gfx/codec/png_codec.h"
+#include "ui/gfx/image/image.h"
 #include "ui/gfx/image/image_unittest_util.h"
 #include "url/gurl.h"
 
@@ -64,6 +80,18 @@ class AIChatUIPageHandlerTest : public ChromeRenderViewHostTestHarness {
     service_ = nullptr;
     page_handler_.reset();
     ChromeRenderViewHostTestHarness::TearDown();
+  }
+
+  // The favicon service, and the history service it stores favicons in, are not
+  // part of a TestingProfile by default.
+  TestingProfile::TestingFactories GetTestingFactories() const override {
+    TestingProfile::TestingFactories factories =
+        ChromeRenderViewHostTestHarness::GetTestingFactories();
+    factories.emplace_back(HistoryServiceFactory::GetInstance(),
+                           HistoryServiceFactory::GetDefaultFactory());
+    factories.emplace_back(FaviconServiceFactory::GetInstance(),
+                           FaviconServiceFactory::GetDefaultFactory());
+    return factories;
   }
 
   AIChatService* service() { return service_; }
@@ -225,6 +253,44 @@ TEST_F(AIChatUIPageHandlerTest, ProcessPdfFile_LooksLikePdfRejection) {
   }
 }
 #endif  // BUILDFLAG(ENABLE_PDF)
+
+TEST_F(AIChatUIPageHandlerTest, GetFaviconDataURL) {
+  const GURL page_url("https://example.com/page");
+  HistoryServiceFactory::GetForProfile(profile(),
+                                       ServiceAccessType::EXPLICIT_ACCESS)
+      ->AddPage(page_url, base::Time::Now(), history::SOURCE_BROWSED);
+  FaviconServiceFactory::GetForProfile(profile(),
+                                       ServiceAccessType::EXPLICIT_ACCESS)
+      ->SetFavicons(
+          {page_url}, GURL("https://example.com/icon.png"),
+          favicon_base::IconType::kFavicon,
+          gfx::Image::CreateFrom1xBitmap(gfx::test::CreateBitmap(16)));
+
+  base::test::TestFuture<const std::optional<std::string>&> future;
+  page_handler()->GetFaviconDataURL(page_url, future.GetCallback());
+
+  const std::optional<std::string>& data_url = future.Get();
+  ASSERT_TRUE(data_url);
+  constexpr std::string_view kPngDataUrlPrefix = "data:image/png;base64,";
+  ASSERT_TRUE(base::StartsWith(*data_url, kPngDataUrlPrefix));
+
+  // The stored favicon should have been resized to the size the UI asks for.
+  std::optional<std::vector<uint8_t>> png = base::Base64Decode(
+      std::string_view(*data_url).substr(kPngDataUrlPrefix.size()));
+  ASSERT_TRUE(png);
+  SkBitmap decoded = gfx::PNGCodec::Decode(*png);
+  EXPECT_EQ(decoded.width(), kFaviconDataURLSizeInPixels);
+  EXPECT_EQ(decoded.height(), kFaviconDataURLSizeInPixels);
+}
+
+TEST_F(AIChatUIPageHandlerTest, GetFaviconDataURL_NoFavicon) {
+  // Nothing is stored for the page, so there is no data URL to provide. The
+  // callback must still run, otherwise the UI would wait forever.
+  base::test::TestFuture<const std::optional<std::string>&> future;
+  page_handler()->GetFaviconDataURL(GURL("https://example.com/no-favicon"),
+                                    future.GetCallback());
+  EXPECT_FALSE(future.Get());
+}
 
 #if !BUILDFLAG(IS_ANDROID)
 

--- a/components/ai_chat/core/common/constants.h
+++ b/components/ai_chat/core/common/constants.h
@@ -37,6 +37,12 @@ inline constexpr char kClaudeSonnetModelKey[] = "chat-claude-sonnet";
 inline constexpr char kCustomModelItemModelKey[] = "model_request_name";
 inline constexpr char kCustomModelItemEndpointUrlKey[] = "endpoint_url";
 
+// Size of the favicon images which mojom::AIChatUIHandler::GetFaviconDataURL
+// provides. They are displayed at icon size, and are embedded in data which we
+// want to keep small, so this only needs to be large enough for a high density
+// display.
+inline constexpr int kFaviconDataURLSizeInPixels = 64;
+
 }  // namespace ai_chat
 
 #endif  // BRAVE_COMPONENTS_AI_CHAT_CORE_COMMON_CONSTANTS_H_

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -249,6 +249,14 @@ interface AIChatUIHandler {
   // Get a plural string for the given key and count.
   GetPluralString(string key, int32 count) => (string plural_string);
 
+  // Get the favicon which the browser has stored for a page as a data URL, so
+  // that it can be included in data which will be displayed outside of the
+  // browser, e.g. a shared conversation. Null if the browser doesn't have one.
+  // The UI renders favicons from the browser's favicon service directly
+  // (chrome://favicon2), so this is only needed when the image data itself is
+  // required.
+  GetFaviconDataURL(url.mojom.Url page_url) => (string? data_url);
+
   // This might be a no-op if the UI isn't closeable
   CloseUI();
 

--- a/components/ai_chat/resources/common/conversation_serialization.test.ts
+++ b/components/ai_chat/resources/common/conversation_serialization.test.ts
@@ -21,8 +21,20 @@ import {
   type ConversationData,
 } from './conversation_serialization'
 
+const sampleAssociatedContent: Mojom.AssociatedContent = {
+  uuid: 'assoc-1',
+  contentType: Mojom.ContentType.PageContent,
+  contentId: 1,
+  title: 'Sample page',
+  url: { url: 'https://example.com/1' },
+  contentUsedPercentage: 100,
+  conversationTurnUuid: '83f505d6-8fe6-448c-aabd-016ed1e2fa82',
+  toolsAttached: false,
+}
+
 const sampleSharedConversation: ConversationData = {
   messages: ComplexConversation,
+  associatedContent: [sampleAssociatedContent],
   title: 'sample title',
 }
 

--- a/components/ai_chat/resources/common/conversation_serialization.ts
+++ b/components/ai_chat/resources/common/conversation_serialization.ts
@@ -11,6 +11,11 @@ import * as Mojom from './mojom'
 // viewer.
 export type ConversationData = {
   messages: Mojom.ConversationTurn[]
+  // Favicons are provided by the client which serialized the conversation,
+  // since the viewer has no access to the browser's favicon service. They are
+  // optional because a favicon may not have been retrievable, and because
+  // conversations shared before they were included don't have them.
+  associatedContent: Mojom.AssociatedContentWithFavicon[]
   title: string
 }
 

--- a/components/ai_chat/resources/common/mojom.ts
+++ b/components/ai_chat/resources/common/mojom.ts
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import * as Mojom from 'gen/brave/components/ai_chat/core/common/mojom/common.mojom.m.js'
 export * from 'gen/brave/components/ai_chat/core/common/mojom/ai_chat.mojom.m.js'
 export * from 'gen/brave/components/ai_chat/core/common/mojom/common.mojom.m.js'
 export * from 'gen/brave/components/ai_chat/core/common/mojom/untrusted_frame.mojom.m.js'
@@ -10,3 +11,8 @@ export * from 'gen/brave/components/ai_chat/core/common/mojom/tab_tracker.mojom.
 export * from 'gen/brave/components/ai_chat/core/common/mojom/bookmarks.mojom.m.js'
 export * from 'gen/brave/components/ai_chat/core/common/mojom/history.mojom.m.js'
 export * from 'gen/brave/components/ai_chat/core/common/mojom/ollama.mojom.m.js'
+
+// Until this is needed outside of the UI, we don't need to add the field to the mojom.
+export type AssociatedContentWithFavicon = Mojom.AssociatedContent & {
+  faviconUrl?: string
+}

--- a/components/ai_chat/resources/page/api/ai_chat_api.ts
+++ b/components/ai_chat/resources/page/api/ai_chat_api.ts
@@ -107,6 +107,9 @@ export default function createAIChatApi(
         getPluralString: {
           response: (result) => result.pluralString,
         },
+        getFaviconDataURL: {
+          response: (result) => result.dataUrl,
+        },
       }),
 
       ...endpointsFor(bookmarksService, {

--- a/components/ai_chat/resources/page/api/mock_interfaces.ts
+++ b/components/ai_chat/resources/page/api/mock_interfaces.ts
@@ -233,6 +233,7 @@ export function createMockUIHandler(
         },
       }),
     getPluralString: () => Promise.resolve({ pluralString: '' }),
+    getFaviconDataURL: () => Promise.resolve({ dataUrl: null }),
     setChatUI: () => Promise.resolve({ isStandalone: false }),
 
     // Action methods - fire and forget stubs

--- a/components/ai_chat/resources/page/components/attachment_item/index.tsx
+++ b/components/ai_chat/resources/page/components/attachment_item/index.tsx
@@ -105,6 +105,12 @@ export function AttachmentSpinnerItem(props: {
 export function AttachmentPageItem(props: {
   title: string
   url: string
+  /**
+   * Optional URL (probably a data URI) for the favicon image.
+   * Without being specified, the browser favicon service will be used
+   * to lookup via the url.
+   */
+  faviconUrl?: string
   remove?: () => void
   className?: string
 }) {
@@ -116,7 +122,10 @@ export function AttachmentPageItem(props: {
       icon={
         <div className={styles.favicon}>
           <img
-            src={`//favicon2?size=256&pageUrl=${encodeURIComponent(props.url)}&allowGoogleServerFallback=0`}
+            src={
+              props.faviconUrl
+              ?? `//favicon2?size=256&pageUrl=${encodeURIComponent(props.url)}&allowGoogleServerFallback=0`
+            }
           />
         </div>
       }

--- a/components/ai_chat/resources/page/components/share_conversation_modal/create_shared_conversation_payload.test.ts
+++ b/components/ai_chat/resources/page/components/share_conversation_modal/create_shared_conversation_payload.test.ts
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as Mojom from '../../../common/mojom'
+import SampleConversation from '../../stories/conversations/multi_tool_multi_turn'
+import {
+  createSharedConversationPayload,
+  type FaviconContext,
+  type ShareableConversationContext,
+} from './create_shared_conversation_payload'
+
+function createAssociatedContent(
+  contentId: number,
+  url: string,
+): Mojom.AssociatedContent {
+  return {
+    uuid: `associated-content-${contentId}`,
+    contentType: Mojom.ContentType.PageContent,
+    contentId,
+    title: `Page ${contentId}`,
+    url: { url },
+    contentUsedPercentage: 100,
+    conversationTurnUuid: SampleConversation[0].uuid,
+    toolsAttached: false,
+  }
+}
+
+function createConversationContext(
+  associatedContent: Mojom.AssociatedContent[],
+): ShareableConversationContext {
+  return {
+    api: {
+      getConversationHistory: { current: () => SampleConversation },
+      getState: { current: () => ({ associatedContent }) },
+    },
+  }
+}
+
+const faviconDataUrl = 'data:image/png;base64,AQID'
+
+describe('createSharedConversationPayload', () => {
+  let getFaviconDataURL: jest.Mock
+  let faviconContext: FaviconContext
+
+  beforeEach(() => {
+    getFaviconDataURL = jest.fn()
+    faviconContext = {
+      api: { getFaviconDataURL: { fetch: getFaviconDataURL } },
+    }
+  })
+
+  it('includes the conversation messages, title and associated content', async () => {
+    getFaviconDataURL.mockResolvedValue(faviconDataUrl)
+    const content = createAssociatedContent(1, 'https://example.com/1')
+
+    const payload = await createSharedConversationPayload(
+      createConversationContext([content]),
+      faviconContext,
+      'A shared conversation',
+    )
+
+    expect(payload.messages).toEqual(SampleConversation)
+    expect(payload.title).toBe('A shared conversation')
+    expect(payload.associatedContent).toEqual([
+      { ...content, faviconUrl: faviconDataUrl },
+    ])
+  })
+
+  it('inlines the favicon of each associated content item', async () => {
+    getFaviconDataURL.mockResolvedValue(faviconDataUrl)
+    const contents = [
+      createAssociatedContent(1, 'https://example.com/1'),
+      createAssociatedContent(2, 'https://example.com/2'),
+    ]
+
+    const payload = await createSharedConversationPayload(
+      createConversationContext(contents),
+      faviconContext,
+      'A shared conversation',
+    )
+
+    // The browser is asked for the favicon of every attached page.
+    expect(getFaviconDataURL.mock.calls.map(([pageUrl]) => pageUrl)).toEqual([
+      { url: 'https://example.com/1' },
+      { url: 'https://example.com/2' },
+    ])
+    expect(payload.associatedContent.map((c) => c.faviconUrl)).toEqual([
+      faviconDataUrl,
+      faviconDataUrl,
+    ])
+  })
+
+  it('shares the conversation without the favicons it cannot retrieve', async () => {
+    // No favicon stored for the page, and a failed call, should both leave the
+    // content without a favicon rather than fail the share.
+    getFaviconDataURL.mockResolvedValueOnce(null)
+    getFaviconDataURL.mockRejectedValueOnce(new Error('Disconnected'))
+    getFaviconDataURL.mockResolvedValueOnce(faviconDataUrl)
+    const contents = [
+      createAssociatedContent(1, 'https://example.com/1'),
+      createAssociatedContent(2, 'https://example.com/2'),
+      createAssociatedContent(3, 'https://example.com/3'),
+    ]
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    const payload = await createSharedConversationPayload(
+      createConversationContext(contents),
+      faviconContext,
+      'A shared conversation',
+    )
+
+    expect(payload.associatedContent).toEqual([
+      { ...contents[0], faviconUrl: undefined },
+      { ...contents[1], faviconUrl: undefined },
+      { ...contents[2], faviconUrl: faviconDataUrl },
+    ])
+  })
+
+  it('does not request favicons when there is no associated content', async () => {
+    const payload = await createSharedConversationPayload(
+      createConversationContext([]),
+      faviconContext,
+      'A shared conversation',
+    )
+
+    expect(payload.associatedContent).toEqual([])
+    expect(getFaviconDataURL).not.toHaveBeenCalled()
+  })
+})

--- a/components/ai_chat/resources/page/components/share_conversation_modal/create_shared_conversation_payload.ts
+++ b/components/ai_chat/resources/page/components/share_conversation_modal/create_shared_conversation_payload.ts
@@ -1,0 +1,88 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { type ConversationData } from '../../../common/conversation_serialization'
+import * as Mojom from '../../../common/mojom'
+
+/**
+ * The parts of the conversation context that a shared conversation payload is
+ * built from. Defined structurally, instead of as a subset of
+ * ConversationContext, so that callers (including tests) can provide only this
+ * data.
+ */
+export interface ShareableConversationContext {
+  api: {
+    getConversationHistory: {
+      current: () => Mojom.ConversationTurn[]
+    }
+    getState: {
+      current: () => Pick<Mojom.ConversationState, 'associatedContent'>
+    }
+  }
+}
+
+/**
+ * The part of the AI Chat context used to resolve favicons. The UI renders
+ * favicons from the browser's favicon service (chrome://favicon2), which serves
+ * a different origin, so the image data has to come from the browser process.
+ */
+export interface FaviconContext {
+  api: {
+    getFaviconDataURL: {
+      fetch: (pageUrl: { url: string }) => Promise<string | null>
+    }
+  }
+}
+
+/**
+ * Resolves a page's favicon to a data URI, or `undefined` when the browser
+ * doesn't have one. A missing favicon only affects how the shared conversation
+ * looks, so it must never prevent sharing.
+ */
+async function getFaviconDataUrl(
+  faviconContext: FaviconContext,
+  pageUrl: string,
+) {
+  try {
+    return (
+      (await faviconContext.api.getFaviconDataURL.fetch({ url: pageUrl }))
+      ?? undefined
+    )
+  } catch (error) {
+    console.error(`Could not get the favicon for ${pageUrl}`, error)
+    return undefined
+  }
+}
+
+/**
+ * Builds the data for a shared conversation from the conversation on display.
+ *
+ * Attached tabs are rendered with the page's favicon, which the local UI gets
+ * from the browser's favicon service. The shared conversation viewer is a
+ * regular website with no access to that service, so each favicon is resolved
+ * here and inlined in the payload as a data URI.
+ */
+export async function createSharedConversationPayload(
+  conversationContext: ShareableConversationContext,
+  faviconContext: FaviconContext,
+  conversationTitle: string,
+): Promise<ConversationData> {
+  const { api } = conversationContext
+
+  const associatedContent = await Promise.all(
+    api.getState.current().associatedContent.map(
+      async (content): Promise<Mojom.AssociatedContentWithFavicon> => ({
+        ...content,
+        faviconUrl: await getFaviconDataUrl(faviconContext, content.url.url),
+      }),
+    ),
+  )
+
+  return {
+    messages: api.getConversationHistory.current(),
+    associatedContent,
+    title: conversationTitle,
+  }
+}

--- a/components/ai_chat/resources/page/components/share_conversation_modal/index.tsx
+++ b/components/ai_chat/resources/page/components/share_conversation_modal/index.tsx
@@ -12,6 +12,7 @@ import { serializeConversationForSharing } from '../../../common/conversation_se
 import { encryptForSharing } from '../../../common/conversation_share_encryption'
 import { useAIChat } from '../../state/ai_chat_context'
 import { useConversation } from '../../state/conversation_context'
+import { createSharedConversationPayload } from './create_shared_conversation_payload'
 import styles from './style.module.scss'
 
 interface Props {
@@ -58,10 +59,13 @@ export default function ShareConversationModal(props: Props) {
       // sees ciphertext. The decryption key stays on the client and is appended
       // to the returned viewer URL as a fragment, so the shared link is only
       // usable by whoever the user shares it with.
-      const json = serializeConversationForSharing({
-        messages: conversationContext.api.getConversationHistory.current(),
-        title: conversationTitle,
-      })
+      const json = serializeConversationForSharing(
+        await createSharedConversationPayload(
+          conversationContext,
+          aiChatContext,
+          conversationTitle,
+        ),
+      )
       const { ciphertext, keyFragment } = await encryptForSharing(json)
       // The browser process combines the key fragment with the server's viewer
       // URL and copies the resulting shareable link to the clipboard, marked as

--- a/components/ai_chat/resources/shared_conversation_lib/render_conversation.test.tsx
+++ b/components/ai_chat/resources/shared_conversation_lib/render_conversation.test.tsx
@@ -7,6 +7,11 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { act, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import * as Mojom from '../common/mojom'
+import {
+  parseConversationData,
+  stringifyConversationData,
+} from '../common/conversation_serialization'
 import { renderConversation } from './render_conversation'
 
 // render_conversation sets the Leo icon base path from `import.meta.url`, which
@@ -22,10 +27,44 @@ jest.mock('./setup_rendering_element', () => ({
 
 // A real conversation exported from the AI Chat "Share conversation" action,
 // in the format expected by renderConversation (see conversation_serialization).
+// It predates associated content being part of the payload, so it also covers
+// rendering conversations shared by an older client.
 const conversationData = fs.readFileSync(
   path.join(__dirname, 'render_conversation.test-data.txt'),
   'utf8',
 )
+
+const sharedConversation = parseConversationData(conversationData)
+
+// Attachments are only rendered on the turn they were submitted with, so the
+// associated content must point at the sample data's human turn.
+const humanTurn = sharedConversation.messages.find(
+  (message) => message.characterType === Mojom.CharacterType.HUMAN,
+)!
+
+// The favicon comes with the payload as a data URI, because the viewer has no
+// access to the browser's favicon service.
+const attachedTabFaviconUrl =
+  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+
+const attachedTab: Mojom.AssociatedContentWithFavicon = {
+  uuid: 'e6b3f6c8-0f2a-4a1e-9d16-3f4f1f7b5c21',
+  contentType: Mojom.ContentType.PageContent,
+  contentId: 1,
+  title: 'Santa Barbara Weather Forecast',
+  url: { url: 'https://weather.example.com/santa-barbara' },
+  contentUsedPercentage: 100,
+  conversationTurnUuid: humanTurn.uuid,
+  toolsAttached: false,
+  faviconUrl: attachedTabFaviconUrl,
+}
+
+// The same conversation as above, as a current client would share it: with the
+// content that was attached to the human turn.
+const conversationDataWithAttachedTab = stringifyConversationData({
+  ...sharedConversation,
+  associatedContent: [attachedTab],
+})
 
 describe('renderConversation', () => {
   let container: HTMLElement
@@ -46,9 +85,9 @@ describe('renderConversation', () => {
     container.remove()
   })
 
-  const render = () => {
+  const render = (data = conversationData) => {
     act(() => {
-      renderConversation(conversationData, container)
+      renderConversation(data, container)
     })
   }
 
@@ -78,5 +117,42 @@ describe('renderConversation', () => {
     expect(
       screen.queryByTitle(S.CHAT_UI_DISMISS_BUTTON_LABEL),
     ).not.toBeInTheDocument()
+  })
+
+  it('shows the attached tabs of the associated content', async () => {
+    render(conversationDataWithAttachedTab)
+
+    // AttachmentPageItem shows the page title, and the URL without its scheme.
+    expect(
+      await screen.findByText(attachedTab.title, { selector: '.title' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('weather.example.com/santa-barbara'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the attached tab favicon provided in the conversation', async () => {
+    render(conversationDataWithAttachedTab)
+
+    await screen.findByText(attachedTab.title, { selector: '.title' })
+
+    expect(
+      container.querySelector(`.favicon img[src="${attachedTabFaviconUrl}"]`),
+    ).toBeInTheDocument()
+    // The browser's favicon service is not available to the viewer, so it must
+    // not be relied on for any image.
+    expect(
+      container.querySelector('img[src*="favicon2"]'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows conversations shared without associated content', async () => {
+    render()
+
+    await screen.findByText('weather in santa barbara')
+
+    // No attachments to display, and rendering the conversation should not be
+    // affected by their absence.
+    expect(container.querySelector('.itemWrapper')).not.toBeInTheDocument()
   })
 })

--- a/components/ai_chat/resources/shared_conversation_lib/render_conversation.tsx
+++ b/components/ai_chat/resources/shared_conversation_lib/render_conversation.tsx
@@ -86,6 +86,9 @@ export function renderConversation(
   }
 
   api.getConversationHistory.update(conversation.messages)
+  // Conversations shared before associated content was included in the payload
+  // don't have the property.
+  api.associatedContent.update(conversation.associatedContent ?? [])
 
   // Render to a shadow DOM to avoid style conflicts with the hosting page
   const container = setupRenderingElement(element)

--- a/components/ai_chat/resources/untrusted_conversation_frame/api/untrusted_conversation_api.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/api/untrusted_conversation_api.ts
@@ -134,6 +134,10 @@ export default function createUntrustedConversationApi(
         isTemporary: false,
       }),
 
+      // Duplicate the result of the `associatedContentChanged` event so that
+      // we can optionally provide favicon URLs.
+      associatedContent: state<Mojom.AssociatedContentWithFavicon[]>([]),
+
       // Service state (profile-level) - updated via UntrustedServiceObserver
       serviceState: state<Mojom.ServiceState>({
         hasAcceptedAgreement: false,
@@ -217,7 +221,10 @@ export default function createUntrustedConversationApi(
             api.state.update(state)
           },
 
-          associatedContentChanged(content) {},
+          associatedContentChanged(content) {
+            // Provide to our wrapper
+            api.associatedContent.update(content)
+          },
         },
         (observer) => {
           conversationObserver = observer

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
@@ -409,6 +409,7 @@ function ConversationEntries(props: {
                                     key={c.contentId}
                                     url={c.url.url}
                                     title={c.title}
+                                    faviconUrl={c.faviconUrl}
                                   />
                                 ))}
                                 <AttachmentUploadItems

--- a/components/ai_chat/resources/untrusted_conversation_frame/untrusted_conversation_context.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/untrusted_conversation_context.ts
@@ -35,7 +35,7 @@ export function useProvideUntrustedConversationContext(
   const serviceState = api.useServiceState().data
   const conversationHistory = api.useGetConversationHistoryData()
 
-  const associatedContent = api.useCurrentAssociatedContentChanged().data?.[0]
+  const associatedContent = api.useAssociatedContentData()
   const contentTaskTabId = api.useCurrentContentTaskStarted().data?.[0]
 
   return {
@@ -123,8 +123,7 @@ export function useProvideUntrustedConversationContext(
     isHistoryFeatureEnabled: IS_HISTORY_FEATURE_ENABLED,
 
     /**
-     * @deprecated Use `api.useCurrentAssociatedContentChanged().data` or
-     * subscribe to `api.useAssociatedContentChanged()` directly.
+     * @deprecated Use `api.useAssociatedContentData()` instead
      */
     associatedContent,
 

--- a/ios/browser/ui/webui/ai_chat/BUILD.gn
+++ b/ios/browser/ui/webui/ai_chat/BUILD.gn
@@ -39,6 +39,7 @@ source_set("ai_chat") {
     "//components/prefs",
     "//components/resources",
     "//ios/chrome/browser/bookmarks/model",
+    "//ios/chrome/browser/favicon/model",
     "//ios/chrome/browser/history/model",
     "//ios/chrome/browser/shared/model/profile",
     "//ios/components/webui:url_constants",
@@ -51,6 +52,7 @@ source_set("ai_chat") {
     "//mojo/public/cpp/bindings",
     "//mojo/public/js:resources",
     "//skia",
+    "//ui/base",
     "//ui/gfx/codec",
   ]
 }

--- a/ios/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
+++ b/ios/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
@@ -12,6 +12,7 @@
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/scoped_observation.h"
+#include "base/task/cancelable_task_tracker.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_service.h"
 #include "brave/components/ai_chat/core/browser/associated_content_driver.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
@@ -70,6 +71,8 @@ class AIChatUIPageHandler : public mojom::AIChatUIHandler,
   void GetPluralString(const std::string& key,
                        int32_t count,
                        GetPluralStringCallback callback) override;
+  void GetFaviconDataURL(const GURL& page_url,
+                         GetFaviconDataURLCallback callback) override;
   void CloseUI() override;
   void SetChatUI(mojo::PendingRemote<mojom::ChatUI> chat_ui,
                  SetChatUICallback callback) override;
@@ -121,6 +124,9 @@ class AIChatUIPageHandler : public mojom::AIChatUIHandler,
 
   raw_ptr<web::WebState> owner_web_state_ = nullptr;
   raw_ptr<ProfileIOS> profile_ = nullptr;
+
+  // Tracks in-progress favicon lookups so they are cancelled with `this`.
+  base::CancelableTaskTracker favicon_task_tracker_;
 
   mojo::Receiver<ai_chat::mojom::AIChatUIHandler> receiver_;
   mojo::Remote<ai_chat::mojom::ChatUI> chat_ui_;

--- a/ios/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.mm
+++ b/ios/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.mm
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "base/apple/foundation_util.h"
+#include "base/containers/span.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_forward.h"
 #include "base/functional/callback_helpers.h"
@@ -27,6 +28,7 @@
 #include "brave/components/ai_chat/core/browser/constants.h"
 #include "brave/components/ai_chat/core/browser/utils.h"
 #include "brave/components/ai_chat/core/common/ai_chat_urls.h"
+#include "brave/components/ai_chat/core/common/constants.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
@@ -42,7 +44,11 @@
 #include "brave/ios/browser/misc_metrics/profile_misc_metrics_service.h"
 #include "brave/ios/browser/misc_metrics/profile_misc_metrics_service_factory.h"
 #include "brave/ios/browser/ui/webui/ai_chat/associated_url_content.h"
+#include "components/favicon/core/favicon_service.h"
+#include "components/favicon_base/favicon_types.h"
 #include "components/grit/brave_components_webui_strings.h"
+#include "components/keyed_service/core/service_access_type.h"
+#include "ios/chrome/browser/favicon/model/favicon_service_factory.h"
 #include "ios/chrome/browser/shared/model/profile/profile_ios.h"
 #include "ios/web/public/navigation/navigation_context.h"
 #include "ios/web/public/navigation/navigation_manager.h"
@@ -55,6 +61,7 @@
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/page_transition_types.h"
+#include "ui/base/webui/web_ui_util.h"
 #include "ui/gfx/codec/png_codec.h"
 
 namespace ai_chat {
@@ -89,6 +96,18 @@ void DecodeAndScaleImage(
   base::ThreadPool::PostTaskAndReplyWithResult(FROM_HERE, {base::MayBlock()},
                                                std::move(encode_image),
                                                std::move(callback));
+}
+
+void OnFaviconRawBitmapAvailable(
+    mojom::AIChatUIHandler::GetFaviconDataURLCallback callback,
+    const favicon_base::FaviconRawBitmapResult& result) {
+  if (!result.is_valid()) {
+    std::move(callback).Run(std::nullopt);
+    return;
+  }
+  // Favicons are always stored as PNG (see FaviconSource::GetMimeType).
+  std::move(callback).Run(
+      webui::GetPngDataUrl(base::span<const uint8_t>(*result.bitmap_data)));
 }
 
 }  // namespace
@@ -216,6 +235,26 @@ void AIChatUIPageHandler::GetPluralString(const std::string& key,
                                 &webui::LocalizedString::name);
   CHECK(iter != webui::kAiChatStrings.end());
   std::move(callback).Run(l10n_util::GetPluralStringFUTF8(iter->id, count));
+}
+
+void AIChatUIPageHandler::GetFaviconDataURL(
+    const GURL& page_url,
+    GetFaviconDataURLCallback callback) {
+  favicon::FaviconService* favicon_service =
+      ios::FaviconServiceFactory::GetForProfile(
+          profile_, ServiceAccessType::EXPLICIT_ACCESS);
+  if (!favicon_service) {
+    std::move(callback).Run(std::nullopt);
+    return;
+  }
+
+  favicon_service->GetRawFaviconForPageURL(
+      page_url, {favicon_base::IconType::kFavicon}, kFaviconDataURLSizeInPixels,
+      // Matches what the UI displays, which comes from the local-storage-only
+      // path of FaviconSource (see FaviconSource::StartDataRequest).
+      /*fallback_to_host=*/true,
+      base::BindOnce(&OnFaviconRawBitmapAvailable, std::move(callback)),
+      &favicon_task_tracker_);
 }
 
 void AIChatUIPageHandler::OpenAIChatSettings() {


### PR DESCRIPTION
So that the sharing viewer can include site title, url, and favicon.

I had to add a new function to provide the Data URI for a favicon because CORS prevents calling `fetch` on `chrome://favicon2` and I didn't fancy modifying that.

- Resolves https://github.com/brave/brave-browser/issues/57707

Adding this data to the payload is already covered by https://github.com/brave/reviews/issues/2271