### PR TITLE
Expand CS-019 to cover comments justifying self-evident design decisions

### DIFF
--- a/docs/best-practices/coding-standards.md
+++ b/docs/best-practices/coding-standards.md
@@ -361,6 +361,16 @@ time, with no knowledge of the PR or change history.** Do not add comments that
 reference removed code, prior behavior, or the change itself. Comments are part
 of the codebase, not a changelog.
 
+This also covers comments that **justify a design decision the finished code
+already makes self-evident.** A comment explaining _why the code is structured
+this way instead of some other way_ only makes sense to someone who knows about
+the "other way" that was considered or abandoned — a reader seeing the code
+fresh does not. These often creep in when an author (or AI assistant) reasons
+through a refactor in a comment and leaves that reasoning behind. If the final
+code stands on its own, the justification is noise; delete it. Keep a comment
+only when it explains a genuinely non-obvious constraint the code cannot express
+itself (e.g. an ordering requirement, a workaround for an upstream bug).
+
 ```cpp
 // ❌ WRONG - references removed code / change history
 // Removed the old caching logic that was causing race conditions.
@@ -370,6 +380,16 @@ of the codebase, not a changelog.
 // ❌ WRONG - describes what was removed rather than what exists
 // The timeout parameter was removed since it's no longer needed.
 int ProcessRequest(const GURL& url);
+
+// ❌ WRONG - justifies the structure against an abandoned alternative;
+// the reader doesn't need to know password import used to live elsewhere.
+// Password import is handled by BraveExternalProcessImporterHost in the
+// browser process, alongside the utility-process import, so it participates
+// in the same import lifecycle.
+StartPasswordImport();
+
+// ✅ CORRECT - the call site is self-explanatory; no comment needed
+StartPasswordImport();
 
 // ✅ CORRECT - describes the code as it is now
 // Processes the request synchronously. Returns the HTTP status code.

--- a/docs/best-practices/coding-standards.md
+++ b/docs/best-practices/coding-standards.md
@@ -362,14 +362,18 @@ reference removed code, prior behavior, or the change itself. Comments are part
 of the codebase, not a changelog.
 
 This also covers comments that **justify a design decision the finished code
-already makes self-evident.** A comment explaining _why the code is structured
-this way instead of some other way_ only makes sense to someone who knows about
-the "other way" that was considered or abandoned — a reader seeing the code
-fresh does not. These often creep in when an author (or AI assistant) reasons
-through a refactor in a comment and leaves that reasoning behind. If the final
-code stands on its own, the justification is noise; delete it. Keep a comment
-only when it explains a genuinely non-obvious constraint the code cannot express
-itself (e.g. an ordering requirement, a workaround for an upstream bug).
+already makes self-evident** — including the development process _within the
+same PR_. If password import lived in `BraveImportDataHandler` in one commit and
+moved to `BraveExternalProcessImporterHost` in a later commit, a reader of the
+final diff does not need a comment narrating that migration. A comment
+explaining _why the code is structured this way instead of some other way_ only
+makes sense to someone who knows about the "other way" that was considered or
+abandoned — a reader seeing the code fresh does not. These often creep in when
+an author (or AI assistant) reasons through a refactor across commits and leaves
+that reasoning behind. If the final code stands on its own, the justification is
+noise; delete it. Keep a comment only when it explains a genuinely non-obvious
+constraint the code cannot express itself (e.g. an ordering requirement, a
+workaround for an upstream bug).
 
 ```cpp
 // ❌ WRONG - references removed code / change history


### PR DESCRIPTION
## Summary

- Broadens best-practice rule CS-019 ("Comments Must Make Sense to Future Readers of the Codebase") in `docs/best-practices/coding-standards.md` to explicitly cover comments that **justify a design decision the finished code already makes self-evident**.
- Adds a ❌/✅ example pair based on a real review comment: an AI-authored comment explaining *why* password import moved into `BraveExternalProcessImporterHost` — reasoning only meaningful to someone who knew the abandoned alternative.

## Motivation

The existing rule caught changelog-style comments (`// Previously...`, `// Changed from...`) via tell-tale words, but missed comments that read as legitimate architecture notes while actually narrating a refactor's reasoning. These slip through code review (and the `/review` skill's chunked checks) because they describe current behavior accurately — they're just unnecessary. Calling this class out explicitly gives reviewers and the review tooling a rule to point at.

## Test plan

- [ ] Docs-only change; `pnpm run format` (prettier) passes on the modified file.