### PR TITLE
Fix tint Shred icon color in private tabs

### DIFF
--- a/browser/hub/internal/android/java/src/org/chromium/chrome/browser/hub/BraveHubToolbarView.java
+++ b/browser/hub/internal/android/java/src/org/chromium/chrome/browser/hub/BraveHubToolbarView.java
@@ -7,6 +7,7 @@ package org.chromium.chrome.browser.hub;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.res.ColorStateList;
 import android.content.res.Configuration;
 import android.util.AttributeSet;
 import android.view.View;
@@ -14,7 +15,10 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.FrameLayout;
 
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
+import androidx.core.widget.TextViewCompat;
 
 import org.chromium.base.ApplicationStatus;
 import org.chromium.base.BraveFeatureList;
@@ -38,6 +42,8 @@ public class BraveHubToolbarView extends HubToolbarView
     private FrameLayout mMenuButton;
     private boolean mIsIncognitoSelected = true;
     private @Nullable FirstPartyStorageCleanerInterface mFpCleaner;
+    private final @NonNull HubColorMixerRegistrationHelper mButtonColorMixerHelper =
+            new HubColorMixerRegistrationHelper();
 
     public BraveHubToolbarView(Context context, AttributeSet attributeSet) {
         super(context, attributeSet);
@@ -50,6 +56,7 @@ public class BraveHubToolbarView extends HubToolbarView
         mShredButton =
                 findViewById(org.chromium.chrome.browser.brave_shields.R.id.shred_data_button);
         mMenuButton = findViewById(R.id.menu_button_wrapper);
+        registerButtonColorBlend(mShredButton);
 
         mShredButton.setOnClickListener(
                 v -> {
@@ -87,6 +94,18 @@ public class BraveHubToolbarView extends HubToolbarView
 
         // Update visibility of action and menu buttons based on the switching panes.
         updateButtonsVisibility();
+    }
+
+    @Override
+    void setColorMixer(HubColorMixer mixer) {
+        super.setColorMixer(mixer);
+        mButtonColorMixerHelper.setColorMixer(mixer);
+    }
+
+    @Override
+    public void destroy() {
+        mButtonColorMixerHelper.destroy();
+        super.destroy();
     }
 
     @Override
@@ -133,6 +152,31 @@ public class BraveHubToolbarView extends HubToolbarView
     public void setFirstPartyStorageCleanerForTesting(
             FirstPartyStorageCleanerInterface firstPartyStorageCleaner) {
         mFpCleaner = firstPartyStorageCleaner;
+    }
+
+    private void registerButtonColorBlend(@NonNull Button button) {
+        mButtonColorMixerHelper.registerBlend(createButtonIconColorBlend(button));
+    }
+
+    /**
+     * Creates the standard Hub icon-color blend for a Brave-specific icon button.
+     *
+     * <p>Mirrors the blend applied to the upstream Hub menu button:
+     * https://chromium.googlesource.com/chromium/src/+/ef35003457e93c278f911a334b06e4a5f8967e06/chrome/browser/hub/internal/android/java/src/org/chromium/chrome/browser/hub/HubToolbarView.java#344
+     */
+    private @NonNull HubViewColorBlend createButtonIconColorBlend(@NonNull Button button) {
+        Context context = getContext();
+        return new SingleHubViewColorBlend(
+                HubAnimationConstants.PANE_COLOR_BLEND_ANIMATION_DURATION_MS,
+                colorScheme -> HubColors.getIconColor(context, colorScheme),
+                color -> updateButtonIconTint(context, button, color));
+    }
+
+    private void updateButtonIconTint(
+            @NonNull Context context, @NonNull Button button, @ColorInt int color) {
+        ColorStateList tint =
+                HubColors.getActionButtonColor(context, color, HubUtils.isGtsUpdateEnabled());
+        TextViewCompat.setCompoundDrawableTintList(button, tint);
     }
 
     private void updateButtonsVisibility() {


### PR DESCRIPTION


<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57258.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

## Changes

**Fix tint Shred icon color in private tabs** (90c8cc5c9285f9082d0b7bca346ddd629cd21e81)

The Shred button is Brave-specific and was not registered with the upstream Hub color mixer. It consequently retained its app-theme tint when the tab switcher changed to the incognito color scheme, making the icon appear disabled in light mode.

Register an icon-only color blend that uses `HubColors.getIconColor()` and apply the result as Shred's stateful drawable tint. This matches upstream's Hub icons.

[Mirrors the blend applied to the upstream Hub menu button](https://chromium.googlesource.com/chromium/src/+/ef35003457e93c278f911a334b06e4a5f8967e06/chrome/browser/hub/internal/android/java/src/org/chromium/chrome/browser/hub/HubToolbarView.java#344).

## Screenshots


&nbsp;|Normal tab|Private tab
--|--|--
Light mode / Dynamic colors off|<img width="1344" height="2992" alt="light-static-normal" src="https://github.com/user-attachments/assets/a974b803-b14b-4528-9579-d74faf360f38" />|<img width="1344" height="2992" alt="light-static-private" src="https://github.com/user-attachments/assets/12a1c4af-8a6b-4003-a4ff-db291f6e2634" />
Light mode / Dynamic colors on|<img width="1344" height="2992" alt="light-dynamic-normal" src="https://github.com/user-attachments/assets/83cdd2f8-9cb3-473e-8ca7-37b466949f4a" />|<img width="1344" height="2992" alt="light-dynamic-private" src="https://github.com/user-attachments/assets/cd5cbced-fa0d-4912-ab26-47ff90b44d4f" />
Dark mode / Dynamic colors off|<img width="1344" height="2992" alt="dark-static-normal" src="https://github.com/user-attachments/assets/2e36036e-348d-495c-af44-9c1ed21f02b5" />|<img width="1344" height="2992" alt="dark-static-private" src="https://github.com/user-attachments/assets/cb823daa-ee44-407d-8768-282c3d07b9e6" />
Dark mode / Dynamic colors on|<img width="1344" height="2992" alt="dark-dynamic-normal" src="https://github.com/user-attachments/assets/1d0073bb-5090-4b24-83b2-2acddff74e06" />|<img width="1344" height="2992" alt="dark-dynamic-private" src="https://github.com/user-attachments/assets/236b0393-595c-4fd6-bde0-fa05aaacfa98" />











