### PR TITLE
Disable V8 additive_safe_int_feedback

### DIFF
--- a/patches/v8/src-flags-flag-definitions.h.patch
+++ b/patches/v8/src-flags-flag-definitions.h.patch
@@ -1,0 +1,14 @@
+diff --git a/src/flags/flag-definitions.h b/src/flags/flag-definitions.h
+index bf210a58890f77dfc5df273868091d45b51bcaa4..e3154b3abb74061a88dd1db870ac44aa7bf18952 100644
+--- a/src/flags/flag-definitions.h
++++ b/src/flags/flag-definitions.h
+@@ -883,7 +883,8 @@ DEFINE_EXPERIMENTAL_FEATURE(
+     "strings.")
+ 
+ #ifdef V8_TARGET_ARCH_64_BIT
+-DEFINE_BOOL(additive_safe_int_feedback, true,
++// Brave: revert when https://crbug.com/542403050 is fixed.
++DEFINE_BOOL(additive_safe_int_feedback, false,
+             "Enable the use of AdditiveSafeInteger feedback")
+ DEFINE_BOOL(turbolev_additive_safe_int_feedback, true,
+             "Enable the use of AdditiveSafeInteger feedback for Turbolev")


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57873

The PR disables the problematic feature (was recently disabled by Finch for Chrome).
More details in the issue.

STR:
1.  open https://atuchin-m.github.io/TestPages/SpeculativeAdditiveSafeIntegerAddSubtrace-issue.html
2. click "Run repro" 

The test PASSES if the feature is disabled (mac, 1.95.40 Chromium: 151.0.7922.71 (Official Build) nightly (arm64)):
<img width="840" height="764" alt="image" src="https://github.com/user-attachments/assets/bce9176f-b19a-445e-aab2-f7cb3a7460d0" />


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
