### PR TITLE
[iOS] Retain QuickView navigations to history

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -153,6 +153,7 @@ extension BrowserViewController: TabManagerDelegate {
         profile: tab.profile,
         syncAPI: profileController.syncAPI,
         sendTabAPI: profileController.sendTabAPI,
+        historyAPI: profileController.historyAPI,
         onOpenInNewTab: { [weak self] request, isPrivateMode in
           guard let self else { return }
           self.tabManager.addTabAndSelect(

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/HistoryTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/HistoryTabHelper.swift
@@ -5,7 +5,7 @@
 
 import BraveCore
 import Shared
-@_spi(ChromiumWebViewAccess) import Web
+import Web
 
 extension TabDataValues {
   private struct HistoryTabHelperKey: TabDataKey {
@@ -21,6 +21,7 @@ public class HistoryTabHelper: TabObserver {
 
   private weak var tab: (any TabState)?
   private let historyAPI: BraveHistoryAPI
+  private var lastRecordedTitle: String?
 
   public init(
     tab: some TabState,
@@ -57,7 +58,8 @@ public class HistoryTabHelper: TabObserver {
   public func tabDidChangeTitle(_ tab: some TabState) {
     guard let title = (tab.title?.isEmpty == true ? tab.visibleURL?.absoluteString : tab.title)
     else { return }
-    if !title.isEmpty && title != tab.lastTitle {
+    if !title.isEmpty && title != lastRecordedTitle {
+      lastRecordedTitle = title
       recordHistoryIfNeeded(for: tab)
     }
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/HistoryTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/HistoryTabHelper.swift
@@ -1,0 +1,68 @@
+// Copyright 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveCore
+import Shared
+@_spi(ChromiumWebViewAccess) import Web
+
+extension TabDataValues {
+  private struct HistoryTabHelperKey: TabDataKey {
+    static var defaultValue: HistoryTabHelper?
+  }
+  public var historyTabHelper: HistoryTabHelper? {
+    get { self[HistoryTabHelperKey.self] }
+    set { self[HistoryTabHelperKey.self] = newValue }
+  }
+}
+
+public class HistoryTabHelper: TabObserver {
+
+  private weak var tab: (any TabState)?
+  private let historyAPI: BraveHistoryAPI
+
+  public init(
+    tab: some TabState,
+    historyAPI: BraveHistoryAPI
+  ) {
+    self.tab = tab
+    self.historyAPI = historyAPI
+    tab.addObserver(self)
+  }
+
+  private func recordHistoryIfNeeded(for tab: some TabState) {
+    guard let url = tab.visibleURL else { return }
+    guard !url.isNewTabURL,
+      !InternalURL.isValid(url: url) || url.isInternalURL(for: .readermode),
+      !url.isFileURL,
+      !url.isInternalURL(for: .readermode)
+    else { return }
+    guard !tab.isPrivate else { return }
+    historyAPI.add(url: url, title: tab.title ?? "", dateAdded: Date())
+  }
+
+  // MARK: - TabObserver
+
+  public func tabDidFinishNavigation(_ tab: some TabState) {
+    recordHistoryIfNeeded(for: tab)
+  }
+
+  public func tabDidUpdateURL(_ tab: some TabState) {
+    if tab.visibleURL?.origin == tab.previousCommittedURL?.origin {
+      recordHistoryIfNeeded(for: tab)
+    }
+  }
+
+  public func tabDidChangeTitle(_ tab: some TabState) {
+    guard let title = (tab.title?.isEmpty == true ? tab.visibleURL?.absoluteString : tab.title)
+    else { return }
+    if !title.isEmpty && title != tab.lastTitle {
+      recordHistoryIfNeeded(for: tab)
+    }
+  }
+
+  public func tabWillBeDestroyed(_ tab: some TabState) {
+    tab.removeObserver(self)
+  }
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
@@ -23,6 +23,7 @@ class QuickViewController: UIViewController {
   private let profile: any Profile
   private let syncAPI: BraveSyncAPI
   private let sendTabAPI: BraveSendTabAPI
+  private let historyAPI: BraveHistoryAPI
   private let toolbarViewModel: QuickViewToolbarModel
   private lazy var toolbarHostingController = UIHostingController(
     rootView: QuickViewToolbarView(viewModel: toolbarViewModel)
@@ -60,6 +61,7 @@ class QuickViewController: UIViewController {
     profile: any Profile,
     syncAPI: BraveSyncAPI,
     sendTabAPI: BraveSendTabAPI,
+    historyAPI: BraveHistoryAPI,
     onOpenInNewTab: ((URLRequest, Bool) -> Void)?,
     onOpenInNewWindow: ((URL, Bool) -> Void)?,
     onAttachTab: ((any TabState) -> Void)?
@@ -68,6 +70,7 @@ class QuickViewController: UIViewController {
     self.profile = profile
     self.syncAPI = syncAPI
     self.sendTabAPI = sendTabAPI
+    self.historyAPI = historyAPI
     self.toolbarViewModel = QuickViewToolbarModel(
       url: url,
       isPrivate: profile.isOffTheRecord
@@ -134,6 +137,7 @@ class QuickViewController: UIViewController {
     tab.readerMode?.onReaderModeDisplayed = { [weak self] in
       self?.showReaderModeBar()
     }
+    tab.historyTabHelper = .init(tab: tab, historyAPI: historyAPI)
     tab.createWebView()
     tab.delegate = self
     tab.webViewProxy?.scrollView?.layer.masksToBounds = true
@@ -181,6 +185,7 @@ class QuickViewController: UIViewController {
           guard let self, let currentTab = self.currentTab else { return }
           currentTab.removeObserver(self.toolbarViewModel)
           currentTab.removeObserver(self)
+          currentTab.historyTabHelper = nil
           self.onAttachTab?(currentTab)
         }
       case .share:
@@ -556,6 +561,7 @@ extension QuickViewController: TabDelegate {
       guard let self, let currentTab = self.currentTab else { return }
       currentTab.removeObserver(self.toolbarViewModel)
       currentTab.removeObserver(self)
+      currentTab.historyTabHelper = nil
       self.onAttachTab?(currentTab)
       self.onOpenInNewTab?(request, profile.isOffTheRecord)
     }


### PR DESCRIPTION
QuickView tab was created outside TabManager, so none of its navigations reached BrowserViewController's history recording path. Add a HistoryTabHelper, following the existing tab-helper pattern, to record history directly for QuickView's tab, and detach it when the tab is promoted to a real tab to avoid double-recording.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58115

Test:
1. enable QuickView
2. search anything in search.brave.com or Ask Leo
3. clear history
4. enter QuickView mode by tapping any search result (url A)
5. tap any link navigation within QuickView (url B)
6. tap `open in tab` button to promote url B from QuickView to regular tab
7. verify in History. you should see url A and url B

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
