### PR TITLE
[infra] Adding `gn_args` lib

### DIFF
--- a/infra/PRESUBMIT.py
+++ b/infra/PRESUBMIT.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Presubmit script for changes affecting infra/
+"""
+
+import os
+
+PRESUBMIT_VERSION = '2.0.0'
+
+
+def CheckTests(input_api, output_api):
+    script_dir = input_api.PresubmitLocalPath()
+    tests = []
+    for root, dirs, files in os.walk(script_dir):
+        dirs[:] = [d for d in dirs if d != '__pycache__']
+        if any(f.endswith('_test.py') for f in files):
+            tests.extend(
+                input_api.canned_checks.GetUnitTestsInDirectory(
+                    input_api,
+                    output_api,
+                    root,
+                    files_to_check=[r'.+_test\.py$']))
+    return input_api.RunTests(tests)

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,4 @@
+# 🚧 `infra/` — under heavy development
+
+Nothing here is stable yet. Expect things to move, rename, or disappear without
+notice.

--- a/infra/config/gn_args.py
+++ b/infra/config/gn_args.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Named GN-arg configs, composed by builders in `builders/ci/*.py`.
+
+Values here are reverse-engineered from a real `linux-x64-asan-brave` nightly
+run (captured `args.gn`/`.env`), not from reading `buildArgs.ts` in the
+abstract, so they hold for that job today. A wider audit across all of
+`config.ts`'s `envConfig.*` call sites (see the ASan migration design doc's
+Appendix C) will likely split some of these further as more builders are
+added.
+"""
+
+from lib.config import gn_args
+
+gn_args.config(name='x64', args={
+    'target_cpu': 'x64',
+})
+
+gn_args.config(
+    name='linux',
+    args={
+        'target_os': 'linux',
+        'symbol_level': 1,
+        'use_debug_fission': True,
+        'use_vaapi': True,
+        'is_universal_binary': False,
+        'enable_cdm_host_verification': False,
+        'skip_signing': True,
+    },
+)
+
+gn_args.config(name='release',
+               args={
+                   'is_debug': False,
+                   'is_component_build': False,
+               })
+
+gn_args.config(
+    name='remoteexec',
+    args={
+        'use_remoteexec': True,
+        'use_siso': True,
+        'use_reclient': False,
+    },
+)
+
+gn_args.config(name='nightly', args={'brave_channel': 'nightly'})
+
+# brave/build/args/brave_defaults.gni
+gn_args.config(
+    name='brave_defaults',
+    args={
+        'disable_fieldtrial_testing_config': True,
+        'translate_genders': False,
+        'enable_precompiled_headers': False,
+        'enable_pseudolocales': False,
+        'ignore_missing_widevine_signing_cert': False,
+        'root_extra_deps': [
+            '//brave',
+        ],
+    },
+)
+
+# brave/build/args/blink_platform_defaults.gni (non-iOS only)
+gn_args.config(
+    name='blink_platform_defaults',
+    args={
+        'proprietary_codecs': True,
+        'ffmpeg_branding': 'Chrome',
+        'enable_widevine': True,
+        'enable_platform_hevc': True,
+        'enable_hevc_parser_and_hw_decoder': True,
+    },
+)
+
+# brave/build/args/branding_defaults.gni
+gn_args.config(
+    name='branding_defaults',
+    args={
+        'branding_path_component': 'brave',
+        'branding_path_product': 'brave',
+    },
+)
+
+# brave/build/args/desktop_defaults.gni (non-mobile only)
+gn_args.config(name='desktop_defaults', args={
+    'safe_browsing_mode': 1,
+})
+
+gn_args.config(
+    name='brave_desktop_defaults',
+    configs=[
+        'brave_defaults',
+        'blink_platform_defaults',
+        'branding_defaults',
+        'desktop_defaults',
+    ],
+)
+
+# What buildArgs.ts derives for any non-branded desktop CI build. Not split
+# further yet since every builder we have so far is this shape.
+gn_args.config(
+    name='ci_desktop_defaults',
+    args={
+        'devtools_skip_typecheck': False,
+        'enable_hangout_services_extension': False,
+        'use_libfuzzer': False,
+    },
+)
+
+gn_args.config(
+    name='brave_service_keys',
+    args={
+        # Unconditionally "dummy" today regardless of secrets availability.
+        'brave_google_api_key': 'dummy',
+    },
+    secrets={
+        'brave_services_key': 'BRAVE_SERVICES_KEY',
+        'brave_stats_api_key': 'BRAVE_STATS_API_KEY',
+        'google_default_client_id': 'GOOGLE_OAUTH_CLIENT_ID',
+        'google_default_client_secret': 'GOOGLE_OAUTH_CLIENT_SECRET',
+        # These three are are not env values actually, but we are going to
+        # handle them later on.
+        'service_key_aichat': 'SERVICE_KEY_AICHAT',
+        'service_key_search': 'SERVICE_KEY_SEARCH',
+        'service_key_stt': 'SERVICE_KEY_STT',
+    },
+)
+
+gn_args.config(
+    name='asan',
+    configs=[
+        'brave_desktop_defaults',
+        'ci_desktop_defaults',
+        'brave_service_keys',
+    ],
+    args={
+        'is_asan': True,
+        'is_lsan': True,
+        'enable_full_stack_frames_for_profiling': True,
+        'v8_enable_verify_heap': True,
+        'is_official_build': False,
+        'enable_update_notifications': False,
+        'dcheck_always_on': False,
+    },
+)

--- a/infra/config/lib/__init__.py
+++ b/infra/config/lib/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Package marker for `brave/infra/config`'s implementation modules."""

--- a/infra/config/lib/config.py
+++ b/infra/config/lib/config.py
@@ -1,0 +1,324 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# For some of the code lifted below.
+#
+# Copyright 2015 The LUCI Authors
+# Use of this source code is governed under the Apache License, Version 2.0
+# that can be found in the LICENSE file.
+"""Host for `brave/infra/config`'s named, composable GN-arg configs.
+
+A config is a node with `args` (GN arg values), `configs` (names of other
+configs it includes) and `args_file` (one `.gni` it imports). `resolve()`
+merges a config with everything it includes: later entries in `configs` beat
+earlier ones, and a config's own `args` beat anything it includes. At most one
+`args_file` may survive a resolution. `target_os`/`target_cpu` are required in
+the result.
+
+Example:
+
+    from lib.config import gn_args
+
+    gn_args.config(name = "linux", args = {"target_os": "linux"})
+    gn_args.config(name = "x64", args = {"target_cpu": "x64"})
+    gn_args.config(
+        name = "asan",
+        configs = ["linux", "x64"],
+        args = {"is_asan": True, "is_lsan": True},
+        secrets = {"brave_services_key": "BRAVE_SERVICES_KEY"},
+    )
+
+    gn_args.resolve("asan")
+    # {"gn_args": {"target_os": "linux", "target_cpu": "x64",
+    #              "is_asan": True, "is_lsan": True},
+    #  "secrets": {"brave_services_key": "BRAVE_SERVICES_KEY"}}
+"""
+
+from __future__ import annotations
+
+import collections.abc
+import functools
+import operator
+from typing import Any, Iterator, Mapping, Sequence, TypeVar
+
+K = TypeVar('K')
+V = TypeVar('V')
+
+
+def freeze(obj: Any) -> Any:
+    """Returns an immutable version of `obj`.
+
+    dict -> FrozenDict, list/tuple -> tuple, set -> frozenset. Anything else is
+    returned as-is, provided it is hashable (raises `TypeError` otherwise).
+    """
+    if isinstance(obj, dict):
+        return FrozenDict((freeze(k), freeze(v)) for k, v in obj.items())
+    if isinstance(obj, (list, tuple)):
+        return tuple(freeze(i) for i in obj)
+    if isinstance(obj, set):
+        return frozenset(freeze(i) for i in obj)
+    hash(obj)  # Raises TypeError for unhashable (assumed mutable) values.
+    return obj
+
+
+def thaw(obj: Any) -> Any:
+    """Returns a mutable version of a value produced by `freeze()`."""
+    if isinstance(obj, (dict, collections.abc.Mapping)):
+        return {k: thaw(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [thaw(i) for i in obj]
+    if isinstance(obj, (set, frozenset)):
+        return {thaw(i) for i in obj}
+    return obj
+
+
+class FrozenDict(collections.abc.Mapping[K, V]):
+    """An immutable, hashable mapping.
+
+    Ported from recipes-py's `recipe_engine/engine_types.py`, trimmed of the
+    `on_missing` hook and the `config_types.Path` carve-out (neither has a use
+    here), and relying on `collections.abc.Mapping`'s own `__eq__` rather than
+    redefining one.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self._d = dict(*args, **kwargs)
+        # Computed eagerly so that constructing a FrozenDict of unhashable
+        # values fails immediately, at the point of freezing, not on first use.
+        self._hash = functools.reduce(operator.xor,
+                                      (hash(i)
+                                       for i in enumerate(self._d.items())), 0)
+
+    def __iter__(self) -> Iterator[K]:
+        return iter(self._d)
+
+    def __len__(self) -> int:
+        return len(self._d)
+
+    def __getitem__(self, key: K) -> V:
+        return self._d[key]
+
+    def __hash__(self) -> int:
+        return self._hash
+
+    def __repr__(self) -> str:
+        return 'FrozenDict(%r)' % (list(self._d.items()), )
+
+
+class ConfigError(Exception):
+    """Raised for any gn_args configuration violation.
+    """
+
+
+class AnonymousGnConfig:
+    """The inline, unnamed form of a GN config.
+
+    Returned by `gn_args.config()` when called without `name`, for embedding
+    directly in a builder definition rather than registering it under a name
+    for reuse.
+    """
+
+    def __init__(self, *, args: Mapping[str, Any], configs: Sequence[str],
+                 args_file: str, secrets: Mapping[str, str]) -> None:
+        # GN arg key-value pairs this config contributes directly.
+        self.gn_args = freeze(args)
+
+        # Names of other configs this one includes, in override order.
+        self.configs = tuple(configs)
+
+        # Path of the one `.gni` this config imports, or '' for none.
+        self.args_file = args_file
+
+        # GN arg name -> environment variable name, resolved outside version
+        # control.
+        self.secrets = freeze(secrets)
+
+    def __repr__(self) -> str:
+        return ('AnonymousGnConfig(gn_args=%r, configs=%r, args_file=%r, '
+                'secrets=%r)' %
+                (self.gn_args, self.configs, self.args_file, self.secrets))
+
+
+class _GnConfigNode:
+    """One registered, named node in the GN-args include graph."""
+
+    def __init__(self, name: str, *, args: Mapping[str, Any],
+                 configs: Sequence[str], args_file: str,
+                 secrets: Mapping[str, str]) -> None:
+        # The name it was registered under.
+        self.name = name
+
+        # GN arg key-value pairs this config contributes directly.
+        self.gn_args = freeze(args)
+
+        # Names of other configs this one includes, in override order.
+        self.configs = tuple(configs)
+
+        # Path of the one `.gni` this config imports, or '' for none.
+        self.args_file = args_file
+
+        # GN arg name -> environment variable name, resolved outside version
+        # control.
+        self.secrets = freeze(secrets)
+
+
+def _merge_into(dst: dict, *, args_file: str, args: Mapping[str, Any],
+                secrets: Mapping[str, str], config_name: str) -> None:
+    """Merges one node's contribution into a resolution-in-progress `dst`.
+
+    `dst`'s existing entries lose to `args`/`secrets` on key conflicts, which
+    is what makes "merge children then merge self last" give the node's own
+    values priority over whatever it includes. `args_file` is the exception:
+    a second non-empty `args_file` raises `ConfigError` rather than winning.
+    """
+    if args_file:
+        if dst['args_file']:
+            raise ConfigError(
+                'gn_args config %r: each GN config can only contain a '
+                'single args_file (already have %r, got %r)' %
+                (config_name, dst['args_file'], args_file))
+        dst['args_file'] = args_file
+    dst['gn_args'].update(args)
+    dst['secrets'].update(secrets)
+
+
+class GnArgsRegistry:
+    """A registry of named GN configs, and their resolver.
+
+    Spec files call `config()` to declare configs. `resolve()` walks the
+    include graph a declared (or builder-level) config names to produce its
+    final `{args_file, gn_args, secrets}`.
+    """
+
+    def __init__(self) -> None:
+        # Name -> declared config.
+        self._nodes: dict[str, _GnConfigNode] = {}
+
+        # Name -> memoized resolve() result.
+        self._resolved: dict[str, dict] = {}
+
+    def config(
+            self,
+            *,
+            name: str | None = None,
+            args: Mapping[str, Any] | None = None,
+            configs: Sequence[str] | None = None,
+            args_file: str = '',
+            secrets: Mapping[str, str] | None = None
+    ) -> None | AnonymousGnConfig:
+        """Defines a GN config, or returns one inline.
+
+        Args:
+            name: The config's name, for reference from another config's
+                `configs` list or from `resolve()`. Registers the config and
+                returns None. Omit to get an `AnonymousGnConfig` back instead,
+                for a one-off builder that need not pollute the config
+                namespace.
+            args: GN arg key-value pairs this config contributes.
+            configs: Names of other configs to include. Later entries beat
+                earlier ones on a duplicate GN arg key. This config's own
+                `args` beat all of them.
+            args_file: The path of one `.gni` this config imports.
+            secrets: GN arg name to environment variable name, for values
+                resolved outside version control instead of checked in.
+
+        Returns:
+            None if `name` is set, otherwise an `AnonymousGnConfig`.
+        """
+        args = args or {}
+        configs = configs or []
+        secrets = secrets or {}
+
+        if name:
+            if name in self._nodes:
+                raise ConfigError('gn_args config %r is already defined' %
+                                  name)
+            self._nodes[name] = _GnConfigNode(name,
+                                              args=args,
+                                              configs=configs,
+                                              args_file=args_file,
+                                              secrets=secrets)
+            return None
+
+        return AnonymousGnConfig(args=args,
+                                 configs=configs,
+                                 args_file=args_file,
+                                 secrets=secrets)
+
+    def resolve(self, name: str) -> dict:
+        """Resolves the named config's GN args, secrets and args_file.
+
+        Returns a dict with a `gn_args` key (never absent nor empty; missing
+        `target_os`/`target_cpu` in it is an error) and, only when non-empty,
+        `args_file` and/or `secrets` keys. The returned dict is a fresh,
+        plain-dict copy: mutating it does not affect the registry's cache.
+
+        Raises:
+            ConfigError: `name` (or something it includes, transitively) is
+                undefined, the include graph has a cycle, more than one
+                `args_file` survives the resolution, or the resolved args are
+                missing `target_os` or `target_cpu`.
+        """
+        try:
+            root = self._nodes[name]
+        except KeyError as e:
+            raise ConfigError('gn_args config %r is not defined' % name) from e
+
+        resolved = self._resolve_node(root, stack=())
+
+        args = dict(resolved['gn_args'])
+        if 'target_os' not in args:
+            raise ConfigError('target_os is required for gn_args: %s' % name)
+        if 'target_cpu' not in args:
+            raise ConfigError('target_cpu is required for gn_args: %s' % name)
+
+        result = {'gn_args': args}
+        if resolved['args_file']:
+            result['args_file'] = resolved['args_file']
+        if resolved['secrets']:
+            result['secrets'] = dict(resolved['secrets'])
+        return result
+
+    def _resolve_node(self, node: _GnConfigNode, stack: tuple[str,
+                                                              ...]) -> dict:
+        if node.name in self._resolved:
+            return self._resolved[node.name]
+        if node.name in stack:
+            raise ConfigError('gn_args config cycle: %s -> %s' %
+                              (' -> '.join(stack), node.name))
+        stack = stack + (node.name, )
+
+        merged = {'args_file': '', 'gn_args': {}, 'secrets': {}}
+
+        # Merge included configs first, in the order given (DEFINITION_ORDER
+        # upstream): a later entry's keys overwrite an earlier entry's, since
+        # each merge is a dict.update() into the same accumulator.
+        for child_name in node.configs:
+            try:
+                child = self._nodes[child_name]
+            except KeyError as e:
+                raise ConfigError(
+                    'gn_args config %r includes undefined config %r' %
+                    (node.name, child_name)) from e
+            child_resolved = self._resolve_node(child, stack)
+            _merge_into(merged,
+                        args_file=child_resolved['args_file'],
+                        args=child_resolved['gn_args'],
+                        secrets=child_resolved['secrets'],
+                        config_name=node.name)
+
+        # Merge the node's own values last, so they win over anything included.
+        _merge_into(merged,
+                    args_file=node.args_file,
+                    args=node.gn_args,
+                    secrets=node.secrets,
+                    config_name=node.name)
+
+        self._resolved[node.name] = merged
+        return merged
+
+
+# What spec files import: `from lib.config import gn_args`.
+gn_args = GnArgsRegistry()

--- a/infra/config/lib/config_test.py
+++ b/infra/config/lib/config_test.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for config.py: freeze/thaw/FrozenDict and GnArgsRegistry."""
+
+# Some tests read `_resolved` directly to check memoization, which is
+# otherwise unobservable from the public API.
+# pylint: disable=protected-access
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# pylint: disable=wrong-import-position
+from config import (AnonymousGnConfig, ConfigError, FrozenDict, GnArgsRegistry,
+                    freeze, thaw)
+
+
+class FreezeThawTest(unittest.TestCase):
+
+    def test_freeze_dict_becomes_frozen_dict(self):
+        frozen = freeze({'a': 1, 'b': 2})
+        self.assertIsInstance(frozen, FrozenDict)
+        self.assertEqual(dict(frozen), {'a': 1, 'b': 2})
+        hash(frozen)  # Must not raise.
+
+    def test_freeze_list_and_tuple_become_tuple(self):
+        self.assertEqual(freeze([1, 2, 3]), (1, 2, 3))
+        self.assertEqual(freeze((1, 2, 3)), (1, 2, 3))
+
+    def test_freeze_set_becomes_frozenset(self):
+        self.assertEqual(freeze({1, 2, 3}), frozenset({1, 2, 3}))
+
+    def test_freeze_is_recursive(self):
+        frozen = freeze({'a': [1, {2, 3}], 'b': {'c': 4}})
+        self.assertEqual(frozen['a'], (1, frozenset({2, 3})))
+        self.assertIsInstance(frozen['b'], FrozenDict)
+
+    def test_freeze_unhashable_leaf_raises(self):
+
+        class Unhashable:
+            __hash__ = None
+
+        with self.assertRaises(TypeError):
+            freeze({'a': Unhashable()})
+
+    def test_freeze_result_is_independent_of_original(self):
+        original = {'a': [1, 2]}
+        frozen = freeze(original)
+        original['a'].append(3)
+        original['b'] = 4
+        self.assertEqual(frozen['a'], (1, 2))
+        self.assertNotIn('b', frozen)
+
+    def test_thaw_reverses_freeze(self):
+        original = {'a': [1, {'b': 2}], 'c': {3, 4}}
+        self.assertEqual(thaw(freeze(original)), original)
+
+    def test_frozen_dict_equality_with_plain_dict(self):
+        self.assertEqual(FrozenDict(a=1, b=2), {'a': 1, 'b': 2})
+
+    def test_frozen_dict_repr(self):
+        self.assertEqual(repr(FrozenDict(a=1)), "FrozenDict([('a', 1)])")
+
+
+class GnArgsConfigTest(unittest.TestCase):
+
+    def setUp(self):
+        self.registry = GnArgsRegistry()
+
+    def test_named_config_returns_none(self):
+        self.assertIsNone(
+            self.registry.config(name='linux', args={'target_os': 'linux'}))
+
+    def test_duplicate_name_raises(self):
+        self.registry.config(name='linux', args={'target_os': 'linux'})
+        with self.assertRaises(ConfigError):
+            self.registry.config(name='linux', args={'target_os': 'linux'})
+
+    def test_anonymous_config_returns_struct(self):
+        anon = self.registry.config(args={'is_asan': True},
+                                    configs=['linux'],
+                                    args_file='//foo.gni',
+                                    secrets={'k': 'ENV_K'})
+        self.assertIsInstance(anon, AnonymousGnConfig)
+        self.assertEqual(dict(anon.gn_args), {'is_asan': True})
+        self.assertEqual(anon.configs, ('linux', ))
+        self.assertEqual(anon.args_file, '//foo.gni')
+        self.assertEqual(dict(anon.secrets), {'k': 'ENV_K'})
+        repr(anon)  # Must not raise.
+
+    def test_config_args_are_frozen_against_later_mutation(self):
+        args = {'target_os': 'linux', 'target_cpu': 'x64'}
+        self.registry.config(name='linux', args=args)
+        args['target_os'] = 'mac'  # Must not affect the registered config.
+        self.assertEqual(
+            self.registry.resolve('linux')['gn_args'], {
+                'target_os': 'linux',
+                'target_cpu': 'x64',
+            })
+
+
+class GnArgsResolveTest(unittest.TestCase):
+
+    def setUp(self):
+        self.registry = GnArgsRegistry()
+
+    def test_undefined_config_raises(self):
+        with self.assertRaises(ConfigError):
+            self.registry.resolve('nope')
+
+    def test_undefined_included_config_raises(self):
+        self.registry.config(name='asan', configs=['nope'])
+        with self.assertRaises(ConfigError):
+            self.registry.resolve('asan')
+
+    def test_missing_target_os_raises(self):
+        self.registry.config(name='x64', args={'target_cpu': 'x64'})
+        with self.assertRaises(ConfigError):
+            self.registry.resolve('x64')
+
+    def test_missing_target_cpu_raises(self):
+        self.registry.config(name='linux', args={'target_os': 'linux'})
+        with self.assertRaises(ConfigError):
+            self.registry.resolve('linux')
+
+    def test_simple_resolution(self):
+        self.registry.config(name='linux', args={'target_os': 'linux'})
+        self.registry.config(name='x64', args={'target_cpu': 'x64'})
+        self.registry.config(name='builder', configs=['linux', 'x64'])
+        self.assertEqual(self.registry.resolve('builder'), {
+            'gn_args': {
+                'target_os': 'linux',
+                'target_cpu': 'x64',
+            },
+        })
+
+    def test_own_args_beat_included_configs(self):
+        self.registry.config(name='base',
+                             args={
+                                 'target_os': 'linux',
+                                 'target_cpu': 'x64',
+                                 'is_debug': True,
+                             })
+        self.registry.config(name='derived',
+                             configs=['base'],
+                             args={'is_debug': False})
+        self.assertFalse(
+            self.registry.resolve('derived')['gn_args']['is_debug'])
+
+    def test_later_config_in_list_beats_earlier(self):
+        self.registry.config(name='base',
+                             args={
+                                 'target_os': 'linux',
+                                 'target_cpu': 'x64',
+                             })
+        self.registry.config(name='a', configs=['base'], args={'v': 1})
+        self.registry.config(name='b', configs=['base'], args={'v': 2})
+        self.registry.config(name='ab', configs=['a', 'b'])
+        self.registry.config(name='ba', configs=['b', 'a'])
+        self.assertEqual(self.registry.resolve('ab')['gn_args']['v'], 2)
+        self.assertEqual(self.registry.resolve('ba')['gn_args']['v'], 1)
+
+    def test_single_args_file_survives(self):
+        self.registry.config(name='base',
+                             args={
+                                 'target_os': 'linux',
+                                 'target_cpu': 'x64',
+                             },
+                             args_file='//base.gni')
+        self.assertEqual(
+            self.registry.resolve('base')['args_file'], '//base.gni')
+
+    def test_two_args_files_in_one_resolution_raises(self):
+        self.registry.config(name='a', args_file='//a.gni')
+        self.registry.config(name='b', args_file='//b.gni')
+        self.registry.config(name='ab',
+                             configs=['a', 'b'],
+                             args={
+                                 'target_os': 'linux',
+                                 'target_cpu': 'x64',
+                             })
+        with self.assertRaises(ConfigError):
+            self.registry.resolve('ab')
+
+    def test_diamond_include_of_the_same_args_file_still_raises(self):
+        # Faithful to upstream: the merge only ever sees each child's already-
+        # resolved args_file string, not node identity, so two siblings that
+        # each transitively carry the *same* args_file still conflict when a
+        # common parent includes both - merging is not deduplicated by value.
+        self.registry.config(name='base', args_file='//base.gni')
+        self.registry.config(name='a', configs=['base'])
+        self.registry.config(name='b', configs=['base'])
+        self.registry.config(name='ab',
+                             configs=['a', 'b'],
+                             args={
+                                 'target_os': 'linux',
+                                 'target_cpu': 'x64',
+                             })
+        with self.assertRaises(ConfigError):
+            self.registry.resolve('ab')
+
+    def test_cycle_raises(self):
+        self.registry.config(name='a', configs=['b'])
+        self.registry.config(name='b', configs=['a'])
+        with self.assertRaises(ConfigError):
+            self.registry.resolve('a')
+
+    def test_secrets_merge_like_gn_args(self):
+        self.registry.config(name='base',
+                             args={
+                                 'target_os': 'linux',
+                                 'target_cpu': 'x64',
+                             },
+                             secrets={'shared_key': 'BASE_ENV'})
+        self.registry.config(name='derived',
+                             configs=['base'],
+                             secrets={'derived_key': 'DERIVED_ENV'})
+        self.assertEqual(
+            self.registry.resolve('derived')['secrets'], {
+                'shared_key': 'BASE_ENV',
+                'derived_key': 'DERIVED_ENV',
+            })
+
+    def test_no_secrets_key_when_empty(self):
+        self.registry.config(name='linux',
+                             args={
+                                 'target_os': 'linux',
+                                 'target_cpu': 'x64',
+                             })
+        self.assertNotIn('secrets', self.registry.resolve('linux'))
+
+    def test_no_args_file_key_when_empty(self):
+        self.registry.config(name='linux',
+                             args={
+                                 'target_os': 'linux',
+                                 'target_cpu': 'x64',
+                             })
+        self.assertNotIn('args_file', self.registry.resolve('linux'))
+
+    def test_resolution_is_memoized(self):
+        self.registry.config(name='linux', args={'target_os': 'linux'})
+        self.registry.config(name='x64', args={'target_cpu': 'x64'})
+        self.registry.config(name='builder', configs=['linux', 'x64'])
+        self.assertNotIn('linux', self.registry._resolved)
+        self.registry.resolve('builder')
+        self.assertIn('linux', self.registry._resolved)
+        self.assertIn('x64', self.registry._resolved)
+        self.assertIn('builder', self.registry._resolved)
+
+    def test_resolve_result_is_a_copy(self):
+        self.registry.config(name='linux',
+                             args={
+                                 'target_os': 'linux',
+                                 'target_cpu': 'x64',
+                             })
+        result = self.registry.resolve('linux')
+        result['gn_args']['target_os'] = 'mac'
+        self.assertEqual(
+            self.registry.resolve('linux')['gn_args']['target_os'], 'linux')
+
+    def test_shared_subgraph_resolves_consistently_across_roots(self):
+        self.registry.config(name='base',
+                             args={
+                                 'target_os': 'linux',
+                                 'target_cpu': 'x64',
+                             })
+        self.registry.config(name='a', configs=['base'], args={'v': 1})
+        self.registry.config(name='b', configs=['base'], args={'v': 2})
+        self.registry.resolve('a')
+        self.registry.resolve('b')
+        # `base` was resolved once, memoized, and reused for both.
+        self.assertEqual(
+            self.registry.resolve('base')['gn_args'], {
+                'target_os': 'linux',
+                'target_cpu': 'x64',
+            })
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is the foundation work for a library to generate `gn_args` in CI.
With this library, we intend to provide a way for users to audit exactly
which arguments are being run in each bot in CI.

This PR also introduces a very basic gn args for the asan builder. This
will evolve later, but for now this is a good starting point.

Bug: https://github.com/brave/brave-browser/issues/47912
