### PR TITLE
[toolchain] Upload published toolchains with `--upload`

### DIFF
--- a/tools/cr/toolchain.py
+++ b/tools/cr/toolchain.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import hashlib
 import os
 import re
 import textwrap
@@ -57,10 +56,6 @@ TOOLCHAINS = {
         'ci': {
             'jobs': ('https://ci.brave.com/view/toolchains/job/'
                      'windows-hermetic-toolchain-build/', ),
-            # The job takes no build parameter and instead reads a JSON
-            # PROPERTIES payload, like the Rust jobs; `chromium_ref` is
-            # auto-filled from the triggered version (see
-            # `Toolchain._properties_payload`).
             'properties': ('chromium_ref', ),
         },
         'repin': {
@@ -80,9 +75,9 @@ TOOLCHAINS = {
                      'mac_sdk_official_build_version'),
         },
         'ci': {
-            'build_param': 'CHROMIUM_TAG',
             'jobs': ('https://ci.brave.com/view/toolchains/job/'
                      'xcode-hermetic-toolchain-build/', ),
+            'properties': ('chromium_tag', ),
         },
         'repin': {
             'script': 'build/mac/download_hermetic_xcode.py',
@@ -421,10 +416,11 @@ class Toolchain:
                             provided: dict) -> dict | None:
         """Builds the `PROPERTIES` payload, checking every field is provided.
 
-        `chromium_ref` (when the toolchain declares it) defaults to the
-        triggered version; all other declared fields must come from `provided`.
-        Raises if a toolchain that takes no properties is given any, or if the
-        supplied fields don't match exactly what the toolchain declares.
+        `chromium_ref`/`chromium_tag` (whichever the toolchain declares)
+        defaults to the triggered version; all other declared fields must come
+        from `provided`. Raises if a toolchain that takes no properties is
+        given any, or if the supplied fields don't match exactly what the
+        toolchain declares.
         """
         if self.spec.properties is None:
             if provided:
@@ -435,6 +431,8 @@ class Toolchain:
         payload = dict(provided)
         if 'chromium_ref' in self.spec.properties:
             payload.setdefault('chromium_ref', str(version))
+        if 'chromium_tag' in self.spec.properties:
+            payload.setdefault('chromium_tag', str(version))
         if set(payload) != set(self.spec.properties):
             raise InvalidInputException(
                 f'The {self.spec.label} toolchain requires the properties '
@@ -593,21 +591,6 @@ class RustToolchain(Toolchain):
         return (f'Rust/WASM toolchain ({match["rust"][:12]}-{match["sub"]}, '
                 f'{match["clang"]}, sub {match["sub"]})')
 
-    @staticmethod
-    def _fetch_archive_info(url: str) -> tuple[str, int]:
-        """Download `url` and return its `(sha256sum, size_bytes)`.
-
-        `setdep` values are read straight off the published archive.
-        """
-        digest = hashlib.sha256()
-        size = 0
-        with requests.get(url, stream=True, timeout=60) as response:
-            response.raise_for_status()
-            for chunk in response.iter_content(chunk_size=1 << 20):
-                digest.update(chunk)
-                size += len(chunk)
-        return digest.hexdigest(), size
-
     # `brave_subrevision` is required here (unlike the base's `**kwargs`
     # catch-all) since this toolchain has no side index to auto-discover it
     # from; see the base `repin`'s docstring.
@@ -623,9 +606,9 @@ class RustToolchain(Toolchain):
         this Chromium tag's Rust+Clang revision (e.g. `1` for a fresh
         Chromium-version bump, or whatever `gen-rust-toolchain
         --brave-subrevision` last built) -- there is no side index to
-        auto-discover it from; every object name and its overlay base are
-        derived deterministically and fetched straight from the bucket, like
-        `tools/clang/scripts/sync_deps.py`'s `GetDepsObjectInfo`.
+        auto-discover it from; every platform's object is read straight from
+        its sibling index (see
+        `build_rust_toolchain.rust_toolchain_extra_dep`).
         """
         self._require_no_staged_files()
 
@@ -634,25 +617,13 @@ class RustToolchain(Toolchain):
                                                       commit=ref)
         upstream_stem = self._upstream_stem(revision_text)
 
-        objects = []
-        platform_conditions = build_rust_toolchain.SUPPORTED_PLATFORM_CONDITIONS
-        for platform_prefix in platform_conditions:
-            object_name = (f'{platform_prefix}-{upstream_stem}-'
-                           f'{brave_subrevision}.tar.xz')
-            url = f'{build_rust_toolchain.TOOLCHAIN_BUCKET_URL}/{object_name}'
-            try:
-                sha256sum, size_bytes = self._fetch_archive_info(url)
-            except requests.RequestException as e:
-                raise BadOutcomeException(
-                    f'Could not fetch published toolchain {url}: {e}') from e
-            host_os = build_rust_toolchain.PLATFORM_PREFIX_TO_CHROMIUM_HOST_OS[
-                platform_prefix]
-            objects.append({
-                'object_name': object_name,
-                'sha256sum': sha256sum,
-                'size_bytes': size_bytes,
-                'overlayed_on': f'{host_os}/{upstream_stem}.tar.xz',
-            })
+        try:
+            extra_dep = build_rust_toolchain.rust_toolchain_extra_dep(
+                upstream_stem, brave_subrevision)
+        except RuntimeError as e:
+            raise BadOutcomeException(str(e)) from e
+        objects = extra_dep[
+            build_rust_toolchain.RUST_TOOLCHAIN_DEP_PATH]['objects']
 
         installer = self.spec.installer
         path = repository.brave.root / installer

--- a/tools/cr/toolchain_test.py
+++ b/tools/cr/toolchain_test.py
@@ -229,14 +229,24 @@ class TriggerTest(unittest.TestCase):
                 toolchain.RustToolchain().trigger(Version(CHROMIUM_TAG))
         launcher.trigger.assert_not_called()
 
-    def test_xcode_triggers_single_job_with_build_param(self):
-        launcher = self._trigger(toolchain.XcodeToolchain())
-        args, kwargs = launcher.trigger.call_args
-        self.assertEqual(len(args[0]), 1)
-        self.assertEqual(kwargs['params'], {'CHROMIUM_TAG': CHROMIUM_TAG})
-        self.assertIsNone(kwargs['properties'])
+    def test_xcode_codifies_properties_and_no_build_param(self):
+        spec = toolchain.XcodeToolchain().spec
+        self.assertIsNone(spec.build_param)
+        self.assertEqual(spec.properties, ('chromium_tag', ))
 
-    def test_build_param_toolchain_rejects_properties(self):
+    def test_xcode_triggers_single_job_with_properties_payload(self):
+        xcode = toolchain.XcodeToolchain()
+        launcher = self._trigger(xcode)
+        args, kwargs = launcher.trigger.call_args
+        self.assertEqual(args[0], xcode.spec.job_urls)
+        self.assertEqual(len(args[0]), 1)
+        # Like Windows and Rust, Xcode has no build parameter; the tag rides
+        # in the PROPERTIES payload instead, filled from the triggered
+        # version under the `chromium_tag` name its recipe expects.
+        self.assertEqual(kwargs['params'], {})
+        self.assertEqual(kwargs['properties'], {'chromium_tag': CHROMIUM_TAG})
+
+    def test_xcode_rejects_unexpected_extra_properties(self):
         launcher = MagicMock()
         with patch('toolchain.JenkinsCi.from_config', return_value=launcher):
             with self.assertRaises(toolchain.InvalidInputException):
@@ -308,21 +318,41 @@ class RustRepinTest(_FakeRepoTest):
     BRAVE_SUBREVISION = 1
 
     @staticmethod
-    def _fake_archive_info(url: str) -> tuple[str, int]:
-        """A deterministic stand-in for a real download: derives a fake
-        `(sha256sum, size_bytes)` from the object name in `url`, so each
-        platform's fetched values are distinguishable without any network
-        access."""
-        name = url.rsplit('/', 1)[-1]
-        return f'sha-{name}', len(name)
+    def _fake_extra_dep(upstream_stem: str, brave_subrevision: int) -> dict:
+        """A deterministic stand-in for
+        `build_rust_toolchain.rust_toolchain_extra_dep`: derives a fake
+        `sha256sum`/`size_bytes` per platform from its object name, so each
+        platform's values are distinguishable without any network access."""
+        build_rust_toolchain = toolchain.build_rust_toolchain
+        objects = []
+        for platform_prefix, condition in (
+                build_rust_toolchain.SUPPORTED_PLATFORM_CONDITIONS.items()):
+            object_name = (f'{platform_prefix}-{upstream_stem}-'
+                           f'{brave_subrevision}.tar.xz')
+            host_os = build_rust_toolchain.PLATFORM_PREFIX_TO_CHROMIUM_HOST_OS[
+                platform_prefix]
+            objects.append({
+                'object_name': object_name,
+                'sha256sum': f'sha-{object_name}',
+                'size_bytes': len(object_name),
+                'overlayed_on': f'{host_os}/{upstream_stem}.tar.xz',
+                'condition': condition,
+            })
+        return {
+            build_rust_toolchain.RUST_TOOLCHAIN_DEP_PATH: {
+                'bucket': f'{build_rust_toolchain.TOOLCHAIN_BUCKET_URL}/',
+                'condition': build_rust_toolchain.RUST_TOOLCHAIN_DEP_CONDITION,
+                'objects': objects,
+            }
+        }
 
     def setUp(self):
         super().setUp()
         self.rust = toolchain.RustToolchain()
         self._seed_installer()
-        patcher = patch.object(toolchain.RustToolchain,
-                               '_fetch_archive_info',
-                               side_effect=self._fake_archive_info)
+        patcher = patch.object(toolchain.build_rust_toolchain,
+                               'rust_toolchain_extra_dep',
+                               side_effect=self._fake_extra_dep)
         self.fetch = patcher.start()
         self.addCleanup(patcher.stop)
 
@@ -376,11 +406,9 @@ class RustRepinTest(_FakeRepoTest):
         self.assertIn(f'Linux_x64/{self.UPSTREAM_STEM}.tar.xz', text)
         self.assertIn(f'Win/{self.UPSTREAM_STEM}.tar.xz', text)
         self.assertNotIn('old-upstream.tar.xz', text)
-        # Every platform is fetched straight from the bucket, no side index.
-        self.assertEqual(self.fetch.call_count, 4)
-        self.fetch.assert_any_call(
-            f'{toolchain.build_rust_toolchain.TOOLCHAIN_BUCKET_URL}/'
-            f'{linux_name}')
+        # Every platform's object is read from its sibling index in one call.
+        self.fetch.assert_called_once_with(self.UPSTREAM_STEM,
+                                           self.BRAVE_SUBREVISION)
         # Everything setdep does not touch survives byte for byte.
         self.assertIn("'src/other-dep'", text)
         self.assertIn('OTHER_CONSTANT = 1', text)
@@ -427,7 +455,7 @@ class RustRepinTest(_FakeRepoTest):
 
     def test_fetch_failure_raises(self):
         self._seed_rust_revision_bump()
-        self.fetch.side_effect = toolchain.requests.RequestException('boom')
+        self.fetch.side_effect = RuntimeError('boom')
         with self.assertRaises(toolchain.BadOutcomeException):
             self._repin(culprit=None)
 

--- a/tools/cr/toolchains/README.md
+++ b/tools/cr/toolchains/README.md
@@ -16,27 +16,7 @@ build:
   used to build Brave without having a Visual Studio install, or to cross-
   compile Brave.
 
-### Reproducibility
-
-Reproducibility of the rust toolchain is important, and the builder we have has
-the necessary constrols to make sure we have enough information to generate the
-same toolchain again if necessary.
-
-Another aspect of reproducibility for the builder is to make sure we are able to
-verify that a toolchain used is distinct, and that there is no chance for an
-archived toolchain to be replaced. For this reason, the builder also maintains
-and index for a given toolchain signature. This archive index can be used by the
-client to query what toolchains we have, and to pin any given toolchain with a
-hashsum value during checkout.
-
-The index aggregates every build for the same platform and upstream Rust+Clang
-combination, and is the canonical source for "what toolchains are available."
-Each entry stores all the relevant information for all the necessary elements
-that led to the creation of the toolchain.
-
-`--brave-subrevision=<int>` exists as the lever for minting a distinct new
-toolchain at the same upstream Rust+Clang revisions. The script encodes it as
-the final section of the tarball filename, so bumping it produces a fresh URL.
-This control is important for cases where there are changes on our end for how
-the toolchain should be generated, and a new distinct archive is necessary for a
-toolchain already in use.
+The three builders above share their publishing plumbing (probing whether a
+toolchain is already published, writing a sibling YAML index, and uploading the
+archive + index pair) via `toolchain_publish.py`, so it stays consistent instead
+of being carried as three near-identical copies.

--- a/tools/cr/toolchains/build_rust_toolchain.py
+++ b/tools/cr/toolchains/build_rust_toolchain.py
@@ -54,21 +54,17 @@ including rebuilds against a different Chromium version with the same upstream
 Rust+Clang stack, since the Chromium version is no longer encoded in the
 filename.
 
-Alongside the archive, a sibling YAML index is also written to `--out-dir`:
+Alongside the archive, a sibling YAML index sharing its name stem is also
+written to `--out-dir`:
 
     <platform>-rust-toolchain-<RUST_REVISION>-<RUST_SUB_REVISION>
-        -llvmorg-<CLANG_REVISION>.yaml
+        -llvmorg-<CLANG_REVISION>-<BRAVE_SUB_REVISION>.yaml
 
-The index aggregates every build for the same platform and upstream Rust+Clang
-combination — i.e. every distinct `<BRAVE_SUB_REVISION>` tarball under a single
-file. The script downloads the existing index from the public toolchain bucket
-(`TOOLCHAIN_BUCKET_URL`) or starts fresh if no prior index is published, appends
-a new entry for the just-built tarball with the relevant metadata, and writes
-the updated index to `--out-dir` for CI to upload back to the same path. Entries
-are appended in chronological order. The last list element is the latest build
-for the combo. The index has been introduced to preserve important information
-about the toolchain build and reproducibility. It also can be used to query how
-many versions we have for a given toolchain.
+The index records the just-built tarball's metadata (bucket URL, SHA-256, size,
+Chromium/brave-core provenance). Publishing refuses if an index already exists
+for this exact `<BRAVE_SUB_REVISION>` (bump `--brave-subrevision` for a fresh
+respin instead). With `--upload`, the archive and its sibling index are
+published to `TOOLCHAIN_BUCKET_URL`.
 
 The build is driven by two scripts that live in `tools/rust/` inside the
 Chromium source tree:
@@ -110,16 +106,13 @@ import tarfile
 import tempfile
 import tomllib
 from types import ModuleType
-import urllib.error
-import urllib.request
-
-import yaml
 
 # This is necessary because these scripts are used by brockit too.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from cherry_picks import (  # pylint: disable=wrong-import-position
     _check_call, cherry_picks)
+import toolchain_publish  # pylint: disable=wrong-import-position
 from upload import sha256_file  # pylint: disable=wrong-import-position
 
 # Executable suffix for host tools on the current platform.
@@ -236,9 +229,11 @@ CLANG_CHERRY_PICK_COMMITS = [
     '0210b44659fd7251672077e9ab83b5324db0c08e',
 ]
 
-# The bucket in our infra where the rust toolchain is archived.
+# The bucket + key prefix in our infra where the rust toolchain is archived.
+TOOLCHAIN_BUCKET = 'brave-build-deps-public'
+TOOLCHAIN_BUCKET_PREFIX = 'rust-toolchain-aux'
 TOOLCHAIN_BUCKET_URL = (
-    'https://brave-build-deps-public.s3.brave.com/rust-toolchain-aux')
+    f'https://{TOOLCHAIN_BUCKET}.s3.brave.com/{TOOLCHAIN_BUCKET_PREFIX}')
 
 # Every platform a Rust/WASM toolchain is published for, mapped to the gclient
 # host condition `install_extra_deps.py` uses to select the matching
@@ -277,44 +272,43 @@ if sys.platform == 'win32':
     GIT_SH_PRESUMED_BIN_PATH = Path(r'C:\Program Files\Git\bin\sh.exe')
 
 
-def _latest_index_object(index_url: str,
-                         expected_stem: str) -> tuple[str, str, int]:
-    """Download a platform's YAML index and return its latest archive.
+def toolchain_index_name(platform_prefix: str, upstream_stem: str,
+                         brave_subrevision: int) -> str:
+    """`<platform>-<upstream_stem>-<brave_subrevision>.yaml`.
 
-    The index lists builds in chronological order, so the last element is the
-    most recent archive for that platform + revision. Returns
-    `(object_name, sha256sum, size_bytes)`, where `object_name` is the
-    archive's basename.
-
-    `expected_stem` is the `<platform>-<upstream-stem>` the archive name must
-    start with. A mismatch means the index was fetched from the wrong key or is
-    cross-contaminated with another platform's builds, and is treated as a hard
-    error rather than silently trusted.
+    The sibling YAML index for one platform's archive, sharing its name stem.
     """
-    try:
-        with urllib.request.urlopen(index_url) as response:
-            entries = yaml.safe_load(response) or []
-    except urllib.error.URLError as e:
-        raise RuntimeError(
-            f'Failed to fetch toolchain index {index_url}: {e}') from e
-    if not entries:
-        raise RuntimeError(f'Published toolchain index is empty: {index_url}')
-    latest = entries[-1]
-    if (not isinstance(latest, dict) or 'url' not in latest
-            or 'sha256sum' not in latest or 'size_bytes' not in latest):
-        raise RuntimeError(
-            f'Malformed entry in toolchain index {index_url}: expected a '
-            f'mapping with "url", "sha256sum", and "size_bytes", got '
-            f'{latest!r}')
-    object_name = latest['url'].rsplit('/', 1)[-1]
-    if not object_name.startswith(f'{expected_stem}-'):
-        raise RuntimeError(
-            f'Toolchain index {index_url} yielded {object_name!r}, which does '
-            f'not start with the expected {expected_stem!r} stem.')
-    return object_name, latest['sha256sum'], latest['size_bytes']
+    return f'{platform_prefix}-{upstream_stem}-{brave_subrevision}.yaml'
 
 
-def rust_toolchain_extra_dep(upstream_stem: str) -> dict[str, dict]:
+def _fetch_index_object(index_url: str, expected_object_name: str) -> dict:
+    """Download one platform's sibling YAML index and return its entry.
+
+    Returns the mapping `ToolchainBuilder._write_index` published (`url`,
+    `sha256sum`, `size_bytes`, ...). `expected_object_name` is the archive
+    basename the index must point at -- a mismatch means the index was
+    fetched from the wrong key, and is treated as a hard error rather than
+    silently trusted.
+
+    Raises:
+        RuntimeError: if the index cannot be fetched or is malformed.
+    """
+    entry = toolchain_publish.fetch_index(index_url, 'rust toolchain')
+    if (not isinstance(entry, dict) or 'url' not in entry
+            or 'sha256sum' not in entry or 'size_bytes' not in entry):
+        raise RuntimeError(
+            f'Malformed toolchain index {index_url}: expected a mapping with '
+            f'"url", "sha256sum", and "size_bytes", got {entry!r}')
+    object_name = entry['url'].rsplit('/', 1)[-1]
+    if object_name != expected_object_name:
+        raise RuntimeError(
+            f'Toolchain index {index_url} yielded {object_name!r}, expected '
+            f'{expected_object_name!r}.')
+    return entry
+
+
+def rust_toolchain_extra_dep(upstream_stem: str,
+                             brave_subrevision: int) -> dict[str, dict]:
     """Assemble the complete `EXTRA_DEPS` entry for the published toolchain.
 
     This function composes a Python dictionary representing the full
@@ -340,21 +334,25 @@ def rust_toolchain_extra_dep(upstream_stem: str) -> dict[str, dict]:
         upstream_stem: The upstream toolchain package stem (i.e.
             `package_rust.RUST_TOOLCHAIN_PACKAGE_NAME` without the `.tar.xz`
             suffix).
+        brave_subrevision: The exact Brave respin counter to pin, naming each
+            platform's sibling index (see `toolchain_index_name`).
 
     Raises:
-        RuntimeError: if any platform's index is missing or empty.
+        RuntimeError: if any platform's index is missing or malformed.
     """
     objects = []
     for platform_prefix, condition in SUPPORTED_PLATFORM_CONDITIONS.items():
         stem = f'{platform_prefix}-{upstream_stem}'
-        index_url = f'{TOOLCHAIN_BUCKET_URL}/{stem}.yaml'
-        object_name, sha256sum, size_bytes = _latest_index_object(
-            index_url, stem)
+        object_name = f'{stem}-{brave_subrevision}.tar.xz'
+        index_name = toolchain_index_name(platform_prefix, upstream_stem,
+                                          brave_subrevision)
+        index_url = f'{TOOLCHAIN_BUCKET_URL}/{index_name}'
+        entry = _fetch_index_object(index_url, object_name)
         host_os = PLATFORM_PREFIX_TO_CHROMIUM_HOST_OS[platform_prefix]
         objects.append({
             'object_name': object_name,
-            'sha256sum': sha256sum,
-            'size_bytes': size_bytes,
+            'sha256sum': entry['sha256sum'],
+            'size_bytes': entry['size_bytes'],
             # Upstream Chromium-built Rust toolchain this archive overlays; see
             # `sync_deps.GetRustObjectNames` for the matching naming scheme.
             'overlayed_on': f'{host_os}/{upstream_stem}.tar.xz',
@@ -398,11 +396,8 @@ class ToolchainBuilder:
     `config.toml.template` (inherited from the host stanza).
     """
 
-    def __init__(self,
-                 chromium_src: str,
-                 out_dir: str,
-                 brave_subrevision: int,
-                 no_index_download: bool = False):
+    def __init__(self, chromium_src: str, out_dir: str,
+                 brave_subrevision: int):
         """ Initialses the builder fields.
 
         Args:
@@ -411,9 +406,6 @@ class ToolchainBuilder:
             brave_subrevision: Integer respin counter encoded as the last
                 section of the output archive name.  See
                 `_package_name` for the full naming schema.
-            no_index_download: If True, the publishing step looks for the
-                prior index as a sibling file under `out_dir` instead of
-                downloading it from the bucket.
         """
         # The absolute path to the Chromium source directory.
         self._chromium_src: Path = Path(chromium_src).expanduser().resolve()
@@ -441,10 +433,6 @@ class ToolchainBuilder:
         # Integer respin counter encoded as the last section of the
         # output archive name.
         self._brave_subrevision: int = brave_subrevision
-
-        # When True, `_publish_archive_index` reads the prior index
-        # from `self._out_dir` instead of fetching it from the bucket.
-        self._no_index_download: bool = no_index_download
 
     def _native_target_stanza(self) -> dict[str, str | bool]:
         """Return the `[target.<native-triple>]` table from the template.
@@ -724,19 +712,6 @@ class ToolchainBuilder:
                            cwd=self._chromium_src,
                            capture_output=True).stdout.strip()
 
-    def _brave_core_commit(self) -> str:
-        """Return the brave-core HEAD commit this builder was run from.
-
-        The builder lives in brave-core, so its repository HEAD identifies the
-        exact version of this script that produced the archive — recorded in the
-        index for provenance and reproducibility.
-        """
-        return _check_call('git',
-                           'rev-parse',
-                           'HEAD',
-                           cwd=Path(__file__).resolve().parent,
-                           capture_output=True).stdout.strip()
-
     @staticmethod
     def _command_line() -> str:
         """Return the shell-quoted command line this script was invoked with.
@@ -748,12 +723,18 @@ class ToolchainBuilder:
         """
         return shlex.join(sys.argv)
 
+    def _upstream_stem(self) -> str:
+        """Upstream toolchain package stem, i.e.
+        `package_rust.RUST_TOOLCHAIN_PACKAGE_NAME` without the `.tar.xz`
+        suffix.
+        """
+        return self._package_rust_module.RUST_TOOLCHAIN_PACKAGE_NAME.removesuffix(
+            '.tar.xz')
+
     def _toolchain_name_stem(self) -> str:
         """Shared filename stem identifying this platform + Rust + Clang combo.
         """
-        upstream_stem = (self._package_rust_module.RUST_TOOLCHAIN_PACKAGE_NAME.
-                         removesuffix('.tar.xz'))
-        return f'{self._platform_prefix()}-{upstream_stem}'
+        return f'{self._platform_prefix()}-{self._upstream_stem()}'
 
     def _package_name(self) -> str:
         """Return the filename for the output archive.
@@ -807,29 +788,35 @@ class ToolchainBuilder:
         return 'linux-x64'
 
     def _index_name(self) -> str:
-        """Filename of the sibling YAML index for this Rust+Clang combo.
+        """Filename of the sibling YAML index for this exact build.
 
-        Naming:
-
-            <platform>-rust-toolchain-<RUST_REVISION>-<RUST_SUB_REVISION>
-                -llvmorg-<CLANG_REVISION>.yaml
+        Sibling of the output archive: shares `_package_name`'s full stem
+        (including `<BRAVE_SUB_REVISION>`), so every respin gets its own index
+        rather than all of them updating one shared file. See
+        `toolchain_index_name`.
         """
-        return f'{self._toolchain_name_stem()}.yaml'
+        return toolchain_index_name(self._platform_prefix(),
+                                    self._upstream_stem(),
+                                    self._brave_subrevision)
 
-    def _publish_archive_index(self,
-                               archive_path: Path,
-                               force_overwrite: bool = False) -> None:
-        """Update the sibling YAML index after archive creation.
+    def _precheck_publishable(self) -> None:
+        """Fail fast if this exact build's sibling index is already published.
 
-        This function is responsible for retrieving the existing index from the
-        bucket, and updating it based on what we have for the current build. It
-        also enforces the uniqueness of the archive, and preserves the relevant
-        details for its reproducibility.
+        Guards against clobbering a toolchain already in use in the wild.
+        Bump `--brave-subrevision` to publish a new respin instead.
+        """
+        index_url = f'{TOOLCHAIN_BUCKET_URL}/{self._index_name()}'
+        if toolchain_publish.remote_url_exists(index_url):
+            raise RuntimeError(
+                f'{index_url} already exists; a toolchain for this exact '
+                '--brave-subrevision is already published.')
 
-        The previous existing archive is downloaded, and the new updated archive
-        is placed under `self._out_dir`, to be uploaded back to the bucket.
+    def _write_index(self, archive_path: Path) -> None:
+        """Write the sibling YAML index describing the just-built archive.
 
-        Each entry in the index has these fields:
+        Writes one index per build, sharing the archive's name stem
+        (`_index_name`) and holding a single mapping. The mapping has these
+        fields:
 
           * `url`              — full bucket URL the tarball will be served at.
           * `timestamp`        — ISO 8601 UTC time of this build.
@@ -842,126 +829,29 @@ class ToolchainBuilder:
                                  invoked with (from `sys.argv`).
           * `brave_core_commit` — brave-core HEAD commit this builder ran from.
 
-        This function accepts `force_overwrite` for when we want to suspend
-        certain rules, but the normal and preferred use of it will enforce these
-        rules:
-
-          - The produced toolchain should be unique. If the archive has another
-            byte-identical toolchain already, a failure occurs.
-          - The resulting URL must be unique. If the archive already contains a
-            different toolchain at the same URL, a failure occurs.
-
-        With `force_overwrite=True` (passed as `--force-overwrite`),
-        both checks are bypassed: any entry at the same URL is
-        removed before the new one is appended, and any matching
-        `sha256sum` elsewhere in the index is tolerated — the index
-        may end up with duplicate hashes if the operator deliberately
-        publishes the same bytes twice.
-
-        Collision matrix:
-
-        +------------+---------------+--------------+---------------------+
-        | URL match? | sha256 match? | Default      | --force-overwrite   |
-        +============+===============+==============+=====================+
-        | yes        | yes           | RuntimeError | replace old entry   |
-        +------------+---------------+--------------+---------------------+
-        | yes        | no            | RuntimeError | replace old entry   |
-        +------------+---------------+--------------+---------------------+
-        | no         | yes           | RuntimeError | allow duplicate     |
-        +------------+---------------+--------------+---------------------+
-        | no         | no            | append       | append              |
-        +------------+---------------+--------------+---------------------+
-
-        Entries are appended in chronological order. The newest entry for any
-        tarball URL is always at the tail, so consumers can treat the last list
-        element as the latest build for the given toolchain stem.
-
-        NOTICE: This function relies on CI not running concurrent jobs for the
-        same platform, and violating that will result in race conditions when
-        updating the index.
+        The "already published" guard lives in `_precheck_publishable`, which
+        `run()` calls early.
         """
-        index_name = self._index_name()
-        local_index = self._out_dir / index_name
-        archive_url = f'{TOOLCHAIN_BUCKET_URL}/{archive_path.name}'
+        index_path = self._out_dir / self._index_name()
 
-        if self._no_index_download:
-            if local_index.is_file():
-                entries = yaml.safe_load(local_index.read_bytes()) or []
-                logging.info(
-                    'Loaded existing local index from %s (%d entries)',
-                    local_index, len(entries))
-            else:
-                entries = []
-                logging.info('No existing local index at %s; starting fresh',
-                             local_index)
-        else:
-            index_url = f'{TOOLCHAIN_BUCKET_URL}/{index_name}'
-            logging.info('Fetching %s', index_url)
-            try:
-                with urllib.request.urlopen(index_url) as response:
-                    entries = yaml.safe_load(response) or []
-                logging.info('Loaded existing index from %s (%d entries)',
-                             index_url, len(entries))
-            except urllib.error.HTTPError as e:
-                # Unfortunately cloudfront seems to return 403 for cases where
-                # it should have returned 404.
-                if e.code not in (403, 404):
-                    raise
-                entries = []
-                logging.info('No existing index at %s; starting fresh',
-                             index_url)
-
-        archive_sha256 = sha256_file(archive_path)
-        sha_match = next(
-            (e for e in entries if e.get('sha256sum') == archive_sha256), None)
-        url_match = next((e for e in entries if e.get('url') == archive_url),
-                         None)
-
-        # Collision is a hard failure: a byte-identical entry already exists
-        # (sha256 match), or the target URL is already taken by different bytes
-        # (URL match).
-        if not force_overwrite:
-            if sha_match is not None:
-                raise RuntimeError(
-                    f'Refusing to publish: a toolchain with sha256 '
-                    f'{archive_sha256} is already in the index at '
-                    f'{sha_match.get("url")!r}.  The just-built tarball '
-                    f'is byte-identical; nothing new to publish.  Pass '
-                    f'--force-overwrite to publish anyway.')
-            if url_match is not None:
-                raise RuntimeError(
-                    f'Refusing to publish: an entry for {archive_url!r} '
-                    f'already exists in the index (sha256 '
-                    f'{url_match.get("sha256sum")!r}).  Pass '
-                    f'--force-overwrite to replace it.')
-
-        # With `--force-overwrite`, drop any prior entry at the same URL so the
-        # new one cleanly replaces it.
-        if force_overwrite and url_match is not None:
-            logging.info(
-                'Replacing existing index entry for %s '
-                '(--force-overwrite in effect)', archive_url)
-            entries = [e for e in entries if e.get('url') != archive_url]
-
-        entry = {
-            'url': archive_url,
+        index = {
+            'url': f'{TOOLCHAIN_BUCKET_URL}/{archive_path.name}',
             'timestamp': datetime.now(timezone.utc).isoformat(),
-            'sha256sum': archive_sha256,
+            'sha256sum': sha256_file(archive_path),
             'size_bytes': archive_path.stat().st_size,
             'chromium_version': self._chromium_version(),
             'chromium_commit': self._chromium_commit(),
             'command_line': self._command_line(),
         }
-        entry['brave_core_commit'] = self._brave_core_commit()
-        entries.append(entry)
+        index['brave_core_commit'] = toolchain_publish.brave_core_commit()
 
-        index_yaml = yaml.safe_dump(entries,
-                                    sort_keys=False,
-                                    default_flow_style=False)
-        local_index.write_text(index_yaml, encoding='utf-8', newline='')
-        logging.info('Wrote toolchain index to %s (%d entries)', local_index,
-                     len(entries))
-        logging.info('Toolchain index contents:\n%s', index_yaml)
+        toolchain_publish.write_index_file(index_path, index)
+
+    def _upload(self, archive_path: Path) -> None:
+        """Upload the archive and its sibling index to the public bucket."""
+        toolchain_publish.upload_files(
+            TOOLCHAIN_BUCKET, TOOLCHAIN_BUCKET_PREFIX,
+            (archive_path, self._out_dir / self._index_name()))
 
     def _package_full_rust(self) -> Path:
         """Build and package the full Rust toolchain via `package_rust.py`.
@@ -1175,14 +1065,17 @@ class ToolchainBuilder:
 
     def run(self,
             clear: bool = False,
-            force_overwrite: bool = False,
+            upload: bool = False,
             full_toolchain: bool = False,
             use_prebuilt_rustc: bool = (USE_PREBUILT_RUSTC_FOR_WASM_STD)):
         """Execute the full build-and-package pipeline.
 
         Coordinates the phases in order:
 
-        1. Within `cherry_picks` (which applies `CLANG_CHERRY_PICK_COMMITS`
+        1. `_precheck_publishable` — fail fast if this exact
+           `--brave-subrevision` is already published, before any of the
+           (expensive) build steps below run.
+        2. Within `cherry_picks` (which applies `CLANG_CHERRY_PICK_COMMITS`
            so both builds cherry-pick to identical hashes):
            a. `_package_full_rust` (only when `full_toolchain`) — build and
               package the complete Rust toolchain via `package_rust.py`.
@@ -1191,15 +1084,18 @@ class ToolchainBuilder:
               - `_run_xpy` — compile the wasm32 stdlib via x.py, either building
                 a stage-1 `rustc` or reusing the prebuilt one (see
                 `USE_PREBUILT_RUSTC_FOR_WASM_STD`).
-        2. Resolve the wasm32 sysroot, using `_assemble_stage0_wasm_sysroot` for
+        3. Resolve the wasm32 sysroot, using `_assemble_stage0_wasm_sysroot` for
            the prebuilt path, `_stage1_wasm_stdlib_dir` otherwise, and assemble
            the output .tar.xz:
            * `_create_full_archive` when `full_toolchain` — overlay the wasm32
              sysroot onto the full-toolchain archive from step 1.
            * `_create_archive` otherwise — the minimal rust-lld + wasm32 subset.
-        3. `_smoke_test_wasm` — compile a wasm32 crate against the packaged
+        4. `_smoke_test_wasm` — compile a wasm32 crate against the packaged
            toolchain so a rustc/std mismatch fails before publishing.
-        4. `_publish_archive_index` — record the build in the sibling index.
+        5. `_write_index` — write the sibling YAML index for the just-built
+           archive.
+        6. `_upload` (only with `--upload`) — publish the archive and its
+           sibling index to `TOOLCHAIN_BUCKET_URL`.
 
         `config.toml.template` is returned to its original state always.
 
@@ -1207,10 +1103,8 @@ class ToolchainBuilder:
             clear: If True, delete every entry under `self._out_dir` at the
                 start of the run so the build produces output into a
                 guaranteed-clean directory.
-            force_overwrite: If True, the publishing step bypasses both
-                index-collision checks: an entry at the same URL is
-                replaced rather than raising, and a matching `sha256sum`
-                elsewhere is tolerated.  See `_publish_archive_index`.
+            upload: If True, upload the archive and its sibling index to
+                `TOOLCHAIN_BUCKET_URL` after building (see `_upload`).
             full_toolchain: If True, package the whole Rust toolchain with
                 `package_rust.py` and overlay the wasm32 sysroot onto it. If
                 False (the default), package only the minimal rust-lld + wasm32
@@ -1225,6 +1119,8 @@ class ToolchainBuilder:
             RuntimeError: If --chromium-src does not point at a valid Chromium
             checkout.
             RuntimeError: If tools_rust directory is not found.
+            RuntimeError: If a toolchain for this exact `--brave-subrevision`
+                is already published.
             RuntimeError: On Windows, if Git sh.exe is not in path and no
             installation for it can be found with Git.
             subprocess.CalledProcessError: If any subprocess command fails
@@ -1255,6 +1151,10 @@ class ToolchainBuilder:
         if not self._package_rust_module:
             self._package_rust_module: ModuleType = importlib.import_module(
                 'package_rust')
+
+        # Fail fast, before any of the expensive build steps below, if this
+        # exact respin is already published.
+        self._precheck_publishable()
 
         # Build process
         if sys.platform == 'win32' and shutil.which('sh') is None:
@@ -1321,8 +1221,9 @@ class ToolchainBuilder:
         # Verify the packaged toolchain compiles wasm32 before publishing.
         self._smoke_test_wasm(archive_path)
 
-        self._publish_archive_index(archive_path,
-                                    force_overwrite=force_overwrite)
+        self._write_index(archive_path)
+        if upload:
+            self._upload(archive_path)
 
         logging.info('Tarball download URL (once published): %s',
                      f'{TOOLCHAIN_BUCKET_URL}/{archive_path.name}')
@@ -1345,20 +1246,14 @@ def main():
         help='Integer respin counter, used to publish a sibling distinct '
         'archive.')
     parser.add_argument(
-        '--no-index-download',
-        action='store_true',
-        help='Does not attempt to download the index from the bucket, but'
-        'rather attempts to retrieve it from the output directory.')
-    parser.add_argument(
         '--clear',
         action='store_true',
         help='Makes sure the output directory is empty before building.')
     parser.add_argument(
-        '--force-overwrite',
+        '--upload',
         action='store_true',
-        help='Bypasses the uniqueness checks for the toolchain being published '
-        'and overwrites any entry on the index that collide with the toolchain '
-        'being built.')
+        help=f'Upload the archive and its sibling index to the public '
+        f'build-deps bucket ({TOOLCHAIN_BUCKET}) after building.')
     # `--full-toolchain` / `--no-full-toolchain` are expressed as a pair of
     # store_true/store_false actions on a shared dest rather than
     # `argparse.BooleanOptionalAction`, which the presubmit's pylint does not
@@ -1405,10 +1300,9 @@ def main():
 
     ToolchainBuilder(args.chromium_src,
                      args.out_dir,
-                     brave_subrevision=args.brave_subrevision,
-                     no_index_download=args.no_index_download).run(
+                     brave_subrevision=args.brave_subrevision).run(
                          clear=args.clear,
-                         force_overwrite=args.force_overwrite,
+                         upload=args.upload,
                          full_toolchain=args.full_toolchain,
                          use_prebuilt_rustc=(args.use_prebuilt_rustc))
     return 0

--- a/tools/cr/toolchains/build_rust_toolchain_test.py
+++ b/tools/cr/toolchains/build_rust_toolchain_test.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `build_rust_toolchain`'s sibling-index naming and lookup.
+
+`urllib.request.urlopen` is mocked throughout (no network access).
+
+Coverage:
+
+* `ToolchainIndexNameTest` -- the `<platform>-<upstream_stem>-
+  <brave_subrevision>.yaml` sibling-index naming.
+* `RustToolchainExtraDepTest` -- `rust_toolchain_extra_dep` end to end: for
+  every supported platform it must derive the exact sibling-index URL and
+  archive object name (`<platform>-<upstream_stem>-<brave_subrevision>
+  .tar.xz`), fetch the (mocked) index, and assemble the `EXTRA_DEPS` entry.
+  This is the per-platform object-name/URL derivation that used to be
+  exercised (as per-platform archive downloads) in `toolchain_test.py`'s
+  `RustRepinTest` before the sibling-index redesign; it now lives here
+  instead.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import build_rust_toolchain as m  # pylint: disable=wrong-import-position
+
+
+def _index_response(entry: dict) -> io.BytesIO:
+    """A `urlopen`-compatible stand-in serving *entry* as YAML bytes."""
+    return io.BytesIO(yaml.safe_dump(entry).encode('utf-8'))
+
+
+class ToolchainIndexNameTest(unittest.TestCase):
+    """Tests for `toolchain_index_name`."""
+
+    def test_names_the_sibling_index_after_platform_stem_and_subrevision(self):
+        self.assertEqual(
+            m.toolchain_index_name('linux-x64',
+                                   'rust-toolchain-abc-2-llvmorg-x', 3),
+            'linux-x64-rust-toolchain-abc-2-llvmorg-x-3.yaml')
+
+    def test_distinct_brave_subrevisions_get_distinct_index_names(self):
+        first = m.toolchain_index_name('win', 'rust-toolchain-abc', 1)
+        second = m.toolchain_index_name('win', 'rust-toolchain-abc', 2)
+        self.assertNotEqual(first, second)
+
+
+class RustToolchainExtraDepTest(unittest.TestCase):
+    """Tests for `rust_toolchain_extra_dep`."""
+
+    UPSTREAM_STEM = 'rust-toolchain-abc123def-2-llvmorg-23-init-10931-g20b6ec66'
+    BRAVE_SUBREVISION = 3
+
+    def _expected_index_url(self, platform_prefix: str) -> str:
+        return (f'{m.TOOLCHAIN_BUCKET_URL}/{platform_prefix}-'
+                f'{self.UPSTREAM_STEM}-{self.BRAVE_SUBREVISION}.yaml')
+
+    def _expected_object_name(self, platform_prefix: str) -> str:
+        return (f'{platform_prefix}-{self.UPSTREAM_STEM}-'
+                f'{self.BRAVE_SUBREVISION}.tar.xz')
+
+    def _responses(self) -> dict[str, dict]:
+        """One well-formed index entry per supported platform, keyed by the
+        exact sibling-index URL that platform's entry must be served at."""
+        return {
+            self._expected_index_url(platform_prefix): {
+                'url': (f'{m.TOOLCHAIN_BUCKET_URL}/'
+                        f'{self._expected_object_name(platform_prefix)}'),
+                'sha256sum': f'sha-{platform_prefix}',
+                'size_bytes': len(platform_prefix),
+            }
+            for platform_prefix in m.SUPPORTED_PLATFORM_CONDITIONS
+        }
+
+    def test_derives_url_and_object_name_per_platform(self):
+        responses = self._responses()
+
+        def fake_urlopen(url, timeout=None):
+            del timeout
+            # KeyError (-> test failure) if a URL other than the exact,
+            # hand-computed sibling-index URL for some platform is requested.
+            return _index_response(responses[url])
+
+        with mock.patch('urllib.request.urlopen',
+                        side_effect=fake_urlopen) as urlopen:
+            extra_dep = m.rust_toolchain_extra_dep(self.UPSTREAM_STEM,
+                                                   self.BRAVE_SUBREVISION)
+
+        self.assertEqual(urlopen.call_count,
+                         len(m.SUPPORTED_PLATFORM_CONDITIONS))
+        for platform_prefix in m.SUPPORTED_PLATFORM_CONDITIONS:
+            urlopen.assert_any_call(
+                self._expected_index_url(platform_prefix),
+                timeout=m.toolchain_publish.DEFAULT_TIMEOUT_SECS)
+
+        objects = extra_dep[m.RUST_TOOLCHAIN_DEP_PATH]['objects']
+        self.assertEqual(len(objects), len(m.SUPPORTED_PLATFORM_CONDITIONS))
+
+        by_name = {obj['object_name']: obj for obj in objects}
+        linux_name = self._expected_object_name('linux-x64')
+        self.assertIn(linux_name, by_name)
+        linux_obj = by_name[linux_name]
+        self.assertEqual(linux_obj['sha256sum'], 'sha-linux-x64')
+        self.assertEqual(linux_obj['size_bytes'], len('linux-x64'))
+        self.assertEqual(linux_obj['overlayed_on'],
+                         f'Linux_x64/{self.UPSTREAM_STEM}.tar.xz')
+        self.assertEqual(linux_obj['condition'], 'host_os == "linux"')
+
+        win_name = self._expected_object_name('win')
+        self.assertIn(win_name, by_name)
+        self.assertEqual(by_name[win_name]['overlayed_on'],
+                         f'Win/{self.UPSTREAM_STEM}.tar.xz')
+
+        self.assertEqual(extra_dep[m.RUST_TOOLCHAIN_DEP_PATH]['bucket'],
+                         f'{m.TOOLCHAIN_BUCKET_URL}/')
+        self.assertEqual(extra_dep[m.RUST_TOOLCHAIN_DEP_PATH]['condition'],
+                         m.RUST_TOOLCHAIN_DEP_CONDITION)
+
+    def test_distinct_brave_subrevisions_derive_distinct_urls(self):
+        seen_urls = []
+
+        def fake_urlopen(url, timeout=None):
+            del timeout
+            seen_urls.append(url)
+            object_name = url.rsplit('/', 1)[-1].removesuffix('.yaml')
+            return _index_response({
+                'url': f'{m.TOOLCHAIN_BUCKET_URL}/{object_name}.tar.xz',
+                'sha256sum': 'sha',
+                'size_bytes': 1,
+            })
+
+        with mock.patch('urllib.request.urlopen', side_effect=fake_urlopen):
+            m.rust_toolchain_extra_dep(self.UPSTREAM_STEM, 1)
+            m.rust_toolchain_extra_dep(self.UPSTREAM_STEM, 2)
+
+        first_round, second_round = seen_urls[:4], seen_urls[4:]
+        self.assertEqual(len(first_round), 4)
+        self.assertEqual(len(second_round), 4)
+        self.assertFalse(set(first_round) & set(second_round))
+
+    def test_missing_index_raises(self):
+        error = urllib.error.HTTPError('https://example.invalid/x', 404,
+                                       'Not Found', {}, io.BytesIO(b''))
+        with mock.patch('urllib.request.urlopen', side_effect=error):
+            with self.assertRaises(RuntimeError):
+                m.rust_toolchain_extra_dep(self.UPSTREAM_STEM,
+                                           self.BRAVE_SUBREVISION)
+
+    def test_index_pointing_at_a_different_object_raises(self):
+        # A well-formed index, but its `url` names an object other than the
+        # one this exact platform/subrevision should have -- i.e. it was
+        # fetched from (or published at) the wrong key.
+        def fake_urlopen(url, timeout=None):
+            del url, timeout
+            return _index_response({
+                'url': f'{m.TOOLCHAIN_BUCKET_URL}/unexpected.tar.xz',
+                'sha256sum': 'sha',
+                'size_bytes': 1,
+            })
+
+        with mock.patch('urllib.request.urlopen', side_effect=fake_urlopen):
+            with self.assertRaises(RuntimeError):
+                m.rust_toolchain_extra_dep(self.UPSTREAM_STEM,
+                                           self.BRAVE_SUBREVISION)
+
+    def test_malformed_index_raises(self):
+        with mock.patch('urllib.request.urlopen',
+                        return_value=_index_response({'unexpected': 'shape'})):
+            with self.assertRaises(RuntimeError):
+                m.rust_toolchain_extra_dep(self.UPSTREAM_STEM,
+                                           self.BRAVE_SUBREVISION)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/cr/toolchains/build_windows_toolchain.py
+++ b/tools/cr/toolchains/build_windows_toolchain.py
@@ -68,20 +68,16 @@ import shutil
 import stat
 import subprocess
 import sys
-import time
-import urllib.error
 import urllib.request
 from pathlib import Path
-
-import yaml
 
 # This is necessary because these scripts are used by brockit too.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from cherry_picks import _check_call  # pylint: disable=wrong-import-position
 import gitiles  # pylint: disable=wrong-import-position
-from upload import (  # pylint: disable=wrong-import-position
-    S3Uploader, sha256_file, summarise)
+import toolchain_publish  # pylint: disable=wrong-import-position
+from upload import sha256_file  # pylint: disable=wrong-import-position
 
 TOOLCHAIN_BUCKET = 'brave-build-deps-internal'
 TOOLCHAIN_BUCKET_PREFIX = 'windows-hermetic-toolchain'
@@ -133,47 +129,6 @@ VSWHERE_PATH = Path(
 DEPOT_TOOLS_PYTHON3 = 'vpython3.bat'
 PACKAGE_FROM_INSTALLED_RELPATH = (Path('win_toolchain') /
                                   'package_from_installed.py')
-
-# License headers used in the index.
-INDEX_LICENSE_HEADER_TEMPLATE = (
-    '# Copyright (c) {year} The Brave Authors. All rights reserved.\n'
-    '# This Source Code Form is subject to the terms of the Mozilla Public\n'
-    '# License, v. 2.0. If a copy of the MPL was not distributed with this '
-    'file,\n'
-    '# You can obtain one at https://mozilla.org/MPL/2.0/.\n')
-
-
-def _remote_url_exists(url: str) -> bool:
-    """Return whether *url* already resolves to a published object.
-
-    Treats HTTP 403/404 as "not published" -- the download bucket's CDN
-    sometimes returns 403 where a 404 is expected. Any other HTTP status or a
-    network error propagates, so a transient failure is never mistaken for
-    "absent".
-    """
-    try:
-        with urllib.request.urlopen(url,
-                                    timeout=gitiles.HTTP_FETCH_TIMEOUT_SECS):
-            return True
-    except urllib.error.HTTPError as e:
-        if e.code in (403, 404):
-            return False
-        raise
-
-
-def _brave_core_commit() -> str:
-    """Return the brave-core HEAD commit this script was run from.
-
-    This script lives in brave-core, so its repository HEAD identifies the
-    exact version that produced the archive -- recorded in the index for
-    provenance.
-    """
-    return _check_call('git',
-                       'rev-parse',
-                       'HEAD',
-                       cwd=Path(__file__).resolve().parent,
-                       capture_output=True).stdout.strip()
-
 
 def _resolve_windows_sdk_installer_url(build: str) -> str:
     """Resolve the standalone installer URL for an exact Windows SDK *build*.
@@ -316,16 +271,8 @@ def fetch_published_index(sdk_info: WinSdkInfo) -> dict:
         RuntimeError: if the index cannot be fetched.
     """
     index_url = PACKAGE_DOWNLOAD_URL_BASE + toolchain_index_name(sdk_info)
-    logging.debug('Fetching hermetic Windows toolchain index %s', index_url)
-    try:
-        with urllib.request.urlopen(
-                index_url,
-                timeout=gitiles.HTTP_FETCH_TIMEOUT_SECS) as response:
-            return yaml.safe_load(response)
-    except urllib.error.URLError as e:
-        raise RuntimeError(
-            f'Failed to fetch hermetic Windows toolchain index {index_url}: '
-            f'{e}') from e
+    return toolchain_publish.fetch_index(index_url,
+                                         'hermetic Windows toolchain')
 
 
 class ToolchainBuilder:
@@ -618,7 +565,7 @@ class ToolchainBuilder:
         """
         assert self._upstream_sdk_info is not None
         index_url = PACKAGE_DOWNLOAD_URL_BASE + self._index_path.name
-        if _remote_url_exists(index_url):
+        if toolchain_publish.remote_url_exists(index_url):
             raise RuntimeError(
                 f'{index_url} already exists; a toolchain for upstream hash '
                 f'{self._upstream_sdk_info.toolchain_hash} is already '
@@ -646,29 +593,16 @@ class ToolchainBuilder:
             'installed_vs_display_name': vswhere_instance['displayName'],
             'chromium_tag': self._chromium_tag,
         }
-        index['brave_core_commit'] = _brave_core_commit()
+        index['brave_core_commit'] = toolchain_publish.brave_core_commit()
 
-        index_yaml = yaml.safe_dump(index,
-                                    sort_keys=False,
-                                    default_flow_style=False)
-        license_header = INDEX_LICENSE_HEADER_TEMPLATE.format(
-            year=time.gmtime().tm_year)
-        index_path = self._index_path
-        index_path.write_text(f'{license_header}\n{index_yaml}',
-                              encoding='utf-8',
-                              newline='')
-        logging.info('Wrote toolchain index %s:', index_path)
-        print(index_path.read_bytes().decode('utf-8'))
+        toolchain_publish.write_index_file(self._index_path, index)
 
     def _upload(self, archive: Path) -> None:
         """Upload the archive and its sibling index to the internal bucket.
         """
-        uploader = S3Uploader(bucket=TOOLCHAIN_BUCKET)
-        for path in (archive, self._index_path):
-            result = uploader.upload(path,
-                                     prefix=TOOLCHAIN_BUCKET_PREFIX,
-                                     sign=False)
-            logging.info('Uploaded %s:\n%s', path.name, summarise(result))
+        toolchain_publish.upload_files(TOOLCHAIN_BUCKET,
+                                       TOOLCHAIN_BUCKET_PREFIX,
+                                       (archive, self._index_path))
 
     def run(self, clear: bool = False, upload: bool = False) -> None:
         """Execute the full inspect-install-pack-index-upload pipeline.

--- a/tools/cr/toolchains/build_xcode_toolchain.py
+++ b/tools/cr/toolchains/build_xcode_toolchain.py
@@ -36,8 +36,9 @@ What it does in summary:
      and symlink targets normalized via `os.path.normpath`.
   7. Writes a sibling YAML index next to the archive, recording where the
      toolchain is served, its SHA-256, and the Xcode provenance. Publishing is
-     refused if an index already exists for the toolchain unless
-     `--force-overwrite` is given.
+     refused if an index already exists for the toolchain.
+  8. With `--upload`, publishes the archive and its sibling index to
+     `TOOLCHAIN_BUCKET`.
 
 The output archive is written under `--out-dir` as
 `xcode-hermetic-toolchain-<sdk-version>-<sdk-build>.tar.gz`, where the pair is
@@ -68,9 +69,6 @@ import re
 import shutil
 import sys
 import tarfile
-import time
-import urllib.error
-import urllib.request
 from pathlib import Path
 
 import yaml
@@ -85,6 +83,7 @@ from cherry_picks import _check_call  # pylint: disable=wrong-import-position
 from ephemeral_xcode import (  # pylint: disable=wrong-import-position
     EphemeralXcode, MacSdkInfo)
 import gitiles  # pylint: disable=wrong-import-position
+import toolchain_publish  # pylint: disable=wrong-import-position
 from upload import sha256_file  # pylint: disable=wrong-import-position
 
 # The base url used by brave to download the toolchain package. This is used in
@@ -93,46 +92,8 @@ PACKAGE_DOWNLOAD_URL_BASE = (
     'https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-2.on.aws/'
     'xcode-hermetic-toolchain/')
 
-# Brave MPL license notice prepended to the generated YAML index, with the
-# current year filled in at write time. YAML treats `#` lines as comments, so
-# the index keeps loading cleanly while carrying the notice.
-INDEX_LICENSE_HEADER_TEMPLATE = (
-    '# Copyright (c) {year} The Brave Authors. All rights reserved.\n'
-    '# This Source Code Form is subject to the terms of the Mozilla Public\n'
-    '# License, v. 2.0. If a copy of the MPL was not distributed with this '
-    'file,\n'
-    '# You can obtain one at https://mozilla.org/MPL/2.0/.\n')
-
-
-def _brave_core_commit() -> str:
-    """Return the brave-core HEAD commit this script was run from.
-
-    This script lives in brave-core, so its repository HEAD identifies the exact
-    version that produced the archive — recorded in the index for provenance.
-    """
-    return _check_call('git',
-                       'rev-parse',
-                       'HEAD',
-                       cwd=Path(__file__).resolve().parent,
-                       capture_output=True).stdout.strip()
-
-
-def _remote_url_exists(url: str) -> bool:
-    """Return whether *url* already resolves to a published object.
-
-    Treats HTTP 403/404 as "not published" -- the download bucket's CDN
-    sometimes returns 403 where a 404 is expected. Any other HTTP status or a
-    network error propagates, so a transient failure is never mistaken for
-    "absent".
-    """
-    try:
-        with urllib.request.urlopen(url,
-                                    timeout=gitiles.HTTP_FETCH_TIMEOUT_SECS):
-            return True
-    except urllib.error.HTTPError as e:
-        if e.code in (403, 404):
-            return False
-        raise
+TOOLCHAIN_BUCKET = 'brave-build-deps-internal'
+TOOLCHAIN_BUCKET_PREFIX = 'xcode-hermetic-toolchain'
 
 
 def _normalize_tar_entry(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo:
@@ -227,16 +188,7 @@ def fetch_published_index(sdk_info: MacSdkInfo) -> dict:
         RuntimeError: if the index cannot be fetched.
     """
     index_url = PACKAGE_DOWNLOAD_URL_BASE + toolchain_index_name(sdk_info)
-    logging.debug('Fetching hermetic Xcode toolchain index %s', index_url)
-    try:
-        with urllib.request.urlopen(
-                index_url,
-                timeout=gitiles.HTTP_FETCH_TIMEOUT_SECS) as response:
-            return yaml.safe_load(response)
-    except urllib.error.URLError as e:
-        raise RuntimeError(
-            f'Failed to fetch hermetic Xcode toolchain index {index_url}: {e}'
-        ) from e
+    return toolchain_publish.fetch_index(index_url, 'hermetic Xcode toolchain')
 
 
 class ToolchainBuilder:
@@ -266,9 +218,10 @@ class ToolchainBuilder:
        across hosts.
     5. **Index** (`_precheck_publishable` / `_write_index`): Refuses early
        (right after reading the upstream SDK, before any heavy work) if an index
-       is already published, unless `--force-overwrite` is set, then writes a
-       sibling YAML index recording the archive URL, its SHA-256, and the
-       Xcode provenance.
+       is already published, then writes a sibling YAML index recording the
+       archive URL, its SHA-256, and the Xcode provenance.
+    6. **Upload** (`_upload`): With `--upload`, publishes the archive and its
+       sibling index to `TOOLCHAIN_BUCKET`.
     """
 
     def __init__(self, chromium_tag: str, out_dir: Path):
@@ -518,11 +471,10 @@ class ToolchainBuilder:
         difficult to recover from such a mistake.
         """
         index_url = PACKAGE_DOWNLOAD_URL_BASE + self._index_path.name
-        if _remote_url_exists(index_url):
+        if toolchain_publish.remote_url_exists(index_url):
             raise RuntimeError(
                 f'An index already exists at {index_url}; this toolchain has '
-                'already been published. Pass --force-overwrite to rebuild and '
-                'replace it.')
+                'already been published.')
 
     def _write_index(self) -> None:
         """Write the sibling YAML index describing the just-built toolchain.
@@ -544,8 +496,7 @@ class ToolchainBuilder:
           * `brave_core_commit` — brave-core HEAD commit this script ran from.
 
         The "already published" guard lives in `_precheck_publishable`, which
-        `run()` calls early. If we got here, and we are overwriting the previous
-        file, this means clobbering was allowed with `--force-overwrite`.
+        `run()` calls early.
 
         After writing, the index file is read back and printed in the console.
         """
@@ -564,19 +515,17 @@ class ToolchainBuilder:
             'metal_build': self._metal_build,
             'chromium_tag': self._chromium_tag,
         }
-        index['brave_core_commit'] = _brave_core_commit()
-        index_yaml = yaml.safe_dump(index,
-                                    sort_keys=False,
-                                    default_flow_style=False)
-        license_header = INDEX_LICENSE_HEADER_TEMPLATE.format(
-            year=time.gmtime().tm_year)
-        index_path.write_text(f'{license_header}\n{index_yaml}',
-                              encoding='utf-8',
-                              newline='')
-        logging.info('Wrote toolchain index %s:', index_path)
-        print(index_path.read_bytes().decode('utf-8'))
+        index['brave_core_commit'] = toolchain_publish.brave_core_commit()
 
-    def run(self, clear: bool = False, force_overwrite: bool = False) -> None:
+        toolchain_publish.write_index_file(index_path, index)
+
+    def _upload(self) -> None:
+        """Upload the archive and its sibling index to the internal bucket."""
+        toolchain_publish.upload_files(TOOLCHAIN_BUCKET,
+                                       TOOLCHAIN_BUCKET_PREFIX,
+                                       (self._archive_path, self._index_path))
+
+    def run(self, clear: bool = False, upload: bool = False) -> None:
         """Execute the full inspect-stage-read-pack pipeline.
 
         On a successful pack, the transient `self._staged_xcode` working
@@ -587,9 +536,8 @@ class ToolchainBuilder:
             clear: If True, delete every entry under `self._out_dir` at the
                 start of the run so the build produces output into a
                 guaranteed-clean directory.
-            force_overwrite: If True, skips the early "already published"
-                check so an existing index for this toolchain is rebuilt and
-                replaced instead of refused. See `_precheck_publishable`.
+            upload: If True, upload the archive and its sibling index to
+                `TOOLCHAIN_BUCKET` after building (see `_upload`).
 
         Raises:
             FileNotFoundError: If a YAML entry refers to a path that is not
@@ -604,8 +552,7 @@ class ToolchainBuilder:
                 Xcode.app, if `xcodebuild` does not report all of Xcode /
                 Build version / SDKVersion / ProductBuildVersion, if
                 `xcrun --find metal` does not resolve to a `Metal.xctoolchain`,
-                or if a published index already exists for this toolchain and
-                `force_overwrite` was not set.
+                or if a published index already exists for this toolchain.
             urllib.error.HTTPError: If a gitiles fetch fails (typically a
                 bad `--chromium-tag`).
             subprocess.CalledProcessError: If any invoked tool
@@ -617,8 +564,7 @@ class ToolchainBuilder:
             shutil.rmtree(self._out_dir, ignore_errors=True)
         self._out_dir.mkdir(parents=True, exist_ok=True)
         self._load_upstream_mac_sdk_info()
-        if not force_overwrite:
-            self._precheck_publishable()
+        self._precheck_publishable()
         assert self._upstream_mac_sdk_info is not None
         # The deployed Xcode is the active one only inside this block; on exit
         # `deploy()` always reverts the selection with `xcode-select --reset`.
@@ -632,6 +578,8 @@ class ToolchainBuilder:
         logging.info('Removing staged Xcode at %s', self._staged_xcode)
         shutil.rmtree(self._staged_xcode)
         self._write_index()
+        if upload:
+            self._upload()
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -654,10 +602,10 @@ def main(argv: list[str] | None = None) -> int:
         action='store_true',
         help='Makes sure the output directory is empty before building.')
     parser.add_argument(
-        '--force-overwrite',
+        '--upload',
         action='store_true',
-        help='Overwrite the published index for this toolchain instead of '
-        'refusing when one already exists.')
+        help=f'Upload the archive and its sibling index to the internal '
+        f'build-deps bucket ({TOOLCHAIN_BUCKET}) after building.')
     parser.add_argument('--verbose',
                         action='store_true',
                         help='Log every archive member at DEBUG level.')
@@ -666,9 +614,8 @@ def main(argv: list[str] | None = None) -> int:
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO,
                         format='%(message)s')
 
-    ToolchainBuilder(args.chromium_tag,
-                     args.out_dir).run(clear=args.clear,
-                                       force_overwrite=args.force_overwrite)
+    ToolchainBuilder(args.chromium_tag, args.out_dir).run(clear=args.clear,
+                                                          upload=args.upload)
     return 0
 
 

--- a/tools/cr/toolchains/cherry_picks.py
+++ b/tools/cr/toolchains/cherry_picks.py
@@ -39,9 +39,10 @@ def _check_call(*command,
                 capture_output=False):
     """Run *command* as a subprocess, logging the invocation.
 
-    Shared subprocess helper for the toolchain build scripts in this directory
-    (`build_rust_toolchain`, `build_xcode_toolchain`, `ephemeral_xcode`), which
-    all import it rather than carrying their own copy.
+    Shared subprocess helper for every script in this directory that shells
+    out (`build_windows_toolchain`, `build_xcode_toolchain`,
+    `build_rust_toolchain`, `ephemeral_xcode`, `toolchain_publish`), which all
+    import it rather than carrying their own copy.
 
     Logs the full command string at INFO level before executing it.  Stdout
     and stderr are inherited from the parent process (so subprocess output

--- a/tools/cr/toolchains/toolchain_publish.py
+++ b/tools/cr/toolchains/toolchain_publish.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Shared publishing helpers for the hermetic toolchain builders.
+
+`build_windows_toolchain.py`, `build_xcode_toolchain.py`, and
+`build_rust_toolchain.py` each build one hermetic toolchain archive and
+publish it alongside a sibling YAML index recording its provenance. The three
+builders are otherwise unrelated (different inputs, different archive
+formats), but that publishing step -- probing whether a toolchain is already
+published, fetching a published index, writing one, and uploading the
+archive + index pair -- is identical across all three, so it lives here
+instead of being carried as three near-identical copies.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+# This is necessary because this module is used by brockit too.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from cherry_picks import _check_call  # pylint: disable=wrong-import-position
+from upload import (  # pylint: disable=wrong-import-position
+    S3Uploader, summarise)
+
+# Read timeout for a single HTTP fetch: a published index, or an "already
+# published?" probe.
+DEFAULT_TIMEOUT_SECS = 30
+
+# Brave MPL license header prepended to every published YAML index.
+INDEX_LICENSE_HEADER_TEMPLATE = (
+    '# Copyright (c) {year} The Brave Authors. All rights reserved.\n'
+    '# This Source Code Form is subject to the terms of the Mozilla Public\n'
+    '# License, v. 2.0. If a copy of the MPL was not distributed with this '
+    'file,\n'
+    '# You can obtain one at https://mozilla.org/MPL/2.0/.\n')
+
+
+def brave_core_commit() -> str:
+    """Return the brave-core HEAD commit this script was run from.
+
+    Every toolchain builder lives in brave-core, so its repository HEAD
+    identifies the exact version that produced the archive -- recorded in
+    the index for provenance.
+    """
+    return _check_call('git',
+                       'rev-parse',
+                       'HEAD',
+                       cwd=Path(__file__).resolve().parent,
+                       capture_output=True).stdout.strip()
+
+
+def remote_url_exists(url: str, timeout: int = DEFAULT_TIMEOUT_SECS) -> bool:
+    """Return whether *url* already resolves to a published object.
+
+    Treats HTTP 403/404 as "not published" -- the download bucket's CDN
+    sometimes returns 403 where a 404 is expected. Any other HTTP status or a
+    network error propagates, so a transient failure is never mistaken for
+    "absent".
+    """
+    try:
+        with urllib.request.urlopen(url, timeout=timeout):
+            return True
+    except urllib.error.HTTPError as e:
+        if e.code in (403, 404):
+            return False
+        raise
+
+
+def fetch_index(index_url: str,
+                description: str = 'toolchain',
+                timeout: int = DEFAULT_TIMEOUT_SECS) -> dict:
+    """Download and parse a published toolchain sibling YAML index.
+
+    *description* customises the log/error messages (e.g. `'hermetic Windows
+    toolchain'`).
+
+    Raises:
+        RuntimeError: if the index cannot be fetched.
+    """
+    logging.debug('Fetching %s index %s', description, index_url)
+    try:
+        with urllib.request.urlopen(index_url, timeout=timeout) as response:
+            return yaml.safe_load(response)
+    except urllib.error.URLError as e:
+        raise RuntimeError(
+            f'Failed to fetch {description} index {index_url}: {e}') from e
+
+
+def write_index_file(index_path: Path, index: dict) -> None:
+    """Write *index* as a Brave-MPL-licensed YAML file at *index_path*.
+
+    Every sibling index a toolchain builder publishes is written the same
+    way: a license header followed by the mapping dumped with stable
+    (insertion) key order. After writing, the file is read back and echoed to
+    the console.
+    """
+    index_yaml = yaml.safe_dump(index,
+                                sort_keys=False,
+                                default_flow_style=False)
+    license_header = INDEX_LICENSE_HEADER_TEMPLATE.format(
+        year=time.gmtime().tm_year)
+    index_path.write_text(f'{license_header}\n{index_yaml}',
+                          encoding='utf-8',
+                          newline='')
+    logging.info('Wrote toolchain index %s:', index_path)
+    print(index_path.read_bytes().decode('utf-8'))
+
+
+def upload_files(bucket: str, prefix: str, paths: Iterable[Path]) -> None:
+    """Upload each of *paths* to *bucket* under *prefix*, logging a summary.
+
+    Shared by every toolchain builder's `--upload` step: each publishes an
+    archive plus its sibling YAML index the same way, unsigned -- these
+    internal/public build-deps buckets don't use the KMS-signed envelope
+    `upload.py` otherwise supports.
+    """
+    uploader = S3Uploader(bucket=bucket)
+    for path in paths:
+        result = uploader.upload(path, prefix=prefix, sign=False)
+        logging.info('Uploaded %s:\n%s', path.name, summarise(result))

--- a/tools/cr/toolchains/toolchain_publish_test.py
+++ b/tools/cr/toolchains/toolchain_publish_test.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `toolchain_publish`.
+
+`urllib.request.urlopen` is mocked throughout (no network access); `S3Uploader`
+is mocked in `UploadFilesTest` (its own behavior is covered by `upload_test.py`).
+`brave_core_commit` is the one exception: it is exercised against the real
+brave-core checkout this test runs from, rather than mocking `git`.
+
+Coverage:
+
+* `BraveCoreCommitTest` -- resolves to the real `git rev-parse HEAD` of the
+  checkout this module lives in.
+* `RemoteUrlExistsTest` -- the 403/404-tolerant "already published?" probe.
+* `FetchIndexTest` -- downloading and parsing a published sibling index, and
+  wrapping a fetch failure in a `RuntimeError` that names *description*.
+* `WriteIndexFileTest` -- the license header + YAML dump + echo-to-console
+  write path.
+* `UploadFilesTest` -- `S3Uploader` construction and the per-path
+  `prefix`/`sign=False` upload call.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import toolchain_publish as m  # pylint: disable=wrong-import-position
+
+
+class _FakeContextResponse:
+    """A context-manager stand-in for `http.client.HTTPResponse`, used where
+    the response body itself is never read (only entering the `with` block
+    matters)."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+class BraveCoreCommitTest(unittest.TestCase):
+    """Tests for `brave_core_commit`."""
+
+    def test_resolves_to_the_real_checkout_head(self):
+        expected = subprocess.run(('git', 'rev-parse', 'HEAD'),
+                                  cwd=Path(m.__file__).resolve().parent,
+                                  check=True,
+                                  capture_output=True,
+                                  text=True).stdout.strip()
+        self.assertEqual(m.brave_core_commit(), expected)
+
+
+class RemoteUrlExistsTest(unittest.TestCase):
+    """Tests for `remote_url_exists`."""
+
+    URL = 'https://example.invalid/toolchain.yaml'
+
+    def test_true_when_url_resolves(self):
+        with mock.patch('urllib.request.urlopen',
+                        return_value=_FakeContextResponse()) as urlopen:
+            self.assertTrue(m.remote_url_exists(self.URL))
+        urlopen.assert_called_once_with(self.URL,
+                                        timeout=m.DEFAULT_TIMEOUT_SECS)
+
+    def test_false_on_404(self):
+        error = urllib.error.HTTPError(self.URL, 404, 'Not Found', {},
+                                       io.BytesIO(b''))
+        with mock.patch('urllib.request.urlopen', side_effect=error):
+            self.assertFalse(m.remote_url_exists(self.URL))
+
+    def test_false_on_403(self):
+        # The download bucket's CDN sometimes returns 403 where a 404 is
+        # expected.
+        error = urllib.error.HTTPError(self.URL, 403, 'Forbidden', {},
+                                       io.BytesIO(b''))
+        with mock.patch('urllib.request.urlopen', side_effect=error):
+            self.assertFalse(m.remote_url_exists(self.URL))
+
+    def test_other_http_error_propagates(self):
+        error = urllib.error.HTTPError(self.URL, 500, 'Internal Server Error',
+                                       {}, io.BytesIO(b''))
+        with mock.patch('urllib.request.urlopen', side_effect=error):
+            with self.assertRaises(urllib.error.HTTPError):
+                m.remote_url_exists(self.URL)
+
+    def test_honours_custom_timeout(self):
+        with mock.patch('urllib.request.urlopen',
+                        return_value=_FakeContextResponse()) as urlopen:
+            m.remote_url_exists(self.URL, timeout=5)
+        urlopen.assert_called_once_with(self.URL, timeout=5)
+
+
+class FetchIndexTest(unittest.TestCase):
+    """Tests for `fetch_index`."""
+
+    URL = 'https://example.invalid/toolchain.yaml'
+
+    def test_parses_the_published_yaml_index(self):
+        body = yaml.safe_dump({'sha256sum': 'abc', 'size_bytes': 3})
+        with mock.patch('urllib.request.urlopen',
+                        return_value=io.BytesIO(
+                            body.encode('utf-8'))) as urlopen:
+            result = m.fetch_index(self.URL)
+        self.assertEqual(result, {'sha256sum': 'abc', 'size_bytes': 3})
+        urlopen.assert_called_once_with(self.URL,
+                                        timeout=m.DEFAULT_TIMEOUT_SECS)
+
+    def test_wraps_fetch_failure_naming_the_description(self):
+        with mock.patch('urllib.request.urlopen',
+                        side_effect=urllib.error.URLError('boom')):
+            with self.assertRaises(RuntimeError) as ctx:
+                m.fetch_index(self.URL,
+                              description='hermetic Windows toolchain')
+        self.assertIn('hermetic Windows toolchain', str(ctx.exception))
+        self.assertIn(self.URL, str(ctx.exception))
+
+    def test_default_description_is_toolchain(self):
+        with mock.patch('urllib.request.urlopen',
+                        side_effect=urllib.error.URLError('boom')):
+            with self.assertRaises(RuntimeError) as ctx:
+                m.fetch_index(self.URL)
+        self.assertIn('toolchain index', str(ctx.exception))
+
+    def test_honours_custom_timeout(self):
+        body = yaml.safe_dump({'k': 'v'})
+        with mock.patch('urllib.request.urlopen',
+                        return_value=io.BytesIO(
+                            body.encode('utf-8'))) as urlopen:
+            m.fetch_index(self.URL, timeout=5)
+        urlopen.assert_called_once_with(self.URL, timeout=5)
+
+
+class WriteIndexFileTest(unittest.TestCase):
+    """Tests for `write_index_file`."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.index_path = Path(self._tmp.name) / 'toolchain.yaml'
+
+    def test_writes_license_header_then_the_yaml_mapping(self):
+        with mock.patch.object(m.time,
+                               'gmtime',
+                               return_value=time.struct_time((2031, ) +
+                                                             (0, ) * 8)):
+            m.write_index_file(self.index_path,
+                               {'url': 'https://example.invalid/x.tar.xz'})
+
+        text = self.index_path.read_text(encoding='utf-8')
+        header = m.INDEX_LICENSE_HEADER_TEMPLATE.format(year=2031)
+        self.assertTrue(text.startswith(header))
+
+        # The mapping survives round-tripping, unaffected by the `#`-comment
+        # license header preceding it.
+        parsed = yaml.safe_load(text)
+        self.assertEqual(parsed, {'url': 'https://example.invalid/x.tar.xz'})
+
+    def test_preserves_insertion_order_over_sorted_order(self):
+        index = {'z_field': 1, 'a_field': 2}
+        m.write_index_file(self.index_path, index)
+        text = self.index_path.read_text(encoding='utf-8')
+        self.assertLess(text.index('z_field'), text.index('a_field'))
+
+    def test_echoes_written_content_to_the_console(self):
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            m.write_index_file(self.index_path, {'k': 'v'})
+        # `print` appends its own trailing newline on top of the file's.
+        self.assertEqual(stdout.getvalue(),
+                         self.index_path.read_text(encoding='utf-8') + '\n')
+
+
+class UploadFilesTest(unittest.TestCase):
+    """Tests for `upload_files`."""
+
+    def test_uploads_every_path_with_bucket_prefix_unsigned(self):
+        calls = []
+        fake_uploader = mock.Mock()
+        fake_uploader.upload.side_effect = (
+            lambda path, prefix, sign: calls.append((path, prefix, sign)))
+
+        paths = [Path('archive.tar.xz'), Path('archive.yaml')]
+        with mock.patch.object(m, 'S3Uploader',
+                               return_value=fake_uploader) as uploader_cls, \
+             mock.patch.object(m, 'summarise', return_value='summary'):
+            m.upload_files('my-bucket', 'my-prefix', paths)
+
+        uploader_cls.assert_called_once_with(bucket='my-bucket')
+        self.assertEqual(calls, [
+            (Path('archive.tar.xz'), 'my-prefix', False),
+            (Path('archive.yaml'), 'my-prefix', False),
+        ])
+
+    def test_uploads_nothing_for_an_empty_path_list(self):
+        fake_uploader = mock.Mock()
+        with mock.patch.object(m, 'S3Uploader', return_value=fake_uploader):
+            m.upload_files('my-bucket', 'my-prefix', [])
+        fake_uploader.upload.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
@@ -291,7 +291,8 @@
       "--brave-subrevision",
       "1",
       "--clear",
-      "--no-full-toolchain"
+      "--no-full-toolchain",
+      "--upload"
     ],
     "name": "build rust toolchain"
   },

--- a/tools/recipes/recipes/toolchains/rust/package_rust.py
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.py
@@ -32,6 +32,9 @@ def RunSteps(api: RecipeScriptApi, properties: InputProperties,
     brave_core_root = api.brave_core_checkout.deploy('tools/cr/toolchains')
 
     vpython3 = api.depot_tools.vpython3()
+    # `--clear` wipes any prior output so every run starts from a clean out
+    # dir. `--upload` publishes the archive + sibling index to the public
+    # build-deps bucket.
     api.step('build rust toolchain', [
         vpython3,
         brave_core_root / 'tools/cr/toolchains/build_rust_toolchain.py',
@@ -43,6 +46,7 @@ def RunSteps(api: RecipeScriptApi, properties: InputProperties,
         str(properties.brave_subrevision),
         '--clear',
         '--no-full-toolchain',
+        '--upload',
     ])
 
 
@@ -61,6 +65,8 @@ def GenTests(api):
         api.post_process(post_process.MustRun, 'build rust toolchain'),
         api.post_process(post_process.StepCommandContains,
                          'build rust toolchain', ['--brave-subrevision', '1']),
+        api.post_process(post_process.StepCommandContains,
+                         'build rust toolchain', ['--upload']),
         api.post_process(post_process.StepCommandContains,
                          'git cache populate', ['--depth', '1']),
         api.post_process(post_process.StepCommandContains,

--- a/tools/recipes/recipes/toolchains/xcode/build_xcode_toolchain.expected/mac.json
+++ b/tools/recipes/recipes/toolchains/xcode/build_xcode_toolchain.expected/mac.json
@@ -60,7 +60,8 @@
       "[WORKSPACE]/out",
       "--chromium-tag",
       "150.0.7841.1",
-      "--clear"
+      "--clear",
+      "--upload"
     ],
     "name": "build xcode toolchain"
   },

--- a/tools/recipes/recipes/toolchains/xcode/build_xcode_toolchain.proto
+++ b/tools/recipes/recipes/toolchains/xcode/build_xcode_toolchain.proto
@@ -12,7 +12,4 @@ message InputProperties {
   // toolchain is built for. Must be a tag: the builder reads it via gitiles'
   // `refs/tags/{tag}` endpoint.
   string chromium_tag = 1;
-  // Rebuild and replace an already-published index instead of refusing. Off
-  // by default so a run never clobbers a toolchain already in use in the wild.
-  bool force_overwrite = 2;
 }

--- a/tools/recipes/recipes/toolchains/xcode/build_xcode_toolchain.py
+++ b/tools/recipes/recipes/toolchains/xcode/build_xcode_toolchain.py
@@ -32,7 +32,9 @@ def RunSteps(api: RecipeScriptApi, properties: InputProperties) -> None:
     brave_core_root = api.brave_core_checkout.deploy('tools/cr/toolchains')
 
     vpython3 = api.depot_tools.vpython3()
-    # `--clear` wipes any prior output so every run starts from a clean out dir.
+    # `--clear` wipes any prior output so every run starts from a clean out
+    # dir. `--upload` publishes the archive + index to the internal build-deps
+    # bucket.
     cmd = [
         vpython3,
         brave_core_root / 'tools/cr/toolchains/build_xcode_toolchain.py',
@@ -41,9 +43,8 @@ def RunSteps(api: RecipeScriptApi, properties: InputProperties) -> None:
         '--chromium-tag',
         properties.chromium_tag,
         '--clear',
+        '--upload',
     ]
-    if properties.force_overwrite:
-        cmd.append('--force-overwrite')
     api.step('build xcode toolchain', cmd)
 
 
@@ -61,16 +62,7 @@ def GenTests(api):
                          ['--chromium-tag', '150.0.7841.1']),
         api.post_process(post_process.StepCommandContains,
                          'build xcode toolchain', ['--clear']),
-        api.post_process(post_process.StatusSuccess),
-    )
-    # `force_overwrite` appends `--force-overwrite` to the build command.
-    yield api.test(
-        'force overwrite',
-        api.platform.name('mac'),
-        api.brave_core_checkout.deployed('tools/cr/toolchains'),
-        api.properties(chromium_tag='150.0.7841.1', force_overwrite=True),
         api.post_process(post_process.StepCommandContains,
-                         'build xcode toolchain', ['--force-overwrite']),
+                         'build xcode toolchain', ['--upload']),
         api.post_process(post_process.StatusSuccess),
-        api.post_process(post_process.DropExpectation),
     )


### PR DESCRIPTION
This change unifies the model of how the different toolchain scripts
upload their toolchains, with all of them now providing a `--upload`
option to upload the produced tarball.

Additionally, this script further flattens the code under
`tools/cr/toolchains`.

Bug: https://github.com/brave/brave-browser/issues/55812
