### PR TITLE
[ads] Add description text under sponsored sites toggle

### DIFF
--- a/browser/resources/brave_new_tab_page_refresh/components/settings/settings_modal.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/settings_modal.style.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { color, radius, spacing } from '@brave/leo/tokens/css/variables'
+import { color, font, radius, spacing } from '@brave/leo/tokens/css/variables'
 import { scoped } from '$web-common/scoped_css'
 
 export const style = scoped.css`
@@ -53,6 +53,15 @@ export const style = scoped.css`
       padding: ${spacing['4Xl']};
       border-radius: ${radius.xl};
       background: ${color.page.background};
+    }
+  }
+
+  .label .subtext {
+    font: ${font.small.regular};
+    color: ${color.text.secondary};
+
+    a {
+      color: inherit;
     }
   }
 `

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.test.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.test.tsx
@@ -7,8 +7,26 @@ import * as React from 'react'
 import { render, screen } from '@testing-library/react'
 import { createStateStore } from '$web-common/state_store'
 import { TopSitesContext } from '../../context/top_sites_context'
-import { TopSitesListKind, TopSitesState } from '../../state/top_sites_store'
+import {
+  sponsoredSiteLearnMoreURL,
+  TopSitesListKind,
+  TopSitesState,
+} from '../../state/top_sites_store'
 import { TopSitesPanel } from './top_sites_panel'
+
+// The default $web-common/locale mock (see components/test/testSetup.ts)
+// echoes the string key back verbatim, which has no $1 placeholder for
+// formatString to replace. Override just the sponsored sites description so
+// it renders with its "Learn more" link as it would in production, while
+// every other string key keeps echoing back for the other assertions below.
+jest.mock('$web-common/locale', () => ({
+  getLocale: (key: string) => {
+    if (key === 'NEW_TAB_SPONSORED_SITES_DESCRIPTION') {
+      return 'Sponsored sites help keep Brave free. $1Learn more/$1.'
+    }
+    return key
+  },
+}))
 
 function createStore(
   state: Partial<TopSitesState>,
@@ -63,6 +81,19 @@ describe('TopSitesPanel', () => {
     expect(
       screen.getByText('NEW_TAB_SHOW_SPONSORED_SITES_LABEL'),
     ).toBeInTheDocument()
+  })
+
+  it('should render the sponsored sites description with a learn more link', () => {
+    renderPanel({ showTopSites: true })
+    expect(
+      screen.getByText('Sponsored sites help keep Brave free.', {
+        exact: false,
+      }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Learn more' })).toHaveAttribute(
+      'href',
+      sponsoredSiteLearnMoreURL,
+    )
   })
 
   it('should update the sponsored sites setting when its toggle changes', () => {

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.tsx
@@ -7,13 +7,18 @@ import * as React from 'react'
 import Icon from '@brave/leo/react/icon'
 import Toggle from '@brave/leo/react/toggle'
 
-import { TopSitesListKind } from '../../state/top_sites_store'
+import {
+  TopSitesListKind,
+  sponsoredSiteLearnMoreURL,
+} from '../../state/top_sites_store'
 import {
   useTopSitesState,
   useTopSitesActions,
 } from '../../context/top_sites_context'
 import { getString } from '../../lib/strings'
 import { SettingsPanel } from './settings_panel'
+import { formatString } from '$web-common/formatString'
+import { Link } from '../common/link'
 import classNames from '$web-common/classnames'
 
 import { style } from './top_sites_panel.style'
@@ -64,6 +69,18 @@ export function TopSitesPanel() {
         >
           <span className='label'>
             {getString(S.NEW_TAB_SHOW_SPONSORED_SITES_LABEL)}
+            <div className='subtext'>
+              {formatString(getString(S.NEW_TAB_SPONSORED_SITES_DESCRIPTION), {
+                $1: (content) => (
+                  <Link
+                    url={sponsoredSiteLearnMoreURL}
+                    openInNewTab
+                  >
+                    {content}
+                  </Link>
+                ),
+              })}
+            </div>
           </span>
         </Toggle>
       )}

--- a/components/resources/brave_new_tab_page_strings.grdp
+++ b/components/resources/brave_new_tab_page_strings.grdp
@@ -289,6 +289,10 @@
     Our new sponsored sites help us keep Brave free. If you use <ph name="SITE_NAME">$1<ex>Amazon</ex></ph> from your New Tab Page, you are supporting Brave's mission. You can hide or change it at any time. <ph name="LINK_BEGIN">$2</ph>Learn more<ph name="LINK_END">/$2</ph>.
   </message>
 
+  <message name="IDS_NEW_TAB_SPONSORED_SITES_DESCRIPTION" desc="Description shown below the toggle that controls sponsored site visibility in top sites, explaining what sponsored sites are." formatter_data="webui=BraveNewTabPage">
+    Occasionally shows a sponsored site among your top sites. <ph name="LINK_BEGIN">$1</ph>Learn more<ph name="LINK_END">/$1</ph>.
+  </message>
+
   <message name="IDS_NEW_TAB_STATS_ADS_BLOCKED_TEXT" desc="Text for trackers and ads blocked stat" formatter_data="webui=BraveNewTabPage">
     Trackers &amp; ads blocked
   </message>


### PR DESCRIPTION
Adds explanatory text with a Learn more link below the sponsored sites toggle in New Tab Page settings, so users understand what sponsored sites are and how to turn them off, since they're shown by default. The subtext style used for this text is shared with the background panel, so it moves to the settings modal stylesheet where both panels can reference it.

Part of https://github.com/brave/brave-browser/issues/57784

Test plan:
- Open NTP settings > Top Sites, confirm the description text appears under the sponsored sites toggle with a working "Learn more" link

<img width="745" height="516" alt="Screenshot 2026-08-03 at 13 17 39" src="https://github.com/user-attachments/assets/c0874e7b-5d97-4d24-96f7-8fa7e12f8654" />

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
