### PR TITLE
[Android] Fixed passwords duplication on Password Manager search (uplift to 1.94.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
+++ b/android/java/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
@@ -536,6 +536,13 @@ public class PasswordSettings extends ChromeBaseSettingsFragment
     public void passwordListAvailable(int count) {
         resetList(PREF_KEY_CATEGORY_SAVED_PASSWORDS);
         resetNoEntriesTextMessage();
+        if (mSearchQuery != null) {
+            // In search mode the results are added directly to the preference screen (there is no
+            // saved-passwords category), so resetList() above does not remove them. Clear them here
+            // so repeated password-store updates (e.g. OnLoginsRetained) don't accumulate duplicate
+            // rows.
+            getPreferenceScreen().removeAll();
+        }
 
         mNoPasswords = count == 0;
         if (mNoPasswords) {

--- a/android/javatests/org/chromium/chrome/browser/password_manager/settings/PasswordSettingsSearchTest.java
+++ b/android/javatests/org/chromium/chrome/browser/password_manager/settings/PasswordSettingsSearchTest.java
@@ -73,6 +73,7 @@ import org.chromium.chrome.browser.flags.ChromeSwitches;
 import org.chromium.chrome.browser.history.HistoryActivity;
 import org.chromium.chrome.browser.history.HistoryContentManager;
 import org.chromium.chrome.browser.history.StubbedHistoryProvider;
+import org.chromium.chrome.browser.profiles.ProfileManager;
 import org.chromium.chrome.browser.settings.SettingsActivityTestRule;
 import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
 import org.chromium.chrome.test.R;
@@ -181,6 +182,41 @@ public class PasswordSettingsSearchTest {
         onView(withText(ARES_AT_OLYMP.getUserName())).check(matches(isDisplayed()));
         onView(withText(PHOBOS_AT_OLYMP.getUserName())).check(matches(isDisplayed()));
         onView(withText(DEIMOS_AT_OLYMP.getUserName())).check(matches(isDisplayed()));
+    }
+
+    /**
+     * Regression test: while a search is open, a password-store update (e.g. OnLoginsRetained) must
+     * not append a second copy of the filtered rows. The results are rendered directly on the
+     * preference screen in search mode, and previously were not cleared before re-adding, so
+     * repeated updates accumulated duplicate rows.
+     */
+    @Test
+    @SmallTest
+    @Feature({"Preferences"})
+    public void testSearchResultsNotDuplicatedOnPasswordListUpdate() {
+        mTestHelper.setPasswordSourceWithMultipleEntries(GREEK_GODS);
+        mTestHelper.startPasswordSettingsFromMainSettings(mSettingsActivityTestRule);
+
+        // "Zeu" matches only Zeus, so the result is shown exactly once.
+        onView(withSearchMenuIdOrText()).perform(click());
+        onView(withId(R.id.search_src_text)).perform(click(), typeText("Zeu"), closeSoftKeyboard());
+        onViewWaiting(allOf(withText(ZEUS_ON_EARTH.getUserName()), isDisplayed()));
+        assertViewCount(withText(ZEUS_ON_EARTH.getUserName()), 1);
+
+        // Simulate a spontaneous password-store update while the search is open. This re-fires
+        // passwordListAvailable() (bypassing rebuildPasswordLists()), which is the path that used
+        // to append a duplicate row.
+        ThreadUtils.runOnUiThreadBlocking(
+                () ->
+                        PasswordManagerHandlerProvider.getForProfile(
+                                        ProfileManager.getLastUsedRegularProfile())
+                                .getPasswordManagerHandler()
+                                .updatePasswordLists());
+
+        // Still exactly one - no duplicate. assertViewCount() runs through Espresso's onView(),
+        // which loops the main thread until idle, so the posted preference/RecyclerView rebuild
+        // triggered by the update above has been applied by the time the count is checked.
+        assertViewCount(withText(ZEUS_ON_EARTH.getUserName()), 1);
     }
 
     /** Check that the search filters the list by URL. */


### PR DESCRIPTION
Uplift of #38860
Resolves https://github.com/brave/brave-browser/issues/57894

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.