### PR TITLE
[plaster] Adding regex macros frontend

### DIFF
--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -136,18 +136,19 @@ YAML).
 The keyed rewrite (`regex:` above) is a **rewriter**. There is on-going work to
 introduce more rewriters. These are the ones we have supported for now.
 
-| Rewriter                | Kind | Description                                       |
-| ----------------------- | ---- | ------------------------------------------------- |
-| `regex`                 | text | A Python `re.subn` substitution (the default).    |
-| `make_virtual`          | AST  | Prepends `virtual ` to a C++ method declaration.  |
-| `add_friend`            | AST  | Adds a `friend` declaration to a private section. |
-| `drop_final`            | AST  | Removes `final` from a C++ class declaration.     |
-| `preempt_function_impl` | AST  | Inserts at the top of a C++ function body.        |
-| `after_function_impl`   | AST  | Wraps a C++ function body and runs code after.    |
-| `rename_class`          | AST  | Renames a C++ class.                              |
-| `add_to_protected`      | AST  | Adds a member to a class `protected:` section.    |
-| `add_to_public`         | AST  | Appends a member to a class `public:` section.    |
-| `add_enum_entries`      | AST  | Appends entries to the end of a C++ enum.         |
+| Rewriter                         | Kind  | Description                                       |
+| -------------------------------- | ----- | ------------------------------------------------- |
+| `regex`                          | text  | A Python `re.subn` substitution (the default).    |
+| `make_virtual`                   | AST   | Prepends `virtual ` to a C++ method declaration.  |
+| `add_friend`                     | AST   | Adds a `friend` declaration to a private section. |
+| `drop_final`                     | AST   | Removes `final` from a C++ class declaration.     |
+| `preempt_function_impl`          | AST   | Inserts at the top of a C++ function body.        |
+| `after_function_impl`            | AST   | Wraps a C++ function body and runs code after.    |
+| `rename_class`                   | AST   | Renames a C++ class.                              |
+| `add_to_protected`               | AST   | Adds a member to a class `protected:` section.    |
+| `add_to_public`                  | AST   | Appends a member to a class `public:` section.    |
+| `add_enum_entries`               | AST   | Appends entries to the end of a C++ enum.         |
+| `set_feature_flag_default_state` | macro | Sets a `BASE_FEATURE`'s default state.            |
 
 Use `plaster --help` to discover rewriters and read their full docs:
 

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -2960,6 +2960,112 @@ class RegexMacroEngine:
         return matches
 
 
+class RegexMacro(Rewriter):
+    """Applies a named `regex_macro` op (declared in `rewriters.pyl`) as a
+    substitution.
+
+    Every `regex_macro` op gets a `RegexMacro` subclass generated automatically
+    from its `rewriters.pyl` spec (see `_regex_macro_rewriters`), carrying only
+    the per-op `NAME` (the `substitutions:` key that selects it), `OP_ID`, and
+    the `SUMMARY`/ `HELP` `plaster --help` renders.
+
+    Behaviour validating a body's keys against the op's declared `inputs`, and
+    applying it via `RegexMacroEngine` lives in this class.
+    """
+
+    # Set on the generated subclass (see `_regex_macro_rewriters`): the
+    # `rewriters.pyl` op id this resolves to (e.g.
+    # `cxx.set_feature_flag_default_state`).
+    OP_ID: ClassVar[str] = ''
+
+    def __init__(self, inputs: dict[str, str]):
+        self._inputs = inputs
+
+    def source_language(self) -> str:
+        """The `<lang>.` prefix for the op (e.g. `cxx`)."""
+        return self.OP_ID.split('.', 1)[0]
+
+    def apply(self,
+              contents: str,
+              *,
+              count: int,
+              description: str,
+              blank_for_parse: bool = False) -> tuple[str, list[str]]:
+        del description  # Only the count matters for the regex diagnostic.
+        del blank_for_parse  # Regex macros run over plain text; nothing to relax.
+        engine = RegexMacroEngine(RewritersEval.load(), contents)
+        matches = engine.run(self.OP_ID, self._inputs)
+        error = MatchExpectation.from_count(count).error_for(matches)
+        return engine.content, [error] if error else []
+
+    @classmethod
+    def parse(cls, body: object, *, description: str) -> RegexMacro:
+        """Validate a `<macro-name>:` body against the op's declared `inputs`.
+        """
+        if not isinstance(body, dict):
+            raise ValueError(
+                f'"{cls.NAME}" must be a mapping (in "{description}")')
+        keys = frozenset(
+            entry['name']
+            for entry in RewritersEval.load().regex_macro(cls.OP_ID)['inputs'])
+        unknown = sorted(set(body) - keys)
+        if unknown:
+            raise ValueError(
+                f'Unrecognised {cls.NAME} arg(s): '
+                f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
+        missing = sorted(keys - set(body))
+        if missing:
+            raise ValueError(f'{cls.NAME} requires arg(s): '
+                             f'{", ".join(missing)} (in "{description}")')
+        for key in sorted(keys):
+            if not isinstance(body[key], str):
+                raise ValueError(f'{cls.NAME} `{key}` must be a string '
+                                 f'(in "{description}")')
+        return cls({key: body[key] for key in keys})
+
+
+def _regex_macro_help(spec: dict) -> str:
+    """Full `plaster --help <macro>` text for one `regex_macro` spec.
+
+    This function produces the markdown text used to show the help section for
+    a given regex macro.
+    """
+    lines = spec['description'].rstrip('\n').splitlines()
+    fields = ['Fields:', ''] + [
+        f"- `{entry['name']}` — {entry['description']}"
+        for entry in spec['inputs']
+    ]
+    for index, line in enumerate(lines):
+        if line.startswith('```'):
+            return '\n'.join(lines[:index] + fields + [''] + lines[index:])
+    return '\n'.join(lines + [''] + fields)
+
+
+def _regex_macro_rewriters() -> dict[str, type[RegexMacro]]:
+    """One auto-generated `RegexMacro` subclass per declared `regex_macro` op.
+
+    This function produces a list of entries to be used by `_REWRITERS` to
+    register all the `regex_macro` ops declared in `rewriters.pyl`.
+    """
+    rewriters: dict[str, type[RegexMacro]] = {}
+    for op_id, spec in RewritersEval.load().regex_macros.items():
+        name = op_id.split('.', 1)[1]
+        first_paragraph = spec['description'].strip().split('\n\n', 1)[0]
+        rewriters[name] = type(
+            f'RegexMacro_{name}', (RegexMacro, ), {
+                'NAME': name,
+                'OP_ID': op_id,
+                'SUMMARY': ' '.join(first_paragraph.split()),
+                'HELP': _regex_macro_help(spec),
+            })
+    return rewriters
+
+
+# Every `regex_macro` op declared in `rewriters.pyl` joins `_REWRITERS`
+# alongside the hand-written rewriters above, each under its own bare name.
+_REWRITERS = MappingProxyType({**_REWRITERS, **_regex_macro_rewriters()})
+
+
 def get_plaster_files(filepaths: list[str] | None = None) -> list[PlasterFile]:
     """Returns plaster files matching the provided file paths.
 

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -3186,6 +3186,197 @@ class RewriterFormsTest(unittest.TestCase):
             '    re_flag: [DOTALL]\n', 'Unrecognised substitution key')
 
 
+class RegexMacroDispatchTest(unittest.TestCase):
+    """End-to-end tests for dispatching a `regex_macro:`-style substitution
+    key (e.g. `set_feature_flag_default_state:`) to `RegexMacro`.
+
+    Every `regex_macro` op declared in `rewriters.pyl` is handled by the same
+    `RegexMacro` class (see `_regex_macro_rewriters`), so these tests exercise
+    that generic dispatch/validation path via the one macro currently shipped
+    (`set_feature_flag_default_state`), rather than the macro's own regex --
+    that is `ToggleBaseFeatureDefaultStateTest`'s job (renamed
+    `OverrideFeatureDefaultStateTest`).
+    """
+
+    def setUp(self):
+        self.fake_chromium_src = FakeChromiumRepo()
+        self.fake_chromium_src.setup()
+        self.addCleanup(self.fake_chromium_src.cleanup)
+
+    def _apply(self, name: str, source: str, yaml_body: str) -> str:
+        """Write `source`+plaster, apply, and return the rewritten source."""
+        src = Path('chrome/common/extensions/api') / name
+        self.fake_chromium_src.write_and_stage_file(
+            src, source, self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit(f'Add {name}',
+                                      self.fake_chromium_src.chromium)
+        plaster_path = plaster.PLASTER_FILES_PATH / (str(src) + '.yaml')
+        plaster_path.parent.mkdir(parents=True, exist_ok=True)
+        plaster_path.write_text(yaml_body)
+        plaster.PlasterFile(plaster_path).apply()
+        return (self.fake_chromium_src.chromium / src).read_text()
+
+    def test_macro_op_applies(self):
+        result = self._apply(
+            'feature.cc',
+            'BASE_FEATURE(kFoo, base::FEATURE_ENABLED_BY_DEFAULT);',
+            'substitutions:\n'
+            '  - description: Ship kFoo disabled.\n'
+            '    set_feature_flag_default_state:\n'
+            '      feature_name: kFoo\n'
+            '      value: base::FEATURE_DISABLED_BY_DEFAULT\n')
+        self.assertEqual(
+            result, 'BASE_FEATURE(kFoo, base::FEATURE_DISABLED_BY_DEFAULT);')
+
+    def test_registered_under_its_bare_name(self):
+        # The YAML key is the op id with its `cxx.` prefix stripped.
+        self.assertIn('set_feature_flag_default_state', plaster._REWRITERS)
+        cls = plaster._REWRITERS['set_feature_flag_default_state']
+        self.assertTrue(issubclass(cls, plaster.RegexMacro))
+        self.assertEqual(cls.OP_ID, 'cxx.set_feature_flag_default_state')
+
+    def test_help_text_lists_every_input(self):
+        # `plaster --help <macro>` must document each input, not just the
+        # macro's own top-level `description`.
+        cls = plaster._REWRITERS['set_feature_flag_default_state']
+        help_text = cls.help_text()
+        self.assertIn('Fields:', help_text)
+        self.assertIn('feature_name', help_text)
+        self.assertIn('value', help_text)
+        spec = plaster.RewritersEval.load().regex_macro(cls.OP_ID)
+        for entry in spec['inputs']:
+            self.assertIn(entry['name'], help_text)
+            self.assertIn(entry['description'], help_text)
+
+    def test_missing_required_arg_is_rejected(self):
+        spec = 'substitutions:\n' \
+              '  - description: d\n' \
+              '    set_feature_flag_default_state:\n' \
+              '      feature_name: kFoo\n'
+        with self.assertRaises(ValueError) as cm:
+            plaster.Substitution.from_yaml(spec)
+        self.assertIn('requires arg(s): value', str(cm.exception))
+
+    def test_unknown_arg_is_rejected(self):
+        spec = ('substitutions:\n'
+                '  - description: d\n'
+                '    set_feature_flag_default_state:\n'
+                '      feature_name: kFoo\n'
+                '      value: base::FEATURE_DISABLED_BY_DEFAULT\n'
+                '      bogus: x\n')
+        with self.assertRaises(ValueError) as cm:
+            plaster.Substitution.from_yaml(spec)
+        self.assertIn("Unrecognised set_feature_flag_default_state arg(s)",
+                      str(cm.exception))
+        self.assertIn("'bogus'", str(cm.exception))
+
+    def test_non_string_arg_is_rejected(self):
+        spec = ('substitutions:\n'
+                '  - description: d\n'
+                '    set_feature_flag_default_state:\n'
+                '      feature_name: kFoo\n'
+                '      value: 1\n')
+        with self.assertRaises(ValueError) as cm:
+            plaster.Substitution.from_yaml(spec)
+        self.assertIn('must be a string', str(cm.exception))
+
+    def test_unknown_macro_name_is_unrecognised(self):
+        # A name that is not a rewriter and not a declared regex macro falls
+        # through to the same "unrecognised" path as any other bad key.
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: d\n'
+            '    not_a_real_macro:\n'
+            '      feature_name: kFoo\n', 'Unknown rewriter')
+
+    def test_only_one_rewriter_allowed_alongside_a_macro(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: d\n'
+            "    regex:\n"
+            "      re_pattern: 'a'\n"
+            "      replace: 'b'\n"
+            '    set_feature_flag_default_state:\n'
+            '      feature_name: kFoo\n'
+            '      value: base::FEATURE_DISABLED_BY_DEFAULT\n',
+            'Only one rewriter allowed per entry')
+
+    def test_count_mismatch_when_value_already_set(self):
+        # `RegexMacro.apply` reports the macro's own match count through the
+        # normal `count:` diagnostic, same as any other rewriter: applying an
+        # override that is already in effect is 0 matches against the
+        # default expectation of 1.
+        with self.assertRaises(plaster.PlasterApplyError) as cm:
+            self._apply(
+                'already_set.cc',
+                'BASE_FEATURE(kFoo, base::FEATURE_DISABLED_BY_DEFAULT);',
+                'substitutions:\n'
+                '  - description: Ship kFoo disabled.\n'
+                '    set_feature_flag_default_state:\n'
+                '      feature_name: kFoo\n'
+                '      value: base::FEATURE_DISABLED_BY_DEFAULT\n')
+        self.assertIn('Unexpected number of matches (0 vs 1)',
+                      str(cm.exception))
+
+    def test_rejected_on_a_non_cxx_source(self):
+        with self.assertRaises(ValueError) as cm:
+            self._apply(
+                'feature.idl', 'irrelevant', 'substitutions:\n'
+                '  - description: Ship kFoo disabled.\n'
+                '    set_feature_flag_default_state:\n'
+                '      feature_name: kFoo\n'
+                '      value: base::FEATURE_DISABLED_BY_DEFAULT\n')
+        self.assertIn(
+            'the `set_feature_flag_default_state` rewriter is only '
+            'supported for C++ sources', str(cm.exception))
+
+    def _expect_value_error(self, yaml_body: str, substr: str):
+        with self.assertRaises(ValueError) as ctx:
+            self._apply('validation.cc', 'dummy', yaml_body)
+        self.assertIn(substr, str(ctx.exception))
+
+
+class RegexMacroHelpTest(unittest.TestCase):
+    """Unit tests for `_regex_macro_help`, independent of the shipped macro.
+    """
+
+    @staticmethod
+    def _spec(description: str) -> dict:
+        return {
+            'description': description,
+            'inputs': [
+                {
+                    'name': 'foo',
+                    'description': 'The foo to use.'
+                },
+                {
+                    'name': 'bar',
+                    'description': 'The bar to use.'
+                },
+            ],
+        }
+
+    def test_fields_inserted_before_example_code_block(self):
+        help_text = plaster._regex_macro_help(
+            self._spec('Does a thing.\n\n```cpp\ncode here\n```\n'))
+        fields_index = help_text.index('Fields:')
+        example_index = help_text.index('```cpp')
+        self.assertLess(fields_index, example_index)
+        self.assertIn('- `foo` — The foo to use.', help_text)
+        self.assertIn('- `bar` — The bar to use.', help_text)
+
+    def test_fields_appended_when_no_code_block(self):
+        help_text = plaster._regex_macro_help(self._spec('Does a thing.'))
+        self.assertTrue(help_text.startswith('Does a thing.'))
+        self.assertIn('Fields:', help_text)
+        self.assertIn('- `foo` — The foo to use.', help_text)
+        self.assertIn('- `bar` — The bar to use.', help_text)
+
+    def test_field_order_matches_declared_inputs(self):
+        help_text = plaster._regex_macro_help(self._spec('Does a thing.'))
+        self.assertLess(help_text.index('`foo`'), help_text.index('`bar`'))
+
+
 class RewriterRegistryTest(unittest.TestCase):
     """The `_REWRITERS` registry drives both YAML dispatch and help."""
 

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -601,6 +601,14 @@ regex: ^{class_name}$
             "description": """\
 Sets a new value to a `BASE_FEATURE` feature flag.
 
+```yaml
+substitutions:
+  - description: Ship kMyFeature disabled.
+    set_feature_flag_default_state:
+      feature_name: kMyFeature
+      value: base::FEATURE_DISABLED_BY_DEFAULT
+```
+
 ```diff
  BASE_FEATURE(kMyFeature,
               "MyFeature",


### PR DESCRIPTION
This PR adds the frontend for the regex macros mechanism. This will
permit us to curate macros for specific operations that are better
handled with a regex.

Fixed: https://github.com/brave/brave-browser/issues/57281
