### PR TITLE
Allow model invocation of preflight skill

### DIFF
--- a/agents/skills/preflight/SKILL.md
+++ b/agents/skills/preflight/SKILL.md
@@ -3,7 +3,6 @@ name: preflight
 description:
   'Run all preflight checks (format, gn_check, presubmit, build, tests) to make
   sure the current work is ready for review.'
-disable-model-invocation: true
 ---
 
 # Preflight Checks


### PR DESCRIPTION
## Summary

Remove `disable-model-invocation: true` from the `preflight` skill so OpenClaw includes the skill in the model-visible `<available_skills>` catalog, including its exact `<location>`.

## Why

I verified the current installed OpenClaw dist behavior:

- Skills with `disable-model-invocation: true` are filtered out before `<available_skills>` is formatted, and each included entry is where the model receives the skill's `<location>`.
- When a `/preflight` slash command resolves, the reply path does not inject the skill body. It rewrites the user message to `Use the "preflight" skill for this request.`

That pointer works for a model-visible skill because the model can read the exact `<location>` from its prompt. With this flag set, the catalog entry and location are absent, leaving the pointer without a path. In practice, fallback filesystem discovery can select a stale `SKILL.md` from another worktree; that has already caused agents to follow deleted instructions.

The installed bundle confirms the inbound chat rewrite above, but I could not conclusively verify every cron/subagent dispatch path from bundled output alone. For programmatically dispatched runs that do not traverse that inbound rewrite path, model visibility provides the direct discovery mechanism for `preflight`.

## Tradeoff

The skill's name and description will re-enter every agent's system prompt. That recurring context cost is the tradeoff the flag originally avoided.

## Compatibility note

brave/brave-core#38701 (`preflight-no-build`) is still open and also modifies `agents/skills/preflight/SKILL.md`, so merge order may cause a trivial frontmatter conflict.

## Test plan

- `pnpm run presubmit --base master` was attempted. It reported a pass, but inspection showed that Brave's script resolved `braveCoreDir` to `/Users/bribot/brave/src/brave` at detached HEAD `3abae8c16c979d6e7e85ca1cfe45e54959f3fe84`, not this branch. Therefore the presubmit result is not considered verified for this change.
- No build or tests are needed for this Markdown frontmatter-only change.
