### PR TITLE
[Wallet]: Remove Bottom Gap for Side Panel

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
@@ -57,7 +57,8 @@ export const LayoutCardWrapper = styled.div<{
     p.hideCardHeader
       ? 'var(--no-header-top-position)'
       : 'var(--header-top-position)'};
-  --bottom-position: ${(p) => (p.hideNav ? 0 : layoutSmallCardBottom)}px;
+  --bottom-position: ${(p) =>
+    p.hideNav || p.isSidePanel ? 0 : layoutSmallCardBottom}px;
   /*
     (100vw / 2) - (${maxCardWidth}px / 2) makes the card body perfectly centered
     horizontally in the browser window.
@@ -89,7 +90,7 @@ export const LayoutCardWrapper = styled.div<{
       ? 'var(--left-padding-without-nav)'
       : 'var(--left-padding-with-nav)'};
   @media screen and (max-width: ${layoutSmallWidth}px) {
-    bottom: ${(p) => (p.isSidePanel ? 0 : 'var(--bottom-position)')};
+    bottom: var(--bottom-position);
     padding: 0px 32px 32px 32px;
     align-items: center;
   }


### PR DESCRIPTION
## Description 

Removes the bottom gap for Wallet `Side Bar` 

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/57877>

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

Before:

<img width="499" height="844" alt="Screenshot 33" src="https://github.com/user-attachments/assets/12c72d2a-7442-49d2-8418-91f664afb229" /> | <img width="493" height="840" alt="Screenshot 34" src="https://github.com/user-attachments/assets/26ddbfe4-a3ad-45e7-91cb-927385d20e28" />
--|--

After:

<img width="490" height="829" alt="Screenshot 36" src="https://github.com/user-attachments/assets/4086ad8c-0ba3-4a4f-a930-2f640b32d0c9" /> | <img width="493" height="838" alt="Screenshot 35" src="https://github.com/user-attachments/assets/e81ff63b-4e14-4d0e-9886-11d1c56f0df3" />
--|--
