### PR TITLE
[iOS] Separate URL text field & display view hierarchies

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Callout.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Callout.swift
@@ -206,7 +206,7 @@ extension BrowserViewController {
     }
 
     if Preferences.DebugFlag.skipNTPCallouts == true || isOnboardingOrFullScreenCalloutPresented
-      || topToolbar.inOverlayMode
+      || isSearchContainerVisible
     {
       return false
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+KeyCommands.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+KeyCommands.swift
@@ -484,7 +484,7 @@ extension BrowserViewController {
     tabNavigationKeyCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }
     additionalPriorityCommandKeys.forEach { $0.wantsPriorityOverSystemBehavior = true }
 
-    if topToolbar.inOverlayMode {
+    if isSearchContainerVisible {
       keyCommandList.append(contentsOf: searchLocationCommands)
     }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Keyboard.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Keyboard.swift
@@ -19,9 +19,9 @@ extension BrowserViewController: KeyboardHelperDelegate {
       tabManager.selectedTab?.webViewProxy?.isKeyboardVisible == true
     let isKeyboardActiveForFindInPage = tabManager.selectedTab?.isFindNavigatorVisible == true
     let isBraveOriginatedKeyboard = state.isLocal
-    if isKeyboardActiveForWebContent || isKeyboardActiveForFindInPage, isBraveOriginatedKeyboard,
-      isUsingBottomBar
-    {
+    isBrowserContentKeyboardActive =
+      (isKeyboardActiveForWebContent || isKeyboardActiveForFindInPage) && isBraveOriginatedKeyboard
+    if isBrowserContentKeyboardActive, isUsingBottomBar {
       UIView.animate(withDuration: 0.1) { [self] in
         // We can't actually set the toolbar state to collapsed since bar collapsing/expanding is
         // based on many web view traits such as content size and such so we will just use the
@@ -55,6 +55,7 @@ extension BrowserViewController: KeyboardHelperDelegate {
     keyboardWillHideWithState state: KeyboardState
   ) {
     keyboardState = nil
+    isBrowserContentKeyboardActive = false
     // Always reset things after orientation change that may change bottom bar
     if isUsingBottomBar, !toolbarVisibilityViewModel.isEnabled {
       UIView.animate(withDuration: 0.1) { [self] in

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Onboarding.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Onboarding.swift
@@ -28,7 +28,7 @@ extension BrowserViewController {
     Preferences.AppState.shouldDeferPromotedPurchase.value = false
     iapObserver.savedPayment = nil
 
-    if !topToolbar.inOverlayMode,
+    if !isSearchContainerVisible,
       topToolbar.currentURL == nil,
       Preferences.DebugFlag.skipNTPCallouts != true
     {
@@ -65,7 +65,7 @@ extension BrowserViewController {
 
     // If a controller is already presented (such as menu), do not show onboarding
     // It also includes the case for overlay mode and tabtray opened
-    guard presentedViewController == nil, !topToolbar.inOverlayMode, !isTabTrayActive else {
+    guard presentedViewController == nil, !isSearchContainerVisible, !isTabTrayActive else {
       return
     }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Onboarding.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Onboarding.swift
@@ -64,7 +64,7 @@ extension BrowserViewController {
     }
 
     // If a controller is already presented (such as menu), do not show onboarding
-    // It also includes the case for overlay mode and tabtray opened
+    // It also includes the case for search visibility and tabtray opened
     guard presentedViewController == nil, !isSearchContainerVisible, !isTabTrayActive else {
       return
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -355,7 +355,7 @@ extension BrowserViewController: TabManagerDelegate {
     updateToolbarUsingTabManager(tabManager)
     // tabDelegate is a weak ref (and the tab's webView may not be destroyed yet)
     // so we don't expcitly unset it.
-    topToolbar.leaveOverlayMode(didCancel: true)
+    dismissSearchInput()
     updateTabsBarVisibility()
     tab.removeObserver(self)
     tab.removePolicyDecider(self)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -28,7 +28,7 @@ import os.log
 
 // MARK: - TopToolbarDelegate
 
-extension BrowserViewController: TopToolbarDelegate {
+extension BrowserViewController: TopToolbarDelegate, SearchContainerViewControllerDelegate {
 
   func showTabTray() {
     if tabManager.tabsForCurrentMode.isEmpty {
@@ -221,33 +221,13 @@ extension BrowserViewController: TopToolbarDelegate {
     }
   }
 
-  func topToolbar(_ topToolbar: TopToolbarView, didEnterText text: String) {
-    guard let searchContainer else { return }
-
-    searchContainer.showSearchResults(!text.isEmpty)
-
-    if text.isEmpty {
-      searchContainer.setSearchQuery(query: "", showSearchSuggestions: false)
-      searchContainer.searchLoaderQuery = ""
-    } else {
-      let locationLastReplacement = topToolbar.locationLastReplacement
-      let isPasting = topToolbar.isPastingInURLBar
-      Task {
-        let shouldShowSearchSuggestions = await URLBarHelper.shared.shouldShowSearchSuggestions(
-          using: locationLastReplacement,
-          isPasting: isPasting
-        )
-        searchContainer.setSearchQuery(
-          query: text,
-          showSearchSuggestions: shouldShowSearchSuggestions
-        )
-      }
-      searchContainer.searchLoaderQuery = text.lowercased()
-    }
-  }
-
-  func topToolbar(_ topToolbar: TopToolbarView, didSubmitText text: String) {
-    processAddressBar(text: text)
+  func topToolbarDidRequestSearchInput(
+    _ topToolbar: TopToolbarView,
+    initialText: String?,
+    pasted: Bool,
+    search: Bool
+  ) {
+    presentSearchInput(initialText: initialText, pasted: pasted, search: search)
   }
 
   func processAddressBar(
@@ -302,7 +282,7 @@ extension BrowserViewController: TopToolbarDelegate {
   ) async -> Bool {
 
     if let url = URL(string: text), url.scheme == "brave" || url.scheme == "chrome" {
-      topToolbar.leaveOverlayMode()
+      dismissSearchInput()
       finishEditingAndSubmit(url, isUserDefinedURLNavigation: isUserDefinedURLNavigation)
       return true
     }
@@ -313,7 +293,7 @@ extension BrowserViewController: TopToolbarDelegate {
 
     // check text is decentralized DNS supported domain
     if let decentralizedDNSHelper = self.decentralizedDNSHelperFor(url: fixupURL) {
-      topToolbar.leaveOverlayMode()
+      dismissSearchInput()
       updateToolbarCurrentURL(fixupURL)
       topToolbar.locationView.loading = true
       let result = await decentralizedDNSHelper.lookup(
@@ -346,20 +326,121 @@ extension BrowserViewController: TopToolbarDelegate {
     return true
   }
 
-  func topToolbarDidEnterOverlayMode(_ topToolbar: TopToolbarView) {
-    updateTabsBarVisibility()
-    displaySearchContainer()
+  var isSearchContainerVisible: Bool {
+    searchContainer?.parent == self
   }
 
-  func topToolbarDidLeaveOverlayMode(_ topToolbar: TopToolbarView) {
-    hideSearchContainer()
+  /// Presents the fullscreen search input over the browser. The toolbar and web view remain static.
+  ///
+  /// - Parameters:
+  ///   - initialText: The text to seed the input field with (the current URL or search query).
+  ///   - pasted: Whether the `initialText` was pasted (avoids highlighting the whole entry).
+  ///   - search: Whether `initialText` should be treated as a search query.
+  func presentSearchInput(initialText: String?, pasted: Bool, search: Bool) {
+    if let searchContainer {
+      // Already editing - just seed the existing input (e.g. from a QR scan) and refocus.
+      searchContainer.applyExternalQuery(initialText ?? "", search: search)
+      searchContainer.inputBar.becomeFirstResponder()
+      return
+    }
+
+    let isPrivate = tabManager.selectedTab?.isPrivate ?? false
+    let container = SearchContainerViewController(
+      tabManager: tabManager,
+      bookmarkManager: bookmarkManager,
+      historyAPI: profileController.historyAPI,
+      searchEngines: profile.searchEngines,
+      privateBrowsingManager: privateBrowsingManager,
+      speechRecognizer: speechRecognizer,
+      isAIChatAvailable: !isPrivate && Preferences.AIChat.leoInQuickSearchBarEnabled.value
+        && AIChatUtils.isAIChatEnabled(for: profileController.profile.prefs),
+      isPlaylistAvailable: profileController.profile.prefs.isPlaylistAvailable,
+      searchDelegate: self,
+      delegate: self,
+      bookmarkAction: { [weak self] bookmark, action in
+        self?.handleFavoriteAction(favorite: bookmark, action: action)
+      },
+      recentSearchAction: { [weak self] recentSearch, shouldSubmitSearch in
+        self?.handleRecentSearch(recentSearch, shouldSubmitSearch: shouldSubmitSearch)
+      }
+    )
+    container.isUsingBottomBar = isUsingBottomBar
+    self.searchContainer = container
+
+    // Presented fullscreen above the toolbar so the toolbar and web view remain static, and so the
+    // browser is never visible behind it (including with a hardware keyboard connected).
+    addChild(container)
+    view.addSubview(container.view)
+    container.view.snp.makeConstraints {
+      $0.edges.equalTo(view)
+    }
+    container.didMove(toParent: self)
+    container.view.setNeedsLayout()
+    container.view.layoutIfNeeded()
+
+    container.view.alpha = 0
+    UIViewPropertyAnimator.runningPropertyAnimator(withDuration: 0.1, delay: 0) {
+      container.view.alpha = 1
+    }
+
+    webViewContainer.accessibilityElementsHidden = true
+    UIAccessibility.post(notification: .screenChanged, argument: nil)
+
+    // Pasted content is treated as a search query so suggestions appear immediately, and is not
+    // selected (the cursor stays at the end).
+    container.beginEditing(
+      with: initialText,
+      search: pasted ? true : search,
+      selectAll: !pasted
+    )
+  }
+
+  /// Dismisses the fullscreen search input and restores the browsing UI.
+  func dismissSearchInput() {
+    guard isSearchContainerVisible else { return }
+
+    if let searchContainer {
+      searchContainer.inputBar.resignFirstResponder()
+      UIViewPropertyAnimator.runningPropertyAnimator(withDuration: 0.05, delay: 0) {
+        searchContainer.view.alpha = 0
+      } completion: { _ in
+        searchContainer.willMove(toParent: nil)
+        searchContainer.view.removeFromSuperview()
+        searchContainer.removeFromParent()
+      }
+    }
+    searchContainer = nil
+
+    webViewContainer.accessibilityElementsHidden = false
+    UIAccessibility.post(notification: .screenChanged, argument: nil)
+
     updateScreenTimeUrl(tabManager.selectedTab?.visibleURL)
     updateInContentHomePanel(tabManager.selectedTab?.visibleURL as URL?)
     updateTabsBarVisibility()
-    if isUsingBottomBar {
-      updateViewConstraints()
-    }
+    topToolbar.updateViewsForOverlayModeAndToolbarChanges()
     activeNewTabPageViewController?.urlBarDidLeaveOverlayMode()
+  }
+
+  // MARK: - SearchContainerViewControllerDelegate
+
+  func searchContainer(_ container: SearchContainerViewController, didSubmitText text: String) {
+    processAddressBar(text: text)
+  }
+
+  func searchContainerDidCancel(_ container: SearchContainerViewController) {
+    dismissSearchInput()
+  }
+
+  func searchContainerDidTapPasteAndGo(_ container: SearchContainerViewController) {
+    topToolbarDidPressPasteAndGoButton(topToolbar)
+  }
+
+  func searchContainerDidTapQRCode(_ container: SearchContainerViewController) {
+    scanQRCode()
+  }
+
+  func searchContainerDidTapVoiceSearch(_ container: SearchContainerViewController) {
+    topToolbarDidPressVoiceSearchButton(topToolbar)
   }
 
   func topToolbarDidBeginDragInteraction(_ topToolbar: TopToolbarView) {
@@ -660,9 +741,6 @@ extension BrowserViewController: TopToolbarDelegate {
       let searchQuery = UIPasteboard.general.string
         ?? UIPasteboard.general.url?.absoluteString
     {
-      self.topToolbar.setLocation(searchQuery, search: false)
-      self.topToolbar(self.topToolbar, didEnterText: searchQuery)
-
       if let fixupURL = URIFixup.getURL(searchQuery) {
         finishEditingAndSubmit(fixupURL)
         return
@@ -694,19 +772,7 @@ extension BrowserViewController: TopToolbarDelegate {
     presentWalletPanel(from: origin, with: tabDappStore)
   }
 
-  func insertSearchContainerView(_ searchContainer: SearchContainerViewController) {
-    if let ntpController = self.activeNewTabPageViewController, ntpController.parent != nil {
-      view.insertSubview(searchContainer.view, aboveSubview: ntpController.view)
-    } else {
-      // Two different behaviors here:
-      // 1. For bottom bar we do not want to show the status bar color
-      // 2. For top bar we do so it matches the address bar background
-      let subview = isUsingBottomBar ? statusBarOverlay : footer
-      view.insertSubview(searchContainer.view, aboveSubview: subview)
-    }
-  }
-
-  /// Handles selection of a recent search in the favorites screen: seeds the URL bar and, when
+  /// Handles selection of a recent search in the favorites screen: seeds the input field and, when
   /// requested, navigates. Passed to the search container as its favorites `recentSearchAction`.
   private func handleRecentSearch(_ recentSearch: RecentSearch?, shouldSubmitSearch: Bool) {
     let submitSearch = { [weak self] (text: String) in
@@ -729,8 +795,7 @@ extension BrowserViewController: TopToolbarDelegate {
     switch searchType {
     case .text:
       if let text = recentSearch.text {
-        self.topToolbar.setLocation(text, search: false)
-        self.topToolbar(self.topToolbar, didEnterText: text)
+        searchContainer?.applyExternalQuery(text, search: true)
 
         if shouldSubmitSearch {
           submitSearch(text)
@@ -738,8 +803,7 @@ extension BrowserViewController: TopToolbarDelegate {
       }
     case .website:
       if let text = recentSearch.text {
-        self.topToolbar.setLocation(text, search: false)
-        self.topToolbar(self.topToolbar, didEnterText: text)
+        searchContainer?.applyExternalQuery(text, search: true)
 
         if shouldSubmitSearch {
           if let urlString = recentSearch.websiteUrl,
@@ -753,90 +817,19 @@ extension BrowserViewController: TopToolbarDelegate {
       }
     case .qrCode:
       if let text = recentSearch.text {
-        self.topToolbar.setLocation(text, search: false)
-        self.topToolbar(self.topToolbar, didEnterText: text)
+        searchContainer?.applyExternalQuery(text, search: true)
 
         if shouldSubmitSearch {
           submitSearch(text)
         }
       } else if let websiteUrl = recentSearch.websiteUrl {
-        self.topToolbar.setLocation(websiteUrl, search: false)
-        self.topToolbar(self.topToolbar, didEnterText: websiteUrl)
+        searchContainer?.applyExternalQuery(websiteUrl, search: true)
 
         if shouldSubmitSearch {
           submitSearch(websiteUrl)
         }
       }
     }
-  }
-
-  private func displaySearchContainer() {
-    if searchContainer == nil {
-      let isPrivate = tabManager.selectedTab?.isPrivate ?? false
-      let container = SearchContainerViewController(
-        tabManager: tabManager,
-        bookmarkManager: bookmarkManager,
-        historyAPI: profileController.historyAPI,
-        searchEngines: profile.searchEngines,
-        privateBrowsingManager: privateBrowsingManager,
-        isAIChatAvailable: !isPrivate && Preferences.AIChat.leoInQuickSearchBarEnabled.value
-          && AIChatUtils.isAIChatEnabled(for: profileController.profile.prefs),
-        isPlaylistAvailable: profileController.profile.prefs.isPlaylistAvailable,
-        searchDelegate: self,
-        autocompleteSuggestionHandler: { [weak self] completion in
-          self?.topToolbar.setAutocompleteSuggestion(completion)
-        },
-        bookmarkAction: { [weak self] bookmark, action in
-          self?.handleFavoriteAction(favorite: bookmark, action: action)
-        },
-        recentSearchAction: { [weak self] recentSearch, shouldSubmitSearch in
-          self?.handleRecentSearch(recentSearch, shouldSubmitSearch: shouldSubmitSearch)
-        }
-      )
-      container.isUsingBottomBar = isUsingBottomBar
-      self.searchContainer = container
-
-      addChild(container)
-      insertSearchContainerView(container)
-      container.didMove(toParent: self)
-
-      container.view.snp.makeConstraints {
-        $0.leading.trailing.equalTo(pageOverlayLayoutGuide)
-        $0.top.bottom.equalTo(view)
-      }
-      container.view.setNeedsLayout()
-      container.view.layoutIfNeeded()
-    }
-    guard let searchContainer else { return }
-    searchContainer.view.alpha = 0.0
-    let animator = UIViewPropertyAnimator(duration: 0.2, dampingRatio: 1.0) {
-      searchContainer.view.alpha = 1
-    }
-    animator.addCompletion { _ in
-      self.webViewContainer.accessibilityElementsHidden = true
-      UIAccessibility.post(notification: .screenChanged, argument: nil)
-    }
-    animator.startAnimation()
-  }
-
-  private func hideSearchContainer() {
-    guard let controller = searchContainer else { return }
-    self.searchContainer = nil
-    UIView.animate(
-      withDuration: 0.1,
-      delay: 0,
-      options: [.beginFromCurrentState],
-      animations: {
-        controller.view.alpha = 0.0
-      },
-      completion: { _ in
-        controller.willMove(toParent: nil)
-        controller.view.removeFromSuperview()
-        controller.removeFromParent()
-        self.webViewContainer.accessibilityElementsHidden = false
-        UIAccessibility.post(notification: .screenChanged, argument: nil)
-      }
-    )
   }
 
   func openAddBookmark() {
@@ -1092,7 +1085,7 @@ extension BrowserViewController: UIContextMenuInteractionDelegate {
         identifier: .pasteAndGo,
         handler: UIAction.deferredActionHandler { _ in
           if let pasteboardContents = UIPasteboard.general.string {
-            self.topToolbar(self.topToolbar, didSubmitText: pasteboardContents)
+            self.processAddressBar(text: pasteboardContents)
           }
         }
       ),
@@ -1100,7 +1093,7 @@ extension BrowserViewController: UIContextMenuInteractionDelegate {
         identifier: .paste,
         handler: UIAction.deferredActionHandler { _ in
           if let pasteboardContents = UIPasteboard.general.string {
-            self.topToolbar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
+            self.presentSearchInput(initialText: pasteboardContents, pasted: true, search: true)
           }
         }
       ),

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -417,8 +417,8 @@ extension BrowserViewController: TopToolbarDelegate, SearchContainerViewControll
     updateScreenTimeUrl(tabManager.selectedTab?.visibleURL)
     updateInContentHomePanel(tabManager.selectedTab?.visibleURL as URL?)
     updateTabsBarVisibility()
-    topToolbar.updateViewsForOverlayModeAndToolbarChanges()
-    activeNewTabPageViewController?.urlBarDidLeaveOverlayMode()
+    topToolbar.updateViewsForToolbarChanges()
+    activeNewTabPageViewController?.searchContainerDidDismiss()
   }
 
   // MARK: - SearchContainerViewControllerDelegate

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Translate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Translate.swift
@@ -25,7 +25,7 @@ extension BrowserViewController: BraveTranslateScriptHandlerDelegate {
     }
 
     return Preferences.Translate.translateEnabled.value
-      && !topToolbar.inOverlayMode
+      && !isSearchContainerVisible
       && topToolbar.secureContentState == .secure
       && Preferences.Translate.translateURLBarOnboardingCount.value < 2
       && shouldShowTranslationOnboardingThisSession && presentedViewController == nil
@@ -79,7 +79,7 @@ extension BrowserViewController: BraveTranslateScriptHandlerDelegate {
   }
 
   func presentTranslateToast(tab: some TabState, languageInfo: BraveTranslateLanguageInfo) {
-    if presentedViewController != nil || topToolbar.inOverlayMode || tab !== tabManager.selectedTab
+    if presentedViewController != nil || isSearchContainerVisible || tab !== tabManager.selectedTab
     {
       return
     }
@@ -95,7 +95,7 @@ extension BrowserViewController: BraveTranslateScriptHandlerDelegate {
   }
 
   func presentTranslateError(tab: some TabState) {
-    if presentedViewController != nil || topToolbar.inOverlayMode || tab !== tabManager.selectedTab
+    if presentedViewController != nil || isSearchContainerVisible || tab !== tabManager.selectedTab
     {
       return
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -110,8 +110,8 @@ public class BrowserViewController: UIViewController {
   }()
 
   private(set) var toolbar: BottomToolbarView?
-  /// The favorites/search-results screens shown while editing the URL bar. Builds and owns the
-  /// favorites, search-results and search-loader instances.
+  /// The fullscreen editing surface (URL input + favorites/search screens) shown while editing the
+  /// URL. Builds and owns the favorites, search-results and search-loader instances.
   var searchContainer: SearchContainerViewController?
 
   /// All content that appears above the footer should be added to this view. (Find In Page/SnackBars)
@@ -193,6 +193,11 @@ public class BrowserViewController: UIViewController {
   var toolbarVisibilityCancellable: AnyCancellable?
 
   var keyboardState: KeyboardState?
+
+  /// Whether the keyboard currently up was presented by web content or find-in-page (as opposed to
+  /// the URL search input). In bottom-bar mode this drives collapsing the toolbar above the
+  /// keyboard; the search input never triggers it, keeping the toolbar and web view static.
+  var isBrowserContentKeyboardActive: Bool = false
 
   /// A toast that might be waiting for BVC to appear before displaying
   var pendingToast: Toast?
@@ -620,7 +625,7 @@ public class BrowserViewController: UIViewController {
     )
     notificationsHandler?.canShowNotifications = { [weak self] in
       guard let self = self else { return false }
-      return !self.privateBrowsingManager.isPrivateBrowsing && !self.topToolbar.inOverlayMode
+      return !self.privateBrowsingManager.isPrivateBrowsing && !self.isSearchContainerVisible
     }
     notificationsHandler?.actionOccured = { [weak self] ad, action in
       guard let self = self, let ad = ad else { return }
@@ -644,11 +649,6 @@ public class BrowserViewController: UIViewController {
       Preferences.General.isUsingBottomBar.value && traitCollection.horizontalSizeClass == .compact
       && traitCollection.verticalSizeClass == .regular
       && traitCollection.userInterfaceIdiom == .phone
-
-    // Reinserts the search container whose parent is based on bottom bar
-    if let searchContainer {
-      insertSearchContainerView(searchContainer)
-    }
   }
 
   public override func viewSafeAreaInsetsDidChange() {
@@ -742,7 +742,7 @@ public class BrowserViewController: UIViewController {
   }
 
   @objc private func tappedCollapsedURLBar() {
-    if keyboardState != nil && isUsingBottomBar && !topToolbar.inOverlayMode {
+    if keyboardState != nil && isUsingBottomBar && !isSearchContainerVisible {
       view.endEditing(true)
     } else {
       tappedTopArea()
@@ -1234,14 +1234,8 @@ public class BrowserViewController: UIViewController {
     // that safe area
     toolbarVisibilityViewModel.minimumCollapsableContentHeight =
       view.bounds.height - view.safeAreaInsets.top
-
-    var additionalInsets: UIEdgeInsets = .zero
-    if isUsingBottomBar {
-      additionalInsets = .init(top: 0, left: 0, bottom: topToolbar.bounds.height, right: 0)
-    } else {
-      additionalInsets = .init(top: header.bounds.height, left: 0, bottom: 0, right: 0)
-    }
-    searchContainer?.applyAdditionalSafeAreaInsets(additionalInsets)
+    // The favorites/search screens are hosted fullscreen by `searchContainer`, which manages their
+    // safe-area insets relative to the URL input bar.
   }
 
   override public var canBecomeFirstResponder: Bool {
@@ -1393,62 +1387,17 @@ public class BrowserViewController: UIViewController {
 
     header.snp.remakeConstraints { make in
       if self.isUsingBottomBar {
-        // Need to check Find In Page Bar is enabled in order to aligh it properly when bottom-bar is enabled
-        var shouldEvaluateKeyboardConstraints = false
-        var activeKeyboardHeight: CGFloat = 0
-        var searchEngineSettingsDismissed = false
-        var clearRecentSearchAlertDismissed = false
-
-        if let keyboardHeight = keyboardState?.intersectionHeightForView(self.view) {
-          activeKeyboardHeight = keyboardHeight
-        }
-
-        if let presentedNavigationController = presentedViewController
-          as? ModalSettingsNavigationController,
-          let presentedRootController = presentedNavigationController.viewControllers.first,
-          presentedRootController is SearchQuickEnginesViewController
+        // When web content or find-in-page presents the keyboard we collapse the URL bar and float
+        // it above the keyboard. The URL search input never triggers this, so the toolbar and web
+        // view stay static during URL editing.
+        let activeKeyboardHeight = keyboardState?.intersectionHeightForView(self.view) ?? 0
+        if isBrowserContentKeyboardActive, activeKeyboardHeight > 0, presentedViewController == nil
         {
-          searchEngineSettingsDismissed = true
-        }
-
-        if let alertController = presentedViewController
-          as? UIAlertController,
-          alertController.preferredStyle == .actionSheet,
-          let action = alertController.actions.first,
-          action.title == Strings.recentSearchClearAlertButton
-        {
-          clearRecentSearchAlertDismissed = true
-        }
-
-        // When the keyboard belongs to the browser (URL bar editing, or the collapsed keyboard
-        // mini-bar shown for web content / find-in-page), keep the bottom bar pinned above the
-        // keyboard even while an unrelated modal is presented (e.g. a download prompt or external
-        // app alert). Otherwise the bar drops back down underneath the keyboard and doesn't
-        // recover once the modal is dismissed.
-        let isBrowserKeyboardActive =
-          topToolbar.inOverlayMode || !toolbarVisibilityViewModel.isEnabled
-
-        shouldEvaluateKeyboardConstraints =
-          (activeKeyboardHeight > 0)
-          && (isBrowserKeyboardActive
-            || presentedViewController == nil
-            || searchEngineSettingsDismissed
-            || clearRecentSearchAlertDismissed
-            || presentedViewController is TabGridHostingController)
-
-        if shouldEvaluateKeyboardConstraints {
-          var offset = -activeKeyboardHeight
-          if !topToolbar.inOverlayMode {
-            // Showing collapsed URL bar while the keyboard is up
-            offset += toolbarVisibilityViewModel.transitionDistance
-          }
+          // Showing collapsed URL bar while the keyboard is up
+          let offset = -activeKeyboardHeight + toolbarVisibilityViewModel.transitionDistance
           make.bottom.equalTo(self.view).offset(offset)
         } else {
-          if topToolbar.inOverlayMode {
-            make.bottom.equalTo(self.view.safeArea.bottom)
-          } else {
-            make.bottom.equalTo(footer.snp.top)
-          }
+          make.bottom.equalTo(footer.snp.top)
         }
       } else {
         make.top.equalTo(toolbarLayoutGuide)
@@ -1511,11 +1460,6 @@ public class BrowserViewController: UIViewController {
         keyboardHeight > 0
       {
         if self.isUsingBottomBar {
-          var offset = -keyboardHeight
-          if !topToolbar.inOverlayMode {
-            // Showing collapsed URL bar while the keyboard is up
-            offset += toolbarVisibilityViewModel.transitionDistance
-          }
           make.bottom.equalTo(header.snp.top)
         } else {
           make.bottom.equalTo(self.view).offset(-keyboardHeight)
@@ -1626,7 +1570,7 @@ public class BrowserViewController: UIViewController {
       return false
     }()
 
-    if !topToolbar.inOverlayMode {
+    if !isSearchContainerVisible {
       guard let url = url else {
         hideActiveNewTabPageController()
         return
@@ -1664,7 +1608,7 @@ public class BrowserViewController: UIViewController {
         (tabManager.selectedTab?.webViewProxy?.isKeyboardVisible == true
           || tabManager.selectedTab?.isFindNavigatorVisible == true)
         && keyboardState?.isLocal == true
-      if isUsingBottomBar, topToolbar.inOverlayMode || isKeyboardActive {
+      if isUsingBottomBar, isKeyboardActive {
         return false
       }
       let tabCount = tabManager.tabsForCurrentMode.count
@@ -1749,7 +1693,7 @@ public class BrowserViewController: UIViewController {
   ///     user defined spot like Favourites or Bookmarks
   func finishEditingAndSubmit(_ url: URL, isUserDefinedURLNavigation: Bool = false) {
     if url.isBookmarklet {
-      topToolbar.leaveOverlayMode()
+      dismissSearchInput()
 
       guard let tab = tabManager.selectedTab else {
         return
@@ -1774,7 +1718,7 @@ public class BrowserViewController: UIViewController {
       }
     } else {
       updateToolbarCurrentURL(url)
-      topToolbar.leaveOverlayMode()
+      dismissSearchInput()
 
       guard let tab = tabManager.selectedTab else {
         return
@@ -1798,7 +1742,7 @@ public class BrowserViewController: UIViewController {
     if !profileController.braveWalletAPI.isAllowed {
       return
     }
-    topToolbar.leaveOverlayMode()
+    dismissSearchInput()
 
     guard let tab = tabManager.selectedTab,
       let encodedURL = originalURL.absoluteString.addingPercentEncoding(
@@ -1820,8 +1764,8 @@ public class BrowserViewController: UIViewController {
   }
 
   override public func accessibilityPerformEscape() -> Bool {
-    if topToolbar.inOverlayMode {
-      topToolbar.didClickCancel()
+    if isSearchContainerVisible {
+      dismissSearchInput()
       return true
     } else if let selectedTab = tabManager.selectedTab, selectedTab.canGoBack {
       selectedTab.goBack()
@@ -1936,7 +1880,7 @@ public class BrowserViewController: UIViewController {
   }
 
   func openURLInNewTab(_ url: URL?, isPrivate: Bool = false, isPrivileged: Bool) {
-    topToolbar.leaveOverlayMode(didCancel: true)
+    dismissSearchInput()
 
     if let selectedTab = tabManager.selectedTab {
       screenshotHelper.takeScreenshot(selectedTab)
@@ -1986,7 +1930,7 @@ public class BrowserViewController: UIViewController {
         // This let's the user spam the Cmd+T button without lots of responder changes.
         guard freshTab === self.tabManager.selectedTab else { return }
         if let text = searchText {
-          self.topToolbar.submitLocation(text)
+          self.processAddressBar(text: text)
         } else {
           self.focusURLBar()
         }
@@ -2061,8 +2005,8 @@ public class BrowserViewController: UIViewController {
 
     if currentViewController != self {
       _ = self.navigationController?.popViewController(animated: true)
-    } else if topToolbar.inOverlayMode {
-      topToolbar.didClickCancel()
+    } else if isSearchContainerVisible {
+      dismissSearchInput()
     }
   }
 
@@ -2301,7 +2245,7 @@ extension BrowserViewController {
     )
 
     popToBVC {
-      self.topToolbar.enterOverlayMode(overlayText, pasted: false, search: false)
+      self.presentSearchInput(initialText: overlayText, pasted: false, search: false)
     }
 
     if !url.isBookmarklet && !privateBrowsingManager.isPrivateBrowsing {
@@ -2404,7 +2348,7 @@ extension BrowserViewController: TabsBarViewControllerDelegate {
 
   func tabsBarDidSelectTab(_ tabsBarController: TabsBarViewController, _ tab: some TabState) {
     if tab === tabManager.selectedTab { return }
-    topToolbar.leaveOverlayMode(didCancel: true)
+    dismissSearchInput()
     tabManager.selectTab(tab)
   }
 
@@ -2551,7 +2495,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
     didSubmit query: String,
     braveSearchPromotion: Bool
   ) {
-    topToolbar.leaveOverlayMode()
+    dismissSearchInput()
     processAddressBar(text: query, isBraveSearchPromotion: braveSearchPromotion)
   }
 
@@ -2588,7 +2532,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
     _ searchViewController: SearchViewController,
     didLongPressSuggestion suggestion: String
   ) {
-    self.topToolbar.setLocation(suggestion, search: true)
+    searchContainer?.applyExternalQuery(suggestion, search: true)
   }
 
   func presentQuickSearchEnginesViewController() {
@@ -2600,14 +2544,14 @@ extension BrowserViewController: SearchViewControllerDelegate {
     didHighlightText text: String,
     search: Bool
   ) {
-    self.topToolbar.setLocation(text, search: search)
+    searchContainer?.applyExternalQuery(text, search: search)
   }
 
   func searchViewController(
     _ searchViewController: SearchViewController,
     shouldFindInPage query: String
   ) {
-    topToolbar.leaveOverlayMode()
+    dismissSearchInput()
     tabManager.selectedTab?.presentFindInteraction(with: query)
   }
 
@@ -2654,7 +2598,7 @@ extension BrowserViewController: ToolbarUrlActionsDelegate {
   }
 
   func openInNewTab(_ url: URL, isPrivate: Bool) {
-    topToolbar.leaveOverlayMode()
+    dismissSearchInput()
 
     select(url, action: .openInNewTab(isPrivate: isPrivate), isUserDefinedURLNavigation: false)
   }
@@ -2692,7 +2636,7 @@ extension BrowserViewController: ToolbarUrlActionsDelegate {
       } else {
         // If we are showing toptabs a user can just use the top tab bar
         // If in overlay mode switching doesnt correctly dismiss the homepanels
-        guard !topToolbar.inOverlayMode else {
+        guard !isSearchContainerVisible else {
           return
         }
         // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
@@ -2839,7 +2783,7 @@ extension BrowserViewController: NewTabPageDelegate {
 
   func showNewTabTakeoverInfoBarIfNeeded() {
     // do not show if topToobar is in overlay mode
-    guard !topToolbar.inOverlayMode,
+    guard !isSearchContainerVisible,
       rewards.ads.shouldDisplayNewTabTakeoverInfobar()
     else { return }
 
@@ -2860,7 +2804,7 @@ extension BrowserViewController: NewTabPageDelegate {
   }
 
   func isURLBarInOverlayMode() -> Bool {
-    return topToolbar.inOverlayMode
+    return isSearchContainerVisible
   }
 }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -603,7 +603,7 @@ public class BrowserViewController: UIViewController {
       if let originService = BraveOriginServiceFactory.get(profile: profileController.profile),
         await originService.checkPurchaseState()
       {
-        topToolbar.updateViewsForOverlayModeAndToolbarChanges()
+        topToolbar.updateViewsForToolbarChanges()
       }
     }
 
@@ -2635,7 +2635,7 @@ extension BrowserViewController: ToolbarUrlActionsDelegate {
         tabManager.selectTab(tab)
       } else {
         // If we are showing toptabs a user can just use the top tab bar
-        // If in overlay mode switching doesnt correctly dismiss the homepanels
+        // If the search container is visible switching doesnt correctly dismiss the homepanels
         guard !isSearchContainerVisible else {
           return
         }
@@ -2782,7 +2782,7 @@ extension BrowserViewController: NewTabPageDelegate {
   }
 
   func showNewTabTakeoverInfoBarIfNeeded() {
-    // do not show if topToobar is in overlay mode
+    // do not show if NTP is occluded by search
     guard !isSearchContainerVisible,
       rewards.ads.shouldDisplayNewTabTakeoverInfobar()
     else { return }
@@ -2803,7 +2803,7 @@ extension BrowserViewController: NewTabPageDelegate {
     self.show(toast: newTabTakeoverInfoBar, duration: nil)
   }
 
-  func isURLBarInOverlayMode() -> Bool {
+  func isNewTabPageOccluded() -> Bool {
     return isSearchContainerVisible
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
@@ -91,7 +91,7 @@ protocol NewTabPageDelegate: AnyObject {
   func brandedImageCalloutActioned(_ state: BrandedImageCalloutState)
   func showNTPOnboarding()
   func showNewTabTakeoverInfoBarIfNeeded()
-  func isURLBarInOverlayMode() -> Bool
+  func isNewTabPageOccluded() -> Bool
 }
 
 /// The new tab page. Shows users a variety of information, including stats and
@@ -528,7 +528,7 @@ class NewTabPageViewController: UIViewController {
   private func reportSponsoredBackgroundViewedEventIfNeeded() {
     // Only record a sponsored background viewed impression when the NTP
     // background is not covered by the URL bar overlay.
-    if delegate?.isURLBarInOverlayMode() == true {
+    if delegate?.isNewTabPageOccluded() == true {
       return
     }
 
@@ -1566,7 +1566,7 @@ extension NewTabPageViewController {
 
 // MARK: - URL bar overlay
 extension NewTabPageViewController {
-  func urlBarDidLeaveOverlayMode() {
+  func searchContainerDidDismiss() {
     reportSponsoredBackgroundViewedEventIfNeeded()
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchContainerViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchContainerViewController.swift
@@ -6,16 +6,29 @@ import BraveCore
 import BraveStrings
 import Data
 import SnapKit
+import SpeechRecognition
 import UIKit
 import Web
 
-/// Hosts the favorites and search-results screens shown while editing the URL bar, showing the
-/// favorites screen while the query is empty and the search screen once the user starts typing.
+/// Events forwarded from the URL input field to the browser.
+protocol SearchContainerViewControllerDelegate: AnyObject {
+  func searchContainer(_ container: SearchContainerViewController, didSubmitText text: String)
+  func searchContainerDidCancel(_ container: SearchContainerViewController)
+  func searchContainerDidTapPasteAndGo(_ container: SearchContainerViewController)
+  func searchContainerDidTapQRCode(_ container: SearchContainerViewController)
+  func searchContainerDidTapVoiceSearch(_ container: SearchContainerViewController)
+}
+
+/// The fullscreen editing surface presented when the user taps the URL bar.
 ///
-/// Consolidates what were previously two independently-managed child controllers
-/// (`FavoritesViewController` and `SearchViewController`, plus a `SearchLoader`) into a single
-/// container so the browser only needs to build and track one object while editing the URL.
+/// Owns the editable URL/search input field and builds and hosts both the favorites and
+/// search-results screens as children, showing the favorites screen while the query is empty and the
+/// search screen once the user starts typing. Both children fill the entire browser so nothing behind
+/// them is visible, including when a hardware keyboard is connected.
 class SearchContainerViewController: UIViewController {
+  weak var delegate: SearchContainerViewControllerDelegate?
+
+  let inputBar: SearchURLBarInputView
   private let favoritesController: FavoritesViewController
   private let searchController: SearchViewController
   private let searchLoader: SearchLoader
@@ -23,6 +36,8 @@ class SearchContainerViewController: UIViewController {
   var isUsingBottomBar: Bool = false {
     didSet {
       searchController.isUsingBottomBar = isUsingBottomBar
+      updateInputBarLayout()
+      updateChildInsets()
     }
   }
 
@@ -32,13 +47,16 @@ class SearchContainerViewController: UIViewController {
     historyAPI: BraveHistoryAPI,
     searchEngines: SearchEngines,
     privateBrowsingManager: PrivateBrowsingManager,
+    speechRecognizer: SpeechRecognizer,
     isAIChatAvailable: Bool,
     isPlaylistAvailable: Bool,
     searchDelegate: SearchViewControllerDelegate,
-    autocompleteSuggestionHandler: @escaping (String?) -> Void,
+    delegate: SearchContainerViewControllerDelegate,
     bookmarkAction: @escaping (Favorite, BookmarksAction) -> Void,
     recentSearchAction: @escaping (RecentSearch?, Bool) -> Void
   ) {
+    self.delegate = delegate
+
     let searchController = SearchViewController(
       with: .init(
         isPrivate: privateBrowsingManager.isPrivateBrowsing,
@@ -57,7 +75,6 @@ class SearchContainerViewController: UIViewController {
       tabManager: tabManager
     )
     searchLoader.addListener(searchController)
-    searchLoader.autocompleteSuggestionHandler = autocompleteSuggestionHandler
     self.searchLoader = searchLoader
 
     self.favoritesController = FavoritesViewController(
@@ -69,7 +86,18 @@ class SearchContainerViewController: UIViewController {
       recentSearchAction: recentSearchAction
     )
 
+    self.inputBar = SearchURLBarInputView(
+      privateBrowsingManager: privateBrowsingManager,
+      speechRecognizer: speechRecognizer
+    )
+
     super.init(nibName: nil, bundle: nil)
+
+    searchLoader.autocompleteSuggestionHandler = { [weak self] completion in
+      self?.setAutocompleteSuggestion(completion)
+    }
+    inputBar.actionDelegate = self
+    inputBar.textField.autocompleteDelegate = self
   }
 
   @available(*, unavailable)
@@ -82,47 +110,93 @@ class SearchContainerViewController: UIViewController {
 
     view.backgroundColor = .clear
 
-    addChild(favoritesController)
-    view.addSubview(favoritesController.view)
-    favoritesController.view.snp.makeConstraints { $0.edges.equalTo(view) }
-    favoritesController.didMove(toParent: self)
+    // Track the view's bottom edge (not the safe area) when the keyboard is down so the bottom-bar
+    // input field's background extends to the bottom of the screen behind the home indicator.
+    view.keyboardLayoutGuide.usesBottomSafeArea = false
 
     addChild(searchController)
     view.addSubview(searchController.view)
     searchController.view.snp.makeConstraints { $0.edges.equalTo(view) }
     searchController.didMove(toParent: self)
 
-    searchController.isUsingBottomBar = isUsingBottomBar
-    searchController.setupSearchEngineList()
+    addChild(favoritesController)
+    view.addSubview(favoritesController.view)
+    favoritesController.view.snp.makeConstraints { $0.edges.equalTo(view) }
+    favoritesController.didMove(toParent: self)
 
-    showSearchResults(false)
+    view.addSubview(inputBar)
+
+    // Favorites shows first; the search screen appears once the user types.
+    searchController.view.isHidden = true
+    favoritesController.view.isHidden = false
+
+    searchController.isUsingBottomBar = isUsingBottomBar
+    // Called after the search view is in the hierarchy so its engine row can be laid out.
+    searchController.setupSearchEngineList()
+    updateInputBarLayout()
   }
 
-  /// Applies the given insets to both the favorites and search-results children so their content
-  /// clears the toolbar/header.
-  func applyAdditionalSafeAreaInsets(_ insets: UIEdgeInsets) {
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    updateChildInsets()
+  }
+
+  private func updateInputBarLayout() {
+    inputBar.snp.remakeConstraints { make in
+      make.leading.trailing.equalTo(view)
+      if isUsingBottomBar {
+        make.bottom.equalTo(view.keyboardLayoutGuide.snp.top)
+      } else {
+        make.top.equalTo(view)
+      }
+    }
+  }
+
+  /// Insets the child screens so their content clears the input bar (which floats above the keyboard
+  /// in bottom-bar mode or sits at the top otherwise). The children handle keyboard avoidance for
+  /// their own content.
+  private func updateChildInsets() {
+    let inputBarHeight =
+      inputBar.bounds.height - inputBar.safeAreaInsets.top - inputBar.safeAreaInsets.bottom
+    let insets: UIEdgeInsets =
+      isUsingBottomBar
+      ? .init(top: 0, left: 0, bottom: inputBarHeight, right: 0)
+      : .init(top: inputBarHeight, left: 0, bottom: 0, right: 0)
     favoritesController.additionalSafeAreaInsets = insets
     searchController.additionalSafeAreaInsets = insets
   }
 
-  /// Toggles between the favorites screen and the search-results screen.
-  func showSearchResults(_ show: Bool) {
+  private func showSearchResults(_ show: Bool) {
     searchController.view.isHidden = !show
     favoritesController.view.isHidden = show
   }
 
-  /// Drives the search results/suggestions for the given field text.
-  func setSearchQuery(query: String, showSearchSuggestions: Bool) {
-    searchController.setSearchQuery(
-      query: query,
-      showSearchSuggestions: showSearchSuggestions
-    )
+  // MARK: - Editing
+
+  /// Focuses the input field, seeding it with the given text. `search: true` treats the text as a
+  /// search query; `false` treats it as a URL being edited. `selectAll` selects the seeded text.
+  func beginEditing(with text: String?, search: Bool, selectAll: Bool) {
+    // Defer becoming first responder so the field is in the hierarchy first and the search query
+    // fires while the field is editing.
+    DispatchQueue.main.async { [weak self] in
+      guard let self else { return }
+      self.inputBar.becomeFirstResponder()
+      self.inputBar.setLocation(text, search: search)
+    }
+    if selectAll {
+      DispatchQueue.main.async { [weak self] in
+        self?.inputBar.selectAllText()
+      }
+    }
   }
 
-  /// The text used to drive the history/bookmarks/open-tabs autocomplete suggestions.
-  var searchLoaderQuery: String {
-    get { searchLoader.query }
-    set { searchLoader.query = newValue }
+  /// Seeds the input field from an external source (recent search, suggestion long-press).
+  func applyExternalQuery(_ text: String, search: Bool) {
+    inputBar.setLocation(text, search: search)
+  }
+
+  func setAutocompleteSuggestion(_ suggestion: String?) {
+    inputBar.setAutocompleteSuggestion(suggestion)
   }
 
   /// Forwards a hardware-keyboard command (arrow keys, etc.) to the search results.
@@ -130,6 +204,7 @@ class SearchContainerViewController: UIViewController {
     searchController.handleKeyCommands(sender: sender)
   }
 
+  /// The delegate for the quick-search-engines settings screen.
   func presentQuickSearchEnginesViewController(profile: LegacyBrowserProfile) {
     let quickSearchEnginesViewController = SearchQuickEnginesViewController(profile: profile)
     quickSearchEnginesViewController.navigationItem.leftBarButtonItem =
@@ -156,5 +231,89 @@ class SearchContainerViewController: UIViewController {
   /// Re-lays out the quick-search-engine row (e.g. after the settings screen is dismissed).
   func reloadSearchEngineLayout() {
     searchController.layoutSearchEngineScrollView()
+  }
+
+  /// Drives the search results/suggestions for the current field text.
+  private func updateSearchResults(for text: String) {
+    if text.isEmpty {
+      searchController.setSearchQuery(query: "", showSearchSuggestions: false)
+      searchLoader.query = ""
+    } else {
+      Task {
+        let showSuggestions = await URLBarHelper.shared.shouldShowSearchSuggestions(
+          using: inputBar.textField.lastReplacement ?? "",
+          isPasting: inputBar.textField.isPasting
+        )
+        searchController.setSearchQuery(query: text, showSearchSuggestions: showSuggestions)
+        searchLoader.query = text.lowercased()
+      }
+    }
+  }
+}
+
+// MARK: - AutocompleteTextFieldDelegate
+
+extension SearchContainerViewController: AutocompleteTextFieldDelegate {
+  func autocompleteTextFieldShouldReturn(_ autocompleteTextField: AutocompleteTextField) -> Bool {
+    guard let text = autocompleteTextField.text else { return true }
+    if !text.trimmingCharacters(in: .whitespaces).isEmpty {
+      delegate?.searchContainer(self, didSubmitText: text)
+      return true
+    }
+    return false
+  }
+
+  func autocompleteTextField(
+    _ autocompleteTextField: AutocompleteTextField,
+    didEnterText text: String
+  ) {
+    showSearchResults(!text.isEmpty)
+    inputBar.updateLocationBarRightView(showToolbarActions: text.isEmpty)
+    updateSearchResults(for: text)
+  }
+
+  func autocompleteTextField(
+    _ autocompleteTextField: AutocompleteTextField,
+    didDeleteAutoSelectedText text: String
+  ) {
+    inputBar.updateLocationBarRightView(showToolbarActions: text.isEmpty)
+  }
+
+  func autocompleteTextFieldDidBeginEditing(_ autocompleteTextField: AutocompleteTextField) {
+    autocompleteTextField.highlightAll()
+    inputBar.updateLocationBarRightView(
+      showToolbarActions: autocompleteTextField.text?.isEmpty == true
+    )
+  }
+
+  func autocompleteTextFieldShouldClear(_ autocompleteTextField: AutocompleteTextField) -> Bool {
+    showSearchResults(false)
+    inputBar.updateLocationBarRightView(showToolbarActions: true)
+    updateSearchResults(for: "")
+    return true
+  }
+
+  func autocompleteTextFieldDidCancel(_ autocompleteTextField: AutocompleteTextField) {
+    delegate?.searchContainerDidCancel(self)
+  }
+}
+
+// MARK: - SearchURLBarInputViewDelegate
+
+extension SearchContainerViewController: SearchURLBarInputViewDelegate {
+  func searchURLBarInputViewDidTapCancel(_ inputView: SearchURLBarInputView) {
+    delegate?.searchContainerDidCancel(self)
+  }
+
+  func searchURLBarInputViewDidTapPasteAndGo(_ inputView: SearchURLBarInputView) {
+    delegate?.searchContainerDidTapPasteAndGo(self)
+  }
+
+  func searchURLBarInputViewDidTapQRCode(_ inputView: SearchURLBarInputView) {
+    delegate?.searchContainerDidTapQRCode(self)
+  }
+
+  func searchURLBarInputViewDidTapVoiceSearch(_ inputView: SearchURLBarInputView) {
+    delegate?.searchContainerDidTapVoiceSearch(self)
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchURLBarInputView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchURLBarInputView.swift
@@ -1,0 +1,313 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveUI
+import DesignSystem
+import Shared
+import SnapKit
+import SpeechRecognition
+import Then
+import UIKit
+
+/// Actions triggered by the buttons alongside the URL input field.
+protocol SearchURLBarInputViewDelegate: AnyObject {
+  func searchURLBarInputViewDidTapCancel(_ inputView: SearchURLBarInputView)
+  func searchURLBarInputViewDidTapPasteAndGo(_ inputView: SearchURLBarInputView)
+  func searchURLBarInputViewDidTapQRCode(_ inputView: SearchURLBarInputView)
+  func searchURLBarInputViewDidTapVoiceSearch(_ inputView: SearchURLBarInputView)
+}
+
+/// The editable URL/search input field shown by `SearchContainerViewController`.
+///
+/// Replaces the address entry that previously lived inside `TopToolbarView`, allowing the
+/// browser toolbar to remain static while the user edits the URL.
+class SearchURLBarInputView: UIView {
+  private struct UX {
+    static let locationPadding: CGFloat = 8
+    static let locationHeight: CGFloat = 44
+  }
+
+  weak var actionDelegate: SearchURLBarInputViewDelegate?
+
+  private let privateBrowsingManager: PrivateBrowsingManager
+  private let speechRecognizer: SpeechRecognizer
+
+  let textField: AutocompleteTextField
+
+  private lazy var searchImageView = UIImageView().then {
+    $0.image = UIImage(braveSystemNamed: "leo.search", compatibleWith: nil)
+    $0.contentMode = .scaleAspectFit
+    $0.tintColor = UIColor(braveSystemName: .iconDefault)
+    $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+    $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+    $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    $0.setContentHuggingPriority(.defaultHigh, for: .vertical)
+  }
+
+  private lazy var qrCodeButton = ToolbarButton().then {
+    $0.accessibilityIdentifier = "TabToolbar.qrCodeButton"
+    $0.isAccessibilityElement = true
+    $0.accessibilityLabel = Strings.quickActionScanQRCode
+    $0.setImage(UIImage(braveSystemNamed: "leo.qr.code", compatibleWith: nil), for: .normal)
+    $0.tintColor = UIColor(braveSystemName: .iconDefault)
+    $0.contentEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)
+    $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+    $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+    $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    $0.setContentHuggingPriority(.defaultHigh, for: .vertical)
+    $0.addTarget(self, action: #selector(didTapQRCodeButton), for: .touchUpInside)
+  }
+
+  private lazy var voiceSearchButton = ToolbarButton().then {
+    $0.accessibilityIdentifier = "TabToolbar.voiceSearchButton"
+    $0.isAccessibilityElement = true
+    $0.accessibilityLabel = Strings.tabToolbarVoiceSearchButtonAccessibilityLabel
+    $0.setImage(UIImage(braveSystemNamed: "leo.microphone", compatibleWith: nil), for: .normal)
+    $0.tintColor = UIColor(braveSystemName: .iconDefault)
+    $0.contentEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)
+    $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+    $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+    $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    $0.setContentHuggingPriority(.defaultHigh, for: .vertical)
+    $0.addTarget(self, action: #selector(didTapVoiceSearchButton), for: .touchUpInside)
+  }
+
+  private lazy var pasteAndGoButton = ToolbarButton().then {
+    $0.accessibilityIdentifier = "TabToolbar.pasteAndGoButton"
+    $0.isAccessibilityElement = true
+    $0.accessibilityLabel = Strings.tabToolbarPasteAndGoButtonAccessibilityLabel
+    $0.setImage(UIImage(braveSystemNamed: "leo.clipboard", compatibleWith: nil), for: .normal)
+    $0.tintColor = UIColor(braveSystemName: .iconDefault)
+    $0.isHidden = !UIPasteboard.general.hasStrings && !UIPasteboard.general.hasURLs
+    $0.contentEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)
+    $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+    $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+    $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    $0.setContentHuggingPriority(.defaultHigh, for: .vertical)
+    $0.addTarget(self, action: #selector(didTapPasteAndGoButton), for: .touchUpInside)
+  }
+
+  private lazy var optionsStackView = UIStackView().then {
+    $0.alignment = .center
+    $0.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 3)
+    $0.isLayoutMarginsRelativeArrangement = true
+    $0.insetsLayoutMarginsFromSafeArea = false
+  }
+
+  private lazy var cancelButton = InsetButton().then {
+    $0.setTitle(Strings.cancelButtonTitle, for: .normal)
+    $0.setTitleColor(UIColor(braveSystemName: .textSecondary), for: .normal)
+    $0.accessibilityIdentifier = "searchURLBarInputView-cancel"
+    $0.addTarget(self, action: #selector(didTapCancelButton), for: .touchUpInside)
+    $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+    $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+  }
+
+  private let locationContainer = LocationContainerView()
+
+  private let mainStackView = UIStackView().then {
+    $0.spacing = 8
+    $0.alignment = .center
+  }
+
+  init(privateBrowsingManager: PrivateBrowsingManager, speechRecognizer: SpeechRecognizer) {
+    self.privateBrowsingManager = privateBrowsingManager
+    self.speechRecognizer = speechRecognizer
+    self.textField = AutocompleteTextField(privateBrowsingManager: privateBrowsingManager)
+
+    super.init(frame: .zero)
+
+    textField.do {
+      $0.translatesAutoresizingMaskIntoConstraints = false
+      $0.keyboardType = .webSearch
+      $0.autocorrectionType = .no
+      $0.autocapitalizationType = .none
+      $0.smartDashesType = .no
+      $0.returnKeyType = .go
+      $0.clearButtonMode = .whileEditing
+      $0.textAlignment = .left
+      $0.font = .preferredFont(forTextStyle: .body)
+      $0.accessibilityIdentifier = "address"
+      $0.accessibilityLabel = Strings.URLBarViewLocationTextViewAccessibilityLabel
+      $0.rightViewMode = .never
+      if let dropInteraction = $0.textDropInteraction {
+        $0.removeInteraction(dropInteraction)
+      }
+    }
+
+    optionsStackView.addArrangedSubview(pasteAndGoButton)
+    if RecentSearchQRCodeScannerController.hasCameraSupport {
+      optionsStackView.addArrangedSubview(qrCodeButton)
+    }
+    optionsStackView.addArrangedSubview(voiceSearchButton)
+    voiceSearchButton.isHidden = !speechRecognizer.isVoiceSearchAvailable
+
+    let locationContentView = UIStackView(arrangedSubviews: [
+      searchImageView, textField, optionsStackView,
+    ]).then {
+      $0.layoutMargins = UIEdgeInsets(top: 2, left: 8, bottom: 2, right: 0)
+      $0.isLayoutMarginsRelativeArrangement = true
+      $0.insetsLayoutMarginsFromSafeArea = false
+      $0.spacing = 8
+      $0.setCustomSpacing(4, after: textField)
+    }
+
+    locationContainer.contentView.addSubview(locationContentView)
+    locationContentView.snp.makeConstraints {
+      $0.edges.equalTo(locationContainer).inset(
+        UIEdgeInsets(top: 0, left: UX.locationPadding, bottom: 0, right: UX.locationPadding)
+      )
+    }
+
+    locationContainer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+    // We need to create a small container view here to avoid corner adaption on iOS 26 from basing
+    // its required horizontal spacing based on the SearchURLBarInputView itself being constrained
+    // in the safe area (so that the background can render all the way to the edge). We then use
+    // this containers layout guide instead of the main views.
+    let contentView = UIView()
+    contentView.layoutMargins = .init(vertical: 8, horizontal: 12)
+    addSubview(contentView)
+    contentView.addSubview(mainStackView)
+    mainStackView.addArrangedSubview(locationContainer)
+    mainStackView.addArrangedSubview(cancelButton)
+
+    contentView.snp.makeConstraints {
+      $0.edges.equalTo(safeAreaLayoutGuide)
+    }
+
+    mainStackView.snp.makeConstraints {
+      if #available(iOS 26.0, *) {
+        $0.leading.trailing.equalTo(
+          contentView.layoutGuide(for: .margins(cornerAdaptation: .horizontal))
+        )
+      } else {
+        $0.leading.trailing.equalTo(contentView.layoutMarginsGuide)
+      }
+      $0.top.bottom.equalTo(contentView.layoutMarginsGuide)
+    }
+    locationContainer.snp.makeConstraints {
+      $0.height.greaterThanOrEqualTo(UX.locationHeight)
+    }
+
+    updateColors()
+    updateLocationBarRightView(showToolbarActions: true)
+  }
+
+  @available(*, unavailable)
+  required init(coder: NSCoder) {
+    fatalError()
+  }
+
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    let clampedTraitCollection = traitCollection.clampingSizeCategory(maximum: .accessibilityLarge)
+    textField.font = .preferredFont(forTextStyle: .body, compatibleWith: clampedTraitCollection)
+  }
+
+  private func makePlaceholder(colors: some BrowserColors) -> NSAttributedString {
+    NSAttributedString(
+      string: Strings.tabToolbarSearchAddressPlaceholderText,
+      attributes: [.foregroundColor: colors.textTertiary]
+    )
+  }
+
+  func updateColors() {
+    overrideUserInterfaceStyle = privateBrowsingManager.isPrivateBrowsing ? .dark : .unspecified
+    let browserColors = privateBrowsingManager.browserColors
+    backgroundColor = browserColors.chromeBackground
+    locationContainer.contentView.backgroundColor = browserColors.containerBackground
+    textField.backgroundColor = browserColors.containerBackground
+    textField.textColor = browserColors.textPrimary
+    textField.attributedPlaceholder = makePlaceholder(colors: browserColors)
+    for button in [qrCodeButton, voiceSearchButton, pasteAndGoButton] {
+      button.primaryTintColor = browserColors.iconDefault
+      button.disabledTintColor = browserColors.iconDisabled
+      button.selectedTintColor = browserColors.iconActive
+    }
+  }
+
+  /// Toggles the paste/QR/voice action buttons. They are only relevant when the field is empty.
+  func updateLocationBarRightView(showToolbarActions: Bool) {
+    optionsStackView.isHidden = !showToolbarActions
+
+    if RecentSearchQRCodeScannerController.hasCameraSupport {
+      qrCodeButton.isHidden = !showToolbarActions
+    } else {
+      qrCodeButton.isHidden = true
+    }
+
+    if speechRecognizer.isVoiceSearchAvailable {
+      voiceSearchButton.isHidden = !showToolbarActions
+    } else {
+      voiceSearchButton.isHidden = true
+    }
+
+    pasteAndGoButton.isHidden =
+      !showToolbarActions
+      || (!UIPasteboard.general.hasStrings && !UIPasteboard.general.hasURLs)
+  }
+
+  func setAutocompleteSuggestion(_ suggestion: String?) {
+    textField.setAutocompleteSuggestion(suggestion)
+  }
+
+  /// Sets the field text. When `search` is true the text is treated as a query and the search
+  /// pipeline is triggered; otherwise it is set as a URL being edited without searching.
+  func setLocation(_ location: String?, search: Bool) {
+    guard let text = location, !text.isEmpty else {
+      textField.text = location
+      updateLocationBarRightView(showToolbarActions: true)
+      return
+    }
+
+    updateLocationBarRightView(showToolbarActions: false)
+
+    if search {
+      textField.text = text
+      // Seeding `text` programmatically does not fire `AutocompleteTextField`'s change
+      // notification (it only fires for real keystrokes), so notify the delegate explicitly to
+      // drive the search.
+      textField.autocompleteDelegate?.autocompleteTextField(textField, didEnterText: text)
+    } else {
+      textField.setTextWithoutSearching(text)
+    }
+  }
+
+  @discardableResult
+  override func becomeFirstResponder() -> Bool {
+    return textField.becomeFirstResponder()
+  }
+
+  /// Selects the entire entry so the user can type over the seeded text.
+  func selectAllText() {
+    textField.selectedTextRange = textField.textRange(
+      from: textField.beginningOfDocument,
+      to: textField.endOfDocument
+    )
+  }
+
+  @discardableResult
+  override func resignFirstResponder() -> Bool {
+    return textField.resignFirstResponder()
+  }
+
+  // MARK: - Actions
+
+  @objc private func didTapCancelButton() {
+    actionDelegate?.searchURLBarInputViewDidTapCancel(self)
+  }
+
+  @objc private func didTapPasteAndGoButton() {
+    actionDelegate?.searchURLBarInputViewDidTapPasteAndGo(self)
+  }
+
+  @objc private func didTapQRCodeButton() {
+    actionDelegate?.searchURLBarInputViewDidTapQRCode(self)
+  }
+
+  @objc private func didTapVoiceSearchButton() {
+    actionDelegate?.searchURLBarInputViewDidTapVoiceSearch(self)
+  }
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/LocationContainerView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/LocationContainerView.swift
@@ -1,0 +1,71 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import UIKit
+
+/// The rounded container view hosting the URL/search bar contents, shared by `TopToolbarView` and
+/// `SearchURLBarInputView`.
+///
+/// UIKit only supports a single shadow per layer, but the location bar's design calls for two
+/// stacked shadows, so a second, background view is used to render the additional shadow behind
+/// `contentView`.
+class LocationContainerView: UIView {
+  /// The visible container that should host the location/search bar's contents.
+  let contentView = UIView().then {
+    $0.backgroundColor = .clear
+    $0.layer.cornerCurve = .continuous
+    $0.layer.shadowOffset = .init(width: 0, height: 1)
+    $0.layer.shadowRadius = 2
+    $0.layer.shadowColor = UIColor.black.cgColor
+    $0.layer.shadowOpacity = 0.1
+  }
+
+  // `contentView` has a second shadow but we can't apply 2 shadows on the same layer in UIKit,
+  // so adding a second view behind it.
+  private let secondShadowView = UIView().then {
+    $0.backgroundColor = .clear
+    $0.layer.cornerCurve = .continuous
+    $0.layer.shadowOffset = .init(width: 0, height: 4)
+    $0.layer.shadowRadius = 16
+    $0.layer.shadowOpacity = 0.08
+    $0.layer.shadowColor = UIColor.black.cgColor
+    $0.isUserInteractionEnabled = false
+  }
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    backgroundColor = .clear
+    addSubview(secondShadowView)
+    addSubview(contentView)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError()
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+
+    let cornerRadius = 10.0
+
+    contentView.frame = bounds
+    secondShadowView.frame = bounds
+
+    contentView.layer.cornerRadius = cornerRadius
+    secondShadowView.layer.cornerRadius = cornerRadius
+
+    contentView.layer.shadowPath =
+      UIBezierPath(
+        roundedRect: contentView.bounds.insetBy(dx: 1, dy: 1),  // -1 spread in Figma
+        cornerRadius: cornerRadius
+      ).cgPath
+    secondShadowView.layer.shadowPath =
+      UIBezierPath(
+        roundedRect: secondShadowView.bounds.insetBy(dx: 2, dy: 2),  // -2 spread in Figma
+        cornerRadius: cornerRadius
+      ).cgPath
+  }
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -493,7 +493,6 @@ class TabLocationView: UIView {
 
   private func updateColors() {
     let browserColors = privateBrowsingManager.browserColors
-    backgroundColor = browserColors.containerBackground
     urlDisplayLabel.textColor = browserColors.textPrimary
     placeholderLabel.textColor = browserColors.textTertiary
     readerModeButton.unselectedTintColor = browserColors.iconDefault

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -25,11 +25,15 @@ protocol TopToolbarDelegate: AnyObject {
     action: PlaylistURLBarButton.MenuAction
   )
   func topToolbarDidPressTranslateButton(_ urlBar: TopToolbarView)
-  func topToolbarDidEnterOverlayMode(_ topToolbar: TopToolbarView)
-  func topToolbarDidLeaveOverlayMode(_ topToolbar: TopToolbarView)
+  /// The user tapped the location bar to begin editing the URL. The receiver should present the
+  /// search input rather than mutating the toolbar.
+  func topToolbarDidRequestSearchInput(
+    _ topToolbar: TopToolbarView,
+    initialText: String?,
+    pasted: Bool,
+    search: Bool
+  )
   func topToolbarDidPressScrollToTop(_ topToolbar: TopToolbarView)
-  func topToolbar(_ topToolbar: TopToolbarView, didEnterText text: String)
-  func topToolbar(_ topToolbar: TopToolbarView, didSubmitText text: String)
   // Returns either (search query, true) or (url, false).
   func topToolbarDisplayTextForURL(_ url: URL?) -> (String?, Bool)
   func topToolbarDidBeginDragInteraction(_ topToolbar: TopToolbarView)
@@ -99,12 +103,6 @@ class TopToolbarView: UIView, ToolbarProtocol {
 
   private var toolbarIsShowing = false
 
-  /// Overlay mode is the state where the lock/reader icons are hidden, the home panels are shown,
-  /// and the Cancel button is visible (allowing the user to leave overlay mode). Overlay mode
-  /// is *not* tied to the location text field's editing state; for instance, when selecting
-  /// a panel, the first responder will be resigned, yet the overlay mode UI is still active.
-  var inOverlayMode = false
-
   var currentURL: URL? {
     get { return locationView.url as URL? }
 
@@ -123,21 +121,11 @@ class TopToolbarView: UIView, ToolbarProtocol {
     didSet {
       if oldValue == isURLBarEnabled { return }
 
-      locationTextField?.isUserInteractionEnabled = isURLBarEnabled
+      locationView.isUserInteractionEnabled = isURLBarEnabled
     }
   }
 
-  var locationLastReplacement: String {
-    locationTextField?.lastReplacement ?? ""
-  }
-
-  var isPastingInURLBar: Bool {
-    locationTextField?.isPasting == true
-  }
-
   // MARK: Views
-
-  private var locationTextField: AutocompleteTextField?
 
   lazy var locationView = TabLocationView(
     speechRecognizer: speechRecognizer,
@@ -154,15 +142,6 @@ class TopToolbarView: UIView, ToolbarProtocol {
   }
 
   let tabsButton = TabsButton()
-
-  private lazy var cancelButton = InsetButton().then {
-    $0.setTitle(Strings.cancelButtonTitle, for: .normal)
-    $0.setTitleColor(UIColor(braveSystemName: .textSecondary), for: .normal)
-    $0.accessibilityIdentifier = "topToolbarView-cancel"
-    $0.addTarget(self, action: #selector(didClickCancel), for: .touchUpInside)
-    $0.setContentCompressionResistancePriority(.required, for: .horizontal)
-    $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-  }
 
   private lazy var scrollToTopButton = UIButton().then {
     $0.addTarget(self, action: #selector(tappedScrollToTopArea), for: .touchUpInside)
@@ -265,34 +244,6 @@ class TopToolbarView: UIView, ToolbarProtocol {
     }
   }
 
-  private var locationTextContentView: UIStackView?
-
-  private lazy var qrCodeButton = ToolbarButton().then {
-    $0.accessibilityIdentifier = "TabToolbar.qrCodeButton"
-    $0.isAccessibilityElement = true
-    $0.accessibilityLabel = Strings.quickActionScanQRCode
-    $0.setImage(UIImage(braveSystemNamed: "leo.qr.code", compatibleWith: nil), for: .normal)
-    $0.tintColor = UIColor(braveSystemName: .iconDefault)
-    $0.contentEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)
-    $0.setContentCompressionResistancePriority(.required, for: .horizontal)
-    $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
-    $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-    $0.setContentHuggingPriority(.defaultHigh, for: .vertical)
-  }
-
-  private lazy var voiceSearchButton = ToolbarButton().then {
-    $0.accessibilityIdentifier = "TabToolbar.voiceSearchButton"
-    $0.isAccessibilityElement = true
-    $0.accessibilityLabel = Strings.tabToolbarVoiceSearchButtonAccessibilityLabel
-    $0.setImage(UIImage(braveSystemNamed: "leo.microphone", compatibleWith: nil), for: .normal)
-    $0.tintColor = UIColor(braveSystemName: .iconDefault)
-    $0.contentEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)
-    $0.setContentCompressionResistancePriority(.required, for: .horizontal)
-    $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
-    $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-    $0.setContentHuggingPriority(.defaultHigh, for: .vertical)
-  }
-
   private(set) lazy var shieldsButton: ToolbarButton = {
     let button = ToolbarButton()
     button.setImage(UIImage(sharedNamed: "brave.logo"), for: .normal)
@@ -312,56 +263,8 @@ class TopToolbarView: UIView, ToolbarProtocol {
     return button
   }()
 
-  private lazy var pasteAndGoButton = ToolbarButton().then {
-    $0.accessibilityIdentifier = "TabToolbar.pasteAndGoButton"
-    $0.isAccessibilityElement = true
-    $0.accessibilityLabel = Strings.tabToolbarPasteAndGoButtonAccessibilityLabel
-    $0.setImage(UIImage(braveSystemNamed: "leo.clipboard", compatibleWith: nil), for: .normal)
-    $0.tintColor = UIColor(braveSystemName: .iconDefault)
-    $0.isHidden = !UIPasteboard.general.hasStrings && !UIPasteboard.general.hasURLs
-    $0.contentEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)
-    $0.setContentCompressionResistancePriority(.required, for: .horizontal)
-    $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
-    $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-    $0.setContentHuggingPriority(.defaultHigh, for: .vertical)
-  }
-
-  private lazy var locationBarOptionsStackView = UIStackView().then {
-    $0.alignment = .center
-    $0.isHidden = true
-    $0.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 3)
-    $0.isLayoutMarginsRelativeArrangement = true
-    $0.insetsLayoutMarginsFromSafeArea = false
-  }
-
-  private lazy var searchImageView = UIImageView().then {
-    $0.image = UIImage(braveSystemNamed: "leo.search", compatibleWith: nil)
-    $0.contentMode = .scaleAspectFit
-    $0.tintColor = UIColor(braveSystemName: .iconDefault)
-    $0.setContentCompressionResistancePriority(.required, for: .horizontal)
-    $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
-    $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-    $0.setContentHuggingPriority(.defaultHigh, for: .vertical)
-  }
-
-  lazy var locationContainer = UIView().then {
+  lazy var locationContainer = LocationContainerView().then {
     $0.translatesAutoresizingMaskIntoConstraints = false
-    $0.backgroundColor = .clear
-    $0.layer.cornerRadius = UX.textFieldCornerRadius
-    $0.layer.cornerCurve = .continuous
-    $0.layer.shadowOffset = .init(width: 0, height: 1)
-    $0.layer.shadowRadius = 2
-    $0.layer.shadowColor = UIColor.black.cgColor
-    $0.layer.shadowOpacity = 0.1
-  }
-
-  // The location container has a second shadow but we can't apply 2 shadows in UIKit, so adding a second view
-  private let secondLocationShadowView = UIView().then {
-    $0.backgroundColor = .clear
-    $0.layer.shadowOffset = .init(width: 0, height: 4)
-    $0.layer.shadowRadius = 16
-    $0.layer.shadowOpacity = 0.08
-    $0.layer.shadowColor = UIColor.black.cgColor
   }
 
   private var speechRecognizer: SpeechRecognizer
@@ -374,10 +277,9 @@ class TopToolbarView: UIView, ToolbarProtocol {
 
     super.init(frame: .zero)
 
-    addSubview(secondLocationShadowView)
-    locationContainer.addSubview(locationView)
+    locationContainer.contentView.addSubview(locationView)
 
-    [scrollToTopButton, tabsButton, cancelButton].forEach(addSubview(_:))
+    [scrollToTopButton, tabsButton].forEach(addSubview(_:))
     addSubview(mainStackView)
 
     helper = ToolbarHelper(toolbar: self)
@@ -417,7 +319,6 @@ class TopToolbarView: UIView, ToolbarProtocol {
 
     [
       leadingItemsStackView, locationContainer, shieldsRewardsStack, trailingItemsStackView,
-      cancelButton,
     ].forEach {
       mainStackView.addArrangedSubview($0)
     }
@@ -444,16 +345,6 @@ class TopToolbarView: UIView, ToolbarProtocol {
       })
       .store(in: &cancellables)
 
-    speechRecognizer.objectWillChange
-      .receive(on: RunLoop.main)
-      .sink { [weak self] in
-        guard let self else { return }
-        updateLocationBarRightView(
-          showToolbarActions: locationView.urlDisplayLabel.text?.isEmpty == true
-        )
-      }
-      .store(in: &cancellables)
-
     updateURLBarButtonsVisibility()
     helper?.updateForTraitCollection(
       traitCollection,
@@ -476,22 +367,6 @@ class TopToolbarView: UIView, ToolbarProtocol {
     locationView.addInteraction(dragInteraction)
 
     self.displayTabTraySwipeGestureRecognizer = swipeGestureRecognizer
-
-    qrCodeButton.addTarget(
-      self,
-      action: #selector(topToolbarDidPressQrCodeButton),
-      for: .touchUpInside
-    )
-    voiceSearchButton.addTarget(
-      self,
-      action: #selector(topToolbarDidPressVoiceSearchButton),
-      for: .touchUpInside
-    )
-    pasteAndGoButton.addTarget(
-      self,
-      action: #selector(topToolbarDidPressPasteAndGoButton),
-      for: .touchUpInside
-    )
 
     updateColors()
   }
@@ -524,11 +399,6 @@ class TopToolbarView: UIView, ToolbarProtocol {
     rewardsButton.snp.remakeConstraints {
       $0.size.equalTo(pointSize)
     }
-    let clampedTraitCollection = traitCollection.clampingSizeCategory(maximum: .accessibilityLarge)
-    locationTextField?.font = .preferredFont(
-      forTextStyle: .body,
-      compatibleWith: clampedTraitCollection
-    )
   }
 
   private func setupConstraints() {
@@ -567,116 +437,13 @@ class TopToolbarView: UIView, ToolbarProtocol {
       bottom: 0,
       right: horizontalInset
     )
-
-    locationContainer.layoutIfNeeded()
-    locationContainer.layer.shadowPath =
-      UIBezierPath(
-        roundedRect: locationContainer.bounds.insetBy(dx: 1, dy: 1),  // -1 spread in Figma
-        cornerRadius: locationContainer.layer.cornerRadius
-      ).cgPath
-
-    secondLocationShadowView.frame = locationContainer.frame
-    secondLocationShadowView.layer.shadowPath =
-      UIBezierPath(
-        roundedRect: secondLocationShadowView.bounds.insetBy(dx: 2, dy: 2),  // -2 spread in Figma
-        cornerRadius: locationContainer.layer.cornerRadius
-      ).cgPath
-  }
-
-  override func becomeFirstResponder() -> Bool {
-    return self.locationTextField?.becomeFirstResponder() ?? false
-  }
-
-  private func makePlaceholder(colors: some BrowserColors) -> NSAttributedString {
-    NSAttributedString(
-      string: Strings.tabToolbarSearchAddressPlaceholderText,
-      attributes: [.foregroundColor: colors.textTertiary]
-    )
   }
 
   private func updateColors() {
     overrideUserInterfaceStyle = privateBrowsingManager.isPrivateBrowsing ? .dark : .unspecified
     let browserColors = privateBrowsingManager.browserColors
     backgroundColor = browserColors.chromeBackground
-    locationTextField?.backgroundColor = browserColors.containerBackground
-    locationTextField?.textColor = browserColors.textPrimary
-    locationTextField?.attributedPlaceholder = makePlaceholder(colors: browserColors)
-    for button in [qrCodeButton, voiceSearchButton, pasteAndGoButton] {
-      button.primaryTintColor = browserColors.iconDefault
-      button.disabledTintColor = browserColors.iconDisabled
-      button.selectedTintColor = browserColors.iconActive
-    }
-  }
-
-  /// Created whenever the location bar on top is selected
-  /// it is "converted" from static to actual TextField
-  private func createLocationTextFieldContainer() {
-    guard locationTextField == nil else { return }
-
-    locationTextField = AutocompleteTextField(privateBrowsingManager: privateBrowsingManager)
-
-    guard let locationTextField = locationTextField else { return }
-
-    locationTextField.do {
-      $0.backgroundColor = privateBrowsingManager.browserColors.containerBackground
-      $0.textColor = privateBrowsingManager.browserColors.textPrimary
-      $0.translatesAutoresizingMaskIntoConstraints = false
-      $0.autocompleteDelegate = self
-      $0.keyboardType = .webSearch
-      $0.autocorrectionType = .no
-      $0.autocapitalizationType = .none
-      $0.smartDashesType = .no
-      $0.returnKeyType = .go
-      $0.clearButtonMode = .whileEditing
-      $0.textAlignment = .left
-      $0.font = .preferredFont(forTextStyle: .body)
-      $0.accessibilityIdentifier = "address"
-      $0.accessibilityLabel = Strings.URLBarViewLocationTextViewAccessibilityLabel
-      $0.attributedPlaceholder = self.makePlaceholder(colors: .standard)
-      $0.clearButtonMode = .whileEditing
-      $0.rightViewMode = .never
-      if let dropInteraction = $0.textDropInteraction {
-        $0.removeInteraction(dropInteraction)
-      }
-    }
-
-    locationBarOptionsStackView.addArrangedSubview(pasteAndGoButton)
-    if RecentSearchQRCodeScannerController.hasCameraSupport {
-      locationBarOptionsStackView.addArrangedSubview(qrCodeButton)
-    }
-    locationBarOptionsStackView.addArrangedSubview(voiceSearchButton)
-    voiceSearchButton.isHidden = !speechRecognizer.isVoiceSearchAvailable
-
-    let subviews = [searchImageView, locationTextField, locationBarOptionsStackView]
-    locationTextContentView = UIStackView(arrangedSubviews: subviews).then {
-      $0.layoutMargins = UIEdgeInsets(top: 2, left: 8, bottom: 2, right: 0)
-      $0.isLayoutMarginsRelativeArrangement = true
-      $0.insetsLayoutMarginsFromSafeArea = false
-      $0.spacing = 8
-      $0.setCustomSpacing(4, after: locationTextField)
-    }
-
-    guard let locationTextContentView = locationTextContentView else { return }
-
-    locationContainer.addSubview(locationTextContentView)
-
-    locationTextContentView.snp.remakeConstraints {
-      let insets = UIEdgeInsets(
-        top: 0,
-        left: UX.locationPadding,
-        bottom: 0,
-        right: UX.locationPadding
-      )
-      $0.edges.equalTo(locationContainer).inset(insets)
-    }
-  }
-
-  private func removeLocationTextField() {
-    locationTextContentView?.removeFromSuperview()
-    locationTextContentView = nil
-
-    locationTextField?.removeFromSuperview()
-    locationTextField = nil
+    locationContainer.contentView.backgroundColor = browserColors.containerBackground
   }
 
   // Ideally we'd split this implementation in two, one TopToolbarView with a toolbar and one without
@@ -739,97 +506,11 @@ class TopToolbarView: UIView, ToolbarProtocol {
     }
   }
 
-  func setAutocompleteSuggestion(_ suggestion: String?) {
-    locationTextField?.setAutocompleteSuggestion(suggestion)
-  }
-
-  func setLocation(_ location: String?, search: Bool) {
-    guard let text = location, !text.isEmpty else {
-      locationTextField?.text = location
-      updateLocationBarRightView(showToolbarActions: true)
-      return
-    }
-
-    updateLocationBarRightView(showToolbarActions: false)
-
-    if search {
-      locationTextField?.text = text
-      // Not notifying when empty agrees with AutocompleteTextField.textDidChange.
-      delegate?.topToolbar(self, didEnterText: text)
-    } else {
-      locationTextField?.setTextWithoutSearching(text)
-    }
-  }
-
-  func submitLocation(_ location: String?) {
-    locationTextField?.text = location
-    guard let text = location, !text.isEmpty else {
-      return
-    }
-    // Not notifying when empty agrees with AutocompleteTextField.textDidChange.
-    delegate?.topToolbar(self, didSubmitText: text)
-  }
-
-  func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
-    createLocationTextFieldContainer()
-    updateForTraitCollection()
-
-    // Show the overlay mode UI, which includes hiding the locationView and replacing it
-    // with the editable locationTextField.
-    animateToOverlayState(overlayMode: true)
-
-    delegate?.topToolbarDidEnterOverlayMode(self)
-
-    // Bug 1193755 Workaround - Calling becomeFirstResponder before the animation happens
-    // won't take the initial frame of the label into consideration, which makes the label
-    // look squished at the start of the animation and expand to be correct. As a workaround,
-    // we becomeFirstResponder as the next event on UI thread, so the animation starts before we
-    // set a first responder.
-    guard let urlTextField = locationTextField else {
-      return
-    }
-
-    if pasted {
-      // Clear any existing text, focus the field, then set the actual pasted text.
-      // This avoids highlighting all of the text.
-      urlTextField.text = ""
-    }
-
-    DispatchQueue.main.async {
-      // have to add some delay to make sure text field is in the view hierarchy
-      urlTextField.becomeFirstResponder()
-      self.setLocation(locationText, search: search)
-    }
-
-    if !pasted {
-      DispatchQueue.main.async {
-        // When Not-pasted selecting text shiuld be from beggining to end
-        let textRange = urlTextField.textRange(
-          from: urlTextField.beginningOfDocument,
-          to: urlTextField.endOfDocument
-        )
-        urlTextField.selectedTextRange = textRange
-      }
-    }
-
-    setNeedsUpdateConstraints()
-  }
-
-  func leaveOverlayMode(didCancel cancel: Bool = false) {
-    if !inOverlayMode { return }
-    locationTextField?.resignFirstResponder()
-    animateToOverlayState(overlayMode: false, didCancel: cancel)
-    delegate?.topToolbarDidLeaveOverlayMode(self)
-  }
-
   func updateViewsForOverlayModeAndToolbarChanges() {
-    cancelButton.stackViewAnimationSafeIsHidden = !inOverlayMode
-    backButton.stackViewAnimationSafeIsHidden = toolbarIsShowing || inOverlayMode
-    forwardButton.stackViewAnimationSafeIsHidden = toolbarIsShowing || inOverlayMode
-    shareButton.stackViewAnimationSafeIsHidden = toolbarIsShowing || inOverlayMode
-    trailingItemsStackView.stackViewAnimationSafeIsHidden = toolbarIsShowing || inOverlayMode
-    locationView.contentView.stackViewAnimationSafeIsHidden = inOverlayMode
-    shieldsRewardsStack.stackViewAnimationSafeIsHidden = inOverlayMode
+    backButton.stackViewAnimationSafeIsHidden = toolbarIsShowing
+    forwardButton.stackViewAnimationSafeIsHidden = toolbarIsShowing
+    shareButton.stackViewAnimationSafeIsHidden = toolbarIsShowing
+    trailingItemsStackView.stackViewAnimationSafeIsHidden = toolbarIsShowing
 
     let selectedShortcut: WidgetShortcut? = {
       let shortcut = Preferences.General.toolbarShortcutButton.value.flatMap(WidgetShortcut.init)
@@ -840,54 +521,13 @@ class TopToolbarView: UIView, ToolbarProtocol {
       }
       return shortcut
     }()
-    shortcutButton.stackViewAnimationSafeIsHidden = selectedShortcut != nil ? inOverlayMode : true
+    shortcutButton.stackViewAnimationSafeIsHidden = selectedShortcut == nil
     if let selectedShortcut {
       shortcutButton.setImage(selectedShortcut.image, for: .normal)
       shortcutButton.accessibilityLabel = selectedShortcut.displayString
     }
     leadingItemsStackView.stackViewAnimationSafeIsHidden = leadingItemsStackView.arrangedSubviews
       .allSatisfy(\.isHidden)
-  }
-
-  private func animateToOverlayState(overlayMode overlay: Bool, didCancel cancel: Bool = false) {
-    inOverlayMode = overlay
-
-    if !overlay {
-      removeLocationTextField()
-    }
-
-    if inOverlayMode {
-      [
-        leadingItemsStackView, shortcutButton, shieldsRewardsStack, trailingItemsStackView,
-        locationView.contentView,
-      ].forEach {
-        $0?.isHidden = true
-      }
-
-      cancelButton.isHidden = false
-    } else {
-      updateViewsForOverlayModeAndToolbarChanges()
-    }
-
-    layoutIfNeeded()
-  }
-
-  private func updateLocationBarRightView(showToolbarActions: Bool) {
-    locationBarOptionsStackView.isHidden = !showToolbarActions
-
-    if RecentSearchQRCodeScannerController.hasCameraSupport {
-      qrCodeButton.isHidden = !showToolbarActions
-    } else {
-      qrCodeButton.isHidden = true
-    }
-
-    if speechRecognizer.isVoiceSearchAvailable {
-      voiceSearchButton.isHidden = !showToolbarActions
-    } else {
-      voiceSearchButton.isHidden = true
-    }
-
-    pasteAndGoButton.isHidden = !UIPasteboard.general.hasStrings && !UIPasteboard.general.hasURLs
   }
 
   /// Update the shields icon based on whether or not shields are enabled for this site
@@ -913,10 +553,6 @@ class TopToolbarView: UIView, ToolbarProtocol {
 
   // MARK: Actions
 
-  @objc func didClickCancel() {
-    leaveOverlayMode(didCancel: true)
-  }
-
   @objc func tappedScrollToTopArea() {
     delegate?.topToolbarDidPressScrollToTop(self)
   }
@@ -927,21 +563,6 @@ class TopToolbarView: UIView, ToolbarProtocol {
 
   @objc func didClickMenu() {
     delegate?.topToolbarDidTapMenuButton(self)
-  }
-
-  @objc func topToolbarDidPressQrCodeButton() {
-    delegate?.topToolbarDidPressQrCodeButton(self)
-    leaveOverlayMode(didCancel: true)
-  }
-
-  @objc func topToolbarDidPressVoiceSearchButton() {
-    leaveOverlayMode(didCancel: true)
-    delegate?.topToolbarDidPressVoiceSearchButton(self)
-  }
-
-  @objc func topToolbarDidPressPasteAndGoButton() {
-    delegate?.topToolbarDidPressPasteAndGoButton(self)
-    leaveOverlayMode(didCancel: true)
   }
 
   @objc private func swipedLocationView() {
@@ -970,7 +591,7 @@ extension TopToolbarView: PreferencesObserver {
 extension TopToolbarView: TabLocationViewDelegate {
   func tabLocationViewDidTapLocation(_ tabLocationView: TabLocationView) {
     guard
-      !inOverlayMode,
+      isURLBarEnabled,
       let (locationText, isSearchQuery) = delegate?.topToolbarDisplayTextForURL(
         locationView.url as URL?
       )
@@ -982,7 +603,12 @@ extension TopToolbarView: TabLocationViewDelegate {
       // When the user is entering text into the URL bar, we must show the entire URL, omitting NOTHING (not even the scheme, or www), and un-escaping NOTHING!
       overlayText = URLFormatter.formatURL(url.absoluteString, formatTypes: [], unescapeOptions: [])
     }
-    enterOverlayMode(overlayText, pasted: false, search: isSearchQuery)
+    delegate?.topToolbarDidRequestSearchInput(
+      self,
+      initialText: overlayText,
+      pasted: false,
+      search: isSearchQuery
+    )
   }
 
   func tabLocationViewDidTapReload(_ tabLocationView: TabLocationView) {
@@ -1029,53 +655,6 @@ extension TopToolbarView: TabLocationViewDelegate {
   }
 }
 
-// MARK:  AutocompleteTextFieldDelegate
-
-extension TopToolbarView: AutocompleteTextFieldDelegate {
-  func autocompleteTextFieldShouldReturn(_ autocompleteTextField: AutocompleteTextField) -> Bool {
-    guard let text = locationTextField?.text else { return true }
-    if !text.trimmingCharacters(in: .whitespaces).isEmpty {
-      delegate?.topToolbar(self, didSubmitText: text)
-      return true
-    } else {
-      return false
-    }
-  }
-
-  func autocompleteTextField(
-    _ autocompleteTextField: AutocompleteTextField,
-    didEnterText text: String
-  ) {
-    delegate?.topToolbar(self, didEnterText: text)
-    updateLocationBarRightView(showToolbarActions: text.isEmpty)
-  }
-
-  func autocompleteTextField(
-    _ autocompleteTextField: AutocompleteTextField,
-    didDeleteAutoSelectedText text: String
-  ) {
-    updateLocationBarRightView(showToolbarActions: text.isEmpty)
-  }
-
-  func autocompleteTextFieldDidBeginEditing(_ autocompleteTextField: AutocompleteTextField) {
-    autocompleteTextField.highlightAll()
-    updateLocationBarRightView(
-      showToolbarActions: locationView.urlDisplayLabel.text?.isEmpty == true
-    )
-  }
-
-  func autocompleteTextFieldShouldClear(_ autocompleteTextField: AutocompleteTextField) -> Bool {
-    delegate?.topToolbar(self, didEnterText: "")
-    updateLocationBarRightView(showToolbarActions: true)
-    return true
-  }
-
-  func autocompleteTextFieldDidCancel(_ autocompleteTextField: AutocompleteTextField) {
-    leaveOverlayMode(didCancel: true)
-    updateLocationBarRightView(showToolbarActions: false)
-  }
-}
-
 extension TopToolbarView: UIDragInteractionDelegate {
   func dragInteraction(
     _ interaction: UIDragInteraction,
@@ -1084,13 +663,12 @@ extension TopToolbarView: UIDragInteractionDelegate {
     // Ensure we actually have a URL in the location bar and that the URL is not local.
     guard let url = self.locationView.url, !InternalURL.isValid(url: url),
       let itemProvider = NSItemProvider(contentsOf: url),
-      !locationView.reloadButton.isHighlighted, !inOverlayMode
+      !locationView.reloadButton.isHighlighted
     else {
       return []
     }
 
     let dragItem = UIDragItem(itemProvider: itemProvider)
-    dragItem.localObject = locationTextField
     return [dragItem]
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -79,7 +79,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
   weak var delegate: TopToolbarDelegate? {
     didSet {
       guard delegate !== oldValue else { return }
-      updateViewsForOverlayModeAndToolbarChanges()
+      updateViewsForToolbarChanges()
     }
   }
   weak var tabToolbarDelegate: ToolbarDelegate?
@@ -327,8 +327,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
 
     Preferences.General.toolbarShortcutButton.observe(from: self)
 
-    // Make sure we hide any views that shouldn't be showing in non-overlay mode.
-    updateViewsForOverlayModeAndToolbarChanges()
+    updateViewsForToolbarChanges()
 
     privateBrowsingManager
       .$isPrivateBrowsing
@@ -457,7 +456,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
     if !toolbarIsShowing {
       updateConstraintsIfNeeded()
     }
-    updateViewsForOverlayModeAndToolbarChanges()
+    updateViewsForToolbarChanges()
   }
 
   func currentProgress() -> Float {
@@ -506,7 +505,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
     }
   }
 
-  func updateViewsForOverlayModeAndToolbarChanges() {
+  func updateViewsForToolbarChanges() {
     backButton.stackViewAnimationSafeIsHidden = toolbarIsShowing
     forwardButton.stackViewAnimationSafeIsHidden = toolbarIsShowing
     shareButton.stackViewAnimationSafeIsHidden = toolbarIsShowing
@@ -582,7 +581,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
 
 extension TopToolbarView: PreferencesObserver {
   func preferencesDidChange(for key: String) {
-    updateViewsForOverlayModeAndToolbarChanges()
+    updateViewsForToolbarChanges()
   }
 }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Widgets/AutocompleteTextField.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Widgets/AutocompleteTextField.swift
@@ -32,7 +32,7 @@ private struct AutocompleteTextFieldUX {
 }
 
 public class AutocompleteTextField: UITextField, UITextFieldDelegate {
-  var autocompleteDelegate: AutocompleteTextFieldDelegate?
+  weak var autocompleteDelegate: AutocompleteTextFieldDelegate?
 
   // AutocompleteTextLabel repersents the actual autocomplete text.
   // The textfields "text" property only contains the entered text, while this label holds the autocomplete text

--- a/ios/brave-ios/Sources/Brave/Frontend/Widgets/AutocompleteTextField.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Widgets/AutocompleteTextField.swift
@@ -46,7 +46,7 @@ public class AutocompleteTextField: UITextField, UITextFieldDelegate {
   }
 
   // This variable is a solution to get the right behavior for refocusing
-  // the AutocompleteTextField. The initial transition into Overlay Mode
+  // the AutocompleteTextField. The initial transition into the search container
   // doesn't involve the user interacting with AutocompleteTextField.
   // Thus, we update shouldApplyCompletion in touchesBegin() to reflect whether
   // the highlight is active and then the text field is updated accordingly


### PR DESCRIPTION
With the upcoming changes to the toolbar design we want to avoid having the bottom bar toolbar playing double-duty and also owning the URL input field which users. This shifts ownership of the actual url bar input to SearchContainerViewController, adding a new SearchURLBarInputView it presents alongside the favourites/search child controllers. This simplifies a lot of the keyboard constraint logic since the toolbar only needs to collapse/expand based on the web view input not the url bar input

## Test
Test matrix:
- Bottom bar and top bar display mode
- iPhone and iPad
- iOS 18 & 26

Steps:
- Verify the normal URL bar while browsing still behaves the same way
- Verify tapping the URL bar brings up the typical input and renders the same way
- Verify typing into the URL bar still brings up auto-complete, and the search options above still show (like history, bookmarks, etc)

Special verification of iPad on iOS 26+:
- Verify that resizing the window below fullscreen properly adjusts the url bar like normal such that it doesnt appear under the window controls (traffic lights) that float in the top-left corner