### PR TITLE
[ads] Only show a sponsored tile over a genuinely visited top site

### DIFF
--- a/browser/resources/brave_new_tab_page_refresh/components/top_sites/top_sites_grid.test.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/top_sites/top_sites_grid.test.tsx
@@ -51,12 +51,17 @@ function createTopSite(url: string): TopSite {
   return { title: 'Site', url, favicon: '' }
 }
 
-function createSponsoredSite(targetUrl: string): SponsoredSite {
+function createSponsoredSite(
+  targetUrl: string,
+  overrides: Partial<SponsoredSite> = {},
+): SponsoredSite {
   return {
     relativeImageUrl: '',
     title: 'foo',
     adDisclosure: 'bar',
     targetUrl,
+    hasGenuineVisit: true,
+    ...overrides,
   }
 }
 

--- a/browser/resources/brave_new_tab_page_refresh/components/top_sites/top_sites_grid_items.test.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/top_sites/top_sites_grid_items.test.tsx
@@ -18,16 +18,26 @@ import {
   useTopSitesGridItems,
 } from './top_sites_grid_items'
 
-function createTopSite(url: string): TopSite {
-  return { title: 'Site', url, favicon: '' }
+function createTopSite(url: string, overrides: Partial<TopSite> = {}): TopSite {
+  return {
+    title: 'Site',
+    url,
+    favicon: '',
+    ...overrides,
+  }
 }
 
-function createSponsoredSite(targetUrl: string): SponsoredSite {
+function createSponsoredSite(
+  targetUrl: string,
+  overrides: Partial<SponsoredSite> = {},
+): SponsoredSite {
   return {
     relativeImageUrl: '',
     title: 'foo',
     adDisclosure: 'bar',
     targetUrl,
+    hasGenuineVisit: true,
+    ...overrides,
   }
 }
 
@@ -190,6 +200,26 @@ describe('useTopSitesGridItems', () => {
   it('should not show a sponsored site with an unparsable target URL', () => {
     const topSite = createTopSite('https://bar.com')
     const sponsoredSite = createSponsoredSite('not-a-url')
+    const store = createStore({
+      topSites: [topSite],
+      sponsoredSites: [sponsoredSite],
+    })
+
+    const { result } = renderHook(
+      () => useTopSitesGridItems({ canAddSite: false }),
+      { wrapper: createWrapper(store) },
+    )
+
+    expect(result.current).toEqual([
+      { type: 'top-site', site: topSite, index: 0 },
+    ])
+  })
+
+  it('should not show a sponsored site with no genuine visit', () => {
+    const topSite = createTopSite('https://bar.com')
+    const sponsoredSite = createSponsoredSite('https://bar.com', {
+      hasGenuineVisit: false,
+    })
     const store = createStore({
       topSites: [topSite],
       sponsoredSites: [sponsoredSite],

--- a/browser/resources/brave_new_tab_page_refresh/components/top_sites/top_sites_grid_items.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/top_sites/top_sites_grid_items.ts
@@ -84,6 +84,9 @@ function sponsoredSitesMatchingTopSites(
   sponsoredSites: SponsoredSite[],
 ): SponsoredSite[] {
   return sponsoredSites.filter((sponsoredSite) => {
+    if (!sponsoredSite.hasGenuineVisit) {
+      return false
+    }
     const domain = advertiserDomain(sponsoredSite)
     return (
       domain !== null

--- a/browser/resources/brave_new_tab_page_refresh/stories/mock_top_sites_store.ts
+++ b/browser/resources/brave_new_tab_page_refresh/stories/mock_top_sites_store.ts
@@ -53,7 +53,11 @@ export function createTopSitesStore() {
         return {
           topSites: [
             ...topSites,
-            { url, title, favicon: 'https://brave.com/favicon.ico' },
+            {
+              url,
+              title,
+              favicon: 'https://brave.com/favicon.ico',
+            },
           ],
         }
       })

--- a/browser/ui/webui/brave_new_tab_page_refresh/BUILD.gn
+++ b/browser/ui/webui/brave_new_tab_page_refresh/BUILD.gn
@@ -224,6 +224,8 @@ source_set("unit_tests") {
     "//brave/components/ntp_background_images/browser",
     "//brave/components/ntp_background_images/browser:test_support",
     "//brave/components/ntp_background_images/common",
+    "//components/history/core/browser",
+    "//components/history/core/test",
     "//components/prefs",
     "//components/prefs:test_support",
     "//components/sync_preferences:test_support",

--- a/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page.mojom
+++ b/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page.mojom
@@ -62,6 +62,9 @@ struct SponsoredSite {
   string title;
   string ad_disclosure;
   string target_url;
+  // Whether the user has genuinely visited this site's domain in Brave,
+  // rather than only added it as a Favorite.
+  bool has_genuine_visit;
 };
 
 struct TopSite {

--- a/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page_ui.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page_ui.cc
@@ -28,6 +28,7 @@
 #include "brave/components/ntp_background_images/browser/ntp_sponsored_rich_media_ad_event_handler.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/contextual_search/contextual_search_service_factory.h"
+#include "chrome/browser/history/history_service_factory.h"
 #include "chrome/browser/ntp_tiles/chrome_most_visited_sites_factory.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/search_engines/template_url_service_factory.h"
@@ -48,7 +49,6 @@
 #include "brave/components/ai_chat/core/browser/tab_tracker_service.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "chrome/browser/bookmarks/bookmark_model_factory.h"
-#include "chrome/browser/history/history_service_factory.h"
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
@@ -108,7 +108,9 @@ void BraveNewTabPageUI::BindInterface(
       g_brave_browser_process->ntp_background_images_service(),
       ntp_background_images::ViewCounterServiceFactory::GetForProfile(profile));
   auto sponsored_sites_facade = std::make_unique<SponsoredSitesFacade>(
-      *prefs, g_brave_browser_process->ntp_background_images_service());
+      *prefs, g_brave_browser_process->ntp_background_images_service(),
+      *HistoryServiceFactory::GetForProfile(
+          profile, ServiceAccessType::EXPLICIT_ACCESS));
   auto top_sites_facade = std::make_unique<TopSitesFacade>(
       ChromeMostVisitedSitesFactory::NewForProfile(profile), *prefs);
 

--- a/browser/ui/webui/brave_new_tab_page_refresh/sponsored_sites_facade.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/sponsored_sites_facade.cc
@@ -9,12 +9,17 @@
 #include <vector>
 
 #include "base/containers/to_vector.h"
+#include "base/functional/bind.h"
 #include "base/task/bind_post_task.h"
+#include "base/time/time.h"
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/ntp_background_images/browser/ntp_sponsored_sites_data.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
+#include "components/history/core/browser/history_service.h"
+#include "components/history/core/browser/history_types.h"
 #include "components/prefs/pref_service.h"
+#include "url/gurl.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
 #include "brave/components/brave_rewards/core/pref_names.h"
@@ -40,14 +45,32 @@ std::vector<mojom::SponsoredSitePtr> ToMojom(
                         [](const auto& ntp_site) { return ToMojom(ntp_site); });
 }
 
+// The advertiser's hostname, with any leading "www." stripped so a visit to
+// either the www or non-www variant counts as the same domain.
+std::string AdvertiserDomain(const GURL& url) {
+  std::string host(url.host());
+  if (host.starts_with("www.")) {
+    return host.substr(4);
+  }
+  return host;
+}
+
+// `HistoryService` matches hosts exactly, with no `www.` normalization, so both
+// variants must be queried. `domain` must not have a `www.` prefix.
+std::vector<std::string> HostVariants(const std::string& domain) {
+  return {domain, "www." + domain};
+}
+
 }  // namespace
 
 SponsoredSitesFacade::SponsoredSitesFacade(
     PrefService& pref_service,
     ntp_background_images::NTPBackgroundImagesService*
-        background_images_service)
+        background_images_service,
+    history::HistoryService& history_service)
     : pref_service_(pref_service),
-      background_images_service_(background_images_service) {
+      background_images_service_(background_images_service),
+      history_service_(history_service) {
   if (background_images_service_) {
     ntp_background_images_service_observation_.Observe(
         background_images_service_);
@@ -72,7 +95,14 @@ void SponsoredSitesFacade::GetSites(GetSitesCallback callback) {
     return;
   }
 
-  std::move(callback).Run(ToMojom(sites_data->sites));
+  std::vector<mojom::SponsoredSitePtr> sites = ToMojom(sites_data->sites);
+  for (auto& site : sites) {
+    site->has_genuine_visit = genuine_visit_domains_.contains(
+        AdvertiserDomain(GURL(site->target_url)));
+  }
+  QueryGenuineVisits(sites);
+
+  std::move(callback).Run(std::move(sites));
 }
 
 void SponsoredSitesFacade::SetSitesUpdatedCallback(
@@ -109,6 +139,50 @@ bool SponsoredSitesFacade::IsRewardsWalletConnected() const {
 #else
   return false;
 #endif  // BUILDFLAG(ENABLE_BRAVE_REWARDS)
+}
+
+void SponsoredSitesFacade::QueryGenuineVisits(
+    const std::vector<mojom::SponsoredSitePtr>& sites) {
+  history_task_tracker_.TryCancelAll();
+  for (auto& site : sites) {
+    if (site->has_genuine_visit) {
+      continue;
+    }
+    GURL target_url(site->target_url);
+    if (!target_url.is_valid()) {
+      continue;
+    }
+    // Matches by host rather than exact URL, since the advertiser's own
+    // landing page frequently isn't the page a visit was actually recorded
+    // against (redirects, trailing slashes).
+    const std::string domain = AdvertiserDomain(target_url);
+    for (auto& host : HostVariants(domain)) {
+      history_service_->GetLastVisitToHost(
+          host, base::Time(), base::Time::Max(),
+          history::VisitQuery404sPolicy::kInclude404s,
+          base::BindOnce(&SponsoredSitesFacade::OnGenuineVisitQueried,
+                         weak_factory_.GetWeakPtr(), domain),
+          &history_task_tracker_);
+    }
+  }
+}
+
+void SponsoredSitesFacade::OnGenuineVisitQueried(
+    const std::string& advertiser_domain,
+    history::HistoryLastVisitResult result) {
+  // Never downgrades: a false result from one host variant doesn't rule
+  // out a confirming visit from the other, still-pending variant.
+  if (!result.success || result.last_visit.is_null()) {
+    return;
+  }
+
+  if (!genuine_visit_domains_.insert(advertiser_domain).second) {
+    return;
+  }
+
+  if (updated_callback_) {
+    updated_callback_.Run();
+  }
 }
 
 }  // namespace brave_new_tab_page_refresh

--- a/browser/ui/webui/brave_new_tab_page_refresh/sponsored_sites_facade.h
+++ b/browser/ui/webui/brave_new_tab_page_refresh/sponsored_sites_facade.h
@@ -6,16 +6,25 @@
 #ifndef BRAVE_BROWSER_UI_WEBUI_BRAVE_NEW_TAB_PAGE_REFRESH_SPONSORED_SITES_FACADE_H_
 #define BRAVE_BROWSER_UI_WEBUI_BRAVE_NEW_TAB_PAGE_REFRESH_SPONSORED_SITES_FACADE_H_
 
+#include <string>
 #include <vector>
 
+#include "base/containers/flat_set.h"
 #include "base/functional/callback.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ref.h"
+#include "base/memory/weak_ptr.h"
 #include "base/scoped_observation.h"
+#include "base/task/cancelable_task_tracker.h"
 #include "brave/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page.mojom.h"
 #include "brave/components/ntp_background_images/browser/ntp_background_images_service.h"
 
 class PrefService;
+
+namespace history {
+class HistoryService;
+struct HistoryLastVisitResult;
+}  // namespace history
 
 namespace brave_new_tab_page_refresh {
 
@@ -26,7 +35,8 @@ class SponsoredSitesFacade
  public:
   SponsoredSitesFacade(PrefService& pref_service,
                        ntp_background_images::NTPBackgroundImagesService*
-                           background_images_service);
+                           background_images_service,
+                       history::HistoryService& history_service);
 
   SponsoredSitesFacade(const SponsoredSitesFacade&) = delete;
   SponsoredSitesFacade& operator=(const SponsoredSitesFacade&) = delete;
@@ -40,6 +50,10 @@ class SponsoredSitesFacade
 
   void SetSitesUpdatedCallback(base::RepeatingClosure callback);
 
+  bool HasPendingGenuineVisitQueriesForTesting() const {
+    return history_task_tracker_.HasTrackedTasks();
+  }
+
  private:
   // NTPBackgroundImagesService::Observer:
   void OnSponsoredSitesDataDidUpdate() override;
@@ -48,15 +62,22 @@ class SponsoredSitesFacade
   bool IsEnabled() const;
   bool IsNewTabPageAdsEnabled() const;
   bool IsRewardsWalletConnected() const;
+  void QueryGenuineVisits(const std::vector<mojom::SponsoredSitePtr>& sites);
+  void OnGenuineVisitQueried(const std::string& advertiser_domain,
+                             history::HistoryLastVisitResult result);
 
   raw_ref<PrefService> pref_service_;
   raw_ptr<ntp_background_images::NTPBackgroundImagesService>
       background_images_service_;
+  raw_ref<history::HistoryService> history_service_;
+  base::CancelableTaskTracker history_task_tracker_;
+  base::flat_set<std::string> genuine_visit_domains_;
   base::RepeatingClosure updated_callback_;
   base::ScopedObservation<
       ntp_background_images::NTPBackgroundImagesService,
       ntp_background_images::NTPBackgroundImagesService::Observer>
       ntp_background_images_service_observation_{this};
+  base::WeakPtrFactory<SponsoredSitesFacade> weak_factory_{this};
 };
 
 }  // namespace brave_new_tab_page_refresh

--- a/browser/ui/webui/brave_new_tab_page_refresh/sponsored_sites_facade_unittest.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/sponsored_sites_facade_unittest.cc
@@ -14,9 +14,11 @@
 #include "base/files/scoped_temp_dir.h"
 #include "base/strings/string_util.h"
 #include "base/test/bind.h"
+#include "base/test/run_until.h"
 #include "base/test/task_environment.h"
 #include "base/test/test_future.h"
 #include "base/test/values_test_util.h"
+#include "base/time/time.h"
 #include "brave/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page.mojom.h"
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
@@ -24,12 +26,16 @@
 #include "brave/components/ntp_background_images/browser/test/fake_ntp_background_images_service.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
 #include "brave/components/ntp_background_images/common/view_counter_pref_registry.h"
+#include "components/history/core/browser/history_database_params.h"
+#include "components/history/core/browser/history_service.h"
+#include "components/history/core/test/history_service_test_util.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/testing_pref_service.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/abseil-cpp/absl/strings/str_format.h"
+#include "url/gurl.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
 #include "brave/components/brave_rewards/core/pref_names.h"
@@ -111,12 +117,48 @@ class SponsoredSitesFacadeTest : public testing::Test {
             /*component_update_service=*/nullptr, &local_state_);
 
     ASSERT_TRUE(installed_dir_.CreateUniqueTempDir());
+
+    ASSERT_TRUE(history_dir_.CreateUniqueTempDir());
+    history_service_ = history::CreateHistoryService(history_dir_.GetPath(),
+                                                     /*create_db=*/true);
+    ASSERT_TRUE(history_service_);
+  }
+
+  // Ensures the backend has no pending work on its own sequence before the
+  // temp directory it reads from is torn down.
+  void TearDown() override {
+    history::BlockUntilHistoryProcessesPendingRequests(history_service_.get());
+    history_service_.reset();
+  }
+
+  std::unique_ptr<SponsoredSitesFacade> CreateFacade() {
+    return std::make_unique<SponsoredSitesFacade>(
+        profile_prefs_, background_images_service_.get(), *history_service_);
   }
 
   std::vector<mojom::SponsoredSitePtr> GetSites(SponsoredSitesFacade& facade) {
     base::test::TestFuture<std::vector<mojom::SponsoredSitePtr>> future;
     facade.GetSites(future.GetCallback());
     return future.Take();
+  }
+
+  // Sets `target_url` as the sole sponsored site and waits for its History
+  // lookup to resolve. The lookup is only kicked off by `GetSites()` itself,
+  // so an initial call is needed before the tracker has anything pending.
+  // Waits on the tracker's pending-task state rather than the sites-updated
+  // callback, since that callback is skipped when nothing changed from the
+  // fail-closed default.
+  bool GetHasGenuineVisit(SponsoredSitesFacade& facade,
+                          const std::string& target_url) {
+    background_images_service_->OnGetSponsoredSitesData(
+        CreateSponsoredSitesData(installed_dir_.GetPath(), "foo", target_url));
+    GetSites(facade);
+    EXPECT_TRUE(base::test::RunUntil(
+        [&] { return !facade.HasPendingGenuineVisitQueriesForTesting(); }));
+
+    auto sites = GetSites(facade);
+    CHECK_EQ(sites.size(), 1u);
+    return sites[0]->has_genuine_visit;
   }
 
  protected:
@@ -126,32 +168,34 @@ class SponsoredSitesFacadeTest : public testing::Test {
   base::ScopedTempDir installed_dir_;
   std::unique_ptr<ntp_background_images::FakeNTPBackgroundImagesService>
       background_images_service_;
+  base::ScopedTempDir history_dir_;
+  std::unique_ptr<history::HistoryService> history_service_;
 };
 
 TEST_F(SponsoredSitesFacadeTest, ReturnsNoSitesWhenSponsoredSitesDisabled) {
   profile_prefs_.SetBoolean(kNewTabPageShowSponsoredSites, false);
 
-  SponsoredSitesFacade facade(profile_prefs_, background_images_service_.get());
+  auto facade = CreateFacade();
   background_images_service_->OnGetSponsoredSitesData(CreateSponsoredSitesData(
       installed_dir_.GetPath(), "foo", "https://foo.com"));
 
-  EXPECT_THAT(GetSites(facade), testing::IsEmpty());
+  EXPECT_THAT(GetSites(*facade), testing::IsEmpty());
 }
 
 TEST_F(SponsoredSitesFacadeTest, ReturnsNoSitesWhenNoSponsoredSitesData) {
-  SponsoredSitesFacade facade(profile_prefs_, background_images_service_.get());
+  auto facade = CreateFacade();
 
-  EXPECT_THAT(GetSites(facade), testing::IsEmpty());
+  EXPECT_THAT(GetSites(*facade), testing::IsEmpty());
 }
 
 TEST_F(SponsoredSitesFacadeTest, ReturnsEligibleSites) {
-  SponsoredSitesFacade facade(profile_prefs_, background_images_service_.get());
+  auto facade = CreateFacade();
   background_images_service_->OnGetSponsoredSitesData(CreateSponsoredSitesData(
       installed_dir_.GetPath(),
       {SponsoredSiteTileSpec{"foo", "https://foo.com"},
        SponsoredSiteTileSpec{"bar", "https://bar.com"}}));
 
-  EXPECT_THAT(GetSites(facade),
+  EXPECT_THAT(GetSites(*facade),
               testing::ElementsAre(testing::Pointee(testing::Field(
                                        &mojom::SponsoredSite::title, "foo")),
                                    testing::Pointee(testing::Field(
@@ -162,25 +206,71 @@ TEST_F(SponsoredSitesFacadeTest, ReturnsEligibleSites) {
 TEST_F(SponsoredSitesFacadeTest, ReturnsNoSitesWhenRewardsWalletConnected) {
   profile_prefs_.SetString(brave_rewards::prefs::kExternalWalletType, "uphold");
 
-  SponsoredSitesFacade facade(profile_prefs_, background_images_service_.get());
+  auto facade = CreateFacade();
   background_images_service_->OnGetSponsoredSitesData(CreateSponsoredSitesData(
       installed_dir_.GetPath(), "foo", "https://foo.com"));
 
-  EXPECT_THAT(GetSites(facade), testing::IsEmpty());
+  EXPECT_THAT(GetSites(*facade), testing::IsEmpty());
 }
 #endif  // BUILDFLAG(ENABLE_BRAVE_REWARDS)
 
 TEST_F(SponsoredSitesFacadeTest, InvokesCallbackWhenSponsoredSitesDataUpdates) {
-  SponsoredSitesFacade facade(profile_prefs_, background_images_service_.get());
+  auto facade = CreateFacade();
 
   bool callback_invoked = false;
-  facade.SetSitesUpdatedCallback(base::BindLambdaForTesting(
+  facade->SetSitesUpdatedCallback(base::BindLambdaForTesting(
       [&callback_invoked] { callback_invoked = true; }));
 
   background_images_service_->OnGetSponsoredSitesData(CreateSponsoredSitesData(
       installed_dir_.GetPath(), "foo", "https://foo.com"));
 
   EXPECT_TRUE(callback_invoked);
+}
+
+TEST_F(SponsoredSitesFacadeTest, NoGenuineVisitWhenAdvertiserHasNoHistory) {
+  auto facade = CreateFacade();
+
+  EXPECT_FALSE(GetHasGenuineVisit(*facade, "https://foo.com"));
+}
+
+TEST_F(SponsoredSitesFacadeTest, GenuineVisitWhenAdvertiserWasVisited) {
+  auto facade = CreateFacade();
+  history_service_->AddPage(GURL("https://foo.com/"), base::Time::Now(),
+                            history::VisitSource::SOURCE_BROWSED);
+
+  EXPECT_TRUE(GetHasGenuineVisit(*facade, "https://foo.com"));
+}
+
+TEST_F(SponsoredSitesFacadeTest, GenuineVisitMatchesByHostNotExactUrl) {
+  auto facade = CreateFacade();
+  history_service_->AddPage(GURL("https://foo.com/some/page?q=1"),
+                            base::Time::Now(),
+                            history::VisitSource::SOURCE_BROWSED);
+
+  EXPECT_TRUE(GetHasGenuineVisit(*facade, "https://foo.com"));
+}
+
+TEST_F(SponsoredSitesFacadeTest, GenuineVisitMatchesWwwVariant) {
+  auto facade = CreateFacade();
+  history_service_->AddPage(GURL("https://www.foo.com/"), base::Time::Now(),
+                            history::VisitSource::SOURCE_BROWSED);
+
+  EXPECT_TRUE(GetHasGenuineVisit(*facade, "https://foo.com"));
+}
+
+TEST_F(SponsoredSitesFacadeTest, PreservesGenuineVisitAcrossRoutineRefresh) {
+  auto facade = CreateFacade();
+  history_service_->AddPage(GURL("https://foo.com/"), base::Time::Now(),
+                            history::VisitSource::SOURCE_BROWSED);
+  ASSERT_TRUE(GetHasGenuineVisit(*facade, "https://foo.com"));
+
+  // A routine refresh re-fetches the same sponsored sites data.
+  background_images_service_->OnGetSponsoredSitesData(CreateSponsoredSitesData(
+      installed_dir_.GetPath(), "foo", "https://foo.com"));
+
+  auto sites = GetSites(*facade);
+  ASSERT_EQ(sites.size(), 1u);
+  EXPECT_TRUE(sites[0]->has_genuine_visit);
 }
 
 }  // namespace brave_new_tab_page_refresh


### PR DESCRIPTION
Sponsored tiles are matched to an existing top site by domain, but a top site can appear there without the user ever actually visiting it, most notably a manually-added Favorite with no visits.

Has TopSitesFacade check each top site's most recent visit to its host via HistoryService, matching by host rather than exact URL since a tile's URL frequently isn't byte-identical to whatever page URL a visit was actually recorded against. HistoryService matches hosts exactly with no www normalization, so both the www and non-www variants are queried and merged. A sponsored tile now only matches a top site the user has genuinely visited.

A most-visited tile always means the user has really visited it, that's why it's on the list. Favorites (custom links) are different: every entry looks the same whether or not it's ever been visited, so that's the case that actually needs checking. Custom links already carry an isMostVisited field, but it doesn't help here: it's only set once, when a link is created, and never updated afterward, so a manually-added link stays false forever even if the user goes on to visit that site for real. Our check queries History fresh on every refresh, so it does pick up a visit made after the link was added.

Part of https://github.com/brave/brave-browser/issues/57784

Test plan:
- Manually add a site as a Favorite that you've never visited; confirm no sponsored tile appears over it
- Visit that site for real, then refresh the NTP; confirm the sponsored tile now appears
Confirm a normal, organically-visited most-visited tile still shows its sponsored tile as before

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
