### PR TITLE
Don't re-add Shield toolbar button for PWA (#38438) (uplift to 1.93.x)

### DIFF
--- a/browser/ui/views/brave_actions/pwa_shields_browsertest.cc
+++ b/browser/ui/views/brave_actions/pwa_shields_browsertest.cc
@@ -51,3 +51,53 @@ IN_PROC_BROWSER_TEST_F(PwaShieldsBrowserTest,
   EXPECT_TRUE(views::IsViewClass<BraveShieldsToolbarButton>(shields));
   EXPECT_TRUE(shields->GetVisible());
 }
+
+// Regression test for https://github.com/brave/brave-browser/issues/57349:
+// macOS immersive fullscreen reparents the web app toolbar (moving it into a
+// separate overlay widget), which re-triggers
+// WebAppToolbarButtonContainer::AddedToWidget(). In this case, we should not
+// add multiple PWA Shields toolbar buttons to the web app window. Note that
+// we are using the same id for the Shield page action view and toolbar button,
+// so the number of views retrieved by BrowserElementsViews::GetAllViews()
+// should remain 2 (1 for the page action view, 1 for the toolbar button) even
+// after the reparenting.
+IN_PROC_BROWSER_TEST_F(PwaShieldsBrowserTest,
+                       ShieldsButtonNotDuplicatedWhenToolbarReparented) {
+  const webapps::AppId app_id = InstallPWA(GetInstallableAppURL());
+  Browser* app_browser = LaunchWebAppBrowser(app_id);
+  ASSERT_TRUE(app_browser);
+
+  auto* elements = BrowserElementsViews::From(app_browser);
+  ASSERT_TRUE(elements);
+  views::View* shields = nullptr;
+  ASSERT_TRUE(base::test::RunUntil([&] {
+    shields = elements->GetView(BraveShieldsActionView::kShieldsActionIcon,
+                                /*require_visible=*/true);
+    return shields != nullptr;
+  }));
+  ASSERT_TRUE(views::IsViewClass<BraveShieldsToolbarButton>(shields));
+
+  views::View* container = shields->parent();
+  ASSERT_TRUE(container);
+  views::View* container_parent = container->parent();
+  ASSERT_TRUE(container_parent);
+
+  // 1 for page action view, 1 for toolbar button
+  ASSERT_EQ(2u, elements
+                    ->GetAllViews(BraveShieldsActionView::kShieldsActionIcon,
+                                  /*require_visible=*/false)
+                    .size());
+
+  // Simulate the transient hidden state and the widget reparenting that
+  // immersive fullscreen performs on macOS - which triggers AddedToWidget
+  shields->SetVisible(false);
+  container_parent->RemoveChildView(container);
+  container_parent->AddChildView(container);
+  shields->SetVisible(true);
+
+  // Shouldn't add another action icon.
+  EXPECT_EQ(2u, elements
+                    ->GetAllViews(BraveShieldsActionView::kShieldsActionIcon,
+                                  /*require_visible=*/false)
+                    .size());
+}

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -80,7 +80,6 @@
 #include "chrome/browser/ui/views/frame/layout/browser_view_layout.h"
 #include "chrome/browser/ui/views/frame/multi_contents_view.h"
 #include "chrome/browser/ui/views/frame/top_container_view.h"
-#include "chrome/browser/ui/views/interaction/browser_elements_views.h"
 #include "chrome/browser/ui/views/side_panel/side_panel.h"
 #include "chrome/browser/ui/views/tab_search_bubble_host.h"
 #include "chrome/browser/ui/views/tabs/shared/tab_strip_combo_button.h"
@@ -1145,26 +1144,15 @@ views::View* BraveBrowserView::side_panel_shadow_overlay_for_testing() {
   return side_panel_shadow_overlay_.get();
 }
 
-// PWA and omnibox Shields share kShieldsActionIcon; the PWA build uses
-// BraveShieldsToolbarButton with that id.
 BraveShieldsToolbarButton* BraveBrowserView::GetPwaShieldsToolbarButton() {
-  BrowserElementsViews* elements = BrowserElementsViews::From(browser());
-  if (!elements) {
-    return nullptr;
-  }
+  return pwa_shields_toolbar_button_.get();
+}
 
-  auto* shield = elements->GetView(BraveShieldsActionView::kShieldsActionIcon,
-                                   /*require_visible=*/true);
-  if (!shield) {
-    return nullptr;
-  }
-
-  if (!views::IsViewClass<BraveShieldsToolbarButton>(shield)) {
-    // This case, BraveShieldsActionView is visible.
-    return nullptr;
-  }
-
-  return views::AsViewClass<BraveShieldsToolbarButton>(shield);
+void BraveBrowserView::SetPwaShieldsToolbarButton(
+    BraveShieldsToolbarButton* button) {
+  CHECK(!pwa_shields_toolbar_button_)
+      << "PWA Shields toolbar button should only be set once";
+  pwa_shields_toolbar_button_ = button;
 }
 
 void BraveBrowserView::OnActiveTabChanged(content::WebContents* old_contents,

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -182,6 +182,12 @@ class BraveBrowserView : public BrowserView,
   // Returns the PWA Shields toolbar button, if it exists. Note that this
   // returns valid pointer only when it's web app browser.
   BraveShieldsToolbarButton* GetPwaShieldsToolbarButton();
+
+  // Should be called once, when the button is first created for this window.
+  // Cached directly here, in order to keep track of the button regardless of
+  // its current widget. (e.g. in macOS immersive fullscreen, the button is
+  // reparented into other widget)
+  void SetPwaShieldsToolbarButton(BraveShieldsToolbarButton* button);
 #endif
 
  private:
@@ -287,6 +293,13 @@ class BraveBrowserView : public BrowserView,
   raw_ptr<views::View> vertical_tab_strip_host_view_ = nullptr;
   raw_ptr<BraveVerticalTabStripContainerView>
       vertical_tab_strip_container_view_ = nullptr;
+
+#if BUILDFLAG(ENABLE_EXTENSIONS)
+  // Caches the PWA Shields toolbar button for this window. Note that this
+  // button could belong to overlay widget in macOS fullscreen. That's why we
+  // cache it here instead of looking it up via BrowserElementsViews.
+  raw_ptr<BraveShieldsToolbarButton> pwa_shields_toolbar_button_;
+#endif
 
 #if defined(USE_AURA)
   raw_ptr<views::View> sidebar_host_view_ = nullptr;

--- a/chromium_src/chrome/browser/ui/views/web_apps/frame_toolbar/web_app_toolbar_button_container.cc
+++ b/chromium_src/chrome/browser/ui/views/web_apps/frame_toolbar/web_app_toolbar_button_container.cc
@@ -18,7 +18,6 @@
 #include "chrome/browser/ui/views/bubble/webui_bubble_manager.h"
 #include "chrome/browser/ui/views/extensions/extensions_toolbar_desktop.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
-#include "chrome/browser/ui/views/interaction/browser_elements_views.h"
 #include "chrome/browser/ui/views/toolbar/pinned_toolbar_actions_container.h"
 #include "chrome/browser/ui/views/toolbar/pinned_toolbar_button_status_indicator.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_action_view.h"
@@ -57,7 +56,9 @@ void MaybeAddPwaShieldsToolbarButton(WebAppToolbarButtonContainer* container) {
     // Page Info owns Shields; do not add a duplicate title-bar control.
     return;
   }
+
   if (BraveBrowserView::From(base_browser_view)->GetPwaShieldsToolbarButton()) {
+    // Already added a PWA Shields toolbar button for this window.
     return;
   }
 
@@ -88,14 +89,14 @@ void MaybeAddPwaShieldsToolbarButton(WebAppToolbarButtonContainer* container) {
       base::BindRepeating(&WebUIBubbleManager::Create<ShieldsPanelUI>));
   ConfigureWebAppToolbarButton(button.get(), frame_toolbar);
 
-  raw_ptr<BraveShieldsToolbarButton> ptr = button.get();
-  container->AddChildViewAt(std::move(button), insert_index);
+  auto* ptr = container->AddChildViewAt(std::move(button), insert_index);
   views::SetHitTestComponent(ptr, static_cast<int>(HTCLIENT));
   ptr->SetProperty(
       views::kFlexBehaviorKey,
       views::FlexSpecification(views::LayoutOrientation::kHorizontal,
                                views::MinimumFlexSizeRule::kPreferredSnapToZero)
           .WithWeight(0));
+  BraveBrowserView::From(base_browser_view)->SetPwaShieldsToolbarButton(ptr);
 }
 
 }  // namespace


### PR DESCRIPTION
* Don't re-add Shield toolbar button for PWA

Previously, we were adding a Shield toolbar button for PWA even if it was already added, whenever AddedToWidget() was called.

<!-- Add brave-browser issue below that this PR will resolve -->

- Uplift of https://github.com/brave/brave-core/pull/38438
- Resolves https://github.com/brave/brave-browser/issues/57349

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
