### PR TITLE
[iOS] Handle download cancellation correctly

### DIFF
--- a/ios/brave-ios/Sources/Web/Chromium/ChromiumDownload.swift
+++ b/ios/brave-ios/Sources/Web/Chromium/ChromiumDownload.swift
@@ -47,6 +47,15 @@ class ChromiumDownload: Download, CWVDownloadTaskDelegate {
   }
 
   func downloadTask(_ downloadTask: CWVDownloadTask, didFinishWithError error: (any Error)?) {
+    let error: (any Error)? = error.map { error in
+      let chromeError = error as NSError
+      if chromeError.code == CWVDownloadErrorAborted {
+        // Swap the Chromium error with a standard cancelled URLError since TabState doesn't expose
+        // Chromium specific types.
+        return URLError(.cancelled)
+      }
+      return error
+    }
     didFinish(self, error)
   }
 

--- a/patches/ios-web_view-internal-cwv_download_task.mm.patch
+++ b/patches/ios-web_view-internal-cwv_download_task.mm.patch
@@ -1,0 +1,21 @@
+diff --git a/ios/web_view/internal/cwv_download_task.mm b/ios/web_view/internal/cwv_download_task.mm
+index 0c61a5c53d8ffcae001bdbf0e83644d5fe4fb9aa..4dd1f502504d2cebb02ddbf63dda623a85141ad8 100644
+--- a/ios/web_view/internal/cwv_download_task.mm
++++ b/ios/web_view/internal/cwv_download_task.mm
+@@ -111,13 +111,12 @@ NSInteger const CWVDownloadErrorAborted = -101;
+       [self notifyFinishWithErrorCode:errorCode];
+       break;
+     }
+-    case web::DownloadTask::State::kNotStarted:
+     case web::DownloadTask::State::kCancelled: {
+-      // Nothing to be done in these states.
+-      // Note that state kCancelled is immediately followed by state kComplete
+-      // with error code net::ERR_ABORTED, which is handled above.
++      [self notifyFinishWithErrorCode:net::ERR_ABORTED];
+       break;
+     }
++    case web::DownloadTask::State::kNotStarted:
++      break;
+   }
+ }
+ 


### PR DESCRIPTION
This introduces a temporary patch which fixes the `CWVDownloadTask` not correctly calling the delegate when a task is explicitly cancelled. Upstream issue: https://crbug.com/545350635, Upstream patch: https://chromium-review.googlesource.com/c/chromium/src/+/8257615
