### PR TITLE
[TEST] Fix typo in contribution instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Brave does consider volunteer translators on a case-by-case basis. If you repres
 Once you've cloned [`brave-core`](https://github.com/brave/brave-core) into `src/brave` in a directory of your choice, you're ready to start making edits!
 
 You'll need to add your fork to the remotes list. By default, `origin` is set to upstream.
-For example, here's how GitHub user `bsclifton` would and `brave-core`:
+For example, here's how GitHub user `bsclifton` would fork `brave-core`:
 ```sh
 # root for the `brave-core` repo
 cd src/brave


### PR DESCRIPTION
## Dummy/test PR

This is an intentionally trivial dummy contributor PR opened to test the contributor PR workflow.

It fixes one missing word in `CONTRIBUTING.md`, changing “would and `brave-core`” to “would fork `brave-core`”. This is documentation-only and does not alter runtime behavior.

## Checks

- `pnpm run format --base master --dry-run --only-prettier` (through `brave-build-lane`) — passed
- `pnpm run presubmit --base master` (through `brave-build-lane`) — passed: 0 messages, 0 warnings, 0 errors
- Repository `/review local` skill — passed with no findings
- `git diff --check upstream/master..HEAD` — passed
- Signed commit verified with `git verify-commit --verbose HEAD`

No issue is resolved; this PR is solely for test/dummy workflow validation.
