### PR TITLE
[AI Chat] [Sync] (8 of n) Add AI Chat sync per-record size budget and truncation

### DIFF
--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
@@ -6,6 +6,7 @@
 #include "brave/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h"
 
 #include <algorithm>
+#include <array>
 #include <memory>
 #include <optional>
 #include <string>
@@ -17,6 +18,7 @@
 #include "base/containers/map_util.h"
 #include "base/containers/span.h"
 #include "base/containers/to_vector.h"
+#include "base/functional/function_ref.h"
 #include "base/hash/hash.h"
 #include "base/logging.h"
 #include "base/notreached.h"
@@ -521,7 +523,241 @@ bool ReadAssociatedContentFromEntry(
   return true;
 }
 
+// --- Size-budget policy: which fields may be omitted, and in what order ---
+
+// One category of omittable field. A pass invokes |visit| for every
+// AIChatCompressibleString it covers; FitEntryWithinSyncBudget omits a whole
+// category at a time, and ForEachOmittableString runs every pass so that the
+// restore side sees the same fields.
+using OmissionPass = void (*)(sync_pb::AIChatConversationSpecifics_Entry*,
+                              CompressibleStringVisitor);
+
+void VisitEachString(google::protobuf::RepeatedPtrField<
+                         sync_pb::AIChatCompressibleString>* strings,
+                     CompressibleStringVisitor visit) {
+  for (auto& value : *strings) {
+    visit(value);
+  }
+}
+
+void VisitEachPageContent(
+    google::protobuf::RepeatedPtrField<sync_pb::AIChatWebSource>* sources,
+    CompressibleStringVisitor visit) {
+  for (auto& source : *sources) {
+    if (source.has_page_content()) {
+      visit(*source.mutable_page_content());
+    }
+  }
+}
+
+// Invokes |visit| for each persisted content block in tool output. Web sources
+// and text both appear here as well as at the event level, so three passes
+// share this walk.
+void ForEachToolOutputBlock(
+    sync_pb::AIChatConversationSpecifics_Entry* entry,
+    base::FunctionRef<void(sync_pb::AIChatContentBlock&)> visit) {
+  for (auto& event : *entry->mutable_events()) {
+    if (!event.has_tool_use()) {
+      continue;
+    }
+    for (auto& block : *event.mutable_tool_use()->mutable_output()) {
+      visit(block);
+    }
+  }
+}
+
+void VisitAssociatedContentTexts(
+    sync_pb::AIChatConversationSpecifics_Entry* entry,
+    CompressibleStringVisitor visit) {
+  for (auto& content : *entry->mutable_associated_content()) {
+    if (content.has_last_contents()) {
+      visit(*content.mutable_last_contents());
+    }
+  }
+}
+
+void VisitUploadedFileTexts(sync_pb::AIChatConversationSpecifics_Entry* entry,
+                            CompressibleStringVisitor visit) {
+  for (auto& file : *entry->mutable_uploaded_files()) {
+    if (file.has_extracted_text()) {
+      visit(*file.mutable_extracted_text());
+    }
+  }
+}
+
+void VisitInlineSearchResults(sync_pb::AIChatConversationSpecifics_Entry* entry,
+                              CompressibleStringVisitor visit) {
+  for (auto& event : *entry->mutable_events()) {
+    if (event.has_inline_search() && event.inline_search().has_results_json()) {
+      visit(*event.mutable_inline_search()->mutable_results_json());
+    }
+  }
+}
+
+void VisitWebSourcePageContents(
+    sync_pb::AIChatConversationSpecifics_Entry* entry,
+    CompressibleStringVisitor visit) {
+  for (auto& event : *entry->mutable_events()) {
+    if (event.has_web_sources()) {
+      VisitEachPageContent(event.mutable_web_sources()->mutable_sources(),
+                           visit);
+    }
+  }
+  ForEachToolOutputBlock(entry, [visit](sync_pb::AIChatContentBlock& block) {
+    if (block.has_web_sources_content_block()) {
+      VisitEachPageContent(
+          block.mutable_web_sources_content_block()->mutable_sources(), visit);
+    }
+  });
+}
+
+void VisitToolOutputTexts(sync_pb::AIChatConversationSpecifics_Entry* entry,
+                          CompressibleStringVisitor visit) {
+  ForEachToolOutputBlock(entry, [visit](sync_pb::AIChatContentBlock& block) {
+    if (block.has_text_content_block() &&
+        block.text_content_block().has_text()) {
+      visit(*block.mutable_text_content_block()->mutable_text());
+    }
+  });
+}
+
+void VisitToolArguments(sync_pb::AIChatConversationSpecifics_Entry* entry,
+                        CompressibleStringVisitor visit) {
+  for (auto& event : *entry->mutable_events()) {
+    if (event.has_tool_use() && event.tool_use().has_arguments_json()) {
+      visit(*event.mutable_tool_use()->mutable_arguments_json());
+    }
+  }
+}
+
+void VisitWebSourceRichResults(
+    sync_pb::AIChatConversationSpecifics_Entry* entry,
+    CompressibleStringVisitor visit) {
+  for (auto& event : *entry->mutable_events()) {
+    if (event.has_web_sources()) {
+      VisitEachString(event.mutable_web_sources()->mutable_rich_results(),
+                      visit);
+    }
+  }
+  ForEachToolOutputBlock(entry, [visit](sync_pb::AIChatContentBlock& block) {
+    if (block.has_web_sources_content_block()) {
+      VisitEachString(
+          block.mutable_web_sources_content_block()->mutable_rich_results(),
+          visit);
+    }
+  });
+}
+
+void VisitToolArtifactContents(
+    sync_pb::AIChatConversationSpecifics_Entry* entry,
+    CompressibleStringVisitor visit) {
+  for (auto& event : *entry->mutable_events()) {
+    if (!event.has_tool_use()) {
+      continue;
+    }
+    for (auto& artifact : *event.mutable_tool_use()->mutable_artifacts()) {
+      if (artifact.has_content_json()) {
+        visit(*artifact.mutable_content_json());
+      }
+    }
+  }
+}
+
+void VisitCompletions(sync_pb::AIChatConversationSpecifics_Entry* entry,
+                      CompressibleStringVisitor visit) {
+  for (auto& event : *entry->mutable_events()) {
+    if (event.has_completion()) {
+      visit(*event.mutable_completion());
+    }
+  }
+}
+
+// Every AIChatCompressibleString the size-budget policy may drop, in the order
+// it drops them. The order weighs what a field is worth as context for
+// continuing the conversation on another device against how much of the budget
+// it costs to carry. Most of it the model can do without or regenerate; what it
+// cannot replace is what the conversation actually said, so that goes last.
+// Adding a compressible field to the proto without listing it here means it can
+// never be omitted, and an entry that only that field makes oversized becomes
+// uncommittable.
+constexpr auto kOmissionPasses = std::to_array<OmissionPass>({
+    // Page text. Bulk context the replies already reflect, and the receiver
+    // still has the URL to re-derive it from.
+    &VisitAssociatedContentTexts,
+    // Text extracted from an attachment. Bulk context, same reasoning.
+    &VisitUploadedFileTexts,
+    // Raw inline-search JSON. Never reaches the model, and not read directly.
+    &VisitInlineSearchResults,
+    // Snippets fetched for cited pages. Costly, and the replies drew on them
+    // already.
+    &VisitWebSourcePageContents,
+    // Tool output the model worked from, likewise reflected in the replies.
+    &VisitToolOutputTexts,
+    // Tool call arguments. Small, and the model can produce them again.
+    &VisitToolArguments,
+    // Rich search result JSON. Costly, and only used to re-render results.
+    &VisitWebSourceRichResults,
+    // Artifact content. Never reaches the model, but the user opens these.
+    &VisitToolArtifactContents,
+    // The assistant's replies — the conversation itself, and the one thing
+    // nothing else can stand in for.
+    &VisitCompletions,
+});
+
+bool FitsWithinBudget(const sync_pb::AIChatConversationSpecifics_Entry& entry) {
+  return entry.ByteSizeLong() <= kSyncMaxRecordBytes;
+}
+
 }  // namespace
+
+void ForEachOmittableString(sync_pb::AIChatConversationSpecifics_Entry* entry,
+                            CompressibleStringVisitor visit) {
+  for (OmissionPass pass : kOmissionPasses) {
+    pass(entry, visit);
+  }
+}
+
+bool FitEntryWithinSyncBudget(
+    sync_pb::AIChatConversationSpecifics_Entry* entry) {
+  if (FitsWithinBudget(*entry)) {
+    return true;
+  }
+
+  // Uploaded file bytes go before any of kOmissionPasses. They are real
+  // context — without them the receiver cannot open the attachment at all —
+  // but one file can take most of the budget, and already-compressed image or
+  // PDF data will not shrink any further.
+  for (auto& file : *entry->mutable_uploaded_files()) {
+    if (!file.data().empty()) {
+      OmitUploadedFileData(&file);
+    }
+  }
+
+  for (OmissionPass pass : kOmissionPasses) {
+    if (FitsWithinBudget(*entry)) {
+      return true;
+    }
+    pass(entry, [](sync_pb::AIChatCompressibleString& value) {
+      // Skip fields that are absent or that a previous pass already omitted;
+      // re-omitting would hash the empty string over the original hash.
+      if (value.has_raw() || value.has_gzipped()) {
+        OmitCompressibleString(&value);
+      }
+    });
+  }
+
+  if (FitsWithinBudget(*entry)) {
+    return true;
+  }
+  // Nothing omittable is left, so the entry is over budget on fields that
+  // cannot be dropped (plain proto strings such as selected_text). Refuse the
+  // commit rather than sending a record the server will reject.
+  DLOG(ERROR) << "AI Chat entry " << entry->uuid()
+              << " exceeds the sync record budget after omitting every "
+                 "omittable field; refusing to commit. Size="
+              << entry->ByteSizeLong();
+  return false;
+}
 
 sync_pb::AIChatConversationSpecifics ConversationMetadataToSpecifics(
     const mojom::Conversation& conversation) {

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.cc
@@ -535,9 +535,7 @@ using OmissionPass = void (*)(sync_pb::AIChatConversationSpecifics_Entry*,
 void VisitEachString(google::protobuf::RepeatedPtrField<
                          sync_pb::AIChatCompressibleString>* strings,
                      CompressibleStringVisitor visit) {
-  for (auto& value : *strings) {
-    visit(value);
-  }
+  std::ranges::for_each(*strings, visit);
 }
 
 void VisitEachPageContent(
@@ -726,11 +724,26 @@ bool FitEntryWithinSyncBudget(
   // Uploaded file bytes go before any of kOmissionPasses. They are real
   // context — without them the receiver cannot open the attachment at all —
   // but one file can take most of the budget, and already-compressed image or
-  // PDF data will not shrink any further.
+  // PDF data will not shrink any further. Drop the biggest first and stop as
+  // soon as the entry fits, so one oversized attachment does not cost the
+  // small ones. Only the visit order is sorted; |uploaded_files| keeps its
+  // original order on the wire.
+  std::vector<sync_pb::AIChatUploadedFile*> files_by_size;
+  files_by_size.reserve(entry->uploaded_files_size());
   for (auto& file : *entry->mutable_uploaded_files()) {
     if (!file.data().empty()) {
-      OmitUploadedFileData(&file);
+      files_by_size.push_back(&file);
     }
+  }
+  std::ranges::sort(files_by_size, std::ranges::greater(),
+                    [](const sync_pb::AIChatUploadedFile* file) {
+                      return file->data().size();
+                    });
+  for (sync_pb::AIChatUploadedFile* file : files_by_size) {
+    if (FitsWithinBudget(*entry)) {
+      return true;
+    }
+    OmitUploadedFileData(file);
   }
 
   for (OmissionPass pass : kOmissionPasses) {
@@ -739,8 +752,12 @@ bool FitEntryWithinSyncBudget(
     }
     pass(entry, [](sync_pb::AIChatCompressibleString& value) {
       // Skip fields that are absent or that a previous pass already omitted;
-      // re-omitting would hash the empty string over the original hash.
-      if (value.has_raw() || value.has_gzipped()) {
+      // re-omitting would hash the empty string over the original hash. An
+      // explicitly-empty raw string is skipped too: ReadCompressibleString()
+      // reports that as a value rather than an omission, and replacing it with
+      // a hash would both lose that distinction and cost more bytes than the
+      // empty string it replaced.
+      if (value.has_gzipped() || (value.has_raw() && !value.raw().empty())) {
         OmitCompressibleString(&value);
       }
     });

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h
@@ -13,12 +13,14 @@
 #include <vector>
 
 #include "base/containers/flat_map.h"
+#include "base/functional/function_ref.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom-forward.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom-forward.h"
 
 namespace sync_pb {
 class AIChatCompressibleString;
 class AIChatConversationSpecifics;
+class AIChatConversationSpecifics_Entry;
 class AIChatUploadedFile;
 class EntitySpecifics;
 }  // namespace sync_pb
@@ -76,6 +78,29 @@ void OmitUploadedFileData(sync_pb::AIChatUploadedFile* file);
 std::optional<std::string> ReadCompressibleString(
     const sync_pb::AIChatCompressibleString& in);
 
+// Invokes |visit| for every AIChatCompressibleString on |entry| that
+// FitEntryWithinSyncBudget is allowed to omit. Callers that have to recognise
+// or undo an omission (see AIChatSyncBridge::RestoreOmittedFieldsFromLocal)
+// use this so they cover exactly the field set the budget policy can drop,
+// rather than maintaining a second list of their own. Uploaded file bytes are
+// not covered — they are raw bytes rather than an AIChatCompressibleString, so
+// callers handle AIChatUploadedFile::omitted_data_hash separately.
+using CompressibleStringVisitor =
+    base::FunctionRef<void(sync_pb::AIChatCompressibleString&)>;
+void ForEachOmittableString(sync_pb::AIChatConversationSpecifics_Entry* entry,
+                            CompressibleStringVisitor visit);
+
+// Drops long-text and binary fields from |entry| (replacing each with a
+// content hash so the receiver can restore it from a byte-identical local
+// copy) until the serialized record fits under the per-record size budget.
+// Fields are dropped in a fixed priority order — see the omission passes in
+// the implementation. Returns true if the entry fits, either because no
+// omission was needed or because omitting brought it under budget, and false
+// if it remains too large even after every omittable field is gone — callers
+// must refuse to commit such records.
+bool FitEntryWithinSyncBudget(
+    sync_pb::AIChatConversationSpecifics_Entry* entry);
+
 // Builds a sync entity containing only conversation metadata.
 sync_pb::AIChatConversationSpecifics ConversationMetadataToSpecifics(
     const mojom::Conversation& conversation);
@@ -103,7 +128,7 @@ mojom::ConversationPtr SpecificsToConversationMetadata(
 // |conversation_turn_uuid|. When non-null, |associated_content_texts|
 // receives the last_contents value for each AC where the sender provided
 // one; absent map entries mean the caller should preserve any existing
-// local text (forward-compat or truncated-for-sync).
+// local text (forward-compat or omitted-for-sync).
 mojom::ConversationTurnPtr SpecificsToEntry(
     const sync_pb::AIChatConversationSpecifics& specifics,
     std::vector<mojom::AssociatedContentPtr>& associated_content,

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h
@@ -79,12 +79,12 @@ std::optional<std::string> ReadCompressibleString(
     const sync_pb::AIChatCompressibleString& in);
 
 // Invokes |visit| for every AIChatCompressibleString on |entry| that
-// FitEntryWithinSyncBudget is allowed to omit. Callers that have to recognise
-// or undo an omission (see AIChatSyncBridge::RestoreOmittedFieldsFromLocal)
-// use this so they cover exactly the field set the budget policy can drop,
-// rather than maintaining a second list of their own. Uploaded file bytes are
-// not covered — they are raw bytes rather than an AIChatCompressibleString, so
-// callers handle AIChatUploadedFile::omitted_data_hash separately.
+// FitEntryWithinSyncBudget is allowed to omit. Code on the receiving side that
+// has to recognise or undo an omission uses this so it covers exactly the field
+// set the budget policy can drop, rather than maintaining a second list of its
+// own. Uploaded file bytes are not covered — they are raw bytes rather than an
+// AIChatCompressibleString, so callers handle
+// AIChatUploadedFile::omitted_data_hash separately.
 using CompressibleStringVisitor =
     base::FunctionRef<void(sync_pb::AIChatCompressibleString&)>;
 void ForEachOmittableString(sync_pb::AIChatConversationSpecifics_Entry* entry,

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions.h
@@ -39,11 +39,16 @@ inline constexpr std::string_view kEntryStorageKeyPrefix = "e:";
 // gain little and may grow under compression overhead.
 inline constexpr size_t kSyncCompressionThresholdBytes = 256;
 
-// Soft cap on the serialized size of a single sync record. Leaves headroom
-// under the 400 KB-per-entity server limit for sync framing and encryption
-// overhead. When an Entry would exceed this size, the size-budget policy omits
-// low-priority fields until it fits.
-inline constexpr size_t kSyncMaxRecordBytes = 350 * 1024;
+// Soft cap on the serialized size of a single sync record, measured on the
+// plaintext specifics. AI_CHAT_CONVERSATION is an encryptable type, so what
+// reaches the server is Nigori::Encrypt() of these bytes: an IV, AES-CBC
+// ciphertext and an HMAC, the whole thing base64-encoded. Base64 makes that
+// overhead multiplicative rather than additive — a record at this cap commits
+// at roughly 4/3 * (size + 64) bytes — so 256 KB arrives near 341 KB, leaving
+// ~59 KB under the 400 KB-per-entity server limit for the rest of the
+// SyncEntity. When an Entry would exceed this size, the size-budget policy
+// omits low-priority fields until it fits.
+inline constexpr size_t kSyncMaxRecordBytes = 256 * 1024;
 
 // Hard cap on the decompressed size of a single field. Protection against
 // malicious or corrupted data that might otherwise allocate unbounded memory.

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions_unittest.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions_unittest.cc
@@ -1279,9 +1279,16 @@ TEST(AIChatSyncConversionsTest, FitEntryRefusesEntryOversizedByPlainField) {
   EXPECT_FALSE(FitEntryWithinSyncBudget(&entry));
 
   EXPECT_TRUE(entry.uploaded_files(0).has_omitted_data_hash());
-  ForEachOmittableString(&entry, [](sync_pb::AIChatCompressibleString& value) {
-    EXPECT_TRUE(value.has_omitted_content_hash());
-  });
+  // A field that survived still holds its marker, so collecting the stragglers
+  // names them in the failure output.
+  std::vector<std::string> not_omitted;
+  ForEachOmittableString(
+      &entry, [&not_omitted](sync_pb::AIChatCompressibleString& value) {
+        if (!value.has_omitted_content_hash()) {
+          not_omitted.push_back(value.raw());
+        }
+      });
+  EXPECT_THAT(not_omitted, testing::IsEmpty());
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions_unittest.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions_unittest.cc
@@ -21,6 +21,7 @@
 #include "brave/components/sync/protocol/ai_chat_specifics.pb.h"
 #include "components/sync/protocol/entity_data.h"
 #include "components/sync/protocol/entity_specifics.pb.h"
+#include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "url/gurl.h"
 
@@ -31,6 +32,53 @@ namespace {
 // repetitive, so gzip is guaranteed to shrink it.
 std::string CompressibleString() {
   return std::string(2 * kSyncCompressionThresholdBytes, 'a');
+}
+
+// Sets one of every AIChatCompressibleString the size-budget policy is allowed
+// to omit to a distinct marker, and returns those markers so a test can assert
+// on the whole set at once instead of field by field.
+std::vector<std::string> PopulateOmittableStrings(
+    sync_pb::AIChatConversationSpecifics_Entry* entry) {
+  auto* content = entry->add_associated_content();
+  content->set_uuid("ac-1");
+  content->mutable_last_contents()->set_raw("associated content text");
+
+  auto* file = entry->add_uploaded_files();
+  file->set_filename("doc.pdf");
+  file->mutable_extracted_text()->set_raw("file extracted text");
+
+  entry->add_events()->mutable_inline_search()->mutable_results_json()->set_raw(
+      "inline search results");
+
+  auto* web_sources = entry->add_events()->mutable_web_sources();
+  web_sources->add_sources()->mutable_page_content()->set_raw(
+      "event page content");
+  web_sources->add_rich_results()->set_raw("event rich result");
+
+  auto* tool_use = entry->add_events()->mutable_tool_use();
+  tool_use->mutable_arguments_json()->set_raw("tool arguments");
+  tool_use->add_artifacts()->mutable_content_json()->set_raw(
+      "artifact content");
+  tool_use->add_output()->mutable_text_content_block()->mutable_text()->set_raw(
+      "tool output text");
+  auto* nested = tool_use->add_output()->mutable_web_sources_content_block();
+  nested->add_sources()->mutable_page_content()->set_raw(
+      "tool output page content");
+  nested->add_rich_results()->set_raw("tool output rich result");
+
+  entry->add_events()->mutable_completion()->set_raw("completion");
+
+  return {"associated content text",
+          "file extracted text",
+          "inline search results",
+          "event page content",
+          "event rich result",
+          "tool arguments",
+          "artifact content",
+          "tool output text",
+          "tool output page content",
+          "tool output rich result",
+          "completion"};
 }
 
 }  // namespace
@@ -1129,6 +1177,111 @@ TEST(AIChatSyncConversionsTest, EntryRoundTripWithoutSkillOrNear) {
   ExpectConversationEntryEquals(FROM_HERE, rebuilt, entry);
   EXPECT_FALSE(rebuilt->skill);
   EXPECT_FALSE(rebuilt->near_verification_status);
+}
+
+TEST(AIChatSyncConversionsTest, FitEntryNoOpBelowBudget) {
+  sync_pb::AIChatConversationSpecifics_Entry entry;
+  entry.set_uuid("e1");
+  entry.set_conversation_uuid("c1");
+  entry.set_entry_text("short");
+
+  ASSERT_LE(entry.ByteSizeLong(), kSyncMaxRecordBytes);
+  EXPECT_TRUE(FitEntryWithinSyncBudget(&entry));
+  // Nothing should have been touched.
+  EXPECT_EQ(entry.entry_text(), "short");
+}
+
+TEST(AIChatSyncConversionsTest, ForEachOmittableStringVisitsEveryCategory) {
+  // Pins the field set the size-budget policy can reach, which is also the set
+  // the receiver has to be able to restore.
+  sync_pb::AIChatConversationSpecifics_Entry entry;
+  const std::vector<std::string> expected = PopulateOmittableStrings(&entry);
+
+  std::vector<std::string> visited;
+  ForEachOmittableString(&entry,
+                         [&visited](sync_pb::AIChatCompressibleString& value) {
+                           visited.push_back(value.raw());
+                         });
+  EXPECT_THAT(visited, testing::UnorderedElementsAreArray(expected));
+}
+
+TEST(AIChatSyncConversionsTest, FitEntryOmitsFileBytesFirst) {
+  sync_pb::AIChatConversationSpecifics_Entry entry;
+  entry.set_uuid("e1");
+  entry.set_conversation_uuid("c1");
+  // Make a single uploaded file that on its own exceeds the budget.
+  auto* file = entry.add_uploaded_files();
+  file->set_filename("big.bin");
+  file->set_filesize(kSyncMaxRecordBytes + 1024);
+  const std::string file_bytes(kSyncMaxRecordBytes + 1024, '\x01');
+  file->set_data(file_bytes);
+
+  // Add an AC with a small last_contents so we can verify it is NOT omitted
+  // when the file alone is enough to bring us under budget.
+  auto* ac = entry.add_associated_content();
+  ac->set_uuid("ac-1");
+  WriteCompressibleString("small page text", ac->mutable_last_contents());
+
+  ASSERT_GT(entry.ByteSizeLong(), kSyncMaxRecordBytes);
+  EXPECT_TRUE(FitEntryWithinSyncBudget(&entry));
+  EXPECT_FALSE(entry.uploaded_files(0).has_data());
+  // The omitted bytes leave behind a hash of the original content.
+  EXPECT_EQ(entry.uploaded_files(0).omitted_data_hash(),
+            base::PersistentHash(file_bytes));
+  // The AC's last_contents must still be intact.
+  EXPECT_FALSE(
+      entry.associated_content(0).last_contents().has_omitted_content_hash());
+  EXPECT_LE(entry.ByteSizeLong(), kSyncMaxRecordBytes);
+}
+
+TEST(AIChatSyncConversionsTest, FitEntryOmitsLowerPriorityFieldsFirst) {
+  // Needs more than one category to go: dropping the file bytes alone leaves
+  // the entry over budget, so the associated content text — the first of the
+  // compressible-string categories — has to go too. The completion is the last
+  // category, so it must survive. Assign raw values rather than going through
+  // WriteCompressibleString so the on-the-wire sizes are deterministic.
+  sync_pb::AIChatConversationSpecifics_Entry entry;
+  entry.set_uuid("e1");
+  entry.set_conversation_uuid("c1");
+
+  auto* file = entry.add_uploaded_files();
+  file->set_data(std::string(50 * 1024, '\x02'));
+
+  auto* ac = entry.add_associated_content();
+  ac->set_uuid("ac-1");
+  ac->mutable_last_contents()->set_raw(std::string(400 * 1024, 'A'));
+
+  entry.add_events()->mutable_completion()->set_raw(
+      std::string(100 * 1024, 'B'));
+
+  ASSERT_GT(entry.ByteSizeLong(), kSyncMaxRecordBytes);
+  EXPECT_TRUE(FitEntryWithinSyncBudget(&entry));
+  EXPECT_TRUE(entry.uploaded_files(0).has_omitted_data_hash());
+  EXPECT_TRUE(
+      entry.associated_content(0).last_contents().has_omitted_content_hash());
+  EXPECT_FALSE(entry.events(0).completion().has_omitted_content_hash());
+  EXPECT_LE(entry.ByteSizeLong(), kSyncMaxRecordBytes);
+}
+
+TEST(AIChatSyncConversionsTest, FitEntryRefusesEntryOversizedByPlainField) {
+  // selected_text is a plain proto string, so no amount of omission can shrink
+  // this entry. The policy must still drop everything it is able to drop
+  // before giving up, and must report the failure so the caller can refuse to
+  // commit.
+  sync_pb::AIChatConversationSpecifics_Entry entry;
+  entry.set_uuid("pathological");
+  entry.set_conversation_uuid("c1");
+  PopulateOmittableStrings(&entry);
+  entry.mutable_uploaded_files(0)->set_data("file bytes");
+  entry.set_selected_text(std::string(kSyncMaxRecordBytes + 1024, 'Z'));
+
+  ASSERT_GT(entry.ByteSizeLong(), kSyncMaxRecordBytes);
+  EXPECT_FALSE(FitEntryWithinSyncBudget(&entry));
+
+  EXPECT_TRUE(entry.uploaded_files(0).has_omitted_data_hash());
+  ForEachOmittableString(&entry, [](sync_pb::AIChatCompressibleString& value) {
+    EXPECT_TRUE(value.has_omitted_content_hash());
+  });
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/sync/ai_chat_sync_conversions_unittest.cc
+++ b/components/ai_chat/core/browser/sync/ai_chat_sync_conversions_unittest.cc
@@ -1234,6 +1234,54 @@ TEST(AIChatSyncConversionsTest, FitEntryOmitsFileBytesFirst) {
   EXPECT_LE(entry.ByteSizeLong(), kSyncMaxRecordBytes);
 }
 
+TEST(AIChatSyncConversionsTest, FitEntryOmitsLargestFileAndStopsWhenItFits) {
+  // Three attachments where dropping the big one alone is enough. The small
+  // two must survive, and they must keep their original order on the wire.
+  sync_pb::AIChatConversationSpecifics_Entry entry;
+  entry.set_uuid("e1");
+  entry.set_conversation_uuid("c1");
+
+  auto* small = entry.add_uploaded_files();
+  small->set_filename("small.bin");
+  small->set_data(std::string(8 * 1024, '\x01'));
+
+  auto* big = entry.add_uploaded_files();
+  big->set_filename("big.bin");
+  big->set_data(std::string(kSyncMaxRecordBytes + 1024, '\x02'));
+
+  auto* medium = entry.add_uploaded_files();
+  medium->set_filename("medium.bin");
+  medium->set_data(std::string(16 * 1024, '\x03'));
+
+  ASSERT_GT(entry.ByteSizeLong(), kSyncMaxRecordBytes);
+  EXPECT_TRUE(FitEntryWithinSyncBudget(&entry));
+
+  // Only the largest went, even though it is not first in the list.
+  EXPECT_TRUE(entry.uploaded_files(1).has_omitted_data_hash());
+  EXPECT_FALSE(entry.uploaded_files(0).has_omitted_data_hash());
+  EXPECT_FALSE(entry.uploaded_files(2).has_omitted_data_hash());
+  // Sorting is only about which bytes to drop; the wire order is untouched.
+  EXPECT_EQ(entry.uploaded_files(0).filename(), "small.bin");
+  EXPECT_EQ(entry.uploaded_files(1).filename(), "big.bin");
+  EXPECT_EQ(entry.uploaded_files(2).filename(), "medium.bin");
+  EXPECT_LE(entry.ByteSizeLong(), kSyncMaxRecordBytes);
+}
+
+TEST(AIChatSyncConversionsTest, FitEntryKeepsExplicitlyEmptyStrings) {
+  // An empty raw string is a value, not an omission: replacing it with a
+  // content hash would tell the receiver to restore from local instead.
+  sync_pb::AIChatConversationSpecifics_Entry entry;
+  entry.set_uuid("e1");
+  entry.set_conversation_uuid("c1");
+  entry.add_events()->mutable_completion()->set_raw("");
+  entry.set_selected_text(std::string(kSyncMaxRecordBytes + 1024, 'Z'));
+
+  ASSERT_GT(entry.ByteSizeLong(), kSyncMaxRecordBytes);
+  EXPECT_FALSE(FitEntryWithinSyncBudget(&entry));
+  EXPECT_TRUE(entry.events(0).completion().has_raw());
+  EXPECT_FALSE(entry.events(0).completion().has_omitted_content_hash());
+}
+
 TEST(AIChatSyncConversionsTest, FitEntryOmitsLowerPriorityFieldsFirst) {
   // Needs more than one category to go: dropping the file bytes alone leaves
   // the entry over budget, so the associated content text — the first of the


### PR DESCRIPTION
Enforces the per-record size budget (`kSyncMaxRecordBytes`) so a single entry record stays under the server's per-entity limit.

- `FitEntryWithinSyncBudget` drops uploaded file bytes, then walks a priority-ordered list of compressible-string categories, replacing each value with a content hash until the record fits. Returns false if it still does not fit so the caller can refuse to commit.
- `ForEachOmittableString` exposes that same field set, so code that has to recognise or undo an omission covers exactly what the policy can drop instead of keeping a second list of its own.
- Unit tests for the no-op, field coverage, drop order and refusal cases.

Spec:
- https://github.com/brave/brave-core/blob/aichat-sync-flow/docs/aichat-sync.md

Based on:
- https://github.com/brave/brave-core/pull/35028
- https://github.com/brave/brave-core/pull/35242
- https://github.com/brave/brave-core/pull/37537
- https://github.com/brave/brave-core/pull/37539
- https://github.com/brave/brave-core/pull/37540
- https://github.com/brave/brave-core/pull/38192
- https://github.com/brave/brave-core/pull/38329
- https://github.com/brave/go-sync/pull/427 (server)

Series:
- https://github.com/brave/brave-browser/issues/53978