### PR TITLE
[AI Chat] Add a dialog listing shared conversations

### DIFF
--- a/components/ai_chat/core/browser/ai_chat_service.cc
+++ b/components/ai_chat/core/browser/ai_chat_service.cc
@@ -917,6 +917,19 @@ void AIChatService::GetConversationShares(
   conversation_share_store_->GetShares(std::move(callback));
 }
 
+void AIChatService::CopyConversationShareLink(const std::string& share_id) {
+  conversation_share_store_->GetShareUrl(
+      share_id, base::BindOnce(&AIChatService::OnShareUrlRetrievedForCopy,
+                               weak_ptr_factory_.GetWeakPtr()));
+}
+
+void AIChatService::OnShareUrlRetrievedForCopy(const GURL& url) {
+  if (!url.is_valid()) {
+    return;
+  }
+  CopyTextToClipboardAsConfidential(url.spec());
+}
+
 void AIChatService::OnPremiumStatusReceived(GetPremiumStatusCallback callback,
                                             mojom::PremiumStatus status,
                                             mojom::PremiumInfoPtr info) {

--- a/components/ai_chat/core/browser/ai_chat_service.cc
+++ b/components/ai_chat/core/browser/ai_chat_service.cc
@@ -919,15 +919,11 @@ void AIChatService::GetConversationShares(
 
 void AIChatService::CopyConversationShareLink(const std::string& share_id) {
   conversation_share_store_->GetShareUrl(
-      share_id, base::BindOnce(&AIChatService::OnShareUrlRetrievedForCopy,
-                               weak_ptr_factory_.GetWeakPtr()));
-}
-
-void AIChatService::OnShareUrlRetrievedForCopy(const GURL& url) {
-  if (!url.is_valid()) {
-    return;
-  }
-  CopyTextToClipboardAsConfidential(url.spec());
+      share_id, base::BindOnce([](std::optional<GURL> url) {
+        if (url && url->is_valid()) {
+          CopyTextToClipboardAsConfidential(url->spec());
+        }
+      }));
 }
 
 void AIChatService::OnPremiumStatusReceived(GetPremiumStatusCallback callback,

--- a/components/ai_chat/core/browser/ai_chat_service.h
+++ b/components/ai_chat/core/browser/ai_chat_service.h
@@ -327,8 +327,6 @@ class AIChatService : public KeyedService,
       ShareConversationCallback callback,
       const std::optional<ConversationShareResult>& share_result);
 
-  void OnShareUrlRetrievedForCopy(const GURL& url);
-
   void MaybeAssociateContent(
       ConversationHandler* conversation,
       int associated_content_id,

--- a/components/ai_chat/core/browser/ai_chat_service.h
+++ b/components/ai_chat/core/browser/ai_chat_service.h
@@ -220,6 +220,7 @@ class AIChatService : public KeyedService,
                          bool copy_to_clipboard,
                          ShareConversationCallback callback) override;
   void GetConversationShares(GetConversationSharesCallback callback) override;
+  void CopyConversationShareLink(const std::string& share_id) override;
   void BindConversation(
       const std::string& uuid,
       mojo::PendingReceiver<mojom::ConversationHandler> receiver,
@@ -325,6 +326,8 @@ class AIChatService : public KeyedService,
       bool copy_to_clipboard,
       ShareConversationCallback callback,
       const std::optional<ConversationShareResult>& share_result);
+
+  void OnShareUrlRetrievedForCopy(const GURL& url);
 
   void MaybeAssociateContent(
       ConversationHandler* conversation,

--- a/components/ai_chat/core/browser/ai_chat_service_share_conversation_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_service_share_conversation_unittest.cc
@@ -274,4 +274,34 @@ TEST_F(AIChatServiceShareConversationTest, RecordsShareSoItCanBeManaged) {
   EXPECT_EQ(shares[0]->conversation_title, "Conversation title");
 }
 
+TEST_F(AIChatServiceShareConversationTest, CopiesRecordedShareLinkAgain) {
+  auto fake_share_manager = std::make_unique<FakeConversationShareManager>();
+  fake_share_manager->share_result = MakeShareResult();
+  ai_chat_service_->SetConversationShareManagerForTesting(
+      std::move(fake_share_manager));
+
+  base::test::TestFuture<const std::optional<GURL>&> share_future;
+  ai_chat_service_->ShareConversation(
+      "ciphertext-blob", "url-safe-key-fragment", "conversation-uuid",
+      "Conversation title",
+      /*copy_to_clipboard=*/false, share_future.GetCallback());
+  ASSERT_TRUE(share_future.Get().has_value());
+
+  ui::TestClipboard* clipboard = ui::TestClipboard::CreateForCurrentThread();
+  ai_chat_service_->CopyConversationShareLink("test-share-id");
+
+  base::test::TestFuture<std::u16string> clipboard_future;
+  clipboard->ReadText(ui::ClipboardBuffer::kCopyPaste,
+                      /*data_dst=*/std::nullopt,
+                      clipboard_future.GetCallback());
+  std::u16string clipboard_text = clipboard_future.Get();
+  ui::Clipboard::DestroyClipboardForCurrentThread();
+
+  // The recorded link includes the key fragment, so the user can share it with
+  // someone else without re-uploading the conversation.
+  EXPECT_EQ(
+      base::UTF16ToUTF8(clipboard_text),
+      "https://leo-ai.brave.app/sharing/test-share-id#url-safe-key-fragment");
+}
+
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/ai_chat_service_share_conversation_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_service_share_conversation_unittest.cc
@@ -129,6 +129,14 @@ class AIChatServiceShareConversationTest : public testing::Test {
 
   void TearDown() override { ai_chat_service_.reset(); }
 
+  // The share store replies on this sequence in the order it was asked, so a
+  // completed listing means anything requested of it earlier has finished.
+  void WaitForShareStore() {
+    base::test::TestFuture<std::vector<mojom::ConversationSharePtr>> future;
+    ai_chat_service_->GetConversationShares(future.GetCallback());
+    ASSERT_TRUE(future.Wait());
+  }
+
  protected:
   base::test::TaskEnvironment task_environment_;
   base::ScopedTempDir temp_directory_;
@@ -289,6 +297,7 @@ TEST_F(AIChatServiceShareConversationTest, CopiesRecordedShareLinkAgain) {
 
   ui::TestClipboard* clipboard = ui::TestClipboard::CreateForCurrentThread();
   ai_chat_service_->CopyConversationShareLink("test-share-id");
+  WaitForShareStore();
 
   base::test::TestFuture<std::u16string> clipboard_future;
   clipboard->ReadText(ui::ClipboardBuffer::kCopyPaste,
@@ -302,6 +311,22 @@ TEST_F(AIChatServiceShareConversationTest, CopiesRecordedShareLinkAgain) {
   EXPECT_EQ(
       base::UTF16ToUTF8(clipboard_text),
       "https://leo-ai.brave.app/sharing/test-share-id#url-safe-key-fragment");
+}
+
+TEST_F(AIChatServiceShareConversationTest, DoesNotCopyLinkForUnknownShare) {
+  ui::TestClipboard* clipboard = ui::TestClipboard::CreateForCurrentThread();
+  ai_chat_service_->CopyConversationShareLink("never-shared");
+  WaitForShareStore();
+
+  base::test::TestFuture<std::u16string> clipboard_future;
+  clipboard->ReadText(ui::ClipboardBuffer::kCopyPaste,
+                      /*data_dst=*/std::nullopt,
+                      clipboard_future.GetCallback());
+  std::u16string clipboard_text = clipboard_future.Get();
+  ui::Clipboard::DestroyClipboardForCurrentThread();
+
+  // Nothing is recorded for the share, so there is no link to put anywhere.
+  EXPECT_TRUE(clipboard_text.empty());
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/conversation_share_store.cc
+++ b/components/ai_chat/core/browser/conversation_share_store.cc
@@ -135,6 +135,28 @@ void ConversationShareStore::GetShares(GetSharesCallback callback) {
       base::BindPostTaskToCurrentDefault(std::move(callback))));
 }
 
+void ConversationShareStore::GetShareUrl(const std::string& share_id,
+                                         GetShareUrlCallback callback) {
+  RunWhenReady(base::BindOnce(
+      [](std::string share_id, GetShareUrlCallback callback,
+         ConversationShareStore& store) {
+        std::unique_ptr<store::ConversationSharesProto> records =
+            store.ReadRecords();
+        if (!records) {
+          // Nothing can be found in records which can't be read.
+          std::move(callback).Run(GURL());
+          return;
+        }
+        // There is nothing worth copying a link to once the server has deleted
+        // it.
+        DropExpiredRecords(*records);
+        const store::ConversationShareProto* record =
+            FindRecord(*records, share_id);
+        std::move(callback).Run(record ? GURL(record->url()) : GURL());
+      },
+      share_id, std::move(callback)));
+}
+
 void ConversationShareStore::OnEncryptorReady(
     scoped_refptr<os_crypt_async::Encryptor> encryptor) {
   encryptor_ = std::move(encryptor);
@@ -207,6 +229,15 @@ ConversationShareStore::ReadRecords() {
     WriteRecords(*records);
   }
   return records;
+}
+
+// static
+const store::ConversationShareProto* ConversationShareStore::FindRecord(
+    const store::ConversationSharesProto& records,
+    const std::string& share_id) {
+  auto it = std::ranges::find(records.shares(), share_id,
+                              &store::ConversationShareProto::share_id);
+  return it == records.shares().end() ? nullptr : &*it;
 }
 
 // static

--- a/components/ai_chat/core/browser/conversation_share_store.cc
+++ b/components/ai_chat/core/browser/conversation_share_store.cc
@@ -144,7 +144,7 @@ void ConversationShareStore::GetShareUrl(const std::string& share_id,
             store.ReadRecords();
         if (!records) {
           // Nothing can be found in records which can't be read.
-          std::move(callback).Run(GURL());
+          std::move(callback).Run(std::nullopt);
           return;
         }
         // There is nothing worth copying a link to once the server has deleted
@@ -152,9 +152,10 @@ void ConversationShareStore::GetShareUrl(const std::string& share_id,
         DropExpiredRecords(*records);
         const store::ConversationShareProto* record =
             FindRecord(*records, share_id);
-        std::move(callback).Run(record ? GURL(record->url()) : GURL());
+        std::move(callback).Run(record ? std::optional<GURL>(record->url())
+                                       : std::nullopt);
       },
-      share_id, std::move(callback)));
+      share_id, base::BindPostTaskToCurrentDefault(std::move(callback))));
 }
 
 void ConversationShareStore::OnEncryptorReady(

--- a/components/ai_chat/core/browser/conversation_share_store.h
+++ b/components/ai_chat/core/browser/conversation_share_store.h
@@ -7,6 +7,7 @@
 #define BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_CONVERSATION_SHARE_STORE_H_
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -55,8 +56,8 @@ class ConversationShareStore {
  public:
   using GetSharesCallback =
       base::OnceCallback<void(std::vector<mojom::ConversationSharePtr>)>;
-  // Invalid if there is no record for the share.
-  using GetShareUrlCallback = base::OnceCallback<void(const GURL&)>;
+  // std::nullopt if there is no record for the share.
+  using GetShareUrlCallback = base::OnceCallback<void(std::optional<GURL>)>;
 
   ConversationShareStore(PrefService* prefs,
                          os_crypt_async::OSCryptAsync* os_crypt_async);

--- a/components/ai_chat/core/browser/conversation_share_store.h
+++ b/components/ai_chat/core/browser/conversation_share_store.h
@@ -29,12 +29,12 @@ class OSCryptAsync;
 namespace ai_chat {
 
 namespace store {
+class ConversationShareProto;
 class ConversationSharesProto;
 }  // namespace store
 
 // Remembers which conversations the user has shared, so that the share
-// management UI can list them, re-copy their links and delete them from the
-// sharing server.
+// management UI can list them and re-copy their links.
 //
 // Records hold the full shareable link, which contains the conversation's
 // decryption key, so the list is encrypted with OSCrypt before it is written to
@@ -55,6 +55,8 @@ class ConversationShareStore {
  public:
   using GetSharesCallback =
       base::OnceCallback<void(std::vector<mojom::ConversationSharePtr>)>;
+  // Invalid if there is no record for the share.
+  using GetShareUrlCallback = base::OnceCallback<void(const GURL&)>;
 
   ConversationShareStore(PrefService* prefs,
                          os_crypt_async::OSCryptAsync* os_crypt_async);
@@ -71,6 +73,10 @@ class ConversationShareStore {
 
   // Unexpired shares, most recently shared first.
   virtual void GetShares(GetSharesCallback callback);
+
+  // The full shareable link, including the decryption key fragment.
+  virtual void GetShareUrl(const std::string& share_id,
+                           GetShareUrlCallback callback);
 
  private:
   // A deferred store operation. It is handed the store when it runs, so that a
@@ -93,6 +99,11 @@ class ConversationShareStore {
   std::unique_ptr<store::ConversationSharesProto> ReadRecords();
 
   void WriteRecords(const store::ConversationSharesProto& records);
+
+  // nullptr if |records| holds no record for |share_id|.
+  static const store::ConversationShareProto* FindRecord(
+      const store::ConversationSharesProto& records,
+      const std::string& share_id);
 
   // Removes records the sharing server will have deleted by now. Returns
   // whether anything was removed.

--- a/components/ai_chat/core/browser/conversation_share_store_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_share_store_unittest.cc
@@ -77,6 +77,12 @@ class ConversationShareStoreUnitTest : public testing::Test {
     return future.Take();
   }
 
+  GURL GetShareUrl(const std::string& share_id) {
+    base::test::TestFuture<const GURL&> future;
+    store_->GetShareUrl(share_id, future.GetCallback());
+    return future.Get();
+  }
+
   // Writes |proto| to the pref the way the store would, so that stored values
   // the store itself would never write can be arranged.
   void StoreProto(os_crypt_async::Encryptor& encryptor,
@@ -127,6 +133,10 @@ TEST_F(ConversationShareStoreUnitTest, AddAndGetShare) {
   EXPECT_EQ(shares[0]->conversation_uuid, "conversation-share-1");
   EXPECT_EQ(shares[0]->conversation_title, "My conversation");
   EXPECT_EQ(shares[0]->created_time, base::Time::Now());
+
+  // The link, which contains the decryption key, is kept so it can be copied
+  // again, but is not part of what the UI displays.
+  EXPECT_EQ(GetShareUrl("share-1").spec(), kShareUrl);
 }
 
 TEST_F(ConversationShareStoreUnitTest, RecordsEveryFieldOfAShare) {
@@ -217,6 +227,10 @@ TEST_F(ConversationShareStoreUnitTest, SharesAreMostRecentFirst) {
   EXPECT_EQ(shares[1]->share_id, "share-1");
 }
 
+TEST_F(ConversationShareStoreUnitTest, GetShareUrlForUnknownShare) {
+  EXPECT_FALSE(GetShareUrl("never-shared").is_valid());
+}
+
 TEST_F(ConversationShareStoreUnitTest, PersistsAcrossStoreInstances) {
   store_->AddShare("share-1", "deletion-1", "conversation-share-1",
                    "My conversation", GURL(kShareUrl));
@@ -228,6 +242,7 @@ TEST_F(ConversationShareStoreUnitTest, PersistsAcrossStoreInstances) {
   EXPECT_EQ(shares[0]->share_id, "share-1");
   EXPECT_EQ(shares[0]->conversation_uuid, "conversation-share-1");
   EXPECT_EQ(shares[0]->conversation_title, "My conversation");
+  EXPECT_EQ(GetShareUrl("share-1").spec(), kShareUrl);
 }
 
 TEST_F(ConversationShareStoreUnitTest, StoredRecordsAreNotReadableAsPlaintext) {

--- a/components/ai_chat/core/browser/conversation_share_store_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_share_store_unittest.cc
@@ -77,10 +77,10 @@ class ConversationShareStoreUnitTest : public testing::Test {
     return future.Take();
   }
 
-  GURL GetShareUrl(const std::string& share_id) {
-    base::test::TestFuture<const GURL&> future;
+  std::optional<GURL> GetShareUrl(const std::string& share_id) {
+    base::test::TestFuture<std::optional<GURL>> future;
     store_->GetShareUrl(share_id, future.GetCallback());
-    return future.Get();
+    return future.Take();
   }
 
   // Writes |proto| to the pref the way the store would, so that stored values
@@ -136,7 +136,7 @@ TEST_F(ConversationShareStoreUnitTest, AddAndGetShare) {
 
   // The link, which contains the decryption key, is kept so it can be copied
   // again, but is not part of what the UI displays.
-  EXPECT_EQ(GetShareUrl("share-1").spec(), kShareUrl);
+  EXPECT_EQ(GetShareUrl("share-1"), GURL(kShareUrl));
 }
 
 TEST_F(ConversationShareStoreUnitTest, RecordsEveryFieldOfAShare) {
@@ -228,7 +228,7 @@ TEST_F(ConversationShareStoreUnitTest, SharesAreMostRecentFirst) {
 }
 
 TEST_F(ConversationShareStoreUnitTest, GetShareUrlForUnknownShare) {
-  EXPECT_FALSE(GetShareUrl("never-shared").is_valid());
+  EXPECT_FALSE(GetShareUrl("never-shared").has_value());
 }
 
 TEST_F(ConversationShareStoreUnitTest, PersistsAcrossStoreInstances) {
@@ -242,7 +242,7 @@ TEST_F(ConversationShareStoreUnitTest, PersistsAcrossStoreInstances) {
   EXPECT_EQ(shares[0]->share_id, "share-1");
   EXPECT_EQ(shares[0]->conversation_uuid, "conversation-share-1");
   EXPECT_EQ(shares[0]->conversation_title, "My conversation");
-  EXPECT_EQ(GetShareUrl("share-1").spec(), kShareUrl);
+  EXPECT_EQ(GetShareUrl("share-1"), GURL(kShareUrl));
 }
 
 TEST_F(ConversationShareStoreUnitTest, StoredRecordsAreNotReadableAsPlaintext) {

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -217,6 +217,13 @@ interface Service {
   // expired, most recently shared first.
   GetConversationShares() => (array<ConversationShare> shares);
 
+  // Copies the link of an existing share to the system clipboard, marked as
+  // confidential in the same way as when the share was created. The link
+  // includes the conversation's decryption key, so it is not returned to the
+  // caller - keys for past shares stay in the browser process. Does nothing if
+  // there is no record of |share_id|.
+  CopyConversationShareLink(string share_id);
+
   // Bind ability to send events to the UI and receive current state
   BindObserver(pending_remote<ServiceObserver> ui) => (ServiceState state);
 

--- a/components/ai_chat/resources/page/api/ai_chat_api.ts
+++ b/components/ai_chat/resources/page/api/ai_chat_api.ts
@@ -69,6 +69,12 @@ export default function createAIChatApi(
           prefetchWithArgs: [],
           placeholderData: [] as Mojom.Skill[],
         },
+        // Not prefetched - only the shared conversations dialog needs this, and
+        // it fetches when it opens.
+        getConversationShares: {
+          response: (result) => result.shares,
+          placeholderData: [] as Mojom.ConversationShare[],
+        },
         getPremiumStatus: {
           response: (result) => ({
             /**

--- a/components/ai_chat/resources/page/api/mock_interfaces.ts
+++ b/components/ai_chat/resources/page/api/mock_interfaces.ts
@@ -176,6 +176,7 @@ export function createMockService(
         },
       }),
     getConversationShares: () => Promise.resolve({ shares: [] }),
+    copyConversationShareLink: () => {},
     createSkill: () => {},
     updateSkill: () => {},
     deleteSkill: () => {},

--- a/components/ai_chat/resources/page/components/feature_button_menu/index.tsx
+++ b/components/ai_chat/resources/page/components/feature_button_menu/index.tsx
@@ -23,6 +23,7 @@ import styles from './style.module.scss'
 
 export interface Props {
   setIsConversationsListOpen?: (value: boolean) => unknown
+  manageSharedConversations: () => void
 }
 
 export default function FeatureMenu(props: Props) {
@@ -193,6 +194,21 @@ export default function FeatureMenu(props: Props) {
             </div>
           </leo-menu-item>
         </>
+      )}
+      {aiChatContext.isConversationShareEnabled && (
+        <leo-menu-item onClick={props.manageSharedConversations}>
+          <div
+            className={classnames(
+              styles.menuItemWithIcon,
+              styles.menuItemMainItem,
+            )}
+          >
+            <Icon name='message-bubble-comments' />
+            <span className={styles.menuText}>
+              {getLocale(S.CHAT_UI_MENU_MANAGE_SHARED_CONVERSATIONS)}
+            </span>
+          </div>
+        </leo-menu-item>
       )}
       {!aiChatContext.isMobile && (
         <leo-menu-item

--- a/components/ai_chat/resources/page/components/main/index.tsx
+++ b/components/ai_chat/resources/page/components/main/index.tsx
@@ -25,6 +25,7 @@ import SkillModal from '../skill_modal/skill_modal'
 import PrivacyMessage from '../privacy_message'
 import FeedbackForm from '../feedback_form'
 import ShareConversationModal from '../share_conversation_modal'
+import SharedConversationsModal from '../shared_conversations_modal'
 import ToolsMenu, {
   ExtendedActionEntry,
   getIsSkill,
@@ -43,6 +44,8 @@ function Main() {
   const [isConversationListOpen, setIsConversationsListOpen] =
     React.useState(false)
   const [isShareDialogOpen, setIsShareDialogOpen] = React.useState(false)
+  const [isSharedConversationsDialogOpen, setIsSharedConversationsDialogOpen] =
+    React.useState(false)
   const { isDragActive, isDragOver } = conversationContext
 
   const showAttachments = !!conversationContext.attachmentsDialog
@@ -187,6 +190,9 @@ function Main() {
         ref={headerElement}
         setIsConversationsListOpen={setIsConversationsListOpen}
         startSharingConversation={() => setIsShareDialogOpen(true)}
+        manageSharedConversations={() =>
+          setIsSharedConversationsDialogOpen(true)
+        }
       />
       <AlertCenter
         position='top-center'
@@ -212,6 +218,14 @@ function Main() {
         <ShareConversationModal
           isOpen={isShareDialogOpen}
           onClose={() => setIsShareDialogOpen(false)}
+        />
+      )}
+      {/* Mounted only while open so the list of shares is fetched fresh each
+      time the dialog is shown. */}
+      {isSharedConversationsDialogOpen && (
+        <SharedConversationsModal
+          isOpen
+          onClose={() => setIsSharedConversationsDialogOpen(false)}
         />
       )}
       {showAttachments && (

--- a/components/ai_chat/resources/page/components/main/index.tsx
+++ b/components/ai_chat/resources/page/components/main/index.tsx
@@ -224,7 +224,6 @@ function Main() {
       time the dialog is shown. */}
       {isSharedConversationsDialogOpen && (
         <SharedConversationsModal
-          isOpen
           onClose={() => setIsSharedConversationsDialogOpen(false)}
         />
       )}

--- a/components/ai_chat/resources/page/components/share_conversation_modal/index.tsx
+++ b/components/ai_chat/resources/page/components/share_conversation_modal/index.tsx
@@ -84,6 +84,9 @@ export default function ShareConversationModal(props: Props) {
       // button in its initial state to allow retrying.
       if (sharedConversationUrl) {
         setIsCopied(true)
+        // The browser has recorded the new share, so anything showing the list
+        // of shares needs to fetch it again.
+        aiChatContext.api.getConversationShares.invalidate()
       }
     } finally {
       setIsGenerating(false)

--- a/components/ai_chat/resources/page/components/shared_conversations_modal/index.test.tsx
+++ b/components/ai_chat/resources/page/components/shared_conversations_modal/index.test.tsx
@@ -43,10 +43,10 @@ const mockShares: Mojom.ConversationShare[] = [
   },
 ]
 
-async function renderModal(...args: Parameters<typeof render>) {
+async function renderModal(ui: React.ReactElement) {
   let result: ReturnType<typeof render>
   await act(async () => {
-    result = render(...args)
+    result = render(ui)
   })
   return result!
 }
@@ -64,10 +64,7 @@ describe('SharedConversationsModal', () => {
           getConversationShares: () => Promise.resolve({ shares: mockShares }),
         }}
       >
-        <SharedConversationsModal
-          isOpen
-          onClose={() => {}}
-        />
+        <SharedConversationsModal onClose={() => {}} />
       </MockContext>,
     )
 
@@ -95,10 +92,7 @@ describe('SharedConversationsModal', () => {
   it('shows an empty state when nothing has been shared', async () => {
     await renderModal(
       <MockContext>
-        <SharedConversationsModal
-          isOpen
-          onClose={() => {}}
-        />
+        <SharedConversationsModal onClose={() => {}} />
       </MockContext>,
     )
 
@@ -119,10 +113,7 @@ describe('SharedConversationsModal', () => {
           copyConversationShareLink,
         }}
       >
-        <SharedConversationsModal
-          isOpen
-          onClose={() => {}}
-        />
+        <SharedConversationsModal onClose={() => {}} />
       </MockContext>,
     )
 

--- a/components/ai_chat/resources/page/components/shared_conversations_modal/index.test.tsx
+++ b/components/ai_chat/resources/page/components/shared_conversations_modal/index.test.tsx
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import '$test-utils/disable_custom_elements'
+
+import * as React from 'react'
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react'
+import { clearAllDataForTesting } from '$web-common/api'
+import { MockContext } from '../../state/mock_context'
+import SharedConversationsModal from './index'
+import * as Mojom from '../../../common/mojom'
+
+const showAlert = jest.fn()
+jest.mock('@brave/leo/react/alertCenter', () => ({
+  __esModule: true,
+  default: () => null,
+  showAlert: (...args: unknown[]) => showAlert(...args),
+}))
+
+// 2026-02-03 09:15 UTC, expressed as microseconds since the Windows epoch.
+const sharedTime = {
+  internalValue:
+    BigInt(
+      Date.UTC(2026, 1, 3, 9, 15)
+        + (Date.UTC(1970, 0, 1) - Date.UTC(1601, 0, 1)),
+    ) * BigInt(1000),
+}
+
+const mockShares: Mojom.ConversationShare[] = [
+  {
+    shareId: 'share-id-1',
+    conversationUuid: 'conversation-uuid-1',
+    conversationTitle: 'How to use TypeScript',
+    createdTime: sharedTime,
+  },
+  {
+    shareId: 'share-id-2',
+    conversationUuid: 'conversation-uuid-2',
+    conversationTitle: '',
+    createdTime: sharedTime,
+  },
+]
+
+async function renderModal(...args: Parameters<typeof render>) {
+  let result: ReturnType<typeof render>
+  await act(async () => {
+    result = render(...args)
+  })
+  return result!
+}
+
+describe('SharedConversationsModal', () => {
+  beforeEach(() => {
+    clearAllDataForTesting()
+    jest.clearAllMocks()
+  })
+
+  it('lists each share with its title, time and share id', async () => {
+    await renderModal(
+      <MockContext
+        service={{
+          getConversationShares: () => Promise.resolve({ shares: mockShares }),
+        }}
+      >
+        <SharedConversationsModal
+          isOpen
+          onClose={() => {}}
+        />
+      </MockContext>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('How to use TypeScript')).toBeInTheDocument()
+    })
+    expect(screen.getByText('share-id-1')).toBeInTheDocument()
+    expect(screen.getByText('share-id-2')).toBeInTheDocument()
+    // A conversation which was never titled still needs to be identifiable.
+    expect(
+      screen.getByText('AI_CHAT_CONVERSATION_LIST_UNTITLED'),
+    ).toBeInTheDocument()
+    // Shown in the user's locale and time zone, so build the expectation the
+    // same way rather than hard-coding a formatted string.
+    const expectedTime = new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    }).format(new Date(Date.UTC(2026, 1, 3, 9, 15)))
+    expect(screen.getAllByText(expectedTime)).toHaveLength(2)
+  })
+
+  it('shows an empty state when nothing has been shared', async () => {
+    await renderModal(
+      <MockContext>
+        <SharedConversationsModal
+          isOpen
+          onClose={() => {}}
+        />
+      </MockContext>,
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('CHAT_UI_SHARED_CONVERSATIONS_DIALOG_EMPTY'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('asks the browser to copy the link, rather than copying it itself', async () => {
+    const copyConversationShareLink = jest.fn()
+
+    await renderModal(
+      <MockContext
+        service={{
+          getConversationShares: () => Promise.resolve({ shares: mockShares }),
+          copyConversationShareLink,
+        }}
+      >
+        <SharedConversationsModal
+          isOpen
+          onClose={() => {}}
+        />
+      </MockContext>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('share-id-1')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getAllByTitle(
+          'CHAT_UI_SHARED_CONVERSATIONS_COPY_LINK_BUTTON_LABEL',
+        )[0],
+      )
+    })
+
+    // Only the browser process holds the decryption key for a past share, and
+    // only it can mark the clipboard entry confidential.
+    expect(copyConversationShareLink).toHaveBeenCalledWith('share-id-1')
+  })
+})

--- a/components/ai_chat/resources/page/components/shared_conversations_modal/index.tsx
+++ b/components/ai_chat/resources/page/components/shared_conversations_modal/index.tsx
@@ -15,7 +15,6 @@ import { useAIChat } from '../../state/ai_chat_context'
 import styles from './style.module.scss'
 
 interface Props {
-  isOpen: boolean
   onClose: () => void
 }
 
@@ -52,7 +51,7 @@ export default function SharedConversationsModal(props: Props) {
 
   return (
     <Dialog
-      isOpen={props.isOpen}
+      isOpen
       showClose
       onClose={props.onClose}
       className={styles.dialog}

--- a/components/ai_chat/resources/page/components/shared_conversations_modal/index.tsx
+++ b/components/ai_chat/resources/page/components/shared_conversations_modal/index.tsx
@@ -1,0 +1,118 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+import Button from '@brave/leo/react/button'
+import Dialog from '@brave/leo/react/dialog'
+import Icon from '@brave/leo/react/icon'
+import ProgressRing from '@brave/leo/react/progressRing'
+import { showAlert } from '@brave/leo/react/alertCenter'
+import { getLocale } from '$web-common/locale'
+import { mojoTimeToJSDate } from '$web-common/mojomUtils'
+import { useAIChat } from '../../state/ai_chat_context'
+import styles from './style.module.scss'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+})
+
+const copyLinkLabel = getLocale(
+  S.CHAT_UI_SHARED_CONVERSATIONS_COPY_LINK_BUTTON_LABEL,
+)
+
+export default function SharedConversationsModal(props: Props) {
+  const aiChatContext = useAIChat()
+
+  const { getConversationSharesData: shares, isPlaceholderData: isLoading } =
+    aiChatContext.api.useGetConversationShares()
+  const handleCopyLink = (shareId: string) => {
+    // The link is copied by the browser process: it holds the conversation's
+    // decryption key, and only the browser can mark the clipboard entry as
+    // confidential.
+    aiChatContext.api.service.copyConversationShareLink(shareId)
+    showAlert({
+      type: 'info',
+      content: getLocale(
+        S.CHAT_UI_SHARE_CONVERSATION_DIALOG_LINK_COPIED_BUTTON_LABEL,
+      ),
+      actions: [],
+    })
+  }
+
+  return (
+    <Dialog
+      isOpen={props.isOpen}
+      showClose
+      onClose={props.onClose}
+      className={styles.dialog}
+    >
+      <div
+        slot='title'
+        className={styles.title}
+      >
+        {getLocale(S.CHAT_UI_MENU_MANAGE_SHARED_CONVERSATIONS)}
+      </div>
+      <div className={styles.body}>
+        <div className={styles.description}>
+          {getLocale(S.CHAT_UI_SHARED_CONVERSATIONS_DIALOG_DESCRIPTION)}
+        </div>
+        {isLoading ? (
+          <div className={styles.placeholder}>
+            <ProgressRing />
+          </div>
+        ) : shares.length === 0 ? (
+          <div className={styles.placeholder}>
+            {getLocale(S.CHAT_UI_SHARED_CONVERSATIONS_DIALOG_EMPTY)}
+          </div>
+        ) : (
+          <ul className={styles.list}>
+            {shares.map((share) => (
+              <li
+                key={share.shareId}
+                className={styles.share}
+              >
+                <div className={styles.shareDetails}>
+                  <div className={styles.shareTitle}>
+                    {share.conversationTitle
+                      || getLocale(S.AI_CHAT_CONVERSATION_LIST_UNTITLED)}
+                  </div>
+                  <div className={styles.shareMeta}>
+                    <span>
+                      {dateTimeFormatter.format(
+                        mojoTimeToJSDate(share.createdTime),
+                      )}
+                    </span>
+                    <span className={styles.shareId}>{share.shareId}</span>
+                  </div>
+                </div>
+                <div className={styles.shareActions}>
+                  <Button
+                    fab
+                    kind='plain-faint'
+                    size='small'
+                    title={copyLinkLabel}
+                    aria-label={copyLinkLabel}
+                    onClick={() => handleCopyLink(share.shareId)}
+                  >
+                    <Icon name='copy' />
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </Dialog>
+  )
+}

--- a/components/ai_chat/resources/page/components/shared_conversations_modal/style.module.scss
+++ b/components/ai_chat/resources/page/components/shared_conversations_modal/style.module.scss
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at https://mozilla.org/MPL/2.0/.
+
+.dialog {
+  --leo-dialog-padding: var(--leo-spacing-2xl);
+  --leo-dialog-width: 480px;
+}
+
+.title {
+  font: var(--leo-font-heading-h3);
+  color: var(--leo-color-text-primary);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--leo-spacing-xl);
+}
+
+.description {
+  font: var(--leo-font-default-regular);
+  color: var(--leo-color-text-secondary);
+}
+
+.placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--leo-spacing-2xl);
+  font: var(--leo-font-default-regular);
+  color: var(--leo-color-text-secondary);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--leo-spacing-m);
+  // Long lists shouldn't push the dialog past the viewport.
+  max-height: 320px;
+  overflow-y: auto;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.share {
+  display: flex;
+  align-items: center;
+  gap: var(--leo-spacing-m);
+  padding: var(--leo-spacing-l) var(--leo-spacing-xl);
+  border-radius: var(--leo-radius-xl);
+  border: 1px solid var(--leo-color-divider-subtle);
+}
+
+.shareDetails {
+  display: flex;
+  flex-direction: column;
+  gap: var(--leo-spacing-xs);
+  // Allows the title to ellipsize rather than widen the row.
+  min-width: 0;
+  flex: 1;
+}
+
+.shareTitle {
+  font: var(--leo-font-default-semibold);
+  color: var(--leo-color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.shareMeta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--leo-spacing-s);
+  font: var(--leo-font-small-regular);
+  color: var(--leo-color-text-secondary);
+}
+
+.shareId {
+  // De-emphasized: only useful for matching a record with a link that has
+  // already been sent to someone.
+  color: var(--leo-color-text-tertiary);
+  word-break: break-all;
+}
+
+.shareActions {
+  display: flex;
+  align-items: center;
+  gap: var(--leo-spacing-xs);
+}

--- a/components/ai_chat/resources/page/stories/components_panel.tsx
+++ b/components/ai_chat/resources/page/stories/components_panel.tsx
@@ -234,6 +234,32 @@ const SAMPLE_SKILLS: Mojom.Skill[] = [
   },
 ]
 
+// base::Time counts microseconds from the Windows epoch, so shift the JS epoch
+// by the same offset used by mojoTimeToJSDate().
+function jsDateToMojoTime(date: Date) {
+  const epochDeltaInMs = Date.UTC(1970, 0, 1) - Date.UTC(1601, 0, 1)
+  // Convert to BigInt before scaling to microseconds: the result exceeds
+  // Number.MAX_SAFE_INTEGER.
+  return {
+    internalValue: BigInt(date.getTime() + epochDeltaInMs) * BigInt(1000),
+  }
+}
+
+const SAMPLE_CONVERSATION_SHARES: Mojom.ConversationShare[] = [
+  {
+    shareId: 'a1b2c3d4e5f6',
+    conversationUuid: '1',
+    conversationTitle: 'What is the best way to make a cup of tea?',
+    createdTime: jsDateToMojoTime(new Date(Date.now() - 3600000)),
+  },
+  {
+    shareId: 'f6e5d4c3b2a1',
+    conversationUuid: '2',
+    conversationTitle: 'Summarize the latest news about space exploration',
+    createdTime: jsDateToMojoTime(new Date(Date.now() - 3 * 86400000)),
+  },
+]
+
 const SAMPLE_TABS: Mojom.TabData[] = [
   {
     id: 1,
@@ -573,6 +599,8 @@ function StoryContext(
               : Mojom.PremiumStatus.Inactive,
             info: null,
           }),
+        getConversationShares: () =>
+          Promise.resolve({ shares: SAMPLE_CONVERSATION_SHARES }),
       }}
       bookmarksService={{
         getBookmarks: () => Promise.resolve({ bookmarks: SAMPLE_BOOKMARKS }),

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -426,7 +426,7 @@
   <message name="IDS_CHAT_UI_SHARE_CONVERSATION_DIALOG_GENERATE_LINK_BUTTON_LABEL" desc="A label for the button which generates and copies a shareable link for the current conversation" formatter_data="webui=AiChat">
     Generate link
   </message>
-  <message name="IDS_CHAT_UI_SHARE_CONVERSATION_DIALOG_LINK_COPIED_BUTTON_LABEL" desc="A label shown on the share button after the shareable link has been copied to the clipboard" formatter_data="webui=AiChat">
+  <message name="IDS_CHAT_UI_SHARE_CONVERSATION_DIALOG_LINK_COPIED_BUTTON_LABEL" desc="Confirmation that the shareable link has been copied to the clipboard. Shown as a label on the share button, and as a notification when a link is copied from the list of shared conversations" formatter_data="webui=AiChat">
     Link copied to clipboard
   </message>
   <message name="IDS_CHAT_UI_MENU_MANAGE_SHARED_CONVERSATIONS" desc="Menu entry which opens a dialog listing the conversations the user has shared" formatter_data="webui=AiChat">

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -429,6 +429,18 @@
   <message name="IDS_CHAT_UI_SHARE_CONVERSATION_DIALOG_LINK_COPIED_BUTTON_LABEL" desc="A label shown on the share button after the shareable link has been copied to the clipboard" formatter_data="webui=AiChat">
     Link copied to clipboard
   </message>
+  <message name="IDS_CHAT_UI_MENU_MANAGE_SHARED_CONVERSATIONS" desc="Menu entry which opens a dialog listing the conversations the user has shared" formatter_data="webui=AiChat">
+    Manage shared conversations
+  </message>
+  <message name="IDS_CHAT_UI_SHARED_CONVERSATIONS_DIALOG_DESCRIPTION" desc="Explanatory text at the top of the dialog listing the conversations the user has shared" formatter_data="webui=AiChat">
+    Anyone with the link can view these conversations until they expire.
+  </message>
+  <message name="IDS_CHAT_UI_SHARED_CONVERSATIONS_DIALOG_EMPTY" desc="Text shown in the shared conversations dialog when the user has not shared any conversations" formatter_data="webui=AiChat">
+    You haven't shared any conversations.
+  </message>
+  <message name="IDS_CHAT_UI_SHARED_CONVERSATIONS_COPY_LINK_BUTTON_LABEL" desc="A label for the button which copies the link to a shared conversation" formatter_data="webui=AiChat">
+    Copy link
+  </message>
   <message name="IDS_CHAT_UI_MENU_RENAME_CONVERSATION" desc="Menu entry for renaming a conversation" formatter_data="webui=AiChat">
     Rename conversation
   </message>


### PR DESCRIPTION
Once a conversation had been shared there was no way to see what had been shared or to get the link again short of re-uploading the conversation.

Add a "Manage shared conversations" item to the conversation menu, opening a dialog which lists each share with the conversation's title, when it was shared, and its share id. The id is de-emphasized: it is only useful for matching an entry against a link already sent to someone.

Copying a link goes through the browser rather than the renderer. The link embeds the conversation's decryption key, so only the browser holds it, and only the browser can mark the clipboard entry confidential - the same treatment the link gets when the share is first created.

The dialog is mounted only while open so the list is fetched fresh each time.

<!-- Add brave-browser issue below that this PR will resolve -->
- Series https://github.com/brave/brave-browser/issues/58054

<img width="636" height="644" alt="image" src="https://github.com/user-attachments/assets/c2e0efa3-ab45-4936-ab38-5f1237d89d32" />

<img width="1048" height="738" alt="image" src="https://github.com/user-attachments/assets/b93cd988-e792-48f6-9ccf-5360eb5cb910" />
