### PR TITLE
Disable flaky PWAShieldBrowserTest on Mac (uplift to 1.93.x)

### DIFF
--- a/browser/ui/views/brave_actions/pwa_shields_browsertest.cc
+++ b/browser/ui/views/brave_actions/pwa_shields_browsertest.cc
@@ -52,6 +52,15 @@ IN_PROC_BROWSER_TEST_F(PwaShieldsBrowserTest,
   EXPECT_TRUE(shields->GetVisible());
 }
 
+#if BUILDFLAG(IS_MAC)
+// Flaky on Mac CI
+#define MAYBE_ShieldsButtonNotDuplicatedWhenToolbarReparented \
+  DISABLED_ShieldsButtonInWebAppTitleBar
+#else
+#define MAYBE_ShieldsButtonNotDuplicatedWhenToolbarReparented \
+  ShieldsButtonNotDuplicatedWhenToolbarReparented
+#endif
+
 // Regression test for https://github.com/brave/brave-browser/issues/57349:
 // macOS immersive fullscreen reparents the web app toolbar (moving it into a
 // separate overlay widget), which re-triggers
@@ -62,7 +71,7 @@ IN_PROC_BROWSER_TEST_F(PwaShieldsBrowserTest,
 // should remain 2 (1 for the page action view, 1 for the toolbar button) even
 // after the reparenting.
 IN_PROC_BROWSER_TEST_F(PwaShieldsBrowserTest,
-                       ShieldsButtonNotDuplicatedWhenToolbarReparented) {
+                       MAYBE_ShieldsButtonNotDuplicatedWhenToolbarReparented) {
   const webapps::AppId app_id = InstallPWA(GetInstallableAppURL());
   Browser* app_browser = LaunchWebAppBrowser(app_id);
   ASSERT_TRUE(app_browser);


### PR DESCRIPTION
Uplift of #38838

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.