### PR TITLE
Run LiteRT embeddings at upstream's per-priority thread count

### DIFF
--- a/chromium_src/services/passage_embeddings/passage_embedder_impl.cc
+++ b/chromium_src/services/passage_embeddings/passage_embedder_impl.cc
@@ -5,6 +5,8 @@
 
 #include <memory>
 
+#include "services/passage_embeddings/public/mojom/passage_embeddings.mojom.h"
+
 namespace base {
 class File;
 }  // namespace base
@@ -15,26 +17,60 @@ class PassageEmbedderExecutor;
 
 namespace brave_history_embeddings {
 
+namespace {
+
+// Resolves the thread count the way upstream's BuildExecutionTask does, so the
+// LiteRT runner only ever sees a count rather than a passage priority.
+int NumThreadsForPriority(passage_embeddings::mojom::PassagePriority priority,
+                          int user_initiated_num_threads,
+                          int urgent_num_threads,
+                          int passive_num_threads) {
+  switch (priority) {
+    case passage_embeddings::mojom::PassagePriority::kUserInitiated:
+      return user_initiated_num_threads;
+    case passage_embeddings::mojom::PassagePriority::kUrgent:
+      return urgent_num_threads;
+    case passage_embeddings::mojom::PassagePriority::kPassive:
+      return passive_num_threads;
+    case passage_embeddings::mojom::PassagePriority::kUnknown:
+      // BuildExecutionTask CHECKs against this; the case keeps the switch
+      // exhaustive.
+      return 1;
+  }
+}
+
+}  // namespace
+
 // Implemented in //brave/services/passage_embeddings:chromium_impl. Returns
 // null when the LiteRT model is unavailable, or when local AI is disabled.
 std::unique_ptr<passage_embeddings::PassageEmbedderExecutor>
 MaybeCreateLitertExecutor(base::File& embeddings_model_file,
                           int bos_id,
                           int eos_id,
-                          int pad_id);
+                          int pad_id,
+                          int num_threads);
 
 }  // namespace brave_history_embeddings
 
 // Injected at the top of PassageEmbedderImpl::BuildExecutionTask so
 // EmbeddingGemma runs through LiteRT's CompiledModel, falling through to the
-// upstream tflite executor otherwise.
-#define BRAVE_PASSAGE_EMBEDDER_IMPL_BUILD_EXECUTION_TASK           \
-  if (std::unique_ptr<PassageEmbedderExecutor> executor =          \
-          brave_history_embeddings::MaybeCreateLitertExecutor(     \
-              embeddings_model_file_, sp_processor_->bos_id(),     \
-              sp_processor_->eos_id(), sp_processor_->pad_id())) { \
-    executor_ = std::move(executor);                               \
-    return true;                                                   \
+// upstream tflite executor otherwise. Returning here skips the thread count
+// upstream applies via InitInterpreter below, so it is resolved here and passed
+// to the runner, which compiles the model with it.
+//
+// The patch must keep this after executor_.reset(): the executor being replaced
+// borrows the cached runner that MaybeCreateLitertExecutor may free.
+#define BRAVE_PASSAGE_EMBEDDER_IMPL_BUILD_EXECUTION_TASK                   \
+  if (std::unique_ptr<PassageEmbedderExecutor> executor =                  \
+          brave_history_embeddings::MaybeCreateLitertExecutor(             \
+              embeddings_model_file_, sp_processor_->bos_id(),             \
+              sp_processor_->eos_id(), sp_processor_->pad_id(),            \
+              brave_history_embeddings::NumThreadsForPriority(             \
+                  current_priority_, user_initiated_priority_num_threads_, \
+                  urgent_priority_num_threads_,                            \
+                  passive_priority_num_threads_))) {                       \
+    executor_ = std::move(executor);                                       \
+    return true;                                                           \
   }
 
 #include <services/passage_embeddings/passage_embedder_impl.cc>

--- a/services/passage_embeddings/litert_executor.cc
+++ b/services/passage_embeddings/litert_executor.cc
@@ -43,8 +43,8 @@ class LitertExecutor : public passage_embeddings::PassageEmbedderExecutor {
   }
 
  private:
-  // The process-global runner cached in MaybeCreateLitertExecutor(); outlives
-  // this executor, so a ref is safe.
+  // The process-global runner cached in MaybeCreateLitertExecutor(), which is
+  // only replaced while no executor holds it, so a ref is safe.
   const raw_ref<LitertModelRunner> runner_;
   const int bos_id_;
   const int eos_id_;
@@ -57,17 +57,32 @@ std::unique_ptr<passage_embeddings::PassageEmbedderExecutor>
 MaybeCreateLitertExecutor(base::File& embeddings_model_file,
                           int bos_id,
                           int eos_id,
-                          int pad_id) {
-  // Building a runner compiles the model, and PassageEmbedderImpl rebuilds its
-  // executor on every priority change, so cache one runner per process and hand
-  // out lightweight executors that borrow it. All calls arrive on the service's
-  // single task-runner sequence, so the lazy init needs no locking.
-  static base::NoDestructor<std::unique_ptr<LitertModelRunner>> runner(
-      LitertModelRunner::CreateFromFile(embeddings_model_file));
-  if (!runner->get()) {
+                          int pad_id,
+                          int num_threads) {
+  // Upstream rebuilds its executor on every priority change, and LiteRT bakes
+  // the thread count into the compiled model, so cache one runner and let
+  // executors borrow it, replacing it when the count changes. Replacing cannot
+  // strand a live borrow, because PassageEmbedderImpl drops its executor before
+  // calling this. Only the service's task runner sequence gets here, so the
+  // cache needs no locking.
+  struct CachedRunner {
+    std::unique_ptr<LitertModelRunner> runner;
+    int num_threads = 0;
+  };
+  static base::NoDestructor<CachedRunner> cached;
+  if (!cached->runner || cached->num_threads != num_threads) {
+    // A compiled model holds XNNPACK's repacked copy of the weights. Assigning
+    // would keep the old one alive while the replacement compiles, so free it
+    // first.
+    cached->runner.reset();
+    cached->runner =
+        LitertModelRunner::CreateFromFile(embeddings_model_file, num_threads);
+    cached->num_threads = num_threads;
+  }
+  if (!cached->runner) {
     return nullptr;
   }
-  return std::make_unique<LitertExecutor>(*runner->get(), bos_id, eos_id,
+  return std::make_unique<LitertExecutor>(*cached->runner, bos_id, eos_id,
                                           pad_id);
 }
 

--- a/services/passage_embeddings/litert_executor_stub.cc
+++ b/services/passage_embeddings/litert_executor_stub.cc
@@ -13,7 +13,7 @@ namespace brave_history_embeddings {
 // Null implementation for builds without local AI (Android, Brave Origin). The
 // override calls the hook unconditionally, so a definition must always link.
 std::unique_ptr<passage_embeddings::PassageEmbedderExecutor>
-MaybeCreateLitertExecutor(base::File&, int, int, int) {
+MaybeCreateLitertExecutor(base::File&, int, int, int, int) {
   return nullptr;
 }
 

--- a/services/passage_embeddings/litert_model_runner.cc
+++ b/services/passage_embeddings/litert_model_runner.cc
@@ -18,6 +18,7 @@
 #include "third_party/litert/src/litert/cc/litert_options.h"
 #include "third_party/litert/src/litert/cc/litert_ranked_tensor_type.h"
 #include "third_party/litert/src/litert/cc/litert_tensor_buffer.h"
+#include "third_party/litert/src/litert/cc/options/litert_cpu_options.h"
 
 namespace brave_history_embeddings {
 
@@ -27,9 +28,10 @@ LitertModelRunner::~LitertModelRunner() = default;
 
 // static
 std::unique_ptr<LitertModelRunner> LitertModelRunner::Create(
-    base::span<const uint8_t> tflite_model) {
+    base::span<const uint8_t> tflite_model,
+    int num_threads) {
   auto runner = base::WrapUnique(new LitertModelRunner());
-  if (!runner->Init(tflite_model)) {
+  if (!runner->Init(tflite_model, num_threads)) {
     return nullptr;
   }
   return runner;
@@ -37,7 +39,8 @@ std::unique_ptr<LitertModelRunner> LitertModelRunner::Create(
 
 // static
 std::unique_ptr<LitertModelRunner> LitertModelRunner::CreateFromFile(
-    base::File& model_file) {
+    base::File& model_file,
+    int num_threads) {
   if (!model_file.IsValid()) {
     return nullptr;
   }
@@ -49,10 +52,11 @@ std::unique_ptr<LitertModelRunner> LitertModelRunner::CreateFromFile(
   if (!model_file.ReadAndCheck(0, bytes)) {
     return nullptr;
   }
-  return Create(bytes);
+  return Create(bytes, num_threads);
 }
 
-bool LitertModelRunner::Init(base::span<const uint8_t> tflite_model) {
+bool LitertModelRunner::Init(base::span<const uint8_t> tflite_model,
+                             int num_threads) {
   // The runtime references the model bytes past compilation; keep our own copy.
   tflite_model_.assign(tflite_model.begin(), tflite_model.end());
 
@@ -72,6 +76,19 @@ bool LitertModelRunner::Init(base::span<const uint8_t> tflite_model) {
     return false;
   }
   compile_options->SetHardwareAccelerators(litert::HwAccelerators::kCpu);
+
+  // XNNPACK sizes its intra-op thread pool from this; LiteRT defaults to a
+  // single thread when no CPU options are attached.
+  auto cpu_options = compile_options->GetCpuOptions();
+  if (!cpu_options) {
+    LOG(ERROR) << "LiteRT runner: cannot create CPU options: "
+               << cpu_options.Error().Message();
+    return false;
+  }
+  if (!cpu_options->SetNumThreads(num_threads)) {
+    LOG(ERROR) << "LiteRT runner: rejected num_threads=" << num_threads;
+    return false;
+  }
 
   auto model = litert::CompiledModel::Create(
       *environment_,

--- a/services/passage_embeddings/litert_model_runner.cc
+++ b/services/passage_embeddings/litert_model_runner.cc
@@ -9,7 +9,6 @@
 #include <utility>
 
 #include "base/containers/extend.h"
-#include "base/containers/heap_array.h"
 #include "base/logging.h"
 #include "base/memory/ptr_util.h"
 #include "third_party/litert/src/litert/cc/litert_element_type.h"
@@ -31,7 +30,8 @@ std::unique_ptr<LitertModelRunner> LitertModelRunner::Create(
     base::span<const uint8_t> tflite_model,
     int num_threads) {
   auto runner = base::WrapUnique(new LitertModelRunner());
-  if (!runner->Init(tflite_model, num_threads)) {
+  runner->owned_model_.assign(tflite_model.begin(), tflite_model.end());
+  if (!runner->Init(runner->owned_model_, num_threads)) {
     return nullptr;
   }
   return runner;
@@ -44,22 +44,20 @@ std::unique_ptr<LitertModelRunner> LitertModelRunner::CreateFromFile(
   if (!model_file.IsValid()) {
     return nullptr;
   }
-  const int64_t length = model_file.GetLength();
-  if (length <= 0) {
+  auto runner = base::WrapUnique(new LitertModelRunner());
+  // Duplicate because the caller keeps ownership of `model_file`; the mapping
+  // needs a descriptor of its own for as long as the runner lives.
+  if (!runner->mapped_model_.Initialize(model_file.Duplicate())) {
     return nullptr;
   }
-  auto bytes = base::HeapArray<uint8_t>::WithSize(static_cast<size_t>(length));
-  if (!model_file.ReadAndCheck(0, bytes)) {
+  if (!runner->Init(runner->mapped_model_.bytes(), num_threads)) {
     return nullptr;
   }
-  return Create(bytes, num_threads);
+  return runner;
 }
 
 bool LitertModelRunner::Init(base::span<const uint8_t> tflite_model,
                              int num_threads) {
-  // The runtime references the model bytes past compilation; keep our own copy.
-  tflite_model_.assign(tflite_model.begin(), tflite_model.end());
-
   std::vector<litert::EnvironmentOptions::Option> env_options;
   auto environment = litert::Environment::Create(litert::EnvironmentOptions(
       litert::Span<const litert::EnvironmentOptions::Option>(
@@ -92,7 +90,7 @@ bool LitertModelRunner::Init(base::span<const uint8_t> tflite_model,
 
   auto model = litert::CompiledModel::Create(
       *environment_,
-      litert::BufferRef<uint8_t>(tflite_model_.data(), tflite_model_.size()),
+      litert::BufferRef<uint8_t>(tflite_model.data(), tflite_model.size()),
       *compile_options);
   if (!model) {
     LOG(ERROR) << "LiteRT runner: CompiledModel::Create failed: "

--- a/services/passage_embeddings/litert_model_runner.h
+++ b/services/passage_embeddings/litert_model_runner.h
@@ -13,6 +13,7 @@
 
 #include "base/containers/span.h"
 #include "base/files/file.h"
+#include "base/files/memory_mapped_file.h"
 #include "third_party/litert/src/litert/cc/litert_compiled_model.h"
 #include "third_party/litert/src/litert/cc/litert_environment.h"
 
@@ -33,8 +34,8 @@ class LitertModelRunner {
       base::span<const uint8_t> tflite_model,
       int num_threads);
 
-  // Reads the `.tflite` out of `model_file` and builds a runner for it, or
-  // returns nullptr if the file or the model is unusable.
+  // Maps the `.tflite` in `model_file` and builds a runner for it, or returns
+  // nullptr if the file or the model is unusable.
   static std::unique_ptr<LitertModelRunner> CreateFromFile(
       base::File& model_file,
       int num_threads);
@@ -54,9 +55,16 @@ class LitertModelRunner {
  private:
   LitertModelRunner();
 
+  // `tflite_model` is aliased, not copied: litert wraps the pointer for as long
+  // as model_ lives. Callers pass `mapped_model_` or `owned_model_`.
   bool Init(base::span<const uint8_t> tflite_model, int num_threads);
 
-  std::vector<uint8_t> tflite_model_;
+  // Backing storage for the model bytes; exactly one is populated. Keep these
+  // declared before model_, which aliases them and so must be destroyed first.
+  // The mapping keeps the model out of anonymous memory and makes recompiling
+  // it for a new thread count cheap.
+  base::MemoryMappedFile mapped_model_;
+  std::vector<uint8_t> owned_model_;
   std::optional<litert::Environment> environment_;
   std::optional<litert::CompiledModel> model_;
   size_t input_window_size_ = 0;

--- a/services/passage_embeddings/litert_model_runner.h
+++ b/services/passage_embeddings/litert_model_runner.h
@@ -26,14 +26,18 @@ namespace brave_history_embeddings {
 // model.
 class LitertModelRunner {
  public:
-  // Builds from the in-memory `.tflite`; nullptr on failure.
+  // Builds from the in-memory `.tflite`; nullptr on failure. `num_threads`
+  // sizes the CPU backend's intra-op thread pool and is fixed for the life of
+  // the runner, because LiteRT bakes it into the model at compile time.
   static std::unique_ptr<LitertModelRunner> Create(
-      base::span<const uint8_t> tflite_model);
+      base::span<const uint8_t> tflite_model,
+      int num_threads);
 
   // Reads the `.tflite` out of `model_file` and builds a runner for it, or
   // returns nullptr if the file or the model is unusable.
   static std::unique_ptr<LitertModelRunner> CreateFromFile(
-      base::File& model_file);
+      base::File& model_file,
+      int num_threads);
 
   ~LitertModelRunner();
 
@@ -50,7 +54,7 @@ class LitertModelRunner {
  private:
   LitertModelRunner();
 
-  bool Init(base::span<const uint8_t> tflite_model);
+  bool Init(base::span<const uint8_t> tflite_model, int num_threads);
 
   std::vector<uint8_t> tflite_model_;
   std::optional<litert::Environment> environment_;

--- a/services/passage_embeddings/litert_model_runner_unittest.cc
+++ b/services/passage_embeddings/litert_model_runner_unittest.cc
@@ -72,12 +72,27 @@ TEST(LitertModelRunnerTest, CreateFailsOnMalformedModel) {
             LitertModelRunner::Create(MalformedModelBytes(), kSingleThread));
 }
 
-// CreateFromFile reads the model from a base::File; an invalid or empty file
-// must fail without reading past the end.
+// An invalid file must fail rather than yield a runner over nothing.
 TEST(LitertModelRunnerTest, CreateFromFileFailsOnInvalidFile) {
   base::File invalid_file;
   EXPECT_EQ(nullptr,
             LitertModelRunner::CreateFromFile(invalid_file, kSingleThread));
+}
+
+// A truncated download leaves a zero-length file, which must not map into an
+// empty model the runner then accepts.
+TEST(LitertModelRunnerTest, CreateFromFileFailsOnEmptyModelFile) {
+  base::ScopedTempDir temp_dir;
+  ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
+  const base::FilePath model_path =
+      temp_dir.GetPath().AppendASCII("empty.tflite");
+  ASSERT_TRUE(base::WriteFile(model_path, base::span<const uint8_t>()));
+
+  base::File model_file(model_path,
+                        base::File::FLAG_OPEN | base::File::FLAG_READ);
+  ASSERT_TRUE(model_file.IsValid());
+  EXPECT_EQ(nullptr,
+            LitertModelRunner::CreateFromFile(model_file, kSingleThread));
 }
 
 TEST(LitertModelRunnerTest, CreateFromFileFailsOnMalformedModelFile) {

--- a/services/passage_embeddings/litert_model_runner_unittest.cc
+++ b/services/passage_embeddings/litert_model_runner_unittest.cc
@@ -43,8 +43,11 @@ std::vector<uint8_t> MalformedModelBytes() {
   return std::vector<uint8_t>(64, 0xAB);
 }
 
+constexpr int kSingleThread = 1;
+
 std::unique_ptr<LitertModelRunner> CreateRunnerForTestModel(
-    const char* model_name) {
+    const char* model_name,
+    int num_threads = kSingleThread) {
   const base::FilePath root =
       base::PathService::CheckedGet(base::DIR_SRC_TEST_DATA_ROOT);
   base::File model_file(root.AppendASCII(kTestDataDir).AppendASCII(model_name),
@@ -52,7 +55,7 @@ std::unique_ptr<LitertModelRunner> CreateRunnerForTestModel(
   if (!model_file.IsValid()) {
     return nullptr;
   }
-  return LitertModelRunner::CreateFromFile(model_file);
+  return LitertModelRunner::CreateFromFile(model_file, num_threads);
 }
 
 }  // namespace
@@ -60,18 +63,21 @@ std::unique_ptr<LitertModelRunner> CreateRunnerForTestModel(
 // A missing/withheld model must surface as nullptr rather than crash, so the
 // utility process degrades gracefully when the component ships no valid model.
 TEST(LitertModelRunnerTest, CreateFailsOnEmptyModel) {
-  EXPECT_EQ(nullptr, LitertModelRunner::Create(base::span<const uint8_t>()));
+  EXPECT_EQ(nullptr, LitertModelRunner::Create(base::span<const uint8_t>(),
+                                               kSingleThread));
 }
 
 TEST(LitertModelRunnerTest, CreateFailsOnMalformedModel) {
-  EXPECT_EQ(nullptr, LitertModelRunner::Create(MalformedModelBytes()));
+  EXPECT_EQ(nullptr,
+            LitertModelRunner::Create(MalformedModelBytes(), kSingleThread));
 }
 
 // CreateFromFile reads the model from a base::File; an invalid or empty file
 // must fail without reading past the end.
 TEST(LitertModelRunnerTest, CreateFromFileFailsOnInvalidFile) {
   base::File invalid_file;
-  EXPECT_EQ(nullptr, LitertModelRunner::CreateFromFile(invalid_file));
+  EXPECT_EQ(nullptr,
+            LitertModelRunner::CreateFromFile(invalid_file, kSingleThread));
 }
 
 TEST(LitertModelRunnerTest, CreateFromFileFailsOnMalformedModelFile) {
@@ -84,7 +90,8 @@ TEST(LitertModelRunnerTest, CreateFromFileFailsOnMalformedModelFile) {
   base::File model_file(model_path,
                         base::File::FLAG_OPEN | base::File::FLAG_READ);
   ASSERT_TRUE(model_file.IsValid());
-  EXPECT_EQ(nullptr, LitertModelRunner::CreateFromFile(model_file));
+  EXPECT_EQ(nullptr,
+            LitertModelRunner::CreateFromFile(model_file, kSingleThread));
 }
 
 // Write() only checks that the buffer is large enough, so int32 tokens written
@@ -117,6 +124,28 @@ TEST(LitertModelRunnerTest, RunReturnsFloatOutputForInt32Model) {
   std::optional<std::vector<float>> output = runner->Run(tokens);
   ASSERT_TRUE(output.has_value());
   EXPECT_FALSE(output->empty());
+}
+
+// LiteRT silently falls back to a single thread when no CPU options are
+// attached, so check that a higher count still compiles and runs.
+TEST(LitertModelRunnerTest, RunReturnsSameShapedOutputWithMultipleThreads) {
+  std::unique_ptr<LitertModelRunner> single_thread_runner =
+      CreateRunnerForTestModel(kInt32InputModel, kSingleThread);
+  ASSERT_TRUE(single_thread_runner);
+  std::unique_ptr<LitertModelRunner> multi_thread_runner =
+      CreateRunnerForTestModel(kInt32InputModel, /*num_threads=*/4);
+  ASSERT_TRUE(multi_thread_runner);
+  ASSERT_EQ(single_thread_runner->window(), multi_thread_runner->window());
+
+  const std::vector<int> tokens(multi_thread_runner->window(), 0);
+  std::optional<std::vector<float>> single_thread_output =
+      single_thread_runner->Run(tokens);
+  std::optional<std::vector<float>> multi_thread_output =
+      multi_thread_runner->Run(tokens);
+  ASSERT_TRUE(single_thread_output.has_value());
+  ASSERT_TRUE(multi_thread_output.has_value());
+  EXPECT_FALSE(multi_thread_output->empty());
+  EXPECT_EQ(single_thread_output->size(), multi_thread_output->size());
 }
 
 TEST(LitertModelRunnerTest, RunRejectsTokensThatDoNotFillTheWindow) {


### PR DESCRIPTION
`PassageEmbedderImpl::BuildExecutionTask` picks a thread count from the
passage priority — four for a user-initiated query, one for background
indexing — and applies it in `InitInterpreter`. Our chromium_src hook
returns above that switch, and LiteRT compiles for a single thread unless
`CpuOptions` are attached, so every priority ran one thread wide.

The hook now resolves the count the same way upstream does and
`LitertModelRunner` applies it with `CpuOptions::SetNumThreads`. LiteRT
fixes the count at compile time, so one model is kept and rebuilt when the
count changes, mirroring the `executor_.reset()` just above the hook — a
compiled model carries XNNPACK's repacked copy of the weights, so only one
is ever resident.

The 2nd commit maps the model instead of reading it, which makes that
rebuild cheap.
