### PR TITLE
Skip optional per-frame injections in widget-only frames

### DIFF
--- a/components/BUILD.gn
+++ b/components/BUILD.gn
@@ -43,6 +43,7 @@ test("brave_components_unittests") {
     "//brave/components/component_updater:unit_tests",
     "//brave/components/https_upgrade_exceptions/browser:unit_tests",
     "//brave/components/json:unit_tests",
+    "//brave/components/minimal_injection_frames:unit_tests",
     "//brave/components/oblivious_http:unit_tests",
     "//brave/components/screenshot/core/browser:unit_tests",
     "//brave/components/static_redirect_helper:unit_tests",

--- a/components/cosmetic_filters/renderer/BUILD.gn
+++ b/components/cosmetic_filters/renderer/BUILD.gn
@@ -28,6 +28,7 @@ source_set("renderer") {
     "//brave/components/cosmetic_filters/common:mojom",
     "//brave/components/cosmetic_filters/resources/data:generated_resources",
     "//brave/components/de_amp/common",
+    "//brave/components/minimal_injection_frames",
     "//components/content_settings/renderer",
     "//content/public/renderer",
     "//gin",
@@ -35,6 +36,7 @@ source_set("renderer") {
     "//net",
     "//third_party/blink/public:blink",
     "//third_party/blink/public/common",
+    "//url",
     "//v8",
   ]
 }

--- a/components/cosmetic_filters/renderer/cosmetic_filters_js_render_frame_observer.cc
+++ b/components/cosmetic_filters/renderer/cosmetic_filters_js_render_frame_observer.cc
@@ -14,10 +14,12 @@
 #include "base/functional/bind.h"
 #include "brave/components/brave_shields/core/common/features.h"
 #include "brave/components/de_amp/common/features.h"
+#include "brave/components/minimal_injection_frames/minimal_injection_frames.h"
 #include "content/public/renderer/render_frame.h"
 #include "third_party/blink/public/platform/web_isolated_world_info.h"
 #include "third_party/blink/public/platform/web_url.h"
 #include "third_party/blink/public/web/web_local_frame.h"
+#include "url/origin.h"
 
 namespace cosmetic_filters {
 
@@ -88,6 +90,12 @@ void CosmeticFiltersJsRenderFrameObserver::ReadyToCommitNavigation(
 
   if (!url_.SchemeIsHTTPOrHTTPS())
     return;
+
+  // Leaves `ready_` unsignaled, so the script is never injected into the frame
+  // and its MutationObserver never runs. Same shape as the scheme check above.
+  if (brave::IsMinimalInjectionFrame(url::Origin::Create(url_))) {
+    return;
+  }
 
   if (base::FeatureList::IsEnabled(
           ::brave_shields::features::kCosmeticFilteringSyncLoad)) {

--- a/components/minimal_injection_frames/BUILD.gn
+++ b/components/minimal_injection_frames/BUILD.gn
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("minimal_injection_frames") {
+  sources = [
+    "minimal_injection_frames.cc",
+    "minimal_injection_frames.h",
+  ]
+
+  deps = [
+    "//base",
+    "//url",
+  ]
+}
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [ "minimal_injection_frames_unittest.cc" ]
+
+  deps = [
+    ":minimal_injection_frames",
+    "//testing/gtest",
+    "//url",
+  ]
+}

--- a/components/minimal_injection_frames/minimal_injection_frames.cc
+++ b/components/minimal_injection_frames/minimal_injection_frames.cc
@@ -1,0 +1,32 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/minimal_injection_frames/minimal_injection_frames.h"
+
+#include <string_view>
+
+#include "base/containers/fixed_flat_set.h"
+#include "url/origin.h"
+
+namespace brave {
+
+namespace {
+
+// Serialized origins, matched against url::Origin::Serialize(). An entry that
+// is not a valid serialized origin (no scheme, a trailing slash, a path, a
+// default port spelled out) silently matches nothing, so keep the format exact.
+constexpr auto kMinimalInjectionOrigins =
+    base::MakeFixedFlatSet<std::string_view>({
+        "https://challenges.cloudflare.com",
+    });
+
+}  // namespace
+
+bool IsMinimalInjectionFrame(const url::Origin& origin) {
+  // Serialize() is "null" for opaque origins, which no entry can match.
+  return kMinimalInjectionOrigins.contains(origin.Serialize());
+}
+
+}  // namespace brave

--- a/components/minimal_injection_frames/minimal_injection_frames.h
+++ b/components/minimal_injection_frames/minimal_injection_frames.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_MINIMAL_INJECTION_FRAMES_MINIMAL_INJECTION_FRAMES_H_
+#define BRAVE_COMPONENTS_MINIMAL_INJECTION_FRAMES_MINIMAL_INJECTION_FRAMES_H_
+
+namespace url {
+class Origin;
+}  // namespace url
+
+namespace brave {
+
+// Returns true for origins that only host a small embedded widget, where the
+// optional per-frame injections below are all no-ops but stay observable by the
+// widget's own script. Callers must still apply their own feature and pref
+// checks.
+bool IsMinimalInjectionFrame(const url::Origin& origin);
+
+}  // namespace brave
+
+#endif  // BRAVE_COMPONENTS_MINIMAL_INJECTION_FRAMES_MINIMAL_INJECTION_FRAMES_H_

--- a/components/minimal_injection_frames/minimal_injection_frames_unittest.cc
+++ b/components/minimal_injection_frames/minimal_injection_frames_unittest.cc
@@ -1,0 +1,50 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/minimal_injection_frames/minimal_injection_frames.h"
+
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+#include "url/origin.h"
+
+namespace brave {
+
+namespace {
+
+bool MatchesUrl(const char* spec) {
+  return IsMinimalInjectionFrame(url::Origin::Create(GURL(spec)));
+}
+
+}  // namespace
+
+TEST(MinimalInjectionFramesTest, MatchesListedOrigin) {
+  EXPECT_TRUE(MatchesUrl("https://challenges.cloudflare.com"));
+  EXPECT_TRUE(MatchesUrl("https://challenges.cloudflare.com/turnstile/v0.js"));
+  // The default port and case are normalized away by url::Origin.
+  EXPECT_TRUE(MatchesUrl("https://challenges.cloudflare.com:443/x"));
+  EXPECT_TRUE(MatchesUrl("https://CHALLENGES.CLOUDFLARE.COM/x"));
+  // Nested origins resolve to the inner origin.
+  EXPECT_TRUE(MatchesUrl("blob:https://challenges.cloudflare.com/uuid"));
+}
+
+TEST(MinimalInjectionFramesTest, RequiresSameOrigin) {
+  EXPECT_FALSE(MatchesUrl("http://challenges.cloudflare.com"));
+  EXPECT_FALSE(MatchesUrl("https://challenges.cloudflare.com:8443"));
+  EXPECT_FALSE(MatchesUrl("https://cloudflare.com"));
+  EXPECT_FALSE(MatchesUrl("https://challenges.cloudflare.com.evil"));
+  EXPECT_FALSE(MatchesUrl("https://evil.challenges.cloudflare.com"));
+  // Host is evil.com, not the listed origin.
+  EXPECT_FALSE(MatchesUrl("https://challenges.cloudflare.com@evil.com/x"));
+}
+
+TEST(MinimalInjectionFramesTest, DoesNotMatchOpaqueOrigins) {
+  EXPECT_FALSE(IsMinimalInjectionFrame(url::Origin()));
+  EXPECT_FALSE(MatchesUrl("about:blank"));
+  EXPECT_FALSE(MatchesUrl("data:text/html,hi"));
+  EXPECT_FALSE(MatchesUrl(""));
+  EXPECT_FALSE(MatchesUrl("not a url"));
+}
+
+}  // namespace brave

--- a/components/misc_metrics/renderer/BUILD.gn
+++ b/components/misc_metrics/renderer/BUILD.gn
@@ -13,6 +13,7 @@ source_set("renderer") {
 
   deps = [
     "//base",
+    "//brave/components/minimal_injection_frames",
     "//brave/components/misc_metrics/common:mojom",
     "//brave/components/resources:static_resources_grit",
     "//brave/components/safe_builtins/renderer",

--- a/components/misc_metrics/renderer/web3_metrics_render_frame_observer.cc
+++ b/components/misc_metrics/renderer/web3_metrics_render_frame_observer.cc
@@ -10,6 +10,7 @@
 #include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/strings/strcat.h"
+#include "brave/components/minimal_injection_frames/minimal_injection_frames.h"
 #include "brave/components/safe_builtins/renderer/safe_builtins_helpers.h"
 #include "components/grit/brave_components_resources.h"
 #include "content/public/renderer/render_frame.h"
@@ -64,6 +65,10 @@ bool Web3MetricsRenderFrameObserver::CanInjectProxy() {
 
   // Scripts can't be executed on provisional frames.
   if (render_frame()->GetWebFrame()->IsProvisional()) {
+    return false;
+  }
+
+  if (brave::IsMinimalInjectionFrame(url::Origin::Create(url_))) {
     return false;
   }
 

--- a/renderer/brave_wallet/BUILD.gn
+++ b/renderer/brave_wallet/BUILD.gn
@@ -23,11 +23,13 @@ source_set("brave_wallet") {
     "//brave/common:mojo_bindings",
     "//brave/components/brave_wallet/common",
     "//brave/components/brave_wallet/renderer",
+    "//brave/components/minimal_injection_frames",
     "//content/public/common",
     "//content/public/renderer",
     "//gin",
     "//third_party/blink/public:blink",
     "//third_party/blink/public/common",
+    "//url",
     "//v8",
   ]
 }

--- a/renderer/brave_wallet/DEPS
+++ b/renderer/brave_wallet/DEPS
@@ -1,3 +1,4 @@
 include_rules = [
   "+brave/components/brave_wallet/renderer",
+  "+brave/components/minimal_injection_frames",
 ]

--- a/renderer/brave_wallet/brave_wallet_render_frame_observer.cc
+++ b/renderer/brave_wallet/brave_wallet_render_frame_observer.cc
@@ -14,9 +14,11 @@
 #include "brave/components/brave_wallet/renderer/js_ethereum_provider.h"
 #include "brave/components/brave_wallet/renderer/js_solana_provider.h"
 #include "brave/components/brave_wallet/renderer/v8_helper.h"
+#include "brave/components/minimal_injection_frames/minimal_injection_frames.h"
 #include "content/public/renderer/render_frame.h"
 #include "third_party/blink/public/platform/scheduler/web_agent_group_scheduler.h"
 #include "third_party/blink/public/web/web_local_frame.h"
+#include "url/origin.h"
 #include "v8/include/v8-microtask-queue.h"
 
 namespace brave_wallet {
@@ -57,6 +59,10 @@ bool BraveWalletRenderFrameObserver::CanCreateProvider() {
 
   // Scripts can't be executed on provisional frames
   if (render_frame()->GetWebFrame()->IsProvisional()) {
+    return false;
+  }
+
+  if (brave::IsMinimalInjectionFrame(url::Origin::Create(url_))) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

Brave injects several optional things into **every** cross-origin subframe. In a
frame that only hosts a small embedded widget none of them have anything to do,
but they still add page-world properties, alter API behavior, and consume main
thread and heap that the embedded script can observe:

| Injection | World | How it's observable |
| --------- | ----- | ------------------- |
| Wallet providers (`braveEthereum`/`solana`/`cardano`) | page | property enumeration |
| web3 metrics `Proxy` on `ethereum`/`cardano`/`solana`/`web3` | page | `getOwnPropertyDescriptor` returns a getter; per-read timing |
| Cosmetic filtering | isolated | shares the frame's event loop and V8 heap — longtask/`performance.now()` gaps, `performance.memory` |

Note the wallet providers are **not** gated on the user having created a wallet:
`install_window_brave_ethereum_provider` only requires the default-wallet pref to
be `!= None`, so `window.braveEthereum` and `window.solana` are present on a
fresh profile. Only the unprefixed `window.ethereum` waits for a wallet. I may change that behavior in a follow-up PR.

All three now consult one shared same-origin check.

## Notes for reviewers

- **Not** delivered via `brave-checks.txt` or the webcompat exceptions
  component: both are keyed on the top-level site, but the decision here is
  about the *subframe's* own origin, so neither mechanism can express it.
- Playlist was considered and deliberately left alone — its scripts are only
  ever sent to the primary main frame (both senders bail on
  `!IsInPrimaryMainFrame()`), so a subframe gate there would be dead code.
- Match is strict same-origin, so a different scheme, port or host keeps its
  injections.

## Test plan

- [x] `brave_components_unittests --filter=MinimalInjectionFrames*` (3/3)
- [x] `brave_browser_tests --filter=*CosmeticFiltering*:*AdBlock*` (92/92) — no
      regression in the load-bearing ad-blocking path
- [x] `brave_browser_tests --filter=*JSEthereumProvider*:*SolanaProvider*:*Web3Metrics*:*JSCardanoProvider*` (55/55)
- [x] format, gn_check (incl. checkdeps), presubmit, full build
- [ ] Manual: confirm the injections are absent in a real widget subframe