### PR TITLE
[Android] Enable dynamic colors preference

### DIFF
--- a/android/java/brave-res/xml/brave_appearance_preferences.xml
+++ b/android/java/brave-res/xml/brave_appearance_preferences.xml
@@ -11,6 +11,7 @@
 
     <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
         android:key="brave_android_dynamic_colors_enabled"
+        android:persistent="false"
         android:icon="@drawable/ic_themes"
         android:title="@string/brave_android_dynamic_colors_title"
         android:summary="@string/brave_android_dynamic_colors_summary"

--- a/android/java/org/chromium/base/BraveFeatureList.java
+++ b/android/java/org/chromium/base/BraveFeatureList.java
@@ -42,7 +42,6 @@ public abstract class BraveFeatureList {
     public static final String BRAVE_NTP_BRANDED_WALLPAPER_SURVEY_PANELIST =
             "BraveNTPBrandedWallpaperSurveyPanelist";
     public static final String BRAVE_ACCOUNT = "BraveAccount";
-    public static final String BRAVE_ANDROID_DYNAMIC_COLORS = "BraveAndroidDynamicColors";
     public static final String BRAVE_ORIGIN = "BraveOrigin";
     public static final String BRAVE_SHRED = "BraveShredFeature";
     public static final String EMAIL_ALIASES = "EmailAliases";

--- a/android/java/org/chromium/base/BraveFeatureList.java
+++ b/android/java/org/chromium/base/BraveFeatureList.java
@@ -42,6 +42,8 @@ public abstract class BraveFeatureList {
     public static final String BRAVE_NTP_BRANDED_WALLPAPER_SURVEY_PANELIST =
             "BraveNTPBrandedWallpaperSurveyPanelist";
     public static final String BRAVE_ACCOUNT = "BraveAccount";
+    public static final String BRAVE_ANDROID_DYNAMIC_COLORS_BY_DEFAULT =
+            "BraveAndroidDynamicColorsByDefault";
     public static final String BRAVE_ORIGIN = "BraveOrigin";
     public static final String BRAVE_SHRED = "BraveShredFeature";
     public static final String EMAIL_ALIASES = "EmailAliases";

--- a/android/java/org/chromium/chrome/browser/app/flags/BraveCachedFlags.java
+++ b/android/java/org/chromium/chrome/browser/app/flags/BraveCachedFlags.java
@@ -7,6 +7,7 @@ package org.chromium.chrome.browser.app.flags;
 
 import org.chromium.build.annotations.NullMarked;
 import org.chromium.chrome.browser.ntp.BraveFreshNtpHelper;
+import org.chromium.chrome.browser.theme.BraveDynamicColors;
 import org.chromium.components.cached_flags.BraveCachedFeatureParam;
 import org.chromium.components.cached_flags.BraveCachedFlagUtils;
 import org.chromium.components.cached_flags.CachedFeatureParam;
@@ -18,7 +19,9 @@ import java.util.List;
 public class BraveCachedFlags extends ChromeCachedFlags {
     // List of cached flags for Brave features - safe to access before native is ready
     private static final List<CachedFlag> sBraveFlagsCached =
-            List.of(BraveFreshNtpHelper.sBraveFreshNtpAfterIdleExperimentEnabled);
+            List.of(
+                    BraveDynamicColors.getCachedDefaultFlag(),
+                    BraveFreshNtpHelper.sBraveFreshNtpAfterIdleExperimentEnabled);
     // List of cached feature params for Brave features - safe to access before native is ready
     private static final List<CachedFeatureParam<?>> sBraveFeatureParamsCached =
             List.of(BraveFreshNtpHelper.sBraveFreshNtpAfterIdleExperimentVariant);

--- a/android/java/org/chromium/chrome/browser/app/flags/BraveCachedFlags.java
+++ b/android/java/org/chromium/chrome/browser/app/flags/BraveCachedFlags.java
@@ -7,7 +7,6 @@ package org.chromium.chrome.browser.app.flags;
 
 import org.chromium.build.annotations.NullMarked;
 import org.chromium.chrome.browser.ntp.BraveFreshNtpHelper;
-import org.chromium.chrome.browser.theme.BraveDynamicColors;
 import org.chromium.components.cached_flags.BraveCachedFeatureParam;
 import org.chromium.components.cached_flags.BraveCachedFlagUtils;
 import org.chromium.components.cached_flags.CachedFeatureParam;
@@ -19,9 +18,7 @@ import java.util.List;
 public class BraveCachedFlags extends ChromeCachedFlags {
     // List of cached flags for Brave features - safe to access before native is ready
     private static final List<CachedFlag> sBraveFlagsCached =
-            List.of(
-                    BraveDynamicColors.getCachedFlag(),
-                    BraveFreshNtpHelper.sBraveFreshNtpAfterIdleExperimentEnabled);
+            List.of(BraveFreshNtpHelper.sBraveFreshNtpAfterIdleExperimentEnabled);
     // List of cached feature params for Brave features - safe to access before native is ready
     private static final List<CachedFeatureParam<?>> sBraveFeatureParamsCached =
             List.of(BraveFreshNtpHelper.sBraveFreshNtpAfterIdleExperimentVariant);

--- a/android/javatests/org/chromium/chrome/browser/settings/BraveAppearancePreferencesTest.java
+++ b/android/javatests/org/chromium/chrome/browser/settings/BraveAppearancePreferencesTest.java
@@ -25,7 +25,9 @@ import org.chromium.base.BravePreferenceKeys;
 import org.chromium.base.test.util.DoNotBatch;
 import org.chromium.base.test.util.Features.DisableFeatures;
 import org.chromium.base.test.util.Features.EnableFeatures;
+import org.chromium.base.test.util.MinAndroidSdkLevel;
 import org.chromium.chrome.browser.appearance.settings.AppearanceSettingsFragment;
+import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
 import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
 
 /** Test for {@link AppearancePreferences}. */
@@ -107,6 +109,18 @@ public class BraveAppearancePreferencesTest {
         } else {
             Assert.assertNull(dynamicColorsPreference);
         }
+    }
+
+    @Test
+    @SmallTest
+    @MinAndroidSdkLevel(Build.VERSION_CODES.S)
+    public void testDynamicColorsInitializationDoesNotPersistDefault() {
+        String key = BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED;
+        ChromeSharedPreferences.getInstance().removeKey(key);
+
+        startSettings();
+
+        Assert.assertFalse(ChromeSharedPreferences.getInstance().contains(key));
     }
 
     @Test

--- a/android/javatests/org/chromium/chrome/browser/settings/BraveAppearancePreferencesTest.java
+++ b/android/javatests/org/chromium/chrome/browser/settings/BraveAppearancePreferencesTest.java
@@ -95,7 +95,6 @@ public class BraveAppearancePreferencesTest {
 
     @Test
     @SmallTest
-    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
     public void testDynamicColorsPreferenceAvailability() {
         startSettings();
 

--- a/android/junit/src/org/chromium/chrome/browser/tabbed_mode/BraveTabbedNavigationBarColorControllerBaseTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/tabbed_mode/BraveTabbedNavigationBarColorControllerBaseTest.java
@@ -25,14 +25,11 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.robolectric.annotation.Config;
 
-import org.chromium.base.BraveFeatureList;
 import org.chromium.base.BravePreferenceKeys;
 import org.chromium.base.supplier.ObservableSuppliers;
 import org.chromium.base.supplier.SettableMonotonicObservableSupplier;
 import org.chromium.base.test.BaseRobolectricTestRunner;
 import org.chromium.base.test.RobolectricUtil;
-import org.chromium.base.test.util.Features.DisableFeatures;
-import org.chromium.base.test.util.Features.EnableFeatures;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.fullscreen.FullscreenManager;
 import org.chromium.chrome.browser.layouts.LayoutManager;
@@ -47,7 +44,6 @@ import org.chromium.ui.edge_to_edge.EdgeToEdgeSystemBarColorHelper;
 /** Unit tests for {@link BraveTabbedNavigationBarColorControllerBase}. */
 @RunWith(BaseRobolectricTestRunner.class)
 @Config(manifest = Config.NONE, sdk = 29)
-@DisableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
 public class BraveTabbedNavigationBarColorControllerBaseTest {
     @Rule public final MockitoRule mMockitoRule = MockitoJUnit.rule();
 
@@ -114,7 +110,9 @@ public class BraveTabbedNavigationBarColorControllerBaseTest {
     }
 
     @Test
-    public void testGetNavigationBarColor_dynamicColorsDisabled_regularTab() {
+    public void testGetNavigationBarColor_dynamicColorsUserDisabled_regularTab() {
+        ChromeSharedPreferences.getInstance()
+                .writeBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, false);
         when(mTabModelSelector.isIncognitoSelected()).thenReturn(false);
         assertEquals(
                 mContext.getColor(R.color.default_bg_color_baseline),
@@ -122,7 +120,9 @@ public class BraveTabbedNavigationBarColorControllerBaseTest {
     }
 
     @Test
-    public void testGetNavigationBarColor_dynamicColorsDisabled_incognitoTab() {
+    public void testGetNavigationBarColor_dynamicColorsUserDisabled_incognitoTab() {
+        ChromeSharedPreferences.getInstance()
+                .writeBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, false);
         when(mTabModelSelector.isIncognitoSelected()).thenReturn(true);
         assertEquals(
                 mContext.getColor(R.color.toolbar_background_primary_dark),
@@ -130,9 +130,10 @@ public class BraveTabbedNavigationBarColorControllerBaseTest {
     }
 
     @Test
-    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
     @Config(sdk = Build.VERSION_CODES.S)
-    public void testGetNavigationBarColor_dynamicColorsEnabled_delegatesToUpstream() {
+    public void testGetNavigationBarColor_dynamicColorsUserEnabled_delegatesToUpstream() {
+        ChromeSharedPreferences.getInstance()
+                .writeBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, true);
         // When dynamic colors is enabled, the Brave-specific block is skipped and the
         // upstream TabbedNavigationBarColorController logic runs, returning the semantic
         // bottom system nav color rather than Brave's hardcoded colors.
@@ -142,20 +143,9 @@ public class BraveTabbedNavigationBarColorControllerBaseTest {
     }
 
     @Test
-    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
-    public void testGetNavigationBarColor_dynamicColorsBelowAndroidS_usesBraveColor() {
-        when(mTabModelSelector.isIncognitoSelected()).thenReturn(false);
-        assertEquals(
-                mContext.getColor(R.color.default_bg_color_baseline),
-                mBase.getNavigationBarColor(false));
-    }
-
-    @Test
-    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
-    @Config(sdk = Build.VERSION_CODES.S)
-    public void testGetNavigationBarColor_dynamicColorsUserDisabled_usesBraveColor() {
+    public void testGetNavigationBarColor_dynamicColorsUserEnabledBelowAndroidS_usesBraveColor() {
         ChromeSharedPreferences.getInstance()
-                .writeBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, false);
+                .writeBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, true);
         when(mTabModelSelector.isIncognitoSelected()).thenReturn(false);
         assertEquals(
                 mContext.getColor(R.color.default_bg_color_baseline),

--- a/android/junit/src/org/chromium/chrome/browser/ui/system/BraveStatusBarColorControllerUnitTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/ui/system/BraveStatusBarColorControllerUnitTest.java
@@ -26,14 +26,11 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.robolectric.annotation.Config;
 
-import org.chromium.base.BraveFeatureList;
 import org.chromium.base.BravePreferenceKeys;
 import org.chromium.base.supplier.MonotonicObservableSupplier;
 import org.chromium.base.supplier.ObservableSuppliers;
 import org.chromium.base.supplier.SettableNonNullObservableSupplier;
 import org.chromium.base.test.BaseRobolectricTestRunner;
-import org.chromium.base.test.util.Features.DisableFeatures;
-import org.chromium.base.test.util.Features.EnableFeatures;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.ActivityTabProvider;
 import org.chromium.chrome.browser.browser_controls.BrowserControlsStateProvider;
@@ -85,18 +82,20 @@ public class BraveStatusBarColorControllerUnitTest {
     }
 
     @Test
-    @DisableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
     @Config(sdk = Build.VERSION_CODES.S)
-    public void testBackgroundColorForNtp_dynamicColorsDisabled_returnsWhite() {
+    public void testBackgroundColorForNtp_dynamicColorsUserDisabled_returnsWhite() {
+        ChromeSharedPreferences.getInstance()
+                .writeBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, false);
         BraveStatusBarColorController controller =
                 newControllerWithUpstreamNtpBackground(TEST_UPSTREAM_NTP_BACKGROUND_COLOR);
         assertEquals(Color.WHITE, controller.getBackgroundColorForNtpForTesting());
     }
 
     @Test
-    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
     @Config(sdk = Build.VERSION_CODES.S)
-    public void testBackgroundColorForNtp_dynamicColorsEnabled_returnsUpstreamDefault() {
+    public void testBackgroundColorForNtp_dynamicColorsUserEnabled_returnsUpstreamDefault() {
+        ChromeSharedPreferences.getInstance()
+                .writeBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, true);
         BraveStatusBarColorController controller =
                 newControllerWithUpstreamNtpBackground(TEST_UPSTREAM_NTP_BACKGROUND_COLOR);
         assertEquals(
@@ -105,20 +104,10 @@ public class BraveStatusBarColorControllerUnitTest {
     }
 
     @Test
-    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
     @Config(sdk = Build.VERSION_CODES.R)
-    public void testBackgroundColorForNtp_dynamicColorsBelowAndroidS_returnsWhite() {
-        BraveStatusBarColorController controller =
-                newControllerWithUpstreamNtpBackground(TEST_UPSTREAM_NTP_BACKGROUND_COLOR);
-        assertEquals(Color.WHITE, controller.getBackgroundColorForNtpForTesting());
-    }
-
-    @Test
-    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
-    @Config(sdk = Build.VERSION_CODES.S)
-    public void testBackgroundColorForNtp_dynamicColorsUserDisabled_returnsWhite() {
+    public void testBackgroundColorForNtp_dynamicColorsUserEnabledBelowAndroidS_returnsWhite() {
         ChromeSharedPreferences.getInstance()
-                .writeBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, false);
+                .writeBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, true);
         BraveStatusBarColorController controller =
                 newControllerWithUpstreamNtpBackground(TEST_UPSTREAM_NTP_BACKGROUND_COLOR);
         assertEquals(Color.WHITE, controller.getBackgroundColorForNtpForTesting());

--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -446,15 +446,6 @@ const char* const kBraveSyncImplLink[1] = {"https://github.com/brave/go-sync"};
       FEATURE_VALUE_TYPE(                                               \
           chrome::android::kAdaptiveButtonInTopToolbarCustomizationV2), \
   })
-#define BRAVE_ANDROID_DYNAMIC_COLORS                                 \
-  EXPAND_FEATURE_ENTRIES({                                           \
-      "brave-android-dynamic-colors",                                \
-      "Dynamic Colors",                                              \
-      "Use dynamic colors in the application. This feature is only " \
-      "available on Android 12 and above.",                          \
-      kOsAndroid,                                                    \
-      FEATURE_VALUE_TYPE(features::kBraveAndroidDynamicColors),      \
-  })
 #define BRAVE_CUSTOM_SEARCH_ENGINES                                        \
   EXPAND_FEATURE_ENTRIES({                                                 \
       "brave-custom-search-engines",                                       \
@@ -476,7 +467,6 @@ const char* const kBraveSyncImplLink[1] = {"https://github.com/brave/go-sync"};
 #define BRAVE_BACKGROUND_VIDEO_PLAYBACK_ANDROID
 #define BRAVE_SAFE_BROWSING_ANDROID
 #define BRAVE_ADAPTIVE_BUTTON_IN_TOOLBAR_ANDROID
-#define BRAVE_ANDROID_DYNAMIC_COLORS
 #define BRAVE_CUSTOM_SEARCH_ENGINES
 #define BRAVE_ANDROID_TAB_GROUPS_SETTINGS
 #endif  // BUILDFLAG(IS_ANDROID)
@@ -1541,7 +1531,6 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
   BRAVE_BACKGROUND_VIDEO_PLAYBACK_ANDROID                                      \
   BRAVE_SAFE_BROWSING_ANDROID                                                  \
   BRAVE_ADAPTIVE_BUTTON_IN_TOOLBAR_ANDROID                                     \
-  BRAVE_ANDROID_DYNAMIC_COLORS                                                 \
   BRAVE_ANDROID_TAB_GROUPS_SETTINGS                                            \
   BRAVE_CUSTOM_SEARCH_ENGINES                                                  \
   BRAVE_CHANGE_ACTIVE_TAB_ON_SCROLL_EVENT_FEATURE_ENTRIES                      \

--- a/browser/brave_browser_features.cc
+++ b/browser/brave_browser_features.cc
@@ -59,12 +59,6 @@ BASE_FEATURE(kBraveV8JitlessMode,
              base::FEATURE_DISABLED_BY_DEFAULT);
 
 #if BUILDFLAG(IS_ANDROID)
-// Enable dynamic colors on Android, which allows the app to adapt its
-// color scheme based on the user's wallpaper and system theme.
-// This feature is only available on Android 12 and above.
-BASE_FEATURE(kBraveAndroidDynamicColors,
-             base::FEATURE_DISABLED_BY_DEFAULT);
-
 // Enable fresh NTP display after idle expiration on Android.
 // This feature allows showing a refreshed NTP when the app has been idle
 // for a specified duration.

--- a/browser/brave_browser_features.cc
+++ b/browser/brave_browser_features.cc
@@ -59,6 +59,11 @@ BASE_FEATURE(kBraveV8JitlessMode,
              base::FEATURE_DISABLED_BY_DEFAULT);
 
 #if BUILDFLAG(IS_ANDROID)
+// Controls the dynamic colors preference default when the user has not made a
+// choice. Dynamic colors are available on Android 12 and above.
+BASE_FEATURE(kBraveAndroidDynamicColorsByDefault,
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
 // Enable fresh NTP display after idle expiration on Android.
 // This feature allows showing a refreshed NTP when the app has been idle
 // for a specified duration.

--- a/browser/brave_browser_features.cc
+++ b/browser/brave_browser_features.cc
@@ -62,7 +62,7 @@ BASE_FEATURE(kBraveV8JitlessMode,
 // Controls the dynamic colors preference default when the user has not made a
 // choice. Dynamic colors are available on Android 12 and above.
 BASE_FEATURE(kBraveAndroidDynamicColorsByDefault,
-             base::FEATURE_DISABLED_BY_DEFAULT);
+             base::FEATURE_ENABLED_BY_DEFAULT);
 
 // Enable fresh NTP display after idle expiration on Android.
 // This feature allows showing a refreshed NTP when the app has been idle

--- a/browser/brave_browser_features.h
+++ b/browser/brave_browser_features.h
@@ -26,6 +26,7 @@ BASE_DECLARE_FEATURE(kBraveWebAssemblyJitless);
 #endif  // BUILDFLAG(BRAVE_V8_ENABLE_DRUMBRAKE)
 BASE_DECLARE_FEATURE(kBraveV8JitlessMode);
 #if BUILDFLAG(IS_ANDROID)
+BASE_DECLARE_FEATURE(kBraveAndroidDynamicColorsByDefault);
 BASE_DECLARE_FEATURE(kBraveFreshNtpAfterIdleExperiment);
 BASE_DECLARE_FEATURE(kBraveCustomSearchEngines);
 BASE_DECLARE_FEATURE(kBraveAndroidTabGroupsSettings);

--- a/browser/brave_browser_features.h
+++ b/browser/brave_browser_features.h
@@ -26,7 +26,6 @@ BASE_DECLARE_FEATURE(kBraveWebAssemblyJitless);
 #endif  // BUILDFLAG(BRAVE_V8_ENABLE_DRUMBRAKE)
 BASE_DECLARE_FEATURE(kBraveV8JitlessMode);
 #if BUILDFLAG(IS_ANDROID)
-BASE_DECLARE_FEATURE(kBraveAndroidDynamicColors);
 BASE_DECLARE_FEATURE(kBraveFreshNtpAfterIdleExperiment);
 BASE_DECLARE_FEATURE(kBraveCustomSearchEngines);
 BASE_DECLARE_FEATURE(kBraveAndroidTabGroupsSettings);

--- a/browser/ui/android/theme/java/src/org/chromium/chrome/browser/theme/BraveDynamicColors.java
+++ b/browser/ui/android/theme/java/src/org/chromium/chrome/browser/theme/BraveDynamicColors.java
@@ -16,17 +16,33 @@ import android.view.View;
 import com.google.android.material.color.DynamicColors;
 import com.google.android.material.color.DynamicColorsOptions;
 
+import org.chromium.base.BraveFeatureList;
 import org.chromium.base.BravePreferenceKeys;
 import org.chromium.build.annotations.NullMarked;
 import org.chromium.build.annotations.Nullable;
+import org.chromium.chrome.browser.flags.ChromeFeatureMap;
 import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
+import org.chromium.components.cached_flags.CachedFlag;
 import org.chromium.ui.R;
 import org.chromium.ui.util.AttrUtils;
 
 /** Controls Brave's runtime use of Material dynamic colors. */
 @NullMarked
 public final class BraveDynamicColors {
+    // ChromeCachedFlags.<clinit> creates a singleton bytecode-redirected to BraveCachedFlags
+    // before BraveCachedFlags' static fields are ready, so this CachedFlag must live separately.
+    private static final CachedFlag sDynamicColorsDefaultFlag =
+            new CachedFlag(
+                    ChromeFeatureMap.getInstance(),
+                    BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS_BY_DEFAULT,
+                    false);
+
     private BraveDynamicColors() {}
+
+    /** Returns the cached feature that supplies the default for an unset user preference. */
+    public static CachedFlag getCachedDefaultFlag() {
+        return sDynamicColorsDefaultFlag;
+    }
 
     /**
      * Returns whether dynamic colors are available for this app session.
@@ -41,17 +57,19 @@ public final class BraveDynamicColors {
     /**
      * Returns whether dynamic colors should be used at runtime.
      *
-     * <p>This requires dynamic colors to be available and the user preference to be enabled. The
-     * preference defaults to enabled when it has not been set.
+     * <p>This requires dynamic colors to be available and the user preference to be enabled. An
+     * unset preference uses the cached remotely controlled default.
      */
     public static boolean isDynamicColorsEnabled() {
         return isDynamicColorsAvailable() && isDynamicColorsUserEnabled();
     }
 
-    /** Returns the persisted user preference, which defaults to enabled when unset. */
+    /** Returns the persisted user preference or the cached default when it is unset. */
     private static boolean isDynamicColorsUserEnabled() {
         return ChromeSharedPreferences.getInstance()
-                .readBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, true);
+                .readBoolean(
+                        BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED,
+                        getCachedDefaultFlag().isEnabled());
     }
 
     /**

--- a/browser/ui/android/theme/java/src/org/chromium/chrome/browser/theme/BraveDynamicColors.java
+++ b/browser/ui/android/theme/java/src/org/chromium/chrome/browser/theme/BraveDynamicColors.java
@@ -16,43 +16,26 @@ import android.view.View;
 import com.google.android.material.color.DynamicColors;
 import com.google.android.material.color.DynamicColorsOptions;
 
-import org.chromium.base.BraveFeatureList;
 import org.chromium.base.BravePreferenceKeys;
 import org.chromium.build.annotations.NullMarked;
 import org.chromium.build.annotations.Nullable;
-import org.chromium.chrome.browser.flags.ChromeFeatureMap;
 import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
-import org.chromium.components.cached_flags.CachedFlag;
 import org.chromium.ui.R;
 import org.chromium.ui.util.AttrUtils;
 
 /** Controls Brave's runtime use of Material dynamic colors. */
 @NullMarked
 public final class BraveDynamicColors {
-    // ChromeCachedFlags.<clinit> creates a singleton bytecode-redirected to BraveCachedFlags
-    // before BraveCachedFlags' static fields are ready, so this CachedFlag must live separately.
-    private static final CachedFlag sDynamicColorsFlag =
-            new CachedFlag(
-                    ChromeFeatureMap.getInstance(),
-                    BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS,
-                    false);
-
     private BraveDynamicColors() {}
-
-    /** Returns the feature flag used for cached-flag registration and early-startup reads. */
-    public static CachedFlag getCachedFlag() {
-        return sDynamicColorsFlag;
-    }
 
     /**
      * Returns whether dynamic colors are available for this app session.
      *
-     * <p>Availability requires the cached feature flag to be enabled and Android 12 or later. It
-     * does not include the user's preference; {@link #isDynamicColorsEnabled()} is the preferred
-     * method for runtime behavior checks.
+     * <p>Availability requires Android 12 or later. It does not include the user's preference;
+     * {@link #isDynamicColorsEnabled()} is the preferred method for runtime behavior checks.
      */
     public static boolean isDynamicColorsAvailable() {
-        return getCachedFlag().isEnabled() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S;
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S;
     }
 
     /**

--- a/browser/ui/android/theme/java/src/org/chromium/chrome/browser/theme/BraveDynamicColors.java
+++ b/browser/ui/android/theme/java/src/org/chromium/chrome/browser/theme/BraveDynamicColors.java
@@ -35,7 +35,7 @@ public final class BraveDynamicColors {
             new CachedFlag(
                     ChromeFeatureMap.getInstance(),
                     BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS_BY_DEFAULT,
-                    false);
+                    true);
 
     private BraveDynamicColors() {}
 

--- a/browser/ui/android/theme/junit/src/org/chromium/chrome/browser/theme/BraveDynamicColorsTest.java
+++ b/browser/ui/android/theme/junit/src/org/chromium/chrome/browser/theme/BraveDynamicColorsTest.java
@@ -44,7 +44,6 @@ public class BraveDynamicColorsTest {
     }
 
     @Test
-    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS_BY_DEFAULT)
     public void testIsDynamicColorsEnabled_defaultEnabled_userPreferenceUnset_returnsTrue() {
         assertTrue(BraveDynamicColors.isDynamicColorsEnabled());
     }

--- a/browser/ui/android/theme/junit/src/org/chromium/chrome/browser/theme/BraveDynamicColorsTest.java
+++ b/browser/ui/android/theme/junit/src/org/chromium/chrome/browser/theme/BraveDynamicColorsTest.java
@@ -15,8 +15,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
+import org.chromium.base.BraveFeatureList;
 import org.chromium.base.BravePreferenceKeys;
 import org.chromium.base.test.BaseRobolectricTestRunner;
+import org.chromium.base.test.util.Features.DisableFeatures;
+import org.chromium.base.test.util.Features.EnableFeatures;
 import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
 
 /** Unit tests for {@link BraveDynamicColors}. */
@@ -41,12 +44,21 @@ public class BraveDynamicColorsTest {
     }
 
     @Test
-    public void testIsDynamicColorsEnabled_userPreferenceUnset_returnsTrue() {
+    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS_BY_DEFAULT)
+    public void testIsDynamicColorsEnabled_defaultEnabled_userPreferenceUnset_returnsTrue() {
         assertTrue(BraveDynamicColors.isDynamicColorsEnabled());
     }
 
     @Test
-    public void testIsDynamicColorsEnabled_userPreferenceDisabled_returnsFalse() {
+    @DisableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS_BY_DEFAULT)
+    public void testIsDynamicColorsEnabled_defaultDisabled_userPreferenceUnset_returnsFalse() {
+        assertFalse(BraveDynamicColors.isDynamicColorsEnabled());
+    }
+
+    @Test
+    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS_BY_DEFAULT)
+    public void
+            testIsDynamicColorsEnabled_userPreferenceDisabledOverridesDefaultEnabled_returnsFalse() {
         ChromeSharedPreferences.getInstance()
                 .writeBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, false);
 
@@ -55,7 +67,9 @@ public class BraveDynamicColorsTest {
     }
 
     @Test
-    public void testIsDynamicColorsEnabled_userPreferenceEnabled_returnsTrue() {
+    @DisableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS_BY_DEFAULT)
+    public void
+            testIsDynamicColorsEnabled_userPreferenceEnabledOverridesDefaultDisabled_returnsTrue() {
         ChromeSharedPreferences.getInstance()
                 .writeBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, true);
 

--- a/browser/ui/android/theme/junit/src/org/chromium/chrome/browser/theme/BraveDynamicColorsTest.java
+++ b/browser/ui/android/theme/junit/src/org/chromium/chrome/browser/theme/BraveDynamicColorsTest.java
@@ -15,11 +15,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-import org.chromium.base.BraveFeatureList;
 import org.chromium.base.BravePreferenceKeys;
 import org.chromium.base.test.BaseRobolectricTestRunner;
-import org.chromium.base.test.util.Features.DisableFeatures;
-import org.chromium.base.test.util.Features.EnableFeatures;
 import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
 
 /** Unit tests for {@link BraveDynamicColors}. */
@@ -33,32 +30,22 @@ public class BraveDynamicColorsTest {
     }
 
     @Test
-    @DisableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
-    public void testIsDynamicColorsAvailable_featureDisabled_returnsFalse() {
-        assertFalse(BraveDynamicColors.isDynamicColorsAvailable());
+    public void testIsDynamicColorsAvailable_androidS_returnsTrue() {
+        assertTrue(BraveDynamicColors.isDynamicColorsAvailable());
     }
 
     @Test
-    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
     @Config(sdk = Build.VERSION_CODES.R)
     public void testIsDynamicColorsAvailable_belowAndroidS_returnsFalse() {
         assertFalse(BraveDynamicColors.isDynamicColorsAvailable());
     }
 
     @Test
-    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
-    public void testIsDynamicColorsAvailable_androidSAndFeatureEnabled_returnsTrue() {
-        assertTrue(BraveDynamicColors.isDynamicColorsAvailable());
-    }
-
-    @Test
-    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
     public void testIsDynamicColorsEnabled_userPreferenceUnset_returnsTrue() {
         assertTrue(BraveDynamicColors.isDynamicColorsEnabled());
     }
 
     @Test
-    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
     public void testIsDynamicColorsEnabled_userPreferenceDisabled_returnsFalse() {
         ChromeSharedPreferences.getInstance()
                 .writeBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, false);
@@ -68,15 +55,20 @@ public class BraveDynamicColorsTest {
     }
 
     @Test
-    @DisableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
-    public void testIsDynamicColorsEnabled_featureDisabled_returnsFalse() {
-        assertFalse(BraveDynamicColors.isDynamicColorsEnabled());
+    public void testIsDynamicColorsEnabled_userPreferenceEnabled_returnsTrue() {
+        ChromeSharedPreferences.getInstance()
+                .writeBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, true);
+
+        assertTrue(BraveDynamicColors.isDynamicColorsAvailable());
+        assertTrue(BraveDynamicColors.isDynamicColorsEnabled());
     }
 
     @Test
-    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
     @Config(sdk = Build.VERSION_CODES.R)
-    public void testIsDynamicColorsEnabled_belowAndroidS_returnsFalse() {
+    public void testIsDynamicColorsEnabled_userPreferenceEnabledBelowAndroidS_returnsFalse() {
+        ChromeSharedPreferences.getInstance()
+                .writeBoolean(BravePreferenceKeys.BRAVE_ANDROID_DYNAMIC_COLORS_ENABLED, true);
+
         assertFalse(BraveDynamicColors.isDynamicColorsEnabled());
     }
 }

--- a/chromium_src/chrome/browser/flags/android/chrome_feature_list.cc
+++ b/chromium_src/chrome/browser/flags/android/chrome_feature_list.cc
@@ -105,6 +105,7 @@
     &brave_shields::features::kBraveShowStrictFingerprintingMode,              \
     &brave_shields::features::kBlockAllCookiesToggle,                          \
     &brave_shields::features::kBraveShieldsElementPicker,                      \
+    &features::kBraveAndroidDynamicColorsByDefault,                            \
     &features::kBraveFreshNtpAfterIdleExperiment,                              \
     &ntp_background_images::features::kBraveNTPBrandedWallpaperSurveyPanelist, \
     &brave_shields::features::kBraveShredFeature,                              \

--- a/chromium_src/chrome/browser/flags/android/chrome_feature_list.cc
+++ b/chromium_src/chrome/browser/flags/android/chrome_feature_list.cc
@@ -105,7 +105,6 @@
     &brave_shields::features::kBraveShowStrictFingerprintingMode,              \
     &brave_shields::features::kBlockAllCookiesToggle,                          \
     &brave_shields::features::kBraveShieldsElementPicker,                      \
-    &features::kBraveAndroidDynamicColors,                                     \
     &features::kBraveFreshNtpAfterIdleExperiment,                              \
     &ntp_background_images::features::kBraveNTPBrandedWallpaperSurveyPanelist, \
     &brave_shields::features::kBraveShredFeature,                              \


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57121.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

## Overview

This PR performs two main tasks:
1. Removes the previous `BRAVE_ANDROID_DYNAMIC_COLORS` flag (previously exposed via `"brave-android-dynamic-colors"` on `brave://flags`) (a44ff9e63da68ff9f791d5152d2caaacd191877c)
2. Adds the `kBraveAndroidDynamicColorsByDefault` feature flag. This is not exposed via `brave://flags`, but allows the default "enable dynamic colors" behavior to be controlled via Griffin. A PR to configure this via https://github.com/brave/brave-variations will follow (a3207b700a4be431162714b0f42f2ec0e06f2f2e).

`kBraveAndroidDynamicColorsByDefault` is enabled by default in 697f8bd864cf79b7a926b5c21dee301bed11a869. 

