### PR TITLE
[infra] Make `chromium-rebase-team` owners of `//brave/infra`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -114,6 +114,7 @@ browser/net/brave_network_audit_search_ad_browsertest.cc @brave/sec-team
 # Chromium and Toolchains
 tools/cr/ @brave/chromium-rebase-team
 tools/recipes/ @brave/chromium-rebase-team
+infra/ @brave/chromium-rebase-team
 
 # Android tests
 android/android_browser_tests.gni @brave/android-tests-reviewers


### PR DESCRIPTION
Adding @brave/chromium-rebase-team owners of infra through the
prototyping period for this idea. Once this is mature enough, following
the prototype document's completion, we should move the ownership to the
build owners group.

Bug: https://github.com/brave/brave-browser/issues/47912
