### PR TITLE
[Android] transparent settings navigation bar

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveSettingsActivity.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSettingsActivity.java
@@ -5,14 +5,130 @@
 
 package org.chromium.chrome.browser.settings;
 
+import static org.chromium.build.NullUtil.assumeNonNull;
+
 import android.content.Intent;
+import android.graphics.Color;
+import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import org.chromium.build.annotations.NullMarked;
+import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.ChromeTabbedActivity;
+import org.chromium.chrome.browser.ui.edge_to_edge.EdgeToEdgeUtils;
+import org.chromium.components.browser_ui.styles.SemanticColorUtils;
+import org.chromium.ui.edge_to_edge.EdgeToEdgeSystemBarColorHelper;
+import org.chromium.ui.util.ColorUtils;
 
+import java.util.HashMap;
+import java.util.Map;
+
+@NullMarked
 public class BraveSettingsActivity extends SettingsActivity {
+
+    private @Nullable View mContentView;
+
+    /**
+     * Original bottom padding for each Settings fragment's RecyclerView.
+     *
+     * <p>Used as the baseline when applying navigation-bar insets so repeated updates do not
+     * accumulate padding.
+     */
+    private final Map<RecyclerView, Integer> mOriginalRecyclerViewBottomPaddings = new HashMap<>();
+
+    private final Runnable mUpdateSettingsContentInsetsRunnable = this::updateSettingsContentInsets;
+
+    private final View.OnLayoutChangeListener mContentViewLayoutListener =
+            this::onContentViewLayoutChanged;
+
+    private final FragmentManager.FragmentLifecycleCallbacks mSettingsFragmentLifecycleCallbacks =
+            new FragmentManager.FragmentLifecycleCallbacks() {
+                @Override
+                public void onFragmentViewCreated(
+                        FragmentManager fragmentManager,
+                        Fragment fragment,
+                        View view,
+                        @Nullable Bundle savedInstanceState) {
+                    view.post(() -> onSettingsFragmentViewReady(fragment, view));
+                }
+
+                @Override
+                public void onFragmentViewDestroyed(
+                        FragmentManager fragmentManager, Fragment fragment) {
+                    View fragmentView = fragment.getView();
+                    if (fragmentView == null) return;
+
+                    RecyclerView recyclerView = fragmentView.findViewById(R.id.recycler_view);
+                    if (recyclerView == null) return;
+
+                    mOriginalRecyclerViewBottomPaddings.remove(recyclerView);
+                }
+            };
+
+    @Override
+    protected boolean shouldDrawEdgeToEdgeOnCreate() {
+        // Settings applies its own navigation-bar inset, so it can always draw behind the bar.
+        return true;
+    }
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        getSupportFragmentManager()
+                .registerFragmentLifecycleCallbacks(
+                        mSettingsFragmentLifecycleCallbacks, /* recursive= */ true);
+        super.onCreate(savedInstanceState);
+
+        // Settings opts into edge-to-edge before the global rollout, so initialize its transparent
+        // navigation bar here when the base activity has not done so.
+        if (!EdgeToEdgeUtils.isEdgeToEdgeEverywhereEnabled()) {
+            initializeSystemBarColors(
+                    assumeNonNull(getEdgeToEdgeManager()).getEdgeToEdgeSystemBarColorHelper());
+        }
+
+        View contentView = getContentView();
+        mContentView = contentView;
+        contentView.setBackgroundColor(SemanticColorUtils.getSettingsBackgroundColor(this));
+        contentView.addOnLayoutChangeListener(mContentViewLayoutListener);
+        contentView.post(mUpdateSettingsContentInsetsRunnable);
+    }
+
+    @Override
+    protected void onDestroy() {
+        getSupportFragmentManager()
+                .unregisterFragmentLifecycleCallbacks(mSettingsFragmentLifecycleCallbacks);
+        if (mContentView != null) {
+            mContentView.removeOnLayoutChangeListener(mContentViewLayoutListener);
+            mContentView.removeCallbacks(mUpdateSettingsContentInsetsRunnable);
+            mContentView = null;
+        }
+        mOriginalRecyclerViewBottomPaddings.clear();
+        super.onDestroy();
+    }
+
+    @Override
+    protected void initializeSystemBarColors(
+            EdgeToEdgeSystemBarColorHelper edgeToEdgeSystemBarColorHelper) {
+        super.initializeSystemBarColors(edgeToEdgeSystemBarColorHelper);
+
+        // Retain the resolved RGB value so the system UI elements on the navigation bar use the
+        // correct contrast.
+        int transparentNavigationBarColor =
+                ColorUtils.setAlphaComponent(
+                        edgeToEdgeSystemBarColorHelper.getNavigationBarColor(), /* alpha= */ 0);
+        edgeToEdgeSystemBarColorHelper.setNavigationBarColor(transparentNavigationBarColor);
+        edgeToEdgeSystemBarColorHelper.setNavigationBarDividerColor(Color.TRANSPARENT);
+    }
+
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         menu.clear();
@@ -36,5 +152,60 @@ public class BraveSettingsActivity extends SettingsActivity {
             return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    private void onSettingsFragmentViewReady(Fragment fragment, View fragmentView) {
+        if (!fragment.isAdded() || fragment.getView() != fragmentView) return;
+        if (isFinishing() || isDestroyed()) return;
+
+        RecyclerView recyclerView = fragmentView.findViewById(R.id.recycler_view);
+        if (recyclerView == null) return;
+
+        mOriginalRecyclerViewBottomPaddings.putIfAbsent(
+                recyclerView, recyclerView.getPaddingBottom());
+        recyclerView.setClipToPadding(false);
+        updateSettingsContentInsets();
+    }
+
+    private void updateSettingsContentInsets() {
+        View contentView = mContentView;
+        if (contentView == null || isFinishing() || isDestroyed()) return;
+
+        WindowInsetsCompat rootWindowInsets = ViewCompat.getRootWindowInsets(contentView);
+        if (rootWindowInsets == null) return;
+
+        setBottomPadding(
+                contentView, rootWindowInsets.getInsets(WindowInsetsCompat.Type.ime()).bottom);
+
+        Insets navigationBarInsets =
+                rootWindowInsets.getInsets(WindowInsetsCompat.Type.navigationBars());
+        Insets tappableElementInsets =
+                rootWindowInsets.getInsets(WindowInsetsCompat.Type.tappableElement());
+        int navigationBarBottomInset =
+                Math.max(navigationBarInsets.bottom, tappableElementInsets.bottom);
+        for (Map.Entry<RecyclerView, Integer> entry :
+                mOriginalRecyclerViewBottomPaddings.entrySet()) {
+            setBottomPadding(entry.getKey(), entry.getValue() + navigationBarBottomInset);
+        }
+    }
+
+    private void onContentViewLayoutChanged(
+            View view,
+            int left,
+            int top,
+            int right,
+            int bottom,
+            int oldLeft,
+            int oldTop,
+            int oldRight,
+            int oldBottom) {
+        updateSettingsContentInsets();
+    }
+
+    private static void setBottomPadding(View view, int bottomPadding) {
+        if (view.getPaddingBottom() == bottomPadding) return;
+
+        view.setPadding(
+                view.getPaddingLeft(), view.getPaddingTop(), view.getPaddingRight(), bottomPadding);
     }
 }

--- a/android/java/org/chromium/chrome/browser/settings/BraveSettingsActivity.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSettingsActivity.java
@@ -46,11 +46,6 @@ public class BraveSettingsActivity extends SettingsActivity {
      */
     private final Map<RecyclerView, Integer> mOriginalRecyclerViewBottomPaddings = new HashMap<>();
 
-    private final Runnable mUpdateSettingsContentInsetsRunnable = this::updateSettingsContentInsets;
-
-    private final View.OnLayoutChangeListener mContentViewLayoutListener =
-            this::onContentViewLayoutChanged;
-
     private final FragmentManager.FragmentLifecycleCallbacks mSettingsFragmentLifecycleCallbacks =
             new FragmentManager.FragmentLifecycleCallbacks() {
                 @Override
@@ -98,8 +93,8 @@ public class BraveSettingsActivity extends SettingsActivity {
         View contentView = getContentView();
         mContentView = contentView;
         contentView.setBackgroundColor(SemanticColorUtils.getSettingsBackgroundColor(this));
-        contentView.addOnLayoutChangeListener(mContentViewLayoutListener);
-        contentView.post(mUpdateSettingsContentInsetsRunnable);
+        ViewCompat.setOnApplyWindowInsetsListener(contentView, this::updateSettingsContentInsets);
+        ViewCompat.requestApplyInsets(contentView);
     }
 
     @Override
@@ -107,8 +102,7 @@ public class BraveSettingsActivity extends SettingsActivity {
         getSupportFragmentManager()
                 .unregisterFragmentLifecycleCallbacks(mSettingsFragmentLifecycleCallbacks);
         if (mContentView != null) {
-            mContentView.removeOnLayoutChangeListener(mContentViewLayoutListener);
-            mContentView.removeCallbacks(mUpdateSettingsContentInsetsRunnable);
+            ViewCompat.setOnApplyWindowInsetsListener(mContentView, null);
             mContentView = null;
         }
         mOriginalRecyclerViewBottomPaddings.clear();
@@ -164,15 +158,19 @@ public class BraveSettingsActivity extends SettingsActivity {
         mOriginalRecyclerViewBottomPaddings.putIfAbsent(
                 recyclerView, recyclerView.getPaddingBottom());
         recyclerView.setClipToPadding(false);
-        updateSettingsContentInsets();
-    }
 
-    private void updateSettingsContentInsets() {
         View contentView = mContentView;
-        if (contentView == null || isFinishing() || isDestroyed()) return;
+        if (contentView == null) return;
 
         WindowInsetsCompat rootWindowInsets = ViewCompat.getRootWindowInsets(contentView);
         if (rootWindowInsets == null) return;
+
+        updateSettingsContentInsets(contentView, rootWindowInsets);
+    }
+
+    private WindowInsetsCompat updateSettingsContentInsets(
+            View contentView, WindowInsetsCompat rootWindowInsets) {
+        if (isFinishing() || isDestroyed()) return rootWindowInsets;
 
         setBottomPadding(
                 contentView, rootWindowInsets.getInsets(WindowInsetsCompat.Type.ime()).bottom);
@@ -187,19 +185,7 @@ public class BraveSettingsActivity extends SettingsActivity {
                 mOriginalRecyclerViewBottomPaddings.entrySet()) {
             setBottomPadding(entry.getKey(), entry.getValue() + navigationBarBottomInset);
         }
-    }
-
-    private void onContentViewLayoutChanged(
-            View view,
-            int left,
-            int top,
-            int right,
-            int bottom,
-            int oldLeft,
-            int oldTop,
-            int oldRight,
-            int oldBottom) {
-        updateSettingsContentInsets();
+        return rootWindowInsets;
     }
 
     private static void setBottomPadding(View view, int bottomPadding) {


### PR DESCRIPTION


<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58116.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

## Changes

- configure Settings for edge-to-edge display
- preserve each list's original padding and refresh it as fragment views and layout change, so the last item remains scrollable above the system controls.
- make the navigation bar and divider transparent while preserving contrast for the system UI navigation icons
- keep the last setting reachable by adding space below the list for Android's navigation controls and for the keyboard when it is open

## Screenshots


https://github.com/user-attachments/assets/c915e12f-f91b-4804-947b-706ab56b91bd


### Tablet
<img width="2562" height="1654" alt="Screenshot_2026-08-13 at 14 25 28" src="https://github.com/user-attachments/assets/9e6c82e5-71a4-4326-b1eb-0f94b61ebf99" />

### System UI navigation bar color

Light theme|Dark theme
--|--
<img width="1344" height="2992" alt="Screenshot_1786598568" src="https://github.com/user-attachments/assets/35e89c65-2e5d-4a53-9613-027f49d1d47a" />|<img width="1344" height="2992" alt="Screenshot_1786598563" src="https://github.com/user-attachments/assets/3bace994-2793-436d-8f64-f2d324dac7ce" />



### Dynamic bottom padding

&nbsp;|Root settings|Sub-screen
--|--|--
Gesture nav|<img width="1344" height="2992" alt="Screenshot_1786595946" src="https://github.com/user-attachments/assets/c7ceccb5-1d86-4e37-9888-9ac2bbc2a44b" />|<img width="1344" height="2992" alt="Screenshot_1786595939" src="https://github.com/user-attachments/assets/85c9fda9-95d1-47b2-9228-a803f0c3aac4" />
3 button nav|<img width="706" height="1634" alt="Screenshot_2026-08-13 at 14 07 22" src="https://github.com/user-attachments/assets/6fc77ae1-39cd-4905-b5b4-31856a7cc30e" />|<img width="706" height="1630" alt="Screenshot_2026-08-13 at 14 07 06" src="https://github.com/user-attachments/assets/c33c648a-218a-486c-aba6-58f2c141d921" />

Keyboard off screen|Keyboard on screen
--|--
<img width="1344" height="2992" alt="Screenshot_1786596008" src="https://github.com/user-attachments/assets/bbd1891f-0479-458d-8678-50691b7eb3f2" />|<img width="1344" height="2992" alt="Screenshot_1786596012" src="https://github.com/user-attachments/assets/bc08f5ae-26b4-4ff8-9e8e-a2bda051d0c3" />

