### PR TITLE
[recipes] `futures` module for in-recipe concurrency

### DIFF
--- a/tools/recipes/.vpython3
+++ b/tools/recipes/.vpython3
@@ -35,3 +35,35 @@ wheel: <
   name: "infra/python/wheels/psutil/${vpython_platform}"
   version: "version:5.8.0.chromium.3"
 >
+
+# The concurrency substrate behind the `futures` module.
+wheel: <
+  name: "infra/python/wheels/gevent/${vpython_platform}"
+  version: "version:23.9.1"
+>
+wheel: <
+  name: "infra/python/wheels/greenlet/${vpython_platform}"
+  version: "version:3.0.1"
+>
+wheel: <
+  name: "infra/python/wheels/zope_event-py3"
+  version: "version:5.0"
+>
+wheel: <
+  name: "infra/python/wheels/zope_interface/${vpython_platform}"
+  version: "version:6.0"
+>
+wheel: <
+  name: "infra/python/wheels/cffi/${vpython_platform}"
+  version: "version:1.15.1"
+
+  # This is only required on the windows version of gevent.
+  match_tag: < platform: "win_amd64" >
+>
+wheel: <
+  name: "infra/python/wheels/pycparser-py2_py3"
+  version: "version:2.21"
+
+  # This is only required for cffi.
+  match_tag: < platform: "win_amd64" >
+>

--- a/tools/recipes/engine_types.py
+++ b/tools/recipes/engine_types.py
@@ -6,19 +6,22 @@
 
 Ported from upstream `recipes-py`'s `recipe_engine/engine_types.py`, keeping
 the upstream semantics (and, where practical, the upstream wording) so the
-behaviour stays comparable when reading either code base.
+behaviour stays comparable when reading either code base:
 
   * `ResourceCost` -- what a step expects to consume, honoured by the step
     scheduler so too many costly steps never run at once.
-
-Upstream's `PerGreenletState` lands here alongside the `futures` module that
-gives it meaning, rather than ahead of it: it derives from `gevent.local.local`
-and so would pull the whole gevent stack in before anything runs concurrently.
+  * `PerGreenletState` -- a base class for module state that must be private to
+    each greenlet, with an explicit hook for carrying values into a newly
+    spawned one.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any
+
 import attr
+from gevent.local import local
 
 
 @attr.s(frozen=True, slots=True)
@@ -74,3 +77,57 @@ class ResourceCost:
         """Whether this cost fits within the given constraints."""
         return (self.cpu <= cpu and self.memory <= memory and self.disk <= disk
                 and self.net <= net)
+
+
+class PerGreenletState(local):
+    """Subclass to get an object whose state is tied to the current greenlet.
+
+        from engine_types import PerGreenletState
+
+        class MyState(PerGreenletState):
+            cool_stuff = True
+            neat_thing = ''
+
+            def _get_setter_on_spawn(self):
+                # Called on greenlet spawn; return a closure propagating values
+                # from the spawning greenlet to the new one.
+                old_cool_stuff = self.cool_stuff
+
+                def _inner():
+                    self.cool_stuff = old_cool_stuff
+
+                return _inner
+    """
+
+    def __new__(cls, *args: Any, **kwargs: Any) -> PerGreenletState:
+        ret = super().__new__(cls, *args, **kwargs)
+        PerGreenletStateRegistry.append(ret)
+        return ret
+
+    def _get_setter_on_spawn(self) -> Callable[[], None] | None:
+        """Hook for subclasses, to carry state into a spawned greenlet.
+
+        The engine invokes this immediately *before* spawning a new greenlet;
+        it should return a 0-argument function which repopulates `self`
+        immediately *after* the spawn (i.e. from inside the new greenlet).
+
+        Returning `None` -- as this default does -- leaves the new greenlet
+        with the class defaults instead of the spawning greenlet's values.
+        """
+        return None
+
+
+class _PerGreenletStateRegistry(list):
+    """A registry of every `PerGreenletState` instance.
+
+    `futures` walks this on spawn to collect each state's setter, and the
+    simulator clears it between test runs so no state leaks across cases.
+    """
+
+    def clear(self) -> None:
+        """Clear the registry."""
+        self[:] = []
+
+
+# The (global) registry of all PerGreenletState objects.
+PerGreenletStateRegistry = _PerGreenletStateRegistry()

--- a/tools/recipes/recipe_modules/context/api.py
+++ b/tools/recipes/recipe_modules/context/api.py
@@ -29,8 +29,10 @@ import collections
 from collections.abc import Mapping, Sequence
 import contextlib
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any
 
+from engine_types import PerGreenletState
 from recipe_api import RecipeApi
 
 
@@ -42,22 +44,55 @@ def _check_type(name: str, var: object,
             f'{name} is not {expected}: {var!r} ({type(var).__name__})')
 
 
+class _State(PerGreenletState):
+    """The current scope, private to whichever greenlet is reading it.
+
+    A `with api.context(...)` block only applies to the steps that greenlet
+    runs. Were this held on the API instance instead, concurrently running
+    steps would share one scope and each other's cwd and env.
+
+    A newly spawned greenlet starts from the scope of the greenlet that
+    spawned it, which `_get_setter_on_spawn` carries across.
+    """
+
+    # Defaults are immutable, to prevent them becoming shared global state if
+    # something ever mutates in place rather than replacing wholesale.
+    cwd: Path | None = None
+    env: Mapping[str, str | None] = MappingProxyType({})
+    env_prefixes: Mapping[str, tuple[str, ...]] = MappingProxyType({})
+    env_suffixes: Mapping[str, tuple[str, ...]] = MappingProxyType({})
+
+    def _get_setter_on_spawn(self):
+        old_cwd = self.cwd
+        old_env = self.env
+        old_env_prefixes = self.env_prefixes
+        old_env_suffixes = self.env_suffixes
+
+        def _inner():
+            self.cwd = old_cwd
+            self.env = old_env
+            self.env_prefixes = old_env_prefixes
+            self.env_suffixes = old_env_suffixes
+
+        return _inner
+
+
 class ContextApi(RecipeApi):
     """Scoped ambient settings (cwd + environment) applied to steps.
 
-    The single per-run instance holds the current scope. `__call__` pushes new
-    values for the duration of a `with` block and restores them afterwards. The
-    `step` module reads the accessors below when building each step.
+    `__call__` pushes new values for the duration of a `with` block and
+    restores them afterwards. The `step` module reads the accessors below when
+    building each step.
+
+    The scope lives in greenlet-local storage, so concurrently running steps
+    each see their own; see `_State`.
     """
 
     def __init__(self) -> None:
         super().__init__()
         # Current scope. Replaced wholesale (never mutated in place) by
         # `__call__`, so an outer scope's dicts are never disturbed.
-        self._cwd: Path | None = None
-        self._env: dict[str, str | None] = {}
-        self._env_prefixes: dict[str, tuple[str, ...]] = {}
-        self._env_suffixes: dict[str, tuple[str, ...]] = {}
+        self._state = _State()
 
     @contextlib.contextmanager
     def __call__(
@@ -83,13 +118,13 @@ class ContextApi(RecipeApi):
         deferred: dict[str, Any] = {}
 
         def _push(member: str, new: Any) -> None:
-            deferred[member] = getattr(self, member)
-            setattr(self, member, new)
+            deferred[member] = getattr(self._state, member)
+            setattr(self._state, member, new)
 
         def _add(member: str, to_add: Mapping | None, adder) -> None:
             if to_add:
                 _check_type(member, to_add, Mapping)
-                new = dict(getattr(self, member))
+                new = dict(getattr(self._state, member))
                 for key, val in to_add.items():
                     adder(key, val, new)
                 _push(member, new)
@@ -120,31 +155,31 @@ class ContextApi(RecipeApi):
         try:
             if cwd is not None:
                 _check_type('cwd', cwd, (str, Path))
-                _push('_cwd', Path(cwd))
-            _add('_env_prefixes', env_prefixes, _as_prefixes)
-            _add('_env_suffixes', env_suffixes, _as_suffixes)
-            _add('_env', env, _as_env)
+                _push('cwd', Path(cwd))
+            _add('env_prefixes', env_prefixes, _as_prefixes)
+            _add('env_suffixes', env_suffixes, _as_suffixes)
+            _add('env', env, _as_env)
             yield
         finally:
             for member, val in deferred.items():
-                setattr(self, member, val)
+                setattr(self._state, member, val)
 
     @property
     def cwd(self) -> Path | None:
         """The cwd steps run in, or `None` to inherit the engine's cwd."""
-        return self._cwd
+        return self._state.cwd
 
     @property
     def env(self) -> dict[str, str | None]:
         """Whole-variable environment overrides currently in effect."""
-        return dict(self._env)
+        return dict(self._state.env)
 
     @property
     def env_prefixes(self) -> dict[str, tuple[str, ...]]:
         """Per-variable path prefixes currently in effect."""
-        return dict(self._env_prefixes)
+        return dict(self._state.env_prefixes)
 
     @property
     def env_suffixes(self) -> dict[str, tuple[str, ...]]:
         """Per-variable path suffixes currently in effect."""
-        return dict(self._env_suffixes)
+        return dict(self._state.env_suffixes)

--- a/tools/recipes/recipe_modules/futures/__init__.py
+++ b/tools/recipes/recipe_modules/futures/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""`futures` module: in-recipe concurrency via green threads."""
+
+DEPS = []

--- a/tools/recipes/recipe_modules/futures/api.py
+++ b/tools/recipes/recipe_modules/futures/api.py
@@ -1,0 +1,337 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Implements in-recipe concurrency via green threads.
+
+A recipe fans work out with `spawn`, bounds how much of it runs at once with
+`make_bounded_semaphore`, and collects results with `wait` or `iwait`:
+
+    sem = api.futures.make_bounded_semaphore(4)
+
+    def worker(url):
+        with sem:
+            return api.step(f'fetch {url}', ['fetch', url])
+
+    futures = [api.futures.spawn(worker, url, __name=url) for url in urls]
+    for future in api.futures.iwait(futures):
+        future.result()
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Iterator
+from typing import Any, Generic, TypeVar
+
+import attr
+from attr.validators import instance_of
+import gevent
+import gevent.lock
+import gevent.queue
+
+from engine_types import PerGreenletStateRegistry
+from recipe_api import RecipeApi
+
+T = TypeVar('T')
+
+
+class Timeout(Exception):
+    """Raised from Future if the requested operation is not done in time."""
+
+
+@attr.s(frozen=True, slots=True)
+class Future(Generic[T]):
+    """Represents a unit of concurrent work.
+
+    Modeled after Python 3's `concurrent.futures.Future`. This API can be
+    expanded carefully as it is needed.
+    """
+
+    _greenlet: gevent.Greenlet = attr.ib(
+        validator=instance_of(gevent.Greenlet))
+    # `_greenlet.name` is not used for this: its automatically generated names
+    # are not unique within a recipe run, so the module keeps its own counter
+    # and assigns a UID when the caller did not pass `__name`.
+    _name: str = attr.ib(validator=instance_of(str))
+    _meta: Any = attr.ib()
+
+    @property
+    def name(self) -> str:
+        """The name of this Future.
+
+        Either the string provided with `__name` at spawn time, or one
+        generated like `Future-<n>`, where `<n>` is globally sequential and
+        guaranteed not to be reused within the same recipe run.
+
+        This makes `name` useful for tracking Future objects when getting them
+        back from e.g. `iwait`. See also `meta`, to attach metadata directly.
+        """
+        return self._name
+
+    @property
+    def meta(self) -> Any:
+        """Metadata associated with this Future.
+
+        This must have been associated with the Future at spawn time with the
+        `__meta` kwarg. It is not interpreted or used in any way. The object
+        may be mutated, but cannot be assigned to, e.g.
+
+            fut = api.futures.spawn(..., __meta={'key': 'value'})
+            fut.meta                    #=> {'key': 'value'}
+            fut.meta['thing'] = 100     # OK
+            fut.meta = 'something else' # FAIL
+        """
+        return self._meta
+
+    def result(self, timeout: float | None = None) -> T:
+        """Block until this Future is done, then return its value.
+
+        Args:
+            timeout: How long, in seconds, to wait for the Future to be done.
+
+        Returns:
+            The result, if the Future is done.
+
+        Raises:
+            Exception: The Future's exception, if it is done with an error.
+            Timeout: If the Future is not done within *timeout*.
+        """
+        with gevent.Timeout(timeout, exception=Timeout()):
+            return self._greenlet.get()
+
+    @property
+    def done(self) -> bool:
+        """Whether this Future is no longer running."""
+        return self._greenlet.dead
+
+    def cancel(self) -> None:
+        """Raise `GreenletExit` in the underlying greenlet.
+
+        Does not block on the death of the greenlet, and does not switch away
+        from the current greenlet.
+        """
+        self._greenlet.kill()
+
+    def exception(self, timeout: float | None = None) -> BaseException | None:
+        """Block until done, then return (rather than raise) the exception.
+
+        Args:
+            timeout: How long, in seconds, to wait for the Future to be done.
+
+        Returns:
+            The exception which `result` would raise, or None if there was
+            none.
+
+        Raises:
+            Timeout: If the Future is not done within *timeout*.
+        """
+        with gevent.Timeout(timeout, exception=Timeout()):
+            done = gevent.wait([self._greenlet])[0]
+            return done.exception
+
+
+class _IWaitWrapper(Iterator[Future[Any]]):
+    """Adapts `gevent.iwait` over greenlets back into Futures."""
+
+    __slots__ = ('_waiter', '_greenlets_to_futures')
+
+    def __init__(self, futures: Iterable[Future[Any]], timeout: float | None,
+                 count: int | None) -> None:
+        # pylint: disable=protected-access
+        self._greenlets_to_futures = {fut._greenlet: fut for fut in futures}
+        self._waiter = gevent.iwait(list(self._greenlets_to_futures.keys()),
+                                    timeout, count)
+
+    def __enter__(self) -> Iterator[Future[Any]]:
+        self._waiter.__enter__()
+        return self
+
+    def __exit__(self, typ, value, tback):
+        return self._waiter.__exit__(typ, value, tback)
+
+    def __iter__(self) -> Iterator[Future[Any]]:
+        return self
+
+    def __next__(self) -> Future[Any]:
+        return self._greenlets_to_futures[self._waiter.__next__()]
+
+
+class FuturesApi(RecipeApi):
+    """Provides access to the recipe concurrency primitives."""
+
+    Timeout: type[Timeout] = Timeout
+    Future: type[Future[Any]] = Future
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._future_id = 0
+
+    def make_bounded_semaphore(self,
+                               value: int = 1) -> gevent.lock.BoundedSemaphore:
+        """Return a `gevent.BoundedSemaphore` with depth *value*.
+
+        Use it as a context manager to create concurrency-limited sections:
+
+            def worker(api, sem, i):
+                with sem:
+                    api.step('one at a time', ...)
+                api.step('unrestricted concurrency', ...)
+        """
+        return gevent.lock.BoundedSemaphore(value)
+
+    def make_channel(self) -> gevent.queue.Channel:
+        """Return a single-slot device for passing data between functions.
+
+        This is useful for running 'background helper' type concurrent
+        processes.
+
+        Passing Channel objects outside of a recipe module is strongly
+        discouraged: mediate access through a class, context manager or
+        function returned to the caller instead.
+
+        It is very rare to need a Channel. Avoid it unless the possibility of
+        introducing deadlocks has been carefully considered.
+        """
+        return gevent.queue.Channel()
+
+    def spawn(self, func: Callable[..., T], *args: Any,
+              **kwargs: Any) -> Future[T]:
+        """Prepare a Future to run `func(*args, **kwargs)` concurrently.
+
+        Because this spawns a greenlet on the same OS thread -- rather than a
+        different thread or process -- *func* may be an inner function,
+        closure or lambda; neither it nor its arguments need be pickleable.
+
+        This does NOT switch to the greenlet: that only happens once something
+        blocks on a future or a step. In particular, this means the following
+        is safe, since no switch point occurs between the check and the
+        assignment:
+
+            if not self._my_future:
+                self._my_future = api.futures.spawn(func)
+
+        Kwargs:
+            __name: Assign this name to the spawned greenlet. Useful for
+                tracking the Future when getting it back from `iwait`. See
+                `Future.name`.
+            __meta: Assign this metadata to the returned Future. For the
+                caller's exclusive use; see `Future.meta`.
+            Everything else is passed to *func*.
+
+        Returns:
+            A `Future` of *func*'s result.
+        """
+        name = kwargs.pop('__name', None)
+        if name is None:
+            name = f'Future-{self._future_id}'
+        self._future_id += 1
+
+        meta = kwargs.pop('__meta', None)
+
+        # Collected in the spawning greenlet and replayed inside the new one,
+        # so it starts from this greenlet's ambient state rather than the class
+        # defaults. A state which does not implement the hook returns None and
+        # is simply left at its defaults, as its docstring promises.
+        setters = [
+            setter for setter in (
+                pgs._get_setter_on_spawn()  # pylint: disable=protected-access
+                for pgs in PerGreenletStateRegistry) if setter is not None
+        ]
+
+        def _runner():
+            for setter in setters:
+                setter()
+            return func(*args, **kwargs)
+
+        greenlet = gevent.spawn(_runner)
+        greenlet.name = name
+        return Future(greenlet, name, meta)
+
+    def spawn_immediate(self, func: Callable[..., T], *args: Any,
+                        **kwargs: Any) -> Future[T]:
+        """Like `spawn`, except it IMMEDIATELY switches to the new greenlet.
+
+        Useful to e.g. launch a background step and then another step which
+        waits for the daemon.
+
+        Kwargs:
+            __name: As `spawn`.
+            __meta: As `spawn`.
+            Everything else is passed to *func*.
+
+        Returns:
+            A `Future` of the concurrently running *func*'s result.
+        """
+        name = kwargs.pop('__name', None)
+        meta = kwargs.pop('__meta', None)
+        chan = self.make_channel()
+
+        def _immediate_runner():
+            chan.get()
+            return func(*args, **kwargs)
+
+        ret = self.spawn(_immediate_runner, __name=name, __meta=meta)
+        chan.put(None)  # Pass execution to _immediate_runner.
+        return ret
+
+    @staticmethod
+    def wait(futures: Iterable[Future[Any]],
+             timeout: float | None = None,
+             count: int | None = None) -> list[Future[Any]]:
+        """Block until *count* *futures* are done, then return them.
+
+        This is analogous to `gevent.wait`.
+
+        Args:
+            futures: The Future objects to wait for.
+            timeout: How long, in seconds, to wait for the Futures to be done.
+                On timeout this returns even if *count* has not been reached.
+            count: How many Futures to wait for. None waits for all of them.
+
+        Returns:
+            The done Futures, in the order in which they completed.
+        """
+        return list(_IWaitWrapper(futures, timeout, count))
+
+    @staticmethod
+    def iwait(futures: Iterable[Future[Any]],
+              timeout: float | None = None,
+              count: int | None = None) -> Iterator[Future[Any]]:
+        """Iteratively yield up to *count* Futures as they become done.
+
+        This is analogous to `gevent.iwait`.
+
+            for future in api.futures.iwait(futures):
+                ...  # consume future
+
+        If the whole iterator will not be consumed, the resource leak is
+        avoided by using it as a context manager:
+
+            with api.futures.iwait(a, b, c) as it:
+                for future in it:
+                    if future is a:
+                        break
+
+        Prefer `iwait` over `wait` to process a group of Futures in the order
+        in which they complete. Compare:
+
+            for task in iwait(tasks):
+                ...  # task is done, do something with it
+
+        against:
+
+            while tasks:
+                task = wait(tasks, count=1)[0]  # some task is done
+                tasks.remove(task)
+                ...  # do something with it
+
+        Args:
+            futures: The Future objects to wait for.
+            timeout: How long, in seconds, to wait for the Futures to be done.
+            count: How many Futures to yield. None yields all of them.
+
+        Yields:
+            Futures in the order in which they complete, until the timeout or
+            *count* is hit.
+        """
+        return _IWaitWrapper(futures, timeout, count)

--- a/tools/recipes/recipe_modules/futures/examples/__init__.py
+++ b/tools/recipes/recipe_modules/futures/examples/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipes exercising the `futures` module."""

--- a/tools/recipes/recipe_modules/futures/examples/full.expected/full.json
+++ b/tools/recipes/recipe_modules/futures/examples/full.expected/full.json
@@ -1,0 +1,145 @@
+[
+  {
+    "cmd": [
+      "echo",
+      "0"
+    ],
+    "name": "work 0"
+  },
+  {
+    "cmd": [
+      "echo",
+      "1"
+    ],
+    "name": "work 1"
+  },
+  {
+    "cmd": [
+      "echo",
+      "2"
+    ],
+    "name": "work 2"
+  },
+  {
+    "cmd": [
+      "echo",
+      "w0",
+      "w1",
+      "w2"
+    ],
+    "name": "collected"
+  },
+  {
+    "cmd": [
+      "echo",
+      "0"
+    ],
+    "name": "partial 0"
+  },
+  {
+    "cmd": [
+      "echo",
+      "1"
+    ],
+    "name": "partial 1"
+  },
+  {
+    "cmd": [
+      "echo",
+      "Future-3"
+    ],
+    "name": "first done"
+  },
+  {
+    "cmd": [
+      "echo",
+      "inner",
+      "True"
+    ],
+    "name": "waited"
+  },
+  {
+    "cmd": [
+      "echo",
+      "0"
+    ],
+    "name": "limited 0"
+  },
+  {
+    "cmd": [
+      "echo",
+      "1"
+    ],
+    "name": "limited 1"
+  },
+  {
+    "cmd": [
+      "echo",
+      "2"
+    ],
+    "name": "limited 2"
+  },
+  {
+    "cmd": [
+      "echo",
+      "now"
+    ],
+    "name": "immediate"
+  },
+  {
+    "cmd": [
+      "echo",
+      "later"
+    ],
+    "name": "after immediate"
+  },
+  {
+    "cmd": [
+      "echo",
+      "inherited"
+    ],
+    "cwd": "[WORKSPACE]/outer",
+    "name": "inherits cwd"
+  },
+  {
+    "cmd": [
+      "echo",
+      "scoped"
+    ],
+    "cwd": "[WORKSPACE]/inner",
+    "name": "own cwd"
+  },
+  {
+    "cmd": [
+      "echo",
+      "outer"
+    ],
+    "cwd": "[WORKSPACE]/outer",
+    "name": "parent cwd intact"
+  },
+  {
+    "cmd": [
+      "false"
+    ],
+    "name": "boom",
+    "retcode": 1
+  },
+  {
+    "cmd": [
+      "echo",
+      "CalledProcessError",
+      "meta-value"
+    ],
+    "name": "caught"
+  },
+  {
+    "cmd": [
+      "echo",
+      "True"
+    ],
+    "name": "after cancel"
+  },
+  {
+    "name": "$result"
+  }
+]

--- a/tools/recipes/recipe_modules/futures/examples/full.py
+++ b/tools/recipes/recipe_modules/futures/examples/full.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipe exercising the `futures` module."""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['context', 'futures', 'path', 'step']
+
+
+def RunSteps(api):
+    # Fan work out, then collect it in completion order. A simulated step never
+    # blocks, so each greenlet runs to completion once it is switched to, and
+    # the steps come out in spawn order.
+    futures = [
+        api.futures.spawn(api.step,
+                          f'work {i}', ['echo', str(i)],
+                          __name=f'w{i}') for i in range(3)
+    ]
+    names = [future.name for future in api.futures.iwait(futures)]
+    api.step('collected', ['echo', *names])
+
+    # Consuming only part of an `iwait` leaks resources unless it is used as a
+    # context manager, which unwinds the wait on the way out.
+    partial = [
+        api.futures.spawn(api.step, f'partial {i}', ['echo', str(i)])
+        for i in range(2)
+    ]
+    with api.futures.iwait(partial) as pending:
+        for future in pending:
+            api.step('first done', ['echo', future.name])
+            break
+    api.futures.wait(partial)
+
+    # `wait` returns the done futures rather than yielding them, and a result
+    # is the spawned callable's return value.
+    done = api.futures.wait([api.futures.spawn(lambda: 'inner')])
+    api.step('waited', ['echo', done[0].result(), str(done[0].done)])
+
+    # A bounded semaphore caps how much of a fan-out runs at once.
+    sem = api.futures.make_bounded_semaphore(2)
+
+    def limited(i):
+        with sem:
+            api.step(f'limited {i}', ['echo', str(i)])
+        return i
+
+    api.futures.wait(
+        [api.futures.spawn(limited, i, __meta={'i': i}) for i in range(3)])
+
+    # `spawn_immediate` switches to the new greenlet straight away, so its step
+    # runs before the one after the spawn.
+    immediate = api.futures.spawn_immediate(api.step, 'immediate',
+                                            ['echo', 'now'])
+    api.step('after immediate', ['echo', 'later'])
+    immediate.result()
+
+    # Ambient context carries into a spawned greenlet, and a scope entered
+    # inside one does not leak back out.
+    with api.context(cwd=api.path.workspace / 'outer'):
+
+        def scoped():
+            api.step('inherits cwd', ['echo', 'inherited'])
+            with api.context(cwd=api.path.workspace / 'inner'):
+                api.step('own cwd', ['echo', 'scoped'])
+
+        api.futures.spawn(scoped).result()
+        api.step('parent cwd intact', ['echo', 'outer'])
+
+    # A failing greenlet surfaces its exception through the Future rather than
+    # at the spawn site, and `__meta` rides along with it.
+    failing = api.futures.spawn(api.step,
+                                'boom', ['false'],
+                                __meta='meta-value')
+    exc = failing.exception()
+    api.step('caught', ['echo', type(exc).__name__, failing.meta])
+
+    # Cancelling a greenlet that has not been switched to kills it outright.
+    cancelled = api.futures.spawn(api.step, 'never runs', ['echo', 'nope'])
+    cancelled.cancel()
+    api.futures.wait([cancelled])
+    api.step('after cancel', ['echo', str(cancelled.done)])
+
+
+def GenTests(api):
+    yield api.test(
+        'full',
+        api.step_data('boom', retcode=1),
+        # Fanned-out work completes in spawn order and is collected by name.
+        api.post_process(post_process.MustRun, 'work 0', 'work 1', 'work 2'),
+        api.post_process(post_process.StepCommandContains, 'collected',
+                         ['w0', 'w1', 'w2']),
+        api.post_process(post_process.StepCommandContains, 'waited',
+                         ['inner', 'True']),
+        api.post_process(post_process.MustRun, 'limited 0', 'limited 1',
+                         'limited 2'),
+        # `spawn_immediate` runs its step before the following one.
+        api.post_process(post_process.MustRun, 'immediate', 'after immediate'),
+        # The expectation records each step's cwd, so the golden is what
+        # asserts that the spawned greenlet inherits its parent's cwd, that a
+        # scope entered inside it applies only there, and that the parent's
+        # scope is undisturbed afterwards.
+        api.post_process(post_process.MustRun, 'inherits cwd', 'own cwd',
+                         'parent cwd intact'),
+        # A failure is delivered through the Future, so the recipe carries on.
+        api.post_process(post_process.StepCommandContains, 'caught',
+                         ['CalledProcessError', 'meta-value']),
+        api.post_process(post_process.DoesNotRun, 'never runs'),
+        api.post_process(post_process.StepCommandContains, 'after cancel',
+                         ['True']),
+        api.post_process(post_process.StatusSuccess),
+    )

--- a/tools/recipes/recipe_test_runner.py
+++ b/tools/recipes/recipe_test_runner.py
@@ -36,6 +36,7 @@ import time
 from typing import TYPE_CHECKING
 
 import engine
+from engine_types import PerGreenletStateRegistry
 import simulation
 from recipe_test_api import TestData
 
@@ -165,6 +166,10 @@ def _simulate(
         test_data: TestData) -> tuple[dict[str, dict], simulation.TestContext]:
     """Run one recipe case in a fresh test-mode engine; return (steps, ctx)."""
     ctx = simulation.TestContext.from_test_data(test_data)
+    # The registry holds every `PerGreenletState` ever constructed, and module
+    # instances are per-engine, so without this the previous case's states pile
+    # up and get their setters replayed into this case's greenlets.
+    PerGreenletStateRegistry.clear()
     # A fresh engine per case: module instances are cached per engine, so
     # reusing one would leak state (deployed depot_tools, set env vars, ...).
     eng = engine._Engine(  # pylint: disable=protected-access

--- a/tools/recipes/simulation.py
+++ b/tools/recipes/simulation.py
@@ -33,9 +33,13 @@ from collections.abc import Callable, Iterable
 import copy
 import inspect
 from pathlib import Path, PurePosixPath
-import subprocess
 import sys
 from typing import Any
+
+# gevent's drop-in `subprocess`, so a running step yields to other greenlets
+# rather than blocking the single OS thread they all share. Without this the
+# `futures` module would hand out concurrency that never actually overlaps.
+from gevent import subprocess
 
 from check import Check, Checker, PostProcessError, VerifySubset
 from engine_env import merge_envs


### PR DESCRIPTION
`futures` is a module for running work as gevent greenlets on a single
OS thread. A recipe schedules out work with `spawn`, managing how much
should be done at once with a semaphore, and collects the results with
`wait` or `iwait`.

Concurrency has to reach all the way down to be real, so this also
moves the production step runner onto `gevent.subprocess`. Without it a
running step would block the one thread every greenlet shares, and the
module would hand out concurrency that never overlaps.

```
sem = api.futures.make_bounded_semaphore(4)

def fetch(url):
    with sem:
        return api.step(f'fetch {url}', ['fetch', url])

futures = [api.futures.spawn(fetch, url, __name=url) for url in urls]
for future in api.futures.iwait(futures):
    future.result()
```

In the example above, four fetches run at a time, `iwait` yields each
future  as it completes, and `result()` returns the step's `StepData`
or re-raise whatever the greenlet raised.

Bug: https://github.com/brave/brave-browser/issues/56748
