### PR TITLE
[Wallet]: Unify Panel Sizes

### DIFF
--- a/components/brave_wallet_ui/components/extension/connections/connections.stories.tsx
+++ b/components/brave_wallet_ui/components/extension/connections/connections.stories.tsx
@@ -19,10 +19,7 @@ export const _Connections = {
   render: () => {
     return (
       <WalletPanelStory>
-        <PanelWrapper
-          width={390}
-          height={650}
-        >
+        <PanelWrapper>
           <LongWrapper padding='0px'>
             <Connections />
           </LongWrapper>

--- a/components/brave_wallet_ui/components/extension/post-confirmation/cancel_transaction/cancel_transaction.stories.tsx
+++ b/components/brave_wallet_ui/components/extension/post-confirmation/cancel_transaction/cancel_transaction.stories.tsx
@@ -23,10 +23,7 @@ export const _CancelTransaction = {
   render: () => {
     return (
       <WalletPanelStory>
-        <PanelWrapper
-          width={390}
-          height={650}
-        >
+        <PanelWrapper>
           <LongWrapper padding='0px'>
             <CancelTransaction
               onBack={() => alert('Back clicked')}

--- a/components/brave_wallet_ui/components/extension/post-confirmation/complete/complete.stories.tsx
+++ b/components/brave_wallet_ui/components/extension/post-confirmation/complete/complete.stories.tsx
@@ -41,10 +41,7 @@ export const _TransactionComplete = {
 
     return (
       <WalletPanelStory>
-        <PanelWrapper
-          width={390}
-          height={650}
-        >
+        <PanelWrapper>
           <LongWrapper padding='0px'>
             <TransactionComplete
               transaction={transaction}

--- a/components/brave_wallet_ui/components/extension/post-confirmation/failed_or_canceled/failed_or_canceled.stories.tsx
+++ b/components/brave_wallet_ui/components/extension/post-confirmation/failed_or_canceled/failed_or_canceled.stories.tsx
@@ -41,10 +41,7 @@ export const _TransactionFailedOrCanceled = {
 
     return (
       <WalletPanelStory>
-        <PanelWrapper
-          width={390}
-          height={650}
-        >
+        <PanelWrapper>
           <LongWrapper padding='0px'>
             <TransactionFailedOrCanceled
               transaction={transaction}

--- a/components/brave_wallet_ui/components/extension/post-confirmation/submitted_or_signed/submitted_or_signed.stories.tsx
+++ b/components/brave_wallet_ui/components/extension/post-confirmation/submitted_or_signed/submitted_or_signed.stories.tsx
@@ -41,10 +41,7 @@ export const _TransactionSubmittedOrSigned = {
 
     return (
       <WalletPanelStory>
-        <PanelWrapper
-          width={390}
-          height={650}
-        >
+        <PanelWrapper>
           <LongWrapper padding='0px'>
             <TransactionSubmittedOrSigned
               onClose={() => alert('Close panel screen clicked.')}

--- a/components/brave_wallet_ui/components/extension/sign-panel/cow_swap_order.stories.tsx
+++ b/components/brave_wallet_ui/components/extension/sign-panel/cow_swap_order.stories.tsx
@@ -18,7 +18,7 @@ export const _SignCowSwapOrder = {
   render: () => {
     return (
       <WalletPanelStory>
-        <PanelWrapper isLonger>
+        <PanelWrapper>
           <LongWrapper>
             <SignCowSwapOrder
               data={mockSignMessageRequest}

--- a/components/brave_wallet_ui/components/extension/sign-panel/sign_panel.stories.tsx
+++ b/components/brave_wallet_ui/components/extension/sign-panel/sign_panel.stories.tsx
@@ -69,7 +69,7 @@ export const _SignPanel = {
   render: () => {
     return (
       <WalletPageStory>
-        <PanelWrapper isLonger>
+        <PanelWrapper>
           <LongWrapper>
             <SignPanel
               showWarning={true}
@@ -120,7 +120,7 @@ export const _SignData = {
 
     return (
       <WalletPanelStory>
-        <PanelWrapper isLonger={true}>
+        <PanelWrapper>
           <LongWrapper>
             <SignPanel
               signMessageData={signMessageDataPayload}

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -31,7 +31,7 @@ import {
   DecryptMessageRequestPanel, //
 } from '../components/extension/public_encryption_key_panels/decrypt_message_request_panel'
 
-import { LongWrapper, ConnectWithSiteWrapper } from '../stories/style'
+import { ConnectWithSiteWrapper } from '../stories/style'
 import { PanelWrapper } from './style'
 import { FullScreenWrapper } from '../page/screens/page-screen.styles'
 
@@ -153,10 +153,7 @@ function Container() {
   // render
   if (!hasInitialized || isLoadingPendingActions) {
     return (
-      <PanelWrapper
-        height={650}
-        isSidePanel={isSidePanel}
-      >
+      <PanelWrapper isSidePanel={isSidePanel}>
         <FullScreenWrapper>
           <ProgressRing mode='indeterminate' />
         </FullScreenWrapper>
@@ -166,10 +163,7 @@ function Container() {
 
   if (!isWalletCreated) {
     return (
-      <PanelWrapper
-        height={650}
-        isSidePanel={isSidePanel}
-      >
+      <PanelWrapper isSidePanel={isSidePanel}>
         <WelcomePanel />
       </PanelWrapper>
     )
@@ -177,10 +171,7 @@ function Container() {
 
   if (isWalletLocked) {
     return (
-      <PanelWrapper
-        height={650}
-        isSidePanel={isSidePanel}
-      >
+      <PanelWrapper isSidePanel={isSidePanel}>
         <PageContainer />
       </PanelWrapper>
     )
@@ -195,7 +186,7 @@ function Container() {
       }
     })
     return (
-      <PanelWrapper height={600}>
+      <PanelWrapper>
         <ConnectWithSiteWrapper>
           <ConnectWithSite
             originInfo={connectToSiteOrigin}
@@ -213,7 +204,7 @@ function Container() {
       || signSolTransactionsRequests?.length)
   ) {
     return (
-      <PanelWrapper height={650}>
+      <PanelWrapper>
         <ConnectHardwareWalletPanel hardwareWalletCode={hardwareWalletCode} />
       </PanelWrapper>
     )
@@ -221,7 +212,7 @@ function Container() {
 
   if (addChainRequest) {
     return (
-      <PanelWrapper height={650}>
+      <PanelWrapper>
         <AllowAddChangeNetworkPanel addChainRequest={addChainRequest} />
       </PanelWrapper>
     )
@@ -229,7 +220,7 @@ function Container() {
 
   if (switchChainRequest) {
     return (
-      <PanelWrapper height={650}>
+      <PanelWrapper>
         <AllowAddChangeNetworkPanel switchChainRequest={switchChainRequest} />
       </PanelWrapper>
     )
@@ -237,7 +228,7 @@ function Container() {
 
   if (signMessageErrorData?.length) {
     return (
-      <PanelWrapper height={650}>
+      <PanelWrapper>
         <SignInWithEthereumError />
       </PanelWrapper>
     )
@@ -245,7 +236,7 @@ function Container() {
 
   if (signMessageData?.length && signMessageData[0].signData.ethSiweData) {
     return (
-      <PanelWrapper height={650}>
+      <PanelWrapper>
         <SignInWithEthereum data={signMessageData[0]} />
       </PanelWrapper>
     )
@@ -253,7 +244,7 @@ function Container() {
 
   if (getEncryptionPublicKeyRequest) {
     return (
-      <PanelWrapper height={650}>
+      <PanelWrapper>
         <ProvidePublicEncryptionKeyPanel
           payload={getEncryptionPublicKeyRequest}
         />
@@ -263,7 +254,7 @@ function Container() {
 
   if (decryptRequest) {
     return (
-      <PanelWrapper height={650}>
+      <PanelWrapper>
         <DecryptMessageRequestPanel payload={decryptRequest} />
       </PanelWrapper>
     )
@@ -271,21 +262,19 @@ function Container() {
 
   if (signMessageData?.length) {
     return (
-      <PanelWrapper isLonger={true}>
-        <LongWrapper>
-          <SignPanel
-            signMessageData={signMessageData}
-            // Pass a boolean here if the signing method is risky
-            showWarning={false}
-          />
-        </LongWrapper>
+      <PanelWrapper>
+        <SignPanel
+          signMessageData={signMessageData}
+          // Pass a boolean here if the signing method is risky
+          showWarning={false}
+        />
       </PanelWrapper>
     )
   }
 
   if (addTokenRequests.length) {
     return (
-      <PanelWrapper height={650}>
+      <PanelWrapper>
         <AddSuggestedTokenPanel />
       </PanelWrapper>
     )
@@ -297,10 +286,8 @@ function Container() {
     && !submittingTransaction
   ) {
     return (
-      <PanelWrapper height={650}>
-        <LongWrapper padding='0px'>
-          <TransactionStatus transactionLookup={selectedTransactionId} />
-        </LongWrapper>
+      <PanelWrapper>
+        <TransactionStatus transactionLookup={selectedTransactionId} />
       </PanelWrapper>
     )
   }
@@ -310,7 +297,7 @@ function Container() {
 
   if (pendingOrConfirmingTransaction) {
     return (
-      <PanelWrapper height={650}>
+      <PanelWrapper>
         <PendingTransactionPanel
           selectedPendingTransaction={pendingOrConfirmingTransaction}
         />
@@ -320,29 +307,22 @@ function Container() {
 
   if (signSolTransactionsRequests?.length) {
     return (
-      <PanelWrapper isLonger={true}>
-        <LongWrapper padding='0px'>
-          <PendingSignSolanaTransactionsRequestsPanel />
-        </LongWrapper>
+      <PanelWrapper>
+        <PendingSignSolanaTransactionsRequestsPanel />
       </PanelWrapper>
     )
   }
 
   if (signCardanoTransactionRequests?.length) {
     return (
-      <PanelWrapper isLonger={true}>
-        <LongWrapper padding='0px'>
-          <PendingSignCardanoTransactionRequestsPanel />
-        </LongWrapper>
+      <PanelWrapper>
+        <PendingSignCardanoTransactionRequestsPanel />
       </PanelWrapper>
     )
   }
 
   return (
-    <PanelWrapper
-      height={650}
-      isSidePanel={isSidePanel}
-    >
+    <PanelWrapper isSidePanel={isSidePanel}>
       <PageContainer />
     </PanelWrapper>
   )

--- a/components/brave_wallet_ui/panel/style.ts
+++ b/components/brave_wallet_ui/panel/style.ts
@@ -6,17 +6,14 @@ import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css/variables'
 
 export const PanelWrapper = styled.div<{
-  isLonger?: boolean
-  width?: number
-  height?: number
   isSidePanel?: boolean
 }>`
   position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: ${(p) => (p.width ? p.width : 390)}px;
-  height: ${(p) => (p.height ? p.height : p.isLonger ? 540 : 400)}px;
+  width: 390px;
+  height: 650px;
   background-color: ${leo.color.page.background};
   /* Cr151+ bubble autosize uses document scrollWidth; clip overflow so
      absolute/fixed children cannot inflate the panel beyond its set size. */


### PR DESCRIPTION
## Description 

Unifies all `Panel` sizes to ensure they are all `390px` x `650px`

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/57640>

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->


Before:

<img width="418" height="563" alt="Screenshot 22" src="https://github.com/user-attachments/assets/db366361-db82-438a-bda4-f633b4a3deed" /> | <img width="411" height="561" alt="Screenshot 23" src="https://github.com/user-attachments/assets/b585ff78-aaf7-4e9d-b3ac-b3122bce62dc" />
--|--

After:

<img width="414" height="677" alt="Screenshot 20" src="https://github.com/user-attachments/assets/ca536752-41b4-4476-a1f5-a7f304db401e" /> | <img width="416" height="674" alt="Screenshot 21" src="https://github.com/user-attachments/assets/1e350d41-7fe5-462f-a08e-eb30a0fef022" />
--|--