### PR TITLE
[plaster] `make_virtual` to handle decl/body functions

### DIFF
--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1249,6 +1249,50 @@ class RewriterFormsTest(unittest.TestCase):
             '      method_name: Foo\n')
         self.assertEqual(result, 'class C {\n  virtual void Foo();\n};\n')
 
+    def test_make_virtual_on_inline_defined_method(self):
+        # A method defined inline (with a body, not just declared) parses as
+        # a function_definition, not a field_declaration -- the real bug this
+        # covers: `UpdateContent` in tab_hover_card_bubble_view.cc is defined
+        # this way, and make_virtual used to find nothing to match.
+        source = ('class C {\n'
+                  ' public:\n'
+                  '  void UpdateContent(const Data* data) {\n'
+                  '    Apply(data);\n'
+                  '  }\n'
+                  '};\n')
+        result = self._apply(
+            'inline_defined.h', source, 'substitutions:\n'
+            '  - description: make the inline-defined method virtual\n'
+            '    make_virtual:\n'
+            '      class_name: C\n'
+            '      method_name: UpdateContent\n')
+        self.assertEqual(
+            result,
+            source.replace('  void UpdateContent',
+                           '  virtual void UpdateContent'))
+
+    def test_make_virtual_on_inline_defined_method_qualified_nested_class(
+            self):
+        # The real fixture: an out-of-line nested class (needing the fully
+        # qualified `class_name`, per the earlier fix) whose method is also
+        # defined inline (needing this fix), together.
+        source = ('class Outer::Inner : public views::View {\n'
+                  ' public:\n'
+                  '  void UpdateContent(const Data* data) {\n'
+                  '    Apply(data);\n'
+                  '  }\n'
+                  '};\n')
+        result = self._apply(
+            'inline_defined_nested.h', source, 'substitutions:\n'
+            '  - description: make the inline-defined nested method virtual\n'
+            '    make_virtual:\n'
+            '      class_name: Outer::Inner\n'
+            '      method_name: UpdateContent\n')
+        self.assertEqual(
+            result,
+            source.replace('  void UpdateContent',
+                           '  virtual void UpdateContent'))
+
     def test_make_virtual_after_leading_attribute(self):
         # `virtual` must land after a leading attribute, not before it.
         result = self._apply(

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -97,17 +97,27 @@
 {
     "ast.matcher": {
 
-        # The full declaration of `class_name::method_name`, including a
-        # multi-line signature and its trailing semicolon. The name is matched
-        # by text, so methods (field_identifier), destructors (destructor_name,
-        # e.g. "~Foo") and constructors (identifier) are all found. Overloads
-        # sharing the name each produce their own match. The result node is a
-        # field_declaration for methods and a declaration for con/destructors.
+        # The full method, including a multi-line signature and either its
+        # trailing semicolon (a bodyless declaration) or its inline `{ ... }`
+        # body (a definition). The name is matched by text, so methods
+        # (field_identifier), destructors (destructor_name, e.g. "~Foo") and
+        # constructors (identifier) are all found. Overloads sharing the name
+        # each produce their own match. The result node is a field_declaration
+        # for a bodyless method, a declaration for a bodyless con/destructor,
+        # or a function_definition for one defined inline.
+        #
+        # Templated functions are guaranteed to be skipped.
         "cxx.find_class_method_decl": {
             "template": """\
 any:
   - kind: field_declaration
   - kind: declaration
+  - all:
+      - kind: function_definition
+      - not:
+          inside:
+            kind: template_declaration
+            stopBy: end
 has:
   kind: function_declarator
   stopBy: end
@@ -296,10 +306,18 @@ inside:
                 "node": "compound_statement",
                 "captures": {
                     "return_type": [
-                        {"text": "TRAILING_RETURN_TYPE"},
-                        {"span": ["LEADING_QUALIFIER", "FUNCTION"]},
-                        {"span": ["RETURN_TYPE", "FUNCTION"]},
-                        {"literal": "void"},
+                        {
+                            "text": "TRAILING_RETURN_TYPE"
+                        },
+                        {
+                            "span": ["LEADING_QUALIFIER", "FUNCTION"]
+                        },
+                        {
+                            "span": ["RETURN_TYPE", "FUNCTION"]
+                        },
+                        {
+                            "literal": "void"
+                        },
                     ],
                 },
             },
@@ -453,8 +471,7 @@ regex: ^{class_name}$
             },
             "replace": {
                 "re_pattern": "(?s)^\\{(.*)\\}$",
-                "replace":
-                "{{\\n  {result_var}[&]() -> {return_type} "
+                "replace": "{{\\n  {result_var}[&]() -> {return_type} "
                 "{{\\1  }}();\\n{epilogue}\\n}}",
             },
             "result": {
@@ -596,7 +613,6 @@ regex: ^{class_name}$
         },
     },
     "regex_macro": {
-
         "cxx.set_feature_flag_default_state": {
             "description": """\
 Sets a new value to a `BASE_FEATURE` feature flag.
@@ -619,13 +635,11 @@ substitutions:
             "inputs": [
                 {
                     "name": "feature_name",
-                    "description":
-                    "The `BASE_FEATURE` feature flag name, e.g. `kMyFeature`.",
+                    "description": "The `BASE_FEATURE` feature flag name, e.g. `kMyFeature`.",
                 },
                 {
                     "name": "value",
-                    "description":
-                    "The new value, e.g. `base::FEATURE_DISABLED_BY_DEFAULT`.",
+                    "description": "The new value, e.g. `base::FEATURE_DISABLED_BY_DEFAULT`.",
                 },
             ],
             "re_pattern": "(BASE_FEATURE\\(\\s*{feature_name}\\s*,)(?!(?:[^;]*,)?\\s*{value}\\s*\\);)([^;]*,)?(\\s*)[^;]*?(\\);)",


### PR DESCRIPTION
This PR fixes `make_virtual` for the following case:

```cxx
class TabHoverCardBubbleView::TabCardView : public views::View {
  METADATA_HEADER(TabCardView, views::View)

// ...

  void UpdateContent(const HoverCardAnchorTarget* anchor_target) {
    CHECK(std::holds_alternative<TabCardData>(anchor_target->data()));
    const TabCardData& card_data = std::get<TabCardData>(anchor_target->data());
```

The matcher has been readjusted to also match a function declaration
followed by a body.

Bug: https://github.com/brave/brave-browser/issues/58161
