### PR TITLE
Update omnibox suggestion parser to handle new `rich_vertical` param for calculator

### DIFF
--- a/components/omnibox/browser/DEPS
+++ b/components/omnibox/browser/DEPS
@@ -11,6 +11,8 @@ include_rules = [
   "+components/omnibox",
   "+components/prefs",
   "+components/search_engines",
+  # For upstream's already-translated omnibox suggestion strings.
+  "+components/strings/grit/components_strings.h",
   "+components/sync_preferences/testing_pref_service_syncable.h",
   "+components/variations",
   "+content/public/test",

--- a/components/omnibox/browser/brave_search_suggestion_parser.cc
+++ b/components/omnibox/browser/brave_search_suggestion_parser.cc
@@ -5,20 +5,53 @@
 
 #include "brave/components/omnibox/browser/brave_search_suggestion_parser.h"
 
+#include <optional>
+#include <string>
+#include <string_view>
 #include <utility>
 
+#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "components/omnibox/browser/search_suggestion_parser.h"
+#include "components/strings/grit/components_strings.h"
 #include "third_party/omnibox_proto/navigational_intent.pb.h"
+#include "ui/base/device_form_factor.h"
+#include "ui/base/l10n/l10n_util.h"
 
 namespace omnibox {
+
+namespace {
+
+// Returns the suggestion's vertical, or an empty view when absent. `type` is
+// only sent when the request asks for `rich_verticals`.
+std::string_view GetVerticalType(const base::DictValue& suggestion) {
+  const std::string* type = suggestion.FindString("type");
+  return type ? *type : std::string_view();
+}
+
+// `answer` is a JSON number for arithmetic, but a string for results like unit
+// conversions.
+std::optional<std::u16string> GetAnswer(const base::DictValue& suggestion) {
+  if (auto* answer = suggestion.FindString("answer")) {
+    return base::UTF8ToUTF16(*answer);
+  }
+  if (auto answer = suggestion.FindDouble("answer")) {
+    return base::NumberToString16(*answer);
+  }
+  return std::nullopt;
+}
+
+}  // namespace
 
 bool ParseSuggestResults(const base::ListValue& root_list,
                          const AutocompleteInput& input,
                          bool is_keyword_result,
                          SearchSuggestionParser::Results* results) {
-  // Example output of rich suggestion
+  // `rich=true` allows for additional information for each suggestion. For
+  // example, a description or image.
+  //
+  // Example suggestion output with `rich=true`
   // 1) Type "hel"
   // [
   //     "hel",
@@ -45,6 +78,24 @@ bool ParseSuggestResults(const base::ListValue& root_list,
   //         },
   //     ]
   // ]
+
+  // `rich_verticals` additionally adds a "type" field to every suggestion plus
+  // vertical-specific fields.
+  //
+  // Example suggestion output with `rich_verticals=true`
+  // [
+  //    "5-2",
+  //    [
+  //        {
+  //            "type": "calculator",
+  //            "is_entity": false,
+  //            "q": "5-2",
+  //            "expression": "5-2",
+  //            "answer": 3
+  //        },
+  //    ]
+  // ]
+
   const std::u16string input_text = input.IsZeroSuggest() ? u"" : input.text();
 
   // 1st element: query.
@@ -80,10 +131,14 @@ bool ParseSuggestResults(const base::ListValue& root_list,
         AutocompleteMatchType::SEARCH_SUGGEST;
     omnibox::SuggestType suggest_type = omnibox::TYPE_QUERY;
     omnibox::EntityInfo entity_info;
-    if (auto is_entity = suggestion_dict.FindBool("is_entity");
-        is_entity.value_or(false)) {
+    if (suggestion_dict.FindBool("is_entity").value_or(false)) {
+      // Entities are flagged by `is_entity`, not by `type`.
       suggest_type = omnibox::TYPE_ENTITY;
       match_type = AutocompleteMatchType::SEARCH_SUGGEST_ENTITY;
+    } else if (GetVerticalType(suggestion_dict) == "calculator") {
+      // Verticals we don't handle stay plain query suggestions.
+      suggest_type = omnibox::TYPE_CALCULATOR;
+      match_type = AutocompleteMatchType::CALCULATOR;
     }
 
     if (auto* name = suggestion_dict.FindString("name")) {
@@ -106,11 +161,35 @@ bool ParseSuggestResults(const base::ListValue& root_list,
       entity_info.set_annotation(*description);
     }
 
-    const auto search_query_in_utf16 = base::UTF8ToUTF16(*search_query);
+    std::u16string suggestion_text;
+    std::u16string match_contents;
+    if (suggest_type == omnibox::TYPE_CALCULATOR) {
+      auto answer = GetAnswer(suggestion_dict);
+      if (!answer || answer->empty()) {
+        continue;
+      }
+      // The suggestion is the answer, so accepting the match searches the text
+      // the user typed. See BaseSearchProvider::CreateSearchSuggestion.
+      suggestion_text = std::move(*answer);
+      match_contents = suggestion_text;
+      if (ui::GetDeviceFormFactor() == ui::DEVICE_FORM_FACTOR_DESKTOP) {
+        // Desktop shows "<expression> = <answer>" on one line, as upstream
+        // does. Leaving the annotation empty keeps the description separator
+        // suppressed for CALCULATOR matches.
+        const auto* expression = suggestion_dict.FindString("expression");
+        match_contents = l10n_util::GetStringFUTF16(
+            IDS_OMNIBOX_ONE_LINE_CALCULATOR_SUGGESTION_TEMPLATE,
+            base::UTF8ToUTF16(expression ? *expression : *search_query),
+            suggestion_text);
+      }
+    } else {
+      suggestion_text = base::UTF8ToUTF16(*search_query);
+      match_contents = suggestion_text;
+    }
+
     auto result = SearchSuggestionParser::SuggestResult(
-        search_query_in_utf16, match_type, suggest_type,
-        /*subtypes*/ {},
-        /*match_contents*/ search_query_in_utf16,
+        suggestion_text, match_type, suggest_type,
+        /*subtypes*/ {}, match_contents,
         /*match_contents_prefix*/ {},
         /*annotation*/ annotation, std::move(entity_info),
         /*deletion_url*/ {}, is_keyword_result, omnibox::NAV_INTENT_NONE,

--- a/components/omnibox/browser/brave_search_suggestion_parser.cc
+++ b/components/omnibox/browser/brave_search_suggestion_parser.cc
@@ -168,14 +168,17 @@ bool ParseSuggestResults(const base::ListValue& root_list,
       if (!answer || answer->empty()) {
         continue;
       }
+      // An annotation becomes the match description, which restores the
+      // separator the desktop match cell suppresses for CALCULATOR -- the row
+      // would read "<answer> - <description>".
+      annotation.clear();
       // The suggestion is the answer, so accepting the match searches the text
       // the user typed. See BaseSearchProvider::CreateSearchSuggestion.
       suggestion_text = std::move(*answer);
       match_contents = suggestion_text;
       if (ui::GetDeviceFormFactor() == ui::DEVICE_FORM_FACTOR_DESKTOP) {
         // Desktop shows "<expression> = <answer>" on one line, as upstream
-        // does. Leaving the annotation empty keeps the description separator
-        // suppressed for CALCULATOR matches.
+        // does.
         const auto* expression = suggestion_dict.FindString("expression");
         match_contents = l10n_util::GetStringFUTF16(
             IDS_OMNIBOX_ONE_LINE_CALCULATOR_SUGGESTION_TEMPLATE,

--- a/components/omnibox/browser/brave_search_suggestion_parser_unittest.cc
+++ b/components/omnibox/browser/brave_search_suggestion_parser_unittest.cc
@@ -206,6 +206,56 @@ TEST(BraveSearchSuggestionParser, ParseSuggestResults_UnknownVertical) {
   EXPECT_EQ(u"weather in toronto", results.suggest_results[0].suggestion());
 }
 
+TEST(BraveSearchSuggestionParser, ParseSuggestResults_CalculatorStringAnswer) {
+  // Unit conversions send `answer` as a string rather than a number.
+  SearchSuggestionParser::Results results;
+  ASSERT_TRUE(ParseSuggestions("5000 m in km", R"([
+      {"type": "calculator", "q": "5000 m in km",
+       "expression": "5000 m in km", "answer": "5 km"}
+  ])",
+                               &results));
+  ASSERT_EQ(1u, results.suggest_results.size());
+
+  const auto& calculator = results.suggest_results[0];
+  EXPECT_EQ(AutocompleteMatchType::CALCULATOR, calculator.type());
+  EXPECT_EQ(u"5 km", calculator.suggestion());
+  if (ui::GetDeviceFormFactor() == ui::DEVICE_FORM_FACTOR_DESKTOP) {
+    EXPECT_EQ(u"5000 m in km = 5 km", calculator.match_contents());
+  } else {
+    EXPECT_EQ(u"5 km", calculator.match_contents());
+  }
+}
+
+TEST(BraveSearchSuggestionParser,
+     ParseSuggestResults_CalculatorWithoutExpression) {
+  // Without `expression` the query stands in for it.
+  SearchSuggestionParser::Results results;
+  ASSERT_TRUE(ParseSuggestions(
+      "5-2", R"([{"type": "calculator", "q": "5-2", "answer": 3}])", &results));
+  ASSERT_EQ(1u, results.suggest_results.size());
+
+  const auto& calculator = results.suggest_results[0];
+  EXPECT_EQ(u"3", calculator.suggestion());
+  if (ui::GetDeviceFormFactor() == ui::DEVICE_FORM_FACTOR_DESKTOP) {
+    EXPECT_EQ(u"5-2 = 3", calculator.match_contents());
+  } else {
+    EXPECT_EQ(u"3", calculator.match_contents());
+  }
+}
+
+TEST(BraveSearchSuggestionParser, ParseSuggestResults_CalculatorIgnoresDesc) {
+  // A description would restore the separator the desktop match cell
+  // suppresses for CALCULATOR, so it is dropped even if the server sends one.
+  SearchSuggestionParser::Results results;
+  ASSERT_TRUE(ParseSuggestions("5-2", R"([
+      {"type": "calculator", "q": "5-2", "expression": "5-2", "answer": 3,
+       "desc": "arithmetic"}
+  ])",
+                               &results));
+  ASSERT_EQ(1u, results.suggest_results.size());
+  EXPECT_TRUE(results.suggest_results[0].annotation().empty());
+}
+
 TEST(BraveSearchSuggestionParser, ParseSuggestResults_CalculatorWithoutAnswer) {
   // Nothing to display, so the suggestion is skipped.
   SearchSuggestionParser::Results results;

--- a/components/omnibox/browser/brave_search_suggestion_parser_unittest.cc
+++ b/components/omnibox/browser/brave_search_suggestion_parser_unittest.cc
@@ -5,10 +5,34 @@
 
 #include "brave/components/omnibox/browser/brave_search_suggestion_parser.h"
 
+#include <string_view>
 #include <utility>
 
+#include "base/strings/utf_string_conversions.h"
+#include "base/test/values_test_util.h"
 #include "components/omnibox/browser/autocomplete_scheme_classifier.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "ui/base/device_form_factor.h"
+
+namespace {
+
+// Parses `suggestions_json` -- the second element of a suggest response -- as
+// though the user had typed `input_text`.
+bool ParseSuggestions(std::string_view input_text,
+                      std::string_view suggestions_json,
+                      SearchSuggestionParser::Results* results) {
+  base::ListValue root_list;
+  root_list.Append(input_text);
+  root_list.Append(base::test::ParseJsonList(suggestions_json));
+
+  const std::u16string input_text16 = base::UTF8ToUTF16(input_text);
+  AutocompleteInput input;
+  input.UpdateText(input_text16, input_text16.size(), /*parts*/ {});
+  return omnibox::ParseSuggestResults(root_list, input,
+                                      /*is_keyword_result*/ false, results);
+}
+
+}  // namespace
 
 TEST(BraveSearchSuggestionParser, ParseSuggestResults_EmptyRootList) {
   base::ListValue root_list;
@@ -136,4 +160,71 @@ TEST(BraveSearchSuggestionParser, ParseSuggestResults_FilterSVGImage) {
   const auto& result = results.suggest_results.front();
 
   EXPECT_FALSE(result.entity_info().has_image_url());
+}
+
+TEST(BraveSearchSuggestionParser, ParseSuggestResults_CalculatorVertical) {
+  SearchSuggestionParser::Results results;
+  ASSERT_TRUE(ParseSuggestions("5-2", R"([
+      {"type": "calculator", "q": "5-2", "expression": "5-2", "answer": 3},
+      {"type": "query", "q": "52 states of america list"}
+  ])",
+                               &results));
+  ASSERT_EQ(2u, results.suggest_results.size());
+
+  // The suggestion is the answer, so accepting the match searches the typed
+  // text. Desktop additionally shows "<expression> = <answer>" as the contents.
+  const auto& calculator = results.suggest_results[0];
+  EXPECT_EQ(AutocompleteMatchType::CALCULATOR, calculator.type());
+  EXPECT_EQ(omnibox::TYPE_CALCULATOR, calculator.suggest_type());
+  EXPECT_EQ(u"3", calculator.suggestion());
+  if (ui::GetDeviceFormFactor() == ui::DEVICE_FORM_FACTOR_DESKTOP) {
+    EXPECT_EQ(u"5-2 = 3", calculator.match_contents());
+  } else {
+    EXPECT_EQ(u"3", calculator.match_contents());
+  }
+  // A description would resurrect the separator that the desktop match cell
+  // suppresses for CALCULATOR.
+  EXPECT_TRUE(calculator.annotation().empty());
+
+  // An explicit "query" type is still a plain search suggestion.
+  const auto& query = results.suggest_results[1];
+  EXPECT_EQ(AutocompleteMatchType::SEARCH_SUGGEST, query.type());
+  EXPECT_EQ(omnibox::TYPE_QUERY, query.suggest_type());
+  EXPECT_EQ(u"52 states of america list", query.suggestion());
+}
+
+TEST(BraveSearchSuggestionParser, ParseSuggestResults_UnknownVertical) {
+  // An unrecognized vertical degrades to a plain query suggestion rather than
+  // being dropped.
+  SearchSuggestionParser::Results results;
+  ASSERT_TRUE(ParseSuggestions(
+      "weather", R"([{"type": "weather", "q": "weather in toronto"}])",
+      &results));
+  ASSERT_EQ(1u, results.suggest_results.size());
+  EXPECT_EQ(AutocompleteMatchType::SEARCH_SUGGEST,
+            results.suggest_results[0].type());
+  EXPECT_EQ(u"weather in toronto", results.suggest_results[0].suggestion());
+}
+
+TEST(BraveSearchSuggestionParser, ParseSuggestResults_CalculatorWithoutAnswer) {
+  // Nothing to display, so the suggestion is skipped.
+  SearchSuggestionParser::Results results;
+  ASSERT_TRUE(ParseSuggestions(
+      "5-2", R"([{"type": "calculator", "q": "5-2", "expression": "5-2"}])",
+      &results));
+  EXPECT_TRUE(results.suggest_results.empty());
+}
+
+TEST(BraveSearchSuggestionParser, ParseSuggestResults_EntityWinsOverType) {
+  // `is_entity` predates `type` and stays authoritative.
+  SearchSuggestionParser::Results results;
+  ASSERT_TRUE(ParseSuggestions("hel", R"([
+      {"type": "query", "is_entity": true, "q": "helldivers 2",
+       "name": "Helldivers 2"}
+  ])",
+                               &results));
+  ASSERT_EQ(1u, results.suggest_results.size());
+  EXPECT_EQ(AutocompleteMatchType::SEARCH_SUGGEST_ENTITY,
+            results.suggest_results[0].type());
+  EXPECT_EQ(omnibox::TYPE_ENTITY, results.suggest_results[0].suggest_type());
 }

--- a/components/search_engines/brave_prepopulated_engines.cc
+++ b/components/search_engines/brave_prepopulated_engines.cc
@@ -219,7 +219,7 @@ const PrepopulatedEngine brave_search = MakeBravePrepopulatedEngine(
 #endif
     "UTF-8",
     "https://search.brave.com/api/"
-    "suggest?q={searchTerms}&rich=true&source="
+    "suggest?q={searchTerms}&rich=true&rich_verticals=true&source="
 #if BUILDFLAG(IS_ANDROID)
     "android",
 #else

--- a/components/search_engines/brave_prepopulated_engines.h
+++ b/components/search_engines/brave_prepopulated_engines.h
@@ -26,7 +26,7 @@ namespace TemplateURLPrepopulateData {
 // For more info, see:
 // ComputeMergeEnginesRequirements in components/search_engines/util.cc;
 
-inline constexpr int kBraveCurrentDataVersion = 32;
+inline constexpr int kBraveCurrentDataVersion = 33;
 
 // DO NOT CHANGE THIS ONE. Used for backfilling kBraveDefaultSearchVersion.
 inline constexpr int kBraveFirstTrackedDataVersion = 6;


### PR DESCRIPTION
## Description
This allows for presenting answers to a calculation as a suggestion. (For use with Brave search)

Fixes https://github.com/brave/brave-browser/issues/52260

Special thanks to @sangwoo108 for the initial work in https://github.com/brave/brave-core/pull/23888 that made this easy

<img width="434" height="314" alt="image" src="https://github.com/user-attachments/assets/7675109b-ef83-498d-ba15-ddb331ec67fc" />

## Out of scope
This only covers calculations. Unit conversions (temperature, distance, etc) are not handled. Yet.
But we can add those in the future. The functionality would be implemented with `rich_vertical=true` 😄 

## Test plan
1. Launch Brave
2. Focus the omnibox (ex: press <kbd>F6</kbd> or <kbd>Ctrl</kbd>+<kbd>L</kbd>)
3. Type in a calculator type expression. For example `6+4`
4. Observe the results

## Known problem
Chromium has a cache for calculator results which can lead to a possibly unexpected behavior. 

Any prior calculator results are cached for 1 hour. For example, if I type: `2 + 2` 
<img width="369" height="275" alt="image" src="https://github.com/user-attachments/assets/dedcd795-60b6-46cb-ab5e-1f3d4aeadf07" />

The calculated result `2 + 2 = 4` is shown (expected). 
However, if I erase that and type in: `2 * 2`...

<img width="261" height="256" alt="image" src="https://github.com/user-attachments/assets/794e9a90-cdd9-485d-a07a-ca1d534fd740" />

There are now two results shown.
Screenshot is from Chrome; I wanted to demonstrate this is present in Chromium.

Calculated results are stored for 1 hour and are erased if you close the browser/re-open.

More info can be found here:
https://issues.chromium.org/u/1/issues/40277846

