### PR TITLE
[Android] Use dynamic tint for Quick Search switches

### DIFF
--- a/browser/quick_search_engines/android/java/res/layout/quick_search_settings_item.xml
+++ b/browser/quick_search_engines/android/java/res/layout/quick_search_settings_item.xml
@@ -39,7 +39,6 @@
                android:id="@+id/search_engine_switch"
                android:layout_width="wrap_content"
                android:layout_height="wrap_content"
-               app:trackTint="@color/brave_switch_stroke_color"
                app:showText="false"
                android:clickable="false"/>
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/56823.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

&nbsp;|Light theme|Dark theme
--|--|--
`Dynamic colors` on |<img width="1344" height="2992" alt="quick-search-engines-light-dynamic-on" src="https://github.com/user-attachments/assets/c1ec1dd4-f8bc-4cc2-8cb0-4924af25aa17" />|<img width="1344" height="2992" alt="quick-search-engines-dark-dynamic-on" src="https://github.com/user-attachments/assets/7b9ac75d-6f6b-41c5-a238-c67e7efc0737" />
`Dynamic colors` off |<img width="1344" height="2992" alt="quick-search-engines-light-dynamic-off" src="https://github.com/user-attachments/assets/8d99a8d8-a46c-42d3-abe5-71a994e3f960" />|<img width="1344" height="2992" alt="quick-search-engines-dark-dynamic-off" src="https://github.com/user-attachments/assets/263d1141-2114-460b-9ea8-87cf6e73ebe4" />

