### PR TITLE
[recipes] Do not pass `--depth` to `git cache populate`

### DIFF
--- a/tools/recipes/post_process.py
+++ b/tools/recipes/post_process.py
@@ -105,6 +105,16 @@ def StepCommandContains(check: Checker, step_odict: Steps, step: str,
                         step_odict[step]['cmd']))
 
 
+def StepCommandDoesNotContain(check: Checker, step_odict: Steps, step: str,
+                              argument_sequence: Sequence[str]) -> None:
+    """Assert that a step's command did not contain the given argument
+    sequence."""
+    check(
+        'command line for step %s did not contain %s' %
+        (step, argument_sequence), not _is_subsequence(
+            [str(a) for a in argument_sequence], step_odict[step]['cmd']))
+
+
 def StepCommandRE(check: Checker, step_odict: Steps, step: str,
                   expected_patterns: Sequence[str | re.Pattern]) -> None:
     """Assert that a step's command matches the given list of regexes.

--- a/tools/recipes/recipe_modules/chromium_checkout/api.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/api.py
@@ -87,9 +87,10 @@ class ChromiumCheckoutApi(RecipeApi):
             git_cache: Optional explicit git cache directory. When given it sets
                 `GIT_CACHE_PATH`; otherwise an existing `GIT_CACHE_PATH` in the
                 environment is used as-is.
-            depth: Optional history depth for the shared git-cache mirror (see
-                `clone`/`checkout_ref`). `None` fetches full history, matching
-                `git cache populate`'s own default.
+            depth: Optional history depth for this working checkout (see
+                `clone`/`checkout_ref`). The shared git-cache mirror is always
+                populated with full history regardless; `None` here checks out
+                full history too.
 
         Returns:
             The resolved absolute `src/` path.
@@ -226,16 +227,16 @@ class ChromiumCheckoutApi(RecipeApi):
         mirror_dir = self._populate_git_cache(
             git_cache_path,
             CHROMIUM_URL,
-            depth=depth,
             populate_step='git cache populate',
             exists_step='git cache exists')
         # `--local --shared`: a same-volume, hardlink-sharing clone of the
         # mirror, effectively free compared to a network clone. `origin` ends up
         # pointing at `mirror_dir` (the clone source), which is exactly what we
         # want for `checkout_ref`'s subsequent fetches to stay local too.
+        depth_args = ['--depth', str(depth)] if depth else []
         self.m.step('clone from git cache', [
-            'git', 'clone', '--no-checkout', '--local', '--shared', mirror_dir,
-            chromium_src
+            'git', 'clone', '--no-checkout', '--local', '--shared',
+            *depth_args, mirror_dir, chromium_src
         ])
         self._disable_git_gc(chromium_src)
         self.m.step('checkout origin/HEAD',
@@ -269,7 +270,6 @@ class ChromiumCheckoutApi(RecipeApi):
             git_cache_path,
             CHROMIUM_URL,
             ref=f'refs/tags/{ref}' if is_tag else None,
-            depth=depth,
             populate_step='git cache populate for ref',
             exists_step='git cache exists for ref')
 
@@ -286,15 +286,13 @@ class ChromiumCheckoutApi(RecipeApi):
             ['git', 'remote', 'set-url', '--push', 'origin', CHROMIUM_URL],
             cwd=chromium_src)
 
-        # `--depth` here (not just on the `populate` above) matters whenever
-        # *chromium_src* is already shallow at a different commit than the
-        # mirror's current one for this ref (e.g. re-checking out a branch
-        # after it moved on): a plain `git fetch` tries to extend the
-        # existing shallow history and fails outright ("did not send all
-        # necessary objects") once the mirror can no longer connect the two.
-        # Passing `--depth` here instead negotiates a fresh, self-contained
-        # shallow window for the requested ref, which doesn't depend on that
-        # connection at all.
+        # `chromium_src` may already be shallow at a different commit than
+        # this ref (e.g. re-checking out a branch after it moved on): a plain
+        # `git fetch` tries to extend the existing shallow history and fails
+        # outright ("did not send all necessary objects") once the
+        # (fully-populated) mirror can no longer connect the two. Passing
+        # `--depth` here instead negotiates a fresh, self-contained shallow
+        # window for the requested ref, independent of that connection.
         depth_args = ['--depth', str(depth)] if depth else []
         if is_tag:
             # Chromium release tag (e.g. `150.0.7850.1`): fetch it as a tag so
@@ -355,7 +353,6 @@ class ChromiumCheckoutApi(RecipeApi):
                             url: str,
                             *,
                             ref: str | None = None,
-                            depth: int | None = None,
                             populate_step: str,
                             exists_step: str) -> str:
         """Populate (or refresh) the shared bare mirror for *url*.
@@ -374,7 +371,6 @@ class ChromiumCheckoutApi(RecipeApi):
             url: The repo to mirror.
             ref: An additional fully-qualified ref (e.g. `refs/tags/<tag>`) to
                 fetch into the mirror, beyond its default `refs/heads/*`.
-            depth: Optional history depth; `None` fetches full history.
             populate_step: Step name for the `git cache populate` call.
             exists_step: Step name for the `git cache exists` call.
 
@@ -387,8 +383,6 @@ class ChromiumCheckoutApi(RecipeApi):
         ]
         if ref:
             populate_cmd.extend(['--ref', ref])
-        if depth:
-            populate_cmd.extend(['--depth', str(depth)])
         self.m.step(populate_step, populate_cmd)
 
         return self.m.step(exists_step, [

--- a/tools/recipes/recipe_modules/chromium_checkout/tests/depth.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/tests/depth.py
@@ -2,11 +2,12 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Test for `ensure_checkout`'s optional `depth` -- threaded down into both
-`git cache populate --depth` (for a shallower shared mirror) and the actual
-`git fetch --depth` that lands the requested ref in `chromium_src` (so
-re-checking out a moved branch negotiates a fresh shallow window instead of
-trying, and failing, to extend the existing one).
+"""Test for `ensure_checkout`'s optional `depth` -- threaded only into the
+working checkout's own `git clone --depth`/`git fetch --depth`, never into
+`git cache populate` (the shared mirror always stays fully populated; see
+`_populate_git_cache`). `git fetch --depth` lands the requested ref in
+`chromium_src` so re-checking out a moved branch negotiates a fresh shallow
+window instead of trying, and failing, to extend the existing one.
 """
 
 from __future__ import annotations
@@ -31,9 +32,11 @@ def GenTests(api):
         api.chromium_checkout.with_git_cache(),
         api.chromium_checkout.git_cache_populated(),
         api.post_process(post_process.StepCommandContains,
-                         'git cache populate', ['--depth', '1']),
-        api.post_process(post_process.StepCommandContains,
-                         'git cache populate for ref', ['--depth', '1']),
+                         'clone from git cache', ['--depth', '1']),
+        api.post_process(post_process.StepCommandDoesNotContain,
+                         'git cache populate', ['--depth']),
+        api.post_process(post_process.StepCommandDoesNotContain,
+                         'git cache populate for ref', ['--depth']),
         api.post_process(post_process.StepCommandContains, 'fetch tag',
                          ['--depth', '1']),
         api.post_process(post_process.StatusSuccess),
@@ -46,21 +49,26 @@ def GenTests(api):
         api.chromium_checkout.with_git_cache(),
         api.chromium_checkout.git_cache_populated(),
         api.post_process(post_process.StepCommandContains,
-                         'git cache populate', ['--depth', '1']),
-        api.post_process(post_process.StepCommandContains,
-                         'git cache populate for ref', ['--depth', '1']),
+                         'clone from git cache', ['--depth', '1']),
+        api.post_process(post_process.StepCommandDoesNotContain,
+                         'git cache populate', ['--depth']),
+        api.post_process(post_process.StepCommandDoesNotContain,
+                         'git cache populate for ref', ['--depth']),
         api.post_process(post_process.StepCommandContains, 'fetch ref',
                          ['--depth', '1']),
         api.post_process(post_process.StatusSuccess),
         api.post_process(post_process.DropExpectation),
     )
-    # Without an explicit `depth`, neither the mirror populate nor the actual
-    # fetch is depth-limited.
+    # Without an explicit `depth`, neither the client clone nor the actual
+    # fetch is depth-limited (and the mirror populate never is, either way).
     yield api.test(
         'no depth requested',
         api.env.set('REF', 'main'),
         api.chromium_checkout.with_git_cache(),
         api.chromium_checkout.git_cache_populated(),
+        api.post_process(post_process.StepCommandRE, 'clone from git cache', [
+            'git', 'clone', '--no-checkout', '--local', '--shared', '.*', '.*'
+        ]),
         api.post_process(post_process.StepCommandRE, 'fetch ref',
                          ['git', 'fetch', 'origin', 'main']),
         api.post_process(post_process.StatusSuccess),

--- a/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
@@ -46,9 +46,7 @@
       "/b/cache",
       "https://chromium.googlesource.com/chromium/src.git",
       "--reset-fetch-config",
-      "--no-fetch-tags",
-      "--depth",
-      "1"
+      "--no-fetch-tags"
     ],
     "env": {
       "CHROME_HEADLESS": "1"
@@ -77,6 +75,8 @@
       "--no-checkout",
       "--local",
       "--shared",
+      "--depth",
+      "1",
       "/b/cache/chromium.googlesource.com-chromium-src",
       "[WORKSPACE]/brave-browser/src"
     ],
@@ -149,9 +149,7 @@
       "--reset-fetch-config",
       "--no-fetch-tags",
       "--ref",
-      "refs/tags/151.0.7917.1",
-      "--depth",
-      "1"
+      "refs/tags/151.0.7917.1"
     ],
     "env": {
       "CHROME_HEADLESS": "1"

--- a/tools/recipes/recipes/toolchains/rust/package_rust.expected/mac.json
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.expected/mac.json
@@ -46,9 +46,7 @@
       "/b/cache",
       "https://chromium.googlesource.com/chromium/src.git",
       "--reset-fetch-config",
-      "--no-fetch-tags",
-      "--depth",
-      "1"
+      "--no-fetch-tags"
     ],
     "env": {
       "CHROME_HEADLESS": "1"
@@ -77,6 +75,8 @@
       "--no-checkout",
       "--local",
       "--shared",
+      "--depth",
+      "1",
       "/b/cache/chromium.googlesource.com-chromium-src",
       "[WORKSPACE]/brave-browser/src"
     ],
@@ -149,9 +149,7 @@
       "--reset-fetch-config",
       "--no-fetch-tags",
       "--ref",
-      "refs/tags/151.0.7917.1",
-      "--depth",
-      "1"
+      "refs/tags/151.0.7917.1"
     ],
     "env": {
       "CHROME_HEADLESS": "1"

--- a/tools/recipes/recipes/toolchains/rust/package_rust.py
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.py
@@ -71,10 +71,6 @@ def GenTests(api):
                          'build rust toolchain', ['--brave-subrevision', '1']),
         api.post_process(post_process.StepCommandContains,
                          'build rust toolchain', ['--upload']),
-        api.post_process(post_process.StepCommandContains,
-                         'git cache populate', ['--depth', '1']),
-        api.post_process(post_process.StepCommandContains,
-                         'git cache populate for ref', ['--depth', '1']),
         api.post_process(post_process.StatusSuccess),
     )
     # On mac, the checkout's pinned Xcode is installed/selected around the

--- a/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/linux.json
+++ b/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/linux.json
@@ -46,9 +46,7 @@
       "/b/cache",
       "https://chromium.googlesource.com/chromium/src.git",
       "--reset-fetch-config",
-      "--no-fetch-tags",
-      "--depth",
-      "1"
+      "--no-fetch-tags"
     ],
     "env": {
       "CHROME_HEADLESS": "1"
@@ -77,6 +75,8 @@
       "--no-checkout",
       "--local",
       "--shared",
+      "--depth",
+      "1",
       "/b/cache/chromium.googlesource.com-chromium-src",
       "[WORKSPACE]/brave-browser/src"
     ],
@@ -149,9 +149,7 @@
       "--reset-fetch-config",
       "--no-fetch-tags",
       "--ref",
-      "refs/tags/151.0.7917.1",
-      "--depth",
-      "1"
+      "refs/tags/151.0.7917.1"
     ],
     "env": {
       "CHROME_HEADLESS": "1"

--- a/tools/recipes/recipes/tools/ast_grep/package_ast_grep.py
+++ b/tools/recipes/recipes/tools/ast_grep/package_ast_grep.py
@@ -55,9 +55,5 @@ def GenTests(api):
         api.properties(chromium_ref='151.0.7917.1'),
         api.post_process(post_process.MustRun, 'clone from git cache'),
         api.post_process(post_process.MustRun, 'package ast-grep'),
-        api.post_process(post_process.StepCommandContains,
-                         'git cache populate', ['--depth', '1']),
-        api.post_process(post_process.StepCommandContains,
-                         'git cache populate for ref', ['--depth', '1']),
         api.post_process(post_process.StatusSuccess),
     )

--- a/tools/recipes/unittests/post_process_test.py
+++ b/tools/recipes/unittests/post_process_test.py
@@ -87,6 +87,14 @@ class CommandTest(unittest.TestCase):
             _run(pp.StepCommandContains, _steps(), 'compile',
                  ['out', 'ninja'])[0], 1)  # wrong order
 
+    def test_command_does_not_contain_subsequence(self):
+        self.assertEqual(
+            _run(pp.StepCommandDoesNotContain, _steps(), 'compile',
+                 ['-C', 'missing'])[0], 0)
+        self.assertEqual(
+            _run(pp.StepCommandDoesNotContain, _steps(), 'compile',
+                 ['ninja', 'out'])[0], 1)
+
     def test_command_re(self):
         self.assertEqual(
             _run(pp.StepCommandRE, _steps(), 'compile',


### PR DESCRIPTION
Removing this flag from being passed to `populate` as it turns the
cached repo into a shallow repo, and disables bootstrapping.

Bug: https://github.com/brave/brave-browser/issues/56748
