### PR TITLE
[ads] Show fallback text for unset Catalog ID/last-updated diagnostics

### DIFF
--- a/components/brave_ads/core/internal/diagnostics/entries/catalog_id_diagnostic_entry.cc
+++ b/components/brave_ads/core/internal/diagnostics/entries/catalog_id_diagnostic_entry.cc
@@ -11,6 +11,7 @@ namespace brave_ads {
 
 namespace {
 constexpr char kName[] = "Catalog ID";
+constexpr char kNotApplicable[] = "N/A";
 }  // namespace
 
 DiagnosticEntryType CatalogIdDiagnosticEntry::GetType() const {
@@ -22,7 +23,12 @@ std::string CatalogIdDiagnosticEntry::GetName() const {
 }
 
 std::string CatalogIdDiagnosticEntry::GetValue() const {
-  return GetCatalogId();
+  std::string catalog_id = GetCatalogId();
+  if (catalog_id.empty()) {
+    return kNotApplicable;
+  }
+
+  return catalog_id;
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/diagnostics/entries/catalog_id_diagnostic_entry_unittest.cc
+++ b/components/brave_ads/core/internal/diagnostics/entries/catalog_id_diagnostic_entry_unittest.cc
@@ -35,7 +35,7 @@ TEST_F(BraveAdsCatalogIdDiagnosticEntryTest, EmptyCatalogId) {
   // Act & Assert
   EXPECT_EQ(DiagnosticEntryType::kCatalogId, diagnostic_entry.GetType());
   EXPECT_EQ("Catalog ID", diagnostic_entry.GetName());
-  EXPECT_THAT(diagnostic_entry.GetValue(), ::testing::IsEmpty());
+  EXPECT_EQ("N/A", diagnostic_entry.GetValue());
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/diagnostics/entries/catalog_last_updated_diagnostic_entry.cc
+++ b/components/brave_ads/core/internal/diagnostics/entries/catalog_last_updated_diagnostic_entry.cc
@@ -13,6 +13,7 @@ namespace brave_ads {
 
 namespace {
 constexpr char kName[] = "Catalog last updated";
+constexpr char kNever[] = "Never";
 }  // namespace
 
 DiagnosticEntryType CatalogLastUpdatedDiagnosticEntry::GetType() const {
@@ -26,7 +27,7 @@ std::string CatalogLastUpdatedDiagnosticEntry::GetName() const {
 std::string CatalogLastUpdatedDiagnosticEntry::GetValue() const {
   const base::Time last_updated_at = GetCatalogLastUpdated();
   if (last_updated_at.is_null()) {
-    return {};
+    return kNever;
   }
 
   return LongFriendlyDateAndTime(last_updated_at,

--- a/components/brave_ads/core/internal/diagnostics/entries/catalog_last_updated_diagnostic_entry_unittest.cc
+++ b/components/brave_ads/core/internal/diagnostics/entries/catalog_last_updated_diagnostic_entry_unittest.cc
@@ -40,7 +40,7 @@ TEST_F(BraveAdsCatalogLastUpdatedDiagnosticEntryTest, CatalogNeverUpdated) {
   EXPECT_EQ(DiagnosticEntryType::kCatalogLastUpdated,
             diagnostic_entry.GetType());
   EXPECT_EQ("Catalog last updated", diagnostic_entry.GetName());
-  EXPECT_THAT(diagnostic_entry.GetValue(), ::testing::IsEmpty());
+  EXPECT_EQ("Never", diagnostic_entry.GetValue());
 }
 
 }  // namespace brave_ads


### PR DESCRIPTION
Return "N/A" for an unset Catalog ID and "Never" for a last-updated timestamp that has not yet occurred, instead of an empty string, matching the existing LastUnIdleTimeDiagnosticEntry precedent.

Part of https://github.com/brave/brave-browser/issues/42034

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
