### PR TITLE
Remove Shields settings service proxy from tab helper

### DIFF
--- a/browser/brave_shields/brave_shields_tab_helper.cc
+++ b/browser/brave_shields/brave_shields_tab_helper.cc
@@ -395,25 +395,8 @@ bool BraveShieldsTabHelper::GetNoScriptEnabled() {
   return brave_shields_settings_->IsNoScriptEnabled(GetCurrentSiteURL());
 }
 
-mojom::ContentSettingsOverriddenDataPtr
-BraveShieldsTabHelper::GetJsContentSettingsOverriddenData() {
-  return brave_shields_settings_->GetJsContentSettingOverriddenData(
-      GetCurrentSiteURL());
-}
-
-bool BraveShieldsTabHelper::GetForgetFirstPartyStorageEnabled() {
-  return brave_shields_settings_->GetForgetFirstPartyStorageEnabled(
-      GetCurrentSiteURL());
-}
-
 void BraveShieldsTabHelper::SetAdBlockMode(mojom::AdBlockMode mode) {
   brave_shields_settings_->SetAdBlockMode(mode, GetCurrentSiteURL());
-
-  ReloadWebContents();
-}
-
-void BraveShieldsTabHelper::SetFingerprintMode(mojom::FingerprintMode mode) {
-  brave_shields_settings_->SetFingerprintMode(mode, GetCurrentSiteURL());
 
   ReloadWebContents();
 }
@@ -464,11 +447,6 @@ void BraveShieldsTabHelper::SetIsNoScriptEnabled(bool is_enabled) {
   brave_shields_settings_->SetNoScriptEnabled(is_enabled, GetCurrentSiteURL());
 
   ReloadWebContents();
-}
-
-void BraveShieldsTabHelper::SetForgetFirstPartyStorageEnabled(bool is_enabled) {
-  brave_shields_settings_->SetForgetFirstPartyStorageEnabled(
-      is_enabled, GetCurrentSiteURL());
 }
 
 void BraveShieldsTabHelper::BlockAllowedScripts(

--- a/browser/brave_shields/brave_shields_tab_helper.h
+++ b/browser/brave_shields/brave_shields_tab_helper.h
@@ -70,6 +70,7 @@ class BraveShieldsTabHelper
   void SetBraveShieldsAdBlockOnlyModeEnabled(bool is_enabled);
   bool ShouldShowShieldsDisabledAdBlockOnlyModePrompt();
   void SetBraveShieldsAdBlockOnlyModePromptDismissed();
+  void ReloadWebContents();
   GURL GetCurrentSiteURL() const;
   GURL GetFaviconURL(bool refresh);
   const base::flat_set<ContentSettingsType>& GetInvokedWebcompatFeatures();
@@ -79,14 +80,10 @@ class BraveShieldsTabHelper
   mojom::CookieBlockMode GetCookieBlockMode();
   mojom::HttpsUpgradeMode GetHttpsUpgradeMode();
   bool GetNoScriptEnabled();
-  mojom::ContentSettingsOverriddenDataPtr GetJsContentSettingsOverriddenData();
-  bool GetForgetFirstPartyStorageEnabled();
   void SetAdBlockMode(mojom::AdBlockMode mode);
-  void SetFingerprintMode(mojom::FingerprintMode mode);
   void SetCookieBlockMode(mojom::CookieBlockMode mode);
   void SetHttpsUpgradeMode(mojom::HttpsUpgradeMode mode);
   void SetIsNoScriptEnabled(bool is_enabled);
-  void SetForgetFirstPartyStorageEnabled(bool is_enabled);
   void EnforceSiteDataCleanup();
   void AllowScriptsOnce(const std::vector<std::string>& origins);
   void BlockAllowedScripts(const std::vector<std::string>& origins);
@@ -127,7 +124,6 @@ class BraveShieldsTabHelper
                         bool icon_url_changed,
                         const gfx::Image& image) override;
 
-  void ReloadWebContents();
   void MaybeNotifyRepeatedReloads(content::NavigationHandle* navigation_handle);
 
   void OnShieldsAdBlockOnlyModeEnabledChanged();

--- a/browser/ui/webui/brave_shields/shields_panel_data_handler.cc
+++ b/browser/ui/webui/brave_shields/shields_panel_data_handler.cc
@@ -28,11 +28,11 @@ ShieldsPanelDataHandler::ShieldsPanelDataHandler(
     TopChromeWebUIController* webui_controller,
     TabStripModel* tab_strip_model,
     favicon::FaviconService* favicon_service,
-    brave_shields::BraveShieldsSettingsService* brave_shields_settings_service)
+    brave_shields::BraveShieldsSettingsService& brave_shields_settings)
     : data_handler_receiver_(this, std::move(data_handler_receiver)),
       webui_controller_(webui_controller),
       favicon_service_(favicon_service),
-      brave_shields_settings_service_(brave_shields_settings_service) {
+      brave_shields_settings_(brave_shields_settings) {
   DCHECK(tab_strip_model);
   tab_strip_model->AddObserver(this);
 
@@ -81,21 +81,22 @@ void ShieldsPanelDataHandler::GetSiteSettings(
   }
 
   SiteSettings settings;
-  settings.ad_block_mode = active_shields_data_controller_->GetAdBlockMode();
+  const auto& site_url = active_shields_data_controller_->GetCurrentSiteURL();
+  settings.ad_block_mode = brave_shields_settings_->GetAdBlockMode(site_url);
   settings.fingerprint_mode =
-      active_shields_data_controller_->GetFingerprintMode();
+      brave_shields_settings_->GetFingerprintMode(site_url);
   settings.cookie_block_mode =
       active_shields_data_controller_->GetCookieBlockMode();
   settings.https_upgrade_mode =
       active_shields_data_controller_->GetHttpsUpgradeMode();
   settings.is_noscript_enabled =
-      active_shields_data_controller_->GetNoScriptEnabled();
+      brave_shields_settings_->IsNoScriptEnabled(site_url);
   settings.is_forget_first_party_storage_enabled =
-      active_shields_data_controller_->GetForgetFirstPartyStorageEnabled();
+      brave_shields_settings_->GetForgetFirstPartyStorageEnabled(site_url);
   settings.webcompat_settings =
       active_shields_data_controller_->GetWebcompatSettings();
   settings.scripts_blocked_override_status =
-      active_shields_data_controller_->GetJsContentSettingsOverriddenData();
+      brave_shields_settings_->GetJsContentSettingOverriddenData(site_url);
 
   std::move(callback).Run(settings.Clone());
 }
@@ -106,7 +107,9 @@ void ShieldsPanelDataHandler::SetAdBlockMode(
     return;
   }
 
-  active_shields_data_controller_->SetAdBlockMode(mode);
+  brave_shields_settings_->SetAdBlockMode(
+      mode, active_shields_data_controller_->GetCurrentSiteURL());
+  active_shields_data_controller_->ReloadWebContents();
 }
 
 void ShieldsPanelDataHandler::SetFingerprintMode(
@@ -115,7 +118,9 @@ void ShieldsPanelDataHandler::SetFingerprintMode(
     return;
   }
 
-  active_shields_data_controller_->SetFingerprintMode(mode);
+  brave_shields_settings_->SetFingerprintMode(
+      mode, active_shields_data_controller_->GetCurrentSiteURL());
+  active_shields_data_controller_->ReloadWebContents();
 }
 
 void ShieldsPanelDataHandler::SetCookieBlockMode(
@@ -141,7 +146,9 @@ void ShieldsPanelDataHandler::SetIsNoScriptsEnabled(bool is_enabled) {
     return;
   }
 
-  active_shields_data_controller_->SetIsNoScriptEnabled(is_enabled);
+  brave_shields_settings_->SetNoScriptEnabled(
+      is_enabled, active_shields_data_controller_->GetCurrentSiteURL());
+  active_shields_data_controller_->ReloadWebContents();
 }
 
 void ShieldsPanelDataHandler::AllowScriptsOnce(
@@ -197,8 +204,8 @@ void ShieldsPanelDataHandler::SetForgetFirstPartyStorageEnabled(
     return;
   }
 
-  active_shields_data_controller_->SetForgetFirstPartyStorageEnabled(
-      is_enabled);
+  brave_shields_settings_->SetForgetFirstPartyStorageEnabled(
+      is_enabled, active_shields_data_controller_->GetCurrentSiteURL());
 }
 
 void ShieldsPanelDataHandler::SetWebcompatEnabled(
@@ -305,14 +312,15 @@ void ShieldsPanelDataHandler::UpdateSiteBlockInfo() {
   site_block_info_.http_redirects_list =
       active_shields_data_controller_->GetHttpRedirectsList();
   site_block_info_.is_brave_shields_enabled =
-      active_shields_data_controller_->IsBraveShieldsEnabled();
+      brave_shields_settings_->IsBraveShieldsEnabled(
+          active_shields_data_controller_->GetCurrentSiteURL());
   site_block_info_.is_brave_shields_ad_block_only_mode_enabled =
       active_shields_data_controller_->IsBraveShieldsAdBlockOnlyModeEnabled();
   site_block_info_.show_shields_disabled_ad_block_only_mode_prompt =
       active_shields_data_controller_
           ->ShouldShowShieldsDisabledAdBlockOnlyModePrompt();
   site_block_info_.is_brave_shields_managed =
-      brave_shields_settings_service_->IsBraveShieldsManaged(current_site_url);
+      brave_shields_settings_->IsBraveShieldsManaged(current_site_url);
   const auto& invoked_webcompat_set =
       active_shields_data_controller_->GetInvokedWebcompatFeatures();
   site_block_info_.invoked_webcompat_list = std::vector<ContentSettingsType>(

--- a/browser/ui/webui/brave_shields/shields_panel_data_handler.h
+++ b/browser/ui/webui/brave_shields/shields_panel_data_handler.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "base/task/cancelable_task_tracker.h"
 #include "brave/browser/brave_shields/brave_shields_tab_helper.h"
 #include "brave/components/brave_shields/core/common/brave_shields_panel.mojom.h"
@@ -30,6 +31,10 @@ namespace brave_shields {
 class BraveShieldsSettingsService;
 }  // namespace brave_shields
 
+namespace brave_shields {
+class BraveShieldsSettingsService;
+}
+
 class ShieldsPanelDataHandler
     : public brave_shields::mojom::DataHandler,
       public brave_shields::BraveShieldsTabHelper::Observer,
@@ -41,7 +46,7 @@ class ShieldsPanelDataHandler
       TopChromeWebUIController* webui_controller,
       TabStripModel* tab_strip_model,
       favicon::FaviconService* favicon_service,
-      brave_shields::BraveShieldsSettingsService* brave_settings_service);
+      brave_shields::BraveShieldsSettingsService& brave_shields_settings);
 
   ShieldsPanelDataHandler(const ShieldsPanelDataHandler&) = delete;
   ShieldsPanelDataHandler& operator=(const ShieldsPanelDataHandler&) = delete;
@@ -97,8 +102,8 @@ class ShieldsPanelDataHandler
   raw_ptr<brave_shields::BraveShieldsTabHelper>
       active_shields_data_controller_ = nullptr;      // not owned
   raw_ptr<favicon::FaviconService> favicon_service_;  // not owned
-  raw_ptr<brave_shields::BraveShieldsSettingsService>
-      brave_shields_settings_service_;  // not owned
+  const raw_ref<brave_shields::BraveShieldsSettingsService>
+      brave_shields_settings_;  // not owned
 };
 
 #endif  // BRAVE_BROWSER_UI_WEBUI_BRAVE_SHIELDS_SHIELDS_PANEL_DATA_HANDLER_H_

--- a/browser/ui/webui/brave_shields/shields_panel_data_handler.h
+++ b/browser/ui/webui/brave_shields/shields_panel_data_handler.h
@@ -31,10 +31,6 @@ namespace brave_shields {
 class BraveShieldsSettingsService;
 }  // namespace brave_shields
 
-namespace brave_shields {
-class BraveShieldsSettingsService;
-}
-
 class ShieldsPanelDataHandler
     : public brave_shields::mojom::DataHandler,
       public brave_shields::BraveShieldsTabHelper::Observer,

--- a/browser/ui/webui/brave_shields/shields_panel_ui.cc
+++ b/browser/ui/webui/brave_shields/shields_panel_ui.cc
@@ -116,11 +116,12 @@ void ShieldsPanelUI::CreatePanelHandler(
   CHECK(browser);
   auto* favicon_service = FaviconServiceFactory::GetForProfile(
       profile, ServiceAccessType::EXPLICIT_ACCESS);
-  auto* brave_shield_settings_service =
+  auto* brave_shields_settings =
       BraveShieldsSettingsServiceFactory::GetForProfile(profile);
+  CHECK(brave_shields_settings);
   data_handler_ = std::make_unique<ShieldsPanelDataHandler>(
       std::move(data_handler_receiver), this, browser->GetTabStripModel(),
-      favicon_service, brave_shield_settings_service);
+      favicon_service, *brave_shields_settings);
 }
 
 ShieldsPanelUIConfig::ShieldsPanelUIConfig()


### PR DESCRIPTION
## Summary

- call `BraveShieldsSettingsService` directly from `ShieldsPanelDataHandler` for service-owned site settings
- keep tab-specific cookie, HTTPS upgrade, webcompat, resource-list, and reload behavior in `BraveShieldsTabHelper`
- remove panel-only service proxy methods from `BraveShieldsTabHelper`

Fixes https://github.com/brave/brave-browser/issues/58112

## Validation

- `pnpm run format`
- `pnpm run gn_check Component` — passed (`Header dependency check OK`; checkdeps `SUCCESS`)
- `pnpm run presubmit --base master` — passed with 0 messages, 0 warnings, and 0 errors
- `pnpm run build Component --target=brave_browser_tests` — passed (30,243 build steps)
- `pnpm run build Component --target=brave_unit_tests` — passed (1,113 build steps)
- `pnpm run test brave_unit_tests --filter="BraveShieldsTabHelperUnitTest.*" Component` — 12/12 tests passed
- final `upstream/master...HEAD` implementation review and `git diff --check` — passed; no issue-scoped findings

Resolves https://github.com/brave/brave-core/pull/39311