### PR TITLE
Fix Rewards Region Selection Dropdown overlapping buttons on Android

### DIFF
--- a/components/brave_rewards/resources/rewards_page/components/onboarding/country_select.tsx
+++ b/components/brave_rewards/resources/rewards_page/components/onboarding/country_select.tsx
@@ -5,6 +5,8 @@
 
 import * as React from 'react'
 
+import Dropdown from '@brave/leo/react/dropdown'
+
 const countryNames = new Intl.DisplayNames(undefined, { type: 'region' })
 
 export function getCountryName(code: string) {
@@ -27,8 +29,7 @@ interface Props {
 }
 
 export function CountrySelect(props: Props) {
-  const onCountryChange = (event: React.FormEvent<HTMLSelectElement>) => {
-    const { value } = event.currentTarget
+  const onCountryChange = ({ value }: { value: string }) => {
     if (value !== props.value) {
       props.onChange(value)
     }
@@ -36,7 +37,7 @@ export function CountrySelect(props: Props) {
 
   // When the select element receives focus, automatically select the "default"
   // option - which will typically be the device country.
-  const onFocus = (event: React.FormEvent<HTMLSelectElement>) => {
+  const onFocus = () => {
     const { countries, defaultCountry } = props
     if (!props.value && defaultCountry && countries.includes(defaultCountry)) {
       props.onChange(defaultCountry)
@@ -44,21 +45,21 @@ export function CountrySelect(props: Props) {
   }
 
   return (
-    <select
+    <Dropdown
       className={!props.value ? 'empty' : ''}
       value={props.value}
       onChange={onCountryChange}
       onFocus={onFocus}
     >
-      <option value=''>{props.placeholderText}</option>
+      <leo-option value=''>{props.placeholderText}</leo-option>
       {getCountryOptions(props.countries).map((option) => (
-        <option
+        <leo-option
           key={option.code}
           value={option.code}
         >
           {option.name}
-        </option>
+        </leo-option>
       ))}
-    </select>
+    </Dropdown>
   )
 }

--- a/components/brave_rewards/resources/rewards_page/components/onboarding/country_select_modal.style.ts
+++ b/components/brave_rewards/resources/rewards_page/components/onboarding/country_select_modal.style.ts
@@ -43,7 +43,7 @@ export const style = scoped.css`
   .selector {
     margin-bottom: 16px;
 
-    select {
+    leo-dropdown {
       width: 100%;
       color: ${color.text.primary};
       font: ${font.default.regular};


### PR DESCRIPTION
## Description
This PR fixes an Android-specific layout bug in the Rewards Onboarding region selection modal.

Previously, the region dropdown used a native HTML `<select>` element. On Android, this triggers the OS-level `SelectFileDialog`, which escapes the DOM constraints and can overlap or completely obscure the "Continue" and "Cancel" action buttons at the bottom of the modal. 

To resolve this, we replaced the native `<select>` element with the standard `@brave/leo` `<Dropdown>` component, which stays contained within the modal's scroll area and prevents UI overlap.

## Fixes
Fixes brave/brave-browser#57756

## Changes
- `country_select.tsx`: Swapped the native `select` element for `@brave/leo/react/dropdown`
- `country_select_modal.style.ts`: Updated CSS selectors to target the new component structure
