### PR TITLE
Add succinctness convention to agent instructions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,6 +6,11 @@ All files in this src/brave directory are for Brave customizations. The chromium
 repository is the parent directory at src/ and all other children of that
 directory.
 
+## Conventions
+
+- Keep comments, commit messages, and PR descriptions succinct — essential "why"
+  only.
+
 ## Development Tasks
 
 When asked to explore a task, read only the docs that you need from docs/ using


### PR DESCRIPTION
## Summary

Adds a convention to `.claude/CLAUDE.md` (the canonical agent instructions referenced by `AGENTS.md`) to keep comments, commit messages, and PR descriptions succinct — essential "why" only.

## Why

Reduces noise in generated comments and messages, keeping them focused on the reasoning that matters.