### PR TITLE
[Wallet]: Sidebar Header Improvements

### DIFF
--- a/browser/ui/webui/brave_wallet/wallet_panel/BUILD.gn
+++ b/browser/ui/webui/brave_wallet/wallet_panel/BUILD.gn
@@ -36,6 +36,8 @@ source_set("wallet_panel") {
     "//brave/components/resources:static_resources_grit",
     "//brave/components/resources:strings_grit",
     "//chrome/browser/ui/browser_window",
+    "//chrome/browser/ui/side_panel",
+    "//chrome/browser/ui/side_panel:side_panel_views_dependent",
     "//chrome/browser/ui/tabs:tab_strip",
     "//chrome/browser/ui/webui",
     "//chrome/browser/ui/webui:favicon_source",

--- a/browser/ui/webui/brave_wallet/wallet_panel/wallet_panel_handler.cc
+++ b/browser/ui/webui/brave_wallet/wallet_panel/wallet_panel_handler.cc
@@ -13,8 +13,14 @@
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/permission_utils.h"
 #include "brave/components/permissions/contexts/brave_wallet_permission_context.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
+#include "chrome/browser/ui/side_panel/side_panel_entry_id.h"
+#include "chrome/browser/ui/side_panel/side_panel_ui.h"
+#include "chrome/browser/ui/webui/webui_embedding_context.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"
+#include "content/public/browser/web_ui.h"
 
 // It's safe to bind the active webcontents when panel is created because
 // the panel will not be shared across tabs.
@@ -41,6 +47,26 @@ void WalletPanelHandler::CloseUI() {
   auto embedder = webui_controller_->embedder();
   if (embedder) {
     embedder->CloseUI();
+  }
+}
+
+void WalletPanelHandler::CloseSidePanel() {
+  content::WebContents* web_contents =
+      webui_controller_->web_ui()->GetWebContents();
+  if (!web_contents) {
+    return;
+  }
+
+  BrowserWindowInterface* browser =
+      webui::GetBrowserWindowInterface(web_contents);
+  if (!browser) {
+    return;
+  }
+
+  SidePanelUI* side_panel_ui = browser->GetFeatures().side_panel_ui();
+  if (side_panel_ui &&
+      side_panel_ui->GetCurrentEntryId() == SidePanelEntryId::kWallet) {
+    side_panel_ui->Close();
   }
 }
 

--- a/browser/ui/webui/brave_wallet/wallet_panel/wallet_panel_handler.h
+++ b/browser/ui/webui/brave_wallet/wallet_panel/wallet_panel_handler.h
@@ -30,6 +30,7 @@ class WalletPanelHandler : public brave_wallet::mojom::PanelHandler {
   // brave_wallet::mojom::PanelHandler:
   void ShowUI() override;
   void CloseUI() override;
+  void CloseSidePanel() override;
   void ConnectToSite(
       const std::vector<std::string>& accounts,
       brave_wallet::mojom::PermissionLifetimeOption option) override;

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -437,6 +437,9 @@ interface PanelHandler {
   // Notify the backend that the dialog should be closed.
   CloseUI();
 
+  // Close the Wallet Chromium side panel (not the popup bubble panel).
+  CloseSidePanel();
+
   ConnectToSite(array<string> accounts, PermissionLifetimeOption option);
 
   CancelConnectToSite();

--- a/components/brave_wallet_ui/common/slices/api.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api.slice.ts
@@ -104,6 +104,13 @@ export function createWalletApi() {
               return { data: true }
             },
           }),
+          closeSidePanelUI: mutation<boolean, void>({
+            queryFn(arg, api, extraOptions, baseQuery) {
+              const { panelHandler } = baseQuery(undefined).data
+              panelHandler?.closeSidePanel()
+              return { data: true }
+            },
+          }),
         }),
       })
       // Wallet management endpoints
@@ -175,6 +182,7 @@ export const {
   useCancelTransactionMutation,
   useCheckExternalWalletPasswordMutation,
   useClosePanelUIMutation,
+  useCloseSidePanelUIMutation,
   useCompleteWalletBackupMutation,
   useConnectToSiteMutation,
   useCreateWalletMutation,

--- a/components/brave_wallet_ui/components/desktop/card-headers/default-panel-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/default-panel-header.tsx
@@ -24,6 +24,7 @@ import { WalletRoutes } from '../../../constants/types'
 
 // Utils
 import { openWalletRouteTab } from '../../../utils/routes-utils'
+import { getLocale } from '../../../../common/locale'
 
 // Components
 import { WalletSettingsMenu } from '../wallet-menus/wallet_settings_menu'
@@ -32,13 +33,16 @@ import { WalletSettingsMenu } from '../wallet-menus/wallet_settings_menu'
 import {
   Button,
   ButtonIcon,
+  SidePanelIcon,
   LeftRightContainer,
+  SidePanelWrapper,
 } from './shared-panel-headers.style'
 import { HeaderTitle } from './shared-card-headers.style'
-import { Row } from '../../shared/style'
+import { Row, Text, HorizontalDivider } from '../../shared/style'
+import { useCloseSidePanelUIMutation } from '../../../common/slices/api.slice'
 
 interface Props {
-  title: string
+  title?: string
   expandRoute?: WalletRoutes
   actionIconName?: string
   onClickActionButton?: () => void
@@ -57,6 +61,9 @@ export const DefaultPanelHeader = (props: Props) => {
     false,
   )
 
+  // Mutations
+  const [closeSidePanelUI] = useCloseSidePanelUIMutation()
+
   // Methods
   const onClickToggleNav = React.useCallback(() => {
     setIsNavOpen((prev) => !prev)
@@ -70,6 +77,71 @@ export const DefaultPanelHeader = (props: Props) => {
     openWalletRouteTab(WalletRoutes.PortfolioAssets)
   }, [expandRoute])
 
+  const onClickClose = React.useCallback(() => {
+    closeSidePanelUI()
+  }, [closeSidePanelUI])
+
+  if (isSidePanel) {
+    return (
+      <SidePanelWrapper
+        padding='16px'
+        justifyContent='space-between'
+      >
+        <LeftRightContainer
+          width='unset'
+          justifyContent='flex-start'
+          gap='12px'
+        >
+          <Button onClick={onClickToggleNav}>
+            <SidePanelIcon name='hamburger-menu' />
+          </Button>
+          <Text
+            variant='heading.h4'
+            textColor='primary'
+          >
+            {getLocale('braveWalletTitle')}
+          </Text>
+          {title && (
+            <>
+              <HorizontalDivider />
+              <Text
+                variant='heading.h4'
+                textColor='secondary'
+              >
+                {title}
+              </Text>
+            </>
+          )}
+        </LeftRightContainer>
+        <LeftRightContainer
+          width='unset'
+          justifyContent='flex-end'
+          gap='12px'
+        >
+          {expandRoute && (
+            <Button onClick={onClickExpand}>
+              <SidePanelIcon name='expand' />
+            </Button>
+          )}
+          {actionIconName && onClickActionButton && (
+            <Button onClick={onClickActionButton}>
+              <SidePanelIcon name={actionIconName} />
+            </Button>
+          )}
+          <WalletSettingsMenu>
+            <Button slot='anchor-content'>
+              <SidePanelIcon name='more-vertical' />
+            </Button>
+          </WalletSettingsMenu>
+          <HorizontalDivider />
+          <Button onClick={onClickClose}>
+            <SidePanelIcon name='close' />
+          </Button>
+        </LeftRightContainer>
+      </SidePanelWrapper>
+    )
+  }
+
   return (
     <Row
       padding='16px'
@@ -79,23 +151,20 @@ export const DefaultPanelHeader = (props: Props) => {
         width='unset'
         justifyContent='flex-start'
       >
-        {!isMobile && expandRoute && !isSidePanel && (
+        {!isMobile && expandRoute && (
           <Button onClick={onClickExpand}>
             <ButtonIcon name='expand' />
           </Button>
         )}
-        {isSidePanel && (
-          <Button onClick={onClickToggleNav}>
-            <ButtonIcon name='hamburger-menu' />
-          </Button>
-        )}
       </LeftRightContainer>
-      <HeaderTitle
-        variant='large.semibold'
-        textColor='primary'
-      >
-        {title}
-      </HeaderTitle>
+      {title && (
+        <HeaderTitle
+          variant='large.semibold'
+          textColor='primary'
+        >
+          {title}
+        </HeaderTitle>
+      )}
       <LeftRightContainer
         width='unset'
         justifyContent='flex-end'

--- a/components/brave_wallet_ui/components/desktop/card-headers/shared-panel-headers.style.ts
+++ b/components/brave_wallet_ui/components/desktop/card-headers/shared-panel-headers.style.ts
@@ -25,6 +25,15 @@ export const ButtonIcon = styled(Icon)`
   color: ${leo.color.icon.default};
 `
 
+export const SidePanelWrapper = styled(Row)`
+  background-color: ${leo.color.page.background};
+`
+
+export const SidePanelIcon = styled(Icon)`
+  --leo-icon-size: 20px;
+  color: ${leo.color.icon.default};
+`
+
 export const LeftRightContainer = styled(Row)`
   min-width: 35%;
 `

--- a/components/brave_wallet_ui/components/shared/style.tsx
+++ b/components/brave_wallet_ui/components/shared/style.tsx
@@ -539,6 +539,14 @@ export const VerticalDivider = styled.div<{ margin?: string }>`
   margin: ${(p) => p.margin || 0};
 `
 
+export const HorizontalDivider = styled.div`
+  flex-shrink: 0;
+  align-self: stretch;
+  min-width: 2px;
+  width: 2px;
+  background-color: ${leo.color.divider.subtle};
+`
+
 export const BraveRewardsIndicator = styled.div`
   font: ${leo.font.xSmall.regular};
 

--- a/components/brave_wallet_ui/page/screens/fund-wallet/deposit-funds.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/deposit-funds.tsx
@@ -114,6 +114,9 @@ import { Skeleton } from '../../../components/shared/loading-skeleton/styles'
 import {
   PanelActionHeader, //
 } from '../../../components/desktop/card-headers/panel-action-header'
+import {
+  DefaultPanelHeader, //
+} from '../../../components/desktop/card-headers/default-panel-header'
 
 const zcashAddressOptions: zcashAddressOptionType[] = [
   {
@@ -141,6 +144,7 @@ export const DepositFundsScreen = () => {
   // Selectors
   const isPanel = useSafeUISelector(UISelectors.isPanel)
   const isMobile = useSafeUISelector(UISelectors.isMobile)
+  const isSidePanel = useSafeUISelector(UISelectors.isSidePanel)
   const isMobileOrPanel = isMobile || isPanel
 
   // render
@@ -151,10 +155,16 @@ export const DepositFundsScreen = () => {
         exact
       >
         <WalletPageWrapper
-          hideNav={isMobileOrPanel}
+          hideNav={!isSidePanel && isMobileOrPanel}
           wrapContentInBox={true}
+          useCardInPanel={true}
           cardHeader={
-            isMobileOrPanel ? (
+            isSidePanel ? (
+              <DefaultPanelHeader
+                expandRoute={WalletRoutes.DepositFundsPage}
+                title={getLocale('braveWalletDepositCryptoButton')}
+              />
+            ) : isMobileOrPanel ? (
               <PanelActionHeader
                 title={getLocale('braveWalletDepositCryptoButton')}
                 expandRoute={WalletRoutes.DepositFundsPage}
@@ -175,11 +185,17 @@ export const DepositFundsScreen = () => {
 
       <Route path={WalletRoutes.DepositFundsPage}>
         <WalletPageWrapper
-          hideNav={isMobileOrPanel}
+          hideNav={!isSidePanel && isMobileOrPanel}
           wrapContentInBox={true}
+          useCardInPanel={true}
           useFullHeight={true}
           cardHeader={
-            isMobileOrPanel ? (
+            isSidePanel ? (
+              <DefaultPanelHeader
+                expandRoute={WalletRoutes.DepositFundsPage}
+                title={getLocale('braveWalletDepositCryptoButton')}
+              />
+            ) : isMobileOrPanel ? (
               <PanelActionHeader
                 title={getLocale('braveWalletDepositCryptoButton')}
                 expandRoute={WalletRoutes.DepositFundsPage}

--- a/components/brave_wallet_ui/page/screens/fund-wallet/fund_wallet_v2.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/fund_wallet_v2.tsx
@@ -33,6 +33,9 @@ import {
   PanelActionHeader, //
 } from '../../../components/desktop/card-headers/panel-action-header'
 import {
+  DefaultPanelHeader, //
+} from '../../../components/desktop/card-headers/default-panel-header'
+import {
   SelectAssetButton, //
 } from './components/select_asset_button/select_asset_button'
 import {
@@ -112,6 +115,7 @@ export const FundWalletScreen = () => {
   // Redux
   const isPanel = useSafeUISelector(UISelectors.isPanel)
   const isMobile = useSafeUISelector(UISelectors.isMobile)
+  const isSidePanel = useSafeUISelector(UISelectors.isSidePanel)
   const isMobileOrPanel = isMobile || isPanel
 
   // Computed
@@ -131,10 +135,16 @@ export const FundWalletScreen = () => {
     <>
       <WalletPageWrapper
         wrapContentInBox={true}
-        hideNav={isMobileOrPanel}
+        useCardInPanel={true}
+        hideNav={!isSidePanel && isMobileOrPanel}
         hideHeader={isMobileOrPanel}
         cardHeader={
-          isMobileOrPanel ? (
+          isSidePanel ? (
+            <DefaultPanelHeader
+              expandRoute={WalletRoutes.FundWalletPageStart}
+              title={pageTitle}
+            />
+          ) : isMobileOrPanel ? (
             <PanelActionHeader
               title={pageTitle}
               expandRoute={WalletRoutes.FundWalletPageStart}

--- a/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
+++ b/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
@@ -95,6 +95,9 @@ import {
 } from '../../../../components/desktop/wallet-page-wrapper/wallet-page-wrapper'
 import { FromAsset } from '../../composer_ui/from_asset/from_asset'
 import {
+  DefaultPanelHeader, //
+} from '../../../../components/desktop/card-headers/default-panel-header'
+import {
   PanelActionHeader, //
 } from '../../../../components/desktop/card-headers/panel-action-header'
 import {
@@ -158,6 +161,7 @@ export const SendScreen = React.memo(() => {
   // Selectors
   const isPanel = useSafeUISelector(UISelectors.isPanel)
   const isMobile = useSafeUISelector(UISelectors.isMobile)
+  const isSidePanel = useSafeUISelector(UISelectors.isSidePanel)
   const isMobileOrPanel = isMobile || isPanel
   const isIOS = useSafeUISelector(UISelectors.isIOS)
   const isKeyboardVisible = useIsKeyboardVisible()
@@ -684,9 +688,15 @@ export const SendScreen = React.memo(() => {
       <WalletPageWrapper
         wrapContentInBox={true}
         noCardPadding={true}
-        hideNav={isMobileOrPanel}
+        useCardInPanel={true}
+        hideNav={!isSidePanel && isMobileOrPanel}
         cardHeader={
-          isMobileOrPanel ? (
+          isSidePanel ? (
+            <DefaultPanelHeader
+              expandRoute={WalletRoutes.Send}
+              title={getLocale('braveWalletSend')}
+            />
+          ) : isMobileOrPanel ? (
             <PanelActionHeader
               title={getLocale('braveWalletSend')}
               expandRoute={WalletRoutes.Send}

--- a/components/brave_wallet_ui/page/screens/swap/swap.tsx
+++ b/components/brave_wallet_ui/page/screens/swap/swap.tsx
@@ -36,6 +36,7 @@ import { QuoteInfo } from './components/swap/quote-info/quote-info'
 import { PrivacyModal } from './components/swap/privacy-modal/privacy-modal'
 import { ComposerControls } from '../composer_ui/composer_controls/composer_controls'
 import WalletPageWrapper from '../../../components/desktop/wallet-page-wrapper/wallet-page-wrapper'
+import { DefaultPanelHeader } from '../../../components/desktop/card-headers/default-panel-header'
 import { PanelActionHeader } from '../../../components/desktop/card-headers/panel-action-header'
 import { SwapProviders } from './components/swap/swap_providers/swap_providers'
 import {
@@ -106,6 +107,7 @@ export const Swap = () => {
   // Selectors
   const isPanel = useSafeUISelector(UISelectors.isPanel)
   const isMobile = useSafeUISelector(UISelectors.isMobile)
+  const isSidePanel = useSafeUISelector(UISelectors.isSidePanel)
   const isMobileOrPanel = isMobile || isPanel
   const isIOS = useSafeUISelector(UISelectors.isIOS)
   const isKeyboardVisible = useIsKeyboardVisible()
@@ -140,22 +142,28 @@ export const Swap = () => {
     ? undefined
     : getDominantColorFromImageURL(toToken?.logo ?? '')
 
+  const title = isBridge
+    ? getLocale('braveWalletBridge')
+    : getLocale('braveWalletSwap')
+
   // render
   return (
     <>
       <WalletPageWrapper
         wrapContentInBox={true}
+        useCardInPanel={true}
         noCardPadding={true}
         noMinCardHeight={true}
-        hideNav={isMobileOrPanel}
+        hideNav={!isSidePanel && isMobileOrPanel}
         cardHeader={
-          isMobileOrPanel ? (
+          isSidePanel ? (
+            <DefaultPanelHeader
+              expandRoute={isBridge ? WalletRoutes.Bridge : WalletRoutes.Swap}
+              title={title}
+            />
+          ) : isMobileOrPanel ? (
             <PanelActionHeader
-              title={
-                isBridge
-                  ? getLocale('braveWalletBridge')
-                  : getLocale('braveWalletSwap')
-              }
+              title={title}
               expandRoute={isBridge ? WalletRoutes.Bridge : WalletRoutes.Swap}
             />
           ) : undefined


### PR DESCRIPTION
## Description 

Makes some improvements to the Wallet Sidebar `Header`

- Header now has a `Wallet` title
- Header now has a `Close` button to close the `Sidebar`
- Header was added to the `Buy, Send, Swap, Bride and Deposit` pages
- Now has a divider between `Menu` and `Close` buttons
- Now includes an `Expand` button.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/57957>

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

<img width="438" height="249" alt="Screenshot 38" src="https://github.com/user-attachments/assets/ee4a975e-a141-4857-86fe-7491b1c397a0" />


https://github.com/user-attachments/assets/f50a4bd7-4b46-42d9-8774-d95127a69fc4

