### PR TITLE
[AI Chat] Feature flag for manual debug JSON conversation copying

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -733,6 +733,15 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
           "Enables sharing a conversation from the conversation header.",      \
           kOsWin | kOsMac | kOsLinux | kOsAndroid,                             \
           FEATURE_VALUE_TYPE(ai_chat::features::kAIChatConversationShare),     \
+      },                                                                       \
+      {                                                                        \
+          "brave-ai-chat-export-json",                                         \
+          "Brave AI Chat Export JSON",                                         \
+          "Enables copying serialized conversation data as JSON to the "       \
+          "clipboard when using the alt+meta key and the \"Copy entire "       \
+          "conversation\" menu option.",                                       \
+          kOsWin | kOsMac | kOsLinux | kOsAndroid,                             \
+          FEATURE_VALUE_TYPE(ai_chat::features::kAIChatExportJSON),            \
       })
 #else
 #define BRAVE_AI_CHAT_FEATURE_ENTRIES

--- a/browser/ui/webui/ai_chat/ai_chat_ui.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.cc
@@ -106,6 +106,9 @@ AIChatUI::AIChatUI(content::WebUI* web_ui)
   source->AddBoolean("isConversationShareEnabled",
                      base::FeatureList::IsEnabled(
                          ai_chat::features::kAIChatConversationShare));
+  source->AddBoolean(
+      "isAIChatExportJSONEnabled",
+      base::FeatureList::IsEnabled(ai_chat::features::kAIChatExportJSON));
   // Brave client version, used to tag serialized conversations for sharing.
   source->AddString("braveVersion",
                     version_info::GetBraveVersionWithoutChromiumMajorVersion());

--- a/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_initializer.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_initializer.cc
@@ -267,6 +267,9 @@ void NewTabPageInitializer::AddLoadTimeValues() {
   source_->AddBoolean("isConversationShareEnabled",
                       base::FeatureList::IsEnabled(
                           ai_chat::features::kAIChatConversationShare));
+  source_->AddBoolean(
+      "isAIChatExportJSONEnabled",
+      base::FeatureList::IsEnabled(ai_chat::features::kAIChatExportJSON));
 #endif
 
   source_->AddBoolean("aiChatInputEnabled", ai_chat_input_enabled);

--- a/components/ai_chat/core/common/features.cc
+++ b/components/ai_chat/core/common/features.cc
@@ -255,4 +255,6 @@ const base::FeatureParam<std::string> kAIChatConversationShareBaseUrl{
     &kAIChatConversationShare, "viewer_base_url",
     "https://leo-ai.brave.app/shared/"};
 
+BASE_FEATURE(kAIChatExportJSON, base::FEATURE_DISABLED_BY_DEFAULT);
+
 }  // namespace ai_chat::features

--- a/components/ai_chat/core/common/features.h
+++ b/components/ai_chat/core/common/features.h
@@ -202,6 +202,12 @@ BASE_DECLARE_FEATURE(kAIChatConversationShare);
 COMPONENT_EXPORT(AI_CHAT_COMMON)
 extern const base::FeatureParam<std::string> kAIChatConversationShareBaseUrl;
 
+// Enables copying serialized conversation data as JSON to the clipboard when
+// using the alt+meta modifier keys and the "Copy entire conversation" menu
+// option.
+COMPONENT_EXPORT(AI_CHAT_COMMON)
+BASE_DECLARE_FEATURE(kAIChatExportJSON);
+
 }  // namespace ai_chat::features
 
 #endif  // BRAVE_COMPONENTS_AI_CHAT_CORE_COMMON_FEATURES_H_

--- a/components/ai_chat/resources/page/components/feature_button_menu/index.tsx
+++ b/components/ai_chat/resources/page/components/feature_button_menu/index.tsx
@@ -11,13 +11,15 @@ import Toggle from '@brave/leo/react/toggle'
 import { showAlert } from '@brave/leo/react/alertCenter'
 import classnames from '$web-common/classnames'
 import { getLocale } from '$web-common/locale'
-import { useAIChat } from '../../state/ai_chat_context'
-import { useConversation } from '../../state/conversation_context'
-import styles from './style.module.scss'
-import useHasConversationStarted from '../../hooks/useHasConversationStarted'
 import {
   formatConversationForClipboard, //
 } from '../../../common/conversation_history_utils'
+import { serializeConversationForSharing } from '../../../common/conversation_serialization'
+import useHasConversationStarted from '../../hooks/useHasConversationStarted'
+import { useAIChat } from '../../state/ai_chat_context'
+import { useConversation } from '../../state/conversation_context'
+import { createSharedConversationPayload } from '../share_conversation_modal/create_shared_conversation_payload'
+import styles from './style.module.scss'
 
 export interface Props {
   setIsConversationsListOpen?: (value: boolean) => unknown
@@ -43,12 +45,32 @@ export default function FeatureMenu(props: Props) {
     conversationContext.setTemporary(detail.checked)
   }
 
-  const copyEntireConversation = async () => {
-    const conversationHistory =
-      conversationContext.api.getConversationHistory.current()
-    const formattedConversation =
-      formatConversationForClipboard(conversationHistory)
-    navigator.clipboard.writeText(formattedConversation).then(() => {
+  const copyEntireConversation = async (e: MouseEvent) => {
+    let textToCopy: string
+
+    if (aiChatContext.isAIChatExportJSONEnabled && e.altKey && e.metaKey) {
+      const conversationTitle =
+        aiChatContext.api.getConversations
+          .current()
+          .find(
+            (c) =>
+              c.uuid
+              === conversationContext.api.getState.current().conversationUuid,
+          )?.title || ''
+      textToCopy = serializeConversationForSharing(
+        await createSharedConversationPayload(
+          conversationContext,
+          aiChatContext,
+          conversationTitle,
+        ),
+      )
+    } else {
+      const conversationHistory =
+        conversationContext.api.getConversationHistory.current()
+      textToCopy = formatConversationForClipboard(conversationHistory)
+    }
+
+    navigator.clipboard.writeText(textToCopy).then(() => {
       showAlert({
         type: 'info',
         content: getLocale(S.CHAT_UI_CONVERSATION_COPIED),
@@ -95,7 +117,7 @@ export default function FeatureMenu(props: Props) {
       )}
 
       {hasConversationStarted && (
-        <leo-menu-item onClick={() => copyEntireConversation()}>
+        <leo-menu-item onClick={(e) => copyEntireConversation(e)}>
           <div
             className={classnames(
               styles.menuItemWithIcon,

--- a/components/ai_chat/resources/page/state/ai_chat_context.tsx
+++ b/components/ai_chat/resources/page/state/ai_chat_context.tsx
@@ -66,6 +66,9 @@ export default function useProvideAIChatContext(props: AIChatContextProps) {
     isConversationShareEnabled: loadTimeData.getBoolean(
       'isConversationShareEnabled',
     ),
+    isAIChatExportJSONEnabled: loadTimeData.getBoolean(
+      'isAIChatExportJSONEnabled',
+    ),
     isGlobalPanel:
       !initiallyTabAssociated && api.isStandalone.current() === false,
 

--- a/components/ai_chat/resources/page/stories/components_panel.tsx
+++ b/components/ai_chat/resources/page/stories/components_panel.tsx
@@ -649,6 +649,7 @@ function StoryContext(
         isMobile: args.isMobile,
         isHistoryFeatureEnabled: args.isHistoryEnabled,
         isConversationShareEnabled: true,
+        isAIChatExportJSONEnabled: true,
         skillDialog: args.skillDialog,
       }}
       conversationOverrides={{

--- a/ios/browser/ui/webui/ai_chat/ai_chat_ui.mm
+++ b/ios/browser/ui/webui/ai_chat/ai_chat_ui.mm
@@ -73,6 +73,9 @@ AIChatUI::AIChatUI(web::WebUIIOS* web_ui, const GURL& url)
   source->AddBoolean("isConversationShareEnabled",
                      base::FeatureList::IsEnabled(
                          ai_chat::features::kAIChatConversationShare));
+  source->AddBoolean(
+      "isAIChatExportJSONEnabled",
+      base::FeatureList::IsEnabled(ai_chat::features::kAIChatExportJSON));
   // Brave client version, used to tag serialized conversations for sharing.
   source->AddString("braveVersion",
                     version_info::GetBraveVersionWithoutChromiumMajorVersion());


### PR DESCRIPTION
New feature flag (`AIChatExportJSON`) enables a user to copy to clipboard a JSON serialization of all conversation data for debug purposes. Activated by holding alt+meta whilst clicking the "Copy entire conversation" menu item.

This will be especially useful when diagnosing issues that aren't reproducible via the dev aichat server.

I was debating between copying only the conversation data and not the full shared-conversation data which includes the browser conversation, but I thought it could be useful to have that information PLUS we can just paste this in to the dev shared conversation viewer site to view the same data with the same version UI it was copied from.