### PR TITLE
[iOS] Enter QuickView after proceeding through blocked-domain interstitial

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/BraveSearchTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/BraveSearchTabHelper.swift
@@ -35,6 +35,8 @@ class BraveSearchTabHelper: TabObserver, TabPolicyDecider, BraveSearchMakeDefaul
 
   var presentInQuickView: ((URL, any TabState) -> Void)?
 
+  var pendingQuickViewURL: URL?
+
   init(tab: some TabState, rewards: BraveRewards, searchEngines: SearchEngines) {
     self.tab = tab
     self.rewards = rewards
@@ -243,6 +245,28 @@ class BraveSearchTabHelper: TabObserver, TabPolicyDecider, BraveSearchMakeDefaul
       Preferences.General.openLinkInQuickViewMode.value,
       shouldOpenInQuickView(requestURL: requestURL, requestInfo: requestInfo, tab: tab)
     {
+      if let etldP1 = requestURL.baseDomain,
+        tab.proceedAnywaysDomainList?.contains(etldP1) == false
+      {
+        let shieldLevel =
+          tab.braveShieldsHelper?.shieldLevel(
+            for: requestURL,
+            considerAllShieldsOption: true
+          ) ?? .standard
+
+        let shouldBlock = await AdBlockGroupsManager.shared.shouldBlock(
+          requestURL: requestURL,
+          sourceURL: requestURL,
+          resourceType: .document,
+          isAdBlockEnabled: shieldLevel.isEnabled,
+          isAdBlockModeAggressive: shieldLevel.isAggressive
+        )
+
+        if shouldBlock {
+          pendingQuickViewURL = requestURL
+          return .cancel
+        }
+      }
       presentInQuickView?(requestURL, tab)
       return .cancel
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/BraveSearchTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/BraveSearchTabHelper.swift
@@ -35,6 +35,7 @@ class BraveSearchTabHelper: TabObserver, TabPolicyDecider, BraveSearchMakeDefaul
 
   var presentInQuickView: ((URL, any TabState) -> Void)?
 
+  /// A helper property that handles pending interstitial screen before entering QuickView mode.
   var pendingQuickViewURL: URL?
 
   init(tab: some TabState, rewards: BraveRewards, searchEngines: SearchEngines) {

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Internal/BlockedDomainScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Internal/BlockedDomainScriptHandler.swift
@@ -52,12 +52,18 @@ class BlockedDomainScriptHandler: TabContentScript {
       return
     }
 
-    let request = URLRequest(url: url)
     tab.proceedAnywaysDomainList?.insert(baseDomain)
-    tab.loadRequest(request)
+    if let pendingURL = tab.braveSearch?.pendingQuickViewURL, pendingURL == url {
+      tab.braveSearch?.pendingQuickViewURL = nil
+      tab.braveSearch?.presentInQuickView?(url, tab)
+      tab.goBack()
+    } else {
+      tab.loadRequest(URLRequest(url: url))
+    }
   }
 
   private func blockedDomainDidGoBack(tab: some TabState) {
+    tab.braveSearch?.pendingQuickViewURL = nil
     guard let url = tab.visibleURL?.strippedInternalURL else {
       assertionFailure(
         "There should be no way this method can be triggered if the tab is not on an internal url"


### PR DESCRIPTION
Links that are blocked by [easyprivacy tracker list](https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_trackingservers_general.txt) from Brave Search  SERP is now flow through the normal blocked-domain interstitial screen. Will only enter QuickView mode after tapping `Proceed`. 

Test: 
1. enable QuickView feature flag
2. manually type any site from [easyprivacy tracker list](https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_trackingservers_general.txt) and load
3. if it doesnt show brave's interstitial screen, try to change `Tracker & AdBlocker` to `Aggressive` and reload again (if the interstitial screen still no showing, file an issue regarding to this)
4. open a new tab
5. search any keywords using Brave Search that will result any links from the [easyprivacy tracker list](https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_trackingservers_general.txt) (or swizzle the href value from web inspector if you can) 
6. tap this link 
7. verify the interstitial screen shows 
8. tap go back 
9. verify it is back to the SERP
10. tap the link again and tap proceed in the interstitial screen
11. verify link is opened in quickview mode
12. close quickview 
13. verify the tab is back to the SERP

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
