### PR TITLE
[iOS] Add support for continuing a download in the background on iOS 26+

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/AppState.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppState.swift
@@ -26,6 +26,7 @@ private let adsRewardsLog = Logger(
 /// Class that does startup initialization
 /// Everything in this class can only be execute ONCE
 /// IE: BraveCore initialization, BuildChannel, Migrations, etc.
+@MainActor
 public class AppState {
   private let log = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "app-state")
 
@@ -38,6 +39,8 @@ public class AppState {
   public let newsFeedDataSource: FeedDataSource
   public let uptimeMonitor = UptimeMonitor()
   public let defaultProfileLoader = DefaultProfileLoader()
+  public let downloadBackgroundTaskModel: DownloadBackgroundTaskScheduler?
+
   private var didBecomeActive = false
 
   public var state: State = .launching(options: [:], active: false) {
@@ -109,6 +112,18 @@ public class AppState {
     localStateMigration.launchMigrations()
 
     newsFeedDataSource = FeedDataSource()
+
+    #if !targetEnvironment(simulator)
+    if #available(iOS 26.0, *) {
+      downloadBackgroundTaskModel = DownloadBackgroundTaskScheduler(
+        taskIdentifier: "\(Bundle.main.bundleIdentifier!).download"
+      )
+    } else {
+      downloadBackgroundTaskModel = nil
+    }
+    #else
+    downloadBackgroundTaskModel = nil
+    #endif
 
     // Setup Custom URL scheme handlers
     setupCustomSchemeHandlers()

--- a/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
@@ -361,7 +361,8 @@ extension SceneDelegate {
       attributionManager: profileState.attributionManager,
       rewards: profileState.rewards,
       newsFeedDataSource: AppState.shared.newsFeedDataSource,
-      userActivity: sceneState.connectionOptions.userActivities.first
+      userActivity: sceneState.connectionOptions.userActivities.first,
+      downloadBackgroundTaskModel: AppState.shared.downloadBackgroundTaskModel
     )
 
     // Setup Playlist Car-Play
@@ -717,7 +718,8 @@ extension SceneDelegate {
     attributionManager: AttributionManager,
     rewards: Brave.BraveRewards,
     newsFeedDataSource: BraveNews.FeedDataSource,
-    userActivity: NSUserActivity?
+    userActivity: NSUserActivity?,
+    downloadBackgroundTaskModel: DownloadBackgroundTaskScheduler?
   ) -> BrowserViewController {
     let privateBrowsingManager = PrivateBrowsingManager()
 
@@ -787,7 +789,8 @@ extension SceneDelegate {
       rewards: rewards,
       crashedLastSession: crashedLastSession,
       newsFeedDataSource: newsFeedDataSource,
-      privateBrowsingManager: privateBrowsingManager
+      privateBrowsingManager: privateBrowsingManager,
+      downloadBackgroundTaskModel: downloadBackgroundTaskModel
     )
 
     browserViewController.do {

--- a/ios/brave-ios/App/iOS/SupportingFiles/Info.plist
+++ b/ios/brave-ios/App/iOS/SupportingFiles/Info.plist
@@ -4,6 +4,10 @@
 <dict>
 	<key>AppIdentifierPrefix</key>
 	<string>$(APP_IDENTIFIER_PREFIX)</string>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).download</string>
+	</array>
 	<key>BRAVE_URL_SCHEME</key>
 	<string>$(BRAVE_URL_SCHEME)</string>
 	<key>CFBundleAllowMixedLocalizations</key>
@@ -45,10 +49,10 @@
 	<string>$(brave_version_build)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
-	<key>KSChannelID</key>
-	<string>$(brave_channel)</string>
 	<key>KSApplicationGroup</key>
 	<string>$(BRAVE_GROUP_ID)</string>
+	<key>KSChannelID</key>
+	<string>$(brave_channel)</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>http</string>
@@ -127,6 +131,7 @@
 		<string>audio</string>
 		<string>remote-notification</string>
 		<string>voip</string>
+		<string>processing</string>
 	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+DownloadQueueDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+DownloadQueueDelegate.swift
@@ -48,6 +48,10 @@ extension BrowserViewController: DownloadQueueDelegate {
   ) {
     downloadToast?.combinedBytesDownloaded = combinedBytesDownloaded
     downloadToast?.combinedTotalBytesExpected = combinedTotalBytesExpected
+
+    if #available(iOS 26.0, *) {
+      downloadBackgroundTaskModel?.updateActiveTaskProgress()
+    }
   }
 
   func downloadQueue(

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDownloadDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDownloadDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -103,10 +103,18 @@ extension BrowserViewController: TabDownloadDelegate {
       downloadQueue.enqueue(download)
 
       download.startDownloadToLocalFileAtPath(url.path)
+
+      if #available(iOS 26.0, *) {
+        downloadBackgroundTaskModel?.addDownload(download)
+      }
     }
   }
 
   public func tab(_ tab: some TabState, didFinishDownload download: Download, error: (any Error)?) {
+    if #available(iOS 26.0, *) {
+      downloadBackgroundTaskModel?.removeDownload(download)
+    }
+
     guard let destinationURL = download.destinationURL, error == nil else {
       downloadQueue.download(download, didCompleteWithError: error)
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -291,6 +291,8 @@ public class BrowserViewController: UIViewController {
 
   let defaultBrowserHelper: DefaultBrowserHelper = .init()
 
+  let downloadBackgroundTaskModel: DownloadBackgroundTaskScheduler?
+
   public init(
     windowId: UUID,
     profile: LegacyBrowserProfile,
@@ -300,7 +302,8 @@ public class BrowserViewController: UIViewController {
     rewards: BraveRewards,
     crashedLastSession: Bool,
     newsFeedDataSource: FeedDataSource,
-    privateBrowsingManager: PrivateBrowsingManager
+    privateBrowsingManager: PrivateBrowsingManager,
+    downloadBackgroundTaskModel: DownloadBackgroundTaskScheduler?,
   ) {
     self.windowId = windowId
     self.profile = profile
@@ -314,6 +317,8 @@ public class BrowserViewController: UIViewController {
     self.feedDataSource = newsFeedDataSource
     self.prefsChangeRegistrar = PrefChangeRegistrar(prefService: profileController.profile.prefs)
     self.braveTalkJitsiCoordinator = .init(prefService: profileController.profile.prefs)
+    self.downloadBackgroundTaskModel = downloadBackgroundTaskModel
+
     feedDataSource.historyAPI = profileController.historyAPI
     backgroundDataSource = .init(
       service: profileController.backgroundImagesService,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/DownloadBackgroundTaskScheduler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/DownloadBackgroundTaskScheduler.swift
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BackgroundTasks
+import Foundation
+import OSLog
+import OrderedCollections
+import Strings
+import Web
+
+@MainActor
+public class DownloadBackgroundTaskScheduler {
+  private var task: BGTask?
+  private let taskIdentifier: String
+  private let taskScheduler: BGTaskScheduler
+  private var isTaskBeingScheduled: Bool = false
+  private var downloads: OrderedSet<Download> = []
+
+  @available(iOS 26.0, *)
+  public init(
+    taskIdentifier: String,
+    taskScheduler: BGTaskScheduler = .shared
+  ) {
+    self.taskIdentifier = taskIdentifier
+    self.taskScheduler = taskScheduler
+
+    taskScheduler.register(
+      forTaskWithIdentifier: taskIdentifier,
+      using: .main
+    ) { [weak self] task in
+      guard let self, let task = task as? BGContinuedProcessingTask else { return }
+      MainActor.assumeIsolated {
+        self.taskSchedulerLaunchedTask(task)
+      }
+    }
+  }
+
+  @available(iOS 26.0, *)
+  public func addDownload(_ download: Download) {
+    downloads.append(download)
+    updateActiveTaskProgress()
+    submitTaskRequestForDownloads()
+  }
+
+  @available(iOS 26.0, *)
+  public func removeDownload(_ download: Download) {
+    downloads.remove(download)
+    updateActiveTaskProgress()
+    if downloads.isEmpty {
+      if let task {
+        task.setTaskCompleted(success: true)
+        self.task = nil
+      } else if isTaskBeingScheduled {
+        taskScheduler.cancel(taskRequestWithIdentifier: taskIdentifier)
+        isTaskBeingScheduled = false
+      }
+    }
+  }
+
+  @available(iOS 26.0, *)
+  public func updateActiveTaskProgress() {
+    guard let task = task as? BGContinuedProcessingTask, !downloads.isEmpty else { return }
+    let progress = currentProgress
+    task.progress.totalUnitCount = progress.totalUnitCount
+    task.progress.completedUnitCount = progress.completedUnitCount
+    task.updateTitle(progress.title, subtitle: progress.subtitle)
+  }
+
+  private struct DownloadsTaskProgress {
+    var title: String
+    var subtitle: String
+    var totalUnitCount: Int64
+    var completedUnitCount: Int64
+  }
+
+  private var currentProgress: DownloadsTaskProgress {
+    let title: String
+    if downloads.count == 1 {
+      title = String.localizedStringWithFormat(
+        Strings.backgroundDownloadingTitleSingleDownload,
+        downloads[0].filename
+      )
+    } else {
+      title = String.localizedStringWithFormat(
+        Strings.backgroundDownloadingTitleMultiDownload,
+        downloads.count
+      )
+    }
+
+    let formatter = ByteCountFormatter()
+    formatter.countStyle = .file
+    formatter.zeroPadsFractionDigits = true  // Otherwise the progress label jumps around
+
+    let combinedBytesDownloaded = downloads.reduce(0) { $0 + $1.bytesDownloaded }
+    let combinedTotalBytesExpected = downloads.reduce(0) { $0 + ($1.totalBytesExpected ?? 0) }
+    let downloadedSize = formatter.string(fromByteCount: combinedBytesDownloaded)
+    let expectedSize =
+      combinedTotalBytesExpected != 0
+      ? formatter.string(fromByteCount: combinedTotalBytesExpected) : nil
+    let subtitle =
+      expectedSize.map {
+        String.localizedStringWithFormat(
+          Strings.backgroundDownloadingSubtitleWithExpectedSize,
+          downloadedSize,
+          $0
+        )
+      } ?? String.localizedStringWithFormat(Strings.backgroundDownloadingSubtitle, downloadedSize)
+    return .init(
+      title: title,
+      subtitle: subtitle,
+      totalUnitCount: combinedTotalBytesExpected,
+      completedUnitCount: combinedBytesDownloaded
+    )
+  }
+
+  @available(iOS 26.0, *)
+  private func submitTaskRequestForDownloads() {
+    // Ensure a task isn't already requested and that there are active downloads being tracked
+    guard task == nil, !isTaskBeingScheduled, !downloads.isEmpty else {
+      return
+    }
+    let progress = currentProgress
+    let request = BGContinuedProcessingTaskRequest(
+      identifier: taskIdentifier,
+      title: progress.title,
+      subtitle: progress.subtitle
+    )
+    do {
+      try taskScheduler.submit(request)
+      isTaskBeingScheduled = true
+    } catch {
+      Logger.module.error("Failed to submit download continued processing task: \(error)")
+    }
+  }
+
+  @available(iOS 26.0, *)
+  private func taskSchedulerLaunchedTask(_ task: BGContinuedProcessingTask) {
+    isTaskBeingScheduled = false
+    if downloads.isEmpty {
+      // Already removed prior download before the task launched
+      task.setTaskCompleted(success: false)
+      return
+    }
+    self.task = task
+    task.expirationHandler = { [weak self] in
+      Task { @MainActor in
+        self?.handleTaskExpiredOrCancelled()
+        task.setTaskCompleted(success: false)
+      }
+    }
+    updateActiveTaskProgress()
+  }
+
+  @available(iOS 26.0, *)
+  private func handleTaskExpiredOrCancelled() {
+    for download in downloads {
+      download.cancel()
+    }
+    downloads.removeAll()
+    self.task = nil
+  }
+}

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -9265,3 +9265,38 @@ extension Strings {
       "Accessibility text for an icon button which will exit QuickView mode and open the current page in a regular tab."
   )
 }
+
+// MARK: - Background Downloading
+extension Strings {
+  public static let backgroundDownloadingTitleSingleDownload = NSLocalizedString(
+    "backgroundDownloadingTitleSingleDownload",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Downloading \"%@\"",
+    comment: "A title that appears in the dynamic island when a download is continuing while Brave is backgrounded. %@ is replaced with a file name"
+  )
+
+  public static let backgroundDownloadingTitleMultiDownload = NSLocalizedString(
+    "backgroundDownloadingTitleMultiDownload",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Downloading %lld files",
+    comment: "A title that appears in the dynamic island when a download is continuing while Brave is backgrounded. %lld is replaced with the number of active downloads"
+  )
+
+  public static let backgroundDownloadingSubtitleWithExpectedSize = NSLocalizedString(
+    "backgroundDownloadingSubtitleWithExpectedSize",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "%@ of %@",
+    comment: "A subtitle that appears in the dynamic island when a download is continuing while Brave is backgrounded. The %@'s are replaced with a progress and a file size. E.g. '1MB of 20MB'"
+  )
+
+  public static let backgroundDownloadingSubtitle = NSLocalizedString(
+    "backgroundDownloadingSubtitle",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "%@",
+    comment: "A subtitle that appears in the dynamic island when a download is continuing while Brave is backgrounded. The %@'s are replaced with the current downloaded amount (e.g. '20MB')"
+  )
+}


### PR DESCRIPTION
This adds support for using `BGContinuedProcessingTask` on iOS 26+ to continue a download while the app is backgrounded.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58098

### Test
- Visit a site that allows you to download something such 
- Start a download and background the app
- Verify the download shows progress in the dynamic island even when the app is backgrounded
- Verify download completes in the background and shows up in the Brave Downloads folder
- Start multiple downloads and background the app
- Verify progress is still shown in the dynamic island even when the app is backgrounded and title shows that its downloading more than one item (title may revert back to single item if all but one item finish)
- Start a download and background the app
- Cancel the background download via the X that appears in the dynamic island overlay and verify the download does cancel in the app and that no file shows up in the Downloads folder
