### PR TITLE
[iOS] Fix toggle color in AI Chat settings

### DIFF
--- a/ios/brave-ios/Sources/AIChat/WebUI/AIChatSettingsView.swift
+++ b/ios/brave-ios/Sources/AIChat/WebUI/AIChatSettingsView.swift
@@ -35,8 +35,8 @@ public struct AIChatSettingsView: View {
               .foregroundStyle(.secondary)
               .font(.caption)
           }
-          .tint(Color(braveSystemName: .primitivePrimary40))
         }
+        .tint(Color(braveSystemName: .primitivePrimary40))
         NavigationLink {
           ModelListPicker(
             modelsWithSubtitles: viewModel.modelsWithSubtitles,


### PR DESCRIPTION
The tint was being applied incorrectly to the label and not the toggle itself

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/57925
