### PR TITLE
[bots][infra] Renaming `generate` to `snapshot`

### DIFF
--- a/infra/PRESUBMIT.py
+++ b/infra/PRESUBMIT.py
@@ -25,7 +25,7 @@ def CheckTests(input_api, output_api):
     return input_api.RunTests(tests)
 
 
-def CheckBotsGenerateOutput(input_api, output_api):
+def CheckBotsSnapshotOutput(input_api, output_api):
     """Verifies infra/config/generated/builders/ is up to date.
 
     Mirrors upstream's canned `CheckLucicfgGenOutput`: runs the generator in
@@ -36,8 +36,8 @@ def CheckBotsGenerateOutput(input_api, output_api):
     bots_py = os.path.join(input_api.PresubmitLocalPath(), 'bots', 'bots.py')
     return input_api.RunTests([
         input_api.Command(
-            name='bots.py generate --check',
-            cmd=[input_api.python3_executable, bots_py, 'generate', '--check'],
+            name='bots.py snapshot --check',
+            cmd=[input_api.python3_executable, bots_py, 'snapshot', '--check'],
             kwargs={},
             message=output_api.PresubmitError,
         ),

--- a/infra/bots/bots.py
+++ b/infra/bots/bots.py
@@ -7,159 +7,23 @@
 
 To generate the builders' output, run:
 
-    python3 infra/bots/bots.py generate
+    python3 infra/bots/bots.py snapshot
 """
 
 from __future__ import annotations
 
 import argparse
-import dataclasses
-import importlib
-import json
-from pathlib import Path
-import pkgutil
 import sys
 
-import gen_paths
 import lookup
-
-
-def _load_config() -> None:
-    """Imports gn_args.py and every builders/*.py file for their registration
-    side effects, populating the shared `lib.config` registries."""
-    config_dir = str(gen_paths.CONFIG_DIR)
-    if config_dir not in sys.path:
-        sys.path.insert(0, config_dir)
-    importlib.import_module('gn_args')
-    import builders as builders_package
-    for module_info in pkgutil.iter_modules(builders_package.__path__):
-        importlib.import_module('builders.' + module_info.name)
-
-
-def _dump(data) -> str:
-    return json.dumps(data, indent=2, sort_keys=True) + '\n'
-
-
-def compute_fresh_output(builders_registry,
-                         gn_args_registry) -> dict[str, str]:
-    """Returns `{relative_path: content}` for every registered builder."""
-    output = {}
-    for builder in builders_registry.all():
-        resolved = gn_args_registry.resolve(builder.name)
-        output[f'{builder.name}/gn-args.json'] = _dump(resolved)
-        output[f'{builder.name}/sync.json'] = _dump({
-            'target_os': builder.sync_config.target_os,
-            'target_cpu': builder.sync_config.target_cpu,
-            'gclient_overrides': builder.sync_config.gclient_overrides,
-        })
-        output[f'{builder.name}/targets.json'] = _dump({
-            'compile': list(builder.targets.compile),
-            'tests': list(builder.targets.tests),
-        })
-    return output
-
-
-@dataclasses.dataclass(frozen=True)
-class GenerateResult:
-    """What a `write_output()` call did, or would do under `dry_run`."""
-
-    # Paths written because they were missing or didn't byte-match the fresh
-    # content.
-    changed: list[str]
-
-    # Paths already byte-identical to the fresh content; left untouched.
-    unchanged: list[str]
-
-    # Paths that existed under the output dir but aren't in the fresh output
-    # anymore; removed as stale.
-    deleted: list[str]
-
-
-def _scan_existing(output_dir: Path) -> set[str]:
-    if not output_dir.is_dir():
-        return set()
-    return {
-        p.relative_to(output_dir).as_posix()
-        for p in output_dir.rglob('*') if p.is_file()
-    }
-
-
-def write_output(output_dir: Path,
-                 fresh: dict[str, str],
-                 *,
-                 dry_run: bool = False) -> GenerateResult:
-    """Reconciles `output_dir` with `fresh` (`{relative_path: content}`).
-
-    Deletes every file under `output_dir` not present in `fresh`, then writes
-    every entry in `fresh` that doesn't already byte-match what's on disk.
-    Creates missing directories. In `dry_run` mode nothing is touched; the
-    result reports what would happen.
-    """
-    existing = _scan_existing(output_dir)
-    deleted = sorted(existing - fresh.keys())
-
-    changed = []
-    unchanged = []
-    for rel_path, content in fresh.items():
-        path = output_dir / rel_path
-        current = path.read_text(encoding='utf-8') if path.is_file() else None
-        (unchanged if current == content else changed).append(rel_path)
-    changed.sort()
-    unchanged.sort()
-
-    if not dry_run:
-        for rel_path in deleted:
-            (output_dir / rel_path).unlink()
-        for rel_path in changed:
-            path = output_dir / rel_path
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(fresh[rel_path], encoding='utf-8')
-
-    return GenerateResult(changed=changed,
-                          unchanged=unchanged,
-                          deleted=deleted)
-
-
-def cmd_generate(args: argparse.Namespace) -> int:
-    _load_config()
-    from lib.config import builders, gn_args
-
-    fresh = compute_fresh_output(builders, gn_args)
-    result = write_output(gen_paths.BUILDERS_OUTPUT_DIR,
-                          fresh,
-                          dry_run=args.check)
-
-    for path in result.deleted:
-        print(f'deleted:   {path}')
-    for path in result.changed:
-        print(f'changed:   {path}')
-    if args.verbose:
-        for path in result.unchanged:
-            print(f'unchanged: {path}')
-
-    if args.check and (result.changed or result.deleted):
-        print(
-            'infra/config/generated/builders/ is stale; run '
-            '`bots.py generate` to update it.',
-            file=sys.stderr)
-        return 1
-    return 0
+import snapshot
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest='command', required=True)
 
-    generate_parser = subparsers.add_parser(
-        'generate', help='Regenerate infra/config/generated/builders/.')
-    generate_parser.add_argument(
-        '--check',
-        action='store_true',
-        help="Don't write anything; exit non-zero if regenerating would "
-        'change anything (for presubmit).')
-    generate_parser.add_argument('-v', '--verbose', action='store_true')
-    generate_parser.set_defaults(func=cmd_generate)
-
+    snapshot.add_subparser(subparsers)
     lookup.add_subparser(subparsers)
 
     args = parser.parse_args(argv)

--- a/infra/bots/bots_test.py
+++ b/infra/bots/bots_test.py
@@ -3,13 +3,10 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Tests for bots.py: compute_fresh_output() and write_output()'s staleness
-handling, plus thin integration tests for the `lookup` subcommand's CLI
-wiring (dispatch, missing-positional handling). lookup.py's own logic
-(rendering args.gn, reading gn-args.json) is covered by lookup_test.py
-instead. _load_config()/main() are exercised manually, not here, since they
-mutate real process-global state (sys.path, sys.modules, the shared
-lib.config registries)."""
+"""Thin integration tests for `bots.py`'s CLI wiring: dispatch to the
+`snapshot`/`lookup` subcommands and their error paths. snapshot.py's own
+logic (compute_fresh_output(), write_output()) is covered by
+snapshot_test.py, and lookup.py's by lookup_test.py."""
 
 import contextlib
 import io
@@ -29,140 +26,6 @@ sys.path.insert(
 import bots
 import gen_paths
 import lookup
-from lib.config import BuildersRegistry, GnArgsRegistry
-
-
-def _make_registries():
-    gn_args_registry = GnArgsRegistry()
-    gn_args_registry.config(name='linux', args={'target_os': 'linux'})
-    gn_args_registry.config(name='x64', args={'target_cpu': 'x64'})
-    builders_registry = BuildersRegistry(gn_args_registry)
-    builders_registry.builder(
-        name='test-builder',
-        sync_config=builders_registry.sync_config(target_os='linux',
-                                                  target_cpu='x64'),
-        gn_args=gn_args_registry.config(configs=['linux', 'x64'],
-                                        args={'is_asan': True}),
-        targets=builders_registry.targets(compile=['brave:all'],
-                                          tests=['a_test']),
-    )
-    return builders_registry, gn_args_registry
-
-
-class ComputeFreshOutputTest(unittest.TestCase):
-
-    def test_produces_three_files_per_builder(self):
-        builders_registry, gn_args_registry = _make_registries()
-        fresh = bots.compute_fresh_output(builders_registry, gn_args_registry)
-        self.assertEqual(
-            set(fresh), {
-                'test-builder/gn-args.json',
-                'test-builder/sync.json',
-                'test-builder/targets.json',
-            })
-
-    def test_gn_args_json_matches_resolve(self):
-        builders_registry, gn_args_registry = _make_registries()
-        fresh = bots.compute_fresh_output(builders_registry, gn_args_registry)
-        self.assertEqual(json.loads(fresh['test-builder/gn-args.json']),
-                         gn_args_registry.resolve('test-builder'))
-
-    def test_sync_and_targets_json(self):
-        builders_registry, gn_args_registry = _make_registries()
-        fresh = bots.compute_fresh_output(builders_registry, gn_args_registry)
-        self.assertEqual(json.loads(fresh['test-builder/sync.json']), {
-            'target_os': 'linux',
-            'target_cpu': 'x64',
-            'gclient_overrides': {},
-        })
-        self.assertEqual(json.loads(fresh['test-builder/targets.json']), {
-            'compile': ['brave:all'],
-            'tests': ['a_test'],
-        })
-
-    def test_no_builders_means_no_output(self):
-        builders_registry = BuildersRegistry(GnArgsRegistry())
-        self.assertEqual(
-            bots.compute_fresh_output(builders_registry, GnArgsRegistry()), {})
-
-
-class WriteOutputTest(unittest.TestCase):
-
-    def setUp(self):
-        tmp = tempfile.TemporaryDirectory()
-        self.addCleanup(tmp.cleanup)
-        self.output_dir = Path(tmp.name)
-
-    def test_fresh_install_writes_everything(self):
-        fresh = {'a/x.json': '{}\n', 'b/y.json': '{}\n'}
-        result = bots.write_output(self.output_dir, fresh)
-        self.assertEqual(sorted(result.changed), ['a/x.json', 'b/y.json'])
-        self.assertEqual(result.unchanged, [])
-        self.assertEqual(result.deleted, [])
-        self.assertEqual((self.output_dir / 'a/x.json').read_text(), '{}\n')
-
-    def test_rerun_with_no_changes_touches_nothing(self):
-        fresh = {'a/x.json': '{}\n'}
-        bots.write_output(self.output_dir, fresh)
-        result = bots.write_output(self.output_dir, fresh)
-        self.assertEqual(result.changed, [])
-        self.assertEqual(result.unchanged, ['a/x.json'])
-        self.assertEqual(result.deleted, [])
-
-    def test_changed_content_is_rewritten(self):
-        bots.write_output(self.output_dir, {'a/x.json': '{"v": 1}\n'})
-        result = bots.write_output(self.output_dir, {'a/x.json': '{"v": 2}\n'})
-        self.assertEqual(result.changed, ['a/x.json'])
-        self.assertEqual((self.output_dir / 'a/x.json').read_text(),
-                         '{"v": 2}\n')
-
-    def test_stale_file_is_deleted(self):
-        bots.write_output(self.output_dir, {
-            'a/x.json': '{}\n',
-            'b/y.json': '{}\n',
-        })
-        result = bots.write_output(self.output_dir, {'a/x.json': '{}\n'})
-        self.assertEqual(result.deleted, ['b/y.json'])
-        self.assertFalse((self.output_dir / 'b/y.json').exists())
-
-    def test_stale_builder_directory_loses_all_its_files(self):
-        # A whole builder disappearing should drop all three of its files.
-        # The now-empty `old-builder/` directory itself is left behind,
-        # faithful to lucicfg's own `generate`: it only ever removes files,
-        # never prunes directories, so we don't either.
-        bots.write_output(
-            self.output_dir, {
-                'old-builder/gn-args.json': '{}\n',
-                'old-builder/sync.json': '{}\n',
-                'old-builder/targets.json': '{}\n',
-            })
-        result = bots.write_output(self.output_dir,
-                                   {'new-builder/gn-args.json': '{}\n'})
-        self.assertEqual(sorted(result.deleted), [
-            'old-builder/gn-args.json',
-            'old-builder/sync.json',
-            'old-builder/targets.json',
-        ])
-        self.assertEqual(list((self.output_dir / 'old-builder').iterdir()), [])
-
-    def test_dry_run_reports_without_touching_disk(self):
-        bots.write_output(self.output_dir, {
-            'a/x.json': '{}\n',
-            'b/y.json': '{}\n',
-        })
-        result = bots.write_output(self.output_dir, {'a/x.json': '{"v": 2}\n'},
-                                   dry_run=True)
-        self.assertEqual(result.changed, ['a/x.json'])
-        self.assertEqual(result.deleted, ['b/y.json'])
-        # Nothing was actually touched.
-        self.assertEqual((self.output_dir / 'a/x.json').read_text(), '{}\n')
-        self.assertTrue((self.output_dir / 'b/y.json').exists())
-
-    def test_first_run_on_missing_directory(self):
-        missing = self.output_dir / 'does-not-exist-yet'
-        result = bots.write_output(missing, {'a/x.json': '{}\n'})
-        self.assertEqual(result.changed, ['a/x.json'])
-        self.assertTrue((missing / 'a/x.json').exists())
 
 
 def _make_generated_output_dir(tmp_dir, builder_names):
@@ -226,10 +89,10 @@ class LookupDispatchTest(unittest.TestCase):
         self.assertIn('b-builder', buf.getvalue())
 
 
-class GenerateDispatchTest(unittest.TestCase):
+class SnapshotDispatchTest(unittest.TestCase):
 
     def test_usage_error_does_not_list_builders(self):
-        # `generate` has nothing to do with a builder name, so its usage
+        # `snapshot` has nothing to do with a builder name, so its usage
         # errors should not carry `lookup`'s builder-listing behaviour.
         tmp = tempfile.TemporaryDirectory()
         self.addCleanup(tmp.cleanup)
@@ -241,7 +104,7 @@ class GenerateDispatchTest(unittest.TestCase):
             buf = io.StringIO()
             with contextlib.redirect_stderr(buf):
                 with self.assertRaises(SystemExit) as ctx:
-                    bots.main(['generate', 'unexpected-positional'])
+                    bots.main(['snapshot', 'unexpected-positional'])
         finally:
             gen_paths.BUILDERS_OUTPUT_DIR = original
 

--- a/infra/bots/lookup.py
+++ b/infra/bots/lookup.py
@@ -53,7 +53,7 @@ class BuilderLookup:
             hint = (' available builders: %s.' %
                     ', '.join(available) if available else '')
             raise BotsError(
-                'builder %r not found under %s; run `bots.py generate` '
+                'builder %r not found under %s; run `bots.py snapshot` '
                 'first, or check the name.%s' %
                 (self.builder_name, gen_paths.BUILDERS_OUTPUT_DIR, hint))
         return json.loads(path.read_text(encoding='utf-8'))

--- a/infra/bots/snapshot.py
+++ b/infra/bots/snapshot.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""bots snapshot: write `infra/config` builders matrix.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import importlib
+import json
+from pathlib import Path
+import pkgutil
+import sys
+
+import gen_paths
+
+
+def _load_config() -> None:
+    """Imports gn_args.py and all builders/*.py."""
+    config_dir = str(gen_paths.CONFIG_DIR)
+    if config_dir not in sys.path:
+        sys.path.insert(0, config_dir)
+    importlib.import_module('gn_args')
+    import builders as builders_package
+    for module_info in pkgutil.iter_modules(builders_package.__path__):
+        importlib.import_module('builders.' + module_info.name)
+
+
+def _dump(data) -> str:
+    return json.dumps(data, indent=2, sort_keys=True) + '\n'
+
+
+def compute_fresh_output(builders_registry,
+                         gn_args_registry) -> dict[str, str]:
+    """Returns `{relative_path: content}` for every registered builder."""
+    output = {}
+    for builder in builders_registry.all():
+        resolved = gn_args_registry.resolve(builder.name)
+        output[f'{builder.name}/gn-args.json'] = _dump(resolved)
+        output[f'{builder.name}/sync.json'] = _dump({
+            'target_os': builder.sync_config.target_os,
+            'target_cpu': builder.sync_config.target_cpu,
+            'gclient_overrides': builder.sync_config.gclient_overrides,
+        })
+        output[f'{builder.name}/targets.json'] = _dump({
+            'compile': list(builder.targets.compile),
+            'tests': list(builder.targets.tests),
+        })
+    return output
+
+
+@dataclasses.dataclass(frozen=True)
+class SnapshotResult:
+    """What a `write_output()` call did, or would do under `dry_run`."""
+
+    # Paths written because they were missing or didn't byte-match the fresh
+    # content.
+    changed: list[str]
+
+    # Paths already byte-identical to the fresh content; left untouched.
+    unchanged: list[str]
+
+    # Paths that existed under the output dir but aren't in the fresh output
+    # anymore; removed as stale.
+    deleted: list[str]
+
+
+def _scan_existing(output_dir: Path) -> set[str]:
+    if not output_dir.is_dir():
+        return set()
+    return {
+        p.relative_to(output_dir).as_posix()
+        for p in output_dir.rglob('*') if p.is_file()
+    }
+
+
+def write_output(output_dir: Path,
+                 fresh: dict[str, str],
+                 *,
+                 dry_run: bool = False) -> SnapshotResult:
+    """Reconciles `output_dir` with `fresh` (`{relative_path: content}`).
+
+    Writes the output dirs, with the builders, and makes sure that freshness/
+    staleness is managed too. With `dry_run=True` no disk writes are made.
+    """
+    existing = _scan_existing(output_dir)
+    deleted = sorted(existing - fresh.keys())
+
+    changed = []
+    unchanged = []
+    for rel_path, content in fresh.items():
+        path = output_dir / rel_path
+        current = path.read_text(encoding='utf-8') if path.is_file() else None
+        (unchanged if current == content else changed).append(rel_path)
+    changed.sort()
+    unchanged.sort()
+
+    if not dry_run:
+        for rel_path in deleted:
+            (output_dir / rel_path).unlink()
+        for rel_path in changed:
+            path = output_dir / rel_path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(fresh[rel_path], encoding='utf-8')
+
+    return SnapshotResult(changed=changed,
+                          unchanged=unchanged,
+                          deleted=deleted)
+
+
+def write_snapshot(builders_registry,
+                   gn_args_registry,
+                   output_dir: Path,
+                   *,
+                   dry_run: bool = False) -> SnapshotResult:
+    """Resolves every registered builder and reconciles `output_dir` with it.
+
+    Combines `compute_fresh_output()` and `write_output()`, so a caller never
+    has to thread the intermediate `fresh` dict through itself.
+    """
+    fresh = compute_fresh_output(builders_registry, gn_args_registry)
+    return write_output(output_dir, fresh, dry_run=dry_run)
+
+
+def cmd_snapshot(args: argparse.Namespace) -> int:
+    _load_config()
+    from lib.config import builders, gn_args
+
+    result = write_snapshot(builders,
+                            gn_args,
+                            gen_paths.BUILDERS_OUTPUT_DIR,
+                            dry_run=args.check)
+
+    for path in result.deleted:
+        print(f'deleted:   {path}')
+    for path in result.changed:
+        print(f'changed:   {path}')
+    if args.verbose:
+        for path in result.unchanged:
+            print(f'unchanged: {path}')
+
+    if args.check and (result.changed or result.deleted):
+        print(
+            'infra/config/generated/builders/ is stale; run '
+            '`bots.py snapshot` to update it.',
+            file=sys.stderr)
+        return 1
+    return 0
+
+
+def add_subparser(subparsers) -> argparse.ArgumentParser:
+    """Registers the `snapshot` subcommand onto `bots.py`'s subparsers."""
+    snapshot_parser = subparsers.add_parser(
+        'snapshot',
+        help='Write infra/config/generated/builders/ from the '
+        'current spec.')
+    snapshot_parser.add_argument(
+        '--check',
+        action='store_true',
+        help="Don't write anything; exit non-zero if snapshotting would "
+        'change anything (for presubmit).')
+    snapshot_parser.add_argument('-v', '--verbose', action='store_true')
+    snapshot_parser.set_defaults(func=cmd_snapshot)
+    return snapshot_parser

--- a/infra/bots/snapshot_test.py
+++ b/infra/bots/snapshot_test.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for snapshot.py: compute_fresh_output() and write_output()'s
+staleness handling. `bots.py`'s CLI wiring for the `snapshot` subcommand is
+exercised in bots_test.py instead. _load_config()/cmd_snapshot() are
+exercised manually, not here, since they mutate real process-global state
+(sys.path, sys.modules, the shared lib.config registries)."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                 'config'))
+
+import snapshot
+from lib.config import BuildersRegistry, GnArgsRegistry
+
+
+def _make_registries():
+    gn_args_registry = GnArgsRegistry()
+    gn_args_registry.config(name='linux', args={'target_os': 'linux'})
+    gn_args_registry.config(name='x64', args={'target_cpu': 'x64'})
+    builders_registry = BuildersRegistry(gn_args_registry)
+    builders_registry.builder(
+        name='test-builder',
+        sync_config=builders_registry.sync_config(target_os='linux',
+                                                  target_cpu='x64'),
+        gn_args=gn_args_registry.config(configs=['linux', 'x64'],
+                                        args={'is_asan': True}),
+        targets=builders_registry.targets(compile=['brave:all'],
+                                          tests=['a_test']),
+    )
+    return builders_registry, gn_args_registry
+
+
+class ComputeFreshOutputTest(unittest.TestCase):
+
+    def test_produces_three_files_per_builder(self):
+        builders_registry, gn_args_registry = _make_registries()
+        fresh = snapshot.compute_fresh_output(builders_registry,
+                                              gn_args_registry)
+        self.assertEqual(
+            set(fresh), {
+                'test-builder/gn-args.json',
+                'test-builder/sync.json',
+                'test-builder/targets.json',
+            })
+
+    def test_gn_args_json_matches_resolve(self):
+        builders_registry, gn_args_registry = _make_registries()
+        fresh = snapshot.compute_fresh_output(builders_registry,
+                                              gn_args_registry)
+        self.assertEqual(json.loads(fresh['test-builder/gn-args.json']),
+                         gn_args_registry.resolve('test-builder'))
+
+    def test_sync_and_targets_json(self):
+        builders_registry, gn_args_registry = _make_registries()
+        fresh = snapshot.compute_fresh_output(builders_registry,
+                                              gn_args_registry)
+        self.assertEqual(json.loads(fresh['test-builder/sync.json']), {
+            'target_os': 'linux',
+            'target_cpu': 'x64',
+            'gclient_overrides': {},
+        })
+        self.assertEqual(json.loads(fresh['test-builder/targets.json']), {
+            'compile': ['brave:all'],
+            'tests': ['a_test'],
+        })
+
+    def test_no_builders_means_no_output(self):
+        builders_registry = BuildersRegistry(GnArgsRegistry())
+        self.assertEqual(
+            snapshot.compute_fresh_output(builders_registry, GnArgsRegistry()),
+            {})
+
+
+class WriteSnapshotTest(unittest.TestCase):
+    """`write_snapshot()` composes `compute_fresh_output()` and
+    `write_output()`; see ComputeFreshOutputTest/WriteOutputTest for each
+    half's own behaviour."""
+
+    def test_writes_resolved_builders_to_disk(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        builders_registry, gn_args_registry = _make_registries()
+
+        result = snapshot.write_snapshot(builders_registry, gn_args_registry,
+                                         Path(tmp.name))
+
+        self.assertEqual(sorted(result.changed), [
+            'test-builder/gn-args.json',
+            'test-builder/sync.json',
+            'test-builder/targets.json',
+        ])
+        self.assertEqual(
+            json.loads(
+                (Path(tmp.name) / 'test-builder/gn-args.json').read_text()),
+            gn_args_registry.resolve('test-builder'))
+
+    def test_rerun_with_no_changes_touches_nothing(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        builders_registry, gn_args_registry = _make_registries()
+
+        snapshot.write_snapshot(builders_registry, gn_args_registry,
+                                Path(tmp.name))
+        result = snapshot.write_snapshot(builders_registry, gn_args_registry,
+                                         Path(tmp.name))
+
+        self.assertEqual(result.changed, [])
+        self.assertEqual(sorted(result.unchanged), [
+            'test-builder/gn-args.json',
+            'test-builder/sync.json',
+            'test-builder/targets.json',
+        ])
+
+
+class WriteOutputTest(unittest.TestCase):
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.output_dir = Path(tmp.name)
+
+    def test_fresh_install_writes_everything(self):
+        fresh = {'a/x.json': '{}\n', 'b/y.json': '{}\n'}
+        result = snapshot.write_output(self.output_dir, fresh)
+        self.assertEqual(sorted(result.changed), ['a/x.json', 'b/y.json'])
+        self.assertEqual(result.unchanged, [])
+        self.assertEqual(result.deleted, [])
+        self.assertEqual((self.output_dir / 'a/x.json').read_text(), '{}\n')
+
+    def test_rerun_with_no_changes_touches_nothing(self):
+        fresh = {'a/x.json': '{}\n'}
+        snapshot.write_output(self.output_dir, fresh)
+        result = snapshot.write_output(self.output_dir, fresh)
+        self.assertEqual(result.changed, [])
+        self.assertEqual(result.unchanged, ['a/x.json'])
+        self.assertEqual(result.deleted, [])
+
+    def test_changed_content_is_rewritten(self):
+        snapshot.write_output(self.output_dir, {'a/x.json': '{"v": 1}\n'})
+        result = snapshot.write_output(self.output_dir,
+                                       {'a/x.json': '{"v": 2}\n'})
+        self.assertEqual(result.changed, ['a/x.json'])
+        self.assertEqual((self.output_dir / 'a/x.json').read_text(),
+                         '{"v": 2}\n')
+
+    def test_stale_file_is_deleted(self):
+        snapshot.write_output(self.output_dir, {
+            'a/x.json': '{}\n',
+            'b/y.json': '{}\n',
+        })
+        result = snapshot.write_output(self.output_dir, {'a/x.json': '{}\n'})
+        self.assertEqual(result.deleted, ['b/y.json'])
+        self.assertFalse((self.output_dir / 'b/y.json').exists())
+
+    def test_stale_builder_directory_loses_all_its_files(self):
+        # A whole builder disappearing should drop all three of its files.
+        # The now-empty `old-builder/` directory itself is left behind,
+        # faithful to lucicfg's own `generate`: it only ever removes files,
+        # never prunes directories, so we don't either.
+        snapshot.write_output(
+            self.output_dir, {
+                'old-builder/gn-args.json': '{}\n',
+                'old-builder/sync.json': '{}\n',
+                'old-builder/targets.json': '{}\n',
+            })
+        result = snapshot.write_output(self.output_dir,
+                                       {'new-builder/gn-args.json': '{}\n'})
+        self.assertEqual(sorted(result.deleted), [
+            'old-builder/gn-args.json',
+            'old-builder/sync.json',
+            'old-builder/targets.json',
+        ])
+        self.assertEqual(list((self.output_dir / 'old-builder').iterdir()), [])
+
+    def test_dry_run_reports_without_touching_disk(self):
+        snapshot.write_output(self.output_dir, {
+            'a/x.json': '{}\n',
+            'b/y.json': '{}\n',
+        })
+        result = snapshot.write_output(self.output_dir,
+                                       {'a/x.json': '{"v": 2}\n'},
+                                       dry_run=True)
+        self.assertEqual(result.changed, ['a/x.json'])
+        self.assertEqual(result.deleted, ['b/y.json'])
+        # Nothing was actually touched.
+        self.assertEqual((self.output_dir / 'a/x.json').read_text(), '{}\n')
+        self.assertTrue((self.output_dir / 'b/y.json').exists())
+
+    def test_first_run_on_missing_directory(self):
+        missing = self.output_dir / 'does-not-exist-yet'
+        result = snapshot.write_output(missing, {'a/x.json': '{}\n'})
+        self.assertEqual(result.changed, ['a/x.json'])
+        self.assertTrue((missing / 'a/x.json').exists())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR renames `bots.py generate` to `bots.py snapshot`. This is being
done to avoid confusion down the line when `bots.py gen` is introduced.

This change also splits `snapshot` out of `bots.py`, the same way
`lookup` has been placed out of it.

Bug: https://github.com/brave/brave-browser/issues/47912
