### PR TITLE
[CodeHealth] Migrate `base::Reversed` to `std::views::reverse`

### DIFF
--- a/browser/ai_chat/tools/tab_management_tool.cc
+++ b/browser/ai_chat/tools/tab_management_tool.cc
@@ -8,12 +8,12 @@
 #include <algorithm>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
 
-#include "base/containers/adapters.h"
 #include "base/containers/fixed_flat_map.h"
 #include "base/containers/flat_map.h"
 #include "base/containers/flat_set.h"
@@ -1206,7 +1206,7 @@ void TabManagementTool::HandleCreateGroup(UseToolCallback callback,
       }
 
       // Reverse the indices to avoid index shifting
-      for (int index : base::Reversed(valid_indices)) {
+      for (int index : std::views::reverse(valid_indices)) {
         tabs_moved_models.push_back(tab_strip->DetachTabAtForInsertion(index));
       }
     }

--- a/browser/ai_chat/tools/tab_management_tool.cc
+++ b/browser/ai_chat/tools/tab_management_tool.cc
@@ -8,12 +8,12 @@
 #include <algorithm>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
 
-#include "base/containers/adapters.h"
 #include "base/containers/fixed_flat_map.h"
 #include "base/containers/flat_map.h"
 #include "base/containers/flat_set.h"
@@ -1208,7 +1208,7 @@ void TabManagementTool::HandleCreateGroup(UseToolCallback callback,
       }
 
       // Reverse the indices to avoid index shifting
-      for (int index : base::Reversed(valid_indices)) {
+      for (int index : std::views::reverse(valid_indices)) {
         tabs_moved_models.push_back(tab_strip->DetachTabAtForInsertion(index));
       }
     }

--- a/browser/download/bubble/download_display_controller_unittest.cc
+++ b/browser/download/bubble/download_display_controller_unittest.cc
@@ -10,10 +10,10 @@
 #include "chrome/browser/download/bubble/download_display_controller.h"
 
 #include <algorithm>
+#include <ranges>
 
 #include "base/check_op.h"
 #include "base/command_line.h"
-#include "base/containers/adapters.h"
 #include "base/files/file_path.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ref.h"
@@ -251,7 +251,7 @@ class MockDownloadBubbleUpdateService : public DownloadBubbleUpdateService {
   void AddModel(ModelType type) { model_types_.push_back(type); }
 
   void RemoveLastDownload() {
-    auto it = std::ranges::find(base::Reversed(model_types_),
+    auto it = std::ranges::find(std::views::reverse(model_types_),
                                 ModelType::kDownloadItem);
     if (it != model_types_.rend()) {
       model_types_.erase(std::prev(it.base()));

--- a/browser/download/bubble/download_display_controller_unittest.cc
+++ b/browser/download/bubble/download_display_controller_unittest.cc
@@ -10,10 +10,10 @@
 #include "chrome/browser/download/bubble/download_display_controller.h"
 
 #include <algorithm>
+#include <ranges>
 
 #include "base/check_op.h"
 #include "base/command_line.h"
-#include "base/containers/adapters.h"
 #include "base/files/file_path.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ref.h"
@@ -253,7 +253,7 @@ class MockDownloadBubbleUpdateService : public DownloadBubbleUpdateService {
   void AddModel(ModelType type) { model_types_.push_back(type); }
 
   void RemoveLastDownload() {
-    auto it = std::ranges::find(base::Reversed(model_types_),
+    auto it = std::ranges::find(std::views::reverse(model_types_),
                                 ModelType::kDownloadItem);
     if (it != model_types_.rend()) {
       model_types_.erase(std::prev(it.base()));

--- a/browser/ui/tabs/brave_tree_tab_strip_collection_delegate.cc
+++ b/browser/ui/tabs/brave_tree_tab_strip_collection_delegate.cc
@@ -670,7 +670,7 @@ void BraveTreeTabStripCollectionDelegate::MoveTabsRecursive(
   // of being flattened.
   const base::flat_set<tabs::TabInterface*> moving_tabs_set(moving_tabs.begin(),
                                                             moving_tabs.end());
-  for (auto* moving_tab : base::Reversed(moving_tabs)) {
+  for (auto* moving_tab : std::views::reverse(moving_tabs)) {
     auto* moving_tab_tree_node = GetParentTreeNodeCollectionOfTab(moving_tab);
     MoveNonSelectedChildrenOfTreeTabNodeToParent(
         static_cast<tabs::TreeTabNodeTabCollection*>(moving_tab_tree_node),
@@ -684,7 +684,7 @@ void BraveTreeTabStripCollectionDelegate::MoveTabsRecursive(
                                       tabs::TabCollection::Type::TREE_NODE});
   std::vector<std::unique_ptr<tabs::TabCollection>>
       unique_moving_tab_collections_reversed;
-  for (auto& tab_or_collection : base::Reversed(compacted_moving_tabs)) {
+  for (auto& tab_or_collection : std::views::reverse(compacted_moving_tabs)) {
     tabs::TabCollection* moving_tab_tree_node = std::visit(
         absl::Overload(
             [this](tabs::TabInterface* tab) {
@@ -861,7 +861,7 @@ void BraveTreeTabStripCollectionDelegate::MoveTabsIntoGroup(
   }
 
   // Attach to the target group at 0 index temporarily.
-  for (auto& tab : base::Reversed(owned_tab_or_collection)) {
+  for (auto& tab : std::views::reverse(owned_tab_or_collection)) {
     std::visit(absl::Overload{
                    [&](std::unique_ptr<tabs::TabInterface>&& tab) {
                      auto* tab_ptr = tab.get();
@@ -1026,7 +1026,7 @@ void BraveTreeTabStripCollectionDelegate::MoveTabsOutOfGroup(
       CompactMovingTabs(moving_tabs, {tabs::TabCollection::Type::SPLIT});
   if (new_pinned_state) {
     // In this case, we just move the tabs to the pinned collection.
-    for (auto& tab_or_collection : base::Reversed(compacted_moving_tabs)) {
+    for (auto& tab_or_collection : std::views::reverse(compacted_moving_tabs)) {
       std::visit(absl::Overload{
                      [&](tabs::TabInterface* tab) {
                        auto detached_tab = DetachTabOutOfGroup(tab);
@@ -1167,7 +1167,7 @@ void BraveTreeTabStripCollectionDelegate::PinTabs(
   // collections to be passed in.
   base::flat_map<split_tabs::SplitTabId, std::set<tabs::TabInterface*>>
       split_tabs;
-  for (auto* moving_tab : base::Reversed(moving_tabs)) {
+  for (auto* moving_tab : std::views::reverse(moving_tabs)) {
     auto* parent_collection =
         collection_->GetParentCollection(moving_tab, GetPassKey());
     if (parent_collection->type() == tabs::TabCollection::Type::PINNED) {
@@ -1291,7 +1291,7 @@ void BraveTreeTabStripCollectionDelegate::UnpinTabs(
   base::flat_map<split_tabs::SplitTabId, std::vector<tabs::TabInterface*>>
       split_tabs;
 
-  for (auto* moving_tab : base::Reversed(moving_tabs)) {
+  for (auto* moving_tab : std::views::reverse(moving_tabs)) {
     if (!IsTabInPinnedCollection(moving_tab)) {
       // Already in unpinned collection. This will be moved together with
       // MoveTabsRecursive() call in the end of this function.
@@ -1375,7 +1375,7 @@ void BraveTreeTabStripCollectionDelegate::MoveChildrenOfTreeTabNodeToNode(
   CHECK_LT(target_index, target_collection->ChildCount());
 
   auto children = tree_tab_node_collection->GetTreeNodeChildren();
-  for (auto& child : base::Reversed(children)) {
+  for (auto& child : std::views::reverse(children)) {
     std::visit(
         absl::Overload{
             [&](tabs::TabInterface* tab) {
@@ -1418,7 +1418,7 @@ void BraveTreeTabStripCollectionDelegate::
   CHECK(local_index.has_value());
 
   auto children = tree_tab_node_collection->GetTreeNodeChildren();
-  for (auto& child : base::Reversed(children)) {
+  for (auto& child : std::views::reverse(children)) {
     std::visit(
         absl::Overload{
             [&](tabs::TabInterface* tab) {

--- a/browser/ui/tabs/brave_tree_tab_strip_collection_delegate.cc
+++ b/browser/ui/tabs/brave_tree_tab_strip_collection_delegate.cc
@@ -667,7 +667,7 @@ void BraveTreeTabStripCollectionDelegate::MoveTabsRecursive(
   // of being flattened.
   const base::flat_set<tabs::TabInterface*> moving_tabs_set(moving_tabs.begin(),
                                                             moving_tabs.end());
-  for (auto* moving_tab : base::Reversed(moving_tabs)) {
+  for (auto* moving_tab : std::views::reverse(moving_tabs)) {
     auto* moving_tab_tree_node = GetParentTreeNodeCollectionOfTab(moving_tab);
     MoveNonSelectedChildrenOfTreeTabNodeToParent(
         static_cast<tabs::TreeTabNodeTabCollection*>(moving_tab_tree_node),
@@ -681,7 +681,7 @@ void BraveTreeTabStripCollectionDelegate::MoveTabsRecursive(
                                       tabs::TabCollection::Type::TREE_NODE});
   std::vector<std::unique_ptr<tabs::TabCollection>>
       unique_moving_tab_collections_reversed;
-  for (auto& tab_or_collection : base::Reversed(compacted_moving_tabs)) {
+  for (auto& tab_or_collection : std::views::reverse(compacted_moving_tabs)) {
     tabs::TabCollection* moving_tab_tree_node = std::visit(
         absl::Overload(
             [this](tabs::TabInterface* tab) {
@@ -858,7 +858,7 @@ void BraveTreeTabStripCollectionDelegate::MoveTabsIntoGroup(
   }
 
   // Attach to the target group at 0 index temporarily.
-  for (auto& tab : base::Reversed(owned_tab_or_collection)) {
+  for (auto& tab : std::views::reverse(owned_tab_or_collection)) {
     std::visit(absl::Overload{
                    [&](tabs::ScopedTab&& tab) {
                      auto* tab_ptr = tab.get();
@@ -1017,7 +1017,7 @@ void BraveTreeTabStripCollectionDelegate::MoveTabsOutOfGroup(
       CompactMovingTabs(moving_tabs, {tabs::TabCollection::Type::SPLIT});
   if (new_pinned_state) {
     // In this case, we just move the tabs to the pinned collection.
-    for (auto& tab_or_collection : base::Reversed(compacted_moving_tabs)) {
+    for (auto& tab_or_collection : std::views::reverse(compacted_moving_tabs)) {
       std::visit(absl::Overload{
                      [&](tabs::TabInterface* tab) {
                        auto detached_tab = DetachTabOutOfGroup(tab);
@@ -1158,7 +1158,7 @@ void BraveTreeTabStripCollectionDelegate::PinTabs(
   // collections to be passed in.
   base::flat_map<split_tabs::SplitTabId, std::set<tabs::TabInterface*>>
       split_tabs;
-  for (auto* moving_tab : base::Reversed(moving_tabs)) {
+  for (auto* moving_tab : std::views::reverse(moving_tabs)) {
     auto* parent_collection =
         collection_->GetParentCollection(moving_tab, GetPassKey());
     if (parent_collection->type() == tabs::TabCollection::Type::PINNED) {
@@ -1282,7 +1282,7 @@ void BraveTreeTabStripCollectionDelegate::UnpinTabs(
   base::flat_map<split_tabs::SplitTabId, std::vector<tabs::TabInterface*>>
       split_tabs;
 
-  for (auto* moving_tab : base::Reversed(moving_tabs)) {
+  for (auto* moving_tab : std::views::reverse(moving_tabs)) {
     if (!IsTabInPinnedCollection(moving_tab)) {
       // Already in unpinned collection. This will be moved together with
       // MoveTabsRecursive() call in the end of this function.
@@ -1366,7 +1366,7 @@ void BraveTreeTabStripCollectionDelegate::MoveChildrenOfTreeTabNodeToNode(
   CHECK_LT(target_index, target_collection->ChildCount());
 
   auto children = tree_tab_node_collection->GetTreeNodeChildren();
-  for (auto& child : base::Reversed(children)) {
+  for (auto& child : std::views::reverse(children)) {
     std::visit(
         absl::Overload{
             [&](tabs::TabInterface* tab) {
@@ -1409,7 +1409,7 @@ void BraveTreeTabStripCollectionDelegate::
   CHECK(local_index.has_value());
 
   auto children = tree_tab_node_collection->GetTreeNodeChildren();
-  for (auto& child : base::Reversed(children)) {
+  for (auto& child : std::views::reverse(children)) {
     std::visit(
         absl::Overload{
             [&](tabs::TabInterface* tab) {

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <limits>
 #include <optional>
+#include <ranges>
 
 #include "base/check.h"
 #include "base/check_op.h"
@@ -321,7 +322,7 @@ std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
 
 void ReorderDraggedViewsForStacking(views::View* parent,
                                     const std::vector<TabSlotView*>& views) {
-  for (TabSlotView* view : base::Reversed(views)) {
+  for (TabSlotView* view : std::views::reverse(views)) {
     if (view->GetTabSlotViewType() == TabSlotView::ViewType::kTab &&
         views::AsViewClass<Tab>(view)->data().pinned) {
       // As can't drag pinned tabs and unpinned tabs together, we don't need to

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <limits>
 #include <optional>
+#include <ranges>
 
 #include "base/check.h"
 #include "base/check_op.h"
@@ -317,7 +318,7 @@ std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
 
 void ReorderDraggedViewsForStacking(views::View* parent,
                                     const std::vector<TabSlotView*>& views) {
-  for (TabSlotView* view : base::Reversed(views)) {
+  for (TabSlotView* view : std::views::reverse(views)) {
     if (view->GetTabSlotViewType() == TabSlotView::ViewType::kTab &&
         views::AsViewClass<Tab>(view)->data().pinned) {
       // As can't drag pinned tabs and unpinned tabs together, we don't need to

--- a/browser/ui/webui/settings/settings_secure_dns_handler_browsertest.cc
+++ b/browser/ui/webui/settings/settings_secure_dns_handler_browsertest.cc
@@ -13,6 +13,8 @@
 
 #include "chrome/browser/ui/webui/settings/settings_secure_dns_handler.h"
 
+#include <ranges>
+
 #include "build/build_config.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/net/secure_dns_config.h"
@@ -84,7 +86,7 @@ class BraveSecureDnsHandlerTest : public InProcessBrowserTest {
                                      std::string* out_doh_config,
                                      int* out_management_mode) {
     for (const std::unique_ptr<content::TestWebUI::CallData>& data :
-         base::Reversed(web_ui_.call_data())) {
+         std::views::reverse(web_ui_.call_data())) {
       if (data->function_name() != "cr.webUIListenerCallback" ||
           !data->arg1()->is_string() ||
           data->arg1()->GetString() != "secure-dns-setting-changed") {

--- a/chromium_src/chrome/browser/ui/views/location_bar/location_bar_view.cc
+++ b/chromium_src/chrome/browser/ui/views/location_bar/location_bar_view.cc
@@ -3,7 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "base/containers/adapters.h"
+#include "chrome/browser/ui/views/location_bar/location_bar_view.h"
+
+#include <ranges>
+
 #include "brave/browser/ui/omnibox/brave_omnibox_client_impl.h"
 #include "brave/browser/ui/views/omnibox/brave_omnibox_popup_view_views.h"
 #include "brave/browser/ui/views/omnibox/brave_omnibox_view_views.h"
@@ -29,7 +32,7 @@
 
 #define BRAVE_LOCATION_BAR_VIEW_LAYOUT_RIGHT_MOST_TRAILING_DECORATIONS \
   auto right_most_trailing_views = GetRightMostTrailingViews();        \
-  for (auto* item : base::Reversed(right_most_trailing_views)) {       \
+  for (auto* item : std::views::reverse(right_most_trailing_views)) {  \
     add_trailing_decoration(                                           \
         item, /*intra_item_padding=*/0,                                \
         /*edge_padding=*/trailing_decorations_edge_padding);           \
@@ -37,7 +40,7 @@
 
 #define BRAVE_LOCATION_BAR_VIEW_LAYOUT_LEFT_MOST_TRAILING_DECORATIONS \
   auto left_most_trailing_views = GetLeftMostTrailingViews();         \
-  for (auto* item : base::Reversed(left_most_trailing_views)) {       \
+  for (auto* item : std::views::reverse(left_most_trailing_views)) {  \
     add_trailing_decoration(                                          \
         item, /*intra_item_padding=*/0,                               \
         /*edge_padding=*/trailing_decorations_edge_padding);          \

--- a/chromium_src/chrome/browser/ui/views/location_bar/location_bar_view.cc
+++ b/chromium_src/chrome/browser/ui/views/location_bar/location_bar_view.cc
@@ -3,7 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "base/containers/adapters.h"
+#include "chrome/browser/ui/views/location_bar/location_bar_view.h"
+
+#include <ranges>
+
 #include "brave/browser/ui/omnibox/brave_omnibox_client_impl.h"
 #include "brave/browser/ui/views/omnibox/brave_omnibox_popup_view_views.h"
 #include "brave/browser/ui/views/omnibox/brave_omnibox_view_views.h"
@@ -28,7 +31,7 @@
 
 #define BRAVE_LOCATION_BAR_VIEW_LAYOUT_RIGHT_MOST_TRAILING_DECORATIONS \
   auto right_most_trailing_views = GetRightMostTrailingViews();        \
-  for (auto* item : base::Reversed(right_most_trailing_views)) {       \
+  for (auto* item : std::views::reverse(right_most_trailing_views)) {  \
     add_trailing_decoration(                                           \
         item, /*intra_item_padding=*/0,                                \
         /*edge_padding=*/trailing_decorations_edge_padding);           \
@@ -36,7 +39,7 @@
 
 #define BRAVE_LOCATION_BAR_VIEW_LAYOUT_LEFT_MOST_TRAILING_DECORATIONS \
   auto left_most_trailing_views = GetLeftMostTrailingViews();         \
-  for (auto* item : base::Reversed(left_most_trailing_views)) {       \
+  for (auto* item : std::views::reverse(left_most_trailing_views)) {  \
     add_trailing_decoration(                                          \
         item, /*intra_item_padding=*/0,                               \
         /*edge_padding=*/trailing_decorations_edge_padding);          \

--- a/chromium_src/components/search_engines/util.cc
+++ b/chromium_src/components/search_engines/util.cc
@@ -3,9 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include <algorithm>
+#include "components/search_engines/util.h"
 
-#include "base/containers/adapters.h"
+#include <algorithm>
+#include <ranges>
 
 #define GetSearchProvidersUsingKeywordResult \
   GetSearchProvidersUsingKeywordResult_ChromiumImpl
@@ -31,7 +32,8 @@ void GetSearchProvidersUsingKeywordResult(
   if (template_urls && !template_urls->empty()) {
     std::vector<std::unique_ptr<TemplateURLData>> prepopulated_urls =
         template_url_data_resolver.GetPrepopulatedEngines();
-    for (const auto& template_url_data : base::Reversed(prepopulated_urls)) {
+    for (const auto& template_url_data :
+         std::views::reverse(prepopulated_urls)) {
       auto it = std::ranges::find_if(
           *template_urls,
           [&template_url_data](std::unique_ptr<TemplateURL>& t_url1) {

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -11,6 +11,7 @@
 #include <iterator>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <string_view>
 #include <variant>
 #include <vector>
@@ -18,7 +19,6 @@
 #include "base/barrier_closure.h"
 #include "base/check.h"
 #include "base/check_op.h"
-#include "base/containers/adapters.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/containers/span.h"
 #include "base/containers/to_vector.h"
@@ -127,7 +127,7 @@ mojom::ConversationEntryEvent* MaybeGetEventToAppend(
                                 ConversationEntryEvent_Tag::kToolUseEvent)
       << "Only completions and tool use events can be split across multiple "
          "events.";
-  for (const auto& event : base::Reversed(events)) {
+  for (const auto& event : std::views::reverse(events)) {
     if (IsNonSplittingEvent(event->which())) {
       continue;
     }

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -11,6 +11,7 @@
 #include <iterator>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <string_view>
 #include <variant>
 #include <vector>
@@ -18,7 +19,6 @@
 #include "base/barrier_closure.h"
 #include "base/check.h"
 #include "base/check_op.h"
-#include "base/containers/adapters.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/containers/span.h"
 #include "base/containers/to_vector.h"
@@ -126,7 +126,7 @@ mojom::ConversationEntryEvent* MaybeGetEventToAppend(
                                 ConversationEntryEvent_Tag::kToolUseEvent)
       << "Only completions and tool use events can be split across multiple "
          "events.";
-  for (const auto& event : base::Reversed(events)) {
+  for (const auto& event : std::views::reverse(events)) {
     if (IsNonSplittingEvent(event->which())) {
       continue;
     }

--- a/components/ai_chat/core/browser/engine/oai_message_utils.cc
+++ b/components/ai_chat/core/browser/engine/oai_message_utils.cc
@@ -5,7 +5,8 @@
 
 #include "brave/components/ai_chat/core/browser/engine/oai_message_utils.h"
 
-#include "base/containers/adapters.h"
+#include <ranges>
+
 #include "base/containers/span.h"
 #include "base/json/json_writer.h"
 #include "base/strings/escape.h"
@@ -126,7 +127,7 @@ std::vector<mojom::ContentBlockPtr> BuildOAIPageContentBlocks(
 
   // Note: We iterate in reverse so that we prefer more recent page content
   // (i.e. the oldest content will be truncated when we run out of context).
-  for (const auto& page_content : base::Reversed(page_contents)) {
+  for (const auto& page_content : std::views::reverse(page_contents)) {
     uint32_t effective_length_limit = max_associated_content_length;
     if (max_per_content_length.has_value()) {
       effective_length_limit =

--- a/components/brave_ads/core/internal/common/time/time_constraint_util.cc
+++ b/components/brave_ads/core/internal/common/time/time_constraint_util.cc
@@ -5,7 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/common/time/time_constraint_util.h"
 
-#include "base/containers/adapters.h"
+#include <ranges>
+
 #include "base/containers/span.h"
 #include "base/time/time.h"
 
@@ -22,7 +23,7 @@ bool DoesHistoryRespectRollingTimeConstraint(
 
   const base::Time threshold = base::Time::Now() - time_constraint;
 
-  for (const auto& time : base::Reversed(history)) {
+  for (const auto& time : std::views::reverse(history)) {
     if (time <= threshold) {
       // If the time point is less than or equal to the threshold, the cap has
       // not been reached.

--- a/components/brave_ads/core/internal/ml/model/linear/linear.cc
+++ b/components/brave_ads/core/internal/ml/model/linear/linear.cc
@@ -6,11 +6,11 @@
 #include "brave/components/brave_ads/core/internal/ml/model/linear/linear.h"
 
 #include <algorithm>
+#include <ranges>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "base/containers/adapters.h"
 #include "brave/components/brave_ads/core/internal/common/resources/flat/text_classification_linear_model_generated.h"
 #include "brave/components/brave_ads/core/internal/ml/ml_prediction_util.h"
 
@@ -81,7 +81,7 @@ std::optional<PredictionMap> LinearModel::GetTopCountPredictionsImpl(
   for (const auto& [segment, probability] : predictions_softmax) {
     prediction_order.emplace_back(probability, segment);
   }
-  std::ranges::sort(base::Reversed(prediction_order));
+  std::ranges::sort(std::views::reverse(prediction_order));
 
   PredictionMap top_predictions;
   if (top_count && top_count < prediction_order.size()) {

--- a/components/brave_ads/core/internal/ml/model/neural/neural.cc
+++ b/components/brave_ads/core/internal/ml/model/neural/neural.cc
@@ -7,11 +7,11 @@
 
 #include <algorithm>
 #include <iterator>
+#include <ranges>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "base/containers/adapters.h"
 #include "brave/components/brave_ads/core/internal/common/resources/flat/text_classification_neural_model_generated.h"
 #include "brave/components/brave_ads/core/internal/ml/data/vector_data.h"
 
@@ -130,7 +130,7 @@ std::optional<PredictionMap> NeuralModel::GetTopCountPredictionsImpl(
   for (const auto& [segment, probability] : *predictions) {
     prediction_order.emplace_back(probability, segment);
   }
-  std::ranges::sort(base::Reversed(prediction_order));
+  std::ranges::sort(std::views::reverse(prediction_order));
 
   PredictionMap top_predictions;
   if (top_count < prediction_order.size()) {

--- a/components/brave_ads/core/internal/targeting/behavioral/purchase_intent/model/purchase_intent_model_segment_predictor.cc
+++ b/components/brave_ads/core/internal/targeting/behavioral/purchase_intent/model/purchase_intent_model_segment_predictor.cc
@@ -6,8 +6,8 @@
 #include "brave/components/brave_ads/core/internal/targeting/behavioral/purchase_intent/model/purchase_intent_model_segment_predictor.h"
 
 #include <cstddef>
+#include <ranges>
 
-#include "base/containers/adapters.h"
 #include "brave/components/brave_ads/core/internal/targeting/behavioral/purchase_intent/purchase_intent_feature.h"
 
 namespace brave_ads {
@@ -27,7 +27,7 @@ SegmentList PredictPurchaseIntentSegments(
   SegmentList segments;
   segments.reserve(kMaximumSegments);
 
-  for (const auto& [score, segment] : base::Reversed(segment_scores)) {
+  for (const auto& [score, segment] : std::views::reverse(segment_scores)) {
     if (score < threshold) {
       continue;
     }

--- a/components/brave_ads/core/internal/user_attention/user_activity/user_activity_util.cc
+++ b/components/brave_ads/core/internal/user_attention/user_activity/user_activity_util.cc
@@ -6,9 +6,9 @@
 #include "brave/components/brave_ads/core/internal/user_attention/user_activity/user_activity_util.h"
 
 #include <algorithm>
+#include <ranges>
 #include <vector>
 
-#include "base/containers/adapters.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
@@ -27,7 +27,7 @@ size_t GetNumberOfUserActivityEvents(const UserActivityEventList& events,
 base::TimeDelta GetTimeSinceLastUserActivityEvent(
     const UserActivityEventList& events,
     UserActivityEventType event_type) {
-  const auto iter = std::ranges::find(base::Reversed(events), event_type,
+  const auto iter = std::ranges::find(std::views::reverse(events), event_type,
                                       &UserActivityEventInfo::type);
   if (iter == events.crend()) {
     return {};

--- a/components/brave_ads/core/internal/user_engagement/conversions/conversions.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/conversions.cc
@@ -5,8 +5,9 @@
 
 #include "brave/components/brave_ads/core/internal/user_engagement/conversions/conversions.h"
 
+#include <ranges>
+
 #include "base/check.h"
-#include "base/containers/adapters.h"
 #include "base/functional/bind.h"
 #include "base/time/time.h"
 #include "base/trace_event/trace_event.h"
@@ -140,7 +141,7 @@ void Conversions::CheckForConversions(
   // Conversions are based on the last touch attribution model.
   bool did_convert = false;
 
-  for (const auto& ad_event : base::Reversed(ad_events)) {
+  for (const auto& ad_event : std::views::reverse(ad_events)) {
     // Do we have creative set conversions for this ad event?
     const auto iter =
         creative_set_conversion_buckets.find(ad_event.creative_set_id);

--- a/components/brave_wallet/browser/fil_transaction.cc
+++ b/components/brave_wallet/browser/fil_transaction.cc
@@ -8,12 +8,12 @@
 #include <algorithm>
 #include <array>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <utility>
 
 #include "base/base64.h"
 #include "base/check.h"
-#include "base/containers/adapters.h"
 #include "base/containers/span.h"
 #include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
@@ -60,7 +60,7 @@ std::optional<std::vector<uint8_t>> ToBigIntBytesArray(
 
   auto bigint_span =
       base::byte_span_from_ref(*bigint).first(significant_bytes_count);
-  for (auto item : base::Reversed(bigint_span)) {
+  for (auto item : std::views::reverse(bigint_span)) {
     result.push_back(item);
   }
 

--- a/components/brave_wallet/common/hash_utils.cc
+++ b/components/brave_wallet/common/hash_utils.cc
@@ -7,9 +7,9 @@
 
 #include <algorithm>
 #include <array>
+#include <ranges>
 
 #include "base/check_op.h"
-#include "base/containers/adapters.h"
 #include "base/containers/span.h"
 #include "base/strings/string_split.h"
 #include "brave/components/brave_wallet/common/eth_abi_utils.h"
@@ -59,7 +59,7 @@ eth_abi::Bytes32 Namehash(std::string_view name) {
   auto labels = SplitStringPiece(name, ".", base::KEEP_WHITESPACE,
                                  base::SPLIT_WANT_NONEMPTY);
 
-  for (const auto& label : base::Reversed(labels)) {
+  for (const auto& label : std::views::reverse(labels)) {
     auto label_hash = KeccakHash(base::as_byte_span(label));
     hash = KeccakHash(ConcatArrays(hash, label_hash));
   }

--- a/components/tabs/impl/tree_tab_node_tab_collection.cc
+++ b/components/tabs/impl/tree_tab_node_tab_collection.cc
@@ -8,12 +8,12 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <ranges>
 #include <utility>
 #include <variant>
 
 #include "absl/functional/overload.h"
 #include "base/check_op.h"
-#include "base/containers/adapters.h"
 #include "base/containers/flat_set.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
@@ -116,7 +116,7 @@ void TreeTabNodeTabCollection::FlattenTreeTabs(TabCollection& root) {
   CollectTreeNodesRecursively(root, all_tree_nodes);
 
   // Process tree nodes in reverse order so we handle children before parents.
-  for (auto* tree_node : base::Reversed(all_tree_nodes)) {
+  for (auto* tree_node : std::views::reverse(all_tree_nodes)) {
     // Move all direct children (tabs and collections e.g. SplitTabCollection)
     // from this tree node back to the tree node's parent, preserving order.
     std::vector<std::variant<tabs::TabInterface*, TabCollection*>> children =

--- a/docs/best-practices/coding-standards-apis.md
+++ b/docs/best-practices/coding-standards-apis.md
@@ -748,10 +748,11 @@ base::StrAppend(&result, {kOpenTag, "\n", "=== METADATA ===\n"});
 
 <a id="CSA-039"></a>
 
-## ✅ Use `base::Reversed()` for Reverse Iteration
+## ✅ Use `std::views::reverse()` for Reverse Iteration
 
-**Prefer `base::Reversed()` with range-based for loops over explicit reverse
-iterators.** Always add a comment explaining why reverse order is needed.
+**Prefer `std::views::reverse()` with range-based for loops over explicit
+reverse iterators.** Always add a comment explaining why reverse order is
+needed.
 
 ```cpp
 // ❌ WRONG - explicit reverse iterators
@@ -759,9 +760,9 @@ for (auto it = history.crbegin(); it != history.crend(); ++it) {
   ProcessEntry(*it);
 }
 
-// ✅ CORRECT - base::Reversed with comment
+// ✅ CORRECT - std::views::reverse with comment
 // Process newest entries first to prioritize recent content.
-for (const auto& entry : base::Reversed(history)) {
+for (const auto& entry : std::views::reverse(history)) {
   ProcessEntry(entry);
 }
 ```

--- a/ios/browser/api/bookmarks/brave_bookmarks_api.mm
+++ b/ios/browser/api/bookmarks/brave_bookmarks_api.mm
@@ -5,9 +5,10 @@
 
 #include "brave/ios/browser/api/bookmarks/brave_bookmarks_api.h"
 
+#include <ranges>
+
 #include "base/check.h"
 #include "base/compiler_specific.h"
-#include "base/containers/adapters.h"
 #include "base/containers/stack.h"
 #include "base/memory/raw_ptr.h"
 #include "base/numerics/safe_conversions.h"
@@ -360,7 +361,8 @@
   std::vector<const bookmarks::BookmarkNode*> bookmarks = {node_};
 
   base::stack<std::pair<const bookmarks::BookmarkNode*, std::int32_t>> stack;
-  for (const bookmarks::BookmarkNode* bookmark : base::Reversed(bookmarks)) {
+  for (const bookmarks::BookmarkNode* bookmark :
+       std::views::reverse(bookmarks)) {
     stack.emplace(bookmark, 0);
   }
 
@@ -392,7 +394,7 @@
       }
     }
 
-    for (const auto* bookmark : base::Reversed(bookmarks)) {
+    for (const auto* bookmark : std::views::reverse(bookmarks)) {
       stack.emplace(bookmark, depth + 1);
     }
   }


### PR DESCRIPTION
Upstream is in the process of deleting `base::Reversed` with some types
of views being allowed in Chromium now.

Chromium changes:
https://chromium.googlesource.com/chromium/src/+/544517ec6719737defc4438962281c596cc7171b

commit 544517ec6719737defc4438962281c596cc7171b
Author: Jan Wilken Dörrie <jdoerrie@chromium.org>
Date:   Wed Aug 5 08:38:06 2026 -0700

    chrome: Migrate base::Reversed to std::views::reverse

    Bug: 493534962
    Change-Id: I307138d6ebce5d0103121de8f5ebe4a06a6a6964
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8158422
    Reviewed-by: Daniel Cheng <dcheng@chromium.org>
    Auto-Submit: Jan Wilken Dörrie <jdoerrie@chromium.org>
    Owners-Override: Daniel Cheng <dcheng@chromium.org>
    Commit-Queue: Daniel Cheng <dcheng@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#1674183}
