### PR TITLE
[plaster] Blank string-adjecent macros

### DIFF
--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -162,9 +162,10 @@ tools/cr/plaster.py --help make_virtual   # full docs for a specific rewriter
 Besides `substitutions:`, a plaster file may set file-wide options at the top
 level:
 
-| Key                            | Default | Description                                                   |
-| ------------------------------ | ------- | ------------------------------------------------------------- |
-| `blank_macros_for_ast_parsing` | `false` | Blank parse-blocking macros/conditionals before AST matching. |
+| Key                                            | Default | Description                                                              |
+| ---------------------------------------------- | ------- | ------------------------------------------------------------------------ |
+| `blank_macros_for_ast_parsing`                 | `false` | Blank parse-blocking macros/conditionals before AST matching.            |
+| `blank_string_adjacent_macros_for_ast_parsing` | `false` | Blank a macro directly adjacent to a string literal before AST matching. |
 
 ### Applying a plaster
 

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -11,6 +11,7 @@ import argparse
 import ast
 from dataclasses import dataclass, field
 import hashlib
+import itertools
 import logging
 import mmap
 from pathlib import Path, PurePath
@@ -23,7 +24,7 @@ import subprocess
 import sys
 import textwrap
 from types import MappingProxyType
-from typing import ClassVar, Final
+from typing import Callable, ClassVar, Final
 
 from rich.markdown import Markdown
 import yaml
@@ -384,6 +385,24 @@ class PatchinfoBuilder:
         self.patchinfo.save_if_changed(content)
 
 
+@dataclass(frozen=True)
+class BlankForParseOptions:
+    """ File level blank-related flags used by ast parsers.
+
+    This type merely bundles these values together.
+    """
+
+    # Blanks class-head export macros and preprocessor conditionals.
+    macros: bool = False
+
+    # Blanks a macro/identifier directly adjacent to a string literal.
+    string_adjacent_macros: bool = False
+
+    def __bool__(self) -> bool:
+        """True if any pass is enabled, i.e. parsing needs preparation at all."""
+        return self.macros or self.string_adjacent_macros
+
+
 class Rewriter(abc.ABC):
     """A single transformation applied to a plaster's target file.
 
@@ -409,12 +428,14 @@ class Rewriter(abc.ABC):
     HELP: ClassVar[str] = ''
 
     @abc.abstractmethod
-    def apply(self,
-              contents: str,
-              *,
-              count: int,
-              description: str,
-              blank_for_parse: bool = False) -> tuple[str, list[str]]:
+    def apply(
+        self,
+        contents: str,
+        *,
+        count: int,
+        description: str,
+        blank_for_parse: BlankForParseOptions = BlankForParseOptions()
+    ) -> tuple[str, list[str]]:
         """Transform `contents`, returning (new_contents, validation_errors).
 
         `count` is the entry's `count:` (default 1, `0` meaning "one or more").
@@ -422,8 +443,9 @@ class Rewriter(abc.ABC):
         the expected number of matches. A composed rewriter may instead give
         each of its operations its own expectation. `errors` is the list of
         human-readable count/validation failures (empty when the entry applied
-        as expected). `blank_for_parse` is the file-wide
-        `blank_macros_for_ast_parsing` flag used by AST rewriters.
+        as expected). `blank_for_parse` bundles the file-wide
+        `blank_macros_for_ast_parsing` / `blank_string_adjacent_macros_for_ast_parsing`
+        flags used by AST rewriters.
         """
 
     @classmethod
@@ -452,8 +474,11 @@ class Rewriter(abc.ABC):
 
 
 # The file-wide plaster keys allowed at the top level of a YAML plaster.
-_TOP_LEVEL_KEYS: Final = frozenset(
-    {'substitutions', 'blank_macros_for_ast_parsing'})
+_TOP_LEVEL_KEYS: Final = frozenset({
+    'substitutions',
+    'blank_macros_for_ast_parsing',
+    'blank_string_adjacent_macros_for_ast_parsing',
+})
 
 # Target-source suffixes plaster treats as C++. `blank_macros_for_ast_parsing`
 # blanks constructs for the tree-sitter C++ parser, so it is only meaningful for
@@ -474,9 +499,13 @@ class PlasterSpec:
     # The `substitutions:` entries, in order.
     substitutions: list[Substitution]
 
-    # Indicates to the AST-rewriter that it needs to blank all cxx preprocessor
-    # directives that can interfere with parsing.
+    # Used to indicate that preprocessor #if/#endif and other macros should be
+    # blanked before AST parsing. C++-only.
     blank_macros_for_ast_parsing: bool = False
+
+    # Used to indicate that preprocessor macros adjacent to string literals
+    # should be blanked before AST parsing. C++-only.
+    blank_string_adjacent_macros_for_ast_parsing: bool = False
 
 
 @dataclass(frozen=True)
@@ -497,10 +526,12 @@ class Substitution:
     # The rewriter this entry composes; `apply` delegates to it.
     rewriter: Rewriter
 
-    def apply(self,
-              contents: str,
-              *,
-              blank_for_parse: bool = False) -> tuple[str, list[str]]:
+    def apply(
+        self,
+        contents: str,
+        *,
+        blank_for_parse: BlankForParseOptions = BlankForParseOptions()
+    ) -> tuple[str, list[str]]:
         """Apply the composed rewriter, returning (new_contents, errors).
         """
         return self.rewriter.apply(contents,
@@ -558,10 +589,16 @@ class Substitution:
                              ', '.join(repr(k)
                                        for k in unknown) + '; allowed: ' +
                              ', '.join(sorted(_TOP_LEVEL_KEYS)))
-        blank_for_parse = data.get('blank_macros_for_ast_parsing', False)
-        if not isinstance(blank_for_parse, bool):
+        blank_macros = data.get('blank_macros_for_ast_parsing', False)
+        if not isinstance(blank_macros, bool):
             raise ValueError(
                 '`blank_macros_for_ast_parsing` must be a boolean')
+        blank_string_adjacent_macros = data.get(
+            'blank_string_adjacent_macros_for_ast_parsing', False)
+        if not isinstance(blank_string_adjacent_macros, bool):
+            raise ValueError(
+                '`blank_string_adjacent_macros_for_ast_parsing` must be a '
+                'boolean')
         raw = data.get('substitutions')
         if raw is None:
             raise ValueError(
@@ -574,7 +611,9 @@ class Substitution:
             )
         return PlasterSpec(
             substitutions=[Substitution._from_item(entry) for entry in raw],
-            blank_macros_for_ast_parsing=blank_for_parse)
+            blank_macros_for_ast_parsing=blank_macros,
+            blank_string_adjacent_macros_for_ast_parsing=(
+                blank_string_adjacent_macros))
 
     @staticmethod
     def _from_item(data: object) -> Substitution:
@@ -775,12 +814,14 @@ class Regex(Rewriter):
         self._replace = replace
         self._re_flags = re_flags
 
-    def apply(self,
-              contents: str,
-              *,
-              count: int,
-              description: str,
-              blank_for_parse: bool = False) -> tuple[str, list[str]]:
+    def apply(
+        self,
+        contents: str,
+        *,
+        count: int,
+        description: str,
+        blank_for_parse: BlankForParseOptions = BlankForParseOptions()
+    ) -> tuple[str, list[str]]:
         del description  # Only the count matters for the regex diagnostic.
         del blank_for_parse  # Text substitution never parses; nothing to relax.
         # `count=0` here means "replace every match"; how many were expected is
@@ -907,12 +948,14 @@ class _AstGrepRewriter(Rewriter):
                       MatchExpectation.from_count(count))
         ]
 
-    def apply(self,
-              contents: str,
-              *,
-              count: int,
-              description: str,
-              blank_for_parse: bool = False) -> tuple[str, list[str]]:
+    def apply(
+        self,
+        contents: str,
+        *,
+        count: int,
+        description: str,
+        blank_for_parse: BlankForParseOptions = BlankForParseOptions()
+    ) -> tuple[str, list[str]]:
         engine = AstRewriter(RewritersEval.load(),
                              contents,
                              blank_for_parse=blank_for_parse)
@@ -1522,12 +1565,14 @@ class AddToProtected(_AstGrepRewriter):
         self._class_name = class_name
         self._code = code
 
-    def apply(self,
-              contents: str,
-              *,
-              count: int,
-              description: str,
-              blank_for_parse: bool = False) -> tuple[str, list[str]]:
+    def apply(
+        self,
+        contents: str,
+        *,
+        count: int,
+        description: str,
+        blank_for_parse: BlankForParseOptions = BlankForParseOptions()
+    ) -> tuple[str, list[str]]:
         # The code is inserted exactly once either in an existing protected
         # section or in a new one created just before a private section. Each
         # placement is indented to the anchor's real column (Chromium members
@@ -1638,12 +1683,14 @@ class AddToPublic(_AstGrepRewriter):
         self._class_name = class_name
         self._code = code
 
-    def apply(self,
-              contents: str,
-              *,
-              count: int,
-              description: str,
-              blank_for_parse: bool = False) -> tuple[str, list[str]]:
+    def apply(
+        self,
+        contents: str,
+        *,
+        count: int,
+        description: str,
+        blank_for_parse: BlankForParseOptions = BlankForParseOptions()
+    ) -> tuple[str, list[str]]:
         # The code is appended exactly once, either just before the section
         # that follows public or, when public is last, before the closing brace.
         # Each placement is indented to the anchor's real column so a nested
@@ -1811,12 +1858,14 @@ class AddEnumEntries(_AstGrepRewriter):
         self._entries = entries
         self._max_value = max_value
 
-    def apply(self,
-              contents: str,
-              *,
-              count: int,
-              description: str,
-              blank_for_parse: bool = False) -> tuple[str, list[str]]:
+    def apply(
+        self,
+        contents: str,
+        *,
+        count: int,
+        description: str,
+        blank_for_parse: BlankForParseOptions = BlankForParseOptions()
+    ) -> tuple[str, list[str]]:
         # The insertion happens exactly once, either above the declared
         # max-value entry or after the enum's current last entry. Both
         # placements anchor on that last entry, so the new entries take its
@@ -2040,11 +2089,15 @@ class PlasterFile:
         if suffix == '.yaml':
             doc = Substitution.from_yaml(info.plaster_contents)
             is_cxx = _is_cxx_source(self.path)
-            if doc.blank_macros_for_ast_parsing and not is_cxx:
-                raise ValueError(
-                    '`blank_macros_for_ast_parsing` is only supported for C++ '
-                    f'sources (in {self.path})')
             if not is_cxx:
+                if doc.blank_macros_for_ast_parsing:
+                    raise ValueError(
+                        '`blank_macros_for_ast_parsing` is only supported for '
+                        f'C++ sources (in {self.path})')
+                if doc.blank_string_adjacent_macros_for_ast_parsing:
+                    raise ValueError(
+                        '`blank_string_adjacent_macros_for_ast_parsing` is '
+                        f'only supported for C++ sources (in {self.path})')
                 for substitution in doc.substitutions:
                     if substitution.rewriter.source_language() == 'cxx':
                         raise ValueError(
@@ -2060,6 +2113,10 @@ class PlasterFile:
                 f'git: {info.source}. The upstream file may have been moved '
                 'or deleted') from e
         errors = []
+        blank_for_parse = BlankForParseOptions(
+            macros=doc.blank_macros_for_ast_parsing,
+            string_adjacent_macros=(
+                doc.blank_string_adjacent_macros_for_ast_parsing))
 
         try:
             for substitution in doc.substitutions:
@@ -2067,7 +2124,7 @@ class PlasterFile:
                 # composed rewriters) and reports any failures; we just attach
                 # the file being patched.
                 contents, sub_errors = substitution.apply(
-                    contents, blank_for_parse=doc.blank_macros_for_ast_parsing)
+                    contents, blank_for_parse=blank_for_parse)
                 errors.extend(f'{error} in {self.path}'
                               for error in sub_errors)
 
@@ -2671,6 +2728,102 @@ def run_ast_grep(*, language: str, rule_body: str,
     return matches
 
 
+class CxxMacrosEraser:
+    """Blanks C++ macros that confuse `ast-grep`.
+
+    Every substitution replaces characters in place, so byte offsets into the
+    original source stay valid.
+
+    There are two types of erasure done in this class. The common macros one
+    (e.g #if, #endif, FOO_EXPORT), which is less controversial, and then the
+    more targeted erasure of macros that are adjacent to string literals, which
+    should be used sparingly.
+    """
+
+    @dataclass(frozen=True)
+    class _OpaqueSpan:
+        """A byte range to copy through untouched."""
+
+        start: int
+        end: int
+        text: str
+
+    # `class MODULES_EXPORT Foo`: tree-sitter reads the macro as the name.
+    _EXPORT_MACRO_RE = re.compile(r'(\b(?:class|struct)\s+)'
+                                  r'([A-Z][A-Z0-9_]*_EXPORT(?:\s*\([^()]*\))?)'
+                                  r'(\s+[A-Za-z_])')
+
+    # `#if`/`#ifdef`/.../`#endif`: no grammar node in e.g. a base-specifier
+    # list.
+    _CXX_CONDITIONAL_RE = re.compile(
+        r'(?m)^[ \t]*#[ \t]*(?:if|ifdef|ifndef|elif|else|endif)\b.*$')
+
+    # Any directive line. `#define FOO "bar"` has the same shape as the
+    # macro-adjacent-string regexes below but isn't one so we skip them in
+    # `_blank_outside_opaque_spans`.
+    _CXX_DIRECTIVE_LINE_RE = re.compile(r'(?m)^[ \t]*#.*$')
+
+    # Raw string literal, matched by its real delimiter-based close so an
+    # embedded `"` isn't mistaken for it. These are also skipped in
+    # `_blank_outside_opaque_spans`.
+    _CXX_RAW_STRING_RE = re.compile(
+        r'(?:u8|u|U|L)?R"([^"\\()\s]{0,16})\(.*?\)\1"', re.DOTALL)
+
+    # Plain string literal. This regex excludes encoding-prefixed forms
+    # (`u8"..."`), which this idiom doesn't use and raw strings already need
+    # separate handling for.
+    _CXX_STRING_LIT = r'(?<![A-Za-z0-9_])"(?:[^"\\]|\\.)*"'
+
+    # Bare identifier with an optional single-level call, e.g. `FOO(BAR)`.
+    _CXX_MACRO_TOKEN = r'[A-Za-z_]\w*(?:\([^()]*\))?'
+
+    # `"Skia/" STRINGIZE(SK_MILESTONE)`: only valid once macros that expand to
+    # (or stringize into) a string literal have run.
+    _CXX_MACRO_AFTER_STRING_RE = re.compile(
+        f'({_CXX_STRING_LIT})([ \\t]+)({_CXX_MACRO_TOKEN})')
+    _CXX_MACRO_BEFORE_STRING_RE = re.compile(
+        f'({_CXX_MACRO_TOKEN})([ \\t]+)({_CXX_STRING_LIT})')
+
+    def __init__(self, blank_for_parse: BlankForParseOptions):
+        self._blank_for_parse = blank_for_parse
+
+    def erase(self, source: str) -> str:
+        """Blank the constructs `self._blank_for_parse` enables."""
+        if self._blank_for_parse.macros:
+            source = self._EXPORT_MACRO_RE.sub(
+                lambda m: m.group(1) + ' ' * len(m.group(2)) + m.group(3),
+                source)
+            source = self._CXX_CONDITIONAL_RE.sub(
+                lambda line: ' ' * len(line.group(0)), source)
+        if self._blank_for_parse.string_adjacent_macros:
+            source = self._blank_outside_opaque_spans(
+                source, self._CXX_MACRO_AFTER_STRING_RE,
+                lambda m: m.group(1) + m.group(2) + ' ' * len(m.group(3)))
+            source = self._blank_outside_opaque_spans(
+                source, self._CXX_MACRO_BEFORE_STRING_RE,
+                lambda m: ' ' * len(m.group(1)) + m.group(2) + m.group(3))
+        return source
+
+    def _blank_outside_opaque_spans(self, source: str, pattern: re.Pattern,
+                                    repl: Callable[[re.Match], str]) -> str:
+        """Apply `pattern.sub(repl, ...)`, skipping directive lines and raw strings."""
+        spans = sorted((self._OpaqueSpan(m.start(), m.end(), m.group(0))
+                        for m in itertools.chain(
+                            self._CXX_DIRECTIVE_LINE_RE.finditer(source),
+                            self._CXX_RAW_STRING_RE.finditer(source))),
+                       key=lambda span: span.start)
+        pieces = []
+        pos = 0
+        for span in spans:
+            if span.start < pos:
+                continue  # Overlaps a span already copied.
+            pieces.append(pattern.sub(repl, source[pos:span.start]))
+            pieces.append(span.text)
+            pos = span.end
+        pieces.append(pattern.sub(repl, source[pos:]))
+        return ''.join(pieces)
+
+
 class AstRewriter:
     """Applies ast-grep rewriter ops to the contents of a single file.
 
@@ -2683,59 +2836,22 @@ class AstRewriter:
     operations to run.
     """
 
-    # Class-head export macro (e.g. `MODULES_EXPORT`, `COMPONENT_EXPORT(FOO)`):
-    # the keyword and its space, the macro, then the start of the real name.
-    # Used by `_prepare_cxx_for_parse`.
-    _EXPORT_MACRO_RE = re.compile(r'(\b(?:class|struct)\s+)'
-                                  r'([A-Z][A-Z0-9_]*_EXPORT(?:\s*\([^()]*\))?)'
-                                  r'(\s+[A-Za-z_])')
-
-    # A preprocessor conditional directive line (`#if`, `#ifdef` ...), matched
-    # without its trailing newline. Used by `_prepare_cxx_for_parse`.
-    _CXX_CONDITIONAL_RE = re.compile(
-        r'(?m)^[ \t]*#[ \t]*(?:if|ifdef|ifndef|elif|else|endif)\b.*$')
-
-    def __init__(self,
-                 rewriters: RewritersEval,
-                 content: str,
-                 *,
-                 blank_for_parse: bool = False):
+    def __init__(
+        self,
+        rewriters: RewritersEval,
+        content: str,
+        *,
+        blank_for_parse: BlankForParseOptions = BlankForParseOptions()):
         self._rewriters = rewriters
         self._source = content
-        # When set, blank constructs tree-sitter cannot parse before matching
-        # (see `_prepare_cxx_for_parse`). Off by default. Opt-in per file.
-        self._blank_for_parse = blank_for_parse
+        # None when no pass is enabled, so `_locate` has nothing to run.
+        self._macros_eraser = (CxxMacrosEraser(blank_for_parse)
+                               if blank_for_parse else None)
 
     @property
     def content(self) -> str:
         """The current file contents, reflecting every applied rewrite."""
         return self._source
-
-    def _prepare_cxx_for_parse(self) -> str:
-        """Normalise C++ source for tree-sitter parsing
-
-        Two constructs are handled:
-
-        - A class-head export macro (`class MODULES_EXPORT Foo`): tree-sitter
-          has no macro definitions, so it reads the macro as the class name and
-          drops the real name, any `final`, and the body into an error node.
-          Blanking the macro leaves a plain `class Foo ...`.
-        - A preprocessor conditional (`#if`/`#endif`/...), most damaging inside
-          a base-specifier list (`#if defined(USE_AURA)`), which has no grammar
-          node and breaks the class head. Blanking the directive lines, keeping
-          the guarded code, makes the head parse.
-
-        Both substitutions only replace characters in place, so every byte
-        offset is preserved. Blanking every conditional file-wide is safe
-        because the caller opts in per file via `blank_macros_for_ast_parsing`,
-        and a directive guarding an alternative definition would leave two
-        matches that the count check flags.
-        """
-        source = self._EXPORT_MACRO_RE.sub(
-            lambda m: m.group(1) + ' ' * len(m.group(2)) + m.group(3),
-            self._source)
-        return self._CXX_CONDITIONAL_RE.sub(
-            lambda line: ' ' * len(line.group(0)), source)
 
     def _locate(self, op: Operation) -> list[AstMatch]:
         """Every match for `op`'s matcher, in source order.
@@ -2745,11 +2861,9 @@ class AstRewriter:
         language = self._rewriters.language_of(op.op_id)
         rule_body = matcher['template'].format(**op.inputs)
 
-        # `_prepare_cxx_for_parse` blanks C++-specific constructs, so it only
-        # applies to `cxx.` ops.
-        blank = self._blank_for_parse and op.op_id.startswith('cxx.')
-        source_for_parse = (self._prepare_cxx_for_parse()
-                            if blank else self._source)
+        source_for_parse = self._source
+        if self._macros_eraser is not None:
+            source_for_parse = self._macros_eraser.erase(self._source)
         return run_ast_grep(language=language,
                             rule_body=rule_body,
                             source=source_for_parse)
@@ -3004,12 +3118,14 @@ class RegexMacro(Rewriter):
         """The `<lang>.` prefix for the op (e.g. `cxx`)."""
         return self.OP_ID.split('.', 1)[0]
 
-    def apply(self,
-              contents: str,
-              *,
-              count: int,
-              description: str,
-              blank_for_parse: bool = False) -> tuple[str, list[str]]:
+    def apply(
+        self,
+        contents: str,
+        *,
+        count: int,
+        description: str,
+        blank_for_parse: BlankForParseOptions = BlankForParseOptions()
+    ) -> tuple[str, list[str]]:
         del description  # Only the count matters for the regex diagnostic.
         del blank_for_parse  # Regex macros run over plain text; nothing to relax.
         engine = RegexMacroEngine(RewritersEval.load(), contents)

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import argparse
 import contextlib
 import copy
+import dataclasses
 import hashlib
 import io
 import json
@@ -3059,6 +3060,86 @@ class RewriterFormsTest(unittest.TestCase):
             self._AURA_CLASS.replace(' private:\n',
                                      ' private:\n  friend class BraveC;\n'))
 
+    # -- functions with a macro-adjacent string literal -------------------
+    #
+    # A bare macro touching a string literal (only valid post-preprocessing,
+    # e.g. Skia's `STRINGIZE(SK_MILESTONE)` version string idiom) drops into
+    # a tree-sitter error node that can swallow everything up to the next
+    # construct it resyncs on. Regression coverage for a real bug: this once
+    # made `after_function_impl` on the *first* function wrap the *second*
+    # function's body too.
+
+    _VERSION_STRING_FUNCTION = (
+        'base::DictValue C::GetClientInfo() {\n'
+        '  base::DictValue dict;\n'
+        '  dict.Set("graphics_backend",\n'
+        '           std::string("Skia/" STRINGIZE(SK_MILESTONE) " " '
+        'SKIA_COMMIT_HASH));\n'
+        '  return dict;\n'
+        '}\n'
+        '\n'
+        'base::ListValue C::GetLogMessages() {\n'
+        '  return GetLogs();\n'
+        '}\n')
+
+    def test_after_function_impl_unaffected_by_later_macro_adjacent_string(
+            self):
+        # Without the fix, `after_function_impl` on `GetClientInfo` would
+        # wrap `GetLogMessages` too, since the STRINGIZE construct inside
+        # `GetClientInfo` throws tree-sitter's parse off. Confirm it now stays
+        # scoped to the target function's own body.
+        result = self._apply(
+            'version_string.cc', self._VERSION_STRING_FUNCTION,
+            'blank_string_adjacent_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: report the executable path after the body\n'
+            '    after_function_impl:\n'
+            '      function_name: C::GetClientInfo\n'
+            '      result_var: dict\n'
+            '      code: |-\n'
+            '        return dict;\n')
+        self.assertEqual(
+            result, 'base::DictValue C::GetClientInfo() {\n'
+            '  base::DictValue dict = [&]() -> base::DictValue {\n'
+            '  base::DictValue dict;\n'
+            '  dict.Set("graphics_backend",\n'
+            '           std::string("Skia/" STRINGIZE(SK_MILESTONE) " " '
+            'SKIA_COMMIT_HASH));\n'
+            '  return dict;\n'
+            '  }();\n'
+            '  return dict;\n'
+            '}\n'
+            '\n'
+            'base::ListValue C::GetLogMessages() {\n'
+            '  return GetLogs();\n'
+            '}\n')
+
+    def test_make_virtual_unaffected_by_macro_adjacent_string_in_sibling(self):
+        # A macro-adjacent string literal in one method must not stop a
+        # rewriter from correctly reaching a *different* method in the same
+        # class.
+        result = self._apply(
+            'version_string.h', 'class C {\n'
+            ' public:\n'
+            '  void GetClientInfo() {\n'
+            '    Log("Skia/" STRINGIZE(SK_MILESTONE) " " SKIA_COMMIT_HASH);\n'
+            '  }\n'
+            '  void Foo();\n'
+            '};\n', 'blank_string_adjacent_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: make Foo virtual\n'
+            '    make_virtual:\n'
+            '      class_name: C\n'
+            '      method_name: Foo\n')
+        self.assertEqual(
+            result, 'class C {\n'
+            ' public:\n'
+            '  void GetClientInfo() {\n'
+            '    Log("Skia/" STRINGIZE(SK_MILESTONE) " " SKIA_COMMIT_HASH);\n'
+            '  }\n'
+            '  virtual void Foo();\n'
+            '};\n')
+
     def test_blanking_is_off_by_default(self):
         # Without `blank_macros_for_ast_parsing`, the export-macro class is
         # unparseable, so the rewriter matches nothing and the apply fails.
@@ -3122,6 +3203,126 @@ class RewriterFormsTest(unittest.TestCase):
             "      re_pattern: 'Chromium'\n"
             "      replace: 'Brave'\n")
         self.assertEqual(result, 'A Brave thing.\n')
+
+    # -- `blank_string_adjacent_macros_for_ast_parsing` (separate flag) ----
+    #
+    # A distinct opt-in from `blank_macros_for_ast_parsing`, with the same
+    # validation shape, plus coverage that the two are independent end to end
+    # (not just at the `CxxMacrosEraser.erase` unit level above).
+
+    _VERSION_STRING_CLASS = ('class C {\n'
+                             ' public:\n'
+                             '  void Bar() { Log("v" STRINGIZE(V)); }\n'
+                             '  void Foo();\n'
+                             '};\n')
+
+    def test_string_adjacent_flag_off_by_default(self):
+        # `after_function_impl` needs `GetClientInfo`'s function_definition
+        # node intact to find its body; on this fixture, without the flag,
+        # the STRINGIZE construct's error node swallows enough of it that the
+        # query comes up empty (0 matches) rather than finding *a* match.
+        # (On the real, larger file this bug was found in, tree-sitter's
+        # error recovery instead re-synced onto a much later, wrong
+        # `compound_statement` -- still broken, just a different symptom.)
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'no_string_blank.cc', self._VERSION_STRING_FUNCTION,
+                'substitutions:\n'
+                '  - description: report the executable path after the body\n'
+                '    after_function_impl:\n'
+                '      function_name: C::GetClientInfo\n'
+                '      result_var: dict\n'
+                '      code: |-\n'
+                '        return dict;\n')
+
+    def test_string_adjacent_flag_must_be_boolean(self):
+        self._expect_value_error(
+            'blank_string_adjacent_macros_for_ast_parsing: yes please\n'
+            'substitutions:\n'
+            '  - description: bad flag type\n'
+            '    drop_final:\n'
+            '      class_name: C\n',
+            '`blank_string_adjacent_macros_for_ast_parsing` must be a boolean')
+
+    def test_string_adjacent_flag_rejected_for_non_cxx_source(self):
+        self._expect_value_error(
+            'blank_string_adjacent_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: flag on a non-C++ source\n'
+            '    regex:\n'
+            "      re_pattern: 'x'\n"
+            "      replace: 'y'\n",
+            '`blank_string_adjacent_macros_for_ast_parsing` is only '
+            'supported for C++ sources')
+
+    def test_macros_flag_alone_does_not_enable_string_adjacent_pass(self):
+        # Setting `blank_macros_for_ast_parsing` must not also enable the
+        # separate string-adjacent pass this construct needs: still fails.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'macros_only.cc', self._VERSION_STRING_FUNCTION,
+                'blank_macros_for_ast_parsing: true\n'
+                'substitutions:\n'
+                '  - description: wrong flag for this construct\n'
+                '    after_function_impl:\n'
+                '      function_name: C::GetClientInfo\n'
+                '      result_var: dict\n'
+                '      code: |-\n'
+                '        return dict;\n')
+
+    def test_string_adjacent_flag_alone_fixes_the_match(self):
+        result = self._apply(
+            'string_adjacent_only.cc', self._VERSION_STRING_FUNCTION,
+            'blank_string_adjacent_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: report the executable path after the body\n'
+            '    after_function_impl:\n'
+            '      function_name: C::GetClientInfo\n'
+            '      result_var: dict\n'
+            '      code: |-\n'
+            '        return dict;\n')
+        # Correctly scoped: the wrap closes right after GetClientInfo's own
+        # `return dict;`, well before GetLogMessages even starts.
+        self.assertNotIn('GetLogMessages', result[:result.index('}();')])
+
+    def test_string_adjacent_flag_alone_reaches_sibling_method(self):
+        # A construct simple enough that tree-sitter handles it fine even
+        # without the flag; this only confirms the flag does not itself
+        # break normal operation on it.
+        result = self._apply(
+            'string_adjacent_only.h', self._VERSION_STRING_CLASS,
+            'blank_string_adjacent_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: make Foo virtual\n'
+            '    make_virtual:\n'
+            '      class_name: C\n'
+            '      method_name: Foo\n')
+        self.assertEqual(
+            result,
+            self._VERSION_STRING_CLASS.replace('void Foo();',
+                                               'virtual void Foo();'))
+
+    def test_both_blank_flags_together(self):
+        # The two flags compose: an export-macro class *and* a
+        # STRINGIZE-guarded method in the same file, both reached in one pass.
+        result = self._apply(
+            'both_flags.h', 'class MODULES_EXPORT C {\n'
+            ' public:\n'
+            '  void Bar() { Log("v" STRINGIZE(V)); }\n'
+            '  void Foo();\n'
+            '};\n', 'blank_macros_for_ast_parsing: true\n'
+            'blank_string_adjacent_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: make Foo virtual on an exported, STRINGIZE-using class\n'
+            '    make_virtual:\n'
+            '      class_name: C\n'
+            '      method_name: Foo\n')
+        self.assertEqual(
+            result, 'class MODULES_EXPORT C {\n'
+            ' public:\n'
+            '  void Bar() { Log("v" STRINGIZE(V)); }\n'
+            '  virtual void Foo();\n'
+            '};\n')
 
     def test_ast_rewriter_rejected_for_non_cxx_source(self):
         # AST rewriters (cxx.* ops) only work on C++ sources; the `.idl` target
@@ -3989,16 +4190,22 @@ _SYNTHETIC_SPEC = {
 }
 
 
-class PrepareForParseTest(unittest.TestCase):
-    """Unit tests for AstRewriter._prepare_cxx_for_parse (no ast-grep binary)."""
+class CxxMacrosEraserTest(unittest.TestCase):
+    """Unit tests for CxxMacrosEraser."""
 
-    def _prepared(self, source: str) -> str:
-        """Return the parse-prepared source, asserting length is preserved.
+    # Both passes on by default: most tests below exercise one pass's
+    # mechanics in isolation and don't care about the other's gating (that
+    # independence gets its own tests further down).
+    _BOTH_PASSES = plaster.BlankForParseOptions(macros=True,
+                                                string_adjacent_macros=True)
 
-        `_prepare_cxx_for_parse` only reads the held source and the class regexes,
-        so the rewriters registry is irrelevant and left as None here.
-        """
-        result = plaster.AstRewriter(None, source)._prepare_cxx_for_parse()
+    def _prepared(
+            self,
+            source: str,
+            blank_for_parse: plaster.BlankForParseOptions = _BOTH_PASSES
+    ) -> str:
+        """Return the erased source, asserting length is preserved."""
+        result = plaster.CxxMacrosEraser(blank_for_parse).erase(source)
         # The whole point is that offsets are preserved for byte-for-byte
         # remapping onto the untouched source.
         self.assertEqual(len(result.encode('utf-8')),
@@ -4075,6 +4282,190 @@ class PrepareForParseTest(unittest.TestCase):
         for src in ('#include <memory>\n', '#define FOO 1\n',
                     '#pragma once\n'):
             self.assertEqual(self._prepared(src), src)
+
+    # -- macros adjacent to string literals --------------------------------
+    #
+    # A bare identifier (optionally called) touching a string literal, with
+    # only whitespace between them, has no raw C++ grammar: it is only valid
+    # once a macro that expands to (or stringizes into) a string literal has
+    # run. Left alone, tree-sitter drops the expression into an error node
+    # that can swallow everything up to the next construct it can resync on.
+
+    def test_blanks_macro_after_string_literal(self):
+        self._assert_blanks('std::string("Skia/" STRINGIZE(SK_MILESTONE));',
+                            'STRINGIZE(SK_MILESTONE)')
+
+    def test_blanks_bare_macro_after_string_literal(self):
+        self._assert_blanks('std::string("Skia/" SKIA_COMMIT_HASH);',
+                            'SKIA_COMMIT_HASH')
+
+    def test_blanks_macro_before_string_literal(self):
+        self._assert_blanks('std::string(SKIA_COMMIT_HASH " built");',
+                            'SKIA_COMMIT_HASH')
+
+    def test_blanks_macro_chain_between_string_literals(self):
+        # The real construct that triggered this: a `STRINGIZE(...)` call and
+        # a bare macro, each adjacent to a string literal on at least one
+        # side, chained together.
+        result = self._prepared(
+            'std::string("Skia/" STRINGIZE(SK_MILESTONE) " " '
+            'SKIA_COMMIT_HASH);')
+        self.assertNotIn('STRINGIZE', result)
+        self.assertNotIn('SKIA_COMMIT_HASH', result)
+        for kept in ('"Skia/"', '" "'):
+            self.assertIn(kept, result)
+
+    def test_leaves_plain_string_concatenation_untouched(self):
+        # Two string literals with only whitespace between them is valid,
+        # unrelated C++ (adjacent string literal concatenation).
+        self.assertEqual(self._prepared('"foo" "bar"'), '"foo" "bar"')
+
+    def test_leaves_string_with_operator_untouched(self):
+        # An operator between the string and the identifier makes this
+        # ordinary, already-parseable C++; nothing to blank.
+        for src in ('"foo" + bar', '"foo" == bar', 'foo + "bar"'):
+            self.assertEqual(self._prepared(src), src)
+
+    def test_leaves_user_defined_literal_suffix_untouched(self):
+        # No whitespace: a real user-defined literal suffix, not this
+        # construct.
+        self.assertEqual(self._prepared('"foo"s'), '"foo"s')
+
+    def test_leaves_string_literal_prefix_untouched(self):
+        # No whitespace: a real encoding prefix, not this construct.
+        for src in ('u8"foo"', 'L"foo"', 'u"foo"', 'U"foo"'):
+            self.assertEqual(self._prepared(src), src)
+
+    def test_macro_after_string_handles_escaped_quote(self):
+        self._assert_blanks(r'std::string("a\"b" FOO);', 'FOO')
+
+    def test_leaves_encoded_prefix_adjacent_to_macro_untouched(self):
+        # `u8"foo"`/`L"foo"`/etc. are excluded from `_CXX_STRING_LIT`
+        # entirely (see its comment), so a macro next to one is left alone
+        # rather than risk misreading the prefixed form.
+        for src in ('std::string(u8"Skia/" FOO);', 'std::string(FOO L"x");'):
+            self.assertEqual(self._prepared(src), src)
+
+    def test_leaves_preprocessor_directive_with_string_untouched(self):
+        # `#define FOO "bar"` and `#include "foo.h"` have the same *shape*
+        # as the macro-adjacent-string construct (identifier/token then
+        # whitespace then a string literal), but they are directive syntax,
+        # not an expression -- the name/path must survive intact.
+        for src in ('#define FOO "bar"\n', '#include "foo.h"\n',
+                    '#define VERSION_STRING "v" MY_STRINGIZE(X)\n'):
+            self.assertEqual(self._prepared(src), src)
+
+    def test_directive_with_string_inside_conditional_still_protected(self):
+        # The conditional lines around it are blanked as usual, but the
+        # `#define` line's own content survives untouched.
+        src = '#if X\n#define FOO "bar"\n#endif\n'
+        result = self._prepared(src)
+        self.assertIn('#define FOO "bar"', result)
+        for directive in ('#if X', '#endif'):
+            self.assertNotIn(directive, result)
+
+    def test_leaves_raw_string_with_embedded_quote_untouched(self):
+        # A raw string's content may contain unescaped `"` characters
+        # (`some "quoted" text` below); naively pairing quotes would misread
+        # `"quoted"` as a standalone string literal sandwiched between two
+        # bare words, and blank them as if they were macros.
+        src = 'Log(R"foo(some "quoted" text)foo" BAR);\n'
+        self.assertEqual(self._prepared(src), src)
+
+    def test_leaves_raw_string_adjacent_to_macro_untouched(self):
+        # A raw string with no embedded quote is safe to reason about, but is
+        # still excluded wholesale (rather than only when it has embedded
+        # quotes) to keep the rule simple and uniformly safe.
+        for src in ('Log(R"(hello)" FOO);\n', 'Log(FOO R"(hello)");\n'):
+            self.assertEqual(self._prepared(src), src)
+
+    def test_raw_string_delimiter_must_match_on_both_sides(self):
+        # `)foo"` inside the content of a `R"bar(...)bar"` literal must not
+        # be mistaken for that literal's own close.
+        src = 'Log(R"bar(text with )foo" inside)bar" BAZ);\n'
+        self.assertEqual(self._prepared(src), src)
+
+    # -- the two passes are independently gated ----------------------------
+    #
+    # `blank_macros_for_ast_parsing` and
+    # `blank_string_adjacent_macros_for_ast_parsing` are separate opt-ins:
+    # each pass only runs when its own flag is set, regardless of the other.
+
+    def test_string_adjacent_macros_alone_does_not_blank_export_macro(self):
+        src = 'class MODULES_EXPORT Foo final {};'
+        result = self._prepared(
+            src,
+            plaster.BlankForParseOptions(macros=False,
+                                         string_adjacent_macros=True))
+        self.assertEqual(result, src)
+
+    def test_string_adjacent_macros_alone_does_not_blank_conditional(self):
+        src = 'a\n#if X\nb\n#endif\n'
+        result = self._prepared(
+            src,
+            plaster.BlankForParseOptions(macros=False,
+                                         string_adjacent_macros=True))
+        self.assertEqual(result, src)
+
+    def test_macros_alone_does_not_blank_macro_after_string_literal(self):
+        src = 'std::string("Skia/" STRINGIZE(SK_MILESTONE));'
+        result = self._prepared(
+            src,
+            plaster.BlankForParseOptions(macros=True,
+                                         string_adjacent_macros=False))
+        self.assertEqual(result, src)
+
+    def test_neither_flag_blanks_anything(self):
+        src = ('class MODULES_EXPORT Foo final {\n'
+               '#if X\n'
+               '  void Bar() { Log("v" STRINGIZE(V)); }\n'
+               '#endif\n'
+               '};\n')
+        self.assertEqual(self._prepared(src, plaster.BlankForParseOptions()),
+                         src)
+
+    def test_both_flags_blank_both_constructs(self):
+        result = self._prepared(
+            'class MODULES_EXPORT Foo final {\n'
+            '  void Bar() { Log("v" STRINGIZE(V)); }\n'
+            '};\n',
+            plaster.BlankForParseOptions(macros=True,
+                                         string_adjacent_macros=True))
+        self.assertNotIn('MODULES_EXPORT', result)
+        self.assertNotIn('STRINGIZE', result)
+
+    # -- construction / identity -------------------------------------------
+
+    def test_regexes_are_shared_across_instances(self):
+        # Class-level: compiled once, not per `CxxMacrosEraser()` call.
+        a = plaster.CxxMacrosEraser(plaster.BlankForParseOptions())
+        b = plaster.CxxMacrosEraser(plaster.BlankForParseOptions())
+        self.assertIs(a._EXPORT_MACRO_RE, b._EXPORT_MACRO_RE)
+        self.assertIs(a._CXX_MACRO_AFTER_STRING_RE,
+                      b._CXX_MACRO_AFTER_STRING_RE)
+
+    def test_two_instances_do_not_share_options(self):
+        macros_only = plaster.CxxMacrosEraser(
+            plaster.BlankForParseOptions(macros=True))
+        string_adjacent_only = plaster.CxxMacrosEraser(
+            plaster.BlankForParseOptions(string_adjacent_macros=True))
+        src = 'class MODULES_EXPORT C { void F() { Log("v" FOO); } };'
+        self.assertNotIn('MODULES_EXPORT', macros_only.erase(src))
+        self.assertIn('FOO', macros_only.erase(src))
+        self.assertIn('MODULES_EXPORT', string_adjacent_only.erase(src))
+        self.assertNotIn('FOO', string_adjacent_only.erase(src))
+
+    def test_erase_is_repeatable_on_the_same_instance(self):
+        eraser = plaster.CxxMacrosEraser(
+            plaster.BlankForParseOptions(macros=True))
+        src = 'class MODULES_EXPORT C {};'
+        self.assertEqual(eraser.erase(src), eraser.erase(src))
+
+    def test_opaque_span_is_frozen(self):
+        span = plaster.CxxMacrosEraser._OpaqueSpan(0, 3, 'abc')
+        self.assertEqual((span.start, span.end, span.text), (0, 3, 'abc'))
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            span.start = 1
 
 
 class RunAstGrepTest(unittest.TestCase):


### PR DESCRIPTION
This change adds `blank_string_adjacent_macros_for_ast_parsing` as new
heuristic to blank C++ macros in upstream files. Unfortunately
`ast-grep` struggles with macros, and you can have some code that looks
like this:

```cxx
  base::DictValue GpuMessageHandler::GetClientInfo() {
    ...
    dict.Set("graphics_backend",
             std::string("Skia/" STRINGIZE(SK_MILESTONE) " " SKIA_COMMIT_HASH));
    return dict;
  }

  base::ListValue GpuMessageHandler::GetLogMessages() { ... }
```

If you try to use a rewriter, like `after_function_impl`, the rewriter
will get confused by the macro concatanation, and swallow the end of the
first function and the next one too.

This change adds a couple of heuristics to let us blank such macros.
Comprehensive tests are being added too. To reduce the impact of this
new blanking heuristic, we are guarding it behind a new flag.

Fixed: https://github.com/brave/brave-browser/issues/58063
