### PR TITLE
Disable V8 additive_safe_int_feedback (uplift to 1.94.x)

### DIFF
--- a/patches/v8/src-flags-flag-definitions.h.patch
+++ b/patches/v8/src-flags-flag-definitions.h.patch
@@ -1,0 +1,14 @@
+diff --git a/src/flags/flag-definitions.h b/src/flags/flag-definitions.h
+index bf210a58890f77dfc5df273868091d45b51bcaa4..e3154b3abb74061a88dd1db870ac44aa7bf18952 100644
+--- a/src/flags/flag-definitions.h
++++ b/src/flags/flag-definitions.h
+@@ -883,7 +883,8 @@ DEFINE_EXPERIMENTAL_FEATURE(
+     "strings.")
+ 
+ #ifdef V8_TARGET_ARCH_64_BIT
+-DEFINE_BOOL(additive_safe_int_feedback, true,
++// Brave: revert when https://crbug.com/542403050 is fixed.
++DEFINE_BOOL(additive_safe_int_feedback, false,
+             "Enable the use of AdditiveSafeInteger feedback")
+ DEFINE_BOOL(turbolev_additive_safe_int_feedback, true,
+             "Enable the use of AdditiveSafeInteger feedback for Turbolev")


### PR DESCRIPTION
Uplift of #38825
Resolves https://github.com/brave/brave-browser/issues/57873

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.