### PR TITLE
[recipes] Adding `proto` placeholders

### DIFF
--- a/tools/recipes/recipe_modules/proto/__init__.py
+++ b/tools/recipes/recipe_modules/proto/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""`proto` module: produce and consume protobuf data to and from steps."""
+
+DEPS = ['raw_io']

--- a/tools/recipes/recipe_modules/proto/api.py
+++ b/tools/recipes/recipe_modules/proto/api.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""The `proto` module API: protobuf messages in and out of steps.
+
+The same shape as the `json` module, one layer up: `api.proto.output(MsgClass,
+'JSONPB')` hands the step a path to write and gives the recipe back a parsed
+message, and `api.proto.input(msg, 'JSONPB')` goes the other way. Three wire
+formats are available -- `BINARY`, `JSONPB` and `TEXTPB` (see `codec.py`).
+
+Deliberately not supported: `add_json_log` (mirroring the parsed message into a
+step log), which needs step presentation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from google.protobuf.message import Message
+
+from recipe_api import OutputPlaceholder, RecipeApi, returns_placeholder
+from recipe_test_api import PlaceholderTestData
+
+from . import codec as codecs
+
+
+class ProtoOutputPlaceholder(OutputPlaceholder):
+    """Renders to a path the step writes a message to, then parses it back.
+
+    A `raw_io` output placeholder with a codec on the end: text-shaped for
+    `JSONPB`/`TEXTPB`, bytes-shaped for `BINARY`. A file the step never wrote,
+    or wrote something unparseable to, results in `None`.
+    """
+
+    def __init__(self, api, msg_class: type[Message], codec: codecs.Codec,
+                 name: str | None, leak_to: str | Path | None,
+                 decoding_kwargs: dict) -> None:
+        suffix = f'.{codec.ext}'
+        self.raw = (api.m.raw_io.output(suffix, leak_to=leak_to)
+                    if codec.is_binary else api.m.raw_io.output_text(
+                        suffix, leak_to=leak_to))
+        self._msg_class = msg_class
+        self._codec = codec
+        self._decoding_kwargs = decoding_kwargs
+        super().__init__(name=name)
+
+    @property
+    def backing_file(self) -> str | None:
+        return self.raw.backing_file
+
+    def render(self, test) -> list[str]:
+        return self.raw.render(test)
+
+    def result(self, test) -> Message | None:
+        if test.enabled and isinstance(test.data, Message):
+            # A test seeds a message, not bytes: the codec is known only here,
+            # so encode it now rather than making every test spell it out.
+            test = PlaceholderTestData(data=codecs.do_encode(
+                test.data, self._codec),
+                                       name=self.name)
+        raw_data = self.raw.result(test)
+        if raw_data is None:
+            return None
+        try:
+            return codecs.do_decode(raw_data, self._msg_class, self._codec,
+                                    **self._decoding_kwargs)
+        except Exception:  # pylint: disable=broad-except
+            # Any of the three parsers may reject the data in its own way; to a
+            # recipe they all mean the same thing.
+            return None
+
+
+class ProtoApi(RecipeApi):
+    """Encode and decode protobuf messages, and carry them through steps."""
+
+    BINARY = codecs.BINARY.name
+    JSONPB = codecs.JSONPB.name
+    TEXTPB = codecs.TEXTPB.name
+
+    @returns_placeholder
+    def input(self, proto_msg: Message, codec: codecs.Codec | str, **kwargs):
+        """A placeholder expanding to the path of a file holding *proto_msg*.
+
+        Args:
+            proto_msg: The message to encode.
+            codec: Which wire format to encode it in.
+            kwargs: Passed to the codec's encoder, overriding its defaults:
+                `BINARY` takes `Message.SerializeToString`'s arguments, `JSONPB`
+                `json_format.MessageToJson`'s, and `TEXTPB`
+                `text_format.MessageToString`'s.
+        """
+        codec = codecs.resolve(codec)
+        encoded = self.encode(proto_msg, codec, **kwargs)
+        suffix = f'.{codec.ext}'
+        if codec.is_binary:
+            return self.m.raw_io.input(encoded, suffix=suffix)
+        return self.m.raw_io.input_text(encoded, suffix=suffix)
+
+    @returns_placeholder
+    def output(self,
+               msg_class: type[Message],
+               codec: codecs.Codec | str,
+               name: str | None = None,
+               leak_to: str | Path | None = None,
+               **kwargs) -> ProtoOutputPlaceholder:
+        """A placeholder expanding to a path the step writes a message to.
+
+        Once the step is done, the engine parses that file and files the message
+        onto the step's result as `step_result.proto.output`.
+
+        Args:
+            msg_class: The message type to decode.
+            codec: Which wire format the step writes.
+            name: Distinguishes this placeholder from others produced by the
+                same method on one step. With a name, the result is also at
+                `step_result.proto.outputs[name]`.
+            leak_to: Write to this path instead of a temporary file, and do not
+                delete it afterwards (i.e. "leak" it), so a later step can pick
+                it up.
+            kwargs: Passed to the codec's decoder, overriding its defaults:
+                `BINARY` takes `Message.ParseFromString`'s arguments, `JSONPB`
+                `json_format.Parse`'s, and `TEXTPB` `text_format.Parse`'s.
+        """
+        codec = codecs.resolve(codec)
+        if not (isinstance(msg_class, type)
+                and issubclass(msg_class, Message)):
+            raise ValueError('msg_class must be a protobuf message class; got '
+                             f'{msg_class!r}')
+        return ProtoOutputPlaceholder(self, msg_class, codec, name, leak_to,
+                                      kwargs)
+
+    @staticmethod
+    def encode(proto_msg: Message, codec: codecs.Codec | str, **kwargs) -> Any:
+        """Encode *proto_msg* with *codec*, returning text or (BINARY) bytes."""
+        if not isinstance(proto_msg, Message):
+            raise ValueError('proto_msg must be a protobuf message; got '
+                             f'{type(proto_msg)}')
+        return codecs.do_encode(proto_msg, codec, **kwargs)
+
+    @staticmethod
+    def decode(data: Any, msg_class: type[Message], codec: codecs.Codec | str,
+               **kwargs) -> Message:
+        """Decode *data* into a fresh *msg_class* with *codec*."""
+        return codecs.do_decode(data, msg_class, codec, **kwargs)

--- a/tools/recipes/recipe_modules/proto/codec.py
+++ b/tools/recipes/recipe_modules/proto/codec.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""The three protobuf wire formats the `proto` module can read and write.
+
+Each codec bundles the file extension it uses, the encode/decode functions, and
+the keyword defaults that make its output stable enough to put in an
+expectation. Kept apart from `api.py` so the module's `test_api.py` can reach
+them without importing the api.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from google.protobuf import json_format, text_format
+from google.protobuf.message import Message
+
+
+@dataclass(frozen=True)
+class Codec:
+    """One protobuf wire format."""
+
+    #: The codec's name, as recipes spell it (e.g. `'JSONPB'`).
+    name: str
+    #: Extension for the temp files placeholders of this codec render to.
+    ext: str
+    #: `(message, **kwargs) -> str | bytes`.
+    encode: Callable[..., Any]
+    #: `(data, message, **kwargs) -> None`, parsing *data* into *message*.
+    decode: Callable[..., Any]
+    #: Keyword defaults for `encode`, overridable per call.
+    encode_defaults: dict[str, Any] = field(default_factory=dict)
+    #: Keyword defaults for `decode`, overridable per call.
+    decode_defaults: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_binary(self) -> bool:
+        """Whether this codec's encoded form is bytes rather than text."""
+        return self is BINARY
+
+
+BINARY = Codec(
+    name='BINARY',
+    ext='pb',
+    encode=lambda msg, **extra: msg.SerializeToString(**extra),
+    decode=lambda data, msg, **_extra: msg.ParseFromString(data),
+    # Deterministic output, so encoding the same message twice (in two builds,
+    # say) gives byte-identical results.
+    encode_defaults={'deterministic': True},
+)
+
+TEXTPB = Codec(
+    name='TEXTPB',
+    ext='tpb',
+    encode=text_format.MessageToString,
+    decode=text_format.Parse,
+)
+
+JSONPB = Codec(
+    name='JSONPB',
+    ext='json',
+    encode=json_format.MessageToJson,
+    decode=json_format.Parse,
+    encode_defaults={
+        'preserving_proto_field_name': True,
+        'sort_keys': True,
+        'indent': 2,
+    },
+    # A message written by an older or newer build of the same schema still
+    # parses; unknown fields are dropped rather than fatal.
+    decode_defaults={'ignore_unknown_fields': True},
+)
+
+ALL_CODECS = (BINARY, JSONPB, TEXTPB)
+_BY_NAME = {codec.name: codec for codec in ALL_CODECS}
+
+
+def resolve(codec: Codec | str) -> Codec:
+    """Return the `Codec` for *codec*, given either a codec or its name."""
+    if isinstance(codec, str):
+        codec = _BY_NAME.get(codec, codec)
+    if codec not in ALL_CODECS:
+        raise ValueError(f'Must specify a valid codec, got {codec!r}; '
+                         f'expected one of {sorted(_BY_NAME)}')
+    return codec
+
+
+def do_encode(proto_msg: Message, codec: Codec | str, **extra) -> Any:
+    """Encode *proto_msg* with *codec*."""
+    codec = resolve(codec)
+    return codec.encode(proto_msg, **{**codec.encode_defaults, **extra})
+
+
+def do_decode(data: Any, msg_class: type[Message], codec: Codec | str,
+              **extra) -> Message:
+    """Decode *data* into a fresh *msg_class* with *codec*."""
+    codec = resolve(codec)
+    msg = msg_class()
+    codec.decode(data, msg, **{**codec.decode_defaults, **extra})
+    return msg

--- a/tools/recipes/recipe_modules/proto/examples/__init__.py
+++ b/tools/recipes/recipe_modules/proto/examples/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tools/recipes/recipe_modules/proto/examples/full.expected/basic.json
+++ b/tools/recipes/recipe_modules/proto/examples/full.expected/basic.json
@@ -1,0 +1,89 @@
+[
+  {
+    "cmd": [
+      "cat",
+      "{\n  \"jobs\": 8,\n  \"name\": \"release\"\n}"
+    ],
+    "name": "cat json"
+  },
+  {
+    "cmd": [
+      "cat",
+      "name: \"release\"\njobs: 8\n"
+    ],
+    "name": "cat text"
+  },
+  {
+    "cmd": [
+      "cat",
+      "\n\u0007release\u0010\b"
+    ],
+    "name": "cat binary"
+  },
+  {
+    "cmd": [
+      "read",
+      "/path/to/tmp/json"
+    ],
+    "name": "read JSONPB"
+  },
+  {
+    "cmd": [
+      "read",
+      "/path/to/tmp/tpb"
+    ],
+    "name": "read TEXTPB"
+  },
+  {
+    "cmd": [
+      "read",
+      "/path/to/tmp/pb"
+    ],
+    "name": "read BINARY"
+  },
+  {
+    "cmd": [
+      "read",
+      "/path/to/tmp/json",
+      "/path/to/tmp/json"
+    ],
+    "name": "read two"
+  },
+  {
+    "cmd": [
+      "read",
+      "/path/to/tmp/json"
+    ],
+    "name": "read garbage"
+  },
+  {
+    "cmd": [
+      "read",
+      "[WORKSPACE]/config.json"
+    ],
+    "name": "read nothing"
+  },
+  {
+    "cmd": [
+      "cat",
+      "{\n  \"jobs\": 8,\n  \"name\": \"release\"\n}"
+    ],
+    "name": "cat camel"
+  },
+  {
+    "cmd": [
+      "read",
+      "/path/to/tmp/json"
+    ],
+    "name": "read strict"
+  },
+  {
+    "cmd": [
+      "read"
+    ],
+    "name": "read stdout"
+  },
+  {
+    "name": "$result"
+  }
+]

--- a/tools/recipes/recipe_modules/proto/examples/full.proto
+++ b/tools/recipes/recipe_modules/proto/examples/full.proto
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+syntax = "proto3";
+
+package recipe_modules.brave.proto.examples.full;
+
+// A message for `full.py` to round-trip through each of the three codecs.
+message Config {
+  string name = 1;
+  int32 jobs = 2;
+}

--- a/tools/recipes/recipe_modules/proto/examples/full.py
+++ b/tools/recipes/recipe_modules/proto/examples/full.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipe exercising the `proto` module's placeholders and codecs."""
+
+from __future__ import annotations
+
+from PB.recipe_modules.brave.proto.examples.full import Config
+
+import post_process
+
+DEPS = ['path', 'proto', 'step']
+
+CONFIG = Config(name='release', jobs=8)
+
+
+def RunSteps(api):
+    # `input` renders to the path of a file holding the encoded message; each
+    # codec picks its own file extension.
+    api.step('cat json', ['cat', api.proto.input(CONFIG, api.proto.JSONPB)])
+    api.step('cat text', ['cat', api.proto.input(CONFIG, api.proto.TEXTPB)])
+    api.step('cat binary', ['cat', api.proto.input(CONFIG, api.proto.BINARY)])
+
+    # `output` goes the other way: the step writes the file, and the message
+    # comes back parsed, filed under the module and method that produced it.
+    for codec in (api.proto.JSONPB, api.proto.TEXTPB, api.proto.BINARY):
+        result = api.step(f'read {codec}',
+                          ['read', api.proto.output(Config, codec)])
+        assert result.proto.output == CONFIG, result.proto.output
+
+    # Several placeholders from one method are told apart by name.
+    result = api.step('read two', [
+        'read',
+        api.proto.output(Config, api.proto.JSONPB, name='a'),
+        api.proto.output(Config, api.proto.JSONPB, name='b')
+    ])
+    assert result.proto.outputs['a'].name == 'release'
+    assert result.proto.outputs['b'].jobs == 4, result.proto.outputs['b']
+
+    # A step that writes something unparseable, or nothing at all, results in
+    # None rather than an exception.
+    result = api.step(
+        'read garbage',
+        ['read', api.proto.output(Config, api.proto.JSONPB)])
+    assert result.proto.output is None, result.proto.output
+    result = api.step('read nothing', [
+        'read',
+        api.proto.output(Config,
+                         api.proto.JSONPB,
+                         leak_to=api.path.workspace / 'config.json')
+    ])
+    assert result.proto.output is None, result.proto.output
+
+    # Codec keyword arguments reach the encoder and decoder. Here the default
+    # `preserving_proto_field_name` is turned off on the way out, and unknown
+    # fields are made fatal on the way in.
+    api.step('cat camel', [
+        'cat',
+        api.proto.input(
+            CONFIG, api.proto.JSONPB, preserving_proto_field_name=False)
+    ])
+    result = api.step('read strict', [
+        'read',
+        api.proto.output(Config, api.proto.JSONPB, ignore_unknown_fields=False)
+    ])
+    assert result.proto.output is None, result.proto.output
+
+    # An output placeholder also works as a step's stdout.
+    result = api.step('read stdout', ['read'],
+                      stdout=api.proto.output(Config, api.proto.JSONPB))
+    assert result.stdout == CONFIG, result.stdout
+
+    # `encode`/`decode` are the same codecs without a step in between.
+    encoded = api.proto.encode(CONFIG, api.proto.TEXTPB)
+    assert api.proto.decode(encoded, Config, api.proto.TEXTPB) == CONFIG
+
+
+def GenTests(api):
+    # A test seeds the message itself; the placeholder knows its own codec, so
+    # nothing here has to mention the encoding.
+    reads = [
+        api.step_data(f'read {codec}', api.proto.output(CONFIG))
+        for codec in ('JSONPB', 'TEXTPB', 'BINARY')
+    ]
+    yield api.test(
+        'basic',
+        *reads,
+        api.step_data(
+            'read two',
+            api.proto.output(CONFIG, name='a'),
+            api.proto.output(Config(name='debug', jobs=4), name='b'),
+        ),
+        api.step_data('read garbage', api.proto.invalid()),
+        api.step_data('read nothing', api.proto.backing_file_missing()),
+        # A message carrying a field `Config` doesn't have: fatal here only
+        # because the step asked for `ignore_unknown_fields=False`.
+        api.step_data('read strict',
+                      api.proto.invalid('{"name": "release", "extra": 1}')),
+        api.step_data('read stdout', stdout=api.proto.output(CONFIG)),
+        api.post_process(post_process.StatusSuccess),
+    )
+    # The test api exposes the same `encode`/`decode` the module does, for a
+    # test that needs the encoded form itself.
+    yield api.test(
+        'encoded by hand',
+        *reads,
+        api.step_data(
+            'read two',
+            api.proto.output(CONFIG, name='a'),
+            api.proto.output(Config(name='debug', jobs=4), name='b'),
+        ),
+        api.step_data(
+            'read garbage',
+            api.proto.invalid(api.proto.encode(CONFIG, 'JSONPB')[:-1])),
+        api.step_data('read nothing', api.proto.backing_file_missing()),
+        api.step_data('read stdout', stdout=api.proto.output(CONFIG)),
+        api.step_data(
+            'read strict',
+            api.proto.invalid(
+                api.proto.encode(
+                    api.proto.decode('name: "release"', Config, 'TEXTPB'),
+                    'JSONPB').replace('}', ', "extra": 1}'))),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )

--- a/tools/recipes/recipe_modules/proto/test_api.py
+++ b/tools/recipes/recipe_modules/proto/test_api.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Test API for `proto`: seed what a proto output placeholder hands back.
+
+Seed the message itself -- the placeholder knows its own codec, so a test never
+has to spell the encoding out:
+
+    api.step_data('read config', api.proto.output(Config(name='release')))
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from google.protobuf.message import Message
+
+from recipe_test_api import RecipeTestApi, placeholder_step_data
+
+from . import codec as codecs
+
+
+class ProtoTestApi(RecipeTestApi):
+    """Seed the simulated data of a `proto` output placeholder."""
+
+    @staticmethod
+    def encode(proto_msg: Message, codec: codecs.Codec | str, **kwargs) -> Any:
+        """Same as `api.proto.encode`."""
+        return codecs.do_encode(proto_msg, codec, **kwargs)
+
+    @staticmethod
+    def decode(data: Any, msg_class: type[Message], codec: codecs.Codec | str,
+               **kwargs) -> Message:
+        """Same as `api.proto.decode`."""
+        return codecs.do_decode(data, msg_class, codec, **kwargs)
+
+    @placeholder_step_data
+    def output(self,
+               proto_msg: Message,
+               retcode: int | None = None,
+               name: str | None = None):
+        """Seed an `api.proto.output()` placeholder to return *proto_msg*."""
+        if not isinstance(proto_msg, Message):
+            raise ValueError('expected a protobuf message, got '
+                             f'{type(proto_msg)}')
+        return proto_msg, retcode, name
+
+    @placeholder_step_data('output')
+    def invalid(self,
+                raw_data: str = 'i are not protoh',
+                retcode: int | None = None,
+                name: str | None = None):
+        """Seed an `api.proto.output()` placeholder with unparseable data.
+
+        For exercising what a recipe does when a step writes garbage: the
+        placeholder's result is then `None`.
+        """
+        return raw_data, retcode, name
+
+    @placeholder_step_data('output')
+    def backing_file_missing(self,
+                             retcode: int | None = None,
+                             name: str | None = None):
+        """Seed an output placeholder as if the step never wrote its file.
+
+        Only meaningful for a placeholder created with `leak_to`; without it the
+        engine creates the backing file itself, so it is always there.
+        """
+        return None, retcode, name

--- a/tools/recipes/recipe_modules/proto/tests/__init__.py
+++ b/tools/recipes/recipe_modules/proto/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tools/recipes/recipe_modules/proto/tests/errors.py
+++ b/tools/recipes/recipe_modules/proto/tests/errors.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for the `proto` module's rejection of bad codecs and message types.
+
+A seeded `MODE` env var selects which mistake to make; each one aborts the
+recipe.
+"""
+
+from __future__ import annotations
+
+from PB.recipe_modules.brave.proto.examples.full import Config
+
+import post_process
+
+DEPS = ['env', 'proto', 'step']
+
+MODES = ('bad_codec', 'output_not_a_message_class', 'input_not_a_message',
+         'output_test_data_not_a_message')
+
+
+def RunSteps(api):
+    mode = api.env.get('MODE')
+    if mode == 'bad_codec':
+        # Only the three named codecs exist.
+        api.step('read', ['read', api.proto.output(Config, 'YAMLPB')])
+    elif mode == 'output_not_a_message_class':
+        # `output` decodes into a message type, not an arbitrary class.
+        api.step('read', ['read', api.proto.output(dict, api.proto.JSONPB)])
+    elif mode == 'input_not_a_message':
+        # ... and `input` encodes a message instance.
+        api.step('cat', ['cat', api.proto.input({'a': 1}, api.proto.JSONPB)])
+    else:
+        api.step('read',
+                 ['read', api.proto.output(Config, api.proto.JSONPB)],
+                 step_test_data=lambda: api.proto.test_api.output('not a msg'))
+
+
+def GenTests(api):
+    for mode in MODES:
+        yield api.test(
+            mode,
+            api.env.set('MODE', mode),
+            api.post_process(post_process.StatusException),
+            api.post_process(post_process.DropExpectation),
+            status='EXCEPTION',
+        )


### PR DESCRIPTION
This placeholder, similar to the `json` one, is built on top of the
`raw_io` base class.

We support the following wire formats: BINARY`, `JSONPB`, `TEXTPB`. In
particular `JSONPB` although similar to the `json` module, is less
generic then that module, and this useful for when a tool needs a
structured output:

```py
    DEPS = ['proto', 'step']

    def RunSteps(api):
        result = api.step('run tests', [
            'run_tests', '--report', api.proto.output(TestReport, api.proto.JSONPB)
        ])
        for failure in result.proto.output.failures:
            api.step(f'flake check: {failure.name}', [...])

    def GenTests(api):
        yield api.test(
            'has_failures',
            api.step_data(
                'run tests',
                api.proto.output(TestReport(failures=[Failure(name='a_test')]))),
            api.post_process(post_process.StatusSuccess),
            api.post_process(post_process.DropExpectation),
        )
```

Bug: https://github.com/brave/brave-browser/issues/56748
