### PR TITLE
Disable CompositorTimelineTrigger to fix a crash (uplift to 1.93.x)

### DIFF
--- a/patches/third_party-blink-renderer-platform-runtime_enabled_features.json5.patch
+++ b/patches/third_party-blink-renderer-platform-runtime_enabled_features.json5.patch
@@ -14,6 +14,15 @@ index 2a689dd0a8bf37497c6d82fa89f8078bbb6e4185..626ea7ca1a254916b78a574a819a4478
      {
        name: "BrowserInitiatedAutomaticPictureInPicture",
        public: true,
+@@ -1317,7 +1322,7 @@
+       // objects that live on the compositor thread.
+       // [1] https://drafts.csswg.org/css-animations-2/#timeline-triggers
+       name: "CompositorTimelineTrigger",
+-      status: "stable",
++      status: "experimental", // Brave: revert when crbug.com/541924666 is fixed.
+     },
+     {
+       name: "CompressionDictionaryTransport",
 @@ -2934,6 +2939,7 @@
        // In-development features for the File System Access API.
        name: "FileSystemAccessAPIExperimental",


### PR DESCRIPTION
Uplift of #38821
Resolves https://github.com/brave/brave-browser/issues/57870

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.