### PR TITLE
Fix crash toggling Email Aliases in Brave Origin settings

### DIFF
--- a/browser/brave_origin/brave_origin_service_factory_unittest.cc
+++ b/browser/brave_origin/brave_origin_service_factory_unittest.cc
@@ -13,9 +13,11 @@
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/p3a/pref_names.h"
 #include "chrome/test/base/testing_browser_process.h"
+#include "chrome/test/base/testing_profile.h"
 #include "chrome/test/base/testing_profile_manager.h"
 #include "components/policy/core/common/policy_details.h"
 #include "components/policy/policy_constants.h"
+#include "components/prefs/pref_service.h"
 #include "content/public/test/browser_task_environment.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -232,6 +234,27 @@ TEST_F(BraveOriginServiceFactoryProfileTest, NoServiceForGuestProfile) {
   // Verify that BraveOriginService is not created for guest profiles
   auto* service = BraveOriginServiceFactory::GetForProfile(guest_profile);
   EXPECT_EQ(service, nullptr);
+}
+
+// Every pref that Brave Origin claims as a profile policy must be registered
+// on a real profile. Brave Origin shows its settings toggles (and writes these
+// prefs via SetPolicyValue) gated only on build flags, so a pref registered
+// solely behind a runtime feature flag would hit an unregistered-pref
+// NOTREACHED when toggled with the feature off. Registering these prefs
+// unconditionally in brave::RegisterProfilePrefs keeps them in sync.
+TEST_F(BraveOriginServiceFactoryProfileTest, ProfilePolicyPrefsAreRegistered) {
+  auto* profile = profile_manager_.CreateTestingProfile("test");
+  auto* prefs = profile->GetPrefs();
+
+  for (const auto& [policy_key, info] :
+       BraveOriginServiceFactory::GetProfilePolicyDefinitions()) {
+    EXPECT_NE(prefs->FindPreference(info.pref_name), nullptr)
+        << "Profile policy " << policy_key << " references pref "
+        << info.pref_name
+        << " which is not registered. Register it unconditionally in "
+           "brave::RegisterProfilePrefs (brave/browser/brave_profile_prefs.cc) "
+           "so it exists regardless of any runtime feature flag.";
+  }
 }
 
 }  // namespace brave_origin

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -42,6 +42,7 @@
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/de_amp/common/pref_names.h"
 #include "brave/components/debounce/core/browser/debounce_service.h"
+#include "brave/components/email_aliases/buildflags/buildflags.h"
 #include "brave/components/global_privacy_control/pref_names.h"
 #include "brave/components/ipfs/ipfs_prefs.h"
 #include "brave/components/local_ai/buildflags/buildflags.h"
@@ -99,6 +100,10 @@
 #include "brave/components/ai_chat/core/browser/model_service.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_chat/core/common/pref_names.h"
+#endif
+
+#if BUILDFLAG(ENABLE_EMAIL_ALIASES)
+#include "brave/components/email_aliases/email_aliases_service.h"
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
@@ -570,6 +575,15 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
 #if BUILDFLAG(ENABLE_AI_CHAT)
   ai_chat::prefs::RegisterProfilePrefs(registry);
   ai_chat::ModelService::RegisterProfilePrefs(registry);
+#endif
+
+#if BUILDFLAG(ENABLE_EMAIL_ALIASES)
+  // Registered unconditionally so the prefs exist even when the kEmailAliases
+  // feature is disabled at runtime. The Brave Origin settings page gates the
+  // Email Aliases toggle on the build flag alone and writes
+  // kEmailAliasesEnabled, which would otherwise hit an unregistered-pref
+  // NOTREACHED.
+  email_aliases::EmailAliasesService::RegisterProfilePrefs(registry);
 #endif
 
 #if BUILDFLAG(ENABLE_LOCAL_AI)

--- a/browser/email_aliases/email_aliases_service_factory.cc
+++ b/browser/email_aliases/email_aliases_service_factory.cc
@@ -13,7 +13,6 @@
 #include "brave/components/email_aliases/features.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/profiles/profile_selections.h"
-#include "components/pref_registry/pref_registry_syncable.h"
 #include "components/prefs/pref_service.h"
 #include "components/user_prefs/user_prefs.h"
 #include "content/public/browser/storage_partition.h"
@@ -51,11 +50,6 @@ EmailAliasesServiceFactory::EmailAliasesServiceFactory()
 }
 
 EmailAliasesServiceFactory::~EmailAliasesServiceFactory() = default;
-
-void EmailAliasesServiceFactory::RegisterProfilePrefs(
-    user_prefs::PrefRegistrySyncable* registry) {
-  EmailAliasesService::RegisterProfilePrefs(registry);
-}
 
 std::unique_ptr<KeyedService>
 EmailAliasesServiceFactory::BuildServiceInstanceForBrowserContext(

--- a/browser/email_aliases/email_aliases_service_factory.h
+++ b/browser/email_aliases/email_aliases_service_factory.h
@@ -19,10 +19,6 @@ namespace content {
 class BrowserContext;
 }
 
-namespace user_prefs {
-class PrefRegistrySyncable;
-}
-
 namespace email_aliases {
 
 class EmailAliasesService;
@@ -41,9 +37,6 @@ class EmailAliasesServiceFactory : public ProfileKeyedServiceFactory {
   ~EmailAliasesServiceFactory() override;
 
   // ProfileKeyedServiceFactory:
-  void RegisterProfilePrefs(
-      user_prefs::PrefRegistrySyncable* registry) override;
-
   std::unique_ptr<KeyedService> BuildServiceInstanceForBrowserContext(
       content::BrowserContext* context) const override;
 };


### PR DESCRIPTION
Resolves brave/brave-browser#56890

`brave.email_aliases.enabled` was only registered via `EmailAliasesServiceFactory`, but the Brave Origin settings toggle writes it gated on the build flag alone. Toggling Email Aliases while the `kEmailAliases` feature was disabled at runtime hit an unregistered-pref `NOTREACHED` and crashed the browser.

## Test plan

- [x] `brave_unit_tests --gtest_filter='BraveOriginServiceFactory*.*'` passes
- [x] Upgrade normal Brave to Origin and make sure you can toggle the feature on and off with restarts
