### PR TITLE
Hide scrollbar on vertical tabs when collapsed with floating mode

### DIFF
--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -29,6 +29,7 @@
 #include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/frame/tab_strip_placement_coordinator.h"
 #include "brave/browser/ui/views/tabs/brave_new_tab_button.h"
+#include "brave/browser/ui/views/tabs/brave_tab_container.h"
 #include "brave/browser/ui/views/tabs/brave_tab_strip_layout_helper.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/vector_icons/vector_icons.h"
@@ -301,6 +302,11 @@ BraveVerticalTabStripRegionView::BraveVerticalTabStripRegionView(
   SetMirrored(false);
   SetNotifyEnterExitOnChild(true);
 
+  if (auto* container =
+          views::AsViewClass<BraveTabContainer>(tab_strip()->tab_container_)) {
+    container->SetVerticalTabStripRegionView(this);
+  }
+
   // The default state is kExpanded, so reset animation state to 1.0.
   width_animation_.Reset(1.0);
 
@@ -411,6 +417,11 @@ BraveVerticalTabStripRegionView::BraveVerticalTabStripRegionView(
 }
 
 BraveVerticalTabStripRegionView::~BraveVerticalTabStripRegionView() {
+  if (auto* container =
+          views::AsViewClass<BraveTabContainer>(tab_strip()->tab_container_)) {
+    // This view can be destroyed before the tab container is destroyed.
+    container->SetVerticalTabStripRegionView(nullptr);
+  }
   // We need to move tab strip region to its original parent to avoid crash
   // during drag and drop session.
   if (auto* coordinator = GetPlacementCoordinator(browser_view_)) {

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -302,10 +302,10 @@ BraveVerticalTabStripRegionView::BraveVerticalTabStripRegionView(
   SetMirrored(false);
   SetNotifyEnterExitOnChild(true);
 
-  if (auto* container =
-          views::AsViewClass<BraveTabContainer>(tab_strip()->tab_container_)) {
-    container->SetVerticalTabStripRegionView(this);
-  }
+  auto* container =
+      views::AsViewClass<BraveTabContainer>(tab_strip()->tab_container_);
+  CHECK(container);
+  container->SetVerticalTabStripRegionView(this);
 
   // The default state is kExpanded, so reset animation state to 1.0.
   width_animation_.Reset(1.0);
@@ -417,11 +417,12 @@ BraveVerticalTabStripRegionView::BraveVerticalTabStripRegionView(
 }
 
 BraveVerticalTabStripRegionView::~BraveVerticalTabStripRegionView() {
-  if (auto* container =
-          views::AsViewClass<BraveTabContainer>(tab_strip()->tab_container_)) {
-    // This view can be destroyed before the tab container is destroyed.
-    container->SetVerticalTabStripRegionView(nullptr);
-  }
+  auto* container =
+      views::AsViewClass<BraveTabContainer>(tab_strip()->tab_container_);
+  CHECK(container);
+  // This view can be destroyed before the tab container is destroyed.
+  container->SetVerticalTabStripRegionView(nullptr);
+
   // We need to move tab strip region to its original parent to avoid crash
   // during drag and drop session.
   if (auto* coordinator = GetPlacementCoordinator(browser_view_)) {

--- a/browser/ui/views/tabs/BUILD.gn
+++ b/browser/ui/views/tabs/BUILD.gn
@@ -19,6 +19,8 @@ source_set("browser_tests") {
     "//base",
     "//base/test:test_support",
     "//brave/browser/ui:brave_tab_prefs",
+    "//brave/browser/ui/tabs:tabs_public",
+    "//brave/browser/ui/views/frame/vertical_tabs",
     "//chrome:resources",
     "//chrome:strings",
     "//chrome/browser",

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -22,7 +22,7 @@
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/tabs/public/vertical_tab_controller.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
-#include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_container_view.h"
+#include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h"
 #include "brave/browser/ui/views/tabs/brave_tab.h"
 #include "brave/browser/ui/views/tabs/brave_tab_group_header.h"
 #include "brave/browser/ui/views/tabs/brave_tab_strip.h"
@@ -128,6 +128,10 @@ BraveTabContainer::BraveTabContainer(
       brave_tabs::kVerticalTabsShowScrollbar, prefs,
       base::BindRepeating(&BraveTabContainer::UpdateScrollBarVisibility,
                           base::Unretained(this)));
+  floating_mode_pref_.Init(
+      brave_tabs::kVerticalTabsFloatingEnabled, prefs,
+      base::BindRepeating(&BraveTabContainer::UpdateScrollBarVisibility,
+                          base::Unretained(this)));
 
   // Create separator view between pinned and unpinned tabs
   separator_ = AddChildView(std::make_unique<views::View>());
@@ -169,14 +173,34 @@ bool BraveTabContainer::ShouldShowVerticalTabs() const {
   return vtc && vtc->ShouldShowBraveVerticalTabs();
 }
 
+void BraveTabContainer::SetVerticalTabStripRegionView(
+    BraveVerticalTabStripRegionView* region_view) {
+  vertical_tab_strip_region_view_ = region_view;
+}
+
 views::ScrollView::ScrollBarMode BraveTabContainer::GetScrollBarMode() const {
   if (!ShouldShowVerticalTabs()) {
     return views::ScrollView::ScrollBarMode::kDisabled;
   }
 
-  return *should_show_scroll_bar_
-             ? views::ScrollView::ScrollBarMode::kEnabled
-             : views::ScrollView::ScrollBarMode::kHiddenButEnabled;
+  if (!*should_show_scroll_bar_) {
+    return views::ScrollView::ScrollBarMode::kHiddenButEnabled;
+  }
+
+  // Even when the scroll bar pref is on, don't show it while the vertical
+  // tab strip is collapsed to a floating mode. It's because when a user tries
+  // to grab the scrollbar, vertical tab will be expanded so showing scroll bar
+  // has no point.
+  auto* vtc = VerticalTabController::FromBrowser(
+      tab_slot_controller_->GetBrowserWindowInterface());
+  if (vtc && vtc->IsFloatingVerticalTabsEnabled() &&
+      vertical_tab_strip_region_view_ &&
+      vertical_tab_strip_region_view_->state() ==
+          BraveVerticalTabStripRegionView::State::kCollapsed) {
+    return views::ScrollView::ScrollBarMode::kHiddenButEnabled;
+  }
+
+  return views::ScrollView::ScrollBarMode::kEnabled;
 }
 
 gfx::Size BraveTabContainer::CalculatePreferredSize(

--- a/browser/ui/views/tabs/brave_tab_container.h
+++ b/browser/ui/views/tabs/brave_tab_container.h
@@ -26,6 +26,8 @@ namespace views {
 class ScrollView;
 }  // namespace views
 
+class BraveVerticalTabStripRegionView;
+
 class BraveTabContainer : public TabContainerImpl,
                           public views::ScrollBarController {
   METADATA_HEADER(BraveTabContainer, TabContainerImpl)
@@ -45,6 +47,12 @@ class BraveTabContainer : public TabContainerImpl,
 
   // Returns the ScrollBarMode for the scroll view used in vertical tab strip.
   views::ScrollView::ScrollBarMode GetScrollBarMode() const;
+
+  // Injected by BraveVerticalTabStripRegionView so this container can query
+  // the vertical tab strip's collapsed/expanded/floating state without
+  // depending on Browser/BrowserView lookups. Pass nullptr on teardown.
+  void SetVerticalTabStripRegionView(
+      BraveVerticalTabStripRegionView* region_view);
 
   // Returns the scroll direction if scrolling is enabled. Returns nullopt if
   // browser is null or scrolling is not enabled.
@@ -313,7 +321,14 @@ class BraveTabContainer : public TabContainerImpl,
   BooleanPrefMember show_vertical_tabs_;
   BooleanPrefMember tree_tabs_enabled_;
   BooleanPrefMember should_show_scroll_bar_;
+  BooleanPrefMember floating_mode_pref_;
   BooleanPrefMember scrollable_horizontal_tab_strip_;
+
+  // Injected via SetVerticalTabStripRegionView() by the
+  // BraveVerticalTabStripRegionView wrapping this tab strip. Used to look up
+  // the vertical tab strip's collapsed/expanded state.
+  raw_ptr<BraveVerticalTabStripRegionView> vertical_tab_strip_region_view_ =
+      nullptr;
 
   bool layout_locked_ = false;
 

--- a/browser/ui/views/tabs/brave_tab_container_browsertest.cc
+++ b/browser/ui/views/tabs/brave_tab_container_browsertest.cc
@@ -12,9 +12,13 @@
 #include "base/task/sequenced_task_runner.h"
 #include "base/test/run_until.h"
 #include "base/test/scoped_feature_list.h"
+#include "brave/browser/ui/browser_commands.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
+#include "brave/browser/ui/tabs/public/vertical_tab_controller.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/brave_tab_strip_region_view.h"
+#include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_container_view.h"
+#include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h"
 #include "brave/browser/ui/views/tabs/brave_tab_strip.h"
 #include "chrome/browser/defaults.h"
 #include "chrome/browser/profiles/profile.h"
@@ -774,4 +778,118 @@ IN_PROC_BROWSER_TEST_F(HorizontalScrollableTabStripBrowserTest,
   ASSERT_EQ(back->GetState(), views::Button::STATE_NORMAL);
   EXPECT_EQ(views::InkDrop::Get(back)->GetMode(),
             views::InkDropHost::InkDropMode::ON);
+}
+
+class VerticalTabsScrollBarModeBrowserTest : public InProcessBrowserTest {
+ public:
+  BraveBrowserView* browser_view() {
+    return static_cast<BraveBrowserView*>(browser()->window());
+  }
+
+  BraveTabContainer* container() {
+    return views::AsViewClass<BraveTabContainer>(
+        views::AsViewClass<BraveTabStrip>(
+            browser_view()->horizontal_tab_strip_for_testing())
+            ->GetTabContainerForTesting());
+  }
+
+  BraveVerticalTabStripRegionView* region_view() {
+    auto* container_view = browser_view()->vertical_tab_strip_container_view();
+    return container_view ? container_view->vertical_tab_strip_region_view()
+                          : nullptr;
+  }
+
+  void ToggleVerticalTabStrip() { brave::ToggleVerticalTabStrip(browser()); }
+};
+
+// When the vertical tab strip is collapsed while floating mode is enabled,
+// the scrollbar shouldn't be shown since hovering over it would expand the
+// strip anyway.
+IN_PROC_BROWSER_TEST_F(VerticalTabsScrollBarModeBrowserTest,
+                       ScrollBarHiddenWhenCollapsedWithFloatingMode) {
+  ToggleVerticalTabStrip();
+
+  auto* prefs = browser()->profile()->GetPrefs();
+  prefs->SetBoolean(brave_tabs::kVerticalTabsShowScrollbar, true);
+
+  auto* vtc = VerticalTabController::FromBrowser(browser());
+  ASSERT_TRUE(vtc);
+  ASSERT_TRUE(vtc->IsFloatingVerticalTabsEnabled())
+      << "Floating mode is enabled by default";
+
+  auto* container_view = container();
+  ASSERT_TRUE(container_view);
+  auto* region = region_view();
+  ASSERT_TRUE(region);
+
+  using State = BraveVerticalTabStripRegionView::State;
+  ASSERT_EQ(State::kExpanded, region->state());
+  EXPECT_EQ(views::ScrollView::ScrollBarMode::kEnabled,
+            container_view->GetScrollBarMode())
+      << "Scrollbar should be shown while expanded, even in floating mode";
+
+  // Collapse the strip while floating mode is still enabled.
+  prefs->SetBoolean(brave_tabs::kVerticalTabsCollapsed, true);
+  ASSERT_EQ(State::kCollapsed, region->state());
+  EXPECT_EQ(views::ScrollView::ScrollBarMode::kHiddenButEnabled,
+            container_view->GetScrollBarMode())
+      << "Scrollbar should be hidden while collapsed in floating mode";
+
+  // Re-expanding should bring the scrollbar back.
+  prefs->SetBoolean(brave_tabs::kVerticalTabsCollapsed, false);
+  ASSERT_EQ(State::kExpanded, region->state());
+  EXPECT_EQ(views::ScrollView::ScrollBarMode::kEnabled,
+            container_view->GetScrollBarMode());
+}
+
+// When floating mode is disabled, collapsing the vertical tab strip doesn't
+// hide the tabs behind a hover-to-expand affordance, so the scrollbar should
+// remain visible.
+IN_PROC_BROWSER_TEST_F(VerticalTabsScrollBarModeBrowserTest,
+                       ScrollBarVisibleWhenCollapsedWithoutFloatingMode) {
+  ToggleVerticalTabStrip();
+
+  auto* prefs = browser()->profile()->GetPrefs();
+  prefs->SetBoolean(brave_tabs::kVerticalTabsShowScrollbar, true);
+  prefs->SetBoolean(brave_tabs::kVerticalTabsFloatingEnabled, false);
+
+  auto* vtc = VerticalTabController::FromBrowser(browser());
+  ASSERT_TRUE(vtc);
+  ASSERT_FALSE(vtc->IsFloatingVerticalTabsEnabled());
+
+  auto* container_view = container();
+  ASSERT_TRUE(container_view);
+  auto* region = region_view();
+  ASSERT_TRUE(region);
+
+  using State = BraveVerticalTabStripRegionView::State;
+  prefs->SetBoolean(brave_tabs::kVerticalTabsCollapsed, true);
+  ASSERT_EQ(State::kCollapsed, region->state());
+  EXPECT_EQ(views::ScrollView::ScrollBarMode::kEnabled,
+            container_view->GetScrollBarMode())
+      << "Without floating mode, collapsing shouldn't hide the scrollbar";
+}
+
+// When the scrollbar pref itself is off, collapsing/floating state shouldn't
+// matter: GetScrollBarMode() should stay kHiddenButEnabled.
+IN_PROC_BROWSER_TEST_F(VerticalTabsScrollBarModeBrowserTest,
+                       ScrollBarStaysHiddenWhenPrefOffRegardlessOfState) {
+  ToggleVerticalTabStrip();
+
+  auto* prefs = browser()->profile()->GetPrefs();
+  ASSERT_FALSE(prefs->GetBoolean(brave_tabs::kVerticalTabsShowScrollbar));
+
+  auto* container_view = container();
+  ASSERT_TRUE(container_view);
+  auto* region = region_view();
+  ASSERT_TRUE(region);
+
+  using State = BraveVerticalTabStripRegionView::State;
+  EXPECT_EQ(views::ScrollView::ScrollBarMode::kHiddenButEnabled,
+            container_view->GetScrollBarMode());
+
+  prefs->SetBoolean(brave_tabs::kVerticalTabsCollapsed, true);
+  ASSERT_EQ(State::kCollapsed, region->state());
+  EXPECT_EQ(views::ScrollView::ScrollBarMode::kHiddenButEnabled,
+            container_view->GetScrollBarMode());
 }


### PR DESCRIPTION
When vertical tab is collapsed with floating mode, we don't have to show scroll bar, as the vtab will be expanded when user tries to grab the scrollbar.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/56114

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
