### PR TITLE
[webgl] Fix getExtension returning null script for extension (uplift to 1.93.x)

### DIFF
--- a/browser/farbling/brave_webgl_farbling_browsertest.cc
+++ b/browser/farbling/brave_webgl_farbling_browsertest.cc
@@ -392,6 +392,43 @@ IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
   EXPECT_EQ(EvalJs(contents(), kTitleScript).ExtractString(), "null");
 }
 
+// Regression test for https://github.com/brave/brave-browser/issues/57902
+//
+// Plotly.js Scattergl (via regl) lowercases required WebGL extension names
+// before calling getExtension(). Chromium matches case-insensitively; Brave's
+// farbling wrapper must do the same or createRegl fails and Plotly shows
+// "WebGL is not supported by your browser".
+IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
+                       GetExtensionMatchesCaseInsensitivelyLikeRegl) {
+  const std::string domain = "a.com";
+  const GURL url = embedded_test_server()->GetURL(domain, "/getExtension.html");
+  // Plotly Scattergl / splom required extensions, lowercased by regl.
+  const std::string kExpectedPlotlyRegl =
+      "ANGLE_instanced_arrays:ok,OES_element_index_uint:ok";
+
+  auto run_checks = [&](const char* fingerprinting_label) {
+    ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+    ASSERT_TRUE(ExecJs(contents(), "getExtensionPlotlyReglStyle()"))
+        << fingerprinting_label;
+    EXPECT_EQ(EvalJs(contents(), kTitleScript).ExtractString(),
+              kExpectedPlotlyRegl)
+        << fingerprinting_label;
+
+    ASSERT_TRUE(ExecJs(contents(), "getExtensionLowercaseAllSupported()"))
+        << fingerprinting_label;
+    EXPECT_EQ(EvalJs(contents(), kTitleScript).ExtractString(), "ok")
+        << fingerprinting_label;
+  };
+
+  // Shields / fingerprinting disabled (reported in the issue).
+  AllowFingerprinting(domain);
+  run_checks("farbling off");
+
+  // Default shields (balanced farbling).
+  SetFingerprintingDefault(domain);
+  run_checks("farbling balanced");
+}
+
 IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
                        FarbleGetSupportedExtensionsWebGL2) {
   std::string domain = "a.com";
@@ -536,8 +573,13 @@ IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
   EXPECT_EQ(EvalJs(contents(), kGetWebGL1Extensions).ExtractString(),
             webgl1_off);
-  EXPECT_EQ(EvalJs(contents(), kGetWebGL2Extensions).ExtractString(),
-            kSupportedExtensionsMax);
+  // Old implementation doesn't make the distinction b/w BRAVE_WEBCOMPAT_WEBGL
+  // and BRAVE_WEBCOMPAT_WEBGL2. So, turning off BRAVE_WEBCOMPAT_WEBGL above
+  // also turns off farbling for WebGL2.
+  if (GetParam()) {
+    EXPECT_EQ(EvalJs(contents(), kGetWebGL2Extensions).ExtractString(),
+              kSupportedExtensionsMax);
+  }
 
   // Exception for WebGL2 only: WebGL2 unfarbled, WebGL1 still maximum.
   brave_shields::SetWebcompatEnabled(content_settings(),
@@ -549,8 +591,12 @@ IN_PROC_BROWSER_TEST_P(BraveWebGLExtensionFarblingTest,
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
   EXPECT_EQ(EvalJs(contents(), kGetWebGL1Extensions).ExtractString(),
             kSupportedExtensionsMax);
-  EXPECT_EQ(EvalJs(contents(), kGetWebGL2Extensions).ExtractString(),
-            webgl2_off);
+  // Old implementation doesn't make the distinction b/w BRAVE_WEBCOMPAT_WEBGL
+  // and BRAVE_WEBCOMPAT_WEBGL2.
+  if (GetParam()) {
+    EXPECT_EQ(EvalJs(contents(), kGetWebGL2Extensions).ExtractString(),
+              webgl2_off);
+  }
 }
 
 // BRAVE_WEBCOMPAT_WEBGL and BRAVE_WEBCOMPAT_WEBGL2 must independently control

--- a/chromium_src/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
@@ -166,6 +166,23 @@ WebGLFarbledExtensionHandler* CreateOrGetValidWebGLExtensionHandler(
 // protections are enabled then the list may include farbled values.
 std::optional<Vector<String>>
 WebGLRenderingContextBase::getSupportedExtensions() {
+  if (!base::FeatureList::IsEnabled(
+          blink::features::kWebGLBalancedFingerprintingProtection)) {
+    // Old implementation.
+    std::optional<Vector<String>> real_extensions =
+        getSupportedExtensions_ChromiumImpl();
+    if (real_extensions == std::nullopt) {
+      return real_extensions;
+    }
+    if (AllowFingerprintingForHost(Host())) {
+      return real_extensions;
+    }
+
+    Vector<String> fake_extensions;
+    fake_extensions.push_back(WebGLDebugRendererInfo::ExtensionName());
+    return fake_extensions;
+  }
+
   WebGLFarbledExtensionHandler* handler = CreateOrGetValidWebGLExtensionHandler(
       Host()->GetTopExecutionContext(), IsWebGL2(),
       [this]() { return getSupportedExtensions_ChromiumImpl(); });
@@ -184,6 +201,17 @@ WebGLRenderingContextBase::getSupportedExtensions() {
 // also represent a farbled object if the extension |name| was farbled.
 ScriptObject WebGLRenderingContextBase::getExtension(ScriptState* script_state,
                                                      const String& name) {
+  if (!base::FeatureList::IsEnabled(
+          blink::features::kWebGLBalancedFingerprintingProtection)) {
+    // Old implementation.
+    if (!AllowFingerprintingForHost(Host())) {
+      if (name != WebGLDebugRendererInfo::ExtensionName()) {
+        return ScriptObject::CreateNull(v8::Isolate::GetCurrent());
+      }
+    }
+    return getExtension_ChromiumImpl(script_state, name);
+  }
+
   WebGLFarbledExtensionHandler* handler = CreateOrGetValidWebGLExtensionHandler(
       Host()->GetTopExecutionContext(), IsWebGL2(),
       [this]() { return getSupportedExtensions_ChromiumImpl(); });

--- a/test/data/webgl/getExtension.html
+++ b/test/data/webgl/getExtension.html
@@ -18,6 +18,40 @@
       function getExtensionWithInvalidName() {
         document.title = gl.getExtension("INVALID_EXTENSION_NAME_666");
       }
+      
+      //https://github.com/brave/brave-browser/issues/57902.
+      function getExtensionPlotlyReglStyle() {
+        const required = [
+          'ANGLE_instanced_arrays',
+          'OES_element_index_uint',
+        ];
+        const supported = gl.getSupportedExtensions() || [];
+        const results = [];
+        for (const name of required) {
+          const isListed = supported.some(
+              (s) => s.toLowerCase() === name.toLowerCase());
+          if (!isListed) {
+            results.push(name + ':absent');
+            continue;
+          }
+          const ext = gl.getExtension(name.toLowerCase());
+          results.push(name + ':' + (ext ? 'ok' : 'fail'));
+        }
+        document.title = results.join(',');
+      }
+
+      // Every name from getSupportedExtensions() must also resolve when
+      // requested in lowercase (Chromium matches case-insensitively).
+      function getExtensionLowercaseAllSupported() {
+        const supported = gl.getSupportedExtensions() || [];
+        const failed = [];
+        for (const name of supported) {
+          if (!gl.getExtension(name.toLowerCase())) {
+            failed.push(name);
+          }
+        }
+        document.title = failed.length ? failed.join(',') : 'ok';
+      }
 
     </script>
   </body>

--- a/third_party/blink/renderer/bindings/core/webgl/webgl_farbled_extension_handler.cc
+++ b/third_party/blink/renderer/bindings/core/webgl/webgl_farbled_extension_handler.cc
@@ -121,9 +121,6 @@ Vector<String> WebGLFarbledExtensionHandler::GetSupportedExtensions() const {
   return supported_extensions_;
 }
 
-// TODO(https://github.com/brave/brave-browser/issues/55858): Cover testing this
-// in browser_tests as it's not straightforward to test it as unittest due to
-// various v8 dependencies.
 blink::ScriptObject WebGLFarbledExtensionHandler::GetExtension(
     blink::ScriptState* script_state,
     const blink::String& name,
@@ -142,7 +139,15 @@ blink::ScriptObject WebGLFarbledExtensionHandler::GetExtension(
   }
 
   // If extension is part of the supported list return the real extension.
-  if (supported_extensions_.Contains(name)) {
+  // Some clients/libraries like Plotly lowercase extension names before
+  // invoking getExtension(); See
+  // https://github.com/brave/brave-browser/issues/57902.
+  bool found = std::ranges::any_of(
+      supported_extensions_, [&name](const String& real_extension) {
+        return EqualIgnoringAsciiCase(name, real_extension);
+      });
+
+  if (found) {
     CHECK(real_extension);
     return *real_extension;
   }
@@ -152,7 +157,8 @@ blink::ScriptObject WebGLFarbledExtensionHandler::GetExtension(
 
 bool WebGLFarbledExtensionHandler::IsExtensionFarbled(
     const blink::String& name) const {
-  return fake_extension_.has_value() && fake_extension_.value().name == name;
+  return fake_extension_.has_value() &&
+         EqualIgnoringAsciiCase(fake_extension_.value().name, name);
 }
 
 base::span<const WebGLFakeExtension> GetFakeSupportedExtensionsForTesting() {

--- a/third_party/blink/renderer/bindings/core/webgl/webgl_farbled_extension_handler.h
+++ b/third_party/blink/renderer/bindings/core/webgl/webgl_farbled_extension_handler.h
@@ -31,8 +31,6 @@ struct WebGLFakeExtension {
 // Handler for returning information around the available webgl extensions.
 // This handler automatically takes into consideration any farbling when the
 // brave shields are up.
-// TODO(https://github.com/brave/brave-browser/issues/55858): Add the
-// integration with the BraveSessionCache.
 class CORE_EXPORT WebGLFarbledExtensionHandler {
  public:
   // Returns the default handler without any farbling logic.


### PR DESCRIPTION
Uplift of #38900
Resolves https://github.com/brave/brave-browser/issues/57902

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.