### PR TITLE
Add `day_zero` attribute to Leo most used entry point metric (uplift to 1.94.x)

### DIFF
--- a/components/misc_metrics/BUILD.gn
+++ b/components/misc_metrics/BUILD.gn
@@ -102,6 +102,8 @@ source_set("unit_tests") {
     "//base",
     "//base/test:test_support",
     "//brave/components/misc_metrics",
+    "//brave/components/p3a_utils",
+    "//brave/components/p3a_utils:test_support",
     "//brave/components/search_engines",
     "//components/language/core/browser",
     "//components/prefs:test_support",

--- a/components/misc_metrics/general_browser_usage.cc
+++ b/components/misc_metrics/general_browser_usage.cc
@@ -10,6 +10,7 @@
 #include "base/time/time.h"
 #include "brave/components/misc_metrics/pref_names.h"
 #include "brave/components/p3a_utils/bucket.h"
+#include "brave/components/p3a_utils/custom_attributes.h"
 #include "brave/components/time_period_storage/iso_weekly_storage.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
@@ -70,6 +71,7 @@ void GeneralBrowserUsage::ReportInstallTime() {
   int days_since_install =
       (base::Time::Now() - first_run_time_).InDaysFloored();
   if (days_since_install < 0 || days_since_install > 30) {
+    p3a_utils::SetCustomAttribute(kDayZeroAttributeName, std::nullopt);
     return;
   }
   auto start_of_report_day = first_run_time_ + base::Days(days_since_install);
@@ -80,15 +82,18 @@ void GeneralBrowserUsage::ReportInstallTime() {
   std::string day_zero_variant =
       local_state_->GetString(kMiscMetricsDayZeroVariantAtInstall);
   if (day_zero_variant.empty()) {
+    p3a_utils::SetCustomAttribute(kDayZeroAttributeName, std::nullopt);
     return;
   }
+  std::string day_zero_variant_lower = base::ToLowerASCII(day_zero_variant);
   // Get index of first char (0-25 for a-z)
-  int variant_index = base::ToLowerASCII(day_zero_variant[0]) - 'a';
+  int variant_index = day_zero_variant_lower[0] - 'a';
   if (variant_index < 0) {
     return;
   }
   local_state_->SetTime(kMiscMetricsLastDayZeroReport, base::Time::Now());
   UMA_HISTOGRAM_EXACT_LINEAR(kDayZeroVariantHistogramName, variant_index, 31);
+  p3a_utils::SetCustomAttribute(kDayZeroAttributeName, day_zero_variant_lower);
 }
 
 void GeneralBrowserUsage::ReportProfileCount(size_t count) {

--- a/components/misc_metrics/general_browser_usage.h
+++ b/components/misc_metrics/general_browser_usage.h
@@ -23,6 +23,7 @@ inline constexpr char kWeeklyUseHistogramName[] = "Brave.Core.WeeklyUsage";
 inline constexpr char kProfileCountHistogramName[] = "Brave.Core.ProfileCount";
 
 inline constexpr char kDayZeroVariantHistogramName[] = "Brave.DayZero.Variant";
+inline constexpr char kDayZeroAttributeName[] = "day_zero";
 
 // TODO(djandries): remove this metric when Nebula experiment is over
 inline constexpr char kWeeklyUseNebulaHistogramName[] =

--- a/components/misc_metrics/general_browser_usage_unittest.cc
+++ b/components/misc_metrics/general_browser_usage_unittest.cc
@@ -3,13 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/components/misc_metrics/general_browser_usage.h"
+
 #include <memory>
 #include <optional>
 #include <string>
 
 #include "base/test/metrics/histogram_tester.h"
 #include "base/time/time.h"
-#include "brave/components/misc_metrics/general_browser_usage.h"
+#include "brave/components/p3a_utils/test_event_relay_observer.h"
 #include "components/prefs/testing_pref_service.h"
 #include "content/public/test/browser_task_environment.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -58,6 +60,7 @@ class GeneralBrowserUsageUnitTest : public testing::Test {
   TestingPrefServiceSimple local_state_;
   std::unique_ptr<base::HistogramTester> histogram_tester_;
   std::unique_ptr<GeneralBrowserUsage> general_browser_usage_;
+  p3a_utils::TestEventRelayObserver event_relay_observer_;
 };
 
 TEST_F(GeneralBrowserUsageUnitTest, WeeklyUsage) {
@@ -115,19 +118,28 @@ TEST_F(GeneralBrowserUsageUnitTest, InstallTimeVariantSwitch) {
   SetUpUsage("B", true, install_time);
 
   histogram_tester_->ExpectUniqueSample(kDayZeroVariantHistogramName, 1, 1);
+  EXPECT_EQ(event_relay_observer_.GetCustomAttribute(kDayZeroAttributeName),
+            "b");
 
   task_environment_.FastForwardBy(base::Days(15));
 
   histogram_tester_->ExpectUniqueSample(kDayZeroVariantHistogramName, 1, 16);
+  EXPECT_EQ(event_relay_observer_.GetCustomAttribute(kDayZeroAttributeName),
+            "b");
 
   SetUpUsage("A", false, install_time);
   // Ensure histogram name does not change if "day zero" is enabled
   // after install; we only want to report the "day zero on" metric
   // if it was enabled at install time.
   histogram_tester_->ExpectUniqueSample(kDayZeroVariantHistogramName, 1, 16);
+  EXPECT_EQ(event_relay_observer_.GetCustomAttribute(kDayZeroAttributeName),
+            "b");
 
   task_environment_.FastForwardBy(base::Days(16));
   histogram_tester_->ExpectUniqueSample(kDayZeroVariantHistogramName, 1, 31);
+  // Past the 30-day window the attribute should be cleared.
+  EXPECT_EQ(event_relay_observer_.GetCustomAttribute(kDayZeroAttributeName),
+            std::nullopt);
 
   ResetHistogramTester();
   // Ensure there are no more reports past 30 days
@@ -135,6 +147,8 @@ TEST_F(GeneralBrowserUsageUnitTest, InstallTimeVariantSwitch) {
 
   histogram_tester_->ExpectTotalCount(kDayZeroVariantHistogramName, 0);
   histogram_tester_->ExpectTotalCount(kDayZeroVariantHistogramName, 0);
+  EXPECT_EQ(event_relay_observer_.GetCustomAttribute(kDayZeroAttributeName),
+            std::nullopt);
 }
 
 TEST_F(GeneralBrowserUsageUnitTest, InstallTimeBasic) {
@@ -149,16 +163,23 @@ TEST_F(GeneralBrowserUsageUnitTest, InstallTimeBasic) {
   SetUpUsage("A", true, install_time);
 
   histogram_tester_->ExpectUniqueSample(kDayZeroVariantHistogramName, 0, 1);
+  EXPECT_EQ(event_relay_observer_.GetCustomAttribute(kDayZeroAttributeName),
+            "a");
 
   task_environment_.FastForwardBy(base::Days(15));
 
   histogram_tester_->ExpectUniqueSample(kDayZeroVariantHistogramName, 0, 16);
+  EXPECT_EQ(event_relay_observer_.GetCustomAttribute(kDayZeroAttributeName),
+            "a");
 
   task_environment_.FastForwardBy(base::Days(15));
   histogram_tester_->ExpectUniqueSample(kDayZeroVariantHistogramName, 0, 31);
 
   task_environment_.FastForwardBy(base::Days(15));
   histogram_tester_->ExpectUniqueSample(kDayZeroVariantHistogramName, 0, 31);
+  // Past the 30-day window the attribute should be cleared.
+  EXPECT_EQ(event_relay_observer_.GetCustomAttribute(kDayZeroAttributeName),
+            std::nullopt);
 }
 
 }  // namespace misc_metrics

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -40,7 +40,11 @@ inline constexpr auto kCollectedTypicalHistograms =
     {"Brave.AIChat.FullPageSwitches", MetricConfig{.ephemeral = true}},
     {"Brave.AIChat.MaxChatDuration", MetricConfig{.ephemeral = true}},
     {"Brave.AIChat.MostUsedContextSource", MetricConfig{.ephemeral = true}},
-    {"Brave.AIChat.MostUsedEntryPoint", MetricConfig{.ephemeral = true}},
+    {"Brave.AIChat.MostUsedEntryPoint", MetricConfig{
+      .ephemeral = true,
+      .attributes = MetricAttributes{MetricAttribute::kCustomAttribute, MetricAttribute::kAnswerIndex, MetricAttribute::kYoi, MetricAttribute::kChannel, MetricAttribute::kPlatform, MetricAttribute::kCountryCode, MetricAttribute::kWoi},
+      .custom_attributes = {"day_zero"},
+    }},
     {"Brave.AIChat.NewUserReturning", {}},
     {"Brave.AIChat.OmniboxOpens", MetricConfig{.ephemeral = true}},
     {"Brave.AIChat.OmniboxWeekCompare", MetricConfig{.ephemeral = true}},


### PR DESCRIPTION
Uplift of #38497
Resolves https://github.com/brave/brave-browser/issues/57603

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.