### PR TITLE
[ads] Fix country change not detected for SeedFileTrial clients

### DIFF
--- a/chromium_src/components/variations/seed_reader_writer.cc
+++ b/chromium_src/components/variations/seed_reader_writer.cc
@@ -1,0 +1,20 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "components/variations/seed_reader_writer.h"
+
+#include <components/variations/seed_reader_writer.cc>
+
+namespace variations {
+
+void SeedReaderWriter::SetSessionCountry(std::string_view country_code) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (ShouldUseSeedFile()) {
+    stored_seed_info_.set_session_country_code(country_code);
+  }
+  local_state_->SetString(fields_prefs_->session_country_code, country_code);
+}
+
+}  // namespace variations

--- a/chromium_src/components/variations/seed_reader_writer_unittest.cc
+++ b/chromium_src/components/variations/seed_reader_writer_unittest.cc
@@ -1,0 +1,99 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <components/variations/seed_reader_writer_unittest.cc>
+
+namespace variations {
+
+TEST_P(SeedReaderWriterSeedFilesGroupTest,
+       SetSessionCountryUpdatesCacheAndPrefWhenUsingSeedFile) {
+  ASSERT_EQ(base::FieldTrialList::FindFullName(kSeedFileTrial),
+            GetParam().field_trial_group);
+  local_state_.SetString(GetParam().seed_fields_prefs.session_country_code,
+                         "us");
+
+  SeedReaderWriter seed_reader_writer(
+      &local_state_, /*seed_file_dir=*/temp_dir_.GetPath(), kSeedFilename,
+      kOldSeedFilename, GetParam().seed_fields_prefs, GetParam().channel,
+      entropy_providers_.get(), GetHistogramSuffix(),
+      file_writer_thread_.task_runner());
+
+  ASSERT_EQ(seed_reader_writer.GetSeedInfo().session_country_code, "us");
+
+  seed_reader_writer.SetSessionCountry("gb");
+
+  EXPECT_EQ(seed_reader_writer.GetSeedInfo().session_country_code, "gb");
+  EXPECT_EQ(
+      local_state_.GetString(GetParam().seed_fields_prefs.session_country_code),
+      "gb");
+}
+
+TEST_P(SeedReaderWriterSeedFilesGroupTest,
+       SetSessionCountryDoesNotAffectGeoLevel1) {
+  ASSERT_EQ(base::FieldTrialList::FindFullName(kSeedFileTrial),
+            GetParam().field_trial_group);
+  if (!GetParam().HasGeoLevel1Pref()) {
+    return;
+  }
+  local_state_.SetString(GetParam().seed_fields_prefs.session_country_code,
+                         "us");
+  local_state_.SetString(GetParam().seed_fields_prefs.session_geo_level1,
+                         "us-ny");
+
+  SeedReaderWriter seed_reader_writer(
+      &local_state_, /*seed_file_dir=*/temp_dir_.GetPath(), kSeedFilename,
+      kOldSeedFilename, GetParam().seed_fields_prefs, GetParam().channel,
+      entropy_providers_.get(), GetHistogramSuffix(),
+      file_writer_thread_.task_runner());
+
+  seed_reader_writer.SetSessionCountry("gb");
+
+  EXPECT_EQ(seed_reader_writer.GetSeedInfo().session_geo_level1, "us-ny");
+}
+
+TEST_P(SeedReaderWriterSeedFilesGroupTest,
+       SetSessionCountryAcceptsEmptyCountryCode) {
+  ASSERT_EQ(base::FieldTrialList::FindFullName(kSeedFileTrial),
+            GetParam().field_trial_group);
+  local_state_.SetString(GetParam().seed_fields_prefs.session_country_code,
+                         "us");
+
+  SeedReaderWriter seed_reader_writer(
+      &local_state_, /*seed_file_dir=*/temp_dir_.GetPath(), kSeedFilename,
+      kOldSeedFilename, GetParam().seed_fields_prefs, GetParam().channel,
+      entropy_providers_.get(), GetHistogramSuffix(),
+      file_writer_thread_.task_runner());
+
+  seed_reader_writer.SetSessionCountry("");
+
+  EXPECT_THAT(seed_reader_writer.GetSeedInfo().session_country_code, IsEmpty());
+  EXPECT_THAT(
+      local_state_.GetString(GetParam().seed_fields_prefs.session_country_code),
+      IsEmpty());
+}
+
+TEST_P(SeedReaderWriterLocalStateGroupsTest,
+       SetSessionCountryUpdatesPrefWhenNotUsingSeedFile) {
+  ASSERT_EQ(base::FieldTrialList::FindFullName(kSeedFileTrial),
+            GetParam().field_trial_group);
+
+  SeedReaderWriter seed_reader_writer(
+      &local_state_, /*seed_file_dir=*/temp_dir_.GetPath(), kSeedFilename,
+      kOldSeedFilename, GetParam().seed_fields_prefs, GetParam().channel,
+      entropy_providers_.get(), GetHistogramSuffix(),
+      file_writer_thread_.task_runner());
+
+  local_state_.SetString(GetParam().seed_fields_prefs.session_country_code,
+                         "us");
+
+  seed_reader_writer.SetSessionCountry("gb");
+
+  EXPECT_EQ(seed_reader_writer.GetSeedInfo().session_country_code, "gb");
+  EXPECT_EQ(
+      local_state_.GetString(GetParam().seed_fields_prefs.session_country_code),
+      "gb");
+}
+
+}  // namespace variations

--- a/chromium_src/components/variations/service/variations_service.cc
+++ b/chromium_src/components/variations/service/variations_service.cc
@@ -5,17 +5,21 @@
 
 #include "net/http/http_response_headers.h"
 
-// Update the country code from the X-Country header on every 304 Not Modified
-// response so that mid-session country changes (e.g. a VPN change) propagate
-// without requiring a browser restart.
-#define GetDateValue(...)                                               \
-  GetDateValue(__VA_ARGS__);                                            \
-  if (response_code == net::HTTP_NOT_MODIFIED) {                        \
-    std::string_view country_code =                                     \
-        GetHeaderValue(headers.get(), "X-Country");                     \
-    if (!country_code.empty()) {                                        \
-      local_state_->SetString(prefs::kVariationsCountry, country_code); \
-    }                                                                   \
+// Update the country code from the X-Country header on every 304 Not
+// Modified response so that mid-session country changes, such as a VPN
+// change, propagate without requiring a browser restart. Routed through
+// `VariationsSeedStore::SetSessionCountry` rather than a raw pref write,
+// as clients in the `SeedFileTrial` experiment's `SeedFiles_V11` group read
+// the country from an in-memory seed cache that a raw pref write does not
+// reach.
+#define GetDateValue(...)                                                 \
+  GetDateValue(__VA_ARGS__);                                              \
+  if (response_code == net::HTTP_NOT_MODIFIED) {                          \
+    std::string_view country_code =                                       \
+        GetHeaderValue(headers.get(), "X-Country");                       \
+    if (!country_code.empty()) {                                          \
+      field_trial_creator_.seed_store()->SetSessionCountry(country_code); \
+    }                                                                     \
   }
 
 #include <components/variations/service/variations_service.cc>

--- a/chromium_src/components/variations/variations_seed_store.cc
+++ b/chromium_src/components/variations/variations_seed_store.cc
@@ -33,6 +33,10 @@ class PublicKeyWrapper {
 
 namespace variations {
 
+void VariationsSeedStore::SetSessionCountry(std::string_view country_code) {
+  seed_reader_writer_->SetSessionCountry(country_code);
+}
+
 // static
 const crypto::keypair::PublicKey& PublicKeyWrapper::GetPublicKey(
     const crypto::keypair::PublicKey& public_key) {

--- a/chromium_src/components/variations/variations_seed_store_unittest.cc
+++ b/chromium_src/components/variations/variations_seed_store_unittest.cc
@@ -1,0 +1,53 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <components/variations/variations_seed_store_unittest.cc>
+
+namespace variations {
+
+TEST_F(VariationsSeedStoreTest,
+       SetSessionCountryUpdatesCountryWhenUsingSeedFile) {
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitWithEmptyFeatureAndFieldTrialLists();
+  SetUpSeedFileTrial(kSeedFilesGroup);
+  ASSERT_EQ(base::FieldTrialList::FindFullName(kSeedFileTrial),
+            kSeedFilesGroup);
+
+  base::ScopedTempDir temp_dir;
+  ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
+  TestingPrefServiceSimple prefs;
+  VariationsSeedStore::RegisterPrefs(prefs.registry());
+
+  TestVariationsSeedStore seed_store(&prefs, temp_dir.GetPath());
+
+  seed_store.SetSessionCountry("gb");
+
+  EXPECT_EQ(seed_store.GetSeedReaderWriterForTesting()
+                ->GetSeedInfo()
+                .session_country_code,
+            "gb");
+  EXPECT_EQ(prefs.GetString(prefs::kVariationsCountry), "gb");
+}
+
+TEST_F(VariationsSeedStoreTest,
+       SetSessionCountryUpdatesCountryWhenNotUsingSeedFile) {
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitWithEmptyFeatureAndFieldTrialLists();
+  SetUpSeedFileTrial(kControlGroup);
+  ASSERT_EQ(base::FieldTrialList::FindFullName(kSeedFileTrial), kControlGroup);
+
+  base::ScopedTempDir temp_dir;
+  ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
+  TestingPrefServiceSimple prefs;
+  VariationsSeedStore::RegisterPrefs(prefs.registry());
+
+  TestVariationsSeedStore seed_store(&prefs, temp_dir.GetPath());
+
+  seed_store.SetSessionCountry("gb");
+
+  EXPECT_EQ(prefs.GetString(prefs::kVariationsCountry), "gb");
+}
+
+}  // namespace variations

--- a/patches/components-variations-seed_reader_writer.h.patch
+++ b/patches/components-variations-seed_reader_writer.h.patch
@@ -1,0 +1,13 @@
+diff --git a/components/variations/seed_reader_writer.h b/components/variations/seed_reader_writer.h
+index 105f2369520ff1ac422d77bf91f1bef4fae7d100..2eb4158ff8f189786f6cbb30a3635a4a6b9d120e 100644
+--- a/components/variations/seed_reader_writer.h
++++ b/components/variations/seed_reader_writer.h
+@@ -271,6 +271,8 @@ class COMPONENT_EXPORT(VARIATIONS) SeedReaderWriter
+   // Converts a time from StoredSeedInfo proto format (int64_t) to a base::Time.
+   static base::Time ProtoTimeToTime(int64_t proto_time);
+ 
++  void SetSessionCountry(std::string_view country_code);
++
+  private:
+   // The storage format of the seed data.
+   // - kCompressed: the seed is compressed. This is used for backward

--- a/patches/components-variations-variations_seed_store.h.patch
+++ b/patches/components-variations-variations_seed_store.h.patch
@@ -1,0 +1,13 @@
+diff --git a/components/variations/variations_seed_store.h b/components/variations/variations_seed_store.h
+index 7a0f2eb295c44267a0f71221ac16439a853e5daf..5e14d2df217c6bf3cccba75834d6c6fcbca793c6 100644
+--- a/components/variations/variations_seed_store.h
++++ b/components/variations/variations_seed_store.h
+@@ -294,6 +294,8 @@ class COMPONENT_EXPORT(VARIATIONS) VariationsSeedStore {
+       base::OnceCallback<void(StoredSeedInfo)> done_callback,
+       SeedType seed_type);
+ 
++  void SetSessionCountry(std::string_view country_code);
++
+  protected:
+   // Stores the serial number of the latest seed.
+   void StoreLatestSerialNumber(std::string_view serial_number);

--- a/rewrite/components/variations/seed_reader_writer.h.yaml
+++ b/rewrite/components/variations/seed_reader_writer.h.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+blank_macros_for_ast_parsing: true
+
+substitutions:
+  - description: |-
+      Add a setter for the session country code.
+
+      Mirrors the existing `ClearSessionCountry`, so a new country can be
+      applied to clients using the in-memory seed-file cache without a full
+      seed store.
+    add_to_public:
+      class_name: SeedReaderWriter
+      code: |-
+        void SetSessionCountry(std::string_view country_code);

--- a/rewrite/components/variations/variations_seed_store.h.yaml
+++ b/rewrite/components/variations/variations_seed_store.h.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+blank_macros_for_ast_parsing: true
+
+substitutions:
+  - description: |-
+      Add a setter for the session country code returned by
+      `GetLatestCountry`.
+
+      Lets callers update the country independently of a full seed store,
+      such as from an X-Country header on a 304 Not Modified response.
+    add_to_public:
+      class_name: VariationsSeedStore
+      code: |-
+        void SetSessionCountry(std::string_view country_code);


### PR DESCRIPTION
`VariationsService::GetLatestCountry` reads `session_country_code` from `SeedReaderWriter`'s in-memory seed-file cache for clients in the `SeedFileTrial` experiment's `SeedFiles_V11` group. Our existing fix for propagating the X-Country header on 304 responses (#35841) wrote directly to the `kVariationsCountry` pref, which that cache never observes, so NTP Sponsored Images and the ads resource component never picked up a mid-session country change for these clients.

Adds `SeedReaderWriter::SetSessionCountry`, mirroring the existing `ClearSessionCountry`, so the 304 handler can update the country through `VariationsSeedStore` instead of writing the pref directly.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58057

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
