### PR TITLE
[recipes] Improve `platform` recipe module

### DIFF
--- a/tools/recipes/.vpython3
+++ b/tools/recipes/.vpython3
@@ -23,3 +23,15 @@ wheel: <
   name: "infra/python/wheels/pyyaml-py3"
   version: "version:6.0.1"
 >
+
+# Declarative attribute classes, used by `engine_types` for `ResourceCost`.
+wheel: <
+  name: "infra/python/wheels/attrs-py3"
+  version: "version:23.1.0"
+>
+
+# Reports the host's logical core count and physical memory.
+wheel: <
+  name: "infra/python/wheels/psutil/${vpython_platform}"
+  version: "version:5.8.0.chromium.3"
+>

--- a/tools/recipes/engine_types.py
+++ b/tools/recipes/engine_types.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Engine-level value types shared by the runner and the built-in modules.
+
+Ported from upstream `recipes-py`'s `recipe_engine/engine_types.py`, keeping
+the upstream semantics (and, where practical, the upstream wording) so the
+behaviour stays comparable when reading either code base.
+
+  * `ResourceCost` -- what a step expects to consume, honoured by the step
+    scheduler so too many costly steps never run at once.
+
+Upstream's `PerGreenletState` lands here alongside the `futures` module that
+gives it meaning, rather than ahead of it: it derives from `gevent.local.local`
+and so would pull the whole gevent stack in before anything runs concurrently.
+"""
+
+from __future__ import annotations
+
+import attr
+
+
+@attr.s(frozen=True, slots=True)
+class ResourceCost:
+    """A structure defining the resources that a given step may need.
+
+    For use with `api.step`; attaching a `ResourceCost` to a step lets the
+    engine prevent too many costly steps from running concurrently.
+
+    See `api.step.ResourceCost` for full documentation.
+    """
+    cpu: int = attr.ib(default=500)
+    memory: int = attr.ib(default=50)
+    disk: int = attr.ib(default=0)
+    net: int = attr.ib(default=0)
+
+    @classmethod
+    def zero(cls) -> ResourceCost:
+        """Return a `ResourceCost` with zero for all resources."""
+        return cls(0, 0, 0, 0)
+
+    def __attrs_post_init__(self) -> None:
+        if self.cpu < 0:
+            raise ValueError('negative cpu amount')
+        if self.memory < 0:
+            raise ValueError('negative memory amount')
+        if self.disk < 0 or self.disk > 100:
+            raise ValueError('disk not in [0,100]')
+        if self.net < 0 or self.net > 100:
+            raise ValueError('net not in [0,100]')
+
+    def __bool__(self) -> bool:
+        """Whether this cost asks for any resource at all.
+
+        A cost of all zeroes never blocks, so the scheduler skips it.
+        """
+        return not self.fits(0, 0, 0, 0)
+
+    def __str__(self) -> str:
+        bits = []
+        if self.cpu > 0:
+            cores = ('%0.2f' % (self.cpu / 1000.)).rstrip('0').rstrip('.')
+            bits.append(f'cpu=[{cores} cores]')
+        if self.memory > 0:
+            bits.append(f'memory=[{self.memory} MiB]')
+        if self.disk > 0:
+            bits.append(f'disk=[{self.disk}%]')
+        if self.net > 0:
+            bits.append(f'net=[{self.net}%]')
+        return ', '.join(bits)
+
+    def fits(self, cpu: int, memory: int, disk: int, net: int) -> bool:
+        """Whether this cost fits within the given constraints."""
+        return (self.cpu <= cpu and self.memory <= memory and self.disk <= disk
+                and self.net <= net)

--- a/tools/recipes/recipe_modules/platform/api.py
+++ b/tools/recipes/recipe_modules/platform/api.py
@@ -2,61 +2,143 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""The `platform` module API: mockable host OS identification.
-
-Modules branch on `api.platform.is_win` (etc.) instead of `sys.platform` /
-`platform.system()` directly, so a `GenTests` case can simulate any OS with
-`api.platform.name('mac')`. In production the name is derived from the real
-host; in test mode it comes from the run's `TestContext`.
+"""Mockable system platform identity functions.
 """
 
 from __future__ import annotations
 
+import platform
 import sys
+
+import psutil
 
 from recipe_api import RecipeApi
 
-# Canonical short platform names.
-_VALID = ('linux', 'mac', 'win')
+
+def norm_bits(arch: str | int) -> int:
+    """Normalise a machine/bitness string to either 32 or 64."""
+    return 64 if '64' in str(arch) else 32
 
 
-def _host_name() -> str:  # pragma: no cover - production host detection.
-    if sys.platform == 'win32':
-        return 'win'
-    if sys.platform == 'darwin':
-        return 'mac'
-    return 'linux'
+def get_arch() -> str:
+    """The current CPU architecture, as either `'arm'` or `'intel'`."""
+    arch = platform.machine()
+    return 'arm' if ('arm' in arch or 'aarch' in arch) else 'intel'
 
 
 class PlatformApi(RecipeApi):
-    """The host platform as a short name plus convenience predicates."""
+    """Provides host-platform-detection properties.
+
+    Mocks:
+        * name (str): One of `'win'`, `'mac'`, or `'linux'`.
+        * bits (int): Either 32 or 64.
+        * arch (str): Either `'intel'` or `'arm'`.
+        * cpu_count (int): Logical CPU cores, via `capacity()`.
+        * total_memory (int): Physical memory in MiB, via `capacity()`.
+    """
 
     def __init__(self) -> None:
         super().__init__()
-        # Default to the real host; refined in initialise() once the engine has
-        # seeded `_test`. Accessors below just read `self._name`. No per-call
-        # test-mode branching.
-        self._name = _host_name()
+        self._name = 'linux'
+        self._bits = 64
+        self._arch = 'intel'
+        self._num_logical_cores = 0
+        self._memory_bytes = 0
 
     def initialise(self) -> None:
-        if self._test is not None:
-            self._name = self._test.platform
-        assert self._name in _VALID, (
-            f'unknown simulated platform {self._name!r}; use one of {_VALID}')
+        self._name = PlatformApi.normalize_platform_name(sys.platform)
+        self._arch = get_arch()
+        self._bits = norm_bits(platform.machine())
 
-    @property
-    def name(self) -> str:
-        """`'linux'`, `'mac'`, or `'win'`."""
-        return self._name
+        if self._test is not None:
+            # Default to linux/64, unless the test case says otherwise.
+            self._name = PlatformApi.normalize_platform_name(
+                self._test.platform)
+            self._bits = norm_bits(self._test.bits)
+            self._arch = self._test.arch
+
+            self._num_logical_cores = self._test.cpu_count
+            self._memory_bytes = self._test.total_memory * (1024**2)
+        else:  # pragma: no cover - production host probe.
+            # platform.machine is based on the running kernel. It is possible
+            # to use a 64-bit kernel with a 32-bit userland, e.g. to give the
+            # linker slightly more memory. Distinguish between different
+            # userland bitness by querying the python binary.
+            if (self._name == 'linux' and self._bits == 64
+                    and platform.architecture()[0] == '32bit'):
+                self._bits = 32
+            # On Mac the inverse of the linux 64-bit-kernel case is true: the
+            # kernel is 32-bit but the CPU and userspace are both capable of
+            # running 64-bit programs.
+            elif (self._name == 'mac' and self._bits == 32
+                  and platform.architecture()[0] == '64bit'):
+                self._bits = 64
+
+            self._num_logical_cores = psutil.cpu_count(True)
+            self._memory_bytes = psutil.virtual_memory().total
 
     @property
     def is_win(self) -> bool:
+        """Whether the recipe is running on Windows."""
         return self.name == 'win'
 
     @property
     def is_mac(self) -> bool:
+        """Whether the recipe is running on macOS."""
         return self.name == 'mac'
 
     @property
     def is_linux(self) -> bool:
+        """Whether the recipe is running on Linux."""
         return self.name == 'linux'
+
+    @property
+    def name(self) -> str:
+        """The current platform name, which will be one of:
+            * win
+            * mac
+            * linux
+        """
+        return self._name
+
+    @property
+    def bits(self) -> int:
+        """The bitness of the userland for the current system, either 32 or 64.
+
+        If anyone needs to query for the kernel bitness, another accessor
+        should be added.
+        """
+        return self._bits
+
+    @property
+    def arch(self) -> str:
+        """The current CPU architecture, either `'arm'` or `'intel'`."""
+        return self._arch
+
+    @property
+    def total_memory(self) -> int:
+        """The total physical memory in MiB.
+
+        Equivalent to `psutil.virtual_memory().total / (1024 ** 2)`.
+        """
+        return self._memory_bytes // (1024**2)
+
+    @property
+    def cpu_count(self) -> int:
+        """The number of logical CPU cores (i.e. including hyper-threaded
+        cores), according to `psutil.cpu_count(True)`."""
+        return self._num_logical_cores
+
+    @staticmethod
+    def normalize_platform_name(plat: str) -> str:
+        """One of python's `sys.platform` values -> 'win', 'linux' or 'mac'."""
+        if plat.startswith('linux'):
+            return 'linux'
+        if plat.startswith(('win', 'cygwin')):
+            return 'win'
+        if plat.startswith(('darwin', 'mac')):
+            return 'mac'
+        # Unreachable from a `GenTests` case, since the test API only accepts
+        # the three known names; this guards an unrecognised real host.
+        raise ValueError(  # pragma: no cover
+            f"Don't understand platform {plat!r}")

--- a/tools/recipes/recipe_modules/platform/examples/full.expected/linux.json
+++ b/tools/recipes/recipe_modules/platform/examples/full.expected/linux.json
@@ -14,6 +14,22 @@
     "name": "linux only"
   },
   {
+    "cmd": [
+      "echo",
+      "8",
+      "16384"
+    ],
+    "name": "report capacity"
+  },
+  {
+    "cmd": [
+      "echo",
+      "64",
+      "intel"
+    ],
+    "name": "report machine"
+  },
+  {
     "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/platform/examples/full.expected/mac.json
+++ b/tools/recipes/recipe_modules/platform/examples/full.expected/mac.json
@@ -14,6 +14,22 @@
     "name": "mac only"
   },
   {
+    "cmd": [
+      "echo",
+      "8",
+      "16384"
+    ],
+    "name": "report capacity"
+  },
+  {
+    "cmd": [
+      "echo",
+      "64",
+      "intel"
+    ],
+    "name": "report machine"
+  },
+  {
     "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/platform/examples/full.expected/win.json
+++ b/tools/recipes/recipe_modules/platform/examples/full.expected/win.json
@@ -14,6 +14,22 @@
     "name": "windows only"
   },
   {
+    "cmd": [
+      "echo",
+      "8",
+      "16384"
+    ],
+    "name": "report capacity"
+  },
+  {
+    "cmd": [
+      "echo",
+      "64",
+      "intel"
+    ],
+    "name": "report machine"
+  },
+  {
     "name": "$result"
   }
 ]

--- a/tools/recipes/recipe_modules/platform/examples/full.py
+++ b/tools/recipes/recipe_modules/platform/examples/full.py
@@ -19,6 +19,13 @@ def RunSteps(api):
         api.step('mac only', ['echo', 'mac'])
     if api.platform.is_linux:
         api.step('linux only', ['echo', 'linux'])
+    api.step('report capacity', [
+        'echo',
+        str(api.platform.cpu_count),
+        str(api.platform.total_memory),
+    ])
+    api.step('report machine',
+             ['echo', str(api.platform.bits), api.platform.arch])
 
 
 def GenTests(api):
@@ -46,4 +53,52 @@ def GenTests(api):
         api.post_process(post_process.MustRun, 'mac only'),
         api.post_process(post_process.DoesNotRun, 'windows only'),
         api.post_process(post_process.StatusSuccess),
+    )
+    # A simulated host reports fixed capacity, so a `ResourceCost` schedules
+    # identically wherever the tests run.
+    yield api.test(
+        'default capacity',
+        api.platform.name('linux'),
+        api.post_process(post_process.StepCommandContains, 'report capacity',
+                         ['8', '16384']),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )
+    # Either figure can be overridden, to exercise a step that has to queue.
+    yield api.test(
+        'overridden capacity',
+        api.platform.name('linux'),
+        api.platform.capacity(cpu_count=2, total_memory=1024),
+        api.post_process(post_process.StepCommandContains, 'report capacity',
+                         ['2', '1024']),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )
+    # A simulated host defaults to 64-bit intel.
+    yield api.test(
+        'default machine',
+        api.platform.name('linux'),
+        api.post_process(post_process.StepCommandContains, 'report machine',
+                         ['64', 'intel']),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )
+    # `api.platform(...)` sets name, bitness and architecture together.
+    yield api.test(
+        'arm mac',
+        api.platform('mac', 64, 'arm'),
+        api.post_process(post_process.StepCommandContains, 'report machine',
+                         ['64', 'arm']),
+        api.post_process(post_process.MustRun, 'mac only'),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )
+    yield api.test(
+        '32 bit windows',
+        api.platform('win', 32),
+        api.post_process(post_process.StepCommandContains, 'report machine',
+                         ['32', 'intel']),
+        api.post_process(post_process.MustRun, 'windows only'),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
     )

--- a/tools/recipes/recipe_modules/platform/test_api.py
+++ b/tools/recipes/recipe_modules/platform/test_api.py
@@ -2,7 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Test API for the `platform` module: choose the simulated host OS."""
+"""Test API for the `platform` module: choose the simulated host."""
 
 from __future__ import annotations
 
@@ -10,8 +10,56 @@ from recipe_test_api import RecipeTestApi, TestData
 
 
 class PlatformTestApi(RecipeTestApi):
-    """Select the platform a `GenTests` case simulates."""
+    """Select the host a `GenTests` case simulates."""
 
     def name(self, name: str) -> TestData:
-        """Simulate host platform *name* (`'linux'`, `'mac'`, or `'win'`)."""
+        """Set the platform 'name' for the current test.
+
+        The only three values currently allowed are 'win', 'linux', and 'mac'.
+        """
+        assert name in ('win', 'linux', 'mac'), f'unknown platform {name!r}'
         return self._mod_data(name=name)
+
+    def bits(self, bits: int) -> TestData:
+        """Set the bitness for the current test.
+
+        The only two values currently allowed are 32 and 64.
+        """
+        assert bits in (32, 64), f'unknown bitness {bits!r}'
+        return self._mod_data(bits=bits)
+
+    def arch(self, arch: str) -> TestData:
+        """Set the architecture for the current test.
+
+        The only two values currently allowed are 'intel' and 'arm'.
+        """
+        assert arch in ('intel', 'arm'), f'unknown arch {arch!r}'
+        return self._mod_data(arch=arch)
+
+    def capacity(self,
+                 cpu_count: int | None = None,
+                 total_memory: int | None = None) -> TestData:
+        """Set the host's capacity, as the step scheduler sees it.
+
+        This has no upstream counterpart: upstream fixes a simulated host at 8
+        cores and 16 GiB with no override, and covers the scheduler with engine
+        level tests instead. Ours is reachable from a `GenTests` case so a
+        recipe can exercise a step that has to queue for resources.
+
+        A simulated host reports those same 8 cores and 16 GiB by default, so a
+        `ResourceCost` schedules identically wherever the tests run.
+
+        Args:
+            cpu_count: Logical cores to report, or None to keep the default.
+            total_memory: Physical memory in MiB, or None to keep the default.
+        """
+        data = {}
+        if cpu_count is not None:
+            data['cpu_count'] = cpu_count
+        if total_memory is not None:
+            data['total_memory'] = total_memory
+        return self._mod_data(**data)
+
+    def __call__(self, name: str, bits: int, arch: str = 'intel') -> TestData:
+        """Set name, bitness and architecture together."""
+        return self.name(name) + self.bits(bits) + self.arch(arch)

--- a/tools/recipes/simulation.py
+++ b/tools/recipes/simulation.py
@@ -52,6 +52,16 @@ SIM_HOME = PurePosixPath('/b/home')
 WORKSPACE_TOKEN = '[WORKSPACE]'
 HOME_TOKEN = '[HOME]'
 
+# What a simulated host reports about itself, matching upstream recipes-py's
+# simulator: linux/64/intel on 8 cores with 16 GiB. Fixed so a step's
+# `ResourceCost` schedules the same way regardless of the machine running the
+# tests; a case that needs different figures asks for them explicitly with
+# `api.platform(...)` / `api.platform.capacity(...)`.
+SIM_BITS = 64
+SIM_ARCH = 'intel'
+SIM_CPU_COUNT = 8
+SIM_TOTAL_MEMORY = 16 * 1024
+
 # This engine's own root (`tools/recipes/`), for stabilizing commands that
 # reference a resource file living next to a recipe module (e.g. `file`'s
 # `resources/fileutil.py`) via a real `Path(__file__).resolve()`-derived
@@ -235,6 +245,10 @@ class TestContext:
     def __init__(self,
                  *,
                  platform: str = 'linux',
+                 bits: int = SIM_BITS,
+                 arch: str = SIM_ARCH,
+                 cpu_count: int = SIM_CPU_COUNT,
+                 total_memory: int = SIM_TOTAL_MEMORY,
                  env: dict[str, str] | None = None,
                  files: Iterable[str | Path] = (),
                  dirs: Iterable[str | Path] = (),
@@ -242,6 +256,10 @@ class TestContext:
                  home: str | Path = SIM_HOME,
                  test_data: TestData | None = None) -> None:
         self.platform = platform
+        self.bits = bits
+        self.arch = arch
+        self.cpu_count = cpu_count
+        self.total_memory = total_memory
         self.env = dict(env or {})
         self.fs = SimFS(files, dirs)
         self.which_map = dict(which_map or {})
@@ -255,11 +273,16 @@ class TestContext:
     def from_test_data(cls, test_data: TestData) -> TestContext:
         """Build a context from the seed values a `GenTests` case supplied."""
         mod = test_data.mod_data
-        platform = mod.get('platform', {}).get('name', 'linux')
+        platform_seed = mod.get('platform', {})
+        platform = platform_seed.get('name', 'linux')
         env_seed = mod.get('env', {})
         path_seed = mod.get('path', {})
         return cls(
             platform=platform,
+            bits=platform_seed.get('bits', SIM_BITS),
+            arch=platform_seed.get('arch', SIM_ARCH),
+            cpu_count=platform_seed.get('cpu_count', SIM_CPU_COUNT),
+            total_memory=platform_seed.get('total_memory', SIM_TOTAL_MEMORY),
             # `api.env.set(...)` vars plus any `api.properties.environ(...)`
             # values; the latter is what the engine decodes into ENV_PROPERTIES.
             env={


### PR DESCRIPTION
This change adds some extras to the platform module, in particular,
capacity, which will permit us to probe certain properties of the
machine we are running a recipe on (number of cores, etc). This also
improves the platform detection.

Bug: https://github.com/brave/brave-browser/issues/56748
