### PR TITLE
[plaster] Regex macros backend

### DIFF
--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -710,6 +710,28 @@ class MatchExpectation:
                 f'{self.minimum}..{upper})')
 
 
+def _is_valid_re_flag_name(flag: str) -> bool:
+    """True if `flag` names a real `re` module flag (e.g. `DOTALL`)."""
+    return flag.isupper() and hasattr(re, flag)
+
+
+def _parse_re_flags(flags_raw: object, description: str) -> int:
+    """Combine `re_flags` flag names (e.g. `['DOTALL']`) into one `re` mask.
+    """
+    if not isinstance(flags_raw, list):
+        raise ValueError(
+            f're_flags must be a list of strings (in "{description}")')
+    re_flags = 0
+    for flag in flags_raw:
+        if not isinstance(flag, str):
+            raise ValueError(
+                f're_flags entries must be strings (in "{description}")')
+        if not _is_valid_re_flag_name(flag):
+            raise ValueError(f'Invalid re flag specified: {flag}')
+        re_flags |= getattr(re, flag)
+    return re_flags
+
+
 class Regex(Rewriter):
     """A regex substitution applied with `re.subn` (the native rewriter).
     """
@@ -806,23 +828,8 @@ class Regex(Rewriter):
 
         return cls(re_pattern=re_pattern,
                    replace=replace,
-                   re_flags=cls._parse_flags(body.get('re_flags', []),
-                                             description))
-
-    @staticmethod
-    def _parse_flags(flags_raw: object, description: str) -> int:
-        if not isinstance(flags_raw, list):
-            raise ValueError(
-                f're_flags must be a list of strings (in "{description}")')
-        re_flags = 0
-        for flag in flags_raw:
-            if not isinstance(flag, str):
-                raise ValueError(
-                    f're_flags entries must be strings (in "{description}")')
-            if not (flag.isupper() and hasattr(re, flag)):
-                raise ValueError(f'Invalid re flag specified: {flag}')
-            re_flags |= getattr(re, flag)
-        return re_flags
+                   re_flags=_parse_re_flags(body.get('re_flags', []),
+                                            description))
 
 
 @dataclass(frozen=True)
@@ -2238,6 +2245,24 @@ _REWRITER_SCHEMA = {
     'result': _RESULT_SCHEMA,
 }
 
+# Regex macros have input fields, and those input fields also require a
+# documentation for them.
+_REGEX_MACRO_INPUT_SCHEMA = {
+    'name': _NON_EMPTY_STR,
+    'description': _NON_EMPTY_STR,
+}
+
+# A regex macro schema. A regex macro is similar to a substitution, so it has
+# the same entries that a regular regex rewriter has.
+_REGEX_MACRO_SCHEMA = {
+    'description': _NON_EMPTY_STR,
+    'inputs': [_REGEX_MACRO_INPUT_SCHEMA],
+    schema.Optional('pattern'): _NON_EMPTY_STR,
+    schema.Optional('re_pattern'): _NON_EMPTY_STR,
+    'replace': str,
+    schema.Optional('re_flags'): [str],
+}
+
 # Top-level schema for rewriters.pyl.
 _REWRITERS_SCHEMA = schema.Schema({
     schema.Optional('ast.matcher'): {
@@ -2245,6 +2270,9 @@ _REWRITERS_SCHEMA = schema.Schema({
     },
     schema.Optional('ast.rewriter'): {
         schema.Optional(_OP_ID): _REWRITER_SCHEMA
+    },
+    schema.Optional('regex_macro'): {
+        schema.Optional(_OP_ID): _REGEX_MACRO_SCHEMA
     },
 })
 
@@ -2276,6 +2304,7 @@ class RewritersEval:
             raise RewritersSchemaError(f'{source}: {e}') from e
         self._matchers = data.get('ast.matcher', {})
         self._rewriters = data.get('ast.rewriter', {})
+        self._regex_macros = data.get('regex_macro', {})
         self._check_cross_references()
 
     @classmethod
@@ -2313,6 +2342,19 @@ class RewritersEval:
         except KeyError:
             raise RewritersSchemaError(
                 f'unknown rewriter op: {op_id!r}') from None
+
+    @property
+    def regex_macros(self) -> MappingProxyType[str, dict]:
+        """Read-only mapping of regex macro op id -> validated macro spec."""
+        return MappingProxyType(self._regex_macros)
+
+    def regex_macro(self, op_id: str) -> dict:
+        """Return the regex macro spec for `op_id`, or raise if unknown."""
+        try:
+            return self._regex_macros[op_id]
+        except KeyError:
+            raise RewritersSchemaError(
+                f'unknown regex macro op: {op_id!r}') from None
 
     @classmethod
     def language_of(cls, op_id: str) -> str:
@@ -2356,6 +2398,8 @@ class RewritersEval:
             self._check_matcher_captures(op_id, spec)
         for op_id, spec in self._rewriters.items():
             self._check_rewriter_interface(op_id, spec)
+        for op_id, spec in self._regex_macros.items():
+            self._check_regex_macro_interface(op_id, spec)
 
     def _check_matcher_captures(self, op_id: str, spec: dict) -> None:
         """Every metavariable a capture reads must be bound by the template."""
@@ -2421,6 +2465,52 @@ class RewritersEval:
         if unused:
             raise RewritersSchemaError(
                 f'{self._source}: rewriter {op_id!r} declares input(s) '
+                f'never used in its templates: {", ".join(unused)}')
+
+    def _check_regex_macro_interface(self, op_id: str, spec: dict) -> None:
+        """A regex macro's `pattern`/`replace` fields and declared `inputs`
+        must line up.
+
+        The macro must pick exactly one of `pattern`/`re_pattern` (the same
+        mutual exclusivity `Regex.parse` enforces for a plain `regex:` block)
+        and name only real `re` flags. Each `inputs` entry's `name` must be
+        unique, and the set of names must be exactly the union of
+        `{placeholder}`s used across the active pattern field and `replace`,
+        so the macro's advertised interface never drifts from what it
+        actually consumes or leaves an input undocumented.
+        """
+        has_pattern = 'pattern' in spec
+        has_re_pattern = 're_pattern' in spec
+        if has_pattern == has_re_pattern:
+            raise RewritersSchemaError(
+                f'{self._source}: regex macro {op_id!r} must specify exactly '
+                f'one of `pattern` or `re_pattern`')
+        for flag in spec.get('re_flags', []):
+            if not _is_valid_re_flag_name(flag):
+                raise RewritersSchemaError(
+                    f'{self._source}: regex macro {op_id!r} has an invalid '
+                    f're_flags entry: {flag!r}')
+
+        names = [entry['name'] for entry in spec['inputs']]
+        duplicates = sorted({name for name in names if names.count(name) > 1})
+        if duplicates:
+            raise RewritersSchemaError(
+                f'{self._source}: regex macro {op_id!r} declares duplicate '
+                f'input name(s): {", ".join(duplicates)}')
+
+        declared = set(names)
+        used = _placeholders(spec.get('pattern', spec.get('re_pattern')))
+        used |= _placeholders(spec['replace'])
+
+        undeclared = sorted(used - declared)
+        if undeclared:
+            raise RewritersSchemaError(
+                f'{self._source}: regex macro {op_id!r} templates use '
+                f'undeclared input(s): {", ".join(undeclared)}')
+        unused = sorted(declared - used)
+        if unused:
+            raise RewritersSchemaError(
+                f'{self._source}: regex macro {op_id!r} declares input(s) '
                 f'never used in its templates: {", ".join(unused)}')
 
 
@@ -2816,6 +2906,58 @@ class AstRewriter:
             source = source[:start] + new_text.encode('utf-8') + source[end:]
         self._source = source.decode('utf-8')
         return total
+
+
+class RegexMacroEngine:
+    """Applies named `regex_macro` ops (from `rewriters.pyl`) to file contents.
+
+    Similar to `AstRewriter` this type is constructed with `RewritersEval`, but
+    it is dedicated to handle regex macros.
+    """
+
+    def __init__(self, rewriters: RewritersEval, content: str):
+        self._rewriters = rewriters
+        self._source = content
+
+    @property
+    def content(self) -> str:
+        """The current file contents, reflecting every applied rewrite."""
+        return self._source
+
+    def run(self, op_id: str, inputs: dict[str, str]) -> int:
+        """Run one regex macro, mutate content, return the change count.
+
+        `inputs` must supply exactly the op's declared `inputs`, no more and
+        no fewer. `pattern` (escaped) or `re_pattern`, and `replace`, are
+        rendered with `inputs` via `str.format` before being handed to
+        `re.subn`, so the macro's own backreferences (`\\1`) reach `re.subn`
+        untouched.
+        """
+        spec = self._rewriters.regex_macro(op_id)
+        declared = frozenset(entry['name'] for entry in spec['inputs'])
+        provided = frozenset(inputs)
+        if provided != declared:
+            problems = []
+            missing = sorted(declared - provided)
+            if missing:
+                problems.append(f'missing input(s): {", ".join(missing)}')
+            unknown = sorted(provided - declared)
+            if unknown:
+                problems.append(f'unknown input(s): {", ".join(unknown)}')
+            raise ValueError(f'{op_id}: ' + '; '.join(problems))
+
+        re_pattern = spec.get('re_pattern')
+        if re_pattern is not None:
+            pattern = re_pattern.format(**inputs)
+        else:
+            pattern = re.escape(spec['pattern'].format(**inputs))
+        replace = spec['replace'].format(**inputs)
+        flags = _parse_re_flags(spec.get('re_flags', []), op_id)
+        self._source, matches = re.subn(pattern,
+                                        replace,
+                                        self._source,
+                                        flags=flags)
+        return matches
 
 
 def get_plaster_files(filepaths: list[str] | None = None) -> list[PlasterFile]:

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -4763,5 +4763,724 @@ class PatchinfoTest(unittest.TestCase):
         self.assertEqual(original, roundtripped)
 
 
+class RegexMacroSchemaTest(unittest.TestCase):
+    """Schema and cross-reference validation for `regex_macro` ops."""
+
+    def setUp(self):
+        # load() memoises a process-wide instance; clear it so tests that
+        # exercise the singleton start from a clean slate.
+        plaster.RewritersEval._instance = None
+        self.addCleanup(setattr, plaster.RewritersEval, '_instance', None)
+
+    @staticmethod
+    def _input(name: str, description: str = 'doc') -> dict:
+        """A documented `inputs` entry: `{name, description}`."""
+        return {'name': name, 'description': description}
+
+    @classmethod
+    def _valid_spec(cls) -> dict:
+        """A minimal, schema-valid `regex_macro` spec as a Python dict."""
+        return {
+            'regex_macro': {
+                'cxx.rename_constant': {
+                    'description': 'Renames a constant.',
+                    'inputs': [
+                        cls._input('old_name'),
+                        cls._input('new_name'),
+                    ],
+                    're_pattern': r'\b{old_name}\b',
+                    'replace': '{new_name}',
+                    're_flags': ['MULTILINE'],
+                },
+            },
+        }
+
+    def _eval_valid(self) -> plaster.RewritersEval:
+        return plaster.RewritersEval(repr(self._valid_spec()))
+
+    def _assert_invalid(self, mutate, expected_substr=None):
+        """Apply `mutate` to a valid spec and assert it fails validation."""
+        spec = self._valid_spec()
+        mutate(spec)
+        with self.assertRaises(plaster.RewritersSchemaError) as cm:
+            plaster.RewritersEval(repr(spec))
+        if expected_substr is not None:
+            self.assertIn(expected_substr, str(cm.exception))
+
+    # -- access ---------------------------------------------------------
+
+    def test_valid_spec_round_trips(self):
+        rewriters = self._eval_valid()
+        self.assertEqual(list(rewriters.regex_macros), ['cxx.rename_constant'])
+        self.assertEqual(
+            rewriters.regex_macro('cxx.rename_constant')['inputs'],
+            [self._input('old_name'),
+             self._input('new_name')])
+        self.assertEqual(
+            rewriters.regex_macro('cxx.rename_constant')['description'],
+            'Renames a constant.')
+
+    def test_unknown_op_access_raises(self):
+        rewriters = self._eval_valid()
+        with self.assertRaises(plaster.RewritersSchemaError):
+            rewriters.regex_macro('cxx.nope')
+
+    def test_exposed_mapping_is_read_only(self):
+        rewriters = self._eval_valid()
+        with self.assertRaises(TypeError):
+            rewriters.regex_macros['x'] = {}
+
+    def test_present_but_empty_is_valid(self):
+        rewriters = plaster.RewritersEval("{'regex_macro': {}}")
+        self.assertEqual(dict(rewriters.regex_macros), {})
+
+    def test_absent_is_valid(self):
+        # `regex_macro` is an optional top-level key, like `ast.matcher` and
+        # `ast.rewriter`.
+        rewriters = plaster.RewritersEval('{}')
+        self.assertEqual(dict(rewriters.regex_macros), {})
+
+    # -- op id ------------------------------------------------------------
+
+    def test_op_id_unknown_prefix_rejected(self):
+
+        def mutate(s):
+            s['regex_macro']['py.rename_constant'] = s['regex_macro'].pop(
+                'cxx.rename_constant')
+
+        self._assert_invalid(mutate, 'Wrong keys')
+
+    # -- field schema -------------------------------------------------------
+
+    def test_missing_description_key_rejected(self):
+        self._assert_invalid(
+            lambda s: s['regex_macro']['cxx.rename_constant'].pop(
+                'description'), 'Missing keys')
+
+    def test_missing_inputs_key_rejected(self):
+        self._assert_invalid(
+            lambda s: s['regex_macro']['cxx.rename_constant'].pop('inputs'),
+            'Missing keys')
+
+    def test_missing_replace_key_rejected(self):
+        self._assert_invalid(
+            lambda s: s['regex_macro']['cxx.rename_constant'].pop('replace'),
+            'Missing keys')
+
+    def test_unknown_field_rejected(self):
+        self._assert_invalid(
+            lambda s: s['regex_macro']['cxx.rename_constant'].update(
+                {'extra': 'x'}), 'Wrong keys')
+
+    def test_inputs_must_be_a_list(self):
+        self._assert_invalid(
+            lambda s: s['regex_macro']['cxx.rename_constant'].__setitem__(
+                'inputs', 'old_name'), "should be instance of 'list'")
+
+    def test_input_entry_must_be_a_mapping(self):
+        self._assert_invalid(
+            lambda s: s['regex_macro']['cxx.rename_constant'].__setitem__(
+                'inputs', ['old_name', self._input('new_name')]))
+
+    def test_input_entry_missing_description_rejected(self):
+        self._assert_invalid(
+            lambda s: s['regex_macro']['cxx.rename_constant'].__setitem__(
+                'inputs', [{
+                    'name': 'old_name'
+                }, self._input('new_name')]), 'Missing keys')
+
+    def test_input_entry_unknown_field_rejected(self):
+        self._assert_invalid(
+            lambda s: s['regex_macro']['cxx.rename_constant'].__setitem__(
+                'inputs', [{
+                    **self._input('old_name'), 'extra': 'x'
+                },
+                           self._input('new_name')]), 'Wrong keys')
+
+    def test_re_flags_must_be_list_of_strings(self):
+        self._assert_invalid(
+            lambda s: s['regex_macro']['cxx.rename_constant'].__setitem__(
+                're_flags', 'MULTILINE'), "should be instance of 'list'")
+
+    # -- pattern / re_pattern mutual exclusivity -----------------------------
+
+    def test_both_pattern_and_re_pattern_rejected(self):
+        self._assert_invalid(
+            lambda s: s['regex_macro']['cxx.rename_constant'].update(
+                {'pattern': '{old_name}'}), 'exactly one of')
+
+    def test_neither_pattern_nor_re_pattern_rejected(self):
+        self._assert_invalid(
+            lambda s: s['regex_macro']['cxx.rename_constant'].pop(
+                're_pattern'), 'exactly one of')
+
+    def test_pattern_only_is_valid(self):
+        spec = self._valid_spec()
+        macro = spec['regex_macro']['cxx.rename_constant']
+        del macro['re_pattern']
+        macro['pattern'] = '{old_name}'
+        rewriters = plaster.RewritersEval(repr(spec))
+        self.assertEqual(
+            rewriters.regex_macro('cxx.rename_constant')['pattern'],
+            '{old_name}')
+
+    # -- re_flags validity ----------------------------------------------
+
+    def test_invalid_re_flags_entry_rejected(self):
+        self._assert_invalid(
+            lambda s: s['regex_macro']['cxx.rename_constant'].__setitem__(
+                're_flags', ['NOT_A_FLAG']), 'invalid')
+
+    # -- inputs <-> template cross-reference ---------------------------------
+
+    def test_undeclared_input_rejected(self):
+        # `replace` uses `{new_name}`, but it is dropped from `inputs`.
+        self._assert_invalid(
+            lambda s: s['regex_macro']['cxx.rename_constant'].__setitem__(
+                'inputs', [self._input('old_name')]), 'undeclared input')
+
+    def test_unused_input_rejected(self):
+        self._assert_invalid(
+            lambda s: s['regex_macro']['cxx.rename_constant']['inputs'].append(
+                self._input('unused')), 'never used')
+
+    def test_duplicate_input_name_rejected(self):
+        self._assert_invalid(
+            lambda s: s['regex_macro']['cxx.rename_constant']['inputs'].append(
+                self._input('old_name')), 'duplicate')
+
+    # -- the real on-disk spec ------------------------------------------
+
+    def test_real_rewriters_file_exposes_toggle_macro(self):
+        rewriters = plaster.RewritersEval.load()
+        self.assertIn('cxx.set_feature_flag_default_state',
+                      rewriters.regex_macros)
+        spec = rewriters.regex_macro('cxx.set_feature_flag_default_state')
+        self.assertEqual([entry['name'] for entry in spec['inputs']],
+                         ['feature_name', 'value'])
+
+
+class RegexMacroEngineTest(unittest.TestCase):
+    """Behavioural tests for `RegexMacroEngine.run`, against synthetic specs."""
+
+    @staticmethod
+    def _rewriters(macro: dict) -> plaster.RewritersEval:
+        """Build a `RewritersEval` from a macro body given as `name: str`
+        inputs; fills in the `description`/`{name, description}` schema
+        boilerplate the individual test bodies below do not care about.
+        """
+        macro = dict(macro)
+        macro.setdefault('description', 'A regex macro used for testing.')
+        macro['inputs'] = [{
+            'name': name,
+            'description': 'doc'
+        } for name in macro['inputs']]
+        return plaster.RewritersEval(
+            repr({'regex_macro': {
+                'cxx.rename_constant': macro
+            }}))
+
+    def test_re_pattern_and_replace_are_rendered_with_inputs(self):
+        rewriters = self._rewriters({
+            'inputs': ['old_name', 'new_name'],
+            're_pattern': r'\b{old_name}\b',
+            'replace': '{new_name}',
+        })
+        engine = plaster.RegexMacroEngine(rewriters, 'int kOld = kOld + 1;')
+        matches = engine.run('cxx.rename_constant', {
+            'old_name': 'kOld',
+            'new_name': 'kNew',
+        })
+        self.assertEqual(matches, 2)
+        self.assertEqual(engine.content, 'int kNew = kNew + 1;')
+
+    def test_pattern_is_escaped_and_rendered_with_inputs(self):
+        # `pattern` is a literal: the rendered text is escaped for regex, so a
+        # regex-meaningful input character like '.' matches only itself.
+        rewriters = self._rewriters({
+            'inputs': ['old_name', 'new_name'],
+            'pattern': '{old_name}',
+            'replace': '{new_name}',
+        })
+        engine = plaster.RegexMacroEngine(rewriters, 'a.b + axb')
+        matches = engine.run('cxx.rename_constant', {
+            'old_name': 'a.b',
+            'new_name': 'X',
+        })
+        self.assertEqual(matches, 1)
+        self.assertEqual(engine.content, 'X + axb')
+
+    def test_re_flags_are_honoured(self):
+        rewriters = self._rewriters({
+            'inputs': ['name'],
+            're_pattern': '^{name}$',
+            're_flags': ['MULTILINE'],
+            'replace': 'X',
+        })
+        engine = plaster.RegexMacroEngine(rewriters, 'foo\nfoo\n')
+        matches = engine.run('cxx.rename_constant', {'name': 'foo'})
+        self.assertEqual(matches, 2)
+        self.assertEqual(engine.content, 'X\nX\n')
+
+    def test_backreferences_in_replace_are_preserved(self):
+        # `.format()` only touches `{}`; a `\1` backreference must reach
+        # `re.subn` untouched.
+        rewriters = self._rewriters({
+            'inputs': ['name'],
+            're_pattern': '({name})',
+            'replace': r'[\1]',
+        })
+        engine = plaster.RegexMacroEngine(rewriters, 'foo bar')
+        matches = engine.run('cxx.rename_constant', {'name': 'foo'})
+        self.assertEqual(matches, 1)
+        self.assertEqual(engine.content, '[foo] bar')
+
+    def test_missing_input_raises(self):
+        rewriters = self._rewriters({
+            'inputs': ['old_name', 'new_name'],
+            're_pattern': '{old_name}',
+            'replace': '{new_name}',
+        })
+        engine = plaster.RegexMacroEngine(rewriters, 'kOld')
+        with self.assertRaises(ValueError) as cm:
+            engine.run('cxx.rename_constant', {'old_name': 'kOld'})
+        self.assertIn('missing input(s): new_name', str(cm.exception))
+
+    def test_unknown_input_raises(self):
+        rewriters = self._rewriters({
+            'inputs': ['name'],
+            're_pattern': '{name}',
+            'replace': 'x',
+        })
+        engine = plaster.RegexMacroEngine(rewriters, 'kOld')
+        with self.assertRaises(ValueError) as cm:
+            engine.run('cxx.rename_constant', {'name': 'kOld', 'extra': '1'})
+        self.assertIn('unknown input(s): extra', str(cm.exception))
+
+    def test_unknown_op_raises(self):
+        rewriters = self._rewriters({
+            'inputs': ['name'],
+            're_pattern': '{name}',
+            'replace': 'x',
+        })
+        engine = plaster.RegexMacroEngine(rewriters, 'kOld')
+        with self.assertRaises(plaster.RewritersSchemaError):
+            engine.run('cxx.nope', {'name': 'kOld'})
+
+    def test_no_match_returns_zero_and_leaves_content_untouched(self):
+        rewriters = self._rewriters({
+            'inputs': ['name'],
+            're_pattern': '{name}',
+            'replace': 'x',
+        })
+        engine = plaster.RegexMacroEngine(rewriters, 'unrelated text')
+        matches = engine.run('cxx.rename_constant', {'name': 'kOld'})
+        self.assertEqual(matches, 0)
+        self.assertEqual(engine.content, 'unrelated text')
+
+    def test_successive_runs_accumulate_edits(self):
+        rewriters = self._rewriters({
+            'inputs': ['old_name', 'new_name'],
+            're_pattern': r'\b{old_name}\b',
+            'replace': '{new_name}',
+        })
+        engine = plaster.RegexMacroEngine(rewriters, 'kOne kTwo')
+        engine.run('cxx.rename_constant', {
+            'old_name': 'kOne',
+            'new_name': 'kA'
+        })
+        engine.run('cxx.rename_constant', {
+            'old_name': 'kTwo',
+            'new_name': 'kB'
+        })
+        self.assertEqual(engine.content, 'kA kB')
+
+
+class OverrideFeatureDefaultStateTest(unittest.TestCase):
+    """Exercises the shipped `cxx.set_feature_flag_default_state` macro.
+
+    The macro replaces a `BASE_FEATURE` call's whole last argument -- from its
+    last top-level comma to the call's own closing `);` -- rather than trying
+    to recognise a particular spelling of the state itself. These tests cover
+    every argument shape the macro is meant to handle, plus the corner cases
+    that shape implies: telling one call's `);` apart from a nested one's, and
+    not running past this call into the next.
+    """
+
+    _OP_ID = 'cxx.set_feature_flag_default_state'
+
+    def setUp(self):
+        self.rewriters = plaster.RewritersEval.load()
+
+    def _run(self, content: str, **inputs) -> tuple[int, str]:
+        engine = plaster.RegexMacroEngine(self.rewriters, content)
+        matches = engine.run(self._OP_ID, inputs)
+        return matches, engine.content
+
+    # -- legacy three-argument form: BASE_FEATURE(kFoo, "Foo", state) -------
+
+    def test_three_argument_flips_disabled_to_enabled(self):
+        source = ('BASE_FEATURE(kIPHDiscardRingFeature,\n'
+                  '             "IPH_DiscardRing",\n'
+                  '             base::FEATURE_DISABLED_BY_DEFAULT);\n')
+        matches, content = self._run(source,
+                                     feature_name='kIPHDiscardRingFeature',
+                                     value='base::FEATURE_ENABLED_BY_DEFAULT')
+        self.assertEqual(matches, 1)
+        self.assertEqual(content,
+                         ('BASE_FEATURE(kIPHDiscardRingFeature,\n'
+                          '             "IPH_DiscardRing",\n'
+                          '             base::FEATURE_ENABLED_BY_DEFAULT);\n'))
+
+    def test_three_argument_flips_enabled_to_disabled(self):
+        source = ('BASE_FEATURE(kFoo,\n'
+                  '             "Foo",\n'
+                  '             base::FEATURE_ENABLED_BY_DEFAULT);\n')
+        matches, content = self._run(source,
+                                     feature_name='kFoo',
+                                     value='base::FEATURE_DISABLED_BY_DEFAULT')
+        self.assertEqual(matches, 1)
+        self.assertEqual(
+            content, ('BASE_FEATURE(kFoo,\n'
+                      '             "Foo",\n'
+                      '             base::FEATURE_DISABLED_BY_DEFAULT);\n'))
+
+    def test_three_argument_single_line(self):
+        source = 'BASE_FEATURE(kFoo, "Foo", base::FEATURE_DISABLED_BY_DEFAULT);'
+        matches, content = self._run(source,
+                                     feature_name='kFoo',
+                                     value='base::FEATURE_ENABLED_BY_DEFAULT')
+        self.assertEqual(matches, 1)
+        self.assertEqual(
+            content,
+            'BASE_FEATURE(kFoo, "Foo", base::FEATURE_ENABLED_BY_DEFAULT);')
+
+    # -- modern two-argument form: BASE_FEATURE(kFoo, state) -----------------
+    # The display-name string was dropped entirely (https://crbug.com/1362858).
+
+    def test_two_argument_form_multiline(self):
+        source = ('BASE_FEATURE(kMyFeature,\n'
+                  '             base::FEATURE_DISABLED_BY_DEFAULT);\n')
+        matches, content = self._run(source,
+                                     feature_name='kMyFeature',
+                                     value='base::FEATURE_ENABLED_BY_DEFAULT')
+        self.assertEqual(matches, 1)
+        self.assertEqual(content,
+                         ('BASE_FEATURE(kMyFeature,\n'
+                          '             base::FEATURE_ENABLED_BY_DEFAULT);\n'))
+
+    def test_two_argument_form_single_line(self):
+        source = 'BASE_FEATURE(kMyFeature, base::FEATURE_DISABLED_BY_DEFAULT);'
+        matches, content = self._run(source,
+                                     feature_name='kMyFeature',
+                                     value='base::FEATURE_ENABLED_BY_DEFAULT')
+        self.assertEqual(matches, 1)
+        self.assertEqual(
+            content,
+            'BASE_FEATURE(kMyFeature, base::FEATURE_ENABLED_BY_DEFAULT);')
+
+    # -- preprocessor-conditional state: per-platform default states are
+    # spelled out as an #if/#else/#endif rather than a single token. The whole
+    # thing is the "last argument" here, and gets replaced wholesale, since
+    # the macro overrides the state unconditionally.
+
+    def test_preprocessor_conditional_state_is_replaced_wholesale(self):
+        source = ('BASE_FEATURE(kStackScanMaxFramePointerToStackEndGap,\n'
+                  '#if BUILDFLAG(IS_CHROMEOS)\n'
+                  '             FEATURE_ENABLED_BY_DEFAULT\n'
+                  '#else\n'
+                  '             FEATURE_DISABLED_BY_DEFAULT\n'
+                  '#endif\n'
+                  ');\n')
+        matches, content = self._run(
+            source,
+            feature_name='kStackScanMaxFramePointerToStackEndGap',
+            value='base::FEATURE_DISABLED_BY_DEFAULT')
+        self.assertEqual(matches, 1)
+        # The whole conditional is gone -- not merely one branch of it.
+        self.assertNotIn('#if', content)
+        self.assertNotIn('#else', content)
+        self.assertNotIn('#endif', content)
+        self.assertNotIn('BUILDFLAG', content)
+        self.assertNotIn('FEATURE_ENABLED_BY_DEFAULT', content)
+        self.assertIn('BASE_FEATURE(kStackScanMaxFramePointerToStackEndGap,',
+                      content)
+        self.assertTrue(
+            content.rstrip().endswith('base::FEATURE_DISABLED_BY_DEFAULT);'))
+
+    def test_preprocessor_conditional_does_not_confuse_nested_parens(self):
+        # `BUILDFLAG(IS_CHROMEOS)` has its own closing `)`, immediately after
+        # the feature name's comma; the match must not stop there instead of
+        # at the call's real, statement-ending `);`.
+        source = ('BASE_FEATURE(kFoo,\n'
+                  '#if BUILDFLAG(IS_CHROMEOS)\n'
+                  '             FEATURE_ENABLED_BY_DEFAULT\n'
+                  '#else\n'
+                  '             FEATURE_DISABLED_BY_DEFAULT\n'
+                  '#endif\n'
+                  ');\n')
+        matches, content = self._run(source,
+                                     feature_name='kFoo',
+                                     value='base::FEATURE_ENABLED_BY_DEFAULT')
+        self.assertEqual(matches, 1)
+        self.assertEqual(
+            content,
+            'BASE_FEATURE(kFoo,\nbase::FEATURE_ENABLED_BY_DEFAULT);\n')
+
+    # -- namespace qualification: the state is matched wholesale, so any
+    # spelling works without special-casing.
+
+    def test_unqualified_state_inside_base_namespace(self):
+        source = 'BASE_FEATURE(kMyFeature, FEATURE_DISABLED_BY_DEFAULT);'
+        matches, content = self._run(source,
+                                     feature_name='kMyFeature',
+                                     value='FEATURE_ENABLED_BY_DEFAULT')
+        self.assertEqual(matches, 1)
+        self.assertEqual(
+            content, 'BASE_FEATURE(kMyFeature, FEATURE_ENABLED_BY_DEFAULT);')
+
+    def test_fully_qualified_state(self):
+        source = 'BASE_FEATURE(kMyFeature, ::base::FEATURE_DISABLED_BY_DEFAULT);'
+        matches, content = self._run(
+            source,
+            feature_name='kMyFeature',
+            value='::base::FEATURE_ENABLED_BY_DEFAULT')
+        self.assertEqual(matches, 1)
+        self.assertEqual(
+            content,
+            'BASE_FEATURE(kMyFeature, ::base::FEATURE_ENABLED_BY_DEFAULT);')
+
+    def test_closing_parenthesis_is_preserved(self):
+        # Regression check: the closing `);` sits in its own capture group,
+        # so a careless replace template could swallow it.
+        source = 'BASE_FEATURE(kMyFeature, base::FEATURE_DISABLED_BY_DEFAULT);'
+        _, content = self._run(source,
+                               feature_name='kMyFeature',
+                               value='base::FEATURE_ENABLED_BY_DEFAULT')
+        self.assertTrue(content.rstrip().endswith(');'))
+
+    # -- multiple features in one file: every pairing of "fewer commas"
+    # (two-argument/conditional) and "more commas" (three-argument) forms,
+    # targeting either one, must stay within its own call. A two-argument
+    # feature followed by a three-argument one is the case that actually
+    # regressed: greedily matching "up to the last comma" without also
+    # forbidding `;` let the match run straight past the two-argument call's
+    # own `);` and land on the three-argument call's instead.
+
+    def test_two_then_three_argument_targeting_the_first(self):
+        source = (
+            'BASE_FEATURE(kFeatureA, base::FEATURE_DISABLED_BY_DEFAULT);\n'
+            '\n'
+            'BASE_FEATURE(kFeatureB,\n'
+            '             "FeatureB",\n'
+            '             base::FEATURE_DISABLED_BY_DEFAULT);\n')
+        matches, content = self._run(source,
+                                     feature_name='kFeatureA',
+                                     value='base::FEATURE_ENABLED_BY_DEFAULT')
+        self.assertEqual(matches, 1)
+        self.assertEqual(
+            content,
+            ('BASE_FEATURE(kFeatureA, base::FEATURE_ENABLED_BY_DEFAULT);\n'
+             '\n'
+             'BASE_FEATURE(kFeatureB,\n'
+             '             "FeatureB",\n'
+             '             base::FEATURE_DISABLED_BY_DEFAULT);\n'))
+
+    def test_two_then_three_argument_targeting_the_second(self):
+        source = (
+            'BASE_FEATURE(kFeatureA, base::FEATURE_DISABLED_BY_DEFAULT);\n'
+            '\n'
+            'BASE_FEATURE(kFeatureB,\n'
+            '             "FeatureB",\n'
+            '             base::FEATURE_DISABLED_BY_DEFAULT);\n')
+        matches, content = self._run(source,
+                                     feature_name='kFeatureB',
+                                     value='base::FEATURE_ENABLED_BY_DEFAULT')
+        self.assertEqual(matches, 1)
+        self.assertEqual(
+            content,
+            ('BASE_FEATURE(kFeatureA, base::FEATURE_DISABLED_BY_DEFAULT);\n'
+             '\n'
+             'BASE_FEATURE(kFeatureB,\n'
+             '             "FeatureB",\n'
+             '             base::FEATURE_ENABLED_BY_DEFAULT);\n'))
+
+    def test_three_then_two_argument_targeting_the_first(self):
+        source = (
+            'BASE_FEATURE(kFeatureA,\n'
+            '             "FeatureA",\n'
+            '             base::FEATURE_DISABLED_BY_DEFAULT);\n'
+            '\n'
+            'BASE_FEATURE(kFeatureB, base::FEATURE_DISABLED_BY_DEFAULT);\n')
+        matches, content = self._run(source,
+                                     feature_name='kFeatureA',
+                                     value='base::FEATURE_ENABLED_BY_DEFAULT')
+        self.assertEqual(matches, 1)
+        self.assertEqual(
+            content,
+            ('BASE_FEATURE(kFeatureA,\n'
+             '             "FeatureA",\n'
+             '             base::FEATURE_ENABLED_BY_DEFAULT);\n'
+             '\n'
+             'BASE_FEATURE(kFeatureB, base::FEATURE_DISABLED_BY_DEFAULT);\n'))
+
+    def test_three_then_two_argument_targeting_the_second(self):
+        source = (
+            'BASE_FEATURE(kFeatureA,\n'
+            '             "FeatureA",\n'
+            '             base::FEATURE_DISABLED_BY_DEFAULT);\n'
+            '\n'
+            'BASE_FEATURE(kFeatureB, base::FEATURE_DISABLED_BY_DEFAULT);\n')
+        matches, content = self._run(source,
+                                     feature_name='kFeatureB',
+                                     value='base::FEATURE_ENABLED_BY_DEFAULT')
+        self.assertEqual(matches, 1)
+        self.assertEqual(
+            content,
+            ('BASE_FEATURE(kFeatureA,\n'
+             '             "FeatureA",\n'
+             '             base::FEATURE_DISABLED_BY_DEFAULT);\n'
+             '\n'
+             'BASE_FEATURE(kFeatureB, base::FEATURE_ENABLED_BY_DEFAULT);\n'))
+
+    def test_only_the_named_feature_is_overridden_when_both_are_three_argument(
+            self):
+        source = ('BASE_FEATURE(kFeatureA,\n'
+                  '             "FeatureA",\n'
+                  '             base::FEATURE_DISABLED_BY_DEFAULT);\n'
+                  '\n'
+                  'BASE_FEATURE(kFeatureB,\n'
+                  '             "FeatureB",\n'
+                  '             base::FEATURE_DISABLED_BY_DEFAULT);\n')
+        matches, content = self._run(source,
+                                     feature_name='kFeatureB',
+                                     value='base::FEATURE_ENABLED_BY_DEFAULT')
+        self.assertEqual(matches, 1)
+        self.assertIn(
+            'kFeatureA,\n'
+            '             "FeatureA",\n'
+            '             base::FEATURE_DISABLED_BY_DEFAULT', content)
+        self.assertIn(
+            'kFeatureB,\n'
+            '             "FeatureB",\n'
+            '             base::FEATURE_ENABLED_BY_DEFAULT', content)
+
+    # -- idempotency and no-match cases --------------------------------------
+    #
+    # Setting a feature to the value it already has finds no match (`count`
+    # of 0) and leaves the text untouched, rather than reporting a match that
+    # happens to be a no-op on the text: `count` is meant to answer "did this
+    # override actually take effect", not merely "was the call found".
+
+    def test_no_match_when_two_argument_form_already_has_the_value(self):
+        source = 'BASE_FEATURE(kFoo, base::FEATURE_DISABLED_BY_DEFAULT);'
+        matches, content = self._run(source,
+                                     feature_name='kFoo',
+                                     value='base::FEATURE_DISABLED_BY_DEFAULT')
+        self.assertEqual(matches, 0)
+        self.assertEqual(content, source)
+
+    def test_no_match_when_three_argument_form_already_has_the_value(self):
+        source = ('BASE_FEATURE(kFoo,\n'
+                  '             "Foo",\n'
+                  '             base::FEATURE_DISABLED_BY_DEFAULT);\n')
+        matches, content = self._run(source,
+                                     feature_name='kFoo',
+                                     value='base::FEATURE_DISABLED_BY_DEFAULT')
+        self.assertEqual(matches, 0)
+        self.assertEqual(content, source)
+
+    def test_still_matches_when_the_value_actually_differs(self):
+        # Sanity check alongside the no-match cases above: a genuinely
+        # different value must still be found and applied.
+        source = ('BASE_FEATURE(kFoo,\n'
+                  '             "Foo",\n'
+                  '             base::FEATURE_DISABLED_BY_DEFAULT);\n')
+        matches, content = self._run(source,
+                                     feature_name='kFoo',
+                                     value='base::FEATURE_ENABLED_BY_DEFAULT')
+        self.assertEqual(matches, 1)
+        self.assertEqual(content,
+                         ('BASE_FEATURE(kFoo,\n'
+                          '             "Foo",\n'
+                          '             base::FEATURE_ENABLED_BY_DEFAULT);\n'))
+
+    def test_no_match_is_specific_to_the_named_feature(self):
+        # The other feature in the file already holds the value being set on
+        # kFeatureA, but that must not suppress the (real) change to kFeatureA.
+        source = (
+            'BASE_FEATURE(kFeatureA, base::FEATURE_DISABLED_BY_DEFAULT);\n'
+            '\n'
+            'BASE_FEATURE(kFeatureB, base::FEATURE_ENABLED_BY_DEFAULT);\n')
+        matches, content = self._run(source,
+                                     feature_name='kFeatureA',
+                                     value='base::FEATURE_ENABLED_BY_DEFAULT')
+        self.assertEqual(matches, 1)
+        self.assertEqual(
+            content,
+            ('BASE_FEATURE(kFeatureA, base::FEATURE_ENABLED_BY_DEFAULT);\n'
+             '\n'
+             'BASE_FEATURE(kFeatureB, base::FEATURE_ENABLED_BY_DEFAULT);\n'))
+
+    def test_no_match_case_does_not_leak_into_a_later_call(self):
+        # kFeatureA already has the value being set (should be a no-match),
+        # while kFeatureB, later in the file, does not. The no-match on
+        # kFeatureA must not cause the engine to drift onto kFeatureB instead.
+        source = (
+            'BASE_FEATURE(kFeatureA, base::FEATURE_DISABLED_BY_DEFAULT);\n'
+            '\n'
+            'BASE_FEATURE(kFeatureB,\n'
+            '             "FeatureB",\n'
+            '             base::FEATURE_ENABLED_BY_DEFAULT);\n')
+        matches, content = self._run(source,
+                                     feature_name='kFeatureA',
+                                     value='base::FEATURE_DISABLED_BY_DEFAULT')
+        self.assertEqual(matches, 0)
+        self.assertEqual(content, source)
+
+    def test_preprocessor_conditional_is_never_treated_as_already_set(self):
+        # A conditional last argument is never a bare token, so it can never
+        # equal `value` outright -- setting either branch's own value is still
+        # a match, replacing the whole conditional.
+        source = ('BASE_FEATURE(kFoo,\n'
+                  '#if BUILDFLAG(IS_CHROMEOS)\n'
+                  '             FEATURE_ENABLED_BY_DEFAULT\n'
+                  '#else\n'
+                  '             FEATURE_DISABLED_BY_DEFAULT\n'
+                  '#endif\n'
+                  ');\n')
+        matches, content = self._run(source,
+                                     feature_name='kFoo',
+                                     value='FEATURE_DISABLED_BY_DEFAULT')
+        self.assertEqual(matches, 1)
+        self.assertEqual(
+            content, 'BASE_FEATURE(kFoo,\nFEATURE_DISABLED_BY_DEFAULT);\n')
+
+    def test_no_match_for_a_different_feature_name(self):
+        source = 'BASE_FEATURE(kFoo, base::FEATURE_DISABLED_BY_DEFAULT);'
+        matches, content = self._run(source,
+                                     feature_name='kOther',
+                                     value='base::FEATURE_ENABLED_BY_DEFAULT')
+        self.assertEqual(matches, 0)
+        self.assertEqual(content, source)
+
+    # -- input validation -----------------------------------------------
+
+    def test_missing_inputs_raise(self):
+        engine = plaster.RegexMacroEngine(self.rewriters, 'irrelevant')
+        with self.assertRaises(ValueError):
+            engine.run(self._OP_ID, {'feature_name': 'kFoo'})
+
+    def test_unknown_input_raises(self):
+        engine = plaster.RegexMacroEngine(self.rewriters, 'irrelevant')
+        with self.assertRaises(ValueError):
+            engine.run(
+                self._OP_ID, {
+                    'feature_name': 'kFoo',
+                    'value': 'base::FEATURE_ENABLED_BY_DEFAULT',
+                    'extra': 'x',
+                })
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -71,6 +71,28 @@
 # An op yields every match in source order; the caller (plaster) decides how
 # many it expects. Input values are injected verbatim into the rule's `regex:`
 # fields, so the caller escapes any regex metacharacters.
+#
+#   "regex_macro" — a named, reusable `regex:` substitution: the templated
+#       equivalent of a substitution's own `regex:` block (see the `Regex`
+#       rewriter), keyed the same way as the ast ops above ("<lang>.<name>").
+#       description: Markdown documenting what the macro is for, meant for a
+#                future `plaster --help <macro>`, the same way a `Rewriter`'s
+#                `HELP` is.
+#       inputs:  the macro's `{placeholder}`s, each documented rather than
+#                bare, since a macro is meant to be read and reused by
+#                someone other than its author: { name, description }, where
+#                `name` is threaded into `pattern`/`re_pattern`/`replace` via
+#                `str.format` and `description` explains what to pass and why.
+#       One of either `pattern` (escaped for you) or `re_pattern`, plus
+#       `replace` and optional `re_flags` -- exactly the fields a
+#       substitution's own `regex:` block takes, applied as one `re.subn`. A
+#       macro need not know the target's current spelling of a value it is
+#       changing (e.g. one of several states a toggle can hold): the pattern
+#       can match every known spelling via alternation and `replace` can
+#       overwrite it wholesale with the wanted one, taken as an input, rather
+#       than the macro inspecting what is there. The substitution's own
+#       `count:` is what tells the caller a match -- and so a change --
+#       actually happened.
 
 {
     "ast.matcher": {
@@ -571,6 +593,35 @@ regex: ^{class_name}$
             "result": {
                 "node": "enumerator",
             },
+        },
+    },
+    "regex_macro": {
+
+        "cxx.set_feature_flag_default_state": {
+            "description": """\
+Sets a new value to a `BASE_FEATURE` feature flag.
+
+```diff
+ BASE_FEATURE(kMyFeature,
+              "MyFeature",
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++             base::FEATURE_DISABLED_BY_DEFAULT);
+```
+""",
+            "inputs": [
+                {
+                    "name": "feature_name",
+                    "description":
+                    "The `BASE_FEATURE` feature flag name, e.g. `kMyFeature`.",
+                },
+                {
+                    "name": "value",
+                    "description":
+                    "The new value, e.g. `base::FEATURE_DISABLED_BY_DEFAULT`.",
+                },
+            ],
+            "re_pattern": "(BASE_FEATURE\\(\\s*{feature_name}\\s*,)(?!(?:[^;]*,)?\\s*{value}\\s*\\);)([^;]*,)?(\\s*)[^;]*?(\\);)",
+            "replace": "\\1\\2\\3{value}\\4",
         },
     },
 }


### PR DESCRIPTION
This change introduces a basic backend for regex macros, which will be
used as a foundation for the frontend integration. The goal is to permit
the use of regexes out of a library, for cases that we know the regex
well, and don't want to reinvent it every time.

The basic format to introduce new flags is:

```
"cxx.my_regex": {
    "description": "",
    "inputs": [
        {
            "name": "feature_name",
            "description": "",
        },
    ],
    "re_flags": [],
    "re_pattern": "",
    "pattern": "",
    "replace": "",
}
```

Follow-up PRs will connect the backend code to the frontend.

This base work provides as a trial case the overriding of feature flags,
which currently we have to rely on cxx macro,
`OVERRIDE_FEATURE_DEFAULT_STATES`, to achieve that, but which we
possibly should move to patches, now that we can do that.

Bug: https://github.com/brave/brave-browser/issues/57281
