### PR TITLE
[recipes] Add `api.step.nest`

### DIFF
--- a/tools/recipes/recipe_modules/brave_core_checkout/examples/full.expected/already_deployed.json
+++ b/tools/recipes/recipe_modules/brave_core_checkout/examples/full.expected/already_deployed.json
@@ -26,6 +26,31 @@
   },
   {
     "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "2",
+      "--filter=blob:none",
+      "--sparse",
+      "--branch",
+      "master",
+      "git@github.com:brave/brave-core.git",
+      "[WORKSPACE]/b/src/brave"
+    ],
+    "name": "clone brave-core (shallow, sparse) (2)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "sparse-checkout",
+      "list"
+    ],
+    "name": "sparse-checkout list (2)"
+  },
+  {
+    "cmd": [
       "npm",
       "--version"
     ],

--- a/tools/recipes/recipe_modules/brave_core_checkout/examples/full.expected/clone.json
+++ b/tools/recipes/recipe_modules/brave_core_checkout/examples/full.expected/clone.json
@@ -31,9 +31,45 @@
       "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "add",
-      "tools/cr/bootstrap"
+      "third_party/node"
     ],
     "name": "sparse-checkout add"
+  },
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "2",
+      "--filter=blob:none",
+      "--sparse",
+      "--branch",
+      "master",
+      "git@github.com:brave/brave-core.git",
+      "[WORKSPACE]/b/src/brave"
+    ],
+    "name": "clone brave-core (shallow, sparse) (2)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "sparse-checkout",
+      "list"
+    ],
+    "name": "sparse-checkout list (2)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "sparse-checkout",
+      "add",
+      "tools/cr/bootstrap"
+    ],
+    "name": "sparse-checkout add (2)"
   },
   {
     "cmd": [

--- a/tools/recipes/recipe_modules/brave_core_checkout/examples/full.expected/reuse.json
+++ b/tools/recipes/recipe_modules/brave_core_checkout/examples/full.expected/reuse.json
@@ -40,9 +40,54 @@
       "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "add",
-      "tools/cr/bootstrap"
+      "third_party/node"
     ],
     "name": "sparse-checkout add"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "fetch",
+      "--depth",
+      "2",
+      "origin",
+      "master"
+    ],
+    "name": "fetch brave-core ref (2)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "checkout",
+      "--force",
+      "FETCH_HEAD"
+    ],
+    "name": "checkout brave-core ref (2)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "sparse-checkout",
+      "list"
+    ],
+    "name": "sparse-checkout list (2)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "sparse-checkout",
+      "add",
+      "tools/cr/bootstrap"
+    ],
+    "name": "sparse-checkout add (2)"
   },
   {
     "cmd": [

--- a/tools/recipes/recipe_modules/brave_core_checkout/examples/full.py
+++ b/tools/recipes/recipe_modules/brave_core_checkout/examples/full.py
@@ -48,6 +48,11 @@ def GenTests(api):
     # Already deployed: the live sparse set already covers both requested
     # paths (`third_party/node` directly, `tools/cr/bootstrap` via its
     # `tools/cr` ancestor), so nothing is re-added.
+    #
+    # `deploy` runs once directly and once more via `bootstrap_on_path`, so the
+    # sparse set is listed twice and each listing is seeded separately -- the
+    # second is `sparse-checkout list (2)`, having been named in the same
+    # namespace as the first.
     yield api.test(
         'already deployed',
         api.path.files('b/src/brave/third_party/node',
@@ -55,7 +60,11 @@ def GenTests(api):
         api.step_data(
             'sparse-checkout list',
             stdout=api.raw_io.output_text('third_party/node\ntools/cr\n')),
+        api.step_data(
+            'sparse-checkout list (2)',
+            stdout=api.raw_io.output_text('third_party/node\ntools/cr\n')),
         api.post_process(post_process.DoesNotRun, 'sparse-checkout add'),
+        api.post_process(post_process.DoesNotRun, 'sparse-checkout add (2)'),
         api.post_process(post_process.MustRun, 'npm version'),
         api.post_process(post_process.StatusSuccess),
     )

--- a/tools/recipes/recipe_modules/step/api.py
+++ b/tools/recipes/recipe_modules/step/api.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
+import contextlib
 import logging
 from pathlib import Path
 import subprocess
@@ -63,6 +64,52 @@ class StepApi(RecipeApi):
         """
         return self._step_stack.active_step
 
+    @contextlib.contextmanager
+    def nest(self, name: str):
+        """Nest the steps run inside the `with` block under a parent step.
+
+        This runs a step of its own, with no command, and names every step run
+        within it under it:
+
+            with api.step.nest('build'):
+                api.step('configure', ['gn', 'gen'])   # `build.configure`
+                api.step('compile', ['ninja'])         # `build.compile`
+
+        Nesting composes, so a nest inside a nest extends the namespace
+        further. Because names are only made distinct within their namespace,
+        two nests may each contain a step of the same name.
+
+        A nest also owns the work spawned inside it: leaving the block waits
+        for any greenlet `futures.spawn` started there, so
+
+            with api.step.nest('fan out'):
+                for url in urls:
+                    api.futures.spawn(fetch, url)
+
+        cannot fall out of the block with fetches still in flight.
+
+        Args:
+            name: The name of this step.
+
+        Yields:
+            The parent step's `StepData`.
+        """
+        assert name, 'invalid empty name'
+
+        parent = self(name, None)
+        # The step just run is the tip, recorded under the right namespace.
+        # Promoting it to a parent is what puts the steps inside the block
+        # under it, rather than beside it, and keeps it open until the block
+        # ends.
+        self._step_stack.make_tip_parent()
+        try:
+            yield parent
+        finally:
+            # Close whatever leaf the block left open, then the parent itself,
+            # which waits for the greenlets spawned inside it.
+            self._step_stack.close_non_parent_step()
+            self._step_stack.pop()
+
     def _runner(self):
         if self._test is None:  # pragma: no cover - production step backend.
             return self._prod_runner_lazy()
@@ -79,7 +126,7 @@ class StepApi(RecipeApi):
     def __call__(
         self,
         name: str,
-        cmd: Sequence[str | Path | Placeholder],
+        cmd: Sequence[str | Path | Placeholder] | None,
         *,
         cwd: str | Path | None = None,
         env: Mapping[str, str] | None = None,
@@ -92,10 +139,14 @@ class StepApi(RecipeApi):
         """Run *cmd* as the step named *name*.
 
         Args:
-            name: Human-readable step name, logged before the command runs.
+            name: Human-readable step name, logged before the command runs. It
+                is namespaced by any enclosing `nest`, and made distinct if the
+                same name has already been used in that namespace.
             cmd: The program and its arguments as a sequence; each element is
                 either a `Placeholder` (rendered into arguments just before the
-                step runs) or stringified (so `Path` objects are fine).
+                step runs) or stringified (so `Path` objects are fine). `None`
+                runs no subprocess, recording a step that exists only to say
+                something happened.
             cwd: Working directory override for the subprocess; defaults to
                 `context.cwd` (and, when neither is set, the engine's cwd).
             env: Whole-variable environment overrides layered on top of
@@ -124,9 +175,11 @@ class StepApi(RecipeApi):
             subprocess.CalledProcessError: If `check` and the process fails.
             RuntimeError: On Windows, if the command cannot be resolved.
         """
-        # The previous leaf step stays open until now, so `active_result` could
-        # reach it; starting another step closes it.
-        self._step_stack.close_non_parent_step()
+        # Namespaces the step under any enclosing `nest` and makes a repeated
+        # name distinct. Also closes the previous leaf step, which stayed open
+        # so `active_result` could reach it.
+        name_tokens = self._step_stack.record_step_name(name)
+        name = '.'.join(name_tokens)
 
         runner = self._runner()
         test_data = runner.step_test_data(name, step_test_data)
@@ -144,7 +197,7 @@ class StepApi(RecipeApi):
 
         rendered_cmd: list[str] = []
         cmd_placeholders: list[Placeholder] = []
-        for arg in cmd:
+        for arg in cmd or ():
             if isinstance(arg, Placeholder):
                 rendered_cmd.extend(arg.render(_test_for(arg)))
                 cmd_placeholders.append(arg)
@@ -191,7 +244,7 @@ class StepApi(RecipeApi):
         result.finalize()
         # Pushed before the failure is raised, so a recipe can still read the
         # failing step's result from `active_result` in a `finally`.
-        self._step_stack.push(result)
+        self._step_stack.push(result, name_tokens)
 
         if check and retcode != 0:
             raise subprocess.CalledProcessError(retcode,

--- a/tools/recipes/recipe_modules/step/tests/nest.expected/nest.json
+++ b/tools/recipes/recipe_modules/step/tests/nest.expected/nest.json
@@ -1,0 +1,93 @@
+[
+  {
+    "cmd": [],
+    "name": "build"
+  },
+  {
+    "cmd": [
+      "gn",
+      "gen"
+    ],
+    "name": "build.configure"
+  },
+  {
+    "cmd": [
+      "ninja"
+    ],
+    "name": "build.compile"
+  },
+  {
+    "cmd": [],
+    "name": "package"
+  },
+  {
+    "cmd": [
+      "ninja",
+      "package"
+    ],
+    "name": "package.compile"
+  },
+  {
+    "cmd": [],
+    "name": "package.sign"
+  },
+  {
+    "cmd": [
+      "codesign"
+    ],
+    "name": "package.sign.compile"
+  },
+  {
+    "cmd": [
+      "echo",
+      "first"
+    ],
+    "name": "twice"
+  },
+  {
+    "cmd": [
+      "echo",
+      "second"
+    ],
+    "name": "twice (2)"
+  },
+  {
+    "cmd": [],
+    "name": "fan out"
+  },
+  {
+    "cmd": [
+      "fetch",
+      "0"
+    ],
+    "name": "fan out.fetch 0"
+  },
+  {
+    "cmd": [
+      "fetch",
+      "1"
+    ],
+    "name": "fan out.fetch 1"
+  },
+  {
+    "cmd": [
+      "echo",
+      "joined"
+    ],
+    "name": "after"
+  },
+  {
+    "cmd": [],
+    "name": "outer"
+  },
+  {
+    "cmd": [
+      "echo",
+      "outer"
+    ],
+    "name": "outer.reports"
+  },
+  {
+    "name": "$result"
+  }
+]

--- a/tools/recipes/recipe_modules/step/tests/nest.py
+++ b/tools/recipes/recipe_modules/step/tests/nest.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `api.step.nest`: namespacing, dedup, and owning spawned work."""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['futures', 'step']
+
+
+def RunSteps(api):
+    # Steps inside the block are named under the nest.
+    with api.step.nest('build'):
+        api.step('configure', ['gn', 'gen'])
+        api.step('compile', ['ninja'])
+
+    # Nesting composes, and a name is only made distinct within its own
+    # namespace -- so each nest may hold its own `compile`.
+    with api.step.nest('package'):
+        api.step('compile', ['ninja', 'package'])
+        with api.step.nest('sign'):
+            api.step('compile', ['codesign'])
+
+    # Repeating a name in one namespace is disambiguated rather than collapsed.
+    api.step('twice', ['echo', 'first'])
+    api.step('twice', ['echo', 'second'])
+
+    # A nest owns the work spawned inside it: leaving the block waits for it,
+    # so `after` cannot run while a fetch is still in flight.
+    with api.step.nest('fan out'):
+        for i in range(2):
+            api.futures.spawn(api.step, f'fetch {i}', ['fetch', str(i)])
+    api.step('after', ['echo', 'joined'])
+
+    # The nest step is itself a step, and is what `active_result` sees inside
+    # the block before anything else has run there.
+    with api.step.nest('outer') as parent:
+        api.step('reports', ['echo', parent.name])
+
+
+def GenTests(api):
+    yield api.test(
+        'nest',
+        # The nest itself is recorded, with no command.
+        api.post_process(post_process.MustRun, 'build'),
+        api.post_process(post_process.MustRun, 'build.configure',
+                         'build.compile'),
+        # Same leaf name under two different namespaces, plus a deeper nest.
+        api.post_process(post_process.MustRun, 'package.compile',
+                         'package.sign.compile'),
+        # Repeated name in one namespace gets suffixed.
+        api.post_process(post_process.MustRun, 'twice', 'twice (2)'),
+        # Spawned work is namespaced under the nest that spawned it, and is
+        # joined before the nest exits.
+        api.post_process(post_process.MustRun, 'fan out.fetch 0',
+                         'fan out.fetch 1', 'after'),
+        # The parent's own name is the namespaced one.
+        api.post_process(post_process.StepCommandContains, 'outer.reports',
+                         ['outer']),
+        api.post_process(post_process.StatusSuccess),
+    )

--- a/tools/recipes/recipes/toolchains/rust/package_rust.expected/mac.json
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.expected/mac.json
@@ -217,6 +217,42 @@
   },
   {
     "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "2",
+      "--filter=blob:none",
+      "--sparse",
+      "--branch",
+      "master",
+      "git@github.com:brave/brave-core.git",
+      "[WORKSPACE]/b/src/brave"
+    ],
+    "name": "clone brave-core (shallow, sparse) (2)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "sparse-checkout",
+      "list"
+    ],
+    "name": "sparse-checkout list (2)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "sparse-checkout",
+      "add",
+      "tools/cr/toolchains"
+    ],
+    "name": "sparse-checkout add (2)"
+  },
+  {
+    "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "[WORKSPACE]/b/src/brave/tools/cr/toolchains/ephemeral_xcode.py",
       "--sdk-version",

--- a/tools/recipes/recipes/tools/node/package_node_modules.expected/basic.json
+++ b/tools/recipes/recipes/tools/node/package_node_modules.expected/basic.json
@@ -31,7 +31,8 @@
       "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "add",
-      "tools/cr/bootstrap"
+      "third_party/node",
+      "tools/cr/toolchains"
     ],
     "name": "sparse-checkout add"
   },
@@ -51,6 +52,42 @@
       "gclient"
     ],
     "name": "verify gclient"
+  },
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "2",
+      "--filter=blob:none",
+      "--sparse",
+      "--branch",
+      "master",
+      "git@github.com:brave/brave-core.git",
+      "[WORKSPACE]/b/src/brave"
+    ],
+    "name": "clone brave-core (shallow, sparse) (2)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "sparse-checkout",
+      "list"
+    ],
+    "name": "sparse-checkout list (2)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "sparse-checkout",
+      "add",
+      "tools/cr/bootstrap"
+    ],
+    "name": "sparse-checkout add (2)"
   },
   {
     "cmd": [

--- a/tools/recipes/recipes/tools/node/package_node_modules.expected/reuse_checkout.json
+++ b/tools/recipes/recipes/tools/node/package_node_modules.expected/reuse_checkout.json
@@ -40,7 +40,8 @@
       "[WORKSPACE]/b/src/brave",
       "sparse-checkout",
       "add",
-      "tools/cr/bootstrap"
+      "third_party/node",
+      "tools/cr/toolchains"
     ],
     "name": "sparse-checkout add"
   },
@@ -60,6 +61,51 @@
       "gclient"
     ],
     "name": "verify gclient"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "fetch",
+      "--depth",
+      "2",
+      "origin",
+      "master"
+    ],
+    "name": "fetch brave-core ref (2)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "checkout",
+      "--force",
+      "FETCH_HEAD"
+    ],
+    "name": "checkout brave-core ref (2)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "sparse-checkout",
+      "list"
+    ],
+    "name": "sparse-checkout list (2)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "sparse-checkout",
+      "add",
+      "tools/cr/bootstrap"
+    ],
+    "name": "sparse-checkout add (2)"
   },
   {
     "cmd": [

--- a/tools/recipes/simulation.py
+++ b/tools/recipes/simulation.py
@@ -145,6 +145,10 @@ class SubprocessStepRunner:
         import shutil
 
         cmd = [str(arg) for arg in step['cmd']]
+        if not cmd:
+            # A command-less step (`api.step(name, None)`, and so every nest
+            # step) records that something happened without running anything.
+            return 0
         if platform.system() == 'Windows':
             # Resolve to an absolute path to avoid bat-file name mismatches
             # (e.g. `gclient` vs `gclient.bat`) without using `shell=True`.

--- a/tools/recipes/step_stack.py
+++ b/tools/recipes/step_stack.py
@@ -24,9 +24,17 @@ class _ActiveStep:
 
     # The step's result, or None for the synthetic root entry.
     step_data: StepData | None = attr.ib()
+
+    # The step's name, as the tuple of nesting tokens leading to it, so a step
+    # named `child` inside a nest named `parent` is `('parent', 'child')`.
+    # Empty for the root entry. This is the namespace a step run inside this one
+    # is named under.
+    name_tokens: tuple[str, ...] = attr.ib()
+
     # Whether this is a parent nesting step, rather than a real (leaf) step.
     # Only the tip of a stack may be False.
     is_parent: bool = attr.ib()
+
     # Greenlets spawned while this entry was the innermost parent.
     greenlets: list = attr.ib(factory=list)
 
@@ -69,12 +77,17 @@ class StepStack:
 
     def __init__(self) -> None:
         self._storage = _Steps()
+        # namespace tokens -> {requested step name: times used}, so a repeated
+        # name within one namespace can be given a distinct one. Shared by the
+        # whole run rather than per greenlet, so concurrent steps cannot end up
+        # with the same name.
+        self._step_names: dict[tuple[str, ...], dict[str, int]] = {}
 
     @property
     def _stack(self) -> list[_ActiveStep]:
         """This greenlet's stack, seeded with the root entry on first use."""
         if self._storage.steps is None:
-            self._storage.steps = [_ActiveStep(None, True)]
+            self._storage.steps = [_ActiveStep(None, (), True)]
         return self._storage.steps
 
     @property
@@ -82,9 +95,44 @@ class StepStack:
         """The tip's step data; None while the tip is the root entry."""
         return self._stack[-1].step_data
 
-    def push(self, step_data: StepData, is_parent: bool = False) -> None:
+    def record_step_name(self, name: str) -> tuple[str, ...]:
+        """Reserve *name* in the current namespace, and return its tokens.
+
+        The namespace is whatever nest the calling greenlet is inside, so a
+        step's tokens are that nest's tokens plus its own name. A name already
+        used in the same namespace gets ` (2)`, ` (3)` and so on appended,
+        rather than silently becoming the same step twice.
+
+        Side effect: closes the tip if it is not a parent, so the namespace is
+        read from the enclosing nest rather than from the step that just ran.
+        """
+        self.close_non_parent_step()
+
+        namespace = self._stack[-1].name_tokens
+        used = self._step_names.setdefault(namespace, {})
+        count = used.setdefault(name, 0)
+        used[name] += 1
+        return namespace + (name if not count else f'{name} ({count + 1})', )
+
+    def push(self,
+             step_data: StepData,
+             name_tokens: tuple[str, ...],
+             is_parent: bool = False) -> None:
         """Make *step_data* the tip of this greenlet's stack."""
-        self._stack.append(_ActiveStep(step_data, is_parent))
+        self._stack.append(_ActiveStep(step_data, name_tokens, is_parent))
+
+    def make_tip_parent(self) -> None:
+        """Turn the tip into a parent nesting step.
+
+        A nest runs an ordinary (command-less) step first, then promotes it, so
+        the steps that follow are named under it and it stays open until the
+        nest ends.
+        """
+        self._stack[-1].is_parent = True
+
+    def pop(self) -> None:
+        """Close the tip and drop it, leaving the entry beneath it as the tip."""
+        self._stack.pop().close()
 
     def close_non_parent_step(self) -> None:
         """Close the tip, unless it is a parent nesting step.


### PR DESCRIPTION
A nest runs a step of its own with no command, and names every step
inside it under that step:

```py
    with api.step.nest('build'):
        api.step('configure', ['gn', 'gen'])   # runs as `build.configure`
        api.step('compile', ['ninja'])         # runs as `build.compile`
```

Nests compose, and a name is only made distinct within its own
namespace, so two nests may each hold a step of the same name. A
repeated name in one namespace now gets ` (2)` appended instead of
silently becoming the same step twice.

A nest also owns the work spawned inside it, so this cannot leave
fetches in flight past the block:

```py
    with api.step.nest('fan out'):
        for url in urls:
            api.futures.spawn(fetch, url)
```

`api.step(name, None)` runs no subprocess, recording a step that exists
only to say something happened. That is what a nest step is, and it is
useful on its own.

Finally a lot of existing expectations were affected, because
deduplication turned up steps that had been hidden: `deploy` runs once
directly and once through `bootstrap_on_path`, so several
`brave_core_checkout` steps ran twice, and the expectation kept only the
last of each.

Bug: https://github.com/brave/brave-browser/issues/56748
