### PR TITLE
Add --temporary-container command line switch

### DIFF
--- a/browser/containers/BUILD.gn
+++ b/browser/containers/BUILD.gn
@@ -47,6 +47,7 @@ source_set("browser_tests") {
     "//brave/components/containers/core/browser",
     "//brave/components/containers/core/browser:test_support",
     "//brave/components/containers/core/common:features",
+    "//brave/components/containers/core/common:switches",
     "//brave/components/containers/core/mojom",
     "//chrome/browser",
     "//chrome/browser/browsing_data:constants",

--- a/browser/containers/containers_browsertest.cc
+++ b/browser/containers/containers_browsertest.cc
@@ -166,9 +166,13 @@ class ContainersBrowserTest : public InProcessBrowserTest {
 
   void SetUpCommandLine(base::CommandLine* command_line) override {
     InProcessBrowserTest::SetUpCommandLine(command_line);
+    // Startup navigations for command line URLs run before SetUpOnMainThread
+    // installs the host resolver rules, so every host has to be mapped here
+    // too, not just port 443.
     command_line->AppendSwitchASCII(
         network::switches::kHostResolverRules,
-        absl::StrFormat("MAP *:443 127.0.0.1:%d", https_server_.port()));
+        absl::StrFormat("MAP *:443 127.0.0.1:%d,MAP * 127.0.0.1",
+                        https_server_.port()));
   }
 
   void SetUpOnMainThread() override {
@@ -2620,31 +2624,13 @@ IN_PROC_BROWSER_TEST_F(ContainersCommandLineContainerBrowserTest,
   EXPECT_EQ(kTestContainerId, config.partition_name());
 }
 
-// Base for tests that open command line URLs at startup. The startup
-// navigation runs before InProcessBrowserTest installs its host resolver rules
-// in SetUpOnMainThread, and the base fixture's command line rule only covers
-// port 443, so map every host to the test server up front. Without this the
-// startup tab commits an error page.
-class ContainersCommandLineUrlBrowserTest : public ContainersBrowserTest {
- public:
-  ContainersCommandLineUrlBrowserTest() = default;
-
-  void SetUpCommandLine(base::CommandLine* command_line) override {
-    ContainersBrowserTest::SetUpCommandLine(command_line);
-    command_line->AppendSwitchASCII(
-        network::switches::kHostResolverRules,
-        absl::StrFormat("MAP *:443 127.0.0.1:%d,MAP * 127.0.0.1",
-                        https_server_.port()));
-  }
-};
-
 class ContainersCommandLineTemporaryContainerBrowserTest
-    : public ContainersCommandLineUrlBrowserTest {
+    : public ContainersBrowserTest {
  public:
   ContainersCommandLineTemporaryContainerBrowserTest() = default;
 
   void SetUpDefaultCommandLine(base::CommandLine* command_line) override {
-    ContainersCommandLineUrlBrowserTest::SetUpDefaultCommandLine(command_line);
+    ContainersBrowserTest::SetUpDefaultCommandLine(command_line);
     command_line->AppendSwitch("temporary-container");
     command_line->AppendArg(
         https_server_.GetURL("a.test", "/simple.html").spec());
@@ -2677,13 +2663,13 @@ IN_PROC_BROWSER_TEST_F(ContainersCommandLineTemporaryContainerBrowserTest,
       << *first_partition_name;
 }
 
-class ContainersCommandLineTemporaryContainerOverridesNamedBrowserTest
-    : public ContainersCommandLineUrlBrowserTest {
+class ContainersCommandLineNamedTemporaryContainerBrowserTest
+    : public ContainersBrowserTest {
  public:
-  ContainersCommandLineTemporaryContainerOverridesNamedBrowserTest() = default;
+  ContainersCommandLineNamedTemporaryContainerBrowserTest() = default;
 
   void SetUpDefaultCommandLine(base::CommandLine* command_line) override {
-    ContainersCommandLineUrlBrowserTest::SetUpDefaultCommandLine(command_line);
+    ContainersBrowserTest::SetUpDefaultCommandLine(command_line);
     command_line->AppendSwitchASCII("container", kNamedContainerName);
     command_line->AppendSwitch("temporary-container");
     command_line->AppendArg(
@@ -2691,12 +2677,12 @@ class ContainersCommandLineTemporaryContainerOverridesNamedBrowserTest
   }
 };
 
-// PRE_ stores a container that the follow-up test's --container switch resolves
-// to. Using a test-owned name rather than a default container keeps the test
-// independent of localized strings.
+// PRE_ stores a synced container with the same name the follow-up test passes
+// to --container. Using a test-owned name rather than a default container keeps
+// the test independent of localized strings.
 IN_PROC_BROWSER_TEST_F(
-    ContainersCommandLineTemporaryContainerOverridesNamedBrowserTest,
-    PRE_TemporaryContainerSwitchOverridesNamedContainer) {
+    ContainersCommandLineNamedTemporaryContainerBrowserTest,
+    PRE_ContainerSwitchNamesTemporaryContainerInsteadOfResolvingIt) {
   Profile* profile = browser()->profile();
   std::vector<mojom::ContainerPtr> synced;
   synced.push_back(MakeContainer(kTestContainerId, kNamedContainerName,
@@ -2709,18 +2695,21 @@ IN_PROC_BROWSER_TEST_F(
                                   SessionStartupPref::kPrefValueNewTab);
 }
 
+// With --temporary-container, --container names the temporary container rather
+// than selecting an existing one, so a synced container with the same name is
+// left alone.
 IN_PROC_BROWSER_TEST_F(
-    ContainersCommandLineTemporaryContainerOverridesNamedBrowserTest,
-    TemporaryContainerSwitchOverridesNamedContainer) {
+    ContainersCommandLineNamedTemporaryContainerBrowserTest,
+    ContainerSwitchNamesTemporaryContainerInsteadOfResolvingIt) {
   ASSERT_EQ(1, browser()->tab_strip_model()->count());
 
   auto* containers_service =
       ContainersServiceFactory::GetForProfile(browser()->profile());
   ASSERT_TRUE(containers_service);
 
-  // Precondition: --container on its own would have resolved to this container,
-  // so the IsTemporaryContainerId/EXPECT_NE checks really do exercise the
-  // override rather than passing because the name never resolved.
+  // Precondition: without --temporary-container the switch would have resolved
+  // to this container, so the checks below really do exercise the naming
+  // behavior rather than passing because the name never resolved.
   const std::optional<std::string> named_container_id =
       containers_service->GetContainerIdFromContainerSpecifier(
           ContainerName(kNamedContainerName));
@@ -2732,6 +2721,13 @@ IN_PROC_BROWSER_TEST_F(
   ASSERT_TRUE(partition_name.has_value());
   EXPECT_TRUE(IsTemporaryContainerId(*partition_name)) << *partition_name;
   EXPECT_NE(kTestContainerId, *partition_name);
+
+  // The temporary container carries the name from the command line, so a later
+  // launch with the same switches opens tabs in this same container.
+  auto temporary_container =
+      containers_service->GetRuntimeContainerById(*partition_name);
+  ASSERT_TRUE(temporary_container);
+  EXPECT_EQ(kNamedContainerName, temporary_container->name);
 }
 
 class ContainersCommandLineTemporaryContainerWithoutUrlsBrowserTest

--- a/browser/containers/containers_browsertest.cc
+++ b/browser/containers/containers_browsertest.cc
@@ -24,6 +24,7 @@
 #include "brave/components/containers/core/browser/prefs.h"
 #include "brave/components/containers/core/browser/temporary_container.h"
 #include "brave/components/containers/core/common/features.h"
+#include "brave/components/containers/core/common/switches.h"
 #include "brave/components/containers/core/mojom/containers.mojom.h"
 #include "chrome/browser/browsing_data/chrome_browsing_data_remover_constants.h"
 #include "chrome/browser/prefs/session_startup_pref.h"
@@ -2584,7 +2585,7 @@ class ContainersCommandLineContainerBrowserTest : public ContainersBrowserTest {
 
   void SetUpDefaultCommandLine(base::CommandLine* command_line) override {
     ContainersBrowserTest::SetUpDefaultCommandLine(command_line);
-    command_line->AppendSwitchASCII("container", "Work");
+    command_line->AppendSwitchASCII(switches::kContainer, "Work");
     command_line->AppendArg(
         https_server_.GetURL("a.test", "/simple.html").spec());
   }
@@ -2631,7 +2632,7 @@ class ContainersCommandLineTemporaryContainerBrowserTest
 
   void SetUpDefaultCommandLine(base::CommandLine* command_line) override {
     ContainersBrowserTest::SetUpDefaultCommandLine(command_line);
-    command_line->AppendSwitch("temporary-container");
+    command_line->AppendSwitch(switches::kTemporaryContainer);
     command_line->AppendArg(
         https_server_.GetURL("a.test", "/simple.html").spec());
     command_line->AppendArg(
@@ -2670,8 +2671,8 @@ class ContainersCommandLineNamedTemporaryContainerBrowserTest
 
   void SetUpDefaultCommandLine(base::CommandLine* command_line) override {
     ContainersBrowserTest::SetUpDefaultCommandLine(command_line);
-    command_line->AppendSwitchASCII("container", kNamedContainerName);
-    command_line->AppendSwitch("temporary-container");
+    command_line->AppendSwitchASCII(switches::kContainer, kNamedContainerName);
+    command_line->AppendSwitch(switches::kTemporaryContainer);
     command_line->AppendArg(
         https_server_.GetURL("a.test", "/simple.html").spec());
   }
@@ -2708,8 +2709,9 @@ IN_PROC_BROWSER_TEST_F(
   ASSERT_TRUE(containers_service);
 
   // Precondition: without --temporary-container the switch would have resolved
-  // to this container, so the checks below really do exercise the naming
-  // behavior rather than passing because the name never resolved.
+  // to this container, so the IsTemporaryContainerId/EXPECT_NE checks really do
+  // exercise the naming behavior rather than passing because the name never
+  // resolved.
   const std::optional<std::string> named_container_id =
       containers_service->GetContainerIdFromContainerSpecifier(
           ContainerName(kNamedContainerName));
@@ -2737,13 +2739,13 @@ class ContainersCommandLineTemporaryContainerWithoutUrlsBrowserTest
 
   void SetUpDefaultCommandLine(base::CommandLine* command_line) override {
     ContainersBrowserTest::SetUpDefaultCommandLine(command_line);
-    command_line->AppendSwitch("temporary-container");
+    command_line->AppendSwitch(switches::kTemporaryContainer);
   }
 };
 
 // With no URLs to open there is nothing to isolate, so no temporary container
-// should be created. The sibling fixture above covers the positive case: the
-// same switch with URLs does create one.
+// should be created. ContainersCommandLineTemporaryContainerBrowserTest covers
+// the positive case: the same switch with URLs does create one.
 IN_PROC_BROWSER_TEST_F(
     ContainersCommandLineTemporaryContainerWithoutUrlsBrowserTest,
     NoTemporaryContainerCreated) {
@@ -2756,10 +2758,14 @@ IN_PROC_BROWSER_TEST_F(
 
   const std::vector<mojom::ContainerPtr> locally_used_containers =
       GetLocallyUsedContainersFromPrefs(*browser()->profile()->GetPrefs());
-  EXPECT_FALSE(std::ranges::any_of(
+  const auto temporary_container = std::ranges::find_if(
       locally_used_containers, [](const mojom::ContainerPtr& container) {
         return IsTemporaryContainerId(container->id);
-      }));
+      });
+  // The streamed message is only evaluated when the check fails, which is
+  // exactly when the iterator is dereferenceable.
+  EXPECT_TRUE(temporary_container == locally_used_containers.end())
+      << "Unexpected temporary container: " << (*temporary_container)->id;
 }
 
 }  // namespace containers

--- a/browser/containers/containers_browsertest.cc
+++ b/browser/containers/containers_browsertest.cc
@@ -4,10 +4,12 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include <algorithm>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "base/files/file_util.h"
+#include "base/location.h"
 #include "base/test/run_until.h"
 #include "base/threading/thread_restrictions.h"
 #include "brave/browser/containers/containers_service_factory.h"
@@ -90,6 +92,55 @@ constexpr char kTestContainerId[] = "test-container-id";
 
 constexpr char kFarblingPluginsStringScript[] =
     "Array.from(navigator.plugins).map(p => p.name).join(',');";
+
+// Name of the container seeded by tests that exercise the --container switch.
+constexpr char kNamedContainerName[] = "Command Line Named Container";
+
+// Returns the storage partition config of the tab at `index`, after waiting for
+// it to finish loading, or std::nullopt if the tab can't be loaded. `location`
+// is the caller's location, reported via SCOPED_TRACE.
+std::optional<content::StoragePartitionConfig> GetStoragePartitionConfigOfTabAt(
+    Browser* browser,
+    int index,
+    const base::Location& location = base::Location::Current()) {
+  SCOPED_TRACE(location.ToString());
+  content::WebContents* web_contents =
+      browser->tab_strip_model()->GetWebContentsAt(index);
+  if (!web_contents) {
+    ADD_FAILURE() << "No tab at index " << index;
+    return std::nullopt;
+  }
+  if (!content::WaitForLoadStop(web_contents)) {
+    ADD_FAILURE() << "Failed to load the tab at index " << index
+                  << ": url=" << web_contents->GetLastCommittedURL()
+                  << " visible_url=" << web_contents->GetVisibleURL();
+    return std::nullopt;
+  }
+  return web_contents->GetPrimaryMainFrame()
+      ->GetStoragePartition()
+      ->GetConfig();
+}
+
+// Returns the container partition name of the tab at `index`, or std::nullopt
+// if the tab can't be loaded or is not in a containers storage partition.
+std::optional<std::string> GetContainerPartitionNameOfTabAt(
+    Browser* browser,
+    int index,
+    const base::Location& location = base::Location::Current()) {
+  SCOPED_TRACE(location.ToString());
+  const std::optional<content::StoragePartitionConfig> config =
+      GetStoragePartitionConfigOfTabAt(browser, index, location);
+  if (!config) {
+    return std::nullopt;
+  }
+  if (config->partition_domain() != kContainersStoragePartitionDomain) {
+    ADD_FAILURE() << "Tab at index " << index
+                  << " is not in a containers storage partition: "
+                  << config->partition_domain();
+    return std::nullopt;
+  }
+  return config->partition_name();
+}
 
 }  // namespace
 
@@ -2567,6 +2618,152 @@ IN_PROC_BROWSER_TEST_F(ContainersCommandLineContainerBrowserTest,
       web_contents->GetPrimaryMainFrame()->GetStoragePartition()->GetConfig();
   EXPECT_EQ(kContainersStoragePartitionDomain, config.partition_domain());
   EXPECT_EQ(kTestContainerId, config.partition_name());
+}
+
+// Base for tests that open command line URLs at startup. The startup
+// navigation runs before InProcessBrowserTest installs its host resolver rules
+// in SetUpOnMainThread, and the base fixture's command line rule only covers
+// port 443, so map every host to the test server up front. Without this the
+// startup tab commits an error page.
+class ContainersCommandLineUrlBrowserTest : public ContainersBrowserTest {
+ public:
+  ContainersCommandLineUrlBrowserTest() = default;
+
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    ContainersBrowserTest::SetUpCommandLine(command_line);
+    command_line->AppendSwitchASCII(
+        network::switches::kHostResolverRules,
+        absl::StrFormat("MAP *:443 127.0.0.1:%d,MAP * 127.0.0.1",
+                        https_server_.port()));
+  }
+};
+
+class ContainersCommandLineTemporaryContainerBrowserTest
+    : public ContainersCommandLineUrlBrowserTest {
+ public:
+  ContainersCommandLineTemporaryContainerBrowserTest() = default;
+
+  void SetUpDefaultCommandLine(base::CommandLine* command_line) override {
+    ContainersCommandLineUrlBrowserTest::SetUpDefaultCommandLine(command_line);
+    command_line->AppendSwitch("temporary-container");
+    command_line->AppendArg(
+        https_server_.GetURL("a.test", "/simple.html").spec());
+    command_line->AppendArg(
+        https_server_.GetURL("b.test", "/simple.html").spec());
+  }
+};
+
+IN_PROC_BROWSER_TEST_F(ContainersCommandLineTemporaryContainerBrowserTest,
+                       AllCommandLineTabsShareOneTemporaryContainer) {
+  ASSERT_EQ(2, browser()->tab_strip_model()->count());
+
+  const std::optional<std::string> first_partition_name =
+      GetContainerPartitionNameOfTabAt(browser(), 0);
+  ASSERT_TRUE(first_partition_name.has_value());
+  EXPECT_TRUE(IsTemporaryContainerId(*first_partition_name))
+      << *first_partition_name;
+
+  // All URLs on a single command line share one temporary container.
+  EXPECT_EQ(first_partition_name,
+            GetContainerPartitionNameOfTabAt(browser(), 1));
+
+  // The temporary container is persisted, so it can be shown in the UI and
+  // restored like a container created from the UI.
+  auto* containers_service =
+      ContainersServiceFactory::GetForProfile(browser()->profile());
+  ASSERT_TRUE(containers_service);
+  EXPECT_TRUE(
+      containers_service->GetRuntimeContainerById(*first_partition_name))
+      << *first_partition_name;
+}
+
+class ContainersCommandLineTemporaryContainerOverridesNamedBrowserTest
+    : public ContainersCommandLineUrlBrowserTest {
+ public:
+  ContainersCommandLineTemporaryContainerOverridesNamedBrowserTest() = default;
+
+  void SetUpDefaultCommandLine(base::CommandLine* command_line) override {
+    ContainersCommandLineUrlBrowserTest::SetUpDefaultCommandLine(command_line);
+    command_line->AppendSwitchASCII("container", kNamedContainerName);
+    command_line->AppendSwitch("temporary-container");
+    command_line->AppendArg(
+        https_server_.GetURL("a.test", "/simple.html").spec());
+  }
+};
+
+// PRE_ stores a container that the follow-up test's --container switch resolves
+// to. Using a test-owned name rather than a default container keeps the test
+// independent of localized strings.
+IN_PROC_BROWSER_TEST_F(
+    ContainersCommandLineTemporaryContainerOverridesNamedBrowserTest,
+    PRE_TemporaryContainerSwitchOverridesNamedContainer) {
+  Profile* profile = browser()->profile();
+  std::vector<mojom::ContainerPtr> synced;
+  synced.push_back(MakeContainer(kTestContainerId, kNamedContainerName,
+                                 mojom::Icon::kWork, SK_ColorRED));
+  SetContainersToPrefs(synced, *profile->GetPrefs());
+
+  SessionStartupPref pref(SessionStartupPref::DEFAULT);
+  SessionStartupPref::SetStartupPref(profile, pref);
+  profile->GetPrefs()->SetInteger(prefs::kRestoreOnStartup,
+                                  SessionStartupPref::kPrefValueNewTab);
+}
+
+IN_PROC_BROWSER_TEST_F(
+    ContainersCommandLineTemporaryContainerOverridesNamedBrowserTest,
+    TemporaryContainerSwitchOverridesNamedContainer) {
+  ASSERT_EQ(1, browser()->tab_strip_model()->count());
+
+  auto* containers_service =
+      ContainersServiceFactory::GetForProfile(browser()->profile());
+  ASSERT_TRUE(containers_service);
+
+  // Precondition: --container on its own would have resolved to this container,
+  // so the IsTemporaryContainerId/EXPECT_NE checks really do exercise the
+  // override rather than passing because the name never resolved.
+  const std::optional<std::string> named_container_id =
+      containers_service->GetContainerIdFromContainerSpecifier(
+          ContainerName(kNamedContainerName));
+  ASSERT_TRUE(named_container_id.has_value());
+  ASSERT_EQ(kTestContainerId, *named_container_id);
+
+  const std::optional<std::string> partition_name =
+      GetContainerPartitionNameOfTabAt(browser(), 0);
+  ASSERT_TRUE(partition_name.has_value());
+  EXPECT_TRUE(IsTemporaryContainerId(*partition_name)) << *partition_name;
+  EXPECT_NE(kTestContainerId, *partition_name);
+}
+
+class ContainersCommandLineTemporaryContainerWithoutUrlsBrowserTest
+    : public ContainersBrowserTest {
+ public:
+  ContainersCommandLineTemporaryContainerWithoutUrlsBrowserTest() = default;
+
+  void SetUpDefaultCommandLine(base::CommandLine* command_line) override {
+    ContainersBrowserTest::SetUpDefaultCommandLine(command_line);
+    command_line->AppendSwitch("temporary-container");
+  }
+};
+
+// With no URLs to open there is nothing to isolate, so no temporary container
+// should be created. The sibling fixture above covers the positive case: the
+// same switch with URLs does create one.
+IN_PROC_BROWSER_TEST_F(
+    ContainersCommandLineTemporaryContainerWithoutUrlsBrowserTest,
+    NoTemporaryContainerCreated) {
+  // The startup tab is in the default storage partition, not a container one.
+  ASSERT_GE(browser()->tab_strip_model()->count(), 1);
+  const std::optional<content::StoragePartitionConfig> config =
+      GetStoragePartitionConfigOfTabAt(browser(), 0);
+  ASSERT_TRUE(config.has_value());
+  EXPECT_NE(kContainersStoragePartitionDomain, config->partition_domain());
+
+  const std::vector<mojom::ContainerPtr> locally_used_containers =
+      GetLocallyUsedContainersFromPrefs(*browser()->profile()->GetPrefs());
+  EXPECT_FALSE(std::ranges::any_of(
+      locally_used_containers, [](const mojom::ContainerPtr& container) {
+        return IsTemporaryContainerId(container->id);
+      }));
 }
 
 }  // namespace containers

--- a/browser/ui/startup/brave_startup_tab_provider_impl.cc
+++ b/browser/ui/startup/brave_startup_tab_provider_impl.cc
@@ -5,17 +5,17 @@
 
 #include "brave/browser/ui/startup/brave_startup_tab_provider_impl.h"
 
+#include <string>
+#include <utility>
+
+#include "base/command_line.h"
+#include "base/feature_list.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/containers/buildflags/buildflags.h"
 #include "chrome/browser/first_run/first_run.h"
 #include "chrome/browser/ui/startup/startup_tab.h"
 
 #if BUILDFLAG(ENABLE_CONTAINERS)
-#include <utility>
-
-#include "base/command_line.h"
-#include "base/feature_list.h"
-#include "base/logging.h"
 #include "brave/browser/containers/containers_service_factory.h"
 #include "brave/components/containers/core/browser/container_specifier.h"
 #include "brave/components/containers/core/browser/containers_service.h"
@@ -27,18 +27,22 @@ namespace {
 // Switch to specify the container to use for the startup tabs.
 constexpr char kContainerSwitch[] = "container";
 
-// Switch to open the startup tabs in a newly created temporary container.
+// Switch to open the startup tabs in a temporary container.
 constexpr char kTemporaryContainerSwitch[] = "temporary-container";
 
 // Returns the container to use for the tabs passed via the command line. All
 // command line tabs share the same container, matching the "open in new
 // temporary container" UI.
 //
-// With `--temporary-container` this creates and persists a new container, so it
-// must not be called more than once per launch, and it returns an empty
-// specifier when the profile has no ContainersService. Returns an empty
-// specifier (no container) when neither switch is given or the Containers
-// feature is disabled.
+// `--temporary-container` opens the tabs in a temporary container: a new one,
+// or, when `--container` also gives a name, the temporary container with that
+// name, created on first use so that a later launch can open more tabs in it.
+// `--container` on its own resolves an existing container by name.
+//
+// Creating a temporary container persists it, so this must not be called more
+// than once per launch. Returns an empty specifier (no container) when neither
+// switch is given, when the Containers feature is disabled, or when the profile
+// has no ContainersService.
 containers::ContainerSpecifier MaybeCreateContainerForCommandLineTabs(
     const base::CommandLine& command_line,
     Profile* profile) {
@@ -46,16 +50,10 @@ containers::ContainerSpecifier MaybeCreateContainerForCommandLineTabs(
     return {};
   }
 
-  const bool has_temporary_switch =
-      command_line.HasSwitch(kTemporaryContainerSwitch);
-  const bool has_container_switch = command_line.HasSwitch(kContainerSwitch);
-  if (has_temporary_switch && has_container_switch) {
-    // A temporary container is the more isolated of the two, so prefer it.
-    DVLOG(1) << "--" << kTemporaryContainerSwitch << " overrides --"
-             << kContainerSwitch;
-  }
+  const std::string container_name =
+      command_line.GetSwitchValueUTF8(kContainerSwitch);
 
-  if (has_temporary_switch) {
+  if (command_line.HasSwitch(kTemporaryContainerSwitch)) {
     auto* containers_service = ContainersServiceFactory::GetForProfile(profile);
     if (!containers_service) {
       // The factory selects regular profiles and their off-the-record
@@ -63,15 +61,18 @@ containers::ContainerSpecifier MaybeCreateContainerForCommandLineTabs(
       // profiles.
       return {};
     }
-    // Address the temporary container by id: its name is randomly generated and
-    // is not guaranteed to be unique.
-    auto container = containers_service->CreateAndPersistTemporaryContainer();
+    auto container =
+        container_name.empty()
+            ? containers_service->CreateAndPersistTemporaryContainer()
+            : containers_service->GetOrCreateTemporaryContainerByName(
+                  container_name);
+    // Address the temporary container by id: names are not guaranteed to be
+    // unique, and a generated one is random.
     return containers::ContainerId(std::move(container->id));
   }
 
-  if (has_container_switch) {
-    return containers::ContainerName(
-        command_line.GetSwitchValueUTF8(kContainerSwitch));
+  if (!container_name.empty()) {
+    return containers::ContainerName(container_name);
   }
 
   return {};

--- a/browser/ui/startup/brave_startup_tab_provider_impl.cc
+++ b/browser/ui/startup/brave_startup_tab_provider_impl.cc
@@ -5,11 +5,7 @@
 
 #include "brave/browser/ui/startup/brave_startup_tab_provider_impl.h"
 
-#include <string>
-#include <utility>
-
 #include "base/command_line.h"
-#include "base/feature_list.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/containers/buildflags/buildflags.h"
 #include "chrome/browser/first_run/first_run.h"
@@ -17,63 +13,9 @@
 
 #if BUILDFLAG(ENABLE_CONTAINERS)
 #include "brave/browser/containers/containers_service_factory.h"
+#include "brave/components/containers/core/browser/command_line_container.h"
 #include "brave/components/containers/core/browser/container_specifier.h"
 #include "brave/components/containers/core/browser/containers_service.h"
-#include "brave/components/containers/core/common/features.h"
-#include "brave/components/containers/core/common/switches.h"
-#include "brave/components/containers/core/mojom/containers.mojom.h"
-
-namespace {
-
-// Returns the container to use for the tabs passed via the command line. All
-// command line tabs share the same container, matching the "open in new
-// temporary container" UI.
-//
-// `--temporary-container` opens the tabs in a temporary container: a new one,
-// or, when `--container` also gives a name, the temporary container with that
-// name, created on first use so that a later launch can open more tabs in it.
-// `--container` on its own resolves an existing container by name.
-//
-// Creating a temporary container persists it, so this must not be called more
-// than once per launch. Returns an empty specifier (no container) when neither
-// switch is given, when the Containers feature is disabled, or when the profile
-// has no ContainersService.
-containers::ContainerSpecifier MaybeCreateContainerForCommandLineTabs(
-    const base::CommandLine& command_line,
-    Profile* profile) {
-  if (!base::FeatureList::IsEnabled(containers::features::kContainers)) {
-    return {};
-  }
-
-  const std::string container_name =
-      command_line.GetSwitchValueUTF8(containers::switches::kContainer);
-
-  if (command_line.HasSwitch(containers::switches::kTemporaryContainer)) {
-    auto* containers_service = ContainersServiceFactory::GetForProfile(profile);
-    if (!containers_service) {
-      // The factory selects regular profiles and their off-the-record
-      // profiles, so no temporary container is created for guest and system
-      // profiles.
-      return {};
-    }
-    auto container =
-        container_name.empty()
-            ? containers_service->CreateAndPersistTemporaryContainer()
-            : containers_service->GetOrCreateTemporaryContainerByName(
-                  container_name);
-    // Address the temporary container by id: names are not guaranteed to be
-    // unique, and a generated one is random.
-    return containers::ContainerId(std::move(container->id));
-  }
-
-  if (!container_name.empty()) {
-    return containers::ContainerName(container_name);
-  }
-
-  return {};
-}
-
-}  // namespace
 #endif  // BUILDFLAG(ENABLE_CONTAINERS)
 
 StartupTabs BraveStartupTabProviderImpl::GetDistributionFirstRunTabs(
@@ -94,10 +36,15 @@ StartupTabs BraveStartupTabProviderImpl::GetCommandLineTabs(
       command_line, cur_dir, profile);
 
 #if BUILDFLAG(ENABLE_CONTAINERS)
-  // Don't create a temporary container when there's nothing to open in it.
-  if (!tabs.empty()) {
+  // Don't create a temporary container when there's nothing to open in it. The
+  // factory returns null when the Containers feature is disabled and for guest
+  // and system profiles, so those launches get no container either.
+  if (auto* containers_service =
+          ContainersServiceFactory::GetForProfile(profile);
+      containers_service && !tabs.empty()) {
     const containers::ContainerSpecifier container_specifier =
-        MaybeCreateContainerForCommandLineTabs(command_line, profile);
+        containers::GetContainerSpecifierForCommandLineTabs(command_line,
+                                                            containers_service);
     for (auto& tab : tabs) {
       tab.container = container_specifier;
     }

--- a/browser/ui/startup/brave_startup_tab_provider_impl.cc
+++ b/browser/ui/startup/brave_startup_tab_provider_impl.cc
@@ -15,7 +15,6 @@
 #include "brave/browser/containers/containers_service_factory.h"
 #include "brave/components/containers/core/browser/command_line_container.h"
 #include "brave/components/containers/core/browser/container_specifier.h"
-#include "brave/components/containers/core/browser/containers_service.h"
 #endif  // BUILDFLAG(ENABLE_CONTAINERS)
 
 StartupTabs BraveStartupTabProviderImpl::GetDistributionFirstRunTabs(

--- a/browser/ui/startup/brave_startup_tab_provider_impl.cc
+++ b/browser/ui/startup/brave_startup_tab_provider_impl.cc
@@ -20,15 +20,10 @@
 #include "brave/components/containers/core/browser/container_specifier.h"
 #include "brave/components/containers/core/browser/containers_service.h"
 #include "brave/components/containers/core/common/features.h"
+#include "brave/components/containers/core/common/switches.h"
 #include "brave/components/containers/core/mojom/containers.mojom.h"
 
 namespace {
-
-// Switch to specify the container to use for the startup tabs.
-constexpr char kContainerSwitch[] = "container";
-
-// Switch to open the startup tabs in a temporary container.
-constexpr char kTemporaryContainerSwitch[] = "temporary-container";
 
 // Returns the container to use for the tabs passed via the command line. All
 // command line tabs share the same container, matching the "open in new
@@ -51,9 +46,9 @@ containers::ContainerSpecifier MaybeCreateContainerForCommandLineTabs(
   }
 
   const std::string container_name =
-      command_line.GetSwitchValueUTF8(kContainerSwitch);
+      command_line.GetSwitchValueUTF8(containers::switches::kContainer);
 
-  if (command_line.HasSwitch(kTemporaryContainerSwitch)) {
+  if (command_line.HasSwitch(containers::switches::kTemporaryContainer)) {
     auto* containers_service = ContainersServiceFactory::GetForProfile(profile);
     if (!containers_service) {
       // The factory selects regular profiles and their off-the-record
@@ -101,7 +96,7 @@ StartupTabs BraveStartupTabProviderImpl::GetCommandLineTabs(
 #if BUILDFLAG(ENABLE_CONTAINERS)
   // Don't create a temporary container when there's nothing to open in it.
   if (!tabs.empty()) {
-    const auto container_specifier =
+    const containers::ContainerSpecifier container_specifier =
         MaybeCreateContainerForCommandLineTabs(command_line, profile);
     for (auto& tab : tabs) {
       tab.container = container_specifier;

--- a/browser/ui/startup/brave_startup_tab_provider_impl.cc
+++ b/browser/ui/startup/brave_startup_tab_provider_impl.cc
@@ -11,13 +11,71 @@
 #include "chrome/browser/ui/startup/startup_tab.h"
 
 #if BUILDFLAG(ENABLE_CONTAINERS)
+#include <utility>
+
+#include "base/command_line.h"
+#include "base/feature_list.h"
+#include "base/logging.h"
+#include "brave/browser/containers/containers_service_factory.h"
 #include "brave/components/containers/core/browser/container_specifier.h"
+#include "brave/components/containers/core/browser/containers_service.h"
 #include "brave/components/containers/core/common/features.h"
+#include "brave/components/containers/core/mojom/containers.mojom.h"
 
 namespace {
 
 // Switch to specify the container to use for the startup tabs.
 constexpr char kContainerSwitch[] = "container";
+
+// Switch to open the startup tabs in a newly created temporary container.
+constexpr char kTemporaryContainerSwitch[] = "temporary-container";
+
+// Returns the container to use for the tabs passed via the command line. All
+// command line tabs share the same container, matching the "open in new
+// temporary container" UI.
+//
+// With `--temporary-container` this creates and persists a new container, so it
+// must not be called more than once per launch, and it returns an empty
+// specifier when the profile has no ContainersService. Returns an empty
+// specifier (no container) when neither switch is given or the Containers
+// feature is disabled.
+containers::ContainerSpecifier MaybeCreateContainerForCommandLineTabs(
+    const base::CommandLine& command_line,
+    Profile* profile) {
+  if (!base::FeatureList::IsEnabled(containers::features::kContainers)) {
+    return {};
+  }
+
+  const bool has_temporary_switch =
+      command_line.HasSwitch(kTemporaryContainerSwitch);
+  const bool has_container_switch = command_line.HasSwitch(kContainerSwitch);
+  if (has_temporary_switch && has_container_switch) {
+    // A temporary container is the more isolated of the two, so prefer it.
+    DVLOG(1) << "--" << kTemporaryContainerSwitch << " overrides --"
+             << kContainerSwitch;
+  }
+
+  if (has_temporary_switch) {
+    auto* containers_service = ContainersServiceFactory::GetForProfile(profile);
+    if (!containers_service) {
+      // The factory selects regular profiles and their off-the-record
+      // profiles, so no temporary container is created for guest and system
+      // profiles.
+      return {};
+    }
+    // Address the temporary container by id: its name is randomly generated and
+    // is not guaranteed to be unique.
+    auto container = containers_service->CreateAndPersistTemporaryContainer();
+    return containers::ContainerId(std::move(container->id));
+  }
+
+  if (has_container_switch) {
+    return containers::ContainerName(
+        command_line.GetSwitchValueUTF8(kContainerSwitch));
+  }
+
+  return {};
+}
 
 }  // namespace
 #endif  // BUILDFLAG(ENABLE_CONTAINERS)
@@ -40,12 +98,10 @@ StartupTabs BraveStartupTabProviderImpl::GetCommandLineTabs(
       command_line, cur_dir, profile);
 
 #if BUILDFLAG(ENABLE_CONTAINERS)
-  if (base::FeatureList::IsEnabled(containers::features::kContainers) &&
-      command_line.HasSwitch(kContainerSwitch)) {
-    // Get the container name from the command line switch to use for the URLs
-    // passed via a command line.
-    auto container_specifier = containers::ContainerName(
-        command_line.GetSwitchValueUTF8(kContainerSwitch));
+  // Don't create a temporary container when there's nothing to open in it.
+  if (!tabs.empty()) {
+    const auto container_specifier =
+        MaybeCreateContainerForCommandLineTabs(command_line, profile);
     for (auto& tab : tabs) {
       tab.container = container_specifier;
     }

--- a/components/containers/core/browser/BUILD.gn
+++ b/components/containers/core/browser/BUILD.gn
@@ -9,6 +9,7 @@ assert(enable_containers)
 
 static_library("browser") {
   public = [
+    "command_line_container.h",
     "container_specifier.h",
     "containers_service.h",
     "containers_service_observer.h",
@@ -19,6 +20,7 @@ static_library("browser") {
   ]
 
   sources = [
+    "command_line_container.cc",
     "containers_service.cc",
     "containers_settings_handler.cc",
     "default_containers_list.cc",
@@ -81,6 +83,7 @@ source_set("test_support") {
 source_set("unit_tests") {
   testonly = true
   sources = [
+    "command_line_container_unittest.cc",
     "containers_service_unittest.cc",
     "containers_settings_handler_unittest.cc",
     "default_containers_list_unittest.cc",

--- a/components/containers/core/browser/command_line_container.cc
+++ b/components/containers/core/browser/command_line_container.cc
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/containers/core/browser/command_line_container.h"
+
+#include <string>
+#include <utility>
+
+#include "base/check.h"
+#include "base/command_line.h"
+#include "brave/components/containers/core/browser/containers_service.h"
+#include "brave/components/containers/core/common/switches.h"
+#include "brave/components/containers/core/mojom/containers.mojom.h"
+
+namespace containers {
+
+ContainerSpecifier GetContainerSpecifierForCommandLineTabs(
+    const base::CommandLine& command_line,
+    ContainersService* containers_service) {
+  CHECK(containers_service);
+
+  const std::string container_name =
+      command_line.GetSwitchValueUTF8(switches::kContainer);
+
+  if (command_line.HasSwitch(switches::kTemporaryContainer)) {
+    auto container =
+        container_name.empty()
+            ? containers_service->CreateAndPersistTemporaryContainer()
+            : containers_service->GetOrCreateTemporaryContainerByName(
+                  container_name);
+    // Address the temporary container by id: names are not guaranteed to be
+    // unique, and a generated one is random.
+    return ContainerId(std::move(container->id));
+  }
+
+  if (!container_name.empty()) {
+    return ContainerName(container_name);
+  }
+
+  return {};
+}
+
+}  // namespace containers

--- a/components/containers/core/browser/command_line_container.h
+++ b/components/containers/core/browser/command_line_container.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_CONTAINERS_CORE_BROWSER_COMMAND_LINE_CONTAINER_H_
+#define BRAVE_COMPONENTS_CONTAINERS_CORE_BROWSER_COMMAND_LINE_CONTAINER_H_
+
+#include "brave/components/containers/core/browser/container_specifier.h"
+
+namespace base {
+class CommandLine;
+}  // namespace base
+
+namespace containers {
+
+class ContainersService;
+
+// Returns the container to use for the tabs passed via the command line. All
+// command line tabs share the same container, matching the "open in new
+// temporary container" UI.
+//
+// `--temporary-container` opens the tabs in a temporary container: a new one,
+// or, when `--container` also gives a name, the temporary container with that
+// name, created on first use so that a later launch can open more tabs in it.
+// `--container` on its own resolves an existing container by name.
+//
+// Creating a temporary container persists it, so this must not be called more
+// than once per launch. Returns an empty specifier (no container) when neither
+// switch is given.
+ContainerSpecifier GetContainerSpecifierForCommandLineTabs(
+    const base::CommandLine& command_line,
+    ContainersService* containers_service);
+
+}  // namespace containers
+
+#endif  // BRAVE_COMPONENTS_CONTAINERS_CORE_BROWSER_COMMAND_LINE_CONTAINER_H_

--- a/components/containers/core/browser/command_line_container_unittest.cc
+++ b/components/containers/core/browser/command_line_container_unittest.cc
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/containers/core/browser/command_line_container.h"
+
+#include <memory>
+#include <string>
+#include <variant>
+
+#include "base/command_line.h"
+#include "base/test/scoped_feature_list.h"
+#include "brave/components/containers/core/browser/container_specifier.h"
+#include "brave/components/containers/core/browser/containers_service.h"
+#include "brave/components/containers/core/browser/containers_test_utils.h"
+#include "brave/components/containers/core/browser/prefs.h"
+#include "brave/components/containers/core/browser/prefs_registration.h"
+#include "brave/components/containers/core/browser/temporary_container.h"
+#include "brave/components/containers/core/common/features.h"
+#include "brave/components/containers/core/common/switches.h"
+#include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace containers {
+
+class CommandLineContainerTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    feature_list_.InitAndEnableFeature(features::kContainers);
+    RegisterProfilePrefs(prefs_.registry());
+
+    auto delegate =
+        std::make_unique<testing::NiceMock<MockContainersServiceDelegate>>();
+    service_ = std::make_unique<ContainersService>(
+        &prefs_, /*is_off_the_record=*/false, std::move(delegate));
+  }
+
+  void TearDown() override {
+    service_->Shutdown();
+    service_.reset();
+  }
+
+  ContainerSpecifier GetSpecifier(const base::CommandLine& command_line) {
+    return GetContainerSpecifierForCommandLineTabs(command_line, service_.get());
+  }
+
+  base::test::ScopedFeatureList feature_list_;
+  sync_preferences::TestingPrefServiceSyncable prefs_;
+  std::unique_ptr<ContainersService> service_;
+};
+
+TEST_F(CommandLineContainerTest, NoSwitchesReturnsEmpty) {
+  base::CommandLine command_line(base::CommandLine::NO_PROGRAM);
+  EXPECT_TRUE(
+      std::holds_alternative<std::monostate>(GetSpecifier(command_line)));
+}
+
+TEST_F(CommandLineContainerTest, ContainerSwitchResolvesByName) {
+  base::CommandLine command_line(base::CommandLine::NO_PROGRAM);
+  command_line.AppendSwitchASCII(switches::kContainer, "Work");
+
+  const ContainerSpecifier specifier = GetSpecifier(command_line);
+  ASSERT_TRUE(std::holds_alternative<ContainerName>(specifier));
+  EXPECT_EQ("Work", std::get<ContainerName>(specifier).value());
+}
+
+TEST_F(CommandLineContainerTest, TemporaryContainerSwitchCreatesTemporary) {
+  base::CommandLine command_line(base::CommandLine::NO_PROGRAM);
+  command_line.AppendSwitch(switches::kTemporaryContainer);
+
+  const ContainerSpecifier specifier = GetSpecifier(command_line);
+  ASSERT_TRUE(std::holds_alternative<ContainerId>(specifier));
+  const std::string& id = std::get<ContainerId>(specifier).value();
+  EXPECT_TRUE(IsTemporaryContainerId(id)) << id;
+  // The temporary container is persisted so a later launch can reuse it.
+  EXPECT_TRUE(GetLocallyUsedContainerFromPrefs(prefs_, id));
+}
+
+TEST_F(CommandLineContainerTest, NamedTemporaryContainerIsReused) {
+  base::CommandLine command_line(base::CommandLine::NO_PROGRAM);
+  command_line.AppendSwitch(switches::kTemporaryContainer);
+  command_line.AppendSwitchASCII(switches::kContainer, "Named");
+
+  const ContainerSpecifier first = GetSpecifier(command_line);
+  ASSERT_TRUE(std::holds_alternative<ContainerId>(first));
+  const std::string first_id = std::get<ContainerId>(first).value();
+  EXPECT_TRUE(IsTemporaryContainerId(first_id)) << first_id;
+
+  auto container = service_->GetRuntimeContainerById(first_id);
+  ASSERT_TRUE(container);
+  EXPECT_EQ("Named", container->name);
+
+  // The same name resolves to the same temporary container on a later launch.
+  const ContainerSpecifier second = GetSpecifier(command_line);
+  ASSERT_TRUE(std::holds_alternative<ContainerId>(second));
+  EXPECT_EQ(first_id, std::get<ContainerId>(second).value());
+}
+
+}  // namespace containers

--- a/components/containers/core/browser/command_line_container_unittest.cc
+++ b/components/containers/core/browser/command_line_container_unittest.cc
@@ -43,7 +43,8 @@ class CommandLineContainerTest : public testing::Test {
   }
 
   ContainerSpecifier GetSpecifier(const base::CommandLine& command_line) {
-    return GetContainerSpecifierForCommandLineTabs(command_line, service_.get());
+    return GetContainerSpecifierForCommandLineTabs(command_line,
+                                                   service_.get());
   }
 
   base::test::ScopedFeatureList feature_list_;

--- a/components/containers/core/browser/containers_service.cc
+++ b/components/containers/core/browser/containers_service.cc
@@ -79,6 +79,23 @@ mojom::ContainerPtr ContainersService::CreateAndPersistTemporaryContainer() {
   return container;
 }
 
+mojom::ContainerPtr ContainersService::GetOrCreateTemporaryContainerByName(
+    std::string_view name) {
+  CHECK(!name.empty());
+
+  // Temporary containers are never synced, so only the locally used list is
+  // searched.
+  for (auto& container : GetLocallyUsedContainersFromPrefs(*prefs_)) {
+    if (container->name == name && IsTemporaryContainerId(container->id)) {
+      return std::move(container);
+    }
+  }
+
+  auto container = CreateTemporaryContainer(name);
+  SetLocallyUsedContainerToPrefs(container, *prefs_);
+  return container;
+}
+
 mojom::ContainerPtr ContainersService::GetRuntimeContainerById(
     std::string_view id) const {
   if (auto container = GetContainerFromPrefs(*prefs_, id)) {

--- a/components/containers/core/browser/containers_service.h
+++ b/components/containers/core/browser/containers_service.h
@@ -71,7 +71,8 @@ class ContainersService : public KeyedService {
   // Returns the temporary container named `name`, creating and persisting it
   // if there isn't one yet. Containers that aren't temporary are never
   // returned, so a synced container sharing the name doesn't turn a request
-  // for a temporary container into a regular one.
+  // for a temporary container into a regular one. `name` must not be empty;
+  // use `CreateAndPersistTemporaryContainer` to get a generated name.
   mojom::ContainerPtr GetOrCreateTemporaryContainerByName(
       std::string_view name);
 

--- a/components/containers/core/browser/containers_service.h
+++ b/components/containers/core/browser/containers_service.h
@@ -68,6 +68,13 @@ class ContainersService : public KeyedService {
   // Creates a temporary container and persists it locally.
   mojom::ContainerPtr CreateAndPersistTemporaryContainer();
 
+  // Returns the temporary container named `name`, creating and persisting it
+  // if there isn't one yet. Containers that aren't temporary are never
+  // returned, so a synced container sharing the name doesn't turn a request
+  // for a temporary container into a regular one.
+  mojom::ContainerPtr GetOrCreateTemporaryContainerByName(
+      std::string_view name);
+
   // Returns the runtime container with the given `id`. Runtime containers are
   // containers that are currently in use by the user. This can be a synced
   // container or a removed, but still used container.

--- a/components/containers/core/browser/containers_service_unittest.cc
+++ b/components/containers/core/browser/containers_service_unittest.cc
@@ -167,7 +167,7 @@ TEST_F(ContainersServiceTest, GetOrCreateTemporaryContainerByName) {
   EXPECT_EQ("Shared Name", container->name);
   EXPECT_TRUE(GetLocallyUsedContainerFromPrefs(prefs_, container->id));
 
-  // The same name resolves to the container created above.
+  // The same name resolves to the same temporary container.
   auto reused = service_->GetOrCreateTemporaryContainerByName("Shared Name");
   ASSERT_TRUE(reused);
   EXPECT_EQ(container->id, reused->id);

--- a/components/containers/core/browser/containers_service_unittest.cc
+++ b/components/containers/core/browser/containers_service_unittest.cc
@@ -154,6 +154,31 @@ TEST_F(ContainersServiceTest, CreateAndPersistTemporaryContainer) {
                   container->background_color);
 }
 
+TEST_F(ContainersServiceTest, GetOrCreateTemporaryContainerByName) {
+  // A synced container with the same name must not be returned: the caller
+  // asked for a temporary container.
+  std::vector<mojom::ContainerPtr> synced_containers;
+  synced_containers.push_back(MakeContainer("container-id", "Shared Name"));
+  SetContainersToPrefs(std::move(synced_containers), prefs_);
+
+  auto container = service_->GetOrCreateTemporaryContainerByName("Shared Name");
+  ASSERT_TRUE(container);
+  EXPECT_TRUE(IsTemporaryContainerId(container->id));
+  EXPECT_EQ("Shared Name", container->name);
+  EXPECT_TRUE(GetLocallyUsedContainerFromPrefs(prefs_, container->id));
+
+  // The same name resolves to the container created above.
+  auto reused = service_->GetOrCreateTemporaryContainerByName("Shared Name");
+  ASSERT_TRUE(reused);
+  EXPECT_EQ(container->id, reused->id);
+
+  // A different name creates another temporary container.
+  auto other = service_->GetOrCreateTemporaryContainerByName("Other Name");
+  ASSERT_TRUE(other);
+  EXPECT_TRUE(IsTemporaryContainerId(other->id));
+  EXPECT_NE(container->id, other->id);
+}
+
 TEST_F(ContainersServiceTest,
        Observer_OnContainersListChanged_WhenContainersListPrefChanges) {
   testing::NiceMock<MockContainersServiceObserver> observer;

--- a/components/containers/core/browser/temporary_container.cc
+++ b/components/containers/core/browser/temporary_container.cc
@@ -96,12 +96,12 @@ bool IsTemporaryContainerId(std::string_view container_id) {
          container_id.starts_with(kTemporaryContainerIdPrefix);
 }
 
-mojom::ContainerPtr CreateTemporaryContainer() {
+mojom::ContainerPtr CreateTemporaryContainer(std::string_view name) {
   return mojom::Container::New(
       base::StrCat({kTemporaryContainerIdPrefix,
                     base::Uuid::GenerateRandomV4().AsLowercaseString()}),
-      GenerateTemporaryContainerName(), PickTemporaryContainerIcon(),
-      PickTemporaryContainerBackground());
+      name.empty() ? GenerateTemporaryContainerName() : std::string(name),
+      PickTemporaryContainerIcon(), PickTemporaryContainerBackground());
 }
 
 }  // namespace containers

--- a/components/containers/core/browser/temporary_container.cc
+++ b/components/containers/core/browser/temporary_container.cc
@@ -6,6 +6,7 @@
 #include "brave/components/containers/core/browser/temporary_container.h"
 
 #include <array>
+#include <optional>
 #include <string>
 
 #include "base/check.h"
@@ -96,11 +97,12 @@ bool IsTemporaryContainerId(std::string_view container_id) {
          container_id.starts_with(kTemporaryContainerIdPrefix);
 }
 
-mojom::ContainerPtr CreateTemporaryContainer(std::string_view name) {
+mojom::ContainerPtr CreateTemporaryContainer(
+    std::optional<std::string_view> name) {
   return mojom::Container::New(
       base::StrCat({kTemporaryContainerIdPrefix,
                     base::Uuid::GenerateRandomV4().AsLowercaseString()}),
-      name.empty() ? GenerateTemporaryContainerName() : std::string(name),
+      name ? std::string(*name) : GenerateTemporaryContainerName(),
       PickTemporaryContainerIcon(), PickTemporaryContainerBackground());
 }
 

--- a/components/containers/core/browser/temporary_container.h
+++ b/components/containers/core/browser/temporary_container.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_COMPONENTS_CONTAINERS_CORE_BROWSER_TEMPORARY_CONTAINER_H_
 #define BRAVE_COMPONENTS_CONTAINERS_CORE_BROWSER_TEMPORARY_CONTAINER_H_
 
+#include <optional>
 #include <string_view>
 
 #include "brave/components/containers/core/mojom/containers.mojom-forward.h"
@@ -21,7 +22,8 @@ bool IsTemporaryContainerId(std::string_view container_id);
 // Builds a temporary container (`t-` prefixed container id, random icon,
 // random background color). Uses `name` when given, otherwise generates a
 // BIP-39 two-word name.
-mojom::ContainerPtr CreateTemporaryContainer(std::string_view name = {});
+mojom::ContainerPtr CreateTemporaryContainer(
+    std::optional<std::string_view> name = std::nullopt);
 
 }  // namespace containers
 

--- a/components/containers/core/browser/temporary_container.h
+++ b/components/containers/core/browser/temporary_container.h
@@ -18,9 +18,10 @@ inline constexpr std::string_view kTemporaryContainerIdPrefix = "t-";
 // Checks if a given container id is a temporary container id.
 bool IsTemporaryContainerId(std::string_view container_id);
 
-// Builds a temporary container (`t-` prefixed container id, BIP-39 two-word
-// name, random icon, random background color).
-mojom::ContainerPtr CreateTemporaryContainer();
+// Builds a temporary container (`t-` prefixed container id, random icon,
+// random background color). Uses `name` when given, otherwise generates a
+// BIP-39 two-word name.
+mojom::ContainerPtr CreateTemporaryContainer(std::string_view name = {});
 
 }  // namespace containers
 

--- a/components/containers/core/browser/temporary_container_unittest.cc
+++ b/components/containers/core/browser/temporary_container_unittest.cc
@@ -76,4 +76,16 @@ TEST_F(TemporaryContainerTest, CreateTemporaryContainer) {
       std::ranges::contains(expected_backgrounds, container->background_color));
 }
 
+TEST_F(TemporaryContainerTest, CreateTemporaryContainerWithName) {
+  auto container = CreateTemporaryContainer("Command Line Container");
+  ASSERT_TRUE(container);
+  EXPECT_TRUE(IsTemporaryContainerId(container->id));
+  EXPECT_EQ("Command Line Container", container->name);
+
+  // Ids stay unique when the same name is used again.
+  auto other = CreateTemporaryContainer("Command Line Container");
+  ASSERT_TRUE(other);
+  EXPECT_NE(container->id, other->id);
+}
+
 }  // namespace containers

--- a/components/containers/core/common/BUILD.gn
+++ b/components/containers/core/common/BUILD.gn
@@ -18,6 +18,13 @@ component("features") {
   deps = [ "//base" ]
 }
 
+source_set("switches") {
+  sources = [ "switches.h" ]
+}
+
 group("common") {
-  public_deps = [ ":features" ]
+  public_deps = [
+    ":features",
+    ":switches",
+  ]
 }

--- a/components/containers/core/common/switches.h
+++ b/components/containers/core/common/switches.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_CONTAINERS_CORE_COMMON_SWITCHES_H_
+#define BRAVE_COMPONENTS_CONTAINERS_CORE_COMMON_SWITCHES_H_
+
+namespace containers::switches {
+
+// Specifies the container to use for the tabs passed on the command line. On
+// its own it resolves an existing container by name; with `kTemporaryContainer`
+// it names the temporary container instead.
+inline constexpr char kContainer[] = "container";
+
+// Opens the tabs passed on the command line in a temporary container.
+inline constexpr char kTemporaryContainer[] = "temporary-container";
+
+}  // namespace containers::switches
+
+#endif  // BRAVE_COMPONENTS_CONTAINERS_CORE_COMMON_SWITCHES_H_


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/57993

Opens command line URLs in a temporary container, reusing the same service call as the "open in new temporary container" menus.

`--temporary-container` on its own creates a new temporary container. Together with `--container=<name>` the temporary container takes that name, so a later launch with the same name opens more tabs in it.

<!-- Add brave-browser issue below that this PR will resolve -->

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

