### PR TITLE
[plaster] `//chrome/browser/extensions/api/cookies` 🩹🩹

### DIFF
--- a/chromium_src/chrome/browser/extensions/api/cookies/cookies_api.cc
+++ b/chromium_src/chrome/browser/extensions/api/cookies/cookies_api.cc
@@ -5,22 +5,7 @@
 
 #include "chrome/browser/extensions/api/cookies/cookies_api.h"
 
-// This disables cookies.onChange routing in Tor windows (as it worked
-// when there was a DCHECK instead of CHECK). Once crbug.com/417228685 is fixed
-// in upstream, we'll be able to manage Tor profiles like any other main-OTR
-// profile.
-
-#define IsSerializeable(...)      \
-  IsSerializeable(__VA_ARGS__) || \
-      (otr && !profile_->GetPrimaryOTRProfile(/*create_if_needed=*/false))
-
-#define OnOffTheRecordProfileCreated(...) \
-  OnOffTheRecordProfileCreated_ChromiumImpl(__VA_ARGS__)
-
 #include <chrome/browser/extensions/api/cookies/cookies_api.cc>
-
-#undef IsSerializeable
-#undef OnOffTheRecordProfileCreated
 
 namespace extensions {
 
@@ -29,14 +14,6 @@ void OnCookieChangeExposeForTesting::CallOnCookieChangeForOtr(
     CookiesAPI* cookies_api) {
   cookies_api->cookies_event_router_->OnCookieChange(true,
                                                      net::CookieChangeInfo());
-}
-
-void CookiesEventRouter::OnOffTheRecordProfileCreated(Profile* off_the_record) {
-  if (off_the_record->IsTor()) {
-    return;
-  }
-
-  OnOffTheRecordProfileCreated_ChromiumImpl(off_the_record);
 }
 
 }  // namespace extensions

--- a/chromium_src/chrome/browser/extensions/api/cookies/cookies_api.h
+++ b/chromium_src/chrome/browser/extensions/api/cookies/cookies_api.h
@@ -10,18 +10,6 @@
 #include "extensions/browser/browser_context_keyed_api_factory.h"
 #include "extensions/browser/event_router.h"
 
-#define OnOffTheRecordProfileCreated(...)                 \
-  OnOffTheRecordProfileCreated_ChromiumImpl(__VA_ARGS__); \
-  void OnOffTheRecordProfileCreated(__VA_ARGS__)
-
-#define MaybeStartListening(...)    \
-  MaybeStartListening(__VA_ARGS__); \
-  friend struct OnCookieChangeExposeForTesting
-
-#define GetFactoryInstance(...)    \
-  GetFactoryInstance(__VA_ARGS__); \
-  friend struct OnCookieChangeExposeForTesting
-
 #include <chrome/browser/extensions/api/cookies/cookies_api.h>  // IWYU pragma: export
 
 namespace extensions {
@@ -29,9 +17,5 @@ struct OnCookieChangeExposeForTesting {
   static void CallOnCookieChangeForOtr(CookiesAPI* cookies_api);
 };
 }  // namespace extensions
-
-#undef OnOffTheRecordProfileCreated
-#undef MaybeStartListening
-#undef GetFactoryInstance
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_EXTENSIONS_API_COOKIES_COOKIES_API_H_

--- a/patches/chrome-browser-extensions-api-cookies-cookies_api.cc.patch
+++ b/patches/chrome-browser-extensions-api-cookies-cookies_api.cc.patch
@@ -1,0 +1,20 @@
+diff --git a/chrome/browser/extensions/api/cookies/cookies_api.cc b/chrome/browser/extensions/api/cookies/cookies_api.cc
+index b605d8520b10243c1e22bc427c5a6a5d5a38b122..7d19ed7fe9f48f4f5583a2b0ae8b76a70ff26edc 100644
+--- a/chrome/browser/extensions/api/cookies/cookies_api.cc
++++ b/chrome/browser/extensions/api/cookies/cookies_api.cc
+@@ -147,6 +147,7 @@ CookiesEventRouter::~CookiesEventRouter() = default;
+ 
+ void CookiesEventRouter::OnCookieChange(bool otr,
+                                         const net::CookieChangeInfo& change) {
++  if (otr && !profile_->GetPrimaryOTRProfile(/*create_if_needed=*/false)) return;
+   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+   // There is no way to represent non-serializable
+   // partition keys in JS so return to prevent a crash.
+@@ -215,6 +216,7 @@ void CookiesEventRouter::OnCookieChange(bool otr,
+ }
+ 
+ void CookiesEventRouter::OnOffTheRecordProfileCreated(Profile* off_the_record) {
++  if (off_the_record->IsTor()) return;
+   // When an off-the-record spinoff of |profile_| is created, start listening
+   // for cookie changes there. The OTR receiver should never be bound, since
+   // there wasn't previously an OTR profile.

--- a/patches/chrome-browser-extensions-api-cookies-cookies_api.h.patch
+++ b/patches/chrome-browser-extensions-api-cookies-cookies_api.h.patch
@@ -1,0 +1,20 @@
+diff --git a/chrome/browser/extensions/api/cookies/cookies_api.h b/chrome/browser/extensions/api/cookies/cookies_api.h
+index efa7b0c339b27e2c4adab738e5321d8b82d856c3..6310755b38d0456c1e77c1eb2324306756105204 100644
+--- a/chrome/browser/extensions/api/cookies/cookies_api.h
++++ b/chrome/browser/extensions/api/cookies/cookies_api.h
+@@ -48,6 +48,7 @@ class CookiesEventRouter : public ProfileObserver {
+   void OnProfileWillBeDestroyed(Profile* profile) override;
+ 
+  private:
++  friend struct OnCookieChangeExposeForTesting;
+   FRIEND_TEST_ALL_PREFIXES(ExtensionApiTest, OTRReceiverMojoConnectionError);
+ 
+   // This helper class connects to the CookieMonster over Mojo, and relays Mojo
+@@ -257,6 +258,7 @@ class CookiesAPI : public BrowserContextKeyedAPI, public EventRouter::Observer {
+   }
+ 
+  private:
++  friend struct OnCookieChangeExposeForTesting;
+   friend class BrowserContextKeyedAPIFactory<CookiesAPI>;
+ 
+   raw_ptr<content::BrowserContext> browser_context_;

--- a/rewrite/chrome/browser/extensions/api/cookies/cookies_api.cc.yaml
+++ b/rewrite/chrome/browser/extensions/api/cookies/cookies_api.cc.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Drop cookie-change events bound for Tor windows.
+
+      A Tor profile behaves as though it has no primary OTR profile
+      (crbug.com/417228685 is not yet fixed upstream). Once it is, Tor
+      profiles can be treated like any other main-OTR profile and this can be
+      removed.
+    preempt_function_impl:
+      function_name: CookiesEventRouter::OnCookieChange
+      return_if:
+        'otr && !profile_->GetPrimaryOTRProfile(/*create_if_needed=*/false)'
+
+  - description: |
+      Skip Tor profiles when starting to observe a new OTR profile.
+
+      Tor windows must not be observed for cookie changes (see the
+      OnCookieChange substitution above for the same reasoning).
+    preempt_function_impl:
+      function_name: CookiesEventRouter::OnOffTheRecordProfileCreated
+      return_if: 'off_the_record->IsTor()'

--- a/rewrite/chrome/browser/extensions/api/cookies/cookies_api.h.yaml
+++ b/rewrite/chrome/browser/extensions/api/cookies/cookies_api.h.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description:
+      'Let OnCookieChangeExposeForTesting call the private OnCookieChange.'
+    add_friend:
+      class_name: CookiesEventRouter
+      friend_type: struct OnCookieChangeExposeForTesting
+
+  - description:
+      'Let OnCookieChangeExposeForTesting reach the private
+      cookies_event_router_.'
+    add_friend:
+      class_name: CookiesAPI
+      friend_type: struct OnCookieChangeExposeForTesting


### PR DESCRIPTION
These plaster migrations are functionally the same.

Bug: https://github.com/brave/brave-browser/issues/45050
