### PR TITLE
Use an explicit Copy Clean Link sharing-hub insertion

### DIFF
--- a/chromium_src/chrome/browser/sharing_hub/sharing_hub_model.cc
+++ b/chromium_src/chrome/browser/sharing_hub/sharing_hub_model.cc
@@ -33,7 +33,7 @@ bool ShouldAddCopyCleanLinkItem(content::BrowserContext* context) {
   return contents->GetLastCommittedURL().SchemeIsHTTPOrHTTPS();
 }
 
-int MaybeAddCopyCleanLinkItem(
+void MaybeAddCopyCleanLinkItem(
     content::BrowserContext* context,
     std::vector<sharing_hub::SharingHubAction>* first_party_action_list) {
   if (ShouldAddCopyCleanLinkItem(context)) {
@@ -42,7 +42,6 @@ int MaybeAddCopyCleanLinkItem(
         l10n_util::GetStringUTF16(IDS_COPY_CLEAN_LINK_SHARING_HUB),
         &kCopyOldIcon, "SharingHubDesktop.CopyURLSelected", IDS_LINK_COPIED);
   }
-  return IDS_SHARING_HUB_COPY_LINK_LABEL;
 }
 
 }  // namespace

--- a/patches/chrome-browser-sharing_hub-sharing_hub_model.cc.patch
+++ b/patches/chrome-browser-sharing_hub-sharing_hub_model.cc.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/browser/sharing_hub/sharing_hub_model.cc b/chrome/browser/sharing_hub/sharing_hub_model.cc
-index 556ab711674dd9680f9b228aaa6ff7215929fd60..d0b93f68ecda1238df3c095969de9f03804bf24c 100644
+index 556ab711674dd9680f9b228aaa6ff7215929fd60..22a5066d9611328b9c4bf061488aa60e766857cf 100644
 --- a/chrome/browser/sharing_hub/sharing_hub_model.cc
 +++ b/chrome/browser/sharing_hub/sharing_hub_model.cc
-@@ -93,6 +93,7 @@ std::vector<SharingHubAction> SharingHubModel::GetFirstPartyActionList(
- }
+@@ -94,6 +94,7 @@ std::vector<SharingHubAction> SharingHubModel::GetFirstPartyActionList(
  
  void SharingHubModel::PopulateFirstPartyActions() {
-+  MaybeAddCopyCleanLinkItem(context_, &first_party_action_list_);
    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  MaybeAddCopyCleanLinkItem(context_, &first_party_action_list_);
  
    first_party_action_list_.emplace_back(
+       IDC_COPY_URL, l10n_util::GetStringUTF16(IDS_SHARING_HUB_COPY_LINK_LABEL),

--- a/patches/chrome-browser-sharing_hub-sharing_hub_model.cc.patch
+++ b/patches/chrome-browser-sharing_hub-sharing_hub_model.cc.patch
@@ -1,13 +1,12 @@
 diff --git a/chrome/browser/sharing_hub/sharing_hub_model.cc b/chrome/browser/sharing_hub/sharing_hub_model.cc
-index cf13237c7ea622fa00a49122c011fcb5cd7870fa..3c981cdde2fbdca28f1eefcf6b66b11d1b225e8b 100644
+index cf13237c7ea622fa00a49122c011fcb5cd7870fa..822a152daa1bc72cf94a3d9d99db971552153507 100644
 --- a/chrome/browser/sharing_hub/sharing_hub_model.cc
 +++ b/chrome/browser/sharing_hub/sharing_hub_model.cc
-@@ -97,7 +97,7 @@ void SharingHubModel::PopulateFirstPartyActions() {
+@@ -94,6 +94,7 @@ std::vector<SharingHubAction> SharingHubModel::GetFirstPartyActionList(
+ }
+ 
+ void SharingHubModel::PopulateFirstPartyActions() {
++  MaybeAddCopyCleanLinkItem(context_, &first_party_action_list_);
    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
  
    first_party_action_list_.emplace_back(
--      IDC_COPY_URL, l10n_util::GetStringUTF16(IDS_SHARING_HUB_COPY_LINK_LABEL),
-+      IDC_COPY_URL, l10n_util::GetStringUTF16(MaybeAddCopyCleanLinkItem(context_, &first_party_action_list_)),
-       &(features::IsRoundedIconsEnabled() ? vector_icons::kContentCopyIcon
-                                           : kCopyOldIcon),
-       "SharingHubDesktop.CopyURLSelected", IDS_LINK_COPIED);

--- a/patches/chrome-browser-sharing_hub-sharing_hub_model.cc.patch
+++ b/patches/chrome-browser-sharing_hub-sharing_hub_model.cc.patch
@@ -1,13 +1,12 @@
 diff --git a/chrome/browser/sharing_hub/sharing_hub_model.cc b/chrome/browser/sharing_hub/sharing_hub_model.cc
-index 556ab711674dd9680f9b228aaa6ff7215929fd60..dc15b6d1969c937a6001832a4e48b444ef20f5d2 100644
+index 556ab711674dd9680f9b228aaa6ff7215929fd60..d0b93f68ecda1238df3c095969de9f03804bf24c 100644
 --- a/chrome/browser/sharing_hub/sharing_hub_model.cc
 +++ b/chrome/browser/sharing_hub/sharing_hub_model.cc
-@@ -96,7 +96,7 @@ void SharingHubModel::PopulateFirstPartyActions() {
+@@ -93,6 +93,7 @@ std::vector<SharingHubAction> SharingHubModel::GetFirstPartyActionList(
+ }
+ 
+ void SharingHubModel::PopulateFirstPartyActions() {
++  MaybeAddCopyCleanLinkItem(context_, &first_party_action_list_);
    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
  
    first_party_action_list_.emplace_back(
--      IDC_COPY_URL, l10n_util::GetStringUTF16(IDS_SHARING_HUB_COPY_LINK_LABEL),
-+      IDC_COPY_URL, l10n_util::GetStringUTF16(MaybeAddCopyCleanLinkItem(context_, &first_party_action_list_)),
-       &(features::IsRoundedIconsEnabled() ? kContentCopyIcon : kCopyOldIcon),
-       "SharingHubDesktop.CopyURLSelected", IDS_LINK_COPIED);
- 

--- a/patches/chrome-browser-sharing_hub-sharing_hub_model.cc.patch
+++ b/patches/chrome-browser-sharing_hub-sharing_hub_model.cc.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/browser/sharing_hub/sharing_hub_model.cc b/chrome/browser/sharing_hub/sharing_hub_model.cc
-index cf13237c7ea622fa00a49122c011fcb5cd7870fa..822a152daa1bc72cf94a3d9d99db971552153507 100644
+index cf13237c7ea622fa00a49122c011fcb5cd7870fa..084de7b3caa122c90065aa950c5e7d0e586dc53f 100644
 --- a/chrome/browser/sharing_hub/sharing_hub_model.cc
 +++ b/chrome/browser/sharing_hub/sharing_hub_model.cc
-@@ -94,6 +94,7 @@ std::vector<SharingHubAction> SharingHubModel::GetFirstPartyActionList(
- }
+@@ -95,6 +95,7 @@ std::vector<SharingHubAction> SharingHubModel::GetFirstPartyActionList(
  
  void SharingHubModel::PopulateFirstPartyActions() {
-+  MaybeAddCopyCleanLinkItem(context_, &first_party_action_list_);
    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  MaybeAddCopyCleanLinkItem(context_, &first_party_action_list_);
  
    first_party_action_list_.emplace_back(
+       IDC_COPY_URL, l10n_util::GetStringUTF16(IDS_SHARING_HUB_COPY_LINK_LABEL),

--- a/rewrite/chrome/browser/sharing_hub/sharing_hub_model.cc.yaml
+++ b/rewrite/chrome/browser/sharing_hub/sharing_hub_model.cc.yaml
@@ -4,12 +4,8 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 substitutions:
-  - description: |
-      Route the sharing hub copy-link label through MaybeAddCopyCleanLinkItem.
-
-      The helper, defined in the chromium_src wrapper for this source, adds a
-      "Copy Clean Link" entry to the first-party action list when applicable and
-      returns the original label ID so the upstream `emplace_back` keeps working.
-    regex:
-      pattern: 'IDS_SHARING_HUB_COPY_LINK_LABEL'
-      replace: 'MaybeAddCopyCleanLinkItem(context_, &first_party_action_list_)'
+  - description: 'Add Copy Clean Link before the upstream Copy Link action.'
+    preempt_function_impl:
+      function_name: SharingHubModel::PopulateFirstPartyActions
+      code: |-
+        MaybeAddCopyCleanLinkItem(context_, &first_party_action_list_);

--- a/rewrite/chrome/browser/sharing_hub/sharing_hub_model.cc.yaml
+++ b/rewrite/chrome/browser/sharing_hub/sharing_hub_model.cc.yaml
@@ -5,7 +5,8 @@
 
 substitutions:
   - description: 'Add Copy Clean Link before the upstream Copy Link action.'
-    preempt_function_impl:
-      function_name: SharingHubModel::PopulateFirstPartyActions
-      code: |-
-        MaybeAddCopyCleanLinkItem(context_, &first_party_action_list_);
+    regex:
+      re_pattern: '(void SharingHubModel::PopulateFirstPartyActions\(\)\s*\{\s*DCHECK_CALLED_ON_VALID_SEQUENCE\(sequence_checker_\);)'
+      replace: |-
+        \1
+          MaybeAddCopyCleanLinkItem(context_, &first_party_action_list_);

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -70,6 +70,37 @@ class PlasterTest(unittest.TestCase):
                     f'File {committed_file_path} does not match '
                     f'expected {expected_file}')
 
+    def test_sharing_hub_copy_clean_link_precedes_upstream_copy_link(self):
+        """The production plaster inserts without rewriting Chromium's label."""
+        fixture_dir = Path(__file__).parent / 'test/plasters'
+        source = Path('chrome/browser/sharing_hub/sharing_hub_model.cc')
+        original = fixture_dir / 'sharing_hub_model-original.cc'
+        expected = fixture_dir / 'sharing_hub_model-expected.cc'
+
+        self.fake_chromium_src.write_and_stage_file(
+            relative_path=source,
+            content=original.read_bytes().decode('utf-8'),
+            repo_path=self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit(
+            commit_message=f'Add {source}',
+            repo_path=self.fake_chromium_src.chromium)
+
+        production_plaster = (
+            Path(__file__).resolve().parents[2] / 'rewrite' /
+            f'{source}.yaml')
+        rewrite_path = plaster.PLASTER_FILES_PATH / f'{source}.yaml'
+        rewrite_path.parent.mkdir(parents=True, exist_ok=True)
+        rewrite_path.write_text(
+            production_plaster.read_bytes().decode('utf-8'),
+            encoding='utf-8',
+            newline='')
+
+        plaster.PlasterFile(rewrite_path).apply()
+
+        rewritten = self.fake_chromium_src.chromium / source
+        self.assertEqual(rewritten.read_bytes().decode('utf-8'),
+                         expected.read_bytes().decode('utf-8'))
+
     def test_plaster_patchinfo_creation(self):
         """Test the patchinfo creation mechanics."""
         test_file_chromium = Path(

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -69,6 +69,37 @@ class PlasterTest(unittest.TestCase):
                     f'File {committed_file_path} does not match '
                     f'expected {expected_file}')
 
+    def test_sharing_hub_copy_clean_link_precedes_upstream_copy_link(self):
+        """The production plaster inserts without rewriting Chromium's label."""
+        fixture_dir = Path(__file__).parent / 'test/plasters'
+        source = Path('chrome/browser/sharing_hub/sharing_hub_model.cc')
+        original = fixture_dir / 'sharing_hub_model-original.cc'
+        expected = fixture_dir / 'sharing_hub_model-expected.cc'
+
+        self.fake_chromium_src.write_and_stage_file(
+            relative_path=source,
+            content=original.read_bytes().decode('utf-8'),
+            repo_path=self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit(
+            commit_message=f'Add {source}',
+            repo_path=self.fake_chromium_src.chromium)
+
+        production_plaster = (
+            Path(__file__).resolve().parents[2] / 'rewrite' /
+            f'{source}.yaml')
+        rewrite_path = plaster.PLASTER_FILES_PATH / f'{source}.yaml'
+        rewrite_path.parent.mkdir(parents=True, exist_ok=True)
+        rewrite_path.write_text(
+            production_plaster.read_bytes().decode('utf-8'),
+            encoding='utf-8',
+            newline='')
+
+        plaster.PlasterFile(rewrite_path).apply()
+
+        rewritten = self.fake_chromium_src.chromium / source
+        self.assertEqual(rewritten.read_bytes().decode('utf-8'),
+                         expected.read_bytes().decode('utf-8'))
+
     def test_plaster_patchinfo_creation(self):
         """Test the patchinfo creation mechanics."""
         test_file_chromium = Path(

--- a/tools/cr/test/plasters/sharing_hub_model-expected.cc
+++ b/tools/cr/test/plasters/sharing_hub_model-expected.cc
@@ -1,8 +1,8 @@
 namespace sharing_hub {
 
 void SharingHubModel::PopulateFirstPartyActions() {
-  MaybeAddCopyCleanLinkItem(context_, &first_party_action_list_);
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  MaybeAddCopyCleanLinkItem(context_, &first_party_action_list_);
 
   first_party_action_list_.emplace_back(
       IDC_COPY_URL, l10n_util::GetStringUTF16(IDS_SHARING_HUB_COPY_LINK_LABEL),

--- a/tools/cr/test/plasters/sharing_hub_model-expected.cc
+++ b/tools/cr/test/plasters/sharing_hub_model-expected.cc
@@ -1,0 +1,12 @@
+namespace sharing_hub {
+
+void SharingHubModel::PopulateFirstPartyActions() {
+  MaybeAddCopyCleanLinkItem(context_, &first_party_action_list_);
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+
+  first_party_action_list_.emplace_back(
+      IDC_COPY_URL, l10n_util::GetStringUTF16(IDS_SHARING_HUB_COPY_LINK_LABEL),
+      &kCopyOldIcon, "SharingHubDesktop.CopyURLSelected", IDS_LINK_COPIED);
+}
+
+}  // namespace sharing_hub

--- a/tools/cr/test/plasters/sharing_hub_model-original.cc
+++ b/tools/cr/test/plasters/sharing_hub_model-original.cc
@@ -1,0 +1,11 @@
+namespace sharing_hub {
+
+void SharingHubModel::PopulateFirstPartyActions() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+
+  first_party_action_list_.emplace_back(
+      IDC_COPY_URL, l10n_util::GetStringUTF16(IDS_SHARING_HUB_COPY_LINK_LABEL),
+      &kCopyOldIcon, "SharingHubDesktop.CopyURLSelected", IDS_LINK_COPIED);
+}
+
+}  // namespace sharing_hub


### PR DESCRIPTION
- Resolves brave/brave-browser#56389

## Summary

Replace the sharing-hub Copy Clean Link label-expression side effect with an explicit statement in `SharingHubModel::PopulateFirstPartyActions`.

The Plaster inserts `MaybeAddCopyCleanLinkItem(...)` immediately after Chromium's sequence DCHECK and before the upstream Copy Link action. The helper returns `void`, and Chromium's `IDS_SHARING_HUB_COPY_LINK_LABEL` expression remains untouched.

This branch is rebased onto current `brave-core/master` after the Chromium 152 refresh. The generated patch now targets Chromium `152.0.7977.54` and preserves the upstream `vector_icons::kContentCopyIcon` change.

The commits remain intentionally separated into:

1. a production-Plaster regression fixture;
2. the helper/YAML/generated-patch implementation;
3. the review-driven correction that keeps the sequence DCHECK first.

## Test plan

```sh
uv run --with rich --with pyyaml --with schema \
  python tools/cr/plaster_test.py \
  PlasterTest.test_sharing_hub_copy_clean_link_precedes_upstream_copy_link
```

Result: `Ran 1 test ... OK` after the rebase.

The production patch was also checked directly in a temporary Git index against the pinned Chromium source. Its preimage hash is `cf13237c7ea622fa00a49122c011fcb5cd7870fa`, and applying the committed patch produces the declared postimage hash `084de7b3caa122c90065aa950c5e7d0e586dc53f`.

The entire `plaster_test.py` file was also attempted in this standalone checkout. Its unrelated AST tests cannot run because the repository's pinned `third_party/ast-grep/.../ast-grep` binary is not present, and some schema-message assertions differ under the ad-hoc latest `schema` package. The focused production-Plaster regression does not use those missing components and passes.

A full `BraveSharingHubTest.CopyCommandsOrder` browser run is not available because this standalone filtered checkout does not contain Chromium build output, so this remains a draft.

## AI assistance

AI tools assisted with issue analysis, implementation, and test drafting. I manually verified the rebased diff, the focused regression, the exact pinned-Chromium patch preimage/postimage, and the clean merge against current `master`. The current head is `0cc11b327fe`.
