### PR TITLE
[recipes] Add the engine's stack of open steps

### DIFF
--- a/tools/recipes/engine.py
+++ b/tools/recipes/engine.py
@@ -34,6 +34,7 @@ from google.protobuf import json_format as jsonpb
 import proto_support
 from recipe_api import RecipeApi
 from recipe_test_api import RecipeTestApi
+from step_stack import StepStack
 
 # Root of the recipes tree (this file's directory). Recipe modules live under
 # `recipe_modules/<name>/` and recipes under `recipes/<name>.py`.
@@ -221,6 +222,9 @@ class _Engine:
         # proto defaults.
         self._properties: dict[str, object] = {}
         self._environ: Mapping[str, str] = {}
+        # The run's stack of open steps, shared by every module so `step` and
+        # `futures` reach the same one without depending on each other.
+        self._step_stack = StepStack()
         # module name -> instantiated RecipeApi (one instance per run).
         self._cache: dict[str, RecipeApi] = {}
         # module name -> instantiated RecipeTestApi, attached to each module as
@@ -295,6 +299,7 @@ class _Engine:
         # keeps the engine out of the instance's protected members directly.
         setattr(inst, '_workspace', self._workspace)
         setattr(inst, '_brave_core_ref', self._brave_core_ref)
+        setattr(inst, '_step_stack', self._step_stack)
         setattr(inst, '_module_name', name)
         setattr(inst, '_config_ctx', _load_config_ctx(name))
         inst.test_api = instantiate_test_module(name, [], self._test_api_cache)
@@ -345,9 +350,15 @@ class _Engine:
         if run_steps is None:
             raise RuntimeError(f"recipe '{recipe_name}' is missing RunSteps")
 
-        return _run_steps(run_steps, api, self._properties, self._environ,
-                          getattr(recipe, 'PROPERTIES', None),
-                          getattr(recipe, 'ENV_PROPERTIES', None))
+        try:
+            return _run_steps(run_steps, api, self._properties, self._environ,
+                              getattr(recipe, 'PROPERTIES', None),
+                              getattr(recipe, 'ENV_PROPERTIES', None))
+        finally:
+            # Closes the last step, then the root, which waits for any work the
+            # recipe spawned and never collected. A recipe that fails partway
+            # unwinds the same way, so nothing is left running.
+            self._step_stack.unwind()
 
 
 def _module_names() -> set[str]:

--- a/tools/recipes/recipe_api.py
+++ b/tools/recipes/recipe_api.py
@@ -24,6 +24,8 @@ import functools
 from pathlib import Path
 from typing import Any
 
+from step_stack import StepStack
+
 
 class ModuleInjectionSite:
     """Namespace holding a module's resolved DEPS (and the module itself).
@@ -183,6 +185,11 @@ class RecipeApi:
         # brave-core ref the checkout modules clone, seeded by the engine.
         # `brave_core_checkout` uses it; defaults to `master` until overridden.
         self._brave_core_ref: str = 'master'
+        # The run's stack of open steps, seeded by the engine. `step` pushes
+        # each step onto it and `futures` registers spawned greenlets against
+        # it; every other module ignores it. Defaults to a private stack so a
+        # module instantiated outside the engine still works.
+        self._step_stack = StepStack()
         # Simulation context, seeded by the engine only in test mode. `None`
         # means production: the seam modules (`path`, `env`, `platform`, `step`)
         # touch the real machine. When set, they read/mutate this instead. Its

--- a/tools/recipes/recipe_modules/futures/api.py
+++ b/tools/recipes/recipe_modules/futures/api.py
@@ -228,6 +228,12 @@ class FuturesApi(RecipeApi):
 
         meta = kwargs.pop('__meta', None)
 
+        # A leaf step left open by this greenlet is closed before control can
+        # reach the new one, so two leaf steps are never open at once at the
+        # same nest level. The greenlet is then attributed to the innermost
+        # enclosing parent, which waits for it when it closes.
+        self._step_stack.close_non_parent_step()
+
         # Collected in the spawning greenlet and replayed inside the new one,
         # so it starts from this greenlet's ambient state rather than the class
         # defaults. A state which does not implement the hook returns None and
@@ -241,10 +247,17 @@ class FuturesApi(RecipeApi):
         def _runner():
             for setter in setters:
                 setter()
-            return func(*args, **kwargs)
+            try:
+                return func(*args, **kwargs)
+            finally:
+                # Symmetric with the close_non_parent_step() call above spawn:
+                # a leaf step this greenlet leaves open is closed as the
+                # greenlet finishes.
+                self._step_stack.close_non_parent_step()
 
         greenlet = gevent.spawn(_runner)
         greenlet.name = name
+        self._step_stack.register_greenlet(greenlet)
         return Future(greenlet, name, meta)
 
     def spawn_immediate(self, func: Callable[..., T], *args: Any,

--- a/tools/recipes/recipe_modules/futures/tests/__init__.py
+++ b/tools/recipes/recipe_modules/futures/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for the `futures` module."""

--- a/tools/recipes/recipe_modules/futures/tests/joined_at_run_end.py
+++ b/tools/recipes/recipe_modules/futures/tests/joined_at_run_end.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Spawned work is waited for when the run unwinds, even if never collected.
+
+`spawn` attributes the greenlet to the innermost enclosing parent on the step
+stack -- with no nesting, that is the root -- and the engine closes the root
+after `RunSteps` returns. So a recipe that spawns and forgets still has its
+greenlets run to completion rather than being dropped on the floor.
+"""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['futures', 'step']
+
+
+def RunSteps(api):
+    # Deliberately never waited on. `spawn` does not switch to the greenlet, so
+    # nothing here gives it a chance to run.
+    api.futures.spawn(api.step, 'forgotten', ['echo', 'ran anyway'])
+    api.step('last', ['echo', 'done'])
+
+
+def GenTests(api):
+    yield api.test(
+        'joined at run end',
+        api.post_process(post_process.MustRun, 'last'),
+        # Only reached because unwinding the stack waits for the greenlet.
+        api.post_process(post_process.MustRun, 'forgotten'),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )

--- a/tools/recipes/recipe_modules/step/api.py
+++ b/tools/recipes/recipe_modules/step/api.py
@@ -46,6 +46,23 @@ class StepApi(RecipeApi):
         # engine seeds `self._test.step_runner`).
         self._prod_runner = None
 
+    @property
+    def active_result(self) -> StepData | None:
+        """The currently active (open) result from the last step that was run.
+
+        Allows you to do things like:
+
+            try:
+                api.step('run test', [..., api.json.output()])
+            finally:
+                result = api.step.active_result
+                if result.json.output:
+                    ...
+
+        `None` before this greenlet has run any step.
+        """
+        return self._step_stack.active_step
+
     def _runner(self):
         if self._test is None:  # pragma: no cover - production step backend.
             return self._prod_runner_lazy()
@@ -107,6 +124,10 @@ class StepApi(RecipeApi):
             subprocess.CalledProcessError: If `check` and the process fails.
             RuntimeError: On Windows, if the command cannot be resolved.
         """
+        # The previous leaf step stays open until now, so `active_result` could
+        # reach it; starting another step closes it.
+        self._step_stack.close_non_parent_step()
+
         runner = self._runner()
         test_data = runner.step_test_data(name, step_test_data)
 
@@ -168,6 +189,9 @@ class StepApi(RecipeApi):
         if stderr is not None:
             result.stderr = stderr.result(test_data.stderr)
         result.finalize()
+        # Pushed before the failure is raised, so a recipe can still read the
+        # failing step's result from `active_result` in a `finally`.
+        self._step_stack.push(result)
 
         if check and retcode != 0:
             raise subprocess.CalledProcessError(retcode,

--- a/tools/recipes/recipe_modules/step/tests/active_result.py
+++ b/tools/recipes/recipe_modules/step/tests/active_result.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `api.step.active_result`, which reads the engine's step stack."""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['futures', 'json', 'step']
+
+
+def RunSteps(api):
+    # Nothing has run yet, so there is no open step: the tip of the stack is
+    # still the synthetic root entry.
+    assert api.step.active_result is None, api.step.active_result
+
+    api.step('first', ['echo', 'hello'])
+    assert api.step.active_result.name == 'first', api.step.active_result.name
+
+    # A step's placeholder results are reachable through the open result, so a
+    # caller that did not keep the return value can still read them.
+    api.step('emit', ['emit', api.json.output()])
+    api.step('read back',
+             ['echo', api.step.active_result.json.output['answer']])
+
+    # The failing step stays open while the exception unwinds, which is the
+    # point of pushing it before raising.
+    try:
+        api.step('fails', ['false'])
+    except Exception:  # pylint: disable=broad-except
+        api.step('in handler', ['echo', api.step.active_result.name])
+
+    # Each greenlet has its own stack, seeded from the tip of its spawner's, so
+    # a step run inside one does not become the parent greenlet's active
+    # result.
+    def worker():
+        api.step('in greenlet', ['echo', 'spawned'])
+        return api.step.active_result.name
+
+    future = api.futures.spawn(worker)
+    api.step('spawned saw', ['echo', future.result()])
+    api.step('parent unaffected', ['echo', api.step.active_result.name])
+
+
+def GenTests(api):
+    yield api.test(
+        'active result',
+        api.step_data('emit', api.json.output({'answer': '42'})),
+        api.step_data('fails', retcode=1),
+        api.post_process(post_process.StepCommandContains, 'read back',
+                         ['42']),
+        # The failing step is what is open inside the handler.
+        api.post_process(post_process.StepCommandContains, 'in handler',
+                         ['fails']),
+        # The greenlet sees the step it ran itself...
+        api.post_process(post_process.StepCommandContains, 'spawned saw',
+                         ['in greenlet']),
+        # ...while the spawning greenlet still sees its own last step, which is
+        # the one it ran before the spawn.
+        api.post_process(post_process.StepCommandContains, 'parent unaffected',
+                         ['spawned saw']),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )

--- a/tools/recipes/step_stack.py
+++ b/tools/recipes/step_stack.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""The engine's stack of open steps.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import attr
+import gevent
+
+from engine_types import PerGreenletState
+
+if TYPE_CHECKING:
+    from step_data import StepData
+
+
+@attr.s(slots=True)
+class _ActiveStep:
+    """An open step, at one nest level of one greenlet's stack."""
+
+    # The step's result, or None for the synthetic root entry.
+    step_data: StepData | None = attr.ib()
+    # Whether this is a parent nesting step, rather than a real (leaf) step.
+    # Only the tip of a stack may be False.
+    is_parent: bool = attr.ib()
+    # Greenlets spawned while this entry was the innermost parent.
+    greenlets: list = attr.ib(factory=list)
+
+    def close(self) -> None:
+        """Wait for the work spawned under this step."""
+        gevent.wait(self.greenlets)
+
+
+class _Steps(PerGreenletState):
+    """Greenlet-local storage for the stack itself.
+
+    `steps` defaults to None rather than `[]`: reading an unset attribute
+    falls through to the class-level default, but in-place mutation (as
+    opposed to assignment) doesn't create a greenlet-private copy, so a
+    mutable default would let every greenlet append to the same shared list.
+    `StepStack` seeds a fresh list per greenlet, via assignment, on first use.
+    """
+
+    steps = None
+
+    def _get_setter_on_spawn(self):
+        # Only the tip carries across: a spawned greenlet starts at the nest
+        # level of the greenlet that spawned it, without inheriting its deeper
+        # history.
+        tip = self.steps[-1] if self.steps else None
+
+        def _inner():
+            self.steps = [tip] if tip is not None else None
+
+        return _inner
+
+
+class StepStack:
+    """One run's stack of open steps, private to each greenlet.
+
+    The engine owns a single instance and seeds it onto every module, so `step`
+    and `futures` share it without depending on one another -- upstream has the
+    same property, by routing both through the engine.
+    """
+
+    def __init__(self) -> None:
+        self._storage = _Steps()
+
+    @property
+    def _stack(self) -> list[_ActiveStep]:
+        """This greenlet's stack, seeded with the root entry on first use."""
+        if self._storage.steps is None:
+            self._storage.steps = [_ActiveStep(None, True)]
+        return self._storage.steps
+
+    @property
+    def active_step(self) -> StepData | None:
+        """The tip's step data; None while the tip is the root entry."""
+        return self._stack[-1].step_data
+
+    def push(self, step_data: StepData, is_parent: bool = False) -> None:
+        """Make *step_data* the tip of this greenlet's stack."""
+        self._stack.append(_ActiveStep(step_data, is_parent))
+
+    def close_non_parent_step(self) -> None:
+        """Close the tip, unless it is a parent nesting step.
+
+        A leaf step stays open after it runs, so `api.step.active_result` can
+        still reach it. Whatever happens next -- another step, a spawn, or the
+        run unwinding -- closes it first.
+        """
+        if self._stack[-1].is_parent:
+            return
+        self._stack.pop().close()
+
+    def register_greenlet(self, greenlet: gevent.Greenlet) -> None:
+        """Attribute *greenlet* to the tip, to be waited for when it closes."""
+        self._stack[-1].greenlets.append(greenlet)
+
+    def unwind(self) -> None:
+        """Close the tip and then the entry beneath it, at the end of a run.
+
+        Mirrors the `finally` upstream runs around `RunSteps`: closing the root
+        is what waits for work the recipe spawned but never collected.
+        """
+        self.close_non_parent_step()
+        self._stack[-1].close()


### PR DESCRIPTION
The engine now keeps a per-greenlet stack of open steps, which provides
two benefits to recipes.

`api.step.active_result` reaches the last step's result without having
kept the return value. A failing step is pushed before its exception is
raised, so it works while unwinding too:

```python
    try:
        api.step('run tests', [script, api.json.output()])
    finally:
        result = api.step.active_result
        if result.json.output:
            api.step('report', ['echo', result.json.output['summary']])
```

And work spawned through `futures` is waited for when the run ends, so a
recipe that spawns without collecting no longer drops it:

```py
    api.futures.spawn(api.step, 'background', ['echo', 'hi'])
    # no wait() -- 'background' still runs, joined as the run unwinds
```

The engine owns one stack per run and seeds it onto every module, so
`futures` needs no dependency on `step`.

Bug: https://github.com/brave/brave-browser/issues/56748
