### PR TITLE
[AI Chat] Share one card between attachments and tabSearch results

### DIFF
--- a/components/ai_chat/resources/page/components/attachment_item/index.tsx
+++ b/components/ai_chat/resources/page/components/attachment_item/index.tsx
@@ -46,14 +46,25 @@ type Props = {
   // this component in the conversation thread where remove
   // is not needed.
   remove?: () => void
+
+  // When set, the whole item becomes a button that activates what it
+  // describes, e.g. switching to the tab it represents.
+  onClick?: () => void
 }
 
 const tooltipHideDelay = 0
 const tooltipShowDelay = 500
 
 export function AttachmentItem(props: Props) {
+  const Wrapper = props.onClick ? 'button' : 'div'
   return (
-    <div className={classnames(styles.itemWrapper, props.className)}>
+    <Wrapper
+      className={classnames(styles.itemWrapper, props.className, {
+        [styles.clickable]: !!props.onClick,
+      })}
+      onClick={props.onClick}
+      title={props.onClick ? props.title : undefined}
+    >
       <div className={styles.leftSide}>
         {props.icon}
         <div className={styles.info}>
@@ -80,7 +91,7 @@ export function AttachmentItem(props: Props) {
           <Icon name='close' />
         </Button>
       )}
-    </div>
+    </Wrapper>
   )
 }
 
@@ -112,6 +123,7 @@ export function AttachmentPageItem(props: {
    */
   faviconUrl?: string
   remove?: () => void
+  onClick?: () => void
   className?: string
 }) {
   // We don't display the scheme in the subtitle.
@@ -166,6 +178,7 @@ export function AttachmentPageItem(props: {
         </>
       }
       remove={props.remove}
+      onClick={props.onClick}
       className={props.className}
     />
   )

--- a/components/ai_chat/resources/page/components/attachment_item/style.module.scss
+++ b/components/ai_chat/resources/page/components/attachment_item/style.module.scss
@@ -17,6 +17,16 @@
   box-sizing: border-box;
 }
 
+.clickable {
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+
+  &:hover {
+    background-color: var(--leo-color-container-highlight);
+  }
+}
+
 .imageButton {
   display: flex;
   padding: 0;

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/inline_tab_search.module.scss
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/inline_tab_search.module.scss
@@ -14,48 +14,4 @@
     flex-direction: column;
     gap: var(--leo-spacing-s);
   }
-
-  li button {
-    display: flex;
-    align-items: center;
-    gap: var(--leo-spacing-m);
-    width: 100%;
-    padding: var(--leo-spacing-m);
-    border: 1px solid var(--leo-color-divider-subtle);
-    border-radius: var(--leo-radius-m);
-    background: transparent;
-    cursor: pointer;
-    text-align: left;
-
-    &:hover {
-      background: var(--leo-color-container-highlight);
-    }
-  }
-}
-
-.favicon {
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
-}
-
-.text {
-  display: flex;
-  flex-direction: column;
-  gap: var(--leo-spacing-xs);
-  min-width: 0;
-  flex: 1;
-}
-
-.title {
-  font: var(--leo-font-default-regular);
-  color: var(--leo-color-text-primary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.host {
-  font: var(--leo-font-small-regular);
-  color: var(--leo-color-text-secondary);
 }

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/inline_tab_search.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/inline_tab_search.test.tsx
@@ -111,9 +111,11 @@ test('InlineTabSearch falls back to the host when a tab has no title', async () 
     </MockContext>,
   )
 
+  // Title falls back to the host; the subtitle is the scheme-stripped URL.
   await waitFor(() =>
-    expect(screen.getAllByText('only.example')).toHaveLength(2),
+    expect(screen.getByText('only.example')).toBeInTheDocument(),
   )
+  expect(screen.getByText('only.example/')).toBeInTheDocument()
 })
 
 test('InlineTabSearch reports when no open tab matched', async () => {

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/inline_tab_search.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/inline_tab_search.tsx
@@ -6,6 +6,7 @@
 import * as React from 'react'
 import { formatLocale } from '$web-common/locale'
 import * as Mojom from '../../../common/mojom'
+import { AttachmentPageItem } from '../../../page/components/attachment_item'
 import { useUntrustedConversationContext } from '../../untrusted_conversation_context'
 import styles from './inline_tab_search.module.scss'
 
@@ -21,32 +22,13 @@ function TabSourceCard(props: { source: Mojom.TabData }) {
     }
   })()
 
-  // Local favicon database only: never fall back to Google's favicon server,
-  // which would send the tab's URL off device.
-  const faviconSrc =
-    `chrome-untrusted://favicon2?size=32&allowGoogleServerFallback=0&pageUrl=`
-    + encodeURIComponent(source.url.url)
-
-  const handleClick = () => {
-    context.api.uiHandler.switchToTab(source.id)
-  }
-
   return (
     <li>
-      <button
-        title={source.title || source.url.url}
-        onClick={handleClick}
-      >
-        <img
-          className={styles.favicon}
-          src={faviconSrc}
-          alt=''
-        />
-        <span className={styles.text}>
-          <span className={styles.title}>{source.title || host}</span>
-          <span className={styles.host}>{host}</span>
-        </span>
-      </button>
+      <AttachmentPageItem
+        url={source.url.url}
+        title={source.title || host}
+        onClick={() => context.api.uiHandler.switchToTab(source.id)}
+      />
     </li>
   )
 }


### PR DESCRIPTION
The `tabSearch` result card rendered its own favicon, title and host, which is how it came to omit `allowGoogleServerFallback=0`. Render it with `AttachmentPageItem` instead, so both show the scheme-stripped URL with a tooltip carrying the full URL.

`AttachmentItem` takes an optional `onClick` that turns the whole item into a button, which the tabSearch card needs to activate the tab it describes.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58107

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
