### PR TITLE
Only Inject web3 providers once a wallet is created

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -849,15 +849,6 @@ public abstract class BraveActivity extends ChromeActivity
                 });
     }
 
-    public void showWalletOnboarding() {
-        BraveToolbarLayoutImpl layout = getBraveToolbarLayout();
-        layout.showWalletIcon(true);
-        if (!BraveWalletPreferences.getPrefWeb3NotificationsEnabled()) {
-            return;
-        }
-        layout.showWalletPanel();
-    }
-
     public void walletInteractionDetected(WebContents webContents) {
         Tab tab = getActivityTab();
         if (tab == null

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/BraveWalletProviderDelegateImplHelper.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/BraveWalletProviderDelegateImplHelper.java
@@ -63,16 +63,6 @@ public class BraveWalletProviderDelegateImplHelper {
     }
 
     @CalledByNative
-    public static void showWalletOnboarding() {
-        try {
-            BraveActivity activity = BraveActivity.getBraveActivity();
-            activity.showWalletOnboarding();
-        } catch (BraveActivity.BraveActivityNotFoundException e) {
-            Log.e(TAG, "showWalletOnboarding", e);
-        }
-    }
-
-    @CalledByNative
     public static void walletInteractionDetected(WebContents webContents) {
         try {
             BraveActivity activity = BraveActivity.getBraveActivity();

--- a/browser/brave_wallet/BUILD.gn
+++ b/browser/brave_wallet/BUILD.gn
@@ -253,6 +253,7 @@ source_set("browser_tests") {
       "//brave/browser/ui/sidebar:sidebar_impl",
       "//brave/components/brave_wallet/browser",
       "//brave/components/brave_wallet/browser:pref_names",
+      "//brave/components/brave_wallet/browser:test_support",
       "//brave/components/brave_wallet/browser:utils",
       "//brave/components/brave_wallet/common",
       "//brave/components/brave_wallet/common:common_constants",

--- a/browser/brave_wallet/brave_wallet_ethereum_chain_browsertest.cc
+++ b/browser/brave_wallet/brave_wallet_ethereum_chain_browsertest.cc
@@ -12,6 +12,7 @@
 #include "brave/components/brave_wallet/browser/brave_wallet_service.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
+#include "brave/components/brave_wallet/browser/keyring_service.h"
 #include "brave/components/brave_wallet/browser/test_utils.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "chrome/browser/profiles/profile.h"
@@ -168,6 +169,11 @@ class BraveWalletEthereumChainTest : public InProcessBrowserTest {
         browser()->GetProfile()->GetPrefs(),
         brave_wallet::mojom::DefaultWallet::BraveWallet);
     InProcessBrowserTest::SetUpOnMainThread();
+    // These tests drive window.ethereum, which is only injected once a wallet
+    // exists.
+    ASSERT_TRUE(GetKeyringService()->RestoreWalletSync(
+        brave_wallet::kMnemonicScarePiece, brave_wallet::kTestWalletPassword,
+        false));
     mock_cert_verifier_.mock_cert_verifier()->set_default_result(net::OK);
     host_resolver()->AddRule("*", "127.0.0.1");
 
@@ -231,6 +237,12 @@ class BraveWalletEthereumChainTest : public InProcessBrowserTest {
     return brave_wallet::BraveWalletServiceFactory::GetInstance()
         ->GetServiceForContext(browser()->GetProfile())
         ->json_rpc_service();
+  }
+
+  brave_wallet::KeyringService* GetKeyringService() {
+    return brave_wallet::BraveWalletServiceFactory::GetInstance()
+        ->GetServiceForContext(browser()->GetProfile())
+        ->keyring_service();
   }
 
   std::vector<brave_wallet::mojom::NetworkInfoPtr> GetAllEthCustomChains() {

--- a/browser/brave_wallet/brave_wallet_event_emitter_browsertest.cc
+++ b/browser/brave_wallet/brave_wallet_event_emitter_browsertest.cc
@@ -139,6 +139,7 @@ class BraveWalletEventEmitterTest : public InProcessBrowserTest {
 };
 
 IN_PROC_BROWSER_TEST_F(BraveWalletEventEmitterTest, CheckForAConnectEvent) {
+  RestoreWallet();
   GURL url =
       https_server()->GetURL("a.com", "/brave_wallet_event_emitter.html");
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
@@ -152,6 +153,7 @@ IN_PROC_BROWSER_TEST_F(BraveWalletEventEmitterTest, CheckForAConnectEvent) {
 
 IN_PROC_BROWSER_TEST_F(BraveWalletEventEmitterTest,
                        CheckForAChainChangedEvent) {
+  RestoreWallet();
   GURL url =
       https_server()->GetURL("a.com", "/brave_wallet_event_emitter.html");
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
@@ -73,11 +73,6 @@ void BraveWalletProviderDelegateImpl::WalletInteractionDetected() {
   ::brave_wallet::WalletInteractionDetected(web_contents());
 }
 
-void BraveWalletProviderDelegateImpl::ShowWalletOnboarding(
-    const url::Origin& origin) {
-  ::brave_wallet::ShowWalletOnboarding(web_contents());
-}
-
 void BraveWalletProviderDelegateImpl::ShowAccountCreation(
     mojom::CoinType type,
     const url::Origin& origin) {

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl.h
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl.h
@@ -43,7 +43,6 @@ class BraveWalletProviderDelegateImpl : public BraveWalletProviderDelegate,
   void ShowWalletBackup() override;
   void UnlockWallet() override;
   void WalletInteractionDetected() override;
-  void ShowWalletOnboarding(const url::Origin& origin) override;
   void ShowAccountCreation(mojom::CoinType type,
                            const url::Origin& origin) override;
   std::optional<std::vector<std::string>> GetAllowedAccounts(

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.cc
@@ -18,7 +18,6 @@
 
 namespace {
 
-base::OnceCallback<void()>* g_new_setup_needed_callback_for_testing = nullptr;
 base::OnceCallback<void(std::string_view coin_name)>*
     g_account_creation_callback_for_testing = nullptr;
 
@@ -52,24 +51,6 @@ void UnlockWallet() {
   NOTREACHED();
 }
 
-void ShowWalletOnboarding(content::WebContents* web_contents) {
-  if (web_contents) {
-    BrowserWindowInterface* browser =
-        GlobalBrowserCollection::GetInstance()->FindBrowserWithTab(
-            web_contents);
-    if (browser) {
-      brave::ShowBraveWalletOnboarding(browser);
-      return;
-    }
-  }
-
-  if (g_new_setup_needed_callback_for_testing) {
-    CHECK_IS_TEST();
-    CHECK(*g_new_setup_needed_callback_for_testing);
-    std::move(*g_new_setup_needed_callback_for_testing).Run();
-  }
-}
-
 void ShowAccountCreation(content::WebContents* web_contents,
                          brave_wallet::mojom::CoinType coin_type) {
   auto it = kAccountCreationCoinName.find(coin_type);
@@ -101,13 +82,6 @@ void WalletInteractionDetected(content::WebContents* web_contents) {}
 // on Android for permissions
 bool IsWeb3NotificationAllowed() {
   return true;
-}
-
-base::AutoReset<base::OnceCallback<void()>*>
-SetNewSetupNeededCallbackForTesting(base::OnceCallback<void()>* callback) {
-  CHECK_IS_TEST();
-  return base::AutoReset<base::OnceCallback<void()>*>(
-      &g_new_setup_needed_callback_for_testing, callback);
 }
 
 base::AutoReset<base::OnceCallback<void(std::string_view)>*>

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.h
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.h
@@ -31,9 +31,6 @@ void ShowWalletBackup();
 // Show native Brave Wallet unlock screen - Used only by Android.
 void UnlockWallet();
 
-// Show wallet onboarding page.
-void ShowWalletOnboarding(content::WebContents* web_contents);
-
 // Show account creation page for keyring id
 void ShowAccountCreation(content::WebContents* web_contents,
                          brave_wallet::mojom::CoinType coin_type);
@@ -49,9 +46,6 @@ bool IsWeb3NotificationAllowed();
 // scope managers in
 // `brave_wallet_provider_delegate_impl_helper_test_util.h` rather than these
 // functions directly.
-[[nodiscard]] base::AutoReset<base::OnceCallback<void()>*>
-SetNewSetupNeededCallbackForTesting(base::OnceCallback<void()>* callback);
-
 [[nodiscard]] base::AutoReset<base::OnceCallback<void(std::string_view)>*>
 SetAccountCreationCallbackForTesting(
     base::OnceCallback<void(std::string_view)>* callback);

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper_android.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper_android.cc
@@ -33,11 +33,6 @@ void UnlockWallet() {
   Java_BraveWalletProviderDelegateImplHelper_unlockWallet(env);
 }
 
-void ShowWalletOnboarding(content::WebContents*) {
-  JNIEnv* env = base::android::AttachCurrentThread();
-  Java_BraveWalletProviderDelegateImplHelper_showWalletOnboarding(env);
-}
-
 void ShowAccountCreation(content::WebContents*,
                          brave_wallet::mojom::CoinType coin_type) {
   JNIEnv* env = base::android::AttachCurrentThread();

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper_test_util.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper_test_util.cc
@@ -11,14 +11,6 @@
 
 namespace brave_wallet {
 
-ScopedNewSetupNeededCallbackForTesting::ScopedNewSetupNeededCallbackForTesting(
-    base::OnceCallback<void()> callback)
-    : callback_(std::move(callback)),
-      resetter_(SetNewSetupNeededCallbackForTesting(&callback_)) {}
-
-ScopedNewSetupNeededCallbackForTesting::
-    ~ScopedNewSetupNeededCallbackForTesting() = default;
-
 ScopedAccountCreationCallbackForTesting::
     ScopedAccountCreationCallbackForTesting(
         base::OnceCallback<void(std::string_view)> callback)

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper_test_util.h
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper_test_util.h
@@ -16,21 +16,6 @@ namespace brave_wallet {
 // These are scope managers to set specific callbacks for certain test-only
 // events.
 
-class ScopedNewSetupNeededCallbackForTesting {
- public:
-  explicit ScopedNewSetupNeededCallbackForTesting(
-      base::OnceCallback<void()> callback);
-  ScopedNewSetupNeededCallbackForTesting(
-      const ScopedNewSetupNeededCallbackForTesting&) = delete;
-  ScopedNewSetupNeededCallbackForTesting& operator=(
-      const ScopedNewSetupNeededCallbackForTesting&) = delete;
-  ~ScopedNewSetupNeededCallbackForTesting();
-
- private:
-  base::OnceCallback<void()> callback_;
-  base::AutoReset<base::OnceCallback<void()>*> resetter_;
-};
-
 class ScopedAccountCreationCallbackForTesting {
  public:
   explicit ScopedAccountCreationCallbackForTesting(

--- a/browser/brave_wallet/brave_wallet_tab_helper_browsertest.cc
+++ b/browser/brave_wallet/brave_wallet_tab_helper_browsertest.cc
@@ -8,7 +8,10 @@
 #include <memory>
 
 #include "base/memory/weak_ptr.h"
+#include "brave/browser/brave_wallet/brave_wallet_service_factory.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_service.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
+#include "brave/components/brave_wallet/browser/keyring_service.h"
 #include "brave/components/brave_wallet/browser/test_utils.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
@@ -106,6 +109,14 @@ class BraveWalletTabHelperBrowserTest : public InProcessBrowserTest {
         browser()->GetProfile()->GetPrefs(),
         brave_wallet::mojom::DefaultWallet::BraveWallet);
     InProcessBrowserTest::SetUpOnMainThread();
+    // The panel is opened by a dApp calling window.ethereum, which is only
+    // injected once a wallet exists.
+    ASSERT_TRUE(brave_wallet::BraveWalletServiceFactory::GetServiceForContext(
+                    browser()->GetProfile())
+                    ->keyring_service()
+                    ->RestoreWalletSync(brave_wallet::kMnemonicScarePiece,
+                                        brave_wallet::kTestWalletPassword,
+                                        false));
     mock_cert_verifier_.mock_cert_verifier()->set_default_result(net::OK);
     host_resolver()->AddRule("*", "127.0.0.1");
 

--- a/browser/brave_wallet/cardano_provider_renderer_browsertest.cc
+++ b/browser/brave_wallet/cardano_provider_renderer_browsertest.cc
@@ -13,6 +13,7 @@
 #include "brave/components/brave_wallet/browser/brave_wallet_service.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"
+#include "brave/components/brave_wallet/browser/test_utils.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/features.h"
 #include "brave/components/constants/brave_paths.h"
@@ -218,6 +219,10 @@ class CardanoProviderRendererTest : public InProcessBrowserTest {
 
   void SetUpOnMainThread() override {
     InProcessBrowserTest::SetUpOnMainThread();
+    // The provider is only injected once a wallet exists, so create one before
+    // the navigations below.
+    ASSERT_TRUE(GetKeyringService()->RestoreWalletSync(
+        kMnemonicScarePiece, kTestWalletPassword, false));
     content::SetBrowserClientForTesting(&test_content_browser_client_);
     base::FilePath test_data_dir =
         base::PathService::CheckedGet(brave::DIR_TEST_DATA);
@@ -351,19 +356,17 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, Properties) {
 }
 
 IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest,
-                       AttachEvenIfNoWalletCreated) {
+                       DoNotAttachIfNoWalletCreated) {
   GetKeyringService()->Reset(false);
 
   ReloadAndWaitForLoadStop(browser());
 
-  auto result = EvalJs(web_contents(browser()), kCheckCardanoProviderScript);
-  EXPECT_EQ(base::Value(true), result);
+  auto result = EvalJs(web_contents(browser()), "!!window.cardano");
+  EXPECT_EQ(base::Value(false), result);
   EXPECT_EQ(browser()->tab_strip_model()->count(), 1);
 }
 
 IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, AttachIfWalletCreated) {
-  GetKeyringService()->CreateWallet("password", base::DoNothing());
-
   ReloadAndWaitForLoadStop(browser());
 
   auto result = EvalJs(web_contents(browser()), kCheckCardanoProviderScript);

--- a/browser/brave_wallet/ethereum_provider_impl_unittest.cc
+++ b/browser/brave_wallet/ethereum_provider_impl_unittest.cc
@@ -25,7 +25,6 @@
 #include "base/test/values_test_util.h"
 #include "base/values.h"
 #include "brave/browser/brave_wallet/brave_wallet_provider_delegate_impl.h"
-#include "brave/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper_test_util.h"
 #include "brave/browser/brave_wallet/brave_wallet_service_delegate_impl.h"
 #include "brave/browser/brave_wallet/brave_wallet_tab_helper.h"
 #include "brave/components/brave_wallet/browser/asset_ratio_service.h"
@@ -1377,27 +1376,7 @@ TEST_F(EthereumProviderImplUnitTest, AddAndApprove1559TransactionNoPermission) {
   EXPECT_TRUE(callback_called);
 }
 
-TEST_F(EthereumProviderImplUnitTest, RequestEthereumPermissionNotNewSetup) {
-  bool new_setup_callback_called = false;
-  ScopedNewSetupNeededCallbackForTesting new_setup_callback(
-      base::BindLambdaForTesting([&]() { new_setup_callback_called = true; }));
-  CreateWallet();
-  auto account_0 = GetAccountUtils().EnsureEthAccount(0);
-  auto address_0 = base::ToLowerASCII(account_0->address);
-
-  GURL url("https://brave.com");
-  Navigate(url);
-
-  AddEthereumPermission(account_0->account_id);
-  base::RunLoop run_loop;
-  EXPECT_THAT(RequestEthereumPermissions(), ElementsAre(address_0));
-  // Make sure even with a delay the new setup callback is not called.
-  browser_task_environment_.RunUntilIdle();
-  EXPECT_FALSE(new_setup_callback_called);
-}
-
 TEST_F(EthereumProviderImplUnitTest, RequestEthereumPermissionsNoPermission) {
-  bool new_setup_callback_called = false;
   bool permission_callback_called = false;
   CreateWallet();
   GetAccountUtils().EnsureEthAccount(0);
@@ -1409,9 +1388,6 @@ TEST_F(EthereumProviderImplUnitTest, RequestEthereumPermissionsNoPermission) {
   // setting (no permission prompt is shown).
   host_content_settings_map()->SetContentSettingDefaultScope(
       url, url, ContentSettingsType::BRAVE_ETHEREUM, CONTENT_SETTING_BLOCK);
-
-  ScopedNewSetupNeededCallbackForTesting new_setup_callback(
-      base::BindLambdaForTesting([&]() { new_setup_callback_called = true; }));
 
   provider()->RequestEthereumPermissions(
       base::BindLambdaForTesting(
@@ -1428,17 +1404,14 @@ TEST_F(EthereumProviderImplUnitTest, RequestEthereumPermissionsNoPermission) {
       base::Value(), "", GetOrigin());
   browser_task_environment_.RunUntilIdle();
   EXPECT_TRUE(permission_callback_called);
-  EXPECT_FALSE(new_setup_callback_called);
 }
 
+// The provider isn't injected without a wallet, but the request must still fail
+// cleanly if one is reset while a page holds a provider.
 TEST_F(EthereumProviderImplUnitTest, RequestEthereumPermissionsNoWallet) {
   GURL url("https://brave.com");
   Navigate(url);
 
-  bool new_setup_callback_called = false;
-  std::optional<ScopedNewSetupNeededCallbackForTesting> new_setup_callback;
-  new_setup_callback.emplace(
-      base::BindLambdaForTesting([&]() { new_setup_callback_called = true; }));
   base::RunLoop run_loop;
   provider()->RequestEthereumPermissions(
       base::BindLambdaForTesting(
@@ -1453,27 +1426,6 @@ TEST_F(EthereumProviderImplUnitTest, RequestEthereumPermissionsNoWallet) {
           }),
       base::Value(), "", GetOrigin());
   run_loop.Run();
-  EXPECT_TRUE(new_setup_callback_called);
-
-  // Setup is called at most once
-  new_setup_callback_called = false;
-  new_setup_callback.emplace(
-      base::BindLambdaForTesting([&]() { new_setup_callback_called = true; }));
-  base::RunLoop run_loop2;
-  provider()->RequestEthereumPermissions(
-      base::BindLambdaForTesting(
-          [&](mojom::EthereumProviderResponsePtr response) {
-            mojom::ProviderError error = mojom::ProviderError::kUnknown;
-            std::string error_message;
-            GetErrorCodeMessage(std::move(response->formed_response), &error,
-                                &error_message);
-            EXPECT_NE(error, mojom::ProviderError::kSuccess);
-            EXPECT_FALSE(error_message.empty());
-            run_loop2.Quit();
-          }),
-      base::Value(), "", GetOrigin());
-  run_loop2.Run();
-  EXPECT_FALSE(new_setup_callback_called);
 }
 
 TEST_F(EthereumProviderImplUnitTest, RequestEthereumPermissionsWithAccounts) {

--- a/browser/brave_wallet/js_ethereum_provider_browsertest.cc
+++ b/browser/brave_wallet/js_ethereum_provider_browsertest.cc
@@ -13,6 +13,7 @@
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"
+#include "brave/components/brave_wallet/browser/test_utils.h"
 #include "brave/components/brave_wallet/browser/wallet_data_files_installer.h"
 #include "brave/components/brave_wallet/common/brave_wallet_types.h"
 #include "brave/components/constants/brave_paths.h"
@@ -143,6 +144,14 @@ class JSEthereumProviderBrowserTest : public InProcessBrowserTest {
         ->keyring_service();
   }
 
+  // Providers are only injected once a wallet exists, so most tests here need
+  // one before they navigate.
+  void RestoreWallet() {
+    ASSERT_TRUE(GetKeyringService()->RestoreWalletSync(
+        brave_wallet::kMnemonicScarePiece, brave_wallet::kTestWalletPassword,
+        false));
+  }
+
  protected:
   net::test_server::EmbeddedTestServerHandle test_server_handle_;
   content::ContentMockCertVerifier mock_cert_verifier_;
@@ -150,6 +159,7 @@ class JSEthereumProviderBrowserTest : public InProcessBrowserTest {
 };
 
 IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, AttachOnReload) {
+  RestoreWallet();
   brave_wallet::SetDefaultEthereumWallet(
       browser()->GetProfile()->GetPrefs(),
       brave_wallet::mojom::DefaultWallet::None);
@@ -248,17 +258,14 @@ IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest,
   const GURL url = https_server_.GetURL("/simple.html");
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
 
-  {
-    std::string command = "window.ethereum.isBraveWallet";
+  // Neither the prefixed nor the unprefixed provider is injected before the
+  // user has created a wallet.
+  for (const char* command : {"window.ethereum.isBraveWallet",
+                              "window.braveEthereum.isBraveWallet"}) {
+    SCOPED_TRACE(command);
     EXPECT_THAT(content::EvalJs(primary_main_frame(), command),
                 content::EvalJsResult::ErrorIs(
                     testing::HasSubstr("Cannot read properties of undefined")));
-  }
-
-  {
-    std::string command = "window.braveEthereum.isBraveWallet";
-    EXPECT_EQ(base::Value(true),
-              content::EvalJs(primary_main_frame(), command));
   }
 
   EXPECT_EQ(browser()->tab_strip_model()->count(), 1);
@@ -401,6 +408,7 @@ IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest,
 #endif  // BUILDFLAG(ENABLE_EXTENSIONS)
 
 IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, NonWritable) {
+  RestoreWallet();
   const GURL url = https_server_.GetURL("/simple.html");
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
 
@@ -453,6 +461,7 @@ IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, NonWritable) {
 
 // See https://github.com/brave/brave-browser/issues/22213 for details
 IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, IsMetaMaskWritable) {
+  RestoreWallet();
   const GURL url = https_server_.GetURL("/simple.html");
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
 
@@ -463,6 +472,7 @@ IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, IsMetaMaskWritable) {
 }
 
 IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, NonConfigurable) {
+  RestoreWallet();
   brave_wallet::SetDefaultEthereumWallet(
       browser()->GetProfile()->GetPrefs(),
       brave_wallet::mojom::DefaultWallet::BraveWallet);
@@ -482,6 +492,7 @@ IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, NonConfigurable) {
 
 IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest,
                        BraveEthereum_NonConfigurable) {
+  RestoreWallet();
   brave_wallet::mojom::DefaultWallet non_configurable_states[] = {
       brave_wallet::mojom::DefaultWallet::BraveWallet,
       brave_wallet::mojom::DefaultWallet::BraveWalletPreferExtension};
@@ -504,6 +515,7 @@ IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest,
 }
 
 IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, OnlyWriteOwnProperty) {
+  RestoreWallet();
   brave_wallet::SetDefaultEthereumWallet(
       browser()->GetProfile()->GetPrefs(),
       brave_wallet::mojom::DefaultWallet::BraveWallet);
@@ -541,6 +553,7 @@ IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, OnlyWriteOwnProperty) {
 }
 
 IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, Iframe3P) {
+  RestoreWallet();
   constexpr char kEvalEthereumUndefined[] =
       R"(typeof window.ethereum === 'undefined')";
 
@@ -678,6 +691,7 @@ IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, Iframe3P) {
 }
 
 IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, SecureContextOnly) {
+  RestoreWallet();
   // Secure context HTTPS server
   GURL url = https_server_.GetURL("a.com", "/simple.html");
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));

--- a/browser/brave_wallet/solana_provider_browsertest.cc
+++ b/browser/brave_wallet/solana_provider_browsertest.cc
@@ -1591,6 +1591,7 @@ IN_PROC_BROWSER_TEST_F(SolanaProviderTest, NoCrashOnShortLivedIframes) {
 }
 
 IN_PROC_BROWSER_TEST_F(SolanaProviderTest, CallViaProxy) {
+  RestoreWallet();
   GURL url =
       https_server_for_files()->GetURL("a.test", "/solana_provider.html");
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));

--- a/browser/brave_wallet/solana_provider_impl_unittest.cc
+++ b/browser/brave_wallet/solana_provider_impl_unittest.cc
@@ -635,21 +635,28 @@ TEST_F(SolanaProviderImplUnitTest, EagerlyConnect) {
   EXPECT_TRUE(IsConnected());
 }
 
+// The provider isn't injected without a wallet, but one can be reset while a
+// page still holds it. Account creation must not be offered in that state.
+TEST_F(SolanaProviderImplUnitTest, ConnectWithNoWallet) {
+  Navigate(GURL("https://brave.com"));
+
+  base::test::TestFuture<std::string_view> account_creation_callback_future;
+  ScopedAccountCreationCallbackForTesting account_creation_callback(
+      account_creation_callback_future.GetCallback());
+
+  mojom::SolanaProviderError error;
+  std::string error_message;
+  EXPECT_TRUE(Connect(std::nullopt, &error, &error_message).empty());
+  EXPECT_EQ(error, mojom::SolanaProviderError::kInternalError);
+  EXPECT_FALSE(IsConnected());
+  EXPECT_FALSE(account_creation_callback_future.IsReady());
+}
+
 TEST_F(SolanaProviderImplUnitTest, ConnectWithNoSolanaAccount) {
-  bool onboarding_callback_called = false;
-  ScopedNewSetupNeededCallbackForTesting new_setup_callback(
-      base::BindLambdaForTesting([&]() { onboarding_callback_called = true; }));
   Navigate(GURL("https://brave.com"));
 
   mojom::SolanaProviderError error;
   std::string error_message;
-  // No wallet setup
-  std::string account = Connect(std::nullopt, &error, &error_message);
-  EXPECT_TRUE(account.empty());
-  EXPECT_EQ(error, mojom::SolanaProviderError::kInternalError);
-  EXPECT_FALSE(IsConnected());
-  EXPECT_TRUE(onboarding_callback_called);
-
   base::test::TestFuture<std::string_view> account_creation_callback_future;
   std::optional<ScopedAccountCreationCallbackForTesting>
       account_creation_callback;
@@ -658,7 +665,7 @@ TEST_F(SolanaProviderImplUnitTest, ConnectWithNoSolanaAccount) {
   // No solana account
   CreateWallet();
   keyring_service_->SetSelectedDappAccountInternal(mojom::CoinType::SOL, {});
-  account = Connect(std::nullopt, &error, &error_message);
+  std::string account = Connect(std::nullopt, &error, &error_message);
   EXPECT_TRUE(account.empty());
   EXPECT_EQ(error, mojom::SolanaProviderError::kInternalError);
   EXPECT_FALSE(IsConnected());

--- a/browser/brave_wallet/solana_provider_renderer_browsertest.cc
+++ b/browser/brave_wallet/solana_provider_renderer_browsertest.cc
@@ -20,6 +20,7 @@
 #include "brave/components/brave_wallet/browser/brave_wallet_service.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"
+#include "brave/components/brave_wallet/browser/test_utils.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/common/encoding_utils.h"
@@ -549,6 +550,11 @@ class SolanaProviderRendererTest : public InProcessBrowserTest {
     brave_wallet::SetDefaultSolanaWallet(
         browser()->GetProfile()->GetPrefs(),
         brave_wallet::mojom::DefaultWallet::BraveWallet);
+    // The provider is only injected once a wallet exists, so create one before
+    // the navigations below.
+    ASSERT_TRUE(GetKeyringService()->RestoreWalletSync(
+        brave_wallet::kMnemonicScarePiece, brave_wallet::kTestWalletPassword,
+        false));
     content::SetBrowserClientForTesting(&test_content_browser_client_);
     base::FilePath test_data_dir;
     base::PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
@@ -643,7 +649,7 @@ IN_PROC_BROWSER_TEST_F(SolanaProviderRendererTest, ExtensionOverwrite) {
 }
 
 IN_PROC_BROWSER_TEST_F(SolanaProviderRendererTest,
-                       AttachEvenIfNoWalletCreated) {
+                       DoNotAttachIfNoWalletCreated) {
   GetKeyringService()->Reset(false);
 
   brave_wallet::SetDefaultSolanaWallet(
@@ -651,16 +657,13 @@ IN_PROC_BROWSER_TEST_F(SolanaProviderRendererTest,
       brave_wallet::mojom::DefaultWallet::BraveWalletPreferExtension);
   ReloadAndWaitForLoadStop(browser());
 
-  constexpr char kEvalIsBraveWallet[] = "window.solana.isBraveWallet";
-  EXPECT_TRUE(content::EvalJs(web_contents(browser())->GetPrimaryMainFrame(),
-                              kEvalIsBraveWallet)
-                  .ExtractBool());
+  EXPECT_EQ(base::Value(false),
+            content::EvalJs(web_contents(browser()),
+                            "!!window.solana || !!window.braveSolana"));
   EXPECT_EQ(browser()->tab_strip_model()->count(), 1);
 }
 
 IN_PROC_BROWSER_TEST_F(SolanaProviderRendererTest, AttachIfWalletCreated) {
-  GetKeyringService()->CreateWallet("password", base::DoNothing());
-
   brave_wallet::SetDefaultSolanaWallet(
       browser()->GetProfile()->GetPrefs(),
       brave_wallet::mojom::DefaultWallet::BraveWalletPreferExtension);

--- a/browser/misc_metrics/BUILD.gn
+++ b/browser/misc_metrics/BUILD.gn
@@ -4,6 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
+import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
 import("//extensions/buildflags/buildflags.gni")
 
 source_set("misc_metrics") {
@@ -185,7 +186,12 @@ source_set("unit_tests") {
 source_set("browser_tests") {
   testonly = true
 
-  sources = [ "web3_metrics_browsertest.cc" ]
+  sources = []
+
+  # The web3 proxy is only injected alongside a wallet provider.
+  if (enable_brave_wallet) {
+    sources += [ "web3_metrics_browsertest.cc" ]
+  }
 
   if (!is_android) {
     sources += [ "vertical_tab_metrics_browsertest.cc" ]
@@ -206,6 +212,14 @@ source_set("browser_tests") {
     "//testing/gtest",
     "//url",
   ]
+
+  if (enable_brave_wallet) {
+    deps += [
+      "//brave/browser/brave_wallet",
+      "//brave/components/brave_wallet/browser",
+      "//brave/components/brave_wallet/browser:test_support",
+    ]
+  }
 
   defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
 }

--- a/browser/misc_metrics/web3_metrics_browsertest.cc
+++ b/browser/misc_metrics/web3_metrics_browsertest.cc
@@ -8,7 +8,12 @@
 #include "base/path_service.h"
 #include "base/test/metrics/histogram_tester.h"
 #include "base/test/run_until.h"
+#include "brave/browser/brave_wallet/brave_wallet_service_factory.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_service.h"
+#include "brave/components/brave_wallet/browser/keyring_service.h"
+#include "brave/components/brave_wallet/browser/test_utils.h"
 #include "brave/components/constants/brave_paths.h"
+#include "chrome/browser/profiles/profile.h"
 #include "chrome/test/base/chrome_test_utils.h"
 #include "chrome/test/base/platform_browser_test.h"
 #include "content/public/browser/render_frame_host.h"
@@ -45,6 +50,16 @@ class Web3MetricsBrowserTest : public PlatformBrowserTest {
 
   void SetUpOnMainThread() override {
     PlatformBrowserTest::SetUpOnMainThread();
+
+    // The proxy is only injected while a wallet provider is installed, which
+    // itself requires a created wallet.
+    auto* keyring_service =
+        brave_wallet::BraveWalletServiceFactory::GetServiceForContext(
+            chrome_test_utils::GetProfile(this))
+            ->keyring_service();
+    ASSERT_TRUE(keyring_service->RestoreWalletSync(
+        brave_wallet::kMnemonicScarePiece, brave_wallet::kTestWalletPassword,
+        false));
 
     base::FilePath test_data_dir;
     base::PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
@@ -104,6 +119,33 @@ IN_PROC_BROWSER_TEST_F(Web3MetricsBrowserTest, ProviderAccessReported) {
                               "window.ethereum.request();"));
 
   WaitForDappVisits(2);
+}
+
+// With no wallet the proxy isn't installed, so the page keeps a plain
+// assignable `window.ethereum` and nothing is recorded.
+IN_PROC_BROWSER_TEST_F(Web3MetricsBrowserTest, NoWalletNotInstrumented) {
+  auto* keyring_service =
+      brave_wallet::BraveWalletServiceFactory::GetServiceForContext(
+          chrome_test_utils::GetProfile(this))
+          ->keyring_service();
+  keyring_service->Reset(false);
+
+  ASSERT_TRUE(content::NavigateToURL(web_contents(),
+                                     https_server_.GetURL("/simple.html")));
+
+  // The property is a plain own data property, not the proxy's accessor.
+  EXPECT_TRUE(content::EvalJs(primary_main_frame(),
+                              "window.ethereum = { request: () => 42 };"
+                              "window.ethereum.request();"
+                              "!Object.getOwnPropertyDescriptor("
+                              "    window, 'ethereum').get")
+                  .ExtractBool());
+
+  ASSERT_TRUE(content::ExecJs(
+      primary_main_frame(),
+      "window.dispatchEvent(new Event('eip6963:requestProvider'));"));
+
+  histogram_tester_.ExpectTotalCount(kWeb3DappVisitHistogramName, 0);
 }
 
 // Pages that never touch a web3 provider record nothing.

--- a/browser/misc_metrics/web3_metrics_browsertest.cc
+++ b/browser/misc_metrics/web3_metrics_browsertest.cc
@@ -122,7 +122,7 @@ IN_PROC_BROWSER_TEST_F(Web3MetricsBrowserTest, ProviderAccessReported) {
 }
 
 // With no wallet the proxy isn't installed, so the page keeps a plain
-// assignable `window.ethereum` and nothing is recorded.
+// assignable `window.ethereum`.
 IN_PROC_BROWSER_TEST_F(Web3MetricsBrowserTest, NoWalletNotInstrumented) {
   auto* keyring_service =
       brave_wallet::BraveWalletServiceFactory::GetServiceForContext(
@@ -140,12 +140,6 @@ IN_PROC_BROWSER_TEST_F(Web3MetricsBrowserTest, NoWalletNotInstrumented) {
                               "!Object.getOwnPropertyDescriptor("
                               "    window, 'ethereum').get")
                   .ExtractBool());
-
-  ASSERT_TRUE(content::ExecJs(
-      primary_main_frame(),
-      "window.dispatchEvent(new Event('eip6963:requestProvider'));"));
-
-  histogram_tester_.ExpectTotalCount(kWeb3DappVisitHistogramName, 0);
 }
 
 // Pages that never touch a web3 provider record nothing.

--- a/browser/profiles/brave_renderer_updater.cc
+++ b/browser/profiles/brave_renderer_updater.cc
@@ -241,22 +241,28 @@ void BraveRendererUpdater::UpdateRenderer(
   // matching interface binder is no longer registered.
   is_wallet_allowed_for_context_ = brave_wallet::IsAllowedForContext(profile_);
 
-  bool should_ignore_brave_wallet_for_eth =
-      !is_wallet_created_ || has_installed_metamask;
+  // Nothing is injected until the user has actually created a wallet. A
+  // provider with no keyring behind it can't serve a dApp anyway, and its mere
+  // presence is observable by page scripts, so users who never opted into the
+  // wallet get no page-world properties at all.
+  bool can_install_providers =
+      is_wallet_allowed_for_context_ && is_wallet_created_;
 
   auto default_ethereum_wallet =
       static_cast<brave_wallet::mojom::DefaultWallet>(
           brave_wallet_ethereum_provider_.GetValue());
   bool install_window_brave_ethereum_provider =
-      is_wallet_allowed_for_context_ &&
+      can_install_providers &&
       default_ethereum_wallet != brave_wallet::mojom::DefaultWallet::None;
+  // The unprefixed `window.ethereum` is additionally yielded to MetaMask when
+  // the user asked to prefer the extension.
   bool install_window_ethereum_provider =
-      ((default_ethereum_wallet ==
+      can_install_providers &&
+      (default_ethereum_wallet ==
+           brave_wallet::mojom::DefaultWallet::BraveWallet ||
+       (default_ethereum_wallet ==
             brave_wallet::mojom::DefaultWallet::BraveWalletPreferExtension &&
-        !should_ignore_brave_wallet_for_eth) ||
-       default_ethereum_wallet ==
-           brave_wallet::mojom::DefaultWallet::BraveWallet) &&
-      is_wallet_allowed_for_context_;
+        !has_installed_metamask));
   bool allow_overwrite_window_ethereum_provider =
       default_ethereum_wallet ==
       brave_wallet::mojom::DefaultWallet::BraveWalletPreferExtension;
@@ -264,11 +270,11 @@ void BraveRendererUpdater::UpdateRenderer(
   auto default_solana_wallet = static_cast<brave_wallet::mojom::DefaultWallet>(
       brave_wallet_solana_provider_.GetValue());
   bool brave_use_native_solana_wallet =
+      can_install_providers &&
       (default_solana_wallet ==
            brave_wallet::mojom::DefaultWallet::BraveWalletPreferExtension ||
        default_solana_wallet ==
-           brave_wallet::mojom::DefaultWallet::BraveWallet) &&
-      is_wallet_allowed_for_context_;
+           brave_wallet::mojom::DefaultWallet::BraveWallet);
   bool allow_overwrite_window_solana_provider =
       default_solana_wallet ==
       brave_wallet::mojom::DefaultWallet::BraveWalletPreferExtension;
@@ -276,10 +282,8 @@ void BraveRendererUpdater::UpdateRenderer(
   auto default_cardano_wallet = static_cast<brave_wallet::mojom::DefaultWallet>(
       brave_wallet_cardano_provider_.GetValue());
   bool install_window_brave_cardano_provider =
-      brave_wallet::IsCardanoDAppSupportEnabled() &&
-      (default_cardano_wallet ==
-       brave_wallet::mojom::DefaultWallet::BraveWallet) &&
-      is_wallet_allowed_for_context_;
+      can_install_providers && brave_wallet::IsCardanoDAppSupportEnabled() &&
+      default_cardano_wallet == brave_wallet::mojom::DefaultWallet::BraveWallet;
 #endif  // BUILDFLAG(ENABLE_BRAVE_WALLET)
 
   PrefService* pref_service = profile_->GetPrefs();

--- a/browser/ui/brave_pages.cc
+++ b/browser/ui/brave_pages.cc
@@ -86,10 +86,6 @@ void ShowBraveWallet(BrowserWindowInterface* browser) {
   ShowSingletonTabOverwritingNTP(browser, GURL(kBraveUIWalletURL));
 }
 
-void ShowBraveWalletOnboarding(BrowserWindowInterface* browser) {
-  ShowSingletonTabOverwritingNTP(browser, GURL(kBraveUIWalletOnboardingURL));
-}
-
 void ShowBraveWalletTxNotificationUrl(BrowserWindowInterface* browser,
                                       GURL url) {
   if (url.GetWithEmptyPath() != GURL(kBraveUIWalletURL)) {

--- a/browser/ui/brave_pages.h
+++ b/browser/ui/brave_pages.h
@@ -23,7 +23,6 @@ void ShowWebcompatReporter(BrowserWindowInterface* browser);
 void ShowBraveRewards(BrowserWindowInterface* browser);
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
 void ShowBraveWallet(BrowserWindowInterface* browser);
-void ShowBraveWalletOnboarding(BrowserWindowInterface* browser);
 void ShowBraveWalletTxNotificationUrl(BrowserWindowInterface* browser,
                                       GURL url);
 void ShowBraveWalletAccountCreation(BrowserWindowInterface* browser,

--- a/components/brave_wallet/browser/brave_wallet_provider_delegate.h
+++ b/components/brave_wallet/browser/brave_wallet_provider_delegate.h
@@ -33,7 +33,6 @@ class BraveWalletProviderDelegate {
   virtual void ShowWalletBackup() = 0;
   virtual void UnlockWallet() = 0;
   virtual void WalletInteractionDetected() = 0;
-  virtual void ShowWalletOnboarding(const url::Origin& origin) = 0;
   virtual void ShowAccountCreation(mojom::CoinType type,
                                    const url::Origin& origin) = 0;
   virtual void RequestPermissions(mojom::CoinType type,

--- a/components/brave_wallet/browser/brave_wallet_utils.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils.cc
@@ -212,6 +212,10 @@ bool IsAllowed(PrefService* prefs) {
   return !IsDisabledByPolicy(prefs);
 }
 
+bool IsWalletCreated(PrefService* prefs) {
+  return !prefs->GetDict(kBraveWalletKeyrings).empty();
+}
+
 bool IsEndpointUsingBraveWalletProxy(const GURL& url) {
   return url.DomainIs("wallet.brave.com") ||
          url.DomainIs("wallet.bravesoftware.com") ||

--- a/components/brave_wallet/browser/brave_wallet_utils.h
+++ b/components/brave_wallet/browser/brave_wallet_utils.h
@@ -27,6 +27,11 @@ class CardanoAddress;
 // Returns true if Brave Wallet is allowed (not disabled by policy).
 bool IsAllowed(PrefService* prefs);
 
+// Returns true if the user has created a wallet. Reads the same pref as
+// KeyringService::IsWalletCreatedSync, for callers deciding whether to install
+// the dApp providers where no KeyringService is at hand.
+bool IsWalletCreated(PrefService* prefs);
+
 bool EncodeString(std::string_view input, std::string* output);
 bool EncodeStringArray(base::span<const std::string> input,
                        std::string* output);

--- a/components/brave_wallet/browser/cardano/cardano_api_impl_unittest.cc
+++ b/components/brave_wallet/browser/cardano/cardano_api_impl_unittest.cc
@@ -75,7 +75,6 @@ class MockBraveWalletProviderDelegate : public BraveWalletProviderDelegate {
   MOCK_METHOD0(ShowWalletBackup, void());
   MOCK_METHOD0(UnlockWallet, void());
   MOCK_METHOD0(WalletInteractionDetected, void());
-  MOCK_METHOD1(ShowWalletOnboarding, void(const url::Origin&));
   MOCK_METHOD2(ShowAccountCreation,
                void(mojom::CoinType type, const url::Origin& origin));
   MOCK_METHOD4(RequestPermissions,

--- a/components/brave_wallet/browser/cardano/cardano_provider_impl.cc
+++ b/components/brave_wallet/browser/cardano/cardano_provider_impl.cc
@@ -80,11 +80,9 @@ void CardanoProviderImpl::RequestCardanoPermissions(EnableCallback callback,
               l10n_util::GetStringUTF8(IDS_WALLET_USER_REJECTED_REQUEST),
               nullptr));
 
+    // The provider is only injected once a wallet exists, so this is a
+    // defensive case (e.g. the wallet was reset while the page stayed open).
     case PermissionCheckResult::kWalletNotCreated:
-      if (!wallet_page_shown_) {
-        delegate_->ShowWalletOnboarding(origin_);
-        wallet_page_shown_ = true;
-      }
       std::move(callback).Run(
           mojo::NullRemote(),
           mojom::CardanoProviderErrorBundle::New(

--- a/components/brave_wallet/browser/cardano/cardano_provider_impl_unittest.cc
+++ b/components/brave_wallet/browser/cardano/cardano_provider_impl_unittest.cc
@@ -51,7 +51,6 @@ class MockBraveWalletProviderDelegate : public BraveWalletProviderDelegate {
   MOCK_METHOD0(ShowWalletBackup, void());
   MOCK_METHOD0(UnlockWallet, void());
   MOCK_METHOD0(WalletInteractionDetected, void());
-  MOCK_METHOD1(ShowWalletOnboarding, void(const url::Origin&));
   MOCK_METHOD2(ShowAccountCreation,
                void(mojom::CoinType type, const url::Origin& origin));
   MOCK_METHOD4(RequestPermissions,
@@ -372,9 +371,10 @@ TEST_F(CardanoProviderImplUnitTest, Enable_OnWalletUnlock_PermissionApproved) {
   main_run_loop.Run();
 }
 
-TEST_F(CardanoProviderImplUnitTest, OnBoarding) {
+// The provider isn't injected without a wallet, but the request must still fail
+// cleanly if one is reset while a page holds a provider.
+TEST_F(CardanoProviderImplUnitTest, NoWallet) {
   ON_CALL(*delegate(), IsTabVisible()).WillByDefault([&]() { return true; });
-  EXPECT_CALL(*delegate(), ShowWalletOnboarding(testing::_)).Times(1);
   EXPECT_CALL(*delegate(), WalletInteractionDetected()).Times(1);
 
   base::test::TestFuture<mojo::PendingRemote<mojom::CardanoApi>,

--- a/components/brave_wallet/browser/ethereum_provider_impl.cc
+++ b/components/brave_wallet/browser/ethereum_provider_impl.cc
@@ -1228,10 +1228,6 @@ void EthereumProviderImpl::RequestEthereumPermissions(
   }
 
   if (addresses.empty()) {
-    if (!wallet_onboarding_shown_) {
-      delegate_->ShowWalletOnboarding(origin);
-      wallet_onboarding_shown_ = true;
-    }
     OnRequestEthereumPermissions(std::move(callback), std::move(id), method,
                                  origin, RequestPermissionsError::kInternal,
                                  std::nullopt);

--- a/components/brave_wallet/browser/ethereum_provider_impl.h
+++ b/components/brave_wallet/browser/ethereum_provider_impl.h
@@ -359,7 +359,6 @@ class EthereumProviderImpl final : public mojom::EthereumProvider,
   EthLogsTracker eth_logs_tracker_;
   bool first_known_accounts_check_ = true;
   const raw_ptr<PrefService> prefs_ = nullptr;
-  bool wallet_onboarding_shown_ = false;
   base::WeakPtrFactory<EthereumProviderImpl> weak_factory_{this};
 };
 

--- a/components/brave_wallet/browser/solana_provider_impl.cc
+++ b/components/brave_wallet/browser/solana_provider_impl.cc
@@ -95,16 +95,16 @@ void SolanaProviderImpl::Connect(std::optional<base::DictValue> arg,
   }
   auto account = keyring_service_->GetSelectedSolanaDappAccount();
   if (!account) {
+    // The provider is only injected once a wallet exists, but the wallet can
+    // still be reset while a page holds one. Don't offer account creation in
+    // that state: it navigates to a page that requires a keyring.
     if (!keyring_service_->IsWalletCreatedSync()) {
-      delegate_->ShowWalletOnboarding(origin_);
       std::move(callback).Run(
           mojom::SolanaProviderError::kInternalError,
           l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR), "");
       return;
     }
 
-    // Prompt users to create a Solana account. If wallet is not setup, users
-    // will be lead to onboarding first.
     if (!account_creation_shown_) {
       delegate_->ShowAccountCreation(mojom::CoinType::SOL, origin_);
       account_creation_shown_ = true;

--- a/components/brave_wallet/common/web_ui_constants.h
+++ b/components/brave_wallet/common/web_ui_constants.h
@@ -8,8 +8,6 @@
 #define BRAVE_COMPONENTS_BRAVE_WALLET_COMMON_WEB_UI_CONSTANTS_H_
 
 inline constexpr char kBraveUIWalletURL[] = "chrome://wallet/";
-inline constexpr char kBraveUIWalletOnboardingURL[] =
-    "brave://wallet/crypto/onboarding";
 inline constexpr char kBraveUIWalletAccountCreationURL[] =
     "brave://wallet/crypto/accounts/add-account/create/";
 inline constexpr char kBraveUIWalletPanelURL[] =

--- a/components/misc_metrics/renderer/web3_metrics_render_frame_observer.cc
+++ b/components/misc_metrics/renderer/web3_metrics_render_frame_observer.cc
@@ -28,9 +28,9 @@ namespace misc_metrics {
 
 Web3MetricsRenderFrameObserver::Web3MetricsRenderFrameObserver(
     content::RenderFrame* render_frame,
-    base::RepeatingCallback<bool()> is_web3_enabled_callback)
+    std::unique_ptr<Delegate> delegate)
     : RenderFrameObserver(render_frame),
-      is_web3_enabled_callback_(std::move(is_web3_enabled_callback)),
+      delegate_(std::move(delegate)),
       install_proxy_script_(base::StrCat(
           {"(",
            ui::ResourceBundle::GetSharedInstance().LoadDataResourceString(
@@ -56,7 +56,7 @@ bool Web3MetricsRenderFrameObserver::IsPageValid() {
 }
 
 bool Web3MetricsRenderFrameObserver::CanInjectProxy() {
-  if (!is_web3_enabled_callback_.Run()) {
+  if (!delegate_->IsWeb3Enabled()) {
     return false;
   }
 

--- a/components/misc_metrics/renderer/web3_metrics_render_frame_observer.cc
+++ b/components/misc_metrics/renderer/web3_metrics_render_frame_observer.cc
@@ -27,8 +27,10 @@
 namespace misc_metrics {
 
 Web3MetricsRenderFrameObserver::Web3MetricsRenderFrameObserver(
-    content::RenderFrame* render_frame)
+    content::RenderFrame* render_frame,
+    base::RepeatingCallback<bool()> is_web3_enabled_callback)
     : RenderFrameObserver(render_frame),
+      is_web3_enabled_callback_(std::move(is_web3_enabled_callback)),
       install_proxy_script_(base::StrCat(
           {"(",
            ui::ResourceBundle::GetSharedInstance().LoadDataResourceString(
@@ -54,6 +56,10 @@ bool Web3MetricsRenderFrameObserver::IsPageValid() {
 }
 
 bool Web3MetricsRenderFrameObserver::CanInjectProxy() {
+  if (!is_web3_enabled_callback_.Run()) {
+    return false;
+  }
+
   if (!IsPageValid()) {
     return false;
   }

--- a/components/misc_metrics/renderer/web3_metrics_render_frame_observer.h
+++ b/components/misc_metrics/renderer/web3_metrics_render_frame_observer.h
@@ -9,6 +9,7 @@
 #include <optional>
 #include <string>
 
+#include "base/functional/callback.h"
 #include "base/memory/weak_ptr.h"
 #include "brave/components/misc_metrics/common/misc_metrics.mojom.h"
 #include "content/public/renderer/render_frame_observer.h"
@@ -24,7 +25,12 @@ namespace misc_metrics {
 
 class Web3MetricsRenderFrameObserver : public content::RenderFrameObserver {
  public:
-  explicit Web3MetricsRenderFrameObserver(content::RenderFrame* render_frame);
+  // `is_web3_enabled_callback` reports whether a wallet provider is being
+  // installed into pages. There is nothing to proxy while it returns false, and
+  // the proxy is itself observable, so injection waits on it.
+  Web3MetricsRenderFrameObserver(
+      content::RenderFrame* render_frame,
+      base::RepeatingCallback<bool()> is_web3_enabled_callback);
   Web3MetricsRenderFrameObserver(const Web3MetricsRenderFrameObserver&) =
       delete;
   Web3MetricsRenderFrameObserver& operator=(
@@ -51,6 +57,7 @@ class Web3MetricsRenderFrameObserver : public content::RenderFrameObserver {
   mojom::Web3Metrics& GetWeb3Metrics();
 
   GURL url_;
+  base::RepeatingCallback<bool()> is_web3_enabled_callback_;
   std::string install_proxy_script_;
   mojo::Remote<mojom::Web3Metrics> web3_metrics_;
   base::WeakPtrFactory<Web3MetricsRenderFrameObserver> weak_ptr_factory_{this};

--- a/components/misc_metrics/renderer/web3_metrics_render_frame_observer.h
+++ b/components/misc_metrics/renderer/web3_metrics_render_frame_observer.h
@@ -6,10 +6,10 @@
 #ifndef BRAVE_COMPONENTS_MISC_METRICS_RENDERER_WEB3_METRICS_RENDER_FRAME_OBSERVER_H_
 #define BRAVE_COMPONENTS_MISC_METRICS_RENDERER_WEB3_METRICS_RENDER_FRAME_OBSERVER_H_
 
+#include <memory>
 #include <optional>
 #include <string>
 
-#include "base/functional/callback.h"
 #include "base/memory/weak_ptr.h"
 #include "brave/components/misc_metrics/common/misc_metrics.mojom.h"
 #include "content/public/renderer/render_frame_observer.h"
@@ -25,12 +25,19 @@ namespace misc_metrics {
 
 class Web3MetricsRenderFrameObserver : public content::RenderFrameObserver {
  public:
-  // `is_web3_enabled_callback` reports whether a wallet provider is being
-  // installed into pages. There is nothing to proxy while it returns false, and
-  // the proxy is itself observable, so injection waits on it.
-  Web3MetricsRenderFrameObserver(
-      content::RenderFrame* render_frame,
-      base::RepeatingCallback<bool()> is_web3_enabled_callback);
+  // Reaches embedder state that this component layer can't see.
+  class Delegate {
+   public:
+    virtual ~Delegate() = default;
+
+    // Whether a wallet provider is being installed into pages. There is nothing
+    // to proxy while this is false, and the proxy is itself observable, so
+    // injection waits on it.
+    virtual bool IsWeb3Enabled() = 0;
+  };
+
+  Web3MetricsRenderFrameObserver(content::RenderFrame* render_frame,
+                                 std::unique_ptr<Delegate> delegate);
   Web3MetricsRenderFrameObserver(const Web3MetricsRenderFrameObserver&) =
       delete;
   Web3MetricsRenderFrameObserver& operator=(
@@ -57,7 +64,7 @@ class Web3MetricsRenderFrameObserver : public content::RenderFrameObserver {
   mojom::Web3Metrics& GetWeb3Metrics();
 
   GURL url_;
-  base::RepeatingCallback<bool()> is_web3_enabled_callback_;
+  std::unique_ptr<Delegate> delegate_;
   std::string install_proxy_script_;
   mojo::Remote<mojom::Web3Metrics> web3_metrics_;
   base::WeakPtrFactory<Web3MetricsRenderFrameObserver> weak_ptr_factory_{this};

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -274,7 +274,11 @@ public class BrowserViewController: UIViewController {
 
   /// Whether a wallet exists, to distinguish create/reset from the account
   /// edits that also write the keyrings pref.
-  private var isWalletCreated: Bool = false
+  private var isWalletCreated: Bool = false {
+    didSet {
+      UserScriptManager.shared.isWalletCreated = isWalletCreated
+    }
+  }
 
   let defaultBrowserHelper: DefaultBrowserHelper = .init()
 
@@ -518,14 +522,14 @@ public class BrowserViewController: UIViewController {
     // refreshes them. The keyrings pref is also written on every account add,
     // rename and removal, so only react when the created state actually
     // changed — refreshing discards every web view.
-    isWalletCreated = profileController.profile.prefs.hasPref(
+    isWalletCreated = !profileController.profile.prefs.dictionary(
       forPath: kBraveWalletKeyrings
-    )
+    ).isEmpty
     prefsChangeRegistrar.addObserver(forPath: kBraveWalletKeyrings) { [weak self] _ in
       guard let self else { return }
-      let isWalletCreated = self.profileController.profile.prefs.hasPref(
+      let isWalletCreated = !self.profileController.profile.prefs.dictionary(
         forPath: kBraveWalletKeyrings
-      )
+      ).isEmpty
       guard isWalletCreated != self.isWalletCreated else { return }
       self.isWalletCreated = isWalletCreated
       self.defaultWalletChanged(for: .eth)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -272,6 +272,10 @@ public class BrowserViewController: UIViewController {
 
   private let prefsChangeRegistrar: PrefChangeRegistrar
 
+  /// Whether a wallet exists, to distinguish create/reset from the account
+  /// edits that also write the keyrings pref.
+  private var isWalletCreated: Bool = false
+
   let defaultBrowserHelper: DefaultBrowserHelper = .init()
 
   public init(
@@ -508,6 +512,23 @@ public class BrowserViewController: UIViewController {
     }
     prefsChangeRegistrar.addObserver(forPath: kDefaultSolanaWallet) { [weak self] _ in
       self?.defaultWalletChanged(for: .sol)
+    }
+    // Creating or resetting a wallet flips whether the providers are injected,
+    // so the scripts have to be refreshed the same way a default wallet change
+    // refreshes them. The keyrings pref is also written on every account add,
+    // rename and removal, so only react when the created state actually
+    // changed — refreshing discards every web view.
+    isWalletCreated = profileController.profile.prefs.hasPref(
+      forPath: kBraveWalletKeyrings
+    )
+    prefsChangeRegistrar.addObserver(forPath: kBraveWalletKeyrings) { [weak self] _ in
+      guard let self else { return }
+      let isWalletCreated = self.profileController.profile.prefs.hasPref(
+        forPath: kBraveWalletKeyrings
+      )
+      guard isWalletCreated != self.isWalletCreated else { return }
+      self.isWalletCreated = isWalletCreated
+      self.defaultWalletChanged(for: .eth)
     }
 
     disconnectVPNIfDisabledByPolicy()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/WalletTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/WalletTabHelper.swift
@@ -313,10 +313,6 @@ extension WalletTabHelper: BraveWalletProviderDelegate {
     // No usage for iOS
   }
 
-  func showWalletOnboarding(withOrigin origin: URLOrigin) {
-    showPanel(withOrigin: origin)
-  }
-
   func isTabVisible() -> Bool {
     guard let tab else { return false }
     return tab.isVisible

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/UserScriptManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/UserScriptManager.swift
@@ -367,14 +367,22 @@ class UserScriptManager {
       // Inject WALLET specific scripts
 
       // A default wallet other than `none` means the Brave Wallet provider
-      // should be injected to communicate with web3.
+      // should be injected to communicate with web3. Nothing is injected until
+      // the user has created a wallet: an empty keyring can't serve a dApp, but
+      // the provider is still observable by page scripts.
       let prefs = tab.profile.prefs
+      // hasPref rather than reading the dict: the keyrings value holds the
+      // encrypted mnemonic and every account, and this runs on each script load.
+      let isWalletCreated = prefs.hasPref(forPath: kBraveWalletKeyrings)
       let isEthProviderEnabled =
-        prefs.integer(forPath: kDefaultEthereumWallet) != BraveWallet.DefaultWallet.none.rawValue
+        isWalletCreated
+        && prefs.integer(forPath: kDefaultEthereumWallet) != BraveWallet.DefaultWallet.none.rawValue
       let isSolProviderEnabled =
-        prefs.integer(forPath: kDefaultSolanaWallet) != BraveWallet.DefaultWallet.none.rawValue
+        isWalletCreated
+        && prefs.integer(forPath: kDefaultSolanaWallet) != BraveWallet.DefaultWallet.none.rawValue
       let isCardanoProviderEnabled =
-        prefs.integer(forPath: kDefaultCardanoWallet) != BraveWallet.DefaultWallet.none.rawValue
+        isWalletCreated
+        && prefs.integer(forPath: kDefaultCardanoWallet) != BraveWallet.DefaultWallet.none.rawValue
 
       if !tab.isPrivate,
         isEthProviderEnabled,
@@ -412,6 +420,7 @@ class UserScriptManager {
       }
 
       if !tab.isPrivate,
+        isSolProviderEnabled,
         let walletStandardScript = Preferences.UserScript.solanaProvider.value
           ? self.walletSolanaWalletStandardScript : nil
       {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/UserScriptManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/UserScriptManager.swift
@@ -106,6 +106,9 @@ class UserScriptManager {
   private var walletSolanaWeb3Script: WKUserScript?
   private var walletSolanaWalletStandardScript: WKUserScript?
 
+  /// Whether or not a wallet is created and web3 provider scripts should be injected into the page
+  var isWalletCreated: Bool = false
+
   enum ScriptType: String, CaseIterable {
     case faviconFetcher
     case cookieBlocking
@@ -371,9 +374,6 @@ class UserScriptManager {
       // the user has created a wallet: an empty keyring can't serve a dApp, but
       // the provider is still observable by page scripts.
       let prefs = tab.profile.prefs
-      // hasPref rather than reading the dict: the keyrings value holds the
-      // encrypted mnemonic and every account, and this runs on each script load.
-      let isWalletCreated = prefs.hasPref(forPath: kBraveWalletKeyrings)
       let isEthProviderEnabled =
         isWalletCreated
         && prefs.integer(forPath: kDefaultEthereumWallet) != BraveWallet.DefaultWallet.none.rawValue

--- a/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios+private.h
+++ b/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios+private.h
@@ -29,7 +29,6 @@ class BraveWalletProviderDelegateBridge
   bool IsTabVisible() override;
   void ShowPanel(const url::Origin& origin) override;
   void WalletInteractionDetected() override;
-  void ShowWalletOnboarding(const url::Origin& origin) override;
   void ShowWalletBackup() override;
   void UnlockWallet() override;
   void ShowAccountCreation(mojom::CoinType type,

--- a/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios.h
+++ b/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios.h
@@ -22,7 +22,6 @@ OBJC_EXPORT
 - (bool)isTabVisible;
 - (void)showPanelWithOrigin:(URLOriginIOS*)origin;
 - (void)walletInteractionDetected;
-- (void)showWalletOnboardingWithOrigin:(URLOriginIOS*)origin;
 - (void)showWalletBackup;
 - (void)unlockWallet;
 - (void)showAccountCreation:(BraveWalletCoinType)type

--- a/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios.mm
+++ b/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios.mm
@@ -29,12 +29,6 @@ void BraveWalletProviderDelegateBridge::WalletInteractionDetected() {
   [bridge_ walletInteractionDetected];
 }
 
-void BraveWalletProviderDelegateBridge::ShowWalletOnboarding(
-    const url::Origin& origin) {
-  URLOriginIOS* origin_ios = [[URLOriginIOS alloc] initWithOrigin:origin];
-  [bridge_ showWalletOnboardingWithOrigin:origin_ios];
-}
-
 void BraveWalletProviderDelegateBridge::ShowWalletBackup() {
   [bridge_ showWalletBackup];
 }

--- a/ios/browser/brave_wallet/cardano_provider_javascript_feature.h
+++ b/ios/browser/brave_wallet/cardano_provider_javascript_feature.h
@@ -29,7 +29,8 @@ namespace brave_wallet {
 // A JavaScriptFeature that injects the `window.cardano.brave` CIP-30 provider
 // into web pages so they can communicate with Brave Wallet. The provider is
 // only installed when Brave Wallet is allowed for the profile, Cardano dApp
-// support is enabled, and Brave is set as the default Cardano wallet.
+// support is enabled, Brave is set as the default Cardano wallet, and the user
+// has created a wallet.
 class CardanoProviderJavaScriptFeature : public web::JavaScriptFeature,
                                          public base::SupportsUserData::Data {
  public:
@@ -51,10 +52,12 @@ class CardanoProviderJavaScriptFeature : public web::JavaScriptFeature,
  private:
   explicit CardanoProviderJavaScriptFeature(ProfileIOS* profile);
 
-  void OnDefaultCardanoWalletChanged();
+  void OnScriptGatingPrefChanged();
+  void OnKeyringsChanged();
 
   web::MessageHandlerToken token_;
   raw_ptr<ProfileIOS> profile_;
+  bool is_wallet_created_ = false;
   PrefChangeRegistrar pref_change_registrar_;
 };
 

--- a/ios/browser/brave_wallet/cardano_provider_javascript_feature.mm
+++ b/ios/browser/brave_wallet/cardano_provider_javascript_feature.mm
@@ -221,8 +221,25 @@ CardanoProviderJavaScriptFeature::CardanoProviderJavaScriptFeature(
   pref_change_registrar_.Add(
       kDefaultCardanoWallet,
       base::BindRepeating(
-          &CardanoProviderJavaScriptFeature::OnDefaultCardanoWalletChanged,
+          &CardanoProviderJavaScriptFeature::OnScriptGatingPrefChanged,
           base::Unretained(this)));
+  // Creating or resetting a wallet flips whether the provider is injected.
+  is_wallet_created_ = IsWalletCreated(profile->GetPrefs());
+  pref_change_registrar_.Add(
+      kBraveWalletKeyrings,
+      base::BindRepeating(&CardanoProviderJavaScriptFeature::OnKeyringsChanged,
+                          base::Unretained(this)));
+}
+
+void CardanoProviderJavaScriptFeature::OnKeyringsChanged() {
+  // The keyrings pref is also written on every account add, rename and
+  // removal. Only rebuild the scripts when the created state actually changed.
+  bool is_wallet_created = IsWalletCreated(profile_->GetPrefs());
+  if (is_wallet_created == is_wallet_created_) {
+    return;
+  }
+  is_wallet_created_ = is_wallet_created;
+  OnScriptGatingPrefChanged();
 }
 
 CardanoProviderJavaScriptFeature::~CardanoProviderJavaScriptFeature() = default;
@@ -244,7 +261,7 @@ CardanoProviderJavaScriptFeature::FromBrowserState(
   return feature;
 }
 
-void CardanoProviderJavaScriptFeature::OnDefaultCardanoWalletChanged() {
+void CardanoProviderJavaScriptFeature::OnScriptGatingPrefChanged() {
   // Feature scripts must be explicitly updated after this pref changes.
   web::WKWebViewConfigurationProvider& config_provider =
       web::WKWebViewConfigurationProvider::FromBrowserState(profile_);
@@ -255,10 +272,10 @@ std::vector<web::JavaScriptFeature::FeatureScript>
 CardanoProviderJavaScriptFeature::GetScripts() const {
   PrefService* prefs = profile_->GetPrefs();
   if (!IsAllowed(prefs) || !IsCardanoDAppSupportEnabled() ||
-      !IsDefaultCardanoWalletBrave(prefs)) {
+      !IsDefaultCardanoWalletBrave(prefs) || !IsWalletCreated(prefs)) {
     // Dont inject the wallet script if wallet is not enabled for this profile,
-    // Cardano dApp support is disabled, or Brave is not set as the default
-    // Cardano wallet provider.
+    // Cardano dApp support is disabled, Brave is not set as the default Cardano
+    // wallet provider, or the user hasn't created a wallet yet.
     return {};
   }
   return {FeatureScript::CreateWithFilename(

--- a/ios/browser/brave_wallet/ethereum_provider_javascript_feature.h
+++ b/ios/browser/brave_wallet/ethereum_provider_javascript_feature.h
@@ -28,7 +28,8 @@ namespace brave_wallet {
 
 // A JavaScriptFeature that injects the `window.ethereum`/`window.braveEthereum`
 // EIP-1193 provider into web pages so they can communicate with Brave Wallet.
-// The provider is only installed when Brave Wallet is allowed for the profile.
+// The provider is only installed when Brave Wallet is allowed for the profile
+// and the user has created a wallet.
 class EthereumProviderJavaScriptFeature : public web::JavaScriptFeature,
                                           public base::SupportsUserData::Data {
  public:
@@ -50,11 +51,13 @@ class EthereumProviderJavaScriptFeature : public web::JavaScriptFeature,
  private:
   explicit EthereumProviderJavaScriptFeature(ProfileIOS* profile);
 
-  void OnDefaultEthereumWalletChanged();
+  void OnScriptGatingPrefChanged();
+  void OnKeyringsChanged();
 
   web::MessageHandlerToken token_;
   raw_ptr<ProfileIOS> profile_;
   std::string provider_bundle_js_;
+  bool is_wallet_created_ = false;
   PrefChangeRegistrar pref_change_registrar_;
 };
 

--- a/ios/browser/brave_wallet/ethereum_provider_javascript_feature.mm
+++ b/ios/browser/brave_wallet/ethereum_provider_javascript_feature.mm
@@ -146,12 +146,29 @@ EthereumProviderJavaScriptFeature::EthereumProviderJavaScriptFeature(
   pref_change_registrar_.Add(
       kDefaultEthereumWallet,
       base::BindRepeating(
-          &EthereumProviderJavaScriptFeature::OnDefaultEthereumWalletChanged,
+          &EthereumProviderJavaScriptFeature::OnScriptGatingPrefChanged,
           base::Unretained(this)));
+  // Creating or resetting a wallet flips whether the provider is injected.
+  is_wallet_created_ = IsWalletCreated(profile->GetPrefs());
+  pref_change_registrar_.Add(
+      kBraveWalletKeyrings,
+      base::BindRepeating(&EthereumProviderJavaScriptFeature::OnKeyringsChanged,
+                          base::Unretained(this)));
 }
 
 EthereumProviderJavaScriptFeature::~EthereumProviderJavaScriptFeature() =
     default;
+
+void EthereumProviderJavaScriptFeature::OnKeyringsChanged() {
+  // The keyrings pref is also written on every account add, rename and
+  // removal. Only rebuild the scripts when the created state actually changed.
+  bool is_wallet_created = IsWalletCreated(profile_->GetPrefs());
+  if (is_wallet_created == is_wallet_created_) {
+    return;
+  }
+  is_wallet_created_ = is_wallet_created;
+  OnScriptGatingPrefChanged();
+}
 
 // static
 EthereumProviderJavaScriptFeature*
@@ -171,7 +188,7 @@ EthereumProviderJavaScriptFeature::FromBrowserState(
   return feature;
 }
 
-void EthereumProviderJavaScriptFeature::OnDefaultEthereumWalletChanged() {
+void EthereumProviderJavaScriptFeature::OnScriptGatingPrefChanged() {
   // Feature scripts must be explicitly updated after this pref changes.
   web::WKWebViewConfigurationProvider& config_provider =
       web::WKWebViewConfigurationProvider::FromBrowserState(profile_);
@@ -181,9 +198,11 @@ void EthereumProviderJavaScriptFeature::OnDefaultEthereumWalletChanged() {
 std::vector<web::JavaScriptFeature::FeatureScript>
 EthereumProviderJavaScriptFeature::GetScripts() const {
   PrefService* prefs = profile_->GetPrefs();
-  if (!IsAllowed(prefs) || !IsDefaultEthereumWalletBrave(prefs)) {
-    // Dont inject wallet scripts if wallet is not enabled for this profile or
-    // Brave is not set as the default ethereum wallet provider
+  if (!IsAllowed(prefs) || !IsDefaultEthereumWalletBrave(prefs) ||
+      !IsWalletCreated(prefs)) {
+    // Dont inject wallet scripts if wallet is not enabled for this profile,
+    // Brave is not set as the default ethereum wallet provider, or the user
+    // hasn't created a wallet yet
     return {};
   }
   return {

--- a/ios/browser/brave_wallet/wallet_pref_names_bridge.h
+++ b/ios/browser/brave_wallet/wallet_pref_names_bridge.h
@@ -13,6 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 OBJC_EXPORT NSString* const kDefaultEthereumWallet;
 OBJC_EXPORT NSString* const kDefaultSolanaWallet;
 OBJC_EXPORT NSString* const kDefaultCardanoWallet;
+// Non-empty once the user has created a wallet.
+OBJC_EXPORT NSString* const kBraveWalletKeyrings;
 
 NS_ASSUME_NONNULL_END
 

--- a/ios/browser/brave_wallet/wallet_pref_names_bridge.mm
+++ b/ios/browser/brave_wallet/wallet_pref_names_bridge.mm
@@ -16,3 +16,6 @@ NSString* const kDefaultSolanaWallet =
 
 NSString* const kDefaultCardanoWallet =
     base::SysUTF8ToNSString(brave_wallet::kDefaultCardanoWallet);
+
+NSString* const kBraveWalletKeyrings =
+    base::SysUTF8ToNSString(brave_wallet::kBraveWalletKeyrings);

--- a/renderer/brave_content_renderer_client.cc
+++ b/renderer/brave_content_renderer_client.cc
@@ -6,6 +6,7 @@
 #include "brave/renderer/brave_content_renderer_client.h"
 
 #include <algorithm>
+#include <memory>
 #include <utility>
 
 #include "base/feature_list.h"
@@ -95,19 +96,25 @@ void MaybeRemoveWidevineSupport(media::GetSupportedKeySystemsCB cb,
   cb.Run(std::move(key_systems));
 }
 
-// Whether any wallet provider object is being installed into pages. The web3
-// metrics proxy has nothing to observe until one is.
-bool IsWeb3ProviderInstalled() {
+class Web3MetricsDelegate
+    : public misc_metrics::Web3MetricsRenderFrameObserver::Delegate {
+ public:
+  ~Web3MetricsDelegate() override = default;
+
+  // Whether any wallet provider object is being installed into pages. The web3
+  // metrics proxy has nothing to observe until one is.
+  bool IsWeb3Enabled() override {
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
-  const auto& dynamic_params = BraveRenderThreadObserver::GetDynamicParams();
-  return dynamic_params.install_window_brave_ethereum_provider ||
-         dynamic_params.install_window_ethereum_provider ||
-         dynamic_params.install_window_brave_cardano_provider ||
-         dynamic_params.brave_use_native_solana_wallet;
+    const auto& dynamic_params = BraveRenderThreadObserver::GetDynamicParams();
+    return dynamic_params.install_window_brave_ethereum_provider ||
+           dynamic_params.install_window_ethereum_provider ||
+           dynamic_params.install_window_brave_cardano_provider ||
+           dynamic_params.brave_use_native_solana_wallet;
 #else
-  return false;
+    return false;
 #endif
-}
+  }
+};
 
 }  // namespace
 
@@ -189,7 +196,7 @@ void BraveContentRendererClient::RenderFrameCreated(
   }
 
   new misc_metrics::Web3MetricsRenderFrameObserver(
-      render_frame, base::BindRepeating(&IsWeb3ProviderInstalled));
+      render_frame, std::make_unique<Web3MetricsDelegate>());
 
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
   if (IsBraveWalletAvailable()) {

--- a/renderer/brave_content_renderer_client.cc
+++ b/renderer/brave_content_renderer_client.cc
@@ -95,6 +95,20 @@ void MaybeRemoveWidevineSupport(media::GetSupportedKeySystemsCB cb,
   cb.Run(std::move(key_systems));
 }
 
+// Whether any wallet provider object is being installed into pages. The web3
+// metrics proxy has nothing to observe until one is.
+bool IsWeb3ProviderInstalled() {
+#if BUILDFLAG(ENABLE_BRAVE_WALLET)
+  const auto& dynamic_params = BraveRenderThreadObserver::GetDynamicParams();
+  return dynamic_params.install_window_brave_ethereum_provider ||
+         dynamic_params.install_window_ethereum_provider ||
+         dynamic_params.install_window_brave_cardano_provider ||
+         dynamic_params.brave_use_native_solana_wallet;
+#else
+  return false;
+#endif
+}
+
 }  // namespace
 
 BraveContentRendererClient::BraveContentRendererClient() = default;
@@ -174,7 +188,8 @@ void BraveContentRendererClient::RenderFrameCreated(
         render_frame, ISOLATED_WORLD_ID_BRAVE_INTERNAL, dynamic_params_closure);
   }
 
-  new misc_metrics::Web3MetricsRenderFrameObserver(render_frame);
+  new misc_metrics::Web3MetricsRenderFrameObserver(
+      render_frame, base::BindRepeating(&IsWeb3ProviderInstalled));
 
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
   if (IsBraveWalletAvailable()) {


### PR DESCRIPTION
Developer docs updated in brave/brave-wallet-docs#290.

Without the wallet created, Brave used to inject `window.braveEthereum`, `window.solana`, and `window.cardano`. Keeping `window.ethereum` for only when the wallet is created and if MetaMask is not installed.

This PR changes that so none of this is ever injected until a wallet is created (keyring exists). 

We used to do this to give sites a way to onboard users to Brave Wallet, but we prefer to reduce the fingerprint and things exposed on sites.

`Web3.DappVisit` now only covers profiles with a created Brave Wallet

3 commits span the main implementation, Android implementation and iOS implementation changes.

## Notes for reviewers

## Test plan

- [ ] Go to https://brave.com and try to access `window.ethereum`, `window.braveEthereum`, `window.solana`, and `window.cardano`.  You should no longer be able to. You should be able to in any build before this change. 
- [ ] Creating a wallet should then expose the above things
- [ ] iOS: TODO test plan
- [ ] Android: TODO test plan
