### PR TITLE
Account: add Email Aliases description with a learn-more link to Brave Account

### DIFF
--- a/browser/resources/settings/getting_started_page/brave_account_logged_out_row.html.ts
+++ b/browser/resources/settings/getting_started_page/brave_account_logged_out_row.html.ts
@@ -83,8 +83,13 @@ export function getHtml(this: BraveAccountLoggedOutRowElement) {
                      .SETTINGS_BRAVE_ACCOUNT_LOGGED_OUT_ROW_TITLE)}
           </div>
           <div class="description">
-            ${this.i18n(
-                BraveAccountSettingsStrings.BRAVE_ACCOUNT_DESCRIPTION)}
+            <localized-link
+                .localizedString=${this.i18nAdvanced(
+                  BraveAccountSettingsStrings
+                       .SETTINGS_BRAVE_ACCOUNT_LOGGED_OUT_ROW_DESCRIPTION,
+                  {tags: ['a']})}
+                .linkUrl=${this.i18n('braveAccountLearnMoreURL')}>
+            </localized-link>
           </div>
         </div>
         <leo-button kind="filled"

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -147,6 +147,9 @@ constexpr char16_t kPsstLearnMoreUrl[] =
     u"https://support.brave.app/hc/en-us/articles/47405731650957";
 #endif
 
+constexpr char16_t kBraveAccountLearnMoreURL[] =
+    u"https://support.brave.app/hc/en-us/articles/45530506862349";
+
 void BraveAddCommonStrings(content::WebUIDataSource* html_source,
                            Profile* profile) {
   webui::LocalizedString localized_strings[] = {
@@ -1303,6 +1306,8 @@ void BraveAddEmailAliasesStrings(content::WebUIDataSource* html_source) {
 void BraveAddBraveAccountStrings(content::WebUIDataSource* html_source) {
   if (brave_account::features::IsBraveAccountEnabled()) {
     html_source->AddLocalizedStrings(webui::kBraveAccountSettingsStrings);
+    html_source->AddString("braveAccountLearnMoreURL",
+                           kBraveAccountLearnMoreURL);
   }
 }
 

--- a/components/brave_account/resources/brave_account_strings.grdp
+++ b/components/brave_account/resources/brave_account_strings.grdp
@@ -222,9 +222,19 @@
   </message>
 
   <!-- Common: -->
-  <message name="IDS_BRAVE_ACCOUNT_DESCRIPTION" desc="Description explaining the benefits of having a Brave Account" formatter_data="webui=BraveAccount,BraveAccountSettings">
-    A Brave account will allow you to easily access Brave services.
-  </message>
+  <if expr="not is_android and not is_ios">
+    <message name="IDS_BRAVE_ACCOUNT_DESCRIPTION" desc="Description explaining the benefits of having a Brave Account" formatter_data="webui=BraveAccount">
+      A Brave account lets you create and manage your email aliases.
+    </message>
+    <message name="IDS_SETTINGS_BRAVE_ACCOUNT_LOGGED_OUT_ROW_DESCRIPTION" desc="Description explaining the benefits of having a Brave Account, shown in the Get started settings page. Ends with a link to a support article." formatter_data="webui=BraveAccountSettings">
+      A Brave account lets you create and manage your email aliases. <ph name="BEGIN_LINK">&lt;a&gt;</ph>Learn more<ph name="END_LINK">&lt;/a&gt;</ph>
+    </message>
+  </if>
+  <if expr="is_android or is_ios">
+    <message name="IDS_BRAVE_ACCOUNT_DESCRIPTION" desc="Description explaining the benefits of having a Brave Account" formatter_data="webui=BraveAccount">
+      A Brave account will allow you to easily access Brave services.
+    </message>
+  </if>
   <message name="IDS_BRAVE_ACCOUNT_BACK_BUTTON_LABEL" desc="Label for the back button" formatter_data="webui=BraveAccount">
     Go back
   </message>


### PR DESCRIPTION
The Brave Account description now mentions Email Aliases on desktop. The `brave://settings` row additionally links to a support article; the `brave://account` dialogs keep the plain text (no learn-more link).

Mobile keeps the previous wording — its logged-out settings row shows no description at all, so only the `brave://account` dialogs are affected there.

<details>
<summary><strong>Screenshots of expected string change</strong></summary>

| brave://settings | Create or Login screen |
|:---:|:---:|
| ![Desktop Screenshot](https://github.com/user-attachments/assets/0305a096-04a4-4d46-9737-d69fe44c8ddd) | ![Settings View](https://github.com/user-attachments/assets/8c8f0109-5f15-43df-8440-98ca7e5d7259) |

| Create screen | Login screen |
|:---:|:---:|
| ![Dialog View 1](https://github.com/user-attachments/assets/c4dfaf07-1c64-40a1-93f5-b3c9dee27cf9) | ![Dialog View 2](https://github.com/user-attachments/assets/8f7f2147-09a8-4982-96c5-6568263dab30) |

</details>


<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58144

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
