### PR TITLE
[Wallet]: Fix Sign Warning Continue Button Color (uplift to 1.94.x)

### DIFF
--- a/components/brave_wallet_ui/components/extension/buttons/nav-button/style.ts
+++ b/components/brave_wallet_ui/components/extension/buttons/nav-button/style.ts
@@ -59,7 +59,7 @@ const StyledButtonCssMixin = (p: StyledButtonProps) => {
             || p.buttonType === 'sign'
           ? leo.color.primitive.primary[40]
           : p.buttonType === 'danger'
-            ? leo.color.systemfeedback.errorBackground
+            ? leo.color.button.errorBackground
             : 'transparent'};
 
     border: ${(p) =>
@@ -97,7 +97,9 @@ export const ButtonText = styled(Text)<{
     || p.buttonType === 'reject'
     || p.buttonType === 'cancel'
       ? leo.color.text.secondary
-      : leo.color.white};
+      : p.buttonType === 'danger'
+        ? leo.color.button.errorText
+        : leo.color.white};
 `
 
 export const RejectIcon = styled.div`


### PR DESCRIPTION
Uplift of #38784
Resolves https://github.com/brave/brave-browser/issues/57843

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.