### PR TITLE
Add best practice for rebase_path usage

### DIFF
--- a/docs/best-practices/build-system.md
+++ b/docs/best-practices/build-system.md
@@ -1114,10 +1114,10 @@ to suppress circular include errors. See [`gni_sources.md`](../gni_sources.md)
 
 ## ❌ Don't Use System-Absolute Paths in Ninja Arguments
 
-**Never use a system-absolute path for anything that will appear in Ninja
-arguments. When calling `rebase_path()`, pass the path's expected base as
-`new_base`—usually `root_build_dir` for GN actions—so the generated Ninja file
-uses a relative, relocatable path.**
+**Targets that are part of the Brave build must never use a system-absolute
+path in Ninja arguments. When calling `rebase_path()`, pass the path's expected
+base as `new_base`—usually `root_build_dir` for GN actions—so the generated
+Ninja file uses a relative, relocatable path.**
 
 ```gn
 # ❌ WRONG - the default empty new_base produces a system-absolute path
@@ -1128,10 +1128,13 @@ args = [ "--output=" + rebase_path(output, root_build_dir) ]
 ```
 
 One-argument `rebase_path()` produces a system-absolute, checkout-specific path,
-so never use it for a value that will appear in Ninja arguments. Such paths can
-interfere with remote build execution and fail when build artifacts are reused
-from a cloned or relocated checkout. If a tool changes its working directory,
-rebase to that directory rather than blindly using `root_build_dir`. See GN's
+so never use it in Ninja arguments for a target that is part of the Brave build.
+Such paths can interfere with remote build execution and fail when build
+artifacts are reused from a cloned or relocated checkout. The exceptions are
+host-side tooling and targets that generate wrapper scripts or configuration
+exclusively for local developer use and never run on a remote bot worker. If a
+tool changes its working directory, rebase to that directory rather than
+blindly using `root_build_dir`. See GN's
 [`rebase_path()` reference](https://gn.googlesource.com/gn/+/master/docs/reference.md#func_rebase_path)
 for the complete API contract.
 

--- a/docs/best-practices/build-system.md
+++ b/docs/best-practices/build-system.md
@@ -1109,3 +1109,31 @@ Only fall back to `brave_chrome_browser_ui_allow_circular_includes_from` /
 `sources.gni` as a temporary last resort, and never use `check_includes = false`
 to suppress circular include errors. See [`gni_sources.md`](../gni_sources.md)
 (Circular dependencies).
+
+<a id="BS-058"></a>
+
+## ❌ Don't Use One-Argument `rebase_path()` for Build Command Paths
+
+**When passing a path to a build command, don't call `rebase_path()` with only
+the input. Pass the command's expected working directory as `new_base`—usually
+`root_build_dir` for GN actions—so the generated command line uses a relative,
+relocatable path.**
+
+```gn
+# ❌ WRONG - the default empty new_base produces a system-absolute path
+args = [ "--output=" + rebase_path(output) ]
+
+# ✅ CORRECT - rebase relative to the command's working directory
+args = [ "--output=" + rebase_path(output, root_build_dir) ]
+```
+
+One-argument `rebase_path()` is appropriate only when the consumer explicitly
+requires a system-absolute path. Otherwise it embeds a checkout-specific path in
+the command line, which can interfere with remote build execution and fail when
+build artifacts are reused from a cloned or relocated checkout. If a tool
+changes its working directory, rebase to that directory rather than blindly
+using `root_build_dir`. See GN's
+[`rebase_path()` reference](https://gn.googlesource.com/gn/+/master/docs/reference.md#func_rebase_path)
+for the complete API contract.
+
+---

--- a/docs/best-practices/build-system.md
+++ b/docs/best-practices/build-system.md
@@ -1130,11 +1130,11 @@ args = [ "--output=" + rebase_path(output, root_build_dir) ]
 One-argument `rebase_path()` produces a system-absolute, checkout-specific path,
 so never use it for a target that is part of the Brave build. Such paths can
 interfere with remote build execution and fail when build artifacts are reused
-from a cloned or relocated checkout. The exceptions are
-host-side tooling and targets that generate wrapper scripts or configuration
-exclusively for local developer use and never run on a remote bot worker. If a
-tool changes its working directory, rebase to that directory rather than
-blindly using `root_build_dir`. See GN's
+from a cloned or relocated checkout. The exceptions are host-side tooling and
+targets that generate wrapper scripts or configuration exclusively for local
+developer use and never run on a remote bot worker. If a tool changes its
+working directory, rebase to that directory rather than blindly using
+`root_build_dir`. See GN's
 [`rebase_path()` reference](https://gn.googlesource.com/gn/+/master/docs/reference.md#func_rebase_path)
 for the complete API contract.
 

--- a/docs/best-practices/build-system.md
+++ b/docs/best-practices/build-system.md
@@ -1134,7 +1134,9 @@ from a cloned or relocated checkout. The exceptions are host-side tooling and
 targets that generate wrapper scripts or configuration exclusively for local
 developer use and never run on a remote bot worker. If a tool changes its
 working directory, rebase to that directory rather than blindly using
-`root_build_dir`. See GN's
+`root_build_dir`. When a tool requires an absolute path, invoke it through a
+wrapper script that receives relative path arguments and converts them to
+absolute paths at runtime. See GN's
 [`rebase_path()` reference](https://gn.googlesource.com/gn/+/master/docs/reference.md#func_rebase_path)
 for the complete API contract.
 

--- a/docs/best-practices/build-system.md
+++ b/docs/best-practices/build-system.md
@@ -1112,12 +1112,12 @@ to suppress circular include errors. See [`gni_sources.md`](../gni_sources.md)
 
 <a id="BS-058"></a>
 
-## ❌ Don't Use System-Absolute Paths in Ninja Arguments
+## ❌ Don't Use System-Absolute Paths in GN
 
-**Targets that are part of the Brave build must never use a system-absolute
-path in Ninja arguments. When calling `rebase_path()`, pass the path's expected
-base as `new_base`—usually `root_build_dir` for GN actions—so the generated
-Ninja file uses a relative, relocatable path.**
+**Targets that are part of the Brave build must never use system-absolute paths
+in GN. When calling `rebase_path()`, pass the path's expected base as
+`new_base`—usually `root_build_dir` for GN actions—so the generated Ninja file
+uses a relative, relocatable path.**
 
 ```gn
 # ❌ WRONG - the default empty new_base produces a system-absolute path
@@ -1128,9 +1128,9 @@ args = [ "--output=" + rebase_path(output, root_build_dir) ]
 ```
 
 One-argument `rebase_path()` produces a system-absolute, checkout-specific path,
-so never use it in Ninja arguments for a target that is part of the Brave build.
-Such paths can interfere with remote build execution and fail when build
-artifacts are reused from a cloned or relocated checkout. The exceptions are
+so never use it for a target that is part of the Brave build. Such paths can
+interfere with remote build execution and fail when build artifacts are reused
+from a cloned or relocated checkout. The exceptions are
 host-side tooling and targets that generate wrapper scripts or configuration
 exclusively for local developer use and never run on a remote bot worker. If a
 tool changes its working directory, rebase to that directory rather than

--- a/docs/best-practices/build-system.md
+++ b/docs/best-practices/build-system.md
@@ -1112,12 +1112,12 @@ to suppress circular include errors. See [`gni_sources.md`](../gni_sources.md)
 
 <a id="BS-058"></a>
 
-## ❌ Don't Use One-Argument `rebase_path()` for Build Command Paths
+## ❌ Don't Use System-Absolute Paths in Ninja Arguments
 
-**When passing a path to a build command, don't call `rebase_path()` with only
-the input. Pass the command's expected working directory as `new_base`—usually
-`root_build_dir` for GN actions—so the generated command line uses a relative,
-relocatable path.**
+**Never use a system-absolute path for anything that will appear in Ninja
+arguments. When calling `rebase_path()`, pass the path's expected base as
+`new_base`—usually `root_build_dir` for GN actions—so the generated Ninja file
+uses a relative, relocatable path.**
 
 ```gn
 # ❌ WRONG - the default empty new_base produces a system-absolute path
@@ -1127,12 +1127,11 @@ args = [ "--output=" + rebase_path(output) ]
 args = [ "--output=" + rebase_path(output, root_build_dir) ]
 ```
 
-One-argument `rebase_path()` is appropriate only when the consumer explicitly
-requires a system-absolute path. Otherwise it embeds a checkout-specific path in
-the command line, which can interfere with remote build execution and fail when
-build artifacts are reused from a cloned or relocated checkout. If a tool
-changes its working directory, rebase to that directory rather than blindly
-using `root_build_dir`. See GN's
+One-argument `rebase_path()` produces a system-absolute, checkout-specific path,
+so never use it for a value that will appear in Ninja arguments. Such paths can
+interfere with remote build execution and fail when build artifacts are reused
+from a cloned or relocated checkout. If a tool changes its working directory,
+rebase to that directory rather than blindly using `root_build_dir`. See GN's
 [`rebase_path()` reference](https://gn.googlesource.com/gn/+/master/docs/reference.md#func_rebase_path)
 for the complete API contract.
 


### PR DESCRIPTION
## Summary
- adds best practice **BS-058** prohibiting system-absolute paths in Ninja arguments for targets that are part of the Brave build
- recommends rebasing against the command’s working directory to keep paths relative and relocatable
- documents exceptions for host-side tooling and targets that generate local-only wrapper scripts or configuration

## Context
Motivated by the path portability and remote build execution issues addressed in https://github.com/brave/brave-core/pull/38738.
