### PR TITLE
[iOS] Add missing `URLPartinessScriptHandler` to `DetachedTabPrivacyHelper` (uplift to 1.94.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/DetachedTabPrivacyHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/DetachedTabPrivacyHelper.swift
@@ -49,6 +49,7 @@ class DetachedTabPrivacyHelper: TabPolicyDecider {
       RequestBlockingContentScriptHandler(),
       SiteStateListenerScriptHandler(),
       CosmeticFiltersScriptHandler(),
+      URLPartinessScriptHandler(),
     ]
     if let contentBlocker = tab.browserData?.contentBlocker {
       privacyRelatedScripts.append(contentBlocker)


### PR DESCRIPTION
Uplift of #38780
Resolves https://github.com/brave/brave-browser/issues/57842

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.