### PR TITLE
[VPN 2.0] Add browser-facing Mojo server to the VPN agent

### DIFF
--- a/components/BUILD.gn
+++ b/components/BUILD.gn
@@ -88,7 +88,10 @@ test("brave_components_unittests") {
   }
 
   if (enable_brave_vpn_v2) {
-    deps += [ "//brave/components/brave_vpn/browser/v2/api:unit_tests" ]
+    deps += [
+      "//brave/components/brave_vpn/browser/v2/api:unit_tests",
+      "//brave/components/brave_vpn/common/v2:unit_tests",
+    ]
   }
 
   if (enable_brave_vpn_v2_apps) {

--- a/components/brave_vpn/app/v2/DEPS
+++ b/components/brave_vpn/app/v2/DEPS
@@ -1,0 +1,4 @@
+include_rules = [
+  "+components/named_mojo_ipc_server",
+  "+mojo/core/embedder",
+]

--- a/components/brave_vpn/app/v2/agent/BUILD.gn
+++ b/components/brave_vpn/app/v2/agent/BUILD.gn
@@ -19,6 +19,12 @@ source_set("core") {
   sources = [
     "agent_app.cc",
     "agent_app.h",
+    "browser_host_impl.cc",
+    "browser_host_impl.h",
+    "browser_host_provider_impl.cc",
+    "browser_host_provider_impl.h",
+    "browser_registry.cc",
+    "browser_registry.h",
     "shutdown_handlers.cc",
     "shutdown_handlers.h",
     "single_instance.h",
@@ -38,7 +44,18 @@ source_set("core") {
     ]
   }
 
-  public_deps = [ "//base" ]
+  public_deps = [
+    "//base",
+    "//brave/components/brave_vpn/common/mojom:agent",
+    "//components/named_mojo_ipc_server",
+    "//mojo/public/cpp/bindings",
+    "//mojo/public/cpp/platform",
+  ]
+
+  deps = [
+    "//brave/components/brave_vpn/common/v2:common",
+    "//mojo/core/embedder",
+  ]
 }
 
 if (is_win) {
@@ -139,18 +156,43 @@ if (is_mac) {
   }
 }
 
+source_set("test_support") {
+  testonly = true
+
+  sources = [
+    "test/fake_browser.cc",
+    "test/fake_browser.h",
+    "test/fake_browser_endpoint.cc",
+    "test/fake_browser_endpoint.h",
+  ]
+
+  public_deps = [
+    "//base",
+    "//base/test:test_support",
+    "//brave/components/brave_vpn/common/mojom:agent",
+    "//mojo/public/cpp/bindings",
+  ]
+}
+
 source_set("unit_tests") {
   testonly = true
   sources = [
     "agent_app_unittest.cc",
+    "browser_host_impl_unittest.cc",
+    "browser_host_provider_impl_unittest.cc",
+    "browser_registry_unittest.cc",
     "shutdown_handlers_unittest.cc",
     "single_instance_unittest.cc",
   ]
 
   deps = [
     ":core",
+    ":test_support",
     "//base",
     "//base/test:test_support",
+    "//brave/components/brave_vpn/common/mojom:agent",
+    "//components/named_mojo_ipc_server:test_support",
+    "//mojo/public/cpp/bindings",
     "//testing/gtest",
   ]
 }

--- a/components/brave_vpn/app/v2/agent/agent_app.cc
+++ b/components/brave_vpn/app/v2/agent/agent_app.cc
@@ -14,11 +14,21 @@
 #include "base/logging.h"
 #include "base/message_loop/message_pump_type.h"
 #include "base/run_loop.h"
+#include "base/strings/utf_ostream_operators.h"
 #include "base/task/single_thread_task_executor.h"
 #include "base/task/single_thread_task_runner.h"
+#include "base/threading/thread.h"
+#include "brave/components/brave_vpn/app/v2/agent/browser_registry.h"
 #include "brave/components/brave_vpn/app/v2/agent/shutdown_handlers.h"
+#include "brave/components/brave_vpn/common/v2/agent_utils.h"
+#include "mojo/core/embedder/configuration.h"
+#include "mojo/core/embedder/embedder.h"
+#include "mojo/core/embedder/scoped_ipc_support.h"
 
 namespace brave_vpn::v2 {
+namespace {
+constexpr char kMojoIpcThreadName[] = "MojoIPC";
+}  // namespace
 
 // Unretained is safe: the shutdown handlers may invoke this callback from a
 // background thread, but only while the process (and hence |this|, which
@@ -30,10 +40,14 @@ AgentApp::AgentApp()
 AgentApp::~AgentApp() = default;
 
 int AgentApp::Run() {
-  VLOG(1) << "Hello from the Brave VPN Agent!";
+  const auto server_name = GetAgentServerName();
+  if (!server_name) {
+    return 1;  // Reason already logged. Non-zero so systemd/launchd sees it.
+  }
 
-  base::SingleThreadTaskExecutor main_task_executor(
-      base::MessagePumpType::DEFAULT);
+  VLOG(1) << "Hello from the Brave VPN Agent: server name = " << *server_name;
+
+  base::SingleThreadTaskExecutor main_task_executor(base::MessagePumpType::IO);
   main_runner_ = base::SingleThreadTaskRunner::GetCurrentDefault();
 
   base::RunLoop run_loop;
@@ -45,7 +59,24 @@ int AgentApp::Run() {
   if (!shutdown_handlers_->Install()) {
     VLOG(1) << "Shutdown handlers not installed";
   }
-  run_loop.Run();
+
+  {
+    // Initialize Mojo on a separate thread.
+    base::Thread ipc_thread(kMojoIpcThreadName);
+    CHECK(ipc_thread.StartWithOptions(
+        base::Thread::Options(base::MessagePumpType::IO, 0)));
+
+    mojo::core::Init(mojo::core::Configuration{.is_broker_process = true});
+    mojo::core::ScopedIPCSupport ipc_support(
+        ipc_thread.task_runner(),
+        mojo::core::ScopedIPCSupport::ShutdownPolicy::CLEAN);
+
+    // Initialize the browser registry, which will manage the lifetime of
+    // client browser instances and their associated Mojo connections.
+    BrowserRegistry browser_registry{*server_name};
+
+    run_loop.Run();
+  }
 
   shutdown_handlers_->SignalShutdownComplete();
   return 0;

--- a/components/brave_vpn/app/v2/agent/agent_app_unittest.cc
+++ b/components/brave_vpn/app/v2/agent/agent_app_unittest.cc
@@ -19,6 +19,7 @@
 #include "base/run_loop.h"
 #include "base/synchronization/waitable_event.h"
 #include "base/task/single_thread_task_executor.h"
+#include "base/task/thread_pool/thread_pool_instance.h"
 #include "base/test/bind.h"
 #include "base/test/gtest_util.h"
 #include "base/test/multiprocess_test.h"
@@ -95,6 +96,7 @@ base::FilePath SignalDirFromCommandLine() {
 // path depends on is provably in place, so a watcher thread polls for that and
 // only then tells the parent it is safe to send the signal under test.
 MULTIPROCESS_TEST_MAIN(AgentAppRunChild) {
+  base::ThreadPoolInstance::CreateAndStartWithDefaultParams("AgentAppRunChild");
   const base::FilePath dir = SignalDirFromCommandLine();
 
   base::Thread readiness("readiness_watcher");
@@ -117,6 +119,7 @@ MULTIPROCESS_TEST_MAIN(AgentAppRunChild) {
 // shutdown. Uses ShutdownHandlers directly (not AgentApp, whose shutdown cannot
 // hang), so readiness can simply be signaled after Install() returns.
 MULTIPROCESS_TEST_MAIN(HungShutdownChild) {
+  base::ThreadPoolInstance::CreateAndStartWithDefaultParams("AgentAppRunChild");
   const base::FilePath dir = SignalDirFromCommandLine();
 
   base::SingleThreadTaskExecutor executor;

--- a/components/brave_vpn/app/v2/agent/browser_host_impl.cc
+++ b/components/brave_vpn/app/v2/agent/browser_host_impl.cc
@@ -1,0 +1,41 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/browser_host_impl.h"
+
+#include <utility>
+
+#include "base/functional/bind.h"
+
+namespace brave_vpn::v2 {
+
+BrowserHostImpl::BrowserHostImpl(
+    mojo::PendingRemote<mojom::BrowserEndpoint> browser_endpoint,
+    mojo::PendingReceiver<mojom::BrowserHost> receiver,
+    base::OnceClosure disconnect_handler)
+    : disconnect_handler_(std::move(disconnect_handler)),
+      browser_endpoint_(std::move(browser_endpoint)),
+      receiver_(this, std::move(receiver)) {
+  browser_endpoint_.set_disconnect_handler(base::BindOnce(
+      &BrowserHostImpl::OnPipeDisconnected, base::Unretained(this)));
+  receiver_.set_disconnect_handler(base::BindOnce(
+      &BrowserHostImpl::OnPipeDisconnected, base::Unretained(this)));
+}
+
+BrowserHostImpl::~BrowserHostImpl() = default;
+
+void BrowserHostImpl::OnPipeDisconnected() {
+  // Whichever pipe closes first reports the session as gone. The other pipe's
+  // handler is destroyed along with this object, so this normally runs once;
+  // the guard covers a caller whose handler leaves this object alive.
+  if (!disconnect_handler_) {
+    return;
+  }
+
+  // May delete this: nothing below may touch members.
+  std::move(disconnect_handler_).Run();
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/browser_host_impl.h
+++ b/components/brave_vpn/app/v2/agent/browser_host_impl.h
@@ -1,0 +1,52 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_BROWSER_HOST_IMPL_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_BROWSER_HOST_IMPL_H_
+
+#include "base/functional/callback.h"
+#include "brave/components/brave_vpn/common/mojom/browser_agent.mojom.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+#include "mojo/public/cpp/bindings/remote.h"
+
+namespace brave_vpn::v2 {
+
+// The authenticated API surface: one instance per authenticated browser,
+// created and owned by BrowserRegistry once authentication succeeds. A browser
+// only ever holds a remote to this after being accepted, so methods here do no
+// further checking.
+class BrowserHostImpl : public brave_vpn::mojom::BrowserHost {
+ public:
+  // Constructs the BrowserHostImpl for a single authenticated browser. The
+  // browser's BrowserEndpoint is passed in to allow the agent to call back into
+  // the browser. The BrowserHost |receiver| is the pipe the browser handed to
+  // BindBrowserHost(), so the browser can start issuing calls as soon as the
+  // reply reaches it. |disconnect_handler| runs if either pipe gets dropped
+  // while keeping the connection open, and is allowed to destroy this object.
+  BrowserHostImpl(mojo::PendingRemote<mojom::BrowserEndpoint> browser_endpoint,
+                  mojo::PendingReceiver<mojom::BrowserHost> receiver,
+                  base::OnceClosure disconnect_handler);
+  ~BrowserHostImpl() override;
+
+  BrowserHostImpl(const BrowserHostImpl&) = delete;
+  BrowserHostImpl& operator=(const BrowserHostImpl&) = delete;
+
+ private:
+  // Runs the disconnect handler the first time either pipe closes. Both pipes
+  // share one handler because the session is only useful while both are up: a
+  // browser that drops its endpoint can no longer be called back, and one that
+  // drops the host can no longer call in.
+  void OnPipeDisconnected();
+
+  base::OnceClosure disconnect_handler_;
+  mojo::Remote<mojom::BrowserEndpoint> browser_endpoint_;
+  mojo::Receiver<mojom::BrowserHost> receiver_;
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_BROWSER_HOST_IMPL_H_

--- a/components/brave_vpn/app/v2/agent/browser_host_impl_unittest.cc
+++ b/components/brave_vpn/app/v2/agent/browser_host_impl_unittest.cc
@@ -1,0 +1,111 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/browser_host_impl.h"
+
+#include <memory>
+#include <utility>
+
+#include "base/functional/callback.h"
+#include "base/run_loop.h"
+#include "base/test/bind.h"
+#include "base/test/task_environment.h"
+#include "base/test/test_future.h"
+#include "brave/components/brave_vpn/app/v2/agent/test/fake_browser.h"
+#include "brave/components/brave_vpn/app/v2/agent/test/fake_browser_endpoint.h"
+#include "brave/components/brave_vpn/common/mojom/browser_agent.mojom.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn::v2 {
+namespace {
+
+// Bounded barrier for asserting that something did not happen: a round trip on
+// a throwaway pipe bound to this sequence completes only after the work already
+// queued on the sequence has run. Needed when neither session pipe survives to
+// be flushed directly.
+void FlushSequence() {
+  FakeBrowserEndpoint endpoint_impl;
+  mojo::Remote<mojom::BrowserEndpoint> remote;
+  mojo::Receiver<mojom::BrowserEndpoint> receiver(
+      &endpoint_impl, remote.BindNewPipeAndPassReceiver());
+  remote.FlushForTesting();
+}
+
+}  // namespace
+
+class BrowserHostImplTest : public testing::Test {
+ protected:
+  void CreateHost() { CreateHost(disconnected_.GetCallback()); }
+  void CreateHost(base::OnceClosure disconnect_handler) {
+    host_ = std::make_unique<BrowserHostImpl>(browser_.BindEndpoint(),
+                                              browser_.BindHost(),
+                                              std::move(disconnect_handler));
+    ASSERT_TRUE(host_);
+  }
+
+  base::test::TaskEnvironment task_environment_;
+  FakeBrowser browser_;
+  std::unique_ptr<BrowserHostImpl> host_;
+  base::test::TestFuture<void> disconnected_;
+};
+
+TEST_F(BrowserHostImplTest, StaysAliveWhileBothPipesAreOpen) {
+  CreateHost();
+  browser_.FlushHost();
+  EXPECT_FALSE(disconnected_.IsReady());
+}
+
+TEST_F(BrowserHostImplTest, DroppingHostReportsDisconnect) {
+  CreateHost();
+  browser_.DropHost();
+  EXPECT_TRUE(disconnected_.Wait());
+}
+
+// A browser that drops only its endpoint can no longer be called back, so the
+// session must end even though the BrowserHost pipe is still open.
+TEST_F(BrowserHostImplTest, DroppingEndpointReportsDisconnect) {
+  CreateHost();
+  browser_.DropEndpoint();
+  EXPECT_TRUE(disconnected_.Wait());
+}
+
+// Both pipes closing must still report exactly once, since the report is what
+// tears the session down. The handler here deliberately keeps the host alive,
+// so the surviving pipe's handler really does run and find the report consumed.
+TEST_F(BrowserHostImplTest, ReportsDisconnectOnceWhenBothPipesClose) {
+  int report_count = 0;
+  base::RunLoop first_report;
+  CreateHost(base::BindLambdaForTesting([&] {
+    ++report_count;
+    first_report.Quit();
+  }));
+
+  browser_.DropEndpoint();
+  first_report.Run();
+  ASSERT_EQ(1, report_count);
+
+  browser_.DropHost();
+  FlushSequence();
+
+  EXPECT_EQ(1, report_count);
+}
+
+// The registry destroys sessions itself when a connection goes away, and must
+// not get a report back for a host it has already deleted.
+TEST_F(BrowserHostImplTest, DestructionDoesNotReportDisconnect) {
+  CreateHost();
+  browser_.WatchHost();
+
+  host_.reset();
+
+  // The browser observing its own end close proves the teardown has been
+  // processed, so the report either happened by now or never will.
+  EXPECT_TRUE(browser_.WaitForHostClosed());
+  EXPECT_FALSE(disconnected_.IsReady());
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/browser_host_provider_impl.cc
+++ b/components/brave_vpn/app/v2/agent/browser_host_provider_impl.cc
@@ -1,0 +1,30 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/browser_host_provider_impl.h"
+
+#include <utility>
+
+#include "base/check_deref.h"
+
+namespace brave_vpn::v2 {
+
+BrowserHostProviderImpl::BrowserHostProviderImpl(Delegate* delegate)
+    : delegate_(CHECK_DEREF(delegate)) {}
+
+BrowserHostProviderImpl::~BrowserHostProviderImpl() = default;
+
+void BrowserHostProviderImpl::BindBrowserHost(
+    uint32_t protocol_version,
+    mojo::PendingRemote<mojom::BrowserEndpoint> browser_endpoint,
+    mojo::PendingReceiver<mojom::BrowserHost> host,
+    BindBrowserHostCallback callback) {
+  // The delegate owns the policy and binds |host| itself on success; this
+  // surface only forwards and relays the result back to the browser.
+  delegate_->Authenticate(protocol_version, std::move(browser_endpoint),
+                          std::move(host), std::move(callback));
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/browser_host_provider_impl.h
+++ b/components/brave_vpn/app/v2/agent/browser_host_provider_impl.h
@@ -29,7 +29,8 @@ class BrowserHostProviderImpl : public brave_vpn::mojom::BrowserHostProvider {
     // Decides whether the connection currently being dispatched may have a
     // BrowserHost, and binds |host| to one if so. Called synchronously from
     // BindBrowserHost(), so implementations may read dispatch state (peer info,
-    // current receiver) before returning, but not afterwards.
+    // current receiver) before returning, but not afterwards. |callback| is
+    // always run from a posted task.
     virtual void Authenticate(
         uint32_t protocol_version,
         mojo::PendingRemote<mojom::BrowserEndpoint> browser_endpoint,

--- a/components/brave_vpn/app/v2/agent/browser_host_provider_impl.h
+++ b/components/brave_vpn/app/v2/agent/browser_host_provider_impl.h
@@ -1,0 +1,60 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_BROWSER_HOST_PROVIDER_IMPL_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_BROWSER_HOST_PROVIDER_IMPL_H_
+
+#include <stdint.h>
+
+#include "base/functional/callback.h"
+#include "base/memory/raw_ref.h"
+#include "brave/components/brave_vpn/common/mojom/browser_agent.mojom.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+
+namespace brave_vpn::v2 {
+
+// The unauthenticated API surface: everything reachable on a fresh connection,
+// which today is authentication and nothing else. A single instance is shared
+// by every connected browser (it is what BrowserRegistry hands the IPC server),
+// so it holds no per-connection state and defers all policy to its delegate.
+class BrowserHostProviderImpl : public brave_vpn::mojom::BrowserHostProvider {
+ public:
+  class Delegate {
+   public:
+    virtual ~Delegate() = default;
+
+    // Decides whether the connection currently being dispatched may have a
+    // BrowserHost, and binds |host| to one if so. Called synchronously from
+    // BindBrowserHost(), so implementations may read dispatch state (peer info,
+    // current receiver) before returning, but not afterwards.
+    virtual void Authenticate(
+        uint32_t protocol_version,
+        mojo::PendingRemote<mojom::BrowserEndpoint> browser_endpoint,
+        mojo::PendingReceiver<mojom::BrowserHost> host,
+        base::OnceCallback<void(mojom::BrowserAuthResult)> callback) = 0;
+  };
+
+  explicit BrowserHostProviderImpl(Delegate* delegate);
+  ~BrowserHostProviderImpl() override;
+
+  BrowserHostProviderImpl(const BrowserHostProviderImpl&) = delete;
+  BrowserHostProviderImpl& operator=(const BrowserHostProviderImpl&) = delete;
+
+ private:
+  // brave_vpn::mojom::BrowserHostProvider:
+  void BindBrowserHost(
+      uint32_t protocol_version,
+      mojo::PendingRemote<mojom::BrowserEndpoint> browser_endpoint,
+      mojo::PendingReceiver<mojom::BrowserHost> host,
+      BindBrowserHostCallback callback) override;
+
+  // Outlives this; the registry owns both.
+  const raw_ref<Delegate> delegate_;
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_BROWSER_HOST_PROVIDER_IMPL_H_

--- a/components/brave_vpn/app/v2/agent/browser_host_provider_impl_unittest.cc
+++ b/components/brave_vpn/app/v2/agent/browser_host_provider_impl_unittest.cc
@@ -18,7 +18,7 @@
 #include "base/task/sequenced_task_runner.h"
 #include "base/test/gtest_util.h"
 #include "base/test/task_environment.h"
-#include "base/test/test_future.h"
+#include "brave/components/brave_vpn/app/v2/agent/test/fake_browser.h"
 #include "brave/components/brave_vpn/common/mojom/browser_agent.mojom.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
@@ -30,16 +30,11 @@
 namespace brave_vpn::v2 {
 namespace {
 
-// Fakes that own the browser's ends of the pipes, so the test can tell whether
-// the forwarded handles arrived intact.
-class FakeBrowserEndpointImpl : public mojom::BrowserEndpoint {
+// Binds the host receiver the provider forwarded, which is the agent's side of
+// that pipe rather than the browser's.
+class FakeBrowserHost : public mojom::BrowserHost {
  public:
-  ~FakeBrowserEndpointImpl() override = default;
-};
-
-class FakeBrowserHostImpl : public mojom::BrowserHost {
- public:
-  ~FakeBrowserHostImpl() override = default;
+  ~FakeBrowserHost() override = default;
 };
 
 // Records what the provider forwards, then answers from a separate task,
@@ -104,12 +99,6 @@ struct BrowserAuthResultParam {
 
 class BrowserHostProviderImplTest : public testing::Test {
  protected:
-  struct BrowserPipes {
-    FakeBrowserEndpointImpl endpoint_impl;
-    mojo::Receiver<mojom::BrowserEndpoint> endpoint{&endpoint_impl};
-    mojo::Remote<mojom::BrowserHost> host;
-  };
-
   // Every connection is handed the same provider instance.
   mojo::Remote<mojom::BrowserHostProvider> ConnectClient() {
     mojo::Remote<mojom::BrowserHostProvider> client;
@@ -127,15 +116,13 @@ TEST_F(BrowserHostProviderImplTest, ForwardsCallToDelegate) {
   constexpr uint32_t kProtocolVersion = 1;
 
   mojo::Remote<mojom::BrowserHostProvider> client = ConnectClient();
-  BrowserPipes pipes;
-  base::test::TestFuture<mojom::BrowserAuthResult> replied;
-  client->BindBrowserHost(
-      kProtocolVersion, pipes.endpoint.BindNewPipeAndPassRemote(),
-      pipes.host.BindNewPipeAndPassReceiver(), replied.GetCallback());
+  FakeBrowser browser;
+  client->BindBrowserHost(kProtocolVersion, browser.BindEndpoint(),
+                          browser.BindHost(), browser.GetReplyCallback());
 
   // The reply only arrives after the delegate has been called, so waiting for
   // it is also how the test waits for the forwarded arguments.
-  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted, replied.Get());
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted, browser.WaitForReply());
   ASSERT_EQ(1u, delegate_.calls().size());
   FakeBrowserHostProviderImplDelegate::Call& call = delegate_.calls()[0];
   EXPECT_EQ(kProtocolVersion, call.protocol_version);
@@ -145,14 +132,14 @@ TEST_F(BrowserHostProviderImplTest, ForwardsCallToDelegate) {
   // along the way would have closed it.
   mojo::Remote<mojom::BrowserEndpoint> endpoint(
       std::move(call.browser_endpoint));
-  FakeBrowserHostImpl host_impl;
+  FakeBrowserHost host_impl;
   mojo::Receiver<mojom::BrowserHost> host_receiver(&host_impl,
                                                    std::move(call.host));
   endpoint.FlushForTesting();
-  pipes.host.FlushForTesting();
+  browser.FlushHost();
 
   EXPECT_TRUE(endpoint.is_connected());
-  EXPECT_TRUE(pipes.host.is_connected());
+  EXPECT_TRUE(browser.host_connected());
 }
 
 // The provider is shared by every connection, so it must hold no per-connection
@@ -168,22 +155,18 @@ TEST_F(BrowserHostProviderImplTest, ServesConcurrentClients) {
 
   mojo::Remote<mojom::BrowserHostProvider> first_client = ConnectClient();
   mojo::Remote<mojom::BrowserHostProvider> second_client = ConnectClient();
-  BrowserPipes first_pipes;
-  BrowserPipes second_pipes;
+  FakeBrowser first_browser;
+  FakeBrowser second_browser;
 
-  base::test::TestFuture<mojom::BrowserAuthResult> first_replied;
-  base::test::TestFuture<mojom::BrowserAuthResult> second_replied;
-  first_client->BindBrowserHost(kFirstVersion,
-                                first_pipes.endpoint.BindNewPipeAndPassRemote(),
-                                first_pipes.host.BindNewPipeAndPassReceiver(),
-                                first_replied.GetCallback());
-  second_client->BindBrowserHost(
-      kSecondVersion, second_pipes.endpoint.BindNewPipeAndPassRemote(),
-      second_pipes.host.BindNewPipeAndPassReceiver(),
-      second_replied.GetCallback());
+  first_client->BindBrowserHost(kFirstVersion, first_browser.BindEndpoint(),
+                                first_browser.BindHost(),
+                                first_browser.GetReplyCallback());
+  second_client->BindBrowserHost(kSecondVersion, second_browser.BindEndpoint(),
+                                 second_browser.BindHost(),
+                                 second_browser.GetReplyCallback());
 
-  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted, first_replied.Get());
-  EXPECT_EQ(mojom::BrowserAuthResult::kRejected, second_replied.Get());
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted, first_browser.WaitForReply());
+  EXPECT_EQ(mojom::BrowserAuthResult::kRejected, second_browser.WaitForReply());
   EXPECT_EQ(2u, delegate_.calls().size());
 }
 
@@ -199,8 +182,8 @@ INSTANTIATE_TEST_SUITE_P(
         BrowserAuthResultParam{mojom::BrowserAuthResult::kRejected, "Rejected"},
         BrowserAuthResultParam{mojom::BrowserAuthResult::kVersionMismatch,
                                "VersionMismatch"},
-        BrowserAuthResultParam{mojom::BrowserAuthResult::kAlreadyAuthenticated,
-                               "AlreadyAuthenticated"}),
+        BrowserAuthResultParam{mojom::BrowserAuthResult::kHostAlreadyRequested,
+                               "HostAlreadyRequested"}),
     [](const testing::TestParamInfo<BrowserAuthResultParam>& info) {
       return std::string(info.param.name);
     });
@@ -210,13 +193,11 @@ TEST_P(BrowserHostProviderImplResultTest, RelaysDelegateResultToClient) {
   delegate_.SetResult(GetParam().result);
 
   mojo::Remote<mojom::BrowserHostProvider> client = ConnectClient();
-  BrowserPipes pipes;
-  base::test::TestFuture<mojom::BrowserAuthResult> replied;
-  client->BindBrowserHost(
-      mojom::kProtocolVersion, pipes.endpoint.BindNewPipeAndPassRemote(),
-      pipes.host.BindNewPipeAndPassReceiver(), replied.GetCallback());
+  FakeBrowser browser;
+  client->BindBrowserHost(mojom::kProtocolVersion, browser.BindEndpoint(),
+                          browser.BindHost(), browser.GetReplyCallback());
 
-  EXPECT_EQ(GetParam().result, replied.Get());
+  EXPECT_EQ(GetParam().result, browser.WaitForReply());
 }
 
 TEST(BrowserHostProviderImplDeathTest, NullDelegateChecks) {

--- a/components/brave_vpn/app/v2/agent/browser_host_provider_impl_unittest.cc
+++ b/components/brave_vpn/app/v2/agent/browser_host_provider_impl_unittest.cc
@@ -1,0 +1,226 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/browser_host_provider_impl.h"
+
+#include <stdint.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "base/containers/flat_map.h"
+#include "base/functional/bind.h"
+#include "base/functional/callback.h"
+#include "base/location.h"
+#include "base/task/sequenced_task_runner.h"
+#include "base/test/gtest_util.h"
+#include "base/test/task_environment.h"
+#include "base/test/test_future.h"
+#include "brave/components/brave_vpn/common/mojom/browser_agent.mojom.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+#include "mojo/public/cpp/bindings/receiver_set.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn::v2 {
+namespace {
+
+// Fakes that own the browser's ends of the pipes, so the test can tell whether
+// the forwarded handles arrived intact.
+class FakeBrowserEndpointImpl : public mojom::BrowserEndpoint {
+ public:
+  ~FakeBrowserEndpointImpl() override = default;
+};
+
+class FakeBrowserHostImpl : public mojom::BrowserHost {
+ public:
+  ~FakeBrowserHostImpl() override = default;
+};
+
+// Records what the provider forwards, then answers from a separate task,
+// mirroring the asynchronous verification hop BrowserRegistry takes. Replying
+// out of band is what lets every test wait on the client's reply rather than
+// draining the sequence.
+class FakeBrowserHostProviderImplDelegate
+    : public BrowserHostProviderImpl::Delegate {
+ public:
+  struct Call {
+    uint32_t protocol_version = 0;
+    mojo::PendingRemote<mojom::BrowserEndpoint> browser_endpoint;
+    mojo::PendingReceiver<mojom::BrowserHost> host;
+  };
+
+  FakeBrowserHostProviderImplDelegate() = default;
+  ~FakeBrowserHostProviderImplDelegate() override = default;
+
+  void SetResult(mojom::BrowserAuthResult result) { default_result_ = result; }
+
+  // Lets a test tell two in-flight calls apart by what they asked for.
+  void SetResultForVersion(uint32_t protocol_version,
+                           mojom::BrowserAuthResult result) {
+    results_.insert_or_assign(protocol_version, result);
+  }
+
+  std::vector<Call>& calls() { return calls_; }
+
+ private:
+  // BrowserHostProviderImpl::Delegate:
+  void Authenticate(
+      uint32_t protocol_version,
+      mojo::PendingRemote<mojom::BrowserEndpoint> browser_endpoint,
+      mojo::PendingReceiver<mojom::BrowserHost> host,
+      base::OnceCallback<void(mojom::BrowserAuthResult)> callback) override {
+    calls_.push_back(Call{.protocol_version = protocol_version,
+                          .browser_endpoint = std::move(browser_endpoint),
+                          .host = std::move(host)});
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE,
+        base::BindOnce(std::move(callback), ResultFor(protocol_version)));
+  }
+
+  mojom::BrowserAuthResult ResultFor(uint32_t protocol_version) const {
+    const auto it = results_.find(protocol_version);
+    return it == results_.end() ? default_result_ : it->second;
+  }
+
+  mojom::BrowserAuthResult default_result_ =
+      mojom::BrowserAuthResult::kAccepted;
+  base::flat_map<uint32_t, mojom::BrowserAuthResult> results_;
+  std::vector<Call> calls_;
+};
+
+// Parameter for parameterized tests.
+struct BrowserAuthResultParam {
+  mojom::BrowserAuthResult result;
+  const char* name;
+};
+
+}  // namespace
+
+class BrowserHostProviderImplTest : public testing::Test {
+ protected:
+  struct BrowserPipes {
+    FakeBrowserEndpointImpl endpoint_impl;
+    mojo::Receiver<mojom::BrowserEndpoint> endpoint{&endpoint_impl};
+    mojo::Remote<mojom::BrowserHost> host;
+  };
+
+  // Every connection is handed the same provider instance.
+  mojo::Remote<mojom::BrowserHostProvider> ConnectClient() {
+    mojo::Remote<mojom::BrowserHostProvider> client;
+    receivers_.Add(&provider_, client.BindNewPipeAndPassReceiver());
+    return client;
+  }
+
+  base::test::TaskEnvironment task_environment_;
+  FakeBrowserHostProviderImplDelegate delegate_;
+  BrowserHostProviderImpl provider_{&delegate_};
+  mojo::ReceiverSet<mojom::BrowserHostProvider> receivers_;
+};
+
+TEST_F(BrowserHostProviderImplTest, ForwardsCallToDelegate) {
+  constexpr uint32_t kProtocolVersion = 1;
+
+  mojo::Remote<mojom::BrowserHostProvider> client = ConnectClient();
+  BrowserPipes pipes;
+  base::test::TestFuture<mojom::BrowserAuthResult> replied;
+  client->BindBrowserHost(
+      kProtocolVersion, pipes.endpoint.BindNewPipeAndPassRemote(),
+      pipes.host.BindNewPipeAndPassReceiver(), replied.GetCallback());
+
+  // The reply only arrives after the delegate has been called, so waiting for
+  // it is also how the test waits for the forwarded arguments.
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted, replied.Get());
+  ASSERT_EQ(1u, delegate_.calls().size());
+  FakeBrowserHostProviderImplDelegate::Call& call = delegate_.calls()[0];
+  EXPECT_EQ(kProtocolVersion, call.protocol_version);
+
+  // Both handles must arrive usable rather than merely non-empty. A round trip
+  // in each direction proves the pipe survived forwarding; a handle dropped
+  // along the way would have closed it.
+  mojo::Remote<mojom::BrowserEndpoint> endpoint(
+      std::move(call.browser_endpoint));
+  FakeBrowserHostImpl host_impl;
+  mojo::Receiver<mojom::BrowserHost> host_receiver(&host_impl,
+                                                   std::move(call.host));
+  endpoint.FlushForTesting();
+  pipes.host.FlushForTesting();
+
+  EXPECT_TRUE(endpoint.is_connected());
+  EXPECT_TRUE(pipes.host.is_connected());
+}
+
+// The provider is shared by every connection, so it must hold no per-connection
+// state: two clients in flight at once each get their own reply.
+TEST_F(BrowserHostProviderImplTest, ServesConcurrentClients) {
+  constexpr uint32_t kFirstVersion = 1;
+  constexpr uint32_t kSecondVersion = 2;
+
+  delegate_.SetResultForVersion(kFirstVersion,
+                                mojom::BrowserAuthResult::kAccepted);
+  delegate_.SetResultForVersion(kSecondVersion,
+                                mojom::BrowserAuthResult::kRejected);
+
+  mojo::Remote<mojom::BrowserHostProvider> first_client = ConnectClient();
+  mojo::Remote<mojom::BrowserHostProvider> second_client = ConnectClient();
+  BrowserPipes first_pipes;
+  BrowserPipes second_pipes;
+
+  base::test::TestFuture<mojom::BrowserAuthResult> first_replied;
+  base::test::TestFuture<mojom::BrowserAuthResult> second_replied;
+  first_client->BindBrowserHost(kFirstVersion,
+                                first_pipes.endpoint.BindNewPipeAndPassRemote(),
+                                first_pipes.host.BindNewPipeAndPassReceiver(),
+                                first_replied.GetCallback());
+  second_client->BindBrowserHost(
+      kSecondVersion, second_pipes.endpoint.BindNewPipeAndPassRemote(),
+      second_pipes.host.BindNewPipeAndPassReceiver(),
+      second_replied.GetCallback());
+
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted, first_replied.Get());
+  EXPECT_EQ(mojom::BrowserAuthResult::kRejected, second_replied.Get());
+  EXPECT_EQ(2u, delegate_.calls().size());
+}
+
+class BrowserHostProviderImplResultTest
+    : public BrowserHostProviderImplTest,
+      public testing::WithParamInterface<BrowserAuthResultParam> {};
+
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    BrowserHostProviderImplResultTest,
+    testing::Values(
+        BrowserAuthResultParam{mojom::BrowserAuthResult::kAccepted, "Accepted"},
+        BrowserAuthResultParam{mojom::BrowserAuthResult::kRejected, "Rejected"},
+        BrowserAuthResultParam{mojom::BrowserAuthResult::kVersionMismatch,
+                               "VersionMismatch"},
+        BrowserAuthResultParam{mojom::BrowserAuthResult::kAlreadyAuthenticated,
+                               "AlreadyAuthenticated"}),
+    [](const testing::TestParamInfo<BrowserAuthResultParam>& info) {
+      return std::string(info.param.name);
+    });
+
+// Every outcome the delegate can produce must reach the browser unchanged.
+TEST_P(BrowserHostProviderImplResultTest, RelaysDelegateResultToClient) {
+  delegate_.SetResult(GetParam().result);
+
+  mojo::Remote<mojom::BrowserHostProvider> client = ConnectClient();
+  BrowserPipes pipes;
+  base::test::TestFuture<mojom::BrowserAuthResult> replied;
+  client->BindBrowserHost(
+      mojom::kProtocolVersion, pipes.endpoint.BindNewPipeAndPassRemote(),
+      pipes.host.BindNewPipeAndPassReceiver(), replied.GetCallback());
+
+  EXPECT_EQ(GetParam().result, replied.Get());
+}
+
+TEST(BrowserHostProviderImplDeathTest, NullDelegateChecks) {
+  EXPECT_CHECK_DEATH({ BrowserHostProviderImpl provider(nullptr); });
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/browser_registry.cc
+++ b/components/brave_vpn/app/v2/agent/browser_registry.cc
@@ -5,12 +5,14 @@
 
 #include "brave/components/brave_vpn/app/v2/agent/browser_registry.h"
 
+#include <memory>
 #include <utility>
 
 #include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/location.h"
 #include "base/logging.h"
+#include "base/memory/ptr_util.h"
 #include "base/notimplemented.h"
 #include "base/sequence_checker.h"
 #include "base/strings/strcat.h"
@@ -64,6 +66,12 @@ BrowserRegistry::BrowserRegistry(
 
 BrowserRegistry::~BrowserRegistry() = default;
 
+// static
+std::unique_ptr<BrowserRegistry> BrowserRegistry::CreateForTesting(  // IN-TEST
+    std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server) {
+  return base::WrapUnique(new BrowserRegistry(std::move(host_server)));
+}
+
 void BrowserRegistry::StartHostServer() {
   VLOG(1) << "Starting IPC server";
   host_server_->set_disconnect_handler(base::BindRepeating(
@@ -101,7 +109,9 @@ void BrowserRegistry::Authenticate(
             << protocol_version << " outside supported range ["
             << kMinSupportedProtocolVersion << ", " << mojom::kProtocolVersion
             << "]";
-    std::move(callback).Run(mojom::BrowserAuthResult::kVersionMismatch);
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE, base::BindOnce(std::move(callback),
+                                  mojom::BrowserAuthResult::kVersionMismatch));
     return;
   }
 
@@ -112,7 +122,10 @@ void BrowserRegistry::Authenticate(
       pending_auth_.contains(receiver_id)) {
     VLOG(1) << "Refusing browser " << receiver_id
             << ": authentication in progress or succeeded already";
-    std::move(callback).Run(mojom::BrowserAuthResult::kAlreadyAuthenticated);
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE,
+        base::BindOnce(std::move(callback),
+                       mojom::BrowserAuthResult::kHostAlreadyRequested));
     return;
   }
 
@@ -122,11 +135,13 @@ void BrowserRegistry::Authenticate(
                       .host = std::move(host),
                       .reply = std::move(callback)};
 
+  // TODO(https://github.com/brave/brave-browser/issues/54623)
   // Real peer verification will be asynchronous (inspecting the peer process,
   // checking signatures), so the hop is posted even while it is a no-op, and
   // nothing past this point may read dispatch state.
   NOTIMPLEMENTED_LOG_ONCE()
       << "Peer verification: accepting every browser for now";
+
   base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
       FROM_HERE, base::BindOnce(&BrowserRegistry::OnPeerVerified,
                                 weak_factory_.GetWeakPtr(), std::move(pending),

--- a/components/brave_vpn/app/v2/agent/browser_registry.cc
+++ b/components/brave_vpn/app/v2/agent/browser_registry.cc
@@ -1,0 +1,191 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/browser_registry.h"
+
+#include <utility>
+
+#include "base/check.h"
+#include "base/functional/bind.h"
+#include "base/location.h"
+#include "base/logging.h"
+#include "base/notimplemented.h"
+#include "base/sequence_checker.h"
+#include "base/strings/strcat.h"
+#include "base/task/sequenced_task_runner.h"
+#include "brave/components/brave_vpn/app/v2/agent/browser_host_impl.h"
+#include "build/build_config.h"
+#include "components/named_mojo_ipc_server/named_mojo_ipc_server.h"
+
+#if BUILDFLAG(IS_WIN)
+#include "base/win/win_util.h"
+#endif  // BUILDFLAG(IS_WIN)
+
+namespace brave_vpn::v2 {
+namespace {
+// Oldest contract the agent still speaks; mojom::kProtocolVersion is the
+// newest. Bumped only when support for older browsers is deliberately dropped,
+// which makes every such bump a compatibility break worth reviewing.
+constexpr uint32_t kMinSupportedProtocolVersion = 1;
+
+named_mojo_ipc_server::EndpointOptions GetEndpointOptions(
+    mojo::NamedPlatformChannel::ServerName server_name) {
+  named_mojo_ipc_server::EndpointOptions endpoint_options(
+      std::move(server_name),
+      named_mojo_ipc_server::EndpointOptions::kUseIsolatedConnection);
+#if BUILDFLAG(IS_WIN)
+  std::wstring user_sid;
+  CHECK(base::win::GetUserSidString(&user_sid));
+  endpoint_options.security_descriptor =
+      base::StrCat({L"D:(A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;", user_sid, L")"});
+  endpoint_options.include_peer_process_info = true;
+#endif  // BUILDFLAG(IS_WIN)
+  return endpoint_options;
+}
+}  // namespace
+
+BrowserRegistry::BrowserRegistry(
+    mojo::NamedPlatformChannel::ServerName server_name)
+    : host_server_(std::make_unique<named_mojo_ipc_server::NamedMojoIpcServer<
+                       brave_vpn::mojom::BrowserHostProvider>>(
+          GetEndpointOptions(std::move(server_name)),
+          base::BindRepeating(&BrowserRegistry::OnBrowserConnecting,
+                              base::Unretained(this)))) {
+  StartHostServer();
+}
+
+BrowserRegistry::BrowserRegistry(
+    std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server)
+    : host_server_(std::move(host_server)) {
+  StartHostServer();
+}
+
+BrowserRegistry::~BrowserRegistry() = default;
+
+void BrowserRegistry::StartHostServer() {
+  VLOG(1) << "Starting IPC server";
+  host_server_->set_disconnect_handler(base::BindRepeating(
+      &BrowserRegistry::OnHostProviderDisconnected, base::Unretained(this)));
+  host_server_->StartServer();
+}
+
+brave_vpn::mojom::BrowserHostProvider* BrowserRegistry::OnBrowserConnecting(
+    const named_mojo_ipc_server::ConnectionInfo& info) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+
+  VLOG(1) << "New browser connecting (pid " << info.pid << ")";
+  return &host_provider_;
+}
+
+void BrowserRegistry::Authenticate(
+    uint32_t protocol_version,
+    mojo::PendingRemote<mojom::BrowserEndpoint> browser_endpoint,
+    mojo::PendingReceiver<mojom::BrowserHost> host,
+    base::OnceCallback<void(mojom::BrowserAuthResult)> callback) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+
+  // Called synchronously from BindBrowserHost(), so the calling browser is
+  // still the current receiver. It is the only handle on the connection that
+  // survives the verification hop below.
+  const mojo::ReceiverId receiver_id = host_server_->current_receiver();
+
+  // Every version in [kMinSupportedProtocolVersion, kProtocolVersion] is
+  // accepted, so a browser and agent from different updates still interoperate.
+  // A browser newer than this agent is refused, because it would go on to call
+  // methods this build does not implement.
+  if (protocol_version < kMinSupportedProtocolVersion ||
+      protocol_version > mojom::kProtocolVersion) {
+    VLOG(1) << "Refusing browser " << receiver_id << ": protocol version "
+            << protocol_version << " outside supported range ["
+            << kMinSupportedProtocolVersion << ", " << mojom::kProtocolVersion
+            << "]";
+    std::move(callback).Run(mojom::BrowserAuthResult::kVersionMismatch);
+    return;
+  }
+
+  // One BrowserHost per connection, whether it is already bound or still being
+  // verified. A browser that drops its host may ask again on the same
+  // connection.
+  if (host_sessions_.contains(receiver_id) ||
+      pending_auth_.contains(receiver_id)) {
+    VLOG(1) << "Refusing browser " << receiver_id
+            << ": authentication in progress or succeeded already";
+    std::move(callback).Run(mojom::BrowserAuthResult::kAlreadyAuthenticated);
+    return;
+  }
+
+  pending_auth_.insert(receiver_id);
+  PendingAuth pending{.receiver_id = receiver_id,
+                      .browser_endpoint = std::move(browser_endpoint),
+                      .host = std::move(host),
+                      .reply = std::move(callback)};
+
+  // Real peer verification will be asynchronous (inspecting the peer process,
+  // checking signatures), so the hop is posted even while it is a no-op, and
+  // nothing past this point may read dispatch state.
+  NOTIMPLEMENTED_LOG_ONCE()
+      << "Peer verification: accepting every browser for now";
+  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+      FROM_HERE, base::BindOnce(&BrowserRegistry::OnPeerVerified,
+                                weak_factory_.GetWeakPtr(), std::move(pending),
+                                /*verified=*/true));
+}
+
+void BrowserRegistry::OnPeerVerified(PendingAuth pending, bool verified) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+
+  const mojo::ReceiverId receiver_id = pending.receiver_id;
+
+  // The connection may have gone away mid-verification; the pending marker is
+  // the only thing that still says whether it is around, and it is cleared by
+  // OnHostProviderDisconnected().
+  if (!pending_auth_.erase(receiver_id)) {
+    VLOG(1) << "Browser " << receiver_id << " went away during verification";
+    // The pipe is already closed, so this reply goes nowhere; run it anyway
+    // rather than dropping a response callback.
+    std::move(pending.reply).Run(mojom::BrowserAuthResult::kRejected);
+    return;
+  }
+
+  if (!verified) {
+    VLOG(1) << "Browser " << receiver_id << " failed verification";
+    std::move(pending.reply).Run(mojom::BrowserAuthResult::kRejected);
+    return;
+  }
+
+  host_sessions_[receiver_id] = std::make_unique<BrowserHostImpl>(
+      std::move(pending.browser_endpoint), std::move(pending.host),
+      base::BindOnce(&BrowserRegistry::OnHostDisconnected,
+                     weak_factory_.GetWeakPtr(), receiver_id));
+
+  VLOG(1) << "Browser " << receiver_id << " authenticated";
+  std::move(pending.reply).Run(mojom::BrowserAuthResult::kAccepted);
+}
+
+void BrowserRegistry::OnHostProviderDisconnected() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+
+  // Runs while the disconnecting receiver is still current; the server closes
+  // it itself once this returns.
+  const mojo::ReceiverId receiver_id = host_server_->current_receiver();
+  VLOG(1) << "Browser " << receiver_id << " disconnected";
+
+  // Per the mojom contract, losing the connection tears down its BrowserHost
+  // too, and abandons any verification still in flight.
+  host_sessions_.erase(receiver_id);
+  pending_auth_.erase(receiver_id);
+}
+
+void BrowserRegistry::OnHostDisconnected(mojo::ReceiverId id) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+
+  VLOG(1) << "Browser " << id << " dropped a session pipe";
+  // Destroys the BrowserHostImpl whose pipe is invoking this, which is safe
+  // for a mojo disconnect handler. The connection stays up, so the browser may
+  // authenticate again.
+  host_sessions_.erase(id);
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/browser_registry.h
+++ b/components/brave_vpn/app/v2/agent/browser_registry.h
@@ -1,0 +1,91 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_BROWSER_REGISTRY_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_BROWSER_REGISTRY_H_
+
+#include <stdint.h>
+
+#include <memory>
+
+#include "base/containers/flat_map.h"
+#include "base/containers/flat_set.h"
+#include "base/functional/callback.h"
+#include "base/memory/weak_ptr.h"
+#include "base/sequence_checker.h"
+#include "brave/components/brave_vpn/app/v2/agent/browser_host_provider_impl.h"
+#include "brave/components/brave_vpn/common/mojom/browser_agent.mojom.h"
+#include "components/named_mojo_ipc_server/connection_info.h"
+#include "components/named_mojo_ipc_server/ipc_server.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/receiver_set.h"
+#include "mojo/public/cpp/platform/named_platform_channel.h"
+
+namespace brave_vpn::v2 {
+
+class BrowserHostImpl;
+
+// Owns the IPC server and every browser to agent connection on it, plus the
+// authentication policy the unauthenticated surface delegates to. Sessions are
+// keyed by the BrowserHostProvider receiver id, which identifies the
+// connection: one authenticated BrowserHost per connection at a time.
+class BrowserRegistry : public BrowserHostProviderImpl::Delegate {
+ public:
+  explicit BrowserRegistry(mojo::NamedPlatformChannel::ServerName server_name);
+  explicit BrowserRegistry(
+      std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server);
+  ~BrowserRegistry() override;
+
+  BrowserRegistry(const BrowserRegistry&) = delete;
+  BrowserRegistry& operator=(const BrowserRegistry&) = delete;
+
+ private:
+  // Everything Authenticate() must carry across the verification hop, since
+  // none of it can be re-read from dispatch state afterwards.
+  struct PendingAuth {
+    mojo::ReceiverId receiver_id = 0;
+    mojo::PendingRemote<mojom::BrowserEndpoint> browser_endpoint;
+    mojo::PendingReceiver<mojom::BrowserHost> host;
+    base::OnceCallback<void(mojom::BrowserAuthResult)> reply;
+  };
+
+  // Wires up and starts the host server; shared by both constructors.
+  void StartHostServer();
+
+  // BrowserHostProviderImpl::Delegate:
+  void Authenticate(
+      uint32_t protocol_version,
+      mojo::PendingRemote<mojom::BrowserEndpoint> browser_endpoint,
+      mojo::PendingReceiver<mojom::BrowserHost> host,
+      base::OnceCallback<void(mojom::BrowserAuthResult)> callback) override;
+
+  // Accept-time policy: cheap, non-blocking checks only; nullptr refuses the
+  // connection.
+  brave_vpn::mojom::BrowserHostProvider* OnBrowserConnecting(
+      const named_mojo_ipc_server::ConnectionInfo& info);
+
+  // Second half of Authenticate(): creates the browser host on success.
+  void OnPeerVerified(PendingAuth pending, bool verified);
+
+  void OnHostProviderDisconnected();
+  void OnHostDisconnected(mojo::ReceiverId id);
+
+  // Shared by every connection: the IPC server hands the same instance to each
+  // one, so it must outlive the host server.
+  BrowserHostProviderImpl host_provider_{this};
+
+  std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server_;
+  base::flat_map<mojo::ReceiverId, std::unique_ptr<BrowserHostImpl>>
+      host_sessions_;
+  base::flat_set<mojo::ReceiverId> pending_auth_;
+
+  SEQUENCE_CHECKER(sequence_checker_);
+  base::WeakPtrFactory<BrowserRegistry> weak_factory_{this};
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_BROWSER_REGISTRY_H_

--- a/components/brave_vpn/app/v2/agent/browser_registry.h
+++ b/components/brave_vpn/app/v2/agent/browser_registry.h
@@ -35,14 +35,20 @@ class BrowserHostImpl;
 class BrowserRegistry : public BrowserHostProviderImpl::Delegate {
  public:
   explicit BrowserRegistry(mojo::NamedPlatformChannel::ServerName server_name);
-  explicit BrowserRegistry(
-      std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server);
   ~BrowserRegistry() override;
 
   BrowserRegistry(const BrowserRegistry&) = delete;
   BrowserRegistry& operator=(const BrowserRegistry&) = delete;
 
+  // Takes the IPC server directly, so a test can choose connection ids and
+  // report disconnects without a real endpoint.
+  static std::unique_ptr<BrowserRegistry> CreateForTesting(
+      std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server);
+
  private:
+  explicit BrowserRegistry(
+      std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server);
+
   // Everything Authenticate() must carry across the verification hop, since
   // none of it can be re-read from dispatch state afterwards.
   struct PendingAuth {

--- a/components/brave_vpn/app/v2/agent/browser_registry_unittest.cc
+++ b/components/brave_vpn/app/v2/agent/browser_registry_unittest.cc
@@ -22,8 +22,9 @@ namespace brave_vpn::v2 {
 class BrowserRegistryTest : public testing::Test {
  protected:
   BrowserRegistryTest()
-      : registry_(std::make_unique<named_mojo_ipc_server::FakeIpcServer>(
-            &server_state_)) {}
+      : registry_(BrowserRegistry::CreateForTesting(
+            std::make_unique<named_mojo_ipc_server::FakeIpcServer>(
+                &server_state_))) {}
 
   // Mojo's ReceiverSet hands out ids from a monotonic counter and never reuses
   // them, so a dropped connection's id can never come back.
@@ -33,9 +34,9 @@ class BrowserRegistryTest : public testing::Test {
                          mojo::ReceiverId connection,
                          uint32_t protocol_version) {
     server_state_.current_receiver = connection;
-    static_cast<BrowserHostProviderImpl::Delegate&>(registry_).Authenticate(
-        protocol_version, browser.BindEndpoint(), browser.BindHost(),
-        browser.GetReplyCallback());
+    static_cast<BrowserHostProviderImpl::Delegate&>(*registry_)
+        .Authenticate(protocol_version, browser.BindEndpoint(),
+                      browser.BindHost(), browser.GetReplyCallback());
   }
 
   mojom::BrowserAuthResult Authenticate(
@@ -55,7 +56,7 @@ class BrowserRegistryTest : public testing::Test {
 
   base::test::TaskEnvironment task_environment_;
   named_mojo_ipc_server::FakeIpcServer::TestState server_state_;
-  BrowserRegistry registry_;
+  std::unique_ptr<BrowserRegistry> registry_;
   mojo::ReceiverId last_connection_id_ = 0;
 };
 
@@ -106,20 +107,20 @@ TEST_F(BrowserRegistryTest, RefusesSecondHostWhileOneIsBound) {
             Authenticate(first, connection));
 
   FakeBrowser second;
-  EXPECT_EQ(mojom::BrowserAuthResult::kAlreadyAuthenticated,
+  EXPECT_EQ(mojom::BrowserAuthResult::kHostAlreadyRequested,
             Authenticate(second, connection));
 }
 
-// The refusal has to cover a request that is still being verified, not just one
-// that already succeeded.
-TEST_F(BrowserRegistryTest, RefusesSecondHostWhileVerificationIsPending) {
+// The refusal has to cover a request that is outstanding, not only one that has
+// already been granted.
+TEST_F(BrowserRegistryTest, RefusesSecondHostWhileFirstIsStillInFlight) {
   const mojo::ReceiverId connection = NextConnectionId();
   FakeBrowser first;
   StartAuthenticate(first, connection, mojom::kProtocolVersion);
   ASSERT_FALSE(first.has_reply());
 
   FakeBrowser second;
-  EXPECT_EQ(mojom::BrowserAuthResult::kAlreadyAuthenticated,
+  EXPECT_EQ(mojom::BrowserAuthResult::kHostAlreadyRequested,
             Authenticate(second, connection));
 
   // The pending request is unaffected by the refused one.
@@ -139,6 +140,23 @@ TEST_F(BrowserRegistryTest, DroppingHostEndsSessionAndAllowsRebinding) {
   EXPECT_TRUE(first.WaitForEndpointClosed());
 
   // The connection itself is still up, so it may authenticate again.
+  FakeBrowser second;
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(second, connection));
+}
+
+TEST_F(BrowserRegistryTest, DroppingHostWhileVerificationPendingEndsSession) {
+  const mojo::ReceiverId connection = NextConnectionId();
+  FakeBrowser first;
+  StartAuthenticate(first, connection, mojom::kProtocolVersion);
+  first.WatchEndpoint();
+
+  first.DropHost();
+
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted, first.WaitForReply());
+  EXPECT_TRUE(first.WaitForEndpointClosed());
+
+  // Neither the session nor the pending marker outlived the request.
   FakeBrowser second;
   EXPECT_EQ(mojom::BrowserAuthResult::kAccepted,
             Authenticate(second, connection));
@@ -170,6 +188,14 @@ TEST_F(BrowserRegistryTest, ConnectionDropTearsDownItsSession) {
   DisconnectConnection(connection);
 
   EXPECT_TRUE(browser.WaitForEndpointClosed());
+
+  // Erasing during the disconnect handler must leave the registry able to serve
+  // new connections. This cannot assert the dropped id itself is gone, since
+  // ReceiverSet never reuses ids; the WaitForEndpointClosed() assertion is that
+  // evidence.
+  FakeBrowser next_browser;
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(next_browser, NextConnectionId()));
 }
 
 // A connection that goes away mid-verification must still have its request
@@ -187,6 +213,21 @@ TEST_F(BrowserRegistryTest, ConnectionDropDuringVerificationAnswersRequest) {
   FakeBrowser next;
   EXPECT_EQ(mojom::BrowserAuthResult::kAccepted,
             Authenticate(next, NextConnectionId()));
+}
+
+// Shutdown while a request is being verified drops the request instead of
+// answering it, which is what the weak pointer on the verification hop is for.
+TEST_F(BrowserRegistryTest, DestroyedWhileVerificationPendingIsSafe) {
+  FakeBrowser browser;
+  StartAuthenticate(browser, NextConnectionId(), mojom::kProtocolVersion);
+  browser.WatchEndpoint();
+
+  registry_.reset();
+
+  // The abandoned request takes the browser's endpoint down with it, which is
+  // how the browser learns the agent will not answer.
+  EXPECT_TRUE(browser.WaitForEndpointClosed());
+  EXPECT_FALSE(browser.has_reply());
 }
 
 TEST_F(BrowserRegistryTest, KeepsOneSessionPerConnection) {

--- a/components/brave_vpn/app/v2/agent/browser_registry_unittest.cc
+++ b/components/brave_vpn/app/v2/agent/browser_registry_unittest.cc
@@ -1,0 +1,213 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/browser_registry.h"
+
+#include <stdint.h>
+
+#include <memory>
+
+#include "base/test/task_environment.h"
+#include "brave/components/brave_vpn/app/v2/agent/browser_host_provider_impl.h"
+#include "brave/components/brave_vpn/app/v2/agent/test/fake_browser.h"
+#include "brave/components/brave_vpn/common/mojom/browser_agent.mojom.h"
+#include "components/named_mojo_ipc_server/fake_ipc_server.h"
+#include "mojo/public/cpp/bindings/receiver_set.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn::v2 {
+
+class BrowserRegistryTest : public testing::Test {
+ protected:
+  BrowserRegistryTest()
+      : registry_(std::make_unique<named_mojo_ipc_server::FakeIpcServer>(
+            &server_state_)) {}
+
+  // Mojo's ReceiverSet hands out ids from a monotonic counter and never reuses
+  // them, so a dropped connection's id can never come back.
+  mojo::ReceiverId NextConnectionId() { return ++last_connection_id_; }
+
+  void StartAuthenticate(FakeBrowser& browser,
+                         mojo::ReceiverId connection,
+                         uint32_t protocol_version) {
+    server_state_.current_receiver = connection;
+    static_cast<BrowserHostProviderImpl::Delegate&>(registry_).Authenticate(
+        protocol_version, browser.BindEndpoint(), browser.BindHost(),
+        browser.GetReplyCallback());
+  }
+
+  mojom::BrowserAuthResult Authenticate(
+      FakeBrowser& browser,
+      mojo::ReceiverId connection,
+      uint32_t protocol_version = mojom::kProtocolVersion) {
+    StartAuthenticate(browser, connection, protocol_version);
+    return browser.WaitForReply();
+  }
+
+  // Reports a dropped connection the way NamedMojoIpcServer does: the
+  // disconnecting receiver is current while the handler runs.
+  void DisconnectConnection(mojo::ReceiverId connection) {
+    server_state_.current_receiver = connection;
+    server_state_.disconnect_handler.Run();
+  }
+
+  base::test::TaskEnvironment task_environment_;
+  named_mojo_ipc_server::FakeIpcServer::TestState server_state_;
+  BrowserRegistry registry_;
+  mojo::ReceiverId last_connection_id_ = 0;
+};
+
+TEST_F(BrowserRegistryTest, StartsServingOnConstruction) {
+  EXPECT_TRUE(server_state_.is_server_started);
+  EXPECT_TRUE(server_state_.disconnect_handler);
+}
+
+TEST_F(BrowserRegistryTest, AcceptsBrowserAndBindsItsHost) {
+  FakeBrowser browser;
+
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(browser, NextConnectionId()));
+
+  // The host pipe answering a round trip proves it was bound, not just that the
+  // reply said so.
+  browser.FlushHost();
+  EXPECT_TRUE(browser.host_connected());
+}
+
+TEST_F(BrowserRegistryTest, RefusesProtocolVersionAboveTheAgentsOwn) {
+  FakeBrowser browser;
+
+  EXPECT_EQ(
+      mojom::BrowserAuthResult::kVersionMismatch,
+      Authenticate(browser, NextConnectionId(), mojom::kProtocolVersion + 1));
+}
+
+TEST_F(BrowserRegistryTest, RefusesProtocolVersionBelowTheSupportedFloor) {
+  const mojo::ReceiverId connection = NextConnectionId();
+  FakeBrowser browser;
+
+  // Zero is below any floor the agent can declare.
+  EXPECT_EQ(mojom::BrowserAuthResult::kVersionMismatch,
+            Authenticate(browser, connection, /*protocol_version=*/0));
+
+  // A refusal must leave nothing behind: the same connection can still
+  // authenticate afterwards.
+  FakeBrowser retry;
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(retry, connection));
+}
+
+TEST_F(BrowserRegistryTest, RefusesSecondHostWhileOneIsBound) {
+  const mojo::ReceiverId connection = NextConnectionId();
+  FakeBrowser first;
+  ASSERT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(first, connection));
+
+  FakeBrowser second;
+  EXPECT_EQ(mojom::BrowserAuthResult::kAlreadyAuthenticated,
+            Authenticate(second, connection));
+}
+
+// The refusal has to cover a request that is still being verified, not just one
+// that already succeeded.
+TEST_F(BrowserRegistryTest, RefusesSecondHostWhileVerificationIsPending) {
+  const mojo::ReceiverId connection = NextConnectionId();
+  FakeBrowser first;
+  StartAuthenticate(first, connection, mojom::kProtocolVersion);
+  ASSERT_FALSE(first.has_reply());
+
+  FakeBrowser second;
+  EXPECT_EQ(mojom::BrowserAuthResult::kAlreadyAuthenticated,
+            Authenticate(second, connection));
+
+  // The pending request is unaffected by the refused one.
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted, first.WaitForReply());
+}
+
+TEST_F(BrowserRegistryTest, DroppingHostEndsSessionAndAllowsRebinding) {
+  const mojo::ReceiverId connection = NextConnectionId();
+  FakeBrowser first;
+  ASSERT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(first, connection));
+  first.WatchEndpoint();
+
+  first.DropHost();
+
+  // Tearing the session down closes the endpoint the agent was calling back on.
+  EXPECT_TRUE(first.WaitForEndpointClosed());
+
+  // The connection itself is still up, so it may authenticate again.
+  FakeBrowser second;
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(second, connection));
+}
+
+TEST_F(BrowserRegistryTest, DroppingEndpointEndsSessionAndAllowsRebinding) {
+  const mojo::ReceiverId connection = NextConnectionId();
+  FakeBrowser first;
+  ASSERT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(first, connection));
+  first.WatchHost();
+
+  first.DropEndpoint();
+
+  EXPECT_TRUE(first.WaitForHostClosed());
+
+  FakeBrowser second;
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(second, connection));
+}
+
+TEST_F(BrowserRegistryTest, ConnectionDropTearsDownItsSession) {
+  const mojo::ReceiverId connection = NextConnectionId();
+  FakeBrowser browser;
+  ASSERT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(browser, connection));
+  browser.WatchEndpoint();
+
+  DisconnectConnection(connection);
+
+  EXPECT_TRUE(browser.WaitForEndpointClosed());
+}
+
+// A connection that goes away mid-verification must still have its request
+// answered, rather than leaving a mojo reply callback unrun.
+TEST_F(BrowserRegistryTest, ConnectionDropDuringVerificationAnswersRequest) {
+  const mojo::ReceiverId connection = NextConnectionId();
+  FakeBrowser browser;
+  StartAuthenticate(browser, connection, mojom::kProtocolVersion);
+
+  DisconnectConnection(connection);
+
+  EXPECT_EQ(mojom::BrowserAuthResult::kRejected, browser.WaitForReply());
+
+  // Nothing was left behind for the next connection.
+  FakeBrowser next;
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(next, NextConnectionId()));
+}
+
+TEST_F(BrowserRegistryTest, KeepsOneSessionPerConnection) {
+  const mojo::ReceiverId first_connection = NextConnectionId();
+  const mojo::ReceiverId second_connection = NextConnectionId();
+  FakeBrowser first;
+  FakeBrowser second;
+  ASSERT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(first, first_connection));
+  ASSERT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(second, second_connection));
+  first.WatchEndpoint();
+  second.WatchHost();
+
+  DisconnectConnection(first_connection);
+  ASSERT_TRUE(first.WaitForEndpointClosed());
+
+  // Only the dropped connection's session goes away.
+  second.FlushHost();
+  EXPECT_TRUE(second.host_connected());
+  EXPECT_FALSE(second.host_closed());
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/main.cc
+++ b/components/brave_vpn/app/v2/agent/main.cc
@@ -12,6 +12,7 @@
 #include "base/logging.h"
 #include "base/process/launch.h"
 #include "base/process/memory.h"
+#include "base/task/thread_pool/thread_pool_instance.h"
 #include "brave/components/brave_vpn/app/v2/agent/agent_app.h"
 #include "brave/components/brave_vpn/app/v2/agent/single_instance.h"
 #include "brave/components/brave_vpn/app/v2/shared/app_utils.h"
@@ -105,6 +106,15 @@ int main(int argc, char* argv[]) {
   CrashReporterClient::InitializeForProcess(
       process_type, kBraveVpnAgentAppProductName, channel_name, user_data_dir);
 
+  base::ThreadPoolInstance::CreateAndStartWithDefaultParams(
+      kBraveVpnAgentAppProductName);
+
   AgentApp agent_app;
-  return agent_app.Run();
+  const int exit_code = agent_app.Run();
+
+  // Blocks until running pool tasks have finished, so the IPC server's socket
+  // work is not still executing while the process unwinds.
+  base::ThreadPoolInstance::Get()->Shutdown();
+
+  return exit_code;
 }

--- a/components/brave_vpn/app/v2/agent/test/fake_browser.cc
+++ b/components/brave_vpn/app/v2/agent/test/fake_browser.cc
@@ -1,0 +1,75 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/test/fake_browser.h"
+
+namespace brave_vpn::v2 {
+
+FakeBrowser::FakeBrowser() = default;
+
+FakeBrowser::~FakeBrowser() = default;
+
+mojo::PendingRemote<mojom::BrowserEndpoint> FakeBrowser::BindEndpoint() {
+  return endpoint_receiver_.BindNewPipeAndPassRemote();
+}
+
+mojo::PendingReceiver<mojom::BrowserHost> FakeBrowser::BindHost() {
+  return host_remote_.BindNewPipeAndPassReceiver();
+}
+
+base::OnceCallback<void(mojom::BrowserAuthResult)>
+FakeBrowser::GetReplyCallback() {
+  return replied_.GetCallback();
+}
+
+bool FakeBrowser::has_reply() const {
+  return replied_.IsReady();
+}
+
+mojom::BrowserAuthResult FakeBrowser::WaitForReply() {
+  return replied_.Get();
+}
+
+void FakeBrowser::WatchHost() {
+  host_remote_.set_disconnect_handler(host_closed_.GetCallback());
+}
+
+void FakeBrowser::WatchEndpoint() {
+  endpoint_receiver_.set_disconnect_handler(endpoint_closed_.GetCallback());
+}
+
+bool FakeBrowser::WaitForHostClosed() {
+  return host_closed_.Wait();
+}
+
+bool FakeBrowser::WaitForEndpointClosed() {
+  return endpoint_closed_.Wait();
+}
+
+bool FakeBrowser::host_closed() const {
+  return host_closed_.IsReady();
+}
+
+bool FakeBrowser::endpoint_closed() const {
+  return endpoint_closed_.IsReady();
+}
+
+void FakeBrowser::DropHost() {
+  host_remote_.reset();
+}
+
+void FakeBrowser::DropEndpoint() {
+  endpoint_receiver_.reset();
+}
+
+void FakeBrowser::FlushHost() {
+  host_remote_.FlushForTesting();
+}
+
+bool FakeBrowser::host_connected() const {
+  return host_remote_.is_connected();
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/test/fake_browser.h
+++ b/components/brave_vpn/app/v2/agent/test/fake_browser.h
@@ -1,0 +1,80 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_TEST_FAKE_BROWSER_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_TEST_FAKE_BROWSER_H_
+
+#include <stdint.h>
+
+#include "base/functional/callback.h"
+#include "base/test/test_future.h"
+#include "brave/components/brave_vpn/app/v2/agent/test/fake_browser_endpoint.h"
+#include "brave/components/brave_vpn/common/mojom/browser_agent.mojom.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+#include "mojo/public/cpp/bindings/remote.h"
+
+namespace brave_vpn::v2 {
+
+// The browser's half of one session: it holds the BrowserHost remote and serves
+// the BrowserEndpoint the agent calls back on.
+class FakeBrowser {
+ public:
+  FakeBrowser();
+  ~FakeBrowser();
+
+  FakeBrowser(const FakeBrowser&) = delete;
+  FakeBrowser& operator=(const FakeBrowser&) = delete;
+
+  // Handles to pass into a BindBrowserHost-style request. Each may only be
+  // called once.
+  mojo::PendingRemote<mojom::BrowserEndpoint> BindEndpoint();
+  mojo::PendingReceiver<mojom::BrowserHost> BindHost();
+
+  // Reply callback for that request, plus its answer. WaitForReply() runs the
+  // sequence until the answer arrives.
+  base::OnceCallback<void(mojom::BrowserAuthResult)> GetReplyCallback();
+  bool has_reply() const;
+  mojom::BrowserAuthResult WaitForReply();
+
+  // Watch for the agent closing its end of either pipe, which is what a
+  // destroyed session looks like from here. Call after the pipes are bound.
+  void WatchHost();
+  void WatchEndpoint();
+
+  // Run the sequence until the agent closes the corresponding pipe.
+  [[nodiscard]] bool WaitForHostClosed();
+  [[nodiscard]] bool WaitForEndpointClosed();
+
+  // Whether the agent has already closed its end. Only meaningful after the
+  // matching Watch call, and paired with a barrier such as FlushHost() when
+  // asserting that it has *not* happened.
+  bool host_closed() const;
+  bool endpoint_closed() const;
+
+  // Closes this side of a pipe, as a browser dropping it would.
+  void DropHost();
+  void DropEndpoint();
+
+  // Round trip through the agent's BrowserHost receiver: returns once the agent
+  // has processed everything already queued on that pipe.
+  void FlushHost();
+
+  bool host_connected() const;
+
+ private:
+  FakeBrowserEndpoint endpoint_impl_;
+  mojo::Receiver<mojom::BrowserEndpoint> endpoint_receiver_{&endpoint_impl_};
+  mojo::Remote<mojom::BrowserHost> host_remote_;
+
+  base::test::TestFuture<mojom::BrowserAuthResult> replied_;
+  base::test::TestFuture<void> host_closed_;
+  base::test::TestFuture<void> endpoint_closed_;
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_TEST_FAKE_BROWSER_H_

--- a/components/brave_vpn/app/v2/agent/test/fake_browser_endpoint.cc
+++ b/components/brave_vpn/app/v2/agent/test/fake_browser_endpoint.cc
@@ -1,0 +1,14 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/test/fake_browser_endpoint.h"
+
+namespace brave_vpn::v2 {
+
+FakeBrowserEndpoint::FakeBrowserEndpoint() = default;
+
+FakeBrowserEndpoint::~FakeBrowserEndpoint() = default;
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/test/fake_browser_endpoint.h
+++ b/components/brave_vpn/app/v2/agent/test/fake_browser_endpoint.h
@@ -1,0 +1,27 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_TEST_FAKE_BROWSER_ENDPOINT_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_TEST_FAKE_BROWSER_ENDPOINT_H_
+
+#include "brave/components/brave_vpn/common/mojom/browser_agent.mojom.h"
+
+namespace brave_vpn::v2 {
+
+// Stands in for the surface a browser exposes to the agent. Owns the browser's
+// end of that pipe; methods get fake implementations here as they are added to
+// the interface.
+class FakeBrowserEndpoint : public mojom::BrowserEndpoint {
+ public:
+  FakeBrowserEndpoint();
+  ~FakeBrowserEndpoint() override;
+
+  FakeBrowserEndpoint(const FakeBrowserEndpoint&) = delete;
+  FakeBrowserEndpoint& operator=(const FakeBrowserEndpoint&) = delete;
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_TEST_FAKE_BROWSER_ENDPOINT_H_

--- a/components/brave_vpn/common/mojom/BUILD.gn
+++ b/components/brave_vpn/common/mojom/BUILD.gn
@@ -27,3 +27,9 @@ mojom("mojom") {
     "//url/mojom:url_mojom_gurl",
   ]
 }
+
+mojom("agent") {
+  sources = [ "browser_agent.mojom" ]
+
+  deps = [ "//mojo/public/mojom/base" ]
+}

--- a/components/brave_vpn/common/mojom/browser_agent.mojom
+++ b/components/brave_vpn/common/mojom/browser_agent.mojom
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+module brave_vpn.mojom;
+
+// Newest version of the browser to agent contract below, sent by browsers in
+// BindBrowserHost(). The agent accepts a range of versions rather than an
+// exact match, so a browser and agent from different updates can still talk;
+// it answers anything outside that range with kVersionMismatch. Bump on an
+// incompatible change, and prefer [MinVersion] for additive ones.
+//
+// Note that on official desktop builds message ID scrambling already stops
+// binaries from different Brave versions exchanging messages at all, so this
+// handshake is only reachable between binaries sharing that salt.
+const uint32 kProtocolVersion = 1;
+
+// Browser's subordinate surface, passed to the agent's BrowserHost, so the
+// agent can call back into the browser once it accepts.
+interface BrowserEndpoint {
+};
+
+enum BrowserAuthResult {
+  kAccepted,
+  kRejected,
+  kVersionMismatch,
+  kAlreadyAuthenticated,
+};
+
+// The browser's connection to the agent, and the only interface reachable on
+// a fresh connection. The browser MUST keep this remote alive for as long as
+// it uses the BrowserHost obtained from it. The underlying transport is bound
+// to this receiver, so dropping it tears down the whole connection,
+// BrowserHost included.
+interface BrowserHostProvider {
+  BindBrowserHost(uint32 protocol_version,
+                  pending_remote<BrowserEndpoint> browser_endpoint,
+                  pending_receiver<BrowserHost> host)
+                    => (BrowserAuthResult result);
+};
+
+// Agent browser-facing real API surface, owns the VPN related functionality
+// passed to the authenticanted browsers.
+interface BrowserHost {
+};

--- a/components/brave_vpn/common/mojom/browser_agent.mojom
+++ b/components/brave_vpn/common/mojom/browser_agent.mojom
@@ -25,7 +25,7 @@ enum BrowserAuthResult {
   kAccepted,
   kRejected,
   kVersionMismatch,
-  kAlreadyAuthenticated,
+  kHostAlreadyRequested,
 };
 
 // The browser's connection to the agent, and the only interface reachable on

--- a/components/brave_vpn/common/v2/BUILD.gn
+++ b/components/brave_vpn/common/v2/BUILD.gn
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
+
+assert(enable_brave_vpn_v2)
+
+source_set("common") {
+  sources = [
+    "agent_utils.cc",
+    "agent_utils.h",
+  ]
+
+  deps = [
+    "//base",
+    "//mojo/public/cpp/platform",
+  ]
+}

--- a/components/brave_vpn/common/v2/BUILD.gn
+++ b/components/brave_vpn/common/v2/BUILD.gn
@@ -8,13 +8,38 @@ import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 assert(enable_brave_vpn_v2)
 
 source_set("common") {
-  sources = [
-    "agent_utils.cc",
-    "agent_utils.h",
-  ]
+  sources = []
 
-  deps = [
-    "//base",
-    "//mojo/public/cpp/platform",
-  ]
+  public_deps = []
+
+  if (enable_brave_vpn_v2_apps) {
+    sources += [
+      "agent_utils.cc",
+      "agent_utils.h",
+    ]
+
+    public_deps += [
+      "//base",
+      "//mojo/public/cpp/platform",
+    ]
+  }
+}
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = []
+
+  deps = []
+
+  if (enable_brave_vpn_v2_apps) {
+    sources += [ "agent_utils_unittest.cc" ]
+
+    deps += [
+      ":common",
+      "//base",
+      "//mojo/public/cpp/platform",
+      "//testing/gtest",
+    ]
+  }
 }

--- a/components/brave_vpn/common/v2/agent_utils.cc
+++ b/components/brave_vpn/common/v2/agent_utils.cc
@@ -24,10 +24,6 @@ namespace {
 constexpr char kAgentServerName[] = "brave_vpn_agent";
 
 #if BUILDFLAG(IS_POSIX)
-// |sun_path| is 104 bytes on macOS and 108 on Linux. The same code has to be
-// correct on both, so the shorter limit applies.
-constexpr size_t kMaxSocketPathLength = 103;
-
 // Returns the directory holding the agent's socket. This is where the
 // per-session scoping comes from on POSIX: both candidate directories are
 // already private to one login session, mode 0700, so the socket's own name can
@@ -70,25 +66,33 @@ std::optional<mojo::NamedPlatformChannel::ServerName> GetAgentServerName() {
   return base::ASCIIToWide(
       base::StrCat({kAgentServerName, ".", base::NumberToString(session_id)}));
 #else
-  const base::FilePath dir = GetSocketDirectory();
-  if (dir.empty()) {
+  return GetAgentServerNameForDirectory(GetSocketDirectory());
+#endif  // BUILDFLAG(IS_WIN)
+}
+
+#if BUILDFLAG(IS_POSIX)
+
+std::optional<mojo::NamedPlatformChannel::ServerName>
+GetAgentServerNameForDirectory(const base::FilePath& socket_dir) {
+  if (socket_dir.empty()) {
     return std::nullopt;
   }
 
   // On POSIX mojo::NamedPlatformChannel uses the ServerName verbatim as the
   // sockaddr_un path, so it must be absolute. A bare name would bind() into
   // whatever the process's current working directory happens to be.
-  const base::FilePath path = dir.Append(kAgentServerName);
+  const base::FilePath path = socket_dir.Append(kAgentServerName);
 
   // Deliberately no truncation or fallback: an over-long path makes bind() and
   // connect() fail identically on both sides, which is a loud and symmetric
   // failure.
-  if (path.value().size() > kMaxSocketPathLength) {
+  if (path.value().size() > kMaxAgentSocketPathLength) {
     LOG(ERROR) << "Agent socket path exceeds the sockaddr_un limit: " << path;
     return std::nullopt;
   }
   return path.value();
-#endif  // BUILDFLAG(IS_WIN)
 }
+
+#endif  // BUILDFLAG(IS_POSIX)
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/common/v2/agent_utils.cc
+++ b/components/brave_vpn/common/v2/agent_utils.cc
@@ -1,0 +1,94 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/common/v2/agent_utils.h"
+
+#include "base/check.h"
+#include "base/environment.h"
+#include "base/files/file_path.h"
+#include "base/logging.h"
+#include "base/path_service.h"
+#include "base/strings/strcat.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/strings/utf_string_conversions.h"
+#include "build/build_config.h"
+
+#if BUILDFLAG(IS_WIN)
+#include <windows.h>
+#endif
+
+namespace brave_vpn::v2 {
+namespace {
+constexpr char kAgentServerName[] = "brave_vpn_agent";
+
+#if BUILDFLAG(IS_POSIX)
+// |sun_path| is 104 bytes on macOS and 108 on Linux. The same code has to be
+// correct on both, so the shorter limit applies.
+constexpr size_t kMaxSocketPathLength = 103;
+
+// Returns the directory holding the agent's socket. This is where the
+// per-session scoping comes from on POSIX: both candidate directories are
+// already private to one login session, mode 0700, so the socket's own name can
+// be a constant.
+base::FilePath GetSocketDirectory() {
+#if BUILDFLAG(IS_MAC)
+  // The per-user confined NSTemporaryDirectory(), distinct for every user and
+  // unreadable by others, which is what "per session" means in practice on
+  // macOS, where concurrent GUI logins are per-user.
+  return base::PathService::CheckedGet(base::DIR_TEMP);
+#elif BUILDFLAG(IS_LINUX)
+  // /run/user/<uid>: mode 0700, created by pam_systemd at login and removed at
+  // last logout. Reading XDG_RUNTIME_DIR specifically: systemd exports
+  // XDG_RUNTIME_DIR to both session scopes and to `user@<uid>.service` units,
+  // so a systemd user unit and the browser agree on it.
+  auto env = base::Environment::Create();
+  std::string runtime_dir =
+      env->GetVar("XDG_RUNTIME_DIR").value_or(std::string());
+  if (runtime_dir.empty()) {
+    LOG(ERROR)
+        << "XDG_RUNTIME_DIR is not set; the agent requires a GUI session";
+    return base::FilePath();
+  }
+  return base::FilePath(runtime_dir);
+#else
+#error unsupported platform
+#endif
+}
+#endif  // BUILDFLAG(IS_POSIX)
+
+}  // namespace
+
+std::optional<mojo::NamedPlatformChannel::ServerName> GetAgentServerName() {
+#if BUILDFLAG(IS_WIN)
+  // Keep the name free of anything user-identifying: any process on the machine
+  // can enumerate the pipe namespace.
+  DWORD session_id = 0;
+  // Cannot fail when querying the calling process's own id.
+  CHECK(::ProcessIdToSessionId(::GetCurrentProcessId(), &session_id));
+  return base::ASCIIToWide(
+      base::StrCat({kAgentServerName, ".", base::NumberToString(session_id)}));
+#else
+  const base::FilePath dir = GetSocketDirectory();
+  if (dir.empty()) {
+    return std::nullopt;
+  }
+
+  // On POSIX mojo::NamedPlatformChannel uses the ServerName verbatim as the
+  // sockaddr_un path, so it must be absolute. A bare name would bind() into
+  // whatever the process's current working directory happens to be.
+  const base::FilePath path = dir.Append(kAgentServerName);
+
+  // Deliberately no truncation or fallback: an over-long path makes bind() and
+  // connect() fail identically on both sides, which is a loud and symmetric
+  // failure.
+  if (path.value().size() > kMaxSocketPathLength) {
+    LOG(ERROR) << "Agent socket path exceeds the sockaddr_un limit: " << path;
+    return std::nullopt;
+  }
+  return path.value();
+#endif  // BUILDFLAG(IS_WIN)
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/common/v2/agent_utils.h
+++ b/components/brave_vpn/common/v2/agent_utils.h
@@ -6,8 +6,12 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_VPN_COMMON_V2_AGENT_UTILS_H_
 #define BRAVE_COMPONENTS_BRAVE_VPN_COMMON_V2_AGENT_UTILS_H_
 
+#include <stddef.h>
+
 #include <optional>
 
+#include "base/files/file_path.h"
+#include "build/build_config.h"
 #include "mojo/public/cpp/platform/named_platform_channel.h"
 
 namespace brave_vpn::v2 {
@@ -20,6 +24,20 @@ namespace brave_vpn::v2 {
 // The name is not a secret and is discoverable by other local processes;
 // authentication of peers is expected.
 std::optional<mojo::NamedPlatformChannel::ServerName> GetAgentServerName();
+
+#if BUILDFLAG(IS_POSIX)
+
+// Longest socket path mojo::NamedPlatformChannel can bind. |sun_path| is 104
+// bytes on macOS and 108 on Linux. The same code has to be correct on both, so
+// the shorter limit applies.
+inline constexpr size_t kMaxAgentSocketPathLength = 103;
+
+// Builds the server name for a socket living in |socket_dir|, or nullopt if the
+// directory is empty or the resulting path would exceed the sockaddr_un limit.
+std::optional<mojo::NamedPlatformChannel::ServerName>
+GetAgentServerNameForDirectory(const base::FilePath& socket_dir);
+
+#endif  // BUILDFLAG(IS_POSIX)
 
 }  // namespace brave_vpn::v2
 

--- a/components/brave_vpn/common/v2/agent_utils.h
+++ b/components/brave_vpn/common/v2/agent_utils.h
@@ -1,0 +1,26 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_COMMON_V2_AGENT_UTILS_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_COMMON_V2_AGENT_UTILS_H_
+
+#include <optional>
+
+#include "mojo/public/cpp/platform/named_platform_channel.h"
+
+namespace brave_vpn::v2 {
+
+// Returns the NamedMojoIpcServer endpoint name for the VPN agent serving the
+// current OS session. The browser and the agent call this independently and
+// must arrive at the same value.
+//
+// The result is a socket path on POSIX and a bare pipe leaf name on Windows.
+// The name is not a secret and is discoverable by other local processes;
+// authentication of peers is expected.
+std::optional<mojo::NamedPlatformChannel::ServerName> GetAgentServerName();
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_COMMON_V2_AGENT_UTILS_H_

--- a/components/brave_vpn/common/v2/agent_utils_unittest.cc
+++ b/components/brave_vpn/common/v2/agent_utils_unittest.cc
@@ -1,0 +1,129 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/common/v2/agent_utils.h"
+
+#include <stddef.h>
+
+#include <optional>
+#include <string>
+
+#include "base/files/file_path.h"
+#include "base/scoped_environment_variable_override.h"
+#include "build/build_config.h"
+#include "mojo/public/cpp/platform/named_platform_channel.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn::v2 {
+namespace {
+#if BUILDFLAG(IS_POSIX)
+constexpr char kSocketRuntimeDir[] = "/run/user/1000";
+#endif
+}  // namespace
+
+// The browser and the agent call this independently and must agree, so the
+// answer cannot depend on anything that varies between calls.
+TEST(BraveVpnAgentUtils, ServerNameIsStableWithinProcess) {
+#if BUILDFLAG(IS_LINUX)
+  // Test bots frequently have no XDG_RUNTIME_DIR, which would leave both calls
+  // below as nullopt and pass without a name ever being built. Safe to override
+  // here because these tests start no threads.
+  base::ScopedEnvironmentVariableOverride runtime_dir("XDG_RUNTIME_DIR",
+                                                      kSocketRuntimeDir);
+#endif  // BUILDFLAG(IS_LINUX)
+
+  const std::optional<mojo::NamedPlatformChannel::ServerName> first =
+      GetAgentServerName();
+  const std::optional<mojo::NamedPlatformChannel::ServerName> second =
+      GetAgentServerName();
+
+  ASSERT_TRUE(first.has_value());
+  EXPECT_EQ(first, second);
+}
+
+#if BUILDFLAG(IS_LINUX)
+
+// Without a runtime directory there is no path for the browser and the agent to
+// agree on, so the name has to be refused rather than resolved somewhere else.
+TEST(BraveVpnAgentUtils, NoRuntimeDirectoryYieldsNoServerName) {
+  base::ScopedEnvironmentVariableOverride unset_runtime_dir("XDG_RUNTIME_DIR");
+  EXPECT_FALSE(GetAgentServerName().has_value());
+}
+
+#endif  // BUILDFLAG(IS_LINUX)
+
+#if BUILDFLAG(IS_POSIX)
+
+// An unusable socket directory has to fail rather than fall back to a
+// relative path, which would bind into the working directory.
+TEST(BraveVpnAgentUtils, NoSocketDirectoryYieldsNoServerName) {
+  EXPECT_FALSE(GetAgentServerNameForDirectory(base::FilePath()).has_value());
+}
+
+TEST(BraveVpnAgentUtils, ServerNameIsAnAbsolutePathInsideTheDirectory) {
+  const base::FilePath dir(kSocketRuntimeDir);
+
+  const std::optional<mojo::NamedPlatformChannel::ServerName> name =
+      GetAgentServerNameForDirectory(dir);
+  ASSERT_TRUE(name.has_value());
+
+  const base::FilePath path(*name);
+  EXPECT_TRUE(path.IsAbsolute());
+  EXPECT_EQ(dir, path.DirName());
+  EXPECT_FALSE(path.BaseName().empty());
+}
+
+// The same leaf name must come back for every directory, or the browser and the
+// agent could disagree about which socket to use.
+TEST(BraveVpnAgentUtils, LeafNameDoesNotDependOnTheDirectory) {
+  const std::optional<mojo::NamedPlatformChannel::ServerName> first =
+      GetAgentServerNameForDirectory(base::FilePath(kSocketRuntimeDir));
+  const std::optional<mojo::NamedPlatformChannel::ServerName> second =
+      GetAgentServerNameForDirectory(base::FilePath("/tmp"));
+
+  ASSERT_TRUE(first.has_value());
+  ASSERT_TRUE(second.has_value());
+  EXPECT_EQ(base::FilePath(*first).BaseName(),
+            base::FilePath(*second).BaseName());
+}
+
+// bind() and connect() fail identically on an over-long path, so the limit is
+// enforced up front. Pinning both sides of it guards against an off-by-one.
+TEST(BraveVpnAgentUtils, SocketPathLengthLimitIsEnforcedExactly) {
+  // Calculate the leaf's contribution.
+  const base::FilePath probe("/probe");
+  const std::optional<mojo::NamedPlatformChannel::ServerName> probe_name =
+      GetAgentServerNameForDirectory(probe);
+  ASSERT_TRUE(probe_name.has_value());
+  const size_t leaf_size = probe_name->size() - probe.value().size();
+  ASSERT_LT(leaf_size, kMaxAgentSocketPathLength);
+
+  // A directory that lands the socket exactly on the limit is usable.
+  const size_t longest_dir = kMaxAgentSocketPathLength - leaf_size;
+  const base::FilePath longest("/" + std::string(longest_dir - 1, 'a'));
+  ASSERT_EQ(longest_dir, longest.value().size());
+  const std::optional<mojo::NamedPlatformChannel::ServerName> accepted =
+      GetAgentServerNameForDirectory(longest);
+  ASSERT_TRUE(accepted.has_value());
+  EXPECT_EQ(kMaxAgentSocketPathLength, accepted->size());
+
+  // One byte more is refused.
+  const std::optional<mojo::NamedPlatformChannel::ServerName> rejected =
+      GetAgentServerNameForDirectory(base::FilePath(longest.value() + "a"));
+  EXPECT_FALSE(rejected.has_value());
+}
+
+#else  // BUILDFLAG(IS_POSIX)
+
+TEST(BraveVpnAgentUtils, ServerNameIsAvailableOnNonPosix) {
+  const std::optional<mojo::NamedPlatformChannel::ServerName> name =
+      GetAgentServerName();
+  ASSERT_TRUE(name.has_value());
+  EXPECT_FALSE(name->empty());
+}
+
+#endif  // BUILDFLAG(IS_POSIX)
+
+}  // namespace brave_vpn::v2


### PR DESCRIPTION
Introduces the agent side of the browser-agent channel. The API is split in two: `BrowserHostProvider` is the only interface reachable on a fresh connection and does nothing but authenticate; `BrowserHost` is handed out per browser once accepted. `BrowserRegistry` owns the named IPC server, the auth policy, and one session per connection, ending a session when either of its pipes closes or the connection drops.

Authentication is a stub that accepts every browser, routed through the asynchronous hop real verification will use. Real verification will land in follow up PRs.

Implements part of https://github.com/brave/brave-browser/issues/54623

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
