### PR TITLE
Fix DCHECK crash in ChromeImporter::LoadFaviconData

### DIFF
--- a/utility/importer/chrome_importer.cc
+++ b/utility/importer/chrome_importer.cc
@@ -230,21 +230,18 @@ void ChromeImporter::LoadFaviconData(
       favicon_base::FaviconUsageData usage;
 
       usage.favicon_url = GURL(s.ColumnString(0));
-      if (!usage.favicon_url.is_valid())
-        continue;  // Don't bother importing favicons with invalid URLs.
-
       std::vector<uint8_t> data = s.ColumnBlobAsVector(1);
-      if (data.empty())
-        continue;  // Data definitely invalid.
-
-      auto decoded_data = importer::ReencodeFavicon(base::span(data));
-      if (!decoded_data) {
-        continue;  // Unable to decode.
+      std::optional<std::vector<uint8_t>> decoded_data;
+      // Skip favicons with invalid URLs, empty data, or that fail to decode.
+      // The conditions are nested rather than using `continue` so that every
+      // path still reaches `s.Reset(true)` below; skipping the reset would
+      // trip a DCHECK when `BindInt64()` is called on the next iteration.
+      if (usage.favicon_url.is_valid() && !data.empty() &&
+          (decoded_data = importer::ReencodeFavicon(base::span(data)))) {
+        usage.urls = entry.second;
+        usage.png_data = std::move(decoded_data).value();
+        favicons->push_back(usage);
       }
-
-      usage.urls = entry.second;
-      usage.png_data = std::move(decoded_data).value();
-      favicons->push_back(usage);
     }
     s.Reset(true);
   }


### PR DESCRIPTION
## Summary

Fixes a `FATAL` DCHECK crash in the utility process during profile import.

`ChromeImporter::LoadFaviconData` iterates favicons with a `sql::Statement`,
calling `BindInt64()` / `Step()` and then `s.Reset(true)` at the end of each
loop iteration. The skip paths for invalid URLs, empty data, or undecodable
favicons used `continue`, which jumped past the `s.Reset(true)`. On the next
iteration `BindInt64()` was then called on a statement that had been `Step()`'d
but not reset, tripping the `!step_called_` DCHECK
(`BindInt64 must not be called after Step()`).

The fix nests the skip conditions so every iteration still reaches
`s.Reset(true)`.

## Crash

```
[92851:21731414:0807/095401.308332:FATAL:sql/statement.cc:271] DCHECK failed: !step_called_. BindInt64 must not be called after Step()
0   libbase.dylib                       base::debug::CollectStackTrace(...) + 18
1   libbase.dylib                       base::debug::StackTrace::StackTrace(unsigned long) + 225
2   libbase.dylib                       logging::LogMessage::Flush() + 171
3   libbase.dylib                       logging::LogMessage::~LogMessage() + 28
4   libbase.dylib                       logging::(anonymous namespace)::DCheckLogMessage::~DCheckLogMessage() + 65
5   libbase.dylib                       logging::CheckError::~CheckError() + 35
6   libbase.dylib                       logging::CheckError::~CheckError() + 9
7   libsql.dylib                        sql::Statement::BindInt64(int, long long) + 281
8   libchrome_dll.dylib                 ChromeImporter::LoadFaviconData(...) + 375
9   libchrome_dll.dylib                 ChromeImporter::ImportBookmarks() + 2037
10  libchrome_dll.dylib                 ChromeImporter::StartImport(user_data_importer::SourceProfile const&, unsigned short, ImporterBridge*) + 556
11  libchrome_dll.dylib                 base::internal::Invoker<...>::RunOnce(base::internal::BindStateBase*) + 137
12  libbase.dylib                       base::OnceCallback<void ()>::Run() && + 113
13  libbase.dylib                       base::TaskAnnotator::RunTaskImpl(base::PendingTask&) + 258
14  libbase.dylib                       base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*) + 2264
...
20  libbase.dylib                       base::Thread::ThreadMain() + 640
21  libbase.dylib                       base::(anonymous namespace)::ThreadFunc(void*) + 114

Task trace:
0   libchrome_dll.dylib                 BraveProfileImportImpl::StartImport(...) + 1152
1   libmojo_public_system_cpp.dylib     mojo::SimpleWatcher::ArmOrNotify() + 290
2   libcontent.dylib                    content::(anonymous namespace)::ServiceBinderImpl::BindServiceInterface(...) + 1034

Crash keys:
  "service-name" = "brave.mojom.ProfileImport"
  "utility-sub-type" = "--utility-sub-type=brave.mojom.ProfileImport"
  "ptype" = "utility"
  "osarch" = "x86_64"
```

## Test plan (Only for dev-build)

- `ChromeImporterTest.ImportFavicons` and the importer unit tests pass.
- Import a profile that has favicons with invalid URLs / empty / undecodable
  data and confirm the utility process no longer crashes.
