### PR TITLE
[Android] Enable fresh NTP after idle by default

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveFreshNtpHelper.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveFreshNtpHelper.java
@@ -24,7 +24,7 @@ public class BraveFreshNtpHelper {
             new CachedFlag(
                     ChromeFeatureMap.getInstance(),
                     BraveFeatureList.BRAVE_FRESH_NTP_AFTER_IDLE_EXPERIMENT,
-                    false);
+                    true);
 
     // Cached variant parameter for fresh NTP experiment - safe to access before native is ready.
     public static final StringCachedFeatureParam sBraveFreshNtpAfterIdleExperimentVariant =
@@ -32,7 +32,7 @@ public class BraveFreshNtpHelper {
                     ChromeFeatureMap.getInstance(),
                     BraveFeatureList.BRAVE_FRESH_NTP_AFTER_IDLE_EXPERIMENT,
                     "variant",
-                    "A");
+                    "B");
 
     /**
      * @return Whether the fresh NTP after idle expiration feature is enabled. This uses a cached
@@ -43,9 +43,8 @@ public class BraveFreshNtpHelper {
     }
 
     /**
-     * Gets the variant of the fresh NTP experiment (e.g., "A", "B", "C"). Returns empty string if
-     * no variant is set. This uses a cached param, so it's safe to call even before native is
-     * ready.
+     * Gets the variant of the fresh NTP experiment: "B" (the default) or "A" for the study's
+     * control arm. This uses a cached param, so it's safe to call even before native is ready.
      *
      * @return The variant string.
      */

--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -126,8 +126,6 @@ public class BraveNewTabPageLayout extends NewTabPageLayout
 
     private @Nullable FetchWallpaperWorkerTask mWorkerTask;
     private boolean mIsFromBottomSheet;
-    // Whether to show sponsored image on NTP based on experiment variant
-    private boolean mShouldShowSponsoredImage;
     private @Nullable NTPBackgroundImagesBridge mNTPBackgroundImagesBridge;
 
     private @Nullable Tab mTab;
@@ -165,10 +163,6 @@ public class BraveNewTabPageLayout extends NewTabPageLayout
 
     public BraveNewTabPageLayout(Context context, AttributeSet attrs) {
         super(context, attrs);
-
-        // Default to show sponsored image on NTP
-        // This will be overridden in onAttachedToWindow if the experiment variant is D
-        mShouldShowSponsoredImage = true;
     }
 
     protected void updateTileGridPlaceholderVisibility() {
@@ -236,7 +230,6 @@ public class BraveNewTabPageLayout extends NewTabPageLayout
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
 
-        mShouldShowSponsoredImage = shouldShowSponsoredImage();
         if (mSponsoredTab == null) {
             initilizeSponsoredTab();
         }
@@ -446,7 +439,7 @@ public class BraveNewTabPageLayout extends NewTabPageLayout
                                     ChromeSharedPreferences.getInstance()
                                             .writeInt(
                                                     BravePreferenceKeys
-                                                                    .BRAVE_RECYCLERVIEW_OFFSET_POSITION
+                                                                    .BRAVE_RECYCLERVIEW_OFFSET_POSITION // presubmit: ignore-long-line
                                                             + tabId,
                                                     verticalOffset);
 
@@ -613,7 +606,7 @@ public class BraveNewTabPageLayout extends NewTabPageLayout
                                                     ChromeSharedPreferences.getInstance()
                                                             .readInt(
                                                                     BravePreferenceKeys
-                                                                                    .BRAVE_RECYCLERVIEW_OFFSET_POSITION
+                                                                                    .BRAVE_RECYCLERVIEW_OFFSET_POSITION // presubmit: ignore-long-line
                                                                             + tab.getId(),
                                                                     0);
 
@@ -1165,22 +1158,10 @@ public class BraveNewTabPageLayout extends NewTabPageLayout
         observer.addOnGlobalLayoutListener(mBgImageViewOnGlobalLayoutListener);
     }
 
-    // Determine if the sponsored image should be shown on NTP based on experiment variant
-    private boolean shouldShowSponsoredImage() {
-        if (!BraveFreshNtpHelper.isEnabled()) {
-            return true;
-        }
-        boolean shouldShowSnackbar =
-                ChromeSharedPreferences.getInstance()
-                        .readBoolean(BravePreferenceKeys.BRAVE_SHOW_RECENT_TABS_SNACKBAR, false);
-        String variant = BraveFreshNtpHelper.getVariant();
-        return variant == null || !variant.equals("D") || !shouldShowSnackbar;
-    }
-
     private void getAndShowNTPImage() {
         assertNonNull(mSponsoredTab);
         mSponsoredTab.getNTPImage(
-                mShouldShowSponsoredImage,
+                /* allowSponsoredImage= */ true,
                 ntpImage -> {
                     if (mActivity == null || mActivity.isFinishing() || mActivity.isDestroyed()) {
                         return;
@@ -1193,7 +1174,7 @@ public class BraveNewTabPageLayout extends NewTabPageLayout
     private void initilizeSponsoredTab() {
         if (TabAttributes.from(getTab()).get(String.valueOf(getTab().getId())) == null) {
             SponsoredTab sponsoredTab =
-                    new SponsoredTab(mNTPBackgroundImagesBridge, mShouldShowSponsoredImage);
+                    new SponsoredTab(mNTPBackgroundImagesBridge, /* allowSponsoredImage= */ true);
             TabAttributes.from(getTab()).set(String.valueOf(getTab().getId()), sponsoredTab);
         }
         mSponsoredTab = TabAttributes.from(getTab()).get(String.valueOf(getTab().getId()));
@@ -1268,19 +1249,12 @@ public class BraveNewTabPageLayout extends NewTabPageLayout
     }
 
     /**
-     * Shows the recent tabs snackbar if variant B, C, or D is active, and either OPTION_NEW_TAB or
+     * Shows the recent tabs snackbar if variant B is active, and either OPTION_NEW_TAB or
      * OPTION_NEW_TAB_AFTER_INACTIVITY is selected. For OPTION_NEW_TAB_AFTER_INACTIVITY, only shows
      * when app was returned from background after inactivity threshold.
      */
     private void maybeShowRecentTabsDialog() {
-        // Check if feature is enabled and variant is B, C, or D
-        if (!BraveFreshNtpHelper.isEnabled()) {
-            return;
-        }
-
-        String variant = BraveFreshNtpHelper.getVariant();
-        if (variant == null
-                || (!variant.equals("B") && !variant.equals("C") && !variant.equals("D"))) {
+        if (!BraveFreshNtpHelper.isEnabled() || !BraveFreshNtpHelper.getVariant().equals("B")) {
             return;
         }
 

--- a/android/java/org/chromium/chrome/browser/settings/BraveRadioButtonGroupOpeningScreenPreference.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveRadioButtonGroupOpeningScreenPreference.java
@@ -16,7 +16,6 @@ import org.chromium.base.BravePreferenceKeys;
 import org.chromium.build.annotations.NullMarked;
 import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.R;
-import org.chromium.chrome.browser.ntp.BraveFreshNtpHelper;
 import org.chromium.components.browser_ui.widget.RadioButtonWithDescription;
 import org.chromium.components.browser_ui.widget.RadioButtonWithDescriptionLayout;
 
@@ -27,9 +26,9 @@ public class BraveRadioButtonGroupOpeningScreenPreference extends Preference
         implements RadioGroup.OnCheckedChangeListener {
     private static final int OPTIONS_SIZE = 3;
 
-    // Inactivity hours by variant
-    private static final int INACTIVITY_HOURS_VARIANT_B_D = 1;
-    private static final int INACTIVITY_HOURS_VARIANT_C = 2;
+    // Inactivity threshold shown in the option label, matching
+    // BraveReturnToChromeUtil.INACTIVITY_THRESHOLD_MS.
+    private static final int INACTIVITY_HOURS = 1;
 
     private int mSetting;
     @Nullable private RadioButtonWithDescription mSettingRadioButton;
@@ -77,24 +76,17 @@ public class BraveRadioButtonGroupOpeningScreenPreference extends Preference
                 (RadioButtonWithDescription)
                         holder.findViewById(R.id.new_opening_screen_new_tab_radio_button));
 
-        // Set dynamic text for inactivity option based on variant
         RadioButtonWithDescription inactivityButton =
                 mButtons.get(
                         BravePreferenceKeys.BRAVE_OPENING_SCREEN_OPTION_NEW_TAB_AFTER_INACTIVITY);
         if (inactivityButton != null) {
-            String variant = BraveFreshNtpHelper.getVariant();
-            int hours = INACTIVITY_HOURS_VARIANT_B_D; // Default for variants B and D
-            if (variant != null && variant.equals("C")) {
-                hours = INACTIVITY_HOURS_VARIANT_C;
-            }
-            String hoursText =
+            inactivityButton.setPrimaryText(
                     getContext()
                             .getResources()
                             .getQuantityString(
                                     R.plurals.opening_screen_new_tab_after_inactivity,
-                                    hours,
-                                    hours);
-            inactivityButton.setPrimaryText(hoursText);
+                                    INACTIVITY_HOURS,
+                                    INACTIVITY_HOURS));
         }
 
         mSettingRadioButton = mButtons.get(mSetting);

--- a/android/java/org/chromium/chrome/browser/tasks/BraveReturnToChromeUtil.java
+++ b/android/java/org/chromium/chrome/browser/tasks/BraveReturnToChromeUtil.java
@@ -28,10 +28,8 @@ import org.chromium.url.GURL;
 @NullMarked
 public final class BraveReturnToChromeUtil {
 
-    // Inactivity threshold for variants B and D: 1 hour in milliseconds
-    private static final long INACTIVITY_THRESHOLD_MS_VARIANT_B_D = 60 * 60 * 1000L; // 1 hour
-    // Inactivity threshold for variant C: 2 hours in milliseconds
-    private static final long INACTIVITY_THRESHOLD_MS_VARIANT_C = 2 * 60 * 60 * 1000L; // 2 hours
+    // Inactivity threshold for variant B: 1 hour in milliseconds
+    private static final long INACTIVITY_THRESHOLD_MS = 60 * 60 * 1000L; // 1 hour
 
     /** Returns whether should show a NTP as the home surface at startup. */
     public static boolean shouldShowNtpAsHomeSurfaceAtStartup(
@@ -47,29 +45,12 @@ public final class BraveReturnToChromeUtil {
             return false;
         }
 
-        String variant = BraveFreshNtpHelper.getVariant();
-        boolean shouldShow = false;
-        switch (variant) {
-            case "A":
-                // Variant A: Brave's default behavior (no NTP at startup)
-                shouldShow = false;
-                break;
-            case "B":
-            case "D":
-                // Variants B and D: Show NTP if app has been backgrounded for ≥ 1 hour
-                // and OPTION_NEW_TAB_AFTER_INACTIVITY is selected
-                shouldShow =
-                        shouldShowNtpForInactivityVariant(
-                                inactivityTracker, INACTIVITY_THRESHOLD_MS_VARIANT_B_D);
-                break;
-            case "C":
-                // Variant C: Show NTP if app has been backgrounded for ≥ 2 hours
-                // and OPTION_NEW_TAB_AFTER_INACTIVITY is selected
-                shouldShow =
-                        shouldShowNtpForInactivityVariant(
-                                inactivityTracker, INACTIVITY_THRESHOLD_MS_VARIANT_C);
-                break;
-        }
+        // Variant B, the default, shows the NTP if the app has been backgrounded for ≥ 1 hour and
+        // OPTION_NEW_TAB_AFTER_INACTIVITY is selected. Variant A is the study's control arm and
+        // keeps the pre-experiment behavior of restoring the last open tab.
+        boolean shouldShow =
+                BraveFreshNtpHelper.getVariant().equals("B")
+                        && shouldShowNtpForInactivity(inactivityTracker);
 
         // Set flag only when shouldShowNtpAsHomeSurfaceAtStartup returns true
         // This ensures maybeShowRecentTabsDialog only executes when this method was called
@@ -85,11 +66,9 @@ public final class BraveReturnToChromeUtil {
      * Checks if NTP should be shown based on inactivity duration and preference.
      *
      * @param inactivityTracker The inactivity tracker to check background time
-     * @param inactivityThresholdMs The inactivity threshold in milliseconds
      * @return true if NTP should be shown, false otherwise
      */
-    private static boolean shouldShowNtpForInactivityVariant(
-            ChromeInactivityTracker inactivityTracker, long inactivityThresholdMs) {
+    private static boolean shouldShowNtpForInactivity(ChromeInactivityTracker inactivityTracker) {
         // Check opening screen option first
         int openingScreenOption =
                 ChromeSharedPreferences.getInstance()
@@ -123,7 +102,8 @@ public final class BraveReturnToChromeUtil {
         // playing in the background — background playback means the user is not truly idle.
         long timeSinceLastBackgroundedMs = inactivityTracker.getTimeSinceLastBackgroundedMs();
 
-        return timeSinceLastBackgroundedMs >= inactivityThresholdMs && !isBackgroundMediaPlaying();
+        return timeSinceLastBackgroundedMs >= INACTIVITY_THRESHOLD_MS
+                && !isBackgroundMediaPlaying();
     }
 
     /**

--- a/android/javatests/org/chromium/chrome/browser/settings/BackgroundImagesPreferencesTest.java
+++ b/android/javatests/org/chromium/chrome/browser/settings/BackgroundImagesPreferencesTest.java
@@ -91,10 +91,10 @@ public class BackgroundImagesPreferencesTest {
     }
 
     // Test for Opening Screen preference when feature is enabled but variant is "A".
-    // The preference should not be shown when variant is "A" (the default).
+    // The preference should not be shown when variant is "A".
     @Test
     @SmallTest
-    @EnableFeatures(BraveFeatureList.BRAVE_FRESH_NTP_AFTER_IDLE_EXPERIMENT)
+    @EnableFeatures(BraveFeatureList.BRAVE_FRESH_NTP_AFTER_IDLE_EXPERIMENT + ":variant/A")
     public void testOpeningScreenPrefNotShownWhenFeatureEnabledButVariantIsA() {
         Assert.assertTrue(
                 "BraveFreshNtpAfterIdleExperiment feature should be enabled",
@@ -105,7 +105,7 @@ public class BackgroundImagesPreferencesTest {
         // Wait for async preference updates to complete
         // Note: We check getPreferenceScreen().findPreference() directly because
         // BravePreferenceFragment.findPreference() may also return removed preferences
-        // The preference should be removed when variant is "A" (default) even if feature is enabled
+        // The preference should be removed when variant is "A" even if feature is enabled
         CriteriaHelper.pollUiThread(
                 () -> {
                     return mBackgroundImagesPreferences
@@ -113,7 +113,7 @@ public class BackgroundImagesPreferencesTest {
                                     .findPreference(PREF_OPENING_SCREEN_CATEGORY)
                             == null;
                 },
-                "Preference category should be removed when variant is A (default)",
+                "Preference category should be removed when variant is A",
                 5000L,
                 100L);
 
@@ -123,7 +123,7 @@ public class BackgroundImagesPreferencesTest {
                                 .getPreferenceScreen()
                                 .findPreference(PREF_OPENING_SCREEN_CATEGORY);
         assertNull(
-                "PREF_OPENING_SCREEN_CATEGORY should not be shown when variant is A (default)",
+                "PREF_OPENING_SCREEN_CATEGORY should not be shown when variant is A",
                 openingScreenCategory);
 
         // Also verify the preference itself is not accessible
@@ -131,9 +131,7 @@ public class BackgroundImagesPreferencesTest {
                 mBackgroundImagesPreferences
                         .getPreferenceScreen()
                         .findPreference(PREF_OPENING_SCREEN);
-        assertNull(
-                "PREF_OPENING_SCREEN should not be shown when variant is A (default)",
-                openingScreenPref);
+        assertNull("PREF_OPENING_SCREEN should not be shown when variant is A", openingScreenPref);
     }
 
     // Test for Opening Screen preference when feature is enabled and variant is "B".
@@ -180,100 +178,6 @@ public class BackgroundImagesPreferencesTest {
                         .findPreference(PREF_OPENING_SCREEN);
         assertNotNull(
                 "PREF_OPENING_SCREEN should be shown when feature is enabled and variant is B",
-                openingScreenPref);
-    }
-
-    // Test for Opening Screen preference when feature is enabled and variant is "C".
-    // The preference should be shown when variant is not "A".
-    @Test
-    @SmallTest
-    @EnableFeatures(BraveFeatureList.BRAVE_FRESH_NTP_AFTER_IDLE_EXPERIMENT + ":variant/C")
-    public void testOpeningScreenPrefShownWhenFeatureEnabledAndVariantIsC() {
-        Assert.assertTrue(
-                "BraveFreshNtpAfterIdleExperiment feature should be enabled",
-                ChromeFeatureList.isEnabled(
-                        BraveFeatureList.BRAVE_FRESH_NTP_AFTER_IDLE_EXPERIMENT));
-        startSettings();
-
-        // Wait for async preference updates to complete
-        // Note: We check getPreferenceScreen().findPreference() directly because
-        // BravePreferenceFragment.findPreference() may also return removed preferences
-        // The preference should be present when variant is not "A" and feature is enabled
-        CriteriaHelper.pollUiThread(
-                () -> {
-                    return mBackgroundImagesPreferences
-                                    .getPreferenceScreen()
-                                    .findPreference(PREF_OPENING_SCREEN_CATEGORY)
-                            != null;
-                },
-                "Preference category should be present when feature is enabled and variant is C",
-                5000L,
-                100L);
-
-        PreferenceCategory openingScreenCategory =
-                (PreferenceCategory)
-                        mBackgroundImagesPreferences
-                                .getPreferenceScreen()
-                                .findPreference(PREF_OPENING_SCREEN_CATEGORY);
-        assertNotNull(
-                "PREF_OPENING_SCREEN_CATEGORY should be shown when feature is enabled and variant"
-                        + " is C",
-                openingScreenCategory);
-
-        // Also verify the preference itself is accessible
-        Preference openingScreenPref =
-                mBackgroundImagesPreferences
-                        .getPreferenceScreen()
-                        .findPreference(PREF_OPENING_SCREEN);
-        assertNotNull(
-                "PREF_OPENING_SCREEN should be shown when feature is enabled and variant is C",
-                openingScreenPref);
-    }
-
-    // Test for Opening Screen preference when feature is enabled and variant is "D".
-    // The preference should be shown when variant is not "A".
-    @Test
-    @SmallTest
-    @EnableFeatures(BraveFeatureList.BRAVE_FRESH_NTP_AFTER_IDLE_EXPERIMENT + ":variant/D")
-    public void testOpeningScreenPrefShownWhenFeatureEnabledAndVariantIsD() {
-        Assert.assertTrue(
-                "BraveFreshNtpAfterIdleExperiment feature should be enabled",
-                ChromeFeatureList.isEnabled(
-                        BraveFeatureList.BRAVE_FRESH_NTP_AFTER_IDLE_EXPERIMENT));
-        startSettings();
-
-        // Wait for async preference updates to complete
-        // Note: We check getPreferenceScreen().findPreference() directly because
-        // BravePreferenceFragment.findPreference() may also return removed preferences
-        // The preference should be present when variant is not "A" and feature is enabled
-        CriteriaHelper.pollUiThread(
-                () -> {
-                    return mBackgroundImagesPreferences
-                                    .getPreferenceScreen()
-                                    .findPreference(PREF_OPENING_SCREEN_CATEGORY)
-                            != null;
-                },
-                "Preference category should be present when feature is enabled and variant is D",
-                5000L,
-                100L);
-
-        PreferenceCategory openingScreenCategory =
-                (PreferenceCategory)
-                        mBackgroundImagesPreferences
-                                .getPreferenceScreen()
-                                .findPreference(PREF_OPENING_SCREEN_CATEGORY);
-        assertNotNull(
-                "PREF_OPENING_SCREEN_CATEGORY should be shown when feature is enabled and variant"
-                        + " is D",
-                openingScreenCategory);
-
-        // Also verify the preference itself is accessible
-        Preference openingScreenPref =
-                mBackgroundImagesPreferences
-                        .getPreferenceScreen()
-                        .findPreference(PREF_OPENING_SCREEN);
-        assertNotNull(
-                "PREF_OPENING_SCREEN should be shown when feature is enabled and variant is D",
                 openingScreenPref);
     }
 

--- a/browser/brave_browser_features.cc
+++ b/browser/brave_browser_features.cc
@@ -69,7 +69,7 @@ BASE_FEATURE(kBraveAndroidDynamicColors,
 // This feature allows showing a refreshed NTP when the app has been idle
 // for a specified duration.
 BASE_FEATURE(kBraveFreshNtpAfterIdleExperiment,
-             base::FEATURE_DISABLED_BY_DEFAULT);
+             base::FEATURE_ENABLED_BY_DEFAULT);
 
 // Enable custom search engines on Android, allowing users to add, edit, and
 // remove their own search engine entries from the search engine settings.
@@ -86,11 +86,12 @@ const base::FeatureParam<std::string> kBraveDayZeroExperimentVariant{
     /*default_value=*/""};
 
 #if BUILDFLAG(IS_ANDROID)
-// The variant of the fresh NTP experiment. i.e. A, B, C, etc.
+// The variant of the fresh NTP experiment: B (the default) or A for the control
+// arm.
 const base::FeatureParam<std::string> kBraveFreshNtpAfterIdleExperimentVariant{
     &kBraveFreshNtpAfterIdleExperiment,
     /*name=*/"variant",
-    /*default_value=*/"A"};
+    /*default_value=*/"B"};
 #endif  // BUILDFLAG(IS_ANDROID)
 
 }  // namespace features


### PR DESCRIPTION
Variant B has been running at 100% on release via BraveDayZeroStudyAndroid, so make it the code default. The feature flag is kept as a kill switch so Griffin can still disable this in the field.

Also removes the variant C and D codepaths, which no study ever used.

Resolves: https://github.com/brave/brave-browser/issues/58056


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
