### PR TITLE
[brockit] Use the correct title in `merge`

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -710,6 +710,23 @@ class Versioned(Task):
         """Returns True if this is a major version upgrade."""
         return self.target_version.major > self.base_version.major
 
+    def compose_issue_title(self):
+        """The title for the upgrade issue.
+
+        This is the title that is used for issues and PRs. For example
+
+        Upgrade from Chromium 151 to Chromium 152
+        """
+        title = 'Upgrade from Chromium {previous} to Chromium {to}'
+        if self.is_major():
+            # Major upgrades only show the major numbers in the title.
+            title = title.format(previous=str(self.base_version.major),
+                                 to=str(self.target_version.major))
+        else:
+            title = title.format(previous=str(self.base_version),
+                                 to=str(self.target_version))
+        return title
+
     def _save_updated_patches(self):
         """Creates the updated patches change
 
@@ -795,26 +812,6 @@ class GitHubIssue(Versioned):
 
     def status_message(self):
         return "Creating/Updating GitHub issue for upgrade..."
-
-    def compose_issue_title(self):
-        """Generates the title for the upgrade issue.
-
-        This function generates the title for the upgrade issue, based on the
-        base and target version. The title is generated in a way that it can be
-        used for both major and minor upgrades.
-
-        This title is the same used for the push request.
-        """
-        title = 'Upgrade from Chromium {previous} to Chromium {to}'
-        if self.is_major():
-            # For major updates, the issue description doesn't have a precise
-            # version number.
-            title = title.format(previous=str(self.base_version.major),
-                                 to=str(self.target_version.major))
-        else:
-            title = title.format(previous=str(self.base_version),
-                                 to=str(self.target_version))
-        return title
 
     def lookup_issue(self, title: str) -> list | None:
         """Looks up the issue for the upgrade.
@@ -1921,7 +1918,7 @@ class Rebase(Task):
             raise InvalidInputException('Rebase failed.') from e
 
 
-class Merge(Task):
+class Merge(Versioned):
     """Merges the current branch into its upstream branch.
 
     Any commits that landed on the upstream branch since the last rebase are
@@ -1933,33 +1930,93 @@ class Merge(Task):
     _NEVER_MERGE_TAG_RE: ClassVar[re.Pattern[str]] = re.compile(
         r'\[wip\]|\[do not[^\]]*\]', re.IGNORECASE)
 
-    def status_message(self):
-        return "Merging current branch into upstream..."
+    def __init__(self, base_version: Version, target_version: Version | None,
+                 *, current_branch: str, upstream: str):
+        super().__init__(base_version, target_version)
 
-    def execute(self, dry_run: bool = False, base_branch: str | None = None):
-        """Merges the current branch into its base branch.
+        # The branch being merged
+        self.current_branch = current_branch
+
+        # The base branch we are merging into
+        self.upstream = upstream
+
+    @staticmethod
+    def _resolve_base_branch(current_branch: str,
+                             base_branch: str | None) -> str:
+        """Resolves the base branch to merge into.
+
+        This function will also defer to whatever `base_branch` is provided.
+        However, in the absence of one, then it will try to resolve the base
+        branch through GitHub, and if that is not available, then it will
+        default to the upstream branch, as is the practice with the rest of
+        brockit.
+        """
+        if base_branch is not None:
+            upstream = base_branch
+        else:
+            upstream = None
+            gh = GhCli()
+            if gh.is_logged_in():
+                upstream = gh.get_pr_base_branch(current_branch)
+            if upstream is None:
+                upstream = _get_current_branch_upstream_name()
+                if upstream is None:
+                    raise InvalidInputException(
+                        'Cannot merge: could not determine the base branch. '
+                        'Pass [bold cyan]--base-branch[/] to specify the base '
+                        'branch to merge into.')
+                if upstream.split('/', 1)[-1] == current_branch:
+                    raise InvalidInputException(
+                        f'Cannot merge: the upstream "{upstream}" tracks the '
+                        'current branch rather than a base branch. Pass '
+                        '[bold cyan]--base-branch[/] to specify the base '
+                        'branch to merge into.')
+        if '/' not in upstream:
+            raise InvalidInputException(
+                f'Cannot merge: the base branch "{upstream}" does not look '
+                'like a remote-tracking branch (expected the form '
+                '<remote>/<branch>).')
+        return upstream
+
+    @classmethod
+    def create(cls, base_branch: str | None = None) -> 'Merge':
+        """A factory function to create `Merge` resolving the base branch.
 
         Args:
-            dry_run:
-                When True, runs every validation, but stops short of the
-                actual merge and push.
             base_branch:
-                The remote-tracking base branch to merge into and push to (in
-                the form <remote>/<branch>, e.g. origin/master). When provided,
-                it overrides every other source. When omitted, the base branch
-                is resolved from the current branch's pull request via the
-                GitHub CLI (when logged in), falling back to the current
-                branch's upstream (used only when it is set and does not track
-                the current branch itself).
+                The current branch's base branch in GitHub that we want to merge
+                into. If not provided, then a resolution is attempted for it.
         """
         current_branch = repository.brave.current_branch()
         if current_branch == 'HEAD':
             raise InvalidInputException(
                 'Cannot merge: not currently on a branch.')
 
-        # A leftover `MERGE_HEAD` means a merge is in progress. Conflict
-        # resolutions must never be committed onto the branch being pushed.
-        # Reject and tell the user to abort the merge and rebase instead.
+        upstream = cls._resolve_base_branch(current_branch, base_branch)
+
+        return cls(Version.from_git(upstream),
+                   None,
+                   current_branch=current_branch,
+                   upstream=upstream)
+
+    def status_message(self):
+        return "Merging current branch into upstream..."
+
+    def execute(self, dry_run: bool = False):
+        """Merges the current branch into its base branch.
+
+        Args:
+            dry_run:
+                When True, runs every validation, but stops short of the
+                actual merge and push.
+        """
+        current_branch = self.current_branch
+        upstream = self.upstream
+        remote, remote_branch = upstream.split('/', 1)
+        repository.brave.run_git('fetch', remote, remote_branch)
+
+        # Checking for a previous merge in progress, as we do not want to
+        # proceed if that's the case.
         if repository.brave.is_valid_git_reference('MERGE_HEAD'):
             raise InvalidInputException(
                 'A merge is already in progress. Do not resolve and commit it: '
@@ -1984,45 +2041,6 @@ class Merge(Task):
                 'Cannot merge: there are uncommitted changes in the working '
                 'tree. Please commit or stash them before merging.')
 
-        # Determine the base branch to merge into and push to. An explicit
-        # `--base-branch` always wins. Otherwise, when the GitHub CLI is
-        # logged in, ask it for the current branch's pull request base, which
-        # is authoritative about where the branch should merge. Failing that,
-        # fall back to the current branch's upstream, but only when it is set
-        # and actually points at a base branch rather than tracking the current
-        # branch itself.
-        if base_branch is not None:
-            upstream = base_branch
-        else:
-            upstream = None
-            gh = GhCli()
-            if gh.is_logged_in():
-                upstream = gh.get_pr_base_branch(current_branch)
-            if upstream is None:
-                upstream = _get_current_branch_upstream_name()
-                if upstream is None:
-                    raise InvalidInputException(
-                        'Cannot merge: could not determine the base branch. '
-                        'Pass [bold cyan]--base-branch[/] to specify the base '
-                        'branch to merge into (e.g. '
-                        '[bold cyan]--base-branch=origin/master[/]), or set '
-                        '[bold cyan]--set-upstream-to[/] on your branch.')
-                if upstream.split('/', 1)[-1] == current_branch:
-                    raise InvalidInputException(
-                        f'Cannot merge: the upstream "{upstream}" tracks the '
-                        'current branch rather than a base branch. Pass '
-                        '[bold cyan]--base-branch[/] to specify the base '
-                        'branch to merge into (e.g. '
-                        '[bold cyan]--base-branch=origin/master[/]).')
-        if '/' not in upstream:
-            raise InvalidInputException(
-                f'Cannot merge: the base branch "{upstream}" does not look '
-                'like a remote-tracking branch (expected the form '
-                '<remote>/<branch>).')
-        remote, remote_branch = upstream.split('/', 1)
-
-        repository.brave.run_git('fetch', remote, remote_branch)
-
         head_before = repository.brave.run_git('rev-parse', 'HEAD')
         if head_before == repository.brave.run_git('rev-parse', upstream):
             raise InvalidInputException(
@@ -2043,35 +2061,31 @@ class Merge(Task):
                 f'{upstream}. (dry run: nothing was merged or pushed)')
             return
 
-        # Merge any new upstream commits into the current branch. When the
-        # histories have not diverged this is a no-op ("Already up to date");
-        # otherwise it produces a merge commit so the push stays a
-        # fast-forward.
-        terminal.log_task(f'Merging {upstream} into {current_branch}...')
         try:
-            repository.brave.run_git('merge', '--no-edit', upstream)
+            # The merge commit uses the regular issue title, however there is
+            # always a small chance for a fast-forward merge that produces no
+            # commit. Passing `--no-verify` too to suppress the hook from adding
+            # a `[crNNN]` tag.
+            repository.brave.run_git('merge', '--no-verify', '-m',
+                                     self.compose_issue_title(), upstream)
         except subprocess.CalledProcessError as e:
             if repository.brave.is_valid_git_reference('MERGE_HEAD'):
                 # Roll back the conflicted merge so the branch is left exactly
                 # as it was before the command ran.
                 repository.brave.run_git('merge', '--abort')
                 raise BadOutcomeException(
-                    f'Merging {upstream} into {current_branch} hit conflicts; '
-                    'the merge was rolled back and nothing was pushed. Rebase '
-                    f'the branch onto {upstream} to resolve the divergence '
-                    '(e.g. [bold cyan]brockit rebase[/]), then rerun '
-                    '[italic]🚀Brockit![/] [bold cyan]merge[/].') from e
+                    f'Merging {upstream} into {current_branch} hits conflicts. '
+                    'Rolling back the merge. Please rebase first.') from e
             raise BadOutcomeException(
                 f'Failed to merge {upstream} into {current_branch}: '
                 f'{e.stderr.strip()}') from e
 
-        terminal.log_task(f'Pushing {current_branch} to {upstream}...')
         try:
             repository.brave.run_git('push', remote, f'HEAD:{remote_branch}')
         except subprocess.CalledProcessError as e:
             raise BadOutcomeException(
                 f'Failed to push to {upstream}. The upstream branch may have '
-                'advanced since the fetch; rerun '
+                'advanced since the fetch. Rerun '
                 f'[italic]🚀Brockit![/] [bold cyan]merge[/] to try again.\n'
                 f'{e.stderr.strip()}') from e
 
@@ -2779,7 +2793,8 @@ def main():
         if args.command == 'update-version-issue':
             GitHubIssue(resolve_version_with_from_ref_arg()).run()
         if args.command == 'merge':
-            Merge().run(dry_run=args.dry_run, base_branch=args.base_branch)
+            Merge.create(base_branch=args.base_branch).run(
+                dry_run=args.dry_run)
         if args.command == 'reassign':
             Reassign().run(change=args.change)
         if args.command == 'drop':

--- a/tools/cr/brockit_test.py
+++ b/tools/cr/brockit_test.py
@@ -1117,6 +1117,13 @@ class GitHubIssueTest(unittest.TestCase):
 class MergeTest(unittest.TestCase):
     """Tests for the `merge` command."""
 
+    # The Chromium versions `_setup_upstream`/`_setup_remote_without_upstream`
+    # bump `origin/master` and `cr149` to, mirroring the real precondition
+    # that a branch only reaches `merge` once `lift` has already committed its
+    # version bump.
+    _BASE_VERSION = '151.0.7049.1'
+    _TARGET_VERSION = '152.0.7204.1'
+
     def setUp(self):
         self.fake_chromium_src = FakeChromiumRepo()
         self.fake_chromium_src.setup()
@@ -1129,19 +1136,22 @@ class MergeTest(unittest.TestCase):
                                                        or self.brave)
 
     def _setup_upstream(self) -> None:
-        """Wires up an `origin/master` upstream for a fresh `cr149` branch.
+        """Wires up an `origin/master` upstream for a fresh `cr149` branch,
+        already bumped from `_BASE_VERSION` to `_TARGET_VERSION`.
         """
         self.fake_chromium_src.create_brave_remote()
         self._git('config',
                   'receive.denyCurrentBranch',
                   'ignore',
                   repo=self.remote)
+        self.fake_chromium_src.update_brave_version(self._BASE_VERSION)
         # The freshly-initialised remote carries its own unrelated "Initial
         # commit" on `master`; force-push so `origin/master` starts from this
         # repo's history and later fast-forwards line up.
         self._git('push', '--force', 'origin', 'HEAD:master')
         self._git('checkout', '-b', 'cr149')
         self._git('branch', '--set-upstream-to=origin/master')
+        self.fake_chromium_src.update_brave_version(self._TARGET_VERSION)
 
     def _advance_upstream(self, relative_path: str, content: str) -> str:
         """Adds a commit to `origin/master` that `cr149` does not have.
@@ -1167,23 +1177,26 @@ class MergeTest(unittest.TestCase):
         self._setup_upstream()
         self._git('checkout', '--detach', 'HEAD')
         with self.assertRaises(brockit.InvalidInputException):
-            brockit.Merge().execute()
+            brockit.Merge.create().execute()
 
     def test_merge_raises_without_upstream(self):
         self._git('checkout', '-b', 'no-upstream')
         with self.assertRaises(brockit.InvalidInputException):
-            brockit.Merge().execute()
+            brockit.Merge.create().execute()
 
     def _setup_remote_without_upstream(self) -> None:
-        """Wires up an `origin/master` remote for a fresh `cr149` branch, but
-        leaves the branch without any upstream set."""
+        """Wires up an `origin/master` remote for a fresh `cr149` branch,
+        already bumped from `_BASE_VERSION` to `_TARGET_VERSION`, but leaves
+        the branch without any upstream set."""
         self.fake_chromium_src.create_brave_remote()
         self._git('config',
                   'receive.denyCurrentBranch',
                   'ignore',
                   repo=self.remote)
+        self.fake_chromium_src.update_brave_version(self._BASE_VERSION)
         self._git('push', '--force', 'origin', 'HEAD:master')
         self._git('checkout', '-b', 'cr149')
+        self.fake_chromium_src.update_brave_version(self._TARGET_VERSION)
 
     def test_merge_with_base_branch_without_upstream(self):
         """`--base-branch` allows merging when no upstream is set."""
@@ -1193,7 +1206,7 @@ class MergeTest(unittest.TestCase):
         self.fake_chromium_src.commit('Branch change', self.brave)
         head = self._git('rev-parse', 'HEAD')
 
-        brockit.Merge().execute(base_branch='origin/master')
+        brockit.Merge.create(base_branch='origin/master').execute()
 
         self.assertEqual(self._remote_master(), head)
 
@@ -1210,7 +1223,7 @@ class MergeTest(unittest.TestCase):
         self.fake_chromium_src.commit('Branch change', self.brave)
 
         with self.assertRaises(brockit.InvalidInputException):
-            brockit.Merge().execute()
+            brockit.Merge.create().execute()
 
     def test_merge_base_branch_overrides_upstream_tracking_current_branch(
             self):
@@ -1224,7 +1237,7 @@ class MergeTest(unittest.TestCase):
         self.fake_chromium_src.commit('Branch change', self.brave)
         head = self._git('rev-parse', 'HEAD')
 
-        brockit.Merge().execute(base_branch='origin/master')
+        brockit.Merge.create(base_branch='origin/master').execute()
 
         self.assertEqual(self._remote_master(), head)
 
@@ -1240,7 +1253,7 @@ class MergeTest(unittest.TestCase):
         self.fake_chromium_src.commit('Branch change', self.brave)
         head = self._git('rev-parse', 'HEAD')
 
-        brockit.Merge().execute(base_branch='origin/master')
+        brockit.Merge.create(base_branch='origin/master').execute()
 
         self.assertEqual(self._remote_master(), head)
 
@@ -1261,7 +1274,7 @@ class MergeTest(unittest.TestCase):
         gh.is_logged_in.return_value = True
         gh.get_pr_base_branch.return_value = 'origin/master'
 
-        brockit.Merge().execute()
+        brockit.Merge.create().execute()
 
         self.assertEqual(self._remote_master(), head)
         gh.get_pr_base_branch.assert_called_once_with('cr149')
@@ -1280,15 +1293,17 @@ class MergeTest(unittest.TestCase):
         gh.is_logged_in.return_value = True
         gh.get_pr_base_branch.return_value = None
 
-        brockit.Merge().execute()
+        brockit.Merge.create().execute()
 
         self.assertEqual(self._remote_master(), head)
 
     def test_merge_raises_when_nothing_to_merge(self):
         """A branch already at its upstream has nothing to push."""
         self._setup_upstream()
+        # Fast-forward `origin/master` to `cr149` so the two are identical.
+        self._git('push', 'origin', 'HEAD:master')
         with self.assertRaises(brockit.InvalidInputException):
-            brockit.Merge().execute()
+            brockit.Merge.create().execute()
 
     def test_merge_raises_on_dirty_tree(self):
         self._setup_upstream()
@@ -1298,7 +1313,7 @@ class MergeTest(unittest.TestCase):
         # Leave an uncommitted modification behind.
         (self.brave / 'foo.txt').write_text('dirty')
         with self.assertRaises(brockit.InvalidInputException):
-            brockit.Merge().execute()
+            brockit.Merge.create().execute()
 
     def test_merge_rejects_when_merge_in_progress(self):
         """A leftover `MERGE_HEAD` is rejected rather than being concluded."""
@@ -1314,7 +1329,7 @@ class MergeTest(unittest.TestCase):
             brockit.repository.brave.is_valid_git_reference('MERGE_HEAD'))
 
         with self.assertRaises(brockit.InvalidInputException):
-            brockit.Merge().execute()
+            brockit.Merge.create().execute()
 
     def test_merge_rejects_when_rebase_in_progress(self):
         """A half-finished rebase blocks the merge until it is concluded."""
@@ -1333,7 +1348,7 @@ class MergeTest(unittest.TestCase):
 
         try:
             with self.assertRaises(brockit.InvalidInputException):
-                brockit.Merge().execute()
+                brockit.Merge.create().execute()
         finally:
             subprocess.run(['git', 'rebase', '--abort'],
                            cwd=self.brave,
@@ -1352,7 +1367,7 @@ class MergeTest(unittest.TestCase):
         self.fake_chromium_src.commit('Second branch change', self.brave)
         head = self._git('rev-parse', 'HEAD')
 
-        brockit.Merge().execute()
+        brockit.Merge.create().execute()
 
         # The remote master now points at the branch tip, and no merge commit
         # was created (HEAD is unchanged).
@@ -1367,13 +1382,27 @@ class MergeTest(unittest.TestCase):
         self.fake_chromium_src.commit('Branch change', self.brave)
         self._advance_upstream('upstream.txt', 'upstream')
 
-        brockit.Merge().execute()
+        brockit.Merge.create().execute()
 
         head = self._git('rev-parse', 'HEAD')
         # The new HEAD is a merge commit (two parents) and the remote master
         # was fast-forwarded to it.
         self.assertEqual(len(self._git('rev-parse', 'HEAD^@').split()), 2)
         self.assertEqual(self._remote_master(), head)
+
+    def test_merge_diverged_titles_commit_for_chromium_upgrade(self):
+        """The merge commit is titled like the upgrade's GitHub issue/PR,
+        rather than git's generic default message."""
+        # `_setup_upstream` already bumps `cr149` from `_BASE_VERSION` to
+        # `_TARGET_VERSION` over `origin/master`; diverge upstream too, so the
+        # merge produces a merge commit.
+        self._setup_upstream()
+        self._advance_upstream('unrelated.txt', 'upstream change')
+
+        brockit.Merge.create().execute()
+
+        self.assertEqual(self._git('log', '-1', '--format=%s'),
+                         'Upgrade from Chromium 151 to Chromium 152')
 
     def test_merge_conflict_rolls_back_and_fails(self):
         """Merge conflicts roll the merge back and fail without pushing."""
@@ -1385,7 +1414,7 @@ class MergeTest(unittest.TestCase):
         upstream_master = self._advance_upstream('conflict.txt', 'upstream')
 
         with self.assertRaises(brockit.BadOutcomeException):
-            brockit.Merge().execute()
+            brockit.Merge.create().execute()
 
         # The merge was aborted: no leftover merge state, the branch tip is
         # unchanged, and nothing was pushed.
@@ -1404,7 +1433,7 @@ class MergeTest(unittest.TestCase):
         master_before = self._remote_master()
 
         with self.assertRaises(brockit.InvalidInputException):
-            brockit.Merge().execute()
+            brockit.Merge.create().execute()
 
         # The branch was never pushed.
         self.assertEqual(self._remote_master(), master_before)
@@ -1418,7 +1447,7 @@ class MergeTest(unittest.TestCase):
         master_before = self._remote_master()
 
         with self.assertRaises(brockit.InvalidInputException):
-            brockit.Merge().execute()
+            brockit.Merge.create().execute()
 
         self.assertEqual(self._remote_master(), master_before)
 
@@ -1436,7 +1465,7 @@ class MergeTest(unittest.TestCase):
         master_before = self._remote_master()
 
         with self.assertRaises(brockit.InvalidInputException):
-            brockit.Merge().execute()
+            brockit.Merge.create().execute()
 
         self.assertEqual(self._remote_master(), master_before)
 
@@ -1448,7 +1477,7 @@ class MergeTest(unittest.TestCase):
         master_before = self._remote_master()
 
         with self.assertRaises(brockit.InvalidInputException):
-            brockit.Merge().execute()
+            brockit.Merge.create().execute()
 
         self.assertEqual(self._remote_master(), master_before)
 
@@ -1504,19 +1533,19 @@ class MergeTest(unittest.TestCase):
                                             self.brave)
         head = self._git('rev-parse', 'HEAD')
 
-        brockit.Merge().execute()
+        brockit.Merge.create().execute()
 
         self.assertEqual(self._remote_master(), head)
 
     def test_merge_allows_canonical_branch(self):
         """A single, correctly-placed pinned commit is merge-ready."""
         self._setup_upstream()
-        self.fake_chromium_src.commit_empty(
-            'Update from Chromium 1.0.0.0 to Chromium 1.0.0.1.', self.brave)
+        # `_setup_upstream` already left a single pinned "Update from
+        # Chromium" commit on the branch; add just the feature commit on top.
         self.fake_chromium_src.commit_empty('[cr149] Feature A', self.brave)
         head = self._git('rev-parse', 'HEAD')
 
-        brockit.Merge().execute()
+        brockit.Merge.create().execute()
 
         self.assertEqual(self._remote_master(), head)
 
@@ -1527,7 +1556,7 @@ class MergeTest(unittest.TestCase):
         head_before = self._git('rev-parse', 'HEAD')
         master_before = self._remote_master()
 
-        brockit.Merge().execute(dry_run=True)
+        brockit.Merge.create().execute(dry_run=True)
 
         # HEAD is unchanged (no merge commit) and the remote was not pushed.
         self.assertEqual(self._git('rev-parse', 'HEAD'), head_before)
@@ -1541,7 +1570,7 @@ class MergeTest(unittest.TestCase):
                                             self.brave)
 
         with self.assertRaises(brockit.InvalidInputException):
-            brockit.Merge().execute(dry_run=True)
+            brockit.Merge.create().execute(dry_run=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When merging `cr152`, we noticed that the resulting merge title looked
like this.

```
[cr152] Merge remote-tracking branch 'origin/master' into cr152
```

This PR corrects this by making sure that the merge commit uses the
merge title we also provide to issue tickets and PR titles.

This change has also reworked `Merge` to be a `Versioned` tasks, as it
now fits the definition for one, which has permitted also the reloaction
of `compose_issue_title` out of the GitHub specific task, and into
`Versioned`.

Bug: https://github.com/brave/brave-browser/issues/58121
