### PR TITLE
[iOS] Expose viewport inset min/max setter on CWVWebView

### DIFF
--- a/ios/web_view/internal/cwv_web_view_extras.mm
+++ b/ios/web_view/internal/cwv_web_view_extras.mm
@@ -50,6 +50,12 @@ const CWVUserAgentType CWVUserAgentTypeDesktop =
   self.webState->GetWebViewProxy().obscuredInsets = obscuredInsets;
 }
 
+- (void)setMinimumViewportInset:(UIEdgeInsets)minInset
+           maximumViewportInset:(UIEdgeInsets)maxInset {
+  [self.webState->GetWebViewProxy() setMinimumViewportInset:minInset
+                                       maximumViewportInset:maxInset];
+}
+
 + (BOOL)isRestoreDataValid:(NSData*)data {
   return [self _isRestoreDataValid:data];
 }

--- a/ios/web_view/public/cwv_web_view_extras.h
+++ b/ios/web_view/public/cwv_web_view_extras.h
@@ -36,6 +36,10 @@ CWV_EXPORT
 // Web view's obscured insets.
 @property(nonatomic) UIEdgeInsets obscuredInsets;
 
+/// Sets the web view's min and max viewport insets
+- (void)setMinimumViewportInset:(UIEdgeInsets)minInset
+           maximumViewportInset:(UIEdgeInsets)maxInset;
+
 /// The user agent type currently used on the page (e.g. mobile/desktop)
 - (CWVUserAgentType)currentItemUserAgentType;
 


### PR DESCRIPTION
Not currently used but will be used when updating web view layouts to utilize obscured insets