### PR TITLE
fix(ai_chat): harden model removal fallback

### DIFF
--- a/components/ai_chat/core/browser/ai_chat_service.cc
+++ b/components/ai_chat/core/browser/ai_chat_service.cc
@@ -1381,7 +1381,11 @@ bool AIChatService::IsPremiumStatus() {
 }
 
 std::unique_ptr<EngineConsumer> AIChatService::GetDefaultAIEngine() {
-  return GetEngineForModel(model_service_->GetDefaultModelKey());
+  std::string model_key = model_service_->GetDefaultModelKey();
+  if (!model_service_->GetModel(model_key)) {
+    model_key = features::kAIModelsDefaultKey.Get();
+  }
+  return GetEngineForModel(model_key);
 }
 
 std::unique_ptr<EngineConsumer> AIChatService::GetEngineForModel(

--- a/components/ai_chat/core/browser/ai_chat_service_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_service_unittest.cc
@@ -39,6 +39,7 @@
 #include "base/time/time.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_credential_manager.h"
 #include "brave/components/ai_chat/core/browser/associated_content_manager.h"
+#include "brave/components/ai_chat/core/browser/constants.h"
 #include "brave/components/ai_chat/core/browser/conversation_handler.h"
 #include "brave/components/ai_chat/core/browser/engine/engine_consumer.h"
 #include "brave/components/ai_chat/core/browser/engine/mock_engine_consumer.h"
@@ -52,6 +53,7 @@
 #include "brave/components/ai_chat/core/browser/tools/tool.h"
 #include "brave/components/ai_chat/core/browser/types.h"
 #include "brave/components/ai_chat/core/browser/utils.h"
+#include "brave/components/ai_chat/core/common/constants.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
@@ -1539,6 +1541,21 @@ TEST_P(AIChatServiceUnitTest, TemporaryConversation_NoDatabaseInteraction) {
   EXPECT_CALL(*mock_db_ptr, UpdateConversationModelKey).Times(1);
   DisconnectConversationClient(client2.get());
   testing::Mock::VerifyAndClearExpectations(mock_db_ptr);
+}
+
+TEST_P(AIChatServiceUnitTest,
+       GetDefaultAIEngineFallsBackToConfiguredDefaultWhenStale) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kAIChat,
+      {{features::kAIModelsDefaultKey.name, kClaudeHaikuModelKey}});
+
+  model_service_->SetDefaultModelKeyWithoutValidationForTesting(
+      "this-model-key-does-not-exist");
+
+  auto engine = ai_chat_service_->GetDefaultAIEngine();
+  ASSERT_TRUE(engine);
+  EXPECT_EQ(engine->GetModelName(), kClaudeHaikuModelName);
 }
 
 TEST_P(AIChatServiceUnitTest,

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -23,12 +23,12 @@
 #include "base/containers/span.h"
 #include "base/containers/to_vector.h"
 #include "base/debug/crash_logging.h"
-#include "base/debug/dump_without_crashing.h"
 #include "base/files/file_path.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "base/logging.h"
 #include "base/memory/weak_ptr.h"
+#include "base/notreached.h"
 #include "base/numerics/safe_math.h"
 #include "base/rand_util.h"
 #include "base/strings/strcat.h"
@@ -47,6 +47,7 @@
 #include "brave/components/ai_chat/core/browser/tools/tool.h"
 #include "brave/components/ai_chat/core/browser/types.h"
 #include "brave/components/ai_chat/core/browser/utils.h"
+#include "brave/components/ai_chat/core/common/constants.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
@@ -384,22 +385,18 @@ void ConversationHandler::InitEngine() {
   if (!model_key_.empty()) {
     model = model_service_->GetModel(model_key_);
   }
-  // Make sure we get a valid model, defaulting to static default or first.
+
   if (!model) {
-    // It is unexpected that we get here. Dump a call stack
-    // to help figure out why it happens.
-    SCOPED_CRASH_KEY_STRING1024("BraveAIChatModel", "key", model_key_);
-    base::debug::DumpWithoutCrashing();
-    // Use default
     model = model_service_->GetModel(features::kAIModelsDefaultKey.Get());
-    if (!model) {
-      SCOPED_CRASH_KEY_STRING1024("BraveAIChatModel", "key",
-                                  features::kAIModelsDefaultKey.Get());
-      base::debug::DumpWithoutCrashing();
-      const auto& all_models = model_service_->GetModels();
-      // Use first if given bad default value
-      model = all_models.at(0).get();
-    }
+  }
+  if (!model) {
+    // default_model is read live from config; failing here means it's
+    // currently misconfigured.
+    SCOPED_CRASH_KEY_STRING1024("BraveAIChatModel", "key",
+                                features::kAIModelsDefaultKey.Get());
+    DUMP_WILL_BE_NOTREACHED();
+    model = model_service_->GetModel(kChatAutomaticModelKey);
+    CHECK(model) << "Automatic model missing from model list";
   }
 
   // Model's key might not be the same as what we asked for (e.g. if the model
@@ -435,11 +432,15 @@ void ConversationHandler::InitEngine() {
 const mojom::Model& ConversationHandler::GetCurrentModel() {
   const mojom::Model* model = model_service_->GetModel(model_key_);
   if (!model) {
-    // Model no longer exists (e.g., custom model was deleted)
-    // Fall back to the automatic model
     DVLOG(1) << "Model " << model_key_
-             << " no longer exists, falling back to automatic model";
+             << " no longer exists, falling back to default model";
     model_key_ = features::kAIModelsDefaultKey.Get();
+    model = model_service_->GetModel(model_key_);
+  }
+  if (!model) {
+    DVLOG(1) << "Default model " << model_key_
+             << " no longer exists, falling back to automatic model";
+    model_key_ = kChatAutomaticModelKey;
     model = model_service_->GetModel(model_key_);
   }
   CHECK(model);

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -23,12 +23,12 @@
 #include "base/containers/span.h"
 #include "base/containers/to_vector.h"
 #include "base/debug/crash_logging.h"
-#include "base/debug/dump_without_crashing.h"
 #include "base/files/file_path.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "base/logging.h"
 #include "base/memory/weak_ptr.h"
+#include "base/notreached.h"
 #include "base/numerics/safe_math.h"
 #include "base/rand_util.h"
 #include "base/strings/strcat.h"
@@ -380,31 +380,7 @@ void ConversationHandler::OnConversationDeleted() {
 }
 
 void ConversationHandler::InitEngine() {
-  const mojom::Model* model = nullptr;
-  if (!model_key_.empty()) {
-    model = model_service_->GetModel(model_key_);
-  }
-  // Make sure we get a valid model, defaulting to static default or first.
-  if (!model) {
-    // It is unexpected that we get here. Dump a call stack
-    // to help figure out why it happens.
-    SCOPED_CRASH_KEY_STRING1024("BraveAIChatModel", "key", model_key_);
-    base::debug::DumpWithoutCrashing();
-    // Use default
-    model = model_service_->GetModel(features::kAIModelsDefaultKey.Get());
-    if (!model) {
-      SCOPED_CRASH_KEY_STRING1024("BraveAIChatModel", "key",
-                                  features::kAIModelsDefaultKey.Get());
-      base::debug::DumpWithoutCrashing();
-      const auto& all_models = model_service_->GetModels();
-      // Use first if given bad default value
-      model = all_models.at(0).get();
-    }
-  }
-
-  // Model's key might not be the same as what we asked for (e.g. if the model
-  // no longer exists).
-  model_key_ = model->key;
+  model_key_ = GetCurrentModel().key;
 
   // Update Conversation metadata's model key
   if (model_key_ != model_service_->GetDefaultModelKey()) {
@@ -435,12 +411,20 @@ void ConversationHandler::InitEngine() {
 const mojom::Model& ConversationHandler::GetCurrentModel() {
   const mojom::Model* model = model_service_->GetModel(model_key_);
   if (!model) {
-    // Model no longer exists (e.g., custom model was deleted)
-    // Fall back to the automatic model
     DVLOG(1) << "Model " << model_key_
-             << " no longer exists, falling back to automatic model";
+             << " no longer exists, falling back to default model";
     model_key_ = features::kAIModelsDefaultKey.Get();
     model = model_service_->GetModel(model_key_);
+  }
+  if (!model) {
+    // default_model is read live from config; failing here means it's
+    // currently misconfigured.
+    SCOPED_CRASH_KEY_STRING1024("BraveAIChatModel", "key",
+                                features::kAIModelsDefaultKey.Get());
+    DUMP_WILL_BE_NOTREACHED();
+    const auto& all_models = model_service_->GetModels();
+    model = all_models.at(0).get();
+    model_key_ = model->key;
   }
   CHECK(model);
   return *model;

--- a/components/ai_chat/core/browser/conversation_handler.h
+++ b/components/ai_chat/core/browser/conversation_handler.h
@@ -274,6 +274,11 @@ class ConversationHandler : public mojom::ConversationHandler,
   }
   EngineConsumer* GetEngineForTesting() { return engine_.get(); }
 
+  // Sets |model_key_| directly, without validation.
+  void SetModelKeyForTesting(std::string model_key) {
+    model_key_ = std::move(model_key);
+  }
+
   ToolProvider* GetFirstToolProviderForTesting() {
     if (tool_providers_.empty()) {
       return nullptr;

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -15,6 +15,7 @@
 #include <variant>
 #include <vector>
 
+#include "base/dcheck_is_on.h"
 #include "base/files/scoped_temp_dir.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
@@ -27,6 +28,7 @@
 #include "base/task/thread_pool.h"
 #include "base/test/bind.h"
 #include "base/test/gmock_callback_support.h"
+#include "base/test/gtest_util.h"
 #include "base/test/mock_callback.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
@@ -6976,5 +6978,89 @@ TEST_F(ConversationHandlerUnitTest, ConversationCapabilities) {
     testing::Mock::VerifyAndClearExpectations(engine);
   }
 }
+
+TEST_F(ConversationHandlerUnitTest, FallsBackWhenModelKeyNoLongerExists) {
+  auto conversation = mojom::Conversation::New(
+      "stale-model-uuid", "title", base::Time::Now(), false,
+      "this-model-key-does-not-exist", 0, 0, false,
+      std::vector<mojom::AssociatedContentPtr>());
+
+  std::vector<std::unique_ptr<ToolProvider>> tool_providers;
+  tool_providers.push_back(std::make_unique<NiceMock<MockToolProvider>>());
+
+  auto handler = std::make_unique<ConversationHandler>(
+      conversation.get(), ai_chat_service_.get(), model_service_.get(),
+      ai_chat_service_->GetCredentialManagerForTesting(),
+      mock_feedback_api_.get(), &prefs_, shared_url_loader_factory_,
+      std::move(tool_providers));
+
+  EXPECT_EQ(handler->GetCurrentModel().key, kChatAutomaticModelKey);
+}
+
+using ConversationHandlerDeathTest = ConversationHandlerUnitTest;
+
+// The configured default failing to resolve means it's actually broken, so
+// this case is a same-build internal-consistency violation, not a resolvable
+// fallback.
+//
+// DUMP_WILL_BE_NOTREACHED() is only guaranteed fatal outside official builds
+// or with DCHECKs enabled; skip this death test in the one configuration
+// (official build, DCHECKs off) where it wouldn't actually crash.
+#if !defined(OFFICIAL_BUILD) || DCHECK_IS_ON()
+TEST_F(ConversationHandlerDeathTest,
+       CrashesWhenConfiguredDefaultModelDoesNotExist) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kAIChat,
+      {{features::kAIModelsDefaultKey.name, "this-default-does-not-exist"}});
+
+  auto conversation = mojom::Conversation::New(
+      "stale-model-and-default-uuid", "title", base::Time::Now(), false,
+      "this-model-key-does-not-exist", 0, 0, false,
+      std::vector<mojom::AssociatedContentPtr>());
+
+  std::vector<std::unique_ptr<ToolProvider>> tool_providers;
+  tool_providers.push_back(std::make_unique<NiceMock<MockToolProvider>>());
+
+  EXPECT_NOTREACHED_DEATH(
+      auto handler = std::make_unique<ConversationHandler>(
+          conversation.get(), ai_chat_service_.get(), model_service_.get(),
+          ai_chat_service_->GetCredentialManagerForTesting(),
+          mock_feedback_api_.get(), &prefs_, shared_url_loader_factory_,
+          std::move(tool_providers)));
+}
+#endif  // !defined(OFFICIAL_BUILD) || DCHECK_IS_ON()
+
+// Bypasses InitEngine()'s up-front resolution to exercise GetCurrentModel()'s
+// own fallback.
+TEST_F(ConversationHandlerUnitTest,
+       GetCurrentModelFallsBackToConfiguredDefault) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kAIChat,
+      {{features::kAIModelsDefaultKey.name, kClaudeSonnetModelKey}});
+
+  conversation_handler_->SetModelKeyForTesting("this-model-key-does-not-exist");
+
+  EXPECT_EQ(conversation_handler_->GetCurrentModel().key,
+            kClaudeSonnetModelKey);
+}
+
+// DUMP_WILL_BE_NOTREACHED() is only guaranteed fatal outside official builds
+// or with DCHECKs enabled; skip this death test in the one configuration
+// (official build, DCHECKs off) where it wouldn't actually crash.
+#if !defined(OFFICIAL_BUILD) || DCHECK_IS_ON()
+TEST_F(ConversationHandlerDeathTest,
+       CrashesWhenConfiguredDefaultModelAlsoMissingInGetCurrentModel) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kAIChat,
+      {{features::kAIModelsDefaultKey.name, "this-default-does-not-exist"}});
+
+  conversation_handler_->SetModelKeyForTesting("this-model-key-does-not-exist");
+
+  EXPECT_NOTREACHED_DEATH(conversation_handler_->GetCurrentModel());
+}
+#endif  // !defined(OFFICIAL_BUILD) || DCHECK_IS_ON()
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -15,6 +15,7 @@
 #include <variant>
 #include <vector>
 
+#include "base/dcheck_is_on.h"
 #include "base/files/scoped_temp_dir.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
@@ -27,6 +28,7 @@
 #include "base/task/thread_pool.h"
 #include "base/test/bind.h"
 #include "base/test/gmock_callback_support.h"
+#include "base/test/gtest_util.h"
 #include "base/test/mock_callback.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
@@ -6954,6 +6956,86 @@ TEST_F(ConversationHandlerUnitTest, ConversationCapabilities) {
 
     testing::Mock::VerifyAndClearExpectations(engine);
   }
+}
+
+TEST_F(ConversationHandlerUnitTest, FallsBackWhenModelKeyNoLongerExists) {
+  auto conversation = mojom::Conversation::New(
+      "stale-model-uuid", "title", base::Time::Now(), false,
+      "this-model-key-does-not-exist", 0, 0, false,
+      std::vector<mojom::AssociatedContentPtr>());
+
+  std::vector<std::unique_ptr<ToolProvider>> tool_providers;
+  tool_providers.push_back(std::make_unique<NiceMock<MockToolProvider>>());
+
+  auto handler = std::make_unique<ConversationHandler>(
+      conversation.get(), ai_chat_service_.get(), model_service_.get(),
+      ai_chat_service_->GetCredentialManagerForTesting(),
+      mock_feedback_api_.get(), &prefs_, shared_url_loader_factory_,
+      std::move(tool_providers));
+
+  EXPECT_EQ(handler->GetCurrentModel().key, kChatAutomaticModelKey);
+}
+
+using ConversationHandlerDeathTest = ConversationHandlerUnitTest;
+
+// The configured default failing to resolve means it's actually broken, so
+// this case is a same-build internal-consistency violation, not a resolvable
+// fallback.
+//
+// DUMP_WILL_BE_NOTREACHED() is only guaranteed fatal outside official builds
+// or with DCHECKs enabled; skip this death test in the one configuration
+// (official build, DCHECKs off) where it wouldn't actually crash.
+#if !defined(OFFICIAL_BUILD) || DCHECK_IS_ON()
+TEST_F(ConversationHandlerDeathTest,
+       CrashesWhenConfiguredDefaultModelDoesNotExist) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kAIChat,
+      {{features::kAIModelsDefaultKey.name, "this-default-does-not-exist"}});
+
+  auto conversation = mojom::Conversation::New(
+      "stale-model-and-default-uuid", "title", base::Time::Now(), false,
+      "this-model-key-does-not-exist", 0, 0, false,
+      std::vector<mojom::AssociatedContentPtr>());
+
+  std::vector<std::unique_ptr<ToolProvider>> tool_providers;
+  tool_providers.push_back(std::make_unique<NiceMock<MockToolProvider>>());
+
+  EXPECT_NOTREACHED_DEATH(
+      auto handler = std::make_unique<ConversationHandler>(
+          conversation.get(), ai_chat_service_.get(), model_service_.get(),
+          ai_chat_service_->GetCredentialManagerForTesting(),
+          mock_feedback_api_.get(), &prefs_, shared_url_loader_factory_,
+          std::move(tool_providers)));
+}
+#endif  // !defined(OFFICIAL_BUILD) || DCHECK_IS_ON()
+
+// Bypasses InitEngine()'s up-front resolution to exercise GetCurrentModel()'s
+// own fallback.
+TEST_F(ConversationHandlerUnitTest,
+       GetCurrentModelFallsBackToConfiguredDefault) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kAIChat,
+      {{features::kAIModelsDefaultKey.name, kClaudeSonnetModelKey}});
+
+  conversation_handler_->SetModelKeyForTesting("this-model-key-does-not-exist");
+
+  EXPECT_EQ(conversation_handler_->GetCurrentModel().key,
+            kClaudeSonnetModelKey);
+}
+
+TEST_F(ConversationHandlerUnitTest,
+       GetCurrentModelFallsBackToAutomaticWhenDefaultAlsoMissing) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kAIChat,
+      {{features::kAIModelsDefaultKey.name, "this-default-does-not-exist"}});
+
+  conversation_handler_->SetModelKeyForTesting("this-model-key-does-not-exist");
+
+  EXPECT_EQ(conversation_handler_->GetCurrentModel().key,
+            kChatAutomaticModelKey);
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/model_service.cc
+++ b/components/ai_chat/core/browser/model_service.cc
@@ -1184,6 +1184,12 @@ std::unique_ptr<EngineConsumer> ModelService::GetEngineForModel(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     AIChatCredentialManager* credential_manager) {
   const mojom::Model* model = GetModel(model_key);
+  if (!model) {
+    // Model no longer exists — fall back to the configured default.
+    model = GetModel(features::kAIModelsDefaultKey.Get());
+  }
+  CHECK(model) << "Default model missing from model list";
+
   std::unique_ptr<EngineConsumer> engine;
   if (model->supports_private_inference ||
       model->options->is_custom_model_options()) {

--- a/components/ai_chat/core/browser/model_service.cc
+++ b/components/ai_chat/core/browser/model_service.cc
@@ -1196,6 +1196,13 @@ std::unique_ptr<EngineConsumer> ModelService::GetEngineForModel(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     AIChatCredentialManager* credential_manager) {
   const mojom::Model* model = GetModel(model_key);
+  if (!model) {
+    // Model no longer exists — fall back to the automatic model, which is
+    // always present.
+    model = GetModel(kChatAutomaticModelKey);
+  }
+  CHECK(model) << "Automatic model missing from model list";
+
   std::unique_ptr<EngineConsumer> engine;
   if (model->supports_private_inference ||
       model->options->is_custom_model_options()) {

--- a/components/ai_chat/core/browser/model_service_unittest.cc
+++ b/components/ai_chat/core/browser/model_service_unittest.cc
@@ -20,9 +20,11 @@
 #include "base/scoped_observation.h"
 #include "base/strings/string_util.h"
 #include "base/test/bind.h"
+#include "base/test/gtest_util.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
 #include "brave/components/ai_chat/core/browser/constants.h"
+#include "brave/components/ai_chat/core/browser/engine/engine_consumer.h"
 #include "brave/components/ai_chat/core/browser/model_validator.h"
 #include "brave/components/ai_chat/core/common/constants.h"
 #include "brave/components/ai_chat/core/common/features.h"
@@ -33,6 +35,7 @@
 #include "components/os_crypt/async/browser/test_utils.h"
 #include "components/prefs/testing_pref_service.h"
 #include "services/network/public/cpp/network_context_getter.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "url/gurl.h"
@@ -420,6 +423,34 @@ TEST_F(ModelServiceTest, GetLeoModelKeyByName_And_GetLeoModelNameByKey) {
   EXPECT_FALSE(key.has_value());
   auto name = GetService()->GetLeoModelNameByKey("nonexistent-key");
   EXPECT_FALSE(name.has_value());
+}
+
+TEST_F(ModelServiceTest,
+       GetEngineForModelFallsBackToConfiguredDefaultForUnknownKey) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kAIChat,
+      {{features::kAIModelsDefaultKey.name, kClaudeHaikuModelKey}});
+
+  // APIRequestHelper posts to the thread pool at construction time.
+  base::test::TaskEnvironment task_environment;
+  auto engine = GetService()->GetEngineForModel("this-model-key-does-not-exist",
+                                                /*url_loader_factory=*/nullptr,
+                                                /*credential_manager=*/nullptr);
+  ASSERT_TRUE(engine);
+  EXPECT_EQ(engine->GetModelName(), kClaudeHaikuModelName);
+}
+
+TEST_F(ModelServiceTest,
+       CrashesWhenConfiguredDefaultModelAlsoMissingInGetEngineForModel) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeatureWithParameters(
+      features::kAIChat,
+      {{features::kAIModelsDefaultKey.name, "this-default-does-not-exist"}});
+
+  EXPECT_CHECK_DEATH(GetService()->GetEngineForModel(
+      "this-model-key-does-not-exist", /*url_loader_factory=*/nullptr,
+      /*credential_manager=*/nullptr));
 }
 
 TEST_F(ModelServiceTest, DeleteCustomModelsByEndpoint) {

--- a/components/ai_chat/core/browser/model_service_unittest.cc
+++ b/components/ai_chat/core/browser/model_service_unittest.cc
@@ -23,6 +23,7 @@
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
 #include "brave/components/ai_chat/core/browser/constants.h"
+#include "brave/components/ai_chat/core/browser/engine/engine_consumer.h"
 #include "brave/components/ai_chat/core/browser/model_validator.h"
 #include "brave/components/ai_chat/core/common/constants.h"
 #include "brave/components/ai_chat/core/common/features.h"
@@ -33,6 +34,7 @@
 #include "components/os_crypt/async/browser/test_utils.h"
 #include "components/prefs/testing_pref_service.h"
 #include "services/network/public/cpp/network_context_getter.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "url/gurl.h"
@@ -420,6 +422,16 @@ TEST_F(ModelServiceTest, GetLeoModelKeyByName_And_GetLeoModelNameByKey) {
   EXPECT_FALSE(key.has_value());
   auto name = GetService()->GetLeoModelNameByKey("nonexistent-key");
   EXPECT_FALSE(name.has_value());
+}
+
+TEST_F(ModelServiceTest, GetEngineForModelFallsBackToAutomaticForUnknownKey) {
+  // APIRequestHelper posts to the thread pool at construction time.
+  base::test::TaskEnvironment task_environment;
+  auto engine = GetService()->GetEngineForModel("this-model-key-does-not-exist",
+                                                /*url_loader_factory=*/nullptr,
+                                                /*credential_manager=*/nullptr);
+  ASSERT_TRUE(engine);
+  EXPECT_EQ(engine->GetModelName(), "automatic");
 }
 
 TEST_F(ModelServiceTest, DeleteCustomModelsByEndpoint) {


### PR DESCRIPTION
Part of brave/brave-browser#53952. This PR adds a bit of hardening to when models are removed from the server.