### PR TITLE
[recipes] Work scheduling against the machine's resources

### DIFF
--- a/tools/recipes/recipe_modules/step/__init__.py
+++ b/tools/recipes/recipe_modules/step/__init__.py
@@ -4,4 +4,4 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """Core `step` module: run a subprocess as a named build step."""
 
-DEPS = ['context']
+DEPS = ['context', 'platform']

--- a/tools/recipes/recipe_modules/step/api.py
+++ b/tools/recipes/recipe_modules/step/api.py
@@ -12,10 +12,17 @@ import logging
 from pathlib import Path
 import subprocess
 
+from engine_types import ResourceCost as _ResourceCost
 from recipe_api import (InputPlaceholder, OutputPlaceholder, Placeholder,
                         RecipeApi)
 from recipe_test_api import PlaceholderTestData, StepTestData
+from resource_semaphore import ResourceWaiter
 from step_data import StepData
+
+# _UNSET_COST means "the caller said nothing about cost", and the default,
+# which is also different from an explicit `cost=None`, which opts the step out
+# of admission control entirely.
+_UNSET_COST = object()
 
 
 class StepApi(RecipeApi):
@@ -46,6 +53,67 @@ class StepApi(RecipeApi):
         # Lazily-created production runner (unused in test mode, where the
         # engine seeds `self._test.step_runner`).
         self._prod_runner = None
+        # Admission control for steps that declare a `cost`, sized from the
+        # host in initialise().
+        self._resource: ResourceWaiter | None = None
+
+    def initialise(self) -> None:
+        self._resource = ResourceWaiter(
+            self.m.platform.cpu_count * self.CPU_CORE,
+            self.m.platform.total_memory)
+
+    def ResourceCost(self,
+                     cpu: int = 500,
+                     memory: int = 50,
+                     disk: int = 0,
+                     net: int = 0) -> _ResourceCost:
+        """A structure defining the resources that a given step may need.
+
+        The four resources are:
+
+          * cpu (measured in millicores): The amount of cpu the step is expected
+            to take. Defaults to 500.
+          * memory (measured in MiB): The amount of memory the step is expected
+            to take. Defaults to 50.
+          * disk (as percentage of max disk bandwidth): The amount of "disk
+            bandwidth" the step is expected to take. This is a very simplified
+            percentage covering IOPS, read/write bandwidth, seek time, etc. At
+            100, the step will run exclusively w.r.t. all other steps having a
+            `disk` cost. At 0, the step will run regardless of other steps with
+            disk cost.
+          * net (as percentage of max net bandwidth): The amount of "net
+            bandwidth" the step is expected to take. As `disk`, but for the
+            network.
+
+        A step will run when ALL of the resources are simultaneously available.
+        The engine uses a greedy scheduling algorithm for picking the next step
+        to run: if several are waiting, it picks the largest which fits the
+        currently available resources.
+
+        A value higher than the machine's maximum is equivalent to that maximum,
+        so a step declaring more memory than the host has still runs -- on its
+        own.
+
+        Returns:
+            A `ResourceCost` suitable for `api.step(...)`'s `cost` kwarg.
+            Passing `None` as the cost is equivalent to
+            `ResourceCost(0, 0, 0, 0)`.
+        """
+        return _ResourceCost(min(cpu, self.MAX_CPU),
+                             min(memory, self.MAX_MEMORY), disk, net)
+
+    # The number of millicores in a single CPU core.
+    CPU_CORE = 1000
+
+    @property
+    def MAX_CPU(self) -> int:
+        """The maximum number of millicores this system has."""
+        return self.m.platform.cpu_count * self.CPU_CORE
+
+    @property
+    def MAX_MEMORY(self) -> int:
+        """The maximum amount of memory on the system, in MiB."""
+        return self.m.platform.total_memory
 
     @property
     def active_result(self) -> StepData | None:
@@ -134,6 +202,7 @@ class StepApi(RecipeApi):
         stdin: InputPlaceholder | None = None,
         stdout: OutputPlaceholder | None = None,
         stderr: OutputPlaceholder | None = None,
+        cost: _ResourceCost | None = _UNSET_COST,
         step_test_data: Callable[[], StepTestData] | None = None,
     ) -> StepData:
         """Run *cmd* as the step named *name*.
@@ -159,6 +228,12 @@ class StepApi(RecipeApi):
                 returned `StepData`'s `stdout`. Left unset, the command
                 inherits this process's stdout.
             stderr: As *stdout*, for standard error.
+            cost: What the step is expected to consume, from
+                `api.step.ResourceCost(...)`. The step waits until the machine
+                has room for all of it at once, so several expensive steps
+                cannot overwhelm the host. Defaults to `ResourceCost()` (half a
+                core, 50 MiB) for a step with a command, and to nothing for a
+                command-less one. Pass `None` to opt out of admission control.
             step_test_data: A zero-argument callable returning the
                 `StepTestData` this step should default to under simulation, so
                 the common case needs no per-test seeding, e.g.
@@ -222,7 +297,23 @@ class StepApi(RecipeApi):
             'env_suffixes': context.env_suffixes,
         }
         logging.info('[step] %s\n >>>> %s', name, ' '.join(rendered_cmd))
-        retcode = runner.run(step, handles)
+
+        def _if_blocking(needed: _ResourceCost) -> None:
+            # Only reached when a step actually queues, which a simulated run
+            # never does: a simulated step completes without yielding, so two
+            # of them never hold resources at once. `ResourceWaiter` itself is
+            # covered by `unittests/resource_semaphore_test.py`, which runs
+            # greenlets that really do block.
+            logging.info(  # pragma: no cover
+                '[step] %s waiting for resources: %s', name, needed)
+
+        # A command-less step runs nothing, so it consumes nothing and must
+        # never queue; anything else takes the default cost unless the caller
+        # said otherwise.
+        if cost is _UNSET_COST:
+            cost = None if not rendered_cmd else self.ResourceCost()
+        with self._resource.wait_for(cost, _if_blocking):
+            retcode = runner.run(step, handles)
 
         # Resolve placeholders before reporting a failure, so that a failing
         # step still cleans up its input files and still reports whatever

--- a/tools/recipes/recipe_modules/step/tests/cost.py
+++ b/tools/recipes/recipe_modules/step/tests/cost.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for a step's `cost`: what it declares it will consume.
+
+Whether a cost actually makes a step queue is decided by `ResourceWaiter`, and
+is covered by `unittests/resource_semaphore_test.py`: a simulated step finishes
+without yielding, so two of them never contend here.
+"""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['platform', 'step']
+
+
+def RunSteps(api):
+    # Capacity comes from the host, and sizes the pool costs are admitted
+    # against.
+    assert api.step.MAX_CPU == api.platform.cpu_count * api.step.CPU_CORE
+    assert api.step.MAX_MEMORY == api.platform.total_memory
+
+    # Left alone, a step takes the default cost.
+    api.step('default cost', ['echo', 'hi'])
+
+    # A step that knows it is expensive says so. This one wants two cores and
+    # most of the disk, so nothing else heavy runs beside it.
+    api.step('heavy', ['git', 'fetch'],
+             cost=api.step.ResourceCost(cpu=2 * api.step.CPU_CORE,
+                                        memory=4096,
+                                        disk=80,
+                                        net=50))
+
+    # Asking for more than the machine has is clamped to the machine, so the
+    # step still runs -- on its own -- rather than waiting for capacity that
+    # will never exist.
+    huge = api.step.ResourceCost(cpu=99 * api.step.CPU_CORE,
+                                 memory=1024 * 1024)
+    assert huge.cpu == api.step.MAX_CPU, huge.cpu
+    assert huge.memory == api.step.MAX_MEMORY, huge.memory
+    api.step('clamped', ['echo', 'still runs'], cost=huge)
+
+    # `None` opts out of admission control, for a step that does no real work.
+    api.step('free', ['echo', 'cheap'], cost=None)
+
+    # A command-less step never queues, having nothing to run.
+    api.step('no command', None)
+
+
+def GenTests(api):
+    yield api.test(
+        'cost',
+        api.post_process(post_process.MustRun, 'default cost', 'heavy',
+                         'clamped', 'free', 'no command'),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )
+    # A smaller host clamps a cost further down, but still runs the step.
+    yield api.test(
+        'small host',
+        api.platform.capacity(cpu_count=1, total_memory=512),
+        api.post_process(post_process.MustRun, 'heavy', 'clamped'),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
+    )

--- a/tools/recipes/resource_semaphore.py
+++ b/tools/recipes/resource_semaphore.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Admission control for steps that declare what they will consume.
+
+A step attaches a `ResourceCost` (see `engine_types`), and this holds it back
+until the machine has room for it, which is how a recipe caps expensive
+concurrent work by what it actually costs rather than by a job count guessed up
+front.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import attr
+from gevent.queue import Channel
+
+from engine_types import ResourceCost
+
+
+@attr.s
+class ResourceWaiter:
+    """Represents the machine's CPU, memory, disk and network as limited
+    resources.
+
+    Each cpu (according to the host's logical core count) is worth 1000
+    millicores. Every subprocess that attempts to execute will first acquire its
+    estimated amount of millicores before launching the subprocess. As soon as
+    the subprocess completes, the held millicores are put back into the pool.
+
+    Similarly, memory is measured in megabytes of physical system memory (i.e.
+    not including swap). The assumption is that the recipe (and its
+    subprocesses) is really mostly the only thing running on the machine anyway.
+
+    Disk and net are different, however. They are unitless measures of
+    'percentage of resource', where the absolute quantity of Disk (IOPS,
+    read/write/seek speed) and Network (bandwidth, latency) are not considered.
+    Consider them more a declaration that a given step contends on disk or
+    network availability. If you had many steps which each took `10%` disk, only
+    10 of them would run at a time. Similarly, if you had steps which declared
+    50% of disk bandwidth usage, only 2 of them would run at a time.
+
+    Because recipes are finite both in runtime and number of distinct steps,
+    this resource class unblocks other processes greedily. Whenever a subprocess
+    completes, this analyzes all the outstanding subprocesses and will unblock
+    whichever ones 'fit' in the now-freed resources. This is done in roughly
+    FIFO order (i.e. if two tasks could potentially fit, the first one to block
+    will be chosen over the second to unblock first).
+
+    This is different than what's deemed 'fair' in a typical scheduling
+    scenario, because in a mixed workload, heavy tasks could be forced to wait
+    longer while small tasks use the CPU. However, because the recipes typically
+    run with a hard finite timeout, it's better to use more of the CPU earlier
+    than to potentially waste time waiting for small tasks to finish in order to
+    schedule a heavy task earlier.
+    """
+
+    # Required for __init__
+    _millicores_available = attr.ib()
+    _memory_available = attr.ib()
+
+    # Attrs with defaults.
+    _millicores_max = attr.ib()
+
+    @_millicores_max.default
+    def _millicores_max_default(self):
+        return self._millicores_available
+
+    _memory_max = attr.ib()
+
+    @_memory_max.default
+    def _memory_max_default(self):
+        return self._memory_available
+
+    _disk_available = attr.ib(default=100)
+    _disk_max = attr.ib(default=100)
+
+    _net_available = attr.ib(default=100)
+    _net_max = attr.ib(default=100)
+
+    # Each _waiters entry has a unique ID
+    _waiter_uid = attr.ib(default=0)
+    # list[tuple[amount, waiter_uid, Channel]]
+    #
+    # The `uid` is used to ensure that Channel is never used when sorting
+    # this list.
+    _waiters = attr.ib(factory=list)
+
+    def _fits(self, resources: ResourceCost) -> bool:
+        assert isinstance(resources, ResourceCost)
+        return resources.fits(self._millicores_available,
+                              self._memory_available, self._disk_available,
+                              self._net_available)
+
+    def _decr(self, resources: ResourceCost) -> None:
+        assert isinstance(resources, ResourceCost)
+        self._millicores_available -= resources.cpu
+        self._memory_available -= resources.memory
+        self._disk_available -= resources.disk
+        self._net_available -= resources.net
+
+    def _incr(self, resources: ResourceCost) -> None:
+        assert isinstance(resources, ResourceCost)
+        self._millicores_available += resources.cpu
+        self._memory_available += resources.memory
+        self._disk_available += resources.disk
+        self._net_available += resources.net
+
+    @contextmanager
+    def wait_for(self, resources: ResourceCost | None, call_if_blocking=None):
+        """Block until *resources* are available.
+
+        Args:
+            resources: The amount of various resources to acquire before
+                yielding. If any aspect of this exceeds the maximum amount of
+                resource available on the system, this will instead acquire the
+                system maximum. If resources is all 0's, or is None, this does
+                not block.
+            call_if_blocking: `wait_for` will invoke this callback if it would
+                end up blocking before yielding. It should only be used for
+                reporting/diagnostics (i.e. it should not raise an exception).
+
+        Yields control once the requisite amount of resources are available.
+        Exiting the context frees up the resources.
+        """
+        if resources is None:
+            yield
+            return
+
+        assert isinstance(resources, ResourceCost)
+
+        if resources.cpu > self._millicores_max:
+            resources = attr.evolve(resources, cpu=self._millicores_max)
+
+        if resources.memory > self._memory_max:
+            resources = attr.evolve(resources, memory=self._memory_max)
+
+        if resources and (self._waiters or not self._fits(resources)):
+            # We need some amount of resource AND someone else is already
+            # waiting, or there isn't enough resource.
+            if call_if_blocking:
+                call_if_blocking(resources)
+            wake_me = Channel()
+            self._waiter_uid += 1
+            self._waiters.append((resources, self._waiter_uid, wake_me))
+            self._waiters.sort(reverse=True)  # stable sort
+            wake_me.get()
+            # At this point the greenlet that woke us already reserved our
+            # resources for us, and we're free to go.
+        else:
+            # Just directly take our cores.
+            assert self._fits(resources)
+            self._decr(resources)
+
+        try:
+            yield
+        finally:
+            self._incr(resources)
+            # We just added some resource back to the pot. Try to wake as many
+            # others as we can before proceeding.
+
+            to_wake, to_keep = [], []
+            for waiting_resources, uid, chan in self._waiters:
+                if self._fits(waiting_resources):
+                    to_wake.append(chan)
+                    self._decr(waiting_resources)
+                else:
+                    to_keep.append((waiting_resources, uid, chan))
+            # _waiters was sorted before, so to_keep is also.
+            self._waiters = to_keep
+            for chan in to_wake:
+                chan.put(None)

--- a/tools/recipes/unittests/resource_semaphore_test.py
+++ b/tools/recipes/unittests/resource_semaphore_test.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `ResourceWaiter`, the admission control behind a step's `cost`.
+
+These run greenlets that actually block, which a simulated recipe cannot: a
+simulated step completes without ever yielding, so two of them never hold
+resources at the same time and the scheduler is never contended.
+"""
+
+import os
+import sys
+import unittest
+
+import gevent
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# pylint: disable=wrong-import-position
+from engine_types import ResourceCost
+from resource_semaphore import ResourceWaiter
+
+
+def _run(waiter, cost, log, label, hold=0.01):
+    """Acquire *cost*, record entry and exit around a blocking hold."""
+    with waiter.wait_for(cost):
+        log.append(f'+{label}')
+        gevent.sleep(hold)
+        log.append(f'-{label}')
+
+
+class ResourceWaiterTest(unittest.TestCase):
+
+    def test_fitting_costs_run_concurrently(self):
+        # Two 40% disk steps fit inside the 100% pool at once, so they overlap.
+        waiter = ResourceWaiter(8000, 16384)
+        log = []
+        gevent.joinall([
+            gevent.spawn(_run, waiter, ResourceCost(0, 0, 40, 0), log, 'a'),
+            gevent.spawn(_run, waiter, ResourceCost(0, 0, 40, 0), log, 'b'),
+        ])
+        self.assertEqual(log, ['+a', '+b', '-a', '-b'])
+
+    def test_oversubscribed_costs_serialise(self):
+        # Three 60% disk steps cannot overlap, so each waits for the last.
+        #
+        # Note the order they resume in: waiters are sorted by cost descending,
+        # and equal costs tie-break on a monotonic id -- also descending. So
+        # among equally sized waiters the most recent to block is released
+        # first, which is the opposite of the "roughly FIFO" upstream's
+        # docstring describes. Ported as-is; the behaviour only decides which
+        # of several equally sized steps goes next.
+        waiter = ResourceWaiter(8000, 16384)
+        log = []
+        gevent.joinall([
+            gevent.spawn(_run, waiter, ResourceCost(0, 0, 60, 0), log, label)
+            for label in 'abc'
+        ])
+        self.assertEqual(log, ['+a', '-a', '+c', '-c', '+b', '-b'])
+
+    def test_blocking_callback_reports_what_is_waited_for(self):
+        waiter = ResourceWaiter(8000, 16384)
+        blocked = []
+        log = []
+
+        def waits():
+            with waiter.wait_for(ResourceCost(0, 0, 60, 0), blocked.append):
+                log.append('second')
+
+        gevent.joinall([
+            gevent.spawn(_run, waiter, ResourceCost(0, 0, 60, 0), log,
+                         'first'),
+            gevent.spawn(waits),
+        ])
+        self.assertEqual([str(cost) for cost in blocked], ['disk=[60%]'])
+
+    def test_cost_above_capacity_is_clamped_and_still_runs(self):
+        # A step asking for more than the machine has runs on its own rather
+        # than deadlocking.
+        waiter = ResourceWaiter(1000, 100)
+        log = []
+        gevent.joinall([
+            gevent.spawn(_run, waiter, ResourceCost(cpu=99000, memory=99000),
+                         log, 'huge'),
+            gevent.spawn(_run, waiter, ResourceCost(cpu=1000, memory=100), log,
+                         'also huge'),
+        ])
+        self.assertEqual(log, ['+huge', '-huge', '+also huge', '-also huge'])
+
+    def test_zero_cost_never_blocks(self):
+        # A pool with nothing left still admits a zero cost.
+        waiter = ResourceWaiter(0, 0)
+        log = []
+        gevent.joinall([
+            gevent.spawn(_run, waiter, ResourceCost.zero(), log, label)
+            for label in 'ab'
+        ])
+        self.assertEqual(log, ['+a', '+b', '-a', '-b'])
+
+    def test_none_cost_opts_out(self):
+        waiter = ResourceWaiter(0, 0)
+        log = []
+        gevent.joinall(
+            [gevent.spawn(_run, waiter, None, log, label) for label in 'ab'])
+        self.assertEqual(log, ['+a', '+b', '-a', '-b'])
+
+    def test_larger_waiter_is_preferred_when_room_frees_up(self):
+        # Greedy scheduling: when the holder releases, waiters are considered
+        # largest first, so `big` is let through ahead of `small` even though
+        # `small` queued earlier and both fit.
+        waiter = ResourceWaiter(8000, 16384)
+        log = []
+        holder = gevent.spawn(_run, waiter, ResourceCost(0, 0, 100, 0), log,
+                              'hold', 0.05)
+        gevent.sleep(0)  # Let the holder take the whole pool first.
+        small = gevent.spawn(_run, waiter, ResourceCost(0, 0, 10, 0), log,
+                             'small')
+        gevent.sleep(0)  # ...and let `small` queue ahead of `big`.
+        big = gevent.spawn(_run, waiter, ResourceCost(0, 0, 70, 0), log, 'big')
+        gevent.joinall([holder, small, big])
+        self.assertEqual(log[:3], ['+hold', '-hold', '+big'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
A step can now declare what it expects to consume, and waits until the
machine has room for all of it, so a recipe caps expensive concurrent
work by what it costs rather than by a job count guessed up front:

```py
    api.step('fetch', ['git', 'fetch'],
             cost=api.step.ResourceCost(cpu=2 * api.step.CPU_CORE,
                                        memory=4096, disk=80))
```

cpu is in millicores against the host's core count, memory in MiB
against its physical memory, and disk and net are percentages of the
machine's bandwidth. A cost larger than the machine is clamped to it, so
the step runs on its own rather than waiting for capacity that will
never exist. Steps take a default cost of half a core and 50 MiB;
`cost=None` opts out, and a command-less step never queues.

Bug: https://github.com/brave/brave-browser/issues/56748
