### PR TITLE
[gerrit] Refresh mirrors recipe

### DIFF
--- a/tools/recipes/recipe_modules/chromium_checkout/api.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/api.py
@@ -410,6 +410,16 @@ class ChromiumCheckoutApi(RecipeApi):
             self.m.env.set(f"GYP_MSVS_HASH_{info['toolchain_hash']}",
                            info['published_hash'])
 
+    def fetch_tags(self, chromium_src: str | Path) -> None:
+        """Fetch every tag from origin into the *chromium_src* checkout.
+
+        Args:
+            chromium_src: Path to the Chromium `src/` directory.
+        """
+        chromium_src = self.m.path.abs(chromium_src)
+        self.m.step('fetch tags', ['git', 'fetch', '--tags', 'origin'],
+                    cwd=chromium_src)
+
     def _populate_git_cache(self,
                             git_cache_path: str | Path,
                             url: str,

--- a/tools/recipes/recipe_modules/chromium_checkout/tests/fetch_tags.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/tests/fetch_tags.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Test for `fetch_tags`: pulls every tag into a checkout backed by the shared
+git cache, since `gclient sync` itself fetches with `--no-tags`.
+"""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['chromium_checkout']
+
+
+def RunSteps(api):
+    api.chromium_checkout.fetch_tags('/b/s/brave-browser/src')
+
+
+def GenTests(api):
+    yield api.test(
+        'fetches every tag',
+        api.post_process(post_process.StepCommandContains, 'fetch tags',
+                         ['git', 'fetch', '--tags', 'origin']),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )

--- a/tools/recipes/recipe_test_runner.py
+++ b/tools/recipes/recipe_test_runner.py
@@ -45,6 +45,16 @@ if TYPE_CHECKING:
 # -- Recipe discovery ---------------------------------------------------------
 
 
+def _is_resource(path: Path) -> bool:
+    """Whether *path* sits under a `<name>.resources/` directory.
+
+    A `.resources` sibling holds standalone scripts a recipe or module shells
+    out to directly (e.g. via `vpython3`) -- ordinary Python files, not
+    recipes/modules themselves, so discovery must not try to import them.
+    """
+    return any(part.endswith('.resources') for part in path.parts)
+
+
 def _iter_recipe_ids() -> list[str]:
     """Every candidate recipe id, from `recipes/` and module examples/tests."""
     root = engine.RECIPES_ROOT
@@ -52,7 +62,7 @@ def _iter_recipe_ids() -> list[str]:
 
     recipes_root = root / engine.RECIPES_PKG
     for path in sorted(recipes_root.rglob('*.py')):
-        if path.name == '__init__.py':
+        if path.name == '__init__.py' or _is_resource(path):
             continue
         ids.append(path.relative_to(recipes_root).with_suffix('').as_posix())
 
@@ -63,7 +73,7 @@ def _iter_recipe_ids() -> list[str]:
             if not directory.is_dir():
                 continue
             for path in sorted(directory.rglob('*.py')):
-                if path.name == '__init__.py':
+                if path.name == '__init__.py' or _is_resource(path):
                     continue
                 ids.append(
                     path.relative_to(modules_root).with_suffix('').as_posix())

--- a/tools/recipes/recipes/gerrit/__init__.py
+++ b/tools/recipes/recipes/gerrit/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Package marker for Gerrit recipes."""

--- a/tools/recipes/recipes/gerrit/refresh_mirrors.expected/fresh_checkout.json
+++ b/tools/recipes/recipes/gerrit/refresh_mirrors.expected/fresh_checkout.json
@@ -1,0 +1,193 @@
+[
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "1",
+      "https://chromium.googlesource.com/chromium/tools/depot_tools",
+      "[WORKSPACE]/b/src/third_party/depot_tools"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "clone depot_tools"
+  },
+  {
+    "cmd": [
+      "gclient"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "verify gclient"
+  },
+  {
+    "cmd": [
+      "gclient",
+      "config",
+      "--name",
+      "src",
+      "--unmanaged",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "cwd": "[WORKSPACE]/b",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "gclient config"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "populate",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git",
+      "--reset-fetch-config",
+      "--no-fetch-tags",
+      "--ref",
+      "main"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache exists"
+  },
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--no-checkout",
+      "--local",
+      "--shared",
+      "/b/cache/chromium.googlesource.com-chromium-src",
+      "[WORKSPACE]/b/src"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "clone from git cache"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.auto",
+      "0"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git config gc.auto=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autodetach",
+      "0"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git config gc.autodetach=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autopacklimit",
+      "0"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git config gc.autopacklimit=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "checkout",
+      "--force",
+      "main",
+      "--"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "checkout ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "remote",
+      "set-url",
+      "--push",
+      "origin",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "restore origin push url"
+  },
+  {
+    "cmd": [
+      "gclient",
+      "sync",
+      "--force",
+      "-D"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "gclient sync"
+  },
+  {
+    "cmd": [
+      "git",
+      "fetch",
+      "--tags",
+      "origin"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "name": "fetch tags"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "[RECIPES_ROOT]/recipes/gerrit/refresh_mirrors.resources/refresh_mirrors.py",
+      "--user",
+      "chromium-mirror-bot",
+      "--git-cache-path",
+      "/b/cache"
+    ],
+    "name": "refresh gerrit mirrors"
+  },
+  {
+    "name": "$result"
+  }
+]

--- a/tools/recipes/recipes/gerrit/refresh_mirrors.expected/reused_checkout_at_explicit_ref.json
+++ b/tools/recipes/recipes/gerrit/refresh_mirrors.expected/reused_checkout_at_explicit_ref.json
@@ -1,0 +1,165 @@
+[
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "1",
+      "https://chromium.googlesource.com/chromium/tools/depot_tools",
+      "[WORKSPACE]/b/src/third_party/depot_tools"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "clone depot_tools"
+  },
+  {
+    "cmd": [
+      "gclient"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "verify gclient"
+  },
+  {
+    "cmd": [
+      "git",
+      "log",
+      "-1",
+      "--oneline",
+      "chrome/VERSION"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "check chrome/VERSION"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "populate",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git",
+      "--reset-fetch-config",
+      "--no-fetch-tags",
+      "--ref",
+      "refs/tags/151.0.7917.1"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate for ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache exists for ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "remote",
+      "set-url",
+      "origin",
+      "/b/cache/chromium.googlesource.com-chromium-src"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "point origin at git cache"
+  },
+  {
+    "cmd": [
+      "git",
+      "remote",
+      "set-url",
+      "--push",
+      "origin",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "restore origin push url"
+  },
+  {
+    "cmd": [
+      "git",
+      "fetch",
+      "--no-tags",
+      "origin",
+      "refs/tags/151.0.7917.1:refs/tags/151.0.7917.1"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "fetch tag"
+  },
+  {
+    "cmd": [
+      "git",
+      "checkout",
+      "--force",
+      "FETCH_HEAD"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "checkout FETCH_HEAD"
+  },
+  {
+    "cmd": [
+      "gclient",
+      "sync",
+      "--force",
+      "-D"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "gclient sync"
+  },
+  {
+    "cmd": [
+      "git",
+      "fetch",
+      "--tags",
+      "origin"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "name": "fetch tags"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "[RECIPES_ROOT]/recipes/gerrit/refresh_mirrors.resources/refresh_mirrors.py",
+      "--user",
+      "chromium-mirror-bot",
+      "--git-cache-path",
+      "/b/cache"
+    ],
+    "name": "refresh gerrit mirrors"
+  },
+  {
+    "name": "$result"
+  }
+]

--- a/tools/recipes/recipes/gerrit/refresh_mirrors.proto
+++ b/tools/recipes/recipes/gerrit/refresh_mirrors.proto
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+syntax = "proto3";
+
+package recipes.brave.gerrit.refresh_mirrors;
+
+message InputProperties {
+  // Gerrit SSH user the script authenticates as.
+  string gerrit_user = 1;
+
+  // Chromium ref (tag or branch) to sync before mirroring the git cache;
+  // defaults to "main" when empty.
+  string chromium_ref = 2;
+}
+
+message EnvProperties {
+  // Optional override for the git cache root; defaults to $GIT_CACHE_PATH in
+  // the environment.
+  string GIT_CACHE = 1;
+}

--- a/tools/recipes/recipes/gerrit/refresh_mirrors.py
+++ b/tools/recipes/recipes/gerrit/refresh_mirrors.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Refresh the Gerrit mirrors from a freshly synced git cache.
+
+Runs in two phases:
+
+  1. Clone/sync Chromium at the latest `main`, so the shared git cache fills
+     with the host OS's dependency repos, then fetch all tags into the cache.
+  2. Once that sync finishes, run this recipe's own `refresh_mirrors.py`
+     resource script, publishing every cached repo into Gerrit.
+
+    vpython3 tools/recipes/engine.py gerrit/refresh_mirrors \\
+        --properties '{"gerrit_user": "chromium-mirror-bot"}'
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import post_process
+from PB.recipes.brave.gerrit.refresh_mirrors import (EnvProperties,
+                                                     InputProperties)
+
+if TYPE_CHECKING:
+    from engine import RecipeScriptApi
+
+DEPS = ['path', 'step', 'chromium_checkout', 'depot_tools']
+
+# Publishes the git cache into Gerrit; lives alongside this recipe (rather than
+# in brave-core proper) since this recipe is its only caller.
+_REFRESH_MIRRORS_SCRIPT = (Path(__file__).resolve().parent /
+                           'refresh_mirrors.resources' / 'refresh_mirrors.py')
+
+PROPERTIES = InputProperties
+ENV_PROPERTIES = EnvProperties
+
+
+def RunSteps(api: RecipeScriptApi, properties: InputProperties,
+             env_properties: EnvProperties) -> None:
+    # Phase 1: sync Chromium so the git cache is populated, then pull all
+    # tags into it (gclient sync fetches with --no-tags).
+    chromium_src = api.chromium_checkout.ensure_checkout(
+        ref=properties.chromium_ref or 'main',
+        git_cache=env_properties.GIT_CACHE or None)
+    api.chromium_checkout.fetch_tags(chromium_src)
+    git_cache_path = api.chromium_checkout.validate_git_cache()
+
+    # Phase 2: publish the now-populated cache into Gerrit.
+    vpython3 = api.depot_tools.vpython3()
+    api.step('refresh gerrit mirrors', [
+        vpython3,
+        _REFRESH_MIRRORS_SCRIPT,
+        '--user',
+        properties.gerrit_user,
+        '--git-cache-path',
+        git_cache_path,
+    ])
+
+
+def GenTests(api):
+    # Happy path: a fresh checkout (seeded git cache), tags fetched, then the
+    # mirror script run.
+    yield api.test(
+        'fresh checkout',
+        api.chromium_checkout.with_git_cache(),
+        api.chromium_checkout.git_cache_populated(),
+        api.properties(gerrit_user='chromium-mirror-bot'),
+        api.post_process(post_process.MustRun, 'clone from git cache'),
+        api.post_process(post_process.MustRun, 'fetch tags'),
+        api.post_process(post_process.MustRun, 'refresh gerrit mirrors'),
+        api.post_process(post_process.StepCommandContains,
+                         'refresh gerrit mirrors',
+                         ['--user', 'chromium-mirror-bot']),
+        api.post_process(post_process.StepCommandContains,
+                         'refresh gerrit mirrors',
+                         ['--git-cache-path', '/b/cache']),
+        api.post_process(post_process.StepCommandContains, 'checkout ref',
+                         ['main']),
+        api.post_process(post_process.StatusSuccess),
+    )
+    # A reused checkout (already valid) is still checked out at the given ref,
+    # rather than only happening on a fresh clone.
+    yield api.test(
+        'reused checkout at explicit ref',
+        api.chromium_checkout.with_git_cache(),
+        api.chromium_checkout.existing_checkout(),
+        api.chromium_checkout.git_cache_populated(),
+        api.properties(gerrit_user='chromium-mirror-bot',
+                       chromium_ref='151.0.7917.1'),
+        api.post_process(post_process.DoesNotRun, 'clone from git cache'),
+        api.post_process(post_process.MustRun, 'fetch tag'),
+        api.post_process(post_process.MustRun, 'fetch tags'),
+        api.post_process(post_process.MustRun, 'refresh gerrit mirrors'),
+        api.post_process(post_process.StatusSuccess),
+    )

--- a/tools/recipes/recipes/gerrit/refresh_mirrors.resources/refresh_mirrors.py
+++ b/tools/recipes/recipes/gerrit/refresh_mirrors.resources/refresh_mirrors.py
@@ -1,0 +1,589 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Publish the local git cache into our Gerrit mirror instance.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from urllib.parse import urlsplit
+
+# Our gerrit endpoint
+GERRIT_SSH_HOST = 'gerrit-ssh.brave.com'
+GERRIT_SSH_PORT = 29418
+
+# The parent project under which all mirrors are created.
+MIRROR_PARENT = 'mirror'
+MIRROR_OWNER_GROUP = 'mirrors-admins'
+
+# Name of the cache repos' upstream remote
+UPSTREAM_REMOTE = 'origin'
+GERRIT_REMOTE = 'gerrit'
+
+# Projects whose history is too large for Gerrit to accept in a single push.
+LARGE_REPOS = frozenset({
+    'mirror/chromium.googlesource.com/chromium/src',
+})
+
+# Max refs to push per `git push` when mirroring many refs at once.
+MIRROR_REFS_PER_PUSH = 200
+
+# Commits to advance a large repo's default branch per push. A single push of
+# all chromium/src history (~600k objects / 1 GiB) OOMs Gerrit's JGit unpacker,
+# so seeding advances the branch through ancestor checkpoints this many commits
+# apart.
+LARGE_REPO_COMMIT_CHUNK = 5000
+
+# Suffix dirs git_cache leaves beside each repo for locking; not repos.
+LOCK_DIR_SUFFIX = '.locked'
+
+
+def _query(*command: str,
+           cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    """Run *command*, capturing output and never raising on a non-zero exit.
+
+    Use this for read-only queries where a non-zero exit is an expected,
+    handled condition (e.g. asking Gerrit whether a project exists).
+    """
+    logging.debug('>>> %s', ' '.join(command))
+    return subprocess.run(list(command),
+                          cwd=cwd,
+                          capture_output=True,
+                          text=True,
+                          check=False)
+
+
+def _run(*command: str, cwd: Path | None = None) -> None:
+    """Run *command*, logging it first, and raise on a non-zero exit.
+
+    Raises:
+        subprocess.CalledProcessError: If the command exits non-zero.
+    """
+    logging.info('>>> %s', ' '.join(command))
+    subprocess.run(list(command), cwd=cwd, check=True)
+
+
+def project_name_for(upstream_url: str) -> str:
+    """Return the Gerrit project name mirroring *upstream_url*.
+
+    The project is the URL's host and path (no trailing `.git`) under the
+    `mirror/` parent, so the on-Gerrit layout reads like the upstream one and
+    stays unique across hosts that share a path:
+
+        https://aomedia.googlesource.com/aom.git
+            -> mirror/aomedia.googlesource.com/aom
+
+    Raises:
+        ValueError: If *upstream_url* lacks a host or a path component.
+    """
+    parts = urlsplit(upstream_url)
+    host = parts.hostname or ''
+    path = parts.path.strip('/')
+    if path.endswith('.git'):
+        path = path[:-len('.git')]
+    path = path.strip('/')
+    if not host or not path:
+        raise ValueError(f'cannot derive a project name from URL: '
+                         f'{upstream_url!r}')
+    return f'{MIRROR_PARENT}/{host}/{path}'
+
+
+@dataclass(frozen=True)
+class Gerrit:
+    """A handle to the Gerrit instance: runs admin commands and builds URLs.
+
+    The instance is fixed (`gerrit-ssh.brave.com:29418`); only the SSH user --
+    the account whose key authorises the create/push -- varies per caller.
+    """
+
+    # SSH user the `gerrit` CLI and git pushes authenticate as.
+    user: str
+    dry_run: bool = False
+
+    def _ssh_prefix(self) -> list[str]:
+        return [
+            'ssh', '-p',
+            str(GERRIT_SSH_PORT), f'{self.user}@{GERRIT_SSH_HOST}'
+        ]
+
+    def project_url(self, project: str) -> str:
+        """Return the SSH git URL for *project*."""
+        return (f'ssh://{self.user}@{GERRIT_SSH_HOST}:{GERRIT_SSH_PORT}/'
+                f'{project}')
+
+    def project_exists(self, project: str) -> bool:
+        """Return whether *project* already exists on the Gerrit instance.
+
+        Uses `gerrit ls-projects --prefix`, which returns every project whose
+        name starts with the prefix; an exact match in that set is the answer.
+        """
+        result = _query(*self._ssh_prefix(), 'gerrit', 'ls-projects',
+                        '--prefix', project)
+        if result.returncode != 0:
+            # A query failure (auth, connectivity) is not "absent"; surface it
+            # rather than silently trying to create a project that may exist.
+            raise RuntimeError(f'gerrit ls-projects failed for {project!r}: '
+                               f'{result.stderr.strip()}')
+        return project in result.stdout.split()
+
+    def create_project(self, project: str) -> None:
+        """Create *project* under the mirror parent, owned by the admin group.
+
+        Mirrors inherit their push-only ACLs from `MIRROR_PARENT`; the explicit
+        owner keeps the mirrors-admins group in control even if the parent
+        changes.
+        """
+        if self.dry_run:
+            logging.info('[dry-run] would create project %s', project)
+            return
+        _run(*self._ssh_prefix(), 'gerrit', 'create-project', project,
+             '--owner', MIRROR_OWNER_GROUP, '--parent', MIRROR_PARENT)
+
+
+def _is_bare_repo(path: Path) -> bool:
+    """Return whether *path* is an existing, valid bare git repository."""
+    if not (path / 'config').is_file():
+        return False
+    return _query('git', '-C', str(path), 'rev-parse',
+                  '--is-bare-repository').stdout.strip() == 'true'
+
+
+class Repo:
+    """A git_cache bare repo, and every git operation performed on it.
+
+    Wraps the repo's path on disk and owns all the plumbing needed to mirror it
+    into Gerrit: inspecting its upstream URL and branches, managing its
+    `gerrit` remote, and pushing refs/tags/history to it.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    @property
+    def name(self) -> str:
+        return self.path.name
+
+    def __repr__(self) -> str:
+        return f'Repo({self.path!r})'
+
+    @staticmethod
+    def is_cache_repo(path: Path) -> bool:
+        """Return whether *path* is a git_cache bare repository to mirror.
+
+        Skips the `*.locked` lock directories git_cache leaves beside each
+        repo, and anything that is not a bare repo with a config (e.g. stray
+        files).
+        """
+        if not path.is_dir() or path.name.endswith(LOCK_DIR_SUFFIX):
+            return False
+        return _is_bare_repo(path)
+
+    def upstream_url(self) -> str | None:
+        """Return this repo's upstream remote URL, or None if it has none."""
+        result = _query('git', '-C', str(self.path), 'config', '--get',
+                        f'remote.{UPSTREAM_REMOTE}.url')
+        return result.stdout.strip() or None
+
+    def head_ref(self) -> str | None:
+        """Return the branch ref this repo's HEAD resolves to, or None.
+
+        git_cache keeps a bare repo's HEAD as a symbolic ref to the upstream
+        default branch (e.g. `refs/heads/main`); that single branch is the one
+        we mirror. Returns None when HEAD is detached, unborn, or *dangling* --
+        a symbolic ref to a branch that has no commit. The last case is common
+        on Chromium's external mirrors, whose HEAD reads `refs/heads/master`
+        while the real branches live under `refs/heads/upstream/*`; the caller
+        then mirrors all heads instead.
+        """
+        ref = _query('git', '-C', str(self.path), 'symbolic-ref', '--quiet',
+                     'HEAD').stdout.strip()
+        if not ref:
+            return None
+        resolves = _query('git', '-C', str(self.path), 'rev-parse', '--verify',
+                          '--quiet', f'{ref}^{{commit}}').returncode == 0
+        return ref if resolves else None
+
+    def has_local_heads(self) -> bool:
+        """Return whether this repo has any local branch under refs/heads/."""
+        return bool(
+            _query('git', '-C', str(self.path), 'for-each-ref', '--count=1',
+                   'refs/heads/').stdout.strip())
+
+    def push_refs_in_batches(self, refs: list[str], label: str) -> None:
+        """Force-push *refs* (full refnames) to the `gerrit` remote, in batches.
+
+        Some repos carry thousands of refs, which overwhelm Gerrit's receive
+        timeout if pushed at once, so at most MIRROR_REFS_PER_PUSH go up per
+        push.
+
+        Raises:
+            subprocess.CalledProcessError: If a batch push fails.
+        """
+        total = len(refs)
+        logging.info('Pushing %d %s in batches of %d', total, label,
+                     MIRROR_REFS_PER_PUSH)
+        for start in range(0, total, MIRROR_REFS_PER_PUSH):
+            batch = refs[start:start + MIRROR_REFS_PER_PUSH]
+            logging.info('  %s %d-%d/%d', label, start + 1, start + len(batch),
+                         total)
+            refspecs = [f'+{ref}:{ref}' for ref in batch]
+            _run('git', '-C', str(self.path), 'push', '-o', 'skip-validation',
+                 GERRIT_REMOTE, *refspecs)
+
+    def mirror_all_heads(self) -> None:
+        """Force-push every local branch to the `gerrit` remote, in batches.
+
+        Used for repos whose HEAD doesn't resolve to a single default branch
+        (e.g. Chromium external mirrors), whose branches must all be mirrored.
+        """
+        refs = _query('git', '-C', str(self.path), 'for-each-ref',
+                      '--format=%(refname)', 'refs/heads/').stdout.split()
+        self.push_refs_in_batches(refs, 'branch(es)')
+
+    def local_tags(self) -> dict[str, str]:
+        """Return this repo's local tags as {refname: object sha}."""
+        out = _query('git', '-C', str(self.path), 'for-each-ref',
+                     '--format=%(refname) %(objectname)', 'refs/tags/').stdout
+        tags = {}
+        for line in out.splitlines():
+            name, _, sha = line.partition(' ')
+            if name and sha:
+                tags[name] = sha
+        return tags
+
+    def remote_tags(self) -> dict[str, str]:
+        """Return the `gerrit` remote's tags as {refname: object sha}."""
+        out = _query('git', '-C', str(self.path), 'ls-remote', '--tags',
+                     GERRIT_REMOTE).stdout
+        tags = {}
+        for line in out.splitlines():
+            sha, tab, ref = line.partition('\t')
+            # Keep the tag object line, skipping the `^{}` peeled entry
+            # ls-remote emits alongside annotated tags.
+            if tab and ref and not ref.endswith('^{}'):
+                tags[ref] = sha
+        return tags
+
+    def push_new_tags(self) -> None:
+        """Push tags the `gerrit` remote is missing or that point somewhere else.
+
+        Compares the local tags against the tags Gerrit advertises (both by
+        the object each points at) and pushes only the new or changed ones, so
+        tags already present at the same object are never re-sent.
+        """
+        local = self.local_tags()
+        if not local:
+            return
+        remote = self.remote_tags()
+        to_push = sorted(name for name, sha in local.items()
+                         if remote.get(name) != sha)
+        if not to_push:
+            logging.info('Tags already up to date (%d tag(s)).', len(local))
+            return
+        self.push_refs_in_batches(to_push, 'tag(s)')
+
+    def ensure_gerrit_remote(self, url: str) -> None:
+        """Point this repo's `gerrit` remote at *url*, adding or updating it."""
+        current = _query('git', '-C', str(self.path), 'remote', 'get-url',
+                         GERRIT_REMOTE)
+        if current.returncode != 0:
+            _run('git', '-C', str(self.path), 'remote', 'add', GERRIT_REMOTE,
+                 url)
+        elif current.stdout.strip() != url:
+            _run('git', '-C', str(self.path), 'remote', 'set-url',
+                 GERRIT_REMOTE, url)
+
+    def is_shallow(self) -> bool:
+        """Return whether this repo has a truncated (shallow) history."""
+        return _query('git', '-C', str(self.path), 'rev-parse',
+                      '--is-shallow-repository').stdout.strip() == 'true'
+
+    def ensure_full_history(self) -> None:
+        """Deepen a shallow repo to its full history before it is ever pushed.
+
+        A shallow clone's boundary commits are stored with their real parent
+        SHAs but those parents were never fetched, so pushing history that
+        crosses the boundary requires the shallow-push protocol extension to
+        graft it in on the other end. Gerrit's JGit-based receive-pack doesn't
+        support that, and rejects the whole pack with a "missing commit
+        <parent>" unpack error instead -- so a shallow cache repo is deepened
+        here, unconditionally, rather than ever letting that push be attempted.
+
+        A cache repo can end up shallow if something else (e.g. a recipe using
+        `chromium_checkout.ensure_checkout(depth=...)`) populated this same
+        `GIT_CACHE_PATH` with a depth-limited fetch before a full mirror pass
+        ever ran; a plain fetch afterwards only extends history forward from
+        that boundary; it never backfills it.
+
+        Raises:
+            subprocess.CalledProcessError: If the unshallow fetch fails.
+        """
+        logging.info(
+            '%s is a shallow clone; fetching full history before mirroring...',
+            self.name)
+        _run('git', '-C', str(self.path), 'fetch', '--unshallow',
+             UPSTREAM_REMOTE)
+
+    def remote_branch_sha(self, head_ref: str) -> str | None:
+        """Return the `gerrit` remote's current tip for *head_ref*, or None."""
+        result = _query('git', '-C', str(self.path), 'ls-remote', '--heads',
+                        GERRIT_REMOTE, head_ref)
+        line = result.stdout.strip()
+        return line.split()[0] if line else None
+
+    def commit_checkpoints(self,
+                           head_ref: str,
+                           chunk_size: int,
+                           start: str | None = None) -> list[str]:
+        """Return ancestor checkpoints of *head_ref* to push, oldest first.
+
+        Lists first-parent history from *start* (exclusive; the root when
+        None) to the tip and picks one commit every *chunk_size* commits,
+        always ending at the tip. Pushing these in order advances the branch
+        in fast-forwarding steps of *chunk_size* commits each, so a huge
+        history is seeded without a single oversized push that would OOM
+        Gerrit. One `rev-list` plus a slice keeps this cheap even on
+        million-commit histories. Empty means nothing to push.
+        """
+        rev_range = head_ref if start is None else f'{start}..{head_ref}'
+        commits = _query('git', '-C', str(self.path), 'rev-list', '--reverse',
+                         '--first-parent', rev_range).stdout.split()
+        if not commits:
+            return []
+
+        checkpoints = commits[chunk_size - 1::chunk_size]
+        # Always finish exactly at the tip.
+        if not checkpoints or checkpoints[-1] != commits[-1]:
+            checkpoints.append(commits[-1])
+        return checkpoints
+
+    def seed_branch(self, branch_ref: str) -> None:
+        """Advance the `gerrit` remote's *branch_ref* to local, in commit chunks.
+
+        Resumes from the remote's current tip (the whole branch when the
+        remote lacks it), then force-pushes ancestor checkpoints in order so a
+        huge history lands without a single oversized push.
+        """
+        start = self.remote_branch_sha(branch_ref)
+        logging.info('Computing seed checkpoints for %s...', branch_ref)
+        checkpoints = self.commit_checkpoints(branch_ref,
+                                              LARGE_REPO_COMMIT_CHUNK, start)
+        if not checkpoints:
+            logging.info('%s already up to date.', branch_ref)
+            return
+        logging.info('Seeding %s in %d push(es) of up to %d commits each',
+                     branch_ref, len(checkpoints), LARGE_REPO_COMMIT_CHUNK)
+        for index, sha in enumerate(checkpoints, start=1):
+            logging.info('  push %d/%d -> %s', index, len(checkpoints),
+                         sha[:12])
+            _run('git', '-C', str(self.path), 'push', '-o', 'skip-validation',
+                 GERRIT_REMOTE, f'+{sha}:{branch_ref}')
+
+    def refresh(self, gerrit: Gerrit) -> bool:
+        """Mirror this cache repo into Gerrit.
+
+        Derives the project from the upstream URL, creates it if absent, then
+        force-pushes the repo's default branch (the ref HEAD points at) to it
+        via a `gerrit` remote on the cache repo. Large repos (LARGE_REPOS) are
+        *always* advanced through commit-chunked checkpoints -- resuming from
+        whatever the remote already has -- since one big push would exceed
+        Gerrit's receive timeout (or OOM its unpacker); they never issue a
+        single full-ref push. A shallow repo is deepened to full history first
+        (see `ensure_full_history`), since Gerrit can't accept a push across a
+        shallow boundary.
+
+        Returns:
+            True if the mirror was handled (pushed, or already in sync);
+            False if the repo was skipped (no upstream URL, or no branch to
+            mirror).
+
+        Raises:
+            subprocess.CalledProcessError: On a git failure (e.g. the push).
+            RuntimeError: On a Gerrit query failure or unusable URL.
+        """
+        upstream = self.upstream_url()
+        if upstream is None:
+            logging.warning('%s has no %s remote URL; skipping.', self.name,
+                            UPSTREAM_REMOTE)
+            return False
+
+        # The default branch HEAD points at, when it resolves. When it
+        # doesn't (detached/unborn/dangling HEAD, as on Chromium external
+        # mirrors), fall back to mirroring every branch so the repo's commits
+        # still reach Gerrit.
+        head_ref = self.head_ref()
+        if head_ref is None and not self.has_local_heads():
+            logging.warning('%s has no branch to mirror; skipping.', self.name)
+            return False
+
+        project = project_name_for(upstream)
+        target = head_ref or 'refs/heads/* (HEAD unresolved)'
+        logging.info('Mirroring %s (%s) -> %s', self.name, target, project)
+
+        exists = gerrit.project_exists(project)
+        if not exists:
+            logging.info('Project %s not found; creating it.', project)
+            gerrit.create_project(project)
+        else:
+            logging.info('Project %s already exists.', project)
+
+        if gerrit.dry_run:
+            seeded = ' (seeded in chunks)' if project in LARGE_REPOS \
+                and head_ref else ''
+            logging.info('[dry-run] would push %s to %s%s', target,
+                         gerrit.project_url(project), seeded)
+            return True
+
+        self.ensure_gerrit_remote(gerrit.project_url(project))
+
+        if self.is_shallow():
+            self.ensure_full_history()
+
+        # A large repo must ALWAYS advance in chunks: a single push of its
+        # full history (or a big catch-up) exceeds Gerrit's receive timeout /
+        # OOMs its unpacker. Resume from the remote's current tip so a partial
+        # seed continues where it stopped, and never fall through to the
+        # full-ref push below.
+        if project in LARGE_REPOS:
+            if head_ref is None:
+                logging.warning(
+                    '%s is large but HEAD does not resolve; skipping to '
+                    'avoid a bulk push.', project)
+                return False
+            self.seed_branch(head_ref)
+            # Publish tags too (release tags point off the default branch);
+            # batched and incremental so only newly cut tags ship each run.
+            self.push_new_tags()
+            return True
+
+        # Push the default branch when HEAD resolves; otherwise mirror every
+        # branch (batched) so a dangling-HEAD repo isn't lost. Forced, so the
+        # mirror tracks upstream even across a history rewrite.
+        if head_ref is not None:
+            _run('git', '-C', str(self.path), 'push', '-o', 'skip-validation',
+                 GERRIT_REMOTE, f'+{head_ref}:{head_ref}')
+        else:
+            self.mirror_all_heads()
+        return True
+
+
+def discover_cache_repos(git_cache_path: Path) -> list[Repo]:
+    """Return the bare cache repos directly under *git_cache_path*, sorted."""
+    return sorted(
+        (Repo(p) for p in git_cache_path.iterdir() if Repo.is_cache_repo(p)),
+        key=lambda repo: repo.path)
+
+
+@dataclass
+class MirrorSummary:
+    """Tally of a mirror run's outcome: which repos were updated, skipped, or
+    failed."""
+
+    updated: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    failed: list[str] = field(default_factory=list)
+
+    def run(self, git_cache_path: Path, gerrit: Gerrit) -> None:
+        """Mirror every cache repo under *git_cache_path* into Gerrit.
+
+        A failure on one repo is logged and the run continues with the rest, so
+        one bad mirror never blocks the others. A summary of the outcome --
+        which repos were updated, skipped, and failed -- is printed at the end.
+        """
+        repos = discover_cache_repos(git_cache_path)
+        logging.info('Found %d cache repo(s) under %s', len(repos),
+                     git_cache_path)
+        for repo in repos:
+            try:
+                if repo.refresh(gerrit):
+                    self.record_updated(repo.name)
+                else:
+                    self.record_skipped(repo.name)
+            except (subprocess.CalledProcessError, RuntimeError,
+                    ValueError) as e:
+                self.record_failed(repo.name)
+                logging.error('Failed to mirror %s: %s', repo.name, e)
+
+        self.log()
+
+    def record_updated(self, name: str) -> None:
+        self.updated.append(name)
+
+    def record_skipped(self, name: str) -> None:
+        self.skipped.append(name)
+
+    def record_failed(self, name: str) -> None:
+        self.failed.append(name)
+
+    @property
+    def failure_count(self) -> int:
+        return len(self.failed)
+
+    def log(self) -> None:
+        """Print a final tally of the run, listing updated and failed repos."""
+        logging.info('')
+        logging.info('==== Mirror refresh summary ====')
+        logging.info('updated: %d  skipped: %d  failed: %d', len(self.updated),
+                     len(self.skipped), len(self.failed))
+        if self.updated:
+            logging.info('Updated:')
+            for name in self.updated:
+                logging.info('  + %s', name)
+        if self.skipped:
+            # Skipped for a repo-specific reason logged inline when it
+            # happened (no upstream URL, or no branch to mirror).
+            logging.info('Skipped:')
+            for name in self.skipped:
+                logging.info('  . %s', name)
+        if self.failed:
+            logging.error('Failed:')
+            for name in self.failed:
+                logging.error('  ! %s', name)
+
+
+def main() -> int:
+    """Parse arguments and refresh every mirror under `GIT_CACHE_PATH`."""
+    parser = argparse.ArgumentParser(
+        description='Publish the local git cache into the Gerrit mirrors.')
+    parser.add_argument(
+        '--git-cache-path',
+        default=os.environ.get('GIT_CACHE_PATH'),
+        help='Root of the git cache (defaults to $GIT_CACHE_PATH).')
+    parser.add_argument('--user', required=True, help='Gerrit username.')
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Log the project creates and pushes without performing them.')
+    parser.add_argument('--verbose',
+                        action='store_true',
+                        help='Enable debug logging.')
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO,
+                        format='%(message)s')
+
+    if not args.git_cache_path:
+        parser.error('GIT_CACHE_PATH is not set; pass --git-cache-path.')
+    git_cache_path = Path(args.git_cache_path).expanduser()
+    if not git_cache_path.is_dir():
+        parser.error(f'git cache path is not a directory: {git_cache_path}')
+
+    gerrit = Gerrit(user=args.user, dry_run=args.dry_run)
+
+    summary = MirrorSummary()
+    summary.run(git_cache_path, gerrit)
+    if summary.failure_count:
+        logging.error('%d mirror(s) failed.', summary.failure_count)
+    return 1 if summary.failure_count else 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/recipes/recipes/gerrit/refresh_mirrors.resources/refresh_mirrors_test.py
+++ b/tools/recipes/recipes/gerrit/refresh_mirrors.resources/refresh_mirrors_test.py
@@ -1,0 +1,718 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for refresh_mirrors.py.
+
+Tests use real git repositories in temporary directories so that git
+operations are exercised end-to-end. The Gerrit instance is replaced by a
+`FakeGerrit` whose "projects" are local bare repos, so project creation and
+pushes are real git operations against the filesystem rather than network calls.
+"""
+
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import refresh_mirrors
+from refresh_mirrors import Repo, discover_cache_repos, project_name_for
+
+
+def _git(*cmd: str, cwd: Path) -> str:
+    """Run a git command and return stripped stdout, raising on failure."""
+    return subprocess.run(['git', *cmd],
+                          cwd=cwd,
+                          capture_output=True,
+                          text=True,
+                          check=True).stdout.strip()
+
+
+def _make_cache_repo(path: Path, upstream_url: str) -> tuple[str, str]:
+    """Create a bare cache-style repo at *path* with one commit on its branch.
+
+    Mimics a depot_tools git_cache entry: a bare repo whose `origin` remote URL
+    is the upstream the mirror is derived from. Returns (branch, head_sha).
+    """
+    work = path.parent / f'{path.name}.work'
+    subprocess.run(['git', 'init', '-q', str(work)],
+                   check=True,
+                   capture_output=True)
+    _git('config', 'user.email', 'test@example.com', cwd=work)
+    _git('config', 'user.name', 'Test', cwd=work)
+    (work / 'README').write_text('hello')
+    _git('add', '.', cwd=work)
+    _git('commit', '-q', '-m', 'initial', cwd=work)
+    branch = _git('rev-parse', '--abbrev-ref', 'HEAD', cwd=work)
+    head = _git('rev-parse', 'HEAD', cwd=work)
+
+    subprocess.run(
+        ['git', 'clone', '-q', '--bare',
+         str(work), str(path)],
+        check=True,
+        capture_output=True)
+    _git('config', 'remote.origin.url', upstream_url, cwd=path)
+    return branch, head
+
+
+def _add_commits(bare_repo: Path, count: int) -> None:
+    """Add *count* linear commits to *bare_repo*'s default branch.
+
+    Uses a throwaway working tree so the bare cache repo gains real history to
+    seed in chunks.
+    """
+    work = Path(tempfile.mkdtemp())
+    try:
+        subprocess.run(
+            ['git', 'clone', '-q',
+             str(bare_repo), str(work)],
+            check=True,
+            capture_output=True)
+        _git('config', 'user.email', 'test@example.com', cwd=work)
+        _git('config', 'user.name', 'Test', cwd=work)
+        # Unique filenames per call so repeated _add_commits don't collide.
+        base = _git('rev-list', '--count', 'HEAD', cwd=work)
+        for i in range(count):
+            name = f'file_{base}_{i}'
+            (work / name).write_text(str(i))
+            _git('add', '.', cwd=work)
+            _git('commit', '-q', '-m', f'commit {name}', cwd=work)
+        _git('push', '-q', 'origin', 'HEAD', cwd=work)
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+def _make_shallow_clone(path: Path, source: Path, upstream_url: str) -> None:
+    """Create *path* as a shallow (depth=1), bare clone of *source*.
+
+    Mimics a cache repo that was populated by a depth-limited fetch:
+    `remote.origin.url` is set to the (fake-looking) *upstream_url*, like a
+    real git_cache entry, but `url.<source>.insteadOf` transparently redirects
+    any actual fetch against it back to the real local *source* -- so
+    `--unshallow` still works against a real repo without a real network URL.
+    """
+    # `--no-local` is required for `--depth` to actually take effect: git
+    # silently ignores `--depth` for the default local (hardlinking) clone
+    # transport, only applying it over a real (or forced) network protocol.
+    subprocess.run([
+        'git', 'clone', '-q', '--bare', '--no-local', '--depth', '1',
+        str(source),
+        str(path)
+    ],
+                   check=True,
+                   capture_output=True)
+    _git('config', 'remote.origin.url', upstream_url, cwd=path)
+    _git('config', f'url.{source}.insteadOf', upstream_url, cwd=path)
+
+
+class FakeGerrit:
+    """Stand-in for `Gerrit` whose projects are local bare repos on disk."""
+
+    def __init__(self, root: Path, dry_run: bool = False):
+        self._root = root
+        self.dry_run = dry_run
+        self.existing: set[str] = set()
+        self.created: list[str] = []
+
+    def project_url(self, project: str) -> str:
+        return str(self._root / project)
+
+    def project_exists(self, project: str) -> bool:
+        return project in self.existing
+
+    def create_project(self, project: str) -> None:
+        if self.dry_run:
+            return
+        path = self._root / project
+        path.mkdir(parents=True)
+        subprocess.run(['git', 'init', '-q', '--bare',
+                        str(path)],
+                       check=True,
+                       capture_output=True)
+        # A real Gerrit advertises push options; enable it so pushes carrying
+        # `-o skip-validation` are accepted instead of rejected outright.
+        _git('config', 'receive.advertisePushOptions', 'true', cwd=path)
+        self.existing.add(project)
+        self.created.append(project)
+
+
+class TestProjectName(unittest.TestCase):
+    """Unit tests for deriving a Gerrit project name from an upstream URL."""
+
+    def test_keeps_host_and_strips_git_suffix(self):
+        self.assertEqual(
+            project_name_for('https://aomedia.googlesource.com/aom.git'),
+            'mirror/aomedia.googlesource.com/aom')
+
+    def test_nested_path(self):
+        self.assertEqual(
+            project_name_for(
+                'https://chromium.googlesource.com/chromium/dom-distiller/'
+                'dist.git'),
+            'mirror/chromium.googlesource.com/chromium/dom-distiller/dist')
+
+    def test_without_git_suffix(self):
+        self.assertEqual(
+            project_name_for('https://chromium.googlesource.com/chromium/src'),
+            'mirror/chromium.googlesource.com/chromium/src')
+
+    def test_empty_path_raises(self):
+        with self.assertRaises(ValueError):
+            project_name_for('https://chromium.googlesource.com')
+
+
+class TestCacheDiscovery(unittest.TestCase):
+    """Tests for finding bare cache repos and skipping non-repos."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.cache = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_finds_bare_repo(self):
+        _make_cache_repo(self.cache / 'example.com-foo',
+                         'https://example.com/foo.git')
+        repos = discover_cache_repos(self.cache)
+        self.assertIn('example.com-foo', [r.name for r in repos])
+
+    def test_returns_repo_instances(self):
+        _make_cache_repo(self.cache / 'example.com-foo',
+                         'https://example.com/foo.git')
+        repos = discover_cache_repos(self.cache)
+        self.assertEqual(len(repos), 1)
+        self.assertIsInstance(repos[0], Repo)
+
+    def test_skips_locked_dir(self):
+        locked = self.cache / 'example.com-foo.locked'
+        locked.mkdir()
+        (locked / 'config').write_text('[core]\n')
+        self.assertFalse(Repo.is_cache_repo(locked))
+
+    def test_skips_stray_file(self):
+        (self.cache / 'not-a-repo').write_text('x')
+        self.assertEqual(discover_cache_repos(self.cache), [])
+
+    def test_skips_non_bare_directory(self):
+        plain = self.cache / 'plain'
+        plain.mkdir()
+        (plain / 'config').write_text('[core]\n')
+        self.assertFalse(Repo.is_cache_repo(plain))
+
+
+class TestEnsureGerritRemote(unittest.TestCase):
+    """Tests for adding/updating the `gerrit` remote on a cache repo."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.repo = Repo(self.tmp / 'repo')
+        _make_cache_repo(self.repo.path, 'https://example.com/foo.git')
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_adds_remote_when_absent(self):
+        self.repo.ensure_gerrit_remote('ssh://host/foo')
+        self.assertEqual(
+            _git('remote', 'get-url', 'gerrit', cwd=self.repo.path),
+            'ssh://host/foo')
+
+    def test_updates_stale_remote(self):
+        self.repo.ensure_gerrit_remote('ssh://host/old')
+        self.repo.ensure_gerrit_remote('ssh://host/new')
+        self.assertEqual(
+            _git('remote', 'get-url', 'gerrit', cwd=self.repo.path),
+            'ssh://host/new')
+
+
+class TestRefreshRepo(unittest.TestCase):
+    """End-to-end tests for mirroring one cache repo into a (fake) Gerrit."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        cache_repo_path = self.tmp / 'cache' / 'example.com-foo'
+        cache_repo_path.parent.mkdir()
+        self.branch, self.head = _make_cache_repo(
+            cache_repo_path, 'https://example.com/group/foo.git')
+        self.repo = Repo(cache_repo_path)
+        self.gerrit = FakeGerrit(self.tmp / 'gerrit')
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _mirror_head(self, project: str) -> str:
+        return _git('rev-parse',
+                    f'refs/heads/{self.branch}',
+                    cwd=self.tmp / 'gerrit' / project)
+
+    def test_creates_project_and_pushes(self):
+        self.repo.refresh(self.gerrit)
+        self.assertEqual(self.gerrit.created, ['mirror/example.com/group/foo'])
+        self.assertEqual(self._mirror_head('mirror/example.com/group/foo'),
+                         self.head)
+
+    def test_existing_project_not_recreated(self):
+        self.gerrit.create_project('mirror/example.com/group/foo')
+        self.gerrit.created.clear()
+        self.repo.refresh(self.gerrit)
+        self.assertEqual(self.gerrit.created, [])
+        self.assertEqual(self._mirror_head('mirror/example.com/group/foo'),
+                         self.head)
+
+    def test_force_push_after_history_rewrite(self):
+        self.repo.refresh(self.gerrit)
+        # Rewrite the cache branch to an unrelated commit (non-fast-forward).
+        work = self.tmp / 'rewrite'
+        subprocess.run(['git', 'init', '-q', str(work)],
+                       check=True,
+                       capture_output=True)
+        _git('config', 'user.email', 'test@example.com', cwd=work)
+        _git('config', 'user.name', 'Test', cwd=work)
+        (work / 'OTHER').write_text('different')
+        _git('add', '.', cwd=work)
+        _git('commit', '-q', '-m', 'rewrite', cwd=work)
+        rewritten = _git('rev-parse', 'HEAD', cwd=work)
+        _git('push',
+             '-q',
+             '--force',
+             str(self.repo.path),
+             f'HEAD:refs/heads/{self.branch}',
+             cwd=work)
+
+        self.repo.refresh(self.gerrit)
+        self.assertEqual(self._mirror_head('mirror/example.com/group/foo'),
+                         rewritten)
+
+    def test_dry_run_creates_and_pushes_nothing(self):
+        self.gerrit.dry_run = True
+        self.repo.refresh(self.gerrit)
+        self.assertEqual(self.gerrit.created, [])
+        self.assertFalse(
+            (self.tmp / 'gerrit' / 'mirror/example.com/group/foo').exists())
+
+    def test_pushes_only_the_default_branch(self):
+        # An extra branch in the cache must not reach the mirror: only the ref
+        # HEAD points at is pushed.
+        _git('branch', 'extra', self.head, cwd=self.repo.path)
+        self.repo.refresh(self.gerrit)
+        mirror = self.tmp / 'gerrit' / 'mirror/example.com/group/foo'
+        refs = _git('for-each-ref', '--format=%(refname)', cwd=mirror)
+        self.assertIn(f'refs/heads/{self.branch}', refs.splitlines())
+        self.assertNotIn('refs/heads/extra', refs.splitlines())
+
+    def test_push_uses_skip_validation(self):
+        with mock.patch.object(refresh_mirrors, '_run') as run:
+            self.repo.refresh(self.gerrit)
+        push = [c.args for c in run.call_args_list if 'push' in c.args]
+        self.assertEqual(len(push), 1)
+        argv = push[0]
+        self.assertEqual(argv[argv.index('-o') + 1], 'skip-validation')
+
+    def test_dangling_head_mirrors_all_branches(self):
+        # Reproduce a Chromium external mirror: HEAD points at a branch that does
+        # not exist, while the real branch lives elsewhere. The repo must still
+        # be mirrored (all heads) rather than fail on the missing ref.
+        _git('branch', '-m', self.branch, 'upstream/main', cwd=self.repo.path)
+        _git('symbolic-ref', 'HEAD', 'refs/heads/master', cwd=self.repo.path)
+        self.repo.refresh(self.gerrit)
+        self.assertEqual(self.gerrit.created, ['mirror/example.com/group/foo'])
+        mirror = self.tmp / 'gerrit' / 'mirror/example.com/group/foo'
+        self.assertEqual(
+            _git('rev-parse', 'refs/heads/upstream/main', cwd=mirror),
+            self.head)
+
+    def test_dangling_head_pushes_all_branches_in_batches(self):
+        # Many branches + dangling HEAD (e.g. LiteRT's 2000+ chromium/* branches)
+        # must be pushed in batches, not one oversized ref update.
+        names = ['upstream/main', 'chromium/1', 'chromium/2', 'chromium/3']
+        for name in names:
+            _git('branch', name, self.head, cwd=self.repo.path)
+        _git('symbolic-ref',
+             'HEAD',
+             'refs/heads/nonexistent',
+             cwd=self.repo.path)
+        with mock.patch.object(refresh_mirrors, 'MIRROR_REFS_PER_PUSH', 2), \
+             mock.patch.object(refresh_mirrors, '_run',
+                               wraps=refresh_mirrors._run) as run:
+            self.repo.refresh(self.gerrit)
+        pushes = [c.args for c in run.call_args_list if 'push' in c.args]
+        # 5 branches (original + 4) at 2 per push -> 3 batched pushes.
+        self.assertEqual(len(pushes), 3)
+        mirror = self.tmp / 'gerrit' / 'mirror/example.com/group/foo'
+        mirrored = _git('for-each-ref',
+                        '--format=%(refname)',
+                        'refs/heads/',
+                        cwd=mirror).splitlines()
+        for name in names + [f'{self.branch}']:
+            self.assertIn(f'refs/heads/{name}', mirrored)
+
+    def test_repo_without_any_branch_is_skipped(self):
+        # Dangling HEAD *and* no branches at all -> nothing to mirror.
+        empty = self.tmp / 'cache' / 'empty'
+        subprocess.run(['git', 'init', '-q', '--bare',
+                        str(empty)],
+                       check=True,
+                       capture_output=True)
+        _git('config',
+             'remote.origin.url',
+             'https://example.com/empty.git',
+             cwd=empty)
+        Repo(empty).refresh(self.gerrit)
+        self.assertEqual(self.gerrit.created, [])
+
+    def test_repo_without_origin_url_is_skipped(self):
+        _git('remote', 'remove', 'origin', cwd=self.repo.path)
+        self.repo.refresh(self.gerrit)
+        self.assertEqual(self.gerrit.created, [])
+
+
+class TestShallowCache(unittest.TestCase):
+    """A shallow cache repo is deepened before ever being pushed.
+
+    Gerrit's JGit-based receive-pack rejects a push that crosses a shallow
+    boundary with a "missing commit" unpack error (the boundary commit's real
+    parent was never fetched); mirroring a shallow cache repo must therefore
+    fetch its full history first rather than ever attempt that push.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.source = self.tmp / 'source'
+        self.branch, self.head = _make_cache_repo(
+            self.source, 'https://example.com/group/foo.git')
+        # Two more commits, so the depth=1 shallow clone below is missing real
+        # history (not just coincidentally identical to the full repo).
+        _add_commits(self.source, 2)
+        self.full_head = _git('rev-parse',
+                              f'refs/heads/{self.branch}',
+                              cwd=self.source)
+
+        cache_repo_path = self.tmp / 'cache' / 'example.com-foo'
+        cache_repo_path.parent.mkdir()
+        _make_shallow_clone(cache_repo_path, self.source,
+                            'https://example.com/group/foo.git')
+        self.repo = Repo(cache_repo_path)
+        self.gerrit = FakeGerrit(self.tmp / 'gerrit')
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _mirror_head(self,
+                     project: str = 'mirror/example.com/group/foo') -> str:
+        return _git('rev-parse',
+                    f'refs/heads/{self.branch}',
+                    cwd=self.tmp / 'gerrit' / project)
+
+    def test_is_shallow_detects_shallow_clone(self):
+        self.assertTrue(self.repo.is_shallow())
+
+    def test_is_shallow_false_for_full_clone(self):
+        self.assertFalse(Repo(self.source).is_shallow())
+
+    def test_refresh_repo_deepens_before_pushing(self):
+        self.repo.refresh(self.gerrit)
+        self.assertFalse(self.repo.is_shallow())
+        # The full history -- not just the depth=1 slice -- reached the mirror.
+        self.assertEqual(self._mirror_head(), self.full_head)
+        self.assertEqual(
+            _git('rev-list',
+                 '--count',
+                 f'refs/heads/{self.branch}',
+                 cwd=self.tmp / 'gerrit' / 'mirror/example.com/group/foo'),
+            _git('rev-list',
+                 '--count',
+                 f'refs/heads/{self.branch}',
+                 cwd=self.source))
+
+    def test_refresh_repo_skips_unshallow_for_full_clone(self):
+        full_cache_repo = self.tmp / 'cache' / 'example.com-full'
+        full_cache_repo.parent.mkdir(exist_ok=True)
+        _make_cache_repo(full_cache_repo, 'https://example.com/other.git')
+        with mock.patch.object(refresh_mirrors.Repo,
+                               'ensure_full_history') as ensure:
+            Repo(full_cache_repo).refresh(self.gerrit)
+        ensure.assert_not_called()
+
+
+class TestLargeRepoSeeding(unittest.TestCase):
+    """Tests for chunked seeding of repos listed in LARGE_REPOS."""
+
+    PROJECT = 'mirror/example.com/group/foo'
+    # Tiny chunk so a handful of commits seeds in several pushes.
+    CHUNK = 2
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        cache_repo_path = self.tmp / 'cache' / 'example.com-foo'
+        cache_repo_path.parent.mkdir()
+        self.branch, _ = _make_cache_repo(cache_repo_path,
+                                          'https://example.com/group/foo.git')
+        _add_commits(cache_repo_path, 5)
+        self.repo = Repo(cache_repo_path)
+        self.gerrit = FakeGerrit(self.tmp / 'gerrit')
+        self._patches = [
+            mock.patch.object(refresh_mirrors, 'LARGE_REPOS',
+                              frozenset({self.PROJECT})),
+            mock.patch.object(refresh_mirrors, 'LARGE_REPO_COMMIT_CHUNK',
+                              self.CHUNK),
+        ]
+        for p in self._patches:
+            p.start()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        self._tmp.cleanup()
+
+    def _cache_head(self) -> str:
+        return _git('rev-parse',
+                    f'refs/heads/{self.branch}',
+                    cwd=self.repo.path)
+
+    def _mirror_head(self) -> str:
+        return _git('rev-parse',
+                    f'refs/heads/{self.branch}',
+                    cwd=self.tmp / 'gerrit' / self.PROJECT)
+
+    def _push_count(self) -> int:
+        with mock.patch.object(refresh_mirrors,
+                               '_run',
+                               wraps=refresh_mirrors._run) as run:
+            self.repo.refresh(self.gerrit)
+        return len([c.args for c in run.call_args_list if 'push' in c.args])
+
+    def test_checkpoints_advance_and_end_at_tip(self):
+        cps = self.repo.commit_checkpoints(f'refs/heads/{self.branch}',
+                                           self.CHUNK)
+        self.assertGreater(len(cps), 1)  # split, not a single checkpoint
+        self.assertEqual(cps[-1], self._cache_head())
+        # Each checkpoint is an ancestor of the next (fast-forwarding order).
+        for older, newer in zip(cps, cps[1:]):
+            self.assertEqual(
+                _git('merge-base', older, newer, cwd=self.repo.path), older)
+
+    def test_seeds_in_chunks_and_reaches_tip(self):
+        self.assertGreater(self._push_count(), 1)  # chunked, not a single push
+        self.assertEqual(self._mirror_head(), self._cache_head())
+
+    def test_resume_advances_from_remote_tip(self):
+        # Seed, then add more commits: the second run resumes from the remote
+        # tip and still reaches the new head.
+        self.repo.refresh(self.gerrit)
+        self.assertEqual(self._mirror_head(), self._cache_head())
+        _add_commits(self.repo.path, 3)
+        new_head = self._cache_head()
+        # Resume start is the already-mirrored tip, so only the new commits ship.
+        self.assertEqual(
+            self.repo.remote_branch_sha(f'refs/heads/{self.branch}'),
+            self._mirror_head())
+        self.repo.refresh(self.gerrit)
+        self.assertEqual(self._mirror_head(), new_head)
+
+    def test_up_to_date_pushes_nothing(self):
+        # Once fully seeded with no new commits (and no tags), a large repo
+        # pushes nothing -- it never falls through to a full-ref push.
+        self.repo.refresh(self.gerrit)
+        self.assertEqual(self._push_count(), 0)
+
+    def _mirror_tags(self) -> list[str]:
+        return _git('for-each-ref',
+                    '--format=%(refname)',
+                    'refs/tags/',
+                    cwd=self.tmp / 'gerrit' / self.PROJECT).splitlines()
+
+    def test_pushes_tags(self):
+        _git('tag', 'v1', self._cache_head(), cwd=self.repo.path)
+        _git('tag', 'v2', self._cache_head(), cwd=self.repo.path)
+        self.repo.refresh(self.gerrit)
+        self.assertEqual(self._mirror_head(), self._cache_head())
+        self.assertIn('refs/tags/v1', self._mirror_tags())
+        self.assertIn('refs/tags/v2', self._mirror_tags())
+
+    def test_only_new_tags_pushed_on_rerun(self):
+        _git('tag', 'v1', self._cache_head(), cwd=self.repo.path)
+        self.repo.refresh(self.gerrit)  # seeds + pushes v1
+        _git('tag', 'v2', self._cache_head(), cwd=self.repo.path)
+        with mock.patch.object(refresh_mirrors,
+                               '_run',
+                               wraps=refresh_mirrors._run) as run:
+            self.repo.refresh(self.gerrit)
+        pushed = [a for c in run.call_args_list for a in c.args]
+        self.assertTrue(any('refs/tags/v2' in a for a in pushed))
+        self.assertFalse(any('refs/tags/v1' in a for a in pushed))
+        self.assertIn('refs/tags/v2', self._mirror_tags())
+
+
+class TestPushNewTags(unittest.TestCase):
+    """New and changed tags are pushed; tags already identical are skipped."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        repo_path = self.tmp / 'repo'
+        _, self.head = _make_cache_repo(repo_path, 'https://example.com/r.git')
+        self.repo = Repo(repo_path)
+        _git('tag', 'same', self.head, cwd=repo_path)  # identical on server
+        _git('tag', 'changed', self.head, cwd=repo_path)  # differs on server
+        _git('tag', 'fresh', self.head, cwd=repo_path)  # not on server
+
+        self.server = self.tmp / 'server'
+        subprocess.run(['git', 'init', '-q', '--bare',
+                        str(self.server)],
+                       check=True,
+                       capture_output=True)
+        _git('config', 'receive.advertisePushOptions', 'true', cwd=self.server)
+        # Server: `same` at the same object, `changed` at a different one.
+        _git('push',
+             str(self.server),
+             f'+{self.head}:refs/tags/same',
+             cwd=repo_path)
+        other = self.tmp / 'other'
+        _make_cache_repo(other, 'https://example.com/o.git')
+        _add_commits(other, 1)  # a genuinely distinct commit
+        other_head = _git('rev-parse', 'HEAD', cwd=other)
+        self.assertNotEqual(other_head, self.head)
+        _git('push',
+             str(self.server),
+             f'+{other_head}:refs/tags/changed',
+             cwd=other)
+        _git('remote', 'add', 'gerrit', str(self.server), cwd=repo_path)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _pushed_refspecs(self, run) -> list[str]:
+        return [a for c in run.call_args_list for a in c.args]
+
+    def test_pushes_new_and_changed_only(self):
+        with mock.patch.object(refresh_mirrors,
+                               '_run',
+                               wraps=refresh_mirrors._run) as run:
+            self.repo.push_new_tags()
+        pushed = self._pushed_refspecs(run)
+        self.assertTrue(any('refs/tags/fresh' in a for a in pushed))  # new
+        self.assertTrue(any('refs/tags/changed' in a for a in pushed))  # moved
+        self.assertFalse(any('refs/tags/same' in a
+                             for a in pushed))  # identical
+
+    def test_no_push_when_identical(self):
+        # Sync the server to match every local tag; a rerun pushes nothing.
+        _git('push',
+             str(self.server),
+             '+refs/tags/fresh:refs/tags/fresh',
+             '+refs/tags/changed:refs/tags/changed',
+             cwd=self.repo.path)
+        with mock.patch.object(refresh_mirrors,
+                               '_run',
+                               wraps=refresh_mirrors._run) as run:
+            self.repo.push_new_tags()
+        self.assertEqual(
+            [c.args for c in run.call_args_list if 'push' in c.args], [])
+
+
+class TestRefreshMirrorsSummary(unittest.TestCase):
+    """Tests for the end-of-run summary and per-repo outcome tallying."""
+
+    def test_categorizes_and_summarizes(self):
+        repos = [
+            Repo(Path('/cache/aaa')),
+            Repo(Path('/cache/bbb')),
+            Repo(Path('/cache/ccc'))
+        ]
+        with mock.patch.object(refresh_mirrors, 'discover_cache_repos',
+                               return_value=repos), \
+             mock.patch.object(refresh_mirrors.Repo, 'refresh') as refresh, \
+             self.assertLogs(level='INFO') as logs:
+            # aaa updated, bbb skipped, ccc failed.
+            refresh.side_effect = [
+                True, False,
+                subprocess.CalledProcessError(1, ['git', 'push'])
+            ]
+            summary = refresh_mirrors.MirrorSummary()
+            summary.run(Path('/cache'), gerrit=object())
+
+        self.assertEqual(summary.failure_count, 1)
+        text = '\n'.join(logs.output)
+        self.assertIn('updated: 1  skipped: 1  failed: 1', text)
+        self.assertIn('+ aaa', text)
+        self.assertIn('. bbb', text)
+        self.assertIn('! ccc', text)
+
+
+class TestMirrorSummary(unittest.TestCase):
+    """Unit tests for the `MirrorSummary` tally itself."""
+
+    def test_record_and_failure_count(self):
+        summary = refresh_mirrors.MirrorSummary()
+        summary.record_updated('aaa')
+        summary.record_skipped('bbb')
+        summary.record_failed('ccc')
+        summary.record_failed('ddd')
+        self.assertEqual(summary.updated, ['aaa'])
+        self.assertEqual(summary.skipped, ['bbb'])
+        self.assertEqual(summary.failed, ['ccc', 'ddd'])
+        self.assertEqual(summary.failure_count, 2)
+
+    def test_starts_empty(self):
+        summary = refresh_mirrors.MirrorSummary()
+        self.assertEqual(summary.updated, [])
+        self.assertEqual(summary.skipped, [])
+        self.assertEqual(summary.failed, [])
+        self.assertEqual(summary.failure_count, 0)
+
+
+class TestGerritCli(unittest.TestCase):
+    """Tests for the real Gerrit CLI wrappers, with subprocess mocked out."""
+
+    def setUp(self):
+        self.gerrit = refresh_mirrors.Gerrit(user='bot')
+
+    def test_project_url(self):
+        self.assertEqual(self.gerrit.project_url('mirror/foo'),
+                         'ssh://bot@gerrit-ssh.brave.com:29418/mirror/foo')
+
+    def test_project_exists_exact_match(self):
+        # ls-projects --prefix returns every project sharing the prefix; only an
+        # exact match counts as the project existing.
+        out = 'mirror/foo\nmirror/foobar\n'
+        with mock.patch.object(refresh_mirrors,
+                               '_query',
+                               return_value=subprocess.CompletedProcess(
+                                   [], 0, stdout=out, stderr='')):
+            self.assertTrue(self.gerrit.project_exists('mirror/foo'))
+            self.assertFalse(self.gerrit.project_exists('mirror/fo'))
+
+    def test_project_exists_raises_on_query_failure(self):
+        with mock.patch.object(refresh_mirrors,
+                               '_query',
+                               return_value=subprocess.CompletedProcess(
+                                   [], 255, stdout='', stderr='denied')):
+            with self.assertRaises(RuntimeError):
+                self.gerrit.project_exists('mirror/foo')
+
+    def test_create_project_argv(self):
+        with mock.patch.object(refresh_mirrors, '_run') as run:
+            self.gerrit.create_project('mirror/foo')
+        argv = list(run.call_args.args)
+        self.assertEqual(argv[:3], ['ssh', '-p', '29418'])
+        self.assertIn('create-project', argv)
+        self.assertEqual(argv[argv.index('--owner') + 1], 'mirrors-admins')
+        self.assertEqual(argv[argv.index('--parent') + 1], 'mirror')
+
+    def test_create_project_dry_run_does_nothing(self):
+        gerrit = refresh_mirrors.Gerrit(user='bot', dry_run=True)
+        with mock.patch.object(refresh_mirrors, '_run') as run:
+            gerrit.create_project('mirror/foo')
+        run.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR introduces a recipe to refresh gerrit mirrors in CI. The basic
logic initially is to go over our local git cache, populated it as
needed, checkout `main` for `chromium/src`, so we get the latest version
for all dependencies, and then sync the cache from that point.

Bug: https://github.com/brave/brave-browser/issues/55044
