### PR TITLE
[iOS] Consolidate favorites/search screens into a container controller

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+KeyCommands.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+KeyCommands.swift
@@ -13,13 +13,13 @@ extension BrowserViewController {
   // MARK: Actions
 
   @objc private func reloadTabKeyCommand() {
-    if let tab = tabManager.selectedTab, favoritesController == nil {
+    if let tab = tabManager.selectedTab, searchContainer == nil {
       tab.reload()
     }
   }
 
   @objc private func goBackKeyCommand() {
-    if let tab = tabManager.selectedTab, tab.canGoBack, favoritesController == nil {
+    if let tab = tabManager.selectedTab, tab.canGoBack, searchContainer == nil {
       tab.goBack()
       tab.browserData?.resetExternalAlertProperties()
     }
@@ -33,13 +33,13 @@ extension BrowserViewController {
   }
 
   @objc private func findInPageKeyCommand() {
-    if let tab = tabManager.selectedTab, favoritesController == nil {
+    if let tab = tabManager.selectedTab, searchContainer == nil {
       tab.presentFindInteraction()
     }
   }
 
   @objc private func selectLocationBarKeyCommand() {
-    if favoritesController == nil {
+    if searchContainer == nil {
       toolbarVisibilityViewModel.toolbarState = .expanded
       topToolbar.tabLocationViewDidTapLocation(topToolbar.locationView)
     }
@@ -174,11 +174,7 @@ extension BrowserViewController {
   }
 
   @objc private func moveURLCompletionKeyCommand(sender: UIKeyCommand) {
-    guard let searchController = self.searchController else {
-      return
-    }
-
-    searchController.handleKeyCommands(sender: sender)
+    searchContainer?.handleSearchKeyCommands(sender: sender)
   }
 
   @objc private func toggleBraveTalkMuteCommand() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -215,31 +215,34 @@ extension BrowserViewController: TopToolbarDelegate {
   }
 
   func topToolbarDidPressScrollToTop(_ topToolbar: TopToolbarView) {
-    if let selectedTab = tabManager.selectedTab, favoritesController == nil {
+    if let selectedTab = tabManager.selectedTab, searchContainer == nil {
       // Only scroll to top if we are not showing the home view controller
       selectedTab.webViewProxy?.scrollView?.setContentOffset(CGPoint.zero, animated: true)
     }
   }
 
   func topToolbar(_ topToolbar: TopToolbarView, didEnterText text: String) {
-    if text.isEmpty {
-      hideSearchController()
-    } else {
-      showSearchController()
+    guard let searchContainer else { return }
 
+    searchContainer.showSearchResults(!text.isEmpty)
+
+    if text.isEmpty {
+      searchContainer.setSearchQuery(query: "", showSearchSuggestions: false)
+      searchContainer.searchLoaderQuery = ""
+    } else {
       let locationLastReplacement = topToolbar.locationLastReplacement
       let isPasting = topToolbar.isPastingInURLBar
       Task {
-        await searchController?.setSearchQuery(
+        let shouldShowSearchSuggestions = await URLBarHelper.shared.shouldShowSearchSuggestions(
+          using: locationLastReplacement,
+          isPasting: isPasting
+        )
+        searchContainer.setSearchQuery(
           query: text,
-          showSearchSuggestions: URLBarHelper.shared.shouldShowSearchSuggestions(
-            using: locationLastReplacement,
-            isPasting: isPasting
-          )
+          showSearchSuggestions: shouldShowSearchSuggestions
         )
       }
-
-      searchLoader?.query = text.lowercased()
+      searchContainer.searchLoaderQuery = text.lowercased()
     }
   }
 
@@ -345,12 +348,11 @@ extension BrowserViewController: TopToolbarDelegate {
 
   func topToolbarDidEnterOverlayMode(_ topToolbar: TopToolbarView) {
     updateTabsBarVisibility()
-    displayFavoritesController()
+    displaySearchContainer()
   }
 
   func topToolbarDidLeaveOverlayMode(_ topToolbar: TopToolbarView) {
-    hideSearchController()
-    hideFavoritesController()
+    hideSearchContainer()
     updateScreenTimeUrl(tabManager.selectedTab?.visibleURL)
     updateInContentHomePanel(tabManager.selectedTab?.visibleURL as URL?)
     updateTabsBarVisibility()
@@ -692,170 +694,123 @@ extension BrowserViewController: TopToolbarDelegate {
     presentWalletPanel(from: origin, with: tabDappStore)
   }
 
-  private func hideSearchController() {
-    if let searchController = searchController {
-      searchController.willMove(toParent: nil)
-      searchController.view.removeFromSuperview()
-      searchController.removeFromParent()
-      self.searchController = nil
-      searchLoader = nil
-      favoritesController?.view.isHidden = false
-    }
-  }
-
-  private func showSearchController() {
-    if searchController != nil { return }
-
-    // Setting up data source for SearchSuggestions
-    let isPrivate = tabManager.selectedTab?.isPrivate ?? false
-    let searchDataSource = SearchSuggestionDataSource(
-      isPrivate: isPrivate,
-      isAIChatAvailable: !isPrivate && Preferences.AIChat.leoInQuickSearchBarEnabled.value
-        && AIChatUtils.isAIChatEnabled(for: profileController.profile.prefs),
-      isPlaylistAvailable: profileController.profile.prefs.isPlaylistAvailable,
-      searchEngines: profile.searchEngines
-    )
-
-    // Setting up controller for SearchSuggestions
-    searchController = SearchViewController(
-      with: searchDataSource,
-      browserColors: privateBrowsingManager.browserColors
-    )
-    searchController?.isUsingBottomBar = isUsingBottomBar
-    guard let searchController = searchController else { return }
-    searchController.setupSearchEngineList()
-    searchController.searchDelegate = self
-
-    searchLoader = SearchLoader(
-      historyAPI: profileController.historyAPI,
-      bookmarkManager: bookmarkManager,
-      tabManager: tabManager
-    )
-    searchLoader?.addListener(searchController)
-    searchLoader?.autocompleteSuggestionHandler = { [weak self] completion in
-      self?.topToolbar.setAutocompleteSuggestion(completion)
-    }
-
-    addChild(searchController)
-    if let favoritesController = favoritesController {
-      view.insertSubview(searchController.view, aboveSubview: favoritesController.view)
-    } else {
-      view.insertSubview(searchController.view, belowSubview: header)
-    }
-    searchController.view.snp.makeConstraints {
-      $0.edges.equalTo(view)
-    }
-    searchController.didMove(toParent: self)
-    searchController.view.setNeedsLayout()
-    searchController.view.layoutIfNeeded()
-
-    favoritesController?.view.isHidden = true
-  }
-
-  func insertFavoritesControllerView(favoritesController: FavoritesViewController) {
+  func insertSearchContainerView(_ searchContainer: SearchContainerViewController) {
     if let ntpController = self.activeNewTabPageViewController, ntpController.parent != nil {
-      view.insertSubview(favoritesController.view, aboveSubview: ntpController.view)
+      view.insertSubview(searchContainer.view, aboveSubview: ntpController.view)
     } else {
       // Two different behaviors here:
       // 1. For bottom bar we do not want to show the status bar color
       // 2. For top bar we do so it matches the address bar background
       let subview = isUsingBottomBar ? statusBarOverlay : footer
-      view.insertSubview(favoritesController.view, aboveSubview: subview)
+      view.insertSubview(searchContainer.view, aboveSubview: subview)
     }
   }
 
-  private func displayFavoritesController() {
-    if favoritesController == nil {
-      let dse = profile.searchEngines.defaultEngine(
-        forType: privateBrowsingManager.isPrivateBrowsing ? .privateMode : .standard
-      )
-      let favoritesController = FavoritesViewController(
+  /// Handles selection of a recent search in the favorites screen: seeds the URL bar and, when
+  /// requested, navigates. Passed to the search container as its favorites `recentSearchAction`.
+  private func handleRecentSearch(_ recentSearch: RecentSearch?, shouldSubmitSearch: Bool) {
+    let submitSearch = { [weak self] (text: String) in
+      if let fixupURL = URIFixup.getURL(text) {
+        self?.finishEditingAndSubmit(fixupURL)
+        return
+      }
+
+      self?.submitSearchText(text)
+    }
+
+    guard let recentSearch = recentSearch,
+      let searchType = RecentSearchType(rawValue: recentSearch.searchType)
+    else { return }
+
+    if shouldSubmitSearch {
+      recentSearch.update(dateAdded: Date())
+    }
+
+    switch searchType {
+    case .text:
+      if let text = recentSearch.text {
+        self.topToolbar.setLocation(text, search: false)
+        self.topToolbar(self.topToolbar, didEnterText: text)
+
+        if shouldSubmitSearch {
+          submitSearch(text)
+        }
+      }
+    case .website:
+      if let text = recentSearch.text {
+        self.topToolbar.setLocation(text, search: false)
+        self.topToolbar(self.topToolbar, didEnterText: text)
+
+        if shouldSubmitSearch {
+          if let urlString = recentSearch.websiteUrl,
+            let url = URL(string: urlString)
+          {
+            finishEditingAndSubmit(url)
+          } else {
+            submitSearch(text)
+          }
+        }
+      }
+    case .qrCode:
+      if let text = recentSearch.text {
+        self.topToolbar.setLocation(text, search: false)
+        self.topToolbar(self.topToolbar, didEnterText: text)
+
+        if shouldSubmitSearch {
+          submitSearch(text)
+        }
+      } else if let websiteUrl = recentSearch.websiteUrl {
+        self.topToolbar.setLocation(websiteUrl, search: false)
+        self.topToolbar(self.topToolbar, didEnterText: websiteUrl)
+
+        if shouldSubmitSearch {
+          submitSearch(websiteUrl)
+        }
+      }
+    }
+  }
+
+  private func displaySearchContainer() {
+    if searchContainer == nil {
+      let isPrivate = tabManager.selectedTab?.isPrivate ?? false
+      let container = SearchContainerViewController(
+        tabManager: tabManager,
+        bookmarkManager: bookmarkManager,
+        historyAPI: profileController.historyAPI,
+        searchEngines: profile.searchEngines,
         privateBrowsingManager: privateBrowsingManager,
-        defaultSearchEngine: dse,
+        isAIChatAvailable: !isPrivate && Preferences.AIChat.leoInQuickSearchBarEnabled.value
+          && AIChatUtils.isAIChatEnabled(for: profileController.profile.prefs),
+        isPlaylistAvailable: profileController.profile.prefs.isPlaylistAvailable,
+        searchDelegate: self,
+        autocompleteSuggestionHandler: { [weak self] completion in
+          self?.topToolbar.setAutocompleteSuggestion(completion)
+        },
         bookmarkAction: { [weak self] bookmark, action in
           self?.handleFavoriteAction(favorite: bookmark, action: action)
         },
         recentSearchAction: { [weak self] recentSearch, shouldSubmitSearch in
-          guard let self = self else { return }
-
-          let submitSearch = { [weak self] (text: String) in
-            if let fixupURL = URIFixup.getURL(text) {
-              self?.finishEditingAndSubmit(fixupURL)
-              return
-            }
-
-            self?.submitSearchText(text)
-          }
-
-          if let recentSearch = recentSearch,
-            let searchType = RecentSearchType(rawValue: recentSearch.searchType)
-          {
-            if shouldSubmitSearch {
-              recentSearch.update(dateAdded: Date())
-            }
-
-            switch searchType {
-            case .text:
-              if let text = recentSearch.text {
-                self.topToolbar.setLocation(text, search: false)
-                self.topToolbar(self.topToolbar, didEnterText: text)
-
-                if shouldSubmitSearch {
-                  submitSearch(text)
-                }
-              }
-            case .website:
-              if let text = recentSearch.text {
-                self.topToolbar.setLocation(text, search: false)
-                self.topToolbar(self.topToolbar, didEnterText: text)
-
-                if shouldSubmitSearch {
-                  if let urlString = recentSearch.websiteUrl,
-                    let url = URL(string: urlString)
-                  {
-                    finishEditingAndSubmit(url)
-                  } else {
-                    submitSearch(text)
-                  }
-                }
-              }
-            case .qrCode:
-              if let text = recentSearch.text {
-                self.topToolbar.setLocation(text, search: false)
-                self.topToolbar(self.topToolbar, didEnterText: text)
-
-                if shouldSubmitSearch {
-                  submitSearch(text)
-                }
-              } else if let websiteUrl = recentSearch.websiteUrl {
-                self.topToolbar.setLocation(websiteUrl, search: false)
-                self.topToolbar(self.topToolbar, didEnterText: websiteUrl)
-
-                if shouldSubmitSearch {
-                  submitSearch(websiteUrl)
-                }
-              }
-            }
-          }
+          self?.handleRecentSearch(recentSearch, shouldSubmitSearch: shouldSubmitSearch)
         }
       )
-      self.favoritesController = favoritesController
+      container.isUsingBottomBar = isUsingBottomBar
+      self.searchContainer = container
 
-      addChild(favoritesController)
-      insertFavoritesControllerView(favoritesController: favoritesController)
-      favoritesController.didMove(toParent: self)
+      addChild(container)
+      insertSearchContainerView(container)
+      container.didMove(toParent: self)
 
-      favoritesController.view.snp.makeConstraints {
+      container.view.snp.makeConstraints {
         $0.leading.trailing.equalTo(pageOverlayLayoutGuide)
         $0.top.bottom.equalTo(view)
       }
-      favoritesController.view.setNeedsLayout()
-      favoritesController.view.layoutIfNeeded()
+      container.view.setNeedsLayout()
+      container.view.layoutIfNeeded()
     }
-    guard let favoritesController = favoritesController else { return }
-    favoritesController.view.alpha = 0.0
+    guard let searchContainer else { return }
+    searchContainer.view.alpha = 0.0
     let animator = UIViewPropertyAnimator(duration: 0.2, dampingRatio: 1.0) {
-      favoritesController.view.alpha = 1
+      searchContainer.view.alpha = 1
     }
     animator.addCompletion { _ in
       self.webViewContainer.accessibilityElementsHidden = true
@@ -864,9 +819,9 @@ extension BrowserViewController: TopToolbarDelegate {
     animator.startAnimation()
   }
 
-  private func hideFavoritesController() {
-    guard let controller = favoritesController else { return }
-    self.favoritesController = nil
+  private func hideSearchContainer() {
+    guard let controller = searchContainer else { return }
+    self.searchContainer = nil
     UIView.animate(
       withDuration: 0.1,
       delay: 0,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -110,9 +110,9 @@ public class BrowserViewController: UIViewController {
   }()
 
   private(set) var toolbar: BottomToolbarView?
-  var searchLoader: SearchLoader?
-  var searchController: SearchViewController?
-  var favoritesController: FavoritesViewController?
+  /// The favorites/search-results screens shown while editing the URL bar. Builds and owns the
+  /// favorites, search-results and search-loader instances.
+  var searchContainer: SearchContainerViewController?
 
   /// All content that appears above the footer should be added to this view. (Find In Page/SnackBars)
   let alertStackView: UIStackView = {
@@ -645,9 +645,9 @@ public class BrowserViewController: UIViewController {
       && traitCollection.verticalSizeClass == .regular
       && traitCollection.userInterfaceIdiom == .phone
 
-    // Reinserts the fav controller whos parent is based on bottom bar
-    if let favoritesController {
-      insertFavoritesControllerView(favoritesController: favoritesController)
+    // Reinserts the search container whose parent is based on bottom bar
+    if let searchContainer {
+      insertSearchContainerView(searchContainer)
     }
   }
 
@@ -766,8 +766,7 @@ public class BrowserViewController: UIViewController {
       webViewContainerBackdrop.alpha = 1
       webViewContainer.alpha = 0
       activeNewTabPageViewController?.view.alpha = 0
-      favoritesController?.view.alpha = 0
-      searchController?.view.alpha = 0
+      searchContainer?.view.alpha = 0
       header.contentView.alpha = 0
       presentedViewController?.popoverPresentationController?.containerView?.alpha = 0
       presentedViewController?.view.alpha = 0
@@ -824,8 +823,7 @@ public class BrowserViewController: UIViewController {
         self.webViewContainer.alpha = 1
         self.header.contentView.alpha = 1
         self.activeNewTabPageViewController?.view.alpha = 1
-        self.favoritesController?.view.alpha = 1
-        self.searchController?.view.alpha = 1
+        self.searchContainer?.view.alpha = 1
         self.presentedViewController?.popoverPresentationController?.containerView?.alpha = 1
         self.presentedViewController?.view.alpha = 1
         self.view.backgroundColor = .clear
@@ -840,7 +838,7 @@ public class BrowserViewController: UIViewController {
     didSet {
       header.isUsingBottomBar = isUsingBottomBar
       collapsedURLBarView.isUsingBottomBar = isUsingBottomBar
-      searchController?.isUsingBottomBar = isUsingBottomBar
+      searchContainer?.isUsingBottomBar = isUsingBottomBar
       bottomBarKeyboardBackground.isHidden = !isUsingBottomBar
       topToolbar.displayTabTraySwipeGestureRecognizer?.isEnabled = isUsingBottomBar
       updateTabsBarVisibility()
@@ -1243,8 +1241,7 @@ public class BrowserViewController: UIViewController {
     } else {
       additionalInsets = .init(top: header.bounds.height, left: 0, bottom: 0, right: 0)
     }
-    searchController?.additionalSafeAreaInsets = additionalInsets
-    favoritesController?.additionalSafeAreaInsets = additionalInsets
+    searchContainer?.applyAdditionalSafeAreaInsets(additionalInsets)
   }
 
   override public var canBecomeFirstResponder: Bool {
@@ -2595,19 +2592,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
   }
 
   func presentQuickSearchEnginesViewController() {
-    let quickSearchEnginesViewController = SearchQuickEnginesViewController(profile: profile)
-    quickSearchEnginesViewController.navigationItem.leftBarButtonItem =
-      UIBarButtonItem(
-        title: Strings.close,
-        style: .done,
-        target: self,
-        action: #selector(dismissQuickSearchEngines)
-      )
-    quickSearchEnginesViewController.delegate = searchController
-    let navVC = ModalSettingsNavigationController(
-      rootViewController: quickSearchEnginesViewController
-    )
-    self.present(navVC, animated: true, completion: nil)
+    searchContainer?.presentQuickSearchEnginesViewController(profile: profile)
   }
 
   func searchViewController(
@@ -2632,13 +2617,6 @@ extension BrowserViewController: SearchViewControllerDelegate {
 
   func searchViewControllerHasPendingWidgetSearchAttribution(_: SearchViewController) -> Bool {
     tabManager.selectedTab?.widgetSearchTabHelper != nil
-  }
-
-  @objc private func dismissQuickSearchEngines() {
-    dismiss(animated: true) { [weak self] in
-      self?.updateViewConstraints()
-      self?.searchController?.layoutSearchEngineScrollView()
-    }
   }
 }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchContainerViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchContainerViewController.swift
@@ -1,0 +1,160 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveCore
+import BraveStrings
+import Data
+import SnapKit
+import UIKit
+import Web
+
+/// Hosts the favorites and search-results screens shown while editing the URL bar, showing the
+/// favorites screen while the query is empty and the search screen once the user starts typing.
+///
+/// Consolidates what were previously two independently-managed child controllers
+/// (`FavoritesViewController` and `SearchViewController`, plus a `SearchLoader`) into a single
+/// container so the browser only needs to build and track one object while editing the URL.
+class SearchContainerViewController: UIViewController {
+  private let favoritesController: FavoritesViewController
+  private let searchController: SearchViewController
+  private let searchLoader: SearchLoader
+
+  var isUsingBottomBar: Bool = false {
+    didSet {
+      searchController.isUsingBottomBar = isUsingBottomBar
+    }
+  }
+
+  init(
+    tabManager: TabManager,
+    bookmarkManager: BookmarkManager,
+    historyAPI: BraveHistoryAPI,
+    searchEngines: SearchEngines,
+    privateBrowsingManager: PrivateBrowsingManager,
+    isAIChatAvailable: Bool,
+    isPlaylistAvailable: Bool,
+    searchDelegate: SearchViewControllerDelegate,
+    autocompleteSuggestionHandler: @escaping (String?) -> Void,
+    bookmarkAction: @escaping (Favorite, BookmarksAction) -> Void,
+    recentSearchAction: @escaping (RecentSearch?, Bool) -> Void
+  ) {
+    let searchController = SearchViewController(
+      with: .init(
+        isPrivate: privateBrowsingManager.isPrivateBrowsing,
+        isAIChatAvailable: isAIChatAvailable,
+        isPlaylistAvailable: isPlaylistAvailable,
+        searchEngines: searchEngines
+      ),
+      browserColors: privateBrowsingManager.browserColors
+    )
+    searchController.searchDelegate = searchDelegate
+    self.searchController = searchController
+
+    let searchLoader = SearchLoader(
+      historyAPI: historyAPI,
+      bookmarkManager: bookmarkManager,
+      tabManager: tabManager
+    )
+    searchLoader.addListener(searchController)
+    searchLoader.autocompleteSuggestionHandler = autocompleteSuggestionHandler
+    self.searchLoader = searchLoader
+
+    self.favoritesController = FavoritesViewController(
+      privateBrowsingManager: privateBrowsingManager,
+      defaultSearchEngine: searchEngines.defaultEngine(
+        forType: privateBrowsingManager.isPrivateBrowsing ? .privateMode : .standard
+      ),
+      bookmarkAction: bookmarkAction,
+      recentSearchAction: recentSearchAction
+    )
+
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    view.backgroundColor = .clear
+
+    addChild(favoritesController)
+    view.addSubview(favoritesController.view)
+    favoritesController.view.snp.makeConstraints { $0.edges.equalTo(view) }
+    favoritesController.didMove(toParent: self)
+
+    addChild(searchController)
+    view.addSubview(searchController.view)
+    searchController.view.snp.makeConstraints { $0.edges.equalTo(view) }
+    searchController.didMove(toParent: self)
+
+    searchController.isUsingBottomBar = isUsingBottomBar
+    searchController.setupSearchEngineList()
+
+    showSearchResults(false)
+  }
+
+  /// Applies the given insets to both the favorites and search-results children so their content
+  /// clears the toolbar/header.
+  func applyAdditionalSafeAreaInsets(_ insets: UIEdgeInsets) {
+    favoritesController.additionalSafeAreaInsets = insets
+    searchController.additionalSafeAreaInsets = insets
+  }
+
+  /// Toggles between the favorites screen and the search-results screen.
+  func showSearchResults(_ show: Bool) {
+    searchController.view.isHidden = !show
+    favoritesController.view.isHidden = show
+  }
+
+  /// Drives the search results/suggestions for the given field text.
+  func setSearchQuery(query: String, showSearchSuggestions: Bool) {
+    searchController.setSearchQuery(
+      query: query,
+      showSearchSuggestions: showSearchSuggestions
+    )
+  }
+
+  /// The text used to drive the history/bookmarks/open-tabs autocomplete suggestions.
+  var searchLoaderQuery: String {
+    get { searchLoader.query }
+    set { searchLoader.query = newValue }
+  }
+
+  /// Forwards a hardware-keyboard command (arrow keys, etc.) to the search results.
+  func handleSearchKeyCommands(sender: UIKeyCommand) {
+    searchController.handleKeyCommands(sender: sender)
+  }
+
+  func presentQuickSearchEnginesViewController(profile: LegacyBrowserProfile) {
+    let quickSearchEnginesViewController = SearchQuickEnginesViewController(profile: profile)
+    quickSearchEnginesViewController.navigationItem.leftBarButtonItem =
+      UIBarButtonItem(
+        title: Strings.close,
+        style: .done,
+        target: self,
+        action: #selector(dismissQuickSearchEngines)
+      )
+    quickSearchEnginesViewController.delegate = searchController
+
+    let navVC = ModalSettingsNavigationController(
+      rootViewController: quickSearchEnginesViewController
+    )
+    self.present(navVC, animated: true, completion: nil)
+  }
+
+  @objc private func dismissQuickSearchEngines() {
+    dismiss(animated: true) {
+      self.reloadSearchEngineLayout()
+    }
+  }
+
+  /// Re-lays out the quick-search-engine row (e.g. after the settings screen is dismissed).
+  func reloadSearchEngineLayout() {
+    searchController.layoutSearchEngineScrollView()
+  }
+}


### PR DESCRIPTION
Adds a new child controller `SearchContainerViewController`, which now owns and manages the visibility of favorites/search controllers. This is a prerequisite to splitting the URL bar into separate display/input views.
