### PR TITLE
[Brave News]: Wait for initial subscriptions before building the feed

### DIFF
--- a/components/brave_news/browser/DEPS
+++ b/components/brave_news/browser/DEPS
@@ -13,6 +13,10 @@ include_rules = [
 ]
 
 specific_include_rules = {
+  "brave_news_controller_unittest\.cc": [
+    "+brave/components/l10n/common/test/scoped_default_locale.h",
+    "+components/history/core/test/history_service_test_util.h",
+  ],
   "direct_feed_fetcher\.cc": [
     "+third_party/rust/cxx/v1/cxx.h",
   ],

--- a/components/brave_news/browser/brave_news_controller.cc
+++ b/components/brave_news/browser/brave_news_controller.cc
@@ -214,18 +214,61 @@ void BraveNewsController::GetFeed(GetFeedCallback callback) {
 
 void BraveNewsController::GetFollowingFeed(GetFollowingFeedCallback callback) {
   DVLOG(1) << __FUNCTION__;
+  if (!pref_manager_.IsEnabled()) {
+    std::move(callback).Run(mojom::FeedV2::New());
+    return;
+  }
+
+  // Note: If we've only recently opted-in but we haven't yet finished adding
+  // the top sources subscription (via the async functions in MaybeInitPrefs),
+  // we need to wait for that to complete. Otherwise we'd build the feed from
+  // an empty set of subscriptions and report it as empty to the UI, which
+  // wouldn't be corrected until the feed was requested again.
+  if (!initialization_promise_.complete()) {
+    initialization_promise_.OnceInitialized(
+        base::BindOnce(&BraveNewsController::GetFollowingFeed,
+                       weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
+    return;
+  }
+
   IN_ENGINE(GetFollowingFeed, std::move(callback));
 }
 
 void BraveNewsController::GetChannelFeed(const std::string& channel,
                                          GetChannelFeedCallback callback) {
   DVLOG(1) << __FUNCTION__;
+  if (!pref_manager_.IsEnabled()) {
+    std::move(callback).Run(mojom::FeedV2::New());
+    return;
+  }
+
+  // See the note in GetFollowingFeed.
+  if (!initialization_promise_.complete()) {
+    initialization_promise_.OnceInitialized(base::BindOnce(
+        &BraveNewsController::GetChannelFeed, weak_ptr_factory_.GetWeakPtr(),
+        channel, std::move(callback)));
+    return;
+  }
+
   IN_ENGINE(GetChannelFeed, std::move(callback), channel);
 }
 
 void BraveNewsController::GetPublisherFeed(const std::string& publisher_id,
                                            GetPublisherFeedCallback callback) {
   DVLOG(1) << __FUNCTION__;
+  if (!pref_manager_.IsEnabled()) {
+    std::move(callback).Run(mojom::FeedV2::New());
+    return;
+  }
+
+  // See the note in GetFollowingFeed.
+  if (!initialization_promise_.complete()) {
+    initialization_promise_.OnceInitialized(base::BindOnce(
+        &BraveNewsController::GetPublisherFeed, weak_ptr_factory_.GetWeakPtr(),
+        publisher_id, std::move(callback)));
+    return;
+  }
+
   IN_ENGINE(GetPublisherFeed, std::move(callback), publisher_id);
 }
 
@@ -259,9 +302,12 @@ void BraveNewsController::EnsureFeedV2IsUpdating() {
 
 void BraveNewsController::GetFeedV2(GetFeedV2Callback callback) {
   DVLOG(1) << __FUNCTION__;
-  // If we're only recently opted-in but we haven't yet finished adding the
-  // top sources subscription (via the async functions in MaybeInitPrefs), we
-  // need to wait for that to complete before we can fetch the feed.
+  if (!pref_manager_.IsEnabled()) {
+    std::move(callback).Run(mojom::FeedV2::New());
+    return;
+  }
+
+  // See the note in GetFollowingFeed.
   if (!initialization_promise_.complete()) {
     initialization_promise_.OnceInitialized(
         base::BindOnce(&BraveNewsController::GetFeedV2,

--- a/components/brave_news/browser/brave_news_controller_unittest.cc
+++ b/components/brave_news/browser/brave_news_controller_unittest.cc
@@ -1,0 +1,199 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_news/browser/brave_news_controller.h"
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+
+#include "base/files/scoped_temp_dir.h"
+#include "base/functional/bind.h"
+#include "base/functional/callback_helpers.h"
+#include "base/memory/weak_ptr.h"
+#include "base/test/bind.h"
+#include "brave/components/brave_news/browser/direct_feed_fetcher.h"
+#include "brave/components/brave_news/browser/test/wait_for_callback.h"
+#include "brave/components/brave_news/browser/urls.h"
+#include "brave/components/brave_news/common/brave_news.mojom.h"
+#include "brave/components/brave_news/common/pref_names.h"
+#include "brave/components/brave_policy/policy_initialization_waiter.h"
+#include "brave/components/l10n/common/test/scoped_default_locale.h"
+#include "components/history/core/browser/history_service.h"
+#include "components/history/core/test/history_service_test_util.h"
+#include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "content/public/test/browser_task_environment.h"
+#include "net/http/http_status_code.h"
+#include "services/network/public/cpp/resource_request.h"
+#include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
+#include "services/network/test/test_url_loader_factory.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_news {
+
+namespace {
+
+constexpr char kLocale[] = "en_NZ";
+
+constexpr char kPublishersResponse[] = R"([
+    {
+        "publisher_id": "111",
+        "publisher_name": "Test Publisher 1",
+        "feed_url": "https://tp1.example.com/feed",
+        "site_url": "https://tp1.example.com",
+        "category": "Tech",
+        "cover_url": "https://tp1.example.com/cover",
+        "background_color": "#FF0000",
+        "locales": [{
+          "locale": "en_NZ",
+          "channels": ["Top Sources", "Tech"]
+        }],
+        "enabled": false
+    }])";
+
+class TestDirectFeedFetcherDelegate : public DirectFeedFetcher::Delegate {
+ public:
+  ~TestDirectFeedFetcherDelegate() override = default;
+
+  HTTPSUpgradeInfo GetURLHTTPSUpgradeInfo(const GURL& url) override {
+    return HTTPSUpgradeInfo{.should_upgrade = false, .should_force = false};
+  }
+
+  base::WeakPtr<DirectFeedFetcher::Delegate> AsWeakPtr() override {
+    return weak_ptr_factory_.GetWeakPtr();
+  }
+
+ private:
+  base::WeakPtrFactory<TestDirectFeedFetcherDelegate> weak_ptr_factory_{this};
+};
+
+class TestControllerDelegate : public BraveNewsController::Delegate {
+ public:
+  ~TestControllerDelegate() override = default;
+  void OpenSettings() override {}
+};
+
+}  // namespace
+
+class BraveNewsControllerTest : public testing::Test {
+ public:
+  BraveNewsControllerTest() = default;
+  ~BraveNewsControllerTest() override = default;
+
+  void SetUp() override {
+    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
+
+    prefs::RegisterProfilePrefs(pref_service_.registry());
+
+    // Brave News starts out disabled, as it is for a user who hasn't opted in
+    // yet.
+    pref_service_.SetBoolean(prefs::kNewTabPageShowToday, true);
+    pref_service_.SetBoolean(prefs::kBraveNewsOptedIn, false);
+
+    history_service_ =
+        history::CreateHistoryService(temp_dir_.GetPath(), /*create_db=*/true);
+
+    // Only respond to the sources request - we aren't interested in the feed
+    // contents here, just in which subscriptions the feed was built from.
+    test_url_loader_factory_.SetInterceptor(
+        base::BindLambdaForTesting([this](const network::ResourceRequest& req) {
+          const bool is_sources = req.url.spec() == GetSourcesUrl();
+          test_url_loader_factory_.AddResponse(
+              req.url.spec(), is_sources ? kPublishersResponse : "",
+              is_sources ? net::HTTP_OK : net::HTTP_NOT_FOUND);
+        }));
+
+    controller_ = std::make_unique<BraveNewsController>(
+        &pref_service_,
+        std::make_unique<brave_policy::PolicyInitializationWaiter>(
+            /*policy_service=*/nullptr),
+        history_service_.get(), test_url_loader_factory_.GetSafeWeakWrapper(),
+        std::make_unique<TestDirectFeedFetcherDelegate>(),
+        std::make_unique<TestControllerDelegate>());
+  }
+
+ protected:
+  static std::string GetSourcesUrl() {
+    return "https://" + GetHostname() + "/sources." + kRegionUrlPart + "json";
+  }
+
+  // Simulates the user opting in from the NTP. Note: this deliberately does
+  // **not** wait for the resulting async work to finish, because the UI
+  // requests the feed immediately after opting in.
+  void OptIn() {
+    controller_->SetConfiguration(
+        mojom::Configuration::New(/*isOptedIn=*/true, /*showOnNTP=*/true,
+                                  /*openArticlesInNewTab=*/true),
+        base::DoNothing());
+  }
+
+  mojom::FeedV2Ptr GetFollowingFeed() {
+    return std::get<0>(
+        WaitForCallback(base::BindOnce(&BraveNewsController::GetFollowingFeed,
+                                       base::Unretained(controller_.get()))));
+  }
+
+  mojom::FeedV2Ptr GetFeedV2() {
+    return std::get<0>(WaitForCallback(base::BindOnce(
+        &BraveNewsController::GetFeedV2, base::Unretained(controller_.get()))));
+  }
+
+  bool HasInitialSubscriptions() {
+    return controller_->prefs().GetSubscriptions().channels().contains(kLocale);
+  }
+
+  // Declared before |task_environment_| so that it outlives it: destroying the
+  // task environment flushes the thread pool, which is what lets the history
+  // backend finish shutting down and release the files in here.
+  base::ScopedTempDir temp_dir_;
+  content::BrowserTaskEnvironment task_environment_;
+  network::TestURLLoaderFactory test_url_loader_factory_;
+  sync_preferences::TestingPrefServiceSyncable pref_service_;
+  std::unique_ptr<history::HistoryService> history_service_;
+  std::unique_ptr<BraveNewsController> controller_;
+
+ private:
+  const brave_l10n::test::ScopedDefaultLocale locale_{kLocale};
+};
+
+// Regression test for https://github.com/brave/brave-browser/issues/57691.
+// Requesting the following feed immediately after opting in should wait for the
+// initial "Top Sources" subscription to be created, instead of building a feed
+// from an empty set of subscriptions and reporting to the UI that the user
+// follows nothing.
+TEST_F(BraveNewsControllerTest, GetFollowingFeedWaitsForInitialSubscriptions) {
+  OptIn();
+  ASSERT_FALSE(HasInitialSubscriptions());
+
+  auto feed = GetFollowingFeed();
+
+  EXPECT_TRUE(HasInitialSubscriptions());
+  EXPECT_NE(mojom::FeedV2Error::NoFeeds, feed->error);
+}
+
+TEST_F(BraveNewsControllerTest, GetFeedV2WaitsForInitialSubscriptions) {
+  OptIn();
+  ASSERT_FALSE(HasInitialSubscriptions());
+
+  auto feed = GetFeedV2();
+
+  EXPECT_TRUE(HasInitialSubscriptions());
+  EXPECT_NE(mojom::FeedV2Error::NoFeeds, feed->error);
+}
+
+TEST_F(BraveNewsControllerTest, GetFollowingFeedIsEmptyWhenDisabled) {
+  auto feed = GetFollowingFeed();
+  EXPECT_TRUE(feed->items.empty());
+  EXPECT_FALSE(HasInitialSubscriptions());
+}
+
+TEST_F(BraveNewsControllerTest, GetFeedV2IsEmptyWhenDisabled) {
+  auto feed = GetFeedV2();
+  EXPECT_TRUE(feed->items.empty());
+  EXPECT_FALSE(HasInitialSubscriptions());
+}
+
+}  // namespace brave_news

--- a/components/brave_news/browser/brave_news_controller_unittest.cc
+++ b/components/brave_news/browser/brave_news_controller_unittest.cc
@@ -15,10 +15,12 @@
 #include "base/functional/callback_helpers.h"
 #include "base/memory/weak_ptr.h"
 #include "base/test/bind.h"
+#include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_news/browser/direct_feed_fetcher.h"
 #include "brave/components/brave_news/browser/test/wait_for_callback.h"
 #include "brave/components/brave_news/browser/urls.h"
 #include "brave/components/brave_news/common/brave_news.mojom.h"
+#include "brave/components/brave_news/common/features.h"
 #include "brave/components/brave_news/common/pref_names.h"
 #include "brave/components/brave_policy/policy_initialization_waiter.h"
 #include "brave/components/l10n/common/test/scoped_default_locale.h"
@@ -80,7 +82,12 @@ class TestControllerDelegate : public BraveNewsController::Delegate {
 
 class BraveNewsControllerTest : public testing::Test {
  public:
-  BraveNewsControllerTest() = default;
+  BraveNewsControllerTest() {
+    // These tests exercise the FeedV2 code paths, which are gated behind
+    // |kBraveNewsFeedUpdate|. That feature is disabled by default on Android,
+    // so enable it explicitly to keep the tests platform independent.
+    feature_list_.InitAndEnableFeature(features::kBraveNewsFeedUpdate);
+  }
   ~BraveNewsControllerTest() override = default;
 
   void SetUp() override {
@@ -144,6 +151,10 @@ class BraveNewsControllerTest : public testing::Test {
   bool HasInitialSubscriptions() {
     return controller_->prefs().GetSubscriptions().channels().contains(kLocale);
   }
+
+  // Declared before |task_environment_| so that it outlives the threads which
+  // read the feature state.
+  base::test::ScopedFeatureList feature_list_;
 
   // Declared before |task_environment_| so that it outlives it: destroying the
   // task environment flushes the thread pool, which is what lets the history

--- a/components/brave_news/browser/test/BUILD.gn
+++ b/components/brave_news/browser/test/BUILD.gn
@@ -13,6 +13,7 @@ source_set("brave_news_unit_tests") {
   testonly = true
   sources = [
     "//brave/components/brave_news/browser/background_history_querier_unittest.cc",
+    "//brave/components/brave_news/browser/brave_news_controller_unittest.cc",
     "//brave/components/brave_news/browser/brave_news_p3a_unittest.cc",
     "//brave/components/brave_news/browser/brave_news_pref_manager_unittest.cc",
     "//brave/components/brave_news/browser/channels_controller_unittest.cc",
@@ -41,10 +42,12 @@ source_set("brave_news_unit_tests") {
     "//brave/components/brave_news/browser:unit_tests",
     "//brave/components/brave_news/common",
     "//brave/components/brave_news/common:mojom",
+    "//brave/components/brave_policy:policy_initialization_waiter",
     "//brave/components/brave_rewards/core",
     "//brave/components/l10n/common:test_support",
     "//brave/components/time_period_storage",
     "//components/history/core/browser",
+    "//components/history/core/test",
     "//components/prefs",
     "//components/prefs:test_support",
     "//components/sync_preferences:test_support",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57691

This happened because we started defaulting to the following feed instead of the For You feed.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
