### PR TITLE
[bots][infra] Adding `lookup <builder>`

### DIFF
--- a/infra/bots/bots.py
+++ b/infra/bots/bots.py
@@ -20,19 +20,18 @@ from pathlib import Path
 import pkgutil
 import sys
 
-_BOTS_DIR = Path(__file__).resolve().parent
-_CONFIG_DIR = _BOTS_DIR.parent / 'config'
-_BUILDERS_OUTPUT_DIR = _CONFIG_DIR / 'generated' / 'builders'
+import gen_paths
+import lookup
 
 
 def _load_config() -> None:
     """Imports gn_args.py and every builders/*.py file for their registration
     side effects, populating the shared `lib.config` registries."""
-    config_dir = str(_CONFIG_DIR)
+    config_dir = str(gen_paths.CONFIG_DIR)
     if config_dir not in sys.path:
         sys.path.insert(0, config_dir)
     importlib.import_module('gn_args')
-    import builders as builders_package  # pylint: disable=import-outside-toplevel
+    import builders as builders_package
     for module_info in pkgutil.iter_modules(builders_package.__path__):
         importlib.import_module('builders.' + module_info.name)
 
@@ -123,10 +122,12 @@ def write_output(output_dir: Path,
 
 def cmd_generate(args: argparse.Namespace) -> int:
     _load_config()
-    from lib.config import builders, gn_args  # pylint: disable=import-outside-toplevel
+    from lib.config import builders, gn_args
 
     fresh = compute_fresh_output(builders, gn_args)
-    result = write_output(_BUILDERS_OUTPUT_DIR, fresh, dry_run=args.check)
+    result = write_output(gen_paths.BUILDERS_OUTPUT_DIR,
+                          fresh,
+                          dry_run=args.check)
 
     for path in result.deleted:
         print(f'deleted:   {path}')
@@ -159,8 +160,14 @@ def main(argv: list[str] | None = None) -> int:
     generate_parser.add_argument('-v', '--verbose', action='store_true')
     generate_parser.set_defaults(func=cmd_generate)
 
+    lookup.add_subparser(subparsers)
+
     args = parser.parse_args(argv)
-    return args.func(args)
+    try:
+        return args.func(args)
+    except lookup.BotsError as e:
+        print(e, file=sys.stderr)
+        return 1
 
 
 if __name__ == '__main__':

--- a/infra/bots/bots_test.py
+++ b/infra/bots/bots_test.py
@@ -4,10 +4,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """Tests for bots.py: compute_fresh_output() and write_output()'s staleness
-handling. _load_config()/main() are exercised manually, not here, since they
+handling, plus thin integration tests for the `lookup` subcommand's CLI
+wiring (dispatch, missing-positional handling). lookup.py's own logic
+(rendering args.gn, reading gn-args.json) is covered by lookup_test.py
+instead. _load_config()/main() are exercised manually, not here, since they
 mutate real process-global state (sys.path, sys.modules, the shared
 lib.config registries)."""
 
+import contextlib
+import io
 import json
 import os
 import sys
@@ -21,8 +26,9 @@ sys.path.insert(
     os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
                  'config'))
 
-# pylint: disable=wrong-import-position
 import bots
+import gen_paths
+import lookup
 from lib.config import BuildersRegistry, GnArgsRegistry
 
 
@@ -157,6 +163,91 @@ class WriteOutputTest(unittest.TestCase):
         result = bots.write_output(missing, {'a/x.json': '{}\n'})
         self.assertEqual(result.changed, ['a/x.json'])
         self.assertTrue((missing / 'a/x.json').exists())
+
+
+def _make_generated_output_dir(tmp_dir, builder_names):
+    """Writes a minimal `gn-args.json` for each name under `tmp_dir`."""
+    for name in builder_names:
+        builder_dir = Path(tmp_dir) / name
+        builder_dir.mkdir()
+        (builder_dir / 'gn-args.json').write_text(json.dumps(
+            {'gn_args': {
+                'is_asan': True
+            }}),
+                                                  encoding='utf-8')
+
+
+class LookupDispatchTest(unittest.TestCase):
+    """`bots.py lookup`'s CLI wiring: dispatch to `lookup.cmd_lookup()` and
+    the missing-positional/unknown-builder error paths. See lookup_test.py
+    for `lookup.py`'s own logic."""
+
+    def test_dispatches_to_lookup_cmd(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        _make_generated_output_dir(tmp.name, ['b'])
+
+        original = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
+        try:
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                ret = bots.main(['lookup', 'b', '--quiet'])
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original
+
+        self.assertEqual(ret, 0)
+        self.assertEqual(buf.getvalue(), 'is_asan = true\n')
+
+    def test_unknown_builder_returns_1(self):
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            ret = bots.main(['lookup', 'does-not-exist', '--quiet'])
+        self.assertEqual(ret, 1)
+        self.assertIn('does-not-exist', buf.getvalue())
+
+    def test_missing_positional_lists_available_builders(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        _make_generated_output_dir(tmp.name, ['a-builder', 'b-builder'])
+
+        original = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
+        try:
+            buf = io.StringIO()
+            with contextlib.redirect_stderr(buf):
+                with self.assertRaises(SystemExit) as ctx:
+                    bots.main(['lookup'])
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original
+
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertIn('a-builder', buf.getvalue())
+        self.assertIn('b-builder', buf.getvalue())
+
+
+class GenerateDispatchTest(unittest.TestCase):
+
+    def test_usage_error_does_not_list_builders(self):
+        # `generate` has nothing to do with a builder name, so its usage
+        # errors should not carry `lookup`'s builder-listing behaviour.
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        _make_generated_output_dir(tmp.name, ['a-builder'])
+
+        original = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
+        try:
+            buf = io.StringIO()
+            with contextlib.redirect_stderr(buf):
+                with self.assertRaises(SystemExit) as ctx:
+                    bots.main(['generate', 'unexpected-positional'])
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original
+
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertNotIn('a-builder', buf.getvalue())
+        self.assertNotIn('available builders', buf.getvalue())
 
 
 if __name__ == '__main__':

--- a/infra/bots/gen_paths.py
+++ b/infra/bots/gen_paths.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+""" Just a source for the paths used by bots.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+BOTS_DIR = Path(__file__).resolve().parent
+CONFIG_DIR = BOTS_DIR.parent / 'config'
+BUILDERS_OUTPUT_DIR = CONFIG_DIR / 'generated' / 'builders'

--- a/infra/bots/lookup.py
+++ b/infra/bots/lookup.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""bots lookup: resolve and print the args.gn a builder would produce.
+"""
+
+from __future__ import annotations
+
+import argparse
+import functools
+import json
+import sys
+
+import gen_paths
+
+_CHROMIUM_SRC_DIR = gen_paths.BOTS_DIR.parents[2]
+sys.path.insert(0, str(_CHROMIUM_SRC_DIR / 'build'))
+import gn_helpers
+
+
+class BotsError(Exception):
+    """Raised for a user-facing `bots.py lookup` failure, e.g. an unknown
+    builder.
+    """
+
+
+def list_generated_builders() -> list[str]:
+    """Every builder with a generated `gn-args.json`, sorted by name."""
+    if not gen_paths.BUILDERS_OUTPUT_DIR.is_dir():
+        return []
+    return sorted(p.name for p in gen_paths.BUILDERS_OUTPUT_DIR.iterdir()
+                  if (p / 'gn-args.json').is_file())
+
+
+class BuilderLookup:
+    """Resolves and renders one builder's generated `gn-args.json`.
+    """
+
+    def __init__(self, builder_name: str) -> None:
+        self.builder_name = builder_name
+
+    def read_generated_gn_args(self) -> dict:
+        """Reads this builder's generated `gn-args.json`.
+
+        Raises:
+            BotsError: this builder has no generated `gn-args.json`.
+        """
+        path = (gen_paths.BUILDERS_OUTPUT_DIR / self.builder_name /
+                'gn-args.json')
+        if not path.is_file():
+            available = list_generated_builders()
+            hint = (' available builders: %s.' %
+                    ', '.join(available) if available else '')
+            raise BotsError(
+                'builder %r not found under %s; run `bots.py generate` '
+                'first, or check the name.%s' %
+                (self.builder_name, gen_paths.BUILDERS_OUTPUT_DIR, hint))
+        return json.loads(path.read_text(encoding='utf-8'))
+
+    def render_args_gn(self, resolved: dict) -> str:
+        """Renders a resolved `gn-args.json` payload as `args.gn` text."""
+        lines = []
+        if resolved.get('secrets'):
+            lines.append('import("//out/%s/brave_secrets.gni")' %
+                         self.builder_name)
+        if resolved.get('args_file'):
+            lines.append('import("%s")' % resolved['args_file'])
+        lines.append(gn_helpers.ToGNString(resolved['gn_args']))
+        return '\n'.join(lines)
+
+    @classmethod
+    def cmd_lookup(cls, args: argparse.Namespace) -> int:
+        lookup = cls(args.builder)
+        resolved = lookup.read_generated_gn_args()
+        args_gn = lookup.render_args_gn(resolved)
+        if args.quiet:
+            print(args_gn, end='')
+        else:
+            print('\nWriting """\\\n%s""" to out/%s/args.gn.\n' %
+                  (args_gn, args.builder))
+        return 0
+
+
+def _error_with_available_builders(parser: argparse.ArgumentParser,
+                                   message: str) -> None:
+    """A `parser.error()` replacement that also lists generated builders.
+
+    This is similar to what you would get with argparser errors, with the only
+    addition that it lists the available builders if no builder was provided.
+    """
+    parser.print_usage(sys.stderr)
+    print('%s: error: %s' % (parser.prog, message), file=sys.stderr)
+    builders = list_generated_builders()
+    if builders:
+        print('\navailable builders:', file=sys.stderr)
+        for name in builders:
+            print('  %s' % name, file=sys.stderr)
+    parser.exit(2)
+
+
+def add_subparser(subparsers) -> argparse.ArgumentParser:
+    """Registers the `lookup` subcommand onto `bots.py`'s subparsers."""
+    lookup_parser = subparsers.add_parser(
+        'lookup',
+        description='Look up the args.gn a builder would resolve to.')
+    lookup_parser.add_argument('builder',
+                               help='A builder name, e.g. '
+                               '"linux-x64-asan-brave".')
+    lookup_parser.add_argument(
+        '--quiet',
+        action='store_true',
+        help='Print just the args.gn contents (like `mb.py lookup --quiet`), '
+        'instead of the human-readable "would write" preamble.')
+    lookup_parser.set_defaults(func=BuilderLookup.cmd_lookup)
+    lookup_parser.error = functools.partial(_error_with_available_builders,
+                                            lookup_parser)
+    return lookup_parser

--- a/infra/bots/lookup_test.py
+++ b/infra/bots/lookup_test.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for lookup.py's own logic: `BuilderLookup`'s reading of a
+generated `gn-args.json`, its rendering of `args.gn` text, and its
+`cmd_lookup()` classmethod. `bots.py`'s CLI wiring for the `lookup`
+subcommand (dispatch, missing-positional handling) is exercised in
+bots_test.py instead."""
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import gen_paths
+import lookup
+
+
+def _make_generated_output_dir(tmp_dir, builder_names):
+    """Writes a minimal `gn-args.json` for each name under `tmp_dir`."""
+    for name in builder_names:
+        builder_dir = Path(tmp_dir) / name
+        builder_dir.mkdir()
+        (builder_dir / 'gn-args.json').write_text(json.dumps(
+            {'gn_args': {
+                'is_asan': True
+            }}),
+                                                  encoding='utf-8')
+
+
+class ListGeneratedBuildersTest(unittest.TestCase):
+
+    def test_no_output_dir_means_no_builders(self):
+        original = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(
+            tempfile.mkdtemp()) / 'does-not-exist'
+        try:
+            self.assertEqual(lookup.list_generated_builders(), [])
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original
+
+    def test_lists_builders_sorted_by_name(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        _make_generated_output_dir(tmp.name, ['z-builder', 'a-builder'])
+
+        original = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
+        try:
+            self.assertEqual(lookup.list_generated_builders(),
+                             ['a-builder', 'z-builder'])
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original
+
+
+class ReadGeneratedGnArgsTest(unittest.TestCase):
+
+    def test_missing_builder_raises_bots_error(self):
+        with self.assertRaises(lookup.BotsError):
+            lookup.BuilderLookup('no-such-builder').read_generated_gn_args()
+
+    def test_missing_builder_hint_lists_available_builders(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        _make_generated_output_dir(tmp.name, ['a-builder', 'b-builder'])
+
+        original = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
+        try:
+            with self.assertRaises(lookup.BotsError) as ctx:
+                lookup.BuilderLookup(
+                    'no-such-builder').read_generated_gn_args()
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original
+
+        self.assertIn('a-builder', str(ctx.exception))
+        self.assertIn('b-builder', str(ctx.exception))
+
+
+class RenderArgsGnTest(unittest.TestCase):
+
+    def test_plain_args_no_secrets(self):
+        rendered = lookup.BuilderLookup('b').render_args_gn(
+            {'gn_args': {
+                'is_asan': True
+            }})
+        self.assertEqual(rendered, 'is_asan = true\n')
+
+    def test_secrets_add_import_line_only_not_values(self):
+        rendered = lookup.BuilderLookup('linux-x64-asan-brave').render_args_gn(
+            {
+                'gn_args': {
+                    'target_os': 'linux'
+                },
+                'secrets': {
+                    'brave_services_key': 'BRAVE_SERVICES_KEY'
+                },
+            })
+        lines = rendered.split('\n')
+        self.assertEqual(
+            lines[0], 'import("//out/linux-x64-asan-brave/brave_secrets.gni")')
+        self.assertNotIn('BRAVE_SERVICES_KEY', rendered)
+        self.assertNotIn('brave_services_key', rendered)
+
+    def test_args_file_import_line(self):
+        rendered = lookup.BuilderLookup('b').render_args_gn({
+            'gn_args': {
+                'target_os': 'linux'
+            },
+            'args_file': '//build/args/chromeos.gni',
+        })
+        self.assertEqual(
+            rendered, 'import("//build/args/chromeos.gni")\n'
+            'target_os = "linux"\n')
+
+    def test_keys_are_sorted(self):
+        rendered = lookup.BuilderLookup('b').render_args_gn(
+            {'gn_args': {
+                'z': True,
+                'a': True
+            }})
+        self.assertEqual(rendered, 'a = true\nz = true\n')
+
+
+class CmdLookupTest(unittest.TestCase):
+
+    def test_quiet_prints_only_args_gn(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        _make_generated_output_dir(tmp.name, ['b'])
+
+        original = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
+        try:
+            args = argparse.Namespace(builder='b', quiet=True)
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                ret = lookup.BuilderLookup.cmd_lookup(args)
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original
+
+        self.assertEqual(ret, 0)
+        self.assertEqual(buf.getvalue(), 'is_asan = true\n')
+
+    def test_unknown_builder_raises(self):
+        args = argparse.Namespace(builder='does-not-exist', quiet=True)
+        with self.assertRaises(lookup.BotsError):
+            lookup.BuilderLookup.cmd_lookup(args)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/infra/config/lib/config_test.py
+++ b/infra/config/lib/config_test.py
@@ -8,7 +8,6 @@ BuildersRegistry."""
 
 # Some tests read `_resolved` directly to check memoization, which is
 # otherwise unobservable from the public API.
-# pylint: disable=protected-access
 
 import os
 import sys
@@ -16,7 +15,6 @@ import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-# pylint: disable=wrong-import-position
 # _UNSET is private (module-internal sentinel); tests reach for it directly
 # rather than duplicating it.
 from config import (AnonymousGnConfig, BuildersRegistry, ConfigError, Defaults,
@@ -460,9 +458,9 @@ class BuildersRegistryTest(unittest.TestCase):
                               targets=self._targets())
         # Both succeeded without an "already defined" clash: each pair's
         # `gn_args` node for 'b' lives in its own registry.
-        self.assertIn('b', self.gn_args._nodes)  # pylint: disable=protected-access
-        self.assertIn('b', other_gn_args._nodes)  # pylint: disable=protected-access
-        self.assertIsNot(self.gn_args._nodes['b'], other_gn_args._nodes['b'])  # pylint: disable=protected-access
+        self.assertIn('b', self.gn_args._nodes)
+        self.assertIn('b', other_gn_args._nodes)
+        self.assertIsNot(self.gn_args._nodes['b'], other_gn_args._nodes['b'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR introduces `bots.py lookup <builder>`, which is inspired on
`mb`'s own lookup command.

This command works exclusively off the data under
`infra/config/generated`, and thefore it has no knowledge about the
builders outside that scope, which is important to keep this information
layer a narrow contract.

`lookup` does not make any writes to disk, but rather it just reads the
generated builder data and produces and through that it renders the
`gn.args` for that builder.

```
$ infra/bots/bots.py lookup linux-x64-asan-brave --quiet
import("//out/linux-x64-asan-brave/brave_secrets.gni")
branding_path_component = "brave"
branding_path_product = "brave"
brave_channel = "nightly"
brave_google_api_key = "dummy"
dcheck_always_on = false
devtools_skip_typecheck = false
...
```

Bug: https://github.com/brave/brave-browser/issues/47912
