### PR TITLE
Add best practices: plaster over #define, resilient rewrite anchors

### DIFF
--- a/agents/skills/review/discover-bp-docs.py
+++ b/agents/skills/review/discover-bp-docs.py
@@ -34,6 +34,7 @@ Category mapping (based on filename prefixes/keywords):
     android:      android*
     ios:          ios*
     patch:        patch*
+    plaster:      plaster*
     nala:         nala*
     always:       everything else (architecture, documentation, etc.)
 """
@@ -56,7 +57,7 @@ CATEGORY_RULES = [
     ("patch", "patch"),
     ("nala", "nala"),
     ("localization", "frontend"),
-    ("plaster", "cpp"),
+    ("plaster", "plaster"),
     ("ui-views", "cpp"),
 ]
 
@@ -101,6 +102,12 @@ CATEGORY_FILE_PATTERNS = {
     "patch": {
         "extensions": {".patch"},
         "path_contains": ["patches/"],
+    },
+    # Plaster rules apply to the rewrite configs themselves, and to
+    # chromium_src C++ where a #define would be reached for instead.
+    "plaster": {
+        "extensions": set(),
+        "path_contains": ["rewrite/", "chromium_src/", "patches/"],
     },
     "nala": {
         "extensions": {".icon", ".svg"},

--- a/docs/best-practices/chromium-src-overrides.md
+++ b/docs/best-practices/chromium-src-overrides.md
@@ -199,24 +199,31 @@ class TranslateURLFetcher {
 
 <a id="CSRC-015"></a>
 
-## ✅ Use `#define` to Add `virtual` Without Patches
+## ❌ Don't Use `#define` to Add `virtual` — Use `make_virtual`
 
-**When a Chromium method needs to be made virtual for override, use a `#define`
-in a chromium_src override of the header instead of a patch.**
+**When a Chromium method needs to be made virtual for override, use the
+`make_virtual` plaster rewriter, not a `#define` in a chromium_src header
+override.**
 
 ```cpp
-// ❌ WRONG - patch to add virtual keyword
--  void SomeMethod(...);
-+  virtual void SomeMethod(...);
-
-// ✅ CORRECT - chromium_src define
+// ❌ WRONG - chromium_src define; rewrites every SomeMethod in the TU
 #define SomeMethod virtual SomeMethod
 #include "src/path/to/original_header.h"
 #undef SomeMethod
 ```
 
-Note: This technique does not work when the return type is a pointer or
-reference (e.g., `T* Method()`).
+```yaml
+# ✅ CORRECT - rewrite/path/to/original_header.h.yaml
+substitutions:
+  - description: 'Let BraveSomeClass override SomeMethod.'
+    make_virtual:
+      class_name: SomeClass
+      method_name: SomeMethod
+```
+
+The rewriter also handles what the `#define` could not: a pointer or reference
+return type (`T* Method()`), and a destructor (quote it — `'~SomeClass'`). See
+[PLSTR-003](./plaster.md#PLSTR-003).
 
 ---
 

--- a/docs/best-practices/plaster.md
+++ b/docs/best-practices/plaster.md
@@ -31,11 +31,13 @@ patterns only when you explicitly intend to replace all occurrences.
 
 <a id="PLSTR-002"></a>
 
-## ✅ Use `pattern` for Simple Symbol Replacement, `re_pattern` for Context-Aware Matches
+## ✅ Use `pattern` When the Literal Is Exactly the Replaced Text, `re_pattern` for Context-Aware Matches
 
-**Only use `pattern` for simple matches—generally a single symbol name that you
-want to replace globally.** If you need more context (including whitespace),
-then `re_pattern` is more appropriate.
+**Use `pattern` when the literal is exactly the text being replaced — no leading
+indentation, and no adjacent tokens that are not themselves changing.** That
+covers a bare symbol name and also a complete statement. Once a match needs to
+reach beyond the replaced text (surrounding structure, flexible whitespace,
+neighbouring conditions), `re_pattern` is the right tool.
 
 ```yaml
 # ✅ CORRECT - simple symbol replacement with pattern for all instances of a constant
@@ -45,6 +47,11 @@ replace: 'kNewConstantName'
 # ✅ CORRECT - simple symbol replacement with pattern for all instances of a method call
 pattern: 'ChromiumMethod'
 replace: 'BraveMethod'
+
+# ✅ CORRECT - a whole statement is fine: every token is text being replaced
+pattern: 'return NavigateWebAppUsingParams(nav_params);'
+replace:
+  'return BraveNavigateWebAppUsingParams(&profile_.get(), *params_, nav_params);'
 
 # ✅ CORRECT - re_pattern handles flexible whitespace
 re_pattern: '(^\s+)(ChromiumMethod\(\))'
@@ -58,13 +65,123 @@ replace: '    BraveMethod()'
 re_pattern: '(if\s+\()MyMethod\(\)([\S\s]+?{)'
 replace: '\1BraveMethod()\2'
 
-# ❌ WRONG - pattern includes additional context
-pattern: 'if (MyMethod() && my_bool) {'  # Breaks if upstream changes indentation
+# ❌ WRONG - drags in adjacent tokens that aren't being replaced; breaks if
+# upstream edits the condition or the brace placement
+pattern: 'if (MyMethod() && my_bool) {'
 replace: 'if (BraveMethod() && my_bool) {'
 ```
 
-Using `pattern` for simple symbol names keeps configs readable and maintainable.
-Reserve `re_pattern` for when you need regex features like whitespace matching,
-character classes, or structural patterns.
+The test is not "how long is the literal" but "is every token in it part of what
+I am changing". `return Foo(bar);` passes; `if (Foo() && my_bool) {` does not,
+because `&& my_bool` and the brace can change upstream without affecting the
+rewrite. Reserve `re_pattern` for when you need regex features like flexible
+whitespace, character classes, or structural anchors.
+
+---
+
+<a id="PLSTR-003"></a>
+
+## ❌ Never Use a Function-Rewriting `#define` in New Code — Use a Plaster
+
+**Do not introduce a `#define` in `chromium_src` to redirect a call, rename a
+function, or wrap an upstream body. Use a plaster rewrite instead.** A `#define`
+rewrites _every_ occurrence of the identifier in all sources included after it,
+invisibly and often unintentionally.
+
+```cpp
+// ❌ WRONG - chromium_src/.../web_app_launch_process.cc
+// Silently rewrites every NavigateWebAppUsingParams call in the TU, including
+// ones pulled in by later #includes.
+#define NavigateWebAppUsingParams(nav_params) \
+  NavigateWebAppInContainerUsingParams(&profile_.get(), *params_, nav_params)
+#include <chrome/browser/ui/web_applications/web_app_launch_process.cc>
+```
+
+```yaml
+# ✅ CORRECT - rewrite/chrome/browser/ui/web_applications/web_app_launch_process.cc.yaml
+# The helper (here renamed Brave*) still lives in chromium_src; only the call
+# redirection moves into the plaster.
+substitutions:
+  - description: |
+      Route command line PWA launches through the containers storage partition.
+    regex:
+      pattern: 'return NavigateWebAppUsingParams(nav_params);'
+      replace:
+        'return BraveNavigateWebAppUsingParams(&profile_.get(), *params_,
+        nav_params);'
+```
+
+Only the one intended call is changed, the change is visible in the generated
+patch, and `count` (default `1`) fails loudly if the premise stops holding.
+Symptoms that a `#define` is fighting you: needing to reorder `#include`s so a
+macro does not mangle unrelated declarations, or `#undef`-ing right after the
+include.
+
+This does **not** ban every macro in `chromium_src`. The rule targets macros
+that **redirect a call target or replace/rename a function definition**. Macros
+that merely decorate a declaration remain correct — see
+[CSRC-015](./chromium-src-overrides.md#CSRC-015)
+(`#define SomeMethod virtual SomeMethod`), as do string-ID overrides.
+
+Prefer an AST rewriter (`preempt_function_impl`, `after_function_impl`,
+`add_to_public`, …) over a regex where one fits, and never rename an upstream
+function to `_ChromiumImpl` just to wrap it. See
+[plaster_dos_and_donts.md](../plaster_dos_and_donts.md).
+
+---
+
+<a id="PLSTR-004"></a>
+
+## ✅ Anchor Rewrites on Stable Context and Wildcard the Rest
+
+**A rewrite should match the anchor that carries its intent, and use wildcards
+for surrounding content that may change upstream without affecting the
+rewrite.** Spelling out incidental detail makes the match fail for reasons
+unrelated to its purpose.
+
+```yaml
+# ❌ WRONG - pins the exact current contents of the deps list. Any upstream
+# addition to it breaks the match, for a reason unrelated to the rewrite.
+re_pattern: '(public_deps = \[ "//chrome/browser:browser_public_dependencies" \])'
+
+# ✅ CORRECT - anchors on the target being changed, wildcards the list body
+re_pattern: '(source_set\("web_applications"\).*?\bpublic_deps\s*=\s*\[.*?\])'
+re_flags: [DOTALL]
+replace: '\1\n  public_deps += brave_web_applications_deps'
+```
+
+Name the thing being changed (the target, the function, the switch variable) and
+let `.*?` absorb the rest. See
+[rewrite/chrome/browser/extensions/BUILD.gn.yaml](../../rewrite/chrome/browser/extensions/BUILD.gn.yaml)
+for a real example of this shape.
+
+---
+
+<a id="PLSTR-005"></a>
+
+## ✅ Prefer a Plain `pattern` Over a Regex When the Anchor Is a Literal
+
+**If the anchor is a single literal statement, use `pattern` — do not reach for
+`re_pattern` with escaped punctuation and capture groups to reproduce
+whitespace.**
+
+```yaml
+# ❌ WRONG - regex escaping and a capture group only to preserve indentation
+re_pattern: '\n([^\S\n]*)return NavigateWebAppUsingParams\(nav_params\);'
+replace: |-
+  \n\1return BraveNavigateWebAppUsingParams(&profile_.get(), *params_, nav_params);
+
+# ✅ CORRECT - the literal statement is its own anchor
+pattern: 'return NavigateWebAppUsingParams(nav_params);'
+replace:
+  'return BraveNavigateWebAppUsingParams(&profile_.get(), *params_,
+  nav_params);'
+```
+
+`pattern` escapes the string for you, so there is nothing to get wrong. This is
+the same test as [PLSTR-002](#PLSTR-002): the literal is safe here because every
+token in it is text being replaced. Do not extend it with leading indentation or
+neighbouring tokens that are not changing — that is what reintroduces fragility
+and calls for `re_pattern`.
 
 ---

--- a/docs/best-practices/plaster.md
+++ b/docs/best-practices/plaster.md
@@ -130,9 +130,10 @@ substitutions:
       method_name: UpdateToolbarButtonState
 ```
 
-Prefer an AST rewriter (`preempt_function_impl`, `after_function_impl`,
-`add_to_public`, …) over a regex where one fits, and never rename an upstream
-function to `_ChromiumImpl` just to wrap it. See
+Prefer an AST rewriter over a regex where one fits, and never rename an upstream
+function to `_ChromiumImpl` just to wrap it. Run `plaster --help` to discover
+the available rewriters and `plaster --help <rewriter>` for a specific one's
+full docs. See also [plaster.md](../plaster.md) and
 [plaster_dos_and_donts.md](../plaster_dos_and_donts.md).
 
 ---

--- a/docs/best-practices/plaster.md
+++ b/docs/best-practices/plaster.md
@@ -81,12 +81,11 @@ whitespace, character classes, or structural anchors.
 
 <a id="PLSTR-003"></a>
 
-## ❌ Never Use a Function-Rewriting `#define` in New Code — Use a Plaster
+## ❌ Never Use a Macro to Edit Upstream Code in New Code — Use a Plaster
 
-**Do not introduce a `#define` in `chromium_src` to redirect a call, rename a
-function, or wrap an upstream body. Use a plaster rewrite instead.** A `#define`
-rewrites _every_ occurrence of the identifier in all sources included after it,
-invisibly and often unintentionally.
+**All new uses of a macro to edit upstream code are banned. Use a plaster
+rewrite instead.** A `#define` rewrites _every_ occurrence of the identifier in
+all sources included after it, invisibly and often unintentionally.
 
 ```cpp
 // ❌ WRONG - chromium_src/.../web_app_launch_process.cc
@@ -117,11 +116,19 @@ Symptoms that a `#define` is fighting you: needing to reorder `#include`s so a
 macro does not mangle unrelated declarations, or `#undef`-ing right after the
 include.
 
-This does **not** ban every macro in `chromium_src`. The rule targets macros
-that **redirect a call target or replace/rename a function definition**. Macros
-that merely decorate a declaration remain correct — see
-[CSRC-015](./chromium-src-overrides.md#CSRC-015)
-(`#define SomeMethod virtual SomeMethod`), as do string-ID overrides.
+This covers macros that merely decorate a declaration, too.
+`#define SomeMethod virtual SomeMethod` is banned in new code — use
+`make_virtual`, alongside `drop_final` and `add_friend` where subclassing needs
+them:
+
+```yaml
+# ✅ CORRECT - rewrite/chrome/browser/download/bubble/download_display_controller.h.yaml
+substitutions:
+  - description: 'Let BraveDownloadDisplayController override the button state.'
+    make_virtual:
+      class_name: DownloadDisplayController
+      method_name: UpdateToolbarButtonState
+```
 
 Prefer an AST rewriter (`preempt_function_impl`, `after_function_impl`,
 `add_to_public`, …) over a regex where one fits, and never rename an upstream


### PR DESCRIPTION
## Summary

Captures review feedback from #38964 as enforceable best practices, and fixes a
gap that meant `/review` never surfaced the plaster doc for plaster changes.

**New rules in `plaster.md`:**

- **PLSTR-003** — never use a call-rewriting `#define` in new `chromium_src`
  code; use a plaster. A `#define` rewrites *every* occurrence of the identifier
  in all sources included after it, invisibly. Carve-out preserved for macros
  that only decorate a declaration (CSRC-015 `#define SomeMethod virtual
  SomeMethod`) and string-ID overrides.
- **PLSTR-004** — anchor rewrites on stable context and wildcard the rest, rather
  than pinning list contents that upstream may edit for unrelated reasons.
- **PLSTR-005** — prefer a plain `pattern` over `re_pattern` when the anchor is a
  literal statement.

**Discovery fix:** `plaster.md` was mapped to the `cpp` category, which only
triggers on `.cc/.h/.mm/.cpp`. A plaster-only change (`rewrite/*.yaml`) therefore
loaded only `architecture.md` and `documentation.md` — the plaster rules were
never read. `plaster` is now its own category triggering on `rewrite/`,
`chromium_src/` and `patches/`.

**Also revises the pre-existing PLSTR-002.** It said "only use `pattern` for
... a single symbol name" and marked a full-statement `pattern` as WRONG, which
directly contradicted the fix requested in #38964. Replaced the length-based
guidance with the criterion that actually matters — *is every token in the
literal part of what I am changing* — which also fixes an inaccurate annotation
(`# Breaks if upstream changes indentation` on a pattern containing no
indentation).

## Source

Review comments by @goodov on #38964:

- "do not use defines in new code. use plaster rewrites"
- "rewrites should target known anchors and use wildcards to avoid matching
  content that might change upstream, but is not important to the rewrite itself"
- "I think this can be simplified to a non-regex rewrite ... see
  brave/docs/plaster.md"

## Test plan

- [x] `manage-bp-ids.py --validate` clean for `PLSTR-*` (pre-existing failures in
      `nala.md` / `patches.md` / `coding-standards-apis.md` are untouched)
- [x] A plaster-only change now loads `plaster.md`; a plain `.cc` change no longer
      pulls it in spuriously
- [x] `chunk-best-practices.py` emits all 5 rules into the review pipeline
- [x] Verified PLSTR-004's example against the real
      `chrome/browser/ui/web_applications/BUILD.gn` — `source_set("web_applications")`
      with `public_deps` exists, so the pattern is valid rather than invented
- [x] Cross-checked PLSTR-003 against CSRC-015/CSRC-016 for contradictions
- [x] `pnpm run format` + presubmit clean