### PR TITLE
[Vertical Tabs] Fix quadratic slowdown of the tab strip with many tabs

### DIFF
--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -310,22 +310,30 @@ bool BraveTabContainer::ShouldTabBeVisible(const Tab* tab) const {
 
     // Handle unpinned tabs in vertical tabs mode.
     // Only show tab if it is not hidden under the pinned tab area.
-    if (auto tab_index = tabs_view_model_.GetIndexOfView(tab)) {
+    if (auto tab_index = GetTabIndex(tab)) {
       const auto tab_bottom =
           tabs_view_model_.ideal_bounds(*tab_index).bottom();
-      return tab_bottom > GetPinnedTabsAreaBottom();
+      const int pinned_tabs_area_bottom =
+          visibility_pass_cache_
+              ? visibility_pass_cache_->pinned_tabs_area_bottom
+              : GetPinnedTabsAreaBottom();
+      return tab_bottom > pinned_tabs_area_bottom;
     }
   } else if (scroll_direction == views::LayoutOrientation::kHorizontal) {
     if (tab->data().pinned || tab->dragging()) {
       return TabContainerImpl::ShouldTabBeVisible(tab);
     }
 
-    if (auto tab_index = tabs_view_model_.GetIndexOfView(tab)) {
+    if (auto tab_index = GetTabIndex(tab)) {
       // Show unpinned tabs only if they are within unpinned tab area.
       // If tabs are fully occluded by pinned tabs area, we should hide the
       // tabs.
+      const int pinned_tabs_area_boundary =
+          visibility_pass_cache_
+              ? visibility_pass_cache_->pinned_tabs_area_boundary
+              : GetPinnedTabsAreaBoundary();
       return tabs_view_model_.ideal_bounds(*tab_index).right() >
-             GetPinnedTabsAreaBoundary();
+             pinned_tabs_area_boundary;
     }
   }
 
@@ -633,7 +641,26 @@ void BraveTabContainer::SetTabSlotVisibility() {
     }
   }
 
+  // The superclass call below queries ShouldTabBeVisible() for every tab;
+  // precompute what those queries need so one pass is O(n log n) instead of
+  // O(n^2).
+  if (GetScrollDirection()) {
+    VisibilityPassCache cache;
+    cache.pinned_tab_count = layout_helper_->GetPinnedTabCount();
+    cache.pinned_tabs_area_bottom = GetPinnedTabsAreaBottom();
+    cache.pinned_tabs_area_boundary = GetPinnedTabsAreaBoundary();
+    std::vector<std::pair<const Tab*, size_t>> indices;
+    indices.reserve(tabs_view_model_.view_size());
+    for (size_t i = 0; i < tabs_view_model_.view_size(); ++i) {
+      indices.emplace_back(tabs_view_model_.view_at(i), i);
+    }
+    cache.tab_indices = base::flat_map<const Tab*, size_t>(std::move(indices));
+    visibility_pass_cache_.emplace(std::move(cache));
+  }
+
   TabContainerImpl::SetTabSlotVisibility();
+
+  visibility_pass_cache_.reset();
 
   if (GetScrollDirection()) {
     // Even though TabContainerImpl::SetTabSlotVisibility() already updates the
@@ -1852,9 +1879,22 @@ bool BraveTabContainer::IsPinned(const Tab* tab) const {
   // AddTabToViewModel -> layout_helper_->InsertTabAt) before calling
   // StartInsertTabAnimation, so GetIndexOfView(tab) returns the correct index
   // and GetPinnedTabCount() is already accurate when IsPinned() is called.
-  const auto pinned_tab_count = layout_helper_->GetPinnedTabCount();
-  auto tab_index = tabs_view_model_.GetIndexOfView(tab);
+  const size_t pinned_tab_count = visibility_pass_cache_
+                                      ? visibility_pass_cache_->pinned_tab_count
+                                      : layout_helper_->GetPinnedTabCount();
+  auto tab_index = GetTabIndex(tab);
   return tab_index && *tab_index < pinned_tab_count;
+}
+
+std::optional<size_t> BraveTabContainer::GetTabIndex(const Tab* tab) const {
+  if (visibility_pass_cache_) {
+    auto it = visibility_pass_cache_->tab_indices.find(tab);
+    if (it == visibility_pass_cache_->tab_indices.end()) {
+      return std::nullopt;
+    }
+    return it->second;
+  }
+  return tabs_view_model_.GetIndexOfView(tab);
 }
 
 bool BraveTabContainer::ShouldShowHorizontalScrollButton() const {

--- a/browser/ui/views/tabs/brave_tab_container.h
+++ b/browser/ui/views/tabs/brave_tab_container.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "base/callback_list.h"
+#include "base/containers/flat_map.h"
 #include "base/gtest_prod_util.h"
 #include "chrome/browser/ui/tabs/tab_style.h"
 #include "chrome/browser/ui/views/tabs/dragging/tab_drag_context.h"
@@ -298,6 +299,10 @@ class BraveTabContainer : public TabContainerImpl,
   bool ShouldShowVerticalTabs() const;
   bool IsPinned(const Tab* tab) const;
 
+  // Returns the view model index of |tab|, served from
+  // |visibility_pass_cache_| during a visibility pass.
+  std::optional<size_t> GetTabIndex(const Tab* tab) const;
+
   // Called when the tree tabs enabled state changes.
   void OnTreeTabsEnabledChanged();
 
@@ -331,6 +336,19 @@ class BraveTabContainer : public TabContainerImpl,
       nullptr;
 
   bool layout_locked_ = false;
+
+  // Per-pass cache for SetTabSlotVisibility(): the superclass queries
+  // ShouldTabBeVisible()/IsPinned() once per tab, and each query performs
+  // linear scans (GetIndexOfView, GetPinnedTabCount), making one visibility
+  // pass O(n^2) with large tab counts. Populated only for the duration of
+  // one SetTabSlotVisibility() call.
+  struct VisibilityPassCache {
+    size_t pinned_tab_count = 0;
+    int pinned_tabs_area_bottom = 0;
+    int pinned_tabs_area_boundary = 0;
+    base::flat_map<const Tab*, size_t> tab_indices;
+  };
+  std::optional<VisibilityPassCache> visibility_pass_cache_;
 
   // Size we last laid out at.
   std::optional<gfx::Size> last_layout_size_;


### PR DESCRIPTION
Related to brave/brave-browser#52225

`TabContainerImpl::SetTabSlotVisibility()` queries `ShouldTabBeVisible()` (and through it `IsPinned()`) once per tab, and each query performed two linear scans — `ViewModel::GetIndexOfView()` and `GetPinnedTabCount()` — making one visibility pass O(n²) in the tab count. The pass runs multiple times per scroll tick, animation frame and tab insertion, so with 1000+ tabs this is a major jank source (full call-chain analysis in the issue comment linked above).

This PR precomputes a per-pass cache (tab→index map plus the pinned-area boundaries) before delegating to the superclass. Results are unchanged; queries outside a visibility pass use the previous code path.

## Benchmark

Measured on Windows 11 x64 (dev Component build, master as of Jul 9, Chromium 150): real-world 1759-tab session imported from my release-channel daily profile, fully automated protocol — `--restore-last-session` + scripted mouse-wheel scrolling over the strip, log-based microsecond probes in the touched functions. Restore numbers reproduced across 6 runs within ±3%.

| Metric | before | after |
|---|---|---|
| one `SetTabSlotVisibility()` pass at 1759 tabs | 8.7 ms | **2.5 ms (−71%)** |
| total time in `SetTabSlotVisibility()` during session restore | 23.5 s | **9.1 s (−61%)** |
| full strip relayout while scrolling (median per pass) | 38.2 ms | **29.3 ms (−23%)** |

## Test coverage

Behavior-preserving optimization; the touched queries are exercised by the existing `VerticalTabStripBrowserTest` suite (ScrollOffset, ClipPathOnScrollOffset, ScrollBarVisibilityWithManyTabs, …). Happy to add a dedicated test if preferred.

Analysis and benchmarks were AI-assisted; I built and verified the change on my machine.