### PR TITLE
[Android] Fixed back gesture in Password Manager search

### DIFF
--- a/android/java/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
+++ b/android/java/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
@@ -23,6 +23,8 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 
+import androidx.activity.OnBackPressedCallback;
+import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.FragmentManager;
 import androidx.preference.Preference;
@@ -135,6 +137,25 @@ public class PasswordSettings extends ChromeBaseSettingsFragment
     private final ImportFlow mImportFlow = new ImportFlow();
 
     private @MonotonicNonNull SearchViewProvider.Observer mSearchViewObserver;
+
+    private final OnBackPressedCallback mBackPressedCallback =
+            new OnBackPressedCallback(/* enabled= */ false) {
+                @Override
+                public void handleOnBackPressed() {
+                    SearchView searchView =
+                            mSearchItem == null ? null : (SearchView) mSearchItem.getActionView();
+                    if (searchView != null && !searchView.isIconified()) {
+                        // The toolbar search view is open, return to the full Password Manager
+                        // passwords list
+                        searchView.setQuery("", false);
+                        searchView.setIconified(true);
+                        // Exit search mode entirely (query = null, not ""), so Save passwords /
+                        // Auto sign-in switches and Import/Export are restored, not just the
+                        // empty-query list.
+                        filterPasswords(null);
+                    }
+                }
+            };
 
     @Override
     protected @NonNull PreferenceGroupAdapter onCreateAdapter(
@@ -342,11 +363,21 @@ public class PasswordSettings extends ChromeBaseSettingsFragment
 
         // Disable animations of preference changes.
         getListView().setItemAnimator(null);
+        requireActivity()
+                .getOnBackPressedDispatcher()
+                .addCallback(getViewLifecycleOwner(), mBackPressedCallback);
     }
 
     @Override
     public void setSearchViewObserver(SearchViewProvider.Observer observer) {
-        mSearchViewObserver = observer;
+        // Enable the back callback exactly while the local search view is open, so back collapses
+        // the search instead of exiting the fragment (see mBackPressedCallback). SearchUtils drives
+        // this observer: onUpdated(true) on open, onUpdated(false) on close.
+        mSearchViewObserver =
+                visible -> {
+                    mBackPressedCallback.setEnabled(visible);
+                    observer.onUpdated(visible);
+                };
     }
 
     @Initializer

--- a/android/javatests/org/chromium/chrome/browser/password_manager/settings/PasswordSettingsSearchTest.java
+++ b/android/javatests/org/chromium/chrome/browser/password_manager/settings/PasswordSettingsSearchTest.java
@@ -304,6 +304,31 @@ public class PasswordSettingsSearchTest {
         onView(withId(R.id.menu_id_search)).check(matches(isDisplayed()));
     }
 
+    /**
+     * Check that the system back gesture/button (not the toolbar arrow) collapses the search and
+     * brings back all non-password prefs. Unlike the up-arrow, this routes through the fragment's
+     * OnBackPressedCallback, which is the path that regressed.
+     */
+    @Test
+    @SmallTest
+    @Feature({"Preferences"})
+    public void testSystemBackRestoresGeneralPrefs() {
+        mTestHelper.setPasswordSourceWithMultipleEntries(GREEK_GODS);
+        mTestHelper.startPasswordSettingsFromMainSettings(mSettingsActivityTestRule);
+
+        onView(withSearchMenuIdOrText()).perform(click());
+        onView(withId(R.id.search_src_text)).perform(click(), typeText("Zeu"), closeSoftKeyboard());
+
+        onView(withText(R.string.password_settings_save_passwords)).check(doesNotExist());
+
+        Espresso.pressBack();
+        onViewWaiting(allOf(withText(R.string.password_settings_save_passwords), isDisplayed()));
+
+        onView(withText(R.string.password_settings_save_passwords)).check(matches(isDisplayed()));
+
+        onView(withId(R.id.menu_id_search)).check(matches(isDisplayed()));
+    }
+
     /** Check that clearing the search also hides the clear button. */
     @Test
     @SmallTest


### PR DESCRIPTION
Add an OnBackPressedCallback that collapses the open search and restores the full Password Manager screen when back is pressed or performed via gesture, instead of leaving the screen. Enabled only while the search view is open.

Resolves https://github.com/brave/brave-browser/issues/57662

#### Demo:

https://github.com/user-attachments/assets/557d9e40-d62a-46e7-8f32-b513a6bdd381



<!-- Add brave-browser issue below that this PR will resolve -->


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
