### PR TITLE
[recipes] Rewrite `file` file module to use placeholders

### DIFF
--- a/tools/recipes/recipe_modules/file/__init__.py
+++ b/tools/recipes/recipe_modules/file/__init__.py
@@ -2,11 +2,11 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""`file` module: basic filesystem operations (read, copy, move, remove, ...)
-as recipe steps.
+"""`file` module: basic filesystem operations (read, write, copy, move,
+remove, ...) as recipe steps.
 
-Covers every operation that doesn't need to inject arbitrary file content
-into the step (see `api.py` for what that excludes and why).
+File content travels in and out of the step through placeholders (see
+`api.py`).
 """
 
-DEPS = ['depot_tools', 'raw_io', 'step']
+DEPS = ['depot_tools', 'json', 'proto', 'raw_io', 'step']

--- a/tools/recipes/recipe_modules/file/api.py
+++ b/tools/recipes/recipe_modules/file/api.py
@@ -9,36 +9,45 @@ only ever answers exists/is_dir/is_file); anything that reads or mutates a
 file's content has to go through a step like everything else that touches
 the real machine, so it is simulatable. This module wraps a resource script
 (`resources/fileutil.py`) run as that step, reporting back a shared
-`{ok, errno_name, message}` result and an `Error` exception, covering every
-operation that doesn't need to inject arbitrary file *content* into the step.
+`{ok, errno_name, message}` result and an `Error` exception.
 
-Deliberately not supported: `write_text`/`write_raw`/`write_json`, and
-`read_proto`/`write_proto`. Those would need a way to carry arbitrary content
-into a step via a file (e.g. a materialized temp-file path/content), which
-this engine has no primitive for -- only a step's own stdout (used here for
-`read_text` and the other value-returning operations below). `read_json` still
-works, since `read_text` (a plain step) plus a client-side `json.loads` is
-enough.
+Content moves in and out through placeholders (see the "Getting data back
+from a step" section of README.md), which is why reading and writing files
+both come down to `copy`: `read_text` copies the file *to* an output
+placeholder the engine then reads, and `write_text` copies *from* an input
+placeholder the engine has already filled in. Every method that returns a
+value also takes a `test_data` argument, giving the step a default result
+under simulation so the common case needs nothing seeded per test.
+
+Deliberately not supported: `include_log` (mirroring the content read or
+written into a step log), which needs step presentation, and `symlink_tree`
+(building up a tree of links to realize in one step).
 """
 
 from __future__ import annotations
 
-import json
+from collections.abc import Callable, Sequence
 import os
-import subprocess
 from pathlib import Path
-from typing import Any
+import subprocess
+from typing import Any, TypeVar
 
-from recipe_api import RecipeApi
+from google.protobuf.message import Message
+
+from recipe_api import OutputPlaceholder, Placeholder, RecipeApi
+from recipe_test_api import StepTestData
+from step_data import StepData
 
 # The resource script `_run` invokes for every operation. Lives alongside this
 # module (not under brave-core), so it's always present -- no sparse checkout
 # needed, unlike e.g. `tools/cr/toolchains/ephemeral_xcode.py`.
 _FILEUTIL = Path(__file__).resolve().parent / 'resources' / 'fileutil.py'
 
+ProtoMessage = TypeVar('ProtoMessage', bound=Message)
+
 
 class FileApi(RecipeApi):
-    """Basic filesystem operations (read, copy, move, remove, ...) as steps."""
+    """Basic filesystem operations (read, write, copy, remove, ...) as steps."""
 
     class Error(subprocess.CalledProcessError):
         """A `fileutil.py` operation reported a filesystem-level failure.
@@ -56,32 +65,80 @@ class FileApi(RecipeApi):
             super().__init__(1, step_name, output=message)
             self.errno_name = errno_name
 
-    def _run(self, name: str, args: list[str]) -> str:
-        """Run a `fileutil.py` operation and return its captured stdout.
+    def _run(self,
+             name: str,
+             args: Sequence[str | Path | Placeholder],
+             step_test_data: Callable[[], StepTestData] | None = None,
+             stdout: OutputPlaceholder | None = None) -> StepData:
+        """Run a `fileutil.py` operation, raising `Error` if it failed.
 
-        Parses the `{ok, errno_name, message}` result `fileutil.py` prints to
-        stderr, defaulting to success when nothing was seeded under
-        simulation, and raises `Error` when it reports failure.
+        The operation's `{ok, errno_name, message}` result comes back through a
+        JSON output placeholder, leaving the step's stdout free for whatever the
+        operation actually returns. Unless a caller says otherwise, a step
+        defaults under simulation to reporting success (`test_api.errno`), so a
+        test only has to seed the steps it cares about.
         """
         vpython3 = self.m.depot_tools.vpython3()
-        result = self.m.step(name, [vpython3, '-u', _FILEUTIL, *args],
-                             stdout=self.m.raw_io.output_text(),
-                             stderr=self.m.raw_io.output_text())
-        status = (json.loads(result.stderr) if result.stderr else {
-            'ok': True,
-            'errno_name': '',
-            'message': ''
-        })
+        cmd = [
+            vpython3, '-u', _FILEUTIL, '--json-output',
+            self.m.json.output(), *args
+        ]
+        result = self.m.step(name,
+                             cmd,
+                             step_test_data=step_test_data
+                             or self.test_api.errno,
+                             stdout=stdout)
+        status = result.json.output
         if not status['ok']:
             raise self.Error(name, status['errno_name'], status['message'])
-        return result.stdout or ''
+        return result
 
-    def read_text(self, name: str, source: str | Path) -> str:
+    def read_raw(self,
+                 name: str,
+                 source: str | Path,
+                 test_data: bytes = b'') -> bytes:
+        """Return the raw (binary) content of *source*.
+
+        Args:
+            name: The name of the step.
+            source: Path, on the host the step runs on, of the file to read.
+            test_data: What this step returns under simulation.
+
+        Returns:
+            The file's content, as bytes.
+
+        Raises:
+            Error: If the file could not be read.
+        """
+        result = self._run(
+            name,
+            ['copy', str(source), self.m.raw_io.output()],
+            step_test_data=lambda: self.test_api.read_raw(test_data))
+        return result.raw_io.output
+
+    def write_raw(self, name: str, dest: str | Path, data: bytes) -> StepData:
+        """Write raw (binary) *data* to *dest*.
+
+        Args:
+            name: The name of the step.
+            dest: Path, on the host the step runs on, of the file to write.
+            data: The bytes to write.
+
+        Raises:
+            Error: If the file could not be written.
+        """
+        return self._run(name, ['copy', self.m.raw_io.input(data), str(dest)])
+
+    def read_text(self,
+                  name: str,
+                  source: str | Path,
+                  test_data: str = '') -> str:
         """Return the UTF-8 text content of *source*.
 
         Args:
             name: The name of the step.
             source: Path, on the host the step runs on, of the file to read.
+            test_data: What this step returns under simulation.
 
         Returns:
             The file's content.
@@ -89,14 +146,40 @@ class FileApi(RecipeApi):
         Raises:
             Error: If the file could not be read.
         """
-        return self._run(name, ['read_text', str(source)])
+        result = self._run(
+            name, ['copy', str(source),
+                   self.m.raw_io.output_text()],
+            step_test_data=lambda: self.test_api.read_text(test_data))
+        return result.raw_io.output_text
 
-    def read_json(self, name: str, source: str | Path) -> Any:
+    def write_text(self, name: str, dest: str | Path,
+                   text_data: str) -> StepData:
+        """Write UTF-8 *text_data* to *dest*.
+
+        Args:
+            name: The name of the step.
+            dest: Path, on the host the step runs on, of the file to write.
+            text_data: The text to write.
+
+        Raises:
+            Error: If the file could not be written.
+        """
+        return self._run(
+            name,
+            ['copy', self.m.raw_io.input_text(text_data),
+             str(dest)])
+
+    def read_json(self,
+                  name: str,
+                  source: str | Path,
+                  test_data: Any = None) -> Any:
         """Return the parsed JSON content of *source*.
 
         Args:
             name: The name of the step.
             source: Path, on the host the step runs on, of the file to read.
+            test_data: What this step returns under simulation, as a
+                JSON-serializable value.
 
         Returns:
             The file's content, parsed as JSON.
@@ -104,9 +187,95 @@ class FileApi(RecipeApi):
         Raises:
             Error: If the file could not be read.
         """
-        return json.loads(self.read_text(name, source))
+        text = self.read_text(name,
+                              source,
+                              test_data=self.m.json.dumps(test_data, indent=2))
+        return self.m.json.loads(text)
 
-    def copy(self, name: str, source: str | Path, dest: str | Path) -> None:
+    def write_json(self,
+                   name: str,
+                   dest: str | Path,
+                   data: Any,
+                   indent: int | str | None = None,
+                   sort_keys: bool = True) -> StepData:
+        """Write JSON-serializable *data* to *dest*.
+
+        Args:
+            name: The name of the step.
+            dest: Path, on the host the step runs on, of the file to write.
+            data: The value to write as JSON.
+            indent: Indent of the written JSON (see `json.dump`).
+            sort_keys: Sort the keys in *data* (see `api.json.input`).
+
+        Raises:
+            Error: If the file could not be written.
+        """
+        return self.write_text(
+            name, dest,
+            self.m.json.dumps(data, indent=indent, sort_keys=sort_keys))
+
+    def read_proto(self,
+                   name: str,
+                   source: str | Path,
+                   msg_class: type[ProtoMessage],
+                   codec: str,
+                   test_proto: ProtoMessage | None = None,
+                   decoding_kwargs: dict | None = None) -> ProtoMessage:
+        """Return the content of *source*, parsed as a protobuf message.
+
+        Args:
+            name: The name of the step.
+            source: Path, on the host the step runs on, of the file to read.
+            msg_class: The message type to read.
+            codec: Which wire format the file is in (see the `proto` module).
+            test_proto: What this step returns under simulation; defaults to an
+                empty *msg_class*.
+            decoding_kwargs: Passed to the codec's decoder.
+
+        Returns:
+            The parsed message.
+
+        Raises:
+            Error: If the file could not be read.
+        """
+        if test_proto is None:
+            test_proto = msg_class()
+        result = self._run(
+            name, [
+                'copy',
+                str(source),
+                self.m.proto.output(msg_class, codec, **(decoding_kwargs
+                                                         or {}))
+            ],
+            step_test_data=lambda: self.test_api.read_proto(test_proto))
+        return result.proto.output
+
+    def write_proto(self,
+                    name: str,
+                    dest: str | Path,
+                    proto_msg: Message,
+                    codec: str,
+                    encoding_kwargs: dict | None = None) -> StepData:
+        """Write *proto_msg* to *dest*.
+
+        Args:
+            name: The name of the step.
+            dest: Path, on the host the step runs on, of the file to write.
+            proto_msg: The message to write.
+            codec: Which wire format to write it in (see the `proto` module).
+            encoding_kwargs: Passed to the codec's encoder.
+
+        Raises:
+            Error: If the file could not be written.
+        """
+        return self._run(name, [
+            'copy',
+            self.m.proto.input(proto_msg, codec, **(encoding_kwargs or {})),
+            str(dest)
+        ])
+
+    def copy(self, name: str, source: str | Path,
+             dest: str | Path) -> StepData:
         """Copy a file (including mode bits) from *source* to *dest*.
 
         Behaves like `shutil.copy`. If *dest* is a directory, the basename of
@@ -115,7 +284,7 @@ class FileApi(RecipeApi):
         Raises:
             Error: If the copy failed.
         """
-        self._run(name, ['copy', str(source), str(dest)])
+        return self._run(name, ['copy', str(source), str(dest)])
 
     def copytree(self,
                  name: str,
@@ -124,7 +293,7 @@ class FileApi(RecipeApi):
                  *,
                  symlinks: bool = False,
                  hardlink: bool = False,
-                 allow_override: bool = False) -> None:
+                 allow_override: bool = False) -> StepData:
         """Recursively copy a directory tree from *source* to *dest*.
 
         Behaves like `shutil.copytree`.
@@ -149,22 +318,23 @@ class FileApi(RecipeApi):
         if allow_override:
             args.append('--allow-override')
         args += [str(source), str(dest)]
-        self._run(name, args)
+        return self._run(name, args)
 
-    def move(self, name: str, source: str | Path, dest: str | Path) -> None:
+    def move(self, name: str, source: str | Path,
+             dest: str | Path) -> StepData:
         """Move/rename *source* to *dest*. Behaves like `shutil.move`.
 
         Raises:
             Error: If the move failed.
         """
-        self._run(name, ['move', str(source), str(dest)])
+        return self._run(name, ['move', str(source), str(dest)])
 
     def chmod(self,
               name: str,
               path: str | Path,
               mode: int,
               *,
-              recursive: bool = False) -> None:
+              recursive: bool = False) -> StepData:
         """Set the access mode for a file or directory.
 
         Args:
@@ -179,26 +349,26 @@ class FileApi(RecipeApi):
         args = ['chmod', str(path), '--mode', oct(mode)]
         if recursive:
             args.append('--recursive')
-        self._run(name, args)
+        return self._run(name, args)
 
-    def remove(self, name: str, source: str | Path) -> None:
+    def remove(self, name: str, source: str | Path) -> StepData:
         """Remove a file. Not an error if it doesn't already exist.
 
         Raises:
             Error: If the removal failed (for a reason other than the file
                 already being absent).
         """
-        self._run(name, ['remove', str(source)])
+        return self._run(name, ['remove', str(source)])
 
-    def rmtree(self, name: str, source: str | Path) -> None:
+    def rmtree(self, name: str, source: str | Path) -> StepData:
         """Recursively remove a directory. A no-op if it doesn't exist.
 
         Raises:
             Error: If the removal failed.
         """
-        self._run(name, ['rmtree', str(source)])
+        return self._run(name, ['rmtree', str(source)])
 
-    def rmcontents(self, name: str, source: str | Path) -> None:
+    def rmcontents(self, name: str, source: str | Path) -> StepData:
         """Remove the contents of *source*, but not *source* itself.
 
         Useful e.g. for clearing out the current working directory, where
@@ -207,7 +377,7 @@ class FileApi(RecipeApi):
         Raises:
             Error: If the removal failed.
         """
-        self._run(name, ['rmcontents', str(source)])
+        return self._run(name, ['rmcontents', str(source)])
 
     def rmglob(self,
                name: str,
@@ -215,7 +385,7 @@ class FileApi(RecipeApi):
                pattern: str,
                *,
                recursive: bool = True,
-               include_hidden: bool = True) -> None:
+               include_hidden: bool = True) -> StepData:
         """Remove entries under *source* matching the glob *pattern*.
 
         Args:
@@ -235,14 +405,16 @@ class FileApi(RecipeApi):
         args = ['rmglob', str(source), pattern]
         if include_hidden:
             args.append('--hidden')
-        self._run(name, args)
+        return self._run(name, args)
 
-    def glob_paths(self,
-                   name: str,
-                   source: str | Path,
-                   pattern: str,
-                   *,
-                   include_hidden: bool = False) -> list[Path]:
+    def glob_paths(
+        self,
+        name: str,
+        source: str | Path,
+        pattern: str,
+        *,
+        include_hidden: bool = False,
+        test_data: Sequence[str] = ()) -> list[Path]:
         """Return paths under *source* matching the glob *pattern*.
 
         Args:
@@ -250,6 +422,8 @@ class FileApi(RecipeApi):
             source: The directory to glob under.
             pattern: The glob pattern (stdlib `glob`, `recursive=True` rules).
             include_hidden: Include files beginning with `.`.
+            test_data: The paths this step finds under simulation, relative to
+                *source*.
 
         Returns:
             The matching paths, as absolute paths under *source*.
@@ -260,14 +434,20 @@ class FileApi(RecipeApi):
         args = ['glob', str(source), pattern]
         if include_hidden:
             args.append('--hidden')
-        out = self._run(name, args)
-        return [Path(source) / line for line in out.splitlines()]
+        result = self._run(
+            name,
+            args,
+            step_test_data=lambda: self.test_api.glob_paths(test_data),
+            stdout=self.m.raw_io.output_text())
+        return [Path(source) / line for line in result.stdout.splitlines()]
 
-    def listdir(self,
-                name: str,
-                source: str | Path,
-                *,
-                recursive: bool = False) -> list[Path]:
+    def listdir(
+        self,
+        name: str,
+        source: str | Path,
+        *,
+        recursive: bool = False,
+        test_data: Sequence[str] = ()) -> list[Path]:
         """Return every file inside *source*.
 
         Args:
@@ -275,6 +455,8 @@ class FileApi(RecipeApi):
             source: The directory to list.
             recursive: List files at any depth under *source* (as paths
                 relative to it), rather than only its direct contents.
+            test_data: The entries this step finds under simulation, relative to
+                *source*.
 
         Returns:
             The absolute paths of every entry found.
@@ -285,14 +467,18 @@ class FileApi(RecipeApi):
         args = ['listdir', str(source)]
         if recursive:
             args.append('--recursive')
-        out = self._run(name, args)
-        return [Path(source) / line for line in out.splitlines()]
+        result = self._run(
+            name,
+            args,
+            step_test_data=lambda: self.test_api.listdir(test_data),
+            stdout=self.m.raw_io.output_text())
+        return [Path(source) / line for line in result.stdout.splitlines()]
 
     def ensure_directory(self,
                          name: str,
                          dest: str | Path,
                          *,
-                         mode: int = 0o777) -> None:
+                         mode: int = 0o777) -> StepData:
         """Ensure *dest* exists and is a directory.
 
         Args:
@@ -305,19 +491,34 @@ class FileApi(RecipeApi):
             Error: If *dest* exists but is not a directory, or creation
                 failed.
         """
-        self._run(name, ['ensure_directory', str(dest), '--mode', oct(mode)])
+        return self._run(name,
+                         ['ensure_directory',
+                          str(dest), '--mode',
+                          oct(mode)])
 
-    def filesizes(self, name: str, files: list[str | Path]) -> list[int]:
+    def filesizes(self,
+                  name: str,
+                  files: Sequence[str | Path],
+                  *,
+                  test_data: Sequence[int] = ()) -> list[int]:
         """Return the size, in bytes, of each of *files*.
+
+        Args:
+            name: The name of the step.
+            files: The files to size.
+            test_data: The sizes this step reports under simulation.
 
         Raises:
             Error: If any file's size could not be read.
         """
-        out = self._run(name, ['filesizes', *[str(f) for f in files]])
-        return [int(line) for line in out.splitlines()]
+        result = self._run(
+            name, ['filesizes', *[str(f) for f in files]],
+            step_test_data=lambda: self.test_api.filesizes(test_data),
+            stdout=self.m.raw_io.output_text())
+        return [int(line) for line in result.stdout.splitlines()]
 
     def symlink(self, name: str, source: str | Path,
-                linkname: str | Path) -> None:
+                linkname: str | Path) -> StepData:
         """Create a symlink at *linkname* pointing to *source*.
 
         Behaves like `os.symlink`.
@@ -325,20 +526,21 @@ class FileApi(RecipeApi):
         Raises:
             Error: If the symlink could not be created.
         """
-        self._run(name, ['symlink', str(source), str(linkname)])
+        return self._run(name, ['symlink', str(source), str(linkname)])
 
     def truncate(self,
                  name: str,
                  path: str | Path,
-                 size_mb: int = 100) -> None:
+                 size_mb: int = 100) -> StepData:
         """Create an empty file at *path*, sized *size_mb* megabytes.
 
         Raises:
             Error: If the file could not be created.
         """
-        self._run(name, ['truncate', str(path), str(size_mb)])
+        return self._run(name, ['truncate', str(path), str(size_mb)])
 
-    def flatten_single_directories(self, name: str, path: str | Path) -> None:
+    def flatten_single_directories(self, name: str,
+                                   path: str | Path) -> StepData:
         """Move the contents of nested singular directories up to *path*.
 
         For example, given `path/only/nested/dir/{a,b}`, this moves `a` and
@@ -350,10 +552,14 @@ class FileApi(RecipeApi):
         Raises:
             Error: If flattening failed.
         """
-        self._run(name, ['flatten_single_directories', str(path)])
+        return self._run(name, ['flatten_single_directories', str(path)])
 
-    def compute_hash(self, name: str, paths: list[str | Path],
-                     base_path: str | Path) -> str:
+    def compute_hash(self,
+                     name: str,
+                     paths: Sequence[str | Path],
+                     base_path: str | Path,
+                     *,
+                     test_data: str = '') -> str:
         """Return a hash of *paths* (files and/or directories).
 
         The hash covers each path's name (relative to *base_path*) and
@@ -364,6 +570,7 @@ class FileApi(RecipeApi):
             name: The name of the step.
             paths: The files/directories to hash.
             base_path: Base directory *paths* are hashed relative to.
+            test_data: The hash this step reports under simulation.
 
         Returns:
             The hex-encoded hash.
@@ -372,21 +579,50 @@ class FileApi(RecipeApi):
             Error: If hashing failed.
         """
         rel_paths = [os.path.relpath(str(p), str(base_path)) for p in paths]
-        out = self._run(name, ['compute_hash', str(base_path), *rel_paths])
-        return out.strip()
+        result = self._run(
+            name, ['compute_hash', str(base_path), *rel_paths],
+            step_test_data=lambda: self.test_api.compute_hash(test_data),
+            stdout=self.m.raw_io.output_text())
+        return result.stdout.strip()
 
-    def file_hash(self, name: str, file_path: str | Path) -> str:
+    def file_hash(self,
+                  name: str,
+                  file_path: str | Path,
+                  *,
+                  test_data: str = '') -> str:
         """Return a hash of *file_path*'s content.
+
+        Args:
+            name: The name of the step.
+            file_path: The file to hash.
+            test_data: The hash this step reports under simulation.
 
         Raises:
             Error: If hashing failed.
         """
-        return self._run(name, ['file_hash', str(file_path)]).strip()
+        result = self._run(
+            name, ['file_hash', str(file_path)],
+            step_test_data=lambda: self.test_api.file_hash(test_data),
+            stdout=self.m.raw_io.output_text())
+        return result.stdout.strip()
 
-    def is_executable(self, name: str, path: str | Path) -> bool:
+    def is_executable(self,
+                      name: str,
+                      path: str | Path,
+                      *,
+                      test_data: bool = True) -> bool:
         """Return whether *path* is executable.
+
+        Args:
+            name: The name of the step.
+            path: The file to check.
+            test_data: The answer this step reports under simulation.
 
         Raises:
             Error: If the check failed.
         """
-        return self._run(name, ['is_executable', str(path)]).strip() == 'True'
+        result = self._run(
+            name, ['is_executable', str(path)],
+            step_test_data=lambda: self.test_api.is_executable(test_data),
+            stdout=self.m.raw_io.output_text())
+        return result.stdout.strip() == 'True'

--- a/tools/recipes/recipe_modules/file/examples/full.expected/basic.json
+++ b/tools/recipes/recipe_modules/file/examples/full.expected/basic.json
@@ -21,8 +21,11 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
-      "read_text",
-      "/etc/greeting"
+      "--json-output",
+      "/path/to/tmp/json",
+      "copy",
+      "/etc/greeting",
+      "/path/to/tmp/"
     ],
     "name": "read greeting"
   },
@@ -32,6 +35,138 @@
       "hello\n"
     ],
     "name": "echo"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "-u",
+      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
+      "copy",
+      "/etc/greeting",
+      "/path/to/tmp/"
+    ],
+    "name": "read raw greeting"
+  },
+  {
+    "cmd": [
+      "echo",
+      "hello bytes"
+    ],
+    "name": "echo raw"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "-u",
+      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
+      "copy",
+      "/etc/config.json",
+      "/path/to/tmp/"
+    ],
+    "name": "read config"
+  },
+  {
+    "cmd": [
+      "echo",
+      "{'key': 'value'}"
+    ],
+    "name": "echo config"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "-u",
+      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
+      "copy",
+      "/etc/greeting.json",
+      "/path/to/tmp/json"
+    ],
+    "name": "read proto greeting"
+  },
+  {
+    "cmd": [
+      "echo",
+      "hello proto"
+    ],
+    "name": "echo proto"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "-u",
+      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
+      "copy",
+      "/etc/empty.json",
+      "/path/to/tmp/json"
+    ],
+    "name": "read empty proto"
+  },
+  {
+    "cmd": [
+      "echo",
+      "''"
+    ],
+    "name": "echo empty proto"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "-u",
+      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
+      "copy",
+      "hello again\n",
+      "/tmp/greeting"
+    ],
+    "name": "write greeting"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "-u",
+      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
+      "copy",
+      "\u0000binary",
+      "/tmp/greeting.bin"
+    ],
+    "name": "write raw greeting"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "-u",
+      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
+      "copy",
+      "{\n  \"key\": \"value\"\n}",
+      "/tmp/config.json"
+    ],
+    "name": "write config"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "-u",
+      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
+      "copy",
+      "{\n  \"text\": \"bye proto\"\n}",
+      "/tmp/greeting.json"
+    ],
+    "name": "write proto greeting"
   },
   {
     "name": "$result"

--- a/tools/recipes/recipe_modules/file/examples/full.proto
+++ b/tools/recipes/recipe_modules/file/examples/full.proto
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+syntax = "proto3";
+
+package recipe_modules.brave.file.examples.full;
+
+// A message for `full.py` to round-trip through `read_proto`/`write_proto`.
+message Greeting {
+  string text = 1;
+}

--- a/tools/recipes/recipe_modules/file/examples/full.py
+++ b/tools/recipes/recipe_modules/file/examples/full.py
@@ -2,12 +2,14 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Example recipe exercising `file.read_text`/`read_json` and `_run`'s core
-`{ok, errno_name, message}` handling. See `examples/operations.py` for the
+"""Example recipe exercising `file`'s content reads and writes, and `_run`'s
+core `{ok, errno_name, message}` handling. See `examples/operations.py` for the
 rest of the module's operations.
 """
 
 from __future__ import annotations
+
+from PB.recipe_modules.brave.file.examples.full import Greeting
 
 import post_process
 
@@ -15,26 +17,77 @@ DEPS = ['file', 'step']
 
 
 def RunSteps(api):
-    text = api.file.read_text('read greeting', '/etc/greeting')
+    # Each read takes a `test_data`: the result the step reports under
+    # simulation, so a test only has to seed the reads it wants to steer.
+    text = api.file.read_text('read greeting',
+                              '/etc/greeting',
+                              test_data='hello\n')
     api.step('echo', ['echo', text])
+
+    raw = api.file.read_raw('read raw greeting',
+                            '/etc/greeting',
+                            test_data=b'hello bytes')
+    api.step('echo raw', ['echo', raw.decode('utf-8')])
+
+    config = api.file.read_json('read config',
+                                '/etc/config.json',
+                                test_data={'key': 'value'})
+    api.step('echo config', ['echo', str(config)])
+
+    greeting = api.file.read_proto('read proto greeting',
+                                   '/etc/greeting.json',
+                                   Greeting,
+                                   'JSONPB',
+                                   test_proto=Greeting(text='hello proto'))
+    api.step('echo proto', ['echo', greeting.text])
+
+    # Left to itself, a `read_proto` returns an empty message under simulation.
+    empty = api.file.read_proto('read empty proto', '/etc/empty.json',
+                                Greeting, 'JSONPB')
+    api.step('echo empty proto', ['echo', repr(empty.text)])
+
+    # Writes carry their content into the step, so there is nothing to seed.
+    api.file.write_text('write greeting', '/tmp/greeting', 'hello again\n')
+    api.file.write_raw('write raw greeting', '/tmp/greeting.bin',
+                       b'\x00binary')
+    api.file.write_json('write config',
+                        '/tmp/config.json', {'key': 'value'},
+                        indent=2)
+    api.file.write_proto('write proto greeting', '/tmp/greeting.json',
+                         Greeting(text='bye proto'), 'JSONPB')
 
 
 def GenTests(api):
-    # Happy path: seeded content flows through to the next step.
+    # Happy path: the recipe's own `test_data` supplies each read's result,
+    # which flows through to the step after it.
     yield api.test(
         'basic',
-        api.file.read_text('read greeting', 'hello\n'),
-        api.post_process(post_process.StepCommandContains, 'read greeting',
-                         ['read_text', '/etc/greeting']),
         api.post_process(post_process.StepCommandContains, 'echo',
                          ['echo', 'hello\n']),
+        api.post_process(post_process.StepCommandContains, 'echo raw',
+                         ['echo', 'hello bytes']),
+        api.post_process(post_process.StepCommandContains, 'echo config',
+                         ['echo', "{'key': 'value'}"]),
+        api.post_process(post_process.StepCommandContains, 'echo proto',
+                         ['echo', 'hello proto']),
         api.post_process(post_process.StatusSuccess),
     )
-    # Nothing seeded: defaults to success with empty content, so a caller
-    # that doesn't care about the result doesn't need to seed anything.
+    # A test can override a read's default by seeding the step directly.
     yield api.test(
-        'unseeded defaults to success',
-        api.post_process(post_process.MustRun, 'read greeting'),
+        'seeded reads',
+        api.step_data('read greeting', api.file.read_text('seeded\n')),
+        api.step_data('read raw greeting', api.file.read_raw(b'seeded bytes')),
+        api.step_data('read config', api.file.read_json({'seeded': True})),
+        api.step_data('read proto greeting',
+                      api.file.read_proto(Greeting(text='seeded proto'))),
+        api.post_process(post_process.StepCommandContains, 'echo',
+                         ['echo', 'seeded\n']),
+        api.post_process(post_process.StepCommandContains, 'echo raw',
+                         ['echo', 'seeded bytes']),
+        api.post_process(post_process.StepCommandContains, 'echo config',
+                         ['echo', "{'seeded': True}"]),
+        api.post_process(post_process.StepCommandContains, 'echo proto',
+                         ['echo', 'seeded proto']),
         api.post_process(post_process.StatusSuccess),
         api.post_process(post_process.DropExpectation),
     )
@@ -42,7 +95,8 @@ def GenTests(api):
     # failure.
     yield api.test(
         'not found',
-        api.file.error('read greeting', errno_name='ENOENT'),
+        api.step_data('read greeting', api.file.errno('ENOENT')),
         api.post_process(post_process.StatusFailure),
         api.post_process(post_process.DropExpectation),
+        status='FAILURE',
     )

--- a/tools/recipes/recipe_modules/file/examples/operations.expected/basic.json
+++ b/tools/recipes/recipe_modules/file/examples/operations.expected/basic.json
@@ -21,23 +21,8 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
-      "read_text",
-      "/etc/config.json"
-    ],
-    "name": "read config"
-  },
-  {
-    "cmd": [
-      "echo",
-      "{'key': 'value'}"
-    ],
-    "name": "echo json"
-  },
-  {
-    "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
-      "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
       "copy",
       "/src/a.txt",
       "/dst/a.txt"
@@ -49,6 +34,8 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
       "copytree",
       "--symlinks",
       "--hardlink",
@@ -63,6 +50,8 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
       "move",
       "/src/b.txt",
       "/dst/b.txt"
@@ -74,6 +63,8 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
       "chmod",
       "/dst/a.txt",
       "--mode",
@@ -87,6 +78,8 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
       "remove",
       "/dst/a.txt"
     ],
@@ -97,6 +90,8 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
       "rmtree",
       "/dst/dir"
     ],
@@ -107,6 +102,8 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
       "rmcontents",
       "/dst"
     ],
@@ -117,6 +114,8 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
       "rmglob",
       "/dst",
       "**/*.txt",
@@ -129,6 +128,8 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
       "glob",
       "/src",
       "*.py",
@@ -148,6 +149,8 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
       "listdir",
       "/src",
       "--recursive"
@@ -166,6 +169,8 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
       "ensure_directory",
       "/newdir",
       "--mode",
@@ -178,6 +183,8 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
       "filesizes",
       "/a.txt",
       "/b.txt"
@@ -196,6 +203,8 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
       "symlink",
       "/target",
       "/link"
@@ -207,6 +216,8 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
       "truncate",
       "/big.bin",
       "10"
@@ -218,6 +229,8 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
       "flatten_single_directories",
       "/nested"
     ],
@@ -228,6 +241,8 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
       "compute_hash",
       "/base",
       "a.txt",
@@ -247,6 +262,8 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
       "file_hash",
       "/a.txt"
     ],
@@ -264,6 +281,8 @@
       "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "--json-output",
+      "/path/to/tmp/json",
       "is_executable",
       "/a.txt"
     ],

--- a/tools/recipes/recipe_modules/file/examples/operations.py
+++ b/tools/recipes/recipe_modules/file/examples/operations.py
@@ -2,8 +2,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Example recipe exercising every `file` operation beyond `read_text`
-(covered separately in `examples/full.py`, alongside `_run`'s core
+"""Example recipe exercising every `file` operation beyond reading and writing
+content (covered separately in `examples/full.py`, alongside `_run`'s core
 success/failure handling that every operation here shares).
 """
 
@@ -15,9 +15,6 @@ DEPS = ['file', 'step']
 
 
 def RunSteps(api):
-    data = api.file.read_json('read config', '/etc/config.json')
-    api.step('echo json', ['echo', str(data)])
-
     api.file.copy('copy file', '/src/a.txt', '/dst/a.txt')
     api.file.copytree('copy tree',
                       '/src/dir',
@@ -36,15 +33,23 @@ def RunSteps(api):
                     recursive=True,
                     include_hidden=True)
 
-    paths = api.file.glob_paths('glob', '/src', '*.py', include_hidden=True)
+    paths = api.file.glob_paths('glob',
+                                '/src',
+                                '*.py',
+                                include_hidden=True,
+                                test_data=['a.py', 'sub/b.py'])
     api.step('echo glob', ['echo', str(paths)])
 
-    entries = api.file.listdir('listdir', '/src', recursive=True)
+    entries = api.file.listdir('listdir',
+                               '/src',
+                               recursive=True,
+                               test_data=['a.txt', 'sub/b.txt'])
     api.step('echo listdir', ['echo', str(entries)])
 
     api.file.ensure_directory('ensure dir', '/newdir', mode=0o755)
 
-    sizes = api.file.filesizes('filesizes', ['/a.txt', '/b.txt'])
+    sizes = api.file.filesizes('filesizes', ['/a.txt', '/b.txt'],
+                               test_data=[111, 222])
     api.step('echo sizes', ['echo', str(sizes)])
 
     api.file.symlink('symlink', '/target', '/link')
@@ -52,26 +57,22 @@ def RunSteps(api):
     api.file.flatten_single_directories('flatten', '/nested')
 
     sha = api.file.compute_hash('compute hash', ['/base/a.txt', '/base/dir'],
-                                '/base')
+                                '/base',
+                                test_data='deadbeef')
     api.step('echo hash', ['echo', sha])
 
-    file_sha = api.file.file_hash('file hash', '/a.txt')
+    file_sha = api.file.file_hash('file hash', '/a.txt', test_data='c0ffee')
     api.step('echo file hash', ['echo', file_sha])
 
-    executable = api.file.is_executable('is executable', '/a.txt')
+    executable = api.file.is_executable('is executable',
+                                        '/a.txt',
+                                        test_data=True)
     api.step('echo executable', ['echo', str(executable)])
 
 
 def GenTests(api):
     yield api.test(
         'basic',
-        api.file.read_json('read config', {'key': 'value'}),
-        api.file.glob_paths('glob', ['a.py', 'sub/b.py']),
-        api.file.listdir('listdir', ['a.txt', 'sub/b.txt']),
-        api.file.filesizes('filesizes', [111, 222]),
-        api.file.compute_hash('compute hash', 'deadbeef'),
-        api.file.file_hash('file hash', 'c0ffee'),
-        api.file.is_executable('is executable', True),
         api.post_process(post_process.StepCommandContains, 'copy tree',
                          ['--symlinks', '--hardlink', '--allow-override']),
         api.post_process(post_process.StepCommandContains, 'chmod file',
@@ -82,10 +83,30 @@ def GenTests(api):
                          ['--hidden']),
         api.post_process(post_process.StepCommandContains, 'listdir',
                          ['--recursive']),
-        api.post_process(post_process.MustRun, 'echo json'),
         api.post_process(post_process.MustRun, 'ensure dir'),
         api.post_process(post_process.MustRun, 'symlink'),
         api.post_process(post_process.MustRun, 'truncate'),
         api.post_process(post_process.MustRun, 'flatten'),
         api.post_process(post_process.StatusSuccess),
+    )
+    # Each value-returning operation's test API helper overrides the
+    # `test_data` the recipe passed.
+    yield api.test(
+        'seeded results',
+        api.step_data('glob', api.file.glob_paths(['seeded.py'])),
+        api.step_data('listdir', api.file.listdir(['seeded.txt'])),
+        api.step_data('filesizes', api.file.filesizes([7])),
+        api.step_data('compute hash', api.file.compute_hash('f00d')),
+        api.step_data('file hash', api.file.file_hash('bead')),
+        api.step_data('is executable', api.file.is_executable(False)),
+        api.post_process(post_process.StepCommandContains, 'echo glob',
+                         ['echo', "[PosixPath('/src/seeded.py')]"]),
+        api.post_process(post_process.StepCommandContains, 'echo sizes',
+                         ['echo', '[7]']),
+        api.post_process(post_process.StepCommandContains, 'echo hash',
+                         ['echo', 'f00d']),
+        api.post_process(post_process.StepCommandContains, 'echo executable',
+                         ['echo', 'False']),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
     )

--- a/tools/recipes/recipe_modules/file/resources/fileutil.py
+++ b/tools/recipes/recipe_modules/file/resources/fileutil.py
@@ -5,11 +5,12 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """Utility exporting basic filesystem operations, run as a recipe step.
 
-Covers every operation that doesn't need to inject arbitrary file *content*
-(e.g. `write_text` -- this engine has no stdin/output-placeholder primitive
-to carry that through a step yet), reporting a shared `{ok, errno_name,
-message}` result on stderr, since several operations here (`read_text`,
-`glob`, ...) already need stdout for their actual return value.
+Every operation reports a shared `{ok, errno_name, message}` result as JSON to
+the file named by `--json-output`, leaving stdout free for the operations that
+have an actual value to return (`glob`, `listdir`, ...). Reading and writing
+file content needs no operation of its own: `copy` does both, given a path that
+the recipe engine has filled in (or will read back) for it -- see the
+"Getting data back from a step" section of ../../../README.md.
 """
 
 from __future__ import annotations
@@ -25,11 +26,6 @@ import os
 import shutil
 import sys
 import tempfile
-
-
-def _read_text(source: str) -> str:
-    with open(source, encoding='utf-8') as f:
-        return f.read()
 
 
 def _copy(source: str, dest: str) -> None:
@@ -231,7 +227,6 @@ def _is_executable(path: str) -> str:
 # parsed `argparse.Namespace` and returns the string to print to stdout (or
 # None, for operations with nothing to report beyond ok/errno_name/message).
 _OPERATIONS = {
-    'read_text': lambda o: _read_text(o.source),
     'copy': lambda o: _copy(o.source, o.dest),
     'copytree': lambda o: _copytree(o.source, o.dest, o.symlinks, o.hardlink, o
                                     .allow_override),
@@ -261,10 +256,12 @@ def _octal(value: str) -> int:
 
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser()
+    parser.add_argument('--json-output',
+                        required=True,
+                        type=argparse.FileType('w'),
+                        help='Where to write the {ok, errno_name, message} '
+                        'result of the operation.')
     subparsers = parser.add_subparsers(dest='command', required=True)
-
-    p = subparsers.add_parser('read_text', help='Read a file as UTF-8 text.')
-    p.add_argument('source')
 
     p = subparsers.add_parser('copy',
                               help='Copy a file. Behaves like shutil.copy().')
@@ -373,7 +370,8 @@ def main(argv: list[str]) -> int:
         result['message'] = f'UNKNOWN: {e}'
 
     sys.stdout.write(output)
-    print(json.dumps(result), file=sys.stderr)
+    with opts.json_output as json_output:
+        json.dump(result, json_output)
     # Success/failure is reported in `result`, not the exit code: `file/api.py`
     # inspects `result['ok']` itself.
     return 0

--- a/tools/recipes/recipe_modules/file/test_api.py
+++ b/tools/recipes/recipe_modules/file/test_api.py
@@ -4,78 +4,119 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """Test API for `file`: seed a `fileutil.py` step's simulated result.
 
-Each helper is merged with `api.step_data(name, ...)` at the call site;
-*name* is a required first argument, matching this engine's name-keyed
-`step_data`.
+Each helper is a fragment for `api.step_data`:
 
-Void operations (`copy`, `move`, `chmod`, `remove`, `rmtree`, `rmcontents`,
-`rmglob`, `ensure_directory`, `symlink`, `truncate`,
-`flatten_single_directories`) need no dedicated helper: they default to
-success with nothing to return, so an unseeded step is already a passing
-test.
+    api.step_data('read greeting', api.file.read_text('hello\\n'))
+    api.step_data('read greeting', api.file.errno('ENOENT'))
+
+Most of the time nothing needs seeding at all: `api.file` methods take a
+`test_data` argument that supplies the step's default simulated result, and an
+unseeded step reports success. These helpers are for the cases a test wants to
+steer -- notably `errno`, to exercise what a recipe does when an operation
+fails.
+
+Void operations (`copy`, `write_text`, `move`, `chmod`, `remove`, `rmtree`,
+`rmcontents`, `rmglob`, `ensure_directory`, `symlink`, `truncate`,
+`flatten_single_directories`) have nothing to return, so `errno` is the only
+helper that applies to them.
 """
 
 from __future__ import annotations
 
 import json
+from typing import Any, Sequence
 
-from recipe_test_api import RecipeTestApi, TestData
+from google.protobuf.message import Message
+
+from recipe_test_api import RecipeTestApi, StepTestData
 
 
 class FileTestApi(RecipeTestApi):
-    """Seed the simulated `{ok, errno_name, message}` result of a step."""
+    """Seed the simulated result of a `fileutil.py` step."""
 
-    def _ok(self, name: str, stdout: str = '') -> TestData:
-        return self.step_data(name,
-                              stdout=self.m.raw_io.output_text(stdout),
-                              stderr=self.m.raw_io.output_text(
-                                  json.dumps({
-                                      'ok': True,
-                                      'errno_name': '',
-                                      'message': '',
-                                  })))
+    def errno(self, errno_name: str | None = None) -> StepTestData:
+        """Seed the shared `{ok, errno_name, message}` result of any operation.
 
-    def read_text(self, name: str, content: str = '') -> TestData:
-        """Seed *name* to succeed, returning *content* as the file's text."""
-        return self._ok(name, content)
+        With no *errno_name* the operation reports success -- which is what an
+        unseeded `file` step defaults to. Pass one (`'ENOENT'`, `'EPERM'`, ...)
+        to make the operation raise `file.Error` instead.
+        """
+        result: dict[str, Any] = {'ok': True}
+        if errno_name:
+            result = {
+                'ok': False,
+                'errno_name': errno_name,
+                # A real run's message comes from the OS and usually carries
+                # more detail than this.
+                'message': f'file command encountered system error {errno_name}'
+            }
+        return self.m.json.output(result)
 
-    def read_json(self, name: str, content=None) -> TestData:
-        """Seed *name* to succeed, returning *content* as parsed JSON."""
-        return self._ok(name, json.dumps(content))
+    def read_raw(self,
+                 content: bytes = b'',
+                 errno_name: str | None = None) -> StepTestData:
+        """Seed the bytes a `read_raw` step returns."""
+        return self.m.raw_io.output(content) + self.errno(errno_name)
 
-    def listdir(self, name: str, paths: tuple[str, ...] = ()) -> TestData:
-        """Seed *name* to succeed, returning *paths* as directory entries."""
-        return self._ok(name, '\n'.join(paths))
+    def read_text(self,
+                  text_content: str = '',
+                  errno_name: str | None = None) -> StepTestData:
+        """Seed the text a `read_text` step returns."""
+        return self.m.raw_io.output_text(text_content) + self.errno(errno_name)
 
-    def glob_paths(self, name: str, paths: tuple[str, ...] = ()) -> TestData:
-        """Seed *name* to succeed, returning *paths* as glob matches."""
-        return self._ok(name, '\n'.join(paths))
+    def read_json(self,
+                  json_content: Any = None,
+                  errno_name: str | None = None) -> StepTestData:
+        """Seed the value a `read_json` step returns."""
+        text = json.dumps(json_content, indent=2, sort_keys=True)
+        return self.m.raw_io.output_text(text) + self.errno(errno_name)
 
-    def filesizes(self, name: str, sizes: tuple[int, ...] = ()) -> TestData:
-        """Seed *name* to succeed, returning *sizes* as file sizes."""
-        return self._ok(name, '\n'.join(str(s) for s in sizes))
+    def read_proto(self,
+                   proto_msg: Message,
+                   errno_name: str | None = None) -> StepTestData:
+        """Seed the message a `read_proto` step returns."""
+        return self.m.proto.output(proto_msg) + self.errno(errno_name)
 
-    def compute_hash(self, name: str, sha256: str = '') -> TestData:
-        """Seed *name* to succeed, returning *sha256* as the computed hash."""
-        return self._ok(name, sha256)
+    def listdir(self,
+                paths: Sequence[str] = (),
+                errno_name: str | None = None) -> StepTestData:
+        """Seed the entries a `listdir` step finds, relative to its source."""
+        return (self.m.raw_io.stream_output_text('\n'.join(
+            sorted(str(p) for p in paths))) + self.errno(errno_name))
 
-    def file_hash(self, name: str, sha256: str = '') -> TestData:
-        """Seed *name* to succeed, returning *sha256* as the file's hash."""
-        return self._ok(name, sha256)
+    def glob_paths(self,
+                   names: Sequence[str] = (),
+                   errno_name: str | None = None) -> StepTestData:
+        """Seed the paths a `glob_paths` step matches, relative to its source."""
+        return (self.m.raw_io.stream_output_text('\n'.join(
+            sorted(str(n) for n in names))) + self.errno(errno_name))
 
-    def is_executable(self, name: str, executable: bool = True) -> TestData:
-        """Seed *name* to succeed, returning *executable* as the result."""
-        return self._ok(name, str(executable))
+    def filesizes(self,
+                  sizes: Sequence[int] = (),
+                  errno_name: str | None = None) -> StepTestData:
+        """Seed the sizes a `filesizes` step reports."""
+        return (
+            self.m.raw_io.stream_output_text('\n'.join(str(s)
+                                                       for s in sizes)) +
+            self.errno(errno_name))
 
-    def error(self,
-              name: str,
-              errno_name: str = 'ENOENT',
-              message: str = '') -> TestData:
-        """Seed *name* to fail with *errno_name* (and optional *message*)."""
-        return self.step_data(name,
-                              stderr=self.m.raw_io.output_text(
-                                  json.dumps({
-                                      'ok': False,
-                                      'errno_name': errno_name,
-                                      'message': message or errno_name,
-                                  })))
+    def compute_hash(self,
+                     digest: str = '',
+                     errno_name: str | None = None) -> StepTestData:
+        """Seed the hash a `compute_hash` step reports."""
+        return (self.m.raw_io.stream_output_text(digest) +
+                self.errno(errno_name))
+
+    def file_hash(self,
+                  digest: str = '',
+                  errno_name: str | None = None) -> StepTestData:
+        """Seed the hash a `file_hash` step reports."""
+        return (self.m.raw_io.stream_output_text(digest) +
+                self.errno(errno_name))
+
+    def is_executable(self,
+                      executable: bool = True,
+                      errno_name: str | None = None) -> StepTestData:
+        """Seed the answer an `is_executable` step reports."""
+        return (self.m.raw_io.stream_output_text(str(executable)) +
+                self.errno(errno_name))


### PR DESCRIPTION
This PR introduces placeholder integration to the file module, which
makes doing file operations as steps much simpler, wihtout having to
shell them out to some script:

```
DEPS = ['file', 'path']

def RunSteps(api):
    state_file = api.path.cache_dir / 'last_run.json'
    api.file.write_json('save last-run state', state_file, {
        'revision': api.buildbucket.gitiles_commit.id,
        'passed': True,
    })
    ...
    last_run = api.file.read_json('load last-run state', state_file,
                                    test_data={'revision': 'HEAD', 'passed': True})
    if last_run['revision'] == current_revision:
        api.step('skip: already ran this revision', ['true'])

def GenTests(api):
    yield api.test(
        'first_run',
        api.step_data('load last-run state', api.file.errno('ENOENT')),
        api.post_process(post_process.DoesNotRun,
                            'skip: already ran this revision'),
        api.post_process(post_process.StatusSuccess),
        api.post_process(post_process.DropExpectation),
```

Bug: https://github.com/brave/brave-browser/issues/56748
