### PR TITLE
Fixes infobars are broken after rotation to landscape mode

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/ButtonToast.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/ButtonToast.swift
@@ -53,10 +53,7 @@ class ButtonToast: Toast {
 
     self.toastView.backgroundColor = backgroundColor
 
-    self.toastView.snp.makeConstraints { make in
-      make.left.right.height.equalTo(self)
-      self.animationConstraint = make.top.equalTo(self.snp.bottom).constraint
-    }
+    self.setupInitialToastConstraints()
 
     self.snp.makeConstraints { make in
       make.height.equalTo(ButtonToastUX.toastHeight)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/ButtonToast.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/ButtonToast.swift
@@ -53,10 +53,7 @@ class ButtonToast: Toast {
 
     self.toastView.backgroundColor = backgroundColor
 
-    self.toastView.snp.makeConstraints { make in
-      make.left.right.height.equalTo(self)
-      self.animationConstraint = make.top.equalTo(self.snp.bottom).constraint
-    }
+    self.setupToastConstraints()
 
     self.snp.makeConstraints { make in
       make.height.equalTo(ButtonToastUX.toastHeight)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/DownloadToast.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/DownloadToast.swift
@@ -92,10 +92,7 @@ class DownloadToast: Toast {
 
     self.addSubview(createView(download.filename, descriptionText: self.descriptionText))
 
-    self.toastView.snp.makeConstraints { make in
-      make.left.right.height.equalTo(self)
-      self.animationConstraint = make.top.equalTo(self.snp.bottom).constraint
-    }
+    self.setupInitialToastConstraints()
 
     self.snp.makeConstraints { make in
       make.height.equalTo(ButtonToastUX.toastHeight)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/DownloadToast.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/DownloadToast.swift
@@ -92,10 +92,7 @@ class DownloadToast: Toast {
 
     self.addSubview(createView(download.filename, descriptionText: self.descriptionText))
 
-    self.toastView.snp.makeConstraints { make in
-      make.left.right.height.equalTo(self)
-      self.animationConstraint = make.top.equalTo(self.snp.bottom).constraint
-    }
+    self.setupToastConstraints()
 
     self.snp.makeConstraints { make in
       make.height.equalTo(ButtonToastUX.toastHeight)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/InfoBar.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/InfoBar.swift
@@ -55,10 +55,7 @@ class InfoBar: Toast, UITextViewDelegate {
     }
 
     addSubview(toastView)
-    toastView.snp.makeConstraints { make in
-      make.left.right.height.equalTo(self)
-      self.animationConstraint = make.top.equalTo(self.snp.bottom).constraint
-    }
+    setupToastConstraints()
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/InfoBar.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/InfoBar.swift
@@ -55,10 +55,7 @@ class InfoBar: Toast, UITextViewDelegate {
     }
 
     addSubview(toastView)
-    toastView.snp.makeConstraints { make in
-      make.left.right.height.equalTo(self)
-      self.animationConstraint = make.top.equalTo(self.snp.bottom).constraint
-    }
+    setupInitialToastConstraints()
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toast.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toast.swift
@@ -57,7 +57,6 @@ class ToastShadowView: UIView {
 }
 
 class Toast: UIView {
-  var animationConstraint: Constraint?
   var completionHandler: ((Bool) -> Void)?
 
   weak var viewController: UIViewController?
@@ -117,11 +116,15 @@ class Toast: UIView {
       self.snp.makeConstraints(makeConstraints)
       self.layoutIfNeeded()
 
+      self.toastView.transform = CGAffineTransform(
+        translationX: 0,
+        y: self.bounds.height
+      )
+
       UIView.animate(
         withDuration: SimpleToastUX.toastAnimationDuration,
         animations: {
-          self.animationConstraint?.update(offset: -self.bounds.height)
-          self.layoutIfNeeded()
+          self.toastView.transform = .identity
         },
         completion: { finished in
           self.displayState = .showing
@@ -148,9 +151,13 @@ class Toast: UIView {
 
     UIView.animate(
       withDuration: duration,
+      delay: 0,
+      options: [.beginFromCurrentState],
       animations: {
-        self.animationConstraint?.update(offset: 0)
-        self.layoutIfNeeded()
+        self.toastView.transform = CGAffineTransform(
+          translationX: 0,
+          y: self.bounds.height
+        )
       },
       completion: { finished in
         self.displayState = .dismissed
@@ -179,6 +186,12 @@ class Toast: UIView {
     }
 
     dismiss(false)
+  }
+
+  func setupToastConstraints() {
+    toastView.snp.makeConstraints { make in
+      make.edges.equalTo(self)
+    }
   }
 
   enum State {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toast.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toast.swift
@@ -57,7 +57,6 @@ class ToastShadowView: UIView {
 }
 
 class Toast: UIView {
-  var animationConstraint: Constraint?
   var completionHandler: ((Bool) -> Void)?
 
   weak var viewController: UIViewController?
@@ -65,6 +64,8 @@ class Toast: UIView {
   var displayState = State.dismissed
 
   var tapDismissalMode: TapDismissalMode = .dismissOnOutsideTap
+
+  private var animationConstraint: Constraint?
 
   private lazy var tapInterceptingOverlay = ToastTapInterceptingOverlay()
 
@@ -74,6 +75,8 @@ class Toast: UIView {
     return gestureRecognizer
   }()
 
+  // TODO(https://github.com/brave/brave-browser/issues/46198): Make private to reduce
+  // coupling with subclasses.
   lazy var toastView: UIView = {
     let toastView = UIView()
     toastView.backgroundColor = SimpleToastUX.toastDefaultColor
@@ -125,6 +128,9 @@ class Toast: UIView {
         },
         completion: { finished in
           self.displayState = .showing
+
+          self.anchorToastToBottom()
+
           if let duration = duration {
             DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
               self.dismiss(false, completion: completion)
@@ -145,6 +151,8 @@ class Toast: UIView {
     layer.removeAllAnimations()
 
     let duration = animated ? SimpleToastUX.toastAnimationDuration : 0.1
+
+    setupDismissalToastConstraints()
 
     UIView.animate(
       withDuration: duration,
@@ -179,6 +187,29 @@ class Toast: UIView {
     }
 
     dismiss(false)
+  }
+
+  // TODO(https://github.com/brave/brave-browser/issues/46198): Make private to reduce
+  // coupling with subclasses.
+  func setupInitialToastConstraints() {
+    toastView.snp.makeConstraints { make in
+      make.leading.trailing.height.equalTo(self)
+      self.animationConstraint = make.top.equalTo(self.snp.bottom).constraint
+    }
+  }
+
+  private func setupDismissalToastConstraints() {
+    toastView.snp.remakeConstraints { make in
+      make.leading.trailing.height.equalTo(self)
+      self.animationConstraint =
+        make.top.equalTo(self.snp.bottom).offset(-self.bounds.height).constraint
+    }
+  }
+
+  private func anchorToastToBottom() {
+    toastView.snp.remakeConstraints { make in
+      make.edges.equalTo(self)
+    }
   }
 
   enum State {


### PR DESCRIPTION
Toasts and infobars are no longer misplaced or clipped after rotating the device and stay anchored to the bottom of the screen.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves: https://github.com/brave/brave-browser/issues/46174

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
