### PR TITLE
[ads] Show sponsored site tile tooltip only on disclosure label

### DIFF
--- a/browser/resources/brave_new_tab_page_refresh/components/common/link.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/common/link.tsx
@@ -12,6 +12,7 @@ interface Props {
   className?: string
   onClick?: () => void
   onContextMenu?: React.MouseEventHandler<HTMLAnchorElement>
+  onBlur?: React.FocusEventHandler<HTMLAnchorElement>
   openInNewTab?: boolean
   children: React.ReactNode
 }
@@ -29,6 +30,7 @@ export function Link(props: Props) {
       target={props.openInNewTab ? '_blank' : '_self'}
       onClick={props.onClick}
       onContextMenu={props.onContextMenu}
+      onBlur={props.onBlur}
     >
       {props.children}
     </a>

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.test.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.test.tsx
@@ -1,0 +1,147 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { createStateStore } from '$web-common/state_store'
+import { BackgroundContext } from '../../context/background_context'
+import { RewardsContext } from '../../context/rewards_context'
+import {
+  BackgroundState,
+  SelectedBackgroundType,
+  gradientPreviewBackground,
+} from '../../state/background_store'
+import { RewardsState } from '../../state/rewards_store'
+import { BackgroundPanel } from './background_panel'
+
+// The default $web-common/locale mock (see components/test/testSetup.ts)
+// echoes the string key back verbatim, which has no $1/$2 placeholders for
+// formatString to replace. Override just the sponsored images earning text
+// so it renders with its links as it would in production.
+jest.mock('$web-common/locale', () => ({
+  getLocale: (key: string) => {
+    if (key === 'NEW_TAB_SHOW_SPONSORED_IMAGES_EARNING_TEXT') {
+      return 'Earn by viewing sponsored images. $1Settings/$1 $2Learn more/$2.'
+    }
+    return key
+  },
+}))
+
+function createBackgroundStore(
+  state: Partial<BackgroundState>,
+  actions: Partial<BackgroundState['actions']> = {},
+) {
+  return createStateStore<BackgroundState>({
+    initialized: true,
+    backgroundsEnabled: true,
+    backgroundsCustomizable: true,
+    sponsoredImagesEnabled: true,
+    braveBackgrounds: [],
+    customBackgrounds: [],
+    selectedBackground: {
+      type: SelectedBackgroundType.kGradient,
+      value: gradientPreviewBackground,
+    },
+    backgroundRotateIndex: 0,
+    backgroundRandomValue: 0,
+    sponsoredImageBackground: null,
+    sponsoredRichMediaBaseUrl: '',
+    actions: {
+      setBackgroundsEnabled() {},
+      setSponsoredImagesEnabled() {},
+      selectBackground() {},
+      async showCustomBackgroundChooser() {
+        return false
+      },
+      async removeCustomBackground() {},
+      notifySponsoredImageLoadError() {},
+      notifySponsoredImageLogoClicked() {},
+      notifySponsoredRichMediaEvent() {},
+      ...actions,
+    },
+    ...state,
+  })
+}
+
+function createRewardsStore(state: Partial<RewardsState>) {
+  return createStateStore<RewardsState>({
+    initialized: true,
+    rewardsFeatureEnabled: true,
+    showRewardsWidget: false,
+    rewardsEnabled: false,
+    rewardsExternalWallet: null,
+    rewardsBalance: null,
+    rewardsExchangeRate: 0,
+    rewardsAdsViewed: null,
+    minEarningsPreviousMonth: 0,
+    payoutStatus: {},
+    tosUpdateRequired: false,
+    actions: {
+      setShowRewardsWidget() {},
+      recordNewTabOnboardingClick() {},
+    },
+    ...state,
+  })
+}
+
+function renderPanel(
+  backgroundState: Partial<BackgroundState> = {},
+  rewardsState: Partial<RewardsState> = {},
+  actions: Partial<BackgroundState['actions']> = {},
+) {
+  const backgroundStore = createBackgroundStore(backgroundState, actions)
+  const rewardsStore = createRewardsStore(rewardsState)
+  render(
+    <BackgroundContext.Provider value={backgroundStore}>
+      <RewardsContext.Provider value={rewardsStore}>
+        <BackgroundPanel />
+      </RewardsContext.Provider>
+    </BackgroundContext.Provider>,
+  )
+}
+
+describe('BackgroundPanel', () => {
+  it('should render the sponsored images description with a learn more link', () => {
+    renderPanel({}, { rewardsFeatureEnabled: true, rewardsEnabled: false })
+    expect(
+      screen.getByText('Earn by viewing sponsored images.', {
+        exact: false,
+      }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Learn more' })).toHaveAttribute(
+      'href',
+      expect.stringContaining('support.brave.app'),
+    )
+  })
+
+  it('should update the sponsored images setting when its toggle changes', () => {
+    const setSponsoredImagesEnabled = jest.fn()
+    renderPanel(
+      { sponsoredImagesEnabled: false },
+      { rewardsFeatureEnabled: true, rewardsEnabled: false },
+      { setSponsoredImagesEnabled },
+    )
+    screen.getByText('NEW_TAB_SHOW_SPONSORED_IMAGES_LABEL').click()
+    expect(setSponsoredImagesEnabled).toHaveBeenCalledWith(true)
+  })
+
+  it('should stop the learn more link click from reaching the toggle', () => {
+    // The Toggle wraps its label content in a native <label>, which
+    // forwards an unstopped click to its associated control. Rather than
+    // relying on jsdom to replicate that native label activation
+    // behavior (uncertain in this test environment), this verifies the
+    // fix's actual mechanism directly: the click must not bubble past the
+    // description's wrapping element.
+    renderPanel({}, { rewardsFeatureEnabled: true, rewardsEnabled: false })
+    const onDocumentClick = jest.fn()
+    document.addEventListener('click', onDocumentClick)
+    try {
+      screen.getByRole('link', { name: 'Learn more' }).click()
+    } finally {
+      document.removeEventListener('click', onDocumentClick)
+    }
+    expect(onDocumentClick).not.toHaveBeenCalled()
+  })
+})

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.tsx
@@ -31,6 +31,9 @@ import {
 
 import { style } from './background_panel.style'
 
+const sponsoredImageLearnMoreURL =
+  'https://support.brave.app/hc/en-us/articles/35182999599501'
+
 export function BackgroundPanel() {
   const actions = useBackgroundActions()
 
@@ -192,25 +195,33 @@ export function BackgroundPanel() {
           }}
         >
           <span className='label'>
-            <div>
-              {getString(S.NEW_TAB_SHOW_SPONSORED_IMAGES_LABEL)}
-              {!rewardsEnabled && (
-                <div className='subtext'>
-                  {formatString(
-                    getString(S.NEW_TAB_SHOW_SPONSORED_IMAGES_EARNING_TEXT),
-                    {
-                      $1: (content) => (
-                        <Link
-                          url={settingsURL}
-                          openInNewTab
-                        >
-                          {content}
-                        </Link>
-                      ),
-                    },
-                  )}
-                </div>
-              )}
+            {getString(S.NEW_TAB_SHOW_SPONSORED_IMAGES_LABEL)}
+            <div
+              className='subtext'
+              onClick={(e) => e.stopPropagation()}
+            >
+              {!rewardsEnabled
+                && formatString(
+                  getString(S.NEW_TAB_SHOW_SPONSORED_IMAGES_EARNING_TEXT),
+                  {
+                    $1: (content) => (
+                      <Link
+                        url={settingsURL}
+                        openInNewTab
+                      >
+                        {content}
+                      </Link>
+                    ),
+                    $2: (content) => (
+                      <Link
+                        url={sponsoredImageLearnMoreURL}
+                        openInNewTab
+                      >
+                        {content}
+                      </Link>
+                    ),
+                  },
+                )}
             </div>
           </span>
         </Toggle>

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.test.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.test.tsx
@@ -96,6 +96,24 @@ describe('TopSitesPanel', () => {
     )
   })
 
+  it('should stop the learn more link click from reaching the toggle', () => {
+    // The Toggle wraps its label content in a native <label>, which
+    // forwards an unstopped click to its associated control. Rather than
+    // relying on jsdom to replicate that native label activation
+    // behavior (uncertain in this test environment), this verifies the
+    // fix's actual mechanism directly: the click must not bubble past the
+    // description's wrapping element.
+    renderPanel({ showTopSites: true })
+    const onDocumentClick = jest.fn()
+    document.addEventListener('click', onDocumentClick)
+    try {
+      screen.getByRole('link', { name: 'Learn more' }).click()
+    } finally {
+      document.removeEventListener('click', onDocumentClick)
+    }
+    expect(onDocumentClick).not.toHaveBeenCalled()
+  })
+
   it('should update the sponsored sites setting when its toggle changes', () => {
     const setShowSponsoredSites = jest.fn()
     renderPanel(

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.tsx
@@ -69,7 +69,10 @@ export function TopSitesPanel() {
         >
           <span className='label'>
             {getString(S.NEW_TAB_SHOW_SPONSORED_SITES_LABEL)}
-            <div className='subtext'>
+            <div
+              className='subtext'
+              onClick={(e) => e.stopPropagation()}
+            >
               {formatString(getString(S.NEW_TAB_SPONSORED_SITES_DESCRIPTION), {
                 $1: (content) => (
                   <Link

--- a/browser/resources/brave_new_tab_page_refresh/components/top_sites/sponsored_site_tile.test.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/top_sites/sponsored_site_tile.test.tsx
@@ -4,7 +4,7 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react'
-import { render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { SponsoredSite } from '../../state/top_sites_store'
 import { SponsoredSitesTile } from './sponsored_site_tile'
 
@@ -26,8 +26,12 @@ function getTileLink() {
 // set directly on the element, not as HTML attributes.
 function getTooltipElement() {
   return document.querySelector('leo-tooltip') as
-    | (HTMLElement & { mouseenterDelay?: number; mouseleaveTimeout?: number })
+    | (HTMLElement & { visible?: boolean; mouseleaveTimeout?: number })
     | null
+}
+
+function getAdDisclosure() {
+  return screen.getByText('bar')
 }
 
 function createSite(overrides: Partial<SponsoredSite> = {}): SponsoredSite {
@@ -55,6 +59,16 @@ describe('SponsoredSitesTile', () => {
       'src',
       'chrome://branded-wallpaper/sponsored-images/foo',
     )
+  })
+
+  it('should give a grace period before hiding on mouse leave, so a pointer moving toward "Learn more" across the gap between the tile and the tooltip is not cut off', () => {
+    render(
+      <SponsoredSitesTile
+        site={createSite()}
+        onContextMenu={() => {}}
+      />,
+    )
+    expect(getTooltipElement()?.mouseleaveTimeout).toBe(500)
   })
 
   it('should omit the ad disclosure when the site does not have one', () => {
@@ -95,24 +109,111 @@ describe('SponsoredSitesTile', () => {
     },
   )
 
-  it('should open its tooltip on a delay rather than immediately on hover', () => {
-    render(
-      <SponsoredSitesTile
-        site={createSite()}
-        onContextMenu={() => {}}
-      />,
-    )
-    expect(getTooltipElement()?.mouseenterDelay).toBe(200)
-  })
+  describe('tooltip visibility', () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+    })
 
-  it('should close its tooltip immediately when the pointer leaves', () => {
-    render(
-      <SponsoredSitesTile
-        site={createSite()}
-        onContextMenu={() => {}}
-      />,
-    )
-    expect(getTooltipElement()?.mouseleaveTimeout).toBe(0)
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('should not show the tooltip immediately on hover', () => {
+      render(
+        <SponsoredSitesTile
+          site={createSite()}
+          onContextMenu={() => {}}
+        />,
+      )
+      fireEvent.mouseEnter(getAdDisclosure())
+      expect(getTooltipElement()?.visible).toBe(false)
+    })
+
+    it('should show the tooltip after a delay on hover', () => {
+      render(
+        <SponsoredSitesTile
+          site={createSite()}
+          onContextMenu={() => {}}
+        />,
+      )
+      fireEvent.mouseEnter(getAdDisclosure())
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      expect(getTooltipElement()?.visible).toBe(true)
+    })
+
+    it('should not show the tooltip if the pointer leaves before the delay elapses', () => {
+      render(
+        <SponsoredSitesTile
+          site={createSite()}
+          onContextMenu={() => {}}
+        />,
+      )
+      fireEvent.mouseEnter(getAdDisclosure())
+      act(() => {
+        jest.advanceTimersByTime(300)
+      })
+      fireEvent.mouseLeave(getAdDisclosure())
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      expect(getTooltipElement()?.visible).toBe(false)
+    })
+
+    it('should show the tooltip immediately on focus', () => {
+      render(
+        <SponsoredSitesTile
+          site={createSite()}
+          onContextMenu={() => {}}
+        />,
+      )
+      fireEvent.focus(getAdDisclosure())
+      expect(getTooltipElement()?.visible).toBe(true)
+    })
+
+    it('should keep the tooltip open when focus moves to the learn more link', () => {
+      render(
+        <SponsoredSitesTile
+          site={createSite()}
+          onContextMenu={() => {}}
+        />,
+      )
+      // Uses real .focus() calls, not fireEvent with a fake relatedTarget,
+      // since only a real focus transfer updates document.activeElement
+      // and gives the resulting blur event a genuine relatedTarget.
+      act(() => getAdDisclosure().focus())
+      act(() => screen.getByRole('link', { name: 'Learn more' }).focus())
+      expect(getTooltipElement()?.visible).toBe(true)
+    })
+
+    it('should close the tooltip when focus moves away from it entirely', () => {
+      render(
+        <SponsoredSitesTile
+          site={createSite()}
+          onContextMenu={() => {}}
+        />,
+      )
+      act(() => getAdDisclosure().focus())
+      const elsewhere = document.createElement('button')
+      document.body.appendChild(elsewhere)
+      act(() => elsewhere.focus())
+      expect(getTooltipElement()?.visible).toBe(false)
+    })
+
+    it('should not show the tooltip when hovering the icon or title', () => {
+      render(
+        <SponsoredSitesTile
+          site={createSite()}
+          onContextMenu={() => {}}
+        />,
+      )
+      fireEvent.mouseEnter(screen.getByText('foo'))
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      expect(getTooltipElement()?.visible).toBe(false)
+    })
   })
 
   it('should not be draggable', () => {

--- a/browser/resources/brave_new_tab_page_refresh/components/top_sites/sponsored_site_tile.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/top_sites/sponsored_site_tile.tsx
@@ -15,8 +15,11 @@ import { formatString } from '$web-common/formatString'
 import { getString } from '../../lib/strings'
 import { Link } from '../common/link'
 
-const tooltipHideDelay = 0
-const tooltipShowDelay = 200
+// Avoids showing the tooltip for a pointer that's just passing over the tile.
+const tooltipShowDelay = 500
+
+// Gives the pointer time to reach "Learn more" without the tooltip closing.
+const tooltipHideDelay = 500
 
 interface Props {
   site: SponsoredSite
@@ -26,13 +29,53 @@ interface Props {
 export function SponsoredSitesTile(props: Props) {
   const { relativeImageUrl, title, adDisclosure, targetUrl } = props.site
 
+  const [tooltipVisible, setTooltipVisible] = React.useState(false)
+  const tooltipShowTimer = React.useRef<number | undefined>(undefined)
+
+  React.useEffect(() => {
+    return () => window.clearTimeout(tooltipShowTimer.current)
+  }, [])
+
+  function scheduleShowTooltip() {
+    window.clearTimeout(tooltipShowTimer.current)
+    tooltipShowTimer.current = window.setTimeout(
+      () => setTooltipVisible(true),
+      tooltipShowDelay,
+    )
+  }
+
+  function cancelScheduledShow() {
+    window.clearTimeout(tooltipShowTimer.current)
+  }
+
+  // Keeps the tooltip open when focus moves to its "Learn more" link, since
+  // that link sits outside Leo's trigger element and would otherwise be
+  // treated as a blur.
+  function handleBlur(e: React.FocusEvent) {
+    const host = e.currentTarget.closest('leo-tooltip')
+    if (host && host.contains(e.relatedTarget as Node | null)) {
+      setTooltipVisible(true)
+    } else {
+      setTooltipVisible(false)
+    }
+  }
+
+  // Tooltip wraps the whole tile rather than just the disclosure label below,
+  // since scoping it to the label would nest the tooltip's "Learn more" link
+  // inside the tile's own anchor, which is invalid HTML and breaks keyboard
+  // access to the link.
   return (
     <Tooltip
-      mode='default'
+      mode='mini'
       placement='bottom'
       positionStrategy='fixed'
       mouseleaveTimeout={tooltipHideDelay}
-      mouseenterDelay={tooltipShowDelay}
+      visible={tooltipVisible}
+      onVisibilityChange={({ visible }) => {
+        if (!visible) {
+          setTooltipVisible(false)
+        }
+      }}
     >
       <a
         className='top-site-tile'
@@ -45,7 +88,16 @@ export function SponsoredSitesTile(props: Props) {
         </span>
         <span className='top-site-title'>{title}</span>
         {adDisclosure && (
-          <span className='top-site-ad-disclosure'>{adDisclosure}</span>
+          <span
+            className='top-site-ad-disclosure'
+            tabIndex={0}
+            onMouseEnter={scheduleShowTooltip}
+            onMouseLeave={cancelScheduledShow}
+            onFocus={() => setTooltipVisible(true)}
+            onBlur={handleBlur}
+          >
+            {adDisclosure}
+          </span>
         )}
       </a>
       <div
@@ -58,6 +110,7 @@ export function SponsoredSitesTile(props: Props) {
             <Link
               url={sponsoredSiteLearnMoreURL}
               openInNewTab
+              onBlur={handleBlur}
             >
               {content}
             </Link>

--- a/components/resources/brave_new_tab_page_strings.grdp
+++ b/components/resources/brave_new_tab_page_strings.grdp
@@ -254,7 +254,7 @@
   </message>
 
   <message name="IDS_NEW_TAB_SHOW_SPONSORED_IMAGES_EARNING_TEXT" desc="Text describing earning for new tab page ads" formatter_data="webui=BraveNewTabPage">
-    With <ph name="LINK_BEGIN">$1</ph>Brave Rewards<ph name="LINK_END">/$1</ph>, you can earn for seeing new tab page ads.
+    With <ph name="REWARDS_LINK_BEGIN">$1</ph>Brave Rewards<ph name="REWARDS_LINK_END">/$1</ph>, you can earn for seeing new tab page ads. <ph name="LEARN_MORE_LINK_BEGIN">$2</ph>Learn more<ph name="LEARN_MORE_LINK_END">/$2</ph>.
   </message>
 
   <message name="IDS_NEW_TAB_SHOW_SPONSORED_IMAGES_LABEL" desc="Text for setting to opt-in to Branded Wallpapers on New Tab Page" formatter_data="webui=BraveNewTabPage">
@@ -286,11 +286,11 @@
   </message>
 
   <message name="IDS_NEW_TAB_SPONSORED_SITE_TOOLTIP_TEXT" desc="Tooltip text shown when hovering a sponsored site tile. $1 is the site name." formatter_data="webui=BraveNewTabPage">
-    Our new sponsored sites help us keep Brave free. If you use <ph name="SITE_NAME">$1<ex>Amazon</ex></ph> from your New Tab Page, you are supporting Brave's mission. You can hide or change it at any time. <ph name="LINK_BEGIN">$2</ph>Learn more<ph name="LINK_END">/$2</ph>.
+    Sponsored sites help keep Brave free. If you use <ph name="SITE_NAME">$1<ex>Amazon</ex></ph>, you're supporting Brave's mission. Disable them anytime. <ph name="LINK_BEGIN">$2</ph>Learn more<ph name="LINK_END">/$2</ph>.
   </message>
 
   <message name="IDS_NEW_TAB_SPONSORED_SITES_DESCRIPTION" desc="Description shown below the toggle that controls sponsored site visibility in top sites, explaining what sponsored sites are." formatter_data="webui=BraveNewTabPage">
-    Occasionally shows a sponsored site among your top sites. <ph name="LINK_BEGIN">$1</ph>Learn more<ph name="LINK_END">/$1</ph>.
+    Sponsored sites help keep Brave free. If you use them, you're supporting Brave's mission. Disable them anytime. <ph name="LINK_BEGIN">$1</ph>Learn more<ph name="LINK_END">/$1</ph>.
   </message>
 
   <message name="IDS_NEW_TAB_STATS_ADS_BLOCKED_TEXT" desc="Text for trackers and ads blocked stat" formatter_data="webui=BraveNewTabPage">


### PR DESCRIPTION
 Restricts the tooltip trigger to the ad disclosure label rather than the whole tile, shows it on a delay to avoid flashing during a quick hover, and gives the pointer a grace period (via Leo's built-in mouseleaveTimeout) to reach the tooltip's "Learn more" link without it closing early.

Also fixes clicking "Learn more" under a sponsored toggle's description forwarding a click to the toggle itself, since Leo wraps toggle labels in a native <label> and an <a> isn't a labelable element that would otherwise handle its own activation. Applies to both the sponsored sites and sponsored images toggles, and adds a matching "Learn more" link to the sponsored images description.

<img width="976" height="1130" alt="Screenshot 2026-08-03 at 15 16 23" src="https://github.com/user-attachments/assets/d01329e2-3e11-4c3a-9971-976d145ab8d4" />

Part of https://github.com/brave/brave-browser/issues/57784

Test plan:
- Hover a sponsored tile's ad disclosure label; confirm the tooltip appears only after a short delay, not immediately, and not when hovering the icon/title
- Click "Learn more" under both the sponsored sites toggle and the sponsored images (background) toggle in settings; confirm the click does not also flip the toggle

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
