### PR TITLE
Remove unused file-path text extraction API

### DIFF
--- a/browser/ai_chat/file_text_extractor_base.cc
+++ b/browser/ai_chat/file_text_extractor_base.cc
@@ -66,15 +66,6 @@ FileTextExtractorBase::~FileTextExtractorBase() {
 
 void FileTextExtractorBase::ExtractText(
     content::BrowserContext* browser_context,
-    const base::FilePath& file_path,
-    ExtractTextCallback callback) {
-  CHECK(!callback_) << "ExtractText called while extraction in progress";
-  callback_ = std::move(callback);
-  LoadInWebContents(browser_context, file_path);
-}
-
-void FileTextExtractorBase::ExtractText(
-    content::BrowserContext* browser_context,
     std::vector<uint8_t> file_bytes,
     const base::FilePath::StringType& extension,
     ExtractTextCallback callback) {
@@ -90,32 +81,6 @@ FileTextExtractorBase::AdditionalUnsandboxFlags() const {
 
 GURL FileTextExtractorBase::GetLoadURL(const base::FilePath& file_path) const {
   return net::FilePathToFileURL(file_path);
-}
-
-void FileTextExtractorBase::LoadInWebContents(
-    content::BrowserContext* browser_context,
-    const base::FilePath& file_path) {
-  content::WebContents::CreateParams create_params(browser_context);
-  create_params.is_never_composited = true;
-  create_params.starting_sandbox_flags =
-      network::mojom::WebSandboxFlags::kAll &
-      ~network::mojom::WebSandboxFlags::kScripts &
-      ~network::mojom::WebSandboxFlags::kOrigin &
-      ~network::mojom::WebSandboxFlags::kNavigation &
-      ~AdditionalUnsandboxFlags();
-  web_contents_ = content::WebContents::Create(create_params);
-  web_contents_->SetOwnerLocationForDebug(FROM_HERE);
-  web_contents_->SetDelegate(this);
-  Observe(web_contents_.get());
-
-  timeout_timer_.Start(FROM_HERE, kExtractionTimeout,
-                       base::BindOnce(&FileTextExtractorBase::OnTimeout,
-                                      base::Unretained(this)));
-
-  const GURL load_url = GetLoadURL(file_path);
-  web_contents_->GetController().LoadURL(load_url, content::Referrer(),
-                                         ui::PAGE_TRANSITION_AUTO_TOPLEVEL,
-                                         std::string());
 }
 
 void FileTextExtractorBase::WriteTempFileAndLoad(
@@ -176,7 +141,28 @@ void FileTextExtractorBase::OnTempFileWritten(
     return;
   }
   temp_file_path_ = *temp_path;
-  LoadInWebContents(browser_context, temp_file_path_);
+
+  content::WebContents::CreateParams create_params(browser_context);
+  create_params.is_never_composited = true;
+  create_params.starting_sandbox_flags =
+      network::mojom::WebSandboxFlags::kAll &
+      ~network::mojom::WebSandboxFlags::kScripts &
+      ~network::mojom::WebSandboxFlags::kOrigin &
+      ~network::mojom::WebSandboxFlags::kNavigation &
+      ~AdditionalUnsandboxFlags();
+  web_contents_ = content::WebContents::Create(create_params);
+  web_contents_->SetOwnerLocationForDebug(FROM_HERE);
+  web_contents_->SetDelegate(this);
+  Observe(web_contents_.get());
+
+  timeout_timer_.Start(FROM_HERE, kExtractionTimeout,
+                       base::BindOnce(&FileTextExtractorBase::OnTimeout,
+                                      base::Unretained(this)));
+
+  const GURL load_url = GetLoadURL(temp_file_path_);
+  web_contents_->GetController().LoadURL(load_url, content::Referrer(),
+                                         ui::PAGE_TRANSITION_AUTO_TOPLEVEL,
+                                         std::string());
 }
 
 void FileTextExtractorBase::OnTimeout() {

--- a/browser/ai_chat/file_text_extractor_base.h
+++ b/browser/ai_chat/file_text_extractor_base.h
@@ -45,14 +45,7 @@ class FileTextExtractorBase : public RestrictedWebContentsDelegate,
   FileTextExtractorBase(const FileTextExtractorBase&) = delete;
   FileTextExtractorBase& operator=(const FileTextExtractorBase&) = delete;
 
-  // Two entry points for text extraction:
-
-  // Use an existing file path directly (e.g. from file picker).
-  void ExtractText(content::BrowserContext* browser_context,
-                   const base::FilePath& file_path,
-                   ExtractTextCallback callback);
-
-  // Write bytes to a temp file first (e.g. from drag-and-drop).
+  // Writes bytes to a temp file before extracting text.
   // |extension| is the file extension for MIME type detection (without
   // leading dot).
   void ExtractText(content::BrowserContext* browser_context,
@@ -72,10 +65,6 @@ class FileTextExtractorBase : public RestrictedWebContentsDelegate,
   // Returns the URL to load for the given file path. Default returns a
   // file:// URL. Override to customize, e.g. view-source:file://.
   virtual GURL GetLoadURL(const base::FilePath& file_path) const;
-
-  // Starts loading a file in a hidden WebContents.
-  void LoadInWebContents(content::BrowserContext* browser_context,
-                         const base::FilePath& file_path);
 
   // Writes bytes to a temp file, then loads it. |extension| is the file
   // extension to use for MIME type detection (without leading dot).

--- a/browser/ai_chat/pdf_text_extractor_browsertest.cc
+++ b/browser/ai_chat/pdf_text_extractor_browsertest.cc
@@ -7,6 +7,7 @@
 
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "base/files/file_util.h"
@@ -34,21 +35,7 @@ class PdfTextExtractorBrowserTest : public InProcessBrowserTest {
   content::BrowserContext* browser_context() { return browser()->profile(); }
 };
 
-IN_PROC_BROWSER_TEST_F(PdfTextExtractorBrowserTest, PathOverload_ExtractsText) {
-  base::FilePath pdf_path = GetTestPdfPath("dummy.pdf");
-
-  auto extractor = std::make_unique<PdfTextExtractor>();
-  base::test::TestFuture<std::optional<std::string>> future;
-
-  extractor->ExtractText(browser_context(), pdf_path, future.GetCallback());
-
-  auto result = future.Take();
-  ASSERT_TRUE(result.has_value());
-  EXPECT_EQ(*result, "This is the way\nI have spoken");
-}
-
-IN_PROC_BROWSER_TEST_F(PdfTextExtractorBrowserTest,
-                       BytesOverload_ExtractsText) {
+IN_PROC_BROWSER_TEST_F(PdfTextExtractorBrowserTest, ExtractsText) {
   std::optional<std::vector<uint8_t>> pdf_bytes;
   {
     base::ScopedAllowBlockingForTesting allow_blocking;
@@ -68,12 +55,18 @@ IN_PROC_BROWSER_TEST_F(PdfTextExtractorBrowserTest,
 }
 
 IN_PROC_BROWSER_TEST_F(PdfTextExtractorBrowserTest, EmptyPdf_ReturnsEmpty) {
-  base::FilePath pdf_path = GetTestPdfPath("empty_pdf.pdf");
+  std::optional<std::vector<uint8_t>> pdf_bytes;
+  {
+    base::ScopedAllowBlockingForTesting allow_blocking;
+    pdf_bytes = base::ReadFileToBytes(GetTestPdfPath("empty_pdf.pdf"));
+  }
+  ASSERT_TRUE(pdf_bytes.has_value());
 
   auto extractor = std::make_unique<PdfTextExtractor>();
   base::test::TestFuture<std::optional<std::string>> future;
 
-  extractor->ExtractText(browser_context(), pdf_path, future.GetCallback());
+  extractor->ExtractText(browser_context(), std::move(*pdf_bytes),
+                         FILE_PATH_LITERAL("pdf"), future.GetCallback());
 
   auto result = future.Take();
   // Empty PDF should either return empty string or nullopt.

--- a/browser/ai_chat/pdf_text_extractor_unittest.cc
+++ b/browser/ai_chat/pdf_text_extractor_unittest.cc
@@ -10,8 +10,7 @@
 #include <utility>
 #include <vector>
 
-#include "base/files/file_util.h"
-#include "base/files/scoped_temp_dir.h"
+#include "base/test/run_until.h"
 #include "base/test/test_future.h"
 #include "chrome/test/base/testing_profile.h"
 #include "content/public/test/browser_task_environment.h"
@@ -19,6 +18,13 @@
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace ai_chat {
+
+class TestPdfTextExtractor : public PdfTextExtractor {
+ public:
+  content::WebContents* GetWebContentsForTesting() {
+    return GetWebContents();
+  }
+};
 
 class PdfTextExtractorTest : public content::RenderViewHostTestHarness {
  public:
@@ -34,7 +40,7 @@ class PdfTextExtractorTest : public content::RenderViewHostTestHarness {
 // Without a real PDF viewer extension, the hidden WebContents will never
 // produce a PDFDocumentHelper. The extraction should time out and return
 // nullopt.
-TEST_F(PdfTextExtractorTest, BytesOverload_TimeoutReturnsNullopt) {
+TEST_F(PdfTextExtractorTest, TimeoutReturnsNullopt) {
   auto extractor = std::make_unique<PdfTextExtractor>();
   base::test::TestFuture<std::optional<std::string>> future;
 
@@ -50,50 +56,26 @@ TEST_F(PdfTextExtractorTest, BytesOverload_TimeoutReturnsNullopt) {
   EXPECT_FALSE(result.has_value());
 }
 
-// Same timeout test but using the file-path overload (no temp file).
-TEST_F(PdfTextExtractorTest, PathOverload_TimeoutReturnsNullopt) {
-  base::ScopedTempDir temp_dir;
-  ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
-  base::FilePath pdf_path = temp_dir.GetPath().AppendASCII("test.pdf");
-  ASSERT_TRUE(base::WriteFile(pdf_path, "%PDF-1.4 dummy content for test"));
-
-  auto extractor = std::make_unique<PdfTextExtractor>();
+// Destroying after the hidden WebContents starts loading must not invoke the
+// extraction callback.
+TEST_F(PdfTextExtractorTest, DestroyAfterLoadStarts_DoesNotRunCallback) {
+  auto extractor = std::make_unique<TestPdfTextExtractor>();
   base::test::TestFuture<std::optional<std::string>> future;
 
-  extractor->ExtractText(browser_context(), pdf_path, future.GetCallback());
+  std::vector<uint8_t> dummy_pdf = {0x25, 0x50, 0x44, 0x46};
+  extractor->ExtractText(browser_context(), std::move(dummy_pdf),
+                         FILE_PATH_LITERAL("pdf"), future.GetCallback());
 
-  task_environment()->FastForwardBy(base::Seconds(31));
-
-  auto result = future.Take();
-  EXPECT_FALSE(result.has_value());
-}
-
-// Destroying the extractor while an extraction is in-flight must not crash
-// or leak.
-TEST_F(PdfTextExtractorTest, DestroyDuringExtraction_NoCrash) {
-  auto extractor = std::make_unique<PdfTextExtractor>();
-
-  base::ScopedTempDir temp_dir;
-  ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
-  base::FilePath pdf_path = temp_dir.GetPath().AppendASCII("test.pdf");
-  ASSERT_TRUE(base::WriteFile(pdf_path, "%PDF-1.4 dummy content for test"));
-
-  bool callback_called = false;
-  extractor->ExtractText(
-      browser_context(), pdf_path,
-      base::BindOnce(
-          [](bool* called, std::optional<std::string>) { *called = true; },
-          &callback_called));
-
-  // Destroy while extraction is in progress — should not crash.
+  ASSERT_TRUE(base::test::RunUntil([&] {
+    return extractor->GetWebContentsForTesting() != nullptr;
+  }));
   extractor.reset();
 
-  EXPECT_FALSE(callback_called);
+  EXPECT_FALSE(future.IsReady());
 }
 
-// The bytes overload writes to a temp file. Verify the extraction and cleanup
-// complete without crashing after timeout.
-TEST_F(PdfTextExtractorTest, BytesOverload_CleanupAfterTimeout) {
+// Verify the extraction and cleanup complete without crashing after timeout.
+TEST_F(PdfTextExtractorTest, CleanupAfterTimeout) {
   auto extractor = std::make_unique<PdfTextExtractor>();
   base::test::TestFuture<std::optional<std::string>> future;
 
@@ -106,26 +88,6 @@ TEST_F(PdfTextExtractorTest, BytesOverload_CleanupAfterTimeout) {
   task_environment()->FastForwardBy(base::Seconds(31));
 
   ASSERT_TRUE(future.Wait());
-}
-
-// The file-path overload should NOT delete the original file after extraction.
-TEST_F(PdfTextExtractorTest, PathOverload_OriginalFileNotDeleted) {
-  base::ScopedTempDir temp_dir;
-  ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
-  base::FilePath pdf_path = temp_dir.GetPath().AppendASCII("keep_me.pdf");
-  ASSERT_TRUE(base::WriteFile(pdf_path, "%PDF-1.4 dummy content for test"));
-
-  auto extractor = std::make_unique<PdfTextExtractor>();
-  base::test::TestFuture<std::optional<std::string>> future;
-
-  extractor->ExtractText(browser_context(), pdf_path, future.GetCallback());
-
-  task_environment()->FastForwardBy(base::Seconds(31));
-
-  ASSERT_TRUE(future.Wait());
-
-  // The original file must still exist — only temp files are cleaned up.
-  EXPECT_TRUE(base::PathExists(pdf_path));
 }
 
 }  // namespace ai_chat

--- a/browser/ai_chat/text_file_extractor_browsertest.cc
+++ b/browser/ai_chat/text_file_extractor_browsertest.cc
@@ -7,6 +7,7 @@
 
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "base/files/file_util.h"
@@ -38,22 +39,7 @@ class TextFileExtractorBrowserTest : public InProcessBrowserTest {
   content::BrowserContext* browser_context() { return browser()->profile(); }
 };
 
-IN_PROC_BROWSER_TEST_F(TextFileExtractorBrowserTest,
-                       PathOverload_ExtractsText) {
-  base::FilePath txt_path = GetTestFilePath("dummy.txt");
-
-  auto extractor = std::make_unique<TextFileExtractor>();
-  base::test::TestFuture<std::optional<std::string>> future;
-
-  extractor->ExtractText(browser_context(), txt_path, future.GetCallback());
-
-  auto result = future.Take();
-  ASSERT_TRUE(result.has_value());
-  EXPECT_EQ(*result, kExpectedTextContent);
-}
-
-IN_PROC_BROWSER_TEST_F(TextFileExtractorBrowserTest,
-                       BytesOverload_ExtractsText) {
+IN_PROC_BROWSER_TEST_F(TextFileExtractorBrowserTest, ExtractsText) {
   std::optional<std::vector<uint8_t>> file_bytes;
   {
     base::ScopedAllowBlockingForTesting allow_blocking;
@@ -74,24 +60,7 @@ IN_PROC_BROWSER_TEST_F(TextFileExtractorBrowserTest,
 
 // HTML files must not be rendered — the extracted text should be the raw
 // source containing HTML tags, not the rendered text content.
-IN_PROC_BROWSER_TEST_F(TextFileExtractorBrowserTest,
-                       PathOverload_HtmlNotRendered) {
-  base::FilePath html_path = GetTestFilePath("dummy.html");
-
-  auto extractor = std::make_unique<TextFileExtractor>();
-  base::test::TestFuture<std::optional<std::string>> future;
-
-  extractor->ExtractText(browser_context(), html_path, future.GetCallback());
-
-  auto result = future.Take();
-  ASSERT_TRUE(result.has_value());
-  // Raw source must contain HTML tags — proves it was NOT rendered.
-  EXPECT_NE(result->find("<p>Hello from an HTML file.</p>"), std::string::npos);
-  EXPECT_NE(result->find("<script>"), std::string::npos);
-}
-
-IN_PROC_BROWSER_TEST_F(TextFileExtractorBrowserTest,
-                       BytesOverload_HtmlNotRendered) {
+IN_PROC_BROWSER_TEST_F(TextFileExtractorBrowserTest, HtmlNotRendered) {
   std::optional<std::vector<uint8_t>> file_bytes;
   {
     base::ScopedAllowBlockingForTesting allow_blocking;
@@ -112,27 +81,17 @@ IN_PROC_BROWSER_TEST_F(TextFileExtractorBrowserTest,
 }
 
 IN_PROC_BROWSER_TEST_F(TextFileExtractorBrowserTest, EmptyFile_ReturnsEmpty) {
-  // Create a temporary empty file
-  base::FilePath temp_path;
-  {
-    base::ScopedAllowBlockingForTesting allow_blocking;
-    ASSERT_TRUE(base::CreateTemporaryFile(&temp_path));
-  }
-
   auto extractor = std::make_unique<TextFileExtractor>();
   base::test::TestFuture<std::optional<std::string>> future;
+  std::vector<uint8_t> file_bytes;
 
-  extractor->ExtractText(browser_context(), temp_path, future.GetCallback());
+  extractor->ExtractText(browser_context(), std::move(file_bytes),
+                         FILE_PATH_LITERAL("txt"), future.GetCallback());
 
   auto result = future.Take();
   // Empty file should either return nullopt or empty string.
   if (result.has_value()) {
     EXPECT_TRUE(result->empty());
-  }
-
-  {
-    base::ScopedAllowBlockingForTesting allow_blocking;
-    base::DeleteFile(temp_path);
   }
 }
 

--- a/browser/ai_chat/text_file_extractor_unittest.cc
+++ b/browser/ai_chat/text_file_extractor_unittest.cc
@@ -10,9 +10,8 @@
 #include <utility>
 #include <vector>
 
-#include "base/files/file_util.h"
-#include "base/files/scoped_temp_dir.h"
 #include "base/strings/strcat.h"
+#include "base/test/run_until.h"
 #include "base/test/test_future.h"
 #include "chrome/test/base/testing_profile.h"
 #include "content/public/test/test_renderer_host.h"
@@ -21,6 +20,13 @@
 #include "ui/base/l10n/l10n_util.h"
 
 namespace ai_chat {
+
+class TestTextFileExtractor : public TextFileExtractor {
+ public:
+  content::WebContents* GetWebContentsForTesting() {
+    return GetWebContents();
+  }
+};
 
 class TextFileExtractorTest : public content::RenderViewHostTestHarness {
  public:
@@ -35,7 +41,7 @@ class TextFileExtractorTest : public content::RenderViewHostTestHarness {
 
 // Without a real renderer producing text content, the extraction should
 // time out and return nullopt.
-TEST_F(TextFileExtractorTest, BytesOverload_TimeoutReturnsNullopt) {
+TEST_F(TextFileExtractorTest, TimeoutReturnsNullopt) {
   auto extractor = std::make_unique<TextFileExtractor>();
   base::test::TestFuture<std::optional<std::string>> future;
 
@@ -49,50 +55,26 @@ TEST_F(TextFileExtractorTest, BytesOverload_TimeoutReturnsNullopt) {
   EXPECT_FALSE(result.has_value());
 }
 
-// Same timeout test but using the file-path overload (no temp file).
-TEST_F(TextFileExtractorTest, PathOverload_TimeoutReturnsNullopt) {
-  base::ScopedTempDir temp_dir;
-  ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
-  base::FilePath txt_path = temp_dir.GetPath().AppendASCII("test.txt");
-  ASSERT_TRUE(base::WriteFile(txt_path, "hello world"));
-
-  auto extractor = std::make_unique<TextFileExtractor>();
+// Destroying after the hidden WebContents starts loading must not invoke the
+// extraction callback.
+TEST_F(TextFileExtractorTest, DestroyAfterLoadStarts_DoesNotRunCallback) {
+  auto extractor = std::make_unique<TestTextFileExtractor>();
   base::test::TestFuture<std::optional<std::string>> future;
 
-  extractor->ExtractText(browser_context(), txt_path, future.GetCallback());
+  std::vector<uint8_t> text_bytes = {'h', 'e', 'l', 'l', 'o'};
+  extractor->ExtractText(browser_context(), std::move(text_bytes),
+                         FILE_PATH_LITERAL("txt"), future.GetCallback());
 
-  task_environment()->FastForwardBy(base::Seconds(31));
-
-  auto result = future.Take();
-  EXPECT_FALSE(result.has_value());
-}
-
-// Destroying the extractor while an extraction is in-flight must not crash
-// or leak.
-TEST_F(TextFileExtractorTest, DestroyDuringExtraction_NoCrash) {
-  auto extractor = std::make_unique<TextFileExtractor>();
-
-  base::ScopedTempDir temp_dir;
-  ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
-  base::FilePath txt_path = temp_dir.GetPath().AppendASCII("test.txt");
-  ASSERT_TRUE(base::WriteFile(txt_path, "hello world"));
-
-  bool callback_called = false;
-  extractor->ExtractText(
-      browser_context(), txt_path,
-      base::BindOnce(
-          [](bool* called, std::optional<std::string>) { *called = true; },
-          &callback_called));
-
-  // Destroy while extraction is in progress — should not crash.
+  ASSERT_TRUE(base::test::RunUntil([&] {
+    return extractor->GetWebContentsForTesting() != nullptr;
+  }));
   extractor.reset();
 
-  EXPECT_FALSE(callback_called);
+  EXPECT_FALSE(future.IsReady());
 }
 
-// The bytes overload writes to a temp file. Verify cleanup completes
-// without crashing after timeout.
-TEST_F(TextFileExtractorTest, BytesOverload_CleanupAfterTimeout) {
+// Verify cleanup completes without crashing after timeout.
+TEST_F(TextFileExtractorTest, CleanupAfterTimeout) {
   auto extractor = std::make_unique<TextFileExtractor>();
   base::test::TestFuture<std::optional<std::string>> future;
 
@@ -103,26 +85,6 @@ TEST_F(TextFileExtractorTest, BytesOverload_CleanupAfterTimeout) {
   task_environment()->FastForwardBy(base::Seconds(31));
 
   ASSERT_TRUE(future.Wait());
-}
-
-// The file-path overload should NOT delete the original file after extraction.
-TEST_F(TextFileExtractorTest, PathOverload_OriginalFileNotDeleted) {
-  base::ScopedTempDir temp_dir;
-  ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
-  base::FilePath txt_path = temp_dir.GetPath().AppendASCII("keep_me.txt");
-  ASSERT_TRUE(base::WriteFile(txt_path, "this file should persist"));
-
-  auto extractor = std::make_unique<TextFileExtractor>();
-  base::test::TestFuture<std::optional<std::string>> future;
-
-  extractor->ExtractText(browser_context(), txt_path, future.GetCallback());
-
-  task_environment()->FastForwardBy(base::Seconds(31));
-
-  ASSERT_TRUE(future.Wait());
-
-  // The original file must still exist — only temp files are cleaned up.
-  EXPECT_TRUE(base::PathExists(txt_path));
 }
 
 // Unit tests for OnTextExtracted view-source stripping logic.


### PR DESCRIPTION
- Resolves brave/brave-browser#55017

## Summary

Remove the unused `base::FilePath` entry point from `FileTextExtractorBase` now that production callers use the byte-plus-extension API.

The remaining API still writes its input to a temporary file and loads it in the same restricted hidden `WebContents`; the former `LoadInWebContents` body is inlined unchanged after the asynchronous write completes. Tests are consolidated around the supported API while retaining extraction, raw-HTML, empty-input, timeout, cleanup, and deterministic teardown coverage.

The commits are separated into:

1. browser-test consolidation;
2. unit and lifecycle-test consolidation;
3. production API removal.

## Test plan

Static verification completed:

- `git diff --check origin/master...HEAD`
- confirmed no remaining `LoadInWebContents`, `PathOverload`, or `BytesOverload` references
- confirmed every remaining file-extractor call supplies bytes and an extension
- independently reviewed the final six-file diff for scope, asynchronous lifetime, cleanup, and WebContents setup equivalence

The targeted unit/browser suites, `gn_check`, and `presubmit` were invoked but could not start in this standalone filtered checkout: Brave requires Node 24, while the host has Node 26, and the checkout has no `node_modules` or parent Chromium build output.

## AI assistance

AI tools assisted with issue analysis, implementation, test migration, and review. I manually verified the final diff. Independent review caught an asynchronous teardown-test hazard; the final tests wait until the temporary path is owned and the hidden WebContents exists before destroying the extractor.
