### PR TITLE
[iOS] Add support for scroll edge effects in the tab grid on 26+

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridContainerView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridContainerView.swift
@@ -119,6 +119,10 @@ class TabGridContainerView: UIView {
       scrolledToInitialTab = true
       scrollToSelectedItem(animated: false)
     }
+
+    if #available(iOS 26.0, *) {
+      updateScrollEdgeViews()
+    }
   }
 
   override var canBecomeFirstResponder: Bool {
@@ -152,6 +156,10 @@ class TabGridContainerView: UIView {
     )
   }
 
+  // iOS 26+ views needed to support the `UIScrollEdgeElementContainerInteraction`
+  private var topEdgeView: UIView?
+  private var bottomEdgeView: UIView?
+
   private func prepareCollectionView() {
     collectionView.alwaysBounceVertical = true
     collectionView.backgroundColor = .clear
@@ -174,6 +182,51 @@ class TabGridContainerView: UIView {
     collectionView.snp.makeConstraints {
       $0.edges.equalToSuperview()
     }
+
+    if #available(iOS 26.0, *) {
+      // In order to support scroll edge effects in this view we must create scroll edge container
+      // interactions, however this interaction does not work unless the view its added to contains
+      // a glass view hierarchy in it (UIGlassEffect/UIGlassContainerEffect). We dont render the
+      // header/footer bars in this representable, so instead we need to create temporary views
+      // that will be added to the container view and laid out using the insets we already pass in.
+      let topEdgeView = UIVisualEffectView(effect: UIGlassEffect())
+      let topEdgeContainerInteraction = UIScrollEdgeElementContainerInteraction()
+      topEdgeContainerInteraction.scrollView = collectionView
+      topEdgeContainerInteraction.edge = .top
+      topEdgeView.addInteraction(topEdgeContainerInteraction)
+      addSubview(topEdgeView)
+      self.topEdgeView = topEdgeView
+
+      let bottomEdgeView = UIVisualEffectView(effect: UIGlassEffect())
+      let bottomEdgeContainerInteraction = UIScrollEdgeElementContainerInteraction()
+      bottomEdgeContainerInteraction.scrollView = collectionView
+      bottomEdgeContainerInteraction.edge = .bottom
+      bottomEdgeView.addInteraction(bottomEdgeContainerInteraction)
+      addSubview(bottomEdgeView)
+      self.bottomEdgeView = bottomEdgeView
+
+      collectionView.topEdgeEffect.style = .soft
+      collectionView.bottomEdgeEffect.style = .soft
+    }
+  }
+
+  @available(iOS 26.0, *)
+  private func updateScrollEdgeViews() {
+    // width is set to `CGFloat.leastNormalMagnitude` for both of these so that they dont appear
+    // in the actual view. The views frames MUST intersect with the scroll view and they cannot
+    // be hidden/have an alpha of 0 or `UIScrollEdgeElementContainerInteraction` does not work
+    topEdgeView?.frame = .init(
+      x: 0,
+      y: 0,
+      width: CGFloat.leastNormalMagnitude,
+      height: maskInsets.top + safeAreaInsets.top
+    )
+    bottomEdgeView?.frame = .init(
+      x: 0,
+      y: bounds.height - maskInsets.bottom - safeAreaInsets.bottom,
+      width: CGFloat.leastNormalMagnitude,
+      height: maskInsets.bottom + safeAreaInsets.bottom
+    )
   }
 
   private func updateContentInsets() {
@@ -188,6 +241,11 @@ class TabGridContainerView: UIView {
         collectionView.contentOffset.y = -maskInsets.top
       }
     }
+
+    if #available(iOS 26.0, *) {
+      updateScrollEdgeViews()
+    }
+
     // iOS 18+'s SwiftUI animation sharing feature is broken and causes weird jumps so we can't use
     // Animation.toolbarsSizeAnimation directly
     let animator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 0.825)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridSearchBar.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridSearchBar.swift
@@ -25,9 +25,18 @@ struct TabGridSearchBar: View {
           }
         } label: {
           Text(Strings.CancelString)
-            .foregroundStyle(Color(braveSystemName: .textInteractive))
+            .frame(maxHeight: .infinity)
         }
         .transition(.move(edge: .trailing).combined(with: .opacity))
+        .osAvailabilityModifiers { content in
+          if #available(iOS 26.0, *) {
+            content
+              .buttonStyle(.plainGlass)
+          } else {
+            content
+              .foregroundStyle(Color(braveSystemName: .textInteractive))
+          }
+        }
       }
     }
     .animation(.toolbarsSizeAnimation, value: isFocused)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridView.swift
@@ -151,18 +151,36 @@ struct TabGridView: View {
         )
         .opacity(isGridHidden ? 0 : 1)
         .accessibilityHidden(isGridHidden)
+        .osAvailabilityModifiers { content in
+          if #available(iOS 26.0, *) {
+            // For Liquid Glass progressive blur
+            content
+              .ignoresSafeArea(.container, edges: .vertical)
+          } else {
+            content
+          }
+        }
       }
     }
     .environment(\.editMode, $editMode)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .mask {
-      // TODO: Test Performance of this mask w/ and w/o drawingGroup
-      let radius = 5.0
-      Color.black
-        .blur(radius: radius)
-        .padding(.horizontal, -(radius * 2))
-        .padding(insets)
-        .animation(.toolbarsSizeAnimation, value: insets)
+    .osAvailabilityModifiers { content in
+      if #available(iOS 26.0, *) {
+        // On 26 we will instead use `UIScrollEdgeElementContainerInteraction` to show progressive
+        // blurs under the header & footer
+        content
+      } else {
+        content
+          .mask {
+            // TODO: Test Performance of this mask w/ and w/o drawingGroup
+            let radius = 5.0
+            Color.black
+              .blur(radius: radius)
+              .padding(.horizontal, -(radius * 2))
+              .padding(insets)
+              .animation(.toolbarsSizeAnimation, value: insets)
+          }
+      }
     }
     .background(alignment: .top) {
       if viewModel.isPrivateBrowsing, horizontalSizeClass == .compact {
@@ -758,13 +776,56 @@ private struct TabGridModeSwitcher: UIViewRepresentable {
     }
   }
 
+  // A segmented control that puts a glass visual effect in the background and assigns it a tint
+  // based on the `backgroundColor` provided
+  @available(iOS 26.0, *)
+  private class GlassBackedSegmentedControl: UISegmentedControl {
+    private let backgroundView = UIVisualEffectView(effect: UIGlassEffect(style: .clear))
+
+    override init(items: [Any]?) {
+      super.init(items: items)
+
+      insertSubview(backgroundView, at: 0)
+      backgroundView.layer.cornerCurve = .continuous
+    }
+
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+      fatalError()
+    }
+
+    override func layoutSubviews() {
+      super.layoutSubviews()
+
+      backgroundView.frame = bounds
+      backgroundView.layer.cornerRadius = layer.cornerRadius
+    }
+
+    override var backgroundColor: UIColor? {
+      get {
+        super.backgroundColor
+      }
+      set {
+        // Only way to set a new tint is to replace the whole effect
+        let newEffect = UIGlassEffect(style: .clear)
+        newEffect.tintColor = newValue
+        backgroundView.effect = newEffect
+        super.backgroundColor = .clear
+      }
+    }
+  }
+
   func makeUIView(context: Context) -> UISegmentedControl {
-    let uiView = UISegmentedControl(
-      items: [
-        tabCount,
-        Strings.TabGrid.privateBrowsingModeTitle,
-      ]
-    )
+    let items: [Any] = [
+      tabCount,
+      Strings.TabGrid.privateBrowsingModeTitle,
+    ]
+    let uiView: UISegmentedControl
+    if #available(iOS 26.0, *) {
+      uiView = GlassBackedSegmentedControl(items: items)
+    } else {
+      uiView = UISegmentedControl(items: items)
+    }
     uiView.addAction(
       .init(handler: { [unowned uiView] _ in
         isPrivateBrowsing = uiView.selectedSegmentIndex == 1


### PR DESCRIPTION
This change adds support for soft scroll edge effects (progressive blur) behind the header/footer views in the tab grid. As a side-effect of this, the cancel button when the search bar is visible is now a glass button

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/58006

### Test

On 18:
- Verify no changes to the tab grid on iOS 18

On 26:
- Verify tabs now scroll under the header/footer with a progressive blur
- Verify search bar cancel button is now glass
