### PR TITLE
[iOS] Debug menu option for Custom Scriptlets

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/LaunchHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/LaunchHelper.swift
@@ -38,6 +38,8 @@ public actor LaunchHelper {
 
       // Load cached data
       // This is done first because compileResources need their results
+      // The scriptlets are loaded before the resources as they are injected into them
+      await CustomFilterListStorage.shared.loadCachedCustomScriptlets()
       await AdBlockGroupsManager.shared.loadResourcesFromCache()
       async let loadEngines: Void = AdBlockGroupsManager.shared.loadEnginesFromCache()
       async let adblockResourceCache: Void = AdBlockGroupsManager.shared.loadBundledDataIfNeeded()

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/AdBlock/AdBlockDebugView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/AdBlock/AdBlockDebugView.swift
@@ -20,6 +20,7 @@ struct AdBlockDebugView: View {
           Text("Adblock Rule Exclusions")
         }
       )
+      CustomScriptletSectionView()
     }
   }
 }
@@ -297,6 +298,57 @@ private struct CorruptCacheSectionView: View {
     await AsyncFileManager.default.createFile(atPath: cachedDATFile.path, contents: corruptedData)
 
     return true
+  }
+}
+
+private struct CustomScriptletSectionView: View {
+  @ObservedObject private var customFilterListStorage = CustomFilterListStorage.shared
+  @State private var isPresentingAddScriptlet = false
+  @State private var editingCustomScriptlet: CustomScriptlet?
+
+  var body: some View {
+    Section {
+      Button {
+        isPresentingAddScriptlet = true
+      } label: {
+        Text("Add New Scriptlet")
+          .foregroundStyle(Color(braveSystemName: .textInteractive))
+      }
+      .fullScreenCover(isPresented: $isPresentingAddScriptlet) {
+        NavigationStack {
+          CustomScriptletView()
+        }
+      }
+      // This button is single item, if added to ForEach blow it will cause
+      // multiple presentation issue
+      .fullScreenCover(item: $editingCustomScriptlet) { scriptlet in
+        NavigationStack {
+          CustomScriptletView(
+            customScriptlet: scriptlet
+          )
+        }
+      }
+      ForEach(customFilterListStorage.customScriptlets) { scriptlet in
+        Button {
+          editingCustomScriptlet = scriptlet
+        } label: {
+          Text(scriptlet.name)
+            .foregroundStyle(Color(braveSystemName: .textInteractive))
+        }
+      }
+      .onDelete(perform: deleteScriptlets)
+    } header: {
+      Text("Custom Scriptlets")
+    }
+  }
+
+  private func deleteScriptlets(at offsets: IndexSet) {
+    let names = offsets.map({ customFilterListStorage.customScriptlets[$0].name })
+    Task {
+      for name in names {
+        try? await customFilterListStorage.deleteCustomScriptlet(named: name)
+      }
+    }
   }
 }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/AdBlock/AdBlockDebugView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/AdBlock/AdBlockDebugView.swift
@@ -20,6 +20,7 @@ struct AdBlockDebugView: View {
           Text("Adblock Rule Exclusions")
         }
       )
+      CustomScriptletSectionView()
     }
   }
 }
@@ -297,6 +298,58 @@ private struct CorruptCacheSectionView: View {
     await AsyncFileManager.default.createFile(atPath: cachedDATFile.path, contents: corruptedData)
 
     return true
+  }
+}
+
+private struct CustomScriptletSectionView: View {
+  @ObservedObject private var customFilterListStorage = CustomFilterListStorage.shared
+  @State private var isPresentingAddScriptlet = false
+  @State private var editingCustomScriptlet: CustomScriptlet?
+
+  var body: some View {
+    Section {
+      ForEach(customFilterListStorage.customScriptlets) { scriptlet in
+        Button {
+          editingCustomScriptlet = scriptlet
+        } label: {
+          Text(scriptlet.name)
+            .foregroundStyle(Color(braveSystemName: .textInteractive))
+        }
+      }
+      .onDelete(perform: deleteScriptlets)
+
+      Button {
+        isPresentingAddScriptlet = true
+      } label: {
+        Text(Strings.Shields.addNewScriptletTitle)
+          .foregroundStyle(Color(braveSystemName: .textInteractive))
+      }
+      .fullScreenCover(isPresented: $isPresentingAddScriptlet) {
+        NavigationStack {
+          CustomScriptletView()
+        }
+      }
+      // This button is single item, if added to ForEach blow it will cause
+      // multiple presentation issue
+      .fullScreenCover(item: $editingCustomScriptlet) { scriptlet in
+        NavigationStack {
+          CustomScriptletView(
+            customScriptlet: scriptlet
+          )
+        }
+      }
+    } header: {
+      Text("Custom Scriptlets")
+    }
+  }
+
+  private func deleteScriptlets(at offsets: IndexSet) {
+    let names = offsets.map({ customFilterListStorage.customScriptlets[$0].name })
+    Task {
+      for name in names {
+        try? await customFilterListStorage.deleteCustomScriptlet(named: name)
+      }
+    }
   }
 }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/AdBlock/AdBlockDebugView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/AdBlock/AdBlockDebugView.swift
@@ -329,7 +329,7 @@ private struct CustomScriptletSectionView: View {
           CustomScriptletView()
         }
       }
-      // This button is single item, if added to ForEach blow it will cause
+      // This button is single item, if added to ForEach below it will cause
       // multiple presentation issue
       .fullScreenCover(item: $editingCustomScriptlet) { scriptlet in
         NavigationStack {

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/CustomScriptletView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/CustomScriptletView.swift
@@ -1,0 +1,221 @@
+// Copyright 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveShields
+import BraveUI
+import DesignSystem
+import Strings
+import SwiftUI
+
+struct CustomScriptletView: View {
+  /// A wrapper around a save failure so it can drive an alert
+  private struct SaveError: Identifiable {
+    let id = UUID()
+    let message: String
+  }
+
+  @Environment(\.dismiss) private var dismiss: DismissAction
+  /// The scriptlet being edited, if any. `nil` when creating a new scriptlet.
+  private let editingScriptlet: CustomScriptlet?
+  /// The name for the custom scriptlet
+  @State private var customScriptletName: String = ""
+  /// The javascript for the custom scriptlet
+  @State private var customScriptletContent: String = ""
+  /// The font size for the custom scriptlet editor
+  @ScaledMetric private var editorFontSize: CGFloat = 14
+  /// A state for showing/hiding the cancelation alert
+  @State private var showCancelAlert = false
+  /// Indicates if we are currently saving the custom scriptlet
+  @State private var isSaving = false
+  /// The error to display if saving the custom scriptlet failed
+  @State private var saveError: SaveError?
+
+  /// The full name of the scriptlet, including `user-` and `.js`
+  private var fullCustomScriptletName: String {
+    CustomScriptlet.namePrefix + customScriptletName + CustomScriptlet.nameExtension
+  }
+
+  private var isSaveEnabled: Bool {
+    CustomScriptlet.isValidName(fullCustomScriptletName) && !customScriptletContent.isEmpty
+  }
+
+  /// Whether the user has made any changes to the scriptlet
+  private var hasChanges: Bool {
+    fullCustomScriptletName != (editingScriptlet?.name ?? "")
+      || customScriptletContent != (editingScriptlet?.content ?? "")
+  }
+
+  init(customScriptlet: CustomScriptlet? = nil) {
+    self.editingScriptlet = customScriptlet
+  }
+
+  private var saveToolbarItem: ToolbarItem<(), some View> {
+    ToolbarItem(placement: .confirmationAction) {
+      if isSaving {
+        ProgressView()
+      } else {
+        Button(
+          action: saveCustomScriptlet,
+          label: {
+            Label(Strings.saveButtonTitle, braveSystemImage: "leo.check.normal")
+              .labelStyle(.titleOnly)
+          }
+        )
+        .disabled(!isSaveEnabled)
+      }
+    }
+  }
+
+  private var cancelToolbarItem: ToolbarItem<(), some View> {
+    ToolbarItem(placement: .cancellationAction) {
+      Button(
+        action: {
+          if hasChanges {
+            showCancelAlert = true
+          } else {
+            dismiss()
+          }
+        },
+        label: {
+          Text(Strings.CancelString)
+        }
+      )
+      .disabled(isSaving)
+      .alert(
+        isPresented: $showCancelAlert,
+        content: {
+          return Alert(
+            title: Text(Strings.dismissChangesConfirmationTitle),
+            message: Text(Strings.dismissChangesConfirmationMessage),
+            primaryButton: .destructive(
+              Text(Strings.dismissChangesButtonTitle),
+              action: {
+                dismiss()
+              }
+            ),
+            secondaryButton: .cancel(
+              Text(Strings.cancelButtonTitle)
+            )
+          )
+        }
+      )
+    }
+  }
+
+  var body: some View {
+    Form {
+      Section(
+        content: {
+          HStack(alignment: .firstTextBaseline, spacing: 0) {
+            Text(CustomScriptlet.namePrefix)
+              .foregroundStyle(Color(braveSystemName: .textSecondary))
+              .padding(4)
+              .background(Color(braveSystemName: .pageBackground), in: .rect(cornerRadius: 4))
+            TextField(
+              "",
+              text: $customScriptletName,
+              prompt: Text(Strings.Shields.customScriptletNameSectionTitle.lowercased())
+            )
+            .autocorrectionDisabled(true)
+            .textInputAutocapitalization(.never)
+            Spacer()
+            Text(CustomScriptlet.nameExtension)
+              .foregroundStyle(Color(braveSystemName: .textSecondary))
+              .padding(4)
+              .background(Color(braveSystemName: .pageBackground), in: .rect(cornerRadius: 4))
+          }
+        },
+        header: {
+          Text(Strings.Shields.customScriptletNameSectionTitle)
+        }
+      )
+      Section(
+        content: {
+          TextEditor(text: $customScriptletContent)
+            .font(.system(size: editorFontSize, weight: .regular).monospaced())
+            .frame(height: 400)
+            .overlay(
+              alignment: .topLeading,
+              content: {
+                Text(Strings.Shields.customScriptletContentWarning)
+                  .multilineTextAlignment(.leading)
+                  .autocorrectionDisabled(true)
+                  .textInputAutocapitalization(.never)
+                  .padding(.vertical, 8)
+                  .padding(.horizontal, 8)
+                  .disabled(true)
+                  .allowsHitTesting(false)
+                  .font(.body)
+                  .frame(
+                    maxWidth: .infinity,
+                    maxHeight: .infinity,
+                    alignment: .topLeading
+                  )
+                  .foregroundColor(Color(braveSystemName: .systemfeedbackErrorText))
+                  .opacity(customScriptletContent.isEmpty ? 1 : 0)
+                  .accessibilityHidden(!customScriptletContent.isEmpty)
+              }
+            )
+            .background(
+              Color(.secondarySystemGroupedBackground),
+              in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+            )
+        },
+        header: {
+          Text(Strings.Shields.customScriptletContentSectionTitle)
+        }
+      )
+    }
+    .task {
+      guard let editingScriptlet else { return }
+      // setup initial values from editingScriptlet
+      customScriptletName = String(
+        editingScriptlet.name.deletingPathExtension.trimmingPrefix(CustomScriptlet.namePrefix)
+      )
+      customScriptletContent = editingScriptlet.content
+    }
+    .scrollContentBackground(.hidden)
+    .scrollDismissesKeyboard(.interactively)
+    .background(
+      Color(braveSystemName: .pageBackground)
+        .edgesIgnoringSafeArea(.all)
+    )
+    .navigationTitle(
+      Text(
+        editingScriptlet == nil
+          ? Strings.Shields.addNewScriptletTitle : Strings.Shields.editScriptletTitle
+      )
+    )
+    .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      cancelToolbarItem
+      saveToolbarItem
+    }
+    .alert(item: $saveError) { error in
+      Alert(
+        title: Text(Strings.genericErrorTitle),
+        message: Text(error.message),
+        dismissButton: .default(Text(Strings.OKString))
+      )
+    }
+  }
+
+  private func saveCustomScriptlet() {
+    guard isSaveEnabled, !isSaving else { return }
+    saveError = SaveError(message: "Not yet supported")
+  }
+}
+
+#Preview {
+  NavigationStack(root: {
+    CustomScriptletView()
+  })
+}
+
+extension String {
+  var deletingPathExtension: String {
+    (self as NSString).deletingPathExtension
+  }
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/CustomScriptletView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/CustomScriptletView.swift
@@ -204,7 +204,29 @@ struct CustomScriptletView: View {
 
   private func saveCustomScriptlet() {
     guard isSaveEnabled, !isSaving else { return }
-    saveError = SaveError(message: "Not yet supported")
+    isSaving = true
+
+    Task { @MainActor in
+      defer { isSaving = false }
+
+      do {
+        try await CustomFilterListStorage.shared.save(
+          customScriptlet: CustomScriptlet(
+            name: fullCustomScriptletName,
+            content: customScriptletContent
+          )
+        )
+        // Remove the old file if the scriptlet was renamed
+        if let editingScriptlet, editingScriptlet.name != fullCustomScriptletName {
+          try await CustomFilterListStorage.shared.deleteCustomScriptlet(
+            named: editingScriptlet.name
+          )
+        }
+        dismiss()
+      } catch {
+        saveError = SaveError(message: error.localizedDescription)
+      }
+    }
   }
 }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/CustomScriptletView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/CustomScriptletView.swift
@@ -1,0 +1,222 @@
+// Copyright 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveShields
+import BraveUI
+import DesignSystem
+import Strings
+import SwiftUI
+
+struct CustomScriptletView: View {
+  /// A wrapper around a save failure so it can drive an alert
+  private struct SaveError: Identifiable {
+    let id = UUID()
+    let message: String
+  }
+
+  @Environment(\.dismiss) private var dismiss: DismissAction
+  /// The scriptlet being edited, if any. `nil` when creating a new scriptlet.
+  private let editingScriptlet: CustomScriptlet?
+  /// The name for the custom scriptlet
+  @State private var customScriptletName: String
+  /// The javascript for the custom scriptlet
+  @State private var customScriptletContent: String
+  /// The font size for the custom scriptlet editor
+  @ScaledMetric private var editorFontSize: CGFloat = 14
+  /// A state for showing/hiding the cancelation alert
+  @State private var showCancelAlert = false
+  /// Indicates if we are currently saving the custom scriptlet
+  @State private var isSaving = false
+  /// The error to display if saving the custom scriptlet failed
+  @State private var saveError: SaveError?
+
+  /// The full name of the scriptlet, including `user-` and `.js`
+  private var fullCustomScriptletName: String {
+    CustomScriptlet.namePrefix + customScriptletName + CustomScriptlet.nameExtension
+  }
+
+  private var isSaveEnabled: Bool {
+    CustomScriptlet.isValidName(fullCustomScriptletName) && !customScriptletContent.isEmpty
+  }
+
+  /// Whether the user has made any changes to the scriptlet
+  private var hasChanges: Bool {
+    fullCustomScriptletName != (editingScriptlet?.name ?? "")
+      || customScriptletContent != (editingScriptlet?.content ?? "")
+  }
+
+  init(customScriptlet: CustomScriptlet? = nil) {
+    self.editingScriptlet = customScriptlet
+    // strip `user-` and `.js` from name, user only edits the other pieces
+    var name = ""
+    if let customName = customScriptlet?.name {
+      name = String(customName.deletingPathExtension.trimmingPrefix(CustomScriptlet.namePrefix))
+    }
+    self._customScriptletName = State(wrappedValue: name)
+    self._customScriptletContent = State(wrappedValue: customScriptlet?.content ?? "")
+  }
+
+  private var saveToolbarItem: ToolbarItem<(), some View> {
+    ToolbarItem(placement: .confirmationAction) {
+      if isSaving {
+        ProgressView()
+      } else {
+        Button(
+          action: saveCustomScriptlet,
+          label: {
+            Label(Strings.saveButtonTitle, braveSystemImage: "leo.check.normal")
+              .labelStyle(.titleOnly)
+          }
+        )
+        .disabled(!isSaveEnabled)
+      }
+    }
+  }
+
+  private var cancelToolbarItem: ToolbarItem<(), some View> {
+    ToolbarItem(placement: .cancellationAction) {
+      Button(
+        action: {
+          if hasChanges {
+            showCancelAlert = true
+          } else {
+            dismiss()
+          }
+        },
+        label: {
+          Text(Strings.CancelString)
+        }
+      )
+      .disabled(isSaving)
+      .alert(
+        isPresented: $showCancelAlert,
+        content: {
+          return Alert(
+            title: Text(Strings.dismissChangesConfirmationTitle),
+            message: Text(Strings.dismissChangesConfirmationMessage),
+            primaryButton: .destructive(
+              Text(Strings.dismissChangesButtonTitle),
+              action: {
+                dismiss()
+              }
+            ),
+            secondaryButton: .cancel(
+              Text(Strings.cancelButtonTitle)
+            )
+          )
+        }
+      )
+    }
+  }
+
+  var body: some View {
+    Form {
+      Section(
+        content: {
+          HStack(alignment: .firstTextBaseline, spacing: 0) {
+            Text(CustomScriptlet.namePrefix)
+              .foregroundStyle(Color(braveSystemName: .textSecondary))
+              .padding(4)
+              .background(Color(white: 0.95))
+              .clipShape(RoundedRectangle(cornerRadius: 4))
+            TextField(
+              "",
+              text: $customScriptletName,
+              prompt: Text(Strings.Shields.customScriptletNameSectionTitle.lowercased())
+            )
+            .autocorrectionDisabled(true)
+            .textInputAutocapitalization(.never)
+            Spacer()
+            Text(CustomScriptlet.nameExtension)
+              .foregroundStyle(Color(braveSystemName: .textSecondary))
+              .padding(4)
+              .background(Color(white: 0.95))
+              .clipShape(RoundedRectangle(cornerRadius: 4))
+          }
+        },
+        header: {
+          Text(Strings.Shields.customScriptletNameSectionTitle)
+        }
+      )
+      Section(
+        content: {
+          TextEditor(text: $customScriptletContent)
+            .font(.system(size: editorFontSize, weight: .regular).monospaced())
+            .frame(height: 400)
+            .overlay(
+              alignment: .topLeading,
+              content: {
+                Text(Strings.Shields.customScriptletContentWarning)
+                  .multilineTextAlignment(.leading)
+                  .autocorrectionDisabled(true)
+                  .textInputAutocapitalization(.never)
+                  .padding(.vertical, 8)
+                  .padding(.horizontal, 8)
+                  .disabled(true)
+                  .allowsHitTesting(false)
+                  .font(.body)
+                  .frame(
+                    maxWidth: .infinity,
+                    maxHeight: .infinity,
+                    alignment: .topLeading
+                  )
+                  .foregroundColor(Color(braveSystemName: .systemfeedbackErrorText))
+                  .opacity(customScriptletContent.isEmpty ? 1 : 0)
+                  .accessibilityHidden(customScriptletContent.isEmpty)
+              }
+            )
+            .background(
+              Color(.secondarySystemGroupedBackground),
+              in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+            )
+        },
+        header: {
+          Text(Strings.Shields.customScriptletContentSectionTitle)
+        }
+      )
+    }
+    .scrollContentBackground(.hidden)
+    .scrollDismissesKeyboard(.interactively)
+    .background(
+      Color(braveSystemName: .pageBackground)
+        .edgesIgnoringSafeArea(.all)
+    )
+    .navigationTitle(
+      Text(
+        editingScriptlet == nil
+          ? Strings.Shields.addNewScriptletTitle : Strings.Shields.editScriptletTitle
+      )
+    )
+    .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      cancelToolbarItem
+      saveToolbarItem
+    }
+    .alert(item: $saveError) { error in
+      Alert(
+        title: Text(Strings.genericErrorTitle),
+        message: Text(error.message),
+        dismissButton: .default(Text(Strings.OKString))
+      )
+    }
+  }
+
+  private func saveCustomScriptlet() {
+    guard isSaveEnabled, !isSaving else { return }
+    saveError = SaveError(message: "Not yet supported")
+  }
+}
+
+#Preview {
+  NavigationStack(root: {
+    CustomScriptletView()
+  })
+}
+
+extension String {
+  var deletingPathExtension: String {
+    (self as NSString).deletingPathExtension
+  }
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/CustomScriptletView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/CustomScriptletView.swift
@@ -136,15 +136,14 @@ struct CustomScriptletView: View {
           TextEditor(text: $customScriptletContent)
             .font(.system(size: editorFontSize, weight: .regular).monospaced())
             .frame(height: 400)
+            .autocorrectionDisabled(true)
+            .textInputAutocapitalization(.never)
             .overlay(
               alignment: .topLeading,
               content: {
                 Text(Strings.Shields.customScriptletContentWarning)
                   .multilineTextAlignment(.leading)
-                  .autocorrectionDisabled(true)
-                  .textInputAutocapitalization(.never)
-                  .padding(.vertical, 8)
-                  .padding(.horizontal, 8)
+                  .padding(8)
                   .disabled(true)
                   .allowsHitTesting(false)
                   .font(.body)
@@ -176,12 +175,7 @@ struct CustomScriptletView: View {
       )
       customScriptletContent = editingScriptlet.content
     }
-    .scrollContentBackground(.hidden)
     .scrollDismissesKeyboard(.interactively)
-    .background(
-      Color(braveSystemName: .pageBackground)
-        .edgesIgnoringSafeArea(.all)
-    )
     .navigationTitle(
       Text(
         editingScriptlet == nil
@@ -193,13 +187,20 @@ struct CustomScriptletView: View {
       cancelToolbarItem
       saveToolbarItem
     }
-    .alert(item: $saveError) { error in
-      Alert(
-        title: Text(Strings.genericErrorTitle),
-        message: Text(error.message),
-        dismissButton: .default(Text(Strings.OKString))
-      )
-    }
+    .alert(
+      Text(Strings.genericErrorTitle),
+      isPresented: Binding(
+        get: { saveError != nil },
+        set: { if !$0 { saveError = nil } }
+      ),
+      presenting: saveError,
+      actions: { _ in
+        Button(Strings.OKString) {}
+      },
+      message: { error in
+        Text(error.message)
+      }
+    )
   }
 
   private func saveCustomScriptlet() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/CustomScriptletView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/CustomScriptletView.swift
@@ -205,7 +205,29 @@ struct CustomScriptletView: View {
 
   private func saveCustomScriptlet() {
     guard isSaveEnabled, !isSaving else { return }
-    saveError = SaveError(message: "Not yet supported")
+    isSaving = true
+
+    Task { @MainActor in
+      defer { isSaving = false }
+
+      do {
+        try await CustomFilterListStorage.shared.save(
+          customScriptlet: CustomScriptlet(
+            name: fullCustomScriptletName,
+            content: customScriptletContent
+          )
+        )
+        // Remove the old file if the scriptlet was renamed
+        if let editingScriptlet, editingScriptlet.name != fullCustomScriptletName {
+          try await CustomFilterListStorage.shared.deleteCustomScriptlet(
+            named: editingScriptlet.name
+          )
+        }
+        dismiss()
+      } catch {
+        saveError = SaveError(message: error.localizedDescription)
+      }
+    }
   }
 }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/CustomScriptletView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/CustomScriptletView.swift
@@ -84,21 +84,18 @@ struct CustomScriptletView: View {
       )
       .disabled(isSaving)
       .alert(
+        Strings.dismissChangesConfirmationTitle,
         isPresented: $showCancelAlert,
-        content: {
-          return Alert(
-            title: Text(Strings.dismissChangesConfirmationTitle),
-            message: Text(Strings.dismissChangesConfirmationMessage),
-            primaryButton: .destructive(
-              Text(Strings.dismissChangesButtonTitle),
-              action: {
-                dismiss()
-              }
-            ),
-            secondaryButton: .cancel(
-              Text(Strings.cancelButtonTitle)
-            )
-          )
+        actions: {
+          Button(Strings.dismissChangesButtonTitle, role: .destructive) {
+            dismiss()
+          }
+          Button(Strings.cancelButtonTitle, role: .cancel) {
+            showCancelAlert = false
+          }
+        },
+        message: {
+          Text(Strings.dismissChangesConfirmationMessage)
         }
       )
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/CustomScriptletView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/CustomScriptletView.swift
@@ -212,14 +212,9 @@ struct CustomScriptletView: View {
           customScriptlet: CustomScriptlet(
             name: fullCustomScriptletName,
             content: customScriptletContent
-          )
+          ),
+          replacing: editingScriptlet?.name
         )
-        // Remove the old file if the scriptlet was renamed
-        if let editingScriptlet, editingScriptlet.name != fullCustomScriptletName {
-          try await CustomFilterListStorage.shared.deleteCustomScriptlet(
-            named: editingScriptlet.name
-          )
-        }
         dismiss()
       } catch {
         saveError = SaveError(message: error.localizedDescription)

--- a/ios/brave-ios/Sources/Brave/WebFilters/AdBlock/AdBlockGroupsManager.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/AdBlock/AdBlockGroupsManager.swift
@@ -4,6 +4,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import BraveCore
+import BraveShared
 import BraveShields
 import Data
 import Foundation
@@ -509,29 +510,114 @@ import os
   }
 
   private func getCachedResourcesInfo() -> GroupedAdBlockEngine.ResourcesInfo? {
+    let cachedFileURL: URL
     if let resourcesFolderURL = AdblockService.makeAbsoluteURL(
       forComponentPath: Preferences.AppState.lastAdBlockResourcesFolderPath.value
     ), FileManager.default.fileExists(atPath: resourcesFolderURL.path) {
       // This is a legacy storage when we were gettting the component folder URL not the file URL
-      let resourcesFileURL = resourcesFolderURL.appendingPathComponent(
+      cachedFileURL = resourcesFolderURL.appendingPathComponent(
         "resources.json",
         conformingTo: .json
       )
-      return getResourcesInfo(fromFileURL: resourcesFileURL)
     } else if let resourcesFileURL = AdblockService.makeAbsoluteURL(
       forComponentPath: Preferences.AppState.lastAdBlockResourcesFilePath.value
     ), FileManager.default.fileExists(atPath: resourcesFileURL.path) {
-      return getResourcesInfo(fromFileURL: resourcesFileURL)
+      cachedFileURL = resourcesFileURL
     } else {
+      return nil
+    }
+
+    return getResourcesInfo(fromFileURL: cachedFileURL)
+  }
+
+  /// Rebuild the resources info so the user's custom scriptlets are picked up by the engines.
+  ///
+  /// The scriptlets only live in the resources so the engines don't need to be recompiled.
+  func didUpdateCustomScriptlets() async {
+    guard let resourcesInfo = getCachedResourcesInfo() else { return }
+    self.resourcesInfo = resourcesInfo
+
+    for engineType in GroupedAdBlockEngine.EngineType.allCases {
+      let manager = getManager(for: engineType)
+      await manager.update(resourcesInfo: resourcesInfo)
+      // The cached cosmetic filter models and frame scripts are built from the previous
+      // resources, so they need to be dropped for the new scriptlet to be injected.
+      await manager.engine?.clearCaches()
+    }
+  }
+
+  /// Read the resources JSON at `sourceURL`, append an entry for each of the given
+  /// `customScriptlets` with its base64-encoded content, and write the result into the
+  /// app caches directory.
+  /// - Returns: The URL of the augmented file, or nil if augmentation failed.
+  private func writeAugmentedResources(
+    from sourceURL: URL,
+    customScriptlets: [CustomScriptlet]
+  ) -> URL? {
+    guard
+      let data = try? Data(contentsOf: sourceURL),
+      var entries = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+    else {
+      return nil
+    }
+
+    for customScriptlet in customScriptlets {
+      entries.append([
+        "name": customScriptlet.name,
+        "aliases": [],
+        "kind": ["mime": "application/javascript"],
+        "content": Data(customScriptlet.content.utf8).base64EncodedString(),
+      ])
+    }
+
+    guard
+      let augmentedData = try? JSONSerialization.data(withJSONObject: entries),
+      let cachesURL = try? AsyncFileManager.default.url(for: .cachesDirectory, in: .userDomainMask)
+    else {
+      return nil
+    }
+
+    let folderURL = cachesURL.appendingPathComponent(
+      "adblock-resources",
+      conformingTo: .folder
+    )
+    let augmentedFileURL = folderURL.appendingPathComponent(
+      "resources.json",
+      conformingTo: .json
+    )
+
+    do {
+      try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+      try augmentedData.write(to: augmentedFileURL, options: .atomic)
+      return augmentedFileURL
+    } catch {
       return nil
     }
   }
 
   /// Convert the given folder URL to a `ResourcesInfo` object
   private func getResourcesInfo(fromFileURL fileURL: URL) -> GroupedAdBlockEngine.ResourcesInfo {
+    let version = fileURL.deletingLastPathComponent().lastPathComponent
+
+    // Inject an entry for each of the user's custom scriptlets so they are available
+    // to the engine. Falls back to the unmodified component file if there are no
+    // custom scriptlets or if augmentation fails.
+    let customScriptlets = CustomFilterListStorage.shared.customScriptlets
+    if !customScriptlets.isEmpty,
+      let augmentedFileURL = writeAugmentedResources(
+        from: fileURL,
+        customScriptlets: customScriptlets
+      )
+    {
+      return GroupedAdBlockEngine.ResourcesInfo(
+        localFileURL: augmentedFileURL,
+        version: version
+      )
+    }
+
     return GroupedAdBlockEngine.ResourcesInfo(
       localFileURL: fileURL,
-      version: fileURL.deletingLastPathComponent().lastPathComponent
+      version: version
     )
   }
 

--- a/ios/brave-ios/Sources/Brave/WebFilters/AdBlock/AdBlockGroupsManager.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/AdBlock/AdBlockGroupsManager.swift
@@ -73,7 +73,7 @@ import os
 
   /// Load any cache data so its ready right during launch
   func loadResourcesFromCache() async {
-    if let resourcesInfo = getCachedResourcesInfo() {
+    if let resourcesInfo = await getCachedResourcesInfo() {
       // We need this for all filter lists so we can't compile anything until we download it
       self.resourcesInfo = resourcesInfo
 
@@ -153,11 +153,11 @@ import os
   }
 
   /// Inform this manager of updates to the resources so our engines can be updated
-  func didUpdateResourcesComponent(resourcesFileURL: URL) {
+  func didUpdateResourcesComponent(resourcesFileURL: URL) async {
     let folderSubPath = AdblockService.extractRelativePath(fromComponentURL: resourcesFileURL)
     Preferences.AppState.lastAdBlockResourcesFilePath.value = folderSubPath
     Preferences.AppState.lastAdBlockResourcesFolderPath.value = nil
-    let resourcesInfo = getResourcesInfo(fromFileURL: resourcesFileURL)
+    let resourcesInfo = await getResourcesInfo(fromFileURL: resourcesFileURL)
     updateIfNeeded(resourcesInfo: resourcesInfo)
   }
 
@@ -509,11 +509,11 @@ import os
     )
   }
 
-  private func getCachedResourcesInfo() -> GroupedAdBlockEngine.ResourcesInfo? {
+  private func getCachedResourcesInfo() async -> GroupedAdBlockEngine.ResourcesInfo? {
     let cachedFileURL: URL
     if let resourcesFolderURL = AdblockService.makeAbsoluteURL(
       forComponentPath: Preferences.AppState.lastAdBlockResourcesFolderPath.value
-    ), FileManager.default.fileExists(atPath: resourcesFolderURL.path) {
+    ), await AsyncFileManager.default.fileExists(atPath: resourcesFolderURL.path) {
       // This is a legacy storage when we were gettting the component folder URL not the file URL
       cachedFileURL = resourcesFolderURL.appendingPathComponent(
         "resources.json",
@@ -521,20 +521,20 @@ import os
       )
     } else if let resourcesFileURL = AdblockService.makeAbsoluteURL(
       forComponentPath: Preferences.AppState.lastAdBlockResourcesFilePath.value
-    ), FileManager.default.fileExists(atPath: resourcesFileURL.path) {
+    ), await AsyncFileManager.default.fileExists(atPath: resourcesFileURL.path) {
       cachedFileURL = resourcesFileURL
     } else {
       return nil
     }
 
-    return getResourcesInfo(fromFileURL: cachedFileURL)
+    return await getResourcesInfo(fromFileURL: cachedFileURL)
   }
 
   /// Rebuild the resources info so the user's custom scriptlets are picked up by the engines.
   ///
   /// The scriptlets only live in the resources so the engines don't need to be recompiled.
   func didUpdateCustomScriptlets() async {
-    guard let resourcesInfo = getCachedResourcesInfo() else { return }
+    guard let resourcesInfo = await getCachedResourcesInfo() else { return }
     self.resourcesInfo = resourcesInfo
 
     for engineType in GroupedAdBlockEngine.EngineType.allCases {
@@ -553,9 +553,11 @@ import os
   private func writeAugmentedResources(
     from sourceURL: URL,
     customScriptlets: [CustomScriptlet]
-  ) -> URL? {
+  ) async -> URL? {
     guard
-      let data = try? Data(contentsOf: sourceURL),
+      let data = await AsyncFileManager.default.contents(
+        atPath: sourceURL.path(percentEncoded: false)
+      ),
       var entries = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
     else {
       return nil
@@ -587,8 +589,18 @@ import os
     )
 
     do {
-      try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
-      try augmentedData.write(to: augmentedFileURL, options: .atomic)
+      try await AsyncFileManager.default.createDirectory(
+        at: folderURL,
+        withIntermediateDirectories: true
+      )
+      guard
+        await AsyncFileManager.default.createFile(
+          atPath: augmentedFileURL.path(percentEncoded: false),
+          contents: augmentedData
+        )
+      else {
+        return nil
+      }
       return augmentedFileURL
     } catch {
       return nil
@@ -596,7 +608,9 @@ import os
   }
 
   /// Convert the given folder URL to a `ResourcesInfo` object
-  private func getResourcesInfo(fromFileURL fileURL: URL) -> GroupedAdBlockEngine.ResourcesInfo {
+  private func getResourcesInfo(
+    fromFileURL fileURL: URL
+  ) async -> GroupedAdBlockEngine.ResourcesInfo {
     let version = fileURL.deletingLastPathComponent().lastPathComponent
 
     // Inject an entry for each of the user's custom scriptlets so they are available
@@ -604,7 +618,7 @@ import os
     // custom scriptlets or if augmentation fails.
     let customScriptlets = CustomFilterListStorage.shared.customScriptlets
     if !customScriptlets.isEmpty,
-      let augmentedFileURL = writeAugmentedResources(
+      let augmentedFileURL = await writeAugmentedResources(
         from: fileURL,
         customScriptlets: customScriptlets
       )

--- a/ios/brave-ios/Sources/Brave/WebFilters/CustomFilterListStorage.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/CustomFilterListStorage.swift
@@ -11,6 +11,34 @@ import Foundation
 import Preferences
 import WebKit
 
+/// A user provided scriptlet that is injected into the ad-block engine's resources
+struct CustomScriptlet: Identifiable, Hashable {
+  /// The name of the scriptlet. This is also the file name it is stored under and the
+  /// name filter list rules refer to (i.e. `user-my-scriptlet.js`)
+  let name: String
+  /// The javascript for this scriptlet
+  let content: String
+
+  var id: String { name }
+
+  /// The required prefix for a scriptlet's name
+  static let namePrefix = "user-"
+  /// The required extension for a scriptlet's name
+  static let nameExtension = ".js"
+
+  /// Tells us if the given name is a valid scriptlet name.
+  ///
+  /// A valid name is prefixed with `user-`, suffixed with `.js` and is safe to use as a
+  /// file name (i.e. contains no path separators or relative path components).
+  static func isValidName(_ name: String) -> Bool {
+    guard name.hasPrefix(namePrefix), name.hasSuffix(nameExtension) else { return false }
+    // Ensure there is something between the prefix and the extension
+    guard name.count > namePrefix.count + nameExtension.count else { return false }
+    guard !name.contains("/"), !name.contains(":"), !name.contains("..") else { return false }
+    return true
+  }
+}
+
 @MainActor class CustomFilterListStorage: ObservableObject {
   enum CustomRulesError: Error, LocalizedError {
     /// We limit the number of lines because UITextView cannot handle large text

--- a/ios/brave-ios/Sources/Brave/WebFilters/CustomFilterListStorage.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/CustomFilterListStorage.swift
@@ -40,6 +40,27 @@ struct CustomScriptlet: Identifiable, Hashable {
 }
 
 @MainActor class CustomFilterListStorage: ObservableObject {
+  enum CustomScriptletError: Error, LocalizedError {
+    /// The scriptlet's name is not prefixed with `user-`, not suffixed with `.js`
+    /// or is unsafe to use as a file name
+    case invalidName
+    /// The scriptlet has no javascript
+    case emptyContent
+
+    var errorDescription: String? {
+      switch self {
+      case .invalidName:
+        return String.localizedStringWithFormat(
+          Strings.Shields.customScriptletInvalidNameError,
+          CustomScriptlet.namePrefix,
+          CustomScriptlet.nameExtension
+        )
+      case .emptyContent:
+        return Strings.Shields.customScriptletEmptyContentError
+      }
+    }
+  }
+
   enum CustomRulesError: Error, LocalizedError {
     /// We limit the number of lines because UITextView cannot handle large text
     case tooManyLines(max: Int)
@@ -80,6 +101,8 @@ struct CustomScriptlet: Identifiable, Hashable {
   let persistChanges: Bool
   /// A list of filter list URLs and their enabled statuses
   @Published var filterListsURLs: [FilterListCustomURL]
+  /// All the saved custom scriptlets, sorted by name
+  @Published private(set) var customScriptlets: [CustomScriptlet] = []
 
   init(persistChanges: Bool) {
     self.persistChanges = persistChanges
@@ -147,6 +170,16 @@ struct CustomScriptlet: Identifiable, Hashable {
       in: .userDomainMask
     ).appending(path: "custom_rules")
     return folderURL.appending(path: "exclusion_rules.txt")
+  }
+
+  /// Folder URL containing the custom scriptlets. Each scriptlet is stored as a
+  /// single file where the file name is the scriptlet's name.
+  private func customScriptletsFolderURL() throws -> URL {
+    let folderURL = try AsyncFileManager.default.url(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask
+    ).appending(path: "custom_rules")
+    return folderURL.appending(path: "scriptlets")
   }
 
   /// Get the file URL to the custom filter list rules if it exists
@@ -246,6 +279,88 @@ struct CustomScriptlet: Identifiable, Hashable {
     case .success(let date):
       filterListsURLs[index].downloadStatus = .downloaded(date)
     }
+  }
+
+  /// Load the saved custom scriptlets into memory.
+  ///
+  /// This must happen before the ad-block resources are loaded so the scriptlets are
+  /// included in every `ResourcesInfo` we hand to the engines.
+  func loadCachedCustomScriptlets() async {
+    self.customScriptlets = (try? await loadCustomScriptlets()) ?? []
+  }
+
+  /// Load all the saved custom scriptlets
+  public func loadCustomScriptlets() async throws -> [CustomScriptlet] {
+    let folderURL = try customScriptletsFolderURL()
+    guard await AsyncFileManager.default.fileExists(atPath: folderURL.path) else { return [] }
+
+    let fileURLs = try await AsyncFileManager.default.contentsOfDirectory(
+      at: folderURL,
+      includingPropertiesForKeys: nil,
+      options: [.skipsHiddenFiles]
+    )
+
+    return
+      await fileURLs
+      .filter({ CustomScriptlet.isValidName($0.lastPathComponent) })
+      .sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
+      .asyncCompactMap({ fileURL in
+        guard let content = await AsyncFileManager.default.utf8Contents(at: fileURL) else {
+          return nil
+        }
+        return CustomScriptlet(name: fileURL.lastPathComponent, content: content)
+      })
+  }
+
+  /// Save the given custom scriptlet and recompile the engines so it takes effect.
+  ///
+  /// An existing scriptlet with the same name is replaced.
+  public func save(customScriptlet: CustomScriptlet) async throws {
+    guard CustomScriptlet.isValidName(customScriptlet.name) else {
+      throw CustomScriptletError.invalidName
+    }
+    guard !customScriptlet.content.isEmpty else {
+      throw CustomScriptletError.emptyContent
+    }
+
+    let folderURL = try customScriptletsFolderURL()
+    let fileURL = folderURL.appending(path: customScriptlet.name)
+    if await AsyncFileManager.default.fileExists(atPath: fileURL.path) {
+      try await AsyncFileManager.default.removeItem(at: fileURL)
+    }
+    _ = try await getOrCreateCustomScriptletsFolder()
+    await AsyncFileManager.default.createUTF8File(
+      atPath: fileURL.path,
+      contents: customScriptlet.content
+    )
+
+    customScriptlets.removeAll(where: { $0.name == customScriptlet.name })
+    customScriptlets.append(customScriptlet)
+    customScriptlets.sort(by: { $0.name < $1.name })
+    await AdBlockGroupsManager.shared.didUpdateCustomScriptlets()
+  }
+
+  /// Delete the saved custom scriptlet with the given name and recompile the engines
+  /// so it is no longer available
+  func deleteCustomScriptlet(named name: String) async throws {
+    guard CustomScriptlet.isValidName(name) else {
+      throw CustomScriptletError.invalidName
+    }
+
+    let fileURL = try customScriptletsFolderURL().appending(path: name)
+    guard await AsyncFileManager.default.fileExists(atPath: fileURL.path) else { return }
+    try await AsyncFileManager.default.removeItem(at: fileURL)
+    customScriptlets.removeAll(where: { $0.name == name })
+    await AdBlockGroupsManager.shared.didUpdateCustomScriptlets()
+  }
+
+  /// Get or create the folder that stores the custom scriptlets
+  private func getOrCreateCustomScriptletsFolder() async throws -> URL {
+    try await AsyncFileManager.default.url(
+      for: .applicationSupportDirectory,
+      appending: "custom_rules/scriptlets",
+      create: true
+    )
   }
 
   /// Load the custom exclusion rules (rules to be removed from AdBlockEngine &

--- a/ios/brave-ios/Sources/Brave/WebFilters/CustomFilterListStorage.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/CustomFilterListStorage.swift
@@ -40,6 +40,27 @@ struct CustomScriptlet: Identifiable, Hashable {
 }
 
 @MainActor class CustomFilterListStorage: ObservableObject {
+  enum CustomScriptletError: Error, LocalizedError {
+    /// The scriptlet's name is not prefixed with `user-`, not suffixed with `.js`
+    /// or is unsafe to use as a file name
+    case invalidName
+    /// The scriptlet has no javascript
+    case emptyContent
+
+    var errorDescription: String? {
+      switch self {
+      case .invalidName:
+        return String.localizedStringWithFormat(
+          Strings.Shields.customScriptletInvalidNameError,
+          CustomScriptlet.namePrefix,
+          CustomScriptlet.nameExtension
+        )
+      case .emptyContent:
+        return Strings.Shields.customScriptletEmptyContentError
+      }
+    }
+  }
+
   enum CustomRulesError: Error, LocalizedError {
     /// We limit the number of lines because UITextView cannot handle large text
     case tooManyLines(max: Int)
@@ -80,6 +101,8 @@ struct CustomScriptlet: Identifiable, Hashable {
   let persistChanges: Bool
   /// A list of filter list URLs and their enabled statuses
   @Published var filterListsURLs: [FilterListCustomURL]
+  /// All the saved custom scriptlets, sorted by name
+  @Published private(set) var customScriptlets: [CustomScriptlet] = []
 
   init(persistChanges: Bool) {
     self.persistChanges = persistChanges
@@ -147,6 +170,16 @@ struct CustomScriptlet: Identifiable, Hashable {
       in: .userDomainMask
     ).appending(path: "custom_rules")
     return folderURL.appending(path: "exclusion_rules.txt")
+  }
+
+  /// Folder URL containing the custom scriptlets. Each scriptlet is stored as a
+  /// single file where the file name is the scriptlet's name.
+  private func customScriptletsFolderURL() throws -> URL {
+    let folderURL = try AsyncFileManager.default.url(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask
+    ).appending(path: "custom_rules")
+    return folderURL.appending(path: "scriptlets")
   }
 
   /// Get the file URL to the custom filter list rules if it exists
@@ -246,6 +279,89 @@ struct CustomScriptlet: Identifiable, Hashable {
     case .success(let date):
       filterListsURLs[index].downloadStatus = .downloaded(date)
     }
+  }
+
+  /// Load the saved custom scriptlets into memory.
+  ///
+  /// This must happen before the ad-block resources are loaded so the scriptlets are
+  /// included in every `ResourcesInfo` we hand to the engines.
+  func loadCachedCustomScriptlets() async {
+    self.customScriptlets = (try? await loadCustomScriptlets()) ?? []
+  }
+
+  /// Load all the saved custom scriptlets
+  public func loadCustomScriptlets() async throws -> [CustomScriptlet] {
+    let folderURL = try customScriptletsFolderURL()
+    guard await AsyncFileManager.default.fileExists(atPath: folderURL.path) else { return [] }
+
+    let fileURLs = try await AsyncFileManager.default.contentsOfDirectory(
+      at: folderURL,
+      includingPropertiesForKeys: nil,
+      options: [.skipsHiddenFiles]
+    )
+
+    return
+      await fileURLs
+      .filter({ CustomScriptlet.isValidName($0.lastPathComponent) })
+      .sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
+      .asyncCompactMap({ fileURL in
+        guard let content = await AsyncFileManager.default.utf8Contents(at: fileURL) else {
+          return nil
+        }
+        return CustomScriptlet(name: fileURL.lastPathComponent, content: content)
+      })
+  }
+
+  /// Save the given custom scriptlet, update engine resources and clear the
+  /// engine caches so it takes effect.
+  ///
+  /// An existing scriptlet with the same name is replaced.
+  public func save(customScriptlet: CustomScriptlet) async throws {
+    guard CustomScriptlet.isValidName(customScriptlet.name) else {
+      throw CustomScriptletError.invalidName
+    }
+    guard !customScriptlet.content.isEmpty else {
+      throw CustomScriptletError.emptyContent
+    }
+
+    let folderURL = try customScriptletsFolderURL()
+    let fileURL = folderURL.appending(path: customScriptlet.name)
+    if await AsyncFileManager.default.fileExists(atPath: fileURL.path) {
+      try await AsyncFileManager.default.removeItem(at: fileURL)
+    }
+    _ = try await getOrCreateCustomScriptletsFolder()
+    await AsyncFileManager.default.createUTF8File(
+      atPath: fileURL.path,
+      contents: customScriptlet.content
+    )
+
+    customScriptlets.removeAll(where: { $0.name == customScriptlet.name })
+    customScriptlets.append(customScriptlet)
+    customScriptlets.sort(by: { $0.name < $1.name })
+    await AdBlockGroupsManager.shared.didUpdateCustomScriptlets()
+  }
+
+  /// Delete the saved custom scriptlet with the given name and, update engine resources and clear the
+  /// engine caches so it is no longer available
+  func deleteCustomScriptlet(named name: String) async throws {
+    guard CustomScriptlet.isValidName(name) else {
+      throw CustomScriptletError.invalidName
+    }
+
+    let fileURL = try customScriptletsFolderURL().appending(path: name)
+    guard await AsyncFileManager.default.fileExists(atPath: fileURL.path) else { return }
+    try await AsyncFileManager.default.removeItem(at: fileURL)
+    customScriptlets.removeAll(where: { $0.name == name })
+    await AdBlockGroupsManager.shared.didUpdateCustomScriptlets()
+  }
+
+  /// Get or create the folder that stores the custom scriptlets
+  private func getOrCreateCustomScriptletsFolder() async throws -> URL {
+    try await AsyncFileManager.default.url(
+      for: .applicationSupportDirectory,
+      appending: "custom_rules/scriptlets",
+      create: true
+    )
   }
 
   /// Load the custom exclusion rules (rules to be removed from AdBlockEngine &

--- a/ios/brave-ios/Sources/Brave/WebFilters/CustomFilterListStorage.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/CustomFilterListStorage.swift
@@ -46,6 +46,8 @@ struct CustomScriptlet: Identifiable, Hashable {
     case invalidName
     /// The scriptlet has no javascript
     case emptyContent
+    /// Failed to save the custom scriptlet
+    case failedToSave
 
     var errorDescription: String? {
       switch self {
@@ -57,6 +59,8 @@ struct CustomScriptlet: Identifiable, Hashable {
         )
       case .emptyContent:
         return Strings.Shields.customScriptletEmptyContentError
+      case .failedToSave:
+        return Strings.Shields.customScriptletFailedToSaveError
       }
     }
   }
@@ -313,10 +317,17 @@ struct CustomScriptlet: Identifiable, Hashable {
   }
 
   /// Save the given custom scriptlet, update engine resources and clear the
-  /// engine caches so it takes effect.
-  ///
-  /// An existing scriptlet with the same name is replaced.
-  public func save(customScriptlet: CustomScriptlet) async throws {
+  /// engine caches so it takes effect. Removes previous scriptlet, but doesn't
+  /// throw if failing to remove, only save failures.
+  /// - parameter customScriptlet: The CustomScriptlet to save
+  /// - parameter previousName: The previous name of the scriptlet (if
+  /// renaming) to remove when saving
+  public func save(
+    customScriptlet: CustomScriptlet,
+    replacing previousName: String? = nil
+  )
+    async throws
+  {
     guard CustomScriptlet.isValidName(customScriptlet.name) else {
       throw CustomScriptletError.invalidName
     }
@@ -330,14 +341,36 @@ struct CustomScriptlet: Identifiable, Hashable {
       try await AsyncFileManager.default.removeItem(at: fileURL)
     }
     _ = try await getOrCreateCustomScriptletsFolder()
-    await AsyncFileManager.default.createUTF8File(
+    let savedSuccessfully = await AsyncFileManager.default.createUTF8File(
       atPath: fileURL.path,
       contents: customScriptlet.content
     )
 
+    if let previousName, previousName != customScriptlet.name,
+      CustomScriptlet.isValidName(previousName)
+    {
+      let previousFileURL = folderURL.appending(path: previousName)
+      do {
+        if await AsyncFileManager.default.fileExists(atPath: previousFileURL.path) {
+          try await AsyncFileManager.default.removeItem(at: previousFileURL)
+        }
+        // Only remove if successful above so it reflects what's found on disk
+        customScriptlets.removeAll(where: { $0.name == previousName })
+      } catch {
+        ContentBlockerManager.log.error(
+          "Failed to remove renamed custom scriptlet `\(previousName)`: \(error.localizedDescription)"
+        )
+      }
+    }
+
     customScriptlets.removeAll(where: { $0.name == customScriptlet.name })
     customScriptlets.append(customScriptlet)
     customScriptlets.sort(by: { $0.name < $1.name })
+    if !savedSuccessfully {
+      // Throw after updating `customScriptlets` as the existing scriptlet
+      // was already removed
+      throw CustomScriptletError.emptyContent
+    }
     await AdBlockGroupsManager.shared.didUpdateCustomScriptlets()
   }
 

--- a/ios/brave-ios/Sources/Brave/WebFilters/CustomFilterListStorage.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/CustomFilterListStorage.swift
@@ -29,7 +29,7 @@ struct CustomScriptlet: Identifiable, Hashable {
   /// Tells us if the given name is a valid scriptlet name.
   ///
   /// A valid name is prefixed with `user-`, suffixed with `.js` and is safe to use as a
-  /// file name (i.e. only contains `[a-zA-Z0-9_\-.]` and no relative path components).
+  /// file name (i.e. only contains `[a-zA-Z0-9_-.]` and no relative path components).
   static func isValidName(_ name: String) -> Bool {
     guard name.hasPrefix(namePrefix), name.hasSuffix(nameExtension) else { return false }
     // Ensure there is something between the prefix and the extension

--- a/ios/brave-ios/Sources/Brave/WebFilters/CustomFilterListStorage.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/CustomFilterListStorage.swift
@@ -29,12 +29,18 @@ struct CustomScriptlet: Identifiable, Hashable {
   /// Tells us if the given name is a valid scriptlet name.
   ///
   /// A valid name is prefixed with `user-`, suffixed with `.js` and is safe to use as a
-  /// file name (i.e. contains no path separators or relative path components).
+  /// file name (i.e. only contains `[a-zA-Z0-9_\-.]` and no relative path components).
   static func isValidName(_ name: String) -> Bool {
     guard name.hasPrefix(namePrefix), name.hasSuffix(nameExtension) else { return false }
     // Ensure there is something between the prefix and the extension
     guard name.count > namePrefix.count + nameExtension.count else { return false }
-    guard !name.contains("/"), !name.contains(":"), !name.contains("..") else { return false }
+    // Intentionally not using `CharacterSet.alphanumerics` which includes
+    // unicode for filenames.
+    let allowed = CharacterSet(
+      charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-."
+    )
+    guard name.unicodeScalars.allSatisfy(allowed.contains) else { return false }
+    guard !name.contains("..") else { return false }
     return true
   }
 }

--- a/ios/brave-ios/Sources/Brave/WebFilters/FilterListResourceDownloader.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/FilterListResourceDownloader.swift
@@ -30,10 +30,10 @@ import os.log
   init() {}
 
   /// Start the adblock service to get adblock file updates
-  public func start(with adBlockService: AdblockService) {
+  public func start(with adBlockService: AdblockService) async {
     if let resourcesPath = adBlockService.resourcesPath {
       // Do an initial load of resources
-      AdBlockGroupsManager.shared.didUpdateResourcesComponent(
+      await AdBlockGroupsManager.shared.didUpdateResourcesComponent(
         resourcesFileURL: resourcesPath
       )
     }
@@ -45,7 +45,7 @@ import os.log
   private func subscribeToResourceChanges(with adBlockService: AdblockService) {
     Task {
       for await resourcesFileURL in adBlockService.resourcesComponentStream() {
-        AdBlockGroupsManager.shared.didUpdateResourcesComponent(
+        await AdBlockGroupsManager.shared.didUpdateResourcesComponent(
           resourcesFileURL: resourcesFileURL
         )
       }

--- a/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
@@ -791,6 +791,25 @@ extension Strings.Shields {
     comment:
       "An error message telling the user that a rule is invalid"
   )
+  /// An error message telling the user that a scriptlet's name is invalid
+  public static let customScriptletInvalidNameError = NSLocalizedString(
+    "CustomScriptletInvalidNameError",
+    tableName: "BraveShared",
+    bundle: .module,
+    value:
+      "Invalid scriptlet name",
+    comment:
+      "An error message telling the user that the name they gave their custom scriptlet is invalid."
+  )
+  /// An error message telling the user that a scriptlet has no content
+  public static let customScriptletEmptyContentError = NSLocalizedString(
+    "CustomScriptletEmptyContentError",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "The scriptlet must contain some javascript",
+    comment:
+      "An error message telling the user that the custom scriptlet they are trying to save has no content"
+  )
 }
 
 // MARK: - Custom scriptlets

--- a/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
@@ -793,6 +793,54 @@ extension Strings.Shields {
   )
 }
 
+// MARK: - Custom scriptlets
+
+extension Strings.Shields {
+  /// A navigation title for the screen where a user creates a new custom scriptlet
+  public static let addNewScriptletTitle = NSLocalizedString(
+    "shields.addNewScriptletTitle",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Add New Scriptlet",
+    comment: "A navigation title for the screen where a user creates a new custom scriptlet"
+  )
+  /// A navigation title for the screen where a user edits an existing custom scriptlet
+  public static let editScriptletTitle = NSLocalizedString(
+    "shields.editScriptletTitle",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Edit Scriptlet",
+    comment: "A navigation title for the screen where a user edits an existing custom scriptlet"
+  )
+  /// A section header above the text field where a user enters the custom scriptlet's name
+  public static let customScriptletNameSectionTitle = NSLocalizedString(
+    "shields.customScriptletNameSectionTitle",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Name",
+    comment:
+      "A section header above the text field where a user enters the custom scriptlet's name"
+  )
+  /// A section header above the text editor where a user enters the custom scriptlet's JavaScript
+  public static let customScriptletContentSectionTitle = NSLocalizedString(
+    "shields.customScriptletContentSectionTitle",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Content",
+    comment:
+      "A section header above the text editor where a user enters the custom scriptlet's JavaScript"
+  )
+  /// A warning shown in an empty custom scriptlet editor
+  public static let customScriptletContentWarning = NSLocalizedString(
+    "shields.customScriptletContentWarning",
+    tableName: "BraveShared",
+    bundle: .module,
+    value:
+      "Don’t paste code here that you don’t understand or haven’t reviewed yourself. This could allow attackers to steal your identity or take control of your computer.",
+    comment: "A warning shown in an empty custom scriptlet editor"
+  )
+}
+
 // MARK: - HTTPS Upgrades
 
 extension Strings.Shields {

--- a/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
@@ -726,6 +726,54 @@ extension Strings.Shields {
   )
 }
 
+// MARK: - Custom scriptlets
+
+extension Strings.Shields {
+  /// A navigation title for the screen where a user creates a new custom scriptlet
+  public static let addNewScriptletTitle = NSLocalizedString(
+    "shields.addNewScriptletTitle",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Add New Scriptlet",
+    comment: "A navigation title for the screen where a user creates a new custom scriptlet"
+  )
+  /// A navigation title for the screen where a user edits an existing custom scriptlet
+  public static let editScriptletTitle = NSLocalizedString(
+    "shields.editScriptletTitle",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Edit Scriptlet",
+    comment: "A navigation title for the screen where a user edits an existing custom scriptlet"
+  )
+  /// A section header above the text field where a user enters the custom scriptlet's name
+  public static let customScriptletNameSectionTitle = NSLocalizedString(
+    "shields.customScriptletNameSectionTitle",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Name",
+    comment:
+      "A section header above the text field where a user enters the custom scriptlet's name"
+  )
+  /// A section header above the text editor where a user enters the custom scriptlet's JavaScript
+  public static let customScriptletContentSectionTitle = NSLocalizedString(
+    "shields.customScriptletContentSectionTitle",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Content",
+    comment:
+      "A section header above the text editor where a user enters the custom scriptlet's JavaScript"
+  )
+  /// A warning shown in an empty custom scriptlet editor
+  public static let customScriptletContentWarning = NSLocalizedString(
+    "shields.customScriptletContentWarning",
+    tableName: "BraveShared",
+    bundle: .module,
+    value:
+      "Don’t paste code here that you don’t understand or haven’t reviewed yourself. This could allow attackers to steal your identity or take control of your computer.",
+    comment: "A warning shown in an empty custom scriptlet editor"
+  )
+}
+
 // MARK: - HTTPS Upgrades
 
 extension Strings.Shields {

--- a/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
@@ -743,6 +743,14 @@ extension Strings.Shields {
     comment:
       "An error message telling the user that the custom scriptlet they are trying to save has no content"
   )
+  /// An error message telling the user that a scriptlet has no content
+  public static let customScriptletFailedToSaveError = NSLocalizedString(
+    "customScriptletFailedToSaveError",
+    bundle: .module,
+    value: "Failed to save custom scriptlet",
+    comment:
+      "An error message telling the user that the custom scriptlet failed to save to disk"
+  )
 }
 
 // MARK: - Custom scriptlets

--- a/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
@@ -788,7 +788,7 @@ extension Strings.Shields {
     tableName: "BraveShared",
     bundle: .module,
     value:
-      "Don’t paste code here that you don’t understand or haven’t reviewed yourself. This could allow attackers to steal your identity or take control of your computer.",
+      "Don’t paste code here that you don’t understand or haven’t reviewed yourself. This could allow attackers to steal your identity or take control of your device.",
     comment: "A warning shown in an empty custom scriptlet editor"
   )
 }

--- a/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
@@ -724,6 +724,25 @@ extension Strings.Shields {
     comment:
       "An error message telling the user that a rule is invalid"
   )
+  /// An error message telling the user that a scriptlet's name is invalid
+  public static let customScriptletInvalidNameError = NSLocalizedString(
+    "CustomScriptletInvalidNameError",
+    tableName: "BraveShared",
+    bundle: .module,
+    value:
+      "Invalid scriptlet name",
+    comment:
+      "An error message telling the user that the name they gave their custom scriptlet is invalid."
+  )
+  /// An error message telling the user that a scriptlet has no content
+  public static let customScriptletEmptyContentError = NSLocalizedString(
+    "CustomScriptletEmptyContentError",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "The scriptlet must contain some javascript",
+    comment:
+      "An error message telling the user that the custom scriptlet they are trying to save has no content"
+  )
 }
 
 // MARK: - Custom scriptlets


### PR DESCRIPTION
- Early support for custom scriptlets on iOS for use by our filter list team, in QA / Developer Options menu only. 
    - The full user-facing support will land via https://github.com/brave/brave-browser/issues/53511 after refactoring for iOS to share the existing desktop custom scriptlet / resource provider.

- Resolves https://github.com/brave/brave-browser/issues/57847

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->


### Testplan

1. Enable Developer Options if needed, behind QA passcode in settings
2. Scroll to `Adblock Debugger` row and open detail page
3. In the `Custom Scriptlets` section, tap `Add Custom Scriptlet`
4. Enter a custom scriptlet you'd like to use for testing. 
    - Here's one to set body text colour to red:
    
```
window.addEventListener("DOMContentLoaded", function() {
    document.body.style.color = "red";
});
```

5. In custom rules, add `<domain>##+js(user-<scriptlet-name>)` as a custom rule (don't include the `.js`)
6. Visit the `domain` from the rule and verify the scriptlet executed (console log would show in macOS Safari Web Inspector)

<img width="300" alt="Custom Scriptlets" src="https://github.com/user-attachments/assets/c393b6bd-73b3-4b95-ab1b-97d8a6c2c6b8" /> | <img width="300" alt="add custom scriptlet" src="https://github.com/user-attachments/assets/b886a19b-0928-45a5-ba8a-4ae501168455" /> | <img width="300" alt="custom filter" src="https://github.com/user-attachments/assets/07212fbe-3e16-4875-ad71-957d4b5672b1" /> |  <img width="300" alt="site" src="https://github.com/user-attachments/assets/096cf635-2157-4886-b13d-3034a11fd1d4" />
--|--|--|--