### PR TITLE
Support anonymous enums in add_enum_entries

### DIFF
--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -1719,7 +1719,8 @@ class AddEnumEntries(_AstGrepRewriter):
 
         Fields:
 
-        - `enum_name` — the enum to extend (can be `enum` or `enum class`).
+        - `enum_name` — optional: the enum to extend (can be `enum` or
+          `enum class`). Omit it to target an anonymous enum.
         - `entries` — the entry to add, or a list of them, in the order they
           should appear. Each is an entry name, optionally with an `= value` of
           its own (`kBraveMaxValue = kBraveCardano`).
@@ -1747,9 +1748,13 @@ class AddEnumEntries(_AstGrepRewriter):
             add_enum_entries:
               enum_name: SignatureAlgorithm
               entries: ECDSA_SHA384
+
+          - description: Add a value to the anonymous enum.
+            add_enum_entries:
+              entries: kBraveValue
         ```
 
-        The first entry turns this upstream enum:
+        The first example turns this upstream enum:
 
         ```cpp
         enum class Property {
@@ -1777,6 +1782,10 @@ class AddEnumEntries(_AstGrepRewriter):
     # enum's current last entry when no `max_value` is declared.
     _INSERT_BEFORE_MAX_VALUE: Final = 'cxx.insert_enum_entries_before_max_value'
     _APPEND_AFTER_LAST: Final = 'cxx.append_enum_entries_after_last'
+    _INSERT_ANONYMOUS_BEFORE_MAX_VALUE: Final = (
+        'cxx.insert_anonymous_enum_entries_before_max_value')
+    _APPEND_AFTER_ANONYMOUS_LAST: Final = (
+        'cxx.append_anonymous_enum_entries_after_last')
 
     # One entry as authored: a name, optionally with an `= value`. A comma or a
     # newline would take the shape of the emitted list out of our hands.
@@ -1797,7 +1806,7 @@ class AddEnumEntries(_AstGrepRewriter):
                              f'accept a count other than 1 '
                              f'(in "{description}")')
 
-    def __init__(self, *, enum_name: str, entries: list[str],
+    def __init__(self, *, enum_name: str | None, entries: list[str],
                  max_value: str | None):
         super().__init__()
         self._enum_name = enum_name
@@ -1819,36 +1828,51 @@ class AddEnumEntries(_AstGrepRewriter):
                              contents,
                              blank_for_parse=blank_for_parse)
         source = contents.encode('utf-8')
-        enum_inputs = {'enum_name': self._enum_name}
+        enum_inputs = ({
+            'enum_name': self._enum_name
+        } if self._enum_name is not None else {})
+        insert_before_max_value = (self._INSERT_BEFORE_MAX_VALUE
+                                   if self._enum_name is not None else
+                                   self._INSERT_ANONYMOUS_BEFORE_MAX_VALUE)
+        append_after_last = (self._APPEND_AFTER_LAST
+                             if self._enum_name is not None else
+                             self._APPEND_AFTER_ANONYMOUS_LAST)
 
-        last = engine.first_match(
-            Operation(self._INSERT_BEFORE_MAX_VALUE, enum_inputs))
-        # A missing anchor leaves the run to report the count shortfall.
-        last_text = source[last.start:last.end].decode('utf-8') if last else ''
-        indent = _leading_indent(source, last.start) if last else ''
+        anchors = engine.find_matches(
+            Operation(insert_before_max_value, enum_inputs))
+        anchor_error = MatchExpectation.exactly(1).error_for(len(anchors))
+        if anchor_error:
+            return contents, [anchor_error]
+        last = anchors[0]
+        last_text = source[last.start:last.end].decode('utf-8')
+        indent = _leading_indent(source, last.start)
 
         if self._max_value is not None:
             name = self._entry_name(last_text)
-            if last is not None and name != self._max_value:
+            if name != self._max_value:
+                enum_label = (f'Enum `{self._enum_name}`' if self._enum_name
+                              is not None else 'Anonymous enum')
                 return contents, [
-                    f'Enum `{self._enum_name}` ends in `{name}`, not in the '
+                    f'{enum_label} ends in `{name}`, not in the '
                     f'declared `max_value` entry `{self._max_value}` '
                     f'(in "{description}")'
                 ]
-            op = Operation(
-                self._INSERT_BEFORE_MAX_VALUE, {
-                    'enum_name': self._enum_name,
-                    'entries': self._entry_block(indent, indent_first=False),
-                    'indent': indent,
-                    'value': self._repointed_entry(last_text),
-                }, MatchExpectation.exactly(1))
+            op_inputs = {
+                **enum_inputs,
+                'entries': self._entry_block(indent, indent_first=False),
+                'indent': indent,
+                'value': self._repointed_entry(last_text),
+            }
+            op = Operation(insert_before_max_value, op_inputs,
+                           MatchExpectation.exactly(1))
         else:
-            op = Operation(
-                self._APPEND_AFTER_LAST, {
-                    'enum_name': self._enum_name,
-                    'entries': self._entry_block(indent, indent_first=True),
-                    'comma': self._separator(source, last.end) if last else '',
-                }, MatchExpectation.exactly(1))
+            op_inputs = {
+                **enum_inputs,
+                'entries': self._entry_block(indent, indent_first=True),
+                'comma': self._separator(source, last.end),
+            }
+            op = Operation(append_after_last, op_inputs,
+                           MatchExpectation.exactly(1))
         changes = engine.run(op)
         error = op.expectation.error_for(changes)
         return engine.content, [error] if error else []
@@ -1912,18 +1936,20 @@ class AddEnumEntries(_AstGrepRewriter):
             raise ValueError(
                 f'Unrecognised {cls.NAME} arg(s): '
                 f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
-        missing = sorted({'enum_name', 'entries'} - set(body))
+        missing = sorted({'entries'} - set(body))
         if missing:
             raise ValueError(f'{cls.NAME} requires arg(s): '
                              f'{", ".join(missing)} (in "{description}")')
-        if not isinstance(body['enum_name'], str) or not body['enum_name']:
+        enum_name = body.get('enum_name')
+        if ('enum_name' in body
+                and (not isinstance(enum_name, str) or not enum_name)):
             raise ValueError(f'{cls.NAME} `enum_name` must be a non-empty '
                              f'string (in "{description}")')
         max_value = body.get('max_value')
         if max_value is not None and not cls._is_entry_name(max_value):
             raise ValueError(f'{cls.NAME} `max_value` must be an entry name '
                              f'(in "{description}")')
-        return cls(enum_name=body['enum_name'],
+        return cls(enum_name=enum_name,
                    entries=cls._parse_entries(body['entries'], description),
                    max_value=max_value)
 
@@ -2657,8 +2683,12 @@ class AstRewriter:
         real source (e.g. to derive an insertion's indentation) at the returned
         offsets before running the op.
         """
-        matches = self._locate(op)
+        matches = self.find_matches(op)
         return matches[0] if matches else None
+
+    def find_matches(self, op: Operation) -> list[AstMatch]:
+        """Every match for `op`'s matcher, without mutating content."""
+        return self._locate(op)
 
     def _resolve_captures(self, matcher: dict, match: AstMatch,
                           needed: set[str], op_id: str) -> dict[str, str]:

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -2557,6 +2557,85 @@ class RewriterFormsTest(unittest.TestCase):
             result, 'enum class Kind {\n  kA,\n  kB,\n};\n\n'
             'enum class Other {\n  kA,\n};\n')
 
+    def test_add_enum_entries_appends_to_anonymous_enum(self):
+        # Omitting enum_name selects the anonymous enum without broadening the
+        # match to its named sibling.
+        result = self._apply(
+            'enum_anonymous.h', 'enum class Named {\n  kNamed,\n};\n\n'
+            'enum {\n  kA,\n};\n', 'substitutions:\n'
+            '  - description: extend the anonymous enum\n'
+            '    add_enum_entries:\n'
+            '      entries: kB\n')
+        self.assertEqual(
+            result, 'enum class Named {\n  kNamed,\n};\n\n'
+            'enum {\n  kA,\n  kB,\n};\n')
+
+    def test_add_enum_entries_extends_typed_anonymous_enum(self):
+        result = self._apply(
+            'enum_anonymous_base.h', 'enum : unsigned {\n  kA,\n};\n',
+            'substitutions:\n'
+            '  - description: extend the typed anonymous enum\n'
+            '    add_enum_entries:\n'
+            '      entries: kB\n')
+        self.assertEqual(result, 'enum : unsigned {\n  kA,\n  kB,\n};\n')
+
+    def test_add_enum_entries_repoints_anonymous_enum_max_value(self):
+        result = self._apply(
+            'enum_anonymous_max.h', 'enum {\n'
+            '  kA,\n'
+            '  kMaxValue = kA,\n'
+            '};\n', 'substitutions:\n'
+            '  - description: extend the anonymous enum range\n'
+            '    add_enum_entries:\n'
+            '      max_value: kMaxValue\n'
+            '      entries: kB\n')
+        self.assertEqual(
+            result, 'enum {\n'
+            '  kA,\n'
+            '  kB,\n'
+            '  kMaxValue = kB,\n'
+            '};\n')
+
+    def test_add_enum_entries_two_anonymous_enums_fail(self):
+        # With no name to disambiguate, exact-one matching intentionally fails.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'enum_anonymous_ambiguous.h', 'enum {\n  kA,\n};\n'
+                'enum {\n  kX,\n};\n', 'substitutions:\n'
+                '  - description: ambiguous anonymous enum\n'
+                '    add_enum_entries:\n'
+                '      entries: kB\n')
+
+    def test_add_enum_entries_ambiguous_anonymous_max_fails_by_count(self):
+        # Ambiguity is diagnosed before inspecting either enum's max entry, so
+        # source order cannot change the reported failure.
+        with self.assertRaises(plaster.PlasterApplyError) as ctx:
+            self._apply(
+                'enum_anonymous_ambiguous_max.h', 'enum {\n  kExtra,\n};\n'
+                'enum {\n  kA,\n  kMaxValue = kA,\n};\n', 'substitutions:\n'
+                '  - description: ambiguous anonymous enum with max\n'
+                '    add_enum_entries:\n'
+                '      max_value: kMaxValue\n'
+                '      entries: kB\n')
+        self.assertIn('Unexpected number of matches (2 vs 1)',
+                      str(ctx.exception))
+
+    def test_add_enum_entries_anonymous_max_value_not_last_fails(self):
+        with self.assertRaises(plaster.PlasterApplyError) as ctx:
+            self._apply(
+                'enum_anonymous_moved_max.h', 'enum {\n'
+                '  kA,\n'
+                '  kMaxValue = kA,\n'
+                '  kExtra,\n'
+                '};\n', 'substitutions:\n'
+                '  - description: anonymous max is no longer last\n'
+                '    add_enum_entries:\n'
+                '      max_value: kMaxValue\n'
+                '      entries: kB\n')
+        self.assertIn(
+            'Anonymous enum ends in `kExtra`, not in the declared `max_value` '
+            'entry `kMaxValue`', str(ctx.exception))
+
     def test_add_enum_entries_extends_an_enum_with_a_base_clause(self):
         # An underlying type on the enum head does not get in the way of the
         # body's entries.
@@ -2636,6 +2715,15 @@ class RewriterFormsTest(unittest.TestCase):
             '  - description: missing entries\n'
             '    add_enum_entries:\n'
             '      enum_name: Kind\n', 'add_enum_entries requires arg')
+
+    def test_add_enum_entries_explicit_null_name_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: null is not omission\n'
+            '    add_enum_entries:\n'
+            '      enum_name: null\n'
+            '      entries: kB\n',
+            'add_enum_entries `enum_name` must be a non-empty string')
 
     def test_add_enum_entries_empty_entry_list_rejected(self):
         self._expect_value_error(

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -310,6 +310,36 @@ inside:
             },
         },
 
+        # The last entry of an anonymous enum. A typed anonymous enum has an
+        # empty MISSING name node in tree-sitter, while an untyped one has no
+        # name field, so both forms select anonymity. The entry/body nesting and
+        # reverse entry position mirror the named-enum matcher above.
+        "cxx.find_last_anonymous_enum_entry": {
+            "template": """\
+kind: enumerator
+nthChild:
+  position: 1
+  reverse: true
+  ofRule:
+    kind: enumerator
+inside:
+  kind: enumerator_list
+  inside:
+    kind: enum_specifier
+    any:
+      - not:
+          has:
+            field: name
+            pattern: $_
+      - has:
+          field: name
+          regex: ^$
+""",
+            "result": {
+                "node": "enumerator",
+            },
+        },
+
         # Every identifier-family token whose text is exactly `class_name`:
         # type positions (type_identifier), the `Class::` qualifier
         # (namespace_identifier), the ctor/dtor name and bare uses (identifier),
@@ -563,6 +593,36 @@ regex: ^{class_name}$
         "cxx.append_enum_entries_after_last": {
             "matcher": "cxx.find_last_enum_entry",
             "inputs": ["enum_name", "entries", "comma"],
+            "replace": {
+                "consume_after": "{comma}",
+                "re_pattern": "(?s)^(.*)$",
+                "replace": "\\1,\\n{entries}",
+            },
+            "result": {
+                "node": "enumerator",
+            },
+        },
+
+        # Anonymous-enum forms of the two operations above. They deliberately
+        # carry no name input; exact-one matching rejects ambiguous files.
+        "cxx.insert_anonymous_enum_entries_before_max_value": {
+            "matcher": "cxx.find_last_anonymous_enum_entry",
+            "inputs": ["entries", "indent", "value"],
+            "when_set": {
+                "value": " = {value}",
+            },
+            "replace": {
+                "re_pattern": "(?s)^(\\w+).*$",
+                "replace": "{entries}\\n{indent}\\1{value}",
+            },
+            "result": {
+                "node": "enumerator",
+            },
+        },
+
+        "cxx.append_anonymous_enum_entries_after_last": {
+            "matcher": "cxx.find_last_anonymous_enum_entry",
+            "inputs": ["entries", "comma"],
             "replace": {
                 "consume_after": "{comma}",
                 "re_pattern": "(?s)^(.*)$",


### PR DESCRIPTION
- Resolves brave/brave-browser#57790

## Summary

`add_enum_entries` can now target an anonymous enum by omitting `enum_name`. Existing named-enum YAML remains unchanged, while an explicitly null or empty name is still rejected.

The implementation keeps Plaster's exact-one safety:

- a named sibling is not matched;
- multiple anonymous enums fail as ambiguous before `max_value` validation;
- both plain and fixed-underlying-type anonymous enums are recognized (the latter has an empty `MISSING` name node in tree-sitter);
- max-value repointing and mismatch diagnostics work as they do for named enums.

The CLI help includes the optional field semantics and an anonymous-enum example.

## Test plan

Using Brave's pinned ast-grep `0.44.1` macOS arm64 artifact:

```sh
tools/cr/plaster_test.py \
  RewritersEvalTest.test_load_real_rewriters_file \
  RewriterFormsTest

tools/cr/plaster_test.py \
  RewriterFormsTest.test_add_enum_entries_appends_to_anonymous_enum \
  RewriterFormsTest.test_add_enum_entries_extends_typed_anonymous_enum \
  RewriterFormsTest.test_add_enum_entries_repoints_anonymous_enum_max_value \
  RewriterFormsTest.test_add_enum_entries_two_anonymous_enums_fail \
  RewriterFormsTest.test_add_enum_entries_ambiguous_anonymous_max_fails_by_count \
  RewriterFormsTest.test_add_enum_entries_anonymous_max_value_not_last_fails \
  RewriterFormsTest.test_add_enum_entries_explicit_null_name_rejected

python3 -m py_compile tools/cr/plaster.py tools/cr/plaster_test.py
git diff --check origin/master...HEAD
```

All commands pass. I also ran the full `plaster_test.py` module; its only failures were eight pre-existing error-message assertions that reproduce on `origin/master` when using the public PyPI `schema` package instead of depot_tools' vendored version.

## AI assistance

AI tools assisted with issue analysis and test drafting. I manually reviewed the final diff, exercised it with the pinned AST engine, and incorporated two independent review findings covering ambiguity diagnostics and typed anonymous enums.
