### PR TITLE
[bootstrap] Use `vpython3` from `vendored/depot_tools`

### DIFF
--- a/tools/cr/alias/cmd.py
+++ b/tools/cr/alias/cmd.py
@@ -71,8 +71,8 @@ def _to_alias_path(p: Path) -> str:
 _SCRIPT_PATH: str = _to_alias_path(Path(__file__).resolve())
 
 # `vpython3` invocation for the alias body. `VPYTHON3_PATH` is either a bare
-# `Path('vpython3')` (when depot_tools is on PATH) or an absolute path to
-# Chromium's bundled `third_party/depot_tools/vpython3` (when it isn't).
+# `Path('vpython3')` (when depot_tools is on PATH) or an absolute path to the
+# vendored `vendor/depot_tools/vpython3` (when it isn't).
 _VPYTHON3_PATH: str = _to_alias_path(VPYTHON3_PATH)
 
 

--- a/tools/cr/bootstrap/bootstrap_test.py
+++ b/tools/cr/bootstrap/bootstrap_test.py
@@ -199,7 +199,7 @@ class ResolveVpython3Test(unittest.TestCase):
 
     def test_resolves_to_a_vpython3_interpreter(self):
         # pylint: disable=protected-access
-        # Whether found on $PATH or via the chromium-bundled fallback, the
+        # Whether found on $PATH or via the vendored depot_tools fallback, the
         # resolved interpreter is always a vpython3 (vpython3.bat on Windows).
         # shutil.which() mirrors the case of the matched PATHEXT entry (often
         # ".BAT" on Windows), so compare case-insensitively.

--- a/tools/cr/bootstrap/launcher.py
+++ b/tools/cr/bootstrap/launcher.py
@@ -145,14 +145,13 @@ def find_shim_target(tool: str) -> Shim:
     raise UnknownShimError(tool)
 
 
-def _resolve_vpython3(src: Path) -> Path:
-    """The `vpython3` to run tools with: one on `$PATH`, else the depot_tools
-    copy under `src` (mirrors `vpython_utils._compute_vpython3_path`)."""
+def _resolve_vpython3(checkout: Path) -> Path:
+    """Resolves `vpython3` either from path, or the one vendored."""
     found = shutil.which('vpython3')
     if found is not None:
         return Path(found)
     name = 'vpython3.bat' if platform.system() == 'Windows' else 'vpython3'
-    return src / 'third_party' / 'depot_tools' / name
+    return checkout / 'vendor' / 'depot_tools' / name
 
 
 # TODO(https://brave.dev/b/57477): this `npm_wrapper` special-casing exists
@@ -337,7 +336,7 @@ def resolve_invocation(tool: str, checkout: Path | None,
         if target.is_file():
             if shim.runtime == 'vpython':
                 invocation = Invocation(
-                    [str(_resolve_vpython3(checkout.parent)),
+                    [str(_resolve_vpython3(checkout)),
                      str(target)])
             elif shim.runtime == 'node':
                 # Run with whatever `node` is on $PATH (our node shim, which

--- a/tools/cr/test/fake_chromium_repo.py
+++ b/tools/cr/test/fake_chromium_repo.py
@@ -8,12 +8,8 @@ from __future__ import annotations
 from pathlib import Path
 import json
 import os
-import platform
-import stat
 import subprocess
 import tempfile
-
-import vpython_utils
 
 CHROME_VERSION_TEMPLATE: str = """MAJOR={major}
 MINOR={minor}
@@ -72,8 +68,6 @@ class FakeChromiumRepo:
         (self.brave / 'chromium_src').mkdir(exist_ok=True)
         (self.brave / 'rewrite').mkdir(exist_ok=True)
         (self.brave / 'patches').mkdir(exist_ok=True)
-
-        self.install_vpython3_shim()
 
         # `FakeChromiumRepo` will change the current directory to a mirro path
         # inside the fake brave repo, relative to the cwd in brave-core when
@@ -212,34 +206,6 @@ class FakeChromiumRepo:
              str(dep_path), relative_path], self.chromium)
         self._run_git_command(
             ['commit', '-m', f'Add submodule {relative_path}'], self.chromium)
-
-    def install_vpython3_shim(self) -> Path | None:
-        """Populates `chromium/third_party/depot_tools/vpython3` for tests.
-
-        No-op when `vpython_utils.is_found_in_path_variable()` reports that
-        `VPYTHON3_PATH` resolves via `$PATH` at invocation time: the alias
-        body and subprocesses then never reach the chromium-bundled
-        location, so the shim is unnecessary.
-
-        Otherwise installs a shim at the bundled location pointing at
-        whatever `vpython_utils.VPYTHON3_PATH` already resolved to (which,
-        in this branch, is always an absolute path). POSIX uses a symlink;
-        Windows writes a `.bat` shim because symlinks there need elevated
-        privileges.
-        """
-        if vpython_utils.is_found_in_path_variable():
-            return None
-        depot_tools = self.chromium / 'third_party' / 'depot_tools'
-        depot_tools.mkdir(parents=True, exist_ok=True)
-        if platform.system() == 'Windows':
-            shim = depot_tools / 'vpython3.bat'
-            shim.write_text('@echo off\r\nvpython3 %*\r\n', encoding='utf-8')
-            shim.chmod(shim.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP
-                       | stat.S_IXOTH)
-        else:
-            shim = depot_tools / 'vpython3'
-            shim.symlink_to(vpython_utils.VPYTHON3_PATH)
-        return shim
 
     def add_tag(self, version: str) -> None:
         """Adds a git tag to the repository.

--- a/tools/cr/vpython_utils.py
+++ b/tools/cr/vpython_utils.py
@@ -12,7 +12,9 @@ from pathlib import Path
 import platform
 import shutil
 
-import repository
+# Using absolute path so tests don't try to resolve `vpython3` via a repo CWD
+# resolution.
+_BRAVE_ROOT: Path = Path(__file__).resolve().parents[2]
 
 
 def _compute_vpython3_path() -> Path:
@@ -25,14 +27,14 @@ def _compute_vpython3_path() -> Path:
          by `shutil.which`, because git's bundled bash (used to execute
          `!`-prefixed aliases) doesn't reliably resolve `.bat` wrappers
          like `vpython3.bat` via `$PATH`.
-      3. Neither — the chromium-bundled `third_party/depot_tools/vpython3`,
-         resolved to absolute at module import so later cwd changes (e.g.
-         `FakeChromiumRepo.setup()`) don't invalidate it.
+      3. Neither — the vendored `vendor/depot_tools/vpython3`
+         (`vpython3.bat` on Windows), already absolute since it's derived
+         from `_BRAVE_ROOT`.
     """
     found = shutil.which('vpython3')
     if found is None:
-        return (repository.chromium.root / 'third_party' / 'depot_tools' /
-                'vpython3').resolve()
+        name = 'vpython3.bat' if platform.system() == 'Windows' else 'vpython3'
+        return _BRAVE_ROOT / 'vendor' / 'depot_tools' / name
     if platform.system() == 'Windows':
         return Path(found)
     return Path('vpython3')
@@ -47,7 +49,7 @@ def is_found_in_path_variable() -> bool:
     A PATH-resolved value is a bare command name like `Path('vpython3')`,
     which has no parent directory (`parent == Path('.')`); shell and
     subprocess machinery look it up via `$PATH` at invocation time. The
-    chromium-bundled fallback, by contrast, is an absolute path with a
-    real parent directory.
+    vendored fallback, by contrast, is an absolute path with a real parent
+    directory.
     """
     return VPYTHON3_PATH.parent == Path('.')


### PR DESCRIPTION
This PR change the `vpython3` from `../third_party/depot_tools/` to the
`depot_tools` copy we have checked under `vpython3`.

Bug: https://github.com/brave/brave-browser/issues/56529
