### PR TITLE
Fix vertical tab group padding and widths

### DIFF
--- a/browser/ui/views/tabs/brave_tab_group_header.cc
+++ b/browser/ui/views/tabs/brave_tab_group_header.cc
@@ -113,10 +113,7 @@ bool BraveTabGroupHeader::ShouldShowVerticalTabs() const {
 
 void BraveTabGroupHeader::LayoutTitleChipForVerticalTabs() {
   auto title_bounds = GetContentsBounds();
-  // Inset the left/top/bottom, but not the right, so the chip's right edge is
-  // flush with the tabs in the group below (which only have a left inset).
-  title_bounds.Inset(gfx::Insets::TLBR(kPaddingForGroup, kPaddingForGroup,
-                                       kPaddingForGroup, 0));
+  title_bounds.Inset(gfx::Insets(kPaddingForGroup));
   title_chip_->SetBoundsRect(title_bounds);
 
   // |title_| is a child view of |title_chip_| and there could be |sync_icon_|

--- a/browser/ui/views/tabs/brave_tab_group_header.cc
+++ b/browser/ui/views/tabs/brave_tab_group_header.cc
@@ -113,7 +113,10 @@ bool BraveTabGroupHeader::ShouldShowVerticalTabs() const {
 
 void BraveTabGroupHeader::LayoutTitleChipForVerticalTabs() {
   auto title_bounds = GetContentsBounds();
-  title_bounds.Inset(gfx::Insets(kPaddingForGroup));
+  // Inset the left/top/bottom, but not the right, so the chip's right edge is
+  // flush with the tabs in the group below (which only have a left inset).
+  title_bounds.Inset(gfx::Insets::TLBR(kPaddingForGroup, kPaddingForGroup,
+                                       kPaddingForGroup, 0));
   title_chip_->SetBoundsRect(title_bounds);
 
   // |title_| is a child view of |title_chip_| and there could be |sync_icon_|

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
@@ -100,10 +100,13 @@ void CalculateVerticalLayout(const std::vector<TabWidthConstraints>& tabs,
       consider_separator_bounds = false;
     }
 
+    // Tabs in a group are indented from the left, but still extend to the same
+    // right edge as tabs outside of a group.
     rect.set_x(
         kMarginForVerticalTabContainers +
         (tab.is_tab_in_group() ? BraveTabGroupHeader::kPaddingForGroup : 0));
-    rect.set_width(width.value_or(tab.GetPreferredWidth()) - rect.x() * 2);
+    rect.set_width(width.value_or(tab.GetPreferredWidth()) - rect.x() -
+                   kMarginForVerticalTabContainers);
 
     if (int level = iter->state().nesting_info().level) {
       // In case of a tab has nesting level, we need to adjust the x position
@@ -271,9 +274,10 @@ std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
       }
 
       if (view->group().has_value()) {
-        // In case it's a tab in a group, set left padding
+        // In case it's a tab in a group, set left padding only, matching the
+        // static vertical layout.
         x = BraveTabGroupHeader::kPaddingForGroup;
-        width -= x * 2;
+        width -= x;
       }
     }
 

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper_unittest.cc
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper_unittest.cc
@@ -12,12 +12,14 @@
 #include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/browser/ui/views/tabs/brave_tab.h"
+#include "brave/browser/ui/views/tabs/brave_tab_group_header.h"
 #include "chrome/browser/ui/tabs/tab_types.h"
 #include "chrome/browser/ui/views/tabs/fake_tab_slot_controller.h"
 #include "chrome/browser/ui/views/tabs/tab_layout_state.h"
 #include "chrome/browser/ui/views/tabs/tab_strip_layout_types.h"
 #include "chrome/browser/ui/views/tabs/tab_width_constraints.h"
 #include "chrome/test/views/chrome_views_test_base.h"
+#include "components/tab_groups/tab_group_id.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
@@ -356,6 +358,37 @@ TEST(BraveTabStripLayoutHelperUnitTest,
 }
 
 TEST(BraveTabStripLayoutHelperUnitTest,
+     CalculateVerticalTabBounds_GroupedTabIsIndentedOnLeftOnly) {
+  std::vector<TabWidthConstraints> tabs;
+  tabs.push_back(MakeTabConstraints(TabPinned::kUnpinned, TabOpen::kOpen,
+                                    TabActive::kInactive, /*in_group=*/false));
+  tabs.push_back(MakeTabConstraints(TabPinned::kUnpinned, TabOpen::kOpen,
+                                    TabActive::kInactive, /*in_group=*/true));
+
+  constexpr int kAvailableWidth = 200;
+  auto [bounds, _] = CalculateVerticalTabBounds(
+      tabs, kAvailableWidth, /*should_layout_pinned_tabs_in_grid=*/false);
+
+  ASSERT_EQ(2u, bounds.size());
+
+  // A tab outside of a group is only inset by the container margins.
+  EXPECT_EQ(kMarginForVerticalTabContainers, bounds[0].x());
+  EXPECT_EQ(kAvailableWidth - 2 * kMarginForVerticalTabContainers,
+            bounds[0].width());
+
+  // A tab in a group is additionally indented from the left by the group
+  // padding, but not from the right.
+  constexpr int kGroupedTabX =
+      kMarginForVerticalTabContainers + BraveTabGroupHeader::kPaddingForGroup;
+  EXPECT_EQ(kGroupedTabX, bounds[1].x());
+  EXPECT_EQ(kAvailableWidth - kGroupedTabX - kMarginForVerticalTabContainers,
+            bounds[1].width());
+
+  // So it ends at the same right edge as a tab outside of a group.
+  EXPECT_EQ(bounds[0].right(), bounds[1].right());
+}
+
+TEST(BraveTabStripLayoutHelperUnitTest,
      CalculateVerticalTabBounds_NestingUsesBaseOffsetWhenEnoughSpace) {
   // Same three-node chain. With enough width, even_offset_per_level >= 20,
   // so offset per level is tabs::kBaseOffsetPerLevel.
@@ -500,6 +533,35 @@ TEST_F(CalculateBoundsForVerticalDraggedViewsTest,
   // same way tabs are indented in the static (non-dragging) layout.
   EXPECT_EQ(bounds[0].x() + kExpectedOffset, bounds[1].x());
   EXPECT_EQ(bounds[0].width() - kExpectedOffset, bounds[1].width());
+}
+
+TEST_F(CalculateBoundsForVerticalDraggedViewsTest,
+       IndentsGroupedTabOnLeftOnly) {
+  FakeTabSlotController controller;
+  views::View parent;
+
+  TestBraveTab* ungrouped = parent.AddChildView(
+      std::make_unique<TestBraveTab>(tabs::TabHandle(1), &controller));
+  ungrouped->SetBoundsRect({0, 0, 0, kVerticalTabHeight});
+
+  TestBraveTab* grouped = parent.AddChildView(
+      std::make_unique<TestBraveTab>(tabs::TabHandle(2), &controller));
+  grouped->SetBoundsRect({0, 0, 0, kVerticalTabHeight});
+  grouped->SetGroup(tab_groups::TabGroupId::GenerateNew());
+
+  constexpr int kDragAreaWidth = 200;
+  std::vector<TabSlotView*> views = {ungrouped, grouped};
+  std::vector<gfx::Rect> bounds = CalculateBoundsForVerticalDraggedViews(
+      views, kDragAreaWidth, /*is_vertical_tabs_floating=*/false);
+
+  ASSERT_EQ(2u, bounds.size());
+
+  // A dragged tab in a group is indented from the left by the group padding,
+  // but keeps the same right edge as an ungrouped one, the same way tabs are
+  // laid out in the static (non-dragging) layout.
+  EXPECT_EQ(0, bounds[0].x());
+  EXPECT_EQ(BraveTabGroupHeader::kPaddingForGroup, bounds[1].x());
+  EXPECT_EQ(bounds[0].right(), bounds[1].right());
 }
 
 TEST_F(CalculateBoundsForVerticalDraggedViewsTest,


### PR DESCRIPTION
Adjust vertical tab group insets and width calculations so group tabs remain flush with the right edge while keeping a left-only indent. Changes:

- brave_tab_group_header.cc: Inset title chip for vertical tabs on left/top/bottom but not right so the chip's right edge is flush with group tabs below.
- brave_tab_strip_layout_helper.cc: Update x and width math for vertical layout so grouped tabs extend to same right edge as non-group tabs (subtract left padding once). Also adjust dragged-view width handling to only remove left padding for grouped tabs.
- brave_tab_strip_layout_helper_unittest.cc: Cover the grouped-tab path with unit tests that assert left-only indent and a shared right edge (static layout + dragged views).

Adds clarifying comments; preserves visual alignment for vertical grouped tabs.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58010

## Fixed screenshot

<img width="160" height="306" alt="image" src="https://github.com/user-attachments/assets/d19f751e-cc67-44fd-a730-65f9c991768d" />

## Test plan

- [ ] Enable vertical tabs
- [ ] Create a tab group with several tabs; confirm grouped tabs are indented on the left only and share the same right edge as ungrouped tabs
- [ ] Confirm the group header/title chip’s right edge aligns with the grouped tabs below (no extra right inset)
- [ ] Drag a grouped tab vertically; confirm the dragged view keeps the left-only indent and matches the ungrouped right edge
- [ ] Collapse/expand the group and resize the vertical tab strip; alignment should hold
- [ ] Unit tests: `brave_unit_tests` — `BraveTabStripLayoutHelperUnitTest.CalculateVerticalTabBounds_GroupedTabIsIndentedOnLeftOnly` and `CalculateBoundsForVerticalDraggedViewsTest.IndentsGroupedTabOnLeftOnly`

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->