### PR TITLE
[iOS] Add Fullscreen helper JavaScriptFeature

### DIFF
--- a/ios/browser/web/BUILD.gn
+++ b/ios/browser/web/BUILD.gn
@@ -41,6 +41,7 @@ source_set("web") {
     "//brave/ios/browser/web/de_amp",
     "//brave/ios/browser/web/document_fetch",
     "//brave/ios/browser/web/force_paste",
+    "//brave/ios/browser/web/fullscreen",
     "//brave/ios/browser/web/logins",
     "//brave/ios/browser/web/media",
     "//brave/ios/browser/web/navigator",

--- a/ios/browser/web/brave_web_client.mm
+++ b/ios/browser/web/brave_web_client.mm
@@ -36,6 +36,7 @@
 #include "brave/ios/browser/web/de_amp/de_amp_javascript_feature.h"
 #include "brave/ios/browser/web/document_fetch/document_fetch_javascript_feature.h"
 #include "brave/ios/browser/web/force_paste/force_paste_javascript_feature.h"
+#include "brave/ios/browser/web/fullscreen/fullscreen_helper_javascript_feature.h"
 #include "brave/ios/browser/web/logins/logins_javascript_feature.h"
 #include "brave/ios/browser/web/media/media_backgrounding_javascript_feature.h"
 #include "brave/ios/browser/web/navigator/brave_navigator_javascript_feature.h"
@@ -170,6 +171,7 @@ std::vector<web::JavaScriptFeature*> BraveWebClient::GetJavaScriptFeatures(
     features.push_back(DeAmpJavaScriptFeature::GetInstance());
     features.push_back(DocumentFetchJavaScriptFeature::GetInstance());
     features.push_back(ForcePasteJavaScriptFeature::GetInstance());
+    features.push_back(FullscreenHelperJavaScriptFeature::GetInstance());
     features.push_back(GPCJavaScriptFeature::FromBrowserState(browser_state));
     features.push_back(
         MediaBackgroundingJavaScriptFeature::FromBrowserState(browser_state));

--- a/ios/browser/web/fullscreen/BUILD.gn
+++ b/ios/browser/web/fullscreen/BUILD.gn
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//ios/web/public/js_messaging/optimize_ts.gni")
+
+source_set("fullscreen") {
+  sources = [
+    "fullscreen_helper_javascript_feature.h",
+    "fullscreen_helper_javascript_feature.mm",
+  ]
+  deps = [ ":fullscreen_helper_js" ]
+  public_deps = [
+    "//base",
+    "//ios/web/public/js_messaging",
+  ]
+}
+
+optimize_ts("fullscreen_helper_js") {
+  visibility = [ ":fullscreen" ]
+
+  sources = [ "resources/fullscreen_helper.ts" ]
+}

--- a/ios/browser/web/fullscreen/fullscreen_helper_javascript_feature.h
+++ b/ios/browser/web/fullscreen/fullscreen_helper_javascript_feature.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_WEB_FULLSCREEN_FULLSCREEN_HELPER_JAVASCRIPT_FEATURE_H_
+#define BRAVE_IOS_BROWSER_WEB_FULLSCREEN_FULLSCREEN_HELPER_JAVASCRIPT_FEATURE_H_
+
+#include "base/no_destructor.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+
+class FullscreenHelperJavaScriptFeature : public web::JavaScriptFeature {
+ public:
+  // This feature holds no state, so only a single static instance is ever
+  // needed.
+  static FullscreenHelperJavaScriptFeature* GetInstance();
+
+ private:
+  friend class base::NoDestructor<FullscreenHelperJavaScriptFeature>;
+
+  FullscreenHelperJavaScriptFeature();
+  ~FullscreenHelperJavaScriptFeature() override;
+};
+
+#endif  // BRAVE_IOS_BROWSER_WEB_FULLSCREEN_FULLSCREEN_HELPER_JAVASCRIPT_FEATURE_H_

--- a/ios/browser/web/fullscreen/fullscreen_helper_javascript_feature.mm
+++ b/ios/browser/web/fullscreen/fullscreen_helper_javascript_feature.mm
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/web/fullscreen/fullscreen_helper_javascript_feature.h"
+
+namespace {
+constexpr char kScriptName[] = "fullscreen_helper";
+}  // namespace
+
+FullscreenHelperJavaScriptFeature::FullscreenHelperJavaScriptFeature()
+    : JavaScriptFeature(
+          web::ContentWorld::kPageContentWorld,
+          {FeatureScript::CreateWithFilename(
+              kScriptName,
+              FeatureScript::InjectionTime::kDocumentStart,
+              FeatureScript::TargetFrames::kAllFrames,
+              FeatureScript::ReinjectionBehavior::kInjectOncePerWindow)}) {}
+
+FullscreenHelperJavaScriptFeature::~FullscreenHelperJavaScriptFeature() =
+    default;
+
+// static
+FullscreenHelperJavaScriptFeature*
+FullscreenHelperJavaScriptFeature::GetInstance() {
+  static base::NoDestructor<FullscreenHelperJavaScriptFeature> instance;
+  return instance.get();
+}

--- a/ios/browser/web/fullscreen/resources/fullscreen_helper.ts
+++ b/ios/browser/web/fullscreen/resources/fullscreen_helper.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// WebKit-prefixed fullscreen APIs that aren't part of the standard DOM types.
+interface FullscreenDocument extends Document {
+  webkitFullscreenEnabled?: boolean
+  mozFullScreenEnabled?: boolean
+  msFullscreenEnabled?: boolean
+}
+
+interface FullscreenElement extends HTMLElement {
+  webkitRequestFullscreen?: () => void
+  webkitEnterFullscreen?: () => void
+}
+
+interface FullscreenVideoElement extends HTMLVideoElement {
+  webkitEnterFullscreen?: () => void
+}
+
+const doc = document as FullscreenDocument
+
+const isFullscreenSupportedNatively =
+  doc.fullscreenEnabled
+  || doc.webkitFullscreenEnabled
+  || doc.mozFullScreenEnabled
+  || doc.msFullscreenEnabled
+
+const videosSupportFullscreen =
+  (HTMLVideoElement.prototype as FullscreenVideoElement).webkitEnterFullscreen
+  !== undefined
+
+if (
+  !isFullscreenSupportedNatively
+  && videosSupportFullscreen
+  && !/mobile/i.test(navigator.userAgent)
+) {
+  HTMLElement.prototype.requestFullscreen = function (): Promise<void> {
+    const element = this as FullscreenElement
+    if (element.webkitRequestFullscreen !== undefined) {
+      element.webkitRequestFullscreen()
+      return Promise.resolve()
+    }
+
+    if (element.webkitEnterFullscreen !== undefined) {
+      element.webkitEnterFullscreen()
+      return Promise.resolve()
+    }
+
+    const video = element.querySelector<FullscreenVideoElement>('video')
+    if (video?.webkitEnterFullscreen !== undefined) {
+      video.webkitEnterFullscreen()
+      return Promise.resolve()
+    }
+
+    return Promise.reject(new TypeError('Fullscreen request denied'))
+  }
+
+  const enabled = () => true
+  Object.defineProperty(document, 'fullscreenEnabled', { get: enabled })
+  Object.defineProperty(document.documentElement, 'fullscreenEnabled', {
+    get: enabled,
+  })
+}


### PR DESCRIPTION
This adds a JavaScriptFeature port of the `FullscreenHelper.js` script to enable `fullscreenEnabled` even on iPhones using desktop UAs

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/57908

### Test
- Enable `UseProfileWebViewConfiguration` feature flag
- Visit a YouTube video and request desktop mode UA
- Verify you can enter fullscreen mode on the video