### PR TITLE
Remove Shields settings service proxy methods

### DIFF
--- a/browser/brave_shields/brave_shields_tab_helper.cc
+++ b/browser/brave_shields/brave_shields_tab_helper.cc
@@ -278,10 +278,6 @@ BraveShieldsTabHelper::GetInvokedWebcompatFeatures() {
   return webcompat_features_invoked_;
 }
 
-bool BraveShieldsTabHelper::IsBraveShieldsEnabled() {
-  return brave_shields_settings_->IsBraveShieldsEnabled(GetCurrentSiteURL());
-}
-
 bool BraveShieldsTabHelper::GetAllowElementBlockerInPrivateModeEnabled() {
   return brave_shields::GetAllowElementBlockerInPrivateModeEnabled(
       g_browser_process->local_state());
@@ -358,14 +354,6 @@ GURL BraveShieldsTabHelper::GetFaviconURL(bool refresh) {
   return url;
 }
 
-mojom::AdBlockMode BraveShieldsTabHelper::GetAdBlockMode() {
-  return brave_shields_settings_->GetAdBlockMode(GetCurrentSiteURL());
-}
-
-mojom::FingerprintMode BraveShieldsTabHelper::GetFingerprintMode() {
-  return brave_shields_settings_->GetFingerprintMode(GetCurrentSiteURL());
-}
-
 mojom::CookieBlockMode BraveShieldsTabHelper::GetCookieBlockMode() {
   auto cookie_settings = CookieSettingsFactory::GetForProfile(
       Profile::FromBrowserContext(web_contents()->GetBrowserContext()));
@@ -399,29 +387,6 @@ mojom::HttpsUpgradeMode BraveShieldsTabHelper::GetHttpsUpgradeMode() {
   } else {
     return mojom::HttpsUpgradeMode::STANDARD_MODE;
   }
-}
-
-bool BraveShieldsTabHelper::GetNoScriptEnabled() {
-  return brave_shields_settings_->IsNoScriptEnabled(GetCurrentSiteURL());
-}
-
-mojom::ContentSettingsOverriddenDataPtr
-BraveShieldsTabHelper::GetJsContentSettingsOverriddenData() {
-  return brave_shields_settings_->GetJsContentSettingOverriddenData(
-      GetCurrentSiteURL());
-}
-
-bool BraveShieldsTabHelper::GetForgetFirstPartyStorageEnabled() {
-  return brave_shields_settings_->GetForgetFirstPartyStorageEnabled(
-      GetCurrentSiteURL());
-}
-
-void BraveShieldsTabHelper::SetAdBlockMode(mojom::AdBlockMode mode) {
-  brave_shields_settings_->SetAdBlockMode(mode, GetCurrentSiteURL());
-}
-
-void BraveShieldsTabHelper::SetFingerprintMode(mojom::FingerprintMode mode) {
-  brave_shields_settings_->SetFingerprintMode(mode, GetCurrentSiteURL());
 }
 
 void BraveShieldsTabHelper::SetCookieBlockMode(mojom::CookieBlockMode mode) {
@@ -464,15 +429,6 @@ void BraveShieldsTabHelper::SetHttpsUpgradeMode(mojom::HttpsUpgradeMode mode) {
                                             g_browser_process->local_state());
 
   ReloadWebContents();
-}
-
-void BraveShieldsTabHelper::SetIsNoScriptEnabled(bool is_enabled) {
-  brave_shields_settings_->SetNoScriptEnabled(is_enabled, GetCurrentSiteURL());
-}
-
-void BraveShieldsTabHelper::SetForgetFirstPartyStorageEnabled(bool is_enabled) {
-  brave_shields_settings_->SetForgetFirstPartyStorageEnabled(
-      is_enabled, GetCurrentSiteURL());
 }
 
 void BraveShieldsTabHelper::BlockAllowedScripts(

--- a/browser/brave_shields/brave_shields_tab_helper.cc
+++ b/browser/brave_shields/brave_shields_tab_helper.cc
@@ -37,6 +37,7 @@
 #include "content/public/browser/security_principal.h"
 #include "content/public/browser/web_contents.h"
 #include "net/base/features.h"
+#include "net/base/registry_controlled_domains/registry_controlled_domain.h"
 #include "net/base/url_util.h"
 
 using net::AppendQueryParameter;
@@ -73,6 +74,7 @@ BraveShieldsTabHelper::BraveShieldsTabHelper(content::WebContents* web_contents)
   favicon::ContentFaviconDriver::FromWebContents(web_contents)
       ->AddObserver(this);
   observation_.Observe(&*host_content_settings_map_);
+  brave_shields_settings_observation_.Observe(&*brave_shields_settings_);
   local_state_change_registrar_.Init(g_browser_process->local_state());
   local_state_change_registrar_.Add(
       brave_shields::prefs::kAdBlockOnlyModeEnabled,
@@ -176,6 +178,16 @@ void BraveShieldsTabHelper::OnContentSettingChanged(
     for (Observer& obs : observer_list_) {
       obs.OnShieldsEnabledChanged();
     }
+  }
+}
+
+void BraveShieldsTabHelper::OnShieldsSettingsChanged(
+    const std::string& etld_plus_one) {
+  if (net::registry_controlled_domains::GetDomainAndRegistry(
+          GetCurrentSiteURL(),
+          net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES) ==
+      etld_plus_one) {
+    ReloadWebContents();
   }
 }
 
@@ -287,8 +299,6 @@ void BraveShieldsTabHelper::SetBraveShieldsEnabled(bool is_enabled) {
         brave_shields::prefs::kShieldsDisabledCount,
         prefs->GetInteger(brave_shields::prefs::kShieldsDisabledCount) + 1);
   }
-
-  ReloadWebContents();
 }
 
 bool BraveShieldsTabHelper::IsBraveShieldsAdBlockOnlyModeEnabled() {
@@ -408,14 +418,10 @@ bool BraveShieldsTabHelper::GetForgetFirstPartyStorageEnabled() {
 
 void BraveShieldsTabHelper::SetAdBlockMode(mojom::AdBlockMode mode) {
   brave_shields_settings_->SetAdBlockMode(mode, GetCurrentSiteURL());
-
-  ReloadWebContents();
 }
 
 void BraveShieldsTabHelper::SetFingerprintMode(mojom::FingerprintMode mode) {
   brave_shields_settings_->SetFingerprintMode(mode, GetCurrentSiteURL());
-
-  ReloadWebContents();
 }
 
 void BraveShieldsTabHelper::SetCookieBlockMode(mojom::CookieBlockMode mode) {
@@ -462,8 +468,6 @@ void BraveShieldsTabHelper::SetHttpsUpgradeMode(mojom::HttpsUpgradeMode mode) {
 
 void BraveShieldsTabHelper::SetIsNoScriptEnabled(bool is_enabled) {
   brave_shields_settings_->SetNoScriptEnabled(is_enabled, GetCurrentSiteURL());
-
-  ReloadWebContents();
 }
 
 void BraveShieldsTabHelper::SetForgetFirstPartyStorageEnabled(bool is_enabled) {

--- a/browser/brave_shields/brave_shields_tab_helper.h
+++ b/browser/brave_shields/brave_shields_tab_helper.h
@@ -66,29 +66,20 @@ class BraveShieldsTabHelper
   std::vector<GURL> GetBlockedJsList();
   std::vector<GURL> GetAllowedJsList();
   std::vector<GURL> GetFingerprintsList();
-  bool IsBraveShieldsEnabled();
   void SetBraveShieldsEnabled(bool is_enabled);
   bool IsBraveShieldsAdBlockOnlyModeEnabled();
   void SetBraveShieldsAdBlockOnlyModeEnabled(bool is_enabled);
   bool ShouldShowShieldsDisabledAdBlockOnlyModePrompt();
   void SetBraveShieldsAdBlockOnlyModePromptDismissed();
+  void ReloadWebContents();
   GURL GetCurrentSiteURL() const;
   GURL GetFaviconURL(bool refresh);
   const base::flat_set<ContentSettingsType>& GetInvokedWebcompatFeatures();
 
-  mojom::AdBlockMode GetAdBlockMode();
-  mojom::FingerprintMode GetFingerprintMode();
   mojom::CookieBlockMode GetCookieBlockMode();
   mojom::HttpsUpgradeMode GetHttpsUpgradeMode();
-  bool GetNoScriptEnabled();
-  mojom::ContentSettingsOverriddenDataPtr GetJsContentSettingsOverriddenData();
-  bool GetForgetFirstPartyStorageEnabled();
-  void SetAdBlockMode(mojom::AdBlockMode mode);
-  void SetFingerprintMode(mojom::FingerprintMode mode);
   void SetCookieBlockMode(mojom::CookieBlockMode mode);
   void SetHttpsUpgradeMode(mojom::HttpsUpgradeMode mode);
-  void SetIsNoScriptEnabled(bool is_enabled);
-  void SetForgetFirstPartyStorageEnabled(bool is_enabled);
   void EnforceSiteDataCleanup();
   void AllowScriptsOnce(const std::vector<std::string>& origins);
   void BlockAllowedScripts(const std::vector<std::string>& origins);
@@ -132,7 +123,6 @@ class BraveShieldsTabHelper
                         bool icon_url_changed,
                         const gfx::Image& image) override;
 
-  void ReloadWebContents();
   void MaybeNotifyRepeatedReloads(content::NavigationHandle* navigation_handle);
 
   void OnShieldsAdBlockOnlyModeEnabledChanged();

--- a/browser/brave_shields/brave_shields_tab_helper.h
+++ b/browser/brave_shields/brave_shields_tab_helper.h
@@ -15,6 +15,7 @@
 #include "base/observer_list.h"
 #include "base/observer_list_types.h"
 #include "base/scoped_observation.h"
+#include "brave/components/brave_shields/core/browser/brave_shields_settings_service.h"
 #include "brave/components/brave_shields/core/common/brave_shields_panel.mojom.h"
 #include "brave/components/brave_shields/core/common/shields_settings.mojom.h"
 #include "brave/components/ephemeral_storage/ephemeral_storage_service.h"
@@ -36,6 +37,7 @@ class BraveShieldsTabHelper
     : public content::WebContentsObserver,
       public content::WebContentsUserData<BraveShieldsTabHelper>,
       public content_settings::Observer,
+      public BraveShieldsSettingsService::Observer,
       public favicon::FaviconDriverObserver {
  public:
   BraveShieldsTabHelper(const BraveShieldsTabHelper&) = delete;
@@ -120,6 +122,9 @@ class BraveShieldsTabHelper
       const ContentSettingsPattern& secondary_pattern,
       ContentSettingsTypeSet content_type_set) override;
 
+  // BraveShieldsSettingsService::Observer
+  void OnShieldsSettingsChanged(const std::string& etld_plus_one) override;
+
   // favicon::FaviconDriverObserver
   void OnFaviconUpdated(favicon::FaviconDriver* favicon_driver,
                         NotificationIconType notification_icon_type,
@@ -146,6 +151,9 @@ class BraveShieldsTabHelper
       observation_{this};
   const raw_ref<HostContentSettingsMap> host_content_settings_map_;
   const raw_ref<BraveShieldsSettingsService> brave_shields_settings_;
+  base::ScopedObservation<BraveShieldsSettingsService,
+                          BraveShieldsSettingsService::Observer>
+      brave_shields_settings_observation_{this};
 
   PrefChangeRegistrar local_state_change_registrar_;
   const raw_ptr<ephemeral_storage::EphemeralStorageService>

--- a/browser/cosmetic_filters/cosmetic_filters_tab_helper.cc
+++ b/browser/cosmetic_filters/cosmetic_filters_tab_helper.cc
@@ -21,9 +21,11 @@
 
 #if !BUILDFLAG(IS_ANDROID)
 #include "base/feature_list.h"
+#include "brave/browser/brave_shields/brave_shields_settings_service_factory.h"
 #include "brave/browser/brave_shields/brave_shields_tab_helper.h"
 #include "brave/browser/ui/brave_pages.h"
 #include "brave/browser/ui/browser_commands.h"
+#include "brave/components/brave_shields/core/browser/brave_shields_settings_service.h"
 #include "brave/components/brave_shields/core/common/features.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"  // nogncheck
@@ -182,8 +184,16 @@ void LaunchContentPicker(BrowserWindowInterface* browser) {
   // Element blocking requires Shields (and ad blocking) to be enabled.
   auto* shields =
       brave_shields::BraveShieldsTabHelper::FromWebContents(contents);
-  if (!shields || !shields->IsBraveShieldsEnabled() ||
-      shields->GetAdBlockMode() == brave_shields::mojom::AdBlockMode::ALLOW) {
+  if (!shields) {
+    return;
+  }
+  auto* shields_settings = BraveShieldsSettingsServiceFactory::GetForProfile(
+      Profile::FromBrowserContext(contents->GetBrowserContext()));
+  CHECK(shields_settings);
+  const auto& url = shields->GetCurrentSiteURL();
+  if (!shields_settings->IsBraveShieldsEnabled(url) ||
+      shields_settings->GetAdBlockMode(url) ==
+          brave_shields::mojom::AdBlockMode::ALLOW) {
     return;
   }
 

--- a/browser/onboarding/onboarding_tab_helper.cc
+++ b/browser/onboarding/onboarding_tab_helper.cc
@@ -15,9 +15,11 @@
 #include "base/functional/callback.h"
 #include "base/strings/string_util.h"
 #include "base/task/thread_pool.h"
+#include "brave/browser/brave_shields/brave_shields_settings_service_factory.h"
 #include "brave/browser/brave_shields/brave_shields_tab_helper.h"
 #include "brave/browser/onboarding/pref_names.h"
 #include "brave/browser/ui/brave_browser_window.h"
+#include "brave/components/brave_shields/core/browser/brave_shields_settings_service.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/first_run/first_run.h"
 #include "chrome/browser/ui/browser_window.h"
@@ -149,7 +151,12 @@ void OnboardingTabHelper::PerformBraveShieldsChecksAndShowHelpBubble() {
       brave_shields::BraveShieldsTabHelper::FromWebContents(web_contents());
   DCHECK(shields_data_controller);
 
-  if (shields_data_controller->IsBraveShieldsEnabled() &&
+  auto* shields_settings = BraveShieldsSettingsServiceFactory::GetForProfile(
+      Profile::FromBrowserContext(web_contents()->GetBrowserContext()));
+  CHECK(shields_settings);
+
+  if (shields_settings->IsBraveShieldsEnabled(
+          shields_data_controller->GetCurrentSiteURL()) &&
       shields_data_controller->GetTotalBlockedCount() > 0 &&
       CanHighlightBraveShields()) {
     ShowBraveHelpBubbleView();

--- a/browser/ui/brave_shields_data_controller_unittest.cc
+++ b/browser/ui/brave_shields_data_controller_unittest.cc
@@ -6,7 +6,9 @@
 #include <memory>
 
 #include "base/memory/raw_ptr.h"
+#include "brave/browser/brave_shields/brave_shields_settings_service_factory.h"
 #include "brave/browser/brave_shields/brave_shields_tab_helper.h"
+#include "brave/components/brave_shields/core/browser/brave_shields_settings_service.h"
 #include "brave/components/brave_shields/core/browser/brave_shields_utils.h"
 #include "brave/components/brave_shields/core/common/brave_shield_constants.h"
 #include "build/build_config.h"
@@ -81,6 +83,10 @@ class BraveShieldsDataControllerTest : public testing::Test {
     return BraveShieldsTabHelper::FromWebContents(web_contents());
   }
 
+  brave_shields::BraveShieldsSettingsService* GetShieldsSettings() {
+    return BraveShieldsSettingsServiceFactory::GetForProfile(profile());
+  }
+
   ContentSetting GetContentSettingFor(Profile* profile,
                                       ContentSettingsType type,
                                       GURL secondary_url = GURL()) {
@@ -149,7 +155,11 @@ TEST_F(BraveShieldsDataControllerTest, RegularVsIncognitoContentSettings) {
   content::WebContentsTester::For(otr_web_contents.get())
       ->SetLastCommittedURL(GURL("http://brave.com"));
 
-  incognito_controller->SetAdBlockMode(AdBlockMode::ALLOW);
+  auto* incognito_settings =
+      BraveShieldsSettingsServiceFactory::GetForProfile(otr_profile);
+  ASSERT_TRUE(incognito_settings);
+  incognito_settings->SetAdBlockMode(AdBlockMode::ALLOW,
+                                     incognito_controller->GetCurrentSiteURL());
 
   EXPECT_EQ(GetContentSettingFor(profile(), ContentSettingsType::BRAVE_ADS),
             CONTENT_SETTING_BLOCK);
@@ -159,6 +169,8 @@ TEST_F(BraveShieldsDataControllerTest, RegularVsIncognitoContentSettings) {
 
 TEST_F(BraveShieldsDataControllerTest, SetAdBlockMode_ForOrigin_1) {
   auto* controller = GetShieldsDataController();
+  auto* settings = GetShieldsSettings();
+  ASSERT_TRUE(settings);
   SetLastCommittedUrl(GURL("http://brave.com"));
 
   /* DEFAULT */
@@ -167,31 +179,33 @@ TEST_F(BraveShieldsDataControllerTest, SetAdBlockMode_ForOrigin_1) {
   EXPECT_EQ(GetSettingForCosmeticFiltering(), ControlType::BLOCK_THIRD_PARTY);
 
   /* ALLOW */
-  controller->SetAdBlockMode(AdBlockMode::ALLOW);
+  settings->SetAdBlockMode(AdBlockMode::ALLOW, controller->GetCurrentSiteURL());
   EXPECT_EQ(GetContentSettingFor(profile(), ContentSettingsType::BRAVE_ADS),
             CONTENT_SETTING_ALLOW);
   EXPECT_EQ(GetSettingForCosmeticFiltering(), ControlType::ALLOW);
 
   /* STANDARD */
-  controller->SetAdBlockMode(AdBlockMode::STANDARD);
+  settings->SetAdBlockMode(AdBlockMode::STANDARD,
+                           controller->GetCurrentSiteURL());
   EXPECT_EQ(GetContentSettingFor(profile(), ContentSettingsType::BRAVE_ADS),
             CONTENT_SETTING_BLOCK);
   EXPECT_EQ(GetSettingForCosmeticFiltering(), ControlType::BLOCK_THIRD_PARTY);
 
   /* ALLOW */
-  controller->SetAdBlockMode(AdBlockMode::ALLOW);
+  settings->SetAdBlockMode(AdBlockMode::ALLOW, controller->GetCurrentSiteURL());
   EXPECT_EQ(GetContentSettingFor(profile(), ContentSettingsType::BRAVE_ADS),
             CONTENT_SETTING_ALLOW);
   EXPECT_EQ(GetSettingForCosmeticFiltering(), ControlType::ALLOW);
 
   /* AGGRESSIVE */
-  controller->SetAdBlockMode(AdBlockMode::AGGRESSIVE);
+  settings->SetAdBlockMode(AdBlockMode::AGGRESSIVE,
+                           controller->GetCurrentSiteURL());
   EXPECT_EQ(GetContentSettingFor(profile(), ContentSettingsType::BRAVE_ADS),
             CONTENT_SETTING_BLOCK);
   EXPECT_EQ(GetSettingForCosmeticFiltering(), ControlType::BLOCK);
 
   /* ALLOW */
-  controller->SetAdBlockMode(AdBlockMode::ALLOW);
+  settings->SetAdBlockMode(AdBlockMode::ALLOW, controller->GetCurrentSiteURL());
   EXPECT_EQ(GetContentSettingFor(profile(), ContentSettingsType::BRAVE_ADS),
             CONTENT_SETTING_ALLOW);
   EXPECT_EQ(GetSettingForCosmeticFiltering(), ControlType::ALLOW);
@@ -199,6 +213,8 @@ TEST_F(BraveShieldsDataControllerTest, SetAdBlockMode_ForOrigin_1) {
 
 TEST_F(BraveShieldsDataControllerTest, SetAdBlockMode_ForOrigin_2) {
   auto* controller = GetShieldsDataController();
+  auto* settings = GetShieldsSettings();
+  ASSERT_TRUE(settings);
   SetLastCommittedUrl(GURL("http://brave.com"));
 
   /* DEFAULT */
@@ -207,31 +223,35 @@ TEST_F(BraveShieldsDataControllerTest, SetAdBlockMode_ForOrigin_2) {
   EXPECT_EQ(GetSettingForCosmeticFiltering(), ControlType::BLOCK_THIRD_PARTY);
 
   /* STANDARD */
-  controller->SetAdBlockMode(AdBlockMode::STANDARD);
+  settings->SetAdBlockMode(AdBlockMode::STANDARD,
+                           controller->GetCurrentSiteURL());
   EXPECT_EQ(GetContentSettingFor(profile(), ContentSettingsType::BRAVE_ADS),
             CONTENT_SETTING_BLOCK);
   EXPECT_EQ(GetSettingForCosmeticFiltering(), ControlType::BLOCK_THIRD_PARTY);
 
   /* ALLOW */
-  controller->SetAdBlockMode(AdBlockMode::ALLOW);
+  settings->SetAdBlockMode(AdBlockMode::ALLOW, controller->GetCurrentSiteURL());
   EXPECT_EQ(GetContentSettingFor(profile(), ContentSettingsType::BRAVE_ADS),
             CONTENT_SETTING_ALLOW);
   EXPECT_EQ(GetSettingForCosmeticFiltering(), ControlType::ALLOW);
 
   /* STANDARD */
-  controller->SetAdBlockMode(AdBlockMode::STANDARD);
+  settings->SetAdBlockMode(AdBlockMode::STANDARD,
+                           controller->GetCurrentSiteURL());
   EXPECT_EQ(GetContentSettingFor(profile(), ContentSettingsType::BRAVE_ADS),
             CONTENT_SETTING_BLOCK);
   EXPECT_EQ(GetSettingForCosmeticFiltering(), ControlType::BLOCK_THIRD_PARTY);
 
   /* AGGRESSIVE */
-  controller->SetAdBlockMode(AdBlockMode::AGGRESSIVE);
+  settings->SetAdBlockMode(AdBlockMode::AGGRESSIVE,
+                           controller->GetCurrentSiteURL());
   EXPECT_EQ(GetContentSettingFor(profile(), ContentSettingsType::BRAVE_ADS),
             CONTENT_SETTING_BLOCK);
   EXPECT_EQ(GetSettingForCosmeticFiltering(), ControlType::BLOCK);
 
   /* STANDARD */
-  controller->SetAdBlockMode(AdBlockMode::STANDARD);
+  settings->SetAdBlockMode(AdBlockMode::STANDARD,
+                           controller->GetCurrentSiteURL());
   EXPECT_EQ(GetContentSettingFor(profile(), ContentSettingsType::BRAVE_ADS),
             CONTENT_SETTING_BLOCK);
   EXPECT_EQ(GetSettingForCosmeticFiltering(), ControlType::BLOCK_THIRD_PARTY);
@@ -239,6 +259,8 @@ TEST_F(BraveShieldsDataControllerTest, SetAdBlockMode_ForOrigin_2) {
 
 TEST_F(BraveShieldsDataControllerTest, SetAdBlockMode_ForOrigin_3) {
   auto* controller = GetShieldsDataController();
+  auto* settings = GetShieldsSettings();
+  ASSERT_TRUE(settings);
   SetLastCommittedUrl(GURL("http://brave.com"));
 
   /* DEFAULT */
@@ -247,31 +269,35 @@ TEST_F(BraveShieldsDataControllerTest, SetAdBlockMode_ForOrigin_3) {
   EXPECT_EQ(GetSettingForCosmeticFiltering(), ControlType::BLOCK_THIRD_PARTY);
 
   /* AGGRESSIVE */
-  controller->SetAdBlockMode(AdBlockMode::AGGRESSIVE);
+  settings->SetAdBlockMode(AdBlockMode::AGGRESSIVE,
+                           controller->GetCurrentSiteURL());
   EXPECT_EQ(GetContentSettingFor(profile(), ContentSettingsType::BRAVE_ADS),
             CONTENT_SETTING_BLOCK);
   EXPECT_EQ(GetSettingForCosmeticFiltering(), ControlType::BLOCK);
 
   /* ALLOW */
-  controller->SetAdBlockMode(AdBlockMode::ALLOW);
+  settings->SetAdBlockMode(AdBlockMode::ALLOW, controller->GetCurrentSiteURL());
   EXPECT_EQ(GetContentSettingFor(profile(), ContentSettingsType::BRAVE_ADS),
             CONTENT_SETTING_ALLOW);
   EXPECT_EQ(GetSettingForCosmeticFiltering(), ControlType::ALLOW);
 
   /* AGGRESSIVE */
-  controller->SetAdBlockMode(AdBlockMode::AGGRESSIVE);
+  settings->SetAdBlockMode(AdBlockMode::AGGRESSIVE,
+                           controller->GetCurrentSiteURL());
   EXPECT_EQ(GetContentSettingFor(profile(), ContentSettingsType::BRAVE_ADS),
             CONTENT_SETTING_BLOCK);
   EXPECT_EQ(GetSettingForCosmeticFiltering(), ControlType::BLOCK);
 
   /* STANDARD */
-  controller->SetAdBlockMode(AdBlockMode::STANDARD);
+  settings->SetAdBlockMode(AdBlockMode::STANDARD,
+                           controller->GetCurrentSiteURL());
   EXPECT_EQ(GetContentSettingFor(profile(), ContentSettingsType::BRAVE_ADS),
             CONTENT_SETTING_BLOCK);
   EXPECT_EQ(GetSettingForCosmeticFiltering(), ControlType::BLOCK_THIRD_PARTY);
 
   /* AGGRESSIVE */
-  controller->SetAdBlockMode(AdBlockMode::AGGRESSIVE);
+  settings->SetAdBlockMode(AdBlockMode::AGGRESSIVE,
+                           controller->GetCurrentSiteURL());
   EXPECT_EQ(GetContentSettingFor(profile(), ContentSettingsType::BRAVE_ADS),
             CONTENT_SETTING_BLOCK);
   EXPECT_EQ(GetSettingForCosmeticFiltering(), ControlType::BLOCK);
@@ -279,24 +305,30 @@ TEST_F(BraveShieldsDataControllerTest, SetAdBlockMode_ForOrigin_3) {
 
 TEST_F(BraveShieldsDataControllerTest, GetAdBlockMode_ForOrigin) {
   auto* controller = GetShieldsDataController();
+  auto* settings = GetShieldsSettings();
+  ASSERT_TRUE(settings);
   SetLastCommittedUrl(GURL("http://brave.com"));
 
   /* DEFAULT */
-  EXPECT_EQ(controller->GetAdBlockMode(), AdBlockMode::STANDARD);
+  EXPECT_EQ(settings->GetAdBlockMode(controller->GetCurrentSiteURL()),
+            AdBlockMode::STANDARD);
 
   /* ALLOW */
   SetContentSettingFor(ContentSettingsType::BRAVE_ADS, CONTENT_SETTING_ALLOW);
-  EXPECT_EQ(controller->GetAdBlockMode(), AdBlockMode::ALLOW);
+  EXPECT_EQ(settings->GetAdBlockMode(controller->GetCurrentSiteURL()),
+            AdBlockMode::ALLOW);
 
   /* STANDARD */
   SetContentSettingFor(ContentSettingsType::BRAVE_ADS, CONTENT_SETTING_BLOCK);
   SetSettingForCosmeticFiltering(ControlType::BLOCK_THIRD_PARTY);
-  EXPECT_EQ(controller->GetAdBlockMode(), AdBlockMode::STANDARD);
+  EXPECT_EQ(settings->GetAdBlockMode(controller->GetCurrentSiteURL()),
+            AdBlockMode::STANDARD);
 
   /* AGGRESSIVE */
   SetContentSettingFor(ContentSettingsType::BRAVE_ADS, CONTENT_SETTING_BLOCK);
   SetSettingForCosmeticFiltering(ControlType::BLOCK);
-  EXPECT_EQ(controller->GetAdBlockMode(), AdBlockMode::AGGRESSIVE);
+  EXPECT_EQ(settings->GetAdBlockMode(controller->GetCurrentSiteURL()),
+            AdBlockMode::AGGRESSIVE);
 }
 
 TEST_F(BraveShieldsDataControllerTest, Observer_OnShieldsEnabledChangedTest) {
@@ -349,16 +381,19 @@ TEST_F(BraveShieldsDataControllerTest, SetBraveShieldsEnabledAsDefaultValue) {
                                           nullptr),
             CONTENT_SETTING_ALLOW);
 
-  EXPECT_TRUE(GetShieldsDataController()->IsBraveShieldsEnabled());
+  EXPECT_TRUE(GetShieldsSettings()->IsBraveShieldsEnabled(
+      GetShieldsDataController()->GetCurrentSiteURL()));
   GetShieldsDataController()->SetBraveShieldsEnabled(false);
-  EXPECT_FALSE(GetShieldsDataController()->IsBraveShieldsEnabled());
+  EXPECT_FALSE(GetShieldsSettings()->IsBraveShieldsEnabled(
+      GetShieldsDataController()->GetCurrentSiteURL()));
   EXPECT_FALSE(profile()
                    ->GetPrefs()
                    ->GetDict("profile.content_settings.exceptions.braveShields")
                    .empty());
 
   GetShieldsDataController()->SetBraveShieldsEnabled(true);
-  EXPECT_TRUE(GetShieldsDataController()->IsBraveShieldsEnabled());
+  EXPECT_TRUE(GetShieldsSettings()->IsBraveShieldsEnabled(
+      GetShieldsDataController()->GetCurrentSiteURL()));
   EXPECT_TRUE(profile()
                   ->GetPrefs()
                   ->GetDict("profile.content_settings.exceptions.braveShields")

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -25,6 +25,7 @@
 #include "base/path_service.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/app/brave_command_ids.h"
+#include "brave/browser/brave_shields/brave_shields_settings_service_factory.h"
 #include "brave/browser/brave_shields/brave_shields_tab_helper.h"
 #include "brave/browser/debounce/debounce_service_factory.h"
 #include "brave/browser/ui/bookmark/brave_bookmark_prefs.h"
@@ -37,6 +38,7 @@
 #include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/browser/url_sanitizer/url_sanitizer_service_factory.h"
+#include "brave/components/brave_shields/core/browser/brave_shields_settings_service.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/containers/buildflags/buildflags.h"
@@ -515,7 +517,11 @@ void ToggleShieldsEnabled(Browser* browser) {
     return;
   }
 
-  shields->SetBraveShieldsEnabled(!shields->IsBraveShieldsEnabled());
+  auto* shields_settings = BraveShieldsSettingsServiceFactory::GetForProfile(
+      Profile::FromBrowserContext(contents->GetBrowserContext()));
+  CHECK(shields_settings);
+  shields->SetBraveShieldsEnabled(
+      !shields_settings->IsBraveShieldsEnabled(shields->GetCurrentSiteURL()));
 }
 
 void ToggleJavascriptEnabled(Browser* browser) {
@@ -533,7 +539,12 @@ void ToggleJavascriptEnabled(Browser* browser) {
     return;
   }
 
-  shields->SetIsNoScriptEnabled(!shields->GetNoScriptEnabled());
+  auto* shields_settings = BraveShieldsSettingsServiceFactory::GetForProfile(
+      Profile::FromBrowserContext(contents->GetBrowserContext()));
+  CHECK(shields_settings);
+  const auto& url = shields->GetCurrentSiteURL();
+  shields_settings->SetNoScriptEnabled(
+      !shields_settings->IsNoScriptEnabled(url), url);
 }
 
 #if BUILDFLAG(ENABLE_COMMANDER)

--- a/browser/ui/toolbar/brave_location_bar_model_delegate.cc
+++ b/browser/ui/toolbar/brave_location_bar_model_delegate.cc
@@ -7,10 +7,12 @@
 
 #include "base/check.h"
 #include "base/feature_list.h"
+#include "brave/browser/brave_shields/brave_shields_settings_service_factory.h"
 #include "brave/browser/brave_shields/brave_shields_tab_helper.h"
 #include "brave/browser/ui/brave_scheme_utils.h"
 #include "brave/browser/ui/page_info/features.h"
 #include "brave/components/brave_origin/buildflags/buildflags.h"
+#include "brave/components/brave_shields/core/browser/brave_shields_settings_service.h"
 #include "brave/components/constants/url_constants.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/vector_icons/vector_icons.h"
@@ -127,6 +129,11 @@ const gfx::VectorIcon* BraveLocationBarModelDelegate::GetVectorIconOverride()
   }
 
   // Return the appropriate shields icon based on the Shields status.
-  return shields_helper->IsBraveShieldsEnabled() ? &kLeoShieldDoneIcon
-                                                 : &kLeoShieldDisableFilledIcon;
+  auto* shields_settings = BraveShieldsSettingsServiceFactory::GetForProfile(
+      Profile::FromBrowserContext(web_contents->GetBrowserContext()));
+  CHECK(shields_settings);
+  return shields_settings->IsBraveShieldsEnabled(
+             shields_helper->GetCurrentSiteURL())
+             ? &kLeoShieldDoneIcon
+             : &kLeoShieldDisableFilledIcon;
 }

--- a/browser/ui/toolbar/brave_location_bar_model_delegate_browsertest.cc
+++ b/browser/ui/toolbar/brave_location_bar_model_delegate_browsertest.cc
@@ -6,8 +6,10 @@
 #include "brave/browser/ui/toolbar/brave_location_bar_model_delegate.h"
 
 #include "base/test/scoped_feature_list.h"
+#include "brave/browser/brave_shields/brave_shields_settings_service_factory.h"
 #include "brave/browser/brave_shields/brave_shields_tab_helper.h"
 #include "brave/browser/ui/page_info/features.h"
+#include "brave/components/brave_shields/core/browser/brave_shields_settings_service.h"
 #include "brave/components/vector_icons/vector_icons.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_location_bar_model_delegate.h"
@@ -132,7 +134,11 @@ IN_PROC_BROWSER_TEST_F(BraveLocationBarModelDelegateShieldsBrowserTest,
 
   auto* shields_helper = GetShieldsHelper();
   ASSERT_TRUE(shields_helper);
-  EXPECT_TRUE(shields_helper->IsBraveShieldsEnabled());
+  auto* shields_settings =
+      BraveShieldsSettingsServiceFactory::GetForProfile(browser()->profile());
+  ASSERT_TRUE(shields_settings);
+  EXPECT_TRUE(shields_settings->IsBraveShieldsEnabled(
+      shields_helper->GetCurrentSiteURL()));
 
   const gfx::VectorIcon* icon = delegate_->GetVectorIconOverride();
   EXPECT_EQ(icon, &kLeoShieldDoneIcon);
@@ -146,7 +152,11 @@ IN_PROC_BROWSER_TEST_F(BraveLocationBarModelDelegateShieldsBrowserTest,
   ASSERT_TRUE(shields_helper);
 
   shields_helper->SetBraveShieldsEnabled(false);
-  EXPECT_FALSE(shields_helper->IsBraveShieldsEnabled());
+  auto* shields_settings =
+      BraveShieldsSettingsServiceFactory::GetForProfile(browser()->profile());
+  ASSERT_TRUE(shields_settings);
+  EXPECT_FALSE(shields_settings->IsBraveShieldsEnabled(
+      shields_helper->GetCurrentSiteURL()));
 
   const gfx::VectorIcon* icon = delegate_->GetVectorIconOverride();
   EXPECT_EQ(icon, &kLeoShieldDisableFilledIcon);

--- a/browser/ui/views/brave_actions/brave_shields_action_controller.cc
+++ b/browser/ui/views/brave_actions/brave_shields_action_controller.cc
@@ -11,8 +11,10 @@
 #include "base/check_deref.h"
 #include "base/memory/weak_ptr.h"
 #include "base/strings/string_number_conversions.h"
+#include "brave/browser/brave_shields/brave_shields_settings_service_factory.h"
 #include "brave/browser/ui/views/brave_actions/brave_icon_with_badge_image_source.h"
 #include "brave/components/brave_origin/buildflags/buildflags.h"
+#include "brave/components/brave_shields/core/browser/brave_shields_settings_service.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/constants/url_constants.h"
 #include "brave/components/constants/webui_url_constants.h"
@@ -181,7 +183,11 @@ BraveShieldsActionController::GetImageSource(
       badge_text = count > 99 ? "99+" : base::NumberToString(count);
     }
 
-    is_enabled = shields_data_controller->IsBraveShieldsEnabled() &&
+    auto* shields_settings = BraveShieldsSettingsServiceFactory::GetForProfile(
+        Profile::FromBrowserContext(web_contents->GetBrowserContext()));
+    CHECK(shields_settings);
+    is_enabled = shields_settings->IsBraveShieldsEnabled(
+                     shields_data_controller->GetCurrentSiteURL()) &&
                  !IsPageInReaderMode(web_contents);
 
     if (!badge_text.empty()) {

--- a/browser/ui/views/page_info/brave_page_info_bubble_view.cc
+++ b/browser/ui/views/page_info/brave_page_info_bubble_view.cc
@@ -5,8 +5,12 @@
 
 #include "brave/browser/ui/views/page_info/brave_page_info_bubble_view.h"
 
+#include "base/check.h"
+#include "brave/browser/brave_shields/brave_shields_settings_service_factory.h"
 #include "brave/browser/ui/page_info/features.h"
 #include "brave/browser/ui/views/page_info/brave_shields_page_info_view.h"
+#include "brave/components/brave_shields/core/browser/brave_shields_settings_service.h"
+#include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/views/page_info/page_info_view_factory.h"
 #include "components/tabs/public/tab_interface.h"
 #include "content/public/browser/navigation_handle.h"
@@ -251,7 +255,14 @@ BravePageInfoBubbleView::GetShieldsTabHelper() {
 
 bool BravePageInfoBubbleView::IsShieldsEnabledForWebContents() {
   auto* tab_helper = GetShieldsTabHelper();
-  return tab_helper && tab_helper->IsBraveShieldsEnabled();
+  if (!tab_helper) {
+    return false;
+  }
+  auto* shields_settings = BraveShieldsSettingsServiceFactory::GetForProfile(
+      Profile::FromBrowserContext(web_contents()->GetBrowserContext()));
+  CHECK(shields_settings);
+  return shields_settings->IsBraveShieldsEnabled(
+      tab_helper->GetCurrentSiteURL());
 }
 
 bool BravePageInfoBubbleView::IsDisplayingSecurityInfo() {

--- a/browser/ui/webui/brave_shields/shields_panel_data_handler.cc
+++ b/browser/ui/webui/brave_shields/shields_panel_data_handler.cc
@@ -28,11 +28,11 @@ ShieldsPanelDataHandler::ShieldsPanelDataHandler(
     TopChromeWebUIController* webui_controller,
     TabStripModel* tab_strip_model,
     favicon::FaviconService* favicon_service,
-    brave_shields::BraveShieldsSettingsService* brave_shields_settings_service)
+    brave_shields::BraveShieldsSettingsService& brave_shields_settings)
     : data_handler_receiver_(this, std::move(data_handler_receiver)),
       webui_controller_(webui_controller),
       favicon_service_(favicon_service),
-      brave_shields_settings_service_(brave_shields_settings_service) {
+      brave_shields_settings_(brave_shields_settings) {
   DCHECK(tab_strip_model);
   tab_strip_model->AddObserver(this);
 
@@ -81,21 +81,22 @@ void ShieldsPanelDataHandler::GetSiteSettings(
   }
 
   SiteSettings settings;
-  settings.ad_block_mode = active_shields_data_controller_->GetAdBlockMode();
+  const auto& site_url = active_shields_data_controller_->GetCurrentSiteURL();
+  settings.ad_block_mode = brave_shields_settings_->GetAdBlockMode(site_url);
   settings.fingerprint_mode =
-      active_shields_data_controller_->GetFingerprintMode();
+      brave_shields_settings_->GetFingerprintMode(site_url);
   settings.cookie_block_mode =
       active_shields_data_controller_->GetCookieBlockMode();
   settings.https_upgrade_mode =
       active_shields_data_controller_->GetHttpsUpgradeMode();
   settings.is_noscript_enabled =
-      active_shields_data_controller_->GetNoScriptEnabled();
+      brave_shields_settings_->IsNoScriptEnabled(site_url);
   settings.is_forget_first_party_storage_enabled =
-      active_shields_data_controller_->GetForgetFirstPartyStorageEnabled();
+      brave_shields_settings_->GetForgetFirstPartyStorageEnabled(site_url);
   settings.webcompat_settings =
       active_shields_data_controller_->GetWebcompatSettings();
   settings.scripts_blocked_override_status =
-      active_shields_data_controller_->GetJsContentSettingsOverriddenData();
+      brave_shields_settings_->GetJsContentSettingOverriddenData(site_url);
 
   std::move(callback).Run(settings.Clone());
 }
@@ -106,7 +107,8 @@ void ShieldsPanelDataHandler::SetAdBlockMode(
     return;
   }
 
-  active_shields_data_controller_->SetAdBlockMode(mode);
+  brave_shields_settings_->SetAdBlockMode(
+      mode, active_shields_data_controller_->GetCurrentSiteURL());
 }
 
 void ShieldsPanelDataHandler::SetFingerprintMode(
@@ -115,7 +117,8 @@ void ShieldsPanelDataHandler::SetFingerprintMode(
     return;
   }
 
-  active_shields_data_controller_->SetFingerprintMode(mode);
+  brave_shields_settings_->SetFingerprintMode(
+      mode, active_shields_data_controller_->GetCurrentSiteURL());
 }
 
 void ShieldsPanelDataHandler::SetCookieBlockMode(
@@ -141,7 +144,8 @@ void ShieldsPanelDataHandler::SetIsNoScriptsEnabled(bool is_enabled) {
     return;
   }
 
-  active_shields_data_controller_->SetIsNoScriptEnabled(is_enabled);
+  brave_shields_settings_->SetNoScriptEnabled(
+      is_enabled, active_shields_data_controller_->GetCurrentSiteURL());
 }
 
 void ShieldsPanelDataHandler::AllowScriptsOnce(
@@ -197,8 +201,8 @@ void ShieldsPanelDataHandler::SetForgetFirstPartyStorageEnabled(
     return;
   }
 
-  active_shields_data_controller_->SetForgetFirstPartyStorageEnabled(
-      is_enabled);
+  brave_shields_settings_->SetForgetFirstPartyStorageEnabled(
+      is_enabled, active_shields_data_controller_->GetCurrentSiteURL());
 }
 
 void ShieldsPanelDataHandler::SetWebcompatEnabled(
@@ -289,9 +293,8 @@ void ShieldsPanelDataHandler::UpdateSiteBlockInfo() {
     return;
   }
 
-  const GURL current_site_url =
-      active_shields_data_controller_->GetCurrentSiteURL();
-  site_block_info_.host = current_site_url.host();
+  site_block_info_.host =
+      active_shields_data_controller_->GetCurrentSiteURL().host();
   site_block_info_.total_blocked_resources =
       active_shields_data_controller_->GetTotalBlockedCount();
   site_block_info_.ads_list =
@@ -305,14 +308,16 @@ void ShieldsPanelDataHandler::UpdateSiteBlockInfo() {
   site_block_info_.http_redirects_list =
       active_shields_data_controller_->GetHttpRedirectsList();
   site_block_info_.is_brave_shields_enabled =
-      active_shields_data_controller_->IsBraveShieldsEnabled();
+      brave_shields_settings_->IsBraveShieldsEnabled(
+          active_shields_data_controller_->GetCurrentSiteURL());
   site_block_info_.is_brave_shields_ad_block_only_mode_enabled =
       active_shields_data_controller_->IsBraveShieldsAdBlockOnlyModeEnabled();
   site_block_info_.show_shields_disabled_ad_block_only_mode_prompt =
       active_shields_data_controller_
           ->ShouldShowShieldsDisabledAdBlockOnlyModePrompt();
   site_block_info_.is_brave_shields_managed =
-      brave_shields_settings_service_->IsBraveShieldsManaged(current_site_url);
+      brave_shields_settings_->IsBraveShieldsManaged(
+          active_shields_data_controller_->GetCurrentSiteURL());
   const auto& invoked_webcompat_set =
       active_shields_data_controller_->GetInvokedWebcompatFeatures();
   site_block_info_.invoked_webcompat_list = std::vector<ContentSettingsType>(

--- a/browser/ui/webui/brave_shields/shields_panel_data_handler.h
+++ b/browser/ui/webui/brave_shields/shields_panel_data_handler.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "base/task/cancelable_task_tracker.h"
 #include "brave/browser/brave_shields/brave_shields_tab_helper.h"
 #include "brave/components/brave_shields/core/common/brave_shields_panel.mojom.h"
@@ -24,11 +25,11 @@ class TopChromeWebUIController;
 
 namespace favicon {
 class FaviconService;
-}  // namespace favicon
+}
 
 namespace brave_shields {
 class BraveShieldsSettingsService;
-}  // namespace brave_shields
+}
 
 class ShieldsPanelDataHandler
     : public brave_shields::mojom::DataHandler,
@@ -41,7 +42,7 @@ class ShieldsPanelDataHandler
       TopChromeWebUIController* webui_controller,
       TabStripModel* tab_strip_model,
       favicon::FaviconService* favicon_service,
-      brave_shields::BraveShieldsSettingsService* brave_settings_service);
+      brave_shields::BraveShieldsSettingsService& brave_shields_settings);
 
   ShieldsPanelDataHandler(const ShieldsPanelDataHandler&) = delete;
   ShieldsPanelDataHandler& operator=(const ShieldsPanelDataHandler&) = delete;
@@ -97,8 +98,8 @@ class ShieldsPanelDataHandler
   raw_ptr<brave_shields::BraveShieldsTabHelper>
       active_shields_data_controller_ = nullptr;      // not owned
   raw_ptr<favicon::FaviconService> favicon_service_;  // not owned
-  raw_ptr<brave_shields::BraveShieldsSettingsService>
-      brave_shields_settings_service_;  // not owned
+  const raw_ref<brave_shields::BraveShieldsSettingsService>
+      brave_shields_settings_;  // not owned
 };
 
 #endif  // BRAVE_BROWSER_UI_WEBUI_BRAVE_SHIELDS_SHIELDS_PANEL_DATA_HANDLER_H_

--- a/browser/ui/webui/brave_shields/shields_panel_ui.cc
+++ b/browser/ui/webui/brave_shields/shields_panel_ui.cc
@@ -12,7 +12,6 @@
 #include "brave/browser/brave_shields/brave_shields_settings_service_factory.h"
 #include "brave/browser/ui/brave_browser_window.h"
 #include "brave/browser/ui/webui/brave_webui_source.h"
-#include "brave/components/brave_shields/core/browser/brave_shields_settings_service.h"
 #include "brave/components/brave_shields/core/browser/brave_shields_utils.h"
 #include "brave/components/brave_shields/core/common/brave_shield_localized_strings.h"
 #include "brave/components/brave_shields/core/common/features.h"
@@ -116,11 +115,12 @@ void ShieldsPanelUI::CreatePanelHandler(
   CHECK(browser);
   auto* favicon_service = FaviconServiceFactory::GetForProfile(
       profile, ServiceAccessType::EXPLICIT_ACCESS);
-  auto* brave_shield_settings_service =
+  auto* brave_shields_settings =
       BraveShieldsSettingsServiceFactory::GetForProfile(profile);
+  CHECK(brave_shields_settings);
   data_handler_ = std::make_unique<ShieldsPanelDataHandler>(
       std::move(data_handler_receiver), this, browser->GetTabStripModel(),
-      favicon_service, brave_shield_settings_service);
+      favicon_service, *brave_shields_settings);
 }
 
 ShieldsPanelUIConfig::ShieldsPanelUIConfig()

--- a/browser/ui/webui/webcompat_reporter/webcompat_reporter_dialog.cc
+++ b/browser/ui/webui/webcompat_reporter/webcompat_reporter_dialog.cc
@@ -16,12 +16,15 @@
 #include "base/json/json_writer.h"
 #include "base/notreached.h"
 #include "base/values.h"
+#include "brave/browser/brave_shields/brave_shields_settings_service_factory.h"
 #include "brave/browser/brave_shields/brave_shields_tab_helper.h"
 #include "brave/browser/webcompat_reporter/webcompat_reporter_service_factory.h"
+#include "brave/components/brave_shields/core/browser/brave_shields_settings_service.h"
 #include "brave/components/brave_shields/core/common/brave_shields_panel.mojom-shared.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/webcompat_reporter/browser/fields.h"
 #include "brave/components/webcompat_reporter/browser/webcompat_reporter_service.h"
+#include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/webui/constrained_web_dialog_ui.h"
 #include "components/web_modal/web_contents_modal_dialog_manager.h"
 #include "content/public/browser/render_frame_host.h"
@@ -167,9 +170,13 @@ void OpenReporterDialog(content::WebContents* initiator, UISource source) {
   brave_shields::BraveShieldsTabHelper* shields_data_controller =
       brave_shields::BraveShieldsTabHelper::FromWebContents(initiator);
   if (shields_data_controller != nullptr) {
-    shields_enabled = shields_data_controller->IsBraveShieldsEnabled();
-    fp_block_mode = shields_data_controller->GetFingerprintMode();
-    ad_block_mode = shields_data_controller->GetAdBlockMode();
+    auto* shields_settings = BraveShieldsSettingsServiceFactory::GetForProfile(
+        Profile::FromBrowserContext(initiator->GetBrowserContext()));
+    CHECK(shields_settings);
+    const auto& url = shields_data_controller->GetCurrentSiteURL();
+    shields_enabled = shields_settings->IsBraveShieldsEnabled(url);
+    fp_block_mode = shields_settings->GetFingerprintMode(url);
+    ad_block_mode = shields_settings->GetAdBlockMode(url);
   }
 
   bool is_error_page = false;

--- a/chromium_src/chrome/browser/renderer_context_menu/DEPS
+++ b/chromium_src/chrome/browser/renderer_context_menu/DEPS
@@ -2,6 +2,7 @@ include_rules = [
   "+brave/components/ai_chat/content/browser",
   "+brave/components/ai_chat/core/browser",
   "+brave/components/ai_chat/core/common",
+  "+brave/components/brave_shields/core/browser",
   "+brave/components/brave_shields/core/common",
   "+brave/components/containers/buildflags",
   "+brave/components/containers/content/browser",

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
@@ -18,6 +18,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "brave/browser/autocomplete/brave_autocomplete_scheme_classifier.h"
 #include "brave/browser/brave_browser_process.h"
+#include "brave/browser/brave_shields/brave_shields_settings_service_factory.h"
 #include "brave/browser/brave_shields/brave_shields_tab_helper.h"
 #include "brave/browser/cosmetic_filters/cosmetic_filters_tab_helper.h"
 #include "brave/browser/misc_metrics/process_misc_metrics.h"
@@ -28,6 +29,7 @@
 #include "brave/browser/ui/browser_commands.h"
 #include "brave/browser/ui/browser_dialogs.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_shields/core/browser/brave_shields_settings_service.h"
 #include "brave/components/brave_shields/core/common/features.h"
 #include "brave/components/email_aliases/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
@@ -740,10 +742,16 @@ void RenderViewContextMenu::AppendDeveloperItems() {
   auto* shields_tab_helper =
       brave_shields::BraveShieldsTabHelper::FromWebContents(
           source_web_contents_);
-  bool add_block_elements = shields_tab_helper &&
-                            shields_tab_helper->IsBraveShieldsEnabled() &&
-                            shields_tab_helper->GetAdBlockMode() !=
-                                brave_shields::mojom::AdBlockMode::ALLOW;
+  bool add_block_elements = false;
+  if (shields_tab_helper) {
+    auto* shields_settings = BraveShieldsSettingsServiceFactory::GetForProfile(
+        Profile::FromBrowserContext(source_web_contents_->GetBrowserContext()));
+    CHECK(shields_settings);
+    const auto& url = shields_tab_helper->GetCurrentSiteURL();
+    add_block_elements = shields_settings->IsBraveShieldsEnabled(url) &&
+                         shields_settings->GetAdBlockMode(url) !=
+                             brave_shields::mojom::AdBlockMode::ALLOW;
+  }
   add_block_elements &=
       params_.selection_text.empty() || !params_.link_url.is_empty();
 

--- a/components/brave_shields/core/browser/BUILD.gn
+++ b/components/brave_shields/core/browser/BUILD.gn
@@ -60,6 +60,7 @@ static_library("browser") {
     "//components/prefs",
     "//components/value_store",
     "//crypto",
+    "//net",
     "//url",
   ]
   public_deps = [

--- a/components/brave_shields/core/browser/brave_shields_settings_service.cc
+++ b/components/brave_shields/core/browser/brave_shields_settings_service.cc
@@ -18,6 +18,7 @@
 #include "components/content_settings/core/common/content_settings_types.h"
 #include "components/pref_registry/pref_registry_syncable.h"
 #include "components/prefs/pref_service.h"
+#include "net/base/registry_controlled_domains/registry_controlled_domain.h"
 #include "net/base/url_util.h"
 #include "url/gurl.h"
 
@@ -97,6 +98,7 @@ void BraveShieldsSettingsService::SetBraveShieldsEnabled(bool is_enabled,
                                                          const GURL& url) {
   brave_shields::SetBraveShieldsEnabled(&*host_content_settings_map_,
                                         is_enabled, url, local_state_);
+  NotifySettingsChanged(url);
 }
 
 bool BraveShieldsSettingsService::IsBraveShieldsEnabled(const GURL& url) {
@@ -145,6 +147,7 @@ void BraveShieldsSettingsService::SetAdBlockMode(mojom::AdBlockMode mode,
   brave_shields::SetCosmeticFilteringControlType(&*host_content_settings_map_,
                                                  control_type_cosmetic, url,
                                                  local_state_, profile_prefs_);
+  NotifySettingsChanged(url);
 }
 
 mojom::AdBlockMode BraveShieldsSettingsService::GetAdBlockMode(
@@ -198,6 +201,7 @@ void BraveShieldsSettingsService::SetFingerprintMode(
   brave_shields::SetFingerprintingControlType(&*host_content_settings_map_,
                                               control_type, url, local_state_,
                                               profile_prefs_);
+  NotifySettingsChanged(url);
 }
 
 mojom::FingerprintMode BraveShieldsSettingsService::GetFingerprintMode(
@@ -234,6 +238,24 @@ void BraveShieldsSettingsService::SetNoScriptEnabled(bool is_enabled,
       is_enabled ? ControlType::BLOCK : ControlType::ALLOW;
   brave_shields::SetNoScriptControlType(&*host_content_settings_map_,
                                         control_type, url, local_state_);
+  NotifySettingsChanged(url);
+}
+
+void BraveShieldsSettingsService::AddObserver(Observer* observer) {
+  observers_.AddObserver(observer);
+}
+
+void BraveShieldsSettingsService::RemoveObserver(Observer* observer) {
+  observers_.RemoveObserver(observer);
+}
+
+void BraveShieldsSettingsService::NotifySettingsChanged(const GURL& url) {
+  const std::string etld_plus_one =
+      net::registry_controlled_domains::GetDomainAndRegistry(
+          url, net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES);
+  for (Observer& observer : observers_) {
+    observer.OnShieldsSettingsChanged(etld_plus_one);
+  }
 }
 
 bool BraveShieldsSettingsService::IsNoScriptEnabled(const GURL& url) {

--- a/components/brave_shields/core/browser/brave_shields_settings_service.h
+++ b/components/brave_shields/core/browser/brave_shields_settings_service.h
@@ -34,8 +34,7 @@ class BraveShieldsSettingsService : public KeyedService {
  public:
   class Observer : public base::CheckedObserver {
    public:
-    virtual void OnShieldsSettingsChanged(
-        const std::string& etld_plus_one) = 0;
+    virtual void OnShieldsSettingsChanged(const std::string& etld_plus_one) = 0;
   };
 
   explicit BraveShieldsSettingsService(

--- a/components/brave_shields/core/browser/brave_shields_settings_service.h
+++ b/components/brave_shields/core/browser/brave_shields_settings_service.h
@@ -6,9 +6,13 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_SHIELDS_CORE_BROWSER_BRAVE_SHIELDS_SETTINGS_SERVICE_H_
 #define BRAVE_COMPONENTS_BRAVE_SHIELDS_CORE_BROWSER_BRAVE_SHIELDS_SETTINGS_SERVICE_H_
 
+#include <string>
+
 #include "base/containers/span.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ref.h"
+#include "base/observer_list.h"
+#include "base/observer_list_types.h"
 #include "base/token.h"
 #include "brave/components/brave_shields/core/common/brave_shields_panel.mojom.h"
 #include "brave/components/brave_shields/core/common/farbling_prng.h"
@@ -28,6 +32,12 @@ namespace brave_shields {
 
 class BraveShieldsSettingsService : public KeyedService {
  public:
+  class Observer : public base::CheckedObserver {
+   public:
+    virtual void OnShieldsSettingsChanged(
+        const std::string& etld_plus_one) = 0;
+  };
+
   explicit BraveShieldsSettingsService(
       HostContentSettingsMap& host_content_settings_map,
       PrefService* local_state = nullptr,
@@ -91,7 +101,12 @@ class BraveShieldsSettingsService : public KeyedService {
   base::Token GetFarblingToken(const GURL& url,
                                base::span<const uint8_t> additional_entropy);
 
+  void AddObserver(Observer* observer);
+  void RemoveObserver(Observer* observer);
+
  private:
+  void NotifySettingsChanged(const GURL& url);
+
   const raw_ref<HostContentSettingsMap>
       host_content_settings_map_;       // NOT OWNED
   raw_ptr<PrefService> local_state_;    // NOT OWNED
@@ -101,6 +116,8 @@ class BraveShieldsSettingsService : public KeyedService {
   // the service is destoryed. It allows to show different farbled values for a
   // site across browser restarts.
   base::Token profile_level_farbling_entropy_;
+
+  base::ObserverList<Observer> observers_;
 };
 
 }  // namespace brave_shields

--- a/components/brave_shields/core/browser/brave_shields_settings_service_unittest.cc
+++ b/components/brave_shields/core/browser/brave_shields_settings_service_unittest.cc
@@ -137,12 +137,12 @@ TEST_F(BraveShieldsSettingsServiceTest, NotifiesSettingsObservers) {
   brave_shields_settings()->SetAdBlockMode(AdBlockMode::AGGRESSIVE, kTestUrl);
   brave_shields_settings()->SetNoScriptEnabled(
       true, GURL("https://subdomain.brave.com/path"));
-  brave_shields_settings()->SetFingerprintMode(
-      FingerprintMode::ALLOW_MODE, GURL("https://example.com"));
+  brave_shields_settings()->SetFingerprintMode(FingerprintMode::ALLOW_MODE,
+                                               GURL("https://example.com"));
 
-  EXPECT_EQ(observer.changed_domains(),
-            (std::vector<std::string>{"brave.com", "brave.com",
-                                      "example.com"}));
+  EXPECT_EQ(
+      observer.changed_domains(),
+      (std::vector<std::string>{"brave.com", "brave.com", "example.com"}));
 }
 
 TEST_F(BraveShieldsSettingsServiceTest, IsBraveShieldsManaged) {

--- a/components/brave_shields/core/browser/brave_shields_settings_service_unittest.cc
+++ b/components/brave_shields/core/browser/brave_shields_settings_service_unittest.cc
@@ -6,8 +6,11 @@
 #include "brave/components/brave_shields/core/browser/brave_shields_settings_service.h"
 
 #include <array>
+#include <string>
 #include <tuple>
+#include <vector>
 
+#include "base/scoped_observation.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
 #include "brave/components/brave_shields/core/browser/brave_shields_p3a.h"
@@ -25,6 +28,33 @@
 using brave_shields::mojom::AdBlockMode;
 using brave_shields::mojom::AutoShredMode;
 using brave_shields::mojom::FingerprintMode;
+
+namespace {
+
+class TestSettingsObserver
+    : public brave_shields::BraveShieldsSettingsService::Observer {
+ public:
+  explicit TestSettingsObserver(
+      brave_shields::BraveShieldsSettingsService& settings_service) {
+    observation_.Observe(&settings_service);
+  }
+
+  void OnShieldsSettingsChanged(const std::string& etld_plus_one) override {
+    changed_domains_.push_back(etld_plus_one);
+  }
+
+  const std::vector<std::string>& changed_domains() const {
+    return changed_domains_;
+  }
+
+ private:
+  std::vector<std::string> changed_domains_;
+  base::ScopedObservation<brave_shields::BraveShieldsSettingsService,
+                          brave_shields::BraveShieldsSettingsService::Observer>
+      observation_{this};
+};
+
+}  // namespace
 
 class BraveShieldsSettingsServiceTest : public testing::Test {
  public:
@@ -99,6 +129,20 @@ TEST_F(BraveShieldsSettingsServiceTest, BraveShieldsEnabled) {
       GURL("https://example.com")));
   EXPECT_TRUE(brave_shields::IsBraveShieldsEnabled(
       GetHostContentSettingsMap(), GURL("https://example.com")));
+}
+
+TEST_F(BraveShieldsSettingsServiceTest, NotifiesSettingsObservers) {
+  TestSettingsObserver observer(*brave_shields_settings());
+
+  brave_shields_settings()->SetAdBlockMode(AdBlockMode::AGGRESSIVE, kTestUrl);
+  brave_shields_settings()->SetNoScriptEnabled(
+      true, GURL("https://subdomain.brave.com/path"));
+  brave_shields_settings()->SetFingerprintMode(
+      FingerprintMode::ALLOW_MODE, GURL("https://example.com"));
+
+  EXPECT_EQ(observer.changed_domains(),
+            (std::vector<std::string>{"brave.com", "brave.com",
+                                      "example.com"}));
 }
 
 TEST_F(BraveShieldsSettingsServiceTest, IsBraveShieldsManaged) {


### PR DESCRIPTION
## Summary

- call `BraveShieldsSettingsService` directly instead of proxying through `BraveShieldsTabHelper`
- remove the remaining settings-service proxy methods and migrate their production/test callers
- rely on the observer-driven reload behavior introduced by the prerequisite PR

Stacked on https://github.com/brave/brave-core/pull/39137; this branch contains that prerequisite commit until it lands.

Fixes https://github.com/brave/brave-browser/issues/58112