### PR TITLE
[infra] Adding `builders` supporting code

### DIFF
--- a/infra/config/builders/__init__.py
+++ b/infra/config/builders/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Package marker for `brave/infra/config`'s builder-group definitions.
+"""

--- a/infra/config/builders/sanitisers.py
+++ b/infra/config/builders/sanitisers.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""The `brave.sanitisers` builder group: the Linux ASan builders."""
+
+from lib.config import builders, gn_args
+
+builders.defaults.set(
+    builder_group='brave.sanitisers',
+    execution_timeout_mins=270,
+    channel='nightly',
+    notifies=[
+        'browser-sanitizers-bot',
+    ],
+)
+
+builders.builder(
+    name='linux-x64-asan-brave',
+    sync_config=builders.sync_config(target_os='linux', target_cpu='x64'),
+    gn_args=gn_args.config(configs=[
+        'release',
+        'asan',
+        'remoteexec',
+        'nightly',
+        'linux',
+        'x64',
+    ]),
+    targets=builders.targets(
+        compile=[
+            'brave:all',
+        ],
+        tests=[
+            'brave_all_unit_tests',
+            'brave_browser_tests',
+            'brave_interactive_ui_tests',
+            'brave_network_audit_tests',
+        ],
+    ),
+)

--- a/infra/config/lib/config.py
+++ b/infra/config/lib/config.py
@@ -108,8 +108,7 @@ class FrozenDict(collections.abc.Mapping[K, V]):
 
 
 class ConfigError(Exception):
-    """Raised for any gn_args configuration violation.
-    """
+    """Raised for any gn_args or builder configuration violation."""
 
 
 class AnonymousGnConfig:
@@ -322,3 +321,213 @@ class GnArgsRegistry:
 
 # What spec files import: `from lib.config import gn_args`.
 gn_args = GnArgsRegistry()
+
+# Sentinel distinguishing "caller didn't pass this" from an explicit falsy
+# value (0, '', [], None), mirroring upstream's `args.DEFAULT`.
+_UNSET = object()
+
+
+class Defaults:
+    """A settable group of module-level defaults for `builder()`.
+    """
+
+    def __init__(self, **defaults: Any) -> None:
+        self._values = dict(defaults)
+
+    def set(self, **kwargs: Any) -> None:
+        """Sets module-level defaults for the given fields."""
+        for key, value in kwargs.items():
+            if key not in self._values:
+                raise ConfigError('%r is not a defaultable field' % key)
+            self._values[key] = value
+
+    def get(self, name: str, value: Any) -> Any:
+        """Returns `value`, or the module-level default if `value` is unset."""
+        if value is not _UNSET:
+            return value
+        return self._values[name]
+
+
+class SyncConfig:
+    """What a builder needs to reach a synced tree: target platform plus
+    whatever gclient overrides `init`/`sync` should apply."""
+
+    def __init__(self, *, target_os: str, target_cpu: str,
+                 **gclient_overrides: Any) -> None:
+        # GN's target_os, and what `init`/`sync` sync a checkout for.
+        self.target_os = target_os
+
+        # GN's target_cpu.
+        self.target_cpu = target_cpu
+
+        # Custom vars, deps or revision pins for gclient, by name. Schema
+        # not yet settled (A1).
+        self.gclient_overrides = gclient_overrides
+
+
+class Targets:
+    """What a builder compiles and runs."""
+
+    def __init__(
+            self,
+            *,
+            compile: Sequence[str],  # pylint: disable=redefined-builtin
+            tests: Sequence[str]) -> None:
+        # GN target labels to compile, e.g. "brave:all".
+        self.compile = tuple(compile)
+
+        # Test target names to run.
+        self.tests = tuple(tests)
+
+
+class Builder:
+    """A registered builder: metadata plus what it builds and runs.
+
+    Its GN args are not stored here — `builder()` registers them into
+    `gn_args` under this builder's own name, so `gn_args.resolve(name)` is
+    the one way to read them back, same as for any other config.
+    """
+
+    def __init__(self, *, name: str, builder_group: str | None,
+                 execution_timeout_mins: int | None, channel: str | None,
+                 notifies: Sequence[str], sync_config: SyncConfig,
+                 targets: Targets) -> None:
+        # The name it was registered under; also its `gn_args` node name.
+        self.name = name
+
+        # The builder group it belongs to, e.g. "brave.sanitisers".
+        self.builder_group = builder_group
+
+        # How long the pipeline may run before it's killed.
+        self.execution_timeout_mins = execution_timeout_mins
+
+        # The release channel this builder builds for, e.g. "nightly".
+        self.channel = channel
+
+        # Who to notify on a build result worth telling someone about.
+        self.notifies = tuple(notifies)
+
+        # This builder's `sync_config()`.
+        self.sync_config = sync_config
+
+        # This builder's `targets()`.
+        self.targets = targets
+
+
+class BuildersRegistry:
+    """A registry of builders, and the `sync_config`/`targets` constructors
+    used to describe them.
+
+    Spec files call `builder()` to declare a builder; `defaults.set()` sets
+    module-level fallbacks for the fields a group of builders share, the way
+    a `chromium.<group>.star` file's `ci.defaults.set(...)` does upstream.
+    """
+
+    def __init__(self, gn_args_registry: GnArgsRegistry) -> None:
+        # Where a builder's GN args get registered (see `_register_gn_args`).
+        # Explicit rather than reaching for the module-level `gn_args` below,
+        # so a registry under test isn't wired to shared global state.
+        self._gn_args = gn_args_registry
+
+        # Module-level fallbacks for builder(), settable via `defaults.set()`.
+        self.defaults = Defaults(
+            builder_group=None,
+            execution_timeout_mins=None,
+            channel=None,
+            notifies=(),
+        )
+
+        # Name -> registered builder.
+        self._builders: dict[str, Builder] = {}
+
+    def _register_gn_args(self, builder_name: str, value: Any) -> None:
+        """Registers `value` as the named `gn_args` config for a builder.
+
+        a builder's GN args become a node in the same include graph as any other
+        config, named after the builder itself. Takes either a config name to
+        include as-is, or the anonymous struct `gn_args.config()` returns when
+        called without `name`.
+        """
+        if isinstance(value, str):
+            self._gn_args.config(name=builder_name, configs=[value])
+        elif isinstance(value, AnonymousGnConfig):
+            self._gn_args.config(name=builder_name,
+                                 configs=list(value.configs),
+                                 args=dict(value.gn_args),
+                                 args_file=value.args_file,
+                                 secrets=dict(value.secrets))
+        else:
+            raise ConfigError(
+                'builder %r: gn_args must be a config name or an anonymous '
+                'gn_args.config(), got %r' % (builder_name, value))
+
+    def sync_config(self, *, target_os: str, target_cpu: str,
+                    **gclient_overrides: Any) -> SyncConfig:
+        return SyncConfig(target_os=target_os,
+                          target_cpu=target_cpu,
+                          **gclient_overrides)
+
+    def targets(
+            self,
+            *,
+            compile: Sequence[str],  # pylint: disable=redefined-builtin
+            tests: Sequence[str]) -> Targets:
+        return Targets(compile=compile, tests=tests)
+
+    def builder(
+            self,
+            *,
+            name: str,
+            sync_config: SyncConfig,
+            gn_args: Any,  # pylint: disable=redefined-outer-name
+            targets: Targets,
+            builder_group: str | None = _UNSET,
+            execution_timeout_mins: int | None = _UNSET,
+            channel: str | None = _UNSET,
+            notifies: Sequence[str] = _UNSET) -> Builder:
+        """Defines a builder.
+
+        Args:
+            name: The builder's name. Also what its GN args are registered
+                under (see `_register_gn_args`).
+            sync_config: This builder's `sync_config()`.
+            gn_args: The config name, or `gn_args.config()` called without
+                `name`, describing this builder's GN args.
+            targets: This builder's `targets()`.
+            builder_group, execution_timeout_mins, channel, notifies: Fall
+                back to `defaults` when omitted.
+
+        Returns:
+            The registered `Builder`.
+        """
+        if name in self._builders:
+            raise ConfigError('builder %r is already defined' % name)
+
+        self._register_gn_args(name, gn_args)
+
+        builder = Builder(
+            name=name,
+            builder_group=self.defaults.get('builder_group', builder_group),
+            execution_timeout_mins=self.defaults.get('execution_timeout_mins',
+                                                     execution_timeout_mins),
+            channel=self.defaults.get('channel', channel),
+            notifies=self.defaults.get('notifies', notifies),
+            sync_config=sync_config,
+            targets=targets,
+        )
+        self._builders[name] = builder
+        return builder
+
+    def get(self, name: str) -> Builder:
+        try:
+            return self._builders[name]
+        except KeyError as e:
+            raise ConfigError('builder %r is not defined' % name) from e
+
+    def all(self) -> tuple[Builder, ...]:
+        """Every registered builder, in definition order."""
+        return tuple(self._builders.values())
+
+
+# What spec files import: `from lib.config import builders`.
+builders = BuildersRegistry(gn_args)

--- a/infra/config/lib/config_test.py
+++ b/infra/config/lib/config_test.py
@@ -3,7 +3,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Tests for config.py: freeze/thaw/FrozenDict and GnArgsRegistry."""
+"""Tests for config.py: freeze/thaw/FrozenDict, GnArgsRegistry and
+BuildersRegistry."""
 
 # Some tests read `_resolved` directly to check memoization, which is
 # otherwise unobservable from the public API.
@@ -16,8 +17,10 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 # pylint: disable=wrong-import-position
-from config import (AnonymousGnConfig, ConfigError, FrozenDict, GnArgsRegistry,
-                    freeze, thaw)
+# _UNSET is private (module-internal sentinel); tests reach for it directly
+# rather than duplicating it.
+from config import (AnonymousGnConfig, BuildersRegistry, ConfigError, Defaults,
+                    FrozenDict, GnArgsRegistry, _UNSET, freeze, thaw)
 
 
 class FreezeThawTest(unittest.TestCase):
@@ -279,6 +282,187 @@ class GnArgsResolveTest(unittest.TestCase):
                 'target_os': 'linux',
                 'target_cpu': 'x64',
             })
+
+
+class DefaultsTest(unittest.TestCase):
+
+    def setUp(self):
+        self.defaults = Defaults(channel=None, notifies=())
+
+    def test_get_returns_value_when_given(self):
+        self.assertEqual(self.defaults.get('channel', 'beta'), 'beta')
+
+    def test_get_falls_back_to_initial_default(self):
+        self.assertIsNone(self.defaults.get('channel', _UNSET))
+
+    def test_set_changes_the_fallback(self):
+        self.defaults.set(channel='nightly')
+        self.assertEqual(self.defaults.get('channel', _UNSET), 'nightly')
+
+    def test_set_unknown_field_raises(self):
+        with self.assertRaises(ConfigError):
+            self.defaults.set(nope='x')
+
+    def test_explicit_falsy_value_is_not_treated_as_unset(self):
+        self.defaults.set(notifies=['a'])
+        self.assertEqual(self.defaults.get('notifies', []), [])
+
+
+class BuildersRegistryTest(unittest.TestCase):
+
+    def setUp(self):
+        self.gn_args = GnArgsRegistry()
+        self.builders = BuildersRegistry(self.gn_args)
+
+    def _sync_config(self):
+        return self.builders.sync_config(target_os='linux', target_cpu='x64')
+
+    def _targets(self):
+        return self.builders.targets(compile=['brave:all'],
+                                     tests=['brave_all_unit_tests'])
+
+    def test_sync_config_fields(self):
+        sync_config = self.builders.sync_config(target_os='linux',
+                                                target_cpu='x64',
+                                                custom_vars={'a': 1})
+        self.assertEqual(sync_config.target_os, 'linux')
+        self.assertEqual(sync_config.target_cpu, 'x64')
+        self.assertEqual(sync_config.gclient_overrides,
+                         {'custom_vars': {
+                             'a': 1
+                         }})
+
+    def test_targets_fields_become_tuples(self):
+        targets = self.builders.targets(compile=['brave:all'],
+                                        tests=['a', 'b'])
+        self.assertEqual(targets.compile, ('brave:all', ))
+        self.assertEqual(targets.tests, ('a', 'b'))
+
+    def test_builder_with_named_gn_args_config(self):
+        self.gn_args.config(name='asan',
+                            args={
+                                'target_os': 'linux',
+                                'target_cpu': 'x64',
+                                'is_asan': True,
+                            })
+        builder = self.builders.builder(name='linux-x64-asan-brave',
+                                        sync_config=self._sync_config(),
+                                        gn_args='asan',
+                                        targets=self._targets())
+        self.assertEqual(builder.name, 'linux-x64-asan-brave')
+        self.assertTrue(
+            self.gn_args.resolve('linux-x64-asan-brave')['gn_args']['is_asan'])
+
+    def test_builder_with_anonymous_gn_args_config(self):
+        self.gn_args.config(name='linux', args={'target_os': 'linux'})
+        self.gn_args.config(name='x64', args={'target_cpu': 'x64'})
+        anon = self.gn_args.config(configs=['linux', 'x64'],
+                                   args={'is_asan': True},
+                                   secrets={'k': 'ENV_K'})
+        self.builders.builder(name='b',
+                              sync_config=self._sync_config(),
+                              gn_args=anon,
+                              targets=self._targets())
+        resolved = self.gn_args.resolve('b')
+        self.assertEqual(resolved['gn_args'], {
+            'target_os': 'linux',
+            'target_cpu': 'x64',
+            'is_asan': True,
+        })
+        self.assertEqual(resolved['secrets'], {'k': 'ENV_K'})
+
+    def test_builder_with_invalid_gn_args_raises(self):
+        with self.assertRaises(ConfigError):
+            self.builders.builder(name='b',
+                                  sync_config=self._sync_config(),
+                                  gn_args=123,
+                                  targets=self._targets())
+
+    def test_duplicate_builder_name_raises(self):
+        self.builders.builder(name='b',
+                              sync_config=self._sync_config(),
+                              gn_args=self.gn_args.config(args={
+                                  'target_os': 'linux',
+                                  'target_cpu': 'x64',
+                              }),
+                              targets=self._targets())
+        with self.assertRaises(ConfigError):
+            self.builders.builder(name='b',
+                                  sync_config=self._sync_config(),
+                                  gn_args=self.gn_args.config(args={
+                                      'target_os': 'linux',
+                                      'target_cpu': 'x64',
+                                  }),
+                                  targets=self._targets())
+
+    def test_defaults_are_applied_and_overridable(self):
+        self.builders.defaults.set(builder_group='brave.sanitizers',
+                                   execution_timeout_mins=270,
+                                   channel='nightly',
+                                   notifies=['browser-sanitizers-bot'])
+        inherited = self.builders.builder(
+            name='inherited',
+            sync_config=self._sync_config(),
+            gn_args=self.gn_args.config(args={
+                'target_os': 'linux',
+                'target_cpu': 'x64',
+            }),
+            targets=self._targets())
+        self.assertEqual(inherited.builder_group, 'brave.sanitizers')
+        self.assertEqual(inherited.execution_timeout_mins, 270)
+        self.assertEqual(inherited.channel, 'nightly')
+        self.assertEqual(inherited.notifies, ('browser-sanitizers-bot', ))
+
+        overridden = self.builders.builder(
+            name='overridden',
+            sync_config=self._sync_config(),
+            gn_args=self.gn_args.config(args={
+                'target_os': 'linux',
+                'target_cpu': 'x64',
+            }),
+            targets=self._targets(),
+            channel='beta',
+            notifies=['browser-bot'])
+        self.assertEqual(overridden.builder_group, 'brave.sanitizers')
+        self.assertEqual(overridden.channel, 'beta')
+        self.assertEqual(overridden.notifies, ('browser-bot', ))
+
+    def test_get_and_all(self):
+        b1 = self.builders.builder(name='b1',
+                                   sync_config=self._sync_config(),
+                                   gn_args=self.gn_args.config(args={
+                                       'target_os': 'linux',
+                                       'target_cpu': 'x64',
+                                   }),
+                                   targets=self._targets())
+        self.assertIs(self.builders.get('b1'), b1)
+        self.assertEqual(self.builders.all(), (b1, ))
+        with self.assertRaises(ConfigError):
+            self.builders.get('nope')
+
+    def test_registries_are_isolated_per_instance(self):
+        other_gn_args = GnArgsRegistry()
+        other_builders = BuildersRegistry(other_gn_args)
+        other_builders.builder(name='b',
+                               sync_config=self._sync_config(),
+                               gn_args=other_gn_args.config(args={
+                                   'target_os': 'linux',
+                                   'target_cpu': 'x64',
+                               }),
+                               targets=self._targets())
+        # A same-named builder in a separate registry pair does not collide.
+        self.builders.builder(name='b',
+                              sync_config=self._sync_config(),
+                              gn_args=self.gn_args.config(args={
+                                  'target_os': 'linux',
+                                  'target_cpu': 'x64',
+                              }),
+                              targets=self._targets())
+        # Both succeeded without an "already defined" clash: each pair's
+        # `gn_args` node for 'b' lives in its own registry.
+        self.assertIn('b', self.gn_args._nodes)  # pylint: disable=protected-access
+        self.assertIn('b', other_gn_args._nodes)  # pylint: disable=protected-access
+        self.assertIsNot(self.gn_args._nodes['b'], other_gn_args._nodes['b'])  # pylint: disable=protected-access
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is the foundation work for a builders library. The files placed
under `infra/config/builders` are supposed to be discoverable, and new
builders added to this path should lead to new output from the `bots`
application.

Bug: https://github.com/brave/brave-browser/issues/47912
