### PR TITLE
[Android] Fixed passwords duplication on Password Manager search

### DIFF
--- a/android/java/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
+++ b/android/java/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
@@ -551,6 +551,13 @@ public class PasswordSettings extends ChromeBaseSettingsFragment
     public void passwordListAvailable(int count) {
         resetList(PREF_KEY_CATEGORY_SAVED_PASSWORDS);
         resetNoEntriesTextMessage();
+        if (mSearchQuery != null) {
+            // In search mode the results are added directly to the preference screen (there is no
+            // saved-passwords category), so resetList() above does not remove them. Clear them here
+            // so repeated password-store updates (e.g. OnLoginsRetained) don't accumulate duplicate
+            // rows.
+            getPreferenceScreen().removeAll();
+        }
 
         mNoPasswords = count == 0;
         if (mNoPasswords) {

--- a/android/javatests/org/chromium/chrome/browser/password_manager/settings/PasswordSettingsSearchTest.java
+++ b/android/javatests/org/chromium/chrome/browser/password_manager/settings/PasswordSettingsSearchTest.java
@@ -73,6 +73,7 @@ import org.chromium.chrome.browser.flags.ChromeSwitches;
 import org.chromium.chrome.browser.history.HistoryActivity;
 import org.chromium.chrome.browser.history.HistoryContentManager;
 import org.chromium.chrome.browser.history.StubbedHistoryProvider;
+import org.chromium.chrome.browser.profiles.ProfileManager;
 import org.chromium.chrome.browser.settings.SettingsActivityTestRule;
 import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
 import org.chromium.chrome.test.R;
@@ -181,6 +182,41 @@ public class PasswordSettingsSearchTest {
         onView(withText(ARES_AT_OLYMP.getUserName())).check(matches(isDisplayed()));
         onView(withText(PHOBOS_AT_OLYMP.getUserName())).check(matches(isDisplayed()));
         onView(withText(DEIMOS_AT_OLYMP.getUserName())).check(matches(isDisplayed()));
+    }
+
+    /**
+     * Regression test: while a search is open, a password-store update (e.g. OnLoginsRetained) must
+     * not append a second copy of the filtered rows. The results are rendered directly on the
+     * preference screen in search mode, and previously were not cleared before re-adding, so
+     * repeated updates accumulated duplicate rows.
+     */
+    @Test
+    @SmallTest
+    @Feature({"Preferences"})
+    public void testSearchResultsNotDuplicatedOnPasswordListUpdate() {
+        mTestHelper.setPasswordSourceWithMultipleEntries(GREEK_GODS);
+        mTestHelper.startPasswordSettingsFromMainSettings(mSettingsActivityTestRule);
+
+        // "Zeu" matches only Zeus, so the result is shown exactly once.
+        onView(withSearchMenuIdOrText()).perform(click());
+        onView(withId(R.id.search_src_text)).perform(click(), typeText("Zeu"), closeSoftKeyboard());
+        onViewWaiting(allOf(withText(ZEUS_ON_EARTH.getUserName()), isDisplayed()));
+        assertViewCount(withText(ZEUS_ON_EARTH.getUserName()), 1);
+
+        // Simulate a spontaneous password-store update while the search is open. This re-fires
+        // passwordListAvailable() (bypassing rebuildPasswordLists()), which is the path that used
+        // to append a duplicate row.
+        ThreadUtils.runOnUiThreadBlocking(
+                () ->
+                        PasswordManagerHandlerProvider.getForProfile(
+                                        ProfileManager.getLastUsedRegularProfile())
+                                .getPasswordManagerHandler()
+                                .updatePasswordLists());
+
+        // Still exactly one - no duplicate. assertViewCount() runs through Espresso's onView(),
+        // which loops the main thread until idle, so the posted preference/RecyclerView rebuild
+        // triggered by the update above has been applied by the time the count is checked.
+        assertViewCount(withText(ZEUS_ON_EARTH.getUserName()), 1);
     }
 
     /** Check that the search filters the list by URL. */


### PR DESCRIPTION
While a search was open, a password-store update (e.g. OnLoginsRetained) re-fired passwordListAvailable and appended a second copy of the filtered rows, because in search mode results are added directly to the preference screen and were not cleared before re-adding.

Resolves https://github.com/brave/brave-browser/issues/57894

<!-- Add brave-browser issue below that this PR will resolve -->


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
