### PR TITLE
[VPN] Fix support-ticket Guardian API call in VPN v1

### DIFF
--- a/components/brave_vpn/browser/api/brave_vpn_api_helper.cc
+++ b/components/brave_vpn/browser/api/brave_vpn_api_helper.cc
@@ -99,7 +99,7 @@ base::DictValue GetValueWithTicketInfos(
   // add subscriber credential to the email body.
   std::string body_with_credential =
       body + "\n\nsubscriber-credential: " + subscriber_credential +
-      "\npayment-validation-method: brave-premium";
+      "\npayment-validation-method: brave-premium\ntimezone: " + timezone;
 
   base::TrimWhitespaceASCII(email, base::TRIM_ALL, &email_trimmed);
   base::TrimWhitespaceASCII(subject, base::TRIM_ALL, &subject_trimmed);
@@ -111,7 +111,8 @@ base::DictValue GetValueWithTicketInfos(
   dict.Set(kSupportTicketSubjectKey, subject_trimmed);
   dict.Set(kSupportTicketSupportTicketKey, base::Base64Encode(body_trimmed));
   dict.Set(kSupportTicketPartnerClientIdKey, "com.brave.browser");
-  dict.Set(kSupportTicketTimezoneKey, timezone);
+  dict.Set(kSupportTicketSubscriberCredential, subscriber_credential);
+  dict.Set(kSupportTicketPaymentValidationMethodKey, "brave-premium");
 
   return dict;
 }

--- a/components/brave_vpn/browser/api/brave_vpn_api_helper_unittest.cc
+++ b/components/brave_vpn/browser/api/brave_vpn_api_helper_unittest.cc
@@ -24,16 +24,23 @@ TEST(BraveVPNAPIHelperTest, TicketInfoTest) {
   const auto support_ticket_encoded =
       *ticket_value.FindString(kSupportTicketSupportTicketKey);
   EXPECT_TRUE(!support_ticket_encoded.empty());
-  auto* timezone = ticket_value.FindString(kSupportTicketTimezoneKey);
-  ASSERT_TRUE(timezone);
-  EXPECT_EQ(*timezone, "USA/Boston");
+  auto* subscriber_credential =
+      ticket_value.FindString(kSupportTicketSubscriberCredential);
+  ASSERT_TRUE(subscriber_credential);
+  EXPECT_EQ(*subscriber_credential, "credential");
+  auto* payment_validation_method =
+      ticket_value.FindString(kSupportTicketPaymentValidationMethodKey);
+  ASSERT_TRUE(payment_validation_method);
+  EXPECT_EQ(*payment_validation_method, "brave-premium");
+
   // Check body contents
   std::string support_ticket_decoded;
   EXPECT_TRUE(
       base::Base64Decode(support_ticket_encoded, &support_ticket_decoded));
   const std::string expected_support_ticket =
       "Love the Brave VPN!\n\nsubscriber-credential: "
-      "credential\npayment-validation-method: brave-premium";
+      "credential\npayment-validation-method: brave-premium\ntimezone: "
+      "USA/Boston";
   EXPECT_EQ(expected_support_ticket, support_ticket_decoded);
 }
 

--- a/components/brave_vpn/common/brave_vpn_constants.h
+++ b/components/brave_vpn/common/brave_vpn_constants.h
@@ -40,7 +40,10 @@ inline constexpr char kSupportTicketEmailKey[] = "email";
 inline constexpr char kSupportTicketSubjectKey[] = "subject";
 inline constexpr char kSupportTicketSupportTicketKey[] = "support-ticket";
 inline constexpr char kSupportTicketPartnerClientIdKey[] = "partner-client-id";
-inline constexpr char kSupportTicketTimezoneKey[] = "timezone";
+inline constexpr char kSupportTicketSubscriberCredential[] =
+    "subscriber-credential";
+inline constexpr char kSupportTicketPaymentValidationMethodKey[] =
+    "payment-validation-method";
 
 inline constexpr char kVpnHost[] = "connect-api.guardianapp.com";
 inline constexpr char kServerRegionsWithCities[] =


### PR DESCRIPTION
Fixes V1 code path for "/api/v1.2/partners/support-ticket" API call. The following changes are made, as per discussion with Guardian:
- "subscriber-credential" and "payment-validation-method" are now replicated in JSON, in addition to the request body;
- "timezone" is moved to the request body from JSON value (which was never supported by the Guardian's API request schema).

Resolves https://github.com/brave/brave-browser/issues/58136

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
