### PR TITLE
Don't place saved-tab-group tabs into an unrelated tab's tree

### DIFF
--- a/browser/ui/tabs/test/tree_tabs_browsertest.cc
+++ b/browser/ui/tabs/test/tree_tabs_browsertest.cc
@@ -922,6 +922,45 @@ IN_PROC_BROWSER_TEST_F(TreeTabsBrowserTest, AddTabRecursive) {
             &unpinned_collection());
 }
 
+// When a saved tab group is restored, Navigate() sets each
+// restored tab's opener to whatever tab happened to be active in the browser
+// at the time (see SavedTabGroupUtils::OpenTabInBrowser()), which isn't a
+// real opener relationship. To avoid nesting restored tabs under that
+// unrelated tab's tree, browser_navigator.cc marks the opener via
+// TabModel::set_opener_was_set_for_empty_new_tab()
+IN_PROC_BROWSER_TEST_F(
+    TreeTabsBrowserTest,
+    AddTabRecursive_OpenerMarkedForEmptyNewTab_DoesNotJoinOpenerTree) {
+  SetTreeTabsEnabled(true);
+
+  tabs::TabInterface* const opener_tab =
+      tab_strip_model().GetTabAtIndex(tab_strip_model().count() - 1);
+  ASSERT_EQ(opener_tab->GetParentCollection()->type(),
+            tabs::TabCollection::Type::TREE_NODE);
+
+  auto tab_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  tab_interface->set_opener(opener_tab);
+  tab_interface->set_opener_was_set_for_empty_new_tab();
+
+  tab_strip_model().AddTab(std::move(tab_interface), -1 /*to the last*/,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+
+  auto* added_tab =
+      tab_strip_model().GetTabAtIndex(tab_strip_model().count() - 1);
+
+  // The opener relationship itself is preserved.
+  // But unlike a normal opener-driven add the tab should not be nested under
+  // opener.
+  EXPECT_EQ(opener_tab, static_cast<tabs::TabModel*>(added_tab)->opener());
+  EXPECT_EQ(added_tab->GetParentCollection()->type(),
+            tabs::TabCollection::Type::TREE_NODE);
+  EXPECT_NE(added_tab->GetParentCollection(),
+            opener_tab->GetParentCollection());
+  EXPECT_EQ(added_tab->GetParentCollection()->GetParentCollection(),
+            &unpinned_collection());
+}
+
 // Regression: opening into the tabbed browser from a popup or app (PWA-like)
 // window can pass an opener tab that belongs to another TabStripModel.
 // https://github.com/brave/brave-browser/issues/54334

--- a/chromium_src/chrome/browser/ui/navigator/browser_navigator.cc
+++ b/chromium_src/chrome/browser/ui/navigator/browser_navigator.cc
@@ -66,6 +66,16 @@ GetStoragePartitionConfigToInherit(const NavigateParams& params) {
 
 #define BRAVE_ADJUST_NAVIGATE_PARAMS_FOR_URL UpdateParams(params);
 
+// Tabs opened from a saved tab group get `source_contents` set to whatever
+// tab happened to be active in the target browser, which is not a real
+// opener relationship. Mark the opener as "for an empty new tab" so the tree
+// tab feature doesn't place these tabs under that unrelated tab, while still
+// keeping the opener for other purposes (e.g. reactivating it on close).
+#define BRAVE_NAVIGATE_MARK_OPENER_FOR_SYNC_NAVIGATION     \
+  if (params->navigation_initiated_from_sync) {            \
+    tab_to_insert->set_opener_was_set_for_empty_new_tab(); \
+  }
+
 #if BUILDFLAG(ENABLE_CONTAINERS)
 #define GetSiteInstanceForNewTab(...)   \
   GetSiteInstanceForNewTab(__VA_ARGS__, \
@@ -79,3 +89,4 @@ GetStoragePartitionConfigToInherit(const NavigateParams& params) {
 #endif  // BUILDFLAG(ENABLE_CONTAINERS)
 
 #undef BRAVE_ADJUST_NAVIGATE_PARAMS_FOR_URL
+#undef BRAVE_NAVIGATE_MARK_OPENER_FOR_SYNC_NAVIGATION

--- a/patches/chrome-browser-ui-navigator-browser_navigator.cc.patch
+++ b/patches/chrome-browser-ui-navigator-browser_navigator.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/navigator/browser_navigator.cc b/chrome/browser/ui/navigator/browser_navigator.cc
-index 67fde190279e188b4c2200cbbac9771ccbc426ec..e93d3e748003229116dce230f2cee40a2a535e2d 100644
+index 67fde190279e188b4c2200cbbac9771ccbc426ec..7aab910217ae5ddf6286706f1ff7517c81c18eb5 100644
 --- a/chrome/browser/ui/navigator/browser_navigator.cc
 +++ b/chrome/browser/ui/navigator/browser_navigator.cc
 @@ -574,6 +574,7 @@ base::WeakPtr<content::NavigationHandle> Navigate(NavigateParams* params) {
@@ -10,3 +10,19 @@ index 67fde190279e188b4c2200cbbac9771ccbc426ec..e93d3e748003229116dce230f2cee40a
  
    // Open System Apps in their standalone window if necessary.
    // TODO(crbug.com/40136163): Remove this code after we integrate with intent
+@@ -813,6 +814,7 @@ base::WeakPtr<content::NavigationHandle> Navigate(NavigateParams* params) {
+          params->user_gesture)) {
+       tab_to_insert->set_opener(
+           tabs::TabInterface::MaybeGetFromContents(params->source_contents));
++      BRAVE_NAVIGATE_MARK_OPENER_FOR_SYNC_NAVIGATION
+     }
+   }
+ 
+@@ -830,6 +832,7 @@ base::WeakPtr<content::NavigationHandle> Navigate(NavigateParams* params) {
+            params->user_gesture)) {
+         tab_to_insert->set_opener(
+             tabs::TabInterface::MaybeGetFromContents(params->source_contents));
++        BRAVE_NAVIGATE_MARK_OPENER_FOR_SYNC_NAVIGATION
+       }
+       contents_to_navigate_or_insert = tab_to_insert->GetContents();
+ 


### PR DESCRIPTION
When a saved tab group is opened, Navigate() sets each new tab's opener to whatever tab happened to be active in the target browser at the time, since SavedTabGroupUtils::OpenTabInBrowser() never supplies a real source_contents. The tree tab feature uses that opener to decide which tree to place a new tab under, so restoring a saved group was grouping its tabs under whichever unrelated tab was active beforehand.

Mark these tabs' opener as "set for an empty new tab" (the same mechanism already used for the TYPED "quick look-up" tab case) so the restored tab groups won't be nested under the unrelated opener.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57164

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
