### PR TITLE
Add Brave backgrounds subpage with disable controls

### DIFF
--- a/browser/ntp_background/ntp_background_prefs.cc
+++ b/browser/ntp_background/ntp_background_prefs.cc
@@ -67,6 +67,7 @@ void NTPBackgroundPrefs::RegisterPref(
   registry->RegisterDictionaryPref(kPrefName, std::move(dict));
 
   registry->RegisterListPref(kCustomImageListPrefName);
+  registry->RegisterListPref(kDisabledBraveImageListPrefName);
 }
 
 void NTPBackgroundPrefs::MigrateOldPref() {
@@ -151,6 +152,36 @@ void NTPBackgroundPrefs::RemoveCustomImageFromList(
 
 std::vector<std::string> NTPBackgroundPrefs::GetCustomImageList() const {
   const auto& list = service_->GetList(kCustomImageListPrefName);
+  std::vector<std::string> result;
+  for (const auto& item : list) {
+    result.push_back(item.GetString());
+  }
+
+  return result;
+}
+
+void NTPBackgroundPrefs::AddDisabledBraveImage(const std::string& file_name) {
+  ScopedListPrefUpdate update(service_, kDisabledBraveImageListPrefName);
+  for (const auto& item : update.Get()) {
+    if (item.is_string() && item.GetString() == file_name) {
+      return;
+    }
+  }
+  update->Append(file_name);
+}
+
+void NTPBackgroundPrefs::RemoveDisabledBraveImage(
+    const std::string& file_name) {
+  ScopedListPrefUpdate update(service_, kDisabledBraveImageListPrefName);
+  auto to_remove = std::ranges::remove_if(
+      update.Get(), [&file_name](const base::Value& value) {
+        return value.is_string() && value.GetString() == file_name;
+      });
+  update->erase(to_remove.begin(), to_remove.end());
+}
+
+std::vector<std::string> NTPBackgroundPrefs::GetDisabledBraveImageList() const {
+  const auto& list = service_->GetList(kDisabledBraveImageListPrefName);
   std::vector<std::string> result;
   for (const auto& item : list) {
     result.push_back(item.GetString());

--- a/browser/ntp_background/ntp_background_prefs.h
+++ b/browser/ntp_background/ntp_background_prefs.h
@@ -54,6 +54,9 @@ class NTPBackgroundPrefs final {
   static constexpr char kCustomImageListPrefName[] =
       "brave.new_tab_page.custom_background_image_list";
 
+  static constexpr char kDisabledBraveImageListPrefName[] =
+      "brave.new_tab_page.disabled_brave_background_image_list";
+
   enum class Type {
     kBrave,  // Images that we supply.
     kCustomImage,
@@ -90,6 +93,10 @@ class NTPBackgroundPrefs final {
   void AddCustomImageToList(const std::string& file_name);
   void RemoveCustomImageFromList(const std::string& file_name);
   std::vector<std::string> GetCustomImageList() const;
+
+  void AddDisabledBraveImage(const std::string& file_name);
+  void RemoveDisabledBraveImage(const std::string& file_name);
+  std::vector<std::string> GetDisabledBraveImageList() const;
 
  private:
   const base::DictValue* GetPrefValue() const;

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.style.ts
@@ -38,9 +38,20 @@ export const style = scoped.css`
     width: 100%;
     height: auto;
     aspect-ratio: 4 / 3;
+    opacity: 1;
+    filter: grayscale(0);
+    transition:
+      opacity 0.2s ease,
+      filter 0.2s ease,
+      box-shadow 0.2s ease;
 
     &.selected {
       box-shadow: ${effect.elevation['01']};
+    }
+
+    &.inactive {
+      opacity: 0.5;
+      filter: grayscale(1);
     }
   }
 
@@ -57,14 +68,15 @@ export const style = scoped.css`
     }
 
     &:hover,
-    &:focus-within {
-      .remove-image {
+    &:focus-within,
+    &.disabled {
+      .overlay-button {
         visibility: visible;
       }
     }
   }
 
-  .remove-image {
+  .overlay-button {
     --leo-icon-color: ${color.icon.default};
     --leo-icon-size: ${icon.m};
 
@@ -79,6 +91,10 @@ export const style = scoped.css`
     background-color: ${color.white};
     border-radius: ${radius.full};
     visibility: hidden;
+
+    &:disabled {
+      opacity: 0.5;
+    }
   }
 
   .upload {

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.style.ts
@@ -29,6 +29,13 @@ export const style = scoped.css`
     }
   }
 
+  .brave-backgrounds-description {
+    margin: 0;
+    padding: ${spacing['2Xl']} ${spacing['2Xl']} 0;
+    font: ${font.small.regular};
+    color: ${color.text.secondary};
+  }
+
   .background-options {
     padding: ${spacing['2Xl']};
     display: grid;

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.style.ts
@@ -47,9 +47,20 @@ export const style = scoped.css`
     width: 100%;
     height: auto;
     aspect-ratio: 4 / 3;
+    opacity: 1;
+    filter: grayscale(0);
+    transition:
+      opacity 0.2s ease,
+      filter 0.2s ease,
+      box-shadow 0.2s ease;
 
     &.selected {
       box-shadow: ${effect.elevation['01']};
+    }
+
+    &.inactive {
+      opacity: 0.5;
+      filter: grayscale(1);
     }
   }
 
@@ -66,14 +77,15 @@ export const style = scoped.css`
     }
 
     &:hover,
-    &:focus-within {
-      .remove-image {
+    &:focus-within,
+    &.disabled {
+      .overlay-button {
         visibility: visible;
       }
     }
   }
 
-  .remove-image {
+  .overlay-button {
     --leo-icon-color: ${color.icon.default};
     --leo-icon-size: ${icon.m};
 
@@ -88,6 +100,10 @@ export const style = scoped.css`
     background-color: ${color.white};
     border-radius: ${radius.full};
     visibility: hidden;
+
+    &:disabled {
+      opacity: 0.5;
+    }
   }
 
   .upload {

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.style.ts
@@ -20,6 +20,22 @@ export const style = scoped.css`
     flex-direction: column;
   }
 
+  .label .subtext {
+    font: ${font.small.regular};
+    color: ${color.text.secondary};
+
+    a {
+      color: inherit;
+    }
+  }
+
+  .brave-backgrounds-description {
+    margin: 0;
+    padding: ${spacing['2Xl']} ${spacing['2Xl']} 0;
+    font: ${font.small.regular};
+    color: ${color.text.secondary};
+  }
+
   .background-options {
     padding: ${spacing['2Xl']};
     display: grid;

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.tsx
@@ -128,11 +128,22 @@ export function BackgroundPanel() {
     })
   }
 
+  function openBackgroundTypePanel(type: SelectedBackgroundType) {
+    // Default to "Refresh on every new tab" when entering a type panel,
+    // unless a specific value of that type is already pinned.
+    const hasPinnedValue =
+      selectedBackground.type === type && !!selectedBackground.value
+    if (!hasPinnedValue) {
+      actions.selectBackground(type, '')
+    }
+    setPanelType(type)
+  }
+
   function onCustomPreviewClick() {
     if (customBackgrounds.length === 0) {
       showCustomBackgroundChooser()
     } else {
-      setPanelType(SelectedBackgroundType.kCustom)
+      openBackgroundTypePanel(SelectedBackgroundType.kCustom)
     }
   }
 
@@ -225,7 +236,9 @@ export function BackgroundPanel() {
           <div className='background-options'>
             <div className='background-option'>
               <button
-                onClick={() => setPanelType(SelectedBackgroundType.kBrave)}
+                onClick={() =>
+                  openBackgroundTypePanel(SelectedBackgroundType.kBrave)
+                }
               >
                 {renderTypePreview(SelectedBackgroundType.kBrave)}
                 {getString(S.NEW_TAB_BRAVE_BACKGROUND_LABEL)}
@@ -239,7 +252,9 @@ export function BackgroundPanel() {
             </div>
             <div className='background-option'>
               <button
-                onClick={() => setPanelType(SelectedBackgroundType.kSolid)}
+                onClick={() =>
+                  openBackgroundTypePanel(SelectedBackgroundType.kSolid)
+                }
               >
                 {renderTypePreview(SelectedBackgroundType.kSolid)}
                 {getString(S.NEW_TAB_SOLID_BACKGROUND_LABEL)}
@@ -247,7 +262,9 @@ export function BackgroundPanel() {
             </div>
             <div className='background-option'>
               <button
-                onClick={() => setPanelType(SelectedBackgroundType.kGradient)}
+                onClick={() =>
+                  openBackgroundTypePanel(SelectedBackgroundType.kGradient)
+                }
               >
                 {renderTypePreview(SelectedBackgroundType.kGradient)}
                 {getString(S.NEW_TAB_GRADIENT_BACKGROUND_LABEL)}

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.tsx
@@ -59,6 +59,9 @@ export function BackgroundPanel() {
     const isSelectedType = type === selectedBackground.type
     switch (type) {
       case SelectedBackgroundType.kBrave:
+        if (isSelectedType && selectedBackground.value) {
+          return selectedBackground.value
+        }
         return braveBackgrounds[0]?.imageUrl ?? ''
       case SelectedBackgroundType.kCustom:
         if (isSelectedType && selectedBackground.value) {
@@ -135,6 +138,8 @@ export function BackgroundPanel() {
 
   function subPanelTitle(type: SelectedBackgroundType) {
     switch (type) {
+      case SelectedBackgroundType.kBrave:
+        return getString(S.NEW_TAB_BRAVE_BACKGROUND_LABEL)
       case SelectedBackgroundType.kCustom:
         return getString(S.NEW_TAB_CUSTOM_BACKGROUND_LABEL)
       case SelectedBackgroundType.kGradient:
@@ -220,9 +225,7 @@ export function BackgroundPanel() {
           <div className='background-options'>
             <div className='background-option'>
               <button
-                onClick={() => {
-                  actions.selectBackground(SelectedBackgroundType.kBrave, '')
-                }}
+                onClick={() => setPanelType(SelectedBackgroundType.kBrave)}
               >
                 {renderTypePreview(SelectedBackgroundType.kBrave)}
                 {getString(S.NEW_TAB_BRAVE_BACKGROUND_LABEL)}

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.tsx
@@ -62,9 +62,7 @@ export function BackgroundPanel() {
     const isSelectedType = type === selectedBackground.type
     switch (type) {
       case SelectedBackgroundType.kBrave:
-        if (isSelectedType && selectedBackground.value) {
-          return selectedBackground.value
-        }
+        // Brave backgrounds always rotate — preview the first available image.
         return braveBackgrounds[0]?.imageUrl ?? ''
       case SelectedBackgroundType.kCustom:
         if (isSelectedType && selectedBackground.value) {
@@ -132,6 +130,13 @@ export function BackgroundPanel() {
   }
 
   function openBackgroundTypePanel(type: SelectedBackgroundType) {
+    // Brave backgrounds always rotate; the sub page only manages enable/disable.
+    if (type === SelectedBackgroundType.kBrave) {
+      actions.selectBackground(type, '')
+      setPanelType(type)
+      return
+    }
+
     // Default to "Refresh on every new tab" when entering a type panel,
     // unless a specific value of that type is already pinned.
     const hasPinnedValue =

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.tsx
@@ -62,6 +62,9 @@ export function BackgroundPanel() {
     const isSelectedType = type === selectedBackground.type
     switch (type) {
       case SelectedBackgroundType.kBrave:
+        if (isSelectedType && selectedBackground.value) {
+          return selectedBackground.value
+        }
         return braveBackgrounds[0]?.imageUrl ?? ''
       case SelectedBackgroundType.kCustom:
         if (isSelectedType && selectedBackground.value) {
@@ -138,6 +141,8 @@ export function BackgroundPanel() {
 
   function subPanelTitle(type: SelectedBackgroundType) {
     switch (type) {
+      case SelectedBackgroundType.kBrave:
+        return getString(S.NEW_TAB_BRAVE_BACKGROUND_LABEL)
       case SelectedBackgroundType.kCustom:
         return getString(S.NEW_TAB_CUSTOM_BACKGROUND_LABEL)
       case SelectedBackgroundType.kGradient:
@@ -233,9 +238,7 @@ export function BackgroundPanel() {
           <div className='background-options'>
             <div className='background-option'>
               <button
-                onClick={() => {
-                  actions.selectBackground(SelectedBackgroundType.kBrave, '')
-                }}
+                onClick={() => setPanelType(SelectedBackgroundType.kBrave)}
               >
                 {renderTypePreview(SelectedBackgroundType.kBrave)}
                 {getString(S.NEW_TAB_BRAVE_BACKGROUND_LABEL)}

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.tsx
@@ -59,9 +59,7 @@ export function BackgroundPanel() {
     const isSelectedType = type === selectedBackground.type
     switch (type) {
       case SelectedBackgroundType.kBrave:
-        if (isSelectedType && selectedBackground.value) {
-          return selectedBackground.value
-        }
+        // Brave backgrounds always rotate — preview the first available image.
         return braveBackgrounds[0]?.imageUrl ?? ''
       case SelectedBackgroundType.kCustom:
         if (isSelectedType && selectedBackground.value) {
@@ -129,6 +127,13 @@ export function BackgroundPanel() {
   }
 
   function openBackgroundTypePanel(type: SelectedBackgroundType) {
+    // Brave backgrounds always rotate; the sub page only manages enable/disable.
+    if (type === SelectedBackgroundType.kBrave) {
+      actions.selectBackground(type, '')
+      setPanelType(type)
+      return
+    }
+
     // Default to "Refresh on every new tab" when entering a type panel,
     // unless a specific value of that type is already pinned.
     const hasPinnedValue =

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_panel.tsx
@@ -131,11 +131,22 @@ export function BackgroundPanel() {
     })
   }
 
+  function openBackgroundTypePanel(type: SelectedBackgroundType) {
+    // Default to "Refresh on every new tab" when entering a type panel,
+    // unless a specific value of that type is already pinned.
+    const hasPinnedValue =
+      selectedBackground.type === type && !!selectedBackground.value
+    if (!hasPinnedValue) {
+      actions.selectBackground(type, '')
+    }
+    setPanelType(type)
+  }
+
   function onCustomPreviewClick() {
     if (customBackgrounds.length === 0) {
       showCustomBackgroundChooser()
     } else {
-      setPanelType(SelectedBackgroundType.kCustom)
+      openBackgroundTypePanel(SelectedBackgroundType.kCustom)
     }
   }
 
@@ -238,7 +249,9 @@ export function BackgroundPanel() {
           <div className='background-options'>
             <div className='background-option'>
               <button
-                onClick={() => setPanelType(SelectedBackgroundType.kBrave)}
+                onClick={() =>
+                  openBackgroundTypePanel(SelectedBackgroundType.kBrave)
+                }
               >
                 {renderTypePreview(SelectedBackgroundType.kBrave)}
                 {getString(S.NEW_TAB_BRAVE_BACKGROUND_LABEL)}
@@ -252,7 +265,9 @@ export function BackgroundPanel() {
             </div>
             <div className='background-option'>
               <button
-                onClick={() => setPanelType(SelectedBackgroundType.kSolid)}
+                onClick={() =>
+                  openBackgroundTypePanel(SelectedBackgroundType.kSolid)
+                }
               >
                 {renderTypePreview(SelectedBackgroundType.kSolid)}
                 {getString(S.NEW_TAB_SOLID_BACKGROUND_LABEL)}
@@ -260,7 +275,9 @@ export function BackgroundPanel() {
             </div>
             <div className='background-option'>
               <button
-                onClick={() => setPanelType(SelectedBackgroundType.kGradient)}
+                onClick={() =>
+                  openBackgroundTypePanel(SelectedBackgroundType.kGradient)
+                }
               >
                 {renderTypePreview(SelectedBackgroundType.kGradient)}
                 {getString(S.NEW_TAB_GRADIENT_BACKGROUND_LABEL)}

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_type_panel.test.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_type_panel.test.tsx
@@ -82,6 +82,13 @@ function renderPanel(
 }
 
 describe('BackgroundTypePanel Brave backgrounds', () => {
+  it('should show a description about rotation and disabling images', () => {
+    renderPanel()
+    expect(
+      screen.getByText('NEW_TAB_BRAVE_BACKGROUNDS_DESCRIPTION'),
+    ).toBeInTheDocument()
+  })
+
   it('should not show the refresh toggle', () => {
     renderPanel()
     expect(

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_type_panel.test.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_type_panel.test.tsx
@@ -1,0 +1,163 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { createStateStore } from '$web-common/state_store'
+import { BackgroundContext } from '../../context/background_context'
+import {
+  BackgroundState,
+  SelectedBackgroundType,
+} from '../../state/background_store'
+import { BackgroundTypePanel } from './background_type_panel'
+
+const braveBackgrounds = [
+  {
+    author: 'Author 1',
+    imageUrl: 'chrome://background-wallpaper/one.jpg',
+    link: 'https://example.com/1',
+  },
+  {
+    author: 'Author 2',
+    imageUrl: 'chrome://background-wallpaper/two.jpg',
+    link: 'https://example.com/2',
+  },
+]
+
+function createStore(
+  state: Partial<BackgroundState>,
+  actions: Partial<BackgroundState['actions']> = {},
+) {
+  return createStateStore<BackgroundState>({
+    initialized: true,
+    backgroundsEnabled: true,
+    backgroundsCustomizable: true,
+    sponsoredImagesEnabled: false,
+    braveBackgrounds,
+    customBackgrounds: [],
+    disabledBraveBackgrounds: [],
+    selectedBackground: {
+      type: SelectedBackgroundType.kBrave,
+      value: '',
+    },
+    backgroundRotateIndex: 0,
+    backgroundRandomValue: 0,
+    sponsoredImageBackground: null,
+    sponsoredRichMediaBaseUrl: '',
+    actions: {
+      setBackgroundsEnabled() {},
+      setSponsoredImagesEnabled() {},
+      selectBackground() {},
+      async showCustomBackgroundChooser() {
+        return false
+      },
+      async removeCustomBackground() {},
+      setBraveBackgroundEnabled() {},
+      notifySponsoredImageLoadError() {},
+      notifySponsoredImageLogoClicked() {},
+      notifySponsoredRichMediaEvent() {},
+      ...actions,
+    },
+    ...state,
+  })
+}
+
+function renderPanel(
+  state: Partial<BackgroundState> = {},
+  actions: Partial<BackgroundState['actions']> = {},
+) {
+  const store = createStore(state, actions)
+  render(
+    <BackgroundContext.Provider value={store}>
+      <BackgroundTypePanel
+        backgroundType={SelectedBackgroundType.kBrave}
+        renderUploadOption={() => null}
+      />
+    </BackgroundContext.Provider>,
+  )
+  return store
+}
+
+describe('BackgroundTypePanel Brave backgrounds', () => {
+  it('should pin the current Brave background when randomize is turned off', () => {
+    const selectBackground = jest.fn()
+    renderPanel(
+      {
+        selectedBackground: {
+          type: SelectedBackgroundType.kBrave,
+          value: '',
+        },
+        backgroundRandomValue: 0,
+      },
+      { selectBackground },
+    )
+
+    const toggle = document.querySelector('leo-toggle') as HTMLElement & {
+      checked?: boolean
+      onChange?: (detail: { checked: boolean }) => void
+    }
+    expect(toggle).toBeTruthy()
+    expect(toggle.checked).toBe(true)
+    toggle.onChange?.({ checked: false })
+
+    expect(selectBackground).toHaveBeenCalledWith(
+      SelectedBackgroundType.kBrave,
+      braveBackgrounds[0].imageUrl,
+    )
+  })
+
+  it('should disable a Brave background when the eye button is clicked', () => {
+    const setBraveBackgroundEnabled = jest.fn()
+    renderPanel({}, { setBraveBackgroundEnabled })
+
+    fireEvent.click(
+      screen.getAllByRole('button', {
+        name: 'NEW_TAB_DISABLE_BACKGROUND_LABEL',
+      })[0],
+    )
+
+    expect(setBraveBackgroundEnabled).toHaveBeenCalledWith(
+      braveBackgrounds[0].imageUrl,
+      false,
+    )
+  })
+
+  it('should not allow disabling the last enabled Brave background', () => {
+    const setBraveBackgroundEnabled = jest.fn()
+    renderPanel(
+      {
+        disabledBraveBackgrounds: [braveBackgrounds[0].imageUrl],
+      },
+      { setBraveBackgroundEnabled },
+    )
+
+    const disableButton = screen.getByRole('button', {
+      name: 'NEW_TAB_DISABLE_BACKGROUND_LABEL',
+    })
+    expect(disableButton).toBeDisabled()
+
+    fireEvent.click(disableButton)
+    expect(setBraveBackgroundEnabled).not.toHaveBeenCalled()
+  })
+
+  it('should re-enable a disabled Brave background when the eye button is clicked', () => {
+    const setBraveBackgroundEnabled = jest.fn()
+    renderPanel(
+      {
+        disabledBraveBackgrounds: [braveBackgrounds[0].imageUrl],
+      },
+      { setBraveBackgroundEnabled },
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'NEW_TAB_ENABLE_BACKGROUND_LABEL' }),
+    )
+
+    expect(setBraveBackgroundEnabled).toHaveBeenCalledWith(
+      braveBackgrounds[0].imageUrl,
+      true,
+    )
+  })
+})

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_type_panel.test.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_type_panel.test.tsx
@@ -82,31 +82,22 @@ function renderPanel(
 }
 
 describe('BackgroundTypePanel Brave backgrounds', () => {
-  it('should pin the current Brave background when randomize is turned off', () => {
+  it('should not show the refresh toggle', () => {
+    renderPanel()
+    expect(
+      screen.queryByText('NEW_TAB_RANDOMIZE_BACKGROUND_LABEL'),
+    ).not.toBeInTheDocument()
+    expect(document.querySelector('leo-toggle')).toBeNull()
+  })
+
+  it('should not select a Brave background when its preview is clicked', () => {
     const selectBackground = jest.fn()
-    renderPanel(
-      {
-        selectedBackground: {
-          type: SelectedBackgroundType.kBrave,
-          value: '',
-        },
-        backgroundRandomValue: 0,
-      },
-      { selectBackground },
-    )
+    renderPanel({}, { selectBackground })
 
-    const toggle = document.querySelector('leo-toggle') as HTMLElement & {
-      checked?: boolean
-      onChange?: (detail: { checked: boolean }) => void
-    }
-    expect(toggle).toBeTruthy()
-    expect(toggle.checked).toBe(true)
-    toggle.onChange?.({ checked: false })
-
-    expect(selectBackground).toHaveBeenCalledWith(
-      SelectedBackgroundType.kBrave,
-      braveBackgrounds[0].imageUrl,
-    )
+    // Brave tiles are not selection buttons — clicking the preview area should
+    // not change the selected background.
+    fireEvent.click(document.querySelectorAll('.preview')[0])
+    expect(selectBackground).not.toHaveBeenCalled()
   })
 
   it('should disable a Brave background when the eye button is clicked', () => {

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_type_panel.test.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_type_panel.test.tsx
@@ -37,6 +37,7 @@ function createStore(
     sponsoredImagesEnabled: false,
     braveBackgrounds,
     customBackgrounds: [],
+    customBackgroundStickyUrl: null,
     disabledBraveBackgrounds: [],
     selectedBackground: {
       type: SelectedBackgroundType.kBrave,

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_type_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_type_panel.tsx
@@ -9,6 +9,7 @@ import Toggle from '@brave/leo/react/toggle'
 
 import { getString } from '../../lib/strings'
 import { inlineCSSVars } from '../../lib/inline_css_vars'
+import classnames from '$web-common/classnames'
 
 import {
   SelectedBackgroundType,
@@ -33,12 +34,18 @@ export function BackgroundTypePanel(props: Props) {
 
   const selectedBackground = useBackgroundState((s) => s.selectedBackground)
   const customBackgrounds = useBackgroundState((s) => s.customBackgrounds)
+  const braveBackgrounds = useBackgroundState((s) => s.braveBackgrounds)
+  const disabledBraveBackgrounds = useBackgroundState(
+    (s) => s.disabledBraveBackgrounds,
+  )
   const currentBackground = useCurrentBackground()
 
   const type = props.backgroundType
 
   function panelValues() {
     switch (type) {
+      case SelectedBackgroundType.kBrave:
+        return braveBackgrounds.map((background) => background.imageUrl)
       case SelectedBackgroundType.kCustom:
         return customBackgrounds
       case SelectedBackgroundType.kGradient:
@@ -55,6 +62,9 @@ export function BackgroundTypePanel(props: Props) {
       actions.selectBackground(type, '')
     } else if (currentBackground) {
       switch (currentBackground.type) {
+        case 'brave':
+          actions.selectBackground(type, currentBackground.imageUrl)
+          break
         case 'custom':
           actions.selectBackground(type, currentBackground.imageUrl)
           break
@@ -68,6 +78,11 @@ export function BackgroundTypePanel(props: Props) {
   }
 
   const values = panelValues()
+  const enabledBraveCount =
+    type === SelectedBackgroundType.kBrave
+      ? values.filter((value) => !disabledBraveBackgrounds.includes(value))
+          .length
+      : 0
 
   return (
     <>
@@ -90,19 +105,35 @@ export function BackgroundTypePanel(props: Props) {
           const isSelected =
             selectedBackground.type === type
             && selectedBackground.value === value
+          const isDisabled =
+            type === SelectedBackgroundType.kBrave
+            && disabledBraveBackgrounds.includes(value)
+          const hasPinnedSelection =
+            selectedBackground.type === type && !!selectedBackground.value
+          // Dim non-selected tiles when one image is pinned, and always dim
+          // disabled Brave backgrounds.
+          const isInactive = isDisabled || (hasPinnedSelection && !isSelected)
+          const canDisable = enabledBraveCount > 1
 
           return (
             <div
               key={value}
-              className='background-option'
+              className={classnames({
+                'background-option': true,
+                disabled: isDisabled,
+              })}
             >
               <button
+                disabled={isDisabled}
                 onClick={() => {
                   actions.selectBackground(type, value)
                 }}
               >
                 <div
-                  className='preview'
+                  className={classnames({
+                    preview: true,
+                    inactive: isInactive,
+                  })}
                   style={inlineCSSVars({
                     '--preview-background': backgroundCSSValue(type, value),
                   })}
@@ -116,12 +147,33 @@ export function BackgroundTypePanel(props: Props) {
               </button>
               {type === SelectedBackgroundType.kCustom && (
                 <button
-                  className='remove-image'
+                  className='overlay-button remove-image'
                   onClick={() => {
                     actions.removeCustomBackground(value)
                   }}
                 >
                   <Icon name='close' />
+                </button>
+              )}
+              {type === SelectedBackgroundType.kBrave && (
+                <button
+                  className='overlay-button toggle-image'
+                  title={getString(
+                    isDisabled
+                      ? S.NEW_TAB_ENABLE_BACKGROUND_LABEL
+                      : S.NEW_TAB_DISABLE_BACKGROUND_LABEL,
+                  )}
+                  aria-label={getString(
+                    isDisabled
+                      ? S.NEW_TAB_ENABLE_BACKGROUND_LABEL
+                      : S.NEW_TAB_DISABLE_BACKGROUND_LABEL,
+                  )}
+                  disabled={!isDisabled && !canDisable}
+                  onClick={() => {
+                    actions.setBraveBackgroundEnabled(value, isDisabled)
+                  }}
+                >
+                  <Icon name={isDisabled ? 'eye-off' : 'eye-on'} />
                 </button>
               )}
             </div>

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_type_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_type_panel.tsx
@@ -41,6 +41,7 @@ export function BackgroundTypePanel(props: Props) {
   const currentBackground = useCurrentBackground()
 
   const type = props.backgroundType
+  const isBravePanel = type === SelectedBackgroundType.kBrave
 
   function panelValues() {
     switch (type) {
@@ -62,9 +63,6 @@ export function BackgroundTypePanel(props: Props) {
       actions.selectBackground(type, '')
     } else if (currentBackground) {
       switch (currentBackground.type) {
-        case 'brave':
-          actions.selectBackground(type, currentBackground.imageUrl)
-          break
         case 'custom':
           actions.selectBackground(type, currentBackground.imageUrl)
           break
@@ -78,42 +76,62 @@ export function BackgroundTypePanel(props: Props) {
   }
 
   const values = panelValues()
-  const enabledBraveCount =
-    type === SelectedBackgroundType.kBrave
-      ? values.filter((value) => !disabledBraveBackgrounds.includes(value))
-          .length
-      : 0
+  const enabledBraveCount = isBravePanel
+    ? values.filter((value) => !disabledBraveBackgrounds.includes(value)).length
+    : 0
 
   return (
     <>
-      <div className='control-row'>
-        <label>{getString(S.NEW_TAB_RANDOMIZE_BACKGROUND_LABEL)}</label>
-        <Toggle
-          size='small'
-          checked={
-            selectedBackground.type === type && !selectedBackground.value
-          }
-          disabled={values.length === 0}
-          onChange={onRandomizeToggle}
-        />
-      </div>
+      {!isBravePanel && (
+        <div className='control-row'>
+          <label>{getString(S.NEW_TAB_RANDOMIZE_BACKGROUND_LABEL)}</label>
+          <Toggle
+            size='small'
+            checked={
+              selectedBackground.type === type && !selectedBackground.value
+            }
+            disabled={values.length === 0}
+            onChange={onRandomizeToggle}
+          />
+        </div>
+      )}
       <div className='background-options'>
         {type === SelectedBackgroundType.kCustom && (
           <div className='background-option'>{props.renderUploadOption()}</div>
         )}
         {values.map((value) => {
           const isSelected =
-            selectedBackground.type === type
+            !isBravePanel
+            && selectedBackground.type === type
             && selectedBackground.value === value
           const isDisabled =
-            type === SelectedBackgroundType.kBrave
-            && disabledBraveBackgrounds.includes(value)
+            isBravePanel && disabledBraveBackgrounds.includes(value)
           const hasPinnedSelection =
-            selectedBackground.type === type && !!selectedBackground.value
+            !isBravePanel
+            && selectedBackground.type === type
+            && !!selectedBackground.value
           // Dim non-selected tiles when one image is pinned, and always dim
           // disabled Brave backgrounds.
           const isInactive = isDisabled || (hasPinnedSelection && !isSelected)
           const canDisable = enabledBraveCount > 1
+
+          const preview = (
+            <div
+              className={classnames({
+                preview: true,
+                inactive: isInactive,
+              })}
+              style={inlineCSSVars({
+                '--preview-background': backgroundCSSValue(type, value),
+              })}
+            >
+              {isSelected && (
+                <span className='selected-marker'>
+                  <Icon name='check-normal' />
+                </span>
+              )}
+            </div>
+          )
 
           return (
             <div
@@ -123,28 +141,17 @@ export function BackgroundTypePanel(props: Props) {
                 disabled: isDisabled,
               })}
             >
-              <button
-                disabled={isDisabled}
-                onClick={() => {
-                  actions.selectBackground(type, value)
-                }}
-              >
-                <div
-                  className={classnames({
-                    preview: true,
-                    inactive: isInactive,
-                  })}
-                  style={inlineCSSVars({
-                    '--preview-background': backgroundCSSValue(type, value),
-                  })}
+              {isBravePanel ? (
+                preview
+              ) : (
+                <button
+                  onClick={() => {
+                    actions.selectBackground(type, value)
+                  }}
                 >
-                  {isSelected && (
-                    <span className='selected-marker'>
-                      <Icon name='check-normal' />
-                    </span>
-                  )}
-                </div>
-              </button>
+                  {preview}
+                </button>
+              )}
               {type === SelectedBackgroundType.kCustom && (
                 <button
                   className='overlay-button remove-image'
@@ -155,7 +162,7 @@ export function BackgroundTypePanel(props: Props) {
                   <Icon name='close' />
                 </button>
               )}
-              {type === SelectedBackgroundType.kBrave && (
+              {isBravePanel && (
                 <button
                   className='overlay-button toggle-image'
                   title={getString(

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/background_type_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/background_type_panel.tsx
@@ -95,6 +95,11 @@ export function BackgroundTypePanel(props: Props) {
           />
         </div>
       )}
+      {isBravePanel && (
+        <p className='brave-backgrounds-description'>
+          {getString(S.NEW_TAB_BRAVE_BACKGROUNDS_DESCRIPTION)}
+        </p>
+      )}
       <div className='background-options'>
         {type === SelectedBackgroundType.kCustom && (
           <div className='background-option'>{props.renderUploadOption()}</div>

--- a/browser/resources/brave_new_tab_page_refresh/state/background_store.test.ts
+++ b/browser/resources/brave_new_tab_page_refresh/state/background_store.test.ts
@@ -77,6 +77,26 @@ describe('getCurrentBackground', () => {
     })
   })
 
+  it('should keep the current Brave background when a different image is disabled', () => {
+    // randomValue 0.5 maps to index 1 in the full 3-image catalog.
+    const before = getCurrentBackground(
+      createState({ backgroundRandomValue: 0.5 }),
+    )
+    expect(before).toEqual({
+      type: 'brave',
+      ...braveBackgrounds[1],
+    })
+
+    const after = getCurrentBackground(
+      createState({
+        disabledBraveBackgrounds: [braveBackgrounds[0].imageUrl],
+        backgroundRandomValue: 0.5,
+      }),
+    )
+
+    expect(after).toEqual(before)
+  })
+
   it('should fall back to the full Brave list when every image is disabled', () => {
     const background = getCurrentBackground(
       createState({

--- a/browser/resources/brave_new_tab_page_refresh/state/background_store.test.ts
+++ b/browser/resources/brave_new_tab_page_refresh/state/background_store.test.ts
@@ -127,4 +127,64 @@ describe('getCurrentBackground', () => {
       ...braveBackgrounds[0],
     })
   })
+
+  it('should keep the current custom background when a different image is removed', () => {
+    const customBackgrounds = [
+      'chrome://custom-wallpaper/a.jpg',
+      'chrome://custom-wallpaper/b.jpg',
+      'chrome://custom-wallpaper/c.jpg',
+    ]
+    const before = getCurrentBackground(
+      createState({
+        selectedBackground: {
+          type: SelectedBackgroundType.kCustom,
+          value: '',
+        },
+        customBackgrounds,
+        backgroundRotateIndex: 1,
+        customBackgroundStickyUrl: customBackgrounds[1],
+      }),
+    )
+    expect(before).toEqual({
+      type: 'custom',
+      imageUrl: customBackgrounds[1],
+    })
+
+    // Removing an earlier list entry used to remap rotateIndex % length.
+    const after = getCurrentBackground(
+      createState({
+        selectedBackground: {
+          type: SelectedBackgroundType.kCustom,
+          value: '',
+        },
+        customBackgrounds: [customBackgrounds[1], customBackgrounds[2]],
+        backgroundRotateIndex: 1,
+        customBackgroundStickyUrl: customBackgrounds[1],
+      }),
+    )
+    expect(after).toEqual(before)
+  })
+
+  it('should pick a new custom background when the sticky image is removed', () => {
+    const remaining = [
+      'chrome://custom-wallpaper/a.jpg',
+      'chrome://custom-wallpaper/c.jpg',
+    ]
+    const background = getCurrentBackground(
+      createState({
+        selectedBackground: {
+          type: SelectedBackgroundType.kCustom,
+          value: '',
+        },
+        customBackgrounds: remaining,
+        backgroundRotateIndex: 1,
+        customBackgroundStickyUrl: 'chrome://custom-wallpaper/b.jpg',
+      }),
+    )
+
+    expect(background).toEqual({
+      type: 'custom',
+      imageUrl: remaining[1],
+    })
+  })
 })

--- a/browser/resources/brave_new_tab_page_refresh/state/background_store.test.ts
+++ b/browser/resources/brave_new_tab_page_refresh/state/background_store.test.ts
@@ -1,0 +1,108 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import {
+  BackgroundState,
+  SelectedBackgroundType,
+  defaultBackgroundStore,
+  getCurrentBackground,
+} from './background_store'
+
+const braveBackgrounds = [
+  {
+    author: 'Author 1',
+    imageUrl: 'chrome://background-wallpaper/one.jpg',
+    link: 'https://example.com/1',
+  },
+  {
+    author: 'Author 2',
+    imageUrl: 'chrome://background-wallpaper/two.jpg',
+    link: 'https://example.com/2',
+  },
+  {
+    author: 'Author 3',
+    imageUrl: 'chrome://background-wallpaper/three.jpg',
+    link: 'https://example.com/3',
+  },
+]
+
+function createState(overrides: Partial<BackgroundState> = {}): BackgroundState {
+  return {
+    ...defaultBackgroundStore().getState(),
+    initialized: true,
+    backgroundsEnabled: true,
+    braveBackgrounds,
+    selectedBackground: {
+      type: SelectedBackgroundType.kBrave,
+      value: '',
+    },
+    backgroundRandomValue: 0,
+    ...overrides,
+  }
+}
+
+describe('getCurrentBackground', () => {
+  it('should use a pinned Brave background when a value is selected', () => {
+    const background = getCurrentBackground(
+      createState({
+        selectedBackground: {
+          type: SelectedBackgroundType.kBrave,
+          value: braveBackgrounds[1].imageUrl,
+        },
+        backgroundRandomValue: 0,
+      }),
+    )
+
+    expect(background).toEqual({
+      type: 'brave',
+      ...braveBackgrounds[1],
+    })
+  })
+
+  it('should exclude disabled Brave backgrounds from the random rotation', () => {
+    const background = getCurrentBackground(
+      createState({
+        disabledBraveBackgrounds: [braveBackgrounds[0].imageUrl],
+        backgroundRandomValue: 0,
+      }),
+    )
+
+    expect(background).toEqual({
+      type: 'brave',
+      ...braveBackgrounds[1],
+    })
+  })
+
+  it('should fall back to the full Brave list when every image is disabled', () => {
+    const background = getCurrentBackground(
+      createState({
+        disabledBraveBackgrounds: braveBackgrounds.map((b) => b.imageUrl),
+        backgroundRandomValue: 0,
+      }),
+    )
+
+    expect(background).toEqual({
+      type: 'brave',
+      ...braveBackgrounds[0],
+    })
+  })
+
+  it('should fall back to random when a pinned Brave background is missing', () => {
+    const background = getCurrentBackground(
+      createState({
+        selectedBackground: {
+          type: SelectedBackgroundType.kBrave,
+          value: 'chrome://background-wallpaper/missing.jpg',
+        },
+        backgroundRandomValue: 0,
+      }),
+    )
+
+    expect(background).toEqual({
+      type: 'brave',
+      ...braveBackgrounds[0],
+    })
+  })
+})

--- a/browser/resources/brave_new_tab_page_refresh/state/background_store.test.ts
+++ b/browser/resources/brave_new_tab_page_refresh/state/background_store.test.ts
@@ -28,7 +28,9 @@ const braveBackgrounds = [
   },
 ]
 
-function createState(overrides: Partial<BackgroundState> = {}): BackgroundState {
+function createState(
+  overrides: Partial<BackgroundState> = {},
+): BackgroundState {
   return {
     ...defaultBackgroundStore().getState(),
     initialized: true,

--- a/browser/resources/brave_new_tab_page_refresh/state/background_store.ts
+++ b/browser/resources/brave_new_tab_page_refresh/state/background_store.ts
@@ -40,6 +40,7 @@ export interface BackgroundState {
   sponsoredImagesEnabled: boolean
   braveBackgrounds: BraveBackground[]
   customBackgrounds: string[]
+  disabledBraveBackgrounds: string[]
   selectedBackground: SelectedBackground
   backgroundRotateIndex: number
   backgroundRandomValue: number
@@ -100,6 +101,7 @@ export function defaultBackgroundStore(): BackgroundStore {
     sponsoredImagesEnabled: true,
     braveBackgrounds: [],
     customBackgrounds: [],
+    disabledBraveBackgrounds: [],
     selectedBackground: {
       type: SelectedBackgroundType.kGradient,
       value: gradientPreviewBackground,
@@ -116,6 +118,7 @@ export function defaultBackgroundStore(): BackgroundStore {
         return false
       },
       async removeCustomBackground(background) {},
+      setBraveBackgroundEnabled(background, enabled) {},
       notifySponsoredImageLoadError() {},
       notifySponsoredImageLogoClicked() {},
       notifySponsoredRichMediaEvent(type) {},
@@ -129,6 +132,7 @@ export interface BackgroundActions {
   selectBackground: (type: SelectedBackgroundType, value: string) => void
   showCustomBackgroundChooser: () => Promise<boolean>
   removeCustomBackground: (background: string) => Promise<void>
+  setBraveBackgroundEnabled: (background: string, enabled: boolean) => void
   notifySponsoredImageLoadError: () => void
   notifySponsoredImageLogoClicked: () => void
   notifySponsoredRichMediaEvent: (type: NewTabPageAdEventType) => void
@@ -161,6 +165,7 @@ export function getCurrentBackground(
     backgroundsEnabled,
     braveBackgrounds,
     customBackgrounds,
+    disabledBraveBackgrounds,
     selectedBackground,
     backgroundRandomValue: randomValue,
     backgroundRotateIndex: rotateIndex,
@@ -189,7 +194,19 @@ export function getCurrentBackground(
 
   switch (type) {
     case SelectedBackgroundType.kBrave: {
-      const braveBackground = chooseRandom(braveBackgrounds, randomValue)
+      if (value) {
+        const pinned = braveBackgrounds.find((b) => b.imageUrl === value)
+        if (pinned) {
+          return { type: 'brave', ...pinned }
+        }
+      }
+      const enabled = braveBackgrounds.filter(
+        (b) => !disabledBraveBackgrounds.includes(b.imageUrl),
+      )
+      const braveBackground = chooseRandom(
+        enabled.length ? enabled : braveBackgrounds,
+        randomValue,
+      )
       return braveBackground ? { type: 'brave', ...braveBackground } : null
     }
     case SelectedBackgroundType.kCustom: {

--- a/browser/resources/brave_new_tab_page_refresh/state/background_store.ts
+++ b/browser/resources/brave_new_tab_page_refresh/state/background_store.ts
@@ -152,6 +152,33 @@ function chooseIndex<T>(list: T[], index: number): T | null {
   return list[index % list.length]
 }
 
+// Picks a Brave background using a seed into the full catalog, then skips any
+// disabled entries. Indexing the full list (not the filtered one) keeps the
+// current NTP image stable when the user disables a different image.
+function chooseBraveBackground(
+  braveBackgrounds: BraveBackground[],
+  disabledBraveBackgrounds: string[],
+  randomValue: number,
+): BraveBackground | null {
+  if (braveBackgrounds.length === 0) {
+    return null
+  }
+
+  const disabled = new Set(disabledBraveBackgrounds)
+  const start = Math.floor(randomValue * braveBackgrounds.length)
+
+  for (let offset = 0; offset < braveBackgrounds.length; offset++) {
+    const candidate =
+      braveBackgrounds[(start + offset) % braveBackgrounds.length]
+    if (!disabled.has(candidate.imageUrl)) {
+      return candidate
+    }
+  }
+
+  // Every image is disabled — fall back to the seeded entry in the full list.
+  return braveBackgrounds[start]
+}
+
 const defaultBackground: Background = {
   type: 'color',
   cssValue: gradientPreviewBackground,
@@ -200,11 +227,9 @@ export function getCurrentBackground(
           return { type: 'brave', ...pinned }
         }
       }
-      const enabled = braveBackgrounds.filter(
-        (b) => !disabledBraveBackgrounds.includes(b.imageUrl),
-      )
-      const braveBackground = chooseRandom(
-        enabled.length ? enabled : braveBackgrounds,
+      const braveBackground = chooseBraveBackground(
+        braveBackgrounds,
+        disabledBraveBackgrounds,
         randomValue,
       )
       return braveBackground ? { type: 'brave', ...braveBackground } : null

--- a/browser/resources/brave_new_tab_page_refresh/state/background_store.ts
+++ b/browser/resources/brave_new_tab_page_refresh/state/background_store.ts
@@ -40,6 +40,10 @@ export interface BackgroundState {
   sponsoredImagesEnabled: boolean
   braveBackgrounds: BraveBackground[]
   customBackgrounds: string[]
+  // Keeps the random custom background stable for this NTP while the list
+  // changes (e.g. the user removes a different image). Cleared/reassigned when
+  // that sticky URL is removed or a new tab rotates the index.
+  customBackgroundStickyUrl: string | null
   disabledBraveBackgrounds: string[]
   selectedBackground: SelectedBackground
   backgroundRotateIndex: number
@@ -101,6 +105,7 @@ export function defaultBackgroundStore(): BackgroundStore {
     sponsoredImagesEnabled: true,
     braveBackgrounds: [],
     customBackgrounds: [],
+    customBackgroundStickyUrl: null,
     disabledBraveBackgrounds: [],
     selectedBackground: {
       type: SelectedBackgroundType.kGradient,
@@ -152,6 +157,19 @@ function chooseIndex<T>(list: T[], index: number): T | null {
   return list[index % list.length]
 }
 
+// Prefer the sticky URL when it is still in the list so removing a different
+// custom image does not remapped rotateIndex to a new background mid-session.
+export function resolveCustomBackgroundUrl(
+  customBackgrounds: string[],
+  rotateIndex: number,
+  stickyUrl: string | null,
+): string | null {
+  if (stickyUrl && customBackgrounds.includes(stickyUrl)) {
+    return stickyUrl
+  }
+  return chooseIndex(customBackgrounds, rotateIndex)
+}
+
 // Picks a Brave background using a seed into the full catalog, then skips any
 // disabled entries. Indexing the full list (not the filtered one) keeps the
 // current NTP image stable when the user disables a different image.
@@ -192,6 +210,7 @@ export function getCurrentBackground(
     backgroundsEnabled,
     braveBackgrounds,
     customBackgrounds,
+    customBackgroundStickyUrl,
     disabledBraveBackgrounds,
     selectedBackground,
     backgroundRandomValue: randomValue,
@@ -235,7 +254,13 @@ export function getCurrentBackground(
       return braveBackground ? { type: 'brave', ...braveBackground } : null
     }
     case SelectedBackgroundType.kCustom: {
-      const imageUrl = value || chooseIndex(customBackgrounds, rotateIndex)
+      const imageUrl =
+        value
+        || resolveCustomBackgroundUrl(
+          customBackgrounds,
+          rotateIndex,
+          customBackgroundStickyUrl,
+        )
       return imageUrl ? { type: 'custom', imageUrl } : null
     }
     case SelectedBackgroundType.kSolid: {

--- a/browser/resources/brave_new_tab_page_refresh/state/browser_background_store.ts
+++ b/browser/resources/brave_new_tab_page_refresh/state/browser_background_store.ts
@@ -12,6 +12,7 @@ import {
   BackgroundActions,
   SelectedBackgroundType,
   defaultBackgroundStore,
+  resolveCustomBackgroundUrl,
 } from './background_store'
 
 export function createBackgroundStore() {
@@ -59,7 +60,14 @@ export function createBackgroundStore() {
 
   async function updateCustomBackgrounds() {
     const { backgrounds } = await handler.getCustomBackgrounds()
-    store.update({ customBackgrounds: backgrounds })
+    store.update((state) => ({
+      customBackgrounds: backgrounds,
+      customBackgroundStickyUrl: resolveCustomBackgroundUrl(
+        backgrounds,
+        state.backgroundRotateIndex,
+        state.customBackgroundStickyUrl,
+      ),
+    }))
   }
 
   async function updateDisabledBraveBackgrounds() {
@@ -110,10 +118,24 @@ export function createBackgroundStore() {
     },
 
     selectBackground(type, value) {
-      store.update({ selectedBackground: { type, value } })
-      if (!value) {
-        store.update({ backgroundRandomValue: Math.random() })
-      }
+      store.update((state) => {
+        const nextState: Partial<typeof state> = {
+          selectedBackground: { type, value },
+        }
+        if (!value) {
+          nextState.backgroundRandomValue = Math.random()
+          if (type === SelectedBackgroundType.kCustom) {
+            // Re-resolve sticky for random custom mode so refresh-on picks a
+            // stable image for this tab.
+            nextState.customBackgroundStickyUrl = resolveCustomBackgroundUrl(
+              state.customBackgrounds,
+              state.backgroundRotateIndex,
+              null,
+            )
+          }
+        }
+        return nextState
+      })
       handler.selectBackground({ type, value })
     },
 
@@ -123,6 +145,21 @@ export function createBackgroundStore() {
     },
 
     async removeCustomBackground(background) {
+      store.update((state) => {
+        const customBackgrounds = state.customBackgrounds.filter(
+          (elem) => elem !== background,
+        )
+        return {
+          customBackgrounds,
+          customBackgroundStickyUrl: resolveCustomBackgroundUrl(
+            customBackgrounds,
+            state.backgroundRotateIndex,
+            state.customBackgroundStickyUrl === background
+              ? null
+              : state.customBackgroundStickyUrl,
+          ),
+        }
+      })
       await handler.removeCustomBackground(background)
     },
 

--- a/browser/resources/brave_new_tab_page_refresh/state/browser_background_store.ts
+++ b/browser/resources/brave_new_tab_page_refresh/state/browser_background_store.ts
@@ -8,7 +8,11 @@ import { SponsoredRichMediaAdEventHandler } from 'gen/brave/components/ntp_backg
 import { NewTabPageProxy } from './new_tab_page_proxy'
 import { debounce } from '$web-common/debounce'
 import { preloadedBackgrounds } from './background_images/preloaded'
-import { BackgroundActions, defaultBackgroundStore } from './background_store'
+import {
+  BackgroundActions,
+  SelectedBackgroundType,
+  defaultBackgroundStore,
+} from './background_store'
 
 export function createBackgroundStore() {
   const store = defaultBackgroundStore()
@@ -58,6 +62,11 @@ export function createBackgroundStore() {
     store.update({ customBackgrounds: backgrounds })
   }
 
+  async function updateDisabledBraveBackgrounds() {
+    const { backgroundUrls } = await handler.getDisabledBraveBackgrounds()
+    store.update({ disabledBraveBackgrounds: backgroundUrls })
+  }
+
   async function updateSponsoredImageBackground() {
     const { background } = await handler.getSponsoredImageBackground()
     store.update({ sponsoredImageBackground: background ?? null })
@@ -65,7 +74,11 @@ export function createBackgroundStore() {
 
   newTabProxy.addListeners({
     onBackgroundsUpdated: debounce(async () => {
-      await Promise.all([updateCustomBackgrounds(), updateSelectedBackground()])
+      await Promise.all([
+        updateCustomBackgrounds(),
+        updateDisabledBraveBackgrounds(),
+        updateSelectedBackground(),
+      ])
     }, 10),
   })
 
@@ -75,6 +88,7 @@ export function createBackgroundStore() {
       updateSponsoredImagesEnabled(),
       updateBraveBackgrounds(),
       updateCustomBackgrounds(),
+      updateDisabledBraveBackgrounds(),
       updateSelectedBackground(),
       updateSponsoredImageBackground(),
     ])
@@ -110,6 +124,33 @@ export function createBackgroundStore() {
 
     async removeCustomBackground(background) {
       await handler.removeCustomBackground(background)
+    },
+
+    setBraveBackgroundEnabled(background, enabled) {
+      store.update((state) => {
+        const disabled = new Set(state.disabledBraveBackgrounds)
+        if (enabled) {
+          disabled.delete(background)
+        } else {
+          disabled.add(background)
+        }
+        const nextState: Partial<typeof state> = {
+          disabledBraveBackgrounds: [...disabled],
+        }
+        if (
+          !enabled
+          && state.selectedBackground.type === SelectedBackgroundType.kBrave
+          && state.selectedBackground.value === background
+        ) {
+          nextState.selectedBackground = {
+            type: SelectedBackgroundType.kBrave,
+            value: '',
+          }
+          nextState.backgroundRandomValue = Math.random()
+        }
+        return nextState
+      })
+      handler.setBraveBackgroundEnabled(background, enabled)
     },
 
     notifySponsoredImageLoadError() {

--- a/browser/resources/brave_new_tab_page_refresh/stories/mock_background_store.ts
+++ b/browser/resources/brave_new_tab_page_refresh/stories/mock_background_store.ts
@@ -105,11 +105,22 @@ export function createBackgroundStore() {
     },
 
     async removeCustomBackground(background) {
-      store.update((state) => ({
-        customBackgrounds: state.customBackgrounds.filter(
+      store.update((state) => {
+        const customBackgrounds = state.customBackgrounds.filter(
           (elem) => elem !== background,
-        ),
-      }))
+        )
+        const sticky =
+          state.customBackgroundStickyUrl === background
+            ? null
+            : state.customBackgroundStickyUrl
+        return {
+          customBackgrounds,
+          customBackgroundStickyUrl:
+            sticky && customBackgrounds.includes(sticky)
+              ? sticky
+              : (customBackgrounds[0] ?? null),
+        }
+      })
     },
 
     setBraveBackgroundEnabled(background, enabled) {

--- a/browser/resources/brave_new_tab_page_refresh/stories/mock_background_store.ts
+++ b/browser/resources/brave_new_tab_page_refresh/stories/mock_background_store.ts
@@ -112,6 +112,32 @@ export function createBackgroundStore() {
       }))
     },
 
+    setBraveBackgroundEnabled(background, enabled) {
+      store.update((state) => {
+        const disabled = new Set(state.disabledBraveBackgrounds)
+        if (enabled) {
+          disabled.delete(background)
+        } else {
+          disabled.add(background)
+        }
+        const nextState: Partial<typeof state> = {
+          disabledBraveBackgrounds: [...disabled],
+        }
+        if (
+          !enabled
+          && state.selectedBackground.type === SelectedBackgroundType.kBrave
+          && state.selectedBackground.value === background
+        ) {
+          nextState.selectedBackground = {
+            type: SelectedBackgroundType.kBrave,
+            value: '',
+          }
+          nextState.backgroundRandomValue = Math.random()
+        }
+        return nextState
+      })
+    },
+
     notifySponsoredImageLoadError() {},
 
     notifySponsoredImageLogoClicked() {},

--- a/browser/ui/webui/brave_new_tab_page_refresh/background_facade.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/background_facade.cc
@@ -11,6 +11,7 @@
 #include "base/barrier_callback.h"
 #include "base/check.h"
 #include "base/functional/callback_helpers.h"
+#include "base/strings/strcat.h"
 #include "brave/browser/ntp_background/custom_background_file_manager.h"
 #include "brave/browser/ntp_background/ntp_background_prefs.h"
 #include "brave/components/ntp_background_images/browser/ntp_background_images_data.h"
@@ -18,6 +19,7 @@
 #include "brave/components/ntp_background_images/browser/url_constants.h"
 #include "brave/components/ntp_background_images/browser/view_counter_service.h"
 #include "components/prefs/pref_service.h"
+#include "url/gurl.h"
 
 namespace brave_new_tab_page_refresh {
 
@@ -92,6 +94,19 @@ NTPBackgroundPrefs GetBackgroundPrefs(const raw_ref<PrefService>& prefs) {
   return NTPBackgroundPrefs(&prefs.get());
 }
 
+std::string GetBackgroundWallpaperUrlPrefix() {
+  return base::StrCat(
+      {"chrome://", ntp_background_images::kBackgroundWallpaperHost, "/"});
+}
+
+std::string BraveBackgroundUrlToFileName(const std::string& background_url) {
+  return GURL(background_url).ExtractFileName();
+}
+
+std::string BraveBackgroundFileNameToUrl(const std::string& file_name) {
+  return GetBackgroundWallpaperUrlPrefix() + file_name;
+}
+
 }  // namespace
 
 BackgroundFacade::BackgroundFacade(
@@ -143,6 +158,15 @@ std::vector<std::string> BackgroundFacade::GetCustomBackgrounds() {
   return backgrounds;
 }
 
+std::vector<std::string> BackgroundFacade::GetDisabledBraveBackgrounds() {
+  auto backgrounds =
+      GetBackgroundPrefs(pref_service_).GetDisabledBraveImageList();
+  for (auto& background : backgrounds) {
+    background = BraveBackgroundFileNameToUrl(background);
+  }
+  return backgrounds;
+}
+
 mojom::SelectedBackgroundPtr BackgroundFacade::GetSelectedBackground() {
   auto background = mojom::SelectedBackground::New();
 
@@ -150,6 +174,9 @@ mojom::SelectedBackgroundPtr BackgroundFacade::GetSelectedBackground() {
   switch (bg_prefs.GetType()) {
     case NTPBackgroundPrefs::Type::kBrave:
       background->type = mojom::SelectedBackgroundType::kBrave;
+      if (!bg_prefs.ShouldUseRandomValue()) {
+        background->value = bg_prefs.GetSelectedValue();
+      }
       break;
     case NTPBackgroundPrefs::Type::kCustomImage:
       background->type = mojom::SelectedBackgroundType::kCustom;
@@ -278,6 +305,31 @@ void BackgroundFacade::RemoveCustomBackground(const std::string& background_url,
       file_path, base::BindOnce(&BackgroundFacade::OnCustomBackgroundRemoved,
                                 weak_factory_.GetWeakPtr(), std::move(callback),
                                 file_path));
+}
+
+void BackgroundFacade::SetBraveBackgroundEnabled(
+    const std::string& background_url,
+    bool enabled) {
+  const std::string file_name = BraveBackgroundUrlToFileName(background_url);
+  if (file_name.empty()) {
+    return;
+  }
+
+  auto bg_prefs = GetBackgroundPrefs(pref_service_);
+  if (enabled) {
+    bg_prefs.RemoveDisabledBraveImage(file_name);
+    return;
+  }
+
+  bg_prefs.AddDisabledBraveImage(file_name);
+
+  // If the disabled image is currently pinned, fall back to a random Brave
+  // background.
+  if (bg_prefs.IsBraveType() && !bg_prefs.ShouldUseRandomValue() &&
+      bg_prefs.GetSelectedValue() == background_url) {
+    bg_prefs.SetSelectedValue("");
+    bg_prefs.SetShouldUseRandomValue(true);
+  }
 }
 
 void BackgroundFacade::NotifySponsoredImageLogoClicked(

--- a/browser/ui/webui/brave_new_tab_page_refresh/background_facade.h
+++ b/browser/ui/webui/brave_new_tab_page_refresh/background_facade.h
@@ -51,6 +51,8 @@ class BackgroundFacade {
 
   std::vector<std::string> GetCustomBackgrounds();
 
+  std::vector<std::string> GetDisabledBraveBackgrounds();
+
   mojom::SelectedBackgroundPtr GetSelectedBackground();
 
   // The `callback` runs synchronously for Wallpaper backgrounds or when an
@@ -65,6 +67,9 @@ class BackgroundFacade {
 
   void RemoveCustomBackground(const std::string& background_url,
                               base::OnceClosure callback);
+
+  void SetBraveBackgroundEnabled(const std::string& background_url,
+                                 bool enabled);
 
   void NotifySponsoredImageLogoClicked(
       const std::string& wallpaper_id,

--- a/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page.mojom
+++ b/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page.mojom
@@ -118,6 +118,10 @@ interface NewTabPageHandler {
   // Returns the list of custom background images supplied by the user.
   GetCustomBackgrounds() => (array<string> backgrounds);
 
+  // Returns the image URLs of Brave backgrounds the user has disabled. Disabled
+  // backgrounds are excluded from the random background rotation.
+  GetDisabledBraveBackgrounds() => (array<string> background_urls);
+
   // Returns the user-selected or default background.
   GetSelectedBackground() => (SelectedBackground? background);
 
@@ -137,6 +141,9 @@ interface NewTabPageHandler {
   // Removes the specified custom image background from the list of available
   // backgrounds.
   RemoveCustomBackground(string background_url) => ();
+
+  // Enables or disables an individual Brave background image.
+  SetBraveBackgroundEnabled(string background_url, bool enabled) => ();
 
   // Notifies the browser that the user has clicked the sponsored image logo.
   NotifySponsoredImageLogoClicked(string wallpaper_id,

--- a/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page.mojom
+++ b/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page.mojom
@@ -121,6 +121,10 @@ interface NewTabPageHandler {
   // Returns the list of custom background images supplied by the user.
   GetCustomBackgrounds() => (array<string> backgrounds);
 
+  // Returns the image URLs of Brave backgrounds the user has disabled. Disabled
+  // backgrounds are excluded from the random background rotation.
+  GetDisabledBraveBackgrounds() => (array<string> background_urls);
+
   // Returns the user-selected or default background.
   GetSelectedBackground() => (SelectedBackground? background);
 
@@ -140,6 +144,9 @@ interface NewTabPageHandler {
   // Removes the specified custom image background from the list of available
   // backgrounds.
   RemoveCustomBackground(string background_url) => ();
+
+  // Enables or disables an individual Brave background image.
+  SetBraveBackgroundEnabled(string background_url, bool enabled) => ();
 
   // Notifies the browser that the user has clicked the sponsored image logo.
   NotifySponsoredImageLogoClicked(string wallpaper_id,

--- a/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_handler.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_handler.cc
@@ -136,6 +136,11 @@ void NewTabPageHandler::GetCustomBackgrounds(
   std::move(callback).Run(background_facade_->GetCustomBackgrounds());
 }
 
+void NewTabPageHandler::GetDisabledBraveBackgrounds(
+    GetDisabledBraveBackgroundsCallback callback) {
+  std::move(callback).Run(background_facade_->GetDisabledBraveBackgrounds());
+}
+
 void NewTabPageHandler::GetSelectedBackground(
     GetSelectedBackgroundCallback callback) {
   std::move(callback).Run(background_facade_->GetSelectedBackground());
@@ -188,6 +193,14 @@ void NewTabPageHandler::RemoveCustomBackground(
     RemoveCustomBackgroundCallback callback) {
   background_facade_->RemoveCustomBackground(background_url,
                                              std::move(callback));
+}
+
+void NewTabPageHandler::SetBraveBackgroundEnabled(
+    const std::string& background_url,
+    bool enabled,
+    SetBraveBackgroundEnabledCallback callback) {
+  background_facade_->SetBraveBackgroundEnabled(background_url, enabled);
+  std::move(callback).Run();
 }
 
 void NewTabPageHandler::NotifySponsoredImageLogoClicked(

--- a/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_handler.h
+++ b/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_handler.h
@@ -78,6 +78,8 @@ class NewTabPageHandler : public mojom::NewTabPageHandler {
       SetSponsoredImagesEnabledCallback callback) override;
   void GetBraveBackgrounds(GetBraveBackgroundsCallback callback) override;
   void GetCustomBackgrounds(GetCustomBackgroundsCallback callback) override;
+  void GetDisabledBraveBackgrounds(
+      GetDisabledBraveBackgroundsCallback callback) override;
   void GetSelectedBackground(GetSelectedBackgroundCallback callback) override;
   void GetSponsoredImageBackground(
       GetSponsoredImageBackgroundCallback callback) override;
@@ -87,6 +89,10 @@ class NewTabPageHandler : public mojom::NewTabPageHandler {
       ShowCustomBackgroundChooserCallback callback) override;
   void RemoveCustomBackground(const std::string& background_url,
                               RemoveCustomBackgroundCallback callback) override;
+  void SetBraveBackgroundEnabled(
+      const std::string& background_url,
+      bool enabled,
+      SetBraveBackgroundEnabledCallback callback) override;
   void NotifySponsoredImageLogoClicked(
       const std::string& wallpaper_id,
       const std::string& creative_instance_id,

--- a/browser/ui/webui/brave_new_tab_page_refresh/update_observer.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/update_observer.cc
@@ -45,6 +45,8 @@ UpdateObserver::UpdateObserver(PrefService& pref_service,
   AddPrefListener(NTPBackgroundPrefs::kPrefName, Source::kBackgrounds);
   AddPrefListener(NTPBackgroundPrefs::kCustomImageListPrefName,
                   Source::kBackgrounds);
+  AddPrefListener(NTPBackgroundPrefs::kDisabledBraveImageListPrefName,
+                  Source::kBackgrounds);
 
   AddPrefListener(brave_search_conversion::prefs::kShowNTPSearchBox,
                   Source::kSearch);

--- a/components/resources/brave_new_tab_page_strings.grdp
+++ b/components/resources/brave_new_tab_page_strings.grdp
@@ -53,12 +53,20 @@
     Customize available engines
   </message>
 
+  <message name="IDS_NEW_TAB_DISABLE_BACKGROUND_LABEL" desc="Label for button that hides a Brave background from the rotation" formatter_data="webui=BraveNewTabPage">
+    Hide this background
+  </message>
+
   <message name="IDS_NEW_TAB_EDIT_TOP_SITE_LABEL" desc="Label for button that opens the Edit Site dialog" formatter_data="webui=BraveNewTabPage">
     Edit site
   </message>
 
   <message name="IDS_NEW_TAB_EDIT_TOP_SITE_TITLE" desc="Title of the Edit Site dialog" formatter_data="webui=BraveNewTabPage">
     Edit site
+  </message>
+
+  <message name="IDS_NEW_TAB_ENABLE_BACKGROUND_LABEL" desc="Label for button that shows a Brave background in the rotation" formatter_data="webui=BraveNewTabPage">
+    Show this background
   </message>
 
   <message name="IDS_NEW_TAB_ENABLED_SEARCH_ENGINES_LABEL" desc="Label for the list of search engines" formatter_data="webui=BraveNewTabPage">

--- a/components/resources/brave_new_tab_page_strings.grdp
+++ b/components/resources/brave_new_tab_page_strings.grdp
@@ -21,6 +21,10 @@
     Brave backgrounds
   </message>
 
+  <message name="IDS_NEW_TAB_BRAVE_BACKGROUNDS_DESCRIPTION" desc="Description shown above the Brave backgrounds image grid explaining rotation and disable behavior" formatter_data="webui=BraveNewTabPage">
+    Brave backgrounds rotate randomly on each New Tab. You can remove specific images from the rotation by clicking the hide button on any of them.
+  </message>
+
   <message name="IDS_NEW_TAB_CANCEL_BUTTON_LABEL" desc="Label for cancel button" formatter_data="webui=BraveNewTabPage">
     Cancel
   </message>


### PR DESCRIPTION
- Resolves https://github.com/brave/brave-browser/issues/57797

## Summary

Enhance the refreshed desktop NTP background settings:

### Brave backgrounds sub page
- **Brave backgrounds** opens a sub page (same pattern as custom / solid / gradient).
- Brave images **always rotate** on new tabs — there is no per-image pin and no **Refresh on every new tab** toggle in this section.
- Opening the Brave panel selects random Brave backgrounds.

### Disable / hide Brave images
- Individual Brave images can be **disabled** (not removed) via Nala `eye-on` / `eye-off` buttons.
- Disabled images are excluded from the rotation pool.
- Disabled tiles are shown at `opacity: 0.5` + grayscale; the eye control stays available so they can be re-enabled.
- Disabling a *different* image no longer remaps the current NTP background (seed indexes the full catalog, then skips disabled entries).
- Persisted in `brave.new_tab_page.disabled_brave_background_image_list`.
- The last remaining enabled Brave image cannot be disabled.

### Other background types (unchanged pin / refresh UX)
- Custom, solid, and gradient keep **Refresh on every new tab** and the ability to pin a specific value.
- Opening those panels turns refresh on by default unless that type already has a pinned value.
- When a specific value is pinned, **non-selected tiles** are dimmed (`opacity: 0.5` + grayscale) with a short CSS transition.

### Custom backgrounds
- Keep the existing **remove (close)** control and permanently delete that image.
- Removing a custom image that is **not** the one currently showing no longer changes the NTP background mid-session (sticky URL for the current tab).
- New tabs with refresh on still rotate through custom images as before.

## Functionality

### Brave backgrounds

https://github.com/user-attachments/assets/092fede5-73f7-4d78-805f-f06301d3a447

### Custom backgrounds

https://github.com/user-attachments/assets/0c0d7924-0725-4caf-8978-e7f1e101fea9

## Test plan

- [ ] Open Customize → Background Image and confirm **Brave backgrounds** opens a sub page with back navigation.
- [ ] Confirm the Brave sub page has **no** Refresh toggle and clicking a Brave tile does **not** pin that image.
- [ ] Opening Brave backgrounds selects rotating Brave images; open several new tabs and confirm images rotate among **enabled** ones only.
- [ ] Disable a Brave image with the eye button; confirm it is dimmed, shows `eye-off`, and does **not** appear across many new tabs.
- [ ] While a Brave background is showing, disable a **different** image and confirm the NTP background behind the panel does **not** change.
- [ ] Re-enable a disabled image; confirm it returns to the rotation.
- [ ] Confirm the last remaining enabled Brave image cannot be disabled.
- [ ] Opening custom / solid / gradient confirms **Refresh on every new tab** is on by default (unless that type already has a pinned value).
- [ ] In **Use your own**, select a specific image and confirm non-selected custom tiles dim; confirm the **X** button still removes that image entirely.
- [ ] With custom refresh on, remove a custom image that is **not** currently showing and confirm the NTP background does **not** change; open a new tab and confirm custom images still rotate.
- [ ] Solid colors and gradients: pin one value and confirm other tiles dim; refresh toggle still works.
- [ ] Unit tests: `pnpm test-unit --testPathPatterns='background_(store|type_panel).test' --coverage=false`