### PR TITLE
Add extension malware blocklist feature flag

### DIFF
--- a/browser/DEPS
+++ b/browser/DEPS
@@ -96,6 +96,7 @@ include_rules += [
   "+brave/components/brave_referrals/browser",
   "+brave/components/https_upgrade_exceptions/browser",
   "+brave/components/brave_user_agent/browser",
+  "+brave/components/extension_malware_blocklist/common",
   "+brave/components/localhost_permission",
   "+brave/components/url_sanitizer/core/browser",
   "+brave/components/body_sniffer",

--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -26,6 +26,7 @@
 #include "brave/components/de_amp/common/features.h"
 #include "brave/components/debounce/core/common/features.h"
 #include "brave/components/email_aliases/buildflags/buildflags.h"
+#include "brave/components/extension_malware_blocklist/common/features.h"
 #include "brave/components/google_sign_in_permission/features.h"
 #include "brave/components/local_ai/buildflags/buildflags.h"
 #include "brave/components/ntp_background_images/browser/features.h"
@@ -809,6 +810,20 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
               extensions::features::kBraveAutoUpdateExtensions),               \
       }))
 
+#define BRAVE_EXTENSION_MALWARE_BLOCKLIST_FEATURE_ENTRY                    \
+  IF_BUILDFLAG(                                                            \
+      ENABLE_EXTENSIONS,                                                   \
+      EXPAND_FEATURE_ENTRIES({                                             \
+          "brave-extension-malware-blocklist",                             \
+          "Enhanced malicious extension blocking",                         \
+          "Also turns off extensions flagged on Brave's own "              \
+          "malicious-extension list, in addition to the extensions Brave " \
+          "already blocks.",                                               \
+          kOsWin | kOsLinux | kOsMac,                                      \
+          FEATURE_VALUE_TYPE(extension_malware_blocklist::features::       \
+                                 kExtensionMalwareBlocklist),              \
+      }))
+
 #if BUILDFLAG(ENABLE_BRAVE_EDUCATION)
 #define BRAVE_EDUCATION_FEATURE_ENTRIES                                       \
   EXPAND_FEATURE_ENTRIES({                                                    \
@@ -1490,6 +1505,7 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
   BRAVE_UPGRADE_WHEN_IDLE_FEATURE_ENTRY                                        \
   BRAVE_EXTENSIONS_MANIFEST_V2                                                 \
   BRAVE_EXTENSION_AUTO_UPDATE_FEATURE_ENTRY                                    \
+  BRAVE_EXTENSION_MALWARE_BLOCKLIST_FEATURE_ENTRY                              \
   BRAVE_WORKAROUND_NEW_WINDOW_FLASH                                            \
   BRAVE_WEBASSEMBLY_JITLESS_FEATURE_ENTRY                                      \
   BRAVE_EDUCATION_FEATURE_ENTRIES                                              \

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -220,6 +220,7 @@ brave_chrome_browser_deps = [
   "//brave/components/de_amp/common",
   "//brave/components/debounce/content/browser",
   "//brave/components/email_aliases/buildflags",
+  "//brave/components/extension_malware_blocklist/common",
   "//brave/components/global_privacy_control",
   "//brave/components/google_sign_in_permission",
   "//brave/components/https_upgrade_exceptions/browser",

--- a/components/extension_malware_blocklist/common/BUILD.gn
+++ b/components/extension_malware_blocklist/common/BUILD.gn
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+component("common") {
+  output_name = "extension_malware_blocklist_common"
+  defines = [ "IS_EXTENSION_MALWARE_BLOCKLIST_COMMON_IMPL" ]
+
+  sources = [
+    "features.cc",
+    "features.h",
+  ]
+  deps = [ "//base" ]
+}

--- a/components/extension_malware_blocklist/common/features.cc
+++ b/components/extension_malware_blocklist/common/features.cc
@@ -7,13 +7,11 @@
 
 #include "base/feature_list.h"
 
-namespace extension_malware_blocklist {
-namespace features {
+namespace extension_malware_blocklist::features {
 
 // Treat extensions on the Brave-distributed malicious-extension list as Safe
 // Browsing malware. Start disabled so rollout can begin on Nightly/Beta before
 // release.
 BASE_FEATURE(kExtensionMalwareBlocklist, base::FEATURE_DISABLED_BY_DEFAULT);
 
-}  // namespace features
-}  // namespace extension_malware_blocklist
+}  // namespace extension_malware_blocklist::features

--- a/components/extension_malware_blocklist/common/features.cc
+++ b/components/extension_malware_blocklist/common/features.cc
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/extension_malware_blocklist/common/features.h"
+
+#include "base/feature_list.h"
+
+namespace extension_malware_blocklist {
+namespace features {
+
+// Treat extensions on the Brave-distributed malicious-extension list as Safe
+// Browsing malware. Start disabled so rollout can begin on Nightly/Beta before
+// release.
+BASE_FEATURE(kExtensionMalwareBlocklist, base::FEATURE_DISABLED_BY_DEFAULT);
+
+}  // namespace features
+}  // namespace extension_malware_blocklist

--- a/components/extension_malware_blocklist/common/features.h
+++ b/components/extension_malware_blocklist/common/features.h
@@ -9,13 +9,11 @@
 #include "base/component_export.h"
 #include "base/feature_list.h"
 
-namespace extension_malware_blocklist {
-namespace features {
+namespace extension_malware_blocklist::features {
 
 COMPONENT_EXPORT(EXTENSION_MALWARE_BLOCKLIST_COMMON)
 BASE_DECLARE_FEATURE(kExtensionMalwareBlocklist);
 
-}  // namespace features
-}  // namespace extension_malware_blocklist
+}  // namespace extension_malware_blocklist::features
 
 #endif  // BRAVE_COMPONENTS_EXTENSION_MALWARE_BLOCKLIST_COMMON_FEATURES_H_

--- a/components/extension_malware_blocklist/common/features.h
+++ b/components/extension_malware_blocklist/common/features.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_EXTENSION_MALWARE_BLOCKLIST_COMMON_FEATURES_H_
+#define BRAVE_COMPONENTS_EXTENSION_MALWARE_BLOCKLIST_COMMON_FEATURES_H_
+
+#include "base/component_export.h"
+#include "base/feature_list.h"
+
+namespace extension_malware_blocklist {
+namespace features {
+
+COMPONENT_EXPORT(EXTENSION_MALWARE_BLOCKLIST_COMMON)
+BASE_DECLARE_FEATURE(kExtensionMalwareBlocklist);
+
+}  // namespace features
+}  // namespace extension_malware_blocklist
+
+#endif  // BRAVE_COMPONENTS_EXTENSION_MALWARE_BLOCKLIST_COMMON_FEATURES_H_


### PR DESCRIPTION
Defines the kExtensionMalwareBlocklist feature and its chrome://flags entry. Defaulted off; nothing consumes it yet.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57967

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
