### PR TITLE
Expand ARCH-003 best practice to cover Profile-as-service-handle

### DIFF
--- a/docs/best-practices/architecture.md
+++ b/docs/best-practices/architecture.md
@@ -101,12 +101,34 @@ void MyComponent::Init(PrefService* prefs) {
 }
 ```
 
+This also applies when an object is passed in only to look up another service
+from it. If a class holds a `Profile*` solely to call
+`SomeService::Get(profile)`, inject the service instead — the class doesn't
+depend on `Profile`, only on the service.
+
+```cpp
+// ❌ WRONG - holding Profile only to fetch another service
+BraveExtensionService::BraveExtensionService(Profile* profile)
+    : profile_(profile) {}
+
+void BraveExtensionService::OnMalwareListUpdated() {
+  ExtensionSystem* extension_system = ExtensionSystem::Get(profile_);
+  // ...only ever used to reach extension_system
+}
+
+// ✅ CORRECT - inject the service actually needed
+BraveExtensionService::BraveExtensionService(ExtensionSystem* extension_system)
+    : extension_system_(extension_system) {}
+```
+
 Common substitutions:
 
 - `Profile*` → `PrefService*` (when only prefs are needed)
 - `Profile*` → `BrowserContext*` (in components)
 - `BrowserContext*` → `scoped_refptr<URLLoaderFactory>` (when only network is
   needed)
+- `Profile*` → the specific service you fetch (e.g. `ExtensionSystem*`), when
+  `Profile` is used only as a lookup handle for that service
 
 ---
 


### PR DESCRIPTION
## Summary

Expands the ARCH-003 best practice (*Pass the Most Specific Dependency*) to cover the case where a class holds a `Profile*` only to look up another service via `SomeService::Get(profile)`. In that case the class depends on the service, not the `Profile`, and should inject the service directly.

Motivated by review feedback on brave/brave-core#38658, where `BraveExtensionService` took a `Profile*` solely to reach `ExtensionSystem`. The existing rule covered this in spirit, but its concrete substitution examples only listed `Profile → PrefService/BrowserContext`, so the "used only to fetch another service" case didn't trigger a best-practices match.

## Changes

- New BAD/GOOD example showing `Profile*` → `ExtensionSystem*` injection.
- Added the substitution to the "Common substitutions" list.

## Test plan

- Docs-only change. Rendered markdown reviewed for formatting.