### PR TITLE
Hide the Brave brand in navigator.userAgentData for excepted sites

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -71,6 +71,7 @@
 #include "brave/components/brave_shields/core/common/brave_shield_constants.h"
 #include "brave/components/brave_shields/core/common/features.h"
 #include "brave/components/brave_shields/core/common/shields_settings.mojom.h"
+#include "brave/components/brave_user_agent/browser/brave_user_agent_exceptions.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
@@ -928,7 +929,8 @@ BraveContentBrowserClient::WorkerGetBraveShieldSettings(
   return brave_shields::mojom::ShieldsSettings::New(
       farbling_level, farbling_token, std::vector<std::string>(),
       brave_shields::IsReduceLanguageEnabledForProfile(pref_service),
-      IsJsBlockingEnforced(browser_context, url));
+      IsJsBlockingEnforced(browser_context, url),
+      brave_user_agent::ShouldHideBraveBrand(url));
 }
 
 bool BraveContentBrowserClient::CanCreateWindow(

--- a/browser/brave_shields/BUILD.gn
+++ b/browser/brave_shields/BUILD.gn
@@ -52,6 +52,7 @@ source_set("brave_shields_impl") {
     "//brave/components/brave_perf_predictor/browser",
     "//brave/components/brave_shields/core/browser",
     "//brave/components/brave_shields/core/common",
+    "//brave/components/brave_user_agent/browser",
     "//brave/components/constants",
     "//chrome/browser:browser_process",
     "//chrome/browser/content_settings:content_settings_factory",

--- a/browser/brave_shields/brave_shields_web_contents_observer.cc
+++ b/browser/brave_shields/brave_shields_web_contents_observer.cc
@@ -20,6 +20,7 @@
 #include "brave/components/brave_shields/core/common/brave_shield_constants.h"
 #include "brave/components/brave_shields/core/common/pref_names.h"
 #include "brave/components/brave_shields/core/common/shields_settings.mojom.h"
+#include "brave/components/brave_user_agent/browser/brave_user_agent_exceptions.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/containers/buildflags/buildflags.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
@@ -360,7 +361,8 @@ void BraveShieldsWebContentsObserver::SendShieldsSettings(
   agent->SetShieldsSettings(brave_shields::mojom::ShieldsSettings::New(
       farbling_level, farbling_token, allowed_scripts_,
       brave_shields::IsReduceLanguageEnabledForProfile(pref_service),
-      IsJsBlockingEnforced(rfh->GetBrowserContext(), primary_url)));
+      IsJsBlockingEnforced(rfh->GetBrowserContext(), primary_url),
+      brave_user_agent::ShouldHideBraveBrand(primary_url)));
 }
 
 void BraveShieldsWebContentsObserver::BindReceiver(

--- a/browser/content_settings/sources.gni
+++ b/browser/content_settings/sources.gni
@@ -7,6 +7,7 @@ import("//brave/components/containers/buildflags/buildflags.gni")
 
 brave_browser_content_settings_deps = [
   "//brave/components/brave_shields/content/browser",
+  "//brave/components/brave_user_agent/browser",
   "//brave/components/containers/buildflags",
   "//components/user_prefs",
 ]

--- a/browser/net/DEPS
+++ b/browser/net/DEPS
@@ -2,6 +2,7 @@ include_rules = [
   "+brave/content/public/browser",
   "+brave/components/brave_shields/core/browser",
   "+brave/components/brave_shields/content/test",
+  "+brave/components/brave_user_agent/common/brand_names.h",
   "+brave/components/brave_user_agent/common/features.h",
   "+brave/components/geolocation",
   "+brave/components/update_client/buildflags.h",

--- a/browser/net/brave_user_agent_network_delegate_helper.cc
+++ b/browser/net/brave_user_agent_network_delegate_helper.cc
@@ -42,20 +42,13 @@ int OnBeforeStartTransaction_UserAgentWork(
     net::HttpRequestHeaders* headers,
     const ResponseCallback& next_callback,
     T<BraveRequestInfo> ctx) {
-  if (ctx) {
-    auto* exceptions =
-        brave_user_agent::BraveUserAgentExceptions::GetInstance();
-    if (exceptions) {
-      bool show_brave = exceptions->CanShowBrave(ctx->tab_origin());
-      if (!show_brave) {
-        if (ReplaceBraveWithGoogleChromeInHeader(headers, kHeaderSecCHUA)) {
-          ctx->mutable_modified_headers().insert(kHeaderSecCHUA);
-        }
-        if (ReplaceBraveWithGoogleChromeInHeader(
-                headers, kHeaderSecCHUAFullVersionList)) {
-          ctx->mutable_modified_headers().insert(kHeaderSecCHUAFullVersionList);
-        }
-      }
+  if (ctx && brave_user_agent::ShouldHideBraveBrand(ctx->tab_origin())) {
+    if (ReplaceBraveWithGoogleChromeInHeader(headers, kHeaderSecCHUA)) {
+      ctx->mutable_modified_headers().insert(kHeaderSecCHUA);
+    }
+    if (ReplaceBraveWithGoogleChromeInHeader(headers,
+                                             kHeaderSecCHUAFullVersionList)) {
+      ctx->mutable_modified_headers().insert(kHeaderSecCHUAFullVersionList);
     }
   }
   return net::OK;

--- a/browser/net/brave_user_agent_network_delegate_helper_browsertest.cc
+++ b/browser/net/brave_user_agent_network_delegate_helper_browsertest.cc
@@ -11,25 +11,29 @@
 #include "base/path_service.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_user_agent/browser/brave_user_agent_exceptions.h"
+#include "brave/components/brave_user_agent/common/brand_names.h"
 #include "brave/components/brave_user_agent/common/features.h"
 #include "brave/components/constants/brave_paths.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
+#include "content/public/browser/render_frame_host.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
 #include "net/dns/mock_host_resolver.h"
 #include "net/http/http_status_code.h"
 #include "net/test/embedded_test_server/http_request.h"
 #include "net/test/embedded_test_server/http_response.h"
+#include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace {
 
 constexpr char kSecCHUAHeader[] = "Sec-CH-UA";
 constexpr char kSecCHUAFullVersionListHeader[] = "Sec-CH-UA-Full-Version-List";
-constexpr char kBraveBrand[] = "Brave";
-constexpr char kGoogleChromeBrand[] = "Google Chrome";
+using brave_user_agent::kBraveBrand;
+using brave_user_agent::kGoogleChromeBrand;
 
 struct HeaderCapture {
   bool allows_brave_header = false;
@@ -96,6 +100,10 @@ class BraveUserAgentNetworkDelegateBrowserTest
   net::EmbeddedTestServer& https_server();
   void RunBrandHeaderTest(const std::string& domain, const std::string& path);
   void NavigateAndWait(const GURL& url);
+  void ExpectBrandsInFrame(const content::ToRenderFrameHost& frame,
+                           bool allows_brave_brand);
+  void ExpectUserAgentDataBrands(const std::string& domain,
+                                 bool allows_brave_brand);
 
   void ExpectHeaderBrands(const std::vector<HeaderCapture>& captures) {
     ASSERT_TRUE(!captures.empty());
@@ -235,6 +243,39 @@ void BraveUserAgentNetworkDelegateBrowserTest::NavigateAndWait(
   )"));
 }
 
+void BraveUserAgentNetworkDelegateBrowserTest::ExpectBrandsInFrame(
+    const content::ToRenderFrameHost& frame,
+    bool allows_brave_brand) {
+  // When the feature is off no domain is excepted, so Brave is always shown.
+  const bool expect_brave = allows_brave_brand || !GetParam();
+  const std::string brands =
+      content::EvalJs(frame,
+                      "navigator.userAgentData.brands.map(b => b.brand)"
+                      ".join(',')")
+          .ExtractString();
+  const std::string full_version_list =
+      content::EvalJs(frame,
+                      "navigator.userAgentData"
+                      ".getHighEntropyValues(['fullVersionList'])"
+                      ".then(v => v.fullVersionList.map(b => b.brand)"
+                      ".join(','))")
+          .ExtractString();
+  for (const std::string& value : {brands, full_version_list}) {
+    SCOPED_TRACE(value);
+    EXPECT_EQ(expect_brave, value.find(kBraveBrand) != std::string::npos);
+    EXPECT_EQ(!expect_brave,
+              value.find(kGoogleChromeBrand) != std::string::npos);
+  }
+}
+
+void BraveUserAgentNetworkDelegateBrowserTest::ExpectUserAgentDataBrands(
+    const std::string& domain,
+    bool allows_brave_brand) {
+  NavigateAndWait(https_server().GetURL(domain, "/" + domain + "/simple.html"));
+  ExpectBrandsInFrame(browser()->tab_strip_model()->GetActiveWebContents(),
+                      allows_brave_brand);
+}
+
 void BraveUserAgentNetworkDelegateBrowserTest::RunBrandHeaderTest(
     const std::string& domain,
     const std::string& path) {
@@ -263,6 +304,69 @@ IN_PROC_BROWSER_TEST_P(BraveUserAgentNetworkDelegateBrowserTest,
 IN_PROC_BROWSER_TEST_P(BraveUserAgentNetworkDelegateBrowserTest,
                        SecCHUAHeadersAfterRedirectFromNonExceptedToExcepted) {
   RunBrandHeaderTest("b.test", "/b.test/redirect_b_to_a.html");
+}
+
+// navigator.userAgentData must agree with the Sec-CH-UA headers, otherwise a
+// site can detect Brave from JavaScript despite the header rewrite.
+IN_PROC_BROWSER_TEST_P(BraveUserAgentNetworkDelegateBrowserTest,
+                       UserAgentDataBrandsOnExceptedDomain) {
+  ExpectUserAgentDataBrands("a.test", /*allows_brave_brand=*/false);
+}
+
+IN_PROC_BROWSER_TEST_P(BraveUserAgentNetworkDelegateBrowserTest,
+                       UserAgentDataBrandsOnNonExceptedDomain) {
+  ExpectUserAgentDataBrands("b.test", /*allows_brave_brand=*/true);
+}
+
+// The decision is keyed on the top frame, so a non-excepted iframe embedded in
+// an excepted page must also hide the brand.
+IN_PROC_BROWSER_TEST_P(BraveUserAgentNetworkDelegateBrowserTest,
+                       UserAgentDataBrandsInIframeFollowsTopFrame) {
+  NavigateAndWait(https_server().GetURL("a.test", "/a.test/simple.html"));
+  content::RenderFrameHost* main_frame = browser()
+                                             ->tab_strip_model()
+                                             ->GetActiveWebContents()
+                                             ->GetPrimaryMainFrame();
+  ASSERT_TRUE(content::ExecJs(
+      main_frame, content::JsReplace(
+                      R"(
+        new Promise(resolve => {
+          const frame = document.createElement('iframe');
+          frame.src = $1;
+          frame.onload = () => resolve();
+          document.body.appendChild(frame);
+        });
+      )",
+                      https_server().GetURL("b.test", "/b.test/simple.html"))));
+  content::RenderFrameHost* child = content::ChildFrameAt(main_frame, 0);
+  ASSERT_TRUE(child);
+  ExpectBrandsInFrame(child, /*allows_brave_brand=*/false);
+}
+
+// Workers get their shields settings over a separate path, so cover one.
+IN_PROC_BROWSER_TEST_P(BraveUserAgentNetworkDelegateBrowserTest,
+                       UserAgentDataBrandsInDedicatedWorker) {
+  NavigateAndWait(https_server().GetURL("a.test", "/a.test/simple.html"));
+  content::RenderFrameHost* main_frame = browser()
+                                             ->tab_strip_model()
+                                             ->GetActiveWebContents()
+                                             ->GetPrimaryMainFrame();
+  const std::string brands = content::EvalJs(main_frame, R"(
+        new Promise(resolve => {
+          const source = `postMessage(
+              navigator.userAgentData.brands.map(b => b.brand).join(','))`;
+          const worker = new Worker(
+              URL.createObjectURL(new Blob([source])));
+          worker.onmessage = e => resolve(e.data);
+        });
+      )")
+                                 .ExtractString();
+  if (GetParam()) {
+    EXPECT_THAT(brands, ::testing::HasSubstr(kGoogleChromeBrand));
+    EXPECT_THAT(brands, ::testing::Not(::testing::HasSubstr(kBraveBrand)));
+  } else {
+    EXPECT_THAT(brands, ::testing::HasSubstr(kBraveBrand));
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(FeatureFlag,

--- a/browser/net/brave_user_agent_network_delegate_helper_browsertest.cc
+++ b/browser/net/brave_user_agent_network_delegate_helper_browsertest.cc
@@ -10,6 +10,7 @@
 #include "base/feature_list.h"
 #include "base/path_service.h"
 #include "base/test/scoped_feature_list.h"
+#include "base/values.h"
 #include "brave/components/brave_user_agent/browser/brave_user_agent_exceptions.h"
 #include "brave/components/brave_user_agent/common/brand_names.h"
 #include "brave/components/brave_user_agent/common/features.h"
@@ -25,7 +26,6 @@
 #include "net/http/http_status_code.h"
 #include "net/test/embedded_test_server/http_request.h"
 #include "net/test/embedded_test_server/http_response.h"
-#include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace {
@@ -100,6 +100,9 @@ class BraveUserAgentNetworkDelegateBrowserTest
   net::EmbeddedTestServer& https_server();
   void RunBrandHeaderTest(const std::string& domain, const std::string& path);
   void NavigateAndWait(const GURL& url);
+  void ExpectBrands(const std::string& brands,
+                    const std::string& full_version_list,
+                    bool allows_brave_brand);
   void ExpectBrandsInFrame(const content::ToRenderFrameHost& frame,
                            bool allows_brave_brand);
   void ExpectUserAgentDataBrands(const std::string& domain,
@@ -243,11 +246,23 @@ void BraveUserAgentNetworkDelegateBrowserTest::NavigateAndWait(
   )"));
 }
 
-void BraveUserAgentNetworkDelegateBrowserTest::ExpectBrandsInFrame(
-    const content::ToRenderFrameHost& frame,
+void BraveUserAgentNetworkDelegateBrowserTest::ExpectBrands(
+    const std::string& brands,
+    const std::string& full_version_list,
     bool allows_brave_brand) {
   // When the feature is off no domain is excepted, so Brave is always shown.
   const bool expect_brave = allows_brave_brand || !GetParam();
+  for (const std::string& value : {brands, full_version_list}) {
+    SCOPED_TRACE(value);
+    EXPECT_EQ(expect_brave, value.find(kBraveBrand) != std::string::npos);
+    EXPECT_EQ(!expect_brave,
+              value.find(kGoogleChromeBrand) != std::string::npos);
+  }
+}
+
+void BraveUserAgentNetworkDelegateBrowserTest::ExpectBrandsInFrame(
+    const content::ToRenderFrameHost& frame,
+    bool allows_brave_brand) {
   const std::string brands =
       content::EvalJs(frame,
                       "navigator.userAgentData.brands.map(b => b.brand)"
@@ -260,12 +275,7 @@ void BraveUserAgentNetworkDelegateBrowserTest::ExpectBrandsInFrame(
                       ".then(v => v.fullVersionList.map(b => b.brand)"
                       ".join(','))")
           .ExtractString();
-  for (const std::string& value : {brands, full_version_list}) {
-    SCOPED_TRACE(value);
-    EXPECT_EQ(expect_brave, value.find(kBraveBrand) != std::string::npos);
-    EXPECT_EQ(!expect_brave,
-              value.find(kGoogleChromeBrand) != std::string::npos);
-  }
+  ExpectBrands(brands, full_version_list, allows_brave_brand);
 }
 
 void BraveUserAgentNetworkDelegateBrowserTest::ExpectUserAgentDataBrands(
@@ -351,22 +361,23 @@ IN_PROC_BROWSER_TEST_P(BraveUserAgentNetworkDelegateBrowserTest,
                                              ->tab_strip_model()
                                              ->GetActiveWebContents()
                                              ->GetPrimaryMainFrame();
-  const std::string brands = content::EvalJs(main_frame, R"(
+  const content::EvalJsResult result = content::EvalJs(main_frame, R"(
         new Promise(resolve => {
-          const source = `postMessage(
-              navigator.userAgentData.brands.map(b => b.brand).join(','))`;
+          const source = `Promise.all([
+              navigator.userAgentData.brands.map(b => b.brand).join(','),
+              navigator.userAgentData
+                  .getHighEntropyValues(['fullVersionList'])
+                  .then(v => v.fullVersionList.map(b => b.brand).join(',')),
+          ]).then(r => postMessage(r))`;
           const worker = new Worker(
               URL.createObjectURL(new Blob([source])));
           worker.onmessage = e => resolve(e.data);
         });
-      )")
-                                 .ExtractString();
-  if (GetParam()) {
-    EXPECT_THAT(brands, ::testing::HasSubstr(kGoogleChromeBrand));
-    EXPECT_THAT(brands, ::testing::Not(::testing::HasSubstr(kBraveBrand)));
-  } else {
-    EXPECT_THAT(brands, ::testing::HasSubstr(kBraveBrand));
-  }
+      )");
+  const base::ListValue& values = result.ExtractList();
+  ASSERT_EQ(2u, values.size());
+  ExpectBrands(values[0].GetString(), values[1].GetString(),
+               /*allows_brave_brand=*/false);
 }
 
 INSTANTIATE_TEST_SUITE_P(FeatureFlag,

--- a/chromium_src/chrome/browser/content_settings/DEPS
+++ b/chromium_src/chrome/browser/content_settings/DEPS
@@ -2,6 +2,7 @@ include_rules = [
   "+brave/components/brave_shields/content/browser",
   "+brave/components/brave_shields/core/browser",
   "+brave/components/brave_shields/core/common",
+  "+brave/components/brave_user_agent/browser",
   "+brave/components/containers/buildflags",
   "+brave/components/containers/content/browser",
   "+brave/components/containers/core/common",

--- a/chromium_src/chrome/browser/content_settings/content_settings_manager_delegate.cc
+++ b/chromium_src/chrome/browser/content_settings/content_settings_manager_delegate.cc
@@ -10,6 +10,7 @@
 #include "brave/components/brave_shields/core/browser/brave_shields_settings_service.h"
 #include "brave/components/brave_shields/core/browser/brave_shields_utils.h"
 #include "brave/components/brave_shields/core/common/shields_settings.mojom-shared.h"
+#include "brave/components/brave_user_agent/browser/brave_user_agent_exceptions.h"
 #include "brave/components/containers/buildflags/buildflags.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "components/user_prefs/user_prefs.h"
@@ -80,7 +81,8 @@ brave_shields::mojom::ShieldsSettingsPtr GetBraveShieldsSettingsOnUI(
   return brave_shields::mojom::ShieldsSettings::New(
       farbling_level, farbling_token, std::vector<std::string>(),
       brave_shields::IsReduceLanguageEnabledForProfile(pref_service),
-      IsJsBlockingEnforced(browser_context, top_frame_url));
+      IsJsBlockingEnforced(browser_context, top_frame_url),
+      brave_user_agent::ShouldHideBraveBrand(top_frame_url));
 }
 
 }  // namespace

--- a/chromium_src/chrome/renderer/worker_content_settings_client.cc
+++ b/chromium_src/chrome/renderer/worker_content_settings_client.cc
@@ -89,7 +89,7 @@ WorkerContentSettingsClient_BraveImpl::GetBraveShieldsSettings(
                           HasContentSettingsRules());
     base::debug::DumpWithoutCrashing();
     return brave_shields::mojom::ShieldsSettings::New(
-        farbling_level, base::Token(), std::vector<std::string>(), false,
+        farbling_level, base::Token(), std::vector<std::string>(), false, false,
         false);
   }
 }

--- a/chromium_src/third_party/blink/renderer/core/frame/navigator_ua.cc
+++ b/chromium_src/third_party/blink/renderer/core/frame/navigator_ua.cc
@@ -1,0 +1,8 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
+
+#include <third_party/blink/renderer/core/frame/navigator_ua.cc>

--- a/components/brave_shields/core/common/shields_settings.mojom
+++ b/components/brave_shields/core/common/shields_settings.mojom
@@ -33,6 +33,9 @@ struct ShieldsSettings {
   array<string> origins_to_allow_scripts;
   bool reduce_language;
   bool enforced_script_blocking;
+  // Set for sites on the brave-checks.txt list, which report "Google Chrome"
+  // instead of "Brave" in Sec-CH-UA and navigator.userAgentData.
+  bool hide_brave_brand;
 };
 
 enum AdBlockMode {

--- a/components/brave_user_agent/browser/brave_user_agent_exceptions.cc
+++ b/components/brave_user_agent/browser/brave_user_agent_exceptions.cc
@@ -84,4 +84,9 @@ void BraveUserAgentExceptions::AddToExceptedDomainsForTesting(
   excepted_domains_.insert(std::string(domain));
 }
 
+bool ShouldHideBraveBrand(const GURL& top_frame_url) {
+  auto* exceptions = BraveUserAgentExceptions::GetInstance();
+  return exceptions && !exceptions->CanShowBrave(top_frame_url);
+}
+
 }  // namespace brave_user_agent

--- a/components/brave_user_agent/browser/brave_user_agent_exceptions.cc
+++ b/components/brave_user_agent/browser/brave_user_agent_exceptions.cc
@@ -84,9 +84,9 @@ void BraveUserAgentExceptions::AddToExceptedDomainsForTesting(
   excepted_domains_.insert(std::string(domain));
 }
 
-bool ShouldHideBraveBrand(const GURL& top_frame_url) {
+bool ShouldHideBraveBrand(const GURL& url) {
   auto* exceptions = BraveUserAgentExceptions::GetInstance();
-  return exceptions && !exceptions->CanShowBrave(top_frame_url);
+  return exceptions && !exceptions->CanShowBrave(url);
 }
 
 }  // namespace brave_user_agent

--- a/components/brave_user_agent/browser/brave_user_agent_exceptions.h
+++ b/components/brave_user_agent/browser/brave_user_agent_exceptions.h
@@ -50,6 +50,11 @@ class BraveUserAgentExceptions {
   friend class BraveUserAgentExceptionsUnitTest;
 };
 
+// Returns true when `top_frame_url` is excepted and should therefore report
+// "Google Chrome" rather than "Brave". Returns false when the feature is
+// disabled or the exceptions list has not loaded yet.
+bool ShouldHideBraveBrand(const GURL& top_frame_url);
+
 }  // namespace brave_user_agent
 
 #endif  // BRAVE_COMPONENTS_BRAVE_USER_AGENT_BROWSER_BRAVE_USER_AGENT_EXCEPTIONS_H_

--- a/components/brave_user_agent/browser/brave_user_agent_exceptions.h
+++ b/components/brave_user_agent/browser/brave_user_agent_exceptions.h
@@ -50,10 +50,10 @@ class BraveUserAgentExceptions {
   friend class BraveUserAgentExceptionsUnitTest;
 };
 
-// Returns true when `top_frame_url` is excepted and should therefore report
+// Returns true when `url` is excepted and should therefore report
 // "Google Chrome" rather than "Brave". Returns false when the feature is
 // disabled or the exceptions list has not loaded yet.
-bool ShouldHideBraveBrand(const GURL& top_frame_url);
+bool ShouldHideBraveBrand(const GURL& url);
 
 }  // namespace brave_user_agent
 

--- a/components/brave_user_agent/common/BUILD.gn
+++ b/components/brave_user_agent/common/BUILD.gn
@@ -8,6 +8,7 @@ component("common") {
   defines = [ "IS_BRAVE_USER_AGENT_COMMON_IMPL" ]
 
   sources = [
+    "brand_names.h",
     "features.cc",
     "features.h",
   ]

--- a/components/brave_user_agent/common/brand_names.h
+++ b/components/brave_user_agent/common/brand_names.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_USER_AGENT_COMMON_BRAND_NAMES_H_
+#define BRAVE_COMPONENTS_BRAVE_USER_AGENT_COMMON_BRAND_NAMES_H_
+
+namespace brave_user_agent {
+
+// Brand names as they appear in navigator.userAgentData brand lists. Sites on
+// the brave-checks.txt list report kGoogleChromeBrand instead of kBraveBrand.
+// Note the Sec-CH-UA header rewrite matches on quoted variants of these, see
+// brave/browser/net/brave_user_agent_network_delegate_helper.cc.
+inline constexpr char kBraveBrand[] = "Brave";
+inline constexpr char kGoogleChromeBrand[] = "Google Chrome";
+
+}  // namespace brave_user_agent
+
+#endif  // BRAVE_COMPONENTS_BRAVE_USER_AGENT_COMMON_BRAND_NAMES_H_

--- a/components/content_settings/renderer/brave_content_settings_agent_impl.cc
+++ b/components/content_settings/renderer/brave_content_settings_agent_impl.cc
@@ -427,7 +427,7 @@ BraveContentSettingsAgentImpl::GetBraveShieldsSettings(
                           HasContentSettingsRules());
     base::debug::DumpWithoutCrashing();
     return brave_shields::mojom::ShieldsSettings::New(
-        farbling_level, base::Token(), std::vector<std::string>(), false,
+        farbling_level, base::Token(), std::vector<std::string>(), false, false,
         false);
   }
 }

--- a/patches/third_party-blink-renderer-core-frame-navigator_ua.cc.patch
+++ b/patches/third_party-blink-renderer-core-frame-navigator_ua.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/third_party/blink/renderer/core/frame/navigator_ua.cc b/third_party/blink/renderer/core/frame/navigator_ua.cc
+index 22483bb57adf790867e081e5d32c1c726e94c3ef..2a4893d064fea9e0f335801223bb61db6b206d46 100644
+--- a/third_party/blink/renderer/core/frame/navigator_ua.cc
++++ b/third_party/blink/renderer/core/frame/navigator_ua.cc
+@@ -15,7 +15,8 @@ NavigatorUAData* NavigatorUA::userAgentData() {
+   NavigatorUAData* ua_data =
+       MakeGarbageCollected<NavigatorUAData>(GetUAExecutionContext());
+ 
+-  UserAgentMetadata metadata = GetUserAgentMetadata();
++  UserAgentMetadata metadata = brave::MaybeHideBraveBrand(
++      GetUAExecutionContext(), GetUserAgentMetadata());
+   ua_data->SetBrandVersionList(metadata.brand_version_list);
+   ua_data->SetMobile(metadata.mobile);
+   ua_data->SetPlatform(String::FromUtf8(metadata.platform),

--- a/rewrite/third_party/blink/renderer/core/frame/navigator_ua.cc.yaml
+++ b/rewrite/third_party/blink/renderer/core/frame/navigator_ua.cc.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Hide the "Brave" brand in navigator.userAgentData for excepted sites.
+
+      Sites on the brave-checks.txt list already have "Brave" replaced with
+      "Google Chrome" in their Sec-CH-UA request headers, but that rewrite
+      happens in the browser process. Without this, the same brand is still
+      readable from JavaScript, which defeats the purpose of the header rewrite.
+      Wrapping the metadata here covers navigator.userAgentData.brands as well
+      as getHighEntropyValues(['fullVersionList']), since both are populated
+      from it.
+    regex:
+      re_pattern: '(UserAgentMetadata metadata = )(GetUserAgentMetadata\(\));'
+      replace: |-
+        \1brave::MaybeHideBraveBrand(
+              GetUAExecutionContext(), \2);

--- a/third_party/blink/renderer/core/farbling/DEPS
+++ b/third_party/blink/renderer/core/farbling/DEPS
@@ -1,5 +1,6 @@
 include_rules = [
   "+brave/components/brave_shields/core/common/farbling_prng.h",
+  "+brave/components/brave_user_agent/common/brand_names.h",
   "+crypto",
   "+components/content_settings/core/common",
   "+third_party/blink/public/platform",

--- a/third_party/blink/renderer/core/farbling/brave_session_cache.cc
+++ b/third_party/blink/renderer/core/farbling/brave_session_cache.cc
@@ -17,6 +17,7 @@
 #include "base/notreached.h"
 #include "base/numerics/byte_conversions.h"
 #include "base/numerics/safe_conversions.h"
+#include "brave/components/brave_user_agent/common/brand_names.h"
 #include "brave/third_party/blink/renderer/brave_farbling_constants.h"
 #include "brave/third_party/blink/renderer/brave_font_whitelist.h"
 #include "build/build_config.h"
@@ -207,6 +208,23 @@ bool BlockScreenFingerprinting(ExecutionContext* context,
             : ContentSettingsType::BRAVE_WEBCOMPAT_SCREEN,
       BraveFarblingLevel::OFF);
   return level != BraveFarblingLevel::OFF;
+}
+
+blink::UserAgentMetadata MaybeHideBraveBrand(
+    ExecutionContext* context,
+    blink::UserAgentMetadata metadata) {
+  if (!context || !BraveSessionCache::From(*context).ShouldHideBraveBrand()) {
+    return metadata;
+  }
+  for (auto* brand_list :
+       {&metadata.brand_version_list, &metadata.brand_full_version_list}) {
+    for (auto& brand_version : *brand_list) {
+      if (brand_version.brand == brave_user_agent::kBraveBrand) {
+        brand_version.brand = brave_user_agent::kGoogleChromeBrand;
+      }
+    }
+  }
+  return metadata;
 }
 
 int FarbledPointerScreenCoordinate(const DOMWindow* view,

--- a/third_party/blink/renderer/core/farbling/brave_session_cache.h
+++ b/third_party/blink/renderer/core/farbling/brave_session_cache.h
@@ -16,6 +16,7 @@
 #include "brave/third_party/blink/renderer/brave_farbling_constants.h"
 #include "brave/third_party/blink/renderer/platform/brave_audio_farbling_helper.h"
 #include "components/content_settings/core/common/content_settings_types.h"
+#include "third_party/blink/public/common/user_agent/user_agent_metadata.h"
 #include "third_party/blink/renderer/core/core_export.h"
 #include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/core/frame/dom_window.h"
@@ -70,6 +71,12 @@ CORE_EXPORT int FarbledPointerScreenCoordinate(const DOMWindow* view,
                                                FarbleKey key,
                                                int client_coordinate,
                                                int true_screen_coordinate);
+// Returns `metadata` with the "Brave" brand renamed to "Google Chrome" when the
+// top frame is on the brave-checks.txt list, so that navigator.userAgentData
+// matches the Sec-CH-UA headers the browser rewrites for those sites.
+CORE_EXPORT blink::UserAgentMetadata MaybeHideBraveBrand(
+    ExecutionContext* context,
+    blink::UserAgentMetadata metadata);
 
 class CORE_EXPORT BraveSessionCache final
     : public GarbageCollected<BraveSessionCache>,
@@ -96,6 +103,9 @@ class CORE_EXPORT BraveSessionCache final
                      int max_random_offset);
   bool AllowFontFamily(blink::WebContentSettingsClient* settings,
                        const blink::AtomicString& family_name);
+  bool ShouldHideBraveBrand() const {
+    return default_shields_settings_->hide_brave_brand;
+  }
   brave_shields::FarblingPRNG MakePseudoRandomGenerator(
       FarbleKey key = FarbleKey::kNone);
   std::optional<blink::BraveAudioFarblingHelper> GetAudioFarblingHelper();

--- a/third_party/blink/renderer/includes.gni
+++ b/third_party/blink/renderer/includes.gni
@@ -39,6 +39,7 @@ brave_blink_renderer_core_sources = [
 brave_blink_renderer_core_deps = [
   "//brave/components/brave_shields/core/common:mojom",
   "//brave/components/brave_shields/core/common/",
+  "//brave/components/brave_user_agent/common",
 ]
 
 if (!is_android && !is_ios) {


### PR DESCRIPTION
Sites on the `brave-checks.txt` list already have `"Brave"` replaced with
`"Google Chrome"` in their `Sec-CH-UA` headers, but that rewrite happens in the
browser process. `navigator.userAgentData` is built in the renderer from
process-wide `UserAgentMetadata`, which has no per-site knowledge. So a site via JS could
still read the real brand and detect Brave anyway. 

Note that Tunrstile does access `navigator.userAgentData` and this could be a contributor to extra captures or fails via its 600010 error code.

What this pr does: 
- Adds `hide_brave_brand` to the existing `ShieldsSettings` mojo struct, which is
  already per-navigation and already reaches frames **and** all worker types
- Fills it browser-side in the 3 producers from
  `brave_user_agent::ShouldHideBraveBrand(top_frame_url)`, each using the same
  top-frame URL as `farbling_level`
- A plaster wraps the metadata at its single source in `navigator_ua.cc`, so
  `.brands`, `getHighEntropyValues(['fullVersionList'])` and `uaFullVersion` are
  all covered
- Collapses the duplicated `GetInstance()`/`CanShowBrave()` policy in the header
  path onto the same shared helper

Resolves https://github.com/brave/brave-browser/issues/47826

## Test plan

QA for brave-browser#47826 — `navigator.userAgentData` must not leak "Brave" on
sites in `brave-checks.txt`.

**Setup**

1. Download [js-ua-test.zip](https://github.com/user-attachments/files/31044732/js-ua-test.zip)
1. Add `127.0.0.1 test.chess.com` to your `/etc/hosts` file
2. Extract the zip to your home directory `~/js-ua-test`
3. `cd js-ua-test && python3 server.py`

If you're using Windows you might need to generate a key manually with `C:\Program Files\Git\usr\bin\openssl.exe` and the hosts file would be here: `C:\Windows\System32\drivers\etc\hosts`
but otherwise you can just skip windows if it's hard to test.



**Test**

Open `https://test.chess.com:8444/` — click through the cert warning, then
**reload once**. Do this in two builds:

| Build | Expect |
| ----- | ------ |
| Released Brave (no fix) | red **MISMATCH** |
| Build with the fix | green **AGREE**, 6/6 `Google Chrome` |
| Build with the fix but 127.0.0.1 | Should reveal Brave everywhere |

The banner at the top is the whole result. Ignore version numbers, brand order,
and `navigator.userAgent`.


Expected result screenshots:

Before:
<img width="1040" height="844" alt="Screenshot 2026-08-13 at 4 12 09 PM" src="https://github.com/user-attachments/assets/0d46ce04-2d02-4100-a028-2873be4dc058" />

After:
<img width="1038" height="882" alt="Screenshot 2026-08-13 at 4 12 13 PM" src="https://github.com/user-attachments/assets/2031b61c-119c-4253-b949-9cc00630480e" />
