### PR TITLE
Drop the WASM-era EmbeddingGemma model paths

### DIFF
--- a/browser/history_embeddings/brave_passage_embeddings_service_controller.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service_controller.cc
@@ -23,10 +23,6 @@ namespace passage_embeddings {
 
 namespace {
 
-// The LiteRT model files ship in the shared EmbeddingGemma component, under a
-// litert/ subdir of its model dir.
-constexpr char kLitertModelSubdir[] = "litert";
-
 // Launches the sandboxed Passage Embeddings utility process, whose LoadModels
 // is chromium_src-overridden to run EmbeddingGemma on LiteRT's CompiledModel
 // inside that process.
@@ -77,12 +73,12 @@ bool BravePassageEmbeddingsServiceController::MaybeUpdateModelInfo(
 
 void BravePassageEmbeddingsServiceController::OnLocalModelsReady(
     const base::FilePath& install_dir) {
-  // The component ships the LiteRT model under a litert/ subdir, laid out the
-  // way optimization guide expects: model.tflite, model-info.pb, and the
-  // SentencePiece model listed in its additional_files. Loading it here reads
-  // the version and the embedder metadata from the component rather than
-  // hard-coding them, and reports no model at all when an older component (or
-  // a withheld download) leaves any of those files missing.
+  // The component ships the LiteRT model in optimization guide's own layout:
+  // model.tflite, model-info.pb, and the SentencePiece model listed in its
+  // additional_files. Loading it here reads the version and the embedder
+  // metadata from the component rather than hard-coding them, and reports no
+  // model at all when an older component (or a withheld download) leaves any
+  // of those files missing.
   base::ThreadPool::PostTaskAndReplyWithResult(
       FROM_HERE,
       {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
@@ -91,8 +87,7 @@ void BravePassageEmbeddingsServiceController::OnLocalModelsReady(
           &optimization_guide::LoadAndVerifyModelInfoOffThread,
           optimization_guide::proto::OPTIMIZATION_TARGET_PASSAGE_EMBEDDER,
           local_ai::LocalModelsUpdaterState::GetInstance()
-              ->GetEmbeddingGemmaModelDir()
-              .AppendASCII(kLitertModelSubdir)),
+              ->GetEmbeddingGemmaLitertDir()),
       base::BindOnce(
           &BravePassageEmbeddingsServiceController::OnLitertModelInfoLoaded,
           base::Unretained(this)));

--- a/components/local_ai/core/local_models_updater.cc
+++ b/components/local_ai/core/local_models_updater.cc
@@ -147,10 +147,11 @@ void LocalModelsUpdaterState::SetInstallDir(const base::FilePath& install_dir) {
   }
   install_dir_ = install_dir;
   if (install_dir.empty()) {
-    embeddinggemma_model_dir_ = base::FilePath();
+    embeddinggemma_litert_dir_ = base::FilePath();
     return;
   }
-  embeddinggemma_model_dir_ = install_dir_.AppendASCII(kEmbeddingGemmaModelDir);
+  embeddinggemma_litert_dir_ = install_dir_.AppendASCII(kEmbeddingGemmaModelDir)
+                                   .AppendASCII(kEmbeddingGemmaLitertDir);
 
   observers_.Notify(&Observer::OnLocalModelsReady, install_dir_);
 }
@@ -159,9 +160,9 @@ const base::FilePath& LocalModelsUpdaterState::GetInstallDir() const {
   return install_dir_;
 }
 
-const base::FilePath& LocalModelsUpdaterState::GetEmbeddingGemmaModelDir()
+const base::FilePath& LocalModelsUpdaterState::GetEmbeddingGemmaLitertDir()
     const {
-  return embeddinggemma_model_dir_;
+  return embeddinggemma_litert_dir_;
 }
 
 LocalModelsUpdaterState::LocalModelsUpdaterState() = default;

--- a/components/local_ai/core/local_models_updater.cc
+++ b/components/local_ai/core/local_models_updater.cc
@@ -148,26 +148,9 @@ void LocalModelsUpdaterState::SetInstallDir(const base::FilePath& install_dir) {
   install_dir_ = install_dir;
   if (install_dir.empty()) {
     embeddinggemma_model_dir_ = base::FilePath();
-    embeddinggemma_model_path_ = base::FilePath();
-    embeddinggemma_dense1_path_ = base::FilePath();
-    embeddinggemma_dense2_path_ = base::FilePath();
-    embeddinggemma_config_path_ = base::FilePath();
-    embeddinggemma_tokenizer_path_ = base::FilePath();
     return;
   }
   embeddinggemma_model_dir_ = install_dir_.AppendASCII(kEmbeddingGemmaModelDir);
-  embeddinggemma_model_path_ =
-      embeddinggemma_model_dir_.AppendASCII(kEmbeddingGemmaModelFile);
-  embeddinggemma_dense1_path_ =
-      embeddinggemma_model_dir_.AppendASCII(kEmbeddingGemmaDense1Dir)
-          .AppendASCII(kEmbeddingGemmaDenseModelFile);
-  embeddinggemma_dense2_path_ =
-      embeddinggemma_model_dir_.AppendASCII(kEmbeddingGemmaDense2Dir)
-          .AppendASCII(kEmbeddingGemmaDenseModelFile);
-  embeddinggemma_config_path_ =
-      embeddinggemma_model_dir_.AppendASCII(kEmbeddingGemmaConfigFile);
-  embeddinggemma_tokenizer_path_ =
-      embeddinggemma_model_dir_.AppendASCII(kEmbeddingGemmaTokenizerFile);
 
   observers_.Notify(&Observer::OnLocalModelsReady, install_dir_);
 }
@@ -179,27 +162,6 @@ const base::FilePath& LocalModelsUpdaterState::GetInstallDir() const {
 const base::FilePath& LocalModelsUpdaterState::GetEmbeddingGemmaModelDir()
     const {
   return embeddinggemma_model_dir_;
-}
-
-const base::FilePath& LocalModelsUpdaterState::GetEmbeddingGemmaModel() const {
-  return embeddinggemma_model_path_;
-}
-
-const base::FilePath& LocalModelsUpdaterState::GetEmbeddingGemmaDense1() const {
-  return embeddinggemma_dense1_path_;
-}
-
-const base::FilePath& LocalModelsUpdaterState::GetEmbeddingGemmaDense2() const {
-  return embeddinggemma_dense2_path_;
-}
-
-const base::FilePath& LocalModelsUpdaterState::GetEmbeddingGemmaConfig() const {
-  return embeddinggemma_config_path_;
-}
-
-const base::FilePath& LocalModelsUpdaterState::GetEmbeddingGemmaTokenizer()
-    const {
-  return embeddinggemma_tokenizer_path_;
 }
 
 LocalModelsUpdaterState::LocalModelsUpdaterState() = default;

--- a/components/local_ai/core/local_models_updater.h
+++ b/components/local_ai/core/local_models_updater.h
@@ -34,12 +34,6 @@ class ComponentUpdateService;
 namespace local_ai {
 
 inline constexpr char kEmbeddingGemmaModelDir[] = "embeddinggemma-300m";
-inline constexpr char kEmbeddingGemmaModelFile[] = "model.gguf";
-inline constexpr char kEmbeddingGemmaConfigFile[] = "config.json";
-inline constexpr char kEmbeddingGemmaTokenizerFile[] = "tokenizer.json";
-inline constexpr char kEmbeddingGemmaDense1Dir[] = "2_Dense";
-inline constexpr char kEmbeddingGemmaDense2Dir[] = "3_Dense";
-inline constexpr char kEmbeddingGemmaDenseModelFile[] = "model.safetensors";
 
 // Exposed for testing - follows upstream Chromium pattern.
 class LocalModelsComponentInstallerPolicy
@@ -92,11 +86,6 @@ class LocalModelsUpdaterState {
   const base::FilePath& GetInstallDir() const;
 
   const base::FilePath& GetEmbeddingGemmaModelDir() const;
-  const base::FilePath& GetEmbeddingGemmaModel() const;
-  const base::FilePath& GetEmbeddingGemmaDense1() const;
-  const base::FilePath& GetEmbeddingGemmaDense2() const;
-  const base::FilePath& GetEmbeddingGemmaConfig() const;
-  const base::FilePath& GetEmbeddingGemmaTokenizer() const;
 
  private:
   friend base::NoDestructor<LocalModelsUpdaterState>;
@@ -105,11 +94,6 @@ class LocalModelsUpdaterState {
 
   base::FilePath install_dir_;
   base::FilePath embeddinggemma_model_dir_;
-  base::FilePath embeddinggemma_model_path_;
-  base::FilePath embeddinggemma_dense1_path_;
-  base::FilePath embeddinggemma_dense2_path_;
-  base::FilePath embeddinggemma_config_path_;
-  base::FilePath embeddinggemma_tokenizer_path_;
 
   base::ObserverList<Observer> observers_;
 

--- a/components/local_ai/core/local_models_updater.h
+++ b/components/local_ai/core/local_models_updater.h
@@ -34,6 +34,10 @@ class ComponentUpdateService;
 namespace local_ai {
 
 inline constexpr char kEmbeddingGemmaModelDir[] = "embeddinggemma-300m";
+// The LiteRT model files sit in a subdir of the model dir, and stay there: the
+// component keeps shipping the files at the top level for the older Brave
+// versions that still read them.
+inline constexpr char kEmbeddingGemmaLitertDir[] = "litert";
 
 // Exposed for testing - follows upstream Chromium pattern.
 class LocalModelsComponentInstallerPolicy
@@ -85,7 +89,9 @@ class LocalModelsUpdaterState {
   void SetInstallDir(const base::FilePath& install_dir);
   const base::FilePath& GetInstallDir() const;
 
-  const base::FilePath& GetEmbeddingGemmaModelDir() const;
+  // Dir the LiteRT EmbeddingGemma model ships in, holding model.tflite,
+  // model-info.pb and the SentencePiece model.
+  const base::FilePath& GetEmbeddingGemmaLitertDir() const;
 
  private:
   friend base::NoDestructor<LocalModelsUpdaterState>;
@@ -93,7 +99,7 @@ class LocalModelsUpdaterState {
   ~LocalModelsUpdaterState();
 
   base::FilePath install_dir_;
-  base::FilePath embeddinggemma_model_dir_;
+  base::FilePath embeddinggemma_litert_dir_;
 
   base::ObserverList<Observer> observers_;
 

--- a/components/local_ai/core/local_models_updater_unittest.cc
+++ b/components/local_ai/core/local_models_updater_unittest.cc
@@ -97,7 +97,7 @@ TEST_F(LocalModelsUpdaterUnitTest, Register) {
   run_loop.Run();
 }
 
-// Tests that ComponentReady sets up the install directory and model paths.
+// Tests that ComponentReady sets up the install directory and model dir.
 TEST_F(LocalModelsUpdaterUnitTest, ComponentReady) {
   LocalModelsComponentInstallerPolicy policy;
   policy.ComponentReady(base::Version("1.0.0"), install_dir_,
@@ -107,23 +107,8 @@ TEST_F(LocalModelsUpdaterUnitTest, ComponentReady) {
   ASSERT_TRUE(base::test::RunUntil(
       [&]() { return state->GetInstallDir() == install_dir_; }));
   EXPECT_EQ(state->GetInstallDir(), install_dir_);
-
-  // Verify embeddinggemma paths are set correctly
-  base::FilePath expected_model_dir =
-      install_dir_.AppendASCII(kEmbeddingGemmaModelDir);
-  EXPECT_EQ(state->GetEmbeddingGemmaModelDir(), expected_model_dir);
-
-  base::FilePath expected_model =
-      expected_model_dir.AppendASCII(kEmbeddingGemmaModelFile);
-  EXPECT_EQ(state->GetEmbeddingGemmaModel(), expected_model);
-
-  base::FilePath expected_config =
-      expected_model_dir.AppendASCII(kEmbeddingGemmaConfigFile);
-  EXPECT_EQ(state->GetEmbeddingGemmaConfig(), expected_config);
-
-  base::FilePath expected_tokenizer =
-      expected_model_dir.AppendASCII(kEmbeddingGemmaTokenizerFile);
-  EXPECT_EQ(state->GetEmbeddingGemmaTokenizer(), expected_tokenizer);
+  EXPECT_EQ(state->GetEmbeddingGemmaModelDir(),
+            install_dir_.AppendASCII(kEmbeddingGemmaModelDir));
 }
 
 // Tests that the component directory is deleted when the feature is disabled.

--- a/components/local_ai/core/local_models_updater_unittest.cc
+++ b/components/local_ai/core/local_models_updater_unittest.cc
@@ -97,7 +97,7 @@ TEST_F(LocalModelsUpdaterUnitTest, Register) {
   run_loop.Run();
 }
 
-// Tests that ComponentReady sets up the install directory and model dir.
+// Tests that ComponentReady sets up the install directory and the model dir.
 TEST_F(LocalModelsUpdaterUnitTest, ComponentReady) {
   LocalModelsComponentInstallerPolicy policy;
   policy.ComponentReady(base::Version("1.0.0"), install_dir_,
@@ -107,8 +107,9 @@ TEST_F(LocalModelsUpdaterUnitTest, ComponentReady) {
   ASSERT_TRUE(base::test::RunUntil(
       [&]() { return state->GetInstallDir() == install_dir_; }));
   EXPECT_EQ(state->GetInstallDir(), install_dir_);
-  EXPECT_EQ(state->GetEmbeddingGemmaModelDir(),
-            install_dir_.AppendASCII(kEmbeddingGemmaModelDir));
+  EXPECT_EQ(state->GetEmbeddingGemmaLitertDir(),
+            install_dir_.AppendASCII(kEmbeddingGemmaModelDir)
+                .AppendASCII(kEmbeddingGemmaLitertDir));
 }
 
 // Tests that the component directory is deleted when the feature is disabled.


### PR DESCRIPTION
Leftover from https://github.com/brave/brave-core/pull/38375, which removed the
Candle/WASM embedder: it read the GGUF weights, the two dense layers,
`config.json` and `tokenizer.json`, and the paths it resolved have been unread
since. `LocalModelsUpdaterState` now keeps only the dir the LiteRT model ships
in, and resolves the `litert/` subdir itself instead of leaving that to the
controller.

Browser-side only — the component keeps shipping those files for the older Brave
versions that still read them, so nothing changes on
https://github.com/brave/leo-local-models.
