### PR TITLE
Account: render truncated Brave Account email through Lit instead of mutating `textContent` (uplift to 1.94.x)

### DIFF
--- a/browser/resources/settings/getting_started_page/brave_account_logged_in_row.html.ts
+++ b/browser/resources/settings/getting_started_page/brave_account_logged_in_row.html.ts
@@ -79,7 +79,7 @@ export function getHtml(this: BraveAccountLoggedInRowElement) {
             ${this.i18n(BraveAccountSettingsStrings.BRAVE_ACCOUNT_TITLE)}
           </div>
           <div class="description">
-            <div id="email">${this.state.email}</div>
+            <div id="email">${this.truncatedEmail}</div>
           </div>
         </div>
         <leo-button kind="plain"

--- a/browser/resources/settings/getting_started_page/brave_account_logged_in_row.ts
+++ b/browser/resources/settings/getting_started_page/brave_account_logged_in_row.ts
@@ -39,10 +39,12 @@ export class BraveAccountLoggedInRowElement extends
     return {
       ...super.properties,
       isChangingPassword: { type: Boolean, state: true },
+      truncatedEmail: { type: String, state: true },
     }
   }
 
   protected accessor isChangingPassword = false
+  protected accessor truncatedEmail = ''
   private measure?: (text: string) => number
   private resizeObserver?: ResizeObserver
 
@@ -112,11 +114,10 @@ export class BraveAccountLoggedInRowElement extends
       return
     }
 
-    if (!this.resizeObserver) {
-      const emailEl =
-          this.shadowRoot?.querySelector<HTMLElement>('#email')
-      if (!emailEl) return
+    const emailEl = this.shadowRoot?.querySelector<HTMLElement>('#email')
+    if (!emailEl) return
 
+    if (!this.resizeObserver) {
       const canvas = document.createElement('canvas')
       const ctx = canvas.getContext('2d')!
       ctx.font = getComputedStyle(emailEl).font
@@ -126,8 +127,12 @@ export class BraveAccountLoggedInRowElement extends
         this.truncateEmail(emailEl)
       })
       this.resizeObserver.observe(emailEl)
-      this.truncateEmail(emailEl)
     }
+
+    // Re-truncate on every `state` change so a live email update (e.g. from
+    // `AuthValidate` polling) is reflected even when the layout width is
+    // unchanged and the `ResizeObserver` does not fire.
+    this.truncateEmail(emailEl)
   }
 
   private truncateEmail(emailEl: HTMLElement) {
@@ -137,10 +142,13 @@ export class BraveAccountLoggedInRowElement extends
     if (!email) return
 
     const availableWidth = emailEl.clientWidth
-    if (!availableWidth) return
+    if (!availableWidth) {
+      this.truncatedEmail = email
+      return
+    }
 
     if (this.measure(email) <= availableWidth) {
-      emailEl.textContent = email
+      this.truncatedEmail = email
       return
     }
 
@@ -167,7 +175,7 @@ export class BraveAccountLoggedInRowElement extends
       }
     }
 
-    emailEl.textContent = truncatedEmail
+    this.truncatedEmail = truncatedEmail
   }
 
   private cleanUpEmailTruncation() {


### PR DESCRIPTION
Uplift of #38636
Resolves https://github.com/brave/brave-browser/issues/57696

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.