### PR TITLE
Avoid duplicate KSChannelID in unsigned macOS packages

### DIFF
--- a/build/mac/signing/internal_config.py
+++ b/build/mac/signing/internal_config.py
@@ -30,8 +30,13 @@ class InternalCodeSignConfig(ChromiumCodeSignConfig):
 
     @property
     def distributions(self):
+        # Unsigned apps already contain KSChannelID so they report the correct
+        # channel when launched directly. Do not ask Chromium's packaging
+        # pipeline to append the same channel a second time.
+        packaging_channel = (None if self.invoker.args.skip_signing else
+                             BRAVE_CHANNEL)
         return [
-            Distribution(channel=BRAVE_CHANNEL,
+            Distribution(channel=packaging_channel,
                          package_as_dmg=True,
                          package_as_pkg=True,
                          package_as_zip=True)

--- a/build/mac/signing/internal_config_test.py
+++ b/build/mac/signing/internal_config_test.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import importlib.util
+import os
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+import unittest
+from unittest import mock
+
+_INTERNAL_CONFIG = Path(__file__).with_name('internal_config.py')
+
+
+class _FakeChromiumCodeSignConfig:
+
+    @property
+    def invoker(self):
+        return self._invoker
+
+
+class _FakeDistribution:
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _load_internal_config():
+    signing = ModuleType('signing')
+    chromium_config = ModuleType('signing.chromium_config')
+    chromium_config.ChromiumCodeSignConfig = _FakeChromiumCodeSignConfig
+    model = ModuleType('signing.model')
+    model.Distribution = _FakeDistribution
+    model.NotarizeAndStapleLevel = SimpleNamespace(STAPLE='staple')
+
+    spec = importlib.util.spec_from_file_location('internal_config_under_test',
+                                                  _INTERNAL_CONFIG)
+    module = importlib.util.module_from_spec(spec)
+    modules = {
+        'signing': signing,
+        'signing.chromium_config': chromium_config,
+        'signing.model': model,
+    }
+    with mock.patch.dict(os.environ, {'BRAVE_CHANNEL': 'nightly'}), \
+         mock.patch.dict('sys.modules', modules):
+        spec.loader.exec_module(module)
+    return module
+
+
+class InternalCodeSignConfigTest(unittest.TestCase):
+
+    def _distribution(self, skip_signing):
+        module = _load_internal_config()
+        config = object.__new__(module.InternalCodeSignConfig)
+        config._invoker = SimpleNamespace(args=SimpleNamespace(
+            skip_signing=skip_signing))
+        return config.distributions[0]
+
+    def test_unsigned_packaging_uses_channel_from_built_app(self):
+        distribution = self._distribution(skip_signing=True)
+
+        self.assertIsNone(distribution.channel)
+
+    def test_signed_packaging_adds_channel(self):
+        distribution = self._distribution(skip_signing=False)
+
+        self.assertEqual('nightly', distribution.channel)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/build/mac/tweak_info_plist.py
+++ b/build/mac/tweak_info_plist.py
@@ -110,8 +110,7 @@ def Main():
     if args.skip_signing and args.brave_channel != "":
         plist['KSChannelID'] = args.brave_channel
     elif 'KSChannelID' in plist:
-        # 'KSChannelID' is set at _modify_plists() of modification.py only
-        # during signing
+        # Signed builds add 'KSChannelID' during macOS packaging.
         del plist['KSChannelID']
 
     if args.brave_product_dir_name:

--- a/build/mac/tweak_info_plist_test.py
+++ b/build/mac/tweak_info_plist_test.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import plistlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from pathlib import Path
+
+_SCRIPT = Path(__file__).with_name('tweak_info_plist.py')
+
+
+class TweakInfoPlistTest(unittest.TestCase):
+
+    def _run_tweak(self, extra_args):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            input_path = Path(temp_dir) / 'input.plist'
+            output_path = Path(temp_dir) / 'output.plist'
+            with input_path.open('wb') as plist_file:
+                plistlib.dump(
+                    {
+                        'CFBundleIdentifier': 'com.brave.Browser.nightly',
+                        'CFBundleShortVersionString': '151.1.93.132',
+                        'CFBundleVersion': '93.132',
+                        'KSChannelID': 'stale-channel',
+                    }, plist_file)
+
+            result = subprocess.run([
+                sys.executable,
+                str(_SCRIPT),
+                f'--plist={input_path}',
+                f'--output={output_path}',
+                '--brave_channel=nightly',
+                '--brave_version=1.93.132',
+                *extra_args,
+            ],
+                                    check=False,
+                                    capture_output=True,
+                                    text=True)
+            self.assertEqual(0, result.returncode, result.stderr)
+            with output_path.open('rb') as plist_file:
+                return plistlib.load(plist_file)
+
+    def test_signing_removes_channel_for_packaging(self):
+        plist = self._run_tweak([])
+
+        self.assertNotIn('KSChannelID', plist)
+
+    def test_skip_signing_embeds_channel_for_unsigned_build(self):
+        plist = self._run_tweak(['--skip_signing'])
+
+        self.assertEqual('nightly', plist['KSChannelID'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Resolves brave/brave-browser#57312

## Summary

Unsigned macOS app bundles need `KSChannelID` baked in so they report the correct channel when launched directly. Chromium's packaging pipeline was then receiving the same channel again and appending it, producing values such as `nightly-nightly`.

This keeps the channel in the unsigned app but makes the packaging distribution channel-less when `--skip_signing` is active. Chromium therefore preserves the existing value instead of appending it. Signed packaging continues to receive the channel normally.

The tests cover both sides of the contract:

- unsigned plist tweaking embeds the channel;
- signed plist tweaking leaves it for packaging;
- unsigned packaging uses the channel already in the app;
- signed packaging adds the configured channel.

## Test plan

```sh
python3 -m unittest \
  build/mac/tweak_info_plist_test.py \
  build/mac/signing/internal_config_test.py -v
python3 -m unittest discover -s build/mac/signing -p '*_test.py' -v
python3 -m py_compile \
  build/mac/tweak_info_plist.py \
  build/mac/tweak_info_plist_test.py \
  build/mac/signing/internal_config.py \
  build/mac/signing/internal_config_test.py
git diff --check origin/master
```

All pass locally on macOS arm64. A full `create_dist --skip_signing` smoke test was not run because this standalone filtered checkout does not contain a Chromium build output.

## AI assistance

AI tools assisted with root-cause analysis and test drafting. I manually reviewed the final diff, verified it against Chromium 151's packaging semantics, and ran the tests above.
