### PR TITLE
`//chrome/browser/history_embeddings` 🩹

### DIFF
--- a/chromium_src/chrome/browser/history_embeddings/history_embeddings_service_factory.cc
+++ b/chromium_src/chrome/browser/history_embeddings/history_embeddings_service_factory.cc
@@ -9,15 +9,6 @@
 
 #if BUILDFLAG(ENABLE_LOCAL_AI)
 #include "brave/browser/history_embeddings/brave_history_embeddings_service.h"
-
-// Swap Chrome's service for Brave's concrete subclass. Brave overrides
-// OnPassageVisibilityCalculated to synthesize a passing visibility score
-// since Brave doesn't use PageContentAnnotationsService.
-#define ChromeHistoryEmbeddingsService BraveHistoryEmbeddingsService
 #endif
 
 #include <chrome/browser/history_embeddings/history_embeddings_service_factory.cc>
-
-#if BUILDFLAG(ENABLE_LOCAL_AI)
-#undef ChromeHistoryEmbeddingsService
-#endif

--- a/chromium_src/chrome/browser/history_embeddings/history_embeddings_utils.cc
+++ b/chromium_src/chrome/browser/history_embeddings/history_embeddings_utils.cc
@@ -3,16 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-// Gate IsHistoryEmbeddingsFeatureEnabled() on the local-state
-// `kBraveLocalAIEnabled` master switch (Brave Origin Settings "Local AI"
-// toggle) so every upstream consumer that reaches the feature through this
-// chokepoint — model component installer, side bar toggle visibility,
-// history embeddings service factory, etc. — folds off when the master
-// switch is off. IsHistoryEmbeddingsEnabledForProfile() is additionally
-// gated on the per-profile `kBraveHistoryEmbeddingsEnabled` pref backing
-// the chrome://history side bar toggle. IsHistoryEmbeddingsSettingVisible()
-// is forced to false so the chrome://settings/ai History Search entry is
-// not surfaced; the per-profile toggle lives on chrome://history.
+#include "chrome/browser/history_embeddings/history_embeddings_utils.h"
+
 #include "brave/components/local_ai/buildflags/buildflags.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/browser_process.h"
@@ -24,36 +16,28 @@
 #include "brave/components/local_ai/core/pref_names.h"
 #endif
 
-#define IsHistoryEmbeddingsFeatureEnabled \
-  IsHistoryEmbeddingsFeatureEnabled_ChromiumImpl
-#define IsHistoryEmbeddingsEnabledForProfile \
-  IsHistoryEmbeddingsEnabledForProfile_ChromiumImpl
-#define IsHistoryEmbeddingsSettingVisible \
-  IsHistoryEmbeddingsSettingVisible_ChromiumImpl
-
-#include <chrome/browser/history_embeddings/history_embeddings_utils.cc>
-
-#undef IsHistoryEmbeddingsFeatureEnabled
-#undef IsHistoryEmbeddingsEnabledForProfile
-#undef IsHistoryEmbeddingsSettingVisible
-
 namespace history_embeddings {
 
-bool IsHistoryEmbeddingsFeatureEnabled() {
+namespace {
+
+// Whether IsHistoryEmbeddingsFeatureEnabled() should short-circuit to false
+// ahead of upstream's own check, per the Brave Origin Settings "Local AI"
+// master switch.
+bool ShouldForceHistoryEmbeddingsFeatureDisabled() {
 #if BUILDFLAG(ENABLE_LOCAL_AI)
   PrefService* local_state =
       g_browser_process ? g_browser_process->local_state() : nullptr;
-  if (local_state &&
-      !local_state->GetBoolean(local_ai::prefs::kBraveLocalAIEnabled)) {
-    return false;
-  }
-  return IsHistoryEmbeddingsFeatureEnabled_ChromiumImpl();
+  return local_state &&
+         !local_state->GetBoolean(local_ai::prefs::kBraveLocalAIEnabled);
 #else
-  return false;
-#endif
+  return true;
+#endif  // BUILDFLAG(ENABLE_LOCAL_AI)
 }
 
-bool IsHistoryEmbeddingsEnabledForProfile(Profile* profile) {
+// Replaces IsHistoryEmbeddingsEnabledForProfile()'s upstream body: gates it on
+// the per-profile kBraveHistoryEmbeddingsEnabled pref backing the
+// chrome://history side bar toggle.
+bool ComputeHistoryEmbeddingsEnabledForProfile(Profile* profile) {
 #if BUILDFLAG(ENABLE_LOCAL_AI)
   if (!IsHistoryEmbeddingsFeatureEnabled()) {
     return false;
@@ -62,11 +46,25 @@ bool IsHistoryEmbeddingsEnabledForProfile(Profile* profile) {
       local_ai::prefs::kBraveHistoryEmbeddingsEnabled);
 #else
   return false;
-#endif
+#endif  // BUILDFLAG(ENABLE_LOCAL_AI)
 }
 
-bool IsHistoryEmbeddingsSettingVisible(Profile* profile) {
-  return false;
-}
+}  // namespace
+
+}  // namespace history_embeddings
+
+#include <chrome/browser/history_embeddings/history_embeddings_utils.cc>
+
+namespace history_embeddings {
+
+namespace {
+
+// kEnabledByDefaultForDesktopOnly is left unused because we disable
+// `kLaunchedHistoryEmbeddings` with a plaster, so we suppress the unused
+// variable warning with this.
+[[maybe_unused]] constexpr auto& kUnusedEnabledByDefaultForDesktopOnly =
+    kEnabledByDefaultForDesktopOnly;
+
+}  // namespace
 
 }  // namespace history_embeddings

--- a/patches/chrome-browser-history_embeddings-history_embeddings_service_factory.cc.patch
+++ b/patches/chrome-browser-history_embeddings-history_embeddings_service_factory.cc.patch
@@ -1,0 +1,34 @@
+diff --git a/chrome/browser/history_embeddings/history_embeddings_service_factory.cc b/chrome/browser/history_embeddings/history_embeddings_service_factory.cc
+index 3b67ca1f8f84484016bfab9f4ed6fe36efc9f3cc..3f940b3a27a85a42b1ae408182281d0a7dc83c01 100644
+--- a/chrome/browser/history_embeddings/history_embeddings_service_factory.cc
++++ b/chrome/browser/history_embeddings/history_embeddings_service_factory.cc
+@@ -101,7 +101,13 @@ std::unique_ptr<KeyedService> HistoryEmbeddingsServiceFactory::
+     return nullptr;
+   }
+ 
+-  return std::make_unique<history_embeddings::ChromeHistoryEmbeddingsService>(
++  return std::make_unique<history_embeddings::
++#if BUILDFLAG(ENABLE_LOCAL_AI)
++    BraveHistoryEmbeddingsService
++#else
++    ChromeHistoryEmbeddingsService
++#endif
++    >(
+       profile,
+       HistoryServiceFactory::GetForProfile(profile,
+                                            ServiceAccessType::EXPLICIT_ACCESS),
+@@ -171,7 +177,13 @@ HistoryEmbeddingsServiceFactory::BuildServiceInstanceForBrowserContext(
+     }
+   }
+ 
+-  return std::make_unique<history_embeddings::ChromeHistoryEmbeddingsService>(
++  return std::make_unique<history_embeddings::
++#if BUILDFLAG(ENABLE_LOCAL_AI)
++    BraveHistoryEmbeddingsService
++#else
++    ChromeHistoryEmbeddingsService
++#endif
++    >(
+       profile,
+       HistoryServiceFactory::GetForProfile(profile,
+                                            ServiceAccessType::EXPLICIT_ACCESS),

--- a/patches/chrome-browser-history_embeddings-history_embeddings_utils.cc.patch
+++ b/patches/chrome-browser-history_embeddings-history_embeddings_utils.cc.patch
@@ -1,8 +1,8 @@
 diff --git a/chrome/browser/history_embeddings/history_embeddings_utils.cc b/chrome/browser/history_embeddings/history_embeddings_utils.cc
-index 8198ba0c74bbfb0e68f8334f9592dddccb182c28..b1bb7482efcbf223be2dcc8f0fc498e6bc316aa9 100644
+index 8198ba0c74bbfb0e68f8334f9592dddccb182c28..9150b3dce9574c0b292af9f3ac277abbff4ed4ed 100644
 --- a/chrome/browser/history_embeddings/history_embeddings_utils.cc
 +++ b/chrome/browser/history_embeddings/history_embeddings_utils.cc
-@@ -57,7 +57,8 @@ constexpr auto kEnabledByDefaultForDesktopOnly =
+@@ -57,9 +57,11 @@ constexpr auto kEnabledByDefaultForDesktopOnly =
  #endif
  
  // These are the kill switches for the launched history embeddings features.
@@ -11,8 +11,19 @@ index 8198ba0c74bbfb0e68f8334f9592dddccb182c28..b1bb7482efcbf223be2dcc8f0fc498e6
 +BASE_FEATURE(kLaunchedHistoryEmbeddings, base::FEATURE_DISABLED_BY_DEFAULT);
  
  bool IsHistoryEmbeddingsEnabledForProfile(Profile* profile) {
++  if ((true)) return ComputeHistoryEmbeddingsEnabledForProfile(profile);
    if (!IsHistoryEmbeddingsFeatureEnabled()) {
-@@ -163,10 +164,10 @@ void PopulateSourceForWebUI(content::WebUIDataSource* source,
+     return false;
+   }
+@@ -94,6 +96,7 @@ bool IsHistoryEmbeddingsAnswersEnabledForProfile(Profile* profile) {
+ }
+ 
+ bool IsHistoryEmbeddingsSettingVisible(Profile* profile) {
++  if ((true)) return false;
+   if (!IsHistoryEmbeddingsFeatureEnabled()) {
+     return false;
+   }
+@@ -163,14 +166,15 @@ void PopulateSourceForWebUI(content::WebUIDataSource* source,
                ModelExecutionEnterprisePolicyValue::kAllowWithoutLogging);
    if (logging_disabled_by_enterprise) {
      source->AddLocalizedString("historyEmbeddingsDisclaimer",
@@ -25,3 +36,8 @@ index 8198ba0c74bbfb0e68f8334f9592dddccb182c28..b1bb7482efcbf223be2dcc8f0fc498e6
    }
  }
  
+ bool IsHistoryEmbeddingsFeatureEnabled() {
++  if (ShouldForceHistoryEmbeddingsFeatureDisabled()) return false;
+ #if BUILDFLAG(IS_CHROMEOS)
+   if (!chromeos::features::IsFeatureManagementHistoryEmbeddingEnabled()) {
+     return false;

--- a/rewrite/chrome/browser/history_embeddings/history_embeddings_service_factory.cc.yaml
+++ b/rewrite/chrome/browser/history_embeddings/history_embeddings_service_factory.cc.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |-
+      Swap Chrome's service for Brave's concrete subclass at both
+      construction sites.
+
+      Brave overrides OnPassageVisibilityCalculated to synthesize a passing
+      visibility score since Brave doesn't use PageContentAnnotationsService.
+      The header this needs is included by the chromium_src override at
+      brave/chromium_src/chrome/browser/history_embeddings/
+      history_embeddings_service_factory.cc.
+    count: 2
+    regex:
+      pattern: 'std::make_unique<history_embeddings::ChromeHistoryEmbeddingsService>('
+      replace: |-
+        std::make_unique<history_embeddings::
+        #if BUILDFLAG(ENABLE_LOCAL_AI)
+            BraveHistoryEmbeddingsService
+        #else
+            ChromeHistoryEmbeddingsService
+        #endif
+            >(

--- a/rewrite/chrome/browser/history_embeddings/history_embeddings_utils.cc.yaml
+++ b/rewrite/chrome/browser/history_embeddings/history_embeddings_utils.cc.yaml
@@ -28,3 +28,40 @@ substitutions:
     set_feature_flag_default_state:
       feature_name: kLaunchedHistoryEmbeddings
       value: base::FEATURE_DISABLED_BY_DEFAULT
+
+  - description: |-
+      Gate IsHistoryEmbeddingsFeatureEnabled on the local-state
+      kBraveLocalAIEnabled master switch.
+
+      This function is the chokepoint every upstream consumer reaches the
+      feature through (model component installer, side bar toggle
+      visibility, history embeddings service factory, etc.), so folding it
+      off here folds off every consumer with it, without needing to touch
+      each of them individually. See ShouldForceHistoryEmbeddingsFeatureDisabled
+      in the chromium_src override for the actual check.
+    preempt_function_impl:
+      function_name: IsHistoryEmbeddingsFeatureEnabled
+      return_if: 'ShouldForceHistoryEmbeddingsFeatureDisabled()'
+      return_value: 'false'
+
+  - description: |-
+      Additionally gate IsHistoryEmbeddingsEnabledForProfile on the
+      per-profile kBraveHistoryEmbeddingsEnabled pref backing the
+      chrome://history side bar toggle.
+
+      See ComputeHistoryEmbeddingsEnabledForProfile in the chromium_src
+      override for the actual check.
+    preempt_function_impl:
+      function_name: IsHistoryEmbeddingsEnabledForProfile
+      code: |-
+        if ((true)) return ComputeHistoryEmbeddingsEnabledForProfile(profile);
+
+  - description: |-
+      Force IsHistoryEmbeddingsSettingVisible off.
+
+      The per-profile toggle lives on chrome://history, so the
+      chrome://settings/ai History Search entry is never surfaced.
+    preempt_function_impl:
+      function_name: IsHistoryEmbeddingsSettingVisible
+      code: |-
+        if ((true)) return false;


### PR DESCRIPTION
This is strict plaster migration for this path.

Bug: https://github.com/brave/brave-browser/issues/45050
