### PR TITLE
Enable kAdblockDatCache by default

### DIFF
--- a/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
@@ -9,13 +9,13 @@
 #include <string>
 #include <utility>
 
-#include "base/check.h"
 #include "base/functional/callback_helpers.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/path_service.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/test/scoped_feature_list.h"
+#include "base/test/scoped_path_override.h"
 #include "brave/browser/brave_browser_process.h"
 #include "brave/browser/net/features.h"
 #include "brave/browser/net/url_context.h"
@@ -111,8 +111,8 @@ class BraveAdBlockTPNetworkDelegateHelperTest : public testing::Test {
         std::make_unique<TestingBraveComponentUpdaterDelegate>(
             TestingBrowserProcess::GetGlobal()->GetTestingLocalState());
 
-    base::FilePath user_data_dir;
-    DCHECK(base::PathService::Get(chrome::DIR_USER_DATA, &user_data_dir));
+    const base::FilePath user_data_dir =
+        base::PathService::CheckedGet(chrome::DIR_USER_DATA);
     auto adblock_service = std::make_unique<brave_shields::AdBlockService>(
         brave_component_updater_delegate_->local_state(),
         brave_component_updater_delegate_->locale(), nullptr,
@@ -188,6 +188,7 @@ class BraveAdBlockTPNetworkDelegateHelperTest : public testing::Test {
   std::unique_ptr<TestingBraveComponentUpdaterDelegate>
       brave_component_updater_delegate_;
 
+  base::ScopedPathOverride user_data_dir_override_{chrome::DIR_USER_DATA};
   content::BrowserTaskEnvironment task_environment_;
 
   std::unique_ptr<net::MockHostResolver> host_resolver_;

--- a/components/brave_shields/content/test/ad_block_service_unittest.cc
+++ b/components/brave_shields/content/test/ad_block_service_unittest.cc
@@ -185,6 +185,11 @@ class AdBlockServiceTestBase : public testing::Test {
 };
 
 class AdBlockServiceTest : public AdBlockServiceTestBase {
+ public:
+  AdBlockServiceTest() {
+    feature_list_.InitAndEnableFeature(features::kAdblockDATCache);
+  }
+
  protected:
   std::unique_ptr<AdBlockService> CreateService() {
     return CreateServiceWithTaskRunner(
@@ -195,6 +200,11 @@ class AdBlockServiceTest : public AdBlockServiceTestBase {
 };
 
 class AdBlockServiceQueuedTest : public AdBlockServiceTestBase {
+ public:
+  AdBlockServiceQueuedTest() {
+    feature_list_.InitAndEnableFeature(features::kAdblockDATCache);
+  }
+
  protected:
   base::test::TaskEnvironment task_environment_{
       base::test::TaskEnvironment::TimeSource::MOCK_TIME,

--- a/components/brave_shields/content/test/ad_block_service_unittest.cc
+++ b/components/brave_shields/content/test/ad_block_service_unittest.cc
@@ -185,11 +185,6 @@ class AdBlockServiceTestBase : public testing::Test {
 };
 
 class AdBlockServiceTest : public AdBlockServiceTestBase {
- public:
-  AdBlockServiceTest() {
-    feature_list_.InitAndEnableFeature(features::kAdblockDATCache);
-  }
-
  protected:
   std::unique_ptr<AdBlockService> CreateService() {
     return CreateServiceWithTaskRunner(
@@ -200,11 +195,6 @@ class AdBlockServiceTest : public AdBlockServiceTestBase {
 };
 
 class AdBlockServiceQueuedTest : public AdBlockServiceTestBase {
- public:
-  AdBlockServiceQueuedTest() {
-    feature_list_.InitAndEnableFeature(features::kAdblockDATCache);
-  }
-
  protected:
   base::test::TaskEnvironment task_environment_{
       base::test::TaskEnvironment::TimeSource::MOCK_TIME,

--- a/components/brave_shields/core/common/features.cc
+++ b/components/brave_shields/core/common/features.cc
@@ -171,6 +171,6 @@ BASE_FEATURE(kShowUpdatedShieldsPanel,
 // When enabled, adblock engines are serialized to DAT files on disk after
 // filter set loading. On subsequent startups, the cached DAT is loaded
 // instead of reprocessing filter lists, improving startup time.
-BASE_FEATURE(kAdblockDATCache, base::FEATURE_DISABLED_BY_DEFAULT);
+BASE_FEATURE(kAdblockDATCache, base::FEATURE_ENABLED_BY_DEFAULT);
 
 }  // namespace brave_shields::features

--- a/components/brave_shields/core/common/features.cc
+++ b/components/brave_shields/core/common/features.cc
@@ -171,6 +171,11 @@ BASE_FEATURE(kShowUpdatedShieldsPanel,
 // When enabled, adblock engines are serialized to DAT files on disk after
 // filter set loading. On subsequent startups, the cached DAT is loaded
 // instead of reprocessing filter lists, improving startup time.
-BASE_FEATURE(kAdblockDATCache, base::FEATURE_ENABLED_BY_DEFAULT);
+BASE_FEATURE(kAdblockDATCache,
+#if BUILDFLAG(IS_IOS)
+             base::FEATURE_DISABLED_BY_DEFAULT);
+#else
+             base::FEATURE_ENABLED_BY_DEFAULT);
+#endif
 
 }  // namespace brave_shields::features

--- a/components/brave_shields/core/test/ad_block_filters_provider_manager_unittest.cc
+++ b/components/brave_shields/core/test/ad_block_filters_provider_manager_unittest.cc
@@ -5,10 +5,8 @@
 
 #include "brave/components/brave_shields/core/browser/ad_block_filters_provider_manager.h"
 
-#include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_shields/content/test/test_filters_provider.h"
 #include "brave/components/brave_shields/core/browser/ad_block_filters_provider.h"
-#include "brave/components/brave_shields/core/common/features.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 class FiltersProviderManagerTestObserver
@@ -72,6 +70,11 @@ TEST(AdBlockFiltersProviderManagerTest,
   FiltersProviderManagerTestObserver observer;
   m.AddObserver(&observer);
 
+  // Simulate AdBlockService::OnDATLoaded(). It's a startup notification, so
+  // the first OnChanged is suppressed.
+  m.ForceNotifyObserver(observer, true);
+  EXPECT_EQ(observer.changed_count, 0);
+
   // Register provider1 — it initializes, OnChanged fires, observer notified.
   brave_shields::TestFiltersProvider provider1("rules_a", true, 0);
   provider1.RegisterAsSourceProvider(&m);
@@ -92,27 +95,9 @@ TEST(AdBlockFiltersProviderManagerTest,
   EXPECT_EQ(observer.changed_count, 2);
 }
 
-class AdBlockFiltersProviderManagerDATCacheTest
-    : public testing::TestWithParam<bool> {
- protected:
-  void SetUp() override {
-    if (GetParam()) {
-      feature_list_.InitAndEnableFeature(
-          brave_shields::features::kAdblockDATCache);
-    } else {
-      feature_list_.InitAndDisableFeature(
-          brave_shields::features::kAdblockDATCache);
-    }
-  }
-
-  base::test::ScopedFeatureList feature_list_;
-};
-
-// Disabled: startup OnChanged notifies observer for each provider init.
-// Enabled: first provider's OnChanged is suppressed; subsequent providers
-// notify normally.
-TEST_P(AdBlockFiltersProviderManagerDATCacheTest, OnChangedNotifiesWhenReady) {
-  const bool dat_cache_enabled = GetParam();
+// First provider's OnChanged is suppressed; subsequent providers notify
+// normally.
+TEST(AdBlockFiltersProviderManagerTest, OnChangedNotifiesWhenReady) {
   brave_shields::AdBlockFiltersProviderManager m;
   FiltersProviderManagerTestObserver observer;
   m.AddObserver(&observer);
@@ -120,18 +105,15 @@ TEST_P(AdBlockFiltersProviderManagerDATCacheTest, OnChangedNotifiesWhenReady) {
   brave_shields::TestFiltersProvider provider1("", true, 0);
   EXPECT_EQ(observer.changed_count, 0);
   provider1.RegisterAsSourceProvider(&m);
-  EXPECT_EQ(observer.changed_count, dat_cache_enabled ? 0 : 1);
+  EXPECT_EQ(observer.changed_count, 0);
 
   brave_shields::TestFiltersProvider provider2("", true, 0);
   provider2.RegisterAsSourceProvider(&m);
-  EXPECT_EQ(observer.changed_count, dat_cache_enabled ? 1 : 2);
+  EXPECT_EQ(observer.changed_count, 1);
 }
 
-// Disabled: init OnChanged fires (count=1), ForceNotify fires again (count=2).
-// Enabled: init OnChanged suppressed (count=0), ForceNotify fires (count=1).
-TEST_P(AdBlockFiltersProviderManagerDATCacheTest,
-       NotifiesAfterRegisterAndForceNotify) {
-  const bool dat_cache_enabled = GetParam();
+// Init OnChanged is suppressed; ForceNotify then fires.
+TEST(AdBlockFiltersProviderManagerTest, NotifiesAfterRegisterAndForceNotify) {
   brave_shields::AdBlockFiltersProviderManager m;
 
   FiltersProviderManagerTestObserver observer;
@@ -139,16 +121,15 @@ TEST_P(AdBlockFiltersProviderManagerDATCacheTest,
 
   brave_shields::TestFiltersProvider provider("rules", true, 0);
   provider.RegisterAsSourceProvider(&m);
-  EXPECT_EQ(observer.changed_count, dat_cache_enabled ? 0 : 1);
+  EXPECT_EQ(observer.changed_count, 0);
 
   m.ForceNotifyObserver(observer, true);
-  EXPECT_EQ(observer.changed_count, dat_cache_enabled ? 1 : 2);
+  EXPECT_EQ(observer.changed_count, 1);
 }
 
 // Provider added but not initialized. ForceNotify defers; observer fires when
-// provider is later initialized. Same result regardless of flag.
-TEST_P(AdBlockFiltersProviderManagerDATCacheTest,
-       FiresWhenProviderLaterInitialized) {
+// provider is later initialized.
+TEST(AdBlockFiltersProviderManagerTest, FiresWhenProviderLaterInitialized) {
   brave_shields::AdBlockFiltersProviderManager m;
 
   FiltersProviderManagerTestObserver observer;
@@ -163,11 +144,3 @@ TEST_P(AdBlockFiltersProviderManagerDATCacheTest,
   provider.Initialize();
   EXPECT_EQ(observer.changed_count, 1);
 }
-
-INSTANTIATE_TEST_SUITE_P(All,
-                         AdBlockFiltersProviderManagerDATCacheTest,
-                         testing::Bool(),
-                         [](const testing::TestParamInfo<bool>& info) {
-                           return info.param ? "DATCacheEnabled"
-                                             : "DATCacheDisabled";
-                         });

--- a/components/brave_shields/core/test/ad_block_filters_provider_manager_unittest.cc
+++ b/components/brave_shields/core/test/ad_block_filters_provider_manager_unittest.cc
@@ -5,8 +5,10 @@
 
 #include "brave/components/brave_shields/core/browser/ad_block_filters_provider_manager.h"
 
+#include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_shields/content/test/test_filters_provider.h"
 #include "brave/components/brave_shields/core/browser/ad_block_filters_provider.h"
+#include "brave/components/brave_shields/core/common/features.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 class FiltersProviderManagerTestObserver
@@ -63,17 +65,36 @@ TEST(AdBlockFiltersProviderManagerTest, ForceNotifyObserverRespectsEngineType) {
   EXPECT_EQ(additional_observer.changed_count, 1);
 }
 
-TEST(AdBlockFiltersProviderManagerTest,
-     OnChangedWaitsForAllProvidersInitialized) {
+class AdBlockFiltersProviderManagerDATCacheTest
+    : public testing::TestWithParam<bool> {
+ protected:
+  void SetUp() override {
+    if (GetParam()) {
+      feature_list_.InitAndEnableFeature(
+          brave_shields::features::kAdblockDATCache);
+    } else {
+      feature_list_.InitAndDisableFeature(
+          brave_shields::features::kAdblockDATCache);
+    }
+  }
+
+  base::test::ScopedFeatureList feature_list_;
+};
+
+TEST_P(AdBlockFiltersProviderManagerDATCacheTest,
+       OnChangedWaitsForAllProvidersInitialized) {
+  const bool dat_cache_enabled = GetParam();
   brave_shields::AdBlockFiltersProviderManager m;
 
   FiltersProviderManagerTestObserver observer;
   m.AddObserver(&observer);
 
-  // Simulate AdBlockService::OnDATLoaded(). It's a startup notification, so
-  // the first OnChanged is suppressed.
-  m.ForceNotifyObserver(observer, true);
-  EXPECT_EQ(observer.changed_count, 0);
+  if (dat_cache_enabled) {
+    // Simulate AdBlockService::OnDATLoaded(). It's a startup notification, so
+    // the first OnChanged is suppressed.
+    m.ForceNotifyObserver(observer, true);
+    EXPECT_EQ(observer.changed_count, 0);
+  }
 
   // Register provider1 — it initializes, OnChanged fires, observer notified.
   brave_shields::TestFiltersProvider provider1("rules_a", true, 0);
@@ -95,9 +116,11 @@ TEST(AdBlockFiltersProviderManagerTest,
   EXPECT_EQ(observer.changed_count, 2);
 }
 
-// First provider's OnChanged is suppressed; subsequent providers notify
-// normally.
-TEST(AdBlockFiltersProviderManagerTest, OnChangedNotifiesWhenReady) {
+// Disabled: startup OnChanged notifies observer for each provider init.
+// Enabled: first provider's OnChanged is suppressed; subsequent providers
+// notify normally.
+TEST_P(AdBlockFiltersProviderManagerDATCacheTest, OnChangedNotifiesWhenReady) {
+  const bool dat_cache_enabled = GetParam();
   brave_shields::AdBlockFiltersProviderManager m;
   FiltersProviderManagerTestObserver observer;
   m.AddObserver(&observer);
@@ -105,15 +128,18 @@ TEST(AdBlockFiltersProviderManagerTest, OnChangedNotifiesWhenReady) {
   brave_shields::TestFiltersProvider provider1("", true, 0);
   EXPECT_EQ(observer.changed_count, 0);
   provider1.RegisterAsSourceProvider(&m);
-  EXPECT_EQ(observer.changed_count, 0);
+  EXPECT_EQ(observer.changed_count, dat_cache_enabled ? 0 : 1);
 
   brave_shields::TestFiltersProvider provider2("", true, 0);
   provider2.RegisterAsSourceProvider(&m);
-  EXPECT_EQ(observer.changed_count, 1);
+  EXPECT_EQ(observer.changed_count, dat_cache_enabled ? 1 : 2);
 }
 
-// Init OnChanged is suppressed; ForceNotify then fires.
-TEST(AdBlockFiltersProviderManagerTest, NotifiesAfterRegisterAndForceNotify) {
+// Disabled: init OnChanged fires (count=1), ForceNotify fires again (count=2).
+// Enabled: init OnChanged suppressed (count=0), ForceNotify fires (count=1).
+TEST_P(AdBlockFiltersProviderManagerDATCacheTest,
+       NotifiesAfterRegisterAndForceNotify) {
+  const bool dat_cache_enabled = GetParam();
   brave_shields::AdBlockFiltersProviderManager m;
 
   FiltersProviderManagerTestObserver observer;
@@ -121,15 +147,16 @@ TEST(AdBlockFiltersProviderManagerTest, NotifiesAfterRegisterAndForceNotify) {
 
   brave_shields::TestFiltersProvider provider("rules", true, 0);
   provider.RegisterAsSourceProvider(&m);
-  EXPECT_EQ(observer.changed_count, 0);
+  EXPECT_EQ(observer.changed_count, dat_cache_enabled ? 0 : 1);
 
   m.ForceNotifyObserver(observer, true);
-  EXPECT_EQ(observer.changed_count, 1);
+  EXPECT_EQ(observer.changed_count, dat_cache_enabled ? 1 : 2);
 }
 
 // Provider added but not initialized. ForceNotify defers; observer fires when
-// provider is later initialized.
-TEST(AdBlockFiltersProviderManagerTest, FiresWhenProviderLaterInitialized) {
+// provider is later initialized. Same result regardless of flag.
+TEST_P(AdBlockFiltersProviderManagerDATCacheTest,
+       FiresWhenProviderLaterInitialized) {
   brave_shields::AdBlockFiltersProviderManager m;
 
   FiltersProviderManagerTestObserver observer;
@@ -144,3 +171,11 @@ TEST(AdBlockFiltersProviderManagerTest, FiresWhenProviderLaterInitialized) {
   provider.Initialize();
   EXPECT_EQ(observer.changed_count, 1);
 }
+
+INSTANTIATE_TEST_SUITE_P(All,
+                         AdBlockFiltersProviderManagerDATCacheTest,
+                         testing::Bool(),
+                         [](const testing::TestParamInfo<bool>& info) {
+                           return info.param ? "DATCacheEnabled"
+                                             : "DATCacheDisabled";
+                         });


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57739

The PR enables the feature by default for Android & Desktop. For iOS the feature is disabled: it has a custom way of caching DAT files.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
