### PR TITLE
[plaster] Escape input fields for regex macros

### DIFF
--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -2931,7 +2931,8 @@ class RegexMacroEngine:
         no fewer. `pattern` (escaped) or `re_pattern`, and `replace`, are
         rendered with `inputs` via `str.format` before being handed to
         `re.subn`, so the macro's own backreferences (`\\1`) reach `re.subn`
-        untouched.
+        untouched. `re_pattern` gets each input escaped first though to avoid
+        confusion.
         """
         spec = self._rewriters.regex_macro(op_id)
         declared = frozenset(entry['name'] for entry in spec['inputs'])
@@ -2948,7 +2949,11 @@ class RegexMacroEngine:
 
         re_pattern = spec.get('re_pattern')
         if re_pattern is not None:
-            pattern = re_pattern.format(**inputs)
+            escaped_inputs = {
+                key: re.escape(value)
+                for key, value in inputs.items()
+            }
+            pattern = re_pattern.format(**escaped_inputs)
         else:
             pattern = re.escape(spec['pattern'].format(**inputs))
         replace = spec['replace'].format(**inputs)

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -5450,6 +5450,26 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
                                value='base::FEATURE_ENABLED_BY_DEFAULT')
         self.assertTrue(content.rstrip().endswith(');'))
 
+    # -- `value` introducing a brand-new conditional: unlike the
+    # already-conditional sources above, `value` itself is plugged into the
+    # lookahead raw. `BUILDFLAG(IS_ANDROID)` is a real, unescaped capture
+    # group once spliced in, which shifts every group number after it -- the
+    # replace template's `\4` stops pointing at the literal `);` capture, and
+    # the call's real closing paren is silently dropped instead of appended.
+
+    def test_new_conditional_value_with_parens_keeps_the_closing_paren(self):
+        source = 'BASE_FEATURE(kFoo, base::FEATURE_ENABLED_BY_DEFAULT);\n'
+        value = ('\n'
+                 '#if BUILDFLAG(IS_ANDROID)\n'
+                 '             base::FEATURE_ENABLED_BY_DEFAULT\n'
+                 '#else\n'
+                 '             base::FEATURE_DISABLED_BY_DEFAULT\n'
+                 '#endif')
+        matches, content = self._run(source, feature_name='kFoo', value=value)
+        self.assertEqual(matches, 1)
+        self.assertIn('BUILDFLAG(IS_ANDROID)', content)
+        self.assertTrue(content.rstrip('\n').endswith('#endif);'))
+
     # -- multiple features in one file: every pairing of "fewer commas"
     # (two-argument/conditional) and "more commas" (three-argument) forms,
     # targeting either one, must stay within its own call. A two-argument


### PR DESCRIPTION
This was overlooked on the first implementation, but values provided as
input fields for a regex macros must be escaped as literals.

Bug: https://github.com/brave/brave-browser/issues/57281
