### PR TITLE
[ai_chat] Add chrome-untrusted://leo-workspace WebUI

### DIFF
--- a/browser/ui/webui/ai_chat/BUILD.gn
+++ b/browser/ui/webui/ai_chat/BUILD.gn
@@ -19,6 +19,8 @@ source_set("ai_chat") {
     "chart_display_ui.h",
     "code_sandbox_ui.cc",
     "code_sandbox_ui.h",
+    "leo_workspace_ui.cc",
+    "leo_workspace_ui.h",
   ]
 
   deps = [

--- a/browser/ui/webui/ai_chat/leo_workspace_ui.cc
+++ b/browser/ui/webui/ai_chat/leo_workspace_ui.cc
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/webui/ai_chat/leo_workspace_ui.h"
+
+#include "base/feature_list.h"
+#include "brave/common/webui_url_constants.h"
+#include "brave/components/ai_chat/core/browser/utils.h"
+#include "brave/components/ai_chat/core/common/features.h"
+#include "brave/components/ai_chat/resources/grit/ai_chat_ui_generated_map.h"
+#include "components/grit/brave_components_resources.h"
+#include "components/user_prefs/user_prefs.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/browser/web_ui.h"
+#include "content/public/browser/web_ui_data_source.h"
+#include "content/public/common/url_constants.h"
+#include "ui/webui/webui_util.h"
+#include "url/gurl.h"
+
+namespace ai_chat {
+
+bool LeoWorkspaceUIConfig::IsWebUIEnabled(
+    content::BrowserContext* browser_context) {
+  return IsAIChatEnabled(user_prefs::UserPrefs::Get(browser_context)) &&
+         base::FeatureList::IsEnabled(features::kAIChatWorkspaceTools);
+}
+
+std::unique_ptr<content::WebUIController>
+LeoWorkspaceUIConfig::CreateWebUIController(content::WebUI* web_ui,
+                                            const GURL& url) {
+  return std::make_unique<LeoWorkspaceUI>(web_ui);
+}
+
+LeoWorkspaceUIConfig::LeoWorkspaceUIConfig()
+    : WebUIConfig(content::kChromeUIUntrustedScheme, kLeoWorkspaceUIHost) {}
+
+LeoWorkspaceUIConfig::~LeoWorkspaceUIConfig() = default;
+
+LeoWorkspaceUI::LeoWorkspaceUI(content::WebUI* web_ui)
+    : ui::UntrustedWebUIController(web_ui) {
+  auto* browser_context = web_ui->GetWebContents()->GetBrowserContext();
+  auto* source = content::WebUIDataSource::CreateAndAdd(browser_context,
+                                                        kLeoWorkspaceUIURL);
+
+  webui::SetupWebUIDataSource(source, kAiChatUiGenerated,
+                              IDR_AI_CHAT_LEO_WORKSPACE_HTML);
+
+  // This page runs its own first-party module bundle only. No network, no
+  // frames, no embedding by other pages. The FileSystemDirectoryHandle it will
+  // operate on is delivered out-of-band (launchQueue), not fetched.
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::DefaultSrc, "default-src 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::ScriptSrc,
+      "script-src 'self' chrome-untrusted://resources;");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::StyleSrc,
+      "style-src 'self' chrome-untrusted://resources;");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::ConnectSrc, "connect-src 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::ObjectSrc, "object-src 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::FrameSrc, "frame-src 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::FrameAncestors,
+      "frame-ancestors 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::WorkerSrc, "worker-src 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::FormAction, "form-action 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::BaseURI, "base-uri 'none';");
+}
+
+LeoWorkspaceUI::~LeoWorkspaceUI() = default;
+
+}  // namespace ai_chat

--- a/browser/ui/webui/ai_chat/leo_workspace_ui.h
+++ b/browser/ui/webui/ai_chat/leo_workspace_ui.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_BROWSER_UI_WEBUI_AI_CHAT_LEO_WORKSPACE_UI_H_
+#define BRAVE_BROWSER_UI_WEBUI_AI_CHAT_LEO_WORKSPACE_UI_H_
+
+#include <memory>
+
+#include "content/public/browser/webui_config.h"
+#include "ui/webui/untrusted_web_ui_controller.h"
+
+namespace ai_chat {
+
+class LeoWorkspaceUIConfig : public content::WebUIConfig {
+ public:
+  LeoWorkspaceUIConfig();
+  ~LeoWorkspaceUIConfig() override;
+
+  // content::WebUIConfig:
+  bool IsWebUIEnabled(content::BrowserContext* browser_context) override;
+  std::unique_ptr<content::WebUIController> CreateWebUIController(
+      content::WebUI* web_ui,
+      const GURL& url) override;
+};
+
+// Hidden, headless Untrusted WebUI that will host the Leo "workspace" tools.
+// One instance is created per conversation and served at
+// chrome-untrusted://leo-workspace/<guid>, with a locked-down CSP that only
+// permits its own first-party bundle. This page has no visible UI.
+//
+// At this stage the page only serves a placeholder document. The file tools
+// bundle and the FileSystemDirectoryHandle plumbing are added separately.
+class LeoWorkspaceUI : public ui::UntrustedWebUIController {
+ public:
+  explicit LeoWorkspaceUI(content::WebUI* web_ui);
+  ~LeoWorkspaceUI() override;
+
+  LeoWorkspaceUI(const LeoWorkspaceUI&) = delete;
+  LeoWorkspaceUI& operator=(const LeoWorkspaceUI&) = delete;
+};
+
+}  // namespace ai_chat
+
+#endif  // BRAVE_BROWSER_UI_WEBUI_AI_CHAT_LEO_WORKSPACE_UI_H_

--- a/chromium_src/chrome/browser/ui/webui/chrome_untrusted_web_ui_configs.cc
+++ b/chromium_src/chrome/browser/ui/webui/chrome_untrusted_web_ui_configs.cc
@@ -28,6 +28,7 @@
 #include "brave/browser/ui/webui/ai_chat/ai_chat_untrusted_conversation_ui.h"
 #include "brave/browser/ui/webui/ai_chat/chart_display_ui.h"
 #include "brave/browser/ui/webui/ai_chat/code_sandbox_ui.h"
+#include "brave/browser/ui/webui/ai_chat/leo_workspace_ui.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #endif
 
@@ -112,6 +113,8 @@ void RegisterChromeUntrustedWebUIConfigs() {
         std::make_unique<ai_chat::ChartDisplayUIConfig>());
     content::WebUIConfigMap::GetInstance().AddUntrustedWebUIConfig(
         std::make_unique<ai_chat::CodeSandboxUIConfig>());
+    content::WebUIConfigMap::GetInstance().AddUntrustedWebUIConfig(
+        std::make_unique<ai_chat::LeoWorkspaceUIConfig>());
   }
 #endif  // BUILDFLAG(ENABLE_AI_CHAT)
 #if BUILDFLAG(ENABLE_BRAVE_NEWS) && !BUILDFLAG(IS_ANDROID)

--- a/common/webui_url_constants.h
+++ b/common/webui_url_constants.h
@@ -14,4 +14,8 @@ inline constexpr char kAIChatChartDisplayUIURL[] =
     "chrome-untrusted://aichat-chart-display/";
 inline constexpr char kAIChatChartDisplayUIHost[] = "aichat-chart-display";
 
+inline constexpr char kLeoWorkspaceUIURL[] =
+    "chrome-untrusted://leo-workspace/";
+inline constexpr char kLeoWorkspaceUIHost[] = "leo-workspace";
+
 #endif  // BRAVE_COMMON_WEBUI_URL_CONSTANTS_H_

--- a/components/ai_chat/resources/BUILD.gn
+++ b/components/ai_chat/resources/BUILD.gn
@@ -41,6 +41,7 @@ preprocess_if_expr("preprocess_html") {
   in_files = [
     "chart_display/chart_display.html",
     "code_sandbox/code_sandbox.html",
+    "leo_workspace/leo_workspace.html",
     "page/ai_chat_ui.html",
     "untrusted_conversation_frame/untrusted_conversation_frame.html",
   ]

--- a/components/ai_chat/resources/ai_chat_ui_resources.grdp
+++ b/components/ai_chat/resources/ai_chat_ui_resources.grdp
@@ -16,6 +16,9 @@
   <include name="IDR_AI_CHAT_CHART_DISPLAY_HTML" file="${root_gen_dir}/brave/components/ai_chat/resources/preprocessed/chart_display/chart_display.html"
     use_base_dir="false"
     type="BINDATA" />
+  <include name="IDR_AI_CHAT_LEO_WORKSPACE_HTML" file="${root_gen_dir}/brave/components/ai_chat/resources/preprocessed/leo_workspace/leo_workspace.html"
+    use_base_dir="false"
+    type="BINDATA" />
   <include name="IDR_AI_CHAT_BIGNUMBER_JS" file="../../node_modules/bignumber.js/bignumber.js"
     type="BINDATA" />
   <include name="IDR_AI_CHAT_INTERFACE_REMOVAL_JS" file="../ai_chat/resources/code_sandbox/interface_removal.js"

--- a/components/ai_chat/resources/leo_workspace/leo_workspace.html
+++ b/components/ai_chat/resources/leo_workspace/leo_workspace.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Leo Workspace</title>
+  </head>
+  <body>
+    <div id="root">test workspace</div>
+  </body>
+</html>


### PR DESCRIPTION
- Series https://github.com/brave/brave-browser/issues/57388

This just adds a new chrome-untrusted://leo-workspace and a placeholder HTML document.

In future, we'll load JavaScript for creating WebMCP tools, and pass a FileSystemDirectoryHandle to the WebUI via the launchQueue API.

The new WebUI is gated behind the `AIChatEnabled` and `LeoAIWorkspaces` flags.