### PR TITLE
[farbling] Fix getSupportedExtensions overlap b/w webgl/webgl2 (uplift to 1.94.x)

### DIFF
--- a/browser/farbling/brave_webgl_farbling_browsertest.cc
+++ b/browser/farbling/brave_webgl_farbling_browsertest.cc
@@ -267,14 +267,14 @@ IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
                        FarbleVendorAndRendererDebugInfoWebGL) {
   std::string domain = "a.com";
   GURL url = embedded_test_server()->GetURL(domain, "/getParameter.html");
+  const std::string kGetWebGL1 = "getWebGL1UnmaskedVendorAndRenderer()";
 
   // Farbling level: off
   // This is tested below in relation with "maximum" and "balanced"
   // farbling.
   AllowFingerprinting(domain);
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
-  std::string actual_value_off =
-      EvalJs(contents(), kTitleScript).ExtractString();
+  std::string actual_value_off = EvalJs(contents(), kGetWebGL1).ExtractString();
 
   // Farbling level: maximum
   // pseudo-random data with no relation to original data
@@ -283,13 +283,13 @@ IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
   const std::string expected_value_maximum =
       GetExpectedString(TestFarblingLevel::MAXIMUM);
   std::string actual_value_maximum =
-      EvalJs(contents(), kTitleScript).ExtractString();
+      EvalJs(contents(), kGetWebGL1).ExtractString();
   EXPECT_EQ(expected_value_maximum, actual_value_maximum);
   // second time, same as the first (tests that results are consistent for the
   // lifetime of a session, and that the PRNG properly resets itself at the
   // beginning of each calculation)
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
-  actual_value_maximum = EvalJs(contents(), kTitleScript).ExtractString();
+  actual_value_maximum = EvalJs(contents(), kGetWebGL1).ExtractString();
   EXPECT_EQ(expected_value_maximum, actual_value_maximum);
   // Check never same as the "off" state.
   EXPECT_NE(actual_value_off, actual_value_maximum);
@@ -299,7 +299,7 @@ IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
   SetFingerprintingDefault(domain);
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
   std::string actual_value_balanced =
-      EvalJs(contents(), kTitleScript).ExtractString();
+      EvalJs(contents(), kGetWebGL1).ExtractString();
   auto expected_value_balanced = GetExpectedString(
       TestFarblingLevel::BALANCED, /*expected_override= */
       GetParam() ? std::nullopt : std::optional<std::string>(actual_value_off));
@@ -314,11 +314,12 @@ IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
   GURL url =
       embedded_test_server()->GetURL(domain, "/getSupportedExtensions.html");
   const std::string kSupportedExtensionsMax = "WEBGL_debug_renderer_info";
+  const std::string kGetWebGL1Extensions = "getWebGL1SupportedExtensions()";
   // Farbling level: maximum
   // WebGL getSupportedExtensions returns abbreviated list
   BlockFingerprinting(domain);
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
-  EXPECT_EQ(EvalJs(contents(), kTitleScript).ExtractString(),
+  EXPECT_EQ(EvalJs(contents(), kGetWebGL1Extensions).ExtractString(),
             kSupportedExtensionsMax);
 
   // Farbling level: off
@@ -326,14 +327,14 @@ IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
   AllowFingerprinting(domain);
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
   std::string actual_value_off =
-      EvalJs(contents(), kTitleScript).ExtractString();
+      EvalJs(contents(), kGetWebGL1Extensions).ExtractString();
   EXPECT_NE(actual_value_off, kSupportedExtensionsMax);
 
   // Farbling level: balanced (default)
   SetFingerprintingDefault(domain);
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
   const auto actual_balanced_value =
-      EvalJs(contents(), kTitleScript).ExtractString();
+      EvalJs(contents(), kGetWebGL1Extensions).ExtractString();
   VerifyBalancedFarblingExtensions(actual_value_off, actual_balanced_value,
                                    GetParam());
 }
@@ -389,4 +390,216 @@ IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
   ASSERT_TRUE(ExecJs(contents(), "getExtensionWithInvalidName()"));
   EXPECT_EQ(EvalJs(contents(), kTitleScript).ExtractString(), "null");
+}
+
+IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
+                       FarbleGetSupportedExtensionsWebGL2) {
+  std::string domain = "a.com";
+  GURL url =
+      embedded_test_server()->GetURL(domain, "/getSupportedExtensions.html");
+  const std::string kSupportedExtensionsMax = "WEBGL_debug_renderer_info";
+  const std::string kGetWebGL2Extensions = "getWebGL2SupportedExtensions()";
+  // Farbling level: maximum
+  // WebGL2 getSupportedExtensions returns abbreviated list
+  BlockFingerprinting(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  EXPECT_EQ(EvalJs(contents(), kGetWebGL2Extensions).ExtractString(),
+            kSupportedExtensionsMax);
+
+  // Farbling level: off
+  // WebGL2 getSupportedExtensions is real
+  AllowFingerprinting(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  std::string actual_value_off =
+      EvalJs(contents(), kGetWebGL2Extensions).ExtractString();
+  ASSERT_FALSE(actual_value_off.empty());
+  EXPECT_NE(actual_value_off, kSupportedExtensionsMax);
+
+  // Farbling level: balanced (default)
+  SetFingerprintingDefault(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  const auto actual_balanced_value =
+      EvalJs(contents(), kGetWebGL2Extensions).ExtractString();
+  VerifyBalancedFarblingExtensions(actual_value_off, actual_balanced_value,
+                                   GetParam());
+}
+
+// Regression test for https://github.com/brave/brave-browser/issues/57736
+IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
+                       WebGL1ExtensionsNotContaminatedByWebGL2) {
+  const std::string domain = "a.com";
+  const GURL url =
+      embedded_test_server()->GetURL(domain, "/getSupportedExtensions.html");
+
+  AllowFingerprinting(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+
+  // Baseline: WebGL1 alone should expose ANGLE_instanced_arrays on desktop.
+  const std::string baseline =
+      EvalJs(contents(), "getWebGL1SupportedExtensions()").ExtractString();
+  ASSERT_FALSE(baseline.empty());
+  ASSERT_NE(baseline.find("ANGLE_instanced_arrays"), std::string::npos)
+      << "Baseline WebGL1 extensions: " << baseline;
+
+  // Fresh document: probe WebGL2 first, then inspect WebGL1.
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  ASSERT_FALSE(EvalJs(contents(), "getWebGL2SupportedExtensions()")
+                   .ExtractString()
+                   .empty());
+  const std::string extensions =
+      EvalJs(contents(), "getWebGL1SupportedExtensions()").ExtractString();
+  ASSERT_FALSE(extensions.empty());
+
+  EXPECT_NE(extensions.find("ANGLE_instanced_arrays"), std::string::npos)
+      << "WebGL1 lost ANGLE_instanced_arrays after a WebGL2 probe. "
+         "extensions="
+      << extensions;
+  EXPECT_EQ(extensions.find("EXT_disjoint_timer_query_webgl2"),
+            std::string::npos)
+      << "WebGL1 exposed a WebGL2-only extension after a WebGL2 probe. "
+         "extensions="
+      << extensions;
+}
+
+// Regression test for https://github.com/brave/brave-browser/issues/57736
+IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
+                       WebGL2ExtensionsNotContaminatedByWebGL1) {
+  const std::string domain = "a.com";
+  const GURL url =
+      embedded_test_server()->GetURL(domain, "/getSupportedExtensions.html");
+
+  AllowFingerprinting(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+
+  // Baseline: WebGL2 alone should expose a WebGL2-only extension on desktop.
+  const std::string baseline =
+      EvalJs(contents(), "getWebGL2SupportedExtensions()").ExtractString();
+  ASSERT_FALSE(baseline.empty());
+  ASSERT_NE(baseline.find("EXT_disjoint_timer_query_webgl2"), std::string::npos)
+      << "Baseline WebGL2 extensions: " << baseline;
+
+  // Fresh document: probe WebGL1 first, then inspect WebGL2.
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  ASSERT_FALSE(EvalJs(contents(), "getWebGL1SupportedExtensions()")
+                   .ExtractString()
+                   .empty());
+  const std::string extensions =
+      EvalJs(contents(), "getWebGL2SupportedExtensions()").ExtractString();
+  ASSERT_FALSE(extensions.empty());
+
+  EXPECT_NE(extensions.find("EXT_disjoint_timer_query_webgl2"),
+            std::string::npos)
+      << "WebGL2 lost EXT_disjoint_timer_query_webgl2 after a WebGL1 probe. "
+         "extensions="
+      << extensions;
+  EXPECT_EQ(extensions.find("ANGLE_instanced_arrays"), std::string::npos)
+      << "WebGL2 exposed a WebGL1-only extension after a WebGL1 probe. "
+         "extensions="
+      << extensions;
+}
+
+// BRAVE_WEBCOMPAT_WEBGL and BRAVE_WEBCOMPAT_WEBGL2 exceptions must apply only
+// to their respective API versions.
+IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
+                       WebcompatExceptionsAreIndependentPerWebGLVersion) {
+  const std::string domain = "a.com";
+  const GURL url =
+      embedded_test_server()->GetURL(domain, "/getSupportedExtensions.html");
+  const std::string kSupportedExtensionsMax = "WEBGL_debug_renderer_info";
+  const std::string kGetWebGL1Extensions = "getWebGL1SupportedExtensions()";
+  const std::string kGetWebGL2Extensions = "getWebGL2SupportedExtensions()";
+
+  // Real (unfarbled) baselines.
+  AllowFingerprinting(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  const std::string webgl1_off =
+      EvalJs(contents(), kGetWebGL1Extensions).ExtractString();
+  const std::string webgl2_off =
+      EvalJs(contents(), kGetWebGL2Extensions).ExtractString();
+  ASSERT_FALSE(webgl1_off.empty());
+  ASSERT_FALSE(webgl2_off.empty());
+  ASSERT_NE(webgl1_off, kSupportedExtensionsMax);
+  ASSERT_NE(webgl2_off, kSupportedExtensionsMax);
+
+  // Maximum farbling: both versions abbreviated.
+  BlockFingerprinting(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  EXPECT_EQ(EvalJs(contents(), kGetWebGL1Extensions).ExtractString(),
+            kSupportedExtensionsMax);
+  EXPECT_EQ(EvalJs(contents(), kGetWebGL2Extensions).ExtractString(),
+            kSupportedExtensionsMax);
+
+  // Exception for WebGL1 only: WebGL1 unfarbled, WebGL2 still maximum.
+  brave_shields::SetWebcompatEnabled(content_settings(),
+                                     ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL,
+                                     true, url, nullptr);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  EXPECT_EQ(EvalJs(contents(), kGetWebGL1Extensions).ExtractString(),
+            webgl1_off);
+  EXPECT_EQ(EvalJs(contents(), kGetWebGL2Extensions).ExtractString(),
+            kSupportedExtensionsMax);
+
+  // Exception for WebGL2 only: WebGL2 unfarbled, WebGL1 still maximum.
+  brave_shields::SetWebcompatEnabled(content_settings(),
+                                     ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL,
+                                     false, url, nullptr);
+  brave_shields::SetWebcompatEnabled(
+      content_settings(), ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL2, true,
+      url, nullptr);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  EXPECT_EQ(EvalJs(contents(), kGetWebGL1Extensions).ExtractString(),
+            kSupportedExtensionsMax);
+  EXPECT_EQ(EvalJs(contents(), kGetWebGL2Extensions).ExtractString(),
+            webgl2_off);
+}
+
+// BRAVE_WEBCOMPAT_WEBGL and BRAVE_WEBCOMPAT_WEBGL2 must independently control
+// UNMASKED_VENDOR_WEBGL / UNMASKED_RENDERER_WEBGL farbling.
+IN_PROC_BROWSER_TEST_P(
+    BraveWebGLExtensionFarblingTest,
+    DebugInfoWebcompatExceptionsAreIndependentPerWebGLVersion) {
+  // Balanced "Brave" farbling only applies when the feature is enabled.
+  if (!GetParam()) {
+    GTEST_SKIP() << "Requires kWebGLBalancedFingerprintingProtection";
+  }
+
+  const std::string domain = "a.com";
+  const GURL url = embedded_test_server()->GetURL(domain, "/getParameter.html");
+  const std::string kBraveDebugInfo = "Brave,Brave";
+  const std::string kGetWebGL1 = "getWebGL1UnmaskedVendorAndRenderer()";
+  const std::string kGetWebGL2 = "getWebGL2UnmaskedVendorAndRenderer()";
+
+  AllowFingerprinting(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  const std::string webgl1_off = EvalJs(contents(), kGetWebGL1).ExtractString();
+  const std::string webgl2_off = EvalJs(contents(), kGetWebGL2).ExtractString();
+  ASSERT_FALSE(webgl1_off.empty());
+  ASSERT_FALSE(webgl2_off.empty());
+  ASSERT_NE(webgl1_off, kBraveDebugInfo);
+  ASSERT_NE(webgl2_off, kBraveDebugInfo);
+
+  // Default farbling: both versions report "Brave".
+  SetFingerprintingDefault(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  EXPECT_EQ(EvalJs(contents(), kGetWebGL1).ExtractString(), kBraveDebugInfo);
+  EXPECT_EQ(EvalJs(contents(), kGetWebGL2).ExtractString(), kBraveDebugInfo);
+
+  // Exception for WebGL1 only: WebGL1 real, WebGL2 still "Brave".
+  brave_shields::SetWebcompatEnabled(content_settings(),
+                                     ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL,
+                                     true, url, nullptr);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  EXPECT_EQ(EvalJs(contents(), kGetWebGL1).ExtractString(), webgl1_off);
+  EXPECT_EQ(EvalJs(contents(), kGetWebGL2).ExtractString(), kBraveDebugInfo);
+
+  // Exception for WebGL2 only: WebGL2 real, WebGL1 still "Brave".
+  brave_shields::SetWebcompatEnabled(content_settings(),
+                                     ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL,
+                                     false, url, nullptr);
+  brave_shields::SetWebcompatEnabled(
+      content_settings(), ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL2, true,
+      url, nullptr);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  EXPECT_EQ(EvalJs(contents(), kGetWebGL1).ExtractString(), kBraveDebugInfo);
+  EXPECT_EQ(EvalJs(contents(), kGetWebGL2).ExtractString(), webgl2_off);
 }

--- a/chromium_src/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
@@ -38,10 +38,13 @@ blink::ScriptValue GetWebGLDebugInfoValue(
     blink::ScriptState* script_state,
     blink::CanvasRenderingContextHost* host,
     const WebGLDebugRendererInfoType type,
-    const blink::String original_string_value) {
+    const blink::String original_string_value,
+    bool is_webgl2) {
   auto level = brave::GetBraveFarblingLevelFor(
       host->GetTopExecutionContext(),
-      ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL, BraveFarblingLevel::OFF);
+      is_webgl2 ? ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL2
+                : ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL,
+      BraveFarblingLevel::OFF);
   blink::ScriptValue original_script_value =
       blink::WebGLAny(script_state, original_string_value);
 
@@ -109,13 +112,13 @@ blink::ScriptValue GetWebGLDebugInfoValue(
   if (ExtensionEnabled(kWebGLDebugRendererInfoName))                \
     return GetWebGLDebugInfoValue(                                  \
         script_state, Host(), WebGLDebugRendererInfoType::RENDERER, \
-        String(ContextGL()->GetString(GL_RENDERER)));
+        String(ContextGL()->GetString(GL_RENDERER)), IsWebGL2());
 
-#define BRAVE_WEBGL_GET_PARAMETER_UNMASKED_VENDOR                     \
-  if (ExtensionEnabled(kWebGLDebugRendererInfoName))                  \
-    return GetWebGLDebugInfoValue(script_state, Host(),               \
-                                  WebGLDebugRendererInfoType::VENDOR, \
-                                  String(ContextGL()->GetString(GL_VENDOR)));
+#define BRAVE_WEBGL_GET_PARAMETER_UNMASKED_VENDOR                 \
+  if (ExtensionEnabled(kWebGLDebugRendererInfoName))              \
+    return GetWebGLDebugInfoValue(                                \
+        script_state, Host(), WebGLDebugRendererInfoType::VENDOR, \
+        String(ContextGL()->GetString(GL_VENDOR)), IsWebGL2());
 
 #define getExtension getExtension_ChromiumImpl
 #define getSupportedExtensions getSupportedExtensions_ChromiumImpl
@@ -135,14 +138,15 @@ namespace {
 template <typename T>
 WebGLFarbledExtensionHandler* CreateOrGetValidWebGLExtensionHandler(
     ExecutionContext* context,
+    bool is_webgl2,
     T&& get_real_extensions) {
   // Check if we have a valid handler for the current context.
+  auto& cache = brave::BraveSessionCache::From(*context);
   WebGLFarbledExtensionHandler* handler =
-      brave::BraveSessionCache::From(*context)
-          .get_webgl_farbled_extension_handler();
+      cache.get_webgl_farbled_extension_handler(is_webgl2);
 
-  // No valid handler found so create a new one which will be re-used until the
-  // lifetime of this context.
+  // No valid handler found so create a new one which will be re-used for this
+  // WebGL API version until the lifetime of the execution context.
   if (!handler) {
     // Get the real list of supported WebGL extensions.
     std::optional<Vector<String>> real_extensions =
@@ -150,20 +154,20 @@ WebGLFarbledExtensionHandler* CreateOrGetValidWebGLExtensionHandler(
     if (real_extensions == std::nullopt) {
       return nullptr;
     }
-    handler = brave::BraveSessionCache::From(*context)
-                  .CreateWebGLFarbledExtensionHandler(real_extensions.value());
+    handler = cache.CreateWebGLFarbledExtensionHandler(real_extensions.value(),
+                                                       is_webgl2);
   }
   return handler;
 }
 
 }  // namespace
 
-// This method returns the supported WebGL extensions. If fingerprinting
+// This method returns the supported WebGL/WebGL2 extensions. If fingerprinting
 // protections are enabled then the list may include farbled values.
 std::optional<Vector<String>>
 WebGLRenderingContextBase::getSupportedExtensions() {
   WebGLFarbledExtensionHandler* handler = CreateOrGetValidWebGLExtensionHandler(
-      Host()->GetTopExecutionContext(),
+      Host()->GetTopExecutionContext(), IsWebGL2(),
       [this]() { return getSupportedExtensions_ChromiumImpl(); });
 
   // Handler can be null when if there were no supported extensions found.
@@ -181,7 +185,7 @@ WebGLRenderingContextBase::getSupportedExtensions() {
 ScriptObject WebGLRenderingContextBase::getExtension(ScriptState* script_state,
                                                      const String& name) {
   WebGLFarbledExtensionHandler* handler = CreateOrGetValidWebGLExtensionHandler(
-      Host()->GetTopExecutionContext(),
+      Host()->GetTopExecutionContext(), IsWebGL2(),
       [this]() { return getSupportedExtensions_ChromiumImpl(); });
 
   if (!handler) {

--- a/test/data/webgl/getParameter.html
+++ b/test/data/webgl/getParameter.html
@@ -5,14 +5,28 @@
     <meta charset="utf-8">
   </head>
   <body>
-    <canvas id="test" width="8" height="8"></canvas>
     <script>
-      var canvas = document.getElementById("test");
-      var gl = canvas.getContext("webgl");
-      var debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
-      var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);
-      var renderer = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
-      document.title = vendor + "," + renderer;
+      function getUnmaskedVendorAndRenderer(contextType) {
+        const gl = document.createElement('canvas').getContext(contextType);
+        if (!gl) {
+          return '';
+        }
+        const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
+        if (!debugInfo) {
+          return '';
+        }
+        const vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);
+        const renderer = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
+        return vendor + ',' + renderer;
+      }
+
+      function getWebGL1UnmaskedVendorAndRenderer() {
+        return getUnmaskedVendorAndRenderer('webgl');
+      }
+
+      function getWebGL2UnmaskedVendorAndRenderer() {
+        return getUnmaskedVendorAndRenderer('webgl2');
+      }
     </script>
   </body>
 </html>

--- a/test/data/webgl/getSupportedExtensions.html
+++ b/test/data/webgl/getSupportedExtensions.html
@@ -5,12 +5,22 @@
     <meta charset="utf-8">
   </head>
   <body>
-    <canvas id="test" width="8" height="8"></canvas>
     <script>
-      var canvas = document.getElementById("test");
-      var gl = canvas.getContext("webgl");
-      var ext_list = gl.getSupportedExtensions();
-      document.title = ext_list.join(",");
+      function getWebGL1SupportedExtensions() {
+        const gl = document.createElement('canvas').getContext('webgl');
+        if (!gl) {
+          return '';
+        }
+        return (gl.getSupportedExtensions() || []).join(',');
+      }
+
+      function getWebGL2SupportedExtensions() {
+        const gl = document.createElement('canvas').getContext('webgl2');
+        if (!gl) {
+          return '';
+        }
+        return (gl.getSupportedExtensions() || []).join(',');
+      }
     </script>
   </body>
 </html>

--- a/third_party/blink/renderer/core/farbling/brave_session_cache.cc
+++ b/third_party/blink/renderer/core/farbling/brave_session_cache.cc
@@ -276,23 +276,37 @@ void BraveSessionCache::Init() {
 
 blink::WebGLFarbledExtensionHandler*
 BraveSessionCache::CreateWebGLFarbledExtensionHandler(
-    const blink::Vector<blink::String>& supported_extensions) {
-  CHECK(!webgl_farbled_extension_handler_);
+    const blink::Vector<blink::String>& supported_extensions,
+    const bool is_webgl2) {
+  if (is_webgl2) {
+    CHECK(!webgl2_farbled_extension_handler_);
+  } else {
+    CHECK(!webgl_farbled_extension_handler_);
+  }
 
-  auto level =
-      GetBraveFarblingLevel(ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL);
-  webgl_farbled_extension_handler_ =
-      level == BraveFarblingLevel::OFF
-          ? blink::WebGLFarbledExtensionHandler::CreateOffHandler(
-                supported_extensions)
-      : level == BraveFarblingLevel::BALANCED
-          ? blink::WebGLFarbledExtensionHandler::CreateBalancedHandler(
-                supported_extensions,
-                default_shields_settings_->farbling_token.low())
-          : blink::WebGLFarbledExtensionHandler::CreateMaximumHandler(
-                supported_extensions);
+  auto level = GetBraveFarblingLevel(
+      is_webgl2 ? ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL2
+                : ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL);
+  std::unique_ptr<blink::WebGLFarbledExtensionHandler>
+      farbled_extension_handler =
+          level == BraveFarblingLevel::OFF
+              ? blink::WebGLFarbledExtensionHandler::CreateOffHandler(
+                    supported_extensions)
+          : level == BraveFarblingLevel::BALANCED
+              ? blink::WebGLFarbledExtensionHandler::CreateBalancedHandler(
+                    supported_extensions,
+                    default_shields_settings_->farbling_token.low())
+              : blink::WebGLFarbledExtensionHandler::CreateMaximumHandler(
+                    supported_extensions);
 
-  return webgl_farbled_extension_handler_.get();
+  if (is_webgl2) {
+    webgl2_farbled_extension_handler_ = std::move(farbled_extension_handler);
+  } else {
+    webgl_farbled_extension_handler_ = std::move(farbled_extension_handler);
+  }
+
+  return is_webgl2 ? webgl2_farbled_extension_handler_.get()
+                   : webgl_farbled_extension_handler_.get();
 }
 
 std::optional<blink::BraveAudioFarblingHelper>

--- a/third_party/blink/renderer/core/farbling/brave_session_cache.h
+++ b/third_party/blink/renderer/core/farbling/brave_session_cache.h
@@ -96,21 +96,24 @@ class CORE_EXPORT BraveSessionCache final
   brave_shields::FarblingPRNG MakePseudoRandomGenerator(
       FarbleKey key = FarbleKey::kNone);
   std::optional<blink::BraveAudioFarblingHelper> GetAudioFarblingHelper();
-  // Returns a non owning reference to |webgl_farbled_extension_handler_|.
+  // Returns a non owning reference to the underlying webgl/webgl2 handler.
   // Callers must not delete it. If a prior call to create this was already made
-  // then this method will crash, otherwise |webgl_farbled_extension_handler_|
-  // is created and its non-owning reference is returned.
-  // If you are only looking to  get a prviously created handler then call the
-  // getter method get_webgl_farbled_extension_handler.
-  // |supported_extensions| is the actual list of the currently supported webgl
-  // extensions on the device which would be farbled.
+  // then this method will crash, otherwise handler is created and its
+  // non-owning reference is returned. If you are only looking to  get a
+  // prviously created handler then call the getter method
+  // get_webgl_farbled_extension_handler. |supported_extensions| is the actual
+  // list of the currently supported webgl extensions on the device which would
+  // be farbled.
   blink::WebGLFarbledExtensionHandler* CreateWebGLFarbledExtensionHandler(
-      const blink::Vector<blink::String>& supported_extensions);
+      const blink::Vector<blink::String>& supported_extensions,
+      const bool is_webgl2);
 
-  // Returns a non owning reference to |webgl_farbled_extension_handler_| if
+  // Returns a non owning reference to the underlying webgl/webgl2 handler if
   // it's already created. Callers must not delete it.
-  blink::WebGLFarbledExtensionHandler* get_webgl_farbled_extension_handler() {
-    return webgl_farbled_extension_handler_.get();
+  blink::WebGLFarbledExtensionHandler* get_webgl_farbled_extension_handler(
+      bool is_webgl2) {
+    return is_webgl2 ? webgl2_farbled_extension_handler_.get()
+                     : webgl_farbled_extension_handler_.get();
   }
 
  private:
@@ -122,6 +125,9 @@ class CORE_EXPORT BraveSessionCache final
   // A handler to farble the webgl supported extensions.
   std::unique_ptr<blink::WebGLFarbledExtensionHandler>
       webgl_farbled_extension_handler_;
+  // A handler to farble the webgl2 supported extensions.
+  std::unique_ptr<blink::WebGLFarbledExtensionHandler>
+      webgl2_farbled_extension_handler_;
   blink::HashMap<ContentSettingsType, BraveFarblingLevel> farbling_levels_;
 };
 


### PR DESCRIPTION
Uplift of #38812
Resolves https://github.com/brave/brave-browser/issues/57736

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.