### PR TITLE
[toolchain] `cherry_picks.py` handling shallow cloned repos

### DIFF
--- a/tools/cr/toolchains/build_rust_toolchain.py
+++ b/tools/cr/toolchains/build_rust_toolchain.py
@@ -211,23 +211,9 @@ VPYTHON_PATH = Path('third_party/depot_tools') / (
 # it is one of those reliable files that are always present in any version.
 CHROME_VERSION_FILE = Path('chrome/VERSION')
 
-# Upstream cherry-picks applied onto the checkout for the build's duration (see
-# `cherry_picks`). Each is skipped automatically if the active Chromium ref
-# already contains it, so commits can stay listed here across version bumps
-# until they age out of the picks we still need.
-#
-#   * a710d2e1475f4c224290ce22f1a21c42d5fad900 — upstream's reproducibility fix
-#     for the committer details used in a cherry-pick commit. See
-#     https://crrev.com/c/7914461. This CL was provided once we reported to them
-#     mismatches on the `rustc` hash between our toolchain and theirs due to
-#     cherry-picks.
-#   * 0210b44659fd7251672077e9ab83b5324db0c08e — adds `--skip-test` to
-#     `package_rust.py` (plumbed into `build_rust.py`) so the packaging step can
-#     skip the rustc/libstd test suites. See https://crrev.com/c/7984649.
-CLANG_CHERRY_PICK_COMMITS = [
-    'a710d2e1475f4c224290ce22f1a21c42d5fad900',
-    '0210b44659fd7251672077e9ab83b5324db0c08e',
-]
+# Upstream cherry-picks applied onto the checkout for the build's duration.
+# Empty for now.
+CLANG_CHERRY_PICK_COMMITS = []
 
 # The bucket + key prefix in our infra where the rust toolchain is archived.
 TOOLCHAIN_BUCKET = 'brave-build-deps-public'

--- a/tools/cr/toolchains/cherry_picks.py
+++ b/tools/cr/toolchains/cherry_picks.py
@@ -37,7 +37,8 @@ def _check_call(*command,
                 env=None,
                 check=True,
                 capture_output=False,
-                timeout=None):
+                timeout=None,
+                input=None):  # pylint: disable=redefined-builtin
     """Run *command* as a subprocess, logging the invocation.
 
     Shared subprocess helper for every script in this directory that shells
@@ -63,6 +64,7 @@ def _check_call(*command,
             the parent's streams.
         timeout: Optional number of seconds to allow the subprocess to run
             before it is killed. `None` (the default) waits indefinitely.
+        input: Optional text piped to the subprocess's stdin.
 
     Returns:
         The `subprocess.CompletedProcess` for the invocation.  When
@@ -95,6 +97,7 @@ def _check_call(*command,
                           check=check,
                           capture_output=capture_output,
                           timeout=timeout,
+                          input=input,
                           text=True,
                           errors='replace')
 
@@ -105,7 +108,7 @@ def cherry_picks(repo_dir: str | Path,
                  metadata_overrides: dict[str, str] | None = None):
     """Context manager: apply upstream cherry-picks for the build's duration.
 
-    Ensures every commit in *commits* is in *repo_dir*'s history while the build
+    Ensures every commit's changes are present in *repo_dir* while the build
     runs, then restores the original HEAD afterwards. Used to pull in upstream
     fixes the checked-out ref may predate — for example the commit that pins the
     git author/committer metadata `tools/clang/scripts/build.py` stamps onto its
@@ -121,8 +124,8 @@ def cherry_picks(repo_dir: str | Path,
 
     Protocol:
     1. For each commit, fetch it if its object is missing (the ref may have
-       branched before it landed), then skip it if it is already reachable
-       from HEAD.
+       branched before it landed), then skip it if its change is already
+       present in the checkout's tree.
     2. If nothing needs applying, `yield` immediately and leave the checkout
        untouched — there is nothing to clean up.
     3. Otherwise cherry-pick the remaining commits — with `metadata_overrides`
@@ -133,10 +136,13 @@ def cherry_picks(repo_dir: str | Path,
     if metadata_overrides is None:
         metadata_overrides = GIT_METADATA_OVERRIDES
 
-    def _run_git(*args,
-                 check: bool = True,
-                 capture_output: bool = False,
-                 env: dict | None = None) -> subprocess.CompletedProcess:
+    def _run_git(
+        *args,
+        check: bool = True,
+        capture_output: bool = False,
+        env: dict | None = None,
+        input: str | None = None  # pylint: disable=redefined-builtin
+    ) -> subprocess.CompletedProcess:
         """Run `git -C <repo_dir> <args...>` via `_check_call`."""
         return _check_call('git',
                            '-C',
@@ -144,6 +150,7 @@ def cherry_picks(repo_dir: str | Path,
                            *args,
                            check=check,
                            capture_output=capture_output,
+                           input=input,
                            env=env)
 
     to_apply = []
@@ -157,17 +164,17 @@ def cherry_picks(repo_dir: str | Path,
             logging.info('Fetching cherry-pick %s.', commit)
             _run_git('fetch', 'origin', commit)
 
-        # This tests commit *reachability*, not whether the change is still
-        # effectively present. A commit that landed and was later reverted
-        # upstream is still an ancestor, so it is treated as applied and not
-        # re-picked. Acceptable for this curated list of upstream fixes;
-        # revisit if a pick can legitimately be reverted-then-wanted.
-        already_applied = _run_git('merge-base',
-                                   '--is-ancestor',
-                                   commit,
-                                   'HEAD',
+        # Commit-graph ancestry (`merge-base --is-ancestor`) can't be used
+        # reliably with a shallow clone, so check if the change is already
+        # present by attempting to reverse-apply the patch.
+        # If it applies cleanly in reverse, the change is already present.
+        patch = _run_git('show', commit, capture_output=True).stdout
+        already_applied = _run_git('apply',
+                                   '--reverse',
+                                   '--check',
                                    check=False,
-                                   capture_output=True).returncode == 0
+                                   capture_output=True,
+                                   input=patch).returncode == 0
         if already_applied:
             logging.info('Cherry-pick %s already present; skipping.', commit)
         else:

--- a/tools/cr/toolchains/cherry_picks_test.py
+++ b/tools/cr/toolchains/cherry_picks_test.py
@@ -22,6 +22,9 @@ Coverage:
 * `MetadataTest` — the committer identity and date are pinned (author is left as
   the original, matching `git cherry-pick` semantics) and the override table is
   configurable.
+* `ShallowCloneTest` — a commit already folded into the tree is still skipped
+  when the checkout is shallow, where its object is absent and its commit-graph
+  ancestry can't be determined at all.
 """
 
 from __future__ import annotations
@@ -252,6 +255,54 @@ class MetadataTest(_RepoTestCase):
         self.assertEqual(got['committer_name'], 'Custom Person')
         self.assertEqual(got['committer_email'], 'custom@example.com')
         self.assertIn('2001', got['committer_date'])
+
+
+class ShallowCloneTest(_RepoTestCase):
+    """A shallow checkout can't see ancestry, but content skipping still works.
+
+    `chromium_checkout.checkout_ref` clones with `depth=1`, so the checkout's
+    HEAD has no recorded parent at all. `git merge-base --is-ancestor` can
+    only walk parent pointers, so on a checkout like this it reports every
+    commit as a non-ancestor -- including ones actually folded into the tree
+    long before the shallow tip. `cherry_picks` must not rely on that check.
+    """
+
+    def test_shallow_clone_skips_commit_already_folded_into_tree(self) -> None:
+        origin = self._new_repo('origin')
+        # The "upstream fix": lands first, then further history accumulates on
+        # top of it, exactly like a real cherry-pick candidate that long ago
+        # made it into a release branch.
+        fix = _commit_file(origin, 'base.txt', 'base\nfixed\n', 'the fix')
+        _commit_file(origin, 'other.txt', 'other\n',
+                     'later, unrelated commit (becomes the shallow tip)')
+
+        local = self.root / 'local'
+        # `file://` forces real fetch negotiation for `--depth`; a same-
+        # filesystem path clone hardlinks the whole object database and
+        # ignores `--depth` entirely (per `git help clone`).
+        _git(self.root, 'clone', '-q', '--depth', '1', f'file://{origin}',
+             str(local))
+        _git(local, 'config', 'user.name', 'Test')
+        _git(local, 'config', 'user.email', 'test@example.com')
+        self.assertEqual(_git(local, 'rev-parse', '--is-shallow-repository'),
+                         'true')
+        # The fix's own commit object isn't present at all -- the shallow
+        # clone only carries the tip.
+        self.assertNotEqual(
+            subprocess.run(('git', '-C', str(local), 'cat-file', '-e',
+                            f'{fix}^{{commit}}'),
+                           check=False,
+                           capture_output=True).returncode, 0)
+
+        local_head = self._head(local)
+        with m.cherry_picks(local, [fix]):
+            # HEAD is checked *inside* the context: `cherry_picks` always
+            # restores HEAD on exit, cherry-picked or not, so only an
+            # assertion here can tell a real skip from a redundant re-pick
+            # that happens to reproduce the same content.
+            self.assertEqual(self._head(local), local_head)
+            self.assertEqual((local / 'base.txt').read_text(), 'base\nfixed\n')
+        self.assertEqual(self._head(local), local_head)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change adds support for shallow clone checks, as the ancestry check
doesn't work as expected. The new check verifies that the cherry-pick is
needed by trying to reverse apply it.

This change also removes the cherry-picks from the rust toolchain
builder, as they are not needed anymore.

Bug: https://github.com/brave/brave-browser/issues/55812
