### PR TITLE
[AI Chat] Don't pad scaled-down attached images

### DIFF
--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler_unittest.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler_unittest.cc
@@ -226,7 +226,7 @@ TEST_F(AIChatUIPageHandlerTest, ProcessImageFile) {
     EXPECT_EQ(result->type, mojom::UploadedFileType::kImage);
     EXPECT_GT(result->data.size(), 0u);
     auto decoded = gfx::PNGCodec::Decode(result->data);
-    EXPECT_EQ(decoded.width(), 1024);
+    EXPECT_EQ(decoded.width(), 768);
     EXPECT_EQ(decoded.height(), 768);
   }
 }

--- a/components/screenshot/core/browser/BUILD.gn
+++ b/components/screenshot/core/browser/BUILD.gn
@@ -9,7 +9,10 @@ static_library("browser") {
     "utils.h",
   ]
 
-  deps = [ "//skia" ]
+  deps = [
+    "//base",
+    "//skia",
+  ]
 }
 
 source_set("unit_tests") {

--- a/components/screenshot/core/browser/DEPS
+++ b/components/screenshot/core/browser/DEPS
@@ -1,4 +1,5 @@
 include_rules = [
+  "+skia/ext",
   "+third_party/skia/include/core",
   "+ui/gfx/image",
 ]

--- a/components/screenshot/core/browser/utils.cc
+++ b/components/screenshot/core/browser/utils.cc
@@ -5,11 +5,10 @@
 
 #include "brave/components/screenshot/core/browser/utils.h"
 
-#include "third_party/skia/include/core/SkCanvas.h"
-#include "third_party/skia/include/core/SkColor.h"
-#include "third_party/skia/include/core/SkImage.h"
-#include "third_party/skia/include/core/SkRect.h"
-#include "third_party/skia/include/core/SkSamplingOptions.h"
+#include <algorithm>
+
+#include "base/numerics/safe_conversions.h"
+#include "skia/ext/image_operations.h"
 
 namespace screenshot {
 
@@ -21,33 +20,25 @@ SkBitmap ScaleDownBitmap(const SkBitmap& bitmap) {
     return bitmap;
   }
 
-  SkBitmap scaled_bitmap;
-  scaled_bitmap.allocN32Pixels(kTargetWidth, kTargetHeight);
+  const float src_aspect = static_cast<float>(bitmap.width()) / bitmap.height();
+  const float dst_aspect = static_cast<float>(kTargetWidth) / kTargetHeight;
 
-  SkCanvas canvas(scaled_bitmap);
-  canvas.clear(SK_ColorTRANSPARENT);
-
-  SkSamplingOptions sampling_options(SkFilterMode::kLinear,
-                                     SkMipmapMode::kLinear);
-
-  float src_aspect = static_cast<float>(bitmap.width()) / bitmap.height();
-  float dst_aspect = static_cast<float>(kTargetWidth) / kTargetHeight;
-
-  SkRect dst_rect;
+  int width;
+  int height;
   if (src_aspect > dst_aspect) {
     // Source is wider — fit to width.
-    float scaled_height = kTargetWidth / src_aspect;
-    float y_offset = (kTargetHeight - scaled_height) / 2;
-    dst_rect = SkRect::MakeXYWH(0, y_offset, kTargetWidth, scaled_height);
+    width = kTargetWidth;
+    height = std::max(1, base::ClampRound(kTargetWidth / src_aspect));
   } else {
     // Source is taller — fit to height.
-    float scaled_width = kTargetHeight * src_aspect;
-    float x_offset = (kTargetWidth - scaled_width) / 2;
-    dst_rect = SkRect::MakeXYWH(x_offset, 0, scaled_width, kTargetHeight);
+    width = std::max(1, base::ClampRound(kTargetHeight * src_aspect));
+    height = kTargetHeight;
   }
 
-  canvas.drawImageRect(bitmap.asImage(), dst_rect, sampling_options);
-  return scaled_bitmap;
+  // Scale with ImageOperations rather than SkCanvas::drawImageRect() for
+  // cross-platform support.
+  return skia::ImageOperations::Resize(
+      bitmap, skia::ImageOperations::RESIZE_BETTER, width, height);
 }
 
 }  // namespace screenshot

--- a/components/screenshot/core/browser/utils.h
+++ b/components/screenshot/core/browser/utils.h
@@ -10,9 +10,11 @@
 
 namespace screenshot {
 
-// Scales `bitmap` so it fits within 1024x768 while preserving aspect ratio,
-// centering the result on a transparent canvas. Bitmaps already within those
-// bounds are returned unchanged.
+// Scales `bitmap` down so it fits within 1024x768 while preserving aspect
+// ratio, so only one dimension reaches those bounds. Bitmaps already within
+// them are returned unchanged, and the result is never upscaled. Safe to call
+// on any platform, including iOS. Returns an empty bitmap if `bitmap` is not
+// N32.
 SkBitmap ScaleDownBitmap(const SkBitmap& bitmap);
 
 }  // namespace screenshot

--- a/components/screenshot/core/browser/utils_unittest.cc
+++ b/components/screenshot/core/browser/utils_unittest.cc
@@ -8,37 +8,39 @@
 #include <utility>
 #include <vector>
 
-#include "base/memory/discardable_memory_allocator.h"
-#include "base/test/test_discardable_memory_allocator.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "ui/gfx/image/image_unittest_util.h"
 
 namespace screenshot {
 
-class ScreenshotUtilsUnitTest : public ::testing::Test {
- public:
-  void SetUp() override {
-    base::DiscardableMemoryAllocator::SetInstance(
-        &discardable_memory_allocator_);
-  }
-
-  void TearDown() override {
-    base::DiscardableMemoryAllocator::SetInstance(nullptr);
-  }
-
- private:
-  base::TestDiscardableMemoryAllocator discardable_memory_allocator_;
-};
-
-TEST_F(ScreenshotUtilsUnitTest, ScaleDownBitmap) {
-  const std::vector<std::pair<int, int>> large_test_dimensions = {
-      {2560, 1440}, {1024, 1440}, {2560, 768}};
-  for (auto& [width, height] : large_test_dimensions) {
+// Deliberately no base::DiscardableMemoryAllocator instance: ScaleDownBitmap()
+// must not depend on one, because iOS does not install one and CHECK-fails if
+// something asks for it (brave-core #35878).
+TEST(ScreenshotUtilsUnitTest, ScaleDownBitmap) {
+  // Oversized bitmaps are scaled to contain within 1024x768, preserving the
+  // source aspect ratio, so only one dimension reaches the target.
+  struct {
+    int width;
+    int height;
+    int expected_width;
+    int expected_height;
+  } const large_test_dimensions[] = {
+      {2560, 1440, 1024, 576},  // 16:9, fits to width.
+      {1024, 1440, 546, 768},   // Taller than wide, fits to height.
+      {2560, 768, 1024, 307},   // Wider than the target, fits to width.
+      {5000, 1, 1024, 1},       // Extreme aspect ratios keep a single pixel.
+      {1, 5000, 1, 768},
+      // Only the height exceeds the target, so the result must be smaller than
+      // the source in both dimensions rather than upscaled to reach 1024.
+      {900, 1000, 691, 768},
+  };
+  for (const auto& [width, height, expected_width, expected_height] :
+       large_test_dimensions) {
     SCOPED_TRACE(testing::Message() << width << "x" << height);
     const auto bitmap = gfx::test::CreateBitmap(width, height);
     const auto scaled_bitmap = ScaleDownBitmap(bitmap);
-    EXPECT_EQ(scaled_bitmap.width(), 1024);
-    EXPECT_EQ(scaled_bitmap.height(), 768);
+    EXPECT_EQ(scaled_bitmap.width(), expected_width);
+    EXPECT_EQ(scaled_bitmap.height(), expected_height);
   }
 
   const std::vector<std::pair<int, int>> no_change_test_dimensions = {

--- a/ios/browser/ui/webui/ai_chat/BUILD.gn
+++ b/ios/browser/ui/webui/ai_chat/BUILD.gn
@@ -3,6 +3,21 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+# Kept separate from ":ai_chat" so it can be unit tested without pulling in the
+# WebUI page handler's dependencies.
+source_set("image_utils") {
+  sources = [
+    "image_utils.h",
+    "image_utils.mm",
+  ]
+
+  deps = [
+    "//brave/components/screenshot/core/browser",
+    "//skia",
+    "//ui/gfx/codec",
+  ]
+}
+
 source_set("ai_chat") {
   sources = [
     "ai_chat_ui.h",
@@ -16,6 +31,7 @@ source_set("ai_chat") {
   ]
 
   deps = [
+    ":image_utils",
     "//base",
     "//brave/components/ai_chat/core/browser",
     "//brave/components/ai_chat/core/common",
@@ -51,8 +67,21 @@ source_set("ai_chat") {
     "//ios/web_view/framework:web_view_sources",
     "//mojo/public/cpp/bindings",
     "//mojo/public/js:resources",
-    "//skia",
     "//ui/base",
+  ]
+}
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [ "image_utils_unittest.mm" ]
+
+  deps = [
+    ":image_utils",
+    "//base",
+    "//skia",
+    "//testing/gtest",
+    "//ui/gfx:test_support",
     "//ui/gfx/codec",
   ]
 }

--- a/ios/browser/ui/webui/ai_chat/DEPS
+++ b/ios/browser/ui/webui/ai_chat/DEPS
@@ -3,5 +3,6 @@ include_rules = [
   "+brave/components/ai_chat/ios/browser",
   "+brave/components/ai_chat/resources/grit",
   "+brave/components/constants",
+  "+brave/components/screenshot/core/browser",
   "+brave/components/version_info",
 ]

--- a/ios/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.mm
+++ b/ios/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.mm
@@ -6,14 +6,12 @@
 #include "brave/ios/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h"
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 
 #include <memory>
 #include <optional>
 #include <string>
 #include <vector>
 
-#include "base/apple/foundation_util.h"
 #include "base/containers/span.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_forward.h"
@@ -44,6 +42,7 @@
 #include "brave/ios/browser/misc_metrics/profile_misc_metrics_service.h"
 #include "brave/ios/browser/misc_metrics/profile_misc_metrics_service_factory.h"
 #include "brave/ios/browser/ui/webui/ai_chat/associated_url_content.h"
+#include "brave/ios/browser/ui/webui/ai_chat/image_utils.h"
 #include "components/favicon/core/favicon_service.h"
 #include "components/favicon_base/favicon_types.h"
 #include "components/grit/brave_components_webui_strings.h"
@@ -57,12 +56,9 @@
 #include "ios/web/public/web_state_observer.h"
 #include "ios/web_view/internal/cwv_web_view_internal.h"
 #include "net/base/apple/url_conversions.h"
-#include "skia/ext/skia_utils_ios.h"
-#include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/page_transition_types.h"
 #include "ui/base/webui/web_ui_util.h"
-#include "ui/gfx/codec/png_codec.h"
 
 namespace ai_chat {
 
@@ -71,31 +67,9 @@ namespace {
 void DecodeAndScaleImage(
     const std::vector<uint8_t>& file_data,
     base::OnceCallback<void(std::optional<std::vector<uint8_t>>)> callback) {
-  NSData* ns_data = [NSData dataWithBytes:file_data.data()
-                                   length:file_data.size()];
-  auto encode_image = base::BindOnce(
-      [](NSData* data) -> std::optional<std::vector<uint8_t>> {
-        CGSize target_size = CGSizeMake(1024, 768);
-        UIImage* image = [[UIImage alloc] initWithData:data];
-        if (image.size.width > target_size.width ||
-            image.size.height > target_size.height) {
-          image = [image imageByPreparingThumbnailOfSize:target_size];
-        }
-        if (!image) {
-          return std::nullopt;
-        }
-        NSData* png_data = UIImagePNGRepresentation(image);
-        if (!png_data) {
-          return std::nullopt;
-        }
-        auto png_span = base::apple::NSDataToSpan(png_data);
-        return std::vector<uint8_t>(png_span.begin(), png_span.end());
-      },
-      ns_data);
-
-  base::ThreadPool::PostTaskAndReplyWithResult(FROM_HERE, {base::MayBlock()},
-                                               std::move(encode_image),
-                                               std::move(callback));
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock()},
+      base::BindOnce(&DecodeAndScaleImageData, file_data), std::move(callback));
 }
 
 void OnFaviconRawBitmapAvailable(

--- a/ios/browser/ui/webui/ai_chat/image_utils.h
+++ b/ios/browser/ui/webui/ai_chat/image_utils.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_UI_WEBUI_AI_CHAT_IMAGE_UTILS_H_
+#define BRAVE_IOS_BROWSER_UI_WEBUI_AI_CHAT_IMAGE_UTILS_H_
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace ai_chat {
+
+// Decodes the image in `image_data`, scales it down to the bounds shared with
+// the other platforms via screenshot::ScaleDownBitmap(), and re-encodes it as a
+// PNG. Returns std::nullopt if `image_data` holds no decodable image or cannot
+// be re-encoded. Blocks, so call this from a sequence that allows blocking.
+std::optional<std::vector<uint8_t>> DecodeAndScaleImageData(
+    std::vector<uint8_t> image_data);
+
+}  // namespace ai_chat
+
+#endif  // BRAVE_IOS_BROWSER_UI_WEBUI_AI_CHAT_IMAGE_UTILS_H_

--- a/ios/browser/ui/webui/ai_chat/image_utils.mm
+++ b/ios/browser/ui/webui/ai_chat/image_utils.mm
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/ui/webui/ai_chat/image_utils.h"
+
+#import <Foundation/Foundation.h>
+
+#include "brave/components/screenshot/core/browser/utils.h"
+#include "skia/ext/skia_utils_ios.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+#include "ui/gfx/codec/png_codec.h"
+
+namespace ai_chat {
+
+std::optional<std::vector<uint8_t>> DecodeAndScaleImageData(
+    std::vector<uint8_t> image_data) {
+  NSData* ns_data = [NSData dataWithBytes:image_data.data()
+                                   length:image_data.size()];
+  // ImageIO decodes, then the shared util scales, so uploads are sized
+  // identically on every platform.
+  const std::vector<SkBitmap> bitmaps = skia::ImageDataToSkBitmaps(ns_data);
+  if (bitmaps.empty()) {
+    return std::nullopt;
+  }
+  return gfx::PNGCodec::EncodeBGRASkBitmap(
+      screenshot::ScaleDownBitmap(bitmaps.front()),
+      /*discard_transparency=*/false);
+}
+
+}  // namespace ai_chat

--- a/ios/browser/ui/webui/ai_chat/image_utils_unittest.mm
+++ b/ios/browser/ui/webui/ai_chat/image_utils_unittest.mm
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/ui/webui/ai_chat/image_utils.h"
+
+#import <Foundation/Foundation.h>
+
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "base/check.h"
+#include "skia/ext/skia_utils_ios.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "testing/platform_test.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+#include "ui/gfx/codec/png_codec.h"
+#include "ui/gfx/image/image_unittest_util.h"
+
+namespace ai_chat {
+
+namespace {
+
+// Encoded bytes for a `width`x`height` image, standing in for the file the
+// WebUI hands the page handler.
+std::vector<uint8_t> CreateEncodedImage(int width, int height) {
+  std::optional<std::vector<uint8_t>> encoded =
+      gfx::PNGCodec::EncodeBGRASkBitmap(gfx::test::CreateBitmap(width, height),
+                                        /*discard_transparency=*/false);
+  CHECK(encoded);
+  return std::move(*encoded);
+}
+
+// Decodes `encoded` back to a bitmap so its dimensions can be asserted on.
+SkBitmap Decode(const std::vector<uint8_t>& encoded) {
+  const std::vector<SkBitmap> bitmaps =
+      skia::ImageDataToSkBitmaps([NSData dataWithBytes:encoded.data()
+                                                length:encoded.size()]);
+  return bitmaps.empty() ? SkBitmap() : bitmaps.front();
+}
+
+}  // namespace
+
+using AIChatImageUtilsTest = PlatformTest;
+
+// Oversized images are scaled to fit within 1024x768 with their aspect ratio
+// preserved, so exactly one dimension reaches the bounds. This used to scale
+// with -imageByPreparingThumbnailOfSize:, which instead fit the longest edge to
+// 1024: the taller-than-4:3 cases came back up to 1024 tall, over the bounds.
+TEST_F(AIChatImageUtilsTest, ScalesOversizedImagesToFitBounds) {
+  struct {
+    int width;
+    int height;
+    int expected_width;
+    int expected_height;
+  } const kCases[] = {
+      {2560, 1440, 1024, 576},  // 16:9, fits to width.
+      {2560, 768, 1024, 307},   // Wider than the bounds, fits to width.
+      {1024, 1440, 546, 768},   // Taller than 4:3, fits to height.
+      {768, 2000, 295, 768},    // Taller than 4:3, fits to height.
+  };
+  for (const auto& [width, height, expected_width, expected_height] : kCases) {
+    SCOPED_TRACE(testing::Message() << width << "x" << height);
+    const std::optional<std::vector<uint8_t>> scaled =
+        DecodeAndScaleImageData(CreateEncodedImage(width, height));
+    ASSERT_TRUE(scaled);
+    const SkBitmap bitmap = Decode(*scaled);
+    EXPECT_EQ(bitmap.width(), expected_width);
+    EXPECT_EQ(bitmap.height(), expected_height);
+  }
+}
+
+// An image that exceeds only one bound must still come back smaller than it
+// went in. -imageByPreparingThumbnailOfSize: scaled these UP to reach 1024 on
+// their longest edge (900x1000 became 921x1024), inflating the upload it was
+// meant to shrink.
+TEST_F(AIChatImageUtilsTest, NeverUpscales) {
+  const std::vector<std::pair<int, int>> kDimensions = {{900, 1000},
+                                                        {1000, 900}};
+  for (const auto& [width, height] : kDimensions) {
+    SCOPED_TRACE(testing::Message() << width << "x" << height);
+    const std::optional<std::vector<uint8_t>> scaled =
+        DecodeAndScaleImageData(CreateEncodedImage(width, height));
+    ASSERT_TRUE(scaled);
+    const SkBitmap bitmap = Decode(*scaled);
+    EXPECT_LE(bitmap.width(), width);
+    EXPECT_LE(bitmap.height(), height);
+    EXPECT_LE(bitmap.width(), 1024);
+    EXPECT_LE(bitmap.height(), 768);
+  }
+}
+
+TEST_F(AIChatImageUtilsTest, LeavesImagesWithinBoundsAtTheirOriginalSize) {
+  const std::vector<std::pair<int, int>> kDimensions = {
+      {1024, 768}, {1024, 720}, {960, 768}, {640, 480}};
+  for (const auto& [width, height] : kDimensions) {
+    SCOPED_TRACE(testing::Message() << width << "x" << height);
+    const std::optional<std::vector<uint8_t>> scaled =
+        DecodeAndScaleImageData(CreateEncodedImage(width, height));
+    ASSERT_TRUE(scaled);
+    const SkBitmap bitmap = Decode(*scaled);
+    EXPECT_EQ(bitmap.width(), width);
+    EXPECT_EQ(bitmap.height(), height);
+  }
+}
+
+TEST_F(AIChatImageUtilsTest, ReturnsNulloptForUndecodableData) {
+  EXPECT_FALSE(DecodeAndScaleImageData({}));
+
+  const std::string not_an_image = "this is not an image";
+  EXPECT_FALSE(DecodeAndScaleImageData(
+      std::vector<uint8_t>(not_an_image.begin(), not_an_image.end())));
+}
+
+}  // namespace ai_chat

--- a/ios/testing/BUILD.gn
+++ b/ios/testing/BUILD.gn
@@ -29,6 +29,7 @@ test("ios_brave_unit_tests") {
     "//brave/ios/browser/brave_shields:unit_tests",
     "//brave/ios/browser/brave_shields/request_blocking:unit_tests",
     "//brave/ios/browser/serp_metrics:unit_tests",
+    "//brave/ios/browser/ui/webui/ai_chat:unit_tests",
 
     # This is required until we can sort out overridden deps symbols
     "//brave/ios/browser",


### PR DESCRIPTION
Instead of scaling to a fixed 1024x768, we maintain the images aspect ratio and scale to contain within 1024x768

<img width="838" height="1292" alt="image" src="https://github.com/user-attachments/assets/732a987e-1d5a-4bba-ad65-737f5ceebf78" />

<img width="1136" height="2168" alt="image" src="https://github.com/user-attachments/assets/b996ae52-c589-4357-a38a-56944f46133f" />


We should probably have `screenshot::ScaleDownBitmap` accept a width/height as params but that can be follow-up.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
