### PR TITLE
[ads] Cleanup Rewards P3A and iOS code from using search result ad pref

### DIFF
--- a/components/brave_rewards/content/rewards_p3a.cc
+++ b/components/brave_rewards/content/rewards_p3a.cc
@@ -94,14 +94,6 @@ void RecordAdTypesEnabled(PrefService* prefs) {
 #endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 }
 
-void RecordSearchResultAdsOptinChange(PrefService* prefs) {
-#if BUILDFLAG(ENABLE_BRAVE_ADS)
-  if (prefs->GetBoolean(brave_ads::prefs::kOptedInToSearchResultAds)) {
-    UMA_HISTOGRAM_BOOLEAN(kSearchResultAdsOptinHistogramName, true);
-  }
-#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
-}
-
 void RecordAdsHistoryView() {
   UMA_HISTOGRAM_BOOLEAN(kAdsHistoryViewHistogramName, true);
 }

--- a/components/brave_rewards/content/rewards_p3a.h
+++ b/components/brave_rewards/content/rewards_p3a.h
@@ -29,8 +29,6 @@ inline constexpr char kAutoContributionsStateHistogramName[] =
     "Brave.Rewards.AutoContributionsState.3";
 inline constexpr char kAdTypesEnabledHistogramName[] =
     "Brave.Rewards.AdTypesEnabled";
-inline constexpr char kSearchResultAdsOptinHistogramName[] =
-    "Brave.Rewards.SearchResultAdsOptin";
 inline constexpr char kAdsHistoryViewHistogramName[] =
     "Brave.Rewards.AdsHistoryView";
 inline constexpr char kMobileConversionHistogramName[] =
@@ -73,8 +71,6 @@ void RecordNoWalletCreatedForAllMetrics();
 void RecordRewardsPageViews(PrefService* prefs, bool new_view);
 
 void RecordAdTypesEnabled(PrefService* prefs);
-
-void RecordSearchResultAdsOptinChange(PrefService* prefs);
 
 void RecordAdsHistoryView();
 

--- a/components/brave_rewards/content/rewards_service_impl.cc
+++ b/components/brave_rewards/content/rewards_service_impl.cc
@@ -303,10 +303,6 @@ void RewardsServiceImpl::InitPrefChangeRegistrar() {
           kNewTabPageShowSponsoredImagesBackgroundImage,
       base::BindRepeating(&RewardsServiceImpl::OnPreferenceChanged,
                           base::Unretained(this)));
-  profile_pref_change_registrar_.Add(
-      brave_ads::prefs::kOptedInToSearchResultAds,
-      base::BindRepeating(&RewardsServiceImpl::OnPreferenceChanged,
-                          base::Unretained(this)));
 #endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 }
 
@@ -324,15 +320,8 @@ void RewardsServiceImpl::OnPreferenceChanged(const std::string& key) {
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
   if (key == ntp_background_images::prefs::
                  kNewTabPageShowSponsoredImagesBackgroundImage ||
-      key == brave_ads::prefs::kNotificationsEnabled ||
-      key == brave_ads::prefs::kOptedInToSearchResultAds) {
+      key == brave_ads::prefs::kNotificationsEnabled) {
     p3a::RecordAdTypesEnabled(prefs_);
-  }
-
-  if (key == brave_ads::prefs::kOptedInToSearchResultAds) {
-    GetExternalWallet(
-        base::BindOnce(&RewardsServiceImpl::OnRecordBackendP3AExternalWallet,
-                       AsWeakPtr(), false, true));
   }
 #endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 }
@@ -360,16 +349,6 @@ void RewardsServiceImpl::CheckPreferences() {
     // utility process.
     StartEngineProcessIfNecessary();
   }
-
-#if BUILDFLAG(ENABLE_BRAVE_ADS)
-  // If Rewards is enabled and the user has a linked account, then ensure that
-  // the "search result ads enabled" pref has the appropriate default value.
-  if (prefs_->GetBoolean(prefs::kEnabled) &&
-      !prefs_->GetString(prefs::kExternalWalletType).empty() &&
-      !prefs_->HasPrefPath(brave_ads::prefs::kOptedInToSearchResultAds)) {
-    prefs_->SetBoolean(brave_ads::prefs::kOptedInToSearchResultAds, false);
-  }
-#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 }
 
 void RewardsServiceImpl::StartEngineProcessIfNecessary() {
@@ -1817,7 +1796,7 @@ void RewardsServiceImpl::RecordBackendP3AStats(bool delay_report) {
 
   GetExternalWallet(
       base::BindOnce(&RewardsServiceImpl::OnRecordBackendP3AExternalWallet,
-                     AsWeakPtr(), delay_report, false));
+                     AsWeakPtr(), delay_report));
 }
 
 void RewardsServiceImpl::OnP3ADailyTimer() {
@@ -1829,7 +1808,6 @@ void RewardsServiceImpl::OnP3ADailyTimer() {
 
 void RewardsServiceImpl::OnRecordBackendP3AExternalWallet(
     bool delay_report,
-    bool search_result_optin_changed,
     mojom::ExternalWalletPtr wallet) {
   if (!Connected()) {
     return;
@@ -1842,9 +1820,7 @@ void RewardsServiceImpl::OnRecordBackendP3AExternalWallet(
     return;
   }
 
-  if (search_result_optin_changed) {
-    p3a::RecordSearchResultAdsOptinChange(prefs_);
-  } else if (delay_report) {
+  if (delay_report) {
     // Use delay to ensure tips are confirmed when counting.
     p3a_tip_report_timer_.Start(
         FROM_HERE, kP3ATipReportDelay,
@@ -1982,11 +1958,6 @@ void RewardsServiceImpl::OnFilesDeletedForCompleteReset(
 }
 
 void RewardsServiceImpl::ExternalWalletConnected() {
-#if BUILDFLAG(ENABLE_BRAVE_ADS)
-  // When the user connects an external wallet, turn off search result ads since
-  // users cannot earn BAT for them yet. The user can turn them on manually.
-  prefs_->SetBoolean(brave_ads::prefs::kOptedInToSearchResultAds, false);
-#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
   for (auto& observer : observers_) {
     observer.OnExternalWalletConnected();
   }

--- a/components/brave_rewards/content/rewards_service_impl.h
+++ b/components/brave_rewards/content/rewards_service_impl.h
@@ -431,7 +431,6 @@ class RewardsServiceImpl final : public RewardsService,
   void OnP3ADailyTimer();
 
   void OnRecordBackendP3AExternalWallet(bool delay_report,
-                                        bool search_result_optin_changed,
                                         mojom::ExternalWalletPtr wallet);
   void GetAllContributionsForP3A();
   void OnRecordBackendP3AStatsContributions(

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -125,7 +125,6 @@ inline constexpr auto kCollectedTypicalHistograms =
     {"Brave.Rewards.NonBraveSearchWalletConnected", {}},
     {"Brave.Rewards.OfferClicks", MetricConfig{.ephemeral = true}},
     {"Brave.Rewards.OffersViewed", MetricConfig{.ephemeral = true}},
-    {"Brave.Rewards.SearchResultAdsOptin", MetricConfig{.ephemeral = true}},
     {"Brave.Rewards.TipsState.2", {}},
     {"Brave.Rewards.ToolbarButtonTrigger", MetricConfig{.ephemeral = true}},
     {"Brave.Rewards.WalletBalance.3", {}},

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/BraveSearchTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/BraveSearchTabHelper.swift
@@ -191,22 +191,6 @@ class BraveSearchTabHelper: TabObserver, TabPolicyDecider, BraveSearchMakeDefaul
           }
         )
       } else {
-        // The Brave-Search-Ads header should be added with a negative value when all
-        // of the following conditions are met:
-        //   - The current tab is not a Private tab
-        //   - Brave Rewards is enabled.
-        //   - The "Search Ads" is opted-out.
-        //   - The requested URL host is one of the Brave Search domains.
-        if !tab.isPrivate && rewards.isEnabled
-          && !rewards.ads.isOptedInToSearchResultAds()
-          && request.allHTTPHeaderFields?["Brave-Search-Ads"] == nil
-        {
-          var modifiedRequest = URLRequest(url: requestURL)
-          modifiedRequest.setValue("?0", forHTTPHeaderField: "Brave-Search-Ads")
-          tab.loadRequest(modifiedRequest)
-          return .cancel
-        }
-
         braveSearchResultAdManager = BraveSearchResultAdManager(
           url: requestURL,
           rewards: rewards,

--- a/ios/browser/api/ads/brave_ads.h
+++ b/ios/browser/api/ads/brave_ads.h
@@ -56,9 +56,6 @@ OBJC_EXPORT
 /// Returns `true` if the ads service is running otherwise returns `false`.
 - (BOOL)isServiceRunning;
 
-/// Returns `true` if the user opted-in to search result ads.
-- (BOOL)isOptedInToSearchResultAds;
-
 /// Returns `true` if the privacy notice infobar should be displayed when a user
 /// clicks on a search result ad. This should be called before calling
 /// `triggerSearchResultAdClickedEvent`.

--- a/ios/browser/api/ads/brave_ads.mm
+++ b/ios/browser/api/ads/brave_ads.mm
@@ -182,11 +182,6 @@ constexpr NSString* kAdsResourceComponentMetadataVersion = @".v1";
   return adsService != nil && adsService->IsInitialized();
 }
 
-- (BOOL)isOptedInToSearchResultAds {
-  return self.profilePrefService->GetBoolean(
-      brave_ads::prefs::kOptedInToSearchResultAds);
-}
-
 - (BOOL)shouldShowSearchResultAdClickedInfoBar {
   return self.profilePrefService->GetBoolean(
       brave_ads::prefs::kShouldShowSearchResultAdClickedInfoBar);


### PR DESCRIPTION
The PR removes reporting of the search result ads opted-in P3A metric `Brave.Rewards.SearchResultAdsOptin`, which is no longer needed since the Search Result Ad toggle was removed from the Rewards settings page.
The preference is also no longer reset when a Rewards external wallet is connected, because the search result ads header is sent regardless of the preference and setting the preference doesn’t have any effect.
The dead code for search result ads header functionality on iOS is removed as well: there is no case when `"Brave-Search-Ads: ?0"` header is sent on iOS because iOS rewards doesn't have connected wallets functionality.

Search Result Ad toggle was removed via: https://github.com/brave/brave-browser/issues/49995

<!-- Add brave-browser issue below that this PR will resolve -->
Part of https://github.com/brave/brave-browser/issues/57204
Resolves https://github.com/brave/brave-browser/issues/58293

## Test plan

### On Desktop:
* Start fresh profile
* Trigger and click search result ad
   EXPECTATION:
     - Search result ad infobar is triggered
     - Conversion was added on brave://ads-internals page
* Join Brave Rewards
* Trigger and click search result ad
   EXPECTATION:
     - Viewed and Clicked events was added on brave://ads-internals page
* Connect Brave Rewards wallet
* Make sure that search result ad cannot be triggered
* Make sure that `Brave.Rewards.SearchResultAdsOptin` P3A metric is no longer sent and is not set in brave://local-state.

### On iOS:
* Start fresh profile
* Trigger and click search result ad
   EXPECTATION:
     - Search result ad infobar is triggered
     - Conversion was added on brave://ads-internals page
* Join Brave Rewards
* Trigger and click search result ad
   EXPECTATION:
     - Viewed and Clicked events was added on brave://ads-internals page

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
