### PR TITLE
[recipes] Add VS hermetic toolchain redirect support

### DIFF
--- a/tools/recipes/.vpython3
+++ b/tools/recipes/.vpython3
@@ -16,3 +16,10 @@ wheel: <
   name: "infra/python/wheels/coverage/${vpython_platform}"
   version: "version:7.3.1"
 >
+
+# Used by resource scripts that parse YAML, e.g.
+# chromium_checkout/resources/win_toolchain_hash.py.
+wheel: <
+  name: "infra/python/wheels/pyyaml-py3"
+  version: "version:6.0.1"
+>

--- a/tools/recipes/recipe_modules/chromium_checkout/__init__.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/__init__.py
@@ -4,4 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """`chromium_checkout` module: clone / sync / validate a Chromium src/ tree."""
 
-DEPS = ['path', 'raw_io', 'step', 'context', 'depot_tools', 'env', 'platform']
+DEPS = [
+    'path', 'raw_io', 'json', 'step', 'context', 'depot_tools', 'env',
+    'platform'
+]

--- a/tools/recipes/recipe_modules/chromium_checkout/api.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/api.py
@@ -28,6 +28,11 @@ WIN_HERMETIC_TOOLCHAIN_BASE_URL = (
 # The URL for Chromium's googlesource.
 CHROMIUM_URL = 'https://chromium.googlesource.com/chromium/src.git'
 
+# Resolves the `GYP_MSVS_HASH_<hash>` override for the hermetic Windows
+# toolchain. See `_pin_win_toolchain_hash`.
+_WIN_TOOLCHAIN_HASH_SCRIPT = (Path(__file__).resolve().parent / 'resources' /
+                              'win_toolchain_hash.py')
+
 
 class ChromiumCheckoutApi(RecipeApi):
     """Clones, syncs, and validates a Chromium `src/` checkout."""
@@ -245,9 +250,12 @@ class ChromiumCheckoutApi(RecipeApi):
         """Check out *ref* in *chromium_src* and resync dependencies."""
         chromium_src = Path(chromium_src)
         logging.info('Checking out Chromium ref %s', ref)
-        if (self.m.platform.is_win
-                and 'DEPOT_TOOLS_WIN_TOOLCHAIN' not in self.m.env):
-            # Build hermetically without a local VS install.
+        # Build hermetically without a local VS install, unless the caller has
+        # already made an explicit choice about the toolchain.
+        using_hermetic_win_toolchain = (self.m.platform.is_win
+                                        and 'DEPOT_TOOLS_WIN_TOOLCHAIN'
+                                        not in self.m.env)
+        if using_hermetic_win_toolchain:
             self.m.env.set('DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL',
                            WIN_HERMETIC_TOOLCHAIN_BASE_URL)
 
@@ -307,8 +315,40 @@ class ChromiumCheckoutApi(RecipeApi):
         self.m.step('checkout FETCH_HEAD',
                     ['git', 'checkout', '--force', 'FETCH_HEAD'],
                     cwd=chromium_src)
+
+        if using_hermetic_win_toolchain:
+            # This is used by `gclient runhooks`.
+            self._pin_win_toolchain_hash(chromium_src)
+
         self.m.step('gclient sync', ['gclient', 'sync', '--force', '-D'],
                     cwd=chromium_src)
+
+    def _pin_win_toolchain_hash(self, chromium_src: Path) -> None:
+        """Point `GYP_MSVS_HASH_<hash>` at Brave's republished toolchain.
+
+        `build/vs_toolchain.py` pins a `TOOLCHAIN_HASH`, which the
+        `win_toolchain` gclient hook resolves to `<TOOLCHAIN_HASH>.zip` on
+        Google's own toolchain bucket. Overriding
+        `DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL` points the hook at our own bucket.
+        `GYP_MSVS_HASH_<TOOLCHAIN_HASH>` is the override
+        `_GetDesiredVsToolchainHashes` (in `build/vs_toolchain.py`) reads to
+        substitute a different hash, so setting it to the hash Brave actually
+        published the archive under.
+
+        Nothing is set if an index with cannot be found with a redirect.
+        """
+        vpython3 = self.m.depot_tools.vpython3()
+        result = self.m.step('resolve win toolchain hash', [
+            vpython3, '-u', _WIN_TOOLCHAIN_HASH_SCRIPT,
+            chromium_src / 'build' / 'vs_toolchain.py',
+            WIN_HERMETIC_TOOLCHAIN_BASE_URL, '--json-output',
+            self.m.json.output()
+        ],
+                             step_test_data=self.test_api.win_toolchain_hash)
+        info = result.json.output
+        if info['published_hash']:
+            self.m.env.set(f"GYP_MSVS_HASH_{info['toolchain_hash']}",
+                           info['published_hash'])
 
     def _populate_git_cache(self,
                             git_cache_path: str | Path,

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_toolchain_hash_pinned.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_toolchain_hash_pinned.json
@@ -158,6 +158,13 @@
     "name": "win toolchain env"
   },
   {
+    "cmd": [
+      "echo",
+      "cafef00dcafe"
+    ],
+    "name": "win toolchain hash env"
+  },
+  {
     "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.py
@@ -14,14 +14,23 @@ DEPS = ['chromium_checkout', 'env', 'platform', 'step']
 
 PROPERTIES = InputProperties
 
+# An arbitrary stand-in for a real `TOOLCHAIN_HASH` pin, only used to compute
+# the `GYP_MSVS_HASH_*` key `win_toolchain_hash_env` below looks up -- a real
+# recipe never knows this value ahead of time, since it comes back from the
+# `resolve win toolchain hash` step itself.
+_TEST_TOOLCHAIN_HASH = 'deadbeef00'
+
 
 def RunSteps(api, properties):
     api.chromium_checkout.ensure_checkout(ref=properties.chromium_ref)
-    # Surface the otherwise-internal hermetic toolchain env as a step so a test
-    # can assert `checkout_ref` set it on Windows.
+    # Surface otherwise-internal hermetic-toolchain env as steps so a test can
+    # assert `checkout_ref` set them on Windows.
     toolchain = api.env.get('DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL')
     if toolchain:
         api.step('win toolchain env', ['echo', toolchain])
+    gyp_hash = api.env.get(f'GYP_MSVS_HASH_{_TEST_TOOLCHAIN_HASH}')
+    if gyp_hash:
+        api.step('win toolchain hash env', ['echo', gyp_hash])
 
 
 def GenTests(api):
@@ -67,7 +76,10 @@ def GenTests(api):
         api.post_process(post_process.DropExpectation),
         status='EXCEPTION',
     )
-    # On Windows, checkout_ref sets the hermetic toolchain base URL
+    # On Windows, checkout_ref sets the hermetic toolchain base URL. No
+    # toolchain index published for the upstream hash yet (the default,
+    # unseeded `resolve win toolchain hash` result) -> GYP_MSVS_HASH_* stays
+    # unset.
     yield api.test(
         'windows hermetic toolchain',
         api.platform.name('win'),
@@ -81,5 +93,23 @@ def GenTests(api):
                 'https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-'
                 '2.on.aws/windows-hermetic-toolchain/'
             ]),
+        api.post_process(post_process.MustRun, 'resolve win toolchain hash'),
+        api.post_process(post_process.DoesNotRun, 'win toolchain hash env'),
+        api.post_process(post_process.StatusSuccess),
+    )
+    # Brave has already republished a toolchain for the upstream hash ->
+    # GYP_MSVS_HASH_<upstream hash> gets pinned to the published one.
+    yield api.test(
+        'windows toolchain hash pinned',
+        api.platform.name('win'),
+        api.chromium_checkout.with_git_cache(),
+        api.chromium_checkout.existing_checkout(),
+        api.chromium_checkout.git_cache_populated(),
+        api.chromium_checkout.win_toolchain_published(_TEST_TOOLCHAIN_HASH,
+                                                      'cafef00dcafe'),
+        api.properties(chromium_ref='main'),
+        api.post_process(post_process.MustRun, 'win toolchain hash env'),
+        api.post_process(post_process.StepCommandContains,
+                         'win toolchain hash env', ['cafef00dcafe']),
         api.post_process(post_process.StatusSuccess),
     )

--- a/tools/recipes/recipe_modules/chromium_checkout/resources/win_toolchain_hash.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/resources/win_toolchain_hash.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Resolve the `GYP_MSVS_HASH_<hash>` override for the hermetic Windows
+toolchain, run as a recipe step.
+
+Chromium's `build/vs_toolchain.py` pins a `TOOLCHAIN_HASH` that gclient's
+`win_toolchain` hook resolves to `<TOOLCHAIN_HASH>.zip` on Google's own
+toolchain bucket. Brave republishes that same toolchain under a hash of its
+own archive's content, alongside a sibling `<TOOLCHAIN_HASH>.yaml` index
+naming it (see `tools/cr/toolchains/build_windows_toolchain.py`), since
+producing a byte-identical archive isn't guaranteed.
+
+`_GetDesiredVsToolchainHashes` in `build/vs_toolchain.py` substitutes hashes
+via `GYP_MSVS_HASH_<TOOLCHAIN_HASH>`, so setting that env var to Brave's
+published hash is what makes the hook fetch Brave's archive instead of
+failing to find upstream's on Brave's bucket.
+
+Writes `{"toolchain_hash": ..., "published_hash": ...}` as JSON to
+`--json-output`. `published_hash` is `null` if no index has been published
+yet for this upstream hash.
+
+The caller can use this utility to set `GYP_MSVS_HASH_<hash>` for a checkout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+
+import yaml
+
+# A single-quoted string value as it appears in `build/vs_toolchain.py`, e.g.
+# the `'3bfcb536c8'` in `TOOLCHAIN_HASH = '3bfcb536c8'`.
+_TOOLCHAIN_HASH_RE = re.compile(r"TOOLCHAIN_HASH = '([^']+)'")
+
+_FETCH_TIMEOUT_SECS = 30
+
+
+def _read_toolchain_hash(vs_toolchain_py: str) -> str:
+    """Return the `TOOLCHAIN_HASH` pin from *vs_toolchain_py*'s source.
+
+    Raises:
+        RuntimeError: If no `TOOLCHAIN_HASH` assignment is found.
+    """
+    with open(vs_toolchain_py, encoding='utf-8') as f:
+        text = f.read()
+    match = _TOOLCHAIN_HASH_RE.search(text)
+    if not match:
+        raise RuntimeError(
+            f'Could not find TOOLCHAIN_HASH in {vs_toolchain_py}.')
+    return match.group(1)
+
+
+def _fetch_published_hash(index_url: str) -> str | None:
+    """Return the `hash` published at *index_url*, or `None` if not found.
+
+    Raises:
+        RuntimeError: If *index_url* could not be fetched (for a reason other
+            than not existing yet) or its content is malformed.
+    """
+    try:
+        with urllib.request.urlopen(index_url,
+                                    timeout=_FETCH_TIMEOUT_SECS) as response:
+            index = yaml.safe_load(response)
+    except urllib.error.HTTPError as e:
+        # Mirrors `build_windows_toolchain._remote_url_exists`: the download
+        # bucket's CDN sometimes returns 403 where a 404 is expected for a
+        # missing key.
+        if e.code in (403, 404):
+            return None
+        raise RuntimeError(f'Failed to fetch {index_url}: {e}') from e
+    except urllib.error.URLError as e:
+        raise RuntimeError(f'Failed to fetch {index_url}: {e}') from e
+
+    try:
+        return index['hash']
+    except (TypeError, KeyError) as e:
+        raise RuntimeError(
+            f'{index_url} has no "hash" entry: {index!r}') from e
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('vs_toolchain_py',
+                        help='Path to the checked-out build/vs_toolchain.py.')
+    parser.add_argument(
+        'index_base_url',
+        help='Base URL the sibling toolchain index is published under '
+        '(the upstream toolchain hash + ".yaml" is appended to it).')
+    parser.add_argument('--json-output',
+                        required=True,
+                        type=argparse.FileType('w'))
+    opts = parser.parse_args(argv)
+
+    toolchain_hash = _read_toolchain_hash(opts.vs_toolchain_py)
+    index_url = f'{opts.index_base_url}{toolchain_hash}.yaml'
+    published_hash = _fetch_published_hash(index_url)
+
+    with opts.json_output as f:
+        json.dump(
+            {
+                'toolchain_hash': toolchain_hash,
+                'published_hash': published_hash,
+            }, f)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/tools/recipes/recipe_modules/chromium_checkout/test_api.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/test_api.py
@@ -43,3 +43,27 @@ class ChromiumCheckoutTestApi(RecipeTestApi):
         stdout = self.m.raw_io.output_text(mirror_dir)
         return (self.step_data('git cache exists', stdout=stdout) +
                 self.step_data('git cache exists for ref', stdout=stdout))
+
+    def win_toolchain_hash(self,
+                           toolchain_hash: str = '',
+                           published_hash: str | None = None) -> TestData:
+        """Seed `_pin_win_toolchain_hash`'s lookup result.
+
+        This is `checkout_ref`'s own default for the `resolve win toolchain
+        hash` step (via `step_test_data`): with no *published_hash*, nothing
+        is published yet for the upstream hash, so `GYP_MSVS_HASH_*` stays
+        unset -- matching what an unseeded step should report.
+        """
+        return self.m.json.output({
+            'toolchain_hash': toolchain_hash,
+            'published_hash': published_hash,
+        })
+
+    def win_toolchain_published(self, toolchain_hash: str,
+                                published_hash: str) -> TestData:
+        """Simulate Brave having already republished a toolchain for the
+        upstream *toolchain_hash*, resolving to *published_hash*.
+        """
+        return self.step_data(
+            'resolve win toolchain hash',
+            self.win_toolchain_hash(toolchain_hash, published_hash))


### PR DESCRIPTION
This PR adds a simple mechanism when checking out `chromium/src` that
permits the use of hermetic toolchain stored in our buckets, even when
the hash we have does not match with the expected by the checked out
Chromium version.

We are adding `win_toolchain_hash.py`, a resource sript, which consults
the published YAML, to determine if a redirect is necessary to a
different toolchain hash.

Bug: https://github.com/brave/brave-browser/issues/56748
