### PR TITLE
Migrate scriptlet globals to a checked resource

### DIFF
--- a/components/cosmetic_filters/common/BUILD.gn
+++ b/components/cosmetic_filters/common/BUILD.gn
@@ -11,7 +11,11 @@ source_set("common") {
     "scriptlet_constants.h",
   ]
 
-  deps = [ "//third_party/abseil-cpp:absl" ]
+  deps = [
+    "//base",
+    "//brave/components/cosmetic_filters/resources/data:scriptlet_globals_generated_resources",
+    "//ui/base",
+  ]
 }
 
 mojom("mojom") {

--- a/components/cosmetic_filters/common/scriptlet_constants.cc
+++ b/components/cosmetic_filters/common/scriptlet_constants.cc
@@ -5,42 +5,31 @@
 
 #include "brave/components/cosmetic_filters/common/scriptlet_constants.h"
 
-#include "third_party/abseil-cpp/absl/strings/str_format.h"
+#include "base/check.h"
+#include "base/strings/strcat.h"
+#include "base/strings/string_util.h"
+#include "brave/components/cosmetic_filters/resources/grit/cosmetic_filters_scriptlet_globals_generated.h"
+#include "ui/base/resource/resource_bundle.h"
 
 namespace cosmetic_filters {
 
 namespace {
 
-// Defines `scriptletGlobals`, a `Map` wrapped in a `Proxy` that some of uBlock
-// Origin's scriptlet resources rely on. It contains a single `%s` placeholder
-// for the `Map` constructor arguments (`canDebug` used on non-iOS platforms).
-constexpr char kScriptletGlobalsScript[] = R"js(
-  const scriptletGlobals = (() => {
-    const forwardedMapMethods = ["has", "get", "set"];
-    const handler = {
-      get(target, prop) {
-        if (forwardedMapMethods.includes(prop)) {
-          return Map.prototype[prop].bind(target)
-        }
-        return target.get(prop);
-      },
-      set(target, prop, value) {
-        if (!forwardedMapMethods.includes(prop)) {
-          target.set(prop, value);
-        }
-      }
-    };
-    return new Proxy(new Map(%s), handler);
-  })();
-  let deAmpEnabled = %s;
-)js";
+constexpr char kScriptletGlobalsConfigPlaceholder[] =
+    "__BRAVE_SCRIPTLET_GLOBALS_CONFIG__";
 
 }  // namespace
 
 std::string GetScriptletGlobalsScript(bool is_de_amp_enabled, bool can_debug) {
-  return absl::StrFormat(kScriptletGlobalsScript,
-                         can_debug ? R"([["canDebug", true]])" : "",
-                         is_de_amp_enabled ? "true" : "false");
+  std::string script =
+      ui::ResourceBundle::GetSharedInstance().LoadDataResourceString(
+          IDR_COSMETIC_FILTERS_SCRIPTLET_GLOBALS_SCRIPTLET_GLOBALS_BUNDLE_JS);
+  CHECK_NE(script.find(kScriptletGlobalsConfigPlaceholder), std::string::npos);
+  base::ReplaceSubstringsAfterOffset(
+      &script, 0, kScriptletGlobalsConfigPlaceholder,
+      base::StrCat({"[", can_debug ? "true" : "false", ",",
+                    is_de_amp_enabled ? "true" : "false", "]"}));
+  return script;
 }
 
 }  // namespace cosmetic_filters

--- a/components/cosmetic_filters/resources/data/BUILD.gn
+++ b/components/cosmetic_filters/resources/data/BUILD.gn
@@ -31,8 +31,27 @@ transpile_web_ui("cosmetic_filters_resources") {
   imports_from = [ "//brave/components/cosmetic_filters/resources/data/" ]
 }
 
+transpile_web_ui("scriptlet_globals_resources") {
+  entry_points = [
+    [
+      "scriptlet_globals",
+      rebase_path("scriptlet_globals.ts"),
+    ],
+  ]
+  resource_name = "cosmetic_filters_scriptlet_globals"
+  imports_from = [ "//brave/components/cosmetic_filters/resources/data/" ]
+  output_module = false
+  no_iife = true
+}
+
 pack_web_resources("generated_resources") {
   resource_name = "cosmetic_filters"
   output_dir = "$root_gen_dir/brave/components/cosmetic_filters/resources"
   deps = [ ":cosmetic_filters_resources" ]
+}
+
+pack_web_resources("scriptlet_globals_generated_resources") {
+  resource_name = "cosmetic_filters_scriptlet_globals"
+  output_dir = "$root_gen_dir/brave/components/cosmetic_filters/resources"
+  deps = [ ":scriptlet_globals_resources" ]
 }

--- a/components/cosmetic_filters/resources/data/scriptlet_globals.ts
+++ b/components/cosmetic_filters/resources/data/scriptlet_globals.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// These names are consumed by scriptlets concatenated after this resource.
+let deAmpEnabled = false
+
+const scriptletGlobals = (() => {
+  const [canDebug, isDeAmpEnabled] = JSON.parse(
+    '__BRAVE_SCRIPTLET_GLOBALS_CONFIG__',
+  ) as [boolean, boolean]
+  deAmpEnabled = isDeAmpEnabled
+
+  const forwardedMapMethods = new Set<PropertyKey>(['has', 'get', 'set'])
+  const handler: ProxyHandler<Map<PropertyKey, unknown>> = {
+    get(target, prop) {
+      if (forwardedMapMethods.has(prop)) {
+        return Reflect.get(target, prop).bind(target)
+      }
+      return target.get(prop)
+    },
+    set(target, prop, value) {
+      if (!forwardedMapMethods.has(prop)) {
+        target.set(prop, value)
+      }
+      return true
+    },
+  }
+
+  const globals = new Map<PropertyKey, unknown>()
+  if (canDebug) {
+    globals.set('canDebug', true)
+  }
+  return new Proxy(globals, handler)
+})()

--- a/components/resources/BUILD.gn
+++ b/components/resources/BUILD.gn
@@ -95,11 +95,13 @@ repack("resources") {
     ":static_resources",
     "//brave/components/brave_account/resources",
     "//brave/components/cosmetic_filters/resources/data:generated_resources",
+    "//brave/components/cosmetic_filters/resources/data:scriptlet_globals_generated_resources",
     "//brave/components/skus/browser/resources:generated_resources",
   ]
   sources = [
     "$root_gen_dir/brave/components/brave_account/resources/brave_account_resources.pak",
     "$root_gen_dir/brave/components/cosmetic_filters/resources/cosmetic_filters_generated.pak",
+    "$root_gen_dir/brave/components/cosmetic_filters/resources/cosmetic_filters_scriptlet_globals_generated.pak",
     "$root_gen_dir/brave/components/skus/browser/resources/skus_internals_generated.pak",
     "$root_gen_dir/components/brave_components_static.pak",
   ]


### PR DESCRIPTION
- Resolves brave/brave-browser#57865

## Summary

Move the cosmetic-filter scriptlet globals from an unchecked C++ raw string into a TypeScript-generated GRD resource.

The generated script preserves the required top-level `scriptletGlobals` and `deAmpEnabled` bindings, is emitted as a classic non-IIFE script, and receives `canDebug`/DeAMP values through one JSON tuple placeholder. The resource is repacked into the shared components pak for desktop, Android, and iOS. C++ now loads it through `ResourceBundle` instead of formatting a raw JavaScript literal.

The commits are separated into:

1. the typed scriptlet source;
2. cross-platform generated-resource packaging;
3. the C++ resource loader and runtime configuration.

## Test plan

Passed:

```sh
npx --yes -p typescript@5.9.3 tsc \
  --noEmit --strict --target es2019 --lib es2019,dom \
  components/cosmetic_filters/resources/data/scriptlet_globals.ts

npx --yes -p prettier@3.5.3 prettier --check \
  components/cosmetic_filters/resources/data/scriptlet_globals.ts

git diff --check origin/master...HEAD
```

A compiled-JavaScript runtime matrix also covered all four boolean combinations, marker uniqueness, `Map` `has`/`get` methods, property reads, and proxy assignment.

Full GN generation and the existing `CanDebugSetToTrue` / `CheckForDeAmpPref` browser tests were not available in this standalone filtered checkout because it has no parent Chromium tree, Brave Node dependencies, GN, or build output.

## AI assistance

AI tools assisted with issue analysis, implementation, test drafting, and review. I manually verified the final diff and ran independent specification and code-quality reviews covering lexical scope, generated resource naming, placeholder order, proxy behavior, and desktop/Android/iOS packaging.
