### PR TITLE
[AI Chat] Support deleting shared conversations

### DIFF
--- a/components/ai_chat/core/browser/ai_chat_service.cc
+++ b/components/ai_chat/core/browser/ai_chat_service.cc
@@ -917,6 +917,32 @@ void AIChatService::GetConversationShares(
   conversation_share_store_->GetShares(std::move(callback));
 }
 
+void AIChatService::DeleteConversationShare(
+    const std::string& share_id,
+    DeleteConversationShareCallback callback) {
+  conversation_share_store_->GetDeletionId(
+      share_id, base::BindOnce(&AIChatService::OnShareDeletionIdRetrieved,
+                               weak_ptr_factory_.GetWeakPtr(), share_id,
+                               std::move(callback)));
+}
+
+void AIChatService::OnShareDeletionIdRetrieved(
+    const std::string& share_id,
+    DeleteConversationShareCallback callback,
+    std::optional<std::string> deletion_id) {
+  if (!deletion_id) {
+    // Nothing is known about this share, so there is nothing to delete and no
+    // way to authorize deleting it. Report success so the UI doesn't offer a
+    // retry that could never work.
+    std::move(callback).Run(true);
+    return;
+  }
+  conversation_share_manager_->DeleteShare(
+      *deletion_id, base::BindOnce(&AIChatService::OnConversationShareDeleted,
+                                   weak_ptr_factory_.GetWeakPtr(), share_id,
+                                   std::move(callback)));
+}
+
 void AIChatService::CopyConversationShareLink(const std::string& share_id) {
   conversation_share_store_->GetShareUrl(
       share_id, base::BindOnce([](std::optional<GURL> url) {
@@ -924,6 +950,18 @@ void AIChatService::CopyConversationShareLink(const std::string& share_id) {
           CopyTextToClipboardAsConfidential(url->spec());
         }
       }));
+}
+
+void AIChatService::OnConversationShareDeleted(
+    const std::string& share_id,
+    DeleteConversationShareCallback callback,
+    bool success) {
+  // Keep the record when the server didn't confirm the deletion, so the user
+  // can retry rather than losing track of a share that still exists.
+  if (success) {
+    conversation_share_store_->RemoveShare(share_id);
+  }
+  std::move(callback).Run(success);
 }
 
 void AIChatService::OnPremiumStatusReceived(GetPremiumStatusCallback callback,

--- a/components/ai_chat/core/browser/ai_chat_service.h
+++ b/components/ai_chat/core/browser/ai_chat_service.h
@@ -220,6 +220,9 @@ class AIChatService : public KeyedService,
                          bool copy_to_clipboard,
                          ShareConversationCallback callback) override;
   void GetConversationShares(GetConversationSharesCallback callback) override;
+  void DeleteConversationShare(
+      const std::string& share_id,
+      DeleteConversationShareCallback callback) override;
   void CopyConversationShareLink(const std::string& share_id) override;
   void BindConversation(
       const std::string& uuid,
@@ -326,6 +329,16 @@ class AIChatService : public KeyedService,
       bool copy_to_clipboard,
       ShareConversationCallback callback,
       const std::optional<ConversationShareResult>& share_result);
+
+  // Steps of DeleteConversationShare(): look up the capability token stored
+  // when the share was created, ask the server to delete the share with it,
+  // and forget the local record once the server has.
+  void OnShareDeletionIdRetrieved(const std::string& share_id,
+                                  DeleteConversationShareCallback callback,
+                                  std::optional<std::string> deletion_id);
+  void OnConversationShareDeleted(const std::string& share_id,
+                                  DeleteConversationShareCallback callback,
+                                  bool success);
 
   void MaybeAssociateContent(
       ConversationHandler* conversation,

--- a/components/ai_chat/core/browser/ai_chat_service_share_conversation_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_service_share_conversation_unittest.cc
@@ -71,11 +71,19 @@ class FakeConversationShareManager : public ConversationShareManager {
     std::move(callback).Run(share_result);
   }
 
+  void DeleteShare(const std::string& deletion_id,
+                   DeleteShareCallback callback) override {
+    last_deletion_id = deletion_id;
+    std::move(callback).Run(delete_succeeds);
+  }
+
   // What the fake server "returns" (the viewer URL has no decryption key
   // fragment).
   std::optional<ConversationShareResult> share_result;
+  bool delete_succeeds = true;
   // Captures what was uploaded, to assert the key fragment never reaches here.
   std::string last_encrypted_contents;
+  std::string last_deletion_id;
 };
 
 ConversationShareResult MakeShareResult() {
@@ -327,6 +335,76 @@ TEST_F(AIChatServiceShareConversationTest, DoesNotCopyLinkForUnknownShare) {
 
   // Nothing is recorded for the share, so there is no link to put anywhere.
   EXPECT_TRUE(clipboard_text.empty());
+}
+
+TEST_F(AIChatServiceShareConversationTest, DeleteConversationShareForgetsIt) {
+  auto fake_share_manager = std::make_unique<FakeConversationShareManager>();
+  fake_share_manager->share_result = MakeShareResult();
+  auto* fake_share_manager_ptr = fake_share_manager.get();
+  ai_chat_service_->SetConversationShareManagerForTesting(
+      std::move(fake_share_manager));
+
+  base::test::TestFuture<const std::optional<GURL>&> share_future;
+  ai_chat_service_->ShareConversation(
+      "ciphertext-blob", "url-safe-key-fragment", "conversation-uuid",
+      "Conversation title",
+      /*copy_to_clipboard=*/false, share_future.GetCallback());
+  ASSERT_TRUE(share_future.Get().has_value());
+
+  base::test::TestFuture<bool> delete_future;
+  ai_chat_service_->DeleteConversationShare("test-share-id",
+                                            delete_future.GetCallback());
+  EXPECT_TRUE(delete_future.Get());
+  // The server is authorized with the deletion id it handed out, not the share
+  // id from the link.
+  EXPECT_EQ(fake_share_manager_ptr->last_deletion_id, "test-deletion-id");
+
+  base::test::TestFuture<std::vector<mojom::ConversationSharePtr>>
+      shares_future;
+  ai_chat_service_->GetConversationShares(shares_future.GetCallback());
+  EXPECT_TRUE(shares_future.Get().empty());
+}
+
+TEST_F(AIChatServiceShareConversationTest, KeepsRecordWhenServerDeleteFails) {
+  auto fake_share_manager = std::make_unique<FakeConversationShareManager>();
+  fake_share_manager->share_result = MakeShareResult();
+  fake_share_manager->delete_succeeds = false;
+  ai_chat_service_->SetConversationShareManagerForTesting(
+      std::move(fake_share_manager));
+
+  base::test::TestFuture<const std::optional<GURL>&> share_future;
+  ai_chat_service_->ShareConversation(
+      "ciphertext-blob", "url-safe-key-fragment", "conversation-uuid",
+      "Conversation title",
+      /*copy_to_clipboard=*/false, share_future.GetCallback());
+  ASSERT_TRUE(share_future.Get().has_value());
+
+  base::test::TestFuture<bool> delete_future;
+  ai_chat_service_->DeleteConversationShare("test-share-id",
+                                            delete_future.GetCallback());
+  EXPECT_FALSE(delete_future.Get());
+
+  // The share still exists on the server, so the user keeps a way to retry.
+  base::test::TestFuture<std::vector<mojom::ConversationSharePtr>>
+      shares_future;
+  ai_chat_service_->GetConversationShares(shares_future.GetCallback());
+  EXPECT_EQ(shares_future.Get().size(), 1u);
+}
+
+TEST_F(AIChatServiceShareConversationTest, DeleteUnknownShareSucceeds) {
+  auto fake_share_manager = std::make_unique<FakeConversationShareManager>();
+  auto* fake_share_manager_ptr = fake_share_manager.get();
+  ai_chat_service_->SetConversationShareManagerForTesting(
+      std::move(fake_share_manager));
+
+  base::test::TestFuture<bool> delete_future;
+  ai_chat_service_->DeleteConversationShare("never-shared",
+                                            delete_future.GetCallback());
+
+  // Nothing is known about the share, so there is nothing to ask the server to
+  // delete and nothing for the user to retry.
+  EXPECT_TRUE(delete_future.Get());
+  EXPECT_TRUE(fake_share_manager_ptr->last_deletion_id.empty());
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/conversation_share_manager.cc
+++ b/components/ai_chat/core/browser/conversation_share_manager.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 
+#include "base/containers/flat_map.h"
 #include "base/functional/bind.h"
 #include "base/json/json_writer.h"
 #include "base/strings/strcat.h"
@@ -18,6 +19,7 @@
 #include "brave/components/brave_service_keys/brave_service_key_utils.h"
 #include "brave/components/constants/brave_services_key.h"
 #include "net/http/http_request_headers.h"
+#include "net/http/http_status_code.h"
 #include "net/traffic_annotation/network_traffic_annotation.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 
@@ -26,6 +28,7 @@ namespace ai_chat {
 namespace {
 
 constexpr char kSharePath[] = "v1/share";
+constexpr char kShareDeletePath[] = "v1/share/delete";
 
 net::NetworkTrafficAnnotationTag GetNetworkTrafficAnnotationTag() {
   return net::DefineNetworkTrafficAnnotation("ai_chat", R"(
@@ -33,15 +36,17 @@ net::NetworkTrafficAnnotationTag GetNetworkTrafficAnnotationTag() {
         sender: "AI Chat"
         description:
           "Uploads an end-to-end encrypted AI Chat conversation to Brave's"
-          "sharing service so the user can share a link to view it. The"
+          "sharing service so the user can share a link to view it, or asks"
+          "the service to delete a previously shared conversation. The"
           "service cannot read the conversation because the decryption key"
           "never leaves the client."
         trigger:
           "Triggered by the user choosing to share a conversation from the"
-          "conversation header."
+          "conversation header, or deleting one of their shared conversations"
+          "from the shared conversations dialog."
         data:
-          "An encrypted blob of the conversation data. The encryption key is"
-          "not included."
+          "An encrypted blob of the conversation data, or the identifier of a"
+          "share to delete. The encryption key is not included."
         destination: WEBSITE
       }
       policy {
@@ -50,6 +55,22 @@ net::NetworkTrafficAnnotationTag GetNetworkTrafficAnnotationTag() {
           "Not implemented."
       }
     )");
+}
+
+// Builds the common relay authentication headers for a signed POST of
+// |request_body| to |api_url|.
+base::flat_map<std::string, std::string> MakeRequestHeaders(
+    const GURL& api_url,
+    const std::string& request_body) {
+  auto headers = GetBraveHeaders(std::nullopt);
+  const auto digest_header = brave_service_keys::GetDigestHeader(request_body);
+  headers.emplace(digest_header.first, digest_header.second);
+  auto auth_header = brave_service_keys::GetAuthorizationHeader(
+      BUILDFLAG(SERVICE_KEY_AICHAT), headers, api_url,
+      net::HttpRequestHeaders::kPostMethod, {"digest"});
+  headers.emplace(auth_header.first, auth_header.second);
+  headers.emplace("Accept", "application/json");
+  return headers;
 }
 
 }  // namespace
@@ -77,23 +98,12 @@ void ConversationShareManager::ShareConversation(
   std::string request_body;
   base::JSONWriter::Write(dict, &request_body);
 
-  // Use the same relay authentication as the conversation API so the request
-  // reaches the same host.
-  auto headers = GetBraveHeaders(std::nullopt);
-  const auto digest_header = brave_service_keys::GetDigestHeader(request_body);
-  headers.emplace(digest_header.first, digest_header.second);
-  auto auth_header = brave_service_keys::GetAuthorizationHeader(
-      BUILDFLAG(SERVICE_KEY_AICHAT), headers, api_url,
-      net::HttpRequestHeaders::kPostMethod, {"digest"});
-  headers.emplace(auth_header.first, auth_header.second);
-  headers.emplace("Accept", "application/json");
-
   api_request_helper_->Request(
       net::HttpRequestHeaders::kPostMethod, api_url, request_body,
       "application/json",
       base::BindOnce(&ConversationShareManager::OnShareCompleted,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback)),
-      headers, {});
+      MakeRequestHeaders(api_url, request_body), {});
 }
 
 void ConversationShareManager::OnShareCompleted(
@@ -125,6 +135,36 @@ void ConversationShareManager::OnShareCompleted(
       .viewer_url = std::move(shared_conversation_viewer_url),
       .share_id = *share_id,
       .deletion_id = deletion_id ? *deletion_id : std::string()});
+}
+
+void ConversationShareManager::DeleteShare(const std::string& deletion_id,
+                                           DeleteShareCallback callback) {
+  const GURL api_url = GetEndpointUrl(/*premium=*/false, kShareDeletePath);
+  if (!api_url.is_valid() || deletion_id.empty()) {
+    std::move(callback).Run(false);
+    return;
+  }
+
+  base::DictValue dict;
+  dict.Set("deletion_id", deletion_id);
+  std::string request_body;
+  base::JSONWriter::Write(dict, &request_body);
+
+  api_request_helper_->Request(
+      net::HttpRequestHeaders::kPostMethod, api_url, request_body,
+      "application/json",
+      base::BindOnce(&ConversationShareManager::OnDeleteShareCompleted,
+                     weak_ptr_factory_.GetWeakPtr(), std::move(callback)),
+      MakeRequestHeaders(api_url, request_body), {});
+}
+
+void ConversationShareManager::OnDeleteShareCompleted(
+    DeleteShareCallback callback,
+    api_request_helper::APIRequestResult result) {
+  // A share the server no longer knows about is already in the desired state,
+  // so treat 404 as success and let the caller drop its local record.
+  std::move(callback).Run(result.Is2XXResponseCode() ||
+                          result.response_code() == net::HTTP_NOT_FOUND);
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/conversation_share_manager.h
+++ b/components/ai_chat/core/browser/conversation_share_manager.h
@@ -43,6 +43,9 @@ class ConversationShareManager {
   // response, or an invalid resulting URL).
   using ShareConversationCallback =
       base::OnceCallback<void(const std::optional<ConversationShareResult>&)>;
+  // Whether the server accepted the deletion.
+  using DeleteShareCallback = base::OnceCallback<void(bool)>;
+
   explicit ConversationShareManager(
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
   ConversationShareManager(const ConversationShareManager&) = delete;
@@ -53,6 +56,12 @@ class ConversationShareManager {
   // produced by the UI.
   virtual void ShareConversation(const std::string& encrypted_contents,
                                  ShareConversationCallback callback);
+
+  // Asks the server to delete a previously uploaded share. |deletion_id| is the
+  // capability token the server returned when the share was created - the share
+  // id alone does not authorize deletion.
+  virtual void DeleteShare(const std::string& deletion_id,
+                           DeleteShareCallback callback);
 
  protected:
   void SetAPIRequestHelperForTesting(
@@ -66,6 +75,8 @@ class ConversationShareManager {
  private:
   void OnShareCompleted(ShareConversationCallback callback,
                         api_request_helper::APIRequestResult result);
+  void OnDeleteShareCompleted(DeleteShareCallback callback,
+                              api_request_helper::APIRequestResult result);
 
   std::unique_ptr<api_request_helper::APIRequestHelper> api_request_helper_;
 

--- a/components/ai_chat/core/browser/conversation_share_manager_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_share_manager_unittest.cc
@@ -208,4 +208,108 @@ TEST_F(ConversationShareManagerUnitTest, ShareConversation_MissingDeletionId) {
   EXPECT_TRUE(result->deletion_id.empty());
 }
 
+TEST_F(ConversationShareManagerUnitTest, DeleteShare_Success) {
+  MockAPIRequestHelper* mock_request_helper =
+      share_manager_->GetMockAPIRequestHelper();
+
+  EXPECT_CALL(*mock_request_helper, Request)
+      .WillOnce(
+          [&](const std::string& method, const GURL& url,
+              const std::string& body, const std::string& content_type,
+              ResultCallback result_callback,
+              const base::flat_map<std::string, std::string>& headers,
+              const api_request_helper::APIRequestOptions& options,
+              api_request_helper::APIRequestHelper::ResponseConversionCallback
+                  conversion_callback) {
+            EXPECT_EQ(net::HttpRequestHeaders::kPostMethod, method);
+            EXPECT_EQ("/v1/share/delete", url.path());
+            EXPECT_EQ("application/json", content_type);
+
+            EXPECT_TRUE(headers.contains("x-brave-key"));
+            EXPECT_TRUE(headers.contains("digest"));
+            EXPECT_TRUE(
+                headers.contains(net::HttpRequestHeaders::kAuthorization));
+
+            auto body_dict = base::test::ParseJsonDict(body);
+            const std::string* deletion_id =
+                body_dict.FindString("deletion_id");
+            EXPECT_TRUE(deletion_id);
+            if (deletion_id) {
+              EXPECT_EQ("del456", *deletion_id);
+            }
+
+            std::move(result_callback)
+                .Run(api_request_helper::APIRequestResult(
+                    net::HTTP_OK, base::Value(), {}, net::OK, GURL()));
+            return Ticket();
+          });
+
+  base::test::TestFuture<bool> future;
+  share_manager_->DeleteShare("del456", future.GetCallback());
+
+  EXPECT_TRUE(future.Get());
+}
+
+TEST_F(ConversationShareManagerUnitTest, DeleteShare_AlreadyGone) {
+  MockAPIRequestHelper* mock_request_helper =
+      share_manager_->GetMockAPIRequestHelper();
+
+  EXPECT_CALL(*mock_request_helper, Request)
+      .WillOnce(
+          [](const std::string&, const GURL&, const std::string&,
+             const std::string&, ResultCallback result_callback,
+             const base::flat_map<std::string, std::string>&,
+             const api_request_helper::APIRequestOptions&,
+             api_request_helper::APIRequestHelper::ResponseConversionCallback) {
+            std::move(result_callback)
+                .Run(api_request_helper::APIRequestResult(
+                    net::HTTP_NOT_FOUND, base::Value(), {}, net::OK, GURL()));
+            return Ticket();
+          });
+
+  base::test::TestFuture<bool> future;
+  share_manager_->DeleteShare("del456", future.GetCallback());
+
+  // A share the server has already forgotten is in the state the user asked
+  // for, so the local record can be dropped too.
+  EXPECT_TRUE(future.Get());
+}
+
+TEST_F(ConversationShareManagerUnitTest, DeleteShare_ServerError) {
+  MockAPIRequestHelper* mock_request_helper =
+      share_manager_->GetMockAPIRequestHelper();
+
+  EXPECT_CALL(*mock_request_helper, Request)
+      .WillOnce(
+          [](const std::string&, const GURL&, const std::string&,
+             const std::string&, ResultCallback result_callback,
+             const base::flat_map<std::string, std::string>&,
+             const api_request_helper::APIRequestOptions&,
+             api_request_helper::APIRequestHelper::ResponseConversionCallback) {
+            std::move(result_callback)
+                .Run(api_request_helper::APIRequestResult(
+                    net::HTTP_INTERNAL_SERVER_ERROR, base::Value(), {}, net::OK,
+                    GURL()));
+            return Ticket();
+          });
+
+  base::test::TestFuture<bool> future;
+  share_manager_->DeleteShare("del456", future.GetCallback());
+
+  EXPECT_FALSE(future.Get());
+}
+
+TEST_F(ConversationShareManagerUnitTest, DeleteShare_NoDeletionId) {
+  MockAPIRequestHelper* mock_request_helper =
+      share_manager_->GetMockAPIRequestHelper();
+
+  // Nothing authorizes the deletion, so no request is made.
+  EXPECT_CALL(*mock_request_helper, Request).Times(0);
+
+  base::test::TestFuture<bool> future;
+  share_manager_->DeleteShare("", future.GetCallback());
+
+  EXPECT_FALSE(future.Get());
+}
+
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/conversation_share_store.cc
+++ b/components/ai_chat/core/browser/conversation_share_store.cc
@@ -135,6 +135,30 @@ void ConversationShareStore::GetShares(GetSharesCallback callback) {
       base::BindPostTaskToCurrentDefault(std::move(callback))));
 }
 
+void ConversationShareStore::GetDeletionId(const std::string& share_id,
+                                           GetDeletionIdCallback callback) {
+  RunWhenReady(base::BindOnce(
+      [](std::string share_id, GetDeletionIdCallback callback,
+         ConversationShareStore& store) {
+        std::unique_ptr<store::ConversationSharesProto> records =
+            store.ReadRecords();
+        if (!records) {
+          // Nothing can be found in records which can't be read.
+          std::move(callback).Run(std::nullopt);
+          return;
+        }
+        // The server has already deleted anything expired, so there is nothing
+        // left to authorize a deletion for.
+        DropExpiredRecords(*records);
+        const store::ConversationShareProto* record =
+            FindRecord(*records, share_id);
+        std::move(callback).Run(
+            record ? std::optional<std::string>(record->deletion_id())
+                   : std::nullopt);
+      },
+      share_id, base::BindPostTaskToCurrentDefault(std::move(callback))));
+}
+
 void ConversationShareStore::GetShareUrl(const std::string& share_id,
                                          GetShareUrlCallback callback) {
   RunWhenReady(base::BindOnce(
@@ -156,6 +180,28 @@ void ConversationShareStore::GetShareUrl(const std::string& share_id,
                                        : std::nullopt);
       },
       share_id, base::BindPostTaskToCurrentDefault(std::move(callback))));
+}
+
+void ConversationShareStore::RemoveShare(const std::string& share_id) {
+  RunWhenReady(base::BindOnce(
+      [](std::string share_id, ConversationShareStore& store) {
+        std::unique_ptr<store::ConversationSharesProto> records =
+            store.ReadRecords();
+        if (!records) {
+          return;
+        }
+        auto& shares = *records->mutable_shares();
+        auto removed = std::ranges::remove_if(
+            shares, [&share_id](const store::ConversationShareProto& record) {
+              return record.share_id() == share_id;
+            });
+        if (!removed.empty()) {
+          shares.erase(removed.begin(), shares.end());
+          store.WriteRecords(*records);
+          store.ScheduleNextPurge(*records);
+        }
+      },
+      share_id));
 }
 
 void ConversationShareStore::OnEncryptorReady(

--- a/components/ai_chat/core/browser/conversation_share_store.h
+++ b/components/ai_chat/core/browser/conversation_share_store.h
@@ -35,7 +35,8 @@ class ConversationSharesProto;
 }  // namespace store
 
 // Remembers which conversations the user has shared, so that the share
-// management UI can list them and re-copy their links.
+// management UI can list them, re-copy their links and delete them from the
+// sharing server.
 //
 // Records hold the full shareable link, which contains the conversation's
 // decryption key, so the list is encrypted with OSCrypt before it is written to
@@ -57,6 +58,9 @@ class ConversationShareStore {
   using GetSharesCallback =
       base::OnceCallback<void(std::vector<mojom::ConversationSharePtr>)>;
   // std::nullopt if there is no record for the share.
+  using GetDeletionIdCallback =
+      base::OnceCallback<void(std::optional<std::string>)>;
+  // std::nullopt if there is no record for the share.
   using GetShareUrlCallback = base::OnceCallback<void(std::optional<GURL>)>;
 
   ConversationShareStore(PrefService* prefs,
@@ -75,9 +79,15 @@ class ConversationShareStore {
   // Unexpired shares, most recently shared first.
   virtual void GetShares(GetSharesCallback callback);
 
+  // The capability token needed to delete the share from the sharing server.
+  virtual void GetDeletionId(const std::string& share_id,
+                             GetDeletionIdCallback callback);
+
   // The full shareable link, including the decryption key fragment.
   virtual void GetShareUrl(const std::string& share_id,
                            GetShareUrlCallback callback);
+
+  virtual void RemoveShare(const std::string& share_id);
 
  private:
   // A deferred store operation. It is handed the store when it runs, so that a

--- a/components/ai_chat/core/browser/conversation_share_store_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_share_store_unittest.cc
@@ -77,6 +77,12 @@ class ConversationShareStoreUnitTest : public testing::Test {
     return future.Take();
   }
 
+  std::optional<std::string> GetDeletionId(const std::string& share_id) {
+    base::test::TestFuture<std::optional<std::string>> future;
+    store_->GetDeletionId(share_id, future.GetCallback());
+    return future.Take();
+  }
+
   std::optional<GURL> GetShareUrl(const std::string& share_id) {
     base::test::TestFuture<std::optional<GURL>> future;
     store_->GetShareUrl(share_id, future.GetCallback());
@@ -134,8 +140,9 @@ TEST_F(ConversationShareStoreUnitTest, AddAndGetShare) {
   EXPECT_EQ(shares[0]->conversation_title, "My conversation");
   EXPECT_EQ(shares[0]->created_time, base::Time::Now());
 
-  // The link, which contains the decryption key, is kept so it can be copied
-  // again, but is not part of what the UI displays.
+  // The deletion id and the link (which contains the decryption key) are kept
+  // for acting on the share, but aren't part of what the UI displays.
+  EXPECT_EQ(GetDeletionId("share-1"), "deletion-1");
   EXPECT_EQ(GetShareUrl("share-1"), GURL(kShareUrl));
 }
 
@@ -231,6 +238,24 @@ TEST_F(ConversationShareStoreUnitTest, GetShareUrlForUnknownShare) {
   EXPECT_FALSE(GetShareUrl("never-shared").has_value());
 }
 
+TEST_F(ConversationShareStoreUnitTest, RemoveShare) {
+  store_->AddShare("share-1", "deletion-1", "conversation-share-1", "First",
+                   GURL(kShareUrl));
+  store_->AddShare("share-2", "deletion-2", "conversation-share-2", "Second",
+                   GURL(kShareUrl));
+
+  store_->RemoveShare("share-1");
+
+  std::vector<mojom::ConversationSharePtr> shares = GetShares();
+  ASSERT_EQ(shares.size(), 1u);
+  EXPECT_EQ(shares[0]->share_id, "share-2");
+  EXPECT_FALSE(GetDeletionId("share-1").has_value());
+}
+
+TEST_F(ConversationShareStoreUnitTest, GetDeletionIdForUnknownShare) {
+  EXPECT_FALSE(GetDeletionId("never-shared").has_value());
+}
+
 TEST_F(ConversationShareStoreUnitTest, PersistsAcrossStoreInstances) {
   store_->AddShare("share-1", "deletion-1", "conversation-share-1",
                    "My conversation", GURL(kShareUrl));
@@ -242,6 +267,7 @@ TEST_F(ConversationShareStoreUnitTest, PersistsAcrossStoreInstances) {
   EXPECT_EQ(shares[0]->share_id, "share-1");
   EXPECT_EQ(shares[0]->conversation_uuid, "conversation-share-1");
   EXPECT_EQ(shares[0]->conversation_title, "My conversation");
+  EXPECT_EQ(GetDeletionId("share-1"), "deletion-1");
   EXPECT_EQ(GetShareUrl("share-1"), GURL(kShareUrl));
 }
 
@@ -312,9 +338,7 @@ TEST_F(ConversationShareStoreUnitTest, NoPendingWorkWithNothingToExpire) {
   EXPECT_EQ(task_environment_.NextMainThreadPendingTaskDelay(),
             base::Days(features::kAIChatConversationShareExpiryDays.Get()));
 
-  // Once it has been purged there is nothing left to wait for.
-  task_environment_.FastForwardBy(
-      base::Days(features::kAIChatConversationShareExpiryDays.Get()));
+  store_->RemoveShare("share-1");
   EXPECT_EQ(task_environment_.NextMainThreadPendingTaskDelay(),
             base::TimeDelta::Max());
 }

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -217,6 +217,12 @@ interface Service {
   // expired, most recently shared first.
   GetConversationShares() => (array<ConversationShare> shares);
 
+  // Asks the sharing server to delete the shared conversation identified by
+  // |share_id| and forgets the local record of it. Returns false if the server
+  // could not be reached, in which case the record is kept so the user can
+  // retry.
+  DeleteConversationShare(string share_id) => (bool success);
+
   // Copies the link of an existing share to the system clipboard, marked as
   // confidential in the same way as when the share was created. The link
   // includes the conversation's decryption key, so it is not returned to the

--- a/components/ai_chat/resources/page/api/ai_chat_api.ts
+++ b/components/ai_chat/resources/page/api/ai_chat_api.ts
@@ -75,6 +75,12 @@ export default function createAIChatApi(
           response: (result) => result.shares,
           placeholderData: [] as Mojom.ConversationShare[],
         },
+        deleteConversationShare: {
+          mutationResponse: (result) => result.success,
+          onSuccess: () => {
+            api.getConversationShares.invalidate()
+          },
+        },
         getPremiumStatus: {
           response: (result) => ({
             /**

--- a/components/ai_chat/resources/page/api/mock_interfaces.ts
+++ b/components/ai_chat/resources/page/api/mock_interfaces.ts
@@ -176,6 +176,7 @@ export function createMockService(
         },
       }),
     getConversationShares: () => Promise.resolve({ shares: [] }),
+    deleteConversationShare: () => Promise.resolve({ success: true }),
     copyConversationShareLink: () => {},
     createSkill: () => {},
     updateSkill: () => {},

--- a/components/ai_chat/resources/page/components/shared_conversations_modal/index.test.tsx
+++ b/components/ai_chat/resources/page/components/shared_conversations_modal/index.test.tsx
@@ -103,6 +103,84 @@ describe('SharedConversationsModal', () => {
     })
   })
 
+  it('deletes the share it was asked to and drops it from the list', async () => {
+    let shares = [...mockShares]
+    const deleteConversationShare = jest.fn((shareId: string) => {
+      shares = shares.filter((share) => share.shareId !== shareId)
+      return Promise.resolve({ success: true })
+    })
+
+    await renderModal(
+      <MockContext
+        service={{
+          getConversationShares: () => Promise.resolve({ shares }),
+          deleteConversationShare,
+        }}
+      >
+        <SharedConversationsModal
+          isOpen
+          onClose={() => {}}
+        />
+      </MockContext>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('How to use TypeScript')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getAllByTitle(
+          'CHAT_UI_SHARED_CONVERSATIONS_DELETE_BUTTON_LABEL',
+        )[0],
+      )
+    })
+
+    expect(deleteConversationShare).toHaveBeenCalledWith('share-id-1')
+    await waitFor(() => {
+      expect(screen.queryByText('share-id-1')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('share-id-2')).toBeInTheDocument()
+    expect(showAlert).not.toHaveBeenCalled()
+  })
+
+  it('keeps the share and alerts when the server refuses to delete it', async () => {
+    await renderModal(
+      <MockContext
+        service={{
+          getConversationShares: () => Promise.resolve({ shares: mockShares }),
+          deleteConversationShare: () => Promise.resolve({ success: false }),
+        }}
+      >
+        <SharedConversationsModal
+          isOpen
+          onClose={() => {}}
+        />
+      </MockContext>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('share-id-1')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getAllByTitle(
+          'CHAT_UI_SHARED_CONVERSATIONS_DELETE_BUTTON_LABEL',
+        )[0],
+      )
+    })
+
+    // The share still exists on the server, so it must stay listed for a retry.
+    expect(screen.getByText('share-id-1')).toBeInTheDocument()
+    expect(showAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        content: 'CHAT_UI_SHARED_CONVERSATIONS_DELETE_ERROR',
+      }),
+    )
+  })
+
   it('asks the browser to copy the link, rather than copying it itself', async () => {
     const copyConversationShareLink = jest.fn()
 

--- a/components/ai_chat/resources/page/components/shared_conversations_modal/index.tsx
+++ b/components/ai_chat/resources/page/components/shared_conversations_modal/index.tsx
@@ -61,7 +61,7 @@ export default function SharedConversationsModal(props: Props) {
   const handleDelete = async (shareId: string) => {
     // The record is only removed once the server confirms the deletion, so a
     // failure leaves the entry in place for the user to retry.
-    const success = await deleteConversationShare([shareId]).catch(() => false)
+    const success = await deleteConversationShare([shareId])
     if (!success) {
       showAlert({
         type: 'error',

--- a/components/ai_chat/resources/page/components/shared_conversations_modal/index.tsx
+++ b/components/ai_chat/resources/page/components/shared_conversations_modal/index.tsx
@@ -29,12 +29,21 @@ const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
 const copyLinkLabel = getLocale(
   S.CHAT_UI_SHARED_CONVERSATIONS_COPY_LINK_BUTTON_LABEL,
 )
+const deleteLabel = getLocale(
+  S.CHAT_UI_SHARED_CONVERSATIONS_DELETE_BUTTON_LABEL,
+)
 
 export default function SharedConversationsModal(props: Props) {
   const aiChatContext = useAIChat()
 
   const { getConversationSharesData: shares, isPlaceholderData: isLoading } =
     aiChatContext.api.useGetConversationShares()
+  const {
+    mutateAsync: deleteConversationShare,
+    isPending: isDeleting,
+    variables: deletingArgs,
+  } = aiChatContext.api.useDeleteConversationShare()
+
   const handleCopyLink = (shareId: string) => {
     // The link is copied by the browser process: it holds the conversation's
     // decryption key, and only the browser can mark the clipboard entry as
@@ -47,6 +56,19 @@ export default function SharedConversationsModal(props: Props) {
       ),
       actions: [],
     })
+  }
+
+  const handleDelete = async (shareId: string) => {
+    // The record is only removed once the server confirms the deletion, so a
+    // failure leaves the entry in place for the user to retry.
+    const success = await deleteConversationShare([shareId]).catch(() => false)
+    if (!success) {
+      showAlert({
+        type: 'error',
+        content: getLocale(S.CHAT_UI_SHARED_CONVERSATIONS_DELETE_ERROR),
+        actions: [],
+      })
+    }
   }
 
   return (
@@ -105,6 +127,19 @@ export default function SharedConversationsModal(props: Props) {
                     onClick={() => handleCopyLink(share.shareId)}
                   >
                     <Icon name='copy' />
+                  </Button>
+                  <Button
+                    fab
+                    kind='plain-faint'
+                    size='small'
+                    title={deleteLabel}
+                    aria-label={deleteLabel}
+                    isLoading={
+                      isDeleting && deletingArgs?.[0] === share.shareId
+                    }
+                    onClick={() => handleDelete(share.shareId)}
+                  >
+                    <Icon name='trash' />
                   </Button>
                 </div>
               </li>

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -433,13 +433,19 @@
     Manage shared conversations
   </message>
   <message name="IDS_CHAT_UI_SHARED_CONVERSATIONS_DIALOG_DESCRIPTION" desc="Explanatory text at the top of the dialog listing the conversations the user has shared" formatter_data="webui=AiChat">
-    Anyone with the link can view these conversations until they expire.
+    Anyone with the link can view these conversations until they expire. Delete a shared conversation to stop its link from working.
   </message>
   <message name="IDS_CHAT_UI_SHARED_CONVERSATIONS_DIALOG_EMPTY" desc="Text shown in the shared conversations dialog when the user has not shared any conversations" formatter_data="webui=AiChat">
     You haven't shared any conversations.
   </message>
+  <message name="IDS_CHAT_UI_SHARED_CONVERSATIONS_DELETE_BUTTON_LABEL" desc="A label for the button which deletes a shared conversation so that its link stops working" formatter_data="webui=AiChat">
+    Delete shared conversation
+  </message>
   <message name="IDS_CHAT_UI_SHARED_CONVERSATIONS_COPY_LINK_BUTTON_LABEL" desc="A label for the button which copies the link to a shared conversation" formatter_data="webui=AiChat">
     Copy link
+  </message>
+  <message name="IDS_CHAT_UI_SHARED_CONVERSATIONS_DELETE_ERROR" desc="An error message shown when a shared conversation could not be deleted" formatter_data="webui=AiChat">
+    Couldn't delete the shared conversation. Check your connection and try again.
   </message>
   <message name="IDS_CHAT_UI_MENU_RENAME_CONVERSATION" desc="Menu entry for renaming a conversation" formatter_data="webui=AiChat">
     Rename conversation


### PR DESCRIPTION
Sharing was one-way: a link stayed live until the server expired it, with no way to withdraw a conversation the user no longer wanted shared.

Add a delete button to each entry in the shared conversations dialog, which asks the server to delete the share via POST /v1/share/delete. The request is authorized with the deletion id the server issued when the share was created, not the share id from the link, so knowing a link is not enough to delete it.

The local record is only dropped once the server confirms; a failure leaves the entry listed and surfaces an error so the user can retry rather than lose track of a share which still exists. A 404 counts as confirmation, since a share the server has already forgotten is in the state the user asked for.

<!-- Add brave-browser issue below that this PR will resolve -->
- Series https://github.com/brave/brave-browser/issues/58054