### PR TITLE
[ads] Fixes duplicate clicked confirmations on double clicks

### DIFF
--- a/components/brave_ads/core/internal/BUILD.gn
+++ b/components/brave_ads/core/internal/BUILD.gn
@@ -1027,6 +1027,8 @@ static_library("internal") {
     "user_engagement/ad_events/ad_event_info.cc",
     "user_engagement/ad_events/ad_event_info.h",
     "user_engagement/ad_events/ad_event_interface.h",
+    "user_engagement/ad_events/ad_event_task_queue.cc",
+    "user_engagement/ad_events/ad_event_task_queue.h",
     "user_engagement/ad_events/ad_event_util.cc",
     "user_engagement/ad_events/ad_event_util.h",
     "user_engagement/ad_events/ad_events.cc",

--- a/components/brave_ads/core/internal/ad_units/ad_handler.cc
+++ b/components/brave_ads/core/internal/ad_units/ad_handler.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "base/check.h"
+#include "base/functional/bind.h"
 #include "brave/components/brave_ads/core/internal/account/deposits/deposit_util.h"
 #include "brave/components/brave_ads/core/internal/account/user_data/fixed/conversion_user_data.h"
 #include "brave/components/brave_ads/core/internal/account/user_data/fixed/page_land_user_data.h"
@@ -43,8 +44,11 @@ void AdHandler::TriggerNotificationAdEvent(
     ResultCallback callback) {
   CHECK(!placement_id.empty());
 
-  notification_ad_handler_.TriggerEvent(placement_id, mojom_ad_event_type,
-                                        std::move(callback));
+  notification_ad_event_task_queue_.Add(
+      base::BindOnce(&NotificationAdHandler::TriggerEvent,
+                     base::Unretained(&notification_ad_handler_), placement_id,
+                     mojom_ad_event_type),
+      std::move(callback));
 }
 
 void AdHandler::ParseAndSaveNewTabPageAds(base::DictValue dict,
@@ -64,9 +68,11 @@ void AdHandler::TriggerNewTabPageAdEvent(
     ResultCallback callback) {
   CHECK(!placement_id.empty());
 
-  new_tab_page_ad_handler_.TriggerEvent(placement_id, creative_instance_id,
-                                        mojom_ad_event_type,
-                                        std::move(callback));
+  new_tab_page_ad_event_task_queue_.Add(
+      base::BindOnce(&NewTabPageAdHandler::TriggerEvent,
+                     base::Unretained(&new_tab_page_ad_handler_), placement_id,
+                     creative_instance_id, mojom_ad_event_type),
+      std::move(callback));
 }
 
 std::optional<mojom::CreativeSearchResultAdInfoPtr>
@@ -87,8 +93,11 @@ void AdHandler::TriggerSearchResultAdEvent(
                                 mojom_creative_ad->Clone());
   }
 
-  search_result_ad_handler_.TriggerEvent(
-      std::move(mojom_creative_ad), mojom_ad_event_type, std::move(callback));
+  search_result_ad_event_task_queue_.Add(
+      base::BindOnce(&SearchResultAdHandler::TriggerEvent,
+                     base::Unretained(&search_result_ad_handler_),
+                     std::move(mojom_creative_ad), mojom_ad_event_type),
+      std::move(callback));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/components/brave_ads/core/internal/ad_units/ad_handler.h
+++ b/components/brave_ads/core/internal/ad_units/ad_handler.h
@@ -22,6 +22,7 @@
 #include "brave/components/brave_ads/core/internal/targeting/contextual/text_classification/resource/text_classification_resource.h"
 #include "brave/components/brave_ads/core/internal/targeting/contextual/text_classification/text_classification_processor.h"
 #include "brave/components/brave_ads/core/internal/targeting/geographical/subdivision/subdivision_targeting.h"
+#include "brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_task_queue.h"
 #include "brave/components/brave_ads/core/internal/user_engagement/conversions/conversions.h"
 #include "brave/components/brave_ads/core/internal/user_engagement/conversions/conversions_observer.h"
 #include "brave/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.h"
@@ -106,8 +107,13 @@ class AdHandler final : public ConversionsObserver, SiteVisitObserver {
   TextClassificationProcessor text_classification_processor_;
 
   NewTabPageAdHandler new_tab_page_ad_handler_;
+  AdEventTaskQueue new_tab_page_ad_event_task_queue_;
+
   NotificationAdHandler notification_ad_handler_;
+  AdEventTaskQueue notification_ad_event_task_queue_;
+
   SearchResultAdHandler search_result_ad_handler_;
+  AdEventTaskQueue search_result_ad_event_task_queue_;
 };
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/ad_units/new_tab_page_ad/new_tab_page_ad_test.cc
+++ b/components/brave_ads/core/internal/ad_units/new_tab_page_ad/new_tab_page_ad_test.cc
@@ -366,4 +366,49 @@ TEST_F(BraveAdsNewTabPageAdIntegrationTest,
   run_loop.Run();
 }
 
+TEST_F(BraveAdsNewTabPageAdIntegrationTest, DoNotTriggerDuplicateClickedEvent) {
+  // Arrange
+  const base::test::ScopedFeatureList scoped_feature_list(
+      {kNewTabPageAdServingFeature});
+
+  test::ForcePermissionRules();
+
+  MockCreativeNewTabPageAds();
+
+  NewTabPageAdInfo ad;
+  base::MockCallback<MaybeServeNewTabPageAdCallback> callback;
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run)
+      .WillOnce([&](base::optional_ref<const NewTabPageAdInfo> served_ad) {
+        ASSERT_TRUE(served_ad);
+        ASSERT_TRUE(served_ad->IsValid());
+        TriggerNewTabPageAdEventAndVerifiyExpectations(
+            served_ad->placement_id, served_ad->creative_instance_id,
+            mojom::NewTabPageAdEventType::kViewedImpression,
+            /*should_fire_event=*/true);
+        ad = *served_ad;
+        run_loop.Quit();
+      });
+  GetAds().MaybeServeNewTabPageAd(callback.Get());
+  run_loop.Run();
+
+  // Act
+  base::test::TestFuture<bool> clicked_future;
+  GetAds().TriggerNewTabPageAdEvent(
+      ad.placement_id, ad.creative_instance_id,
+      mojom::NewTabPageAdMetricType::kConfirmation,
+      mojom::NewTabPageAdEventType::kClicked, clicked_future.GetCallback());
+
+  base::test::TestFuture<bool> duplicate_clicked_future;
+  GetAds().TriggerNewTabPageAdEvent(
+      ad.placement_id, ad.creative_instance_id,
+      mojom::NewTabPageAdMetricType::kConfirmation,
+      mojom::NewTabPageAdEventType::kClicked,
+      duplicate_clicked_future.GetCallback());
+
+  // Assert
+  EXPECT_TRUE(clicked_future.Get());
+  EXPECT_FALSE(duplicate_clicked_future.Get());
+}
+
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_for_non_rewards_test.cc
+++ b/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_for_non_rewards_test.cc
@@ -4,7 +4,6 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "base/test/test_future.h"
-#include "brave/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_handler.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/creatives/search_result_ads/test/creative_search_result_ad_test_util.h"
 #include "brave/components/brave_ads/core/internal/serving/permission_rules/test/permission_rules_test_util.h"
@@ -53,30 +52,6 @@ TEST_F(BraveAdsSearchResultAdForNonRewardsIntegrationTest,
 }
 
 TEST_F(BraveAdsSearchResultAdForNonRewardsIntegrationTest,
-       DoNotTriggerDeferredViewedEvents) {
-  // Arrange
-  SearchResultAdHandler::DeferTriggeringAdViewedEventForTesting();
-
-  TriggerSearchResultAdEventAndVerifyExpectations(
-      // This viewed impression ad event will be deferred.
-      test::BuildCreativeSearchResultAdWithConversion(
-          /*use_random_uuids=*/true),
-      mojom::SearchResultAdEventType::kViewedImpression,
-      /*should_fire_event=*/false);
-
-  // Act & Assert
-  TriggerSearchResultAdEventAndVerifyExpectations(
-      // This viewed impression ad event will be deferred as the previous viewed
-      // impression ad event has not fired.
-      test::BuildCreativeSearchResultAdWithConversion(
-          /*use_random_uuids=*/true),
-      mojom::SearchResultAdEventType::kViewedImpression,
-      /*should_fire_event=*/false);
-
-  SearchResultAdHandler::TriggerDeferredAdViewedEventForTesting();
-}
-
-TEST_F(BraveAdsSearchResultAdForNonRewardsIntegrationTest,
        TriggerClickedEvent) {
   // Arrange
   const mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad =
@@ -87,6 +62,29 @@ TEST_F(BraveAdsSearchResultAdForNonRewardsIntegrationTest,
   TriggerSearchResultAdEventAndVerifyExpectations(
       mojom_creative_ad.Clone(), mojom::SearchResultAdEventType::kClicked,
       /*should_fire_event=*/true);
+}
+
+TEST_F(BraveAdsSearchResultAdForNonRewardsIntegrationTest,
+       DoNotTriggerDuplicateClickedEvent) {
+  // Arrange
+  const mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad =
+      test::BuildCreativeSearchResultAdWithConversion(
+          /*use_random_uuids=*/true);
+
+  // Act
+  base::test::TestFuture<bool> clicked_future;
+  GetAds().TriggerSearchResultAdEvent(mojom_creative_ad.Clone(),
+                                      mojom::SearchResultAdEventType::kClicked,
+                                      clicked_future.GetCallback());
+
+  base::test::TestFuture<bool> duplicate_clicked_future;
+  GetAds().TriggerSearchResultAdEvent(mojom_creative_ad.Clone(),
+                                      mojom::SearchResultAdEventType::kClicked,
+                                      duplicate_clicked_future.GetCallback());
+
+  // Assert
+  EXPECT_TRUE(clicked_future.Get());
+  EXPECT_FALSE(duplicate_clicked_future.Get());
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_for_rewards_test.cc
+++ b/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_for_rewards_test.cc
@@ -4,7 +4,6 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "base/test/test_future.h"
-#include "brave/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_handler.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/creatives/search_result_ads/test/creative_search_result_ad_test_util.h"
 #include "brave/components/brave_ads/core/internal/serving/permission_rules/test/permission_rules_test_util.h"
@@ -52,29 +51,6 @@ TEST_F(BraveAdsSearchResultAdForRewardsIntegrationTest, TriggerViewedEvents) {
       /*should_fire_event=*/true);
 }
 
-TEST_F(BraveAdsSearchResultAdForRewardsIntegrationTest,
-       TriggerDeferredViewedEvents) {
-  // Arrange
-  SearchResultAdHandler::DeferTriggeringAdViewedEventForTesting();
-
-  TriggerSearchResultAdEventAndVerifyExpectations(
-      // This viewed impression ad event will be deferred.
-      test::BuildCreativeSearchResultAdWithConversion(
-          /*use_random_uuids=*/true),
-      mojom::SearchResultAdEventType::kViewedImpression,
-      /*should_fire_event=*/true);
-
-  // Act & Assert
-  TriggerSearchResultAdEventAndVerifyExpectations(
-      // This viewed impression ad event will be deferred as the previous viewed
-      // impression ad event has not fired.
-      test::BuildCreativeSearchResultAd(/*use_random_uuids=*/true),
-      mojom::SearchResultAdEventType::kViewedImpression,
-      /*should_fire_event=*/true);
-
-  SearchResultAdHandler::TriggerDeferredAdViewedEventForTesting();
-}
-
 TEST_F(BraveAdsSearchResultAdForRewardsIntegrationTest, TriggerClickedEvent) {
   // Arrange
   const mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad =
@@ -89,6 +65,83 @@ TEST_F(BraveAdsSearchResultAdForRewardsIntegrationTest, TriggerClickedEvent) {
   TriggerSearchResultAdEventAndVerifyExpectations(
       mojom_creative_ad.Clone(), mojom::SearchResultAdEventType::kClicked,
       /*should_fire_event=*/true);
+}
+
+TEST_F(BraveAdsSearchResultAdForRewardsIntegrationTest,
+       TriggerConcurrentViewedEventsForDifferentAds) {
+  // Arrange
+  const mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad =
+      test::BuildCreativeSearchResultAd(/*use_random_uuids=*/true);
+  const mojom::CreativeSearchResultAdInfoPtr another_mojom_creative_ad =
+      test::BuildCreativeSearchResultAd(/*use_random_uuids=*/true);
+
+  // Act
+  base::test::TestFuture<bool> viewed_impression_future;
+  GetAds().TriggerSearchResultAdEvent(
+      mojom_creative_ad.Clone(),
+      mojom::SearchResultAdEventType::kViewedImpression,
+      viewed_impression_future.GetCallback());
+
+  base::test::TestFuture<bool> another_viewed_impression_future;
+  GetAds().TriggerSearchResultAdEvent(
+      another_mojom_creative_ad.Clone(),
+      mojom::SearchResultAdEventType::kViewedImpression,
+      another_viewed_impression_future.GetCallback());
+
+  // Assert
+  EXPECT_TRUE(viewed_impression_future.Get());
+  EXPECT_TRUE(another_viewed_impression_future.Get());
+}
+
+TEST_F(BraveAdsSearchResultAdForRewardsIntegrationTest,
+       DoNotTriggerDuplicateViewedEvent) {
+  // Arrange
+  const mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad =
+      test::BuildCreativeSearchResultAd(/*use_random_uuids=*/true);
+
+  // Act
+  base::test::TestFuture<bool> viewed_impression_future;
+  GetAds().TriggerSearchResultAdEvent(
+      mojom_creative_ad.Clone(),
+      mojom::SearchResultAdEventType::kViewedImpression,
+      viewed_impression_future.GetCallback());
+
+  base::test::TestFuture<bool> duplicate_viewed_impression_future;
+  GetAds().TriggerSearchResultAdEvent(
+      mojom_creative_ad.Clone(),
+      mojom::SearchResultAdEventType::kViewedImpression,
+      duplicate_viewed_impression_future.GetCallback());
+
+  // Assert
+  EXPECT_TRUE(viewed_impression_future.Get());
+  EXPECT_FALSE(duplicate_viewed_impression_future.Get());
+}
+
+TEST_F(BraveAdsSearchResultAdForRewardsIntegrationTest,
+       DoNotTriggerDuplicateClickedEvent) {
+  // Arrange
+  const mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad =
+      test::BuildCreativeSearchResultAd(/*use_random_uuids=*/true);
+
+  TriggerSearchResultAdEventAndVerifyExpectations(
+      mojom_creative_ad.Clone(),
+      mojom::SearchResultAdEventType::kViewedImpression,
+      /*should_fire_event=*/true);
+
+  // Act
+  base::test::TestFuture<bool> clicked_future;
+  GetAds().TriggerSearchResultAdEvent(mojom_creative_ad.Clone(),
+                                      mojom::SearchResultAdEventType::kClicked,
+                                      clicked_future.GetCallback());
+
+  base::test::TestFuture<bool> duplicate_clicked_future;
+  GetAds().TriggerSearchResultAdEvent(mojom_creative_ad.Clone(),
+                                      mojom::SearchResultAdEventType::kClicked,
+                                      duplicate_clicked_future.GetCallback());
+
+  // Assert
+  EXPECT_TRUE(clicked_future.Get());
+  EXPECT_FALSE(duplicate_clicked_future.Get());
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_handler.cc
+++ b/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_handler.cc
@@ -7,11 +7,8 @@
 
 #include <utility>
 
-#include "base/check.h"
-#include "base/check_is_test.h"
 #include "base/check_op.h"
 #include "base/functional/bind.h"
-#include "base/functional/callback_helpers.h"
 #include "brave/components/brave_ads/core/internal/account/deposits/deposit_util.h"
 #include "brave/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_info.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
@@ -20,14 +17,10 @@
 #include "brave/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 #include "brave/components/brave_ads/core/public/ads_callback.h"
-#include "third_party/abseil-cpp/absl/cleanup/cleanup.h"
 
 namespace brave_ads {
 
 namespace {
-
-SearchResultAdHandler* g_search_result_ad_handler_for_testing = nullptr;
-bool g_defer_triggering_of_ad_viewed_event_for_testing = false;
 
 void FireEventCallback(ResultCallback callback,
                        bool success,
@@ -44,38 +37,6 @@ SearchResultAdHandler::SearchResultAdHandler(SiteVisit& site_visit)
 }
 
 SearchResultAdHandler::~SearchResultAdHandler() = default;
-
-// static
-void SearchResultAdHandler::DeferTriggeringAdViewedEventForTesting() {
-  CHECK_IS_TEST();
-  CHECK(!g_defer_triggering_of_ad_viewed_event_for_testing);
-
-  g_defer_triggering_of_ad_viewed_event_for_testing = true;
-}
-
-// static
-void SearchResultAdHandler::TriggerDeferredAdViewedEventForTesting() {
-  CHECK_IS_TEST();
-  CHECK(g_defer_triggering_of_ad_viewed_event_for_testing);
-
-  g_defer_triggering_of_ad_viewed_event_for_testing = false;
-
-  absl::Cleanup cleanup = [] {
-    // `g_search_result_ad_handler_for_testing` was set in
-    // `FireAdViewedEventCallback` to defer the ad viewed event. Reset it when
-    // this scope exits now that the deferred event has been triggered.
-    g_search_result_ad_handler_for_testing = nullptr;
-  };
-
-  if (!g_search_result_ad_handler_for_testing) {
-    return;
-  }
-
-  g_search_result_ad_handler_for_testing->is_processing_viewed_ad_event_queue_ =
-      false;
-  g_search_result_ad_handler_for_testing->MaybeTriggerDeferredAdViewedEvent(
-      /*intentional*/ base::DoNothing());
-}
 
 void SearchResultAdHandler::TriggerEvent(
     mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad,
@@ -121,51 +82,10 @@ void SearchResultAdHandler::FireServedEventCallback(
     return std::move(callback).Run(/*success=*/false);
   }
 
-  viewed_ad_event_queue_.push_front(std::move(mojom_creative_ad));
-
-  MaybeTriggerDeferredAdViewedEvent(std::move(callback));
-}
-
-void SearchResultAdHandler::MaybeTriggerDeferredAdViewedEvent(
-    ResultCallback callback) {
-  CHECK((!viewed_ad_event_queue_.empty() ||
-         !is_processing_viewed_ad_event_queue_));
-
-  if (viewed_ad_event_queue_.empty() || is_processing_viewed_ad_event_queue_) {
-    return std::move(callback).Run(/*success=*/true);
-  }
-  is_processing_viewed_ad_event_queue_ = true;
-
-  mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad =
-      std::move(viewed_ad_event_queue_.back());
-  viewed_ad_event_queue_.pop_back();
-
   event_handler_.FireEvent(
       std::move(mojom_creative_ad),
       mojom::SearchResultAdEventType::kViewedImpression,
-      base::BindOnce(&SearchResultAdHandler::FireAdViewedEventCallback,
-                     weak_factory_.GetWeakPtr(), std::move(callback)));
-}
-
-void SearchResultAdHandler::FireAdViewedEventCallback(
-    ResultCallback callback,
-    bool success,
-    const std::string& /*placement_id*/,
-    mojom::SearchResultAdEventType mojom_ad_event_type) {
-  CHECK_EQ(mojom_ad_event_type,
-           mojom::SearchResultAdEventType::kViewedImpression);
-
-  if (g_defer_triggering_of_ad_viewed_event_for_testing) {
-    CHECK_IS_TEST();
-
-    g_search_result_ad_handler_for_testing = this;
-
-    return std::move(callback).Run(success);
-  }
-
-  is_processing_viewed_ad_event_queue_ = false;
-
-  MaybeTriggerDeferredAdViewedEvent(std::move(callback));
+      base::BindOnce(&FireEventCallback, std::move(callback)));
 }
 
 void SearchResultAdHandler::OnDidFireSearchResultAdServedEvent(

--- a/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_handler.h
+++ b/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_handler.h
@@ -8,7 +8,6 @@
 
 #include <string>
 
-#include "base/containers/circular_deque.h"
 #include "base/memory/raw_ref.h"
 #include "base/memory/weak_ptr.h"
 #include "brave/components/brave_ads/core/internal/user_engagement/ad_events/search_result_ads/search_result_ad_event_handler.h"
@@ -30,11 +29,6 @@ class SearchResultAdHandler final : public SearchResultAdEventHandlerDelegate {
 
   ~SearchResultAdHandler() override;
 
-  static void DeferTriggeringAdViewedEventForTesting();
-
-  // You must call this if `DeferTriggeringAdViewedEventForTesting` is called.
-  static void TriggerDeferredAdViewedEventForTesting();
-
   void TriggerEvent(mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad,
                     mojom::SearchResultAdEventType mojom_ad_event_type,
                     ResultCallback callback);
@@ -42,13 +36,6 @@ class SearchResultAdHandler final : public SearchResultAdEventHandlerDelegate {
  private:
   void FireServedEventCallback(
       mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad,
-      ResultCallback callback,
-      bool success,
-      const std::string& placement_id,
-      mojom::SearchResultAdEventType mojom_ad_event_type);
-
-  void MaybeTriggerDeferredAdViewedEvent(ResultCallback callback);
-  void FireAdViewedEventCallback(
       ResultCallback callback,
       bool success,
       const std::string& placement_id,
@@ -67,10 +54,6 @@ class SearchResultAdHandler final : public SearchResultAdEventHandlerDelegate {
   const raw_ref<SiteVisit> site_visit_;
 
   SearchResultAdEventHandler event_handler_;
-
-  bool is_processing_viewed_ad_event_queue_ = false;
-  base::circular_deque<mojom::CreativeSearchResultAdInfoPtr>
-      viewed_ad_event_queue_;
 
   base::WeakPtrFactory<SearchResultAdHandler> weak_factory_{this};
 };

--- a/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_task_queue.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_task_queue.cc
@@ -1,0 +1,52 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_task_queue.h"
+
+#include <utility>
+
+#include "base/check.h"
+
+namespace brave_ads {
+
+AdEventTaskQueue::AdEventTaskQueue() = default;
+
+AdEventTaskQueue::~AdEventTaskQueue() = default;
+
+void AdEventTaskQueue::Add(AdEventTask task, ResultCallback callback) {
+  CHECK(task);
+  CHECK(callback);
+
+  queue_.push_back(base::BindOnce(
+      std::move(task),
+      base::BindOnce(&AdEventTaskQueue::OnDidProcessTask,
+                     weak_factory_.GetWeakPtr(), std::move(callback))));
+
+  MaybeProcessNextTask();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+void AdEventTaskQueue::MaybeProcessNextTask() {
+  if (is_processing_task_ || queue_.empty()) {
+    return;
+  }
+  is_processing_task_ = true;
+
+  base::OnceClosure task = std::move(queue_.front());
+  queue_.pop_front();
+
+  std::move(task).Run();
+}
+
+void AdEventTaskQueue::OnDidProcessTask(ResultCallback callback, bool success) {
+  is_processing_task_ = false;
+
+  std::move(callback).Run(success);
+
+  MaybeProcessNextTask();
+}
+
+}  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_task_queue.h
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_task_queue.h
@@ -1,0 +1,43 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_USER_ENGAGEMENT_AD_EVENTS_AD_EVENT_TASK_QUEUE_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_USER_ENGAGEMENT_AD_EVENTS_AD_EVENT_TASK_QUEUE_H_
+
+#include "base/containers/circular_deque.h"
+#include "base/functional/callback.h"
+#include "base/memory/weak_ptr.h"
+#include "brave/components/brave_ads/core/public/ads_callback.h"
+
+namespace brave_ads {
+
+using AdEventTask = base::OnceCallback<void(ResultCallback callback)>;
+
+// Triggers ad events in a queue, so each ad event observes the results of the
+// previous ones.
+class AdEventTaskQueue final {
+ public:
+  AdEventTaskQueue();
+
+  AdEventTaskQueue(const AdEventTaskQueue&) = delete;
+  AdEventTaskQueue& operator=(const AdEventTaskQueue&) = delete;
+
+  ~AdEventTaskQueue();
+
+  void Add(AdEventTask task, ResultCallback callback);
+
+ private:
+  void MaybeProcessNextTask();
+  void OnDidProcessTask(ResultCallback callback, bool success);
+
+  base::circular_deque<base::OnceClosure> queue_;
+  bool is_processing_task_ = false;
+
+  base::WeakPtrFactory<AdEventTaskQueue> weak_factory_{this};
+};
+
+}  // namespace brave_ads
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_USER_ENGAGEMENT_AD_EVENTS_AD_EVENT_TASK_QUEUE_H_

--- a/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_task_queue_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_task_queue_unittest.cc
@@ -1,0 +1,164 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_task_queue.h"
+
+#include <utility>
+#include <vector>
+
+#include "base/functional/callback_helpers.h"
+#include "base/test/mock_callback.h"
+#include "base/test/test_future.h"
+#include "brave/components/brave_ads/core/public/ads_callback.h"
+#include "testing/gmock/include/gmock/gmock.h"
+
+// npm run test -- brave_unit_tests --filter=BraveAds*
+
+namespace brave_ads {
+
+TEST(BraveAdsAdEventTaskQueueTest, ProcessTaskWhenAdded) {
+  // Arrange
+  AdEventTaskQueue queue;
+
+  base::MockCallback<AdEventTask> task;
+  base::test::TestFuture<bool> callback;
+  EXPECT_CALL(task, Run).WillOnce([](ResultCallback callback) {
+    std::move(callback).Run(/*success=*/true);
+  });
+
+  // Act
+  queue.Add(task.Get(), callback.GetCallback());
+
+  // Assert
+  EXPECT_TRUE(callback.IsReady());
+  EXPECT_TRUE(callback.Take());
+}
+
+TEST(BraveAdsAdEventTaskQueueTest, ProcessTaskAddedAfterPreviousTaskCompletes) {
+  // Arrange
+  AdEventTaskQueue queue;
+
+  base::MockCallback<AdEventTask> first_task;
+  base::test::TestFuture<bool> first_callback;
+  EXPECT_CALL(first_task, Run).WillOnce([](ResultCallback callback) {
+    std::move(callback).Run(/*success=*/true);
+  });
+  queue.Add(first_task.Get(), first_callback.GetCallback());
+  ASSERT_TRUE(first_callback.Take());
+
+  base::MockCallback<AdEventTask> second_task;
+  base::test::TestFuture<bool> second_callback;
+  EXPECT_CALL(second_task, Run).WillOnce([](ResultCallback callback) {
+    std::move(callback).Run(/*success=*/true);
+  });
+
+  // Act
+  queue.Add(second_task.Get(), second_callback.GetCallback());
+
+  // Assert
+  EXPECT_TRUE(second_callback.IsReady());
+  EXPECT_TRUE(second_callback.Take());
+}
+
+TEST(BraveAdsAdEventTaskQueueTest,
+     ProcessPendingTaskAfterCurrentTaskCompletes) {
+  // Arrange
+  AdEventTaskQueue queue;
+
+  base::MockCallback<AdEventTask> first_task;
+  base::test::TestFuture<ResultCallback> first_callback;
+  EXPECT_CALL(first_task, Run)
+      .WillOnce([&first_callback](ResultCallback callback) {
+        first_callback.SetValue(std::move(callback));
+      });
+  queue.Add(first_task.Get(), base::DoNothing());
+
+  base::MockCallback<AdEventTask> second_task;
+  base::test::TestFuture<bool> second_callback;
+  EXPECT_CALL(second_task, Run).WillOnce([](ResultCallback callback) {
+    std::move(callback).Run(/*success=*/true);
+  });
+  queue.Add(second_task.Get(), second_callback.GetCallback());
+
+  // The second task must wait for the first one to complete.
+  ASSERT_FALSE(second_callback.IsReady());
+
+  // Act
+  first_callback.Take().Run(/*success=*/true);
+
+  // Assert
+  EXPECT_TRUE(second_callback.IsReady());
+  EXPECT_TRUE(second_callback.Take());
+}
+
+TEST(BraveAdsAdEventTaskQueueTest, ProcessPendingTaskAfterCurrentTaskFails) {
+  // Arrange
+  AdEventTaskQueue queue;
+
+  base::MockCallback<AdEventTask> first_task;
+  base::test::TestFuture<ResultCallback> first_callback;
+  EXPECT_CALL(first_task, Run)
+      .WillOnce([&first_callback](ResultCallback callback) {
+        first_callback.SetValue(std::move(callback));
+      });
+  queue.Add(first_task.Get(), base::DoNothing());
+
+  base::MockCallback<AdEventTask> second_task;
+  base::test::TestFuture<bool> second_callback;
+  EXPECT_CALL(second_task, Run).WillOnce([](ResultCallback callback) {
+    std::move(callback).Run(/*success=*/true);
+  });
+  queue.Add(second_task.Get(), second_callback.GetCallback());
+
+  // Act
+  first_callback.Take().Run(/*success=*/false);
+
+  // Assert
+  EXPECT_TRUE(second_callback.IsReady());
+  EXPECT_TRUE(second_callback.Take());
+}
+
+TEST(BraveAdsAdEventTaskQueueTest, ProcessTasksInTheOrderTheyWereAdded) {
+  // Arrange
+  AdEventTaskQueue queue;
+
+  std::vector<std::string> processed_tasks;
+
+  base::MockCallback<AdEventTask> first_task;
+  base::test::TestFuture<ResultCallback> first_callback;
+  EXPECT_CALL(first_task, Run)
+      .WillOnce([&first_callback, &processed_tasks](ResultCallback callback) {
+        processed_tasks.push_back("task 1");
+        first_callback.SetValue(std::move(callback));
+      });
+  queue.Add(first_task.Get(), base::DoNothing());
+
+  base::MockCallback<AdEventTask> second_task;
+  EXPECT_CALL(second_task, Run)
+      .WillOnce([&processed_tasks](ResultCallback callback) {
+        processed_tasks.push_back("task 2");
+        std::move(callback).Run(/*success=*/true);
+      });
+  queue.Add(second_task.Get(), base::DoNothing());
+
+  base::MockCallback<AdEventTask> third_task;
+  EXPECT_CALL(third_task, Run)
+      .WillOnce([&processed_tasks](ResultCallback callback) {
+        processed_tasks.push_back("task 3");
+        std::move(callback).Run(/*success=*/true);
+      });
+  queue.Add(third_task.Get(), base::DoNothing());
+
+  ASSERT_THAT(processed_tasks, ::testing::ElementsAre("task 1"));
+
+  // Act
+  first_callback.Take().Run(/*success=*/true);
+
+  // Assert
+  EXPECT_THAT(processed_tasks,
+              ::testing::ElementsAre("task 1", "task 2", "task 3"));
+}
+
+}  // namespace brave_ads

--- a/components/brave_ads/core/test/BUILD.gn
+++ b/components/brave_ads/core/test/BUILD.gn
@@ -605,6 +605,7 @@ source_set("brave_ads_unit_tests") {
     "//brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_builder_unittest.cc",
     "//brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_feature_unittest.cc",
     "//brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_handler_util_unittest.cc",
+    "//brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_task_queue_unittest.cc",
     "//brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_util_unittest.cc",
     "//brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_events_database_table_unittest.cc",
     "//brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_events_database_table_util_unittest.cc",


### PR DESCRIPTION
Double clicking an ad could report the clicked confirmation twice because both clicked events were handled at the same time. Ad events for each ad type are now handled one after another so that each event observes the outcome of the previous one.

BLOCKING TODO:
Need to add timings when triggering several ad events before and after this change.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55320

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
