### PR TITLE
[recipes] Use short-form path for checkout

### DIFF
--- a/tools/recipes/engine.py
+++ b/tools/recipes/engine.py
@@ -196,8 +196,8 @@ class _Engine:
         # in test mode: it seeds this onto every module (so the seam modules
         # simulate I/O) and does not touch the real cwd.
         self._test = test
-        # Root directory the job runs in. Recipe paths (brave-browser/src,
-        # out, ...) are derived from it by the `path` module.
+        # Root directory the job runs in. Recipe paths (b/src, out, ...) are
+        # derived from it by the `path` module.
         if self._test is not None:
             # Fixed synthetic workspace so module-derived paths are
             # deterministic; never chdir'd into (nothing runs on disk).
@@ -451,7 +451,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument('--workspace',
                         default=None,
                         help='Root directory the job runs in; recipe paths '
-                        '(brave-browser/src, out, ...) are relative to it '
+                        '(b/src, out, ...) are relative to it '
                         '(default: current directory)')
     parser.add_argument('--brave-core-ref',
                         default='master',

--- a/tools/recipes/recipe_modules/brave_core_checkout/examples/full.expected/already_deployed.json
+++ b/tools/recipes/recipe_modules/brave_core_checkout/examples/full.expected/already_deployed.json
@@ -10,7 +10,7 @@
       "--branch",
       "master",
       "git@github.com:brave/brave-core.git",
-      "[WORKSPACE]/brave-browser/src/brave"
+      "[WORKSPACE]/b/src/brave"
     ],
     "name": "clone brave-core (shallow, sparse)"
   },
@@ -18,7 +18,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "list"
     ],
@@ -31,7 +31,7 @@
     ],
     "env_prefixes": {
       "PATH": [
-        "[WORKSPACE]/brave-browser/src/brave/tools/cr/bootstrap"
+        "[WORKSPACE]/b/src/brave/tools/cr/bootstrap"
       ]
     },
     "name": "npm version"

--- a/tools/recipes/recipe_modules/brave_core_checkout/examples/full.expected/clone.json
+++ b/tools/recipes/recipe_modules/brave_core_checkout/examples/full.expected/clone.json
@@ -10,7 +10,7 @@
       "--branch",
       "master",
       "git@github.com:brave/brave-core.git",
-      "[WORKSPACE]/brave-browser/src/brave"
+      "[WORKSPACE]/b/src/brave"
     ],
     "name": "clone brave-core (shallow, sparse)"
   },
@@ -18,7 +18,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "list"
     ],
@@ -28,7 +28,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "add",
       "tools/cr/bootstrap"
@@ -42,7 +42,7 @@
     ],
     "env_prefixes": {
       "PATH": [
-        "[WORKSPACE]/brave-browser/src/brave/tools/cr/bootstrap"
+        "[WORKSPACE]/b/src/brave/tools/cr/bootstrap"
       ]
     },
     "name": "npm version"

--- a/tools/recipes/recipe_modules/brave_core_checkout/examples/full.expected/reuse.json
+++ b/tools/recipes/recipe_modules/brave_core_checkout/examples/full.expected/reuse.json
@@ -3,7 +3,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "fetch",
       "--depth",
       "2",
@@ -16,7 +16,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "checkout",
       "--force",
       "FETCH_HEAD"
@@ -27,7 +27,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "list"
     ],
@@ -37,7 +37,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "add",
       "tools/cr/bootstrap"
@@ -51,7 +51,7 @@
     ],
     "env_prefixes": {
       "PATH": [
-        "[WORKSPACE]/brave-browser/src/brave/tools/cr/bootstrap"
+        "[WORKSPACE]/b/src/brave/tools/cr/bootstrap"
       ]
     },
     "name": "npm version"

--- a/tools/recipes/recipe_modules/brave_core_checkout/examples/full.py
+++ b/tools/recipes/recipe_modules/brave_core_checkout/examples/full.py
@@ -24,8 +24,8 @@ def GenTests(api):
     # requested paths are seeded so the post-checkout existence checks pass.
     yield api.test(
         'clone',
-        api.path.files('brave-browser/src/brave/third_party/node',
-                       'brave-browser/src/brave/tools/cr/bootstrap'),
+        api.path.files('b/src/brave/third_party/node',
+                       'b/src/brave/tools/cr/bootstrap'),
         api.post_process(post_process.MustRun,
                          'clone brave-core (shallow, sparse)'),
         api.post_process(post_process.MustRun, 'sparse-checkout add'),
@@ -36,9 +36,9 @@ def GenTests(api):
     # instead of cloning.
     yield api.test(
         'reuse',
-        api.path.dirs('brave-browser/src/brave/.git'),
-        api.path.files('brave-browser/src/brave/third_party/node',
-                       'brave-browser/src/brave/tools/cr/bootstrap'),
+        api.path.dirs('b/src/brave/.git'),
+        api.path.files('b/src/brave/third_party/node',
+                       'b/src/brave/tools/cr/bootstrap'),
         api.post_process(post_process.MustRun, 'fetch brave-core ref'),
         api.post_process(post_process.MustRun, 'checkout brave-core ref'),
         api.post_process(post_process.DoesNotRun,
@@ -50,8 +50,8 @@ def GenTests(api):
     # `tools/cr` ancestor), so nothing is re-added.
     yield api.test(
         'already deployed',
-        api.path.files('brave-browser/src/brave/third_party/node',
-                       'brave-browser/src/brave/tools/cr/bootstrap'),
+        api.path.files('b/src/brave/third_party/node',
+                       'b/src/brave/tools/cr/bootstrap'),
         api.step_data(
             'sparse-checkout list',
             stdout=api.raw_io.output_text('third_party/node\ntools/cr\n')),

--- a/tools/recipes/recipe_modules/brave_core_checkout/test_api.py
+++ b/tools/recipes/recipe_modules/brave_core_checkout/test_api.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from recipe_test_api import RecipeTestApi, TestData
 
 # Where the module checks brave-core out (matches `api.path.brave_core`).
-_BRAVE_CORE = 'brave-browser/src/brave'
+_BRAVE_CORE = 'b/src/brave'
 
 
 class BraveCoreCheckoutTestApi(RecipeTestApi):

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/existing_branch.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/existing_branch.json
@@ -6,7 +6,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
+      "[WORKSPACE]/b/src/third_party/depot_tools"
     ],
     "env": {
       "CHROME_HEADLESS": "1"
@@ -30,7 +30,7 @@
       "--oneline",
       "chrome/VERSION"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -75,7 +75,7 @@
       "origin",
       "/b/cache/chromium.googlesource.com-chromium-src"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -90,7 +90,7 @@
       "origin",
       "https://chromium.googlesource.com/chromium/src.git"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -103,7 +103,7 @@
       "origin",
       "main"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -116,7 +116,7 @@
       "--force",
       "FETCH_HEAD"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -129,7 +129,7 @@
       "--force",
       "-D"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/fresh_tag.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/fresh_tag.json
@@ -6,7 +6,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
+      "[WORKSPACE]/b/src/third_party/depot_tools"
     ],
     "env": {
       "CHROME_HEADLESS": "1"
@@ -31,7 +31,7 @@
       "--unmanaged",
       "https://chromium.googlesource.com/chromium/src.git"
     ],
-    "cwd": "[WORKSPACE]/brave-browser",
+    "cwd": "[WORKSPACE]/b",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -76,7 +76,7 @@
       "--local",
       "--shared",
       "/b/cache/chromium.googlesource.com-chromium-src",
-      "[WORKSPACE]/brave-browser/src"
+      "[WORKSPACE]/b/src"
     ],
     "env": {
       "CHROME_HEADLESS": "1"
@@ -90,7 +90,7 @@
       "gc.auto",
       "0"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -103,7 +103,7 @@
       "gc.autodetach",
       "0"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -116,7 +116,7 @@
       "gc.autopacklimit",
       "0"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -130,7 +130,7 @@
       "origin/HEAD",
       "--"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -177,7 +177,7 @@
       "origin",
       "/b/cache/chromium.googlesource.com-chromium-src"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -192,7 +192,7 @@
       "origin",
       "https://chromium.googlesource.com/chromium/src.git"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -206,7 +206,7 @@
       "origin",
       "refs/tags/151.0.7917.1:refs/tags/151.0.7917.1"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -219,7 +219,7 @@
       "--force",
       "FETCH_HEAD"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -232,7 +232,7 @@
       "--force",
       "-D"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_hermetic_toolchain.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_hermetic_toolchain.json
@@ -6,7 +6,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
+      "[WORKSPACE]/b/src/third_party/depot_tools"
     ],
     "env": {
       "CHROME_HEADLESS": "1"
@@ -30,7 +30,7 @@
       "--oneline",
       "chrome/VERSION"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -75,7 +75,7 @@
       "origin",
       "/b/cache/chromium.googlesource.com-chromium-src"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -90,7 +90,7 @@
       "origin",
       "https://chromium.googlesource.com/chromium/src.git"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -103,7 +103,7 @@
       "origin",
       "main"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -116,7 +116,7 @@
       "--force",
       "FETCH_HEAD"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -124,10 +124,10 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3.bat",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3.bat",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/chromium_checkout/resources/win_toolchain_hash.py",
-      "[WORKSPACE]/brave-browser/src/build/vs_toolchain.py",
+      "[WORKSPACE]/b/src/build/vs_toolchain.py",
       "https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-2.on.aws/windows-hermetic-toolchain/",
       "--json-output",
       "/path/to/tmp/json"
@@ -144,7 +144,7 @@
       "--force",
       "-D"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_toolchain_hash_pinned.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_toolchain_hash_pinned.json
@@ -6,7 +6,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
+      "[WORKSPACE]/b/src/third_party/depot_tools"
     ],
     "env": {
       "CHROME_HEADLESS": "1"
@@ -30,7 +30,7 @@
       "--oneline",
       "chrome/VERSION"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -75,7 +75,7 @@
       "origin",
       "/b/cache/chromium.googlesource.com-chromium-src"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -90,7 +90,7 @@
       "origin",
       "https://chromium.googlesource.com/chromium/src.git"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -103,7 +103,7 @@
       "origin",
       "main"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -116,7 +116,7 @@
       "--force",
       "FETCH_HEAD"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -124,10 +124,10 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3.bat",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3.bat",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/chromium_checkout/resources/win_toolchain_hash.py",
-      "[WORKSPACE]/brave-browser/src/build/vs_toolchain.py",
+      "[WORKSPACE]/b/src/build/vs_toolchain.py",
       "https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-2.on.aws/windows-hermetic-toolchain/",
       "--json-output",
       "/path/to/tmp/json"
@@ -144,7 +144,7 @@
       "--force",
       "-D"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },

--- a/tools/recipes/recipe_modules/chromium_checkout/test_api.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/test_api.py
@@ -30,7 +30,7 @@ class ChromiumCheckoutTestApi(RecipeTestApi):
 
     def existing_checkout(self) -> TestData:
         """Simulate a valid existing checkout (`chrome/VERSION` present)."""
-        return self.m.path.files('brave-browser/src/chrome/VERSION')
+        return self.m.path.files('b/src/chrome/VERSION')
 
     def git_cache_populated(self, mirror_dir: str = _MIRROR_DIR) -> TestData:
         """Seed `clone`/`checkout_ref`'s `git cache exists` lookups.

--- a/tools/recipes/recipe_modules/chromium_checkout/tests/git_cache.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/tests/git_cache.py
@@ -38,7 +38,7 @@ def GenTests(api):
         'ensure with cache',
         api.env.set('MODE', 'with_cache'),
         api.path.dirs('/b/cache'),
-        api.path.files('brave-browser/src/chrome/VERSION'),
+        api.path.files('b/src/chrome/VERSION'),
         api.env.on_path('gclient', '/dt/gclient'),
         api.chromium_checkout.git_cache_populated(),
         api.post_process(post_process.StatusSuccess),

--- a/tools/recipes/recipe_modules/depot_tools/examples/full.expected/already_deployed.json
+++ b/tools/recipes/recipe_modules/depot_tools/examples/full.expected/already_deployed.json
@@ -7,7 +7,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "--version"
     ],
     "name": "use vpython3"

--- a/tools/recipes/recipe_modules/depot_tools/examples/full.expected/clone.json
+++ b/tools/recipes/recipe_modules/depot_tools/examples/full.expected/clone.json
@@ -6,7 +6,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
+      "[WORKSPACE]/b/src/third_party/depot_tools"
     ],
     "name": "clone depot_tools"
   },
@@ -18,7 +18,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "--version"
     ],
     "name": "use vpython3"

--- a/tools/recipes/recipe_modules/depot_tools/examples/full.expected/windows.json
+++ b/tools/recipes/recipe_modules/depot_tools/examples/full.expected/windows.json
@@ -6,7 +6,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
+      "[WORKSPACE]/b/src/third_party/depot_tools"
     ],
     "name": "clone depot_tools"
   },
@@ -18,7 +18,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3.bat",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3.bat",
       "--version"
     ],
     "name": "use vpython3"

--- a/tools/recipes/recipe_modules/depot_tools/examples/full.py
+++ b/tools/recipes/recipe_modules/depot_tools/examples/full.py
@@ -36,7 +36,7 @@ def GenTests(api):
         'already deployed',
         api.platform.name('linux'),
         # A standalone depot_tools already sits inside the Chromium checkout.
-        api.path.files('brave-browser/src/third_party/depot_tools/gclient'),
+        api.path.files('b/src/third_party/depot_tools/gclient'),
         api.post_process(post_process.DoesNotRun, 'clone depot_tools'),
         api.post_process(post_process.MustRun, 'verify gclient'),
         api.post_process(post_process.StatusSuccess),

--- a/tools/recipes/recipe_modules/file/examples/full.expected/basic.json
+++ b/tools/recipes/recipe_modules/file/examples/full.expected/basic.json
@@ -6,7 +6,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
+      "[WORKSPACE]/b/src/third_party/depot_tools"
     ],
     "name": "clone depot_tools"
   },
@@ -18,7 +18,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -38,7 +38,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -58,7 +58,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -78,7 +78,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -98,7 +98,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -118,7 +118,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -131,7 +131,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -144,7 +144,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -157,7 +157,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",

--- a/tools/recipes/recipe_modules/file/examples/operations.expected/basic.json
+++ b/tools/recipes/recipe_modules/file/examples/operations.expected/basic.json
@@ -6,7 +6,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
+      "[WORKSPACE]/b/src/third_party/depot_tools"
     ],
     "name": "clone depot_tools"
   },
@@ -18,7 +18,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -31,7 +31,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -47,7 +47,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -60,7 +60,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -75,7 +75,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -87,7 +87,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -99,7 +99,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -111,7 +111,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -125,7 +125,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -146,7 +146,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -166,7 +166,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -180,7 +180,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -200,7 +200,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -213,7 +213,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -226,7 +226,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -238,7 +238,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -259,7 +259,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",
@@ -278,7 +278,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
       "--json-output",

--- a/tools/recipes/recipe_modules/json/examples/full.py
+++ b/tools/recipes/recipe_modules/json/examples/full.py
@@ -64,7 +64,7 @@ def RunSteps(api):
     # Encoding: `dumps` handles the types recipes pass around routinely; other
     # types raise `TypeError`, same as stdlib's `json.dumps` (see
     # `recipe_modules/json/tests/errors.py`).
-    assert api.json.dumps(api.path.workspace) == '"/b/s"'
+    assert api.json.dumps(api.path.workspace) == '"/b/w"'
     assert api.json.dumps(
         struct_pb2.Struct(fields={'foo': struct_pb2.Value(
             string_value='bar')})) == ('{"foo": "bar"}')

--- a/tools/recipes/recipe_modules/osx_sdk/examples/full.expected/mac.json
+++ b/tools/recipes/recipe_modules/osx_sdk/examples/full.expected/mac.json
@@ -6,7 +6,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
+      "[WORKSPACE]/b/src/third_party/depot_tools"
     ],
     "name": "clone depot_tools"
   },
@@ -18,7 +18,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/osx_sdk/resources/read_mac_sdk_gni.py",
       "/b/checkout/src/build/config/mac/mac_sdk.gni",
@@ -38,7 +38,7 @@
       "--branch",
       "master",
       "git@github.com:brave/brave-core.git",
-      "[WORKSPACE]/brave-browser/src/brave"
+      "[WORKSPACE]/b/src/brave"
     ],
     "name": "clone brave-core (shallow, sparse)"
   },
@@ -46,7 +46,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "list"
     ],
@@ -56,7 +56,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "add",
       "tools/cr/toolchains"
@@ -65,8 +65,8 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
-      "[WORKSPACE]/brave-browser/src/brave/tools/cr/toolchains/ephemeral_xcode.py",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/brave/tools/cr/toolchains/ephemeral_xcode.py",
       "--sdk-version",
       "26.5",
       "--sdk-build",

--- a/tools/recipes/recipe_modules/osx_sdk/tests/default_chromium_src.py
+++ b/tools/recipes/recipe_modules/osx_sdk/tests/default_chromium_src.py
@@ -24,9 +24,8 @@ def GenTests(api):
         api.platform.name('mac'),
         api.brave_core_checkout.deployed('tools/cr/toolchains'),
         api.osx_sdk.installed(),
-        api.post_process(
-            post_process.StepCommandContains, 'read mac_sdk.gni',
-            ['[WORKSPACE]/brave-browser/src/build/config/mac/mac_sdk.gni']),
+        api.post_process(post_process.StepCommandContains, 'read mac_sdk.gni',
+                         ['[WORKSPACE]/b/src/build/config/mac/mac_sdk.gni']),
         api.post_process(post_process.StatusSuccess),
         api.post_process(post_process.DropExpectation),
     )

--- a/tools/recipes/recipe_modules/path/api.py
+++ b/tools/recipes/recipe_modules/path/api.py
@@ -100,8 +100,12 @@ class PathApi(RecipeApi):
 
     @property
     def chromium_src(self) -> Path:
-        """Chromium `src/` checkout: `<workspace>/brave-browser/src`."""
-        return self._workspace / 'brave-browser' / 'src'
+        """Chromium `src/` checkout: `<workspace>/b/src`.
+
+        Named `b` to keep paths short on Windows, as long paths on Windows can
+        cause linking errors for code we have no control over (e.g. LLVM).
+        """
+        return self._workspace / 'b' / 'src'
 
     @property
     def brave_core(self) -> Path:

--- a/tools/recipes/recipe_modules/path/examples/full.py
+++ b/tools/recipes/recipe_modules/path/examples/full.py
@@ -37,7 +37,7 @@ def RunSteps(api):
 def GenTests(api):
     yield api.test(
         'seeded',
-        api.path.files('brave-browser/src/chrome/VERSION'),
+        api.path.files('b/src/chrome/VERSION'),
         api.post_process(post_process.MustRun, 'found version'),
         api.post_process(post_process.MustRun, 'out ready'),
         api.post_process(post_process.StepCommandContains, 'out ready',

--- a/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
@@ -6,7 +6,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
+      "[WORKSPACE]/b/src/third_party/depot_tools"
     ],
     "env": {
       "CHROME_HEADLESS": "1"
@@ -31,7 +31,7 @@
       "--unmanaged",
       "https://chromium.googlesource.com/chromium/src.git"
     ],
-    "cwd": "[WORKSPACE]/brave-browser",
+    "cwd": "[WORKSPACE]/b",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -78,7 +78,7 @@
       "--depth",
       "1",
       "/b/cache/chromium.googlesource.com-chromium-src",
-      "[WORKSPACE]/brave-browser/src"
+      "[WORKSPACE]/b/src"
     ],
     "env": {
       "CHROME_HEADLESS": "1"
@@ -92,7 +92,7 @@
       "gc.auto",
       "0"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -105,7 +105,7 @@
       "gc.autodetach",
       "0"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -118,7 +118,7 @@
       "gc.autopacklimit",
       "0"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -132,7 +132,7 @@
       "origin/HEAD",
       "--"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -179,7 +179,7 @@
       "origin",
       "/b/cache/chromium.googlesource.com-chromium-src"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -194,7 +194,7 @@
       "origin",
       "https://chromium.googlesource.com/chromium/src.git"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -210,7 +210,7 @@
       "origin",
       "refs/tags/151.0.7917.1:refs/tags/151.0.7917.1"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -223,7 +223,7 @@
       "--force",
       "FETCH_HEAD"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -236,7 +236,7 @@
       "--force",
       "-D"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -253,7 +253,7 @@
       "--branch",
       "master",
       "git@github.com:brave/brave-core.git",
-      "[WORKSPACE]/brave-browser/src/brave"
+      "[WORKSPACE]/b/src/brave"
     ],
     "name": "clone brave-core (shallow, sparse)"
   },
@@ -261,7 +261,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "list"
     ],
@@ -271,7 +271,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "add",
       "tools/cr/toolchains"
@@ -280,12 +280,12 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
-      "[WORKSPACE]/brave-browser/src/brave/tools/cr/toolchains/build_rust_toolchain.py",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/brave/tools/cr/toolchains/build_rust_toolchain.py",
       "--out-dir",
       "[WORKSPACE]/out",
       "--chromium-src",
-      "[WORKSPACE]/brave-browser/src",
+      "[WORKSPACE]/b/src",
       "--brave-subrevision",
       "1",
       "--clear",

--- a/tools/recipes/recipes/toolchains/rust/package_rust.expected/mac.json
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.expected/mac.json
@@ -6,7 +6,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
+      "[WORKSPACE]/b/src/third_party/depot_tools"
     ],
     "env": {
       "CHROME_HEADLESS": "1"
@@ -31,7 +31,7 @@
       "--unmanaged",
       "https://chromium.googlesource.com/chromium/src.git"
     ],
-    "cwd": "[WORKSPACE]/brave-browser",
+    "cwd": "[WORKSPACE]/b",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -78,7 +78,7 @@
       "--depth",
       "1",
       "/b/cache/chromium.googlesource.com-chromium-src",
-      "[WORKSPACE]/brave-browser/src"
+      "[WORKSPACE]/b/src"
     ],
     "env": {
       "CHROME_HEADLESS": "1"
@@ -92,7 +92,7 @@
       "gc.auto",
       "0"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -105,7 +105,7 @@
       "gc.autodetach",
       "0"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -118,7 +118,7 @@
       "gc.autopacklimit",
       "0"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -132,7 +132,7 @@
       "origin/HEAD",
       "--"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -179,7 +179,7 @@
       "origin",
       "/b/cache/chromium.googlesource.com-chromium-src"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -194,7 +194,7 @@
       "origin",
       "https://chromium.googlesource.com/chromium/src.git"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -210,7 +210,7 @@
       "origin",
       "refs/tags/151.0.7917.1:refs/tags/151.0.7917.1"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -223,7 +223,7 @@
       "--force",
       "FETCH_HEAD"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -236,7 +236,7 @@
       "--force",
       "-D"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -253,7 +253,7 @@
       "--branch",
       "master",
       "git@github.com:brave/brave-core.git",
-      "[WORKSPACE]/brave-browser/src/brave"
+      "[WORKSPACE]/b/src/brave"
     ],
     "name": "clone brave-core (shallow, sparse)"
   },
@@ -261,7 +261,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "list"
     ],
@@ -271,7 +271,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "add",
       "tools/cr/toolchains"
@@ -280,10 +280,10 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/osx_sdk/resources/read_mac_sdk_gni.py",
-      "[WORKSPACE]/brave-browser/src/build/config/mac/mac_sdk.gni",
+      "[WORKSPACE]/b/src/build/config/mac/mac_sdk.gni",
       "--json-output",
       "/path/to/tmp/json"
     ],
@@ -291,8 +291,8 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
-      "[WORKSPACE]/brave-browser/src/brave/tools/cr/toolchains/ephemeral_xcode.py",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/brave/tools/cr/toolchains/ephemeral_xcode.py",
       "--sdk-version",
       "26.5",
       "--sdk-build",
@@ -305,12 +305,12 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
-      "[WORKSPACE]/brave-browser/src/brave/tools/cr/toolchains/build_rust_toolchain.py",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/brave/tools/cr/toolchains/build_rust_toolchain.py",
       "--out-dir",
       "[WORKSPACE]/out",
       "--chromium-src",
-      "[WORKSPACE]/brave-browser/src",
+      "[WORKSPACE]/b/src",
       "--brave-subrevision",
       "1",
       "--clear",

--- a/tools/recipes/recipes/toolchains/windows/build_windows_toolchain.expected/win.json
+++ b/tools/recipes/recipes/toolchains/windows/build_windows_toolchain.expected/win.json
@@ -10,7 +10,7 @@
       "--branch",
       "master",
       "git@github.com:brave/brave-core.git",
-      "[WORKSPACE]/brave-browser/src/brave"
+      "[WORKSPACE]/b/src/brave"
     ],
     "name": "clone brave-core (shallow, sparse)"
   },
@@ -18,7 +18,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "list"
     ],
@@ -28,7 +28,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "add",
       "tools/cr/toolchains"
@@ -42,7 +42,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
+      "[WORKSPACE]/b/src/third_party/depot_tools"
     ],
     "name": "clone depot_tools"
   },
@@ -54,8 +54,8 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3.bat",
-      "[WORKSPACE]/brave-browser/src/brave/tools/cr/toolchains/build_windows_toolchain.py",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3.bat",
+      "[WORKSPACE]/b/src/brave/tools/cr/toolchains/build_windows_toolchain.py",
       "--out-dir",
       "[WORKSPACE]/out",
       "--chromium-tag",

--- a/tools/recipes/recipes/toolchains/xcode/build_xcode_toolchain.expected/mac.json
+++ b/tools/recipes/recipes/toolchains/xcode/build_xcode_toolchain.expected/mac.json
@@ -10,7 +10,7 @@
       "--branch",
       "master",
       "git@github.com:brave/brave-core.git",
-      "[WORKSPACE]/brave-browser/src/brave"
+      "[WORKSPACE]/b/src/brave"
     ],
     "name": "clone brave-core (shallow, sparse)"
   },
@@ -18,7 +18,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "list"
     ],
@@ -28,7 +28,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "add",
       "tools/cr/toolchains"
@@ -42,7 +42,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
+      "[WORKSPACE]/b/src/third_party/depot_tools"
     ],
     "name": "clone depot_tools"
   },
@@ -54,8 +54,8 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
-      "[WORKSPACE]/brave-browser/src/brave/tools/cr/toolchains/build_xcode_toolchain.py",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/brave/tools/cr/toolchains/build_xcode_toolchain.py",
       "--out-dir",
       "[WORKSPACE]/out",
       "--chromium-tag",

--- a/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/linux.json
+++ b/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/linux.json
@@ -6,7 +6,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
+      "[WORKSPACE]/b/src/third_party/depot_tools"
     ],
     "env": {
       "CHROME_HEADLESS": "1"
@@ -31,7 +31,7 @@
       "--unmanaged",
       "https://chromium.googlesource.com/chromium/src.git"
     ],
-    "cwd": "[WORKSPACE]/brave-browser",
+    "cwd": "[WORKSPACE]/b",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -78,7 +78,7 @@
       "--depth",
       "1",
       "/b/cache/chromium.googlesource.com-chromium-src",
-      "[WORKSPACE]/brave-browser/src"
+      "[WORKSPACE]/b/src"
     ],
     "env": {
       "CHROME_HEADLESS": "1"
@@ -92,7 +92,7 @@
       "gc.auto",
       "0"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -105,7 +105,7 @@
       "gc.autodetach",
       "0"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -118,7 +118,7 @@
       "gc.autopacklimit",
       "0"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -132,7 +132,7 @@
       "origin/HEAD",
       "--"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -179,7 +179,7 @@
       "origin",
       "/b/cache/chromium.googlesource.com-chromium-src"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -194,7 +194,7 @@
       "origin",
       "https://chromium.googlesource.com/chromium/src.git"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -210,7 +210,7 @@
       "origin",
       "refs/tags/151.0.7917.1:refs/tags/151.0.7917.1"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -223,7 +223,7 @@
       "--force",
       "FETCH_HEAD"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -236,7 +236,7 @@
       "--force",
       "-D"
     ],
-    "cwd": "[WORKSPACE]/brave-browser/src",
+    "cwd": "[WORKSPACE]/b/src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -253,7 +253,7 @@
       "--branch",
       "master",
       "git@github.com:brave/brave-core.git",
-      "[WORKSPACE]/brave-browser/src/brave"
+      "[WORKSPACE]/b/src/brave"
     ],
     "name": "clone brave-core (shallow, sparse)"
   },
@@ -261,7 +261,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "list"
     ],
@@ -271,7 +271,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "add",
       "third_party/ast-grep",
@@ -281,8 +281,8 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
-      "[WORKSPACE]/brave-browser/src/brave/third_party/ast-grep/package_ast_grep.py",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/brave/third_party/ast-grep/package_ast_grep.py",
       "--clean",
       "--out-dir",
       "[WORKSPACE]/out",

--- a/tools/recipes/recipes/tools/node/package_node.expected/basic.json
+++ b/tools/recipes/recipes/tools/node/package_node.expected/basic.json
@@ -10,7 +10,7 @@
       "--branch",
       "master",
       "git@github.com:brave/brave-core.git",
-      "[WORKSPACE]/brave-browser/src/brave"
+      "[WORKSPACE]/b/src/brave"
     ],
     "name": "clone brave-core (shallow, sparse)"
   },
@@ -18,7 +18,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "list"
     ],
@@ -28,7 +28,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "add",
       "third_party/node"
@@ -42,7 +42,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
+      "[WORKSPACE]/b/src/third_party/depot_tools"
     ],
     "name": "clone depot_tools"
   },
@@ -54,16 +54,16 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
-      "[WORKSPACE]/brave-browser/src/brave/third_party/node/download_node.py",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/brave/third_party/node/download_node.py",
       "--clear"
     ],
     "name": "download node"
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
-      "[WORKSPACE]/brave-browser/src/brave/third_party/node/package_node.py",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/brave/third_party/node/package_node.py",
       "--output-dir",
       "[WORKSPACE]/out"
     ],

--- a/tools/recipes/recipes/tools/node/package_node.expected/reuse_checkout.json
+++ b/tools/recipes/recipes/tools/node/package_node.expected/reuse_checkout.json
@@ -3,7 +3,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "fetch",
       "--depth",
       "2",
@@ -16,7 +16,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "checkout",
       "--force",
       "FETCH_HEAD"
@@ -27,7 +27,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "list"
     ],
@@ -37,7 +37,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "add",
       "third_party/node"
@@ -51,7 +51,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
+      "[WORKSPACE]/b/src/third_party/depot_tools"
     ],
     "name": "clone depot_tools"
   },
@@ -63,16 +63,16 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
-      "[WORKSPACE]/brave-browser/src/brave/third_party/node/download_node.py",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/brave/third_party/node/download_node.py",
       "--clear"
     ],
     "name": "download node"
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
-      "[WORKSPACE]/brave-browser/src/brave/third_party/node/package_node.py",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/brave/third_party/node/package_node.py",
       "--output-dir",
       "[WORKSPACE]/out"
     ],

--- a/tools/recipes/recipes/tools/node/package_node_modules.expected/basic.json
+++ b/tools/recipes/recipes/tools/node/package_node_modules.expected/basic.json
@@ -10,7 +10,7 @@
       "--branch",
       "master",
       "git@github.com:brave/brave-core.git",
-      "[WORKSPACE]/brave-browser/src/brave"
+      "[WORKSPACE]/b/src/brave"
     ],
     "name": "clone brave-core (shallow, sparse)"
   },
@@ -18,7 +18,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "list"
     ],
@@ -28,7 +28,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "add",
       "tools/cr/bootstrap"
@@ -42,7 +42,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
+      "[WORKSPACE]/b/src/third_party/depot_tools"
     ],
     "name": "clone depot_tools"
   },
@@ -54,27 +54,27 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
-      "[WORKSPACE]/brave-browser/src/brave/third_party/node/download_node_modules.py"
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/brave/third_party/node/download_node_modules.py"
     ],
     "env_prefixes": {
       "PATH": [
-        "[WORKSPACE]/brave-browser/src/brave/tools/cr/bootstrap"
+        "[WORKSPACE]/b/src/brave/tools/cr/bootstrap"
       ]
     },
     "name": "download node_modules"
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
-      "[WORKSPACE]/brave-browser/src/brave/third_party/node/package_node_modules.py",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/brave/third_party/node/package_node_modules.py",
       "--output-dir",
       "[WORKSPACE]/out",
       "--upload"
     ],
     "env_prefixes": {
       "PATH": [
-        "[WORKSPACE]/brave-browser/src/brave/tools/cr/bootstrap"
+        "[WORKSPACE]/b/src/brave/tools/cr/bootstrap"
       ]
     },
     "name": "package node_modules"

--- a/tools/recipes/recipes/tools/node/package_node_modules.expected/reuse_checkout.json
+++ b/tools/recipes/recipes/tools/node/package_node_modules.expected/reuse_checkout.json
@@ -3,7 +3,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "fetch",
       "--depth",
       "2",
@@ -16,7 +16,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "checkout",
       "--force",
       "FETCH_HEAD"
@@ -27,7 +27,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "list"
     ],
@@ -37,7 +37,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/brave-browser/src/brave",
+      "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "add",
       "tools/cr/bootstrap"
@@ -51,7 +51,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools"
+      "[WORKSPACE]/b/src/third_party/depot_tools"
     ],
     "name": "clone depot_tools"
   },
@@ -63,27 +63,27 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
-      "[WORKSPACE]/brave-browser/src/brave/third_party/node/download_node_modules.py"
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/brave/third_party/node/download_node_modules.py"
     ],
     "env_prefixes": {
       "PATH": [
-        "[WORKSPACE]/brave-browser/src/brave/tools/cr/bootstrap"
+        "[WORKSPACE]/b/src/brave/tools/cr/bootstrap"
       ]
     },
     "name": "download node_modules"
   },
   {
     "cmd": [
-      "[WORKSPACE]/brave-browser/src/third_party/depot_tools/vpython3",
-      "[WORKSPACE]/brave-browser/src/brave/third_party/node/package_node_modules.py",
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/brave/third_party/node/package_node_modules.py",
       "--output-dir",
       "[WORKSPACE]/out",
       "--upload"
     ],
     "env_prefixes": {
       "PATH": [
-        "[WORKSPACE]/brave-browser/src/brave/tools/cr/bootstrap"
+        "[WORKSPACE]/b/src/brave/tools/cr/bootstrap"
       ]
     },
     "name": "package node_modules"

--- a/tools/recipes/simulation.py
+++ b/tools/recipes/simulation.py
@@ -46,7 +46,7 @@ from recipe_test_api import (DisabledTestData, PostprocessHookContext,
 # Fixed synthetic locations used in test mode. They are never touched on disk;
 # they exist only so module-derived paths are deterministic, and are rewritten
 # to tokens in expectations so goldens are machine-independent.
-SIM_WORKSPACE = PurePosixPath('/b/s')
+SIM_WORKSPACE = PurePosixPath('/b/w')
 SIM_HOME = PurePosixPath('/b/home')
 
 WORKSPACE_TOKEN = '[WORKSPACE]'

--- a/tools/recipes/unittests/engine_test.py
+++ b/tools/recipes/unittests/engine_test.py
@@ -233,10 +233,8 @@ class WorkspaceTest(unittest.TestCase):
             path = eng._instantiate_module('path', [])
             workspace = Path(tmp).resolve()
             self.assertEqual(path.workspace, workspace)
-            self.assertEqual(path.chromium_src,
-                             workspace / 'brave-browser/src')
-            self.assertEqual(path.brave_core,
-                             workspace / 'brave-browser/src/brave')
+            self.assertEqual(path.chromium_src, workspace / 'b/src')
+            self.assertEqual(path.brave_core, workspace / 'b/src/brave')
             self.assertEqual(path.out, workspace / 'out')
             self.assertEqual(Path.cwd(), workspace)
 

--- a/tools/recipes/unittests/simulation_test.py
+++ b/tools/recipes/unittests/simulation_test.py
@@ -131,21 +131,21 @@ class TestContextTest(unittest.TestCase):
         self.assertEqual(ctx.which_map['gclient'], '/g')
         # Relative seed resolves under the simulated workspace.
         self.assertTrue(
-            ctx.fs.is_file('/b/s/brave-browser/src/chrome/VERSION'))
+            ctx.fs.is_file('/b/w/brave-browser/src/chrome/VERSION'))
 
 
 class ExpectationTest(unittest.TestCase):
 
     def test_stabilize_tokens(self):
         ctx = simulation.TestContext()
-        self.assertEqual(simulation.stabilize('/b/s/out/x', ctx),
+        self.assertEqual(simulation.stabilize('/b/w/out/x', ctx),
                          '[WORKSPACE]/out/x')
         self.assertEqual(simulation.stabilize('/b/home/.cache', ctx),
                          '[HOME]/.cache')
 
     def test_build_steps_success_result(self):
         runner = simulation.SimulationStepRunner()
-        _run(runner, {'name': 'a', 'cmd': ['/b/s/out/tool']})
+        _run(runner, {'name': 'a', 'cmd': ['/b/w/out/tool']})
         steps = simulation.build_steps(runner, None, simulation.TestContext())
         self.assertEqual(steps['a']['cmd'], ['[WORKSPACE]/out/tool'])
         # A successful run's $result carries no failure key.
@@ -153,7 +153,7 @@ class ExpectationTest(unittest.TestCase):
 
     def test_build_steps_failure_result_stabilizes_reason(self):
         runner = simulation.SimulationStepRunner()
-        failure = {'humanReason': 'boom at /b/s/out/tool'}
+        failure = {'humanReason': 'boom at /b/w/out/tool'}
         steps = simulation.build_steps(runner, failure,
                                        simulation.TestContext())
         # An infra failure carries only humanReason (paths stabilized).


### PR DESCRIPTION
When running the Rust/WASM toolchain builder on Windows, there was a
linking failure:

```
LINK : fatal error LNK1181: cannot open input file 'tools\clang\lib\ScalableStaticAnalysisFramework\Core\CMakeFiles\obj.clangScalableStaticAnalysisFrameworkCore.dir\Serialization\JSONFormat\JSONEntitySummaryEncoding.cpp.obj'
```

This failure is occasioned by the linker not being able to use a long
path on Windows, and this being the LLVM build, we can't do much about
that. This change shortens the checkout path for the browser to only
`b`, to work around this issue.

Bug: https://github.com/brave/brave-browser/issues/55812
Bug: https://github.com/brave/brave-browser/issues/56748
