### PR TITLE
[iOS] Run TabState policy deciders in sequence

### DIFF
--- a/ios/brave-ios/Sources/Web/TabStateImpl.swift
+++ b/ios/brave-ios/Sources/Web/TabStateImpl.swift
@@ -60,29 +60,12 @@ extension TabStateImpl {
     for policyDeciders: OrderedSet<AnyTabPolicyDecider>,
     task: @escaping (AnyTabPolicyDecider) async -> WebPolicyDecision
   ) async -> WebPolicyDecision {
-    let result = await withTaskGroup(of: WebPolicyDecision.self, returning: WebPolicyDecision.self)
-    { group in
-      for policyDecider in policyDeciders {
-        group.addTask { @MainActor in
-          if Task.isCancelled {
-            return .cancel
-          }
-          let decision = await task(policyDecider)
-          if decision == .cancel {
-            return .cancel
-          }
-          return .allow
-        }
+    for policyDecider in policyDeciders {
+      if await task(policyDecider) == .cancel {
+        return .cancel
       }
-      for await result in group {
-        if result == .cancel {
-          group.cancelAll()
-          return .cancel
-        }
-      }
-      return .allow
     }
-    return result
+    return .allow
   }
 
   func shouldAllowRequest(


### PR DESCRIPTION
This better matches the expectation of most policy deciders which will typically do work synchronously anyways and fixes the problem of subsequent policy deciders running anyways even if a prior decider cancelled the request.
