### PR TITLE
[Vertical Tabs] Skip tab strip auto-scroll during session restore

### DIFF
--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -30,6 +30,7 @@
 #include "brave/ui/color/nala/nala_color_id.h"
 #include "cc/paint/paint_flags.h"
 #include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/sessions/session_restore.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
@@ -344,12 +345,20 @@ std::vector<Tab*> BraveTabContainer::AddTabs(
     std::vector<TabInsertionParams> tabs_params) {
   std::vector<Tab*> added_tabs =
       TabContainerImpl::AddTabs(std::move(tabs_params));
-  if (GetScrollDirection()) {
+  // Session restore inserts many background tabs back-to-back; scrolling to
+  // each one forces an extra full strip relayout per insert. The active tab
+  // is scrolled into view on activation anyway (see SetActiveTab).
+  if (GetScrollDirection() && !IsSessionRestoreInProgress()) {
     for (Tab* const tab : added_tabs) {
       ScrollTabToBeVisible(tab);
     }
   }
   return added_tabs;
+}
+
+bool BraveTabContainer::IsSessionRestoreInProgress() const {
+  auto* browser = tab_slot_controller_->GetBrowserWindowInterface();
+  return browser && SessionRestore::IsRestoring(browser->GetProfile());
 }
 
 void BraveTabContainer::StartInsertTabAnimation(int model_index) {

--- a/browser/ui/views/tabs/brave_tab_container.h
+++ b/browser/ui/views/tabs/brave_tab_container.h
@@ -303,6 +303,10 @@ class BraveTabContainer : public TabContainerImpl,
   // |visibility_pass_cache_| during a visibility pass.
   std::optional<size_t> GetTabIndex(const Tab* tab) const;
 
+  // Returns true while this container's profile is having its session
+  // restored.
+  bool IsSessionRestoreInProgress() const;
+
   // Called when the tree tabs enabled state changes.
   void OnTreeTabsEnabledChanged();
 


### PR DESCRIPTION
Related to brave/brave-browser#52225

`BraveTabContainer::AddTabs()` scrolls the vertical tab strip to every inserted tab. During session restore this fires for every restored background tab, and each scroll forces an extra full strip relayout (O(tab count) work) — exactly doubling the number of layout passes for the whole restore. The visible end state doesn't need it: the active tab is scrolled into view on activation via `SetActiveTab()`.

This PR skips the auto-scroll while `SessionRestore::IsRestoring()` reports a restore in progress for this profile. Normal user-initiated tab opening is unaffected.

## Benchmark

Same setup as the sibling PR (see #39058): 1759-tab real-world session, dev Component build (master as of Jul 9, Chromium 150), fully automated protocol, restore numbers reproduced across 6 runs within ±3%.

| Metric | before | after |
|---|---|---|
| full strip relayouts during session restore | 3523 | **1766 (−50%, exactly 1 per inserted tab)** |
| total session restore time | 139.8 s | **123.0 s (−12%)** |

## Test coverage

`SessionRestore::IsRestoring()` is global static state that can't be faked from a browser test without a testability refactor; the invariant that matters to users (active tab scrolled into view on activation) has existing coverage. Happy to refactor for injectability if the team prefers.

Analysis and benchmarks were AI-assisted; I built and verified the change on my machine.