### PR TITLE
Account: add re-entrancy guard to sign-in and password-reset dialogs (uplift to 1.94.x)

### DIFF
--- a/components/brave_account/resources/brave_account_password_reset_dialog.html.ts
+++ b/components/brave_account/resources/brave_account_password_reset_dialog.html.ts
@@ -28,7 +28,7 @@ export function getHtml(this: BraveAccountPasswordResetDialogElement) {
       </div>
       <leo-button
         slot="buttons"
-        ?isDisabled=${!this.isEmailValid}
+        ?isDisabled=${!this.isEmailValid || this.isSubmitting}
         @click=${this.onResetPasswordButtonClicked}
       >
         $i18n{BRAVE_ACCOUNT_RESET_PASSWORD_BUTTON_LABEL}

--- a/components/brave_account/resources/brave_account_password_reset_dialog.ts
+++ b/components/brave_account/resources/brave_account_password_reset_dialog.ts
@@ -34,10 +34,14 @@ export class BraveAccountPasswordResetDialogElement extends CrLitElement {
     return {
       email: { type: String },
       isEmailValid: { type: Boolean },
+      isSubmitting: { type: Boolean, state: true },
     }
   }
 
   protected async onResetPasswordButtonClicked() {
+    if (this.isSubmitting) return
+    this.isSubmitting = true
+
     try {
       await this.browserProxy.authentication.resetPasswordVerifyInit(this.email)
     } catch (e) {
@@ -54,6 +58,8 @@ export class BraveAccountPasswordResetDialogElement extends CrLitElement {
 
       showError({ kind: 'resetPassword', details: error })
     }
+
+    this.isSubmitting = false
   }
 
   private browserProxy: BraveAccountBrowserProxy =
@@ -61,6 +67,7 @@ export class BraveAccountPasswordResetDialogElement extends CrLitElement {
 
   protected accessor email: string = ''
   protected accessor isEmailValid: boolean = false
+  protected accessor isSubmitting: boolean = false
 }
 
 declare global {

--- a/components/brave_account/resources/brave_account_sign_in_dialog.html.ts
+++ b/components/brave_account/resources/brave_account_sign_in_dialog.html.ts
@@ -47,7 +47,9 @@ export function getHtml(this: BraveAccountSignInDialogElement) {
       </div>
       <leo-button
         slot="buttons"
-        ?isDisabled=${!this.isEmailValid || !this.isPasswordValid}
+        ?isDisabled=${!this.isEmailValid
+        || !this.isPasswordValid
+        || this.isSubmitting}
         @click=${this.onSignInButtonClicked}
       >
         $i18n{BRAVE_ACCOUNT_SIGN_IN_BUTTON_LABEL}

--- a/components/brave_account/resources/brave_account_sign_in_dialog.ts
+++ b/components/brave_account/resources/brave_account_sign_in_dialog.ts
@@ -42,6 +42,7 @@ export class BraveAccountSignInDialogElement extends CrLitElement {
       isEmailValid: { type: Boolean },
       isCapsLockOn: { type: Boolean },
       isPasswordValid: { type: Boolean },
+      isSubmitting: { type: Boolean, state: true },
       password: { type: String },
     }
   }
@@ -54,6 +55,9 @@ export class BraveAccountSignInDialogElement extends CrLitElement {
   // (`loginInitialize`/`loginFinalize`). We'll revisit handling this
   // through Mojo in C++ if that proves practical.
   protected async onSignInButtonClicked() {
+    if (this.isSubmitting) return
+    this.isSubmitting = true
+
     try {
       const serializedKE1 = this.login.start(this.password)
       const { encryptedLoginToken, serializedKE2 } =
@@ -94,6 +98,8 @@ export class BraveAccountSignInDialogElement extends CrLitElement {
 
       showError({ kind: 'login', details: error })
     }
+
+    this.isSubmitting = false
   }
 
   private browserProxy: BraveAccountBrowserProxy =
@@ -105,6 +111,7 @@ export class BraveAccountSignInDialogElement extends CrLitElement {
   protected accessor isEmailValid: boolean = false
   protected accessor isCapsLockOn: boolean = false
   protected accessor isPasswordValid: boolean = false
+  protected accessor isSubmitting: boolean = false
   protected accessor password: string = ''
 }
 


### PR DESCRIPTION
Uplift of #38864
Resolves https://github.com/brave/brave-browser/issues/57903

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.