### PR TITLE
Update tab strip margin properly 

### DIFF
--- a/browser/ui/views/frame/brave_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/brave_tab_strip_region_view.cc
@@ -424,8 +424,8 @@ void BraveHorizontalTabStripRegionView::Layout(PassKey) {
     return;
   }
 
-  UpdateTabStripMargin();
   UpdateScrollButtonsVisibility();
+  UpdateTabStripMargin();
 
   if (!VerticalTabController::FromBrowser(
            tab_strip_->GetBrowserWindowInterface())
@@ -438,7 +438,9 @@ void BraveHorizontalTabStripRegionView::Layout(PassKey) {
     // the overflow state of tab container. In this case, schedule layout.
     if (HaveScrollButtons() && ShouldShowHorizontalScrollButton() !=
                                    tab_scroll_next_button_->GetVisible()) {
-      InvalidateLayout();
+      UpdateScrollButtonsVisibility();
+      UpdateTabStripMargin();
+      LayoutSuperclass<HorizontalTabStripRegionView>(this);
     }
 
     // NTB is ignored by flex (`kViewIgnoredByLayoutKey`) and positioned
@@ -509,8 +511,6 @@ void BraveHorizontalTabStripRegionView::UpdateTabStripMargin() {
       VerticalTabController::FromBrowser(browser_window_interface)
           ->ShouldShowBraveVerticalTabs();
 
-  UpdateTrailingScrollButtonMargin(vertical_tabs);
-
   gfx::Insets margins;
 
   // In horizontal mode, take the current right margin. It is required so that
@@ -547,6 +547,12 @@ void BraveHorizontalTabStripRegionView::UpdateTabStripMargin() {
   }
 
   tab_strip_->SetProperty(views::kMarginsKey, margins);
+  tab_strip_->InvalidateLayout();
+
+  // This will move the right margin to the trailing scroll button when it is
+  // visible. So this should be called after the right margin for tab strip is
+  // set.
+  UpdateTrailingScrollButtonMargin(vertical_tabs);
 }
 
 void BraveHorizontalTabStripRegionView::UpdateTrailingScrollButtonMargin(
@@ -575,6 +581,7 @@ void BraveHorizontalTabStripRegionView::UpdateTrailingScrollButtonMargin(
 
   const bool scroll_active = container->ShouldShowHorizontalScrollButton() &&
                              *show_horizontal_tab_scroll_buttons_;
+  CHECK_EQ(scroll_active, tab_scroll_next_button_->GetVisible());
 
   if (scroll_active) {
     // Upstream reserves a right margin on the tab strip so the layered NTB can
@@ -585,12 +592,14 @@ void BraveHorizontalTabStripRegionView::UpdateTrailingScrollButtonMargin(
     if (auto* current = tab_strip_->GetProperty(views::kMarginsKey)) {
       upstream_right = current->right();
     }
+    upstream_right -= tab_scroll_next_button_->GetPreferredSize().width();
     tab_scroll_next_button_->SetProperty(
         views::kMarginsKey, gfx::Insets::TLBR(0, 0, 0, upstream_right));
     // Clear the strip's right margin so tabs extend to the trailing button.
     if (auto* current = tab_strip_->GetProperty(views::kMarginsKey)) {
       tab_strip_->SetProperty(views::kMarginsKey,
                               gfx::Insets::TLBR(0, current->left(), 0, 0));
+      tab_strip_->InvalidateLayout();
     }
   } else {
     tab_scroll_next_button_->ClearProperty(views::kMarginsKey);

--- a/browser/ui/views/frame/brave_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/brave_tab_strip_region_view.cc
@@ -450,18 +450,14 @@ void BraveHorizontalTabStripRegionView::Layout(PassKey) {
     // flex slot; we paint NTB above the combo in GetChildrenInZOrder so it
     // stays clickable.
     if (new_tab_button_) {
-      if (tab_scroll_next_button_ && tab_scroll_next_button_->GetVisible()) {
-        const gfx::Size button_size = new_tab_button_->GetPreferredSize();
-        const int x = tab_scroll_next_button_->bounds().right() +
-                      GetLayoutConstant(LayoutConstant::kTabStripPadding) +
-                      GetLayoutConstant(LayoutConstant::kToolbarDividerSpacing);
-        new_tab_button_->SetBoundsRect(
-            gfx::Rect(gfx::Point(x, 0), button_size));
-      } else {
-        new_tab_button_->SetX(
-            tab_strip_->bounds().right() +
-            GetLayoutConstant(LayoutConstant::kTabStripPadding));
-      }
+      auto* anchor =
+          tab_scroll_next_button_ && tab_scroll_next_button_->GetVisible()
+              ? static_cast<views::View*>(tab_scroll_next_button_.get())
+              : static_cast<views::View*>(tab_strip_.get());
+      const int x = anchor->bounds().right() +
+                    GetLayoutConstant(LayoutConstant::kTabStripPadding);
+      new_tab_button_->SetBoundsRect(
+          gfx::Rect(gfx::Point(x, 0), new_tab_button_->GetPreferredSize()));
     }
 
     // Upstream positions combo_button_ at the leading edge via
@@ -592,7 +588,7 @@ void BraveHorizontalTabStripRegionView::UpdateTrailingScrollButtonMargin(
     if (auto* current = tab_strip_->GetProperty(views::kMarginsKey)) {
       upstream_right = current->right();
     }
-    upstream_right -= tab_scroll_next_button_->GetPreferredSize().width();
+    // upstream_right += tab_scroll_next_button_->GetPreferredSize().width()
     tab_scroll_next_button_->SetProperty(
         views::kMarginsKey, gfx::Insets::TLBR(0, 0, 0, upstream_right));
     // Clear the strip's right margin so tabs extend to the trailing button.

--- a/browser/ui/views/frame/brave_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/brave_tab_strip_region_view.cc
@@ -445,10 +445,7 @@ void BraveHorizontalTabStripRegionView::Layout(PassKey) {
 
     // NTB is ignored by flex (`kViewIgnoredByLayoutKey`) and positioned
     // manually by `HorizontalTabStripRegionView::Layout` relative to the tab
-    // strip edge. When scroll buttons are visible, leave a gap using layout
-    // constants (same family as toolbar spacing). That can overlap the combo's
-    // flex slot; we paint NTB above the combo in GetChildrenInZOrder so it
-    // stays clickable.
+    // strip edge.
     if (new_tab_button_) {
       auto* anchor =
           tab_scroll_next_button_ && tab_scroll_next_button_->GetVisible()
@@ -577,8 +574,6 @@ void BraveHorizontalTabStripRegionView::UpdateTrailingScrollButtonMargin(
 
   const bool scroll_active = container->ShouldShowHorizontalScrollButton() &&
                              *show_horizontal_tab_scroll_buttons_;
-  CHECK_EQ(scroll_active, tab_scroll_next_button_->GetVisible());
-
   if (scroll_active) {
     // Upstream reserves a right margin on the tab strip so the layered NTB can
     // overlap it.  Move that reserve to the trailing scroll button: the strip
@@ -588,7 +583,6 @@ void BraveHorizontalTabStripRegionView::UpdateTrailingScrollButtonMargin(
     if (auto* current = tab_strip_->GetProperty(views::kMarginsKey)) {
       upstream_right = current->right();
     }
-    // upstream_right += tab_scroll_next_button_->GetPreferredSize().width()
     tab_scroll_next_button_->SetProperty(
         views::kMarginsKey, gfx::Insets::TLBR(0, 0, 0, upstream_right));
     // Clear the strip's right margin so tabs extend to the trailing button.

--- a/browser/ui/views/tabs/brave_tab_container_browsertest.cc
+++ b/browser/ui/views/tabs/brave_tab_container_browsertest.cc
@@ -780,6 +780,35 @@ IN_PROC_BROWSER_TEST_F(HorizontalScrollableTabStripBrowserTest,
             views::InkDropHost::InkDropMode::ON);
 }
 
+IN_PROC_BROWSER_TEST_F(
+    HorizontalScrollableTabStripBrowserTest,
+    TabStripRightMarginShouldBeZeroWhenScrollButtonsAreVisible) {
+  auto* tab_strip = views::AsViewClass<BraveTabStrip>(
+      browser_view()->horizontal_tab_strip_for_testing());
+  BraveTabContainer* container = views::AsViewClass<BraveTabContainer>(
+      tab_strip->GetTabContainerForTesting());
+  ASSERT_TRUE(container);
+
+  browser()->profile()->GetPrefs()->SetBoolean(
+      brave_tabs::kShowHorizontalTabScrollButtons, true);
+
+  while (container->GetMaxScrollOffsetForTesting() == 0) {
+    AppendTab();
+    StopAnimatingAndLayout();
+  }
+
+  BraveHorizontalTabStripRegionView* region = tab_strip_region();
+  ASSERT_TRUE(region);
+  ASSERT_TRUE(region->tab_scroll_next_for_testing()->GetVisible());
+
+  auto* margins = tab_strip->GetProperty(views::kMarginsKey);
+  ASSERT_TRUE(margins);
+  EXPECT_EQ(margins->right(), 0)
+      << "When scroll buttons are visible, the tab strip's right margin "
+         "should be zero to avoid extra spacing between the last tab and "
+         "the scroll button.";
+}
+
 class VerticalTabsScrollBarModeBrowserTest : public InProcessBrowserTest {
  public:
   BraveBrowserView* browser_view() {

--- a/browser/ui/views/tabs/brave_tab_container_browsertest.cc
+++ b/browser/ui/views/tabs/brave_tab_container_browsertest.cc
@@ -775,3 +775,32 @@ IN_PROC_BROWSER_TEST_F(HorizontalScrollableTabStripBrowserTest,
   EXPECT_EQ(views::InkDrop::Get(back)->GetMode(),
             views::InkDropHost::InkDropMode::ON);
 }
+
+IN_PROC_BROWSER_TEST_F(
+    HorizontalScrollableTabStripBrowserTest,
+    TabStripRightMarginShouldBeZeroWhenScrollButtonsAreVisible) {
+  auto* tab_strip = views::AsViewClass<BraveTabStrip>(
+      browser_view()->horizontal_tab_strip_for_testing());
+  BraveTabContainer* container = views::AsViewClass<BraveTabContainer>(
+      tab_strip->GetTabContainerForTesting());
+  ASSERT_TRUE(container);
+
+  browser()->profile()->GetPrefs()->SetBoolean(
+      brave_tabs::kShowHorizontalTabScrollButtons, true);
+
+  while (container->GetMaxScrollOffsetForTesting() == 0) {
+    AppendTab();
+    StopAnimatingAndLayout();
+  }
+
+  BraveHorizontalTabStripRegionView* region = tab_strip_region();
+  ASSERT_TRUE(region);
+  ASSERT_TRUE(region->tab_scroll_next_for_testing()->GetVisible());
+
+  auto* margins = tab_strip->GetProperty(views::kMarginsKey);
+  ASSERT_TRUE(margins);
+  EXPECT_EQ(margins->right(), 0)
+      << "When scroll buttons are visible, the tab strip's right margin "
+         "should be zero to avoid extra spacing between the last tab and "
+         "the scroll button.";
+}

--- a/browser/ui/views/tabs/brave_tab_container_browsertest.cc
+++ b/browser/ui/views/tabs/brave_tab_container_browsertest.cc
@@ -797,6 +797,7 @@ IN_PROC_BROWSER_TEST_F(
 
   BraveHorizontalTabStripRegionView* region = tab_strip_region();
   ASSERT_TRUE(region);
+  ASSERT_TRUE(region->tab_scroll_next_for_testing());
   ASSERT_TRUE(region->tab_scroll_next_for_testing()->GetVisible());
 
   auto* margins = tab_strip->GetProperty(views::kMarginsKey);

--- a/browser/ui/views/tabs/brave_tab_container_browsertest.cc
+++ b/browser/ui/views/tabs/brave_tab_container_browsertest.cc
@@ -433,11 +433,9 @@ IN_PROC_BROWSER_TEST_F(HorizontalScrollableTabStripBrowserTest,
   ASSERT_TRUE(ntb);
 
   const int pad = GetLayoutConstant(LayoutConstant::kTabStripPadding);
-  const int divider = GetLayoutConstant(LayoutConstant::kToolbarDividerSpacing);
-  EXPECT_EQ(ntb->x(), next->bounds().right() + pad + divider)
+  EXPECT_EQ(ntb->x(), next->bounds().right() + pad)
       << "ntb->x()=" << ntb->x()
-      << " next->bounds().right()=" << next->bounds().right() << " pad=" << pad
-      << " divider=" << divider;
+      << " next->bounds().right()=" << next->bounds().right() << " pad=" << pad;
 }
 
 IN_PROC_BROWSER_TEST_F(HorizontalScrollableTabStripBrowserTest,


### PR DESCRIPTION
When the tab strip scroll button becomes visible, the tab strip margin
should be updated properly. Otherwise, the tab strip will have
additional margin.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57341


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
