### PR TITLE
[webgl] Fix getExtension returning null script for extension

### DIFF
--- a/browser/farbling/brave_webgl_farbling_browsertest.cc
+++ b/browser/farbling/brave_webgl_farbling_browsertest.cc
@@ -392,6 +392,43 @@ IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
   EXPECT_EQ(EvalJs(contents(), kTitleScript).ExtractString(), "null");
 }
 
+// Regression test for https://github.com/brave/brave-browser/issues/57902
+//
+// Plotly.js Scattergl (via regl) lowercases required WebGL extension names
+// before calling getExtension(). Chromium matches case-insensitively; Brave's
+// farbling wrapper must do the same or createRegl fails and Plotly shows
+// "WebGL is not supported by your browser".
+IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
+                       GetExtensionMatchesCaseInsensitivelyLikeRegl) {
+  const std::string domain = "a.com";
+  const GURL url = embedded_test_server()->GetURL(domain, "/getExtension.html");
+  // Plotly Scattergl / splom required extensions, lowercased by regl.
+  const std::string kExpectedPlotlyRegl =
+      "ANGLE_instanced_arrays:ok,OES_element_index_uint:ok";
+
+  auto run_checks = [&](const char* fingerprinting_label) {
+    ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+    ASSERT_TRUE(ExecJs(contents(), "getExtensionPlotlyReglStyle()"))
+        << fingerprinting_label;
+    EXPECT_EQ(EvalJs(contents(), kTitleScript).ExtractString(),
+              kExpectedPlotlyRegl)
+        << fingerprinting_label;
+
+    ASSERT_TRUE(ExecJs(contents(), "getExtensionLowercaseAllSupported()"))
+        << fingerprinting_label;
+    EXPECT_EQ(EvalJs(contents(), kTitleScript).ExtractString(), "ok")
+        << fingerprinting_label;
+  };
+
+  // Shields / fingerprinting disabled (reported in the issue).
+  AllowFingerprinting(domain);
+  run_checks("farbling off");
+
+  // Default shields (balanced farbling).
+  SetFingerprintingDefault(domain);
+  run_checks("farbling balanced");
+}
+
 IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
                        FarbleGetSupportedExtensionsWebGL2) {
   std::string domain = "a.com";

--- a/browser/farbling/brave_webgl_farbling_browsertest.cc
+++ b/browser/farbling/brave_webgl_farbling_browsertest.cc
@@ -573,8 +573,13 @@ IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
   EXPECT_EQ(EvalJs(contents(), kGetWebGL1Extensions).ExtractString(),
             webgl1_off);
-  EXPECT_EQ(EvalJs(contents(), kGetWebGL2Extensions).ExtractString(),
-            kSupportedExtensionsMax);
+  // Old implementation doesn't make the distinction b/w BRAVE_WEBCOMPAT_WEBGL
+  // and BRAVE_WEBCOMPAT_WEBGL2. So, turning off BRAVE_WEBCOMPAT_WEBGL above
+  // also turns off farbling for WebGL2.
+  if (GetParam()) {
+    EXPECT_EQ(EvalJs(contents(), kGetWebGL2Extensions).ExtractString(),
+              kSupportedExtensionsMax);
+  }
 
   // Exception for WebGL2 only: WebGL2 unfarbled, WebGL1 still maximum.
   brave_shields::SetWebcompatEnabled(content_settings(),
@@ -586,8 +591,12 @@ IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
   EXPECT_EQ(EvalJs(contents(), kGetWebGL1Extensions).ExtractString(),
             kSupportedExtensionsMax);
-  EXPECT_EQ(EvalJs(contents(), kGetWebGL2Extensions).ExtractString(),
-            webgl2_off);
+  // Old implementation doesn't make the distinction b/w BRAVE_WEBCOMPAT_WEBGL
+  // and BRAVE_WEBCOMPAT_WEBGL2.
+  if (GetParam()) {
+    EXPECT_EQ(EvalJs(contents(), kGetWebGL2Extensions).ExtractString(),
+              webgl2_off);
+  }
 }
 
 // BRAVE_WEBCOMPAT_WEBGL and BRAVE_WEBCOMPAT_WEBGL2 must independently control

--- a/chromium_src/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
@@ -166,6 +166,23 @@ WebGLFarbledExtensionHandler* CreateOrGetValidWebGLExtensionHandler(
 // protections are enabled then the list may include farbled values.
 std::optional<Vector<String>>
 WebGLRenderingContextBase::getSupportedExtensions() {
+  if (!base::FeatureList::IsEnabled(
+          blink::features::kWebGLBalancedFingerprintingProtection)) {
+    // Old implementation.
+    std::optional<Vector<String>> real_extensions =
+        getSupportedExtensions_ChromiumImpl();
+    if (real_extensions == std::nullopt) {
+      return real_extensions;
+    }
+    if (AllowFingerprintingForHost(Host())) {
+      return real_extensions;
+    }
+
+    Vector<String> fake_extensions;
+    fake_extensions.push_back(WebGLDebugRendererInfo::ExtensionName());
+    return fake_extensions;
+  }
+
   WebGLFarbledExtensionHandler* handler = CreateOrGetValidWebGLExtensionHandler(
       Host()->GetTopExecutionContext(), IsWebGL2(),
       [this]() { return getSupportedExtensions_ChromiumImpl(); });
@@ -184,6 +201,17 @@ WebGLRenderingContextBase::getSupportedExtensions() {
 // also represent a farbled object if the extension |name| was farbled.
 ScriptObject WebGLRenderingContextBase::getExtension(ScriptState* script_state,
                                                      const String& name) {
+  if (!base::FeatureList::IsEnabled(
+          blink::features::kWebGLBalancedFingerprintingProtection)) {
+    // Old implementation.
+    if (!AllowFingerprintingForHost(Host())) {
+      if (name != WebGLDebugRendererInfo::ExtensionName()) {
+        return ScriptObject::CreateNull(v8::Isolate::GetCurrent());
+      }
+    }
+    return getExtension_ChromiumImpl(script_state, name);
+  }
+
   WebGLFarbledExtensionHandler* handler = CreateOrGetValidWebGLExtensionHandler(
       Host()->GetTopExecutionContext(), IsWebGL2(),
       [this]() { return getSupportedExtensions_ChromiumImpl(); });

--- a/test/data/webgl/getExtension.html
+++ b/test/data/webgl/getExtension.html
@@ -18,6 +18,40 @@
       function getExtensionWithInvalidName() {
         document.title = gl.getExtension("INVALID_EXTENSION_NAME_666");
       }
+      
+      //https://github.com/brave/brave-browser/issues/57902.
+      function getExtensionPlotlyReglStyle() {
+        const required = [
+          'ANGLE_instanced_arrays',
+          'OES_element_index_uint',
+        ];
+        const supported = gl.getSupportedExtensions() || [];
+        const results = [];
+        for (const name of required) {
+          const isListed = supported.some(
+              (s) => s.toLowerCase() === name.toLowerCase());
+          if (!isListed) {
+            results.push(name + ':absent');
+            continue;
+          }
+          const ext = gl.getExtension(name.toLowerCase());
+          results.push(name + ':' + (ext ? 'ok' : 'fail'));
+        }
+        document.title = results.join(',');
+      }
+
+      // Every name from getSupportedExtensions() must also resolve when
+      // requested in lowercase (Chromium matches case-insensitively).
+      function getExtensionLowercaseAllSupported() {
+        const supported = gl.getSupportedExtensions() || [];
+        const failed = [];
+        for (const name of supported) {
+          if (!gl.getExtension(name.toLowerCase())) {
+            failed.push(name);
+          }
+        }
+        document.title = failed.length ? failed.join(',') : 'ok';
+      }
 
     </script>
   </body>

--- a/third_party/blink/renderer/bindings/core/webgl/webgl_farbled_extension_handler.cc
+++ b/third_party/blink/renderer/bindings/core/webgl/webgl_farbled_extension_handler.cc
@@ -64,6 +64,19 @@ GetFakeSupportedExtensions() {
   return *fake_values;
 }
 
+// Some clients/libraries like Plotly lowercase
+// extension names before invoking getExtension();
+// See https://github.com/brave/brave-browser/issues/57902.
+bool ContainsExtensionIgnoringCase(const Vector<String>& extensions,
+                                   const String& name) {
+  for (const String& extension : extensions) {
+    if (EqualIgnoringAsciiCase(extension, name)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 }  // namespace
 
 WebGLFarbledExtensionHandler::WebGLFarbledExtensionHandler(
@@ -142,7 +155,7 @@ blink::ScriptObject WebGLFarbledExtensionHandler::GetExtension(
   }
 
   // If extension is part of the supported list return the real extension.
-  if (supported_extensions_.Contains(name)) {
+  if (ContainsExtensionIgnoringCase(supported_extensions_, name)) {
     CHECK(real_extension);
     return *real_extension;
   }
@@ -152,7 +165,8 @@ blink::ScriptObject WebGLFarbledExtensionHandler::GetExtension(
 
 bool WebGLFarbledExtensionHandler::IsExtensionFarbled(
     const blink::String& name) const {
-  return fake_extension_.has_value() && fake_extension_.value().name == name;
+  return fake_extension_.has_value() &&
+         EqualIgnoringAsciiCase(fake_extension_.value().name, name);
 }
 
 base::span<const WebGLFakeExtension> GetFakeSupportedExtensionsForTesting() {

--- a/third_party/blink/renderer/bindings/core/webgl/webgl_farbled_extension_handler.cc
+++ b/third_party/blink/renderer/bindings/core/webgl/webgl_farbled_extension_handler.cc
@@ -64,19 +64,6 @@ GetFakeSupportedExtensions() {
   return *fake_values;
 }
 
-// Some clients/libraries like Plotly lowercase
-// extension names before invoking getExtension();
-// See https://github.com/brave/brave-browser/issues/57902.
-bool ContainsExtensionIgnoringCase(const Vector<String>& extensions,
-                                   const String& name) {
-  for (const String& extension : extensions) {
-    if (EqualIgnoringAsciiCase(extension, name)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 }  // namespace
 
 WebGLFarbledExtensionHandler::WebGLFarbledExtensionHandler(
@@ -134,9 +121,6 @@ Vector<String> WebGLFarbledExtensionHandler::GetSupportedExtensions() const {
   return supported_extensions_;
 }
 
-// TODO(https://github.com/brave/brave-browser/issues/55858): Cover testing this
-// in browser_tests as it's not straightforward to test it as unittest due to
-// various v8 dependencies.
 blink::ScriptObject WebGLFarbledExtensionHandler::GetExtension(
     blink::ScriptState* script_state,
     const blink::String& name,
@@ -155,7 +139,15 @@ blink::ScriptObject WebGLFarbledExtensionHandler::GetExtension(
   }
 
   // If extension is part of the supported list return the real extension.
-  if (ContainsExtensionIgnoringCase(supported_extensions_, name)) {
+  // Some clients/libraries like Plotly lowercase extension names before
+  // invoking getExtension(); See
+  // https://github.com/brave/brave-browser/issues/57902.
+  bool found = std::ranges::any_of(
+      supported_extensions_, [&name](const String& real_extension) {
+        return EqualIgnoringAsciiCase(name, real_extension);
+      });
+
+  if (found) {
     CHECK(real_extension);
     return *real_extension;
   }

--- a/third_party/blink/renderer/bindings/core/webgl/webgl_farbled_extension_handler.h
+++ b/third_party/blink/renderer/bindings/core/webgl/webgl_farbled_extension_handler.h
@@ -31,8 +31,6 @@ struct WebGLFakeExtension {
 // Handler for returning information around the available webgl extensions.
 // This handler automatically takes into consideration any farbling when the
 // brave shields are up.
-// TODO(https://github.com/brave/brave-browser/issues/55858): Add the
-// integration with the BraveSessionCache.
 class CORE_EXPORT WebGLFarbledExtensionHandler {
  public:
   // Returns the default handler without any farbling logic.


### PR DESCRIPTION
This change: 

a) Put backs the old [implementation](https://github.com/brave/brave-core/commit/fa5cf216e44252e1cb52f61bde8c9c36cc4b2545) when the `kWebGLBalancedFingerprintingProtection` is disabled. To ensure release is not affected afterwards.
 
b) When FF is enabled, it fixes an issue where WebGL clients calling the `getExtension` with a case-insensitive parameter name may get a null value. For example: The actual `ANGLE_instanced_arrays` extension name could be called by clients as `gl.getExtension(AnGlE_iNsTanced_ArraYS)` which could return null. In our code, we had added a case-sensitive check during a refactoring work. So, this change fixes that check to be case-insensitive instead.

This change also adds browser tests for the same.

### Manual testing
Test sites outlined in https://github.com/brave/brave-browser/issues/57919 description.

https://github.com/user-attachments/assets/9b671ec9-7fc9-48a7-a563-3ace4ac2876c

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57902

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
