### PR TITLE
Uplift test fixes to 1.94.x

### DIFF
--- a/browser/ephemeral_storage/blob_url_browsertest.cc
+++ b/browser/ephemeral_storage/blob_url_browsertest.cc
@@ -5,26 +5,28 @@
 
 #include <string_view>
 
+#include "base/location.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/scoped_refptr.h"
+#include "base/run_loop.h"
 #include "base/strings/pattern.h"
 #include "base/strings/string_number_conversions.h"
+#include "base/task/single_thread_task_runner.h"
+#include "base/test/test_timeouts.h"
+#include "base/time/time.h"
 #include "brave/browser/ephemeral_storage/ephemeral_storage_browsertest.h"
 #include "brave/components/brave_shields/core/browser/brave_shields_utils.h"
-#include "build/build_config.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/tabs/tab_enums.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/test/base/ui_test_utils.h"
-#include "content/public/browser/browser_thread.h"
 #include "content/public/common/content_switches.h"
 #include "content/public/common/url_constants.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
 #include "content/public/test/test_frame_navigation_observer.h"
 #include "content/public/test/test_navigation_observer.h"
-#include "content/public/test/test_utils.h"
 #include "extensions/buildflags/buildflags.h"
 #include "net/base/features.h"
 #include "net/test/embedded_test_server/embedded_test_server.h"
@@ -71,6 +73,13 @@ constexpr char kFetchBlobViaWorkerScript[] = R"(
   });
 )";
 
+void NonBlockingDelay(base::TimeDelta delay) {
+  base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
+  base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
+      FROM_HERE, run_loop.QuitWhenIdleClosure(), delay);
+  run_loop.Run();
+}
+
 }  // namespace
 
 class BlobUrlBrowserTestBase : public EphemeralStorageBrowserTest {
@@ -88,11 +97,21 @@ class BlobUrlBrowserTestBase : public EphemeralStorageBrowserTest {
                     .ExtractString());
   }
 
+  // Fetches `url` using the Fetch API only. Unlike FetchBlob() the result is
+  // not cross-checked against a fetch from a dedicated worker, which makes this
+  // usable while a blob URL revocation is still in flight and the two fetches
+  // may legitimately disagree.
+  static content::EvalJsResult FetchBlobViaFetchApi(
+      content::RenderFrameHost* render_frame_host,
+      const GURL& url) {
+    return EvalJs(render_frame_host,
+                  content::JsReplace(kFetchBlobScript, url.spec()));
+  }
+
   static content::EvalJsResult FetchBlob(
       content::RenderFrameHost* render_frame_host,
       const GURL& url) {
-    auto fetch_result = EvalJs(
-        render_frame_host, content::JsReplace(kFetchBlobScript, url.spec()));
+    auto fetch_result = FetchBlobViaFetchApi(render_frame_host, url);
     auto fetch_via_webworker_result = EvalJs(
         render_frame_host,
         content::JsReplace(kFetchBlobViaWorkerScript,
@@ -207,14 +226,34 @@ class BlobUrlBrowserTestBase : public EphemeralStorageBrowserTest {
     browser()->tab_strip_model()->CloseWebContentsAt(1,
                                                      TabCloseTypes::CLOSE_NONE);
     EXPECT_EQ(previous_tab_count - 1, browser()->tab_strip_model()->count());
-    // Flush IO thread first: the Mojo associated pipe disconnect for
-    // BlobURLStoreImpl is detected on IO and posted to UI. Then flush
-    // remaining tasks so ~BlobURLStoreImpl runs and removes URL mappings.
-    content::RunAllPendingInMessageLoop(content::BrowserThread::IO);
-    content::RunAllTasksUntilIdle();
+    // Closing the tab destroys its RenderFrameHosts in the browser process
+    // right away, but the blob URL mappings are owned by the browser-side
+    // BlobURLStoreImpl objects, which remove their mappings from
+    // BlobUrlRegistry only when they are destroyed
+    // (BlobURLStoreImpl::~BlobURLStoreImpl). Each of those objects is kept
+    // alive by its mojo receiver, so it is destroyed only after the closed
+    // document is torn down in its renderer, which resets the BlobURLStore
+    // remote, and the resulting pipe disconnect is processed in the browser.
+    // Nothing on the browser side reports that renderer-side teardown, so poll
+    // until the blob URLs actually become unfetchable instead of assuming the
+    // revocation already happened. base::test::RunUntil() can't be used here
+    // because EvalJs() spins a nested run loop (see
+    // docs/best-practices/testing-async.md).
+    const base::TimeTicks deadline =
+        base::TimeTicks::Now() + TestTimeouts::action_max_timeout();
     for (size_t idx = 0; idx < a_com2_registered_blobs.size(); ++idx) {
       auto* rfh = a_com2_registered_blobs[idx].rfh.get();
-      EXPECT_EQ("error", FetchBlob(rfh, a_com_registered_blobs[idx].blob_url));
+      const GURL& blob_url = a_com_registered_blobs[idx].blob_url;
+      SCOPED_TRACE(blob_url.spec());
+      while (FetchBlobViaFetchApi(rfh, blob_url) != "error") {
+        ASSERT_LT(base::TimeTicks::Now(), deadline)
+            << "Timeout waiting for the blob URL of the closed tab to be "
+               "revoked";
+        NonBlockingDelay(base::Milliseconds(10));
+      }
+      // The blob URL is revoked, so it must be unavailable from a dedicated
+      // worker as well.
+      EXPECT_EQ("error", FetchBlob(rfh, blob_url));
     }
 
     // Ensure blobs are navigatable in same iframes.
@@ -231,13 +270,8 @@ class BlobUrlBrowserTestBase : public EphemeralStorageBrowserTest {
 
 using BlobUrlPartitionEnabledBrowserTest = BlobUrlBrowserTestBase;
 
-#if BUILDFLAG(IS_MAC)
-#define MAYBE_BlobsArePartitioned DISABLED_BlobsArePartitioned
-#else
-#define MAYBE_BlobsArePartitioned BlobsArePartitioned
-#endif
 IN_PROC_BROWSER_TEST_F(BlobUrlPartitionEnabledBrowserTest,
-                       MAYBE_BlobsArePartitioned) {
+                       BlobsArePartitioned) {
   TestBlobsArePartitioned();
 }
 
@@ -306,31 +340,18 @@ class BlobUrlPartitionEnabledWithoutSiteIsolationBrowserTest
 };
 
 IN_PROC_BROWSER_TEST_F(BlobUrlPartitionEnabledWithoutSiteIsolationBrowserTest,
-                       MAYBE_BlobsArePartitioned) {
+                       BlobsArePartitioned) {
   TestBlobsArePartitioned();
 }
 
-#if BUILDFLAG(IS_MAC)
-#define MAYBE_BlobsArePartitionedIn1PESMode \
-  DISABLED_BlobsArePartitionedIn1PESMode
-#else
-#define MAYBE_BlobsArePartitionedIn1PESMode BlobsArePartitionedIn1PESMode
-#endif
 IN_PROC_BROWSER_TEST_F(BlobUrlPartitionEnabledBrowserTest,
-                       MAYBE_BlobsArePartitionedIn1PESMode) {
+                       BlobsArePartitionedIn1PESMode) {
   SetCookieSetting(a_site_ephemeral_storage_url_, CONTENT_SETTING_SESSION_ONLY);
   TestBlobsArePartitioned();
 }
 
-#if BUILDFLAG(IS_MAC)
-#define MAYBE_BlobsArePartitionedIn1PESModeForBothSites \
-  DISABLED_BlobsArePartitionedIn1PESModeForBothSites
-#else
-#define MAYBE_BlobsArePartitionedIn1PESModeForBothSites \
-  BlobsArePartitionedIn1PESModeForBothSites
-#endif
 IN_PROC_BROWSER_TEST_F(BlobUrlPartitionEnabledBrowserTest,
-                       MAYBE_BlobsArePartitionedIn1PESModeForBothSites) {
+                       BlobsArePartitionedIn1PESModeForBothSites) {
   SetCookieSetting(a_site_ephemeral_storage_url_, CONTENT_SETTING_SESSION_ONLY);
   SetCookieSetting(b_site_ephemeral_storage_url_, CONTENT_SETTING_SESSION_ONLY);
   TestBlobsArePartitioned();

--- a/browser/sync/network_time_helper_browsertest.cc
+++ b/browser/sync/network_time_helper_browsertest.cc
@@ -10,7 +10,6 @@
 #include "base/test/bind.h"
 #include "base/test/gtest_util.h"
 #include "brave/components/brave_sync/brave_sync_prefs.h"
-#include "build/build_config.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/test/base/platform_browser_test.h"
@@ -94,18 +93,27 @@ IN_PROC_BROWSER_TEST_F(BraveSyncNetworkTimeHelperBrowserTest, DidntCrash) {
   EXPECT_TRUE(true);
 }
 
-using BraveSyncNetworkTimeHelperBrowserDeathTest =
-    BraveSyncNetworkTimeHelperBrowserTest;
+// Deliberately does NOT derive from BraveSyncNetworkTimeHelperBrowserTest: the
+// death test only needs `NetworkTimeHelper`, which is owned by the browser
+// process and is initialized independently of sync, in
+// BraveBrowserProcessImpl::PreMainMessageLoopRun(). Configuring a sync chain
+// here would start the sync engine, whose
+// `HttpBridge::MakeSynchronousPost()` blocks one `MayBlock()` ThreadPool
+// sequence until a second ThreadPool sequence completes the request. Death
+// tests run in the "threadsafe" style, so `EXPECT_DEATH` re-executes the test
+// binary and blocks until that second browser process dies; while it starts
+// up, the sequence that would complete the request can be starved for tens of
+// seconds (~33s in the reported runs). That is long enough for the blocked
+// sync task to exceed `TaskEnvironment`'s 30s `action_max_timeout()` per-task
+// watchdog, which fails this test with "RunTask took more than 30 seconds.
+// Posted from TrySyncCycleJob". The request itself is never slow: browser
+// tests already fail external DNS instantly via content::TestHostResolver.
+// See https://github.com/brave/brave-browser/issues/50706 and
+// https://github.com/brave/brave-browser/issues/57184
+using BraveSyncNetworkTimeHelperBrowserDeathTest = PlatformBrowserTest;
 
-// There is a CI report about this test failure on Windows x64,
-// See https://github.com/brave/brave-browser/issues/50706
-#if BUILDFLAG(IS_WIN) && defined(ARCH_CPU_X86_64)
-#define MAYBE_CrashNoUiTaskRunner DISABLED_CrashNoUiTaskRunner
-#else
-#define MAYBE_CrashNoUiTaskRunner CrashNoUiTaskRunner
-#endif
 IN_PROC_BROWSER_TEST_F(BraveSyncNetworkTimeHelperBrowserDeathTest,
-                       MAYBE_CrashNoUiTaskRunner) {
+                       CrashNoUiTaskRunner) {
   brave_sync::NetworkTimeHelper::GetInstance()->SetNetworkTimeTracker(
       g_browser_process->network_time_tracker(), nullptr);
 

--- a/components/brave_referrals/browser/brave_referrals_service.cc
+++ b/components/brave_referrals/browser/brave_referrals_service.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_referrals/browser/brave_referrals_service.h"
 
+#include <algorithm>
 #include <memory>
 #include <type_traits>
 #include <vector>
@@ -42,6 +43,16 @@
 
 // Perform finalization checks once a day.
 constexpr int kFinalizationChecksFrequency = 60 * 60 * 24;
+
+// Lower bound for the randomized finalization checks interval.
+// `brave_base::random::Geometric()` is supported on nonnegative integers, so it
+// can return 0 (with probability ~1/86400 for a one day period) or a handful of
+// seconds. A zero interval makes the repeating timer refire immediately and
+// forever, spinning the thread it runs on. Finalization checks are separately
+// rate limited to one per 24 hours in MaybeCheckForReferralFinalization(), so
+// clamping the timer interval here does not change how often the referral
+// endpoint is contacted.
+constexpr base::TimeDelta kMinFinalizationChecksInterval = base::Hours(1);
 
 // Report initialization once a day (after initial failure).
 constexpr int kReportInitializationFrequency = 60 * 60 * 24;
@@ -170,7 +181,7 @@ void BraveReferralsService::Start() {
   finalization_checks_timer_ = std::make_unique<base::RepeatingTimer>();
   finalization_checks_timer_->Start(
       FROM_HERE,
-      base::Seconds(
+      GetFinalizationChecksInterval(
           brave_base::random::Geometric(kFinalizationChecksFrequency)),
       this, &BraveReferralsService::OnFinalizationChecksTimerFired);
   DCHECK(finalization_checks_timer_->IsRunning());
@@ -215,6 +226,13 @@ void BraveReferralsService::SetReferralInitializedCallbackForTesting(
 // static
 bool BraveReferralsService::IsDefaultReferralCode(const std::string& code) {
   return code == kDefaultPromoCode;
+}
+
+// static
+base::TimeDelta BraveReferralsService::GetFinalizationChecksInterval(
+    uint64_t random_seconds) {
+  return std::max(kMinFinalizationChecksInterval,
+                  base::Seconds(random_seconds));
 }
 
 void BraveReferralsService::OnFinalizationChecksTimerFired() {

--- a/components/brave_referrals/browser/brave_referrals_service.h
+++ b/components/brave_referrals/browser/brave_referrals_service.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_REFERRALS_BROWSER_BRAVE_REFERRALS_SERVICE_H_
 #define BRAVE_COMPONENTS_BRAVE_REFERRALS_BROWSER_BRAVE_REFERRALS_SERVICE_H_
 
+#include <stdint.h>
+
 #include <memory>
 #include <optional>
 #include <string>
@@ -16,6 +18,7 @@
 #include "base/memory/weak_ptr.h"
 #include "base/scoped_observation.h"
 #include "base/task/sequenced_task_runner.h"
+#include "base/time/time.h"
 #include "base/timer/timer.h"
 #include "build/build_config.h"
 
@@ -75,6 +78,11 @@ class BraveReferralsService {
   static void SetPromoFilePathForTesting(const base::FilePath& path);
 
   static bool IsDefaultReferralCode(const std::string& code);
+
+  // Returns the interval to use for the periodic finalization checks timer for
+  // a randomized draw of `random_seconds`, clamped to a non-zero minimum so
+  // that the timer can never refire immediately and forever.
+  static base::TimeDelta GetFinalizationChecksInterval(uint64_t random_seconds);
 
  private:
   void GetFirstRunTime();

--- a/components/brave_referrals/browser/brave_referrals_service_unittest.cc
+++ b/components/brave_referrals/browser/brave_referrals_service_unittest.cc
@@ -13,6 +13,7 @@
 #include "base/files/file_util.h"
 #include "base/files/scoped_temp_dir.h"
 #include "base/test/bind.h"
+#include "base/time/time.h"
 #include "brave/components/brave_referrals/common/pref_names.h"
 #include "brave/components/constants/pref_names.h"
 #include "components/prefs/pref_registry_simple.h"
@@ -190,6 +191,23 @@ TEST_F(BraveReferralsServiceTest, StatsDisabledAfterInit) {
   task_environment_.FastForwardBy(base::Days(35));
 
   EXPECT_GE(request_count_, 1u);
+}
+
+// The finalization checks timer interval is drawn from a geometric
+// distribution, which can return 0 or a handful of seconds. Such an interval
+// would make the repeating timer refire immediately (and, for 0, forever), so
+// it has to be clamped to a non-zero minimum.
+TEST(BraveReferralsServiceIntervalTest, FinalizationChecksIntervalIsClamped) {
+  EXPECT_EQ(BraveReferralsService::GetFinalizationChecksInterval(0),
+            base::Hours(1));
+  EXPECT_EQ(BraveReferralsService::GetFinalizationChecksInterval(1),
+            base::Hours(1));
+  EXPECT_EQ(BraveReferralsService::GetFinalizationChecksInterval(
+                base::Hours(1).InSeconds() - 1),
+            base::Hours(1));
+  EXPECT_EQ(BraveReferralsService::GetFinalizationChecksInterval(
+                base::Days(1).InSeconds()),
+            base::Days(1));
 }
 
 }  // namespace brave

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -2237,13 +2237,21 @@
 # https://github.com/brave/brave-browser/issues/54240
 -All/SaveToDriveEventDispatcherBrowserTest.Notify/0
 
-# Known upstream flake (8.2% flake rate over 30 days). Race condition between
-# autofill form classification and APC extraction: GetAutofillFieldData()
-# returns nullopt when autofill hasn't cached the cross-site iframe's form yet,
-# so no bounding boxes are generated and screenshot redaction is skipped.
-# Not disabled by Chromium. No Brave chromium_src modifications in this area.
+# Known upstream flake (4.5% flake rate over 30 days, 20k+ verdicts). Race
+# condition between autofill form classification and APC extraction:
+# GetAutofillFieldData() returns nullopt when autofill hasn't cached the
+# cross-site iframe's form yet, so no bounding boxes are generated and screenshot
+# redaction is skipped (bitmap stays white instead of the redaction color and
+# Glic.PageContextFetcher.ScreenshotRedacted records false). The test is
+# value-parameterized (testing::Bool with an empty instantiation prefix), so the
+# entry needs a "/*" suffix to match the PasswordTrackedElements{Enabled,
+# Disabled} instances; the original bare entry matched nothing, which is why the
+# failure recurred. Chromium disables the sibling
+# RedactionWhenScreenshotReceivedFirst on Linux/ASAN/MSAN (crbug.com/515405394).
+# No Brave chromium_src modifications affecting screenshot redaction.
 # https://github.com/brave/brave-browser/issues/54104
--SensitivePaymentRedactionMultiSourcePageContextFetcherBrowserTest.BasicRedactionInIframe
+# https://github.com/brave/brave-browser/issues/56792
+-SensitivePaymentRedactionMultiSourcePageContextFetcherBrowserTest.BasicRedactionInIframe/*
 
 # Chromium test: upstream flake. The globally registered UpdateMetricsProvider
 # may record histogram samples during browser startup (e.g. via initial

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -1238,6 +1238,28 @@
 # Upstream Chromium test, no Brave modifications in this code path.
 -AutoPictureInPictureTabHelperBrowserTest.PromptResultRecorded_VideoConferencingAllowOnce
 
+# Null pointer dereference at the same crash site as the entry above
+# (AutoPipSettingView::OnButtonPressed), reached from the HaTS survey test.
+# AutoPipSettingOverlayView::ShowBubble() is what assigns the pointer that
+# get_view_for_testing() returns, and it runs from a task posted by
+# PictureInPictureBrowserFrameView::AddedToWidget(). The test waits only for the
+# kEnterPictureInPicture media event, so that task can still be queued when
+# simulate_button_press_for_testing() dereferences the null pointer. ASan
+# changes which of the two lands first; observed as an access-violation on the
+# Windows x64 nightly ASan builder.
+# Stable upstream per LUCI Analysis (0.3% over 30 days: 229 failed + 150 flaky),
+# but an unsynchronized posted task is not sanitizer-specific, so this goes in
+# the all-platform filter rather than browser_tests-windows-asan.filter.
+# Upstream Chromium test. There is no Brave override or patch for
+# chrome/browser/picture_in_picture/ or picture_in_picture_browser_frame_view.*,
+# and Brave's other picture-in-picture overrides and patches touch only the
+# video PiP path and Android, while this test covers document PiP. Brave does
+# substitute BraveBrowserView/BraveBrowserWidget for the PiP window, which can
+# perturb main-thread task ordering but cannot supply the synchronization the
+# test is missing.
+# https://github.com/brave/brave-browser/issues/56974
+-All/AutoPictureInPictureTabHelperHatsDocumentPipBrowserTest.TriggersSurveyOnTabActivation/0
+
 # Brave disables Session Cookies restore when ContinueWhereILeftOff is enabled.
 -ContinueWhereILeftOffTest.SessionCookies
 


### PR DESCRIPTION
Uplift of #38159
Uplift of #38534
Uplift of #38604
Uplift of #38610
Uplift of #38607
Uplift of #38546
Resolves brave/brave-browser#56792
Resolves brave/brave-browser#56970
Resolves brave/brave-browser#56974
Resolves brave/brave-browser#57184
Resolves brave/brave-browser#57292
Resolves brave/brave-browser#57252
Resolves brave/brave-browser#57629

## Included PRs
- #38159 - Disable flaky BasicRedactionInIframe payment redaction browser test
- #38534 - Disable flaky upstream AutoPiP HaTS document PiP survey browser test
- #38604 - Don't start the sync engine in CrashNoUiTaskRunner death test
- #38610 - Clamp referral finalization checks timer to a non-zero interval
- #38607 - Fix flaky blob URL revocation check in BlobUrlBrowserTestBase
- #38546 - Report the committed URL when HSTSPreloadWorks fails

Pre-approval checklist:
- [ ] You have tested your change on Nightly.
- [ ] This contains text which needs to be translated.
    - [ ] There are more than 7 days before the release.
    - [ ] I've notified folks in #l10n on Slack that translations are needed.
- [ ] The PR milestones match the branch they are landing to.


Pre-merge checklist:
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.

Post-merge checklist:
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
