### PR TITLE
[docs] Update gni_sources.md

### DIFF
--- a/docs/gni_sources.md
+++ b/docs/gni_sources.md
@@ -2,23 +2,111 @@
 
 #### Background
 
-The use of sources.gni was initially added to help deal with the issue of
-circular dependencies. We often subclass upstream code like
-`BraveContentBrowserClient` -> `ChromeContentBrowserClient`, but in
-`//brave/browser` instead of `//chrome/browser`. This created a circular
-dependency because:
+[sources.gni](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/browser/sources.gni)
+was originally added to work around circular dependencies. We often subclass
+upstream code, for example `BraveContentBrowserClient` ->
+`ChromeContentBrowserClient`, but we keep the subclass in `//brave/browser`
+instead of `//chrome/browser`. That creates two dependency edges pointing in
+opposite directions.
 
-- `BraveContentBrowserClient` depends on `//chrome/brave`.
-- `//chrome/brave` depends on `//chrome/brave` because it now was to instantiate
-  `BraveContentBrowserClient` instead of `ChromeContentBrowserClient`.
+**Edge 1 - inheritance.** You cannot derive from an incomplete type, so the
+subclass needs the full upstream header and the base class code, which means the
+Brave target needs a dep on the upstream target. From
+`//brave/browser/brave_content_browser_client.h`:
 
-This became a problem when we started running `gn check` and `checkdeps` so
-worked around it by using `sources.gni` to add
-`sources += brave_chrome_browser_sources` so both `BraveContentBrowserClient`
-and `ChromeContentBrowserClient` were in the same target. This is mainly an
-issue for `//chrome/browser` and `//chrome/browser/ui` and upstream is actively
-working to break these up so we need to make sure we are not adding to the
-problem on our side.
+```cpp
+#include "chrome/browser/chrome_content_browser_client.h"
+
+class BraveContentBrowserClient : public ChromeContentBrowserClient {
+  ...
+};
+```
+
+**Edge 2 - instantiation.** A subclass that nobody constructs never runs, and
+upstream is what constructs it. Written naively, an upstream file has to name
+our type, so the upstream target needs a dep on `//brave/browser`:
+
+```cpp
+// somewhere in //chrome/browser
+content_browser_client_ = std::make_unique<BraveContentBrowserClient>();
+```
+
+Together the two edges are a cycle: `//brave/browser` -> `//chrome/browser` ->
+`//brave/browser`. GN rejects a `deps` cycle outright, and `gn check` and
+`checkdeps` reject the includes that imply it. The edges exist for different
+reasons - edge 1 is about inheriting from something, edge 2 is about being used
+by something - so neither disappears on its own.
+
+The original workaround broke neither edge. It removed the second _target_, by
+adding `sources += brave_chrome_browser_sources` to `//chrome/browser` so that
+both classes ended up in one target, and a target may always use its own files.
+
+This is mainly an issue for `//chrome/browser` and `//chrome/browser/ui`, and
+upstream is actively working to break these up, so we need to make sure we are
+not adding to the problem on our side. Three reasons it matters more for these
+two targets than elsewhere:
+
+- Nearly everything depends on them and they depend on nearly everything, so
+  almost any edge back into a Brave target closes a loop through something.
+  Smaller targets let us depend only on the piece we actually subclass.
+- `gn check` works per target, so a file compiled inside a monolith inherits
+  that target's visibility of almost the whole tree. We do not satisfy the
+  layering rules that way, we opt out of them.
+- We inject sources by patching upstream's `BUILD.gn`. Those are among the most
+  frequently changed files in the tree, so the patches conflict on rebases, and
+  every injected file has to be relocated as upstream splits the target up.
+
+Upstream now guards against this directly: `//chrome/browser` ends with
+`sources = []` and a
+[comment](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/BUILD.gn;l=1972-1976_)
+telling you not to add sources there. Since GN evaluates sequentially, an
+earlier `sources += [...]` in that target is silently discarded.
+
+#### How this looks today
+
+`brave_chrome_browser_sources` is no longer added to `//chrome/browser`. It is
+the `sources` of the `//brave/browser:core` `source_set` in
+[//brave/browser/BUILD.gn](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/browser/BUILD.gn?L75),
+and upstream picks that target up through a one line patch in
+[patches/chrome-browser-BUILD.gn.patch](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/patches/chrome-browser-BUILD.gn.patch?L9).
+
+The detail that makes this work is that `//chrome/browser` and
+`//chrome/browser:core` are two **different** targets that happen to live in the
+same `BUILD.gn`. `//chrome/browser` is GN shorthand for
+`//chrome/browser:browser`; it has `sources = []` and is a pure aggregator.
+`//chrome/browser:core` is where `ChromeContentBrowserClient` and most of
+upstream's browser code actually lives.
+
+```
+//chrome/browser  (== //chrome/browser:browser)
+  sources = []  -- pure aggregator, no code of its own
+  |
+  |-- public_deps --> //chrome/browser:core
+  |                     ChromeContentBrowserClient lives here
+  |
+  '-- public_deps --> //brave/browser:core        <-- added by our patch
+                        BraveContentBrowserClient lives here
+                        deps --> //chrome/browser:core
+```
+
+There is no cycle because no edge leaves `//chrome/browser:core` and arrives
+back at `//brave/browser:core` or at the aggregator. Two rules keep it that way:
+
+- `brave_chrome_browser_deps` must never contain `"//chrome/browser"`. Depend on
+  `"//chrome/browser:core"`, or on a fine grained subtarget such as
+  `"//chrome/browser/autofill"`, instead. Depending on the aggregator closes the
+  loop immediately.
+- `//brave/browser:core` declares `visibility = [ "//chrome/browser" ]`, which
+  in GN names only the `:browser` target. Nothing else, `//chrome/browser:core`
+  included, is allowed to depend on it, so the cycle cannot be reintroduced by
+  adding a dep in the wrong place.
+
+`BraveContentBrowserClient` is also no longer instantiated from
+`//chrome/browser`, see
+[Instantiate from a higher level target](#instantiate-from-a-higher-level-target).
+
+Everything below still applies to anything you add to
+`brave_chrome_browser_sources`.
 
 #### Usage of sources.gni
 
@@ -33,6 +121,21 @@ appropriate when adding a very small number of sources to an existing upstream
 target, but please consider other approaches below first. Using sources.gni to
 add dependencies and other non-source configuration to upstream targets is
 generally ok.
+
+Adding deps for a `chromium_src` override is a separate, always acceptable use.
+A `chromium_src` override is compiled as part of the upstream target that owns
+the file it replaces, so a new dependency has to be added to that upstream
+target. The convention is a deps only `sources.gni` next to the override, for
+example `//brave/chromium_src/chrome/browser/ui/autofill/sources.gni`, imported
+by a patched line in the corresponding upstream `BUILD.gn`. Note that `gn check`
+does not run for `chromium_src`, so nothing will flag a missing dep for you.
+
+A small, legitimate example of adding sources is `BraveContentClient`. It
+subclasses `ChromeContentClient`, so `//chrome/common/BUILD.gn` gets
+`sources += brave_chrome_common_sources` from `//brave/common/sources.gni`,
+which puts the subclass in the same target as its base. The type is then swapped
+in `//brave/chromium_src/chrome/app/chrome_main_delegate.h` with
+`#define ChromeContentClient BraveContentClient`.
 
 #### Methods to avoid circular dependencies
 
@@ -61,8 +164,10 @@ dependency].
 The chromium ios code is also a good model for separating out dependencies and
 sometimes makes use of interface/implementation patterns.
 
-Another technique to avoid circular dependencies is to use a template so the
-subclass does not need a dependency on the base class.
+##### Use a template to remove the inheritance edge
+
+A template removes edge 1, because the base class becomes a type parameter and
+the subclass header includes no upstream header at all.
 
 brave_class.h
 
@@ -70,11 +175,15 @@ brave_class.h
 template <typename ChromeClass>
 class BraveClass : public ChromeClass {
   ...
-}
+};
 ```
 
 The chrome target that we override will need a dependency on the brave target,
-but there is no circular dependency some_chromium_source.cc
+but with edge 1 gone there is only one direction left and therefore no circular
+dependency. The template is bound at the point of use by a `chromium_src`
+override.
+
+some_chromium_source.cc
 
 ```cpp
   chrome_class_ = std::make_unique<ChromeClass>();
@@ -83,8 +192,65 @@ but there is no circular dependency some_chromium_source.cc
 chromium_src/some_chromium_source.cc
 
 ```cpp
-#define ChromeClass BraveClass<ChromeClass>()
+#define ChromeClass BraveClass<ChromeClass>
 ```
+
+##### Instantiate from a higher level target
+
+Edge 2 disappears if the code that constructs the object lives in a target above
+both, because then that target depends on both and neither depends on the other.
+This is how the content browser client works now:
+`BraveMainDelegate::CreateContentBrowserClient()` in
+`//brave/app/brave_main_delegate.cc` creates it, and that code is compiled into
+the chrome executable rather than into `//chrome/browser`.
+
+```cpp
+content::ContentBrowserClient* BraveMainDelegate::CreateContentBrowserClient() {
+  if (chrome_content_browser_client_ == nullptr) {
+    chrome_content_browser_client_ =
+        std::make_unique<BraveContentBrowserClient>();
+  }
+  return chrome_content_browser_client_.get();
+}
+```
+
+`CreateContentBrowserClient()` is already virtual upstream, so the client itself
+needs no preprocessor work, only an override. Constructing the delegate is not
+virtual, so that one is handled with a macro, below.
+
+##### Substitute the type in a chromium_src override
+
+A `chromium_src` override replaces an upstream file inside the upstream target,
+so a macro there can change which type upstream constructs without adding
+anything to the GN graph. `//brave/chromium_src/chrome/app/chrome_main.cc`:
+
+```cpp
+#include "brave/app/brave_main_delegate.h"
+
+#define ChromeMainDelegate BraveMainDelegate
+#include <chrome/app/chrome_main.cc>
+#undef ChromeMainDelegate
+```
+
+The angle bracket include is required. `brave/chromium_src` is added to the
+quoted include path only, so `<...>` reaches the real upstream file instead of
+recursing into the override. See
+[patching_and_chromium_src.md](patching_and_chromium_src.md) for the full
+mechanism.
+
+When the override also needs the subclass implementation in the same translation
+unit it can include the `.cc` directly, as
+`//brave/chromium_src/chrome/app/chrome_main_delegate.cc` does:
+
+```cpp
+#include "brave/app/brave_main_delegate.cc"  // IWYU pragma: export
+
+#include <chrome/app/chrome_main_delegate.cc>  // IWYU pragma: export
+```
+
+That is the same "put them in one target" trick as `sources.gni`, done with the
+preprocessor instead of GN, and it has the same drawback of growing the upstream
+target. Prefer the options above.
 
 #### Circular dependencies
 

--- a/docs/gni_sources.md
+++ b/docs/gni_sources.md
@@ -2,23 +2,111 @@
 
 #### Background
 
-The use of sources.gni was initially added to help deal with the issue of
-circular dependencies. We often subclass upstream code like
-`BraveContentBrowserClient` -> `ChromeContentBrowserClient`, but in
-`//brave/browser` instead of `//chrome/browser`. This created a circular
-dependency because:
+[sources.gni](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/browser/sources.gni)
+was originally added to work around circular dependencies. We often subclass
+upstream code, for example `BraveContentBrowserClient` ->
+`ChromeContentBrowserClient`, but we keep the subclass in `//brave/browser`
+instead of `//chrome/browser`. That creates two dependency edges pointing in
+opposite directions.
 
-- `BraveContentBrowserClient` depends on `//chrome/brave`.
-- `//chrome/brave` depends on `//chrome/brave` because it now was to instantiate
-  `BraveContentBrowserClient` instead of `ChromeContentBrowserClient`.
+**Edge 1 - inheritance.** You cannot derive from an incomplete type, so the
+subclass needs the full upstream header and the base class code, which means the
+Brave target needs a dep on the upstream target. From
+`//brave/browser/brave_content_browser_client.h`:
 
-This became a problem when we started running `gn check` and `checkdeps` so
-worked around it by using `sources.gni` to add
-`sources += brave_chrome_browser_sources` so both `BraveContentBrowserClient`
-and `ChromeContentBrowserClient` were in the same target. This is mainly an
-issue for `//chrome/browser` and `//chrome/browser/ui` and upstream is actively
-working to break these up so we need to make sure we are not adding to the
-problem on our side.
+```cpp
+#include "chrome/browser/chrome_content_browser_client.h"
+
+class BraveContentBrowserClient : public ChromeContentBrowserClient {
+  ...
+};
+```
+
+**Edge 2 - instantiation.** A subclass that nobody constructs never runs, and
+upstream is what constructs it. Written naively, an upstream file has to name
+our type, so the upstream target needs a dep on `//brave/browser`:
+
+```cpp
+// somewhere in //chrome/browser
+content_browser_client_ = std::make_unique<BraveContentBrowserClient>();
+```
+
+Together the two edges are a cycle: `//brave/browser` -> `//chrome/browser` ->
+`//brave/browser`. GN rejects a `deps` cycle outright, and `gn check` and
+`checkdeps` reject the includes that imply it. The edges exist for different
+reasons - edge 1 is about inheriting from something, edge 2 is about being used
+by something - so neither disappears on its own.
+
+The original workaround broke neither edge. It removed the second _target_, by
+adding `sources += brave_chrome_browser_sources` to `//chrome/browser` so that
+both classes ended up in one target, and a target may always use its own files.
+
+This is mainly an issue for `//chrome/browser` and `//chrome/browser/ui`, and
+upstream is actively working to break these up, so we need to make sure we are
+not adding to the problem on our side. Three reasons it matters more for these
+two targets than elsewhere:
+
+- Nearly everything depends on them and they depend on nearly everything, so
+  almost any edge back into a Brave target closes a loop through something.
+  Smaller targets let us depend only on the piece we actually subclass.
+- `gn check` works per target, so a file compiled inside a monolith inherits
+  that target's visibility of almost the whole tree. We do not satisfy the
+  layering rules that way, we opt out of them.
+- We inject sources by patching upstream's `BUILD.gn`. Those are among the most
+  frequently changed files in the tree, so the patches conflict on rebases, and
+  every injected file has to be relocated as upstream splits the target up.
+
+Upstream now guards against this directly: `//chrome/browser` ends with
+`sources = []` and a
+[comment](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/BUILD.gn;l=1972-1976)
+telling you not to add sources there. Since GN evaluates sequentially, an
+earlier `sources += [...]` in that target is silently discarded.
+
+#### How this looks today
+
+`brave_chrome_browser_sources` is no longer added to `//chrome/browser`. It is
+the `sources` of the `//brave/browser:core` `source_set` in
+[//brave/browser/BUILD.gn](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/browser/BUILD.gn?L75),
+and upstream picks that target up through a one line patch in
+[patches/chrome-browser-BUILD.gn.patch](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/patches/chrome-browser-BUILD.gn.patch?L9).
+
+The detail that makes this work is that `//chrome/browser` and
+`//chrome/browser:core` are two **different** targets that happen to live in the
+same `BUILD.gn`. `//chrome/browser` is GN shorthand for
+`//chrome/browser:browser`; it has `sources = []` and is a pure aggregator.
+`//chrome/browser:core` is where `ChromeContentBrowserClient` and most of
+upstream's browser code actually lives.
+
+```
+//chrome/browser  (== //chrome/browser:browser)
+  sources = []  -- pure aggregator, no code of its own
+  |
+  |-- public_deps --> //chrome/browser:core
+  |                     ChromeContentBrowserClient lives here
+  |
+  '-- public_deps --> //brave/browser:core        <-- added by our patch
+                        BraveContentBrowserClient lives here
+                        deps --> //chrome/browser:core
+```
+
+There is no cycle because no edge leaves `//chrome/browser:core` and arrives
+back at `//brave/browser:core` or at the aggregator. Two rules keep it that way:
+
+- `brave_chrome_browser_deps` must never contain `"//chrome/browser"`. Depend on
+  `"//chrome/browser:core"`, or on a fine grained subtarget such as
+  `"//chrome/browser/autofill"`, instead. Depending on the aggregator closes the
+  loop immediately.
+- `//brave/browser:core` declares `visibility = [ "//chrome/browser" ]`, which
+  in GN names only the `:browser` target. Nothing else, `//chrome/browser:core`
+  included, is allowed to depend on it, so the cycle cannot be reintroduced by
+  adding a dep in the wrong place.
+
+`BraveContentBrowserClient` is also no longer instantiated from
+`//chrome/browser`, see
+[Instantiate from a higher level target](#instantiate-from-a-higher-level-target).
+
+Everything below still applies to anything you add to
+`brave_chrome_browser_sources`.
 
 #### Usage of sources.gni
 
@@ -33,6 +121,21 @@ appropriate when adding a very small number of sources to an existing upstream
 target, but please consider other approaches below first. Using sources.gni to
 add dependencies and other non-source configuration to upstream targets is
 generally ok.
+
+Adding deps for a `chromium_src` override is a separate, always acceptable use.
+A `chromium_src` override is compiled as part of the upstream target that owns
+the file it replaces, so a new dependency has to be added to that upstream
+target. The convention is a deps only `sources.gni` next to the override, for
+example `//brave/chromium_src/chrome/browser/ui/autofill/sources.gni`, imported
+by a patched line in the corresponding upstream `BUILD.gn`. Note that `gn check`
+does not run for `chromium_src`, so nothing will flag a missing dep for you.
+
+A small, legitimate example of adding sources is `BraveContentClient`. It
+subclasses `ChromeContentClient`, so `//chrome/common/BUILD.gn` gets
+`sources += brave_chrome_common_sources` from `//brave/common/sources.gni`,
+which puts the subclass in the same target as its base. The type is then swapped
+in `//brave/chromium_src/chrome/app/chrome_main_delegate.h` with
+`#define ChromeContentClient BraveContentClient`.
 
 #### Methods to avoid circular dependencies
 
@@ -61,8 +164,10 @@ dependency].
 The chromium ios code is also a good model for separating out dependencies and
 sometimes makes use of interface/implementation patterns.
 
-Another technique to avoid circular dependencies is to use a template so the
-subclass does not need a dependency on the base class.
+##### Use a template to remove the inheritance edge
+
+A template removes edge 1, because the base class becomes a type parameter and
+the subclass header includes no upstream header at all.
 
 brave_class.h
 
@@ -70,11 +175,15 @@ brave_class.h
 template <typename ChromeClass>
 class BraveClass : public ChromeClass {
   ...
-}
+};
 ```
 
 The chrome target that we override will need a dependency on the brave target,
-but there is no circular dependency some_chromium_source.cc
+but with edge 1 gone there is only one direction left and therefore no circular
+dependency. The template is bound at the point of use by a `chromium_src`
+override.
+
+some_chromium_source.cc
 
 ```cpp
   chrome_class_ = std::make_unique<ChromeClass>();
@@ -83,8 +192,71 @@ but there is no circular dependency some_chromium_source.cc
 chromium_src/some_chromium_source.cc
 
 ```cpp
-#define ChromeClass BraveClass<ChromeClass>()
+#define ChromeClass BraveClass<ChromeClass>
 ```
+
+##### Instantiate from a higher level target
+
+Edge 2 disappears if the code that constructs the object lives in a target above
+both, because then that target depends on both and neither depends on the other.
+This is how the content browser client works now:
+`BraveMainDelegate::CreateContentBrowserClient()` in
+`//brave/app/brave_main_delegate.cc` creates it, and that code is compiled into
+the chrome executable rather than into `//chrome/browser`.
+
+```cpp
+content::ContentBrowserClient* BraveMainDelegate::CreateContentBrowserClient() {
+  if (chrome_content_browser_client_ == nullptr) {
+    chrome_content_browser_client_ =
+        std::make_unique<BraveContentBrowserClient>();
+  }
+  return chrome_content_browser_client_.get();
+}
+```
+
+`CreateContentBrowserClient()` is already virtual upstream, so the client itself
+needs no preprocessor work, only an override. Constructing the delegate is not
+virtual, so that one is handled with a macro, below.
+
+##### Substitute the type in a chromium_src override
+
+A `chromium_src` override replaces an upstream file inside the upstream target,
+so a macro there can change which type upstream constructs without adding
+anything to the GN graph. `//brave/chromium_src/chrome/app/chrome_main.cc`:
+
+```cpp
+#include "brave/app/brave_main_delegate.h"
+
+#define ChromeMainDelegate BraveMainDelegate
+#include <chrome/app/chrome_main.cc>
+#undef ChromeMainDelegate
+```
+
+The angle bracket include is required. `brave/chromium_src` is added to the
+quoted include path only, so `<...>` reaches the real upstream file instead of
+recursing into the override. See
+[patching_and_chromium_src.md](patching_and_chromium_src.md) for the full
+mechanism. Also note, we now rarely have the need to modify/patch the upstream
+files manually, we do it via Plaster. So, it's recommended to read these plaster
+guides
+[plaster_dos_and_donts.md](https://github.com/brave/brave-core/blob/master/docs/plaster_dos_and_donts.md)
+and
+[plaster.md](https://github.com/brave/brave-core/blob/master/docs/plaster.md)
+before.
+
+When the override also needs the subclass implementation in the same translation
+unit it can include the `.cc` directly, as
+`//brave/chromium_src/chrome/app/chrome_main_delegate.cc` does:
+
+```cpp
+#include "brave/app/brave_main_delegate.cc"  // IWYU pragma: export
+
+#include <chrome/app/chrome_main_delegate.cc>  // IWYU pragma: export
+```
+
+That is the same "put them in one target" trick as `sources.gni`, done with the
+preprocessor instead of GN, and it has the same drawback of growing the upstream
+target. Prefer the options above.
 
 #### Circular dependencies
 


### PR DESCRIPTION
This change updates the doc to add more insight around how the dependency are configured between the brave code and the upstream code. It highlights the issues around how circular dependency can occur and how in Brave we handle this. It adds more insights on why deps around chrome/browser and chrome/browser/ui should be avoided in general. The rest is the same as the previous iteration. This document was generated with the help of LLM which was guided across multiple iterations and links were added by the author.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/57719

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
