### PR TITLE
Don't paint small accent icon when scroll is active

### DIFF
--- a/browser/containers/containers_browsertest.cc
+++ b/browser/containers/containers_browsertest.cc
@@ -13,6 +13,7 @@
 #include "brave/browser/containers/containers_service_factory.h"
 #include "brave/browser/containers/used_container_storage_partitions.h"
 #include "brave/browser/ui/browser_commands.h"
+#include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/tabs/brave_new_tab_button.h"
 #include "brave/browser/ui/views/tabs/brave_tab.h"
 #include "brave/components/containers/content/browser/storage_partition_utils.h"
@@ -1456,6 +1457,45 @@ IN_PROC_BROWSER_TEST_F(ContainersBrowserTest,
   EXPECT_FALSE(browser()->window()->IsFullscreen());
   EXPECT_TRUE(small_accent_view->GetVisible());
   EXPECT_TRUE(small_accent_view->layer());
+}
+
+IN_PROC_BROWSER_TEST_F(ContainersBrowserTest,
+                       SmallAccentIconViewNotLayeredWhenScrollIsActive) {
+  auto animation_resetter = gfx::AnimationTestApi::SetRichAnimationRenderMode(
+      gfx::Animation::RichAnimationRenderMode::FORCE_DISABLED);
+  auto* tab_strip_model = browser()->tab_strip_model();
+  auto* tab_strip =
+      browser()->GetBrowserView().horizontal_tab_strip_for_testing();
+
+  // Add a tab in a container
+  const GURL url("https://a.test/simple.html");
+  auto container = containers::mojom::Container::New();
+  container->id = "accent-scroll-test-container";
+  container->name = "Accent Scroll Test Container";
+  container->icon = containers::mojom::Icon::kSocial;
+  container->background_color = SK_ColorYELLOW;
+  brave::OpenUrlInContainer(browser(), url, container);
+  EXPECT_EQ(2, tab_strip_model->count());
+
+  auto* tab_in_container = views::AsViewClass<BraveTab>(
+      tab_strip->tab_at(tab_strip_model->active_index()));
+  ASSERT_TRUE(tab_strip->ShouldPaintTabAccent(tab_in_container));
+  content::WebContents* contents_in_container =
+      tab_strip_model->GetActiveWebContents();
+  ASSERT_TRUE(contents_in_container);
+  EXPECT_TRUE(content::WaitForLoadStop(contents_in_container));
+
+  // By default, the small accent icon view should be visible and have a layer.
+  views::View* small_accent_view =
+      tab_in_container->small_accent_icon_view_for_test();
+  EXPECT_TRUE(small_accent_view->layer());
+
+  // When the tab strip is scrollable, the small accent icon view should not
+  // have a layer.
+  browser()->profile()->GetPrefs()->SetBoolean(
+      brave_tabs::kScrollableHorizontalTabStrip, true);
+  views::test::RunScheduledLayout(tab_strip);
+  EXPECT_FALSE(small_accent_view->layer());
 }
 
 IN_PROC_BROWSER_TEST_F(ContainersBrowserTest,

--- a/browser/ui/views/tabs/brave_tab.cc
+++ b/browser/ui/views/tabs/brave_tab.cc
@@ -68,9 +68,6 @@ void BraveTab::SmallAccentIconView::SetCanPaintToLayer(
 }
 
 void BraveTab::SmallAccentIconView::RefreshLayer() {
-  // In order to be clipped by Tab::PaintChildren(), we need to set paint to
-  // layer. Disable layer painting in fullscreen where the tab strip may be
-  // sliding in or out.
   if (can_paint_to_layer_ == !!layer()) {
     return;
   }
@@ -446,8 +443,15 @@ void BraveTab::UpdateSmallAccentIconLayer() {
     return;
   }
   const views::Widget* widget = GetWidget();
-  small_accent_icon_view_->SetCanPaintToLayer(widget &&
-                                              !widget->IsFullscreen());
+
+  // In order to be clipped by Tab::PaintChildren(), we need to set paint to
+  // layer. Disable layer painting
+  // * in fullscreen where the tab strip may be sliding in or out.
+  // * when tab are scrollable(!CanPaintThrobberToLayer()), which needs to be
+  //   clipped by viewport bound.
+  small_accent_icon_view_->SetCanPaintToLayer(
+      widget && !widget->IsFullscreen() &&
+      controller_->CanPaintThrobberToLayer());
   small_accent_icon_view_->SchedulePaint();
 }
 


### PR DESCRIPTION
When scroll mode is active, the icon should not have a layer. Otherwise, it won't be clipped by viewport bound

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57255

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
