### PR TITLE
Account: add `kMaximumCodeVerificationAttemptsExceeded` to the resend verification email flow (uplift to 1.94.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveAccountSectionController.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveAccountSectionController.java
@@ -61,7 +61,7 @@ public class BraveAccountSectionController
                     R.string.brave_account_password_reset_email_already_verified,
                     ChangePasswordServerErrorCode.MAXIMUM_CODE_VERIFICATION_ATTEMPTS_EXCEEDED,
                     R.string
-                            .brave_account_password_reset_maximum_code_verification_attempts_exceeded,
+                            .brave_account_resend_confirmation_email_maximum_code_verification_attempts_exceeded,
                     ChangePasswordServerErrorCode.INVALID_VERIFICATION_CODE,
                     R.string.brave_account_register_invalid_verification_code,
                     ChangePasswordServerErrorCode.TOKEN_HAS_EXPIRED,
@@ -76,6 +76,10 @@ public class BraveAccountSectionController
                     R.string.brave_account_resend_confirmation_email_maximum_send_attempts_exceeded,
                     ResendConfirmationEmailServerErrorCode.EMAIL_ALREADY_VERIFIED,
                     R.string.brave_account_resend_confirmation_email_already_verified,
+                    ResendConfirmationEmailServerErrorCode
+                            .MAXIMUM_CODE_VERIFICATION_ATTEMPTS_EXCEEDED,
+                    R.string
+                            .brave_account_resend_confirmation_email_maximum_code_verification_attempts_exceeded,
                     ResendConfirmationEmailServerErrorCode.TOKEN_HAS_EXPIRED,
                     R.string.brave_account_resend_confirmation_email_token_has_expired);
 

--- a/browser/resources/settings/getting_started_page/brave_account_row_base.ts
+++ b/browser/resources/settings/getting_started_page/brave_account_row_base.ts
@@ -45,7 +45,7 @@ const CHANGE_PASSWORD_SERVER_ERROR_STRINGS: Partial<
       .BRAVE_ACCOUNT_PASSWORD_RESET_EMAIL_ALREADY_VERIFIED,
   [ChangePasswordServerErrorCode.kMaximumCodeVerificationAttemptsExceeded]:
     BraveAccountSettingsStrings
-      .BRAVE_ACCOUNT_PASSWORD_RESET_MAXIMUM_CODE_VERIFICATION_ATTEMPTS_EXCEEDED,
+      .BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_MAXIMUM_CODE_VERIFICATION_ATTEMPTS_EXCEEDED,
   [ChangePasswordServerErrorCode.kInvalidVerificationCode]:
     BraveAccountSettingsStrings
       .BRAVE_ACCOUNT_REGISTER_INVALID_VERIFICATION_CODE,
@@ -67,6 +67,9 @@ const RESEND_CONFIRMATION_EMAIL_SERVER_ERROR_STRINGS: Partial<
   [ResendConfirmationEmailServerErrorCode.kEmailAlreadyVerified]:
     BraveAccountSettingsStrings
       .BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_ALREADY_VERIFIED,
+  [ResendConfirmationEmailServerErrorCode.kMaximumCodeVerificationAttemptsExceeded]:
+    BraveAccountSettingsStrings
+      .BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_MAXIMUM_CODE_VERIFICATION_ATTEMPTS_EXCEEDED,
   [ResendConfirmationEmailServerErrorCode.kTokenHasExpired]:
     BraveAccountSettingsStrings
       .BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_TOKEN_HAS_EXPIRED,

--- a/components/brave_account/endpoints/verify_resend_unittest.cc
+++ b/components/brave_account/endpoints/verify_resend_unittest.cc
@@ -42,6 +42,7 @@ const VerifyResendTestCase* Success() {
 //   - { "code": null, "error": "Bad Request", "status": 400 }
 //   - { "code": 13008, "error": "maximum email send attempts exceeded", "status": 400 }
 //   - { "code": 13009, "error": "email already verified", "status": 400 }
+//   - { "code": 13010, "error": "maximum code verification attempts exceeded", "status": 400 }
 // - HTTP 401:
 //   - { "code": 14014, "error": "token has expired", "status": 401 }
 // - HTTP 5XX:

--- a/components/brave_account/mojom/brave_account.mojom
+++ b/components/brave_account/mojom/brave_account.mojom
@@ -137,17 +137,18 @@ struct ResendConfirmationEmailClientError {
 enum ResendConfirmationEmailServerErrorCode {
   // Sentinel: server returned a malformed response
   // (e.g. success body missing required fields).
-  kInvalidResponse                  = -1,
+  kInvalidResponse                         = -1,
   // Sentinel: server returned "code": null in the JSON body.
-  kNull                             = 0,
+  kNull                                    = 0,
   // Sentinel: server returned an unrecognized "code" in the JSON body.
-  kUnknown                          = 1,
+  kUnknown                                 = 1,
   // /v2/verify/resend:
   // - internal: -
   // - user-facing:
-  kMaximumEmailSendAttemptsExceeded = 13008,
-  kEmailAlreadyVerified             = 13009,
-  kTokenHasExpired                  = 14014,
+  kMaximumEmailSendAttemptsExceeded        = 13008,
+  kEmailAlreadyVerified                    = 13009,
+  kMaximumCodeVerificationAttemptsExceeded = 13010,
+  kTokenHasExpired                         = 14014,
 };
 
 struct ResendConfirmationEmailServerError {

--- a/components/brave_account/resources/brave_account_common.ts
+++ b/components/brave_account/resources/brave_account_common.ts
@@ -88,7 +88,7 @@ const CHANGE_PASSWORD_SERVER_ERROR_STRINGS: Partial<
   [ChangePasswordServerErrorCode.kEmailAlreadyVerified]:
     BraveAccountStrings.BRAVE_ACCOUNT_PASSWORD_RESET_EMAIL_ALREADY_VERIFIED,
   [ChangePasswordServerErrorCode.kMaximumCodeVerificationAttemptsExceeded]:
-    BraveAccountStrings.BRAVE_ACCOUNT_PASSWORD_RESET_MAXIMUM_CODE_VERIFICATION_ATTEMPTS_EXCEEDED,
+    BraveAccountStrings.BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_MAXIMUM_CODE_VERIFICATION_ATTEMPTS_EXCEEDED,
   [ChangePasswordServerErrorCode.kInvalidVerificationCode]:
     BraveAccountStrings.BRAVE_ACCOUNT_REGISTER_INVALID_VERIFICATION_CODE,
   [ChangePasswordServerErrorCode.kTokenHasExpired]:
@@ -129,7 +129,7 @@ const REGISTER_SERVER_ERROR_STRINGS: Partial<
   [RegisterServerErrorCode.kTooManyVerifications]:
     BraveAccountStrings.BRAVE_ACCOUNT_REGISTER_TOO_MANY_VERIFICATIONS,
   [RegisterServerErrorCode.kMaximumCodeVerificationAttemptsExceeded]:
-    BraveAccountStrings.BRAVE_ACCOUNT_REGISTER_MAXIMUM_CODE_VERIFICATION_ATTEMPTS_EXCEEDED,
+    BraveAccountStrings.BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_MAXIMUM_CODE_VERIFICATION_ATTEMPTS_EXCEEDED,
   [RegisterServerErrorCode.kInvalidVerificationCode]:
     BraveAccountStrings.BRAVE_ACCOUNT_REGISTER_INVALID_VERIFICATION_CODE,
   [RegisterServerErrorCode.kRegistrationVerificationAlreadyPendingForThisEmail]:
@@ -151,6 +151,8 @@ const RESEND_CONFIRMATION_EMAIL_SERVER_ERROR_STRINGS: Partial<
     BraveAccountStrings.BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_MAXIMUM_SEND_ATTEMPTS_EXCEEDED,
   [ResendConfirmationEmailServerErrorCode.kEmailAlreadyVerified]:
     BraveAccountStrings.BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_ALREADY_VERIFIED,
+  [ResendConfirmationEmailServerErrorCode.kMaximumCodeVerificationAttemptsExceeded]:
+    BraveAccountStrings.BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_MAXIMUM_CODE_VERIFICATION_ATTEMPTS_EXCEEDED,
   [ResendConfirmationEmailServerErrorCode.kTokenHasExpired]:
     BraveAccountStrings.BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_TOKEN_HAS_EXPIRED,
 }
@@ -173,7 +175,7 @@ const RESET_PASSWORD_SERVER_ERROR_STRINGS: Partial<
   [ResetPasswordServerErrorCode.kEmailAlreadyVerified]:
     BraveAccountStrings.BRAVE_ACCOUNT_PASSWORD_RESET_EMAIL_ALREADY_VERIFIED,
   [ResetPasswordServerErrorCode.kMaximumCodeVerificationAttemptsExceeded]:
-    BraveAccountStrings.BRAVE_ACCOUNT_PASSWORD_RESET_MAXIMUM_CODE_VERIFICATION_ATTEMPTS_EXCEEDED,
+    BraveAccountStrings.BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_MAXIMUM_CODE_VERIFICATION_ATTEMPTS_EXCEEDED,
   [ResetPasswordServerErrorCode.kInvalidVerificationCode]:
     BraveAccountStrings.BRAVE_ACCOUNT_REGISTER_INVALID_VERIFICATION_CODE,
   [ResetPasswordServerErrorCode.kTokenHasExpired]:

--- a/components/brave_account/resources/brave_account_strings.grdp
+++ b/components/brave_account/resources/brave_account_strings.grdp
@@ -205,9 +205,6 @@
   <message name="IDS_BRAVE_ACCOUNT_REGISTER_TOO_MANY_VERIFICATIONS" desc="Error message shown when too many email verifications have been requested and the user must wait before trying again" formatter_data="webui=BraveAccount,BraveAccountSettings android_java">
     Email verification limit exceeded. Please wait 30 minutes before trying again.
   </message>
-  <message name="IDS_BRAVE_ACCOUNT_REGISTER_MAXIMUM_CODE_VERIFICATION_ATTEMPTS_EXCEEDED" desc="" formatter_data="webui=BraveAccount">
-    Too many incorrect codes were entered. Start the registration process again.
-  </message>
   <message name="IDS_BRAVE_ACCOUNT_REGISTER_INVALID_VERIFICATION_CODE" desc="Error message shown when the entered email verification code is incorrect" formatter_data="webui=BraveAccount,BraveAccountSettings android_java">
     Wrong code, please try again.
   </message>
@@ -222,9 +219,6 @@
   </message>
   <message name="IDS_BRAVE_ACCOUNT_PASSWORD_RESET_EMAIL_ALREADY_VERIFIED" desc="Error message shown during password reset when the email is already verified, indicating an internal error" formatter_data="webui=BraveAccount,BraveAccountSettings android_java">
     Internal error. Close the dialog, cancel the verification, and try again.
-  </message>
-  <message name="IDS_BRAVE_ACCOUNT_PASSWORD_RESET_MAXIMUM_CODE_VERIFICATION_ATTEMPTS_EXCEEDED" desc="Error message shown during password reset when too many incorrect verification codes have been entered" formatter_data="webui=BraveAccount,BraveAccountSettings android_java">
-    Too many incorrect codes were entered. Start the password change process again.
   </message>
 
   <!-- Common: -->
@@ -267,6 +261,9 @@
   </message>
   <message name="IDS_BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_ALREADY_VERIFIED" desc="Error message shown in an alert when the email has already been verified" formatter_data="webui=BraveAccount,BraveAccountSettings android_java">
     Email already verified.
+  </message>
+  <message name="IDS_BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_MAXIMUM_CODE_VERIFICATION_ATTEMPTS_EXCEEDED" desc="Error message shown when too many incorrect verification codes have been entered" formatter_data="webui=BraveAccount,BraveAccountSettings android_java">
+    You entered too many incorrect codes. Cancel the verification and try again.
   </message>
   <message name="IDS_BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_TOKEN_HAS_EXPIRED" desc="Error message shown in an alert when the verification token has expired" formatter_data="webui=BraveAccount,BraveAccountSettings android_java">
     The verification code has expired. Cancel the verification and try again.

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -723,6 +723,8 @@ class SettingsViewController: TableViewController, BraveAccountAuthenticationObs
           .BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_MAXIMUM_SEND_ATTEMPTS_EXCEEDED,
         .emailAlreadyVerified:
           .BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_ALREADY_VERIFIED,
+        .maximumCodeVerificationAttemptsExceeded:
+          .BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_MAXIMUM_CODE_VERIFICATION_ATTEMPTS_EXCEEDED,
         .tokenHasExpired:
           .BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_TOKEN_HAS_EXPIRED,
       ],
@@ -748,7 +750,7 @@ class SettingsViewController: TableViewController, BraveAccountAuthenticationObs
         .emailAlreadyVerified:
           .BRAVE_ACCOUNT_PASSWORD_RESET_EMAIL_ALREADY_VERIFIED,
         .maximumCodeVerificationAttemptsExceeded:
-          .BRAVE_ACCOUNT_PASSWORD_RESET_MAXIMUM_CODE_VERIFICATION_ATTEMPTS_EXCEEDED,
+          .BRAVE_ACCOUNT_RESEND_CONFIRMATION_EMAIL_MAXIMUM_CODE_VERIFICATION_ATTEMPTS_EXCEEDED,
         .invalidVerificationCode:
           .BRAVE_ACCOUNT_REGISTER_INVALID_VERIFICATION_CODE,
         .tokenHasExpired:


### PR DESCRIPTION
Uplift of #38933
Resolves https://github.com/brave/brave-browser/issues/57867
Resolves https://github.com/brave/brave-browser/issues/57893

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.