### PR TITLE
Support base::test::TestFuture over uint256_t

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -25,6 +25,7 @@ source_set("base_unittests") {
     "test/launcher/teamcity_reporter_integration_unittest.cc",
     "test/launcher/teamcity_reporter_unittest.cc",
     "test/launcher/teamcity_service_messages_unittest.cc",
+    "to_string_unittest.cc",
   ]
   deps = [
     "//base",

--- a/base/to_string_unittest.cc
+++ b/base/to_string_unittest.cc
@@ -1,0 +1,25 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/strings/to_string.h"
+
+#include "base/containers/span.h"
+#include "base/test/test_future.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+TEST(ToString, Uint256) {
+  using uint256_t = unsigned _BitInt(256);
+
+  uint256_t val{1};
+  // `ToString` compiles and uses fallback representation for uint256_t.
+  EXPECT_THAT(base::ToString(val),
+              testing::StartsWith("[32-byte object at 0x"));
+
+  // TestFuture::SetValue is also able to compile.
+  base::test::TestFuture<uint256_t> future;
+  future.SetValue(uint256_t{7});
+  EXPECT_EQ(future.Take(), uint256_t{7});
+}

--- a/patches/base-strings-to_string.h.patch
+++ b/patches/base-strings-to_string.h.patch
@@ -1,0 +1,13 @@
+diff --git a/base/strings/to_string.h b/base/strings/to_string.h
+index bfd24406c4086ad35dc8b5170aba9d23f7c57ae4..d566a08ec0d1be43b6e6685f3462cc02f56f6a7d 100644
+--- a/base/strings/to_string.h
++++ b/base/strings/to_string.h
+@@ -75,7 +75,7 @@ struct ToStringHelper<T> {
+ 
+ // Integral types that can't stream, like char16_t.
+ template <typename T>
+-  requires(!SupportsOstreamOperator<const T&> && std::is_integral_v<T>)
++  requires(!SupportsOstreamOperator<const T&> && std::is_integral_v<T> && sizeof(T) <= 8)
+ struct ToStringHelper<T> {
+   static void Stringify(const T& v, std::ostringstream& ss) {
+     if constexpr (std::is_signed_v<T>) {

--- a/rewrite/base/strings/to_string.h.yaml
+++ b/rewrite/base/strings/to_string.h.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |-
+      Exclude integral types wider than 8 bytes from the non-streamable-integral
+       `ToStringHelper` specialization, so they fall through to the generic
+       byte-dump fallback instead of failing on the 
+       `static_assert(sizeof(T) <= 8)` below.
+    regex:
+      pattern:
+        requires(!SupportsOstreamOperator<const T&> && std::is_integral_v<T>)
+      replace:
+        requires(!SupportsOstreamOperator<const T&> && std::is_integral_v<T> &&
+        sizeof(T) <= 8)


### PR DESCRIPTION
```
  base::test::TestFuture<uint256_t> future;
```
would be useful to support in unit tests, but `ToString` compile-time restrictions prevent that.